### PR TITLE
fix(skills): hide Claude skills from public discovery

### DIFF
--- a/.claude/skills/add-onboarding-tour/SKILL.md
+++ b/.claude/skills/add-onboarding-tour/SKILL.md
@@ -1,5 +1,7 @@
 ---
 name: add-onboarding-tour
+metadata:
+  internal: true
 description: Add a first-run guided tour, product walkthrough, coachmarks, or empty-state mock/example data to a Lightdash frontend feature. Use when the user wants to onboard users to a page, add a "Take the tour" flow, explain an unfamiliar UI, or show sample data on an empty page.
 allowed-tools: Read, Edit, Write, Glob, Grep
 ---

--- a/.claude/skills/add-warehouse-adapter/SKILL.md
+++ b/.claude/skills/add-warehouse-adapter/SKILL.md
@@ -1,3 +1,8 @@
+---
+metadata:
+  internal: true
+---
+
 # Add a Warehouse Adapter
 
 Step-by-step checklist for adding a new warehouse connection to Lightdash. Follow the Athena adapter as the canonical example (PRs #19751/#19752). The MotherDuck/DuckDB adapter is the most recent implementation.

--- a/.claude/skills/agent-harness/SKILL.md
+++ b/.claude/skills/agent-harness/SKILL.md
@@ -1,5 +1,7 @@
 ---
 name: agent-harness
+metadata:
+  internal: true
 description: Guide for AI agents running in the isolated agent-harness environment. Use when you need to discover your agent ID, find your ports, manage your stack with agent-cli.sh, run verification, or understand the multi-agent development setup.
 ---
 

--- a/.claude/skills/breakup-pr/SKILL.md
+++ b/.claude/skills/breakup-pr/SKILL.md
@@ -1,5 +1,7 @@
 ---
 name: breakup-pr
+metadata:
+  internal: true
 description: |
   Break up a large PR into vertical feature slices delivered incrementally via Graphite stacked PRs.
   All verticals share a single feature flag so the entire feature ships atomically.

--- a/.claude/skills/creating-pull-requests/SKILL.md
+++ b/.claude/skills/creating-pull-requests/SKILL.md
@@ -1,5 +1,7 @@
 ---
 name: creating-pull-requests
+metadata:
+  internal: true
 description: Use when creating, opening, or writing the title/description of a pull request, or writing PR bodies via `gh pr create` or `gt submit`. Covers what must go in the PR description (Linear ticket, GitHub issue) and what must never appear (client/customer names or their data).
 invocation: user
 ---

--- a/.claude/skills/debug-local/SKILL.md
+++ b/.claude/skills/debug-local/SKILL.md
@@ -1,5 +1,7 @@
 ---
 name: debug-local
+metadata:
+  internal: true
 description: Debug the Lightdash app using PM2 logs, Spotlight traces, and browser automation. Use when investigating issues, tracking down bugs, understanding request flow, or correlating frontend actions with backend behavior.
 ---
 

--- a/.claude/skills/deprecate-endpoint/SKILL.md
+++ b/.claude/skills/deprecate-endpoint/SKILL.md
@@ -1,5 +1,7 @@
 ---
 name: deprecate-endpoint
+metadata:
+  internal: true
 description: Use when deprecating, sunsetting, or removing a backend HTTP API endpoint in Lightdash — wiring deprecation logging, deadline/sunset dates, response headers, and Sentry alerting onto a TSOA controller route. Also covers making the deprecation visible on docs.lightdash.com and llms.txt (description lead line, x-mint migration banner). Covers the first-party-caller precondition and the shared deprecation middleware.
 allowed-tools: Read, Grep, Glob, Edit, Bash
 ---

--- a/.claude/skills/fix-vulnerability/SKILL.md
+++ b/.claude/skills/fix-vulnerability/SKILL.md
@@ -1,5 +1,7 @@
 ---
 name: fix-vulnerability
+metadata:
+  internal: true
 description: Fix a Snyk vulnerability PR by regenerating the pnpm lockfile, checking changelogs for breaking changes, and posting findings as a PR comment. Use when asked to fix a vulnerability PR or handle a Snyk dependency upgrade.
 allowed-tools: Bash, Read, Grep, Glob, Task, WebFetch, WebSearch
 ---

--- a/.claude/skills/frontend-style-guide/SKILL.md
+++ b/.claude/skills/frontend-style-guide/SKILL.md
@@ -1,5 +1,7 @@
 ---
 name: frontend-style-guide
+metadata:
+  internal: true
 description: Apply the Lightdash frontend style guide when working on React components, migrating Mantine v6 to v8, or styling frontend code. Use when editing TSX files, fixing styling issues, or when user mentions Mantine, styling, or CSS modules.
 allowed-tools: Read, Edit, Write, Glob, Grep
 ---

--- a/.claude/skills/graphite/SKILL.md
+++ b/.claude/skills/graphite/SKILL.md
@@ -1,5 +1,7 @@
 ---
 name: graphite
+metadata:
+  internal: true
 description: |
   Manage stacked PRs with Graphite CLI (gt) instead of git for branch/PR operations.
   Auto-detects Graphite repos via .git/.graphite_repo_config.

--- a/.claude/skills/har-replay/SKILL.md
+++ b/.claude/skills/har-replay/SKILL.md
@@ -1,5 +1,7 @@
 ---
 name: har-replay
+metadata:
+  internal: true
 description: Replay a HAR file as a mock backend to reproduce frontend performance issues with production data. Use when asked to replay a HAR file, reproduce a dashboard with a HAR, or test frontend performance with captured traffic.
 ---
 

--- a/.claude/skills/ld-permissions/SKILL.md
+++ b/.claude/skills/ld-permissions/SKILL.md
@@ -1,5 +1,7 @@
 ---
 name: ld-permissions
+metadata:
+  internal: true
 description: Guide for Lightdash's CASL-based authorization system. Use when working with scopes, custom roles, abilities, permissions, ForbiddenError, authorization, or access control. Helps with adding new scopes, debugging permission issues, understanding the permission flow, and creating custom roles.
 allowed-tools: Read, Grep, Glob, Task
 ---

--- a/.claude/skills/renovate-pr/SKILL.md
+++ b/.claude/skills/renovate-pr/SKILL.md
@@ -1,5 +1,7 @@
 ---
 name: renovate-pr
+metadata:
+  internal: true
 description: Test and assess an open Renovate dependency-bump PR. Picks the first open Renovate PR, checks out the branch, starts the app, exercises code paths affected by the upgraded package, reviews the changelog and (if needed) the upstream source diff, and reports whether the bump is safe to merge. Use when asked to "test a renovate PR", "triage renovate", "assess a renovate bump", or "check a dependency upgrade".
 ---
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #26140

### Description:

- Mark repository-only `.claude/skills` as internal to public `skills` CLI discovery.

### Validation:

- `CI=1 NO_COLOR=1 npx --yes skills@1.5.20 add ./ --list` reports one visible skill: `developing-in-lightdash`.
- Fresh-agent review completed with no remaining findings.