### PR TITLE
fix: enforce org ownership on project role assignments

### DIFF
--- a/packages/backend/src/services/RolesService/RolesService.mock.ts
+++ b/packages/backend/src/services/RolesService/RolesService.mock.ts
@@ -191,6 +191,7 @@ export const mockUserModel: Record<string, MockFn> = {
     getUserDetailsByUuid: vi.fn().mockResolvedValue({
         firstName: 'Test',
         lastName: 'User',
+        organizationUuid: 'test-org-uuid',
     }),
 };
 
@@ -216,6 +217,7 @@ export const mockGroupsModel: Record<string, MockFn> = {
     getGroup: vi.fn().mockResolvedValue({
         groupUuid: 'test-group-uuid',
         name: 'Test Group',
+        organizationUuid: 'test-org-uuid',
     }),
 };
 

--- a/packages/backend/src/services/RolesService/RolesService.test.ts
+++ b/packages/backend/src/services/RolesService/RolesService.test.ts
@@ -905,6 +905,7 @@ describe('RolesService', () => {
                 firstName: 'Target',
                 lastName: 'User',
                 role: OrganizationMemberRole.MEMBER,
+                organizationUuid,
             });
             mockRolesModel.getOrganizationAdmins.mockResolvedValue([
                 'admin-uuid-1',
@@ -1073,6 +1074,182 @@ describe('RolesService', () => {
                         { roleId: mockCustomRoleWithScopes.roleUuid },
                     ),
                 ).rejects.toThrow(ParameterError);
+            });
+
+            it('should reject custom roles belonging to another organization', async () => {
+                mockRolesModel.getRoleWithScopesByUuid.mockResolvedValue({
+                    ...mockCustomRoleWithScopes,
+                    level: 'project',
+                    organizationUuid: 'another-org-uuid',
+                    scopes: ['view:Dashboard'],
+                });
+
+                await expect(
+                    service.upsertProjectUserRoleAssignment(
+                        mockAccount,
+                        projectUuid,
+                        userUuid,
+                        { roleId: mockCustomRoleWithScopes.roleUuid },
+                    ),
+                ).rejects.toThrow(ForbiddenError);
+                expect(
+                    mockRolesModel.upsertCustomRoleProjectAccess,
+                ).not.toHaveBeenCalled();
+            });
+
+            it('should reject assigning a user from another organization', async () => {
+                mockUserModel.getUserDetailsByUuid.mockResolvedValue({
+                    userUuid,
+                    firstName: 'Target',
+                    lastName: 'User',
+                    role: OrganizationMemberRole.MEMBER,
+                    organizationUuid: 'another-org-uuid',
+                });
+
+                await expect(
+                    service.upsertProjectUserRoleAssignment(
+                        mockAccount,
+                        projectUuid,
+                        userUuid,
+                        { roleId: ProjectMemberRole.ADMIN },
+                    ),
+                ).rejects.toThrow(ForbiddenError);
+                expect(
+                    mockRolesModel.upsertSystemRoleProjectAccess,
+                ).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('upsertProjectGroupRoleAssignment', () => {
+            const groupUuid = 'test-group-uuid';
+
+            beforeEach(() => {
+                mockGroupsModel.getGroup.mockResolvedValue({
+                    uuid: groupUuid,
+                    name: 'Test Group',
+                    organizationUuid,
+                });
+            });
+
+            it('should assign a system role to a group in the same organization', async () => {
+                await service.upsertProjectGroupRoleAssignment(
+                    mockAccount,
+                    projectUuid,
+                    groupUuid,
+                    { roleId: ProjectMemberRole.VIEWER },
+                );
+
+                expect(
+                    mockRolesModel.upsertSystemRoleGroupAccess,
+                ).toHaveBeenCalledWith(
+                    groupUuid,
+                    projectUuid,
+                    ProjectMemberRole.VIEWER,
+                );
+            });
+
+            it('should reject groups belonging to another organization', async () => {
+                mockGroupsModel.getGroup.mockResolvedValue({
+                    uuid: groupUuid,
+                    name: 'Foreign Group',
+                    organizationUuid: 'another-org-uuid',
+                });
+
+                await expect(
+                    service.upsertProjectGroupRoleAssignment(
+                        mockAccount,
+                        projectUuid,
+                        groupUuid,
+                        { roleId: ProjectMemberRole.VIEWER },
+                    ),
+                ).rejects.toThrow(ForbiddenError);
+                expect(
+                    mockRolesModel.upsertSystemRoleGroupAccess,
+                ).not.toHaveBeenCalled();
+            });
+
+            it('should reject custom roles belonging to another organization', async () => {
+                mockRolesModel.getRoleWithScopesByUuid.mockResolvedValue({
+                    ...mockCustomRoleWithScopes,
+                    level: 'project',
+                    organizationUuid: 'another-org-uuid',
+                    scopes: ['view:Dashboard'],
+                });
+
+                await expect(
+                    service.upsertProjectGroupRoleAssignment(
+                        mockAccount,
+                        projectUuid,
+                        groupUuid,
+                        { roleId: mockCustomRoleWithScopes.roleUuid },
+                    ),
+                ).rejects.toThrow(ForbiddenError);
+                expect(
+                    mockRolesModel.upsertCustomRoleGroupAccess,
+                ).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('assignRoleToGroup', () => {
+            const groupUuid = 'test-group-uuid';
+
+            beforeEach(() => {
+                mockRolesModel.getRoleByUuid.mockResolvedValue(mockCustomRole);
+                mockGroupsModel.getGroup.mockResolvedValue({
+                    uuid: groupUuid,
+                    name: 'Test Group',
+                    organizationUuid,
+                });
+            });
+
+            it('should assign a custom role to a group in the same organization', async () => {
+                await service.assignRoleToGroup(
+                    mockAccount,
+                    groupUuid,
+                    mockCustomRole.roleUuid,
+                    projectUuid,
+                );
+
+                expect(mockRolesModel.assignRoleToGroup).toHaveBeenCalledWith(
+                    groupUuid,
+                    mockCustomRole.roleUuid,
+                    projectUuid,
+                );
+            });
+
+            it('should reject groups belonging to another organization', async () => {
+                mockGroupsModel.getGroup.mockResolvedValue({
+                    uuid: groupUuid,
+                    name: 'Foreign Group',
+                    organizationUuid: 'another-org-uuid',
+                });
+
+                await expect(
+                    service.assignRoleToGroup(
+                        mockAccount,
+                        groupUuid,
+                        mockCustomRole.roleUuid,
+                        projectUuid,
+                    ),
+                ).rejects.toThrow(ForbiddenError);
+                expect(mockRolesModel.assignRoleToGroup).not.toHaveBeenCalled();
+            });
+
+            it('should reject roles from a different organization than the project', async () => {
+                mockProjectModel.getSummary.mockResolvedValue({
+                    projectUuid,
+                    organizationUuid: 'another-org-uuid',
+                });
+
+                await expect(
+                    service.assignRoleToGroup(
+                        mockAccount,
+                        groupUuid,
+                        mockCustomRole.roleUuid,
+                        projectUuid,
+                    ),
+                ).rejects.toThrow(ForbiddenError);
+                expect(mockRolesModel.assignRoleToGroup).not.toHaveBeenCalled();
             });
         });
     });

--- a/packages/backend/src/services/RolesService/RolesService.ts
+++ b/packages/backend/src/services/RolesService/RolesService.ts
@@ -1294,6 +1294,11 @@ export class RolesService extends BaseService {
         await this.validateProjectAccess(account, projectUuid);
         const role = await this.rolesModel.getRoleWithScopesByUuid(roleId);
 
+        const user = await this.userModel.getUserDetailsByUuid(userUuid);
+        if (user.organizationUuid !== project.organizationUuid) {
+            throw new ForbiddenError();
+        }
+
         const userProjectRole =
             await this.rolesModel.getProjectAccessByUserUuid(
                 userUuid,
@@ -1307,6 +1312,10 @@ export class RolesService extends BaseService {
                 roleId,
             );
         } else {
+            if (role.organizationUuid !== project.organizationUuid) {
+                throw new ForbiddenError();
+            }
+
             if (role.scopes.length === 0) {
                 throw new ParameterError(
                     'Custom role must have at least one scope',
@@ -1321,7 +1330,6 @@ export class RolesService extends BaseService {
                 roleId,
             );
         }
-        const user = await this.userModel.getUserDetailsByUuid(userUuid);
 
         // If the user is added to the project for the first time, send an invitation email
         const userEmail = user.email;
@@ -1413,6 +1421,10 @@ export class RolesService extends BaseService {
         );
         await this.validateProjectAccess(account, projectUuid);
         const role = await this.rolesModel.getRoleWithScopesByUuid(roleId);
+        const group = await this.groupsModel.getGroup(groupUuid);
+        if (group.organizationUuid !== project.organizationUuid) {
+            throw new ForbiddenError();
+        }
 
         if (isSystemRole(roleId)) {
             await this.rolesModel.upsertSystemRoleGroupAccess(
@@ -1421,6 +1433,10 @@ export class RolesService extends BaseService {
                 roleId,
             );
         } else {
+            if (role.organizationUuid !== project.organizationUuid) {
+                throw new ForbiddenError();
+            }
+
             if (role.scopes.length === 0) {
                 throw new ParameterError(
                     'Custom role must have at least one scope',
@@ -1449,7 +1465,6 @@ export class RolesService extends BaseService {
             },
         });
 
-        const group = await this.groupsModel.getGroup(groupUuid);
         return {
             roleId,
             roleName: role.name,
@@ -1553,7 +1568,19 @@ export class RolesService extends BaseService {
         const auditedAbility = this.createAuditedAbility(account);
         RolesService.validateRoleOwnership(account, auditedAbility, role);
         RolesService.validateCustomRoleLevel(role, 'project');
+        const project = await this.projectModel.getSummary(projectUuid);
         await this.validateProjectAccess(account, projectUuid);
+
+        if (
+            !isSystemRole(roleUuid) &&
+            role.organizationUuid !== project.organizationUuid
+        ) {
+            throw new ForbiddenError();
+        }
+        const group = await this.groupsModel.getGroup(groupUuid);
+        if (group.organizationUuid !== project.organizationUuid) {
+            throw new ForbiddenError();
+        }
 
         await this.rolesModel.assignRoleToGroup(
             groupUuid,


### PR DESCRIPTION
Adds organization-ownership checks to the project role/group assignment paths in RolesService so roles, groups, and users from other organizations are rejected with ForbiddenError; covered by unit tests.

Linear: SPK-586