### PR TITLE
fix(scheduler): include all tabs in dashboard export when "Include all tabs" is selected

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -551,8 +551,21 @@ export default class SchedulerTask {
 
             const queryParams = new URLSearchParams();
             if (schedulerUuid) queryParams.set('schedulerUuid', schedulerUuid);
-            if (selectedTabs)
-                queryParams.set('selectedTabs', JSON.stringify(selectedTabs));
+            // When no tabs are explicitly selected ("Include all tabs"), forward
+            // every tab UUID present on the dashboard plus `null` for orphan
+            // tiles so the frontend aggregates all tabs into one render instead
+            // of falling back to the active (first) tab only. Mirrors
+            // UnfurlService.exportDashboard.
+            const selectedTabsList: (string | null)[] =
+                selectedTabs ??
+                Array.from(
+                    new Set(dashboard.tiles.map((tile) => tile.tabUuid ?? null)),
+                );
+            if (selectedTabsList.length > 0)
+                queryParams.set(
+                    'selectedTabs',
+                    JSON.stringify(selectedTabsList),
+                );
             if (context) queryParams.set('context', context);
 
             return {


### PR DESCRIPTION



<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #26123 

### Description:

Dashboard exports (image/PDF) and scheduled deliveries configured with "Include all tabs" (the default) only rendered the tiles from the **first tab**. The only workaround was to uncheck "Include all tabs" and manually select every tab.

**Root cause:** When "Include all tabs" is checked, the frontend sends `selectedTabs: null`. Both the async image/PDF export (modal → `EXPORT_CONTENT` job) and scheduled deliveries build the headless-browser render URL via `SchedulerTask.getChartOrDashboard`, which only added the `selectedTabs` query param when `selectedTabs` was truthy. With no param on the URL, `MinimalDashboard` falls back to its "single active tab" render path and captures only the first tab's tiles.

The interactive sync path (`UnfurlService.exportDashboard`) and the opt-in paged-PDF path (`resolveExportTabs`) already expanded `null` to all tabs — only the scheduler/notification path (used by the modal's async export **and** scheduled deliveries) was missing this.

**Fix:** In `getChartOrDashboard`, when `selectedTabs` is `null`, expand it to every tab UUID on the dashboard plus `null` (the orphan-tile sentinel) so the frontend aggregates all tabs into a single render. This mirrors the existing `UnfurlService.exportDashboard` behaviour and stays consistent with the downstream tile-readiness filtering (which already treats `null` as "all tiles").

**Testing:**
- Export a multi-tab dashboard as image/PDF with "Include all tabs" → all tabs included
- Scheduled delivery with "Include all tabs" → all tabs included
- Explicit tab selection still exports only the selected tabs (no regression)
<!-- Even better add a screenshot / gif / loom -->
