### PR TITLE
feat: track AI agent memory analytics

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -2736,6 +2736,66 @@ export type AiAgentReviewEvent =
     | AiAgentReviewItemWritebackCompletedEvent
     | AiAgentReviewItemWritebackFailedEvent;
 
+export type AiAgentMemoryGeneratedEvent = BaseTrack & {
+    event: 'ai_agent_memory.generated';
+    anonymousId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        agentId: string | null;
+        memoryId: string;
+        channel: 'web' | 'slack';
+        isRedistill: boolean;
+        objectCount: number;
+        unresolvedObjectCount: number;
+    };
+};
+
+export type AiAgentMemoryGenerationFailedEvent = BaseTrack & {
+    event: 'ai_agent_memory.generation_failed';
+    anonymousId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        agentId: string | null;
+        channel: 'web' | 'slack';
+        failureStage: 'distillation' | 'persistence';
+        errorType: string;
+    };
+};
+
+export type AiAgentMemoryCitedEvent = BaseTrack & {
+    event: 'ai_agent_memory.cited';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        agentId: string;
+        memoryId: string;
+        citationCount: number;
+        channel: 'web' | 'slack';
+    };
+};
+
+export type AiAgentMemoryViewedEvent = BaseTrack & {
+    event: 'ai_agent_memory.viewed';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        agentId: string | null;
+        memoryId: string;
+        status: 'active' | 'superseded' | 'retired';
+        provenanceType: 'source_thread' | 'consolidated';
+    };
+};
+
+export type AiAgentMemoryEvent =
+    | AiAgentMemoryGeneratedEvent
+    | AiAgentMemoryGenerationFailedEvent
+    | AiAgentMemoryCitedEvent
+    | AiAgentMemoryViewedEvent;
+
 export type AiRouterConfigUpdatedEvent = BaseTrack & {
     event: 'ai_router.config_updated';
     userId: string;
@@ -2944,6 +3004,7 @@ type TypedEvent =
     | AiAgentSuggestionSubmitEvent
     | AiAgentPullRequestViewedEvent
     | AiAgentReviewEvent
+    | AiAgentMemoryEvent
     | AiRouterConfigUpdatedEvent
     | AiRouterInstructionsUpdatedEvent
     | AiRouterMessageRoutedEvent

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -137,6 +137,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
         serviceProviders: {
             aiAgentMemoryService: ({ models, clients, context, repository }) =>
                 new AiAgentMemoryService({
+                    analytics: context.lightdashAnalytics,
                     aiAgentMemoryModel:
                         models.getAiAgentMemoryModel<AiAgentMemoryModel>(),
                     aiAgentModel: models.getAiAgentModel(),

--- a/packages/backend/src/ee/models/AiAgentMemoryModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentMemoryModel.integration.test.ts
@@ -47,6 +47,7 @@ describe('AiAgentMemoryModel integration', () => {
     let model: AiAgentMemoryModel;
     let featureFlagService: FeatureFlagService;
     let schedulerClient: CommercialSchedulerClient;
+    let analytics: LightdashAnalytics;
     const originalFlags = new Map<string, DbFeatureFlag | undefined>();
     const threadUuids = new Set<string>();
     const memoryUuids = new Set<string>();
@@ -80,14 +81,15 @@ describe('AiAgentMemoryModel integration', () => {
             lightdashConfig,
             featureFlagModel,
         });
+        analytics = new LightdashAnalytics({
+            lightdashConfig,
+            writeKey: 'notrack',
+            dataPlaneUrl: 'notrack',
+            options: { enable: false },
+        });
         schedulerClient = new CommercialSchedulerClient({
             lightdashConfig,
-            analytics: new LightdashAnalytics({
-                lightdashConfig,
-                writeKey: 'notrack',
-                dataPlaneUrl: 'notrack',
-                options: { enable: false },
-            }),
+            analytics,
             schedulerModel: getTestContext()
                 .app.getModels()
                 .getSchedulerModel(),
@@ -252,6 +254,7 @@ describe('AiAgentMemoryModel integration', () => {
         > = getTestContext().app.getModels().getProjectModel(),
     ) =>
         new AiAgentMemoryService({
+            analytics,
             aiAgentMemoryModel: model,
             aiAgentModel: getTestContext().app.getModels().getAiAgentModel(),
             groupsModel: getTestContext().app.getModels().getGroupsModel(),
@@ -353,7 +356,7 @@ describe('AiAgentMemoryModel integration', () => {
             .where('ai_agent_memory_uuid', retired.ai_agent_memory_uuid)
             .update({ status: 'retired' });
 
-        const updatedSlugs = await model.incrementCitedForActiveMemories({
+        await model.incrementCitedForActiveMemories({
             projectUuid: SEED_PROJECT.project_uuid,
             slugs: [active.slug, active.slug, retired.slug, 'unknown-memory'],
         });
@@ -371,7 +374,6 @@ describe('AiAgentMemoryModel integration', () => {
             (row) => row.ai_agent_memory_uuid === retired.ai_agent_memory_uuid,
         );
 
-        expect(updatedSlugs).toEqual([active.slug]);
         expect(activeRow).toMatchObject({
             cited_count: 1,
             pulled_count: 0,

--- a/packages/backend/src/ee/models/AiAgentMemoryModel.ts
+++ b/packages/backend/src/ee/models/AiAgentMemoryModel.ts
@@ -580,7 +580,7 @@ export class AiAgentMemoryModel {
     async incrementCitedForActiveMemories(args: {
         projectUuid: string;
         slugs: string[];
-    }): Promise<string[]> {
+    }): Promise<Array<{ memoryId: string; slug: string }>> {
         const slugs = [...new Set(args.slugs)];
         if (slugs.length === 0) return [];
 
@@ -594,8 +594,11 @@ export class AiAgentMemoryModel {
                 cited_count: this.database.raw('cited_count + 1'),
                 last_cited_at: this.database.fn.now(),
             } as never)
-            .returning('slug');
+            .returning(['ai_agent_memory_uuid', 'slug']);
 
-        return rows.map(({ slug }) => slug);
+        return rows.map(({ ai_agent_memory_uuid: memoryId, slug }) => ({
+            memoryId,
+            slug,
+        }));
     }
 }

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
@@ -143,6 +143,7 @@ describe('AiAgentMemoryService', () => {
                 projectUuid === 'project-other' ? 'org-other' : 'org-enabled',
         }));
         const service = new AiAgentMemoryService({
+            analytics: { track: vi.fn() } as AnyType,
             aiAgentMemoryModel: {
                 findByProjectAndSlug,
                 findThreadsDueForDistill,

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
@@ -594,6 +594,7 @@ export class AiAgentMemoryService extends BaseService {
                 projectUuid: args.thread.projectUuid,
                 agentUuid: args.thread.agentUuid,
                 threadUuid: args.thread.threadUuid,
+                recordIO: copilotConfig.telemetryEnabled,
                 ...getLanguageModelAttribution(model.model),
             }),
             messages: [

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
@@ -21,6 +21,12 @@ import { generateObject } from 'ai';
 import { createHash, randomBytes } from 'crypto';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
+import {
+    type AiAgentMemoryGeneratedEvent,
+    type AiAgentMemoryGenerationFailedEvent,
+    type AiAgentMemoryViewedEvent,
+    type LightdashAnalytics,
+} from '../../../analytics/LightdashAnalytics';
 import { type GroupsModel } from '../../../models/GroupsModel';
 import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { BaseService } from '../../../services/BaseService';
@@ -66,7 +72,13 @@ type MemorySchedulerClient = {
     ) => Promise<unknown>;
 };
 
+type MemoryServiceAnalyticsEvent =
+    | AiAgentMemoryGeneratedEvent
+    | AiAgentMemoryGenerationFailedEvent
+    | AiAgentMemoryViewedEvent;
+
 type Dependencies = {
+    analytics: LightdashAnalytics;
     aiAgentMemoryModel: AiAgentMemoryModel;
     aiAgentModel: Pick<AiAgentModel, 'getAgent' | 'findThreadOwnership'>;
     groupsModel: Pick<GroupsModel, 'findUserInGroups'>;
@@ -112,6 +124,8 @@ export const validateMemoryObjects = (
 };
 
 export class AiAgentMemoryService extends BaseService {
+    private readonly analytics: LightdashAnalytics;
+
     private readonly aiAgentMemoryModel: AiAgentMemoryModel;
 
     private readonly aiAgentModel: Dependencies['aiAgentModel'];
@@ -132,6 +146,7 @@ export class AiAgentMemoryService extends BaseService {
 
     constructor(dependencies: Dependencies) {
         super({ serviceName: 'AiAgentMemoryService' });
+        this.analytics = dependencies.analytics;
         this.aiAgentMemoryModel = dependencies.aiAgentMemoryModel;
         this.aiAgentModel = dependencies.aiAgentModel;
         this.groupsModel = dependencies.groupsModel;
@@ -142,6 +157,17 @@ export class AiAgentMemoryService extends BaseService {
             dependencies.orgAiCopilotConfigResolver;
         this.distillCall =
             dependencies.distillCall ?? this.distillWithLlm.bind(this);
+    }
+
+    private track(event: MemoryServiceAnalyticsEvent): void {
+        try {
+            this.analytics.track(event);
+        } catch (error) {
+            this.logger.warn('Unable to track AI agent memory analytics', {
+                event: event.event,
+                error: getErrorMessage(error),
+            });
+        }
     }
 
     private async canViewSourceThread(
@@ -297,7 +323,7 @@ export class AiAgentMemoryService extends BaseService {
             )
         ).filter((source) => source !== null);
 
-        return {
+        const response: AiAgentMemory = {
             slug: result.memory.slug,
             title: result.memory.title,
             rawMemory: result.memory.raw_memory,
@@ -312,6 +338,23 @@ export class AiAgentMemoryService extends BaseService {
                     : { type: 'consolidated', sources },
             replacementSlug: result.replacement?.slug ?? null,
         };
+
+        this.track({
+            event: 'ai_agent_memory.viewed',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+                agentId: result.memory.agent_uuid,
+                memoryId: result.memory.ai_agent_memory_uuid,
+                status: result.memory.status,
+                provenanceType: result.memory.source_thread_uuid
+                    ? 'source_thread'
+                    : 'consolidated',
+            },
+        });
+
+        return response;
     }
 
     async sweep(now = new Date()): Promise<number> {
@@ -418,6 +461,9 @@ export class AiAgentMemoryService extends BaseService {
             return 'skipped';
         }
 
+        let failureStage: AiAgentMemoryGenerationFailedEvent['properties']['failureStage'] =
+            'distillation';
+        let memoryGenerated = false;
         try {
             abortSignal?.throwIfAborted();
             const output = await this.distillCall({
@@ -444,20 +490,37 @@ export class AiAgentMemoryService extends BaseService {
                 output.result.objects,
             );
             abortSignal?.throwIfAborted();
-            await this.aiAgentMemoryModel.upsertSourceThreadMemory({
-                organizationUuid: thread.organizationUuid,
-                projectUuid: thread.projectUuid,
-                agentUuid: thread.agentUuid,
-                userUuid: thread.userUuid,
-                sourceThreadUuid: thread.threadUuid,
-                slug: `${output.result.slug}-${randomBytes(4).toString('hex')}`,
-                title: output.result.title,
-                rawMemory: output.result.raw_memory,
-                threadSummary: output.result.thread_summary,
-                terms: output.result.terms,
-                objects: output.result.objects,
-                unresolvedObjects,
-                generatedAt: new Date(),
+            failureStage = 'persistence';
+            const memory =
+                await this.aiAgentMemoryModel.upsertSourceThreadMemory({
+                    organizationUuid: thread.organizationUuid,
+                    projectUuid: thread.projectUuid,
+                    agentUuid: thread.agentUuid,
+                    userUuid: thread.userUuid,
+                    sourceThreadUuid: thread.threadUuid,
+                    slug: `${output.result.slug}-${randomBytes(4).toString('hex')}`,
+                    title: output.result.title,
+                    rawMemory: output.result.raw_memory,
+                    threadSummary: output.result.thread_summary,
+                    terms: output.result.terms,
+                    objects: output.result.objects,
+                    unresolvedObjects,
+                    generatedAt: new Date(),
+                });
+            memoryGenerated = true;
+            this.track({
+                event: 'ai_agent_memory.generated',
+                anonymousId: thread.organizationUuid,
+                properties: {
+                    organizationId: thread.organizationUuid,
+                    projectId: thread.projectUuid,
+                    agentId: thread.agentUuid,
+                    memoryId: memory.ai_agent_memory_uuid,
+                    channel: thread.createdFrom === 'slack' ? 'slack' : 'web',
+                    isRedistill: thread.distilledUpTo !== null,
+                    objectCount: output.result.objects.length,
+                    unresolvedObjectCount: unresolvedObjects.length,
+                },
             });
             await this.aiAgentMemoryModel.upsertThreadDistill({
                 aiThreadUuid: thread.threadUuid,
@@ -479,6 +542,24 @@ export class AiAgentMemoryService extends BaseService {
                 threadUuid: thread.threadUuid,
                 error: errorMessage,
             });
+            if (!memoryGenerated) {
+                this.track({
+                    event: 'ai_agent_memory.generation_failed',
+                    anonymousId: thread.organizationUuid,
+                    properties: {
+                        organizationId: thread.organizationUuid,
+                        projectId: thread.projectUuid,
+                        agentId: thread.agentUuid,
+                        channel:
+                            thread.createdFrom === 'slack' ? 'slack' : 'web',
+                        failureStage,
+                        errorType:
+                            error instanceof Error
+                                ? error.name
+                                : 'UnknownError',
+                    },
+                });
+            }
             return 'failed';
         }
     }

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -155,6 +155,7 @@ import {
     AiAgentEvalCreatedEvent,
     AiAgentEvalRunEvent,
     AiAgentFindContentCoverageEvent,
+    AiAgentMemoryCitedEvent,
     AiAgentPromptCreatedEvent,
     AiAgentPromptFeedbackEvent,
     AiAgentPullRequestViewedEvent,
@@ -8645,7 +8646,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     update.response !== undefined &&
                     update.tokenUsage !== undefined
                         ? updatePromise.then(async () => {
-                              const { slugs, malformedCount } =
+                              const { slugs, citationCounts, malformedCount } =
                                   parseMemoryCitations(update.response ?? '');
                               if (malformedCount > 0) {
                                   this.logger.warn(
@@ -8655,20 +8656,52 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                               if (slugs.length === 0) return;
 
                               try {
-                                  const citedSlugs =
+                                  const citedMemories =
                                       await this.aiAgentMemoryModel.incrementCitedForActiveMemories(
                                           {
                                               projectUuid: prompt.projectUuid,
                                               slugs,
                                           },
                                       );
-                                  const cited = new Set(citedSlugs);
+                                  const cited = new Set(
+                                      citedMemories.map(({ slug }) => slug),
+                                  );
                                   const dropped = slugs.filter(
                                       (slug) => !cited.has(slug),
                                   );
                                   if (dropped.length > 0) {
                                       this.logger.warn(
                                           `Dropped ${dropped.length} unknown or inactive memory citation(s) for prompt ${update.promptUuid}`,
+                                      );
+                                  }
+                                  if (citedMemories.length > 0) {
+                                      citedMemories.forEach(
+                                          ({ memoryId, slug }) =>
+                                              this.analytics.track<AiAgentMemoryCitedEvent>(
+                                                  {
+                                                      event: 'ai_agent_memory.cited',
+                                                      userId: user.userUuid,
+                                                      properties: {
+                                                          organizationId:
+                                                              prompt.organizationUuid,
+                                                          projectId:
+                                                              prompt.projectUuid,
+                                                          agentId:
+                                                              agentSettings.uuid,
+                                                          memoryId,
+                                                          citationCount:
+                                                              citationCounts[
+                                                                  slug
+                                                              ] ?? 0,
+                                                          channel:
+                                                              isSlackPrompt(
+                                                                  prompt,
+                                                              )
+                                                                  ? 'slack'
+                                                                  : 'web',
+                                                      },
+                                                  },
+                                              ),
                                       );
                                   }
                               } catch (error) {

--- a/packages/backend/src/ee/services/ai/utils/memoryCitation.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/memoryCitation.test.ts
@@ -7,7 +7,10 @@ describe('memory citations', () => {
             parseMemoryCitations(
                 'One.<ld-mem-cite id="first"></ld-mem-cite> Two.<ld-mem-cite id="second" />',
             ),
-        ).toEqual({ slugs: ['first', 'second'], malformedCount: 0 });
+        ).toMatchObject({
+            slugs: ['first', 'second'],
+            malformedCount: 0,
+        });
     });
 
     it('deduplicates multiple adjacent markers', () => {
@@ -23,15 +26,17 @@ describe('memory citations', () => {
             parseMemoryCitations(
                 '```html\n<ld-mem-cite id="example"></ld-mem-cite>\n```',
             ),
-        ).toEqual({ slugs: [], malformedCount: 0 });
+        ).toMatchObject({ slugs: [], malformedCount: 0 });
     });
 
     it('reports malformed markers without citing them', () => {
-        expect(parseMemoryCitations('<ld-mem-cite id="Uppercase" />')).toEqual({
+        expect(
+            parseMemoryCitations('<ld-mem-cite id="Uppercase" />'),
+        ).toMatchObject({
             slugs: [],
             malformedCount: 1,
         });
-        expect(parseMemoryCitations('<ld-mem-cite>')).toEqual({
+        expect(parseMemoryCitations('<ld-mem-cite>')).toMatchObject({
             slugs: [],
             malformedCount: 1,
         });

--- a/packages/backend/src/ee/services/ai/utils/memoryCitation.ts
+++ b/packages/backend/src/ee/services/ai/utils/memoryCitation.ts
@@ -17,25 +17,27 @@ const FENCED_CODE_BLOCK_REGEX = /```[\s\S]*?```|~~~[\s\S]*?~~~/g;
 
 export type ParsedMemoryCitations = {
     slugs: string[];
+    citationCounts: Record<string, number>;
     malformedCount: number;
 };
 
 export const parseMemoryCitations = (value: string): ParsedMemoryCitations => {
     const prose = value.replace(FENCED_CODE_BLOCK_REGEX, '');
-    const slugs = [
-        ...new Set(
-            [...prose.matchAll(VALID_MEMORY_CITATION_REGEX)].map(
-                (match) => match[1],
-            ),
-        ),
-    ];
+    const citations = [...prose.matchAll(VALID_MEMORY_CITATION_REGEX)].map(
+        (match) => match[1],
+    );
+    const citationCounts: Record<string, number> = {};
+    citations.forEach((slug) => {
+        citationCounts[slug] = (citationCounts[slug] ?? 0) + 1;
+    });
+    const slugs = Object.keys(citationCounts);
     const malformedCount = (
         prose
             .replace(VALID_MEMORY_CITATION_REGEX, '')
             .match(MEMORY_CITATION_OPEN_REGEX) ?? []
     ).length;
 
-    return { slugs, malformedCount };
+    return { slugs, citationCounts, malformedCount };
 };
 
 export const stripMemoryCitations = (value: string): string =>


### PR DESCRIPTION
## Summary

- add typed analytics events for memory generation, generation failure, citation, and authorized viewing
- emit generation events at durable memory-row boundaries with privacy-safe metadata
- resolve active cited memories to stable UUIDs and preserve per-memory citation occurrence counts
- keep no-op, skipped, injected, and pulled behavior out of product analytics

## Testing

- pnpm -F backend run linter -- changed files
- pnpm -F backend typecheck:fast
- pnpm -F backend test --run src/ee/services/ai/utils/memoryCitation.test.ts src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
- pnpm -F backend test:integration --run src/ee/models/AiAgentMemoryModel.integration.test.ts

Relates: ZAP-672