### PR TITLE
fix: enforce invite link expiry in InviteLinkModel.getByCode

### DIFF
--- a/packages/backend/src/models/InviteLinkModel.test.ts
+++ b/packages/backend/src/models/InviteLinkModel.test.ts
@@ -1,0 +1,98 @@
+import {
+    ExpiredError,
+    InviteLinkPurpose,
+    NotFoundError,
+} from '@lightdash/common';
+import { Knex } from 'knex';
+import { lightdashConfigMock } from '../config/lightdashConfig.mock';
+import { InviteLinkModel } from './InviteLinkModel';
+
+const inviteCode = 'test-invite-code';
+const userUuid = '22222222-2222-4222-8222-222222222222';
+
+const dbRow = {
+    invite_code_hash: InviteLinkModel._hash(inviteCode),
+    organization_id: 1,
+    organization_uuid: '11111111-1111-4111-8111-111111111111',
+    user_uuid: userUuid,
+    email: 'invitee@example.com',
+    purpose: 'member',
+    created_at: new Date('2026-07-15T12:00:00.000Z'),
+    expires_at: new Date('2099-07-15T12:00:00.000Z'),
+};
+
+const createDatabase = (rows: unknown[]) => {
+    const selectBuilder = {
+        leftJoin: vi.fn(),
+        joinRaw: vi.fn(),
+        where: vi.fn(),
+        select: vi.fn(async () => rows),
+    };
+    selectBuilder.leftJoin.mockReturnValue(selectBuilder);
+    selectBuilder.joinRaw.mockReturnValue(selectBuilder);
+    selectBuilder.where.mockReturnValue(selectBuilder);
+    const deleteBuilder = {
+        where: vi.fn(),
+        delete: vi.fn(async () => 1),
+    };
+    deleteBuilder.where.mockReturnValue(deleteBuilder);
+    const database = vi
+        .fn()
+        .mockReturnValueOnce(selectBuilder)
+        .mockReturnValueOnce(deleteBuilder) as unknown as Knex;
+    return { database, selectBuilder, deleteBuilder };
+};
+
+describe('InviteLinkModel', () => {
+    describe('getByCode', () => {
+        it('returns the invite link when it is not expired', async () => {
+            const { database } = createDatabase([dbRow]);
+            const model = new InviteLinkModel({
+                database,
+                lightdashConfig: lightdashConfigMock,
+            });
+
+            await expect(model.getByCode(inviteCode)).resolves.toEqual({
+                inviteCode,
+                expiresAt: dbRow.expires_at,
+                inviteUrl: `https://test.lightdash.cloud/invite/${inviteCode}`,
+                organizationUuid: dbRow.organization_uuid,
+                userUuid,
+                email: dbRow.email,
+                purpose: InviteLinkPurpose.Member,
+            });
+        });
+
+        it('deletes and rejects an expired invite link', async () => {
+            const { database, deleteBuilder } = createDatabase([
+                { ...dbRow, expires_at: new Date('2000-01-01T00:00:00.000Z') },
+            ]);
+            const model = new InviteLinkModel({
+                database,
+                lightdashConfig: lightdashConfigMock,
+            });
+
+            await expect(model.getByCode(inviteCode)).rejects.toThrow(
+                new ExpiredError('Invite link expired'),
+            );
+            expect(deleteBuilder.where).toHaveBeenCalledWith(
+                'invite_code_hash',
+                InviteLinkModel._hash(inviteCode),
+            );
+            expect(deleteBuilder.delete).toHaveBeenCalledOnce();
+        });
+
+        it('throws not found for an unknown invite code', async () => {
+            const { database, deleteBuilder } = createDatabase([]);
+            const model = new InviteLinkModel({
+                database,
+                lightdashConfig: lightdashConfigMock,
+            });
+
+            await expect(model.getByCode('unknown')).rejects.toThrow(
+                new NotFoundError('No invite link found'),
+            );
+            expect(deleteBuilder.delete).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/backend/src/models/InviteLinkModel.ts
+++ b/packages/backend/src/models/InviteLinkModel.ts
@@ -1,4 +1,5 @@
 import {
+    ExpiredError,
     InviteLink,
     InviteLinkPurpose,
     NotFoundError,
@@ -97,7 +98,15 @@ export class InviteLinkModel {
         if (inviteLinks.length === 0) {
             throw new NotFoundError('No invite link found');
         }
-        return this.mapDbObjectToInviteLink(inviteCode, inviteLinks[0]);
+        const inviteLink = this.mapDbObjectToInviteLink(
+            inviteCode,
+            inviteLinks[0],
+        );
+        if (inviteLink.expiresAt <= new Date()) {
+            await this.deleteByCode(inviteCode);
+            throw new ExpiredError('Invite link expired');
+        }
+        return inviteLink;
     }
 
     async upsert(

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -632,11 +632,10 @@ describe('UserService', () => {
             });
         });
 
-        test('rejects and consumes an expired invite without activating the user', async () => {
-            vi.mocked(inviteLinkModel.getByCode).mockResolvedValueOnce({
-                ...validInviteLink,
-                expiresAt: new Date('2000-01-01'),
-            });
+        test('rejects an expired invite without activating the user', async () => {
+            vi.mocked(inviteLinkModel.getByCode).mockRejectedValueOnce(
+                new ExpiredError('Invite link expired'),
+            );
             const service = createUserService(lightdashConfigMock);
 
             await expect(
@@ -645,9 +644,6 @@ describe('UserService', () => {
                 ),
             ).rejects.toThrow(new ExpiredError('Invite link expired'));
 
-            expect(inviteLinkModel.deleteByCode).toHaveBeenCalledWith(
-                validInviteLink.inviteCode,
-            );
             expect(
                 userModel.activateUserWithoutPassword,
             ).not.toHaveBeenCalled();

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -22,7 +22,6 @@ import {
     DeleteOpenIdentity,
     EmailStatus,
     EmailStatusExpiring,
-    ExpiredError,
     FeatureFlags,
     ForbiddenError,
     getEmailDomain,
@@ -1509,17 +1508,7 @@ export class UserService extends BaseService {
     }
 
     async getInviteLink(inviteCode: string): Promise<InviteLink> {
-        const inviteLink = await this.inviteLinkModel.getByCode(inviteCode);
-        const now = new Date();
-        if (inviteLink.expiresAt <= now) {
-            try {
-                await this.inviteLinkModel.deleteByCode(inviteLink.inviteCode);
-            } catch (e) {
-                throw new NotFoundError('Invite link not found');
-            }
-            throw new ExpiredError('Invite link expired');
-        }
-        return inviteLink;
+        return this.inviteLinkModel.getByCode(inviteCode);
     }
 
     async loginWithPassword(


### PR DESCRIPTION
Invite link expiry is now enforced centrally in `InviteLinkModel.getByCode` (expired links are deleted and rejected), so every code path that resolves an invite link applies the same check. `UserService.getInviteLink` now delegates to it, and model-level tests cover the unexpired/expired/unknown cases.

Linear: SPK-587