### PR TITLE
chore(dead-code): remove unused exports from the CLI package

### DIFF
--- a/packages/cli/src/dbt/manifest.ts
+++ b/packages/cli/src/dbt/manifest.ts
@@ -6,10 +6,7 @@ import globalState from '../globalState';
 
 // The merge core moved to @lightdash/common (server + CLI share one implementation);
 // re-exported here so existing CLI imports of combineManifests are unchanged.
-export {
-    combineManifests,
-    type CombineManifestsResult,
-} from '@lightdash/common';
+export { combineManifests } from '@lightdash/common';
 
 export type LoadManifestArgs = {
     targetDir: string;

--- a/packages/cli/src/dbt/schema.ts
+++ b/packages/cli/src/dbt/schema.ts
@@ -1,33 +1,9 @@
 import {
     DbtSchemaEditor,
-    DimensionType,
     ParseError,
     SupportedDbtVersions,
 } from '@lightdash/common';
 import { promises as fs } from 'fs';
-
-type YamlColumnMeta = {
-    dimension?: {
-        type?: DimensionType;
-    };
-};
-
-type YamlColumn = {
-    name: string;
-    description?: string;
-    meta?: YamlColumnMeta;
-};
-
-export type YamlModel = {
-    name: string;
-    description?: string;
-    columns?: YamlColumn[];
-};
-
-export type YamlSchema = {
-    version?: 2;
-    models?: YamlModel[];
-};
 
 const loadYamlSchema = async (
     path: string,

--- a/packages/cli/src/handlers/connectSnowflake.ts
+++ b/packages/cli/src/handlers/connectSnowflake.ts
@@ -509,7 +509,3 @@ export const connectSnowflakeHandler = async (
         throw error;
     }
 };
-
-export const connectSnowflakeTestHelpers = {
-    resolveConnectionValues,
-};

--- a/packages/cli/src/lightdash/projectType.ts
+++ b/packages/cli/src/lightdash/projectType.ts
@@ -63,18 +63,6 @@ export type DbtProjectConfig = {
 
 export type ProjectTypeConfig = LightdashYamlProjectConfig | DbtProjectConfig;
 
-export function isLightdashYamlProject(
-    config: ProjectTypeConfig,
-): config is LightdashYamlProjectConfig {
-    return config.type === CliProjectType.LightdashYaml;
-}
-
-export function isDbtProject(
-    config: ProjectTypeConfig,
-): config is DbtProjectConfig {
-    return config.type === CliProjectType.Dbt;
-}
-
 type DetectProjectTypeOptions = {
     /**
      * Path to the project directory


### PR DESCRIPTION
Deletes every unused export in `packages/cli/src` — **44 deleted lines across 4 files, nothing else changed**. After this, `ts-prune` reports zero unused exports for the CLI package.

| File | Removed |
|---|---|
| `src/dbt/schema.ts` | `YamlSchema`, plus the types it stranded (`YamlModel`, `YamlColumn`, `YamlColumnMeta`) and the now-unused `DimensionType` import |
| `src/lightdash/projectType.ts` | `isLightdashYamlProject`, `isDbtProject` |
| `src/dbt/manifest.ts` | `type CombineManifestsResult` from the `@lightdash/common` re-export |
| `src/handlers/connectSnowflake.ts` | `connectSnowflakeTestHelpers` |

## Why it's dead

**Static-analysis signal.** `ts-prune -p packages/cli/tsconfig.json`, filtered to `packages/cli/src` and excluding `(used in module)`, reported exactly five unused exports — the complete set for the package:

```
packages/cli/src/dbt/manifest.ts:11 - CombineManifestsResult
packages/cli/src/dbt/schema.ts:27 - YamlSchema
packages/cli/src/handlers/connectSnowflake.ts:513 - connectSnowflakeTestHelpers
packages/cli/src/lightdash/projectType.ts:66 - isLightdashYamlProject
packages/cli/src/lightdash/projectType.ts:72 - isDbtProject
```

The CLI's `tsconfig.json` sets `"include": ["src/**/*.ts"]`, so test files are inside ts-prune's analysis — these are unused by tests too, not only by production code.

**Investigation.** Each symbol was grepped across the whole repo (not just `packages/`; including test files, stories, scripts, configs and CI workflows), matching bare text so quoted / dynamic / registry-map uses would also hit:

```
$ grep -rn --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=dist --exclude-dir=build <symbol> .
```

- **`isLightdashYamlProject`** → 1 hit, its own definition. Callers compare the discriminant inline instead — `projectTypeConfig.type === CliProjectType.Dbt` in `handlers/deploy.ts:611,665` and `handlers/preview.ts:387`. The guards were never adopted.
- **`isDbtProject`** → 1 hit, its own definition.
- **`connectSnowflakeTestHelpers`** → 1 hit, its own definition. `src/handlers/connectSnowflake.test.ts` does exist, but it imports only `connectSnowflakeHandler` / `ConnectSnowflakeOptions` and never touches the helper object. The wrapped `resolveConnectionValues` stays in the module (still called at line 463) — it simply goes back to being private.
- **`YamlSchema`** → hits only in `src/dbt/schema.ts` itself (plus the unrelated local `loadYamlSchema` function and an unrelated `lightdashDbtYamlSchema` in the frontend). `YamlModel` → only `src/dbt/schema.ts` and `packages/common`'s own copy; `YamlColumn` / `YamlColumnMeta` → only inside `src/dbt/schema.ts`. These four types are a stale duplicate of the canonical `packages/common/src/types/yamlSchema.ts` (identical `YamlModel` / `YamlSchema` shapes), left behind when `DbtSchemaEditor` moved into `@lightdash/common` — `DbtSchemaEditor.ts` imports those types from common, never from the CLI. The only reference chain was `YamlSchema → YamlModel → YamlColumn → YamlColumnMeta → DimensionType`, dead at the root, so the whole block plus the import goes.
- **`CombineManifestsResult`** → hits in `src/dbt/manifest.ts` (the re-export) and `packages/common/src/dbt/manifest.ts` (the definition, which stays). The sibling `combineManifests` **value** re-export *is* used — `src/handlers/compile.ts:34` imports it from `../dbt/manifest` — and is untouched.

**Scope checks.** None of this is public surface: the CLI ships a binary only (`"bin": {"lightdash": "dist/index.js"}`, no `main`, no `exports` map), so no external consumer can import these modules. No command, flag, config key or dbt/YAML key is touched. Four of the five removals are TypeScript types, erased at build time and unreachable by any dynamic path; the two type guards and the helper object have zero string / bracket-access / registry references anywhere in the repo.

## Verification

- `pnpm -F cli typecheck:fast` — clean (strong confirmation nothing referenced the removals).
- `pnpm --filter cli run linter <the 4 touched paths>` — clean; `oxfmt --check` on the same paths — clean.
- `pnpm -F cli exec vitest run src/handlers/connectSnowflake.test.ts src/dbt/manifest.test.ts` — 14 tests pass.
- `ts-prune -p packages/cli/tsconfig.json` re-run after the removal — zero unused exports in `packages/cli/src`.

## Residual risk

Low. The realistic objection is intent rather than reachability: `connectSnowflakeTestHelpers` was plainly added to expose the private `resolveConnectionValues` to tests, and no test ever used it — anyone wanting to unit-test that function later re-adds a one-line export. Same for the `projectType` guards, which were ergonomics for a comparison callers already do inline. `git log` shows no in-flight work on these modules expecting them.

Linear: SPK-657

---

Raised as a **draft** pending human review, per the agent merge freeze — not marked ready and not to be auto-merged.
