### PR TITLE
fix(filters): hide stale value on 'is null' / 'is not null' filter badges

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/utils.test.ts
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/utils.test.ts
@@ -85,6 +85,40 @@ describe('getConditionalRuleLabel', () => {
         expect(result.value).toBe('a');
     });
 
+    it('should not render a value for a null date filter with a stale value', () => {
+        const rule: BaseFilterRule = {
+            id: 'test-rule-id',
+            operator: FilterOperator.NULL,
+            values: ['2024-01-01'],
+        };
+
+        const result = getConditionalRuleLabel(
+            rule,
+            FilterType.DATE,
+            'Created At',
+        );
+
+        expect(result.operator).toBe('is null');
+        expect(result.value).toBeUndefined();
+    });
+
+    it('should not render a value for a not-null date filter with a stale value', () => {
+        const rule: BaseFilterRule = {
+            id: 'test-rule-id',
+            operator: FilterOperator.NOT_NULL,
+            values: ['2024-01-01'],
+        };
+
+        const result = getConditionalRuleLabel(
+            rule,
+            FilterType.DATE,
+            'Created At',
+        );
+
+        expect(result.operator).toBe('is not null');
+        expect(result.value).toBeUndefined();
+    });
+
     it('should return correct labels for a number filter', () => {
         // Arrange
         const rule: BaseFilterRule = {

--- a/packages/frontend/src/components/common/Filters/FilterInputs/utils.ts
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/utils.ts
@@ -146,6 +146,14 @@ const getValueAsString = (
     const firstValue = values?.[0];
     const secondValue = values?.[1];
 
+    // Null operators take no value; never render a stale value left in `values`
+    if (
+        operator === FilterOperator.NULL ||
+        operator === FilterOperator.NOT_NULL
+    ) {
+        return undefined;
+    }
+
     switch (filterType) {
         case FilterType.STRING:
         case FilterType.NUMBER:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #26057

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

Date filter badges using the `is null` / `is not null` operators displayed a
stale date value next to the operator, even though these operators take no value.

**Root cause:** `getValueAsString()` in
`packages/frontend/src/components/common/Filters/FilterInputs/utils.ts` groups
`NULL` / `NOT_NULL` with `EQUALS`, `GREATER_THAN`, etc. in the `DATE` switch
branch, which formats every entry in `rule.values` as a date. When a user sets a
date value first and then switches the operator to `is null` / `is not null`, the
old value stays in `rule.values`, so the badge rendered a formatted (granularity-
truncated) date next to the null operator.

**Fix:** Return `undefined` early for the `NULL` / `NOT_NULL` operators in
`getValueAsString()`, regardless of filter type. Null operators never have a
display value, so badges now show only the field name and operator. This also
covers the same latent issue for STRING / NUMBER / BOOLEAN filters.

Added unit tests covering date filters with a stale value for both null operators.

<!-- Even better add a screenshot / gif / loom -->
