### PR TITLE
feat: add Slack Block Kit memory citations

### DIFF
--- a/packages/backend/src/ee/models/AiAgentMemoryModel.ts
+++ b/packages/backend/src/ee/models/AiAgentMemoryModel.ts
@@ -563,23 +563,15 @@ export class AiAgentMemoryModel {
     async findActiveBySlugs(args: {
         projectUuid: string;
         slugs: string[];
-    }): Promise<Array<{ memoryId: string; slug: string; title: string }>> {
+    }): Promise<Array<{ slug: string; title: string }>> {
         const slugs = [...new Set(args.slugs)];
         if (slugs.length === 0) return [];
 
-        const rows = await this.database<AiAgentMemoryTable>(
-            AiAgentMemoryTableName,
-        )
+        return this.database<AiAgentMemoryTable>(AiAgentMemoryTableName)
             .where('project_uuid', args.projectUuid)
             .where('status', 'active')
             .whereIn('slug', slugs)
-            .select(['ai_agent_memory_uuid', 'slug', 'title']);
-
-        return rows.map(({ ai_agent_memory_uuid: memoryId, slug, title }) => ({
-            memoryId,
-            slug,
-            title,
-        }));
+            .select(['slug', 'title']);
     }
 
     async incrementPulledForActiveMemories(args: {

--- a/packages/backend/src/ee/models/AiAgentMemoryModel.ts
+++ b/packages/backend/src/ee/models/AiAgentMemoryModel.ts
@@ -560,6 +560,28 @@ export class AiAgentMemoryModel {
         return { memory, sources, replacement };
     }
 
+    async findActiveBySlugs(args: {
+        projectUuid: string;
+        slugs: string[];
+    }): Promise<Array<{ memoryId: string; slug: string; title: string }>> {
+        const slugs = [...new Set(args.slugs)];
+        if (slugs.length === 0) return [];
+
+        const rows = await this.database<AiAgentMemoryTable>(
+            AiAgentMemoryTableName,
+        )
+            .where('project_uuid', args.projectUuid)
+            .where('status', 'active')
+            .whereIn('slug', slugs)
+            .select(['ai_agent_memory_uuid', 'slug', 'title']);
+
+        return rows.map(({ ai_agent_memory_uuid: memoryId, slug, title }) => ({
+            memoryId,
+            slug,
+            title,
+        }));
+    }
+
     async incrementPulledForActiveMemories(args: {
         projectUuid: string;
         slugs: string[];

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -9546,7 +9546,6 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 if (!memory) return [];
                 return [
                     {
-                        memoryId: memory.memoryId,
                         slug,
                         title: memory.title,
                         url: `${this.lightdashConfig.siteUrl}/projects/${slackPrompt.projectUuid}/ai-agents/${agent.uuid}/memories/${slug}`,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -325,6 +325,7 @@ import {
     getFeedbackBlocks,
     getFollowUpToolBlocks,
     getMarkdownBlocks,
+    getMemoryCitationBlocks,
     getModernArtifactCardBlocks,
     getModernPullRequestCardBlocks,
     getProjectSelectionBlocks,
@@ -9516,15 +9517,74 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         return [uuid, createdThread];
     }
 
+    // Markers are stripped from Slack prose, so cited memories surface as native
+    // citation elements instead. Slugs without an active memory row are dropped.
+    private async getSlackMemoryCitationBlocks({
+        slackPrompt,
+        agent,
+        response,
+    }: {
+        slackPrompt: SlackPrompt;
+        agent: AiAgent | undefined;
+        response: string;
+    }): Promise<(Block | KnownBlock)[]> {
+        if (!agent) return [];
+
+        const { slugs } = parseMemoryCitations(response);
+        if (slugs.length === 0) return [];
+
+        try {
+            const memories = await this.aiAgentMemoryModel.findActiveBySlugs({
+                projectUuid: slackPrompt.projectUuid,
+                slugs,
+            });
+            const memoriesBySlug = new Map(
+                memories.map((memory) => [memory.slug, memory]),
+            );
+            const citations = slugs.flatMap((slug) => {
+                const memory = memoriesBySlug.get(slug);
+                if (!memory) return [];
+                return [
+                    {
+                        memoryId: memory.memoryId,
+                        slug,
+                        title: memory.title,
+                        url: `${this.lightdashConfig.siteUrl}/projects/${slackPrompt.projectUuid}/ai-agents/${agent.uuid}/memories/${slug}`,
+                    },
+                ];
+            });
+
+            if (citations.length < slugs.length) {
+                this.logger.warn(
+                    `Dropped ${
+                        slugs.length - citations.length
+                    } unknown or inactive memory citation(s) from Slack answer for prompt ${
+                        slackPrompt.promptUuid
+                    }`,
+                );
+            }
+
+            return getMemoryCitationBlocks(citations);
+        } catch (error) {
+            this.logger.error(
+                `Failed to build Slack memory citation blocks for prompt ${slackPrompt.promptUuid}`,
+                error,
+            );
+            return [];
+        }
+    }
+
     // TODO: user permissions
     private async getSlackAgentFinalBlocks({
         user,
         slackPrompt,
         agent,
+        response,
     }: {
         user: SessionUser;
         slackPrompt: SlackPrompt;
         agent: AiAgent | undefined;
+        response: string;
     }): Promise<(Block | KnownBlock)[]> {
         const referencedArtifactsMap =
             await this.aiAgentModel.findThreadReferencedArtifacts({
@@ -9640,7 +9700,14 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                   )
                 : [];
 
+        const memoryCitationBlocks = await this.getSlackMemoryCitationBlocks({
+            slackPrompt,
+            agent,
+            response,
+        });
+
         return [
+            ...memoryCitationBlocks,
             ...exploreBlocks,
             ...sqlArtifactBlocks,
             ...editDbtProjectBlocks,
@@ -10479,6 +10546,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 user,
                 slackPrompt,
                 agent,
+                response,
             });
             const slackResponse = stripMemoryCitations(response);
             const slackifiedMarkdown = slackifyMarkdown(slackResponse).replace(

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
@@ -9,6 +9,7 @@ import {
     buildSlackTaskUpdate,
     getFollowUpToolBlocks,
     getMarkdownBlocks,
+    getMemoryCitationBlocks,
     getModernArtifactCardBlocks,
     getModernPullRequestCardBlocks,
     getProjectSelectionBlocks,
@@ -139,6 +140,94 @@ describe('Slack AI agent blocks', () => {
 
         expect(blocks).toEqual([{ type: 'markdown', text: 'Answer. Next.' }]);
         expect(JSON.stringify(blocks)).not.toContain('ld-mem-cite');
+    });
+
+    it('renders cited memories as native citation elements', () => {
+        const blocks = getMemoryCitationBlocks([
+            {
+                memoryId: 'memory-uuid-1',
+                slug: 'revenue-is-net',
+                title: 'Revenue is net of refunds',
+                url: 'https://ld.example.com/projects/p1/ai-agents/a1/memories/revenue-is-net',
+            },
+            {
+                memoryId: 'memory-uuid-2',
+                slug: 'fiscal-year',
+                title: 'x'.repeat(200),
+                url: 'https://ld.example.com/projects/p1/ai-agents/a1/memories/fiscal-year',
+            },
+        ]);
+
+        expect(blocks).toEqual([
+            {
+                type: 'rich_text',
+                elements: [
+                    {
+                        type: 'rich_text_section',
+                        elements: [
+                            {
+                                type: 'citation',
+                                url: 'https://ld.example.com/projects/p1/ai-agents/a1/memories/revenue-is-net',
+                                text: 'Revenue is net of refunds',
+                                index: 1,
+                                from_llm: true,
+                                details: {
+                                    citation_type: 'memory',
+                                    memory_id: 'memory-uuid-1',
+                                },
+                            },
+                            {
+                                type: 'citation',
+                                url: 'https://ld.example.com/projects/p1/ai-agents/a1/memories/fiscal-year',
+                                text: `${'x'.repeat(72)}...`,
+                                index: 2,
+                                from_llm: true,
+                                details: {
+                                    citation_type: 'memory',
+                                    memory_id: 'memory-uuid-2',
+                                },
+                            },
+                        ],
+                    },
+                ],
+            },
+        ]);
+    });
+
+    it('renders no citation block without citations', () => {
+        expect(getMemoryCitationBlocks([])).toEqual([]);
+    });
+
+    it('labels a citation by slug when the memory has no title', () => {
+        const blocks = getMemoryCitationBlocks([
+            {
+                memoryId: 'memory-uuid-1',
+                slug: 'fiscal-year',
+                title: '   ',
+                url: 'https://ld.example.com/memories/fiscal-year',
+            },
+        ]);
+
+        expect(blocks).toMatchObject([
+            {
+                elements: [
+                    { elements: [{ type: 'citation', text: 'fiscal-year' }] },
+                ],
+            },
+        ]);
+    });
+
+    it('renders no citation block when nothing can be labelled', () => {
+        expect(
+            getMemoryCitationBlocks([
+                {
+                    memoryId: 'memory-uuid-1',
+                    slug: '',
+                    title: '',
+                    url: 'https://ld.example.com/memories/x',
+                },
+            ]),
+        ).toEqual([]);
     });
 
     it('keeps project picker option values within Slack limits', () => {

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
@@ -145,13 +145,11 @@ describe('Slack AI agent blocks', () => {
     it('renders cited memories as native citation elements', () => {
         const blocks = getMemoryCitationBlocks([
             {
-                memoryId: 'memory-uuid-1',
                 slug: 'revenue-is-net',
                 title: 'Revenue is net of refunds',
                 url: 'https://ld.example.com/projects/p1/ai-agents/a1/memories/revenue-is-net',
             },
             {
-                memoryId: 'memory-uuid-2',
                 slug: 'fiscal-year',
                 title: 'x'.repeat(200),
                 url: 'https://ld.example.com/projects/p1/ai-agents/a1/memories/fiscal-year',
@@ -171,9 +169,11 @@ describe('Slack AI agent blocks', () => {
                                 text: 'Revenue is net of refunds',
                                 index: 1,
                                 from_llm: true,
+                                is_slack_url: false,
                                 details: {
-                                    citation_type: 'memory',
-                                    memory_id: 'memory-uuid-1',
+                                    citation_type: 'web',
+                                    display_name: 'Lightdash memory',
+                                    title: 'Revenue is net of refunds',
                                 },
                             },
                             {
@@ -182,9 +182,11 @@ describe('Slack AI agent blocks', () => {
                                 text: `${'x'.repeat(72)}...`,
                                 index: 2,
                                 from_llm: true,
+                                is_slack_url: false,
                                 details: {
-                                    citation_type: 'memory',
-                                    memory_id: 'memory-uuid-2',
+                                    citation_type: 'web',
+                                    display_name: 'Lightdash memory',
+                                    title: `${'x'.repeat(72)}...`,
                                 },
                             },
                         ],
@@ -201,7 +203,6 @@ describe('Slack AI agent blocks', () => {
     it('labels a citation by slug when the memory has no title', () => {
         const blocks = getMemoryCitationBlocks([
             {
-                memoryId: 'memory-uuid-1',
                 slug: 'fiscal-year',
                 title: '   ',
                 url: 'https://ld.example.com/memories/fiscal-year',
@@ -221,7 +222,6 @@ describe('Slack AI agent blocks', () => {
         expect(
             getMemoryCitationBlocks([
                 {
-                    memoryId: 'memory-uuid-1',
                     slug: '',
                     title: '',
                     url: 'https://ld.example.com/memories/x',

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -199,6 +199,60 @@ const truncateTaskText = (text: string, maxLength = 256) =>
 const truncateCardText = (text: string, maxLength: number) =>
     text.length > maxLength ? `${text.slice(0, maxLength - 3)}...` : text;
 
+// Slack renders citations as compact chips, so keep the label short.
+const SLACK_CITATION_TEXT_LIMIT = 75;
+
+export type SlackMemoryCitation = {
+    memoryId: string;
+    slug: string;
+    title: string;
+    url: string;
+};
+
+/**
+ * Native Block Kit citation elements for the memories an answer cited. They're
+ * rich-text-only (not valid inside `markdown` blocks), so they ride in their
+ * own trailing `rich_text` block after the answer prose.
+ */
+export const getMemoryCitationBlocks = (
+    citations: SlackMemoryCitation[],
+): (Block | KnownBlock)[] => {
+    // Slack rejects a citation with empty `text` (min_length 1), and an
+    // invalid block fails the whole answer message — so drop unlabelled ones.
+    const labelled = citations.flatMap((citation) => {
+        const text = citation.title.trim() || citation.slug.trim();
+        return text ? [{ ...citation, text }] : [];
+    });
+    if (labelled.length === 0) {
+        return [];
+    }
+
+    return [
+        {
+            type: 'rich_text',
+            elements: [
+                {
+                    type: 'rich_text_section',
+                    elements: labelled.map((citation, index) => ({
+                        type: 'citation',
+                        url: citation.url,
+                        text: truncateCardText(
+                            citation.text,
+                            SLACK_CITATION_TEXT_LIMIT,
+                        ),
+                        index: index + 1,
+                        from_llm: true,
+                        details: {
+                            citation_type: 'memory',
+                            memory_id: citation.memoryId,
+                        },
+                    })),
+                },
+            ],
+        } as unknown as Block,
+    ];
+};
+
 const getSlackTaskId = (toolName: string) =>
     toolName.replace(/[^A-Za-z0-9_-]/g, '_').slice(0, 80);
 

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -203,7 +203,6 @@ const truncateCardText = (text: string, maxLength: number) =>
 const SLACK_CITATION_TEXT_LIMIT = 75;
 
 export type SlackMemoryCitation = {
-    memoryId: string;
     slug: string;
     title: string;
     url: string;
@@ -213,6 +212,9 @@ export type SlackMemoryCitation = {
  * Native Block Kit citation elements for the memories an answer cited. They're
  * rich-text-only (not valid inside `markdown` blocks), so they ride in their
  * own trailing `rich_text` block after the answer prose.
+ *
+ * Uses the `web` details variant, not `memory`: Slack resolves `memory` against
+ * its own memory store, ignoring our `url` and label.
  */
 export const getMemoryCitationBlocks = (
     citations: SlackMemoryCitation[],
@@ -233,20 +235,25 @@ export const getMemoryCitationBlocks = (
             elements: [
                 {
                     type: 'rich_text_section',
-                    elements: labelled.map((citation, index) => ({
-                        type: 'citation',
-                        url: citation.url,
-                        text: truncateCardText(
+                    elements: labelled.map((citation, index) => {
+                        const text = truncateCardText(
                             citation.text,
                             SLACK_CITATION_TEXT_LIMIT,
-                        ),
-                        index: index + 1,
-                        from_llm: true,
-                        details: {
-                            citation_type: 'memory',
-                            memory_id: citation.memoryId,
-                        },
-                    })),
+                        );
+                        return {
+                            type: 'citation',
+                            url: citation.url,
+                            text,
+                            index: index + 1,
+                            from_llm: true,
+                            is_slack_url: false,
+                            details: {
+                                citation_type: 'web',
+                                display_name: 'Lightdash memory',
+                                title: text,
+                            },
+                        };
+                    }),
                 },
             ],
         } as unknown as Block,


### PR DESCRIPTION
## Summary

Slack answers now carry real memory citations. Markers keep being stripped from the prose (slice 5), and a trailing `rich_text` block of native Block Kit `citation` elements is appended, one per distinct cited memory, each linking that memory's read-only page (slice 8).

- `AiAgentMemoryModel.findActiveBySlugs` resolves cited slugs to `{memoryId, slug, title}`, active rows only
- `getMemoryCitationBlocks` builds the trailing `rich_text` block — citation elements are rich-text-only, so they can't live inside the answer's `markdown` blocks
- `AiAgentService.getSlackMemoryCitationBlocks` parses markers from the raw response, drops slugs without an active memory row (`logger.warn` with the prompt uuid), and builds `/projects/:projectUuid/ai-agents/:agentUuid/memories/:slug` URLs
- Citations ride in `trailingBlocks`, which attach to the last message only, so they land directly after the prose in both delivery paths (streaming task card and plain messages). `splitMarkdownIntoMessages` is untouched.

Field mapping (was left as a build-time decision in ZAP-657): `details.citation_type: 'memory'` + `memory_id`, plus `from_llm: true`.

## Verification

- `getSlackBlocks` + `memoryCitation` unit tests: 36 passed; `typecheck:fast` and focused lint clean
- `blocks.validate` against the real Slack API on actual builder output: `{"ok":true}` — including a citation block combined with the answer's `markdown` blocks in one message payload, and 30 citations with long titles
- Local DB run: an answer citing 3 slugs (1 active, 1 retired, 1 nonexistent) rendered 1 chip and logged 2 drops; the chip's URL resolves to real memory data via the API

## Notes for review

- **No cap on citation count.** An earlier draft capped the row at 10, but that silently dropped memories and contradicted "one element per distinct cited memory". Slack accepts 30 elements, and oversized messages already fall back to a Lightdash link via `isSlackMessageTooLongError`.
- **Blank labels are dropped.** Slack rejects a citation with empty `text` (`min_length` 1), and `invalid_blocks` is not a "too long" error — it would rethrow past the delivery fallback and cost the user their whole answer. Blank titles fall back to the slug; citations with neither are dropped.
- **Residual risk, same as our other custom blocks:** `citation` is absent from `@slack/types`, so it's cast `as unknown as Block` and verified only via `blocks.validate` — identical to how `card`, `carousel`, `context_actions` and `feedback_buttons` already ship here. If Slack ever rejects it at post time on the non-streaming path, the answer is lost rather than degraded. Happy to add an `invalid_blocks` retry-without-citations fallback if you'd rather not accept that.

Closes: https://linear.app/lightdash/issue/ZAP-681/memory-slice-9-slack-block-kit-citations
