### PR TITLE
fix: classify data app generation failures and fail fast when retries can't help

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -2681,16 +2681,19 @@ export class AppGenerateService extends BaseService {
                 4000,
             );
 
-            if (attempt >= AppGenerateService.MAX_GENERATION_ATTEMPTS) {
+            const classification = classifyClaudeCliFailure(
+                result.stderr,
+                result.stdout,
+            );
+            if (
+                attempt >= AppGenerateService.MAX_GENERATION_ATTEMPTS ||
+                !classification.retryable
+            ) {
                 // On final failure, promote stderr+stdout to info so the
                 // upstream API error (often emitted to stdout in
                 // stream-json mode) is captured in production logs.
-                const classification = classifyClaudeCliFailure(
-                    result.stderr,
-                    result.stdout,
-                );
                 this.logger.info(
-                    `App ${appUuid}: Claude failure (category=${classification.category}, exit=${result.exitCode})`,
+                    `App ${appUuid}: Claude failure (category=${classification.category}, retryable=${classification.retryable}, exit=${result.exitCode}, attempt=${attempt})`,
                 );
                 this.logger.info(
                     `App ${appUuid}: Claude stderr (tail): ${stderrTail}`,
@@ -2698,14 +2701,16 @@ export class AppGenerateService extends BaseService {
                 this.logger.info(
                     `App ${appUuid}: Claude stdout (tail): ${stdoutTail}`,
                 );
-                const message = `Claude generation failed (exit ${result.exitCode}): ${result.stderr}`;
-                if (classification.category === 'unknown') {
-                    throw new Error(message);
-                }
+                // Prefer the CLI's human-readable error over stderr, which is
+                // usually empty in stream-json mode.
+                const message = `Claude generation failed (exit ${result.exitCode}): ${
+                    classification.providerDetail ?? result.stderr
+                }`;
                 throw new ClaudeGenerationError({
                     message,
                     userMessage: classification.userMessage,
                     category: classification.category,
+                    providerDetail: classification.providerDetail,
                 });
             }
 
@@ -3830,20 +3835,35 @@ export class AppGenerateService extends BaseService {
                 this.logger.error(
                     `App ${appUuid}: generation failed after ${totalMs}ms: ${getErrorMessage(error)}`,
                 );
-                // Prefer a classified upstream-API message (quota /
-                // rate-limit / auth / overloaded). Otherwise fall back to
-                // the existing branches: Bedrock failures are often the
-                // model not being enabled in the configured region — point
-                // operators at that instead of the generic "try rephrasing".
+                // Prefer a classified upstream-API message (quota / spend
+                // limit / rate-limit / auth / overloaded). For unclassified
+                // provider errors, show the provider's own message — it's
+                // already human-readable (e.g. "API Error: 400 ..."). Then:
+                // Bedrock failures are often the model not being enabled in
+                // the configured region — point operators at that. The last
+                // resort is honest about not knowing the cause rather than
+                // blaming the user's request — infra failures (connection
+                // loss, sandbox death) land here too.
                 let userMessage: string;
-                if (error instanceof ClaudeGenerationError) {
+                if (
+                    error instanceof ClaudeGenerationError &&
+                    error.userMessage
+                ) {
                     userMessage = error.userMessage;
+                } else if (
+                    error instanceof ClaudeGenerationError &&
+                    error.providerDetail
+                ) {
+                    userMessage = `Couldn't generate the app — the AI provider returned an error: ${AppGenerateService.truncateEnd(
+                        error.providerDetail,
+                        500,
+                    )}`;
                 } else if (claudeCodeEnv.CLAUDE_CODE_USE_BEDROCK === '1') {
                     userMessage =
                         'Failed to generate the app. If this keeps happening, check that the selected model is enabled in your AWS Bedrock region (see server logs).';
                 } else {
                     userMessage =
-                        'Failed to generate app code. Try rephrasing your request.';
+                        'Something unexpected went wrong while generating your app. Please try again.';
                 }
                 const marked = await this.markError(
                     appUuid,
@@ -3978,11 +3998,15 @@ export class AppGenerateService extends BaseService {
                 this.logger.error(
                     `App ${appUuid}: build failed after ${totalMs}ms: ${getErrorMessage(error)}`,
                 );
+                // Auto-fix runs Claude too — a classified upstream failure
+                // there (quota, spend limit, auth) is not a compile problem.
                 const marked = await this.markError(
                     appUuid,
                     version,
                     error,
-                    "The generated code couldn't be compiled. Try again or simplify your request.",
+                    error instanceof ClaudeGenerationError && error.userMessage
+                        ? error.userMessage
+                        : "The generated code couldn't be compiled. Try again or simplify your request.",
                 );
                 if (marked) {
                     this.trackVersionFailed(

--- a/packages/backend/src/ee/services/AppGenerateService/claudeCliFailure.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/claudeCliFailure.test.ts
@@ -1,81 +1,170 @@
 import { classifyClaudeCliFailure } from './claudeCliFailure';
 
+// Condensed from real CLI stream-json output: the final `result` event
+// carries the failure as structured fields plus a human-readable message.
+const cliResultLine = (apiErrorStatus: number, resultText: string): string =>
+    JSON.stringify({
+        is_error: true,
+        terminal_reason: 'api_error',
+        subtype: 'success',
+        api_error_status: apiErrorStatus,
+        result: resultText,
+        type: 'result',
+    });
+
+const streamWithResult = (resultLine: string): string =>
+    [
+        '{"type":"system","subtype":"init","session_id":"abc"}',
+        '{"type":"system","subtype":"api_retry","attempt":1,"max_retries":10,"retry_delay_ms":511,"error_status":401,"error":"authentication_failed"}',
+        resultLine,
+    ].join('\n');
+
 describe('classifyClaudeCliFailure', () => {
-    test('classifies Anthropic credit-balance error from stdout', () => {
-        const stdout = JSON.stringify({
-            type: 'result',
-            subtype: 'error',
-            error: 'Your credit balance is too low to access the Claude API. Please go to Plans & Billing to upgrade or purchase credits.',
-        });
-        const result = classifyClaudeCliFailure('', stdout);
-        expect(result.category).toBe('quota');
-        if (result.category !== 'unknown') {
-            expect(result.userMessage).toMatch(/out of credits/i);
-        }
-    });
-
-    test('classifies insufficient_quota error from stderr', () => {
+    test('classifies monthly spend limit from the result event as non-retryable', () => {
+        const detail =
+            'API Error: 400 Your organization has reached its monthly spend limit. Your limit will reset on the first of next month, or you can increase your limit in the Console.';
         const result = classifyClaudeCliFailure(
-            'API Error 400: insufficient_quota',
             '',
+            streamWithResult(cliResultLine(400, detail)),
         );
-        expect(result.category).toBe('quota');
+        expect(result.category).toBe('spend_limit');
+        expect(result.retryable).toBe(false);
+        expect(result.userMessage).toMatch(/usage limit/i);
+        expect(result.providerDetail).toBe(detail);
     });
 
-    test('classifies Anthropic rate_limit_error', () => {
+    test('classifies a 401 by status even though the CLI rewrites the message', () => {
         const result = classifyClaudeCliFailure(
             '',
-            '{"error":{"type":"rate_limit_error","message":"Number of request tokens has exceeded your per-minute rate limit"}}',
+            streamWithResult(
+                cliResultLine(
+                    401,
+                    'Failed to authenticate. API Error: 401 API key is invalid.',
+                ),
+            ),
+        );
+        expect(result.category).toBe('auth');
+        expect(result.retryable).toBe(false);
+    });
+
+    test('classifies a 429 from the result event as retryable', () => {
+        const result = classifyClaudeCliFailure(
+            '',
+            streamWithResult(
+                cliResultLine(
+                    429,
+                    'API Error: Request rejected (429) · Number of request tokens has exceeded your per-minute rate limit',
+                ),
+            ),
         );
         expect(result.category).toBe('rate_limit');
+        expect(result.retryable).toBe(true);
     });
 
-    test('classifies Bedrock ThrottlingException as rate_limit', () => {
+    test("classifies the CLI's canned credit-balance message on a 400", () => {
+        const result = classifyClaudeCliFailure(
+            '',
+            streamWithResult(cliResultLine(400, 'Credit balance is too low')),
+        );
+        expect(result.category).toBe('quota');
+        expect(result.retryable).toBe(false);
+        expect(result.userMessage).toMatch(/out of credits/i);
+    });
+
+    test('classifies a 402 billing error by status', () => {
+        const result = classifyClaudeCliFailure(
+            '',
+            streamWithResult(
+                cliResultLine(402, 'API Error: 402 billing problem'),
+            ),
+        );
+        expect(result.category).toBe('billing');
+        expect(result.retryable).toBe(false);
+    });
+
+    test('classifies a 5xx from the result event as overloaded', () => {
+        const result = classifyClaudeCliFailure(
+            '',
+            streamWithResult(cliResultLine(529, 'API Error: 529 Overloaded')),
+        );
+        expect(result.category).toBe('overloaded');
+        expect(result.retryable).toBe(true);
+    });
+
+    test('marks an unrecognized 4xx as unknown but non-retryable', () => {
+        const detail = 'API Error: 400 some new validation failure';
+        const result = classifyClaudeCliFailure(
+            '',
+            streamWithResult(cliResultLine(400, detail)),
+        );
+        expect(result).toEqual({
+            category: 'unknown',
+            retryable: false,
+            userMessage: null,
+            providerDetail: detail,
+        });
+    });
+
+    test('classifies a Claude subscription usage-limit message without a result event', () => {
+        const result = classifyClaudeCliFailure(
+            '',
+            'Claude AI usage limit reached|1753372800',
+        );
+        expect(result.category).toBe('spend_limit');
+        expect(result.retryable).toBe(false);
+    });
+
+    test('classifies Bedrock ThrottlingException from stderr without a result event', () => {
         const result = classifyClaudeCliFailure(
             'ThrottlingException: Too many requests',
             '',
         );
         expect(result.category).toBe('rate_limit');
+        expect(result.retryable).toBe(true);
     });
 
-    test('classifies Anthropic invalid_api_key as auth', () => {
+    test('classifies raw API error signatures via text fallback', () => {
+        expect(
+            classifyClaudeCliFailure(
+                '',
+                '{"error":{"type":"authentication_error","message":"invalid x-api-key header"}}',
+            ).category,
+        ).toBe('auth');
+        expect(
+            classifyClaudeCliFailure(
+                '',
+                '{"error":{"type":"overloaded_error","message":"Overloaded"}}',
+            ).category,
+        ).toBe('overloaded');
+        expect(
+            classifyClaudeCliFailure('API Error 400: insufficient_quota', '')
+                .category,
+        ).toBe('quota');
+    });
+
+    test('falls back to text matching when a result-looking line is not valid JSON', () => {
         const result = classifyClaudeCliFailure(
             '',
-            '{"error":{"type":"authentication_error","message":"invalid_api_key: x-api-key header"}}',
+            '{"type":"result", truncated garbage\nCredit balance is too low',
         );
-        expect(result.category).toBe('auth');
+        expect(result.category).toBe('quota');
+        expect(result.providerDetail).toBeNull();
     });
 
-    test('classifies Bedrock AccessDeniedException as auth', () => {
-        const result = classifyClaudeCliFailure(
-            'AccessDeniedException: not authorized to invoke this model',
-            '',
-        );
-        expect(result.category).toBe('auth');
-    });
-
-    test('classifies Anthropic overloaded_error', () => {
-        const result = classifyClaudeCliFailure(
-            '',
-            '{"error":{"type":"overloaded_error","message":"Overloaded"}}',
-        );
-        expect(result.category).toBe('overloaded');
-    });
-
-    test('returns unknown for empty output', () => {
-        const result = classifyClaudeCliFailure('', '');
-        expect(result).toEqual({ category: 'unknown' });
-    });
-
-    test('returns unknown for a generic crash with no matching signature', () => {
+    test('returns retryable unknown for a generic crash with no matching signature', () => {
         const result = classifyClaudeCliFailure(
             'Error: ENOENT: no such file or directory',
             '',
         );
-        expect(result).toEqual({ category: 'unknown' });
+        expect(result).toEqual({
+            category: 'unknown',
+            retryable: true,
+            userMessage: null,
+            providerDetail: null,
+        });
     });
 
-    test('is case-insensitive', () => {
+    test('matches signatures case-insensitively', () => {
         const result = classifyClaudeCliFailure('CREDIT BALANCE TOO LOW', '');
         expect(result.category).toBe('quota');
     });

--- a/packages/backend/src/ee/services/AppGenerateService/claudeCliFailure.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/claudeCliFailure.ts
@@ -1,86 +1,207 @@
 export type ClaudeCliFailureCategory =
     | 'quota'
+    | 'spend_limit'
+    | 'billing'
     | 'rate_limit'
     | 'auth'
     | 'overloaded'
     | 'unknown';
 
-export type ClaudeCliFailureClassification =
-    | {
-          category: Exclude<ClaudeCliFailureCategory, 'unknown'>;
-          userMessage: string;
-      }
-    | { category: 'unknown' };
+export type ClaudeCliFailureClassification = {
+    category: ClaudeCliFailureCategory;
+    // False when retrying cannot succeed (bad credentials, exhausted
+    // credits, hard usage caps) — callers should fail fast instead of
+    // burning further attempts.
+    retryable: boolean;
+    // User-facing summary; null when the failure isn't a recognized
+    // upstream-API condition.
+    userMessage: string | null;
+    // Human-readable error from the CLI's final `result` event (e.g.
+    // "API Error: 400 Your organization has reached its monthly spend
+    // limit."). Null when the CLI died before emitting one.
+    providerDetail: string | null;
+};
+
+const USER_MESSAGES: Record<
+    Exclude<ClaudeCliFailureCategory, 'unknown'>,
+    string
+> = {
+    quota: "Couldn't generate the app — the AI provider account is out of credits.",
+    spend_limit:
+        "Couldn't generate the app — the AI provider account has reached its usage limit.",
+    billing:
+        "Couldn't generate the app — there's a billing issue with the AI provider account.",
+    rate_limit:
+        "Couldn't generate the app — the AI provider is rate-limiting requests. Try again in a few minutes.",
+    auth: "Couldn't generate the app — the AI provider rejected the API credentials.",
+    overloaded:
+        'The AI provider is temporarily overloaded. Try again in a few minutes.',
+};
+
+const RETRYABLE: Record<ClaudeCliFailureCategory, boolean> = {
+    quota: false,
+    spend_limit: false,
+    billing: false,
+    auth: false,
+    rate_limit: true,
+    overloaded: true,
+    unknown: true,
+};
+
+const classification = (
+    category: ClaudeCliFailureCategory,
+    providerDetail: string | null,
+): ClaudeCliFailureClassification => ({
+    category,
+    retryable: RETRYABLE[category],
+    userMessage: category === 'unknown' ? null : USER_MESSAGES[category],
+    providerDetail,
+});
 
 /**
- * Classifies a Claude CLI non-zero exit by scanning its stdout + stderr
- * for known upstream-API error signatures. The CLI emits its `result`
- * event (including failure messages) to stdout in stream-json mode, so
- * stderr alone is often empty — both streams must be searched.
+ * The CLI rewrites upstream API errors into its own phrasing before emitting
+ * them (e.g. a 401 becomes "Failed to authenticate. API Error: 401 API key is
+ * invalid."), so these patterns cover both raw API signatures (Bedrock/Vertex
+ * errors pass through on stderr) and the CLI's rewritten strings.
+ */
+const categoryFromText = (haystack: string): ClaudeCliFailureCategory => {
+    if (/credit balance|insufficient_quota/.test(haystack)) {
+        return 'quota';
+    }
+    // "usage limit reached" is the Claude subscription (OAuth token) cap;
+    // "spend limit" is the Anthropic Console monthly org cap.
+    if (/spend limit|usage limit/.test(haystack)) {
+        return 'spend_limit';
+    }
+    if (/rate.?limit|throttlingexception/.test(haystack)) {
+        return 'rate_limit';
+    }
+    if (
+        /invalid_api_key|authentication_error|accessdeniedexception|failed to authenticate|api key is invalid/.test(
+            haystack,
+        )
+    ) {
+        return 'auth';
+    }
+    if (/overloaded_error|serviceunavailableexception/.test(haystack)) {
+        return 'overloaded';
+    }
+    return 'unknown';
+};
+
+/**
+ * The CLI's final stream-json `result` event, which carries structured
+ * failure fields alongside a human-readable `result` message:
+ * `{"type":"result","is_error":true,"api_error_status":400,
+ *   "result":"API Error: 400 ...", ...}`
+ */
+type CliResultEvent = {
+    isError: boolean;
+    apiErrorStatus: number | null;
+    resultText: string | null;
+};
+
+function parseCliResultEvent(stdout: string): CliResultEvent | null {
+    const lines = stdout.split('\n');
+    for (let i = lines.length - 1; i >= 0; i -= 1) {
+        const line = lines[i].trim();
+        if (!line.startsWith('{') || !line.includes('"type":"result"')) {
+            // eslint-disable-next-line no-continue
+            continue;
+        }
+        try {
+            const event = JSON.parse(line) as Record<string, unknown>;
+            if (event.type !== 'result') {
+                // eslint-disable-next-line no-continue
+                continue;
+            }
+            return {
+                isError: event.is_error === true,
+                apiErrorStatus:
+                    typeof event.api_error_status === 'number'
+                        ? event.api_error_status
+                        : null,
+                resultText:
+                    typeof event.result === 'string' ? event.result : null,
+            };
+        } catch {
+            // Not valid JSON despite looking like a result line — keep scanning.
+        }
+    }
+    return null;
+}
+
+/**
+ * Classifies a Claude CLI non-zero exit. Prefers the structured
+ * `api_error_status` from the CLI's final `result` event (emitted to stdout
+ * in stream-json mode — stderr alone is often empty); falls back to scanning
+ * stdout + stderr for known error signatures when no result event parsed.
  */
 export function classifyClaudeCliFailure(
     stderr: string,
     stdout: string,
 ): ClaudeCliFailureClassification {
-    const haystack = `${stderr}\n${stdout}`.toLowerCase();
+    const resultEvent = parseCliResultEvent(stdout);
+    const providerDetail = resultEvent?.resultText ?? null;
+    const haystack =
+        `${providerDetail ?? ''}\n${stderr}\n${stdout}`.toLowerCase();
 
-    if (/credit balance|insufficient_quota/.test(haystack)) {
+    const status = resultEvent?.isError ? resultEvent.apiErrorStatus : null;
+    if (status !== null) {
+        if (status === 401 || status === 403) {
+            return classification('auth', providerDetail);
+        }
+        if (status === 402) {
+            return classification('billing', providerDetail);
+        }
+        if (status === 429) {
+            return classification('rate_limit', providerDetail);
+        }
+        if (status >= 500) {
+            return classification('overloaded', providerDetail);
+        }
+        // Remaining 4xxs carry the interesting cases (credit balance, spend
+        // limit) only in the message text.
+        const textCategory = categoryFromText(haystack);
+        if (textCategory !== 'unknown') {
+            return classification(textCategory, providerDetail);
+        }
+        // A definite 4xx won't succeed on retry even when we can't name it.
         return {
-            category: 'quota',
-            userMessage:
-                "Couldn't generate the app — the AI provider account is out of credits.",
-        };
-    }
-    if (/rate.?limit|throttlingexception/.test(haystack)) {
-        return {
-            category: 'rate_limit',
-            userMessage:
-                "Couldn't generate the app — the AI provider is rate-limiting requests. Try again in a few minutes.",
-        };
-    }
-    if (
-        /invalid_api_key|authentication_error|accessdeniedexception/.test(
-            haystack,
-        )
-    ) {
-        return {
-            category: 'auth',
-            userMessage:
-                "Couldn't generate the app — the AI provider rejected the API credentials.",
-        };
-    }
-    if (/overloaded_error|serviceunavailableexception/.test(haystack)) {
-        return {
-            category: 'overloaded',
-            userMessage:
-                'The AI provider is temporarily overloaded. Try again in a few minutes.',
+            category: 'unknown',
+            retryable: false,
+            userMessage: null,
+            providerDetail,
         };
     }
 
-    return { category: 'unknown' };
+    return classification(categoryFromText(haystack), providerDetail);
 }
 
 /**
- * Thrown by the generation step when retries are exhausted AND the
- * failure was classified as a known upstream-API condition. Carries a
- * user-facing message so the outer pipeline can surface a meaningful
- * explanation instead of the generic "Try rephrasing" fallback. Unknown
- * failures throw a plain Error so the caller's default branch handles
- * them.
+ * Thrown by the generation step when it gives up — either retries are
+ * exhausted or the failure is a non-retryable upstream condition (bad
+ * credentials, exhausted credits, usage caps). Carries the classification so
+ * the outer pipeline can surface a meaningful user message (falling back to a
+ * generic one when `userMessage` is null) and the provider's own error text.
  */
 export class ClaudeGenerationError extends Error {
-    readonly userMessage: string;
+    readonly userMessage: string | null;
 
-    readonly category: Exclude<ClaudeCliFailureCategory, 'unknown'>;
+    readonly category: ClaudeCliFailureCategory;
+
+    readonly providerDetail: string | null;
 
     constructor(opts: {
         message: string;
-        userMessage: string;
-        category: Exclude<ClaudeCliFailureCategory, 'unknown'>;
+        userMessage: string | null;
+        category: ClaudeCliFailureCategory;
+        providerDetail: string | null;
     }) {
         super(opts.message);
         this.name = 'ClaudeGenerationError';
         this.userMessage = opts.userMessage;
         this.category = opts.category;
+        this.providerDetail = opts.providerDetail;
     }
 }


### PR DESCRIPTION
## Summary

When data-app generation failed because of an upstream AI-provider problem (out of credits, monthly spend limit, invalid key, rate limiting), users got the generic "Failed to generate app code. Try rephrasing your request." and the stored error detail was often just `Claude generation failed (exit 1):` with nothing after it — in stream-json mode the Claude CLI emits its error to stdout, so stderr is empty.

Two root causes, established by running the real CLI against a mock Anthropic API returning each error:

- The classifier matched raw Anthropic API error signatures, but the CLI rewrites errors into its own phrasing before emitting them (a 401 becomes `Failed to authenticate. API Error: 401 API key is invalid.`), so most real failures fell through to the generic message. Spend/usage-limit errors weren't recognized at all.
- Non-retryable failures were retried anyway: the CLI already retries 401/429 up to 10× with backoff (~3 min) before exiting non-zero, and the pipeline re-ran the whole generation 3×, so a dead key took ~9 minutes to fail.


Closes: PROD-7969
Closes: #23579

🤖 Generated with [Claude Code](https://claude.com/claude-code)