### PR TITLE
fix(scheduler): omit dangling `?` from scheduled delivery links missing scheduler_uuid

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -1,5 +1,6 @@
 import {
     AnyType,
+    appendUuidParam,
     applyDimensionOverrides,
     assertUnreachable,
     CompileProjectPayload,
@@ -89,7 +90,6 @@ import {
     SchedulerLog,
     SchedulerResourceType,
     SessionUser,
-    setUuidParam,
     SlackInstallationNotFoundError,
     SlackNotificationPayload,
     sleep,
@@ -651,17 +651,25 @@ export default class SchedulerTask {
             appUuid,
         );
 
-        const schedulerUuidParam = setUuidParam(
-            'scheduler_uuid',
-            schedulerUuid,
-        );
         let deliveryUrl: string;
         if (appUuid) {
-            deliveryUrl = `${this.lightdashConfig.siteUrl}/projects/${projectUuid}/apps/${appUuid}/view?${schedulerUuidParam}`;
+            deliveryUrl = appendUuidParam(
+                `${this.lightdashConfig.siteUrl}/projects/${projectUuid}/apps/${appUuid}/view`,
+                'scheduler_uuid',
+                schedulerUuid,
+            );
         } else if (savedChartUuid) {
-            deliveryUrl = `${this.lightdashConfig.siteUrl}/projects/${projectUuid}/saved/${savedChartUuid}/view?${schedulerUuidParam}`;
+            deliveryUrl = appendUuidParam(
+                `${this.lightdashConfig.siteUrl}/projects/${projectUuid}/saved/${savedChartUuid}/view`,
+                'scheduler_uuid',
+                schedulerUuid,
+            );
         } else {
-            deliveryUrl = `${this.lightdashConfig.siteUrl}/projects/${projectUuid}/dashboards/${dashboardUuid}/view?${schedulerUuidParam}`;
+            deliveryUrl = appendUuidParam(
+                `${this.lightdashConfig.siteUrl}/projects/${projectUuid}/dashboards/${dashboardUuid}/view`,
+                'scheduler_uuid',
+                schedulerUuid,
+            );
         }
         const minimalRenderUrl = new URL(minimalUrl);
         if (exportOptions?.dateZoomGranularity) {
@@ -1525,7 +1533,8 @@ export default class SchedulerTask {
             const showExpirationWarning = format !== SchedulerFormat.IMAGE;
             const slackExpirationDays = Math.ceil(slackExpiration / 86400);
             const schedulerFooter = includeLinks
-                ? `<${url}?${setUuidParam(
+                ? `<${appendUuidParam(
+                      url,
                       'scheduler_uuid',
                       schedulerUuid,
                   )}|scheduled delivery>`
@@ -1562,7 +1571,8 @@ export default class SchedulerTask {
                             title: name,
                         });
                     const thresholdFooter = includeLinks
-                        ? `<${url}?${setUuidParam(
+                        ? `<${appendUuidParam(
+                              url,
                               'threshold_uuid',
                               schedulerUuid,
                           )}|data alert>`
@@ -3055,10 +3065,11 @@ export default class SchedulerTask {
                     ? await this.getImageBufferFromStorage(imageS3Key)
                     : undefined;
 
-            const schedulerUrl = `${url}?${setUuidParam(
+            const schedulerUrl = appendUuidParam(
+                url,
                 'scheduler_uuid',
                 schedulerUuid,
-            )}`;
+            );
 
             const defaultSchedulerTimezone =
                 await this.schedulerService.getSchedulerDefaultTimezone(
@@ -3481,11 +3492,6 @@ export default class SchedulerTask {
                 scheduler.createdBy,
             );
 
-            const schedulerUuidParam = setUuidParam(
-                'scheduler_uuid',
-                schedulerUuid,
-            );
-
             if (format !== SchedulerFormat.GSHEETS) {
                 throw new UnexpectedServerError(
                     `Unable to process format ${format} on sendGdriveNotification`,
@@ -3495,7 +3501,11 @@ export default class SchedulerTask {
                     await this.schedulerService.savedChartModel.get(
                         savedChartUuid,
                     );
-                deliveryUrl = `${this.lightdashConfig.siteUrl}/projects/${chart.projectUuid}/saved/${savedChartUuid}/view?${schedulerUuidParam}&isSync=true`;
+                deliveryUrl = appendUuidParam(
+                    `${this.lightdashConfig.siteUrl}/projects/${chart.projectUuid}/saved/${savedChartUuid}/view?isSync=true`,
+                    'scheduler_uuid',
+                    schedulerUuid,
+                );
 
                 const defaultSchedulerTimezone =
                     await this.schedulerService.getSchedulerDefaultTimezone(
@@ -3542,7 +3552,11 @@ export default class SchedulerTask {
                     scheduler.createdBy,
                 );
 
-                const reportUrl = `${this.lightdashConfig.siteUrl}/projects/${chart.projectUuid}/saved/${chart.uuid}/view?${schedulerUuidParam}&isSync=true`;
+                const reportUrl = appendUuidParam(
+                    `${this.lightdashConfig.siteUrl}/projects/${chart.projectUuid}/saved/${chart.uuid}/view?isSync=true`,
+                    'scheduler_uuid',
+                    schedulerUuid,
+                );
                 await this.googleDriveClient.uploadMetadata(
                     refreshToken,
                     gdriveId,
@@ -3606,7 +3620,11 @@ export default class SchedulerTask {
                     sessionUser,
                     dashboardUuid,
                 );
-                deliveryUrl = `${this.lightdashConfig.siteUrl}/projects/${dashboard.projectUuid}/dashboards/${dashboardUuid}/view?${schedulerUuidParam}&isSync=true`;
+                deliveryUrl = appendUuidParam(
+                    `${this.lightdashConfig.siteUrl}/projects/${dashboard.projectUuid}/dashboards/${dashboardUuid}/view?isSync=true`,
+                    'scheduler_uuid',
+                    schedulerUuid,
+                );
 
                 const defaultSchedulerTimezone =
                     await this.schedulerService.getSchedulerDefaultTimezone(
@@ -3776,7 +3794,11 @@ export default class SchedulerTask {
                         scheduler.savedSqlUuid,
                         {},
                     );
-                deliveryUrl = `${this.lightdashConfig.siteUrl}/projects/${sqlChart.project.projectUuid}/sql-runner/${sqlChart.slug}?${schedulerUuidParam}&isSync=true`;
+                deliveryUrl = appendUuidParam(
+                    `${this.lightdashConfig.siteUrl}/projects/${sqlChart.project.projectUuid}/sql-runner/${sqlChart.slug}?isSync=true`,
+                    'scheduler_uuid',
+                    schedulerUuid,
+                );
 
                 const defaultSchedulerTimezone =
                     await this.schedulerService.getSchedulerDefaultTimezone(
@@ -4599,22 +4621,22 @@ export default class SchedulerTask {
                     scheduler.createdBy,
                 );
                 if (user.email) {
-                    const schedulerUrlParam = setUuidParam(
-                        'scheduler_uuid',
-                        schedulerUuid,
-                    );
                     const schedulerUrl =
                         scheduler.savedChartUuid || scheduler.dashboardUuid
-                            ? `${this.lightdashConfig.siteUrl}/projects/${
-                                  schedulerPayload.projectUuid
-                              }/${
-                                  scheduler.savedChartUuid
-                                      ? 'saved'
-                                      : 'dashboards'
-                              }/${
-                                  scheduler.savedChartUuid ||
-                                  scheduler.dashboardUuid
-                              }/view?${schedulerUrlParam}`
+                            ? appendUuidParam(
+                                  `${this.lightdashConfig.siteUrl}/projects/${
+                                      schedulerPayload.projectUuid
+                                  }/${
+                                      scheduler.savedChartUuid
+                                          ? 'saved'
+                                          : 'dashboards'
+                                  }/${
+                                      scheduler.savedChartUuid ||
+                                      scheduler.dashboardUuid
+                                  }/view`,
+                                  'scheduler_uuid',
+                                  schedulerUuid,
+                              )
                             : this.lightdashConfig.siteUrl;
 
                     await this.emailClient.sendScheduledDeliveryFailureEmail(
@@ -5615,11 +5637,6 @@ export default class SchedulerTask {
                 return;
             }
 
-            const schedulerUrlParam = setUuidParam(
-                'scheduler_uuid',
-                scheduler.schedulerUuid,
-            );
-
             const resourceUuid =
                 scheduler.savedChartUuid || scheduler.dashboardUuid;
             const resourceType = scheduler.savedChartUuid
@@ -5628,7 +5645,11 @@ export default class SchedulerTask {
 
             let schedulerUrl = this.lightdashConfig.siteUrl;
             if (resourceUuid && projectUuid) {
-                schedulerUrl = `${this.lightdashConfig.siteUrl}/projects/${projectUuid}/${resourceType}/${resourceUuid}/view?${schedulerUrlParam}`;
+                schedulerUrl = appendUuidParam(
+                    `${this.lightdashConfig.siteUrl}/projects/${projectUuid}/${resourceType}/${resourceUuid}/view`,
+                    'scheduler_uuid',
+                    scheduler.schedulerUuid,
+                );
             }
 
             const failedTargets = batchResult.results

--- a/packages/common/src/utils/searchParams.test.ts
+++ b/packages/common/src/utils/searchParams.test.ts
@@ -1,0 +1,39 @@
+import { appendUuidParam } from './searchParams';
+
+const VALID_UUID = '11111111-1111-4111-8111-111111111111';
+
+describe('appendUuidParam', () => {
+    it('appends the param with `?` when the URL has no query string', () => {
+        expect(
+            appendUuidParam('https://app/view', 'scheduler_uuid', VALID_UUID),
+        ).toBe(`https://app/view?scheduler_uuid=${VALID_UUID}`);
+    });
+
+    it('appends the param with `&` when the URL already has a query string', () => {
+        expect(
+            appendUuidParam(
+                'https://app/view?isSync=true',
+                'scheduler_uuid',
+                VALID_UUID,
+            ),
+        ).toBe(`https://app/view?isSync=true&scheduler_uuid=${VALID_UUID}`);
+    });
+
+    it('returns the URL unchanged (no dangling `?`) when the value is undefined', () => {
+        expect(
+            appendUuidParam('https://app/view', 'scheduler_uuid', undefined),
+        ).toBe('https://app/view');
+    });
+
+    it('returns the URL unchanged when the value is null', () => {
+        expect(
+            appendUuidParam('https://app/view', 'scheduler_uuid', null),
+        ).toBe('https://app/view');
+    });
+
+    it('returns the URL unchanged when the value is not a valid uuid', () => {
+        expect(
+            appendUuidParam('https://app/view', 'scheduler_uuid', 'sched-1'),
+        ).toBe('https://app/view');
+    });
+});

--- a/packages/common/src/utils/searchParams.ts
+++ b/packages/common/src/utils/searchParams.ts
@@ -1,8 +1,18 @@
 import { validate as validateUuid } from 'uuid';
 
-export function setUuidParam(key: string, value?: string | null) {
+/**
+ * Appends a uuid query param to a URL, picking the right separator (`?` or `&`)
+ * and only when the value is a valid uuid. Returns the URL unchanged otherwise,
+ * so links never end with a dangling `?` when the uuid is missing.
+ */
+export function appendUuidParam(
+    url: string,
+    key: string,
+    value?: string | null,
+): string {
     if (value && validateUuid(value)) {
-        return `${key}=${value}`;
+        const separator = url.includes('?') ? '&' : '?';
+        return `${url}${separator}${key}=${value}`;
     }
-    return '';
+    return url;
 }


### PR DESCRIPTION

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #26124

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

Scheduled delivery links in delivery emails and the Slack message footer did not always
contain the `scheduler_uuid` query parameter. When it was missing the URL ended in a bare
`?` (e.g. `.../dashboards/<uuid>/view?`), and opening it showed the resource without opening
the corresponding scheduled delivery.

**Root cause**

Every link was built as `` `${url}?${setUuidParam('scheduler_uuid', schedulerUuid)}` ``.
`setUuidParam` returns an empty string when the uuid is missing or invalid, but the `?`
separator was hard-coded by the caller — so an absent uuid produced a dangling `?`.

The uuid is absent whenever "Send now" is triggered from the scheduler form modal:
that path (`POST /schedulers/send` → `sendScheduler`) sends the unsaved config with
`schedulerUuid: undefined`. The same pattern also affected the Slack footer, the
gdrive/gsheets sync links, and the failure notification emails.

**Fix**

- Replace `setUuidParam` (which returned `key=value` or `''`) with
  `appendUuidParam(url, key, value)`, which appends the param with the correct separator
  (`?` or `&`) only when the uuid is valid, and returns the URL unchanged otherwise — so
  links never end with a bare `?`.
- Update every delivery / failure / gdrive URL builder in `SchedulerTask.ts` to use it.
  For the `&isSync=true` gdrive links, `isSync=true` is seeded into the base URL so the
  query string stays well-formed even when the uuid is absent.

<!-- Even better add a screenshot / gif / loom -->
