### PR TITLE
fix: sanitize scheduler name and markdown message in notification emails

### DIFF
--- a/packages/backend/src/clients/EmailClient/EmailClient.test.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.test.ts
@@ -89,6 +89,56 @@ describe('EmailClient', () => {
             expect(client.transporter?.sendMail).toHaveBeenCalledTimes(1);
         });
 
+        test('should sanitize scheduler name in delivery failure emails', async () => {
+            const client = new EmailClient({
+                lightdashConfig: lightdashConfigWithBasicSMTP,
+            });
+            await client.sendScheduledDeliveryFailureEmail(
+                'recipient@example.com',
+                'daily <img src=x onerror=alert(1)>',
+                'https://example.com/scheduler',
+                'something went wrong',
+            );
+            expect(
+                vi.mocked(client.transporter!.sendMail),
+            ).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    context: expect.objectContaining({
+                        message: expect.not.stringContaining('<img'),
+                    }),
+                }),
+            );
+        });
+
+        test('should sanitize markdown message in notification emails', async () => {
+            const client = new EmailClient({
+                lightdashConfig: lightdashConfigWithBasicSMTP,
+            });
+            await client.sendChartCsvNotificationEmail(
+                'recipient@example.com',
+                'subject',
+                'title',
+                'description',
+                'Hello **world** <script>alert(1)</script>',
+                'date',
+                'frequency',
+                {
+                    path: 'https://example.com/file.csv',
+                    filename: 'file.csv',
+                    localPath: '',
+                    truncated: false,
+                },
+                'https://example.com/chart',
+                'https://example.com/scheduler',
+                true,
+            );
+            const sentOptions = vi.mocked(client.transporter!.sendMail).mock
+                .calls[0][0] as unknown as { context?: { message?: string } };
+            const sentMessage = sentOptions.context?.message ?? '';
+            expect(sentMessage).not.toContain('<script>');
+            expect(sentMessage).toContain('<strong>world</strong>');
+        });
+
         test('should use the setup invitation template for setup invites', async () => {
             const client = new EmailClient({
                 lightdashConfig: lightdashConfigWithBasicSMTP,

--- a/packages/backend/src/clients/EmailClient/EmailClient.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.ts
@@ -432,8 +432,9 @@ export default class EmailClient {
             });
         }
 
+        const safeName = sanitizeHtml(schedulerName);
         const message = `
-            <p>Your Google Sheets sync <strong>"${schedulerName}"</strong> failed.</p>
+            <p>Your Google Sheets sync <strong>"${safeName}"</strong> failed.</p>
             <br />
             <br />
             <br />
@@ -482,8 +483,9 @@ export default class EmailClient {
 
         const urlWithRef = appendCorrelationRef(schedulerUrl, correlationId);
 
+        const safeName = sanitizeHtml(schedulerName);
         const message = `
-            <p>Your scheduled delivery <strong>"${schedulerName}"</strong> failed to send.</p>
+            <p>Your scheduled delivery <strong>"${safeName}"</strong> failed to send.</p>
             <br />
             <br />
             <br />
@@ -577,8 +579,9 @@ export default class EmailClient {
             )
             .join('');
 
+        const safeName = sanitizeHtml(schedulerName);
         const message = `
-            <p>Your scheduled delivery <strong>"${schedulerName}"</strong> failed to deliver to ${failedCount} of ${totalTargets} ${deliveryTypeLabel} target${
+            <p>Your scheduled delivery <strong>"${safeName}"</strong> failed to deliver to ${failedCount} of ${totalTargets} ${deliveryTypeLabel} target${
                 totalTargets > 1 ? 's' : ''
             }.</p>
             <br />
@@ -757,7 +760,7 @@ export default class EmailClient {
             context: {
                 title,
                 hasMessage: !!message,
-                message: message && marked(message),
+                message: message && sanitizeHtml(marked(message)),
                 imageUrl: useCidImage ? 'cid:chart-image' : imageUrl,
                 description,
                 date,
@@ -812,7 +815,7 @@ export default class EmailClient {
                 title,
                 description,
                 hasMessage: !!message,
-                message: message && marked(message),
+                message: message && sanitizeHtml(marked(message)),
                 date,
                 frequency,
                 url,
@@ -886,7 +889,7 @@ export default class EmailClient {
                 title,
                 description,
                 hasMessage: !!message,
-                message: message && marked(message),
+                message: message && sanitizeHtml(marked(message)),
                 date,
                 frequency,
                 csvUrls,
@@ -1019,7 +1022,7 @@ export default class EmailClient {
             template: 'genericNotification',
             context: {
                 title,
-                message: marked(message),
+                message: sanitizeHtml(marked(message)),
                 host: this.lightdashConfig.siteUrl,
             },
             text: `${title}\n\n${message}`,


### PR DESCRIPTION
Escape the scheduler name and run the markdown delivery message through the HTML sanitizer before rendering notification email templates.

Linear: SPK-588