### PR TITLE
feat(analytics): aggregated feature-flag check telemetry

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -68,6 +68,7 @@ import {
 } from './logging/winston';
 import { sessionAccountMiddleware } from './middlewares/accountMiddleware';
 import { jwtAuthMiddleware } from './middlewares/jwtAuthMiddleware';
+import { flush as flushFeatureFlagChecks } from './models/FeatureFlagModel/flagCheckAggregator';
 import { ModelProviderMap, ModelRepository } from './models/ModelRepository';
 import PrometheusMetrics from './prometheus/PrometheusMetrics';
 import { apiV1Router } from './routers/apiV1Router';
@@ -95,6 +96,8 @@ import { VERSION } from './version';
 // the compilation entry point (e.g. knex seed/migrate via sucrase).
 
 initOtelTracing();
+
+const FEATURE_FLAG_CHECK_FLUSH_INTERVAL_MS = 15 * 60 * 1000;
 
 const schedulerWorkerFactory = (context: {
     lightdashConfig: LightdashConfig;
@@ -213,6 +216,8 @@ export default class App {
 
     private readonly analyticsEventEmitter: EventEmitter;
 
+    private featureFlagCheckFlushInterval: NodeJS.Timeout | undefined;
+
     constructor(args: AppArguments) {
         this.lightdashConfig = args.lightdashConfig;
         this.port = args.port;
@@ -288,6 +293,14 @@ export default class App {
     }
 
     async start() {
+        this.featureFlagCheckFlushInterval = setInterval(() => {
+            this.analytics.trackFeatureFlagChecks(
+                flushFeatureFlagChecks(),
+                'api',
+            );
+        }, FEATURE_FLAG_CHECK_FLUSH_INTERVAL_MS);
+        this.featureFlagCheckFlushInterval.unref();
+
         this.prometheusMetrics.start();
         setGithubRateLimitObserver((rl) =>
             this.prometheusMetrics.observeGithubRateLimit(rl),
@@ -1046,6 +1059,11 @@ export default class App {
     }
 
     async stop() {
+        if (this.featureFlagCheckFlushInterval) {
+            clearInterval(this.featureFlagCheckFlushInterval);
+            this.featureFlagCheckFlushInterval = undefined;
+        }
+        this.analytics.trackFeatureFlagChecks(flushFeatureFlagChecks(), 'api');
         if (this.pgWireServer) {
             await this.pgWireServer.close();
             Logger.info('Stopped Postgres wire protocol server');

--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -294,10 +294,14 @@ export default class App {
 
     async start() {
         this.featureFlagCheckFlushInterval = setInterval(() => {
-            this.analytics.trackFeatureFlagChecks(
-                flushFeatureFlagChecks(),
-                'api',
-            );
+            try {
+                this.analytics.trackFeatureFlagChecks(
+                    flushFeatureFlagChecks(),
+                    'api',
+                );
+            } catch {
+                // telemetry must never break the app
+            }
         }, FEATURE_FLAG_CHECK_FLUSH_INTERVAL_MS);
         this.featureFlagCheckFlushInterval.unref();
 
@@ -1063,7 +1067,14 @@ export default class App {
             clearInterval(this.featureFlagCheckFlushInterval);
             this.featureFlagCheckFlushInterval = undefined;
         }
-        this.analytics.trackFeatureFlagChecks(flushFeatureFlagChecks(), 'api');
+        try {
+            this.analytics.trackFeatureFlagChecks(
+                flushFeatureFlagChecks(),
+                'api',
+            );
+        } catch {
+            // telemetry must never break shutdown
+        }
         if (this.pgWireServer) {
             await this.pgWireServer.close();
             Logger.info('Stopped Postgres wire protocol server');

--- a/packages/backend/src/SchedulerApp.ts
+++ b/packages/backend/src/SchedulerApp.ts
@@ -18,6 +18,7 @@ import {
 import { setGithubRateLimitObserver } from './clients/github/Github';
 import { LightdashConfig } from './config/parseConfig';
 import Logger from './logging/logger';
+import { flush as flushFeatureFlagChecks } from './models/FeatureFlagModel/flagCheckAggregator';
 import { ModelProviderMap, ModelRepository } from './models/ModelRepository';
 import {
     initOtelHttpMetrics,
@@ -46,6 +47,8 @@ import {
 } from './tracing/tracing';
 import { UtilProviderMap, UtilRepository } from './utils/UtilRepository';
 import { VERSION } from './version';
+
+const FEATURE_FLAG_CHECK_FLUSH_INTERVAL_MS = 15 * 60 * 1000;
 
 type SchedulerAppArguments = {
     lightdashConfig: LightdashConfig;
@@ -139,6 +142,8 @@ export default class SchedulerApp {
 
     private readonly analyticsEventEmitter: EventEmitter;
 
+    private featureFlagCheckFlushInterval: NodeJS.Timeout | undefined;
+
     constructor(args: SchedulerAppArguments) {
         this.lightdashConfig = args.lightdashConfig;
         this.port = args.port;
@@ -216,6 +221,14 @@ export default class SchedulerApp {
     }
 
     public async start() {
+        this.featureFlagCheckFlushInterval = setInterval(() => {
+            this.analytics.trackFeatureFlagChecks(
+                flushFeatureFlagChecks(),
+                'scheduler',
+            );
+        }, FEATURE_FLAG_CHECK_FLUSH_INTERVAL_MS);
+        this.featureFlagCheckFlushInterval.unref();
+
         registerOAuthRefreshStrategies();
 
         this.prometheusMetrics.start();
@@ -315,6 +328,14 @@ export default class SchedulerApp {
                 Logger.info('Shutting down gracefully');
             },
             onSignal: async () => {
+                if (this.featureFlagCheckFlushInterval) {
+                    clearInterval(this.featureFlagCheckFlushInterval);
+                    this.featureFlagCheckFlushInterval = undefined;
+                }
+                this.analytics.trackFeatureFlagChecks(
+                    flushFeatureFlagChecks(),
+                    'scheduler',
+                );
                 if (this.eventStreamWriter) {
                     Logger.info('Flushing usage event stream writer');
                     await this.eventStreamWriter.close();

--- a/packages/backend/src/SchedulerApp.ts
+++ b/packages/backend/src/SchedulerApp.ts
@@ -222,10 +222,14 @@ export default class SchedulerApp {
 
     public async start() {
         this.featureFlagCheckFlushInterval = setInterval(() => {
-            this.analytics.trackFeatureFlagChecks(
-                flushFeatureFlagChecks(),
-                'scheduler',
-            );
+            try {
+                this.analytics.trackFeatureFlagChecks(
+                    flushFeatureFlagChecks(),
+                    'scheduler',
+                );
+            } catch {
+                // telemetry must never break the app
+            }
         }, FEATURE_FLAG_CHECK_FLUSH_INTERVAL_MS);
         this.featureFlagCheckFlushInterval.unref();
 
@@ -332,10 +336,14 @@ export default class SchedulerApp {
                     clearInterval(this.featureFlagCheckFlushInterval);
                     this.featureFlagCheckFlushInterval = undefined;
                 }
-                this.analytics.trackFeatureFlagChecks(
-                    flushFeatureFlagChecks(),
-                    'scheduler',
-                );
+                try {
+                    this.analytics.trackFeatureFlagChecks(
+                        flushFeatureFlagChecks(),
+                        'scheduler',
+                    );
+                } catch {
+                    // telemetry must never break shutdown
+                }
                 if (this.eventStreamWriter) {
                     Logger.info('Flushing usage event stream writer');
                     await this.eventStreamWriter.close();

--- a/packages/backend/src/analytics/LightdashAnalytics.test.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.test.ts
@@ -1,0 +1,57 @@
+import { lightdashConfigMock } from '../config/lightdashConfig.mock';
+import type { FeatureFlagCheckAggregateEntry } from '../models/FeatureFlagModel/flagCheckAggregator';
+import { LightdashAnalytics } from './LightdashAnalytics';
+
+describe('LightdashAnalytics', () => {
+    it('tracks one aggregated feature flag check event per entry', () => {
+        const analytics = new LightdashAnalytics({
+            lightdashConfig: lightdashConfigMock,
+            writeKey: 'notrack',
+            dataPlaneUrl: 'notrack',
+            options: { enable: false },
+        });
+        const trackSpy = vi.spyOn(analytics, 'track');
+        const entries: FeatureFlagCheckAggregateEntry[] = [
+            {
+                flagId: 'enabled-flag',
+                checkCount: 3,
+                enabledCount: 2,
+                disabledCount: 1,
+                uniqueOrgCount: 2,
+                orgUuids: ['org-1', 'org-2'],
+                orgUuidsTruncated: false,
+                windowStartAt: '2026-07-25T00:00:00.000Z',
+                windowEndAt: '2026-07-25T00:15:00.000Z',
+            },
+            {
+                flagId: 'disabled-flag',
+                checkCount: 1,
+                enabledCount: 0,
+                disabledCount: 1,
+                uniqueOrgCount: 1,
+                orgUuids: ['org-3'],
+                orgUuidsTruncated: true,
+                windowStartAt: '2026-07-25T00:00:00.000Z',
+                windowEndAt: '2026-07-25T00:15:00.000Z',
+            },
+        ];
+
+        analytics.trackFeatureFlagChecks(entries, 'scheduler');
+
+        expect(trackSpy).toHaveBeenCalledTimes(2);
+        expect(trackSpy).toHaveBeenNthCalledWith(1, {
+            event: 'feature_flag.checked_aggregated',
+            properties: {
+                ...entries[0],
+                processType: 'scheduler',
+            },
+        });
+        expect(trackSpy).toHaveBeenNthCalledWith(2, {
+            event: 'feature_flag.checked_aggregated',
+            properties: {
+                ...entries[1],
+                processType: 'scheduler',
+            },
+        });
+    });
+});

--- a/packages/backend/src/analytics/LightdashAnalytics.test.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.test.ts
@@ -41,6 +41,7 @@ describe('LightdashAnalytics', () => {
         expect(trackSpy).toHaveBeenCalledTimes(2);
         expect(trackSpy).toHaveBeenNthCalledWith(1, {
             event: 'feature_flag.checked_aggregated',
+            anonymousId: LightdashAnalytics.anonymousId,
             properties: {
                 ...entries[0],
                 processType: 'scheduler',
@@ -48,6 +49,7 @@ describe('LightdashAnalytics', () => {
         });
         expect(trackSpy).toHaveBeenNthCalledWith(2, {
             event: 'feature_flag.checked_aggregated',
+            anonymousId: LightdashAnalytics.anonymousId,
             properties: {
                 ...entries[1],
                 processType: 'scheduler',

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -3180,6 +3180,7 @@ export class LightdashAnalytics extends Analytics {
         entries.forEach((entry) => {
             this.track({
                 event: 'feature_flag.checked_aggregated',
+                anonymousId: LightdashAnalytics.anonymousId,
                 properties: {
                     ...entry,
                     processType,

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -50,6 +50,7 @@ import { Request } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 import { LightdashConfig } from '../config/parseConfig';
 import { type ExternalConnectionEvent } from '../ee/analytics';
+import type { FeatureFlagCheckAggregateEntry } from '../models/FeatureFlagModel/flagCheckAggregator';
 import { type PersistentDownloadFileSource } from '../services/PersistentDownloadFileService/PersistentDownloadFileService';
 import { VERSION } from '../version';
 import type { AiUsageEvent } from './aiUsage';
@@ -2856,6 +2857,24 @@ export type PromptFetchedEvent = BaseTrack & {
     };
 };
 
+export type FeatureFlagCheckProcessType = 'api' | 'scheduler' | null;
+
+export type FeatureFlagCheckedAggregatedEvent = BaseTrack & {
+    event: 'feature_flag.checked_aggregated';
+    properties: {
+        flagId: string;
+        checkCount: number;
+        enabledCount: number;
+        disabledCount: number;
+        uniqueOrgCount: number;
+        orgUuids: string[];
+        orgUuidsTruncated: boolean;
+        windowStartAt: string;
+        windowEndAt: string;
+        processType: FeatureFlagCheckProcessType;
+    };
+};
+
 type TypedEvent =
     | TrackSimpleEvent
     | CreateUserEvent
@@ -3012,6 +3031,7 @@ type TypedEvent =
     | SchedulerOwnershipReassignedEvent
     | ImpersonationEvent
     | PromptFetchedEvent
+    | FeatureFlagCheckedAggregatedEvent
     | PersistentFileGenerationRequestedEvent
     | PersistentFileGenerationCompletedEvent
     | PersistentFileUrlRequestedEvent
@@ -3150,6 +3170,21 @@ export class LightdashAnalytics extends Analytics {
         super.group({
             ...payload,
             context: { ...this.lightdashContext }, // NOTE: spread because rudderstack manipulates arg
+        });
+    }
+
+    trackFeatureFlagChecks(
+        entries: FeatureFlagCheckAggregateEntry[],
+        processType: FeatureFlagCheckProcessType,
+    ) {
+        entries.forEach((entry) => {
+            this.track({
+                event: 'feature_flag.checked_aggregated',
+                properties: {
+                    ...entry,
+                    processType,
+                },
+            });
         });
     }
 

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
@@ -10,6 +10,16 @@ import {
 } from '../../database/entities/featureFlags';
 import Logger from '../../logging/logger';
 import { FeatureFlagModel } from './FeatureFlagModel';
+import { record } from './flagCheckAggregator';
+
+vi.mock('./flagCheckAggregator', async (importOriginal) => {
+    const original =
+        await importOriginal<typeof import('./flagCheckAggregator')>();
+    return {
+        ...original,
+        record: vi.fn<typeof original.record>(),
+    };
+});
 
 // Minimal stub — tests below don't exercise the database layer
 const databaseStub = {} as Knex;
@@ -86,6 +96,49 @@ const buildFakeDatabase = (rows: FakeRows): Knex => {
 };
 
 describe('FeatureFlagModel', () => {
+    describe('check telemetry', () => {
+        beforeEach(() => {
+            vi.mocked(record).mockReset();
+        });
+
+        it('records the resolved value and organization', async () => {
+            const model = buildModel({
+                enabledFeatureFlags: new Set(['telemetry-flag']),
+            });
+
+            await expect(
+                model.get({
+                    featureFlagId: 'telemetry-flag',
+                    user: {
+                        userUuid: VALID_USER_UUID,
+                        organizationUuid: 'org-uuid',
+                    },
+                }),
+            ).resolves.toEqual({ id: 'telemetry-flag', enabled: true });
+
+            expect(vi.mocked(record)).toHaveBeenCalledWith(
+                'telemetry-flag',
+                'org-uuid',
+                true,
+            );
+        });
+
+        it('does not break resolution when recording throws', async () => {
+            vi.mocked(record).mockImplementationOnce(() => {
+                throw new Error('telemetry failure');
+            });
+            const model = buildModel({
+                disabledFeatureFlags: new Set(['telemetry-flag']),
+            });
+
+            await expect(
+                model.get({
+                    featureFlagId: 'telemetry-flag',
+                }),
+            ).resolves.toEqual({ id: 'telemetry-flag', enabled: false });
+        });
+    });
+
     describe('env var override', () => {
         it('returns enabled for any flag listed in LIGHTDASH_ENABLE_FEATURE_FLAGS', async () => {
             const model = buildModel({

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -6,6 +6,7 @@ import {
     FeatureFlagsTableName,
 } from '../../database/entities/featureFlags';
 import Logger from '../../logging/logger';
+import { record } from './flagCheckAggregator';
 
 const UUID_REGEX =
     /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -53,31 +54,39 @@ export class FeatureFlagModel {
         args: FeatureFlagLogicArgs,
         options: FeatureFlagQueryOptions = {},
     ): Promise<FeatureFlag> {
+        let result: FeatureFlag;
+
         // 1a. Check env var enable-allowlist (self-hosted escape hatch)
         if (this.lightdashConfig.enabledFeatureFlags.has(args.featureFlagId)) {
-            return { id: args.featureFlagId, enabled: true };
+            result = { id: args.featureFlagId, enabled: true };
+        } else if (
+            this.lightdashConfig.disabledFeatureFlags.has(args.featureFlagId)
+        ) {
+            // 1b. Check env var disable-allowlist (self-hosted kill switch)
+            result = { id: args.featureFlagId, enabled: false };
+        } else {
+            // 2. Check per-flag config handlers
+            const handler = this.featureFlagHandlers[args.featureFlagId];
+            if (handler) {
+                result = await handler(args, options);
+            } else {
+                // 3. Check database (user override > org override > flag default)
+                const dbResult = await this.tryGetFromDatabase(args, options);
+                result = dbResult ?? { id: args.featureFlagId, enabled: false };
+            }
         }
 
-        // 1b. Check env var disable-allowlist (self-hosted kill switch)
-        if (this.lightdashConfig.disabledFeatureFlags.has(args.featureFlagId)) {
-            return { id: args.featureFlagId, enabled: false };
+        try {
+            record(
+                args.featureFlagId,
+                args.user?.organizationUuid ?? null,
+                result.enabled,
+            );
+        } catch {
+            return result;
         }
 
-        // 2. Check per-flag config handlers
-        const handler = this.featureFlagHandlers[args.featureFlagId];
-        if (handler) {
-            return handler(args, options);
-        }
-
-        // 3. Check database (user override > org override > flag default)
-        const dbResult = await this.tryGetFromDatabase(args, options);
-        if (dbResult !== null) {
-            return dbResult;
-        }
-
-        // Unknown flags default to disabled.
-        // See: GLITCH-331
-        return { id: args.featureFlagId, enabled: false };
+        return result;
     }
 
     private async getEditYamlInUiEnabled({

--- a/packages/backend/src/models/FeatureFlagModel/flagCheckAggregator.test.ts
+++ b/packages/backend/src/models/FeatureFlagModel/flagCheckAggregator.test.ts
@@ -1,0 +1,85 @@
+import { flush, record } from './flagCheckAggregator';
+
+describe('flagCheckAggregator', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime('2026-07-25T00:00:00.000Z');
+        flush();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('aggregates checks by flag and resolved value', () => {
+        record('test-flag', 'org-1', true);
+        record('test-flag', 'org-1', false);
+        record('test-flag', null, false);
+
+        vi.advanceTimersByTime(15 * 60 * 1000);
+
+        expect(flush()).toEqual([
+            {
+                flagId: 'test-flag',
+                checkCount: 3,
+                enabledCount: 1,
+                disabledCount: 2,
+                uniqueOrgCount: 1,
+                orgUuids: ['org-1'],
+                orgUuidsTruncated: false,
+                windowStartAt: '2026-07-25T00:00:00.000Z',
+                windowEndAt: '2026-07-25T00:15:00.000Z',
+            },
+        ]);
+    });
+
+    it('caps organization UUIDs at 50 and marks truncated aggregates', () => {
+        Array.from({ length: 50 }, (_, index) => `org-${index}`).forEach(
+            (orgUuid) => record('capped-flag', orgUuid, true),
+        );
+        Array.from({ length: 51 }, (_, index) => `org-${index}`).forEach(
+            (orgUuid) => record('truncated-flag', orgUuid, false),
+        );
+
+        const [cappedEntry, truncatedEntry] = flush();
+
+        expect(cappedEntry).toMatchObject({
+            flagId: 'capped-flag',
+            uniqueOrgCount: 50,
+            orgUuidsTruncated: false,
+        });
+        expect(cappedEntry.orgUuids).toHaveLength(50);
+        expect(truncatedEntry).toMatchObject({
+            flagId: 'truncated-flag',
+            uniqueOrgCount: 50,
+            orgUuidsTruncated: true,
+        });
+        expect(truncatedEntry.orgUuids).toHaveLength(50);
+        expect(truncatedEntry.orgUuids).not.toContain('org-50');
+    });
+
+    it('resets aggregates and advances the window on flush', () => {
+        record('test-flag', 'org-1', true);
+        vi.advanceTimersByTime(1000);
+
+        expect(flush()).toHaveLength(1);
+        expect(flush()).toEqual([]);
+
+        vi.advanceTimersByTime(1000);
+        record('test-flag', 'org-2', false);
+
+        expect(flush()).toEqual([
+            {
+                flagId: 'test-flag',
+                checkCount: 1,
+                enabledCount: 0,
+                disabledCount: 1,
+                uniqueOrgCount: 1,
+                orgUuids: ['org-2'],
+                orgUuidsTruncated: false,
+                windowStartAt: '2026-07-25T00:00:01.000Z',
+                windowEndAt: '2026-07-25T00:00:02.000Z',
+            },
+        ]);
+    });
+});

--- a/packages/backend/src/models/FeatureFlagModel/flagCheckAggregator.ts
+++ b/packages/backend/src/models/FeatureFlagModel/flagCheckAggregator.ts
@@ -1,0 +1,75 @@
+const MAX_ORG_UUIDS = 50;
+
+type FeatureFlagCheckAggregate = {
+    checkCount: number;
+    enabledCount: number;
+    disabledCount: number;
+    orgUuids: Set<string>;
+    orgUuidsTruncated: boolean;
+};
+
+export type FeatureFlagCheckAggregateEntry = {
+    flagId: string;
+    checkCount: number;
+    enabledCount: number;
+    disabledCount: number;
+    uniqueOrgCount: number;
+    orgUuids: string[];
+    orgUuidsTruncated: boolean;
+    windowStartAt: string;
+    windowEndAt: string;
+};
+
+let aggregates = new Map<string, FeatureFlagCheckAggregate>();
+let windowStartAt = new Date();
+
+export const record = (
+    flagId: string,
+    orgUuid: string | null,
+    enabled: boolean,
+) => {
+    const aggregate = aggregates.get(flagId) ?? {
+        checkCount: 0,
+        enabledCount: 0,
+        disabledCount: 0,
+        orgUuids: new Set<string>(),
+        orgUuidsTruncated: false,
+    };
+
+    aggregate.checkCount += 1;
+    if (enabled) {
+        aggregate.enabledCount += 1;
+    } else {
+        aggregate.disabledCount += 1;
+    }
+
+    if (orgUuid !== null && !aggregate.orgUuids.has(orgUuid)) {
+        if (aggregate.orgUuids.size < MAX_ORG_UUIDS) {
+            aggregate.orgUuids.add(orgUuid);
+        } else {
+            aggregate.orgUuidsTruncated = true;
+        }
+    }
+
+    aggregates.set(flagId, aggregate);
+};
+
+export const flush = (): FeatureFlagCheckAggregateEntry[] => {
+    const windowEndAt = new Date();
+    const entries = Array.from(aggregates, ([flagId, aggregate]) => ({
+        flagId,
+        checkCount: aggregate.checkCount,
+        enabledCount: aggregate.enabledCount,
+        disabledCount: aggregate.disabledCount,
+        uniqueOrgCount: aggregate.orgUuids.size,
+        orgUuids: Array.from(aggregate.orgUuids),
+        orgUuidsTruncated: aggregate.orgUuidsTruncated,
+        windowStartAt: windowStartAt.toISOString(),
+        windowEndAt: windowEndAt.toISOString(),
+    }));
+
+    aggregates = new Map();
+    windowStartAt = windowEndAt;
+
+    return entries;
+};


### PR DESCRIPTION
## What

Emits aggregated telemetry for feature-flag checks so we can answer, fleet-wide: does any code path still ask about flag X, which orgs trigger checks, and do those checks resolve enabled or disabled. This is the primary usage signal for evidence-backed feature-flag cleanup.

- `FeatureFlagModel.get()` records every resolution (env allowlist, config handler, and DB paths alike) into an in-memory per-flag aggregator — fire-and-forget, error-swallowed, so telemetry can never affect flag resolution. `CommercialFeatureFlagModel` is covered via inheritance.
- No per-check events: one `feature_flag.checked_aggregated` event per flag per 15-minute window, flushed from both the API and scheduler processes (interval is `unref()`d; final flush on graceful shutdown). Properties: `flagId`, `checkCount`, `enabledCount`, `disabledCount`, `uniqueOrgCount`, `orgUuids` (capped at 50) + explicit `orgUuidsTruncated`, `windowStartAt`/`windowEndAt`, `processType` (`api` | `scheduler` | null).
- Memory is bounded: one map entry per distinct flag id, org sets capped at 50.
- Kill switch = the existing tracking opt-out (the analytics client no-ops); no new config.

## Verification

- `pnpm -F backend typecheck:fast` ✅
- 23 tests across `flagCheckAggregator.test.ts`, `FeatureFlagModel.test.ts`, `LightdashAnalytics.test.ts` ✅ (includes: aggregator cap/truncation/flush-reset, record fires with resolved value, a throwing aggregator does not break `get()`)
- Lint on touched paths ✅

Draft pending human review.

Linear: SPK-660

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gw6yYGx6TtcNjrpaq9XGFh