### PR TITLE
feat: add AI agent memory prometheus metrics

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -135,7 +135,13 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
 
     return {
         serviceProviders: {
-            aiAgentMemoryService: ({ models, clients, context, repository }) =>
+            aiAgentMemoryService: ({
+                models,
+                clients,
+                context,
+                repository,
+                prometheusMetrics,
+            }) =>
                 new AiAgentMemoryService({
                     analytics: context.lightdashAnalytics,
                     aiAgentMemoryModel:
@@ -146,6 +152,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     featureFlagService: repository.getFeatureFlagService(),
                     schedulerClient:
                         clients.getSchedulerClient() as CommercialSchedulerClient,
+                    prometheusMetrics,
                     orgAiCopilotConfigResolver: new OrgAiCopilotConfigResolver({
                         lightdashConfig: context.lightdashConfig,
                         aiOrganizationSettingsModel:

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
@@ -29,6 +29,8 @@ import {
 } from '../../../analytics/LightdashAnalytics';
 import { type GroupsModel } from '../../../models/GroupsModel';
 import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
+import type PrometheusMetrics from '../../../prometheus/PrometheusMetrics';
+import { type AiAgentMemoryDistillOutcome } from '../../../prometheus/PrometheusMetrics';
 import { BaseService } from '../../../services/BaseService';
 import { type FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
 import {
@@ -85,6 +87,7 @@ type Dependencies = {
     projectModel: Pick<ProjectModel, 'findExploresFromCache' | 'getSummary'>;
     featureFlagService: FeatureFlagService;
     schedulerClient: MemorySchedulerClient;
+    prometheusMetrics?: PrometheusMetrics;
 } & (
     | {
           orgAiCopilotConfigResolver: OrgAiCopilotConfigResolver;
@@ -138,6 +141,8 @@ export class AiAgentMemoryService extends BaseService {
 
     private readonly schedulerClient: MemorySchedulerClient;
 
+    private readonly prometheusMetrics: PrometheusMetrics | undefined;
+
     private readonly orgAiCopilotConfigResolver:
         | OrgAiCopilotConfigResolver
         | undefined;
@@ -153,6 +158,7 @@ export class AiAgentMemoryService extends BaseService {
         this.projectModel = dependencies.projectModel;
         this.featureFlagService = dependencies.featureFlagService;
         this.schedulerClient = dependencies.schedulerClient;
+        this.prometheusMetrics = dependencies.prometheusMetrics;
         this.orgAiCopilotConfigResolver =
             dependencies.orgAiCopilotConfigResolver;
         this.distillCall =
@@ -394,13 +400,27 @@ export class AiAgentMemoryService extends BaseService {
                 }),
             ),
         );
+        this.prometheusMetrics?.incrementAiAgentMemorySweepEnqueued(due.length);
         return due.length;
     }
 
     async distillThread(
         payload: AiAgentMemoryDistillJobPayload,
         abortSignal?: AbortSignal,
-    ): Promise<'disabled' | 'skipped' | 'memory' | 'no_op' | 'failed'> {
+    ): Promise<AiAgentMemoryDistillOutcome> {
+        const startTime = Date.now();
+        const outcome = await this.runDistillThread(payload, abortSignal);
+        this.prometheusMetrics?.trackAiAgentMemoryDistill(
+            outcome,
+            Date.now() - startTime,
+        );
+        return outcome;
+    }
+
+    private async runDistillThread(
+        payload: AiAgentMemoryDistillJobPayload,
+        abortSignal?: AbortSignal,
+    ): Promise<AiAgentMemoryDistillOutcome> {
         const sweptUpdatedAt =
             typeof payload.sweptUpdatedAt === 'string'
                 ? new Date(payload.sweptUpdatedAt)

--- a/packages/backend/src/prometheus/PrometheusMetrics.ts
+++ b/packages/backend/src/prometheus/PrometheusMetrics.ts
@@ -56,6 +56,17 @@ const SCHEDULED_CONTEXTS: ReadonlySet<string> = new Set<string>([
     QueryExecutionContext.PRE_AGGREGATE_MATERIALIZATION,
 ]);
 
+export const AI_AGENT_MEMORY_DISTILL_OUTCOMES = [
+    'disabled',
+    'skipped',
+    'memory',
+    'no_op',
+    'failed',
+] as const;
+
+export type AiAgentMemoryDistillOutcome =
+    (typeof AI_AGENT_MEMORY_DISTILL_OUTCOMES)[number];
+
 export function getQueryContextLabel(
     context: string,
 ): 'interactive' | 'scheduled' {
@@ -96,6 +107,15 @@ export default class PrometheusMetrics {
     public aiAgentStreamFirstChunkHistogram: prometheus.Histogram | null = null;
 
     public aiAgentTTFTHistogram: prometheus.Histogram | null = null;
+
+    // AI agent memory background pipeline (sweep + distill jobs)
+    public aiAgentMemoryDistillCounter: prometheus.Counter<'outcome'> | null =
+        null;
+
+    public aiAgentMemoryDistillDurationHistogram: prometheus.Histogram<'outcome'> | null =
+        null;
+
+    public aiAgentMemorySweepEnqueuedCounter: prometheus.Counter | null = null;
 
     // repoShell (read-only repo VFS) GitHub API latency
     public repoFsGithubTreeDurationHistogram: prometheus.Histogram | null =
@@ -470,6 +490,34 @@ export default class PrometheusMetrics {
                     ...rest,
                 });
 
+                // AI agent memory background pipeline
+                this.aiAgentMemoryDistillCounter = new prometheus.Counter({
+                    name: 'ai_agent_memory_distill_total',
+                    help: 'AI agent memory distill jobs by outcome (disabled | skipped | memory | no_op | failed)',
+                    labelNames: ['outcome'],
+                    ...rest,
+                });
+
+                this.aiAgentMemoryDistillDurationHistogram =
+                    new prometheus.Histogram({
+                        name: 'ai_agent_memory_distill_duration_ms',
+                        help: 'AI agent memory distill job duration in ms by outcome',
+                        labelNames: ['outcome'],
+                        buckets: [
+                            100, 250, 500, 1000, 2500, 5000, 10000, 20000,
+                            30000, 60000, 120000, 300000,
+                        ],
+                        ...rest,
+                    });
+
+                this.aiAgentMemorySweepEnqueuedCounter = new prometheus.Counter(
+                    {
+                        name: 'ai_agent_memory_sweep_enqueued_total',
+                        help: 'Threads enqueued for memory distill by the sweep job',
+                        ...rest,
+                    },
+                );
+
                 // repoShell GitHub API latency (per-request round-trips)
                 const githubRequestBuckets = [
                     25, 50, 100, 150, 200, 300, 500, 750, 1000, 2000, 5000,
@@ -617,6 +665,13 @@ export default class PrometheusMetrics {
                 AI_WRITEBACK_STAGES.forEach((stage) => {
                     this.aiWritebackStageDurationHistogram?.zero({ stage });
                 });
+                AI_AGENT_MEMORY_DISTILL_OUTCOMES.forEach((outcome) => {
+                    this.aiAgentMemoryDistillCounter?.inc({ outcome }, 0);
+                    this.aiAgentMemoryDistillDurationHistogram?.zero({
+                        outcome,
+                    });
+                });
+                this.aiAgentMemorySweepEnqueuedCounter?.inc(0);
 
                 // Initialize pre-aggregate metrics
                 this.preAggregateMatchCounter = new prometheus.Counter({
@@ -1435,6 +1490,21 @@ export default class PrometheusMetrics {
                 rl.used,
             );
         }
+    }
+
+    public trackAiAgentMemoryDistill(
+        outcome: AiAgentMemoryDistillOutcome,
+        durationMs: number,
+    ) {
+        this.aiAgentMemoryDistillCounter?.inc({ outcome });
+        this.aiAgentMemoryDistillDurationHistogram?.observe(
+            { outcome },
+            durationMs,
+        );
+    }
+
+    public incrementAiAgentMemorySweepEnqueued(count: number) {
+        this.aiAgentMemorySweepEnqueuedCounter?.inc(count);
     }
 
     public observeAiWritebackSandboxCreateDuration(durationMs: number) {


### PR DESCRIPTION
## Summary

Prometheus metrics for the AI agent memory background pipeline, so sweep/distill job health is visible at a glance:

- `ai_agent_memory_distill_total{outcome}` — distill jobs by outcome (`disabled | skipped | memory | no_op | failed`)
- `ai_agent_memory_distill_duration_ms{outcome}` — distill job duration histogram (buckets 100ms–5min)
- `ai_agent_memory_sweep_enqueued_total` — threads enqueued for distill by the sweep job

All series are pre-zeroed at startup so Managed Prometheus `rate()` sees a counter-reset baseline (same pattern as writeback/repoFs metrics).

`AiAgentMemoryService.distillThread` is wrapped to record outcome + wall-clock duration; `sweep` records the enqueued count. Metrics are injected via the existing optional `prometheusMetrics` service-provider arg.

## Testing

- Verified locally with a Prometheus-enabled instance: zero baselines on boot, `skipped` outcomes from not-found threads (~5ms), a real LLM distill recorded as `no_op` at 1857ms, sweep counter correctly at 0 with no idle-eligible threads.
- A companion Cloud Monitoring dashboard (`ai-agent-memory.json`) lives in lightdash-cloud `gcp_dashboards`.

Relates: ZAP-672

🤖 Generated with [Claude Code](https://claude.com/claude-code)
