### PR TITLE
fix(cli): filter uploads when apps are selected

### DIFF
--- a/packages/cli/src/handlers/download.test.ts
+++ b/packages/cli/src/handlers/download.test.ts
@@ -29,7 +29,7 @@ const {
     downloadSpaces,
     getDashboardChartSlugs,
     getFlatSpaceFileNames,
-    hasUploadFilters,
+    hasContentFilters,
     readAiAgentFiles,
     readSpaceFiles,
     readSpaceNames,
@@ -43,9 +43,9 @@ const {
     writeSpaceFiles,
 } = testHelpers;
 
-const makeUploadFilterOptions = (
-    overrides: Partial<Parameters<typeof hasUploadFilters>[0]> = {},
-): Parameters<typeof hasUploadFilters>[0] => ({
+const makeContentFilterOptions = (
+    overrides: Partial<Parameters<typeof hasContentFilters>[0]> = {},
+): Parameters<typeof hasContentFilters>[0] => ({
     spacesOnly: false,
     charts: [],
     dashboards: [],
@@ -58,23 +58,23 @@ const makeUploadFilterOptions = (
     ...overrides,
 });
 
-describe('hasUploadFilters', () => {
-    it('treats explicit apps as a filtered upload', () => {
+describe('hasContentFilters', () => {
+    it('treats explicit apps as a filtered download and upload', () => {
         expect(
-            hasUploadFilters(
-                makeUploadFilterOptions({ apps: ['app-reference'] }),
+            hasContentFilters(
+                makeContentFilterOptions({ apps: ['app-reference'] }),
             ),
         ).toBe(true);
     });
 
-    it('keeps an unfiltered upload unfiltered', () => {
-        expect(hasUploadFilters(makeUploadFilterOptions())).toBe(false);
+    it('keeps an unfiltered content operation unfiltered', () => {
+        expect(hasContentFilters(makeContentFilterOptions())).toBe(false);
     });
 
     it('does not treat content selections as filters in spaces-only mode', () => {
         expect(
-            hasUploadFilters(
-                makeUploadFilterOptions({
+            hasContentFilters(
+                makeContentFilterOptions({
                     spacesOnly: true,
                     apps: ['app-reference'],
                 }),

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -206,7 +206,7 @@ const shouldDownloadAiAgents = ({
     appsOnly !== true &&
     (includeAll === true || includeAgents === true || agents.length > 0);
 
-const hasUploadFilters = ({
+const hasContentFilters = ({
     spacesOnly,
     charts,
     dashboards,
@@ -1424,7 +1424,7 @@ export const downloadHandler = async (
         );
     }
 
-    const hasFilters = hasUploadFilters(options);
+    const hasFilters = hasContentFilters(options);
     const shouldDownloadSpaces =
         !isOrganizationDownload && !options.skipSpaces && !hasFilters;
     let skipEmbeddedSpaces = !hasFilters || options.skipSpaces;
@@ -2474,15 +2474,7 @@ export const uploadHandler = async (
     }
 
     const isOrganizationUpload = options.organization === true;
-    const hasFilters =
-        !options.spacesOnly &&
-        (options.charts.length > 0 ||
-            options.dashboards.length > 0 ||
-            options.agents.length > 0 ||
-            options.alerts.length > 0 ||
-            options.googleSheets.length > 0 ||
-            options.scheduledDeliveries.length > 0 ||
-            options.virtualViews.length > 0);
+    const hasFilters = hasContentFilters(options);
     const shouldReconcileSpaces =
         !isOrganizationUpload && !options.skipSpaces && !hasFilters;
     let preflightSpaceFiles: SpaceCodeFile[] = [];
@@ -3208,7 +3200,7 @@ export const testHelpers = {
     downloadSpaces,
     getFlatSpaceFileNames,
     getDashboardChartSlugs,
-    hasUploadFilters,
+    hasContentFilters,
     readAiAgentFiles,
     readSpaceFiles,
     readSpaceNames,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -903,7 +903,7 @@ const downloadCommand = program
     )
     .option(
         '--apps <appReferences...>',
-        'Include specific data apps by UUID or URL (enterprise). Works for apps not added to a space.',
+        'Download only specified data apps by UUID or URL (enterprise). Works for apps not added to a space.',
     )
     .option(
         '--include-apps',
@@ -1015,7 +1015,7 @@ const uploadCommand = program
     .option('--gzip', 'Enable gzip compression for request bodies', false)
     .option(
         '--apps <appReferences...>',
-        'Upload specific data apps by UUID or URL (enterprise).',
+        'Upload only specified data apps by UUID or URL (enterprise).',
     )
     .option(
         '--include-apps',


### PR DESCRIPTION
Closes: #26136

### Description:

- treat explicit `--apps` references as content filters during upload
- reuse the same filter detection already used by downloads
- clarify the download and upload CLI help text
- cover app filtering for both operations with a regression test

### Validation:

- `pnpm -F cli exec vitest run --config vitest.config.ts src/handlers/download.test.ts src/handlers/apps/appsDownload.test.ts` (99 tests passed)
- `pnpm -F cli typecheck:fast`
- focused CLI lint and formatting checks
- `pnpm -F cli build`
- manually uploaded a selected data app and confirmed unrelated content was skipped