### PR TITLE
fix(e2e): update user attribute button label

### DIFF
--- a/packages/e2e/cypress/e2e/app/userAttributes.cy.ts
+++ b/packages/e2e/cypress/e2e/app/userAttributes.cy.ts
@@ -42,7 +42,7 @@ describe('User attributes sql_filter', () => {
 
     it('Create user attribute', () => {
         cy.visit(`/generalSettings/userAttributes`);
-        cy.findByText('Add new attribute').click();
+        cy.findByText('Add attribute').click();
 
         cy.get('input[name="name"]').type('customer_id');
         cy.findByText('Add user').click();
@@ -143,7 +143,7 @@ describe('User attributes dimension required_attribute', () => {
 
     it('Create user attribute', () => {
         cy.visit(`/generalSettings/userAttributes`);
-        cy.findByText('Add new attribute').click();
+        cy.findByText('Add attribute').click();
 
         cy.get('input[name="name"]').type('is_admin');
         cy.findByText('Add user').click();


### PR DESCRIPTION
Updates the user attribute Cypress selectors to match the button label introduced by #26104.

## Verification

- `pnpm -F e2e run linter ./cypress/e2e/app/userAttributes.cy.ts`
- `pnpm -F e2e exec oxfmt ./cypress/e2e/app/userAttributes.cy.ts --check`

test-all
