### PR TITLE
fix: preserve AI memory sweep watermark

### DIFF
--- a/packages/backend/src/ee/models/AiAgentMemoryModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentMemoryModel.integration.test.ts
@@ -5,6 +5,7 @@ import {
     SEED_ORG_1,
     SEED_ORG_1_ADMIN,
     SEED_PROJECT,
+    type AiAgentMemoryDistillJobPayload,
     type AiThreadCreatedFrom,
 } from '@lightdash/common';
 import type { Knex } from 'knex';
@@ -727,6 +728,7 @@ describe('AiAgentMemoryModel integration', () => {
             organizationUuid: SEED_ORG_1.organization_uuid,
             projectUuid: SEED_PROJECT.project_uuid,
             userUuid: 'system',
+            sweptUpdatedAt: idleAt.toISOString(),
         };
 
         await expect(
@@ -774,6 +776,7 @@ describe('AiAgentMemoryModel integration', () => {
                 projectUuid: SEED_PROJECT.project_uuid,
                 userUuid: 'system',
                 threadUuid,
+                sweptUpdatedAt: activity.toISOString(),
             }),
         ).resolves.toBe('skipped');
         expect(distillCall).not.toHaveBeenCalled();
@@ -822,8 +825,140 @@ describe('AiAgentMemoryModel integration', () => {
             projectUuid: SEED_PROJECT.project_uuid,
             userUuid: 'system',
             threadUuid,
+            sweptUpdatedAt: '2026-07-22T05:00:00.000Z',
         });
         expect(distillCall).not.toHaveBeenCalled();
+    });
+
+    it('keeps a resumed thread due after distilling its swept watermark', async () => {
+        const now = new Date('2026-07-22T12:00:00Z');
+        const sweptActivity = new Date('2026-07-22T05:00:00Z');
+        const resumedActivity = new Date('2026-07-22T05:05:00Z');
+        const threadUuid = await createThread();
+        await createPrompt(threadUuid, sweptActivity);
+        const distillCall = vi
+            .fn<AiAgentMemoryDistillCall>()
+            .mockResolvedValue({
+                result: {
+                    type: 'no_op',
+                    reason: 'no_positive_evidence',
+                },
+            });
+        const service = buildService(distillCall);
+        const jobKey = `ai-agent-memory-distill:${threadUuid}`;
+
+        await service.sweep(now);
+        const graphileClient = await schedulerClient.graphileUtils;
+        const job = await graphileClient.withPgClient(async (client) => {
+            const result = await client.query<{
+                payload: AiAgentMemoryDistillJobPayload;
+            }>('SELECT payload FROM graphile_worker.jobs WHERE key = $1', [
+                jobKey,
+            ]);
+            return result.rows[0];
+        });
+        expect(job?.payload.sweptUpdatedAt).toBe(sweptActivity.toISOString());
+
+        await createPrompt(threadUuid, resumedActivity);
+        await expect(service.distillThread(job!.payload)).resolves.toBe(
+            'no_op',
+        );
+        expect(distillCall).toHaveBeenCalledExactlyOnceWith(
+            expect.objectContaining({
+                thread: expect.objectContaining({
+                    latestActivity: resumedActivity,
+                    turns: expect.arrayContaining([
+                        expect.objectContaining({ createdAt: sweptActivity }),
+                        expect.objectContaining({ createdAt: resumedActivity }),
+                    ]),
+                }),
+            }),
+        );
+        await expect(
+            database(AiAgentThreadDistillTableName)
+                .where('ai_thread_uuid', threadUuid)
+                .first(),
+        ).resolves.toMatchObject({
+            outcome: 'no_op',
+            distilled_up_to: sweptActivity,
+        });
+
+        const candidates = await model.findThreadsDueForDistill({
+            idleBefore: resumedActivity,
+            activityFloor: new Date(
+                resumedActivity.getTime() - 24 * 60 * 60 * 1000,
+            ),
+        });
+        expect(candidates).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    threadUuid,
+                    latestActivity: resumedActivity,
+                }),
+            ]),
+        );
+        await expect(service.distillThread(job!.payload)).resolves.toBe(
+            'skipped',
+        );
+    });
+
+    it('ignores missing, invalid, and future swept watermarks', async () => {
+        const activity = new Date('2026-07-22T05:00:00Z');
+        const [missing, invalid, future] = await Promise.all([
+            createThread(),
+            createThread(),
+            createThread(),
+        ]);
+        await Promise.all(
+            [missing, invalid, future].map((threadUuid) =>
+                createPrompt(threadUuid, activity),
+            ),
+        );
+        const distillCall = vi
+            .fn<AiAgentMemoryDistillCall>()
+            .mockResolvedValue({
+                result: {
+                    type: 'no_op',
+                    reason: 'no_positive_evidence',
+                },
+            });
+        const service = buildService(distillCall);
+        const base = {
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            projectUuid: SEED_PROJECT.project_uuid,
+            userUuid: 'system',
+        };
+        const payloads = [
+            {
+                ...base,
+                threadUuid: missing,
+            } as unknown as AiAgentMemoryDistillJobPayload,
+            {
+                ...base,
+                threadUuid: invalid,
+                sweptUpdatedAt: 'not-a-date',
+            },
+            {
+                ...base,
+                threadUuid: future,
+                sweptUpdatedAt: new Date(
+                    activity.getTime() + 60 * 1000,
+                ).toISOString(),
+            },
+        ];
+
+        await Promise.all(
+            payloads.map((payload) =>
+                expect(service.distillThread(payload)).resolves.toBe('skipped'),
+            ),
+        );
+
+        expect(distillCall).not.toHaveBeenCalled();
+        await expect(
+            database(AiAgentThreadDistillTableName)
+                .whereIn('ai_thread_uuid', [missing, invalid, future])
+                .select(),
+        ).resolves.toHaveLength(0);
     });
 
     it('aborts before persistence and records the exact activity watermark', async () => {
@@ -852,6 +987,7 @@ describe('AiAgentMemoryModel integration', () => {
                 projectUuid: SEED_PROJECT.project_uuid,
                 userUuid: 'system',
                 threadUuid,
+                sweptUpdatedAt: activity.toISOString(),
             },
             controller.signal,
         );
@@ -906,6 +1042,7 @@ describe('AiAgentMemoryModel integration', () => {
             projectUuid: SEED_PROJECT.project_uuid,
             userUuid: 'system',
             threadUuid,
+            sweptUpdatedAt: firstActivity.toISOString(),
         };
 
         await expect(service.distillThread(payload)).resolves.toBe('memory');
@@ -933,7 +1070,13 @@ describe('AiAgentMemoryModel integration', () => {
 
         const secondActivity = new Date('2026-07-22T05:05:00Z');
         await createPrompt(threadUuid, secondActivity);
-        await expect(service.distillThread(payload)).resolves.toBe('no_op');
+        const resumedPayload = {
+            ...payload,
+            sweptUpdatedAt: secondActivity.toISOString(),
+        };
+        await expect(service.distillThread(resumedPayload)).resolves.toBe(
+            'no_op',
+        );
 
         const memories = await database(AiAgentMemoryTableName).where(
             'source_thread_uuid',
@@ -949,7 +1092,9 @@ describe('AiAgentMemoryModel integration', () => {
             no_op_reason: 'no_positive_evidence',
             distilled_up_to: secondActivity,
         });
-        await expect(service.distillThread(payload)).resolves.toBe('skipped');
+        await expect(service.distillThread(resumedPayload)).resolves.toBe(
+            'skipped',
+        );
         expect(distillCall).toHaveBeenCalledTimes(2);
     });
 
@@ -993,6 +1138,7 @@ describe('AiAgentMemoryModel integration', () => {
                 projectUuid: SEED_PROJECT.project_uuid,
                 userUuid: 'system',
                 threadUuid,
+                sweptUpdatedAt: activity.toISOString(),
             }),
         ).resolves.toBe('memory');
 

--- a/packages/backend/src/ee/scheduler/SchedulerClient.test.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerClient.test.ts
@@ -59,6 +59,7 @@ describe('CommercialSchedulerClient.aiAgentMemoryDistill', () => {
             organizationUuid: 'org-1',
             projectUuid: 'project-1',
             userUuid: 'system',
+            sweptUpdatedAt: '2026-07-22T05:00:00.000Z',
         };
 
         await client.aiAgentMemoryDistill(payload);

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
@@ -120,6 +120,8 @@ describe('AiAgentMemoryService', () => {
                     featureFlagId === CommercialFeatureFlags.AiCopilot),
         }));
         const findByProjectAndSlug = vi.fn();
+        const findThreadsDueForDistill = vi.fn();
+        const aiAgentMemoryDistill = vi.fn();
         const getAgent = vi.fn().mockResolvedValue({
             uuid: 'agent-1',
             name: 'Agent',
@@ -141,22 +143,53 @@ describe('AiAgentMemoryService', () => {
                 projectUuid === 'project-other' ? 'org-other' : 'org-enabled',
         }));
         const service = new AiAgentMemoryService({
-            aiAgentMemoryModel: { findByProjectAndSlug } as AnyType,
+            aiAgentMemoryModel: {
+                findByProjectAndSlug,
+                findThreadsDueForDistill,
+            } as AnyType,
             aiAgentModel: { getAgent, findThreadOwnership } as AnyType,
             groupsModel: { findUserInGroups } as AnyType,
             projectModel: { getSummary: getProjectSummary } as AnyType,
             featureFlagService: { get: getFlag } as AnyType,
-            schedulerClient: { aiAgentMemoryDistill: vi.fn() },
+            schedulerClient: { aiAgentMemoryDistill },
             distillCall: vi.fn(),
         });
         return {
             service,
             getFlag,
             findByProjectAndSlug,
+            findThreadsDueForDistill,
+            aiAgentMemoryDistill,
             getAgent,
             findThreadOwnership,
         };
     };
+
+    it('enqueues the exact activity watermark selected by the sweep', async () => {
+        const { service, findThreadsDueForDistill, aiAgentMemoryDistill } =
+            build();
+        const latestActivity = new Date('2026-07-22T05:00:00.123Z');
+        findThreadsDueForDistill.mockResolvedValue([
+            {
+                threadUuid: 'thread-enabled',
+                organizationUuid: 'org-enabled',
+                projectUuid: 'project-enabled',
+                latestActivity,
+            },
+        ]);
+
+        await expect(
+            service.sweep(new Date('2026-07-22T12:00:00.000Z')),
+        ).resolves.toBe(1);
+
+        expect(aiAgentMemoryDistill).toHaveBeenCalledWith({
+            organizationUuid: 'org-enabled',
+            projectUuid: 'project-enabled',
+            userUuid: 'system',
+            threadUuid: 'thread-enabled',
+            sweptUpdatedAt: '2026-07-22T05:00:00.123Z',
+        });
+    });
 
     it('returns a project-visible memory with source provenance', async () => {
         const { service, findByProjectAndSlug, getAgent } = build();

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
@@ -347,6 +347,7 @@ export class AiAgentMemoryService extends BaseService {
                     projectUuid: candidate.projectUuid,
                     userUuid: 'system',
                     threadUuid: candidate.threadUuid,
+                    sweptUpdatedAt: candidate.latestActivity.toISOString(),
                 }),
             ),
         );
@@ -357,6 +358,18 @@ export class AiAgentMemoryService extends BaseService {
         payload: AiAgentMemoryDistillJobPayload,
         abortSignal?: AbortSignal,
     ): Promise<'disabled' | 'skipped' | 'memory' | 'no_op' | 'failed'> {
+        const sweptUpdatedAt =
+            typeof payload.sweptUpdatedAt === 'string'
+                ? new Date(payload.sweptUpdatedAt)
+                : undefined;
+        if (
+            !sweptUpdatedAt ||
+            Number.isNaN(sweptUpdatedAt.getTime()) ||
+            sweptUpdatedAt.toISOString() !== payload.sweptUpdatedAt
+        ) {
+            return 'skipped';
+        }
+
         if (!(await this.isEnabled(payload.organizationUuid))) {
             return 'disabled';
         }
@@ -372,9 +385,13 @@ export class AiAgentMemoryService extends BaseService {
             return 'skipped';
         }
 
+        if (sweptUpdatedAt.getTime() > thread.latestActivity.getTime()) {
+            return 'skipped';
+        }
+
         if (
             thread.distilledUpTo !== null &&
-            thread.distilledUpTo.getTime() >= thread.latestActivity.getTime()
+            thread.distilledUpTo.getTime() >= sweptUpdatedAt.getTime()
         ) {
             return 'skipped';
         }
@@ -396,7 +413,7 @@ export class AiAgentMemoryService extends BaseService {
                 aiThreadUuid: thread.threadUuid,
                 outcome: 'skipped',
                 distillPromptHash: null,
-                distilledUpTo: thread.latestActivity,
+                distilledUpTo: sweptUpdatedAt,
             });
             return 'skipped';
         }
@@ -417,7 +434,7 @@ export class AiAgentMemoryService extends BaseService {
                     outcome: 'no_op',
                     noOpReason: output.result.reason,
                     distillPromptHash,
-                    distilledUpTo: thread.latestActivity,
+                    distilledUpTo: sweptUpdatedAt,
                 });
                 return 'no_op';
             }
@@ -446,7 +463,7 @@ export class AiAgentMemoryService extends BaseService {
                 aiThreadUuid: thread.threadUuid,
                 outcome: 'memory',
                 distillPromptHash,
-                distilledUpTo: thread.latestActivity,
+                distilledUpTo: sweptUpdatedAt,
             });
             return 'memory';
         } catch (error) {
@@ -456,7 +473,7 @@ export class AiAgentMemoryService extends BaseService {
                 outcome: 'failed',
                 errorMessage,
                 distillPromptHash: await distillPromptHashPromise,
-                distilledUpTo: thread.latestActivity,
+                distilledUpTo: sweptUpdatedAt,
             });
             this.logger.warn('Dropping AI agent memory distill', {
                 threadUuid: thread.threadUuid,

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -112,6 +112,7 @@ export type AiAgentEditDbtProjectPipelineJobPayload = TraceTaskBase & {
 
 export type AiAgentMemoryDistillJobPayload = TraceTaskBase & {
     threadUuid: UUID;
+    sweptUpdatedAt: string;
 };
 
 export const EE_SCHEDULER_TASKS = {


### PR DESCRIPTION
### Description

- Carries the exact thread activity timestamp captured by the scheduler sweep in each distill job.
- Persists that swept watermark for every ledger outcome so activity resumed after enqueue remains eligible for a later sweep.
- Rejects missing, malformed, or future sweep watermarks without invoking the distiller.

### Testing

- Backend unit tests: 13 passed
- Backend `typecheck:fast`: passed
- PostgreSQL race and invalid-watermark integration coverage exercised during the E2E run
- Commit hooks: lint, format, unused exports passed

Closes: https://linear.app/lightdash/issue/ZAP-672/spec-ai-agent-memory-v0