### PR TITLE
chore(dead-code): remove unused lodash and fast-json-patch dependencies

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -52,7 +52,6 @@
     "dayjs": "1.11.10",
     "dependency-graph": "0.11.0",
     "echarts": "5.6.0",
-    "fast-json-patch": "3.1.1",
     "handlebars": "4.7.9",
     "js-yaml": "4.3.0",
     "liquidjs": "10.26.0",

--- a/packages/warehouses/package.json
+++ b/packages/warehouses/package.json
@@ -40,7 +40,6 @@
     "@google-cloud/bigquery": "7.9.2",
     "@lightdash/common": "workspace:*",
     "big.js": "6.1.1",
-    "lodash": "4.18.1",
     "node-fetch": "2.7.0",
     "pg": "8.13.1",
     "pg-cursor": "2.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -900,9 +900,6 @@ importers:
       echarts:
         specifier: 5.6.0
         version: 5.6.0
-      fast-json-patch:
-        specifier: 3.1.1
-        version: 3.1.1
       handlebars:
         specifier: 4.7.9
         version: 4.7.9
@@ -1814,9 +1811,6 @@ importers:
       big.js:
         specifier: 6.1.1
         version: 6.1.1
-      lodash:
-        specifier: 4.18.1
-        version: 4.18.1
       node-fetch:
         specifier: 2.7.0
         version: 2.7.0(encoding@0.1.13)


### PR DESCRIPTION
Drops two runtime dependencies that no code in their owning package imports. 3 files changed, 8 deleted lines, no source changes.

| Package | Removed dependency | Added by | Went unused |
| -- | -- | -- | -- |
| `packages/warehouses` | `lodash@4.18.1` | #4101 (Trino datasource support) | never imported — see history check below |
| `packages/common` | `fast-json-patch@3.1.1` | #17186 (moved changeset application logic into common) | #25362 (`refactor(changesets): remove backend changeset runtime`) removed the last consumer |

`pnpm-lock.yaml` was regenerated with `pnpm install --lockfile-only`; the diff is exactly the two importer entries (6 lines). Both packages' resolved entries stay in the lockfile because other workspace packages still depend on them.

## Static-analysis signal

Dependency-vs-import audit over `packages/warehouses`, `packages/common` and `packages/cli`: for every declared runtime dependency, count import/require sites inside the owning package. Only three came back with zero, of which two are real — the third (`@types/columnify` in the CLI) is a type-only package and was left alone, as was `@types/lodash` in common, which types common's own `lodash` dependency.

## Why it's dead

**`lodash` in `packages/warehouses`** — a bare-string grep over the whole package (not just `src`, so scripts, configs and tests are covered) matched nothing but the manifest line itself:

```
$ git grep -n "lodash" -- packages/warehouses
packages/warehouses/package.json:43:    "lodash": "4.18.1",
```

Grepping the bare string rather than an import form also rules out `require('lodash')`, `import('lodash')`, subpath imports (`lodash/pick`) and any string-keyed dynamic resolution.

History confirms it was never used — the only commit in the package's entire history that changes the occurrence count of `lodash` is the one that added the manifest line:

```
$ git log --oneline -S"lodash" -- packages/warehouses
a453a5a5f9 feat: support for Trino as datasource (#4101)

$ git log --oneline -S"lodash" -- packages/warehouses/src
(no output)
```

**`fast-json-patch` in `packages/common`** — same bare-string grep, same result:

```
$ git grep -rn "fast-json-patch" -- packages/common
packages/common/package.json:55:    "fast-json-patch": "3.1.1",
```

Repo-wide, the only importer is the backend, which declares the dependency itself:

```
$ git grep -rln "fast-json-patch" -- packages ':!pnpm-lock.yaml'
packages/backend/package.json
packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
```

**No transitive reliance inside the monorepo.** Every workspace package that uses `lodash` (backend, frontend, cli, common) declares `lodash@4.18.1` directly, so none was reaching it through `@lightdash/warehouses`. The backend declares `fast-json-patch@3.1.1` directly.

**Not a binary, not a build input.** Neither package name appears in any `scripts` entry, CI workflow, or bundler config — the greps above cover the whole package directories, and the repo-wide `fast-json-patch` grep returns only the two backend hits.

## Verification

- `pnpm -F warehouses typecheck:fast` — clean
- `pnpm -F common typecheck:fast` — clean
- No source files touched, so there is nothing for eslint to re-check.

## Residual risk

Low, and confined to consumers outside this repo. Both packages are published, so an external consumer that (incorrectly) relied on getting `lodash` or `fast-json-patch` transitively from `@lightdash/warehouses` / `@lightdash/common` would need to declare it itself. Neither package's published output imports the dropped dependency, so the packages themselves cannot break. Note that the typecheck runs above still had the pre-existing `node_modules` on disk, so they confirm the source compiles but are not by themselves proof of absence — the grep and history evidence is what establishes that.

Linear: SPK-658

---

Raised as a **draft** pending human review, per the agent merge freeze.
