### PR TITLE
fix(echarts): deterministic reference line values on time axes

### DIFF
--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -36,6 +36,8 @@ import {
     isItemTimezoneAffected,
     isMomentInput,
     isTimestampString,
+    parseCalendarValueUTC,
+    parseTimestampValueUTC,
     shouldShiftItemTimezone,
     toIsoWithProjectOffset,
 } from './formatting';
@@ -3616,5 +3618,79 @@ describe('Formatting', () => {
             // Without clearing the legacy expression this renders '929,000,000'.
             expect(formatItemValue(field, 929_000_000)).toEqual('929M');
         });
+    });
+});
+
+describe('parseCalendarValueUTC', () => {
+    test('parses each canonical grain format to the UTC start of its period', () => {
+        expect(parseCalendarValueUTC('2024-07-22')?.toISOString()).toEqual(
+            '2024-07-22T00:00:00.000Z',
+        );
+        expect(parseCalendarValueUTC('2024-07')?.toISOString()).toEqual(
+            '2024-07-01T00:00:00.000Z',
+        );
+        expect(parseCalendarValueUTC('2024-Q3')?.toISOString()).toEqual(
+            '2024-07-01T00:00:00.000Z',
+        );
+        expect(parseCalendarValueUTC('2024')?.toISOString()).toEqual(
+            '2024-01-01T00:00:00.000Z',
+        );
+    });
+
+    test('rejects values outside the canonical formats instead of coercing', () => {
+        expect(parseCalendarValueUTC('42')).toBeUndefined();
+        expect(parseCalendarValueUTC('50.5')).toBeUndefined();
+        expect(parseCalendarValueUTC('')).toBeUndefined();
+        expect(parseCalendarValueUTC('garbage')).toBeUndefined();
+        expect(parseCalendarValueUTC('2024-13')).toBeUndefined();
+        expect(parseCalendarValueUTC('2024-Q5')).toBeUndefined();
+        expect(parseCalendarValueUTC('2024-01-15 12:00')).toBeUndefined();
+        expect(parseCalendarValueUTC('2024-01-15T00:00:00Z')).toBeUndefined();
+    });
+});
+
+describe('parseTimestampValueUTC', () => {
+    test('parses offset-less datetimes as naive UTC with hasZone false', () => {
+        expect(parseTimestampValueUTC('2024-01-15 12:00')).toEqual({
+            date: new Date('2024-01-15T12:00:00.000Z'),
+            hasZone: false,
+        });
+        expect(parseTimestampValueUTC('2024-01-15T12:00:00')).toEqual({
+            date: new Date('2024-01-15T12:00:00.000Z'),
+            hasZone: false,
+        });
+        expect(parseTimestampValueUTC('2024-01-15 12:00:00.123456')).toEqual({
+            date: new Date('2024-01-15T12:00:00.123Z'),
+            hasZone: false,
+        });
+    });
+
+    test('parses explicitly zoned datetimes to their instant with hasZone true', () => {
+        expect(parseTimestampValueUTC('2024-01-15T12:00:00Z')).toEqual({
+            date: new Date('2024-01-15T12:00:00.000Z'),
+            hasZone: true,
+        });
+        expect(parseTimestampValueUTC('2024-01-15T12:00:00z')).toEqual({
+            date: new Date('2024-01-15T12:00:00.000Z'),
+            hasZone: true,
+        });
+        expect(parseTimestampValueUTC('2024-01-15 21:00:00+09:00')).toEqual({
+            date: new Date('2024-01-15T12:00:00.000Z'),
+            hasZone: true,
+        });
+        expect(parseTimestampValueUTC('2024-01-15T12:00:00.123-0500')).toEqual({
+            date: new Date('2024-01-15T17:00:00.123Z'),
+            hasZone: true,
+        });
+    });
+
+    test('rejects values outside the canonical shapes instead of coercing', () => {
+        expect(parseTimestampValueUTC('2024-01-15')).toBeUndefined();
+        expect(
+            parseTimestampValueUTC('2024-01-15 12:00 garbage'),
+        ).toBeUndefined();
+        expect(parseTimestampValueUTC('42')).toBeUndefined();
+        expect(parseTimestampValueUTC('')).toBeUndefined();
+        expect(parseTimestampValueUTC('2024-01-15 25:00')).toBeUndefined();
     });
 });

--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -36,6 +36,7 @@ import {
     isItemTimezoneAffected,
     isMomentInput,
     isTimestampString,
+    isUnambiguousTemporalString,
     parseCalendarValueUTC,
     parseTimestampValueUTC,
     shouldShiftItemTimezone,
@@ -3693,4 +3694,23 @@ describe('parseTimestampValueUTC', () => {
         expect(parseTimestampValueUTC('')).toBeUndefined();
         expect(parseTimestampValueUTC('2024-01-15 25:00')).toBeUndefined();
     });
+});
+
+describe('isUnambiguousTemporalString', () => {
+    test.each([
+        '2024-07-22',
+        '2024-07',
+        '2024-Q3',
+        '2024-01-15 12:00',
+        '2024-01-15T12:00:00Z',
+    ])('accepts unambiguous temporal value %s', (value) => {
+        expect(isUnambiguousTemporalString(value)).toBe(true);
+    });
+
+    test.each(['2024', '42', '50.5', '', 'garbage', null])(
+        'rejects ambiguous or non-temporal value %s',
+        (value) => {
+            expect(isUnambiguousTemporalString(value)).toBe(false);
+        },
+    );
 });

--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -3642,7 +3642,7 @@ describe('parseCalendarValueUTC', () => {
         expect(parseCalendarValueUTC('42')).toBeUndefined();
         expect(parseCalendarValueUTC('50.5')).toBeUndefined();
         expect(parseCalendarValueUTC('')).toBeUndefined();
-        expect(parseCalendarValueUTC('garbage')).toBeUndefined();
+        expect(parseCalendarValueUTC('not-a-date')).toBeUndefined();
         expect(parseCalendarValueUTC('2024-13')).toBeUndefined();
         expect(parseCalendarValueUTC('2024-Q5')).toBeUndefined();
         expect(parseCalendarValueUTC('2024-01-15 12:00')).toBeUndefined();
@@ -3688,7 +3688,7 @@ describe('parseTimestampValueUTC', () => {
     test('rejects values outside the canonical shapes instead of coercing', () => {
         expect(parseTimestampValueUTC('2024-01-15')).toBeUndefined();
         expect(
-            parseTimestampValueUTC('2024-01-15 12:00 garbage'),
+            parseTimestampValueUTC('2024-01-15 12:00 unexpected-suffix'),
         ).toBeUndefined();
         expect(parseTimestampValueUTC('42')).toBeUndefined();
         expect(parseTimestampValueUTC('')).toBeUndefined();
@@ -3707,7 +3707,7 @@ describe('isUnambiguousTemporalString', () => {
         expect(isUnambiguousTemporalString(value)).toBe(true);
     });
 
-    test.each(['2024', '42', '50.5', '', 'garbage', null])(
+    test.each(['2024', '42', '50.5', '', 'not-a-date', null])(
         'rejects ambiguous or non-temporal value %s',
         (value) => {
             expect(isUnambiguousTemporalString(value)).toBe(false);

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -398,6 +398,19 @@ export const parseTimestampValueUTC = (
     return undefined;
 };
 
+// Temporal strings safe to move out of a slot that may also hold a numeric
+// value. Bare years are deliberately excluded because `2024` is equally valid
+// as a calendar year and as a numeric threshold.
+export const isUnambiguousTemporalString = (raw: unknown): raw is string => {
+    if (typeof raw !== 'string') return false;
+    const value = raw.trim();
+    if (value !== '' && Number.isFinite(Number(value))) return false;
+    return (
+        parseTimestampValueUTC(value) !== undefined ||
+        parseCalendarValueUTC(value) !== undefined
+    );
+};
+
 export const parseTimestamp = (
     str: string,
     timeInterval: TimeFrames | undefined = TimeFrames.MILLISECOND,

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -356,6 +356,48 @@ export const parseDate = (
     timeInterval: TimeFrames | undefined = TimeFrames.DAY,
 ): Date => moment(str, getDateFormat(timeInterval)).toDate();
 
+// The canonical stored formats for calendar values — what the pickers write
+// via formatDate for each grain family (WEEK shares the DAY format).
+const calendarValueFormats = [
+    TimeFrames.DAY,
+    TimeFrames.MONTH,
+    TimeFrames.QUARTER,
+    TimeFrames.YEAR,
+].map((timeInterval) => getDateFormat(timeInterval));
+
+// Strict UTC parse of a stored calendar value (`2024-07-22`, `2024-07`,
+// `2024-Q3`, `2024`) to the start of its period, browser-independent. Unlike
+// parseDate this rejects anything outside the canonical formats — numeric
+// strings, datetimes, garbage — instead of leniently coercing them.
+export const parseCalendarValueUTC = (value: string): Date | undefined => {
+    const parsed = moment.utc(value, calendarValueFormats, true);
+    return parsed.isValid() ? parsed.toDate() : undefined;
+};
+
+// Datetime shapes: date + time with an optional T separator, optional seconds
+// and up to microsecond fractions. Zoned variants append moment's Z token
+// (`Z`, `±hh:mm`, `±hhmm`, `±hh`).
+const naiveTimestampFormats = ['HH:mm', 'HH:mm:ss', 'HH:mm:ss.SSSSSS'].flatMap(
+    (time) => [`YYYY-MM-DD ${time}`, `YYYY-MM-DD[T]${time}`],
+);
+const zonedTimestampFormats = naiveTimestampFormats.map(
+    (format) => `${format}Z`,
+);
+
+// Strict UTC parse of a datetime string, classifying whether it carries an
+// explicit zone. A zoned value parses to its instant; an offset-less value
+// parses naive-as-UTC. Both are browser-independent; anything outside the
+// canonical shapes is rejected instead of leniently coerced.
+export const parseTimestampValueUTC = (
+    value: string,
+): { date: Date; hasZone: boolean } | undefined => {
+    const zoned = moment.utc(value, zonedTimestampFormats, true);
+    if (zoned.isValid()) return { date: zoned.toDate(), hasZone: true };
+    const naive = moment.utc(value, naiveTimestampFormats, true);
+    if (naive.isValid()) return { date: naive.toDate(), hasZone: false };
+    return undefined;
+};
+
 export const parseTimestamp = (
     str: string,
     timeInterval: TimeFrames | undefined = TimeFrames.MILLISECOND,

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -367,8 +367,8 @@ const calendarValueFormats = [
 
 // Strict UTC parse of a stored calendar value (`2024-07-22`, `2024-07`,
 // `2024-Q3`, `2024`) to the start of its period, browser-independent. Unlike
-// parseDate this rejects anything outside the canonical formats — numeric
-// strings, datetimes, garbage — instead of leniently coercing them.
+// parseDate this accepts only canonical calendar formats and does not
+// leniently coerce other inputs.
 export const parseCalendarValueUTC = (value: string): Date | undefined => {
     const parsed = moment.utc(value, calendarValueFormats, true);
     return parsed.isValid() ? parsed.toDate() : undefined;

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.test.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.test.ts
@@ -950,6 +950,22 @@ describe('reference-line semantic to physical axis integration', () => {
 
             expect(line?.[expectedTimeSlot]).toBe('2024-07-15');
             expect(line?.[expectedValueSlot]).toBeUndefined();
+
+            const finalized = finalizeTimeAxisOptions(
+                {
+                    dataset: {
+                        source: [{ [timeField]: '2024-07-15' }],
+                    },
+                    series,
+                },
+                { kind: 'calendar', fieldId: timeField, flipAxes },
+            );
+            const finalizedLine = finalized.series?.[0].markLine?.data[0];
+
+            expect(finalizedLine?.[expectedTimeSlot]).toBe(
+                Date.parse('2024-07-15T00:00:00Z'),
+            );
+            expect(finalizedLine?.[expectedValueSlot]).toBeUndefined();
         },
     );
 
@@ -1007,7 +1023,7 @@ describe('reference-line semantic to physical axis integration', () => {
         expect(flagOffResult[0].markLine?.data[0].yAxis).toBeUndefined();
     });
 
-    test('does not reinterpret a date-shaped category reference as a time line', () => {
+    test('does not reinterpret a date-shaped category reference during finalization', () => {
         const series = applyReferenceLines(
             makeSeries(stringField),
             {
@@ -1026,9 +1042,14 @@ describe('reference-line semantic to physical axis integration', () => {
             ],
             { itemsMap, resolvedTimezone: 'UTC' },
         );
+        const finalized = finalizeTimeAxisOptions(
+            { dataset: { source: [] }, series },
+            { kind: 'plain', flipAxes: true },
+        );
+        const line = finalized.series?.[0].markLine?.data[0];
 
-        expect(series[0].markLine?.data[0].xAxis).toBe('2024-07-15');
-        expect(series[0].markLine?.data[0].yAxis).toBeUndefined();
+        expect(line?.xAxis).toBe('2024-07-15');
+        expect(line?.yAxis).toBeUndefined();
     });
 
     test.each([

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.test.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.test.ts
@@ -12,7 +12,11 @@ vi.mock('../useServerOrClientFeatureFlag', () => ({
     useServerFeatureFlag: async () => ({ data: { enabled: false } }),
 }));
 
-import useCartesianChartConfig from './useCartesianChartConfig';
+import { type ReferenceLineField } from '../../components/common/ReferenceLine';
+import { finalizeTimeAxisOptions } from '../echarts/timezoneShift';
+import useCartesianChartConfig, {
+    applyReferenceLines,
+} from './useCartesianChartConfig';
 import {
     existingMixedSeries,
     expectedMixedSeriesMap,
@@ -790,6 +794,84 @@ describe('getSeriesGroupedByField', () => {
             getSeriesGroupedByField(Object.values(mergedMixedSeries)),
         ).toStrictEqual(groupedMixedSeries);
     });
+});
+
+describe('reference-line semantic to physical axis integration', () => {
+    const timeField = 'orders_created_day';
+    const valueField = 'orders_revenue';
+    const makeSeries = (): Series[] => [
+        {
+            type: CartesianSeriesType.BAR,
+            yAxisIndex: 0,
+            encode: {
+                xRef: { field: timeField },
+                yRef: { field: valueField },
+            },
+        },
+    ];
+    const editorReferenceLines: ReferenceLineField[] = [
+        {
+            fieldId: timeField,
+            data: {
+                uuid: 'date',
+                name: 'Year start',
+                xAxis: '2024',
+            },
+        },
+        {
+            fieldId: valueField,
+            data: {
+                uuid: 'threshold',
+                name: 'Revenue target',
+                yAxis: '2024',
+            },
+        },
+    ];
+
+    test.each([
+        { orientation: 'vertical', flipAxes: false },
+        { orientation: 'flipped', flipAxes: true },
+    ])(
+        'keeps editor-produced date and numeric lines on their physical axes when $orientation',
+        ({ flipAxes }) => {
+            const series = applyReferenceLines(
+                makeSeries(),
+                {
+                    xField: timeField,
+                    yField: [valueField],
+                    flipAxes,
+                },
+                editorReferenceLines,
+            );
+            const options = { dataset: { source: [] }, series };
+            const timeSlot = flipAxes ? 'yAxis' : 'xAxis';
+            const valueSlot = flipAxes ? 'xAxis' : 'yAxis';
+
+            const flagOn = finalizeTimeAxisOptions(options, {
+                kind: 'plain',
+                flipAxes,
+            });
+            const data = flagOn.series?.[0].markLine?.data ?? [];
+            const dateLine = data.find((line) => line.uuid === 'date');
+            const thresholdLine = data.find(
+                (line) => line.uuid === 'threshold',
+            );
+
+            expect(dateLine?.[timeSlot]).toBe(
+                Date.parse('2024-01-01T00:00:00Z'),
+            );
+            expect(dateLine?.[valueSlot]).toBeUndefined();
+            expect(dateLine?.label?.formatter).toBe('Year start');
+            expect(thresholdLine?.[valueSlot]).toBe('2024');
+            expect(thresholdLine?.[timeSlot]).toBeUndefined();
+
+            // No timezone mode means flag-off options and authored values pass
+            // through by reference, after the normal field-aware axis mapping.
+            expect(finalizeTimeAxisOptions(options, undefined)).toBe(options);
+            expect(series[0].markLine?.data[0][timeSlot]).toBe('2024');
+            expect(series[0].markLine?.data[1][valueSlot]).toBe('2024');
+        },
+    );
 });
 
 describe('useCartesianChartConfig', () => {

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.test.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.test.ts
@@ -804,13 +804,14 @@ describe('getSeriesGroupedByField', () => {
 describe('reference-line semantic to physical axis integration', () => {
     const timeField = 'orders_created_day';
     const valueField = 'orders_revenue';
-    const makeSeries = (): Series[] => [
+    const stringField = 'orders_status';
+    const makeSeries = (yField: string = valueField): Series[] => [
         {
             type: CartesianSeriesType.BAR,
             yAxisIndex: 0,
             encode: {
                 xRef: { field: timeField },
-                yRef: { field: valueField },
+                yRef: { field: yField },
             },
         },
     ];
@@ -835,9 +836,20 @@ describe('reference-line semantic to physical axis integration', () => {
         tableLabel: 'Orders',
         type: DimensionType.NUMBER,
     };
+    const stringFieldItem: Dimension = {
+        fieldType: FieldType.DIMENSION,
+        hidden: false,
+        label: 'Status',
+        name: stringField,
+        sql: '',
+        table: 'orders',
+        tableLabel: 'Orders',
+        type: DimensionType.STRING,
+    };
     const itemsMap: ItemsMap = {
         [timeField]: timeFieldItem,
         [valueField]: valueFieldItem,
+        [stringField]: stringFieldItem,
     };
     const editorReferenceLines: ReferenceLineField[] = [
         {
@@ -993,6 +1005,30 @@ describe('reference-line semantic to physical axis integration', () => {
         expect(numericResult[0].markLine?.data[0].yAxis).toBeUndefined();
         expect(flagOffResult[0].markLine?.data[0].xAxis).toBe('2024-07-15');
         expect(flagOffResult[0].markLine?.data[0].yAxis).toBeUndefined();
+    });
+
+    test('does not reinterpret a date-shaped category reference as a time line', () => {
+        const series = applyReferenceLines(
+            makeSeries(stringField),
+            {
+                xField: timeField,
+                yField: [stringField],
+                flipAxes: true,
+            },
+            [
+                {
+                    fieldId: stringField,
+                    data: {
+                        uuid: 'category-date-shape',
+                        xAxis: '2024-07-15',
+                    },
+                },
+            ],
+            { itemsMap, resolvedTimezone: 'UTC' },
+        );
+
+        expect(series[0].markLine?.data[0].xAxis).toBe('2024-07-15');
+        expect(series[0].markLine?.data[0].yAxis).toBeUndefined();
     });
 
     test.each([

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.test.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.test.ts
@@ -1,8 +1,13 @@
 import {
     CartesianSeriesType,
     createConditionalFormattingConfigWithSingleColor,
+    DimensionType,
+    FieldType,
     getItemMap,
     StackType,
+    TimeFrames,
+    type Dimension,
+    type ItemsMap,
     type Series,
 } from '@lightdash/common';
 import { act, renderHook } from '@testing-library/react';
@@ -809,6 +814,31 @@ describe('reference-line semantic to physical axis integration', () => {
             },
         },
     ];
+    const timeFieldItem: Dimension = {
+        fieldType: FieldType.DIMENSION,
+        hidden: false,
+        label: 'Created month',
+        name: timeField,
+        sql: '',
+        table: 'orders',
+        tableLabel: 'Orders',
+        type: DimensionType.DATE,
+        timeInterval: TimeFrames.MONTH,
+    };
+    const valueFieldItem: Dimension = {
+        fieldType: FieldType.DIMENSION,
+        hidden: false,
+        label: 'Revenue',
+        name: valueField,
+        sql: '',
+        table: 'orders',
+        tableLabel: 'Orders',
+        type: DimensionType.NUMBER,
+    };
+    const itemsMap: ItemsMap = {
+        [timeField]: timeFieldItem,
+        [valueField]: valueFieldItem,
+    };
     const editorReferenceLines: ReferenceLineField[] = [
         {
             fieldId: timeField,
@@ -870,6 +900,171 @@ describe('reference-line semantic to physical axis integration', () => {
             expect(finalizeTimeAxisOptions(options, undefined)).toBe(options);
             expect(series[0].markLine?.data[0][timeSlot]).toBe('2024');
             expect(series[0].markLine?.data[1][valueSlot]).toBe('2024');
+        },
+    );
+
+    test.each([
+        {
+            orientation: 'flipped',
+            flipAxes: true,
+            legacyData: { xAxis: '2024-07-15' },
+            expectedTimeSlot: 'yAxis' as const,
+            expectedValueSlot: 'xAxis' as const,
+        },
+        {
+            orientation: 'vertical after flip-save-unflip',
+            flipAxes: false,
+            legacyData: { yAxis: '2024-07-15' },
+            expectedTimeSlot: 'xAxis' as const,
+            expectedValueSlot: 'yAxis' as const,
+        },
+    ])(
+        'repairs a legacy coarse-grain line before axis inference when $orientation',
+        ({ flipAxes, legacyData, expectedTimeSlot, expectedValueSlot }) => {
+            const series = applyReferenceLines(
+                makeSeries(),
+                { xField: timeField, yField: [valueField], flipAxes },
+                [
+                    {
+                        // Legacy extraction attributed the semantic time value
+                        // to the numeric field because it assumed physical keys.
+                        fieldId: valueField,
+                        data: { uuid: 'legacy-date', ...legacyData },
+                    },
+                ],
+                { itemsMap, resolvedTimezone: 'UTC' },
+            );
+            const line = series[0].markLine?.data[0];
+
+            expect(line?.[expectedTimeSlot]).toBe('2024-07-15');
+            expect(line?.[expectedValueSlot]).toBeUndefined();
+        },
+    );
+
+    test('repairs an unambiguous explicitly-zoned legacy time value', () => {
+        const series = applyReferenceLines(
+            makeSeries(),
+            { xField: timeField, yField: [valueField], flipAxes: true },
+            [
+                {
+                    fieldId: valueField,
+                    data: {
+                        uuid: 'legacy-zoned',
+                        xAxis: '2024-07-15T12:00:00Z',
+                    },
+                },
+            ],
+            { itemsMap, resolvedTimezone: 'UTC' },
+        );
+
+        expect(series[0].markLine?.data[0].yAxis).toBe('2024-07-15T12:00:00Z');
+        expect(series[0].markLine?.data[0].xAxis).toBeUndefined();
+    });
+
+    test('leaves ambiguous numeric years and flag-off mappings unchanged', () => {
+        const layout = {
+            xField: timeField,
+            yField: [valueField],
+            flipAxes: true,
+        };
+        const numericYear: ReferenceLineField = {
+            fieldId: valueField,
+            data: { uuid: 'threshold', xAxis: '2024' },
+        };
+        const legacyDate: ReferenceLineField = {
+            fieldId: valueField,
+            data: { uuid: 'legacy-date', xAxis: '2024-07-15' },
+        };
+
+        const numericResult = applyReferenceLines(
+            makeSeries(),
+            layout,
+            [numericYear],
+            { itemsMap, resolvedTimezone: 'UTC' },
+        );
+        const flagOffResult = applyReferenceLines(
+            makeSeries(),
+            layout,
+            [legacyDate],
+            { itemsMap, resolvedTimezone: undefined },
+        );
+
+        expect(numericResult[0].markLine?.data[0].xAxis).toBe('2024');
+        expect(numericResult[0].markLine?.data[0].yAxis).toBeUndefined();
+        expect(flagOffResult[0].markLine?.data[0].xAxis).toBe('2024-07-15');
+        expect(flagOffResult[0].markLine?.data[0].yAxis).toBeUndefined();
+    });
+
+    test.each([
+        {
+            mode: 'flag on',
+            resolvedTimezone: 'UTC',
+            expectedSlot: 'yAxis' as const,
+            clearedSlot: 'xAxis' as const,
+        },
+        {
+            mode: 'flag off',
+            resolvedTimezone: undefined,
+            expectedSlot: 'xAxis' as const,
+            clearedSlot: 'yAxis' as const,
+        },
+    ])(
+        'maps a mis-keyed saved coarse-grain line through the full config hook when $mode',
+        ({ resolvedTimezone, expectedSlot, clearedSlot }) => {
+            const initialSeries = makeSeries()[0];
+            const params: Parameters<typeof useCartesianChartConfig>[0] = {
+                initialChartConfig: {
+                    layout: {
+                        xField: timeField,
+                        yField: [valueField],
+                        flipAxes: true,
+                    },
+                    eChartsConfig: {
+                        series: [
+                            {
+                                ...initialSeries,
+                                markLine: {
+                                    data: [
+                                        {
+                                            uuid: 'legacy-saved-date',
+                                            xAxis: '2024-07-15',
+                                        },
+                                    ],
+                                },
+                            },
+                        ],
+                    },
+                },
+                pivotKeys: undefined,
+                resultsData: {
+                    rows: [],
+                    metricQuery: {
+                        dimensions: [timeField],
+                        metrics: [valueField],
+                        filters: {},
+                        sorts: [],
+                        limit: 500,
+                        tableCalculations: [],
+                        additionalMetrics: [],
+                    },
+                    hasFetchedAllRows: true,
+                    resolvedTimezone,
+                } as never,
+                columnOrder: [timeField, valueField],
+                itemsMap,
+                stacking: false,
+                cartesianType: undefined,
+                colorPalette: [],
+            };
+            const { result } = renderHook(() =>
+                useCartesianChartConfig(params),
+            );
+            const line =
+                result.current.validConfig.eChartsConfig.series?.[0].markLine
+                    ?.data[0];
+
+            expect(line?.[expectedSlot]).toBe('2024-07-15');
+            expect(line?.[clearedSlot]).toBeUndefined();
         },
     );
 });

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -128,7 +128,7 @@ const dedupeReferenceLines = (referenceLines: ReferenceLineField[]) => {
     });
 };
 
-const applyReferenceLines = (
+export const applyReferenceLines = (
     series: Series[],
     dirtyLayout: Partial<Partial<CompleteCartesianChartLayout>> | undefined,
     referenceLines: ReferenceLineField[],

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -8,9 +8,8 @@ import {
     isCompleteEchartsConfig,
     isCompleteLayout,
     isNumericItem,
+    isUnambiguousTemporalString,
     MetricType,
-    parseCalendarValueUTC,
-    parseTimestampValueUTC,
     StackType,
     TableCalculationType,
     XAxisSort,
@@ -149,16 +148,6 @@ const isTemporalReferenceField = (
     ].includes(type);
 };
 
-const isUnambiguousTemporalReferenceValue = (raw: unknown): boolean => {
-    if (typeof raw !== 'string') return false;
-    const value = raw.trim();
-    if (parseTimestampValueUTC(value)) return true;
-    return (
-        !Number.isFinite(Number(value)) &&
-        parseCalendarValueUTC(value) !== undefined
-    );
-};
-
 const resolveReferenceLineFieldId = (
     referenceLine: ReferenceLineField,
     dirtyLayout: Partial<Partial<CompleteCartesianChartLayout>> | undefined,
@@ -190,7 +179,7 @@ const resolveReferenceLineFieldId = (
         return fieldId;
     }
     const raw = referenceLine.data.xAxis ?? referenceLine.data.yAxis;
-    return isUnambiguousTemporalReferenceValue(raw) ? timeFieldId : fieldId;
+    return isUnambiguousTemporalString(raw) ? timeFieldId : fieldId;
 };
 
 export const applyReferenceLines = (

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -1,12 +1,18 @@
 import {
     assertUnreachable,
     CartesianSeriesType,
+    DimensionType,
+    getItemType,
     getSeriesId,
     hashFieldReference,
     isCompleteEchartsConfig,
     isCompleteLayout,
     isNumericItem,
+    MetricType,
+    parseCalendarValueUTC,
+    parseTimestampValueUTC,
     StackType,
+    TableCalculationType,
     XAxisSort,
     XAxisSortType,
     type CartesianChart,
@@ -128,14 +134,88 @@ const dedupeReferenceLines = (referenceLines: ReferenceLineField[]) => {
     });
 };
 
+const isTemporalReferenceField = (
+    item: ItemsMap[string] | undefined,
+): boolean => {
+    if (!item) return false;
+    const type = getItemType(item);
+    return [
+        DimensionType.DATE,
+        DimensionType.TIMESTAMP,
+        MetricType.DATE,
+        MetricType.TIMESTAMP,
+        TableCalculationType.DATE,
+        TableCalculationType.TIMESTAMP,
+    ].includes(type);
+};
+
+const isUnambiguousTemporalReferenceValue = (raw: unknown): boolean => {
+    if (typeof raw !== 'string') return false;
+    const value = raw.trim();
+    if (parseTimestampValueUTC(value)) return true;
+    return (
+        !Number.isFinite(Number(value)) &&
+        parseCalendarValueUTC(value) !== undefined
+    );
+};
+
+const resolveReferenceLineFieldId = (
+    referenceLine: ReferenceLineField,
+    dirtyLayout: Partial<Partial<CompleteCartesianChartLayout>> | undefined,
+    mappingContext:
+        | {
+              itemsMap: ItemsMap | undefined;
+              resolvedTimezone: string | undefined;
+          }
+        | undefined,
+): string | undefined => {
+    const fieldId = getReferenceFieldId(referenceLine);
+    if (
+        mappingContext?.resolvedTimezone === undefined ||
+        referenceLine.fieldRef ||
+        !fieldId
+    ) {
+        return fieldId;
+    }
+    const timeFieldId = dirtyLayout?.xField;
+    if (!timeFieldId || timeFieldId === fieldId || !mappingContext.itemsMap) {
+        return fieldId;
+    }
+    const timeField = mappingContext.itemsMap[timeFieldId];
+    const attributedField = mappingContext.itemsMap[fieldId];
+    if (
+        !isTemporalReferenceField(timeField) ||
+        isTemporalReferenceField(attributedField)
+    ) {
+        return fieldId;
+    }
+    const raw = referenceLine.data.xAxis ?? referenceLine.data.yAxis;
+    return isUnambiguousTemporalReferenceValue(raw) ? timeFieldId : fieldId;
+};
+
 export const applyReferenceLines = (
     series: Series[],
     dirtyLayout: Partial<Partial<CompleteCartesianChartLayout>> | undefined,
     referenceLines: ReferenceLineField[],
+    mappingContext?: {
+        itemsMap: ItemsMap | undefined;
+        resolvedTimezone: string | undefined;
+    },
 ): Series[] => {
     // Track which reference lines have been applied to visible series
     let appliedReferenceLines: string[] = [];
-    const uniqueReferenceLines = dedupeReferenceLines(referenceLines);
+    const uniqueReferenceLines = dedupeReferenceLines(referenceLines).map(
+        (referenceLine) => {
+            const fieldId = resolveReferenceLineFieldId(
+                referenceLine,
+                dirtyLayout,
+                mappingContext,
+            );
+            return fieldId === getReferenceFieldId(referenceLine)
+                ? referenceLine
+                : { ...referenceLine, fieldId };
+        },
+    );
 
     return series.map((serie) => {
         // If series is filtered out or hidden, ensure it has no markLine
@@ -1230,6 +1310,10 @@ const useCartesianChartConfig = ({
                     newSeries,
                     dirtyLayout,
                     referenceLines,
+                    {
+                        itemsMap,
+                        resolvedTimezone: resultsData.resolvedTimezone,
+                    },
                 );
 
                 return {

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -185,7 +185,7 @@ const resolveReferenceLineFieldId = (
     const attributedField = mappingContext.itemsMap[fieldId];
     if (
         !isTemporalReferenceField(timeField) ||
-        isTemporalReferenceField(attributedField)
+        !isNumericItem(attributedField)
     ) {
         return fieldId;
     }

--- a/packages/frontend/src/hooks/echarts/timezoneShift.test.ts
+++ b/packages/frontend/src/hooks/echarts/timezoneShift.test.ts
@@ -9,8 +9,10 @@ import { describe, expect, test } from 'vitest';
 import {
     applyTimezoneShiftToEchartsOptions,
     detectCalendarTimeAxisField,
+    normalizeMarkLineTimeValues,
     resolveAxisTimezone,
     type EchartsOptionsShape,
+    type MarkLineTimeNormalization,
     type TimezoneShiftedField,
 } from './timezoneShift';
 
@@ -806,14 +808,19 @@ describe('applyTimezoneShiftToEchartsOptions calendar DATE anchoring (timezone U
     });
 });
 
-// Reference lines must ride the same transform as the plotted coordinates:
-// ECharts parses a raw date-only markLine value as browser-local midnight, so
-// an untransformed line sits offset from its (rewritten) bars.
-describe('applyTimezoneShiftToEchartsOptions markLine values', () => {
-    const calendarDay: TimezoneShiftedField = {
-        fieldId: 'orders_created_day',
-        timezone: 'UTC',
+// Reference-line values are user-authored strings; normalizeMarkLineTimeValues
+// defines the stored-value → position rule. Explicit-zone strings, numbers,
+// and Dates are instants (shifted like the data points); offset-less strings
+// in the strict grain formats are wall-clock positions plotted directly with
+// no offset (browser-independent); everything else is untouched.
+describe('normalizeMarkLineTimeValues', () => {
+    const identity: MarkLineTimeNormalization = {
         flipAxes: false,
+        instantTimezone: undefined,
+    };
+    const shiftedTokyo: MarkLineTimeNormalization = {
+        flipAxes: false,
+        instantTimezone: TZ,
     };
 
     const makeMarkLineSeries = (
@@ -830,26 +837,272 @@ describe('applyTimezoneShiftToEchartsOptions markLine values', () => {
             }
         ).data;
 
-    test('anchors a calendar date-only xAxis line to its UTC-midnight epoch', () => {
+    test('plots a date-only value at the visible day boundary on a shifted axis', () => {
         const options = makeMarkLineSeries([
-            { uuid: 'a', xAxis: '2024-07-22', name: 'Launch' },
+            { uuid: 'a', xAxis: '2024-01-15', name: 'Jan 15' },
         ]);
 
-        const result = applyTimezoneShiftToEchartsOptions(options, calendarDay);
+        const result = normalizeMarkLineTimeValues(options, shiftedTokyo);
 
+        // Wall-clock position: NOT offset by the +9h display shift.
         expect(getMarkLineData(result)).toEqual([
             {
                 uuid: 'a',
-                xAxis: Date.parse('2024-07-22T00:00:00Z'),
-                name: 'Launch',
+                xAxis: Date.parse('2024-01-15T00:00:00Z'),
+                name: 'Jan 15',
+                label: { formatter: '2024-01-15' },
             },
         ]);
     });
 
-    test('shifts an instant xAxis line by the project timezone offset', () => {
+    test('preserves the author text as the default label when numericizing', () => {
+        const options = makeMarkLineSeries([
+            // no formatter → gains one so the label is not the epoch number
+            {
+                uuid: 'a',
+                xAxis: '2024-01-16 06:00',
+                label: { position: 'end' },
+            },
+            // an existing formatter always wins
+            {
+                uuid: 'b',
+                xAxis: '2024-01-15',
+                label: { position: 'end', formatter: 'Launch' },
+            },
+            // numbers were always numeric; no label is invented for them
+            { uuid: 'c', xAxis: UTC_MS },
+        ]);
+
+        const result = normalizeMarkLineTimeValues(options, identity);
+
+        // Unnamed entries are named after the author text: the shared
+        // reference-line style formatter renders `name || value`.
+        expect(getMarkLineData(result)[0].name).toBe('2024-01-16 06:00');
+        expect(getMarkLineData(result)[0].label).toEqual({
+            position: 'end',
+            formatter: '2024-01-16 06:00',
+        });
+        expect(getMarkLineData(result)[1].label).toEqual({
+            position: 'end',
+            formatter: 'Launch',
+        });
+        expect(getMarkLineData(result)[2].name).toBeUndefined();
+        expect(getMarkLineData(result)[2].label).toBeUndefined();
+    });
+
+    test('plots an offset-less datetime at its wall-clock position, browser-independent', () => {
+        const options = makeMarkLineSeries([
+            { uuid: 'a', xAxis: '2024-01-15 12:00' },
+            { uuid: 'b', xAxis: '2024-01-15T12:00:00' },
+        ]);
+
+        const result = normalizeMarkLineTimeValues(options, shiftedTokyo);
+
+        expect(getMarkLineData(result)[0].xAxis).toBe(UTC_MS);
+        expect(getMarkLineData(result)[1].xAxis).toBe(UTC_MS);
+    });
+
+    test('shifts explicit-zone instants by the axis wall-clock offset', () => {
         const options = makeMarkLineSeries([
             { uuid: 'a', xAxis: '2024-01-15T12:00:00Z' },
+            { uuid: 'b', xAxis: '2024-01-15 21:00:00+09:00' },
         ]);
+
+        const result = normalizeMarkLineTimeValues(options, shiftedTokyo);
+
+        expect(getMarkLineData(result)[0].xAxis).toBe(SHIFTED_MS);
+        // 21:00+09:00 is the same instant as 12:00Z.
+        expect(getMarkLineData(result)[1].xAxis).toBe(SHIFTED_MS);
+    });
+
+    test('keeps instants at their raw epoch on unshifted axes', () => {
+        const options = makeMarkLineSeries([
+            { uuid: 'a', xAxis: '2024-01-15T12:00:00Z' },
+            { uuid: 'b', xAxis: UTC_MS },
+        ]);
+
+        const result = normalizeMarkLineTimeValues(options, identity);
+
+        expect(getMarkLineData(result)[0].xAxis).toBe(UTC_MS);
+        expect(getMarkLineData(result)[1].xAxis).toBe(UTC_MS);
+    });
+
+    test('shifts numeric epoch values like instants on shifted axes', () => {
+        const options = makeMarkLineSeries([{ uuid: 'a', xAxis: UTC_MS }]);
+
+        const result = normalizeMarkLineTimeValues(options, shiftedTokyo);
+
+        expect(getMarkLineData(result)[0].xAxis).toBe(SHIFTED_MS);
+    });
+
+    test('parses month, year, and quarter grain values to their period start', () => {
+        const options = makeMarkLineSeries([
+            { uuid: 'a', xAxis: '2024-07' },
+            { uuid: 'b', xAxis: '2024' },
+            { uuid: 'c', xAxis: '2024-Q3' },
+        ]);
+
+        const result = normalizeMarkLineTimeValues(options, identity);
+
+        expect(getMarkLineData(result)[0].xAxis).toBe(
+            Date.parse('2024-07-01T00:00:00Z'),
+        );
+        expect(getMarkLineData(result)[1].xAxis).toBe(
+            Date.parse('2024-01-01T00:00:00Z'),
+        );
+        expect(getMarkLineData(result)[2].xAxis).toBe(
+            Date.parse('2024-07-01T00:00:00Z'),
+        );
+    });
+
+    test('places a wall-clock value inside a DST spring-forward gap deterministically', () => {
+        // 02:30 on 2024-03-10 does not exist in America/New_York; as a naive
+        // wall-clock position it still lands between the 02:00 and 03:00
+        // slots of the merged wall-clock axis.
+        const options = makeMarkLineSeries([
+            { uuid: 'a', xAxis: '2024-03-10 02:30' },
+        ]);
+
+        const result = normalizeMarkLineTimeValues(options, {
+            flipAxes: false,
+            instantTimezone: 'America/New_York',
+        });
+
+        expect(getMarkLineData(result)[0].xAxis).toBe(
+            Date.parse('2024-03-10T02:30:00Z'),
+        );
+    });
+
+    test('leaves non-time strings untouched', () => {
+        const data = [
+            { uuid: 'a', xAxis: '42' },
+            { uuid: 'b', xAxis: '50.5' },
+            { uuid: 'c', xAxis: '' },
+            { uuid: 'd', xAxis: 'garbage' },
+            { uuid: 'e', xAxis: '2024-13' },
+        ];
+        const options = makeMarkLineSeries(data);
+
+        const result = normalizeMarkLineTimeValues(options, shiftedTokyo);
+
+        expect(getMarkLineData(result)).toEqual(data);
+    });
+
+    test('skips series-relative marks even when they carry stale slot values', () => {
+        const data = [
+            { uuid: 'a', type: 'average' },
+            { uuid: 'b', type: 'average', xAxis: '2024-01-15' },
+        ];
+        const options = makeMarkLineSeries(data);
+
+        const result = normalizeMarkLineTimeValues(options, shiftedTokyo);
+
+        expect(getMarkLineData(result)).toEqual(data);
+    });
+
+    test('targets the yAxis slot when flipped', () => {
+        const options = makeMarkLineSeries([
+            { uuid: 'a', yAxis: '2024-07-22' },
+        ]);
+
+        const result = normalizeMarkLineTimeValues(options, {
+            ...identity,
+            flipAxes: true,
+        });
+
+        expect(getMarkLineData(result)).toEqual([
+            {
+                uuid: 'a',
+                yAxis: Date.parse('2024-07-22T00:00:00Z'),
+                name: '2024-07-22',
+                label: { formatter: '2024-07-22' },
+            },
+        ]);
+    });
+
+    test('rescues a date value stranded in the value-axis slot and clears the source', () => {
+        // Semantic keying stores the date under xAxis even when flipped; the
+        // date lives on physical Y, so ECharts drops the line entirely today.
+        const flipped = normalizeMarkLineTimeValues(
+            makeMarkLineSeries([{ uuid: 'a', xAxis: '2020-07-05' }]),
+            { ...identity, flipAxes: true },
+        );
+        expect(getMarkLineData(flipped)).toEqual([
+            {
+                uuid: 'a',
+                yAxis: Date.parse('2020-07-05T00:00:00Z'),
+                xAxis: undefined,
+                name: '2020-07-05',
+                label: { formatter: '2020-07-05' },
+            },
+        ]);
+
+        // Orientation-generic: flip→save→unflip can strand a date in yAxis.
+        const vertical = normalizeMarkLineTimeValues(
+            makeMarkLineSeries([{ uuid: 'b', yAxis: '2020-07-05' }]),
+            identity,
+        );
+        expect(getMarkLineData(vertical)).toEqual([
+            {
+                uuid: 'b',
+                xAxis: Date.parse('2020-07-05T00:00:00Z'),
+                yAxis: undefined,
+                name: '2020-07-05',
+                label: { formatter: '2020-07-05' },
+            },
+        ]);
+    });
+
+    test('never rescues numeric strings from the value axis', () => {
+        const data = [{ uuid: 'a', yAxis: '50' }];
+        const options = makeMarkLineSeries(data);
+
+        const result = normalizeMarkLineTimeValues(options, identity);
+
+        expect(getMarkLineData(result)).toEqual(data);
+    });
+
+    test('does not rescue when the time slot is occupied', () => {
+        const options = makeMarkLineSeries([
+            { uuid: 'a', xAxis: '2024-01-15', yAxis: '2024-02-01' },
+        ]);
+
+        const result = normalizeMarkLineTimeValues(options, identity);
+
+        expect(getMarkLineData(result)).toEqual([
+            {
+                uuid: 'a',
+                xAxis: Date.parse('2024-01-15T00:00:00Z'),
+                yAxis: '2024-02-01',
+                name: '2024-01-15',
+                label: { formatter: '2024-01-15' },
+            },
+        ]);
+    });
+
+    test('leaves options without series and series without markLine untouched', () => {
+        const noSeries: EchartsOptionsShape = { dataset: { source: [] } };
+        expect(normalizeMarkLineTimeValues(noSeries, identity)).toBe(noSeries);
+
+        const noMarkLine: EchartsOptionsShape = {
+            dataset: { source: [] },
+            series: [{ data: [] }],
+        };
+        expect(
+            normalizeMarkLineTimeValues(noMarkLine, identity).series?.[0],
+        ).toEqual({ data: [] });
+    });
+});
+
+// The dataset/encode walker no longer touches markLine values — that is
+// normalizeMarkLineTimeValues' job, run for every flag-on time axis.
+describe('applyTimezoneShiftToEchartsOptions markLine values', () => {
+    test('passes markLine data through unchanged', () => {
+        const data = [{ uuid: 'a', xAxis: '2024-07-22' }];
+        const options: EchartsOptionsShape = {
+            dataset: { source: [] },
+            series: [{ markLine: { symbol: 'none', data } }],
+        };
 
         const result = applyTimezoneShiftToEchartsOptions(options, {
             fieldId: 'orders_created_day',
@@ -857,47 +1110,9 @@ describe('applyTimezoneShiftToEchartsOptions markLine values', () => {
             flipAxes: false,
         });
 
-        expect(getMarkLineData(result)[0].xAxis).toBe(SHIFTED_MS);
-    });
-
-    test('transforms the yAxis slot and leaves xAxis alone when flipped', () => {
-        const options = makeMarkLineSeries([
-            { uuid: 'a', yAxis: '2024-07-22' },
-            { uuid: 'b', xAxis: '2024-07-23' },
-        ]);
-
-        const result = applyTimezoneShiftToEchartsOptions(options, {
-            ...calendarDay,
-            flipAxes: true,
-        });
-
-        expect(getMarkLineData(result)).toEqual([
-            { uuid: 'a', yAxis: Date.parse('2024-07-22T00:00:00Z') },
-            { uuid: 'b', xAxis: '2024-07-23' },
-        ]);
-    });
-
-    test('leaves value-axis lines and series-relative marks untouched', () => {
-        const data = [
-            { uuid: 'a', yAxis: '50' },
-            { uuid: 'b', type: 'average' },
-        ];
-        const options = makeMarkLineSeries(data);
-
-        const result = applyTimezoneShiftToEchartsOptions(options, calendarDay);
-
-        expect(getMarkLineData(result)).toEqual(data);
-    });
-
-    test('leaves series without markLine untouched', () => {
-        const options: EchartsOptionsShape = {
-            dataset: { source: [] },
-            series: [{ data: [] }],
-        };
-
-        const result = applyTimezoneShiftToEchartsOptions(options, calendarDay);
-
-        expect(result.series?.[0]).toEqual({ data: [] });
+        expect((result.series?.[0].markLine as { data: unknown }).data).toEqual(
+            data,
+        );
     });
 });
 

--- a/packages/frontend/src/hooks/echarts/timezoneShift.test.ts
+++ b/packages/frontend/src/hooks/echarts/timezoneShift.test.ts
@@ -1056,6 +1056,23 @@ describe('normalizeMarkLineTimeValues', () => {
         ]);
     });
 
+    test('rescues an explicitly-zoned timestamp stranded in the value-axis slot', () => {
+        const result = normalizeMarkLineTimeValues(
+            makeMarkLineSeries([{ uuid: 'a', yAxis: '2024-01-15T12:00:00Z' }]),
+            identity,
+        );
+
+        expect(getMarkLineData(result)).toEqual([
+            {
+                uuid: 'a',
+                xAxis: UTC_MS,
+                yAxis: undefined,
+                name: '2024-01-15T12:00:00Z',
+                label: { formatter: '2024-01-15T12:00:00Z' },
+            },
+        ]);
+    });
+
     test('never rescues numeric strings from the value axis', () => {
         const data = [
             { uuid: 'a', yAxis: '50' },

--- a/packages/frontend/src/hooks/echarts/timezoneShift.test.ts
+++ b/packages/frontend/src/hooks/echarts/timezoneShift.test.ts
@@ -852,7 +852,7 @@ describe('normalizeMarkLineTimeValues', () => {
                 uuid: 'a',
                 xAxis: Date.parse('2024-01-15T00:00:00Z'),
                 name: 'Jan 15',
-                label: { formatter: '2024-01-15' },
+                label: { formatter: 'Jan 15' },
             },
         ]);
     });
@@ -1056,10 +1056,37 @@ describe('normalizeMarkLineTimeValues', () => {
     });
 
     test('never rescues numeric strings from the value axis', () => {
-        const data = [{ uuid: 'a', yAxis: '50' }];
+        const data = [
+            { uuid: 'a', yAxis: '50' },
+            { uuid: 'b', yAxis: '2024', name: 'Revenue target' },
+        ];
         const options = makeMarkLineSeries(data);
 
         const result = normalizeMarkLineTimeValues(options, identity);
+
+        expect(getMarkLineData(result)).toEqual(data);
+    });
+
+    test('never rescues a numeric year string when flipped', () => {
+        const data = [{ uuid: 'a', xAxis: '2024', name: 'Revenue target' }];
+        const options = makeMarkLineSeries(data);
+
+        const result = normalizeMarkLineTimeValues(options, {
+            ...identity,
+            flipAxes: true,
+        });
+
+        expect(getMarkLineData(result)).toEqual(data);
+    });
+
+    test('never rescues a line from another physical time axis', () => {
+        const data = [{ uuid: 'a', yAxis: '2024-02-01' }];
+        const options = makeMarkLineSeries(data);
+
+        const result = normalizeMarkLineTimeValues(options, {
+            ...identity,
+            canRescueFromOppositeAxis: false,
+        });
 
         expect(getMarkLineData(result)).toEqual(data);
     });
@@ -1359,5 +1386,23 @@ describe('finalizeTimeAxisOptions', () => {
         expect(result.series?.[0].encode?.x).toBe('orders_created_hour');
         // Instants keep their raw epoch on an unshifted axis.
         expect(getMarkLineValue(result)).toBe(UTC_MS);
+    });
+
+    test('does not rescue from a second physical time axis', () => {
+        const data = [{ yAxis: '2024-02-01' }];
+        const options: EchartsOptionsShape = {
+            dataset: { source: [] },
+            series: [{ markLine: { data } }],
+        };
+
+        const result = finalizeTimeAxisOptions(
+            options,
+            { kind: 'plain', flipAxes: false },
+            { canRescueFromOppositeAxis: false },
+        );
+
+        expect(
+            (result.series?.[0].markLine as { data: unknown[] }).data,
+        ).toEqual(data);
     });
 });

--- a/packages/frontend/src/hooks/echarts/timezoneShift.test.ts
+++ b/packages/frontend/src/hooks/echarts/timezoneShift.test.ts
@@ -15,6 +15,7 @@ import {
     resolveAxisTimezone,
     type EchartsOptionsShape,
     type MarkLineTimeNormalization,
+    type TimeAxisMode,
     type TimezoneShiftedField,
 } from './timezoneShift';
 
@@ -1280,6 +1281,22 @@ describe('detectTimeAxisMode', () => {
         expect(result).toEqual({ kind: 'plain', flipAxes: false });
     });
 
+    test('plain carries the timezone used to format its raw coordinates', () => {
+        const result = detectTimeAxisMode({
+            validCartesianConfig: makeCartesian({ xField: 'orders_total' }),
+            itemsMap,
+            resolvedTimezone: TZ,
+            physicalAxisType: 'time',
+            plainWallClockTimezone: TZ,
+        });
+
+        expect(result).toEqual({
+            kind: 'plain',
+            flipAxes: false,
+            wallClockTimezone: TZ,
+        });
+    });
+
     test('propagates flipAxes on every mode', () => {
         const result = detectTimeAxisMode({
             validCartesianConfig: makeCartesian({
@@ -1386,6 +1403,30 @@ describe('finalizeTimeAxisOptions', () => {
         expect(result.series?.[0].encode?.x).toBe('orders_created_hour');
         // Instants keep their raw epoch on an unshifted axis.
         expect(getMarkLineValue(result)).toBe(UTC_MS);
+    });
+
+    test('plain: maps offset-less values onto a timezone-formatted raw axis', () => {
+        const mode: TimeAxisMode = {
+            kind: 'plain',
+            flipAxes: false,
+            wallClockTimezone: TZ,
+        };
+
+        const wallClock = finalizeTimeAxisOptions(
+            makeOptions('2024-01-15 12:00'),
+            mode,
+        );
+        const explicitInstant = finalizeTimeAxisOptions(
+            makeOptions('2024-01-15T12:00:00Z'),
+            mode,
+        );
+
+        // 12:00 as displayed in Tokyo is the raw 03:00Z coordinate. Explicit
+        // instants remain raw because this axis is not coordinate-shifted.
+        expect(getMarkLineValue(wallClock)).toBe(
+            Date.parse('2024-01-15T03:00:00Z'),
+        );
+        expect(getMarkLineValue(explicitInstant)).toBe(UTC_MS);
     });
 
     test('does not rescue from a second physical time axis', () => {

--- a/packages/frontend/src/hooks/echarts/timezoneShift.test.ts
+++ b/packages/frontend/src/hooks/echarts/timezoneShift.test.ts
@@ -9,6 +9,8 @@ import { describe, expect, test } from 'vitest';
 import {
     applyTimezoneShiftToEchartsOptions,
     detectCalendarTimeAxisField,
+    detectTimeAxisMode,
+    finalizeTimeAxisOptions,
     normalizeMarkLineTimeValues,
     resolveAxisTimezone,
     type EchartsOptionsShape,
@@ -1166,5 +1168,196 @@ describe('applyTimezoneShiftToEchartsOptions across DST (sub-day, America/New_Yo
             Date.parse('2024-03-10T03:30:00Z'),
         ]);
         expect(shifted).not.toContain(Date.parse('2024-03-10T02:30:00Z'));
+    });
+});
+
+describe('detectTimeAxisMode', () => {
+    const itemsMap: ItemsMap = {
+        orders_created_hour: makeTimeDimension(
+            'orders_created_hour',
+            TimeFrames.HOUR,
+        ),
+        orders_date: makeTimeDimension('orders_date', undefined, {
+            type: DimensionType.DATE,
+        }),
+        orders_total: makeMetric('orders_total'),
+    };
+
+    test('returns undefined when timezone support is off (no resolvedTimezone)', () => {
+        const result = detectTimeAxisMode({
+            validCartesianConfig: makeCartesian({
+                xField: 'orders_created_hour',
+            }),
+            itemsMap,
+            resolvedTimezone: undefined,
+            physicalAxisType: 'time',
+        });
+        expect(result).toBeUndefined();
+    });
+
+    test.each([['category'], ['value'], [undefined]])(
+        'returns undefined when the physical axis type is %s',
+        (physicalAxisType) => {
+            const result = detectTimeAxisMode({
+                validCartesianConfig: makeCartesian({
+                    xField: 'orders_created_hour',
+                }),
+                itemsMap,
+                resolvedTimezone: TZ,
+                physicalAxisType,
+            });
+            expect(result).toBeUndefined();
+        },
+    );
+
+    test('detects a shiftable instant dim as instant-shifted', () => {
+        const result = detectTimeAxisMode({
+            validCartesianConfig: makeCartesian({
+                xField: 'orders_created_hour',
+            }),
+            itemsMap,
+            resolvedTimezone: TZ,
+            physicalAxisType: 'time',
+        });
+        expect(result).toEqual({
+            kind: 'instant-shifted',
+            fieldId: 'orders_created_hour',
+            timezone: TZ,
+            flipAxes: false,
+        });
+    });
+
+    test('detects a calendar DATE as calendar even on a shifted project', () => {
+        const result = detectTimeAxisMode({
+            validCartesianConfig: makeCartesian({ xField: 'orders_date' }),
+            itemsMap,
+            resolvedTimezone: TZ,
+            physicalAxisType: 'time',
+        });
+        expect(result).toEqual({
+            kind: 'calendar',
+            fieldId: 'orders_date',
+            flipAxes: false,
+        });
+    });
+
+    test('falls back to plain for a UTC project so ref lines still normalize', () => {
+        const result = detectTimeAxisMode({
+            validCartesianConfig: makeCartesian({
+                xField: 'orders_created_hour',
+            }),
+            itemsMap,
+            resolvedTimezone: 'UTC',
+            physicalAxisType: 'time',
+        });
+        expect(result).toEqual({ kind: 'plain', flipAxes: false });
+    });
+
+    test('propagates flipAxes on every mode', () => {
+        const result = detectTimeAxisMode({
+            validCartesianConfig: makeCartesian({
+                xField: 'orders_created_hour',
+                yField: ['orders_total'],
+                flipAxes: true,
+            }),
+            itemsMap,
+            resolvedTimezone: TZ,
+            physicalAxisType: 'time',
+        });
+        expect(result).toMatchObject({
+            kind: 'instant-shifted',
+            flipAxes: true,
+        });
+    });
+});
+
+describe('finalizeTimeAxisOptions', () => {
+    const shiftedDim = 'orders_created_hour_ld_tz_shifted';
+    const makeOptions = (markLineValue: unknown): EchartsOptionsShape => ({
+        dataset: {
+            source: [
+                {
+                    orders_created_hour: '2024-01-15T12:00:00Z',
+                    orders_total: 10,
+                },
+            ],
+        },
+        series: [
+            {
+                encode: { x: 'orders_created_hour', y: 'orders_total' },
+                markLine: { data: [{ xAxis: markLineValue }] },
+            },
+        ],
+    });
+
+    const getSourceRow = (result: EchartsOptionsShape) =>
+        (result.dataset as { source: Record<string, unknown>[] }).source[0];
+
+    const getMarkLineValue = (result: EchartsOptionsShape) =>
+        (result.series?.[0].markLine as { data: Record<string, unknown>[] })
+            .data[0].xAxis;
+
+    test('no mode: options pass through untouched (flag off / no time axis)', () => {
+        const options = makeOptions('2024-01-15');
+        expect(finalizeTimeAxisOptions(options, undefined)).toBe(options);
+    });
+
+    test('instant-shifted: rewrites coordinates and gives ref-line instants the same shift', () => {
+        const result = finalizeTimeAxisOptions(
+            makeOptions('2024-01-15T12:00:00Z'),
+            {
+                kind: 'instant-shifted',
+                fieldId: 'orders_created_hour',
+                timezone: TZ,
+                flipAxes: false,
+            },
+        );
+        expect(getSourceRow(result)[shiftedDim]).toBe(SHIFTED_MS);
+        expect(result.series?.[0].encode?.x).toBe(shiftedDim);
+        expect(getMarkLineValue(result)).toBe(SHIFTED_MS);
+    });
+
+    test('instant-shifted: plots a date-only ref line at the visible day boundary', () => {
+        const result = finalizeTimeAxisOptions(makeOptions('2024-01-15'), {
+            kind: 'instant-shifted',
+            fieldId: 'orders_created_hour',
+            timezone: TZ,
+            flipAxes: false,
+        });
+        expect(getMarkLineValue(result)).toBe(
+            Date.parse('2024-01-15T00:00:00Z'),
+        );
+    });
+
+    test('calendar: anchors coordinates and ref lines to UTC midnight without shifting', () => {
+        const options: EchartsOptionsShape = {
+            dataset: { source: [{ orders_date: '2024-07-22' }] },
+            series: [
+                {
+                    encode: { x: 'orders_date', y: 'orders_total' },
+                    markLine: { data: [{ xAxis: '2024-07-22' }] },
+                },
+            ],
+        };
+        const result = finalizeTimeAxisOptions(options, {
+            kind: 'calendar',
+            fieldId: 'orders_date',
+            flipAxes: false,
+        });
+        const anchoredMs = Date.parse('2024-07-22T00:00:00Z');
+        expect(getSourceRow(result).orders_date_ld_tz_shifted).toBe(anchoredMs);
+        expect(getMarkLineValue(result)).toBe(anchoredMs);
+    });
+
+    test('plain: leaves coordinates untouched but still normalizes ref lines', () => {
+        const options = makeOptions('2024-01-15T12:00:00Z');
+        const result = finalizeTimeAxisOptions(options, {
+            kind: 'plain',
+            flipAxes: false,
+        });
+        expect(result.dataset).toBe(options.dataset);
+        expect(result.series?.[0].encode?.x).toBe('orders_created_hour');
+        // Instants keep their raw epoch on an unshifted axis.
+        expect(getMarkLineValue(result)).toBe(UTC_MS);
     });
 });

--- a/packages/frontend/src/hooks/echarts/timezoneShift.test.ts
+++ b/packages/frontend/src/hooks/echarts/timezoneShift.test.ts
@@ -981,7 +981,7 @@ describe('normalizeMarkLineTimeValues', () => {
             { uuid: 'a', xAxis: '42' },
             { uuid: 'b', xAxis: '50.5' },
             { uuid: 'c', xAxis: '' },
-            { uuid: 'd', xAxis: 'garbage' },
+            { uuid: 'd', xAxis: 'not-a-date' },
             { uuid: 'e', xAxis: '2024-13' },
         ];
         const options = makeMarkLineSeries(data);
@@ -1023,60 +1023,12 @@ describe('normalizeMarkLineTimeValues', () => {
         ]);
     });
 
-    test('rescues a date value stranded in the value-axis slot and clears the source', () => {
-        // Semantic keying stores the date under xAxis even when flipped; the
-        // date lives on physical Y, so ECharts drops the line entirely today.
-        const flipped = normalizeMarkLineTimeValues(
-            makeMarkLineSeries([{ uuid: 'a', xAxis: '2020-07-05' }]),
-            { ...identity, flipAxes: true },
-        );
-        expect(getMarkLineData(flipped)).toEqual([
-            {
-                uuid: 'a',
-                yAxis: Date.parse('2020-07-05T00:00:00Z'),
-                xAxis: undefined,
-                name: '2020-07-05',
-                label: { formatter: '2020-07-05' },
-            },
-        ]);
-
-        // Orientation-generic: flip→save→unflip can strand a date in yAxis.
-        const vertical = normalizeMarkLineTimeValues(
-            makeMarkLineSeries([{ uuid: 'b', yAxis: '2020-07-05' }]),
-            identity,
-        );
-        expect(getMarkLineData(vertical)).toEqual([
-            {
-                uuid: 'b',
-                xAxis: Date.parse('2020-07-05T00:00:00Z'),
-                yAxis: undefined,
-                name: '2020-07-05',
-                label: { formatter: '2020-07-05' },
-            },
-        ]);
-    });
-
-    test('rescues an explicitly-zoned timestamp stranded in the value-axis slot', () => {
-        const result = normalizeMarkLineTimeValues(
-            makeMarkLineSeries([{ uuid: 'a', yAxis: '2024-01-15T12:00:00Z' }]),
-            identity,
-        );
-
-        expect(getMarkLineData(result)).toEqual([
-            {
-                uuid: 'a',
-                xAxis: UTC_MS,
-                yAxis: undefined,
-                name: '2024-01-15T12:00:00Z',
-                label: { formatter: '2024-01-15T12:00:00Z' },
-            },
-        ]);
-    });
-
-    test('never rescues numeric strings from the value axis', () => {
+    test('never infers time-axis ownership from opposite-slot value shapes', () => {
         const data = [
-            { uuid: 'a', yAxis: '50' },
-            { uuid: 'b', yAxis: '2024', name: 'Revenue target' },
+            { uuid: 'a', yAxis: '2020-07-05' },
+            { uuid: 'b', yAxis: '2024-01-15T12:00:00Z' },
+            { uuid: 'c', yAxis: '50' },
+            { uuid: 'd', yAxis: '2024', name: 'Revenue target' },
         ];
         const options = makeMarkLineSeries(data);
 
@@ -1085,8 +1037,11 @@ describe('normalizeMarkLineTimeValues', () => {
         expect(getMarkLineData(result)).toEqual(data);
     });
 
-    test('never rescues a numeric year string when flipped', () => {
-        const data = [{ uuid: 'a', xAxis: '2024', name: 'Revenue target' }];
+    test('never infers time-axis ownership from the opposite slot when flipped', () => {
+        const data = [
+            { uuid: 'a', xAxis: '2020-07-05' },
+            { uuid: 'b', xAxis: '2024', name: 'Revenue target' },
+        ];
         const options = makeMarkLineSeries(data);
 
         const result = normalizeMarkLineTimeValues(options, {
@@ -1097,19 +1052,7 @@ describe('normalizeMarkLineTimeValues', () => {
         expect(getMarkLineData(result)).toEqual(data);
     });
 
-    test('never rescues a line from another physical time axis', () => {
-        const data = [{ uuid: 'a', yAxis: '2024-02-01' }];
-        const options = makeMarkLineSeries(data);
-
-        const result = normalizeMarkLineTimeValues(options, {
-            ...identity,
-            canRescueFromOppositeAxis: false,
-        });
-
-        expect(getMarkLineData(result)).toEqual(data);
-    });
-
-    test('does not rescue when the time slot is occupied', () => {
+    test('normalizes only the time slot when both slots are occupied', () => {
         const options = makeMarkLineSeries([
             { uuid: 'a', xAxis: '2024-01-15', yAxis: '2024-02-01' },
         ]);
@@ -1446,18 +1389,17 @@ describe('finalizeTimeAxisOptions', () => {
         expect(getMarkLineValue(explicitInstant)).toBe(UTC_MS);
     });
 
-    test('does not rescue from a second physical time axis', () => {
+    test('leaves opposite-axis values untouched during finalization', () => {
         const data = [{ yAxis: '2024-02-01' }];
         const options: EchartsOptionsShape = {
             dataset: { source: [] },
             series: [{ markLine: { data } }],
         };
 
-        const result = finalizeTimeAxisOptions(
-            options,
-            { kind: 'plain', flipAxes: false },
-            { canRescueFromOppositeAxis: false },
-        );
+        const result = finalizeTimeAxisOptions(options, {
+            kind: 'plain',
+            flipAxes: false,
+        });
 
         expect(
             (result.series?.[0].markLine as { data: unknown[] }).data,

--- a/packages/frontend/src/hooks/echarts/timezoneShift.ts
+++ b/packages/frontend/src/hooks/echarts/timezoneShift.ts
@@ -438,13 +438,13 @@ export const applyTimezoneShiftToEchartsOptions = <
 // construction. Anything else (numeric metric values stranded in the wrong
 // slot by semantic keying, empty strings, garbage) is left untouched rather
 // than leniently coerced.
-const isRescuableWallClockTimeString = (value: string): boolean => {
+const isRescuableTimeString = (value: string): boolean => {
     // Bare years are valid calendar values in the actual time slot, but in the
     // opposite slot they are indistinguishable from numeric thresholds entered
     // through the reference-line TextInput (e.g. revenue = "2024").
     if (value !== '' && Number.isFinite(Number(value))) return false;
     return (
-        parseTimestampValueUTC(value)?.hasZone === false ||
+        parseTimestampValueUTC(value) !== undefined ||
         parseCalendarValueUTC(value) !== undefined
     );
 };
@@ -509,7 +509,7 @@ const readTimeAxisSlot = (
         canRescue &&
         timeSlotEmpty &&
         typeof valueSlotValue === 'string' &&
-        isRescuableWallClockTimeString(valueSlotValue.trim())
+        isRescuableTimeString(valueSlotValue.trim())
     ) {
         return { raw: valueSlotValue, stranded: true };
     }

--- a/packages/frontend/src/hooks/echarts/timezoneShift.ts
+++ b/packages/frontend/src/hooks/echarts/timezoneShift.ts
@@ -1,4 +1,5 @@
 import {
+    assertUnreachable,
     extractableTimeFrames,
     isCalendarValueItem,
     isDimension,
@@ -179,6 +180,74 @@ export const detectCalendarTimeAxisField = ({
         timezone: 'UTC',
         flipAxes: !!validCartesianConfig.layout?.flipAxes,
     };
+};
+
+// The single descriptor for how the physical time axis plots its coordinates.
+// undefined means no time axis or timezone support off — no rewrite at all.
+export type TimeAxisMode =
+    | {
+          // Instant values rewritten to project-tz wall-clock; ref-line
+          // instants get the same shift.
+          kind: 'instant-shifted';
+          fieldId: string;
+          timezone: string;
+          flipAxes: boolean;
+      }
+    | {
+          // Calendar DATEs anchored to UTC midnight; the date itself is
+          // never shifted.
+          kind: 'calendar';
+          fieldId: string;
+          flipAxes: boolean;
+      }
+    | {
+          // Time axis whose coordinates stay raw (e.g. UTC project);
+          // ref lines still need the browser-independent parse.
+          kind: 'plain';
+          flipAxes: boolean;
+      };
+
+// physicalAxisType must come from the axis actually built for the field
+// (xAxis[0], or yAxis[0] when flipped). Requiring `time` here is safe for the
+// instant path too: shiftable instants are DATE/TIMESTAMP fields whose grains
+// are excluded from the category-axis downgrade, so they always build a
+// `time` axis.
+export const detectTimeAxisMode = ({
+    validCartesianConfig,
+    itemsMap,
+    resolvedTimezone,
+    physicalAxisType,
+}: {
+    validCartesianConfig: CartesianChart | undefined;
+    itemsMap: ItemsMap | undefined;
+    resolvedTimezone: string | undefined;
+    physicalAxisType: string | undefined;
+}): TimeAxisMode | undefined => {
+    if (!resolvedTimezone || physicalAxisType !== 'time') return undefined;
+    const flipAxes = !!validCartesianConfig?.layout?.flipAxes;
+    const shifted = detectTimezoneShiftedField({
+        validCartesianConfig,
+        itemsMap,
+        resolvedTimezone,
+    });
+    if (shifted) {
+        return {
+            kind: 'instant-shifted',
+            fieldId: shifted.fieldId,
+            timezone: shifted.timezone,
+            flipAxes,
+        };
+    }
+    const calendar = detectCalendarTimeAxisField({
+        validCartesianConfig,
+        itemsMap,
+        resolvedTimezone,
+        physicalAxisType,
+    });
+    if (calendar) {
+        return { kind: 'calendar', fieldId: calendar.fieldId, flipAxes };
+    }
+    return { kind: 'plain', flipAxes };
 };
 
 const SHIFTED_DIM_SUFFIX = '_ld_tz_shifted';
@@ -388,13 +457,53 @@ const parseTimeAxisMarkLineValue = (
     return parseCalendarValueUTC(value)?.getTime();
 };
 
+// Legacy flipped-chart configs key the date by the semantic `xAxis` even when
+// the date renders on physical Y, stranding it in the value-axis slot where
+// ECharts drops the line. Read the time slot, rescuing a wall-clock string
+// out of the value slot when the time slot is empty.
+const readTimeAxisSlot = (
+    entry: Record<string, unknown>,
+    timeSlot: string,
+    valueSlot: string,
+): { raw: unknown; stranded: boolean } => {
+    const timeValue = entry[timeSlot];
+    const timeSlotEmpty =
+        timeValue === undefined || timeValue === null || timeValue === '';
+    const valueSlotValue = entry[valueSlot];
+    if (
+        timeSlotEmpty &&
+        typeof valueSlotValue === 'string' &&
+        isWallClockTimeString(valueSlotValue.trim())
+    ) {
+        return { raw: valueSlotValue, stranded: true };
+    }
+    return { raw: timeValue, stranded: false };
+};
+
+// After numericizing, default labels would echo the epoch ms: ECharts' own
+// default label formatter echoes the value, and the reference-line style
+// formatter renders `name || value`. Keep the author's text by naming
+// unnamed entries and providing a plain formatter where none exists.
+const authoredLabelProps = (
+    entry: Record<string, unknown>,
+    text: string,
+): Record<string, unknown> => {
+    const props: Record<string, unknown> = {};
+    if (entry.name === undefined || entry.name === '') {
+        props.name = text;
+    }
+    const label = isPlainObject(entry.label) ? entry.label : undefined;
+    if (label?.formatter === undefined) {
+        props.label = { ...label, formatter: text };
+    }
+    return props;
+};
+
 // Runs on the final options for every physical time axis when timezone
 // support is on (shifted or not): reference lines carry user-authored strings
-// that ECharts would otherwise parse browser-locally. Also rescues a
-// time-formatted value stranded in the value-axis slot by semantic keying
-// (a dead entry today — ECharts drops a date string aimed at a value axis)
-// into the time slot. Series-relative marks (type 'average' etc.) carry no
-// axis position and are skipped, including any stale slot values on them.
+// that ECharts would otherwise parse browser-locally. Series-relative marks
+// (type 'average' etc.) carry no axis position and are skipped, including any
+// stale slot values on them.
 export const normalizeMarkLineTimeValues = <O extends EchartsOptionsShape>(
     options: O,
     normalization: MarkLineTimeNormalization,
@@ -410,43 +519,69 @@ export const normalizeMarkLineTimeValues = <O extends EchartsOptionsShape>(
         let mutated = false;
         const newData = markLine.data.map((entry) => {
             if (!isPlainObject(entry) || entry.type !== undefined) return entry;
-            const timeValue = entry[timeSlot];
-            const stranded =
-                (timeValue === undefined ||
-                    timeValue === null ||
-                    timeValue === '') &&
-                typeof entry[valueSlot] === 'string' &&
-                isWallClockTimeString((entry[valueSlot] as string).trim());
-            const raw = stranded ? entry[valueSlot] : timeValue;
+            const { raw, stranded } = readTimeAxisSlot(
+                entry,
+                timeSlot,
+                valueSlot,
+            );
             if (raw === undefined || raw === null) return entry;
             const ms = parseTimeAxisMarkLineValue(raw, normalization);
             if (ms === undefined) return entry;
             mutated = true;
-            const next: Record<string, unknown> = {
+            return {
                 ...entry,
+                ...(typeof raw === 'string'
+                    ? authoredLabelProps(entry, raw.trim())
+                    : {}),
                 [timeSlot]: ms,
+                ...(stranded ? { [valueSlot]: undefined } : {}),
             };
-            if (stranded) next[valueSlot] = undefined;
-            // After numericizing, default labels would echo the epoch ms:
-            // ECharts' own default label formatter echoes the value, and the
-            // reference-line style formatter renders `name || value`. Keep the
-            // author's text by naming unnamed entries and providing a
-            // formatter where none exists.
-            if (typeof raw === 'string') {
-                const text = raw.trim();
-                if (next.name === undefined || next.name === '') {
-                    next.name = text;
-                }
-                const label = isPlainObject(entry.label)
-                    ? entry.label
-                    : undefined;
-                if (label?.formatter === undefined) {
-                    next.label = { ...label, formatter: text };
-                }
-            }
-            return next;
         });
         return mutated ? { ...s, markLine: { ...markLine, data: newData } } : s;
     });
     return { ...options, series };
+};
+
+// The one entry point the chart hook calls on its built options: applies the
+// coordinate rewrite the mode calls for, then the ref-line normalization
+// every time axis needs. No mode, no rewrite — flag-off options pass through
+// untouched.
+export const finalizeTimeAxisOptions = <O extends EchartsOptionsShape>(
+    options: O,
+    mode: TimeAxisMode | undefined,
+): O => {
+    if (!mode) return options;
+    switch (mode.kind) {
+        case 'instant-shifted': {
+            const shifted = applyTimezoneShiftToEchartsOptions(options, {
+                fieldId: mode.fieldId,
+                timezone: mode.timezone,
+                flipAxes: mode.flipAxes,
+            });
+            return normalizeMarkLineTimeValues(shifted, {
+                flipAxes: mode.flipAxes,
+                instantTimezone: mode.timezone,
+            });
+        }
+        case 'calendar': {
+            // The 'UTC' target is a zero-offset transport anchor encoding the
+            // calendar day as UTC midnight, not a timezone conversion.
+            const anchored = applyTimezoneShiftToEchartsOptions(options, {
+                fieldId: mode.fieldId,
+                timezone: 'UTC',
+                flipAxes: mode.flipAxes,
+            });
+            return normalizeMarkLineTimeValues(anchored, {
+                flipAxes: mode.flipAxes,
+                instantTimezone: undefined,
+            });
+        }
+        case 'plain':
+            return normalizeMarkLineTimeValues(options, {
+                flipAxes: mode.flipAxes,
+                instantTimezone: undefined,
+            });
+        default:
+            return assertUnreachable(mode, 'Unknown time axis mode');
+    }
 };

--- a/packages/frontend/src/hooks/echarts/timezoneShift.ts
+++ b/packages/frontend/src/hooks/echarts/timezoneShift.ts
@@ -245,7 +245,11 @@ export const detectTimeAxisMode = ({
         physicalAxisType,
     });
     if (calendar) {
-        return { kind: 'calendar', fieldId: calendar.fieldId, flipAxes };
+        return {
+            kind: 'calendar',
+            fieldId: calendar.fieldId,
+            flipAxes,
+        };
     }
     return { kind: 'plain', flipAxes };
 };
@@ -425,15 +429,23 @@ export const applyTimezoneShiftToEchartsOptions = <
 // construction. Anything else (numeric metric values stranded in the wrong
 // slot by semantic keying, empty strings, garbage) is left untouched rather
 // than leniently coerced.
-const isWallClockTimeString = (value: string): boolean =>
-    parseTimestampValueUTC(value)?.hasZone === false ||
-    parseCalendarValueUTC(value) !== undefined;
+const isRescuableWallClockTimeString = (value: string): boolean => {
+    // Bare years are valid calendar values in the actual time slot, but in the
+    // opposite slot they are indistinguishable from numeric thresholds entered
+    // through the reference-line TextInput (e.g. revenue = "2024").
+    if (value !== '' && Number.isFinite(Number(value))) return false;
+    return (
+        parseTimestampValueUTC(value)?.hasZone === false ||
+        parseCalendarValueUTC(value) !== undefined
+    );
+};
 
 export type MarkLineTimeNormalization = {
     flipAxes: boolean;
     // Zone the axis's plotted coordinates are wall-clock-shifted to; undefined
     // means instants plot at their raw epoch (unshifted or UTC-anchored axis).
     instantTimezone: string | undefined;
+    canRescueFromOppositeAxis?: boolean;
 };
 
 const parseTimeAxisMarkLineValue = (
@@ -465,15 +477,17 @@ const readTimeAxisSlot = (
     entry: Record<string, unknown>,
     timeSlot: string,
     valueSlot: string,
+    canRescue: boolean,
 ): { raw: unknown; stranded: boolean } => {
     const timeValue = entry[timeSlot];
     const timeSlotEmpty =
         timeValue === undefined || timeValue === null || timeValue === '';
     const valueSlotValue = entry[valueSlot];
     if (
+        canRescue &&
         timeSlotEmpty &&
         typeof valueSlotValue === 'string' &&
-        isWallClockTimeString(valueSlotValue.trim())
+        isRescuableWallClockTimeString(valueSlotValue.trim())
     ) {
         return { raw: valueSlotValue, stranded: true };
     }
@@ -489,12 +503,17 @@ const authoredLabelProps = (
     text: string,
 ): Record<string, unknown> => {
     const props: Record<string, unknown> = {};
-    if (entry.name === undefined || entry.name === '') {
+    const hasAuthoredName =
+        typeof entry.name === 'string' && entry.name.trim() !== '';
+    if (!hasAuthoredName) {
         props.name = text;
     }
     const label = isPlainObject(entry.label) ? entry.label : undefined;
     if (label?.formatter === undefined) {
-        props.label = { ...label, formatter: text };
+        props.label = {
+            ...label,
+            formatter: hasAuthoredName ? entry.name : text,
+        };
     }
     return props;
 };
@@ -523,6 +542,7 @@ export const normalizeMarkLineTimeValues = <O extends EchartsOptionsShape>(
                 entry,
                 timeSlot,
                 valueSlot,
+                normalization.canRescueFromOppositeAxis !== false,
             );
             if (raw === undefined || raw === null) return entry;
             const ms = parseTimeAxisMarkLineValue(raw, normalization);
@@ -549,6 +569,9 @@ export const normalizeMarkLineTimeValues = <O extends EchartsOptionsShape>(
 export const finalizeTimeAxisOptions = <O extends EchartsOptionsShape>(
     options: O,
     mode: TimeAxisMode | undefined,
+    {
+        canRescueFromOppositeAxis = true,
+    }: { canRescueFromOppositeAxis?: boolean } = {},
 ): O => {
     if (!mode) return options;
     switch (mode.kind) {
@@ -561,6 +584,7 @@ export const finalizeTimeAxisOptions = <O extends EchartsOptionsShape>(
             return normalizeMarkLineTimeValues(shifted, {
                 flipAxes: mode.flipAxes,
                 instantTimezone: mode.timezone,
+                canRescueFromOppositeAxis,
             });
         }
         case 'calendar': {
@@ -574,12 +598,14 @@ export const finalizeTimeAxisOptions = <O extends EchartsOptionsShape>(
             return normalizeMarkLineTimeValues(anchored, {
                 flipAxes: mode.flipAxes,
                 instantTimezone: undefined,
+                canRescueFromOppositeAxis,
             });
         }
         case 'plain':
             return normalizeMarkLineTimeValues(options, {
                 flipAxes: mode.flipAxes,
                 instantTimezone: undefined,
+                canRescueFromOppositeAxis,
             });
         default:
             return assertUnreachable(mode, 'Unknown time axis mode');

--- a/packages/frontend/src/hooks/echarts/timezoneShift.ts
+++ b/packages/frontend/src/hooks/echarts/timezoneShift.ts
@@ -205,6 +205,9 @@ export type TimeAxisMode =
           // ref lines still need the browser-independent parse.
           kind: 'plain';
           flipAxes: boolean;
+          // When the raw coordinate is formatted into a timezone, authored
+          // wall-clock values must map back to the corresponding raw instant.
+          wallClockTimezone?: string;
       };
 
 // physicalAxisType must come from the axis actually built for the field
@@ -217,11 +220,13 @@ export const detectTimeAxisMode = ({
     itemsMap,
     resolvedTimezone,
     physicalAxisType,
+    plainWallClockTimezone,
 }: {
     validCartesianConfig: CartesianChart | undefined;
     itemsMap: ItemsMap | undefined;
     resolvedTimezone: string | undefined;
     physicalAxisType: string | undefined;
+    plainWallClockTimezone?: string;
 }): TimeAxisMode | undefined => {
     if (!resolvedTimezone || physicalAxisType !== 'time') return undefined;
     const flipAxes = !!validCartesianConfig?.layout?.flipAxes;
@@ -251,7 +256,11 @@ export const detectTimeAxisMode = ({
             flipAxes,
         };
     }
-    return { kind: 'plain', flipAxes };
+    return {
+        kind: 'plain',
+        flipAxes,
+        wallClockTimezone: plainWallClockTimezone,
+    };
 };
 
 const SHIFTED_DIM_SUFFIX = '_ld_tz_shifted';
@@ -445,18 +454,26 @@ export type MarkLineTimeNormalization = {
     // Zone the axis's plotted coordinates are wall-clock-shifted to; undefined
     // means instants plot at their raw epoch (unshifted or UTC-anchored axis).
     instantTimezone: string | undefined;
+    wallClockTimezone?: string;
     canRescueFromOppositeAxis?: boolean;
 };
 
 const parseTimeAxisMarkLineValue = (
     raw: unknown,
-    { instantTimezone }: Pick<MarkLineTimeNormalization, 'instantTimezone'>,
+    {
+        instantTimezone,
+        wallClockTimezone,
+    }: Pick<MarkLineTimeNormalization, 'instantTimezone' | 'wallClockTimezone'>,
 ): number | undefined => {
     const toShiftedInstant = (ms: number): number | undefined =>
         Number.isFinite(ms)
             ? ms +
               (instantTimezone ? getTimezoneOffsetMs(ms, instantTimezone) : 0)
             : undefined;
+    const toRawWallClockCoordinate = (ms: number): number =>
+        wallClockTimezone
+            ? dayjs.utc(ms).tz(wallClockTimezone, true).valueOf()
+            : ms;
     if (typeof raw === 'number') return toShiftedInstant(raw);
     if (raw instanceof Date) return toShiftedInstant(raw.getTime());
     if (typeof raw !== 'string') return undefined;
@@ -464,9 +481,14 @@ const parseTimeAxisMarkLineValue = (
     const timestamp = parseTimestampValueUTC(value);
     if (timestamp) {
         const ms = timestamp.date.getTime();
-        return timestamp.hasZone ? toShiftedInstant(ms) : ms;
+        return timestamp.hasZone
+            ? toShiftedInstant(ms)
+            : toRawWallClockCoordinate(ms);
     }
-    return parseCalendarValueUTC(value)?.getTime();
+    const calendarMs = parseCalendarValueUTC(value)?.getTime();
+    return calendarMs === undefined
+        ? undefined
+        : toRawWallClockCoordinate(calendarMs);
 };
 
 // Legacy flipped-chart configs key the date by the semantic `xAxis` even when
@@ -605,6 +627,7 @@ export const finalizeTimeAxisOptions = <O extends EchartsOptionsShape>(
             return normalizeMarkLineTimeValues(options, {
                 flipAxes: mode.flipAxes,
                 instantTimezone: undefined,
+                wallClockTimezone: mode.wallClockTimezone,
                 canRescueFromOppositeAxis,
             });
         default:

--- a/packages/frontend/src/hooks/echarts/timezoneShift.ts
+++ b/packages/frontend/src/hooks/echarts/timezoneShift.ts
@@ -3,6 +3,7 @@ import {
     extractableTimeFrames,
     isCalendarValueItem,
     isDimension,
+    isUnambiguousTemporalString,
     parseCalendarValueUTC,
     parseTimestampValueUTC,
     shouldShiftItemTimezone,
@@ -438,17 +439,6 @@ export const applyTimezoneShiftToEchartsOptions = <
 // construction. Anything else (numeric metric values stranded in the wrong
 // slot by semantic keying, empty strings, garbage) is left untouched rather
 // than leniently coerced.
-const isRescuableTimeString = (value: string): boolean => {
-    // Bare years are valid calendar values in the actual time slot, but in the
-    // opposite slot they are indistinguishable from numeric thresholds entered
-    // through the reference-line TextInput (e.g. revenue = "2024").
-    if (value !== '' && Number.isFinite(Number(value))) return false;
-    return (
-        parseTimestampValueUTC(value) !== undefined ||
-        parseCalendarValueUTC(value) !== undefined
-    );
-};
-
 export type MarkLineTimeNormalization = {
     flipAxes: boolean;
     // Zone the axis's plotted coordinates are wall-clock-shifted to; undefined
@@ -509,7 +499,7 @@ const readTimeAxisSlot = (
         canRescue &&
         timeSlotEmpty &&
         typeof valueSlotValue === 'string' &&
-        isRescuableTimeString(valueSlotValue.trim())
+        isUnambiguousTemporalString(valueSlotValue)
     ) {
         return { raw: valueSlotValue, stranded: true };
     }

--- a/packages/frontend/src/hooks/echarts/timezoneShift.ts
+++ b/packages/frontend/src/hooks/echarts/timezoneShift.ts
@@ -2,6 +2,8 @@ import {
     extractableTimeFrames,
     isCalendarValueItem,
     isDimension,
+    parseCalendarValueUTC,
+    parseTimestampValueUTC,
     shouldShiftItemTimezone,
     TimeFrames,
     type CartesianChart,
@@ -321,39 +323,9 @@ const shiftBareArraySeriesData = (
     });
 };
 
-// Reference lines carry raw axis values that ECharts would parse differently
-// from the rewritten data coordinates, leaving the line offset from its bars.
-// Run the time-axis slot (xAxis, or yAxis when flipped) through the same
-// transform. Value-axis slots and series-relative marks (type 'average' etc.,
-// which carry no axis value) are untouched.
-const shiftSeriesMarkLineValues = (
-    series: EchartsSeriesShape[],
-    shifted: TimezoneShiftedField,
-): EchartsSeriesShape[] => {
-    const axisKey = shifted.flipAxes ? 'yAxis' : 'xAxis';
-    return series.map((s) => {
-        const markLine = s.markLine;
-        if (!isPlainObject(markLine) || !Array.isArray(markLine.data)) {
-            return s;
-        }
-        let mutated = false;
-        const newData = markLine.data.map((entry) => {
-            if (!isPlainObject(entry)) return entry;
-            const raw = entry[axisKey];
-            if (raw === undefined || raw === null) return entry;
-            const shiftedMs = shiftRawToTimezoneWallClockMs(
-                raw,
-                shifted.timezone,
-            );
-            if (shiftedMs === undefined) return entry;
-            mutated = true;
-            return { ...entry, [axisKey]: shiftedMs };
-        });
-        return mutated ? { ...s, markLine: { ...markLine, data: newData } } : s;
-    });
-};
-
-// Run last on the built echarts options — the rest of the pipeline stays in UTC.
+// Run last on the built echarts options — the rest of the pipeline stays in
+// UTC. Dataset and encode rewrite only; markLine values are handled by the
+// separate normalizeMarkLineTimeValues pass.
 export const applyTimezoneShiftToEchartsOptions = <
     O extends EchartsOptionsShape,
 >(
@@ -369,9 +341,112 @@ export const applyTimezoneShiftToEchartsOptions = <
     return {
         ...options,
         dataset: shiftDatasetSources(options.dataset, shifted, shiftedDim),
-        series: shiftSeriesMarkLineValues(
-            shiftBareArraySeriesData(renamedSeries, shifted),
-            shifted,
-        ),
+        series: shiftBareArraySeriesData(renamedSeries, shifted),
     };
+};
+
+// A reference line's stored value aimed at the time axis is one of exactly two
+// things. A number, Date, or datetime string with an explicit zone
+// (parseTimestampValueUTC hasZone) is an instant: parsed, then given the same
+// transform as the data points (wall-clock shift on shifted axes, identity
+// otherwise). An offset-less string — a datetime without a zone, or a
+// calendar value in the canonical picker formats (parseCalendarValueUTC) — is
+// a wall-clock position on the axis as the viewer sees it: parsed naive as
+// UTC, plotted directly, no offset. Both reads are browser-independent by
+// construction. Anything else (numeric metric values stranded in the wrong
+// slot by semantic keying, empty strings, garbage) is left untouched rather
+// than leniently coerced.
+const isWallClockTimeString = (value: string): boolean =>
+    parseTimestampValueUTC(value)?.hasZone === false ||
+    parseCalendarValueUTC(value) !== undefined;
+
+export type MarkLineTimeNormalization = {
+    flipAxes: boolean;
+    // Zone the axis's plotted coordinates are wall-clock-shifted to; undefined
+    // means instants plot at their raw epoch (unshifted or UTC-anchored axis).
+    instantTimezone: string | undefined;
+};
+
+const parseTimeAxisMarkLineValue = (
+    raw: unknown,
+    { instantTimezone }: Pick<MarkLineTimeNormalization, 'instantTimezone'>,
+): number | undefined => {
+    const toShiftedInstant = (ms: number): number | undefined =>
+        Number.isFinite(ms)
+            ? ms +
+              (instantTimezone ? getTimezoneOffsetMs(ms, instantTimezone) : 0)
+            : undefined;
+    if (typeof raw === 'number') return toShiftedInstant(raw);
+    if (raw instanceof Date) return toShiftedInstant(raw.getTime());
+    if (typeof raw !== 'string') return undefined;
+    const value = raw.trim();
+    const timestamp = parseTimestampValueUTC(value);
+    if (timestamp) {
+        const ms = timestamp.date.getTime();
+        return timestamp.hasZone ? toShiftedInstant(ms) : ms;
+    }
+    return parseCalendarValueUTC(value)?.getTime();
+};
+
+// Runs on the final options for every physical time axis when timezone
+// support is on (shifted or not): reference lines carry user-authored strings
+// that ECharts would otherwise parse browser-locally. Also rescues a
+// time-formatted value stranded in the value-axis slot by semantic keying
+// (a dead entry today — ECharts drops a date string aimed at a value axis)
+// into the time slot. Series-relative marks (type 'average' etc.) carry no
+// axis position and are skipped, including any stale slot values on them.
+export const normalizeMarkLineTimeValues = <O extends EchartsOptionsShape>(
+    options: O,
+    normalization: MarkLineTimeNormalization,
+): O => {
+    if (!options.series) return options;
+    const timeSlot = normalization.flipAxes ? 'yAxis' : 'xAxis';
+    const valueSlot = normalization.flipAxes ? 'xAxis' : 'yAxis';
+    const series = options.series.map((s) => {
+        const markLine = s.markLine;
+        if (!isPlainObject(markLine) || !Array.isArray(markLine.data)) {
+            return s;
+        }
+        let mutated = false;
+        const newData = markLine.data.map((entry) => {
+            if (!isPlainObject(entry) || entry.type !== undefined) return entry;
+            const timeValue = entry[timeSlot];
+            const stranded =
+                (timeValue === undefined ||
+                    timeValue === null ||
+                    timeValue === '') &&
+                typeof entry[valueSlot] === 'string' &&
+                isWallClockTimeString((entry[valueSlot] as string).trim());
+            const raw = stranded ? entry[valueSlot] : timeValue;
+            if (raw === undefined || raw === null) return entry;
+            const ms = parseTimeAxisMarkLineValue(raw, normalization);
+            if (ms === undefined) return entry;
+            mutated = true;
+            const next: Record<string, unknown> = {
+                ...entry,
+                [timeSlot]: ms,
+            };
+            if (stranded) next[valueSlot] = undefined;
+            // After numericizing, default labels would echo the epoch ms:
+            // ECharts' own default label formatter echoes the value, and the
+            // reference-line style formatter renders `name || value`. Keep the
+            // author's text by naming unnamed entries and providing a
+            // formatter where none exists.
+            if (typeof raw === 'string') {
+                const text = raw.trim();
+                if (next.name === undefined || next.name === '') {
+                    next.name = text;
+                }
+                const label = isPlainObject(entry.label)
+                    ? entry.label
+                    : undefined;
+                if (label?.formatter === undefined) {
+                    next.label = { ...label, formatter: text };
+                }
+            }
+            return next;
+        });
+        return mutated ? { ...s, markLine: { ...markLine, data: newData } } : s;
+    });
+    return { ...options, series };
 };

--- a/packages/frontend/src/hooks/echarts/timezoneShift.ts
+++ b/packages/frontend/src/hooks/echarts/timezoneShift.ts
@@ -3,7 +3,6 @@ import {
     extractableTimeFrames,
     isCalendarValueItem,
     isDimension,
-    isUnambiguousTemporalString,
     parseCalendarValueUTC,
     parseTimestampValueUTC,
     shouldShiftItemTimezone,
@@ -436,16 +435,15 @@ export const applyTimezoneShiftToEchartsOptions = <
 // calendar value in the canonical picker formats (parseCalendarValueUTC) — is
 // a wall-clock position on the axis as the viewer sees it: parsed naive as
 // UTC, plotted directly, no offset. Both reads are browser-independent by
-// construction. Anything else (numeric metric values stranded in the wrong
-// slot by semantic keying, empty strings, garbage) is left untouched rather
-// than leniently coerced.
+// construction. Other inputs are left untouched rather than leniently
+// coerced. Axis ownership is resolved earlier while field identity is still
+// available; this pass never infers it from the value's shape.
 export type MarkLineTimeNormalization = {
     flipAxes: boolean;
     // Zone the axis's plotted coordinates are wall-clock-shifted to; undefined
     // means instants plot at their raw epoch (unshifted or UTC-anchored axis).
     instantTimezone: string | undefined;
     wallClockTimezone?: string;
-    canRescueFromOppositeAxis?: boolean;
 };
 
 const parseTimeAxisMarkLineValue = (
@@ -479,31 +477,6 @@ const parseTimeAxisMarkLineValue = (
     return calendarMs === undefined
         ? undefined
         : toRawWallClockCoordinate(calendarMs);
-};
-
-// Legacy flipped-chart configs key the date by the semantic `xAxis` even when
-// the date renders on physical Y, stranding it in the value-axis slot where
-// ECharts drops the line. Read the time slot, rescuing a wall-clock string
-// out of the value slot when the time slot is empty.
-const readTimeAxisSlot = (
-    entry: Record<string, unknown>,
-    timeSlot: string,
-    valueSlot: string,
-    canRescue: boolean,
-): { raw: unknown; stranded: boolean } => {
-    const timeValue = entry[timeSlot];
-    const timeSlotEmpty =
-        timeValue === undefined || timeValue === null || timeValue === '';
-    const valueSlotValue = entry[valueSlot];
-    if (
-        canRescue &&
-        timeSlotEmpty &&
-        typeof valueSlotValue === 'string' &&
-        isUnambiguousTemporalString(valueSlotValue)
-    ) {
-        return { raw: valueSlotValue, stranded: true };
-    }
-    return { raw: timeValue, stranded: false };
 };
 
 // After numericizing, default labels would echo the epoch ms: ECharts' own
@@ -541,7 +514,6 @@ export const normalizeMarkLineTimeValues = <O extends EchartsOptionsShape>(
 ): O => {
     if (!options.series) return options;
     const timeSlot = normalization.flipAxes ? 'yAxis' : 'xAxis';
-    const valueSlot = normalization.flipAxes ? 'xAxis' : 'yAxis';
     const series = options.series.map((s) => {
         const markLine = s.markLine;
         if (!isPlainObject(markLine) || !Array.isArray(markLine.data)) {
@@ -550,12 +522,7 @@ export const normalizeMarkLineTimeValues = <O extends EchartsOptionsShape>(
         let mutated = false;
         const newData = markLine.data.map((entry) => {
             if (!isPlainObject(entry) || entry.type !== undefined) return entry;
-            const { raw, stranded } = readTimeAxisSlot(
-                entry,
-                timeSlot,
-                valueSlot,
-                normalization.canRescueFromOppositeAxis !== false,
-            );
+            const raw = entry[timeSlot];
             if (raw === undefined || raw === null) return entry;
             const ms = parseTimeAxisMarkLineValue(raw, normalization);
             if (ms === undefined) return entry;
@@ -566,7 +533,6 @@ export const normalizeMarkLineTimeValues = <O extends EchartsOptionsShape>(
                     ? authoredLabelProps(entry, raw.trim())
                     : {}),
                 [timeSlot]: ms,
-                ...(stranded ? { [valueSlot]: undefined } : {}),
             };
         });
         return mutated ? { ...s, markLine: { ...markLine, data: newData } } : s;
@@ -581,9 +547,6 @@ export const normalizeMarkLineTimeValues = <O extends EchartsOptionsShape>(
 export const finalizeTimeAxisOptions = <O extends EchartsOptionsShape>(
     options: O,
     mode: TimeAxisMode | undefined,
-    {
-        canRescueFromOppositeAxis = true,
-    }: { canRescueFromOppositeAxis?: boolean } = {},
 ): O => {
     if (!mode) return options;
     switch (mode.kind) {
@@ -596,7 +559,6 @@ export const finalizeTimeAxisOptions = <O extends EchartsOptionsShape>(
             return normalizeMarkLineTimeValues(shifted, {
                 flipAxes: mode.flipAxes,
                 instantTimezone: mode.timezone,
-                canRescueFromOppositeAxis,
             });
         }
         case 'calendar': {
@@ -610,7 +572,6 @@ export const finalizeTimeAxisOptions = <O extends EchartsOptionsShape>(
             return normalizeMarkLineTimeValues(anchored, {
                 flipAxes: mode.flipAxes,
                 instantTimezone: undefined,
-                canRescueFromOppositeAxis,
             });
         }
         case 'plain':
@@ -618,7 +579,6 @@ export const finalizeTimeAxisOptions = <O extends EchartsOptionsShape>(
                 flipAxes: mode.flipAxes,
                 instantTimezone: undefined,
                 wallClockTimezone: mode.wallClockTimezone,
-                canRescueFromOppositeAxis,
             });
         default:
             return assertUnreachable(mode, 'Unknown time axis mode');

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -3358,13 +3358,6 @@ const useEchartsCartesianConfig = (
             : undefined;
     }, [validCartesianConfig?.layout?.flipAxes, axes]);
 
-    const canRescueFromOppositeAxis = useMemo(() => {
-        const physicalAxis = validCartesianConfig?.layout?.flipAxes
-            ? axes.xAxis[0]
-            : axes.yAxis[0];
-        return physicalAxis?.type !== 'time';
-    }, [validCartesianConfig?.layout?.flipAxes, axes]);
-
     const plainWallClockTimezone = useMemo(() => {
         if (!axisTimezone) return undefined;
         const physicalAxis = validCartesianConfig?.layout?.flipAxes
@@ -4477,9 +4470,7 @@ const useEchartsCartesianConfig = (
             }),
         };
 
-        return finalizeTimeAxisOptions(baseOptions, timeAxisMode, {
-            canRescueFromOppositeAxis,
-        });
+        return finalizeTimeAxisOptions(baseOptions, timeAxisMode);
     }, [
         sortedAxes,
         sortedSeriesForChart,
@@ -4494,7 +4485,6 @@ const useEchartsCartesianConfig = (
         theme?.other.chartFont,
         validCartesianConfig,
         timeAxisMode,
-        canRescueFromOppositeAxis,
     ]);
 
     if (

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -111,6 +111,7 @@ import { getCartesianConditionalFormattingColor } from './cartesianConditionalFo
 import {
     applyTimezoneShiftToEchartsOptions,
     detectCalendarTimeAxisField,
+    normalizeMarkLineTimeValues,
     resolveAxisTimezone,
     TIME_INTERVALS_FOR_CATEGORY_AXIS,
 } from './timezoneShift';
@@ -3346,25 +3347,35 @@ const useEchartsCartesianConfig = (
         timeAxisField,
     ]);
 
-    // Calendar DATEs plotted on an actual `time` axis get their coordinate
-    // encoded as UTC midnight so ECharts' browser-local parse of the bare
-    // `YYYY-MM-DD` can't move the day. Derived from the built axes so
-    // reference-line-forced time axes are covered, and kept separate from
-    // timeAxisField so isTimeAxisShifted stays instant-shift only.
-    const calendarTimeAxisField = useMemo(() => {
+    // Type of the axis the semantic time dimension actually renders on
+    // (xAxis[0], or yAxis[0] when flipped). Derived from the built axes so
+    // reference-line-forced time axes on coarse grains are covered.
+    const physicalTimeAxisType = useMemo(() => {
         const physicalAxis = validCartesianConfig?.layout?.flipAxes
             ? axes.yAxis[0]
             : axes.xAxis[0];
+        return typeof physicalAxis?.type === 'string'
+            ? physicalAxis.type
+            : undefined;
+    }, [validCartesianConfig?.layout?.flipAxes, axes]);
+
+    // Calendar DATEs plotted on an actual `time` axis get their coordinate
+    // encoded as UTC midnight so ECharts' browser-local parse of the bare
+    // `YYYY-MM-DD` can't move the day. Kept separate from timeAxisField so
+    // isTimeAxisShifted stays instant-shift only.
+    const calendarTimeAxisField = useMemo(() => {
         return detectCalendarTimeAxisField({
             validCartesianConfig,
             itemsMap,
             resolvedTimezone,
-            physicalAxisType:
-                typeof physicalAxis?.type === 'string'
-                    ? physicalAxis.type
-                    : undefined,
+            physicalAxisType: physicalTimeAxisType,
         });
-    }, [validCartesianConfig, itemsMap, resolvedTimezone, axes]);
+    }, [
+        validCartesianConfig,
+        itemsMap,
+        resolvedTimezone,
+        physicalTimeAxisType,
+    ]);
 
     // Shared by stackedSeriesWithColorAssignments (non-stacked bar styling) and
     // decoratedSeriesForChart (stacked rounded corners). Same inputs in both
@@ -4434,12 +4445,22 @@ const useEchartsCartesianConfig = (
         };
 
         const plottedCoordinateField = timeAxisField ?? calendarTimeAxisField;
-        return plottedCoordinateField
+        const shiftedOptions = plottedCoordinateField
             ? applyTimezoneShiftToEchartsOptions(
                   baseOptions,
                   plottedCoordinateField,
               )
             : baseOptions;
+        // Reference-line values are user-authored strings; on any time axis
+        // they need the browser-independent parse rule, including unshifted
+        // axes (e.g. UTC projects) where no plotted-coordinate field exists.
+        if (physicalTimeAxisType === 'time' && resolvedTimezone) {
+            return normalizeMarkLineTimeValues(shiftedOptions, {
+                flipAxes: !!flipAxes,
+                instantTimezone: timeAxisField?.timezone,
+            });
+        }
+        return shiftedOptions;
     }, [
         sortedAxes,
         sortedSeriesForChart,
@@ -4455,6 +4476,8 @@ const useEchartsCartesianConfig = (
         validCartesianConfig,
         timeAxisField,
         calendarTimeAxisField,
+        physicalTimeAxisType,
+        resolvedTimezone,
     ]);
 
     if (

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -3358,6 +3358,13 @@ const useEchartsCartesianConfig = (
             : undefined;
     }, [validCartesianConfig?.layout?.flipAxes, axes]);
 
+    const canRescueFromOppositeAxis = useMemo(() => {
+        const physicalAxis = validCartesianConfig?.layout?.flipAxes
+            ? axes.xAxis[0]
+            : axes.yAxis[0];
+        return physicalAxis?.type !== 'time';
+    }, [validCartesianConfig?.layout?.flipAxes, axes]);
+
     // How the time axis plots its coordinates (instant-shifted, calendar
     // UTC-anchored, or plain). undefined when there is no time axis or
     // timezone support is off — the built options then pass through
@@ -4443,7 +4450,9 @@ const useEchartsCartesianConfig = (
             }),
         };
 
-        return finalizeTimeAxisOptions(baseOptions, timeAxisMode);
+        return finalizeTimeAxisOptions(baseOptions, timeAxisMode, {
+            canRescueFromOppositeAxis,
+        });
     }, [
         sortedAxes,
         sortedSeriesForChart,
@@ -4458,6 +4467,7 @@ const useEchartsCartesianConfig = (
         theme?.other.chartFont,
         validCartesianConfig,
         timeAxisMode,
+        canRescueFromOppositeAxis,
     ]);
 
     if (

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -3365,6 +3365,31 @@ const useEchartsCartesianConfig = (
         return physicalAxis?.type !== 'time';
     }, [validCartesianConfig?.layout?.flipAxes, axes]);
 
+    const plainWallClockTimezone = useMemo(() => {
+        if (!axisTimezone) return undefined;
+        const physicalAxis = validCartesianConfig?.layout?.flipAxes
+            ? axes.yAxis[0]
+            : axes.xAxis[0];
+        const axisLabel = physicalAxis?.axisLabel;
+        if (
+            !axisLabel ||
+            typeof axisLabel !== 'object' ||
+            !('formatter' in axisLabel) ||
+            typeof axisLabel.formatter !== 'function'
+        ) {
+            return undefined;
+        }
+        const fieldId = validCartesianConfig?.layout?.xField;
+        const field = fieldId ? itemsMap?.[fieldId] : undefined;
+        return getFormatterTimezone(field, new Date(0), axisTimezone);
+    }, [
+        axisTimezone,
+        validCartesianConfig?.layout?.flipAxes,
+        validCartesianConfig?.layout?.xField,
+        axes,
+        itemsMap,
+    ]);
+
     // How the time axis plots its coordinates (instant-shifted, calendar
     // UTC-anchored, or plain). undefined when there is no time axis or
     // timezone support is off — the built options then pass through
@@ -3375,12 +3400,14 @@ const useEchartsCartesianConfig = (
             itemsMap,
             resolvedTimezone,
             physicalAxisType: physicalTimeAxisType,
+            plainWallClockTimezone,
         });
     }, [
         validCartesianConfig,
         itemsMap,
         resolvedTimezone,
         physicalTimeAxisType,
+        plainWallClockTimezone,
     ]);
 
     // Shared by stackedSeriesWithColorAssignments (non-stacked bar styling) and

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -109,9 +109,8 @@ import {
 import { type InfiniteQueryResults } from '../useQueryResults';
 import { getCartesianConditionalFormattingColor } from './cartesianConditionalFormatting';
 import {
-    applyTimezoneShiftToEchartsOptions,
-    detectCalendarTimeAxisField,
-    normalizeMarkLineTimeValues,
+    detectTimeAxisMode,
+    finalizeTimeAxisOptions,
     resolveAxisTimezone,
     TIME_INTERVALS_FOR_CATEGORY_AXIS,
 } from './timezoneShift';
@@ -3359,12 +3358,12 @@ const useEchartsCartesianConfig = (
             : undefined;
     }, [validCartesianConfig?.layout?.flipAxes, axes]);
 
-    // Calendar DATEs plotted on an actual `time` axis get their coordinate
-    // encoded as UTC midnight so ECharts' browser-local parse of the bare
-    // `YYYY-MM-DD` can't move the day. Kept separate from timeAxisField so
-    // isTimeAxisShifted stays instant-shift only.
-    const calendarTimeAxisField = useMemo(() => {
-        return detectCalendarTimeAxisField({
+    // How the time axis plots its coordinates (instant-shifted, calendar
+    // UTC-anchored, or plain). undefined when there is no time axis or
+    // timezone support is off — the built options then pass through
+    // finalizeTimeAxisOptions untouched.
+    const timeAxisMode = useMemo(() => {
+        return detectTimeAxisMode({
             validCartesianConfig,
             itemsMap,
             resolvedTimezone,
@@ -4444,23 +4443,7 @@ const useEchartsCartesianConfig = (
             }),
         };
 
-        const plottedCoordinateField = timeAxisField ?? calendarTimeAxisField;
-        const shiftedOptions = plottedCoordinateField
-            ? applyTimezoneShiftToEchartsOptions(
-                  baseOptions,
-                  plottedCoordinateField,
-              )
-            : baseOptions;
-        // Reference-line values are user-authored strings; on any time axis
-        // they need the browser-independent parse rule, including unshifted
-        // axes (e.g. UTC projects) where no plotted-coordinate field exists.
-        if (physicalTimeAxisType === 'time' && resolvedTimezone) {
-            return normalizeMarkLineTimeValues(shiftedOptions, {
-                flipAxes: !!flipAxes,
-                instantTimezone: timeAxisField?.timezone,
-            });
-        }
-        return shiftedOptions;
+        return finalizeTimeAxisOptions(baseOptions, timeAxisMode);
     }, [
         sortedAxes,
         sortedSeriesForChart,
@@ -4474,10 +4457,7 @@ const useEchartsCartesianConfig = (
         currentGrid,
         theme?.other.chartFont,
         validCartesianConfig,
-        timeAxisField,
-        calendarTimeAxisField,
-        physicalTimeAxisType,
-        resolvedTimezone,
+        timeAxisMode,
     ]);
 
     if (


### PR DESCRIPTION
## Problem

Reference lines on time axes had three related bugs when timezone support is enabled (none are regressions; surfaced during the pre-merge review of #26130):

1. **Browser-dependent placement** — offset-less datetime values (`2024-01-15 12:00`, API/chart-as-code authored) were parsed as browser-local time, so the same saved chart drew the line in a different place per viewer.
2. **Date-only lines at "offset o'clock"** — `2024-01-15` parsed as UTC midnight and then received the display offset, so on a Tokyo-shifted hourly axis the line rendered at 09:00 instead of the visible day boundary.
3. **Flipped charts dropped date lines** — legacy configs can key the value by semantic `xAxis` even when the date renders on physical Y, so ECharts aimed a date string at the value axis and rendered nothing.

## Fix

A stored reference-line value already owned by a time axis is now one of exactly two things:

- **Instant** — a number, `Date`, or datetime string with an explicit zone (`Z`, `±hh:mm`, `±hhmm`, `±hh`): parsed, then given the same transform as the data points.
- **Wall-clock position** — an offset-less datetime or canonical picker value (`2024-07-22`, `2024-07`, `2024-Q3`, `2024`): parsed as naive UTC and plotted at the authored wall-clock position.

Classification uses strict common parsers, so unsupported shapes are left untouched instead of being coerced.

Axis ownership and value parsing have separate responsibilities:

- `applyReferenceLines` performs the legacy semantic-to-physical repair while field identity and types are available. It only reattributes an unambiguous temporal value from a numeric field to the semantic time field.
- `finalizeTimeAxisOptions` normalizes values already on the physical time axis. It never guesses ownership from a string's shape.

This preserves legitimate category and numeric reference lines while repairing the legacy flipped-chart case before coarse-grain axis inference.

## Flag safety

With `EnableTimezoneSupport` off, the query response carries no `resolvedTimezone`, no time-axis mode is selected, and the built options pass through by reference.

## Testing

- Common strict-parser tests: 200 passing.
- Frontend ECharts/config tests: 277 passing under `TZ=UTC`.
- Timezone normalization tests: 77 passing under `TZ=Etc/GMT-2`.
- Regression coverage runs repaired legacy temporal lines and legitimate date-shaped category lines through finalization.
- Browser matrix covers flag on/off, UTC and non-UTC viewers, flipped lines, labels, and a numeric `2024` threshold remaining on its value axis.

### Before
<img width="1280" height="944" alt="flag-on-tokyo-line-at-0900" src="https://github.com/user-attachments/assets/eebf2af4-061a-41b5-ba36-4791bb98fbc7" />

### After
<img width="1280" height="944" alt="fix-flag-on-tokyo-line-at-day-boundary" src="https://github.com/user-attachments/assets/78ab281a-98aa-4b2b-9069-25779d5530b8" />

test-all

Closes: GLITCH-638
