### PR TITLE
docs: fix dead documentation links in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Step 1 - ⚡️ [Self-host Lightdash (optional)](https://docs.lightdash.com/self
 
 Step 2 - 🔌 [Connect a project](https://docs.lightdash.com/get-started/setup-lightdash/connect-project)
 
-Step 3 - 👩‍💻 [Create your first metric](https://docs.lightdash.com/get-started/setup-lightdash/intro-metrics-dimensions)
+Step 3 - 👩‍💻 [Create your first metric](https://docs.lightdash.com/get-started/develop-in-lightdash/how-to-create-metrics)
 
 ## Community Support
 
@@ -161,7 +161,7 @@ See our [instructions](https://github.com/lightdash/lightdash/blob/main/.github/
 
 ## Contributors ✨
 
-Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/en/reference/emoji-key/)):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->

--- a/examples/full-jaffle-shop-demo/dbt/README.md
+++ b/examples/full-jaffle-shop-demo/dbt/README.md
@@ -1,11 +1,11 @@
 ## How to use this project in Lightdash 
 
 ### Install Lightdash:
-Take advantage of our installation script to easily run Lightdash locally. Check the [documentation page](https://docs.lightdash.com/get-started/setup-lightdash/install-lightdash#deploy-locally-with-our-installation-script) for more details.
+Take advantage of our installation script to easily run Lightdash locally. See the [self-hosting docs](https://docs.lightdash.com/self-host/self-host-lightdash-docker-compose) for other ways to run Lightdash locally.
 ```bash
 git clone https://github.com/lightdash/lightdash
 cd lightdash
-./install.sh
+./scripts/install.sh
 
 # when prompted, select "fast" setup (option 1)
 ```

--- a/packages/iframe-test-app/README.md
+++ b/packages/iframe-test-app/README.md
@@ -103,5 +103,5 @@ To monitor additional Lightdash events:
 
 - [Lightdash Embedding Environment Variables](https://docs.lightdash.com/self-host/customize-deployment/environment-variables#embedding)
 - [How to Embed Lightdash Content](https://docs.lightdash.com/guides/how-to-embed-content#how-to-embed-content)
-- [Lightdash API Documentation](https://docs.lightdash.com/references/api)
+- [Lightdash API Documentation](https://docs.lightdash.com/api-reference)
 - [Lightdash Dashboard Documentation](https://docs.lightdash.com/get-started/exploring-data/dashboards)


### PR DESCRIPTION
## Summary

Fixes dead links across the repo's README files, plus a broken command in the demo install snippet. All replacement doc URLs verified returning HTTP 200 and confirmed against the pages' actual (or historic) content — not just "looks related."

| File | Link / item | Was | Now |
|------|-------------|-----|-----|
| `README.md` | emoji key | `allcontributors.org/docs/en/emoji-key` (404) | `allcontributors.org/en/reference/emoji-key/` |
| `README.md` | "Create your first metric" | `docs.lightdash.com/get-started/setup-lightdash/intro-metrics-dimensions` (404) | `docs.lightdash.com/get-started/develop-in-lightdash/how-to-create-metrics` |
| `packages/iframe-test-app/README.md` | "Lightdash API Documentation" | `docs.lightdash.com/references/api` (404) | `docs.lightdash.com/api-reference` |
| `examples/full-jaffle-shop-demo/dbt/README.md` | local-install docs link | `.../setup-lightdash/install-lightdash#deploy-locally-with-our-installation-script` (404) | `.../self-host/self-host-lightdash-docker-compose` |
| `examples/full-jaffle-shop-demo/dbt/README.md` | install command | `./install.sh` (wrong path) | `./scripts/install.sh` |

### Notes on the trickier ones

- **"Create your first metric"** → the old target (`intro-metrics-dimensions`) was a *"what are metrics and dimensions?"* concept page; for a getting-started step literally titled "Create your first metric", the how-to page (`how-to-create-metrics`) is the better destination.

- **jaffle-shop install section** — the reasoning here is more involved, so spelled out in full below.

### Reasoning: the jaffle-shop demo install section

This one block had three separate problems, so here's the full picture behind the change.

**1. The doc link (404).** The old link pointed at the *"Deploy locally with our installation script"* section of `get-started/setup-lightdash/install-lightdash`. That page no longer exists — it was removed in #4949 (*"docs: improve self-hosted docs"*, Mar 2023), a self-host docs restructure that replaced it with the docker-compose and Kubernetes/Helm self-host guides. So the section, not just the anchor, is gone.

**2. Is the install script itself dead?** No — and this mattered for picking the right fix, so it was checked directly rather than assumed:
- `scripts/install.sh` is still present and **actively maintained** — most recent fix is #24222 (*detect Windows*, Jun 2026), preceded by #18640 (Dec 2025).
- It still works end-to-end: it runs `docker compose --env-file ./.env.fast-install -f docker-compose.yml up`, and both `docker-compose.yml` and `.env.fast-install` are committed at the repo root.
- It's **still officially advertised** — the current root `README.md` "Run locally" section promotes it and calls `./scripts/install.sh`.
- The only nearby "deprecation" was #11532, about the deprecated *docker-compose command syntax*; Lightdash responded by updating the script to keep it working (#11588), i.e. investing in its survival. #15987 (open) even proposes *more* install-script tooling. There is no evidence of intent to deprecate or remove the script.
- **Conclusion:** the script is supported and recommended; only its dedicated *documentation page* was retired. So the "installation script" wording is kept.

**3. The command was wrong.** The snippet called `./install.sh`, but the script lives at `scripts/install.sh` — the historic docs and the current root README both use `./scripts/install.sh`. Corrected to match.

**Resulting change:** keep the install-script instructions, fix the path to `./scripts/install.sh`, and point the link at the docker-compose self-host guide framed as *"other ways to run Lightdash locally"* — since no current page documents the script itself, this adds a useful pointer without implying it does.

> Not fixed here (maintainers' call): the install script ships and works but is no longer documented anywhere. Options are to re-document it or steer the READMEs fully to docker-compose. Left out of this docs-link fix.

## How it was tested

Extracted URLs from human-authored docs and checked each with `curl` (following redirects). Confirmed replacements against page content (and, for moved/removed pages, against the original content in git history). Remaining link failures were third-party contributor sites, placeholder/example URLs, and intentional non-resolving hostnames (`minio:9000`, `lightdash-dev:3000`) — out of scope.

Docs-only change — no code paths affected.