### PR TITLE
feat: allow typing in data app prompt box while AI is generating

### DIFF
--- a/packages/frontend/src/features/apps/AppPromptEditor.tsx
+++ b/packages/frontend/src/features/apps/AppPromptEditor.tsx
@@ -47,6 +47,9 @@ type Props = {
     placeholder?: string;
     autoFocus?: boolean;
     disabled?: boolean;
+    /** Blocks Enter-to-submit while the editor stays editable — lets users
+     *  draft their next prompt while the AI is generating. */
+    submitDisabled?: boolean;
     /** Called after every content change with whether the editor is empty —
      *  the parent uses this to enable/disable the submit button. */
     onEmptyChange?: (isEmpty: boolean) => void;
@@ -169,7 +172,15 @@ const ElementMention = Mention.extend({
 
 const AppPromptEditor = forwardRef<AppPromptEditorHandle, Props>(
     function AppPromptEditor(
-        { placeholder, autoFocus, disabled, onEmptyChange, onSubmit, onPaste },
+        {
+            placeholder,
+            autoFocus,
+            disabled,
+            submitDisabled,
+            onEmptyChange,
+            onSubmit,
+            onPaste,
+        },
         ref,
     ) {
         // Refs so the editor's stable handlers (configured once at editor
@@ -178,6 +189,8 @@ const AppPromptEditor = forwardRef<AppPromptEditorHandle, Props>(
         onSubmitRef.current = onSubmit;
         const onPasteRef = useRef(onPaste);
         onPasteRef.current = onPaste;
+        const submitDisabledRef = useRef(submitDisabled);
+        submitDisabledRef.current = submitDisabled;
         const editorRef = useRef<Editor | null>(null);
 
         const editor = useEditor({
@@ -208,7 +221,11 @@ const AppPromptEditor = forwardRef<AppPromptEditorHandle, Props>(
                         const submit = onSubmitRef.current;
                         if (text.trim() && submit) {
                             event.preventDefault();
-                            submit(text);
+                            // Swallow Enter while submission is gated so the
+                            // draft doesn't gain stray newlines.
+                            if (!submitDisabledRef.current) {
+                                submit(text);
+                            }
                             return true;
                         }
                     }

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -844,9 +844,10 @@ const AppGenerate: FC = () => {
         return null;
     }, [appData]);
     const isBuilding = latestBuildingVersion !== null;
-    // Clarifying counts as loading for the chat input (disable typing/send),
-    // and a pending unanswered clarification keeps the input area disabled
-    // until the user clicks "Build" on the question bubble.
+    // Clarifying counts as loading for the chat input (disable send; typing
+    // stays enabled so the next prompt can be drafted), and a pending
+    // unanswered clarification keeps send disabled until the user clicks
+    // "Build" on the question bubble.
     const hasPendingClarification = pendingClarification !== null;
     // Server-side work that warrants showing a placeholder assistant bubble.
     // Excludes `isSubmitting` (client-side upload — too early to claim
@@ -2725,7 +2726,12 @@ const AppGenerate: FC = () => {
                                         ref={promptEditorRef}
                                         placeholder="Describe the app you want to build..."
                                         autoFocus
-                                        disabled={isLoading}
+                                        // Editable while the agent works so the
+                                        // next prompt can be drafted; disabled
+                                        // only during the client-side submit,
+                                        // where clear() would wipe typed text.
+                                        disabled={isSubmitting}
+                                        submitDisabled={isLoading}
                                         onEmptyChange={setIsPromptEmpty}
                                         onSubmit={() => void handleSubmit()}
                                         onPaste={handlePaste}
@@ -2819,7 +2825,7 @@ const AppGenerate: FC = () => {
                                                                 ),
                                                         )
                                                     }
-                                                    disabled={isLoading}
+                                                    disabled={isSubmitting}
                                                 />
                                             )}
                                             {selectedDashboard && (
@@ -2847,7 +2853,7 @@ const AppGenerate: FC = () => {
                                                                     : null,
                                                         )
                                                     }
-                                                    disabled={isLoading}
+                                                    disabled={isSubmitting}
                                                 />
                                             )}
                                             {imageAttachments.length > 0 && (
@@ -2861,7 +2867,7 @@ const AppGenerate: FC = () => {
                                                     onRemove={(previewUrl) =>
                                                         clearImage(previewUrl)
                                                     }
-                                                    disabled={isLoading}
+                                                    disabled={isSubmitting}
                                                     loading={isSubmitting}
                                                 />
                                             )}
@@ -2967,7 +2973,7 @@ const AppGenerate: FC = () => {
                                                 onAddImages={() =>
                                                     fileInputRef.current?.click()
                                                 }
-                                                disabled={isLoading}
+                                                disabled={isSubmitting}
                                                 imagesDisabled={
                                                     imageAttachments.length >=
                                                     MAX_IMAGES_PER_VERSION
@@ -2982,7 +2988,7 @@ const AppGenerate: FC = () => {
                                                 disabled={
                                                     !previewApp ||
                                                     !screenshotAvailable ||
-                                                    isLoading ||
+                                                    isSubmitting ||
                                                     imageAttachments.length >=
                                                         MAX_IMAGES_PER_VERSION
                                                 }
@@ -3009,7 +3015,7 @@ const AppGenerate: FC = () => {
                                             <ModelPicker
                                                 value={selectedModel}
                                                 onChange={handleModelChange}
-                                                disabled={isLoading}
+                                                disabled={isSubmitting}
                                             />
                                             {isBuilding ? (
                                                 <ActionIcon


### PR DESCRIPTION
## Summary

Decouples editability from submit-ability in the data-app prompt composer so the next prompt can be drafted while the AI is generating:

- `AppPromptEditor` gets a `submitDisabled` prop — the editor stays editable while generation is in flight; Enter is swallowed (no submit, no stray newline in the draft).
- The editor is only fully disabled during the brief client-side submit window, where `clear()` would wipe typed text.
- Draft-composition controls (attach resources, chart/dashboard/image chips, screenshot, model picker) are likewise enabled during generation — they only mutate local state read at the next submit.
- Send button + Enter remain gated until generation completes (no queueing). Theme chip and version restore stay locked while the agent works since they trigger real server work.

## Testing

Verified in the browser against a seeded in-flight build: typing/attaching works during generation, Enter does nothing, and on completion the draft survives and becomes submittable.

Closes: PROD-8119
Closes: #23867

🤖 Generated with [Claude Code](https://claude.com/claude-code)