### PR TITLE
feat(auth): warmer copy on login and register pages

### DIFF
--- a/packages/frontend/src/components/RegisterForms/CreateEmailOnlyUserForm.tsx
+++ b/packages/frontend/src/components/RegisterForms/CreateEmailOnlyUserForm.tsx
@@ -45,7 +45,7 @@ const CreateEmailOnlyUserForm: FC<Props> = ({ isLoading, onSubmit }) => {
                     Sign up
                 </Button>
                 <Text mx="auto" c="ldGray.7" ta="center" fz="sm" fw={500}>
-                    Already Registered?{' '}
+                    Already have an account?{' '}
                     <Anchor href="/signin" fz="sm" fw={500}>
                         Sign in
                     </Anchor>

--- a/packages/frontend/src/components/RegisterForms/CreateUserForm.tsx
+++ b/packages/frontend/src/components/RegisterForms/CreateUserForm.tsx
@@ -91,7 +91,7 @@ const CreateUserForm: FC<Props> = ({ isLoading, readOnlyEmail, onSubmit }) => {
                     Sign up
                 </Button>
                 <Text mx="auto" c="ldGray.7" ta="center" fz="sm" fw={500}>
-                    Already Registered?{' '}
+                    Already have an account?{' '}
                     <Anchor href="/signin" fz="sm" fw={500}>
                         Sign in
                     </Anchor>

--- a/packages/frontend/src/features/users/components/LoginLanding.tsx
+++ b/packages/frontend/src/features/users/components/LoginLanding.tsx
@@ -304,7 +304,7 @@ const Login: FC<{}> = () => {
             </Box>
             <Card id={LOGIN_PAGE_ID} p="xl" radius="xs" withBorder shadow="xs">
                 <Title order={3} ta="center" mb="md">
-                    Sign in
+                    Welcome back
                 </Title>
                 <form
                     name="login"
@@ -446,12 +446,12 @@ const Login: FC<{}> = () => {
                             </>
                         )}
                         <Text mx="auto" mt="md" fz="sm">
-                            Don't have an account?{' '}
+                            New to Lightdash?{' '}
                             <Anchor
                                 href={health.data?.signupUrl || '/register'}
                                 fz="sm"
                             >
-                                Sign up
+                                Create an account
                             </Anchor>
                         </Text>
                     </Stack>

--- a/packages/frontend/src/pages/Register.tsx
+++ b/packages/frontend/src/pages/Register.tsx
@@ -158,7 +158,7 @@ const Register: FC = () => {
                 </Box>
                 <Card p="xl" radius="xs" withBorder shadow="xs">
                     <Title order={3} ta="center" mb="md">
-                        Sign up
+                        Welcome to Lightdash
                     </Title>
                     {logins}
                 </Card>


### PR DESCRIPTION
## Summary
- Softens the login and register page titles ("Welcome back" / "Welcome to Lightdash") and the register-switcher microcopy so the auth flow feels more inviting.
- No functional or layout changes — text-only tweaks in existing components.

## Copy changes
- Login title: `Sign in` → `Welcome back`
- Login switcher: `Don't have an account? Sign up` → `New to Lightdash? Create an account`
- Register title: `Sign up` → `Welcome to Lightdash`
- Register forms: `Already Registered?` → `Already have an account?`

## Test plan
- [ ] Load `/login` and confirm the new title + switcher render
- [ ] Load `/register` and confirm the new title renders on both `CreateUserForm` and `CreateEmailOnlyUserForm`
- [ ] Confirm SSO buttons and form validation still work end-to-end

_No Linear ticket — internal copy polish._

🤖 Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)