### PR TITLE
fix: reject dbt Cloud webhooks when no HMAC secret is configured

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -25,6 +25,7 @@ import {
     type CreateWarehouseCredentials,
     type Explore,
     type PossibleAbilities,
+    type Project,
     type RegisteredAccount,
 } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
@@ -3172,6 +3173,44 @@ type ProjectServiceInternals = {
     ) => Promise<ProjectAdapter>;
     buildMergedManifestAdapter: (args: unknown) => Promise<ProjectAdapter>;
 };
+
+describe('ProjectService.createPreviewFromDbtCloudWebhook', () => {
+    const service = getMockedProjectService(lightdashConfigMock);
+
+    it('throws ForbiddenError when the project has no webhook_hmac_secret configured', async () => {
+        projectModel.getWithSensitiveFields.mockResolvedValueOnce({
+            ...projectWithSensitiveFields,
+            warehouseConnection:
+                warehouseClientMock.credentials as Project['warehouseConnection'],
+        });
+
+        await expect(
+            service.createPreviewFromDbtCloudWebhook('projectUuid', 123, 456, {
+                rawBody: Buffer.from('{}'),
+                signature: 'signature',
+            }),
+        ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('throws ForbiddenError when the signature does not match the configured webhook_hmac_secret', async () => {
+        projectModel.getWithSensitiveFields.mockResolvedValueOnce({
+            ...projectWithSensitiveFields,
+            warehouseConnection:
+                warehouseClientMock.credentials as Project['warehouseConnection'],
+            dbtConnection: {
+                ...projectWithSensitiveFields.dbtConnection,
+                webhook_hmac_secret: 'secret',
+            } as Project['dbtConnection'],
+        });
+
+        await expect(
+            service.createPreviewFromDbtCloudWebhook('projectUuid', 123, 456, {
+                rawBody: Buffer.from('{}'),
+                signature: 'wrong-signature',
+            }),
+        ).rejects.toThrow(ForbiddenError);
+    });
+});
 
 describe('ProjectService.resolveCompileAdapter (MultiDbtSources regression firewall)', () => {
     const primaryAdapter = {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -9888,22 +9888,21 @@ export class ProjectService extends BaseService {
         }
 
         const webhookSecret = project.dbtConnection.webhook_hmac_secret;
-        if (webhookSecret) {
-            if (
-                !webhookAuth.rawBody ||
-                !webhookAuth.signature ||
-                !isValidDbtCloudWebhookSignature(
-                    webhookSecret,
-                    webhookAuth.rawBody,
-                    webhookAuth.signature,
-                )
-            ) {
-                throw new ForbiddenError('Invalid dbt Cloud webhook signature');
-            }
-        } else {
-            this.logger.info(
-                `dbt Cloud webhook for project ${projectUuid} processed without signature verification (no webhook_hmac_secret configured)`,
+        if (!webhookSecret) {
+            throw new ForbiddenError(
+                'dbt Cloud webhook rejected: no webhook_hmac_secret configured for this project',
             );
+        }
+        if (
+            !webhookAuth.rawBody ||
+            !webhookAuth.signature ||
+            !isValidDbtCloudWebhookSignature(
+                webhookSecret,
+                webhookAuth.rawBody,
+                webhookAuth.signature,
+            )
+        ) {
+            throw new ForbiddenError('Invalid dbt Cloud webhook signature');
         }
 
         // todo: fix this


### PR DESCRIPTION
Fail closed in createPreviewFromDbtCloudWebhook: dbt Cloud webhooks for projects without a configured webhook_hmac_secret are now rejected instead of processed unsigned.

Linear: SPK-590