### PR TITLE
fix(cli): shorten onboarding PAT network-policy bypass window

### DIFF
--- a/packages/cli/src/handlers/connectSnowflake.test.ts
+++ b/packages/cli/src/handlers/connectSnowflake.test.ts
@@ -347,7 +347,7 @@ describe('connectSnowflakeHandler', () => {
         expect(createProgrammaticAccessToken).toHaveBeenCalledWith(
             expect.stringMatching(/^LIGHTDASH_ONBOARDING_\d+$/),
             365,
-            1440,
+            60,
         );
         const request: DepositWarehouseConnectionRequest = {
             code: options.code,
@@ -400,10 +400,15 @@ describe('connectSnowflakeHandler', () => {
         expect(createProgrammaticAccessToken).toHaveBeenCalledWith(
             expect.stringMatching(/^LIGHTDASH_ONBOARDING_\d+$/),
             365,
-            1440,
+            60,
         );
         expect(write).toHaveBeenCalledWith(
             'Secured with a programmatic access token (expires 2027-07-14)',
+        );
+        expect(write).toHaveBeenCalledWith(
+            expect.stringContaining(
+                'bypasses your Snowflake network policy for the next 60 minutes',
+            ),
         );
     });
 

--- a/packages/cli/src/handlers/connectSnowflake.ts
+++ b/packages/cli/src/handlers/connectSnowflake.ts
@@ -72,7 +72,7 @@ type ResolvedConnectionValues = {
 };
 
 const PAT_EXPIRY_DAYS = 365;
-const PAT_NETWORK_POLICY_BYPASS_MINUTES = 1440;
+const PAT_NETWORK_POLICY_BYPASS_MINUTES = 60;
 const KEY_VERIFICATION_ATTEMPTS = 3;
 const KEY_VERIFICATION_RETRY_DELAY_MS = 5_000;
 
@@ -403,6 +403,9 @@ const createDurableCredential = async (
         const expiresAt = new Date(
             dependencies.now().getTime() +
                 PAT_EXPIRY_DAYS * 24 * 60 * 60 * 1000,
+        );
+        dependencies.write(
+            `The token bypasses your Snowflake network policy for the next ${PAT_NETWORK_POLICY_BYPASS_MINUTES} minutes so this connection can be verified. Allowlist Lightdash's IP addresses in your network policy to keep it working afterwards.`,
         );
         return {
             credentials: {


### PR DESCRIPTION
Reduces the Snowflake onboarding PAT network-policy bypass window from 24 hours to 60 minutes, tells the user about the window, and prompts them to allowlist Lightdash IPs in their network policy.

Linear: SPK-583