### PR TITLE
feat: add AI agent memories admin tab

### DIFF
--- a/packages/backend/src/ee/controllers/AiAgentAdminController.ts
+++ b/packages/backend/src/ee/controllers/AiAgentAdminController.ts
@@ -1,9 +1,12 @@
 import {
     AiAgentAdminFilters,
+    AiAgentAdminMemoryFilters,
+    AiAgentAdminMemorySort,
     AiAgentAdminSort,
     AiAgentReviewItemStatus,
     AiAgentReviewReplayCaptureRequest,
     ApiAiAgentAdminConversationsResponse,
+    ApiAiAgentAdminMemoriesResponse,
     ApiAiAgentAdminPromptActivityResponse,
     ApiAiAgentReviewItemActivityResponse,
     ApiAiAgentReviewItemPrDiffResponse,
@@ -64,6 +67,7 @@ import { type AiAgentAdminService } from '../services/AiAgentAdminService';
 import { type AiOrganizationSettingsService } from '../services/AiOrganizationSettingsService';
 
 const MCP_ACTIVITY_MAX_PAGE_SIZE = 100;
+const AI_AGENT_MEMORIES_MAX_PAGE_SIZE = 100;
 
 // Rejects malformed date filters at the boundary (422) instead of letting
 // Postgres fail the query with a 500
@@ -321,6 +325,61 @@ export class AiAgentAdminController extends BaseController {
             results: await this.getAiAgentAdminService().listAgents(
                 toSessionUser(req.account),
             ),
+        };
+    }
+
+    /**
+     * Get all AI agent memories for admin
+     * @summary List AI agent memories
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/memories')
+    @OperationId('getAllAiAgentMemories')
+    async getAllAiAgentMemories(
+        @Request() req: express.Request,
+        // Pagination
+        @Query() page?: KnexPaginateArgs['page'],
+        @Query() pageSize?: KnexPaginateArgs['pageSize'],
+        // Filtering
+        @Query() projectUuids?: AiAgentAdminMemoryFilters['projectUuids'],
+        @Query() userUuids?: AiAgentAdminMemoryFilters['userUuids'],
+        @Query() statuses?: AiAgentAdminMemoryFilters['statuses'],
+        @Query() search?: AiAgentAdminMemoryFilters['search'],
+        // Sorting
+        @Query() sortField?: AiAgentAdminMemorySort['field'],
+        @Query() sortDirection?: AiAgentAdminMemorySort['direction'],
+    ): Promise<ApiAiAgentAdminMemoriesResponse> {
+        assertRegisteredAccount(req.account);
+        validateUuidFilter('projectUuids', projectUuids);
+        validateUuidFilter('userUuids', userUuids);
+
+        const filters: AiAgentAdminMemoryFilters = {
+            ...(projectUuids && { projectUuids }),
+            ...(userUuids && { userUuids }),
+            ...(statuses && { statuses }),
+            ...(search && { search }),
+        };
+
+        const memories = await this.getAiAgentAdminService().getAllMemories(
+            toSessionUser(req.account),
+            {
+                page: page ?? 1,
+                pageSize: Math.min(
+                    pageSize ?? 50,
+                    AI_AGENT_MEMORIES_MAX_PAGE_SIZE,
+                ),
+            },
+            filters,
+            sortField
+                ? { field: sortField, direction: sortDirection ?? 'desc' }
+                : undefined,
+        );
+
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: memories,
         };
     }
 

--- a/packages/backend/src/ee/database/entities/aiAgentMemory.ts
+++ b/packages/backend/src/ee/database/entities/aiAgentMemory.ts
@@ -1,10 +1,12 @@
-import type { AiProjectContextTypedObjectRef } from '@lightdash/common';
+import type {
+    AiAgentMemoryStatus,
+    AiProjectContextTypedObjectRef,
+} from '@lightdash/common';
 import { Knex } from 'knex';
 
 export const AiAgentMemoryTableName = 'ai_agent_memory';
 export const AiAgentThreadDistillTableName = 'ai_agent_thread_distill';
 
-export type AiAgentMemoryStatus = 'active' | 'superseded' | 'retired';
 export type AiAgentThreadDistillOutcome =
     | 'memory'
     | 'no_op'

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -492,6 +492,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 new AiAgentAdminService({
                     analytics: context.lightdashAnalytics,
                     aiAgentModel: models.getAiAgentModel(),
+                    aiAgentMemoryModel:
+                        models.getAiAgentMemoryModel<AiAgentMemoryModel>(),
                     aiAgentReviewClassifierModel:
                         models.getAiAgentReviewClassifierModel<AiAgentReviewClassifierModel>(),
                     aiAgentReviewClassifierService:

--- a/packages/backend/src/ee/models/AiAgentMemoryModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentMemoryModel.integration.test.ts
@@ -491,6 +491,119 @@ describe('AiAgentMemoryModel integration', () => {
         expect(Number(ledgerCount?.count)).toBe(1);
     });
 
+    it('paginates admin memories with project, user, status and search filters', async () => {
+        const [citedThread, uncitedThread, retiredThread] = await Promise.all([
+            createThread(),
+            createThread(),
+            createThread(),
+        ]);
+        const cited = await model.upsertSourceThreadMemory(
+            memoryInput(citedThread, {
+                title: 'Net revenue convention',
+                rawMemory: 'Use net revenue for every board report.',
+                userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                generatedAt: new Date('2026-07-22T12:00:00Z'),
+            }),
+        );
+        const uncited = await model.upsertSourceThreadMemory(
+            memoryInput(uncitedThread, {
+                title: 'Fiscal year offset',
+                rawMemory: 'The fiscal year starts in February.',
+                generatedAt: new Date('2026-07-22T11:00:00Z'),
+            }),
+        );
+        const retired = await model.upsertSourceThreadMemory(
+            memoryInput(retiredThread, {
+                title: 'Legacy tiering',
+                rawMemory: 'Tiers were retired.',
+                generatedAt: new Date('2026-07-22T10:00:00Z'),
+            }),
+        );
+        await database(AiAgentMemoryTableName)
+            .where('ai_agent_memory_uuid', cited.ai_agent_memory_uuid)
+            .update({ cited_count: 4, last_cited_at: new Date() });
+        await database(AiAgentMemoryTableName)
+            .where('ai_agent_memory_uuid', retired.ai_agent_memory_uuid)
+            .update({ status: 'retired' });
+
+        const listAll = await model.findAdminMemoriesPaginated({
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            paginateArgs: { page: 1, pageSize: 50 },
+            filters: { projectUuids: [SEED_PROJECT.project_uuid] },
+        });
+        const listed = listAll.data.memories.filter((memory) =>
+            [
+                cited.ai_agent_memory_uuid,
+                uncited.ai_agent_memory_uuid,
+                retired.ai_agent_memory_uuid,
+            ].includes(memory.uuid),
+        );
+        expect(listed.map((memory) => memory.uuid)).toEqual([
+            cited.ai_agent_memory_uuid,
+            uncited.ai_agent_memory_uuid,
+            retired.ai_agent_memory_uuid,
+        ]);
+        expect(listed[0]).toMatchObject({
+            slug: cited.slug,
+            title: 'Net revenue convention',
+            summary: 'Use net revenue for every board report.',
+            status: 'active',
+            project: { uuid: SEED_PROJECT.project_uuid },
+            citedCount: 4,
+            sourceThreadUuid: citedThread,
+        });
+        expect(listed[0].user?.uuid).toBe(SEED_ORG_1_ADMIN.user_uuid);
+        expect(listed[1].user).toBeNull();
+
+        const byUser = await model.findAdminMemoriesPaginated({
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            paginateArgs: { page: 1, pageSize: 50 },
+            filters: { userUuids: [SEED_ORG_1_ADMIN.user_uuid] },
+        });
+        expect(
+            byUser.data.memories.some(
+                (memory) => memory.uuid === cited.ai_agent_memory_uuid,
+            ),
+        ).toBe(true);
+        expect(
+            byUser.data.memories.some(
+                (memory) => memory.uuid === uncited.ai_agent_memory_uuid,
+            ),
+        ).toBe(false);
+
+        const retiredOnly = await model.findAdminMemoriesPaginated({
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            paginateArgs: { page: 1, pageSize: 50 },
+            filters: {
+                projectUuids: [SEED_PROJECT.project_uuid],
+                statuses: ['retired'],
+                search: 'Legacy',
+            },
+        });
+        expect(
+            retiredOnly.data.memories.map((memory) => memory.uuid),
+        ).toContain(retired.ai_agent_memory_uuid);
+        expect(
+            retiredOnly.data.memories.every(
+                (memory) => memory.status === 'retired',
+            ),
+        ).toBe(true);
+
+        const firstPage = await model.findAdminMemoriesPaginated({
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            paginateArgs: { page: 1, pageSize: 1 },
+            filters: { projectUuids: [SEED_PROJECT.project_uuid] },
+            sort: { field: 'citedCount', direction: 'desc' },
+        });
+        expect(firstPage.data.memories).toHaveLength(1);
+        expect(firstPage.data.memories[0].uuid).toBe(
+            cited.ai_agent_memory_uuid,
+        );
+        expect(firstPage.pagination?.totalResults).toBe(
+            listAll.pagination?.totalResults,
+        );
+    });
+
     it('returns only active project memories in citation then generation order', async () => {
         const [firstThread, secondThread, thirdThread, retiredThread] =
             await Promise.all([

--- a/packages/backend/src/ee/models/AiAgentMemoryModel.ts
+++ b/packages/backend/src/ee/models/AiAgentMemoryModel.ts
@@ -1,11 +1,19 @@
 import {
     ProjectType,
+    type AiAgentAdminMemoriesSummary,
+    type AiAgentAdminMemoryFilters,
+    type AiAgentAdminMemorySort,
     type AiProjectContextTypedObjectRef,
     type AiThreadCreatedFrom,
+    type KnexPaginateArgs,
+    type KnexPaginatedData,
     type UUID,
 } from '@lightdash/common';
 import { Knex } from 'knex';
+import { EmailTableName } from '../../database/entities/emails';
 import { ProjectTableName } from '../../database/entities/projects';
+import { UserTableName } from '../../database/entities/users';
+import KnexPaginate from '../../database/pagination';
 import {
     AiAgentToolCallTableName,
     AiAgentToolResultTableName,
@@ -13,6 +21,7 @@ import {
     AiPromptTableName,
     AiThreadTableName,
 } from '../database/entities/ai';
+import { AiAgentTableName } from '../database/entities/aiAgent';
 import {
     AiAgentMemoryTableName,
     AiAgentThreadDistillTableName,
@@ -21,6 +30,9 @@ import {
     type DbAiAgentMemory,
     type DbAiAgentThreadDistill,
 } from '../database/entities/aiAgentMemory';
+
+// Keeps the admin list payload bounded; the memory page shows the full body
+const ADMIN_MEMORY_SUMMARY_MAX_LENGTH = 280;
 
 export const AI_AGENT_MEMORY_THREAD_SOURCES = [
     'web_app',
@@ -432,6 +444,200 @@ export class AiAgentMemoryModel {
         }
 
         return query;
+    }
+
+    private buildAdminMemoriesQuery(
+        organizationUuid: string,
+        filters: AiAgentAdminMemoryFilters | undefined,
+    ) {
+        const query = this.database<AiAgentMemoryTable>(
+            AiAgentMemoryTableName,
+        ).where(
+            `${AiAgentMemoryTableName}.organization_uuid`,
+            organizationUuid,
+        );
+
+        if (filters?.projectUuids && filters.projectUuids.length > 0) {
+            void query.whereIn(
+                `${AiAgentMemoryTableName}.project_uuid`,
+                filters.projectUuids,
+            );
+        }
+        if (filters?.userUuids && filters.userUuids.length > 0) {
+            void query.whereIn(
+                `${AiAgentMemoryTableName}.user_uuid`,
+                filters.userUuids,
+            );
+        }
+        if (filters?.statuses && filters.statuses.length > 0) {
+            void query.whereIn(
+                `${AiAgentMemoryTableName}.status`,
+                filters.statuses,
+            );
+        }
+        if (filters?.search) {
+            const pattern = `%${filters.search}%`;
+            void query.where((builder) => {
+                void builder
+                    .whereILike(`${AiAgentMemoryTableName}.title`, pattern)
+                    .orWhereILike(`${AiAgentMemoryTableName}.slug`, pattern)
+                    .orWhereILike(
+                        `${AiAgentMemoryTableName}.raw_memory`,
+                        pattern,
+                    );
+            });
+        }
+
+        return query;
+    }
+
+    async findAdminMemoriesPaginated(args: {
+        organizationUuid: string;
+        paginateArgs?: KnexPaginateArgs;
+        filters?: AiAgentAdminMemoryFilters;
+        sort?: AiAgentAdminMemorySort;
+    }): Promise<KnexPaginatedData<AiAgentAdminMemoriesSummary>> {
+        const sortColumn = {
+            generatedAt: 'generated_at',
+            citedCount: 'cited_count',
+        }[args.sort?.field ?? 'generatedAt'];
+        const direction = args.sort?.direction ?? 'desc';
+
+        const query = this.buildAdminMemoriesQuery(
+            args.organizationUuid,
+            args.filters,
+        )
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_uuid`,
+                `${AiAgentMemoryTableName}.project_uuid`,
+            )
+            .leftJoin(
+                AiAgentTableName,
+                `${AiAgentTableName}.ai_agent_uuid`,
+                `${AiAgentMemoryTableName}.agent_uuid`,
+            )
+            .leftJoin(
+                UserTableName,
+                `${UserTableName}.user_uuid`,
+                `${AiAgentMemoryTableName}.user_uuid`,
+            )
+            .leftJoin(EmailTableName, function joinPrimaryEmail() {
+                void this.on(
+                    `${EmailTableName}.user_id`,
+                    '=',
+                    `${UserTableName}.user_id`,
+                ).andOnVal(`${EmailTableName}.is_primary`, true);
+            })
+            .select<
+                Array<{
+                    ai_agent_memory_uuid: string;
+                    slug: string;
+                    title: string;
+                    summary: string;
+                    status: DbAiAgentMemory['status'];
+                    project_uuid: string;
+                    project_name: string;
+                    agent_uuid: string | null;
+                    agent_name: string | null;
+                    agent_image_url: string | null;
+                    user_uuid: string | null;
+                    user_name: string | null;
+                    user_email: string | null;
+                    source_thread_uuid: string | null;
+                    cited_count: number;
+                    last_cited_at: Date | null;
+                    pulled_count: number;
+                    last_pulled_at: Date | null;
+                    generated_at: Date;
+                }>
+            >([
+                `${AiAgentMemoryTableName}.ai_agent_memory_uuid`,
+                `${AiAgentMemoryTableName}.slug`,
+                `${AiAgentMemoryTableName}.title`,
+                this.database.raw('LEFT(??, ?) as summary', [
+                    `${AiAgentMemoryTableName}.raw_memory`,
+                    ADMIN_MEMORY_SUMMARY_MAX_LENGTH,
+                ]),
+                `${AiAgentMemoryTableName}.status`,
+                `${AiAgentMemoryTableName}.project_uuid`,
+                `${ProjectTableName}.name as project_name`,
+                `${AiAgentMemoryTableName}.agent_uuid`,
+                `${AiAgentTableName}.name as agent_name`,
+                `${AiAgentTableName}.image_url as agent_image_url`,
+                `${AiAgentMemoryTableName}.user_uuid`,
+                this.database.raw(
+                    `NULLIF(TRIM(CONCAT(${UserTableName}.first_name, ' ', ${UserTableName}.last_name)), '') as user_name`,
+                ),
+                `${EmailTableName}.email as user_email`,
+                `${AiAgentMemoryTableName}.source_thread_uuid`,
+                `${AiAgentMemoryTableName}.cited_count`,
+                `${AiAgentMemoryTableName}.last_cited_at`,
+                `${AiAgentMemoryTableName}.pulled_count`,
+                `${AiAgentMemoryTableName}.last_pulled_at`,
+                `${AiAgentMemoryTableName}.generated_at`,
+            ])
+            // uuid tie-breaker keeps pagination stable when sort values collide
+            .orderBy([
+                {
+                    column: `${AiAgentMemoryTableName}.${sortColumn}`,
+                    order: direction,
+                    nulls: 'last',
+                },
+                {
+                    column: `${AiAgentMemoryTableName}.ai_agent_memory_uuid`,
+                    order: 'asc',
+                },
+            ]);
+
+        // Counting the un-joined base query skips the display joins. Row count
+        // is identical: project_uuid is NOT NULL with a CASCADE FK, so the
+        // project inner join never drops a memory.
+        const { data, pagination } = await KnexPaginate.paginate(
+            query,
+            args.paginateArgs,
+            this.buildAdminMemoriesQuery(args.organizationUuid, args.filters),
+        );
+
+        return {
+            data: {
+                memories: data.map((row) => ({
+                    uuid: row.ai_agent_memory_uuid,
+                    slug: row.slug,
+                    title: row.title,
+                    summary: row.summary,
+                    status: row.status,
+                    project: {
+                        uuid: row.project_uuid,
+                        name: row.project_name,
+                    },
+                    agent: row.agent_uuid
+                        ? {
+                              uuid: row.agent_uuid,
+                              name: row.agent_name ?? 'Unknown agent',
+                              imageUrl: row.agent_image_url,
+                          }
+                        : null,
+                    user: row.user_uuid
+                        ? {
+                              uuid: row.user_uuid,
+                              name:
+                                  row.user_name ??
+                                  row.user_email ??
+                                  'Unknown user',
+                              email: row.user_email,
+                          }
+                        : null,
+                    sourceThreadUuid: row.source_thread_uuid,
+                    citedCount: row.cited_count,
+                    lastCitedAt: row.last_cited_at?.toISOString() ?? null,
+                    pulledCount: row.pulled_count,
+                    lastPulledAt: row.last_pulled_at?.toISOString() ?? null,
+                    generatedAt: row.generated_at.toISOString(),
+                })),
+            },
+            pagination,
+        };
     }
 
     async findByProjectAndSlug(args: {

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -201,6 +201,7 @@ const makeOrgViewerUser = (): SessionUser => ({
 
 const makeService = ({
     aiAgentModel = {},
+    aiAgentMemoryModel = {},
     aiAgentReviewClassifierModel = {},
     aiAgentReviewClassifierService = {},
     aiAgentReviewNotificationModel = {},
@@ -219,6 +220,7 @@ const makeService = ({
     aiAgentReviewNotificationService = {},
 }: {
     aiAgentModel?: Record<string, unknown>;
+    aiAgentMemoryModel?: Record<string, unknown>;
     aiAgentReviewClassifierModel?: Record<string, unknown>;
     aiAgentReviewClassifierService?: Record<string, unknown>;
     aiAgentReviewNotificationModel?: Record<string, unknown>;
@@ -245,6 +247,12 @@ const makeService = ({
             }),
             updateThreadTitle: vi.fn().mockResolvedValue(undefined),
             ...aiAgentModel,
+        },
+        aiAgentMemoryModel: {
+            findAdminMemoriesPaginated: vi
+                .fn()
+                .mockResolvedValue({ data: { memories: [] } }),
+            ...aiAgentMemoryModel,
         },
         aiAgentReviewClassifierModel: {
             getReviewRemediation: vi.fn().mockResolvedValue(makeRemediation()),
@@ -464,6 +472,106 @@ describe('AiAgentAdminService review access', () => {
             'Insufficient permissions to access AI agent reviews',
         );
         expect(listReviewSignals).not.toHaveBeenCalled();
+    });
+});
+
+describe('AiAgentAdminService.getAllMemories', () => {
+    it('rejects when the memory feature flag is disabled', async () => {
+        const service = makeService({
+            featureFlagService: {
+                get: vi.fn().mockResolvedValue({ enabled: false }),
+            },
+        });
+
+        await expect(service.getAllMemories(makeAdminUser())).rejects.toThrow(
+            'AI agent memory is not enabled',
+        );
+    });
+
+    it('rejects principals without manage access to any project', async () => {
+        const service = makeService();
+
+        await expect(
+            service.getAllMemories(makeOrgViewerUser()),
+        ).rejects.toThrow(
+            'Insufficient permissions to access AI agent features',
+        );
+    });
+
+    it('scopes project-scoped principals to their own projects', async () => {
+        const findAdminMemoriesPaginated = vi
+            .fn()
+            .mockResolvedValue({ data: { memories: [] } });
+        const service = makeService({
+            aiAgentMemoryModel: { findAdminMemoriesPaginated },
+            projectModel: {
+                getAllByOrganizationUuid: vi
+                    .fn()
+                    .mockResolvedValue([
+                        { projectUuid: PROJECT_UUID },
+                        { projectUuid: 'other-project-uuid' },
+                    ]),
+            },
+        });
+
+        await service.getAllMemories(makeProjectUser(), undefined, {
+            projectUuids: [PROJECT_UUID, 'other-project-uuid'],
+        });
+
+        expect(findAdminMemoriesPaginated).toHaveBeenCalledWith(
+            expect.objectContaining({
+                organizationUuid: ORGANIZATION_UUID,
+                filters: { projectUuids: [PROJECT_UUID] },
+            }),
+        );
+    });
+
+    it('returns an empty page without querying when the scope is empty', async () => {
+        const findAdminMemoriesPaginated = vi.fn();
+        const service = makeService({
+            aiAgentMemoryModel: { findAdminMemoriesPaginated },
+            projectModel: {
+                getAllByOrganizationUuid: vi
+                    .fn()
+                    .mockResolvedValue([{ projectUuid: PROJECT_UUID }]),
+            },
+        });
+
+        const result = await service.getAllMemories(
+            makeProjectUser(),
+            undefined,
+            { projectUuids: ['other-project-uuid'] },
+        );
+
+        expect(result).toEqual({ data: { memories: [] } });
+        expect(findAdminMemoriesPaginated).not.toHaveBeenCalled();
+    });
+
+    it('passes pagination, filters and sort through for org admins', async () => {
+        const findAdminMemoriesPaginated = vi
+            .fn()
+            .mockResolvedValue({ data: { memories: [] } });
+        const service = makeService({
+            aiAgentMemoryModel: { findAdminMemoriesPaginated },
+        });
+
+        await service.getAllMemories(
+            makeAdminUser(),
+            { page: 2, pageSize: 25 },
+            { userUuids: ['user-1'], statuses: ['active'], search: 'revenue' },
+            { field: 'citedCount', direction: 'asc' },
+        );
+
+        expect(findAdminMemoriesPaginated).toHaveBeenCalledWith({
+            organizationUuid: ORGANIZATION_UUID,
+            paginateArgs: { page: 2, pageSize: 25 },
+            filters: {
+                userUuids: ['user-1'],
+                statuses: ['active'],
+                search: 'revenue',
+            },
+            sort: { field: 'citedCount', direction: 'asc' },
+        });
     });
 });
 

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -2,6 +2,9 @@ import { subject } from '@casl/ability';
 import {
     AiAgentAdminConversationsSummary,
     AiAgentAdminFilters,
+    AiAgentAdminMemoriesSummary,
+    AiAgentAdminMemoryFilters,
+    AiAgentAdminMemorySort,
     AiAgentAdminPromptActivityPoint,
     AiAgentAdminSort,
     AiAgentReviewActivityEvent,
@@ -75,6 +78,7 @@ import { type UserModel } from '../../models/UserModel';
 import { BaseService } from '../../services/BaseService';
 import { type FeatureFlagService } from '../../services/FeatureFlag/FeatureFlagService';
 import { type ProjectService } from '../../services/ProjectService/ProjectService';
+import { type AiAgentMemoryModel } from '../models/AiAgentMemoryModel';
 import { AiAgentModel } from '../models/AiAgentModel';
 import { type AiAgentReviewClassifierModel } from '../models/AiAgentReviewClassifierModel';
 import { type AiAgentReviewNotificationModel } from '../models/AiAgentReviewNotificationModel';
@@ -95,6 +99,7 @@ import { type ProjectContextService } from './ProjectContextService/ProjectConte
 type AiAgentAdminServiceDependencies = {
     analytics: LightdashAnalytics;
     aiAgentModel: AiAgentModel;
+    aiAgentMemoryModel: Pick<AiAgentMemoryModel, 'findAdminMemoriesPaginated'>;
     aiAgentReviewClassifierModel: AiAgentReviewClassifierModel;
     aiAgentReviewClassifierService: Pick<
         AiAgentReviewClassifierService,
@@ -325,6 +330,8 @@ export class AiAgentAdminService extends BaseService {
 
     private readonly aiAgentModel: AiAgentModel;
 
+    private readonly aiAgentMemoryModel: AiAgentAdminServiceDependencies['aiAgentMemoryModel'];
+
     private readonly lightdashConfig: LightdashConfig;
 
     private readonly aiAgentReviewClassifierModel: AiAgentReviewClassifierModel;
@@ -370,6 +377,7 @@ export class AiAgentAdminService extends BaseService {
         super();
         this.analytics = dependencies.analytics;
         this.aiAgentModel = dependencies.aiAgentModel;
+        this.aiAgentMemoryModel = dependencies.aiAgentMemoryModel;
         this.aiAgentReviewClassifierModel =
             dependencies.aiAgentReviewClassifierModel;
         this.aiAgentReviewClassifierService =
@@ -646,6 +654,43 @@ export class AiAgentAdminService extends BaseService {
             organizationUuid,
             projectUuid,
             days: boundedDays,
+        });
+    }
+
+    /**
+     * Read-only org-wide memory audit surface. Same scope rules as threads:
+     * org principals see all, project-scoped principals see their projects.
+     */
+    async getAllMemories(
+        user: SessionUser,
+        paginateArgs?: KnexPaginateArgs,
+        filters?: AiAgentAdminMemoryFilters,
+        sort?: AiAgentAdminMemorySort,
+    ): Promise<KnexPaginatedData<AiAgentAdminMemoriesSummary>> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+        const { enabled } = await this.featureFlagService.get({
+            featureFlagId: FeatureFlags.AiAgentMemory,
+            user,
+        });
+        if (!enabled) {
+            throw new ForbiddenError('AI agent memory is not enabled');
+        }
+
+        const scope = await this.resolveReadScope(user, organizationUuid);
+        const { filters: scopedFilters, empty } =
+            AiAgentAdminService.restrictFiltersToScope(scope, filters);
+        if (empty) {
+            return { data: { memories: [] } };
+        }
+
+        return this.aiAgentMemoryModel.findAdminMemoriesPaginated({
+            organizationUuid,
+            paginateArgs,
+            filters: scopedFilters,
+            sort,
         });
     }
 

--- a/packages/common/src/ee/AiAgent/adminTypes.ts
+++ b/packages/common/src/ee/AiAgent/adminTypes.ts
@@ -1,5 +1,6 @@
 import type { ApiSuccess, KnexPaginatedData } from '../..';
 import type {
+    AiAgentMemoryStatus,
     AiAgentSummary,
     AiAgentThreadSummary,
     AiAgentUser,
@@ -60,6 +61,57 @@ export type AiAgentAdminConversationsSummary = {
 
 export type ApiAiAgentAdminConversationsResponse = ApiSuccess<
     KnexPaginatedData<AiAgentAdminConversationsSummary>
+>;
+
+export type AiAgentAdminMemoryFilters = {
+    projectUuids?: string[];
+    userUuids?: string[];
+    statuses?: AiAgentMemoryStatus[];
+    search?: string; // Search by memory title, slug or body
+};
+
+export type AiAgentAdminMemorySortField = 'generatedAt' | 'citedCount';
+
+export type AiAgentAdminMemorySort = {
+    field: AiAgentAdminMemorySortField;
+    direction: 'asc' | 'desc';
+};
+
+export type AiAgentAdminMemoryItem = {
+    uuid: string;
+    slug: string;
+    title: string;
+    // Memory body, truncated server-side for the list view
+    summary: string;
+    status: AiAgentMemoryStatus;
+    project: {
+        uuid: string;
+        name: string;
+    };
+    agent: {
+        uuid: string;
+        name: string;
+        imageUrl: string | null;
+    } | null;
+    user: {
+        uuid: string;
+        name: string;
+        email: string | null;
+    } | null;
+    sourceThreadUuid: string | null;
+    citedCount: number;
+    lastCitedAt: string | null;
+    pulledCount: number;
+    lastPulledAt: string | null;
+    generatedAt: string;
+};
+
+export type AiAgentAdminMemoriesSummary = {
+    memories: AiAgentAdminMemoryItem[];
+};
+
+export type ApiAiAgentAdminMemoriesResponse = ApiSuccess<
+    KnexPaginatedData<AiAgentAdminMemoriesSummary>
 >;
 
 export type AiAgentAdminPromptActivityPoint = {

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -350,13 +350,15 @@ export type AiAgentMemorySource = {
       }
 );
 
+export type AiAgentMemoryStatus = 'active' | 'superseded' | 'retired';
+
 export type AiAgentMemory = {
     slug: string;
     title: string;
     rawMemory: string;
     terms: string[];
     objects: AiProjectContextTypedObjectRef[];
-    status: 'active' | 'superseded' | 'retired';
+    status: AiAgentMemoryStatus;
     generatedAt: string;
     citedCount: number;
     provenance:

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -8,6 +8,7 @@ import type {
     ApiAgentOnboardingRunResponse,
     ApiAgentSuggestionsResponse,
     ApiAiAgentAdminConversationsResponse,
+    ApiAiAgentAdminMemoriesResponse,
     ApiAiAgentAdminPromptActivityResponse,
     ApiAiAgentArtifactResponse,
     ApiAiAgentArtifactVizQueryResponse,
@@ -1258,6 +1259,7 @@ type ApiResults =
     | ApiAiAgentProjectThreadSummaryListResponse['results']
     | Account
     | ApiAiAgentAdminConversationsResponse['results']
+    | ApiAiAgentAdminMemoriesResponse['results']
     | ApiAiAgentAdminPromptActivityResponse['results']
     | ApiMcpActivityResponse['results']
     | ApiMcpActivityStatsResponse['results']

--- a/packages/frontend/src/ee/CommercialRoutes.tsx
+++ b/packages/frontend/src/ee/CommercialRoutes.tsx
@@ -215,6 +215,10 @@ const COMMERCIAL_AI_AGENTS_ROUTES: RouteObject[] = [
         element: <Navigate to="/generalSettings/ai/agents" replace />,
     },
     {
+        path: '/ai-agents/admin/memories',
+        element: <Navigate to="/generalSettings/ai/memories" replace />,
+    },
+    {
         path: '/ai-agents/admin/reviews',
         element: <Navigate to="/generalSettings/ai/issues" replace />,
     },

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AdminMemoryDetailsModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AdminMemoryDetailsModal.tsx
@@ -1,0 +1,60 @@
+import { Box, Loader, Text } from '@mantine-8/core';
+import { type FC } from 'react';
+import MantineModal from '../../../../../components/common/MantineModal';
+import { useAiAgentMemory } from '../../hooks/useAiAgentMemory';
+import { MemoryDetailsModal } from '../MemoryDetails/MemoryDetails';
+
+export type AdminMemorySelection = {
+    projectUuid: string;
+    agentUuid: string;
+    slug: string;
+    title: string;
+};
+
+type AdminMemoryDetailsModalProps = {
+    selection: AdminMemorySelection;
+    onClose: () => void;
+};
+
+/**
+ * The admin list carries only a summary, so the full memory is fetched on open
+ * and handed to the shared details modal.
+ */
+export const AdminMemoryDetailsModal: FC<AdminMemoryDetailsModalProps> = ({
+    selection,
+    onClose,
+}) => {
+    const { projectUuid, agentUuid, slug, title } = selection;
+    const memoryQuery = useAiAgentMemory({ projectUuid, agentUuid, slug });
+
+    if (memoryQuery.data) {
+        return (
+            <MemoryDetailsModal
+                opened
+                onClose={onClose}
+                memory={memoryQuery.data}
+                projectUuid={projectUuid}
+                agentUuid={agentUuid}
+            />
+        );
+    }
+
+    return (
+        <MantineModal
+            opened
+            onClose={onClose}
+            title={title}
+            cancelLabel={false}
+        >
+            <Box py="xl" ta="center">
+                {memoryQuery.isError ? (
+                    <Text c="dimmed" fz="sm">
+                        Unable to load this memory.
+                    </Text>
+                ) : (
+                    <Loader size="sm" color="gray" />
+                )}
+            </Box>
+        </MantineModal>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminMemoriesTable.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminMemoriesTable.module.css
@@ -1,0 +1,14 @@
+.toolbarDivider {
+    align-self: center;
+}
+
+.resultCount {
+    display: flex;
+    align-items: center;
+    height: 32px;
+    border-radius: 6px;
+}
+
+.bottomToolbar {
+    border-top: 1px solid var(--mantine-color-ldGray-3);
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminMemoriesTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminMemoriesTable.tsx
@@ -3,7 +3,6 @@ import {
     type AiAgentAdminMemorySortField,
 } from '@lightdash/common';
 import {
-    Anchor,
     Badge,
     Box,
     Button,
@@ -24,14 +23,19 @@ import {
     IconCircleDotted,
     IconClock,
     IconFileText,
-    IconMessageCircleStar,
     IconQuote,
     IconRobotFace,
     IconTrash,
     IconUser,
 } from '@tabler/icons-react';
-import { useCallback, useEffect, useMemo, useRef, type UIEvent } from 'react';
-import { Link, useNavigate } from 'react-router';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type UIEvent,
+} from 'react';
 import {
     ContentTable,
     useContentTable,
@@ -42,6 +46,10 @@ import MantineIcon from '../../../../../components/common/MantineIcon';
 import { useInfiniteAiAgentAdminMemories } from '../../hooks/useAiAgentAdmin';
 import { useAiAgentAdminMemoryFilters } from '../../hooks/useAiAgentAdminMemoryFilters';
 import { AgentNamePill } from '../AgentNamePill';
+import {
+    AdminMemoryDetailsModal,
+    type AdminMemorySelection,
+} from './AdminMemoryDetailsModal';
 import styles from './AiAgentAdminMemoriesTable.module.css';
 import { MEMORY_STATUS_COLORS, MEMORY_STATUS_LABELS } from './memoryStatus';
 import MemoryStatusFilter from './MemoryStatusFilter';
@@ -60,40 +68,10 @@ const isSortableColumn = (id: string): id is AiAgentAdminMemorySortField =>
 const formatDate = (value: string | null) =>
     value ? new Date(value).toLocaleDateString() : 'Never';
 
-const telemetryColumn = ({
-    countKey,
-    lastAtKey,
-    header,
-    sortable,
-}: {
-    countKey: 'citedCount' | 'pulledCount';
-    lastAtKey: 'lastCitedAt' | 'lastPulledAt';
-    header: string;
-    sortable: boolean;
-}): ContentTableColumnDef<AiAgentAdminMemoryItem> => ({
-    accessorKey: countKey,
-    header,
-    enableSorting: sortable,
-    size: 140,
-    Header: ({ column }) => (
-        <Group gap="two">
-            <MantineIcon icon={IconQuote} color="ldGray.6" />
-            {column.columnDef.header}
-        </Group>
-    ),
-    Cell: ({ row }) => (
-        <Stack gap={2}>
-            <Badge variant="default">{row.original[countKey]}</Badge>
-            <Text fz="xs" c="ldGray.6">
-                {formatDate(row.original[lastAtKey])}
-            </Text>
-        </Stack>
-    ),
-});
-
 const AiAgentAdminMemoriesTable = () => {
     const theme = useMantineTheme();
-    const navigate = useNavigate();
+    const [selectedMemory, setSelectedMemory] =
+        useState<AdminMemorySelection | null>(null);
 
     const {
         search,
@@ -342,60 +320,27 @@ const AiAgentAdminMemoriesTable = () => {
                 },
             },
             {
-                accessorKey: 'sourceThreadUuid',
-                header: 'Provenance',
-                enableSorting: false,
+                accessorKey: 'citedCount',
+                header: 'Cited',
+                enableSorting: true,
                 size: 140,
                 Header: ({ column }) => (
                     <Group gap="two">
-                        <MantineIcon
-                            icon={IconMessageCircleStar}
-                            color="ldGray.6"
-                        />
+                        <MantineIcon icon={IconQuote} color="ldGray.6" />
                         {column.columnDef.header}
                     </Group>
                 ),
-                Cell: ({ row }) => {
-                    const { agent, project, sourceThreadUuid } = row.original;
-                    if (!sourceThreadUuid) {
-                        return (
-                            <Text fz="xs" c="ldGray.7" fw={500}>
-                                Consolidated
-                            </Text>
-                        );
-                    }
-                    if (!agent) {
-                        return (
-                            <Text fz="xs" c="ldGray.7" fw={500}>
-                                Thread
-                            </Text>
-                        );
-                    }
-                    return (
-                        <Anchor
-                            component={Link}
-                            fz="xs"
-                            fw={500}
-                            to={`/projects/${project.uuid}/ai-agents/${agent.uuid}/threads/${sourceThreadUuid}`}
-                            onClick={(event) => event.stopPropagation()}
-                        >
-                            Thread
-                        </Anchor>
-                    );
-                },
+                Cell: ({ row }) => (
+                    <Stack gap={2}>
+                        <Badge variant="default">
+                            {row.original.citedCount}
+                        </Badge>
+                        <Text fz="xs" c="ldGray.6">
+                            {formatDate(row.original.lastCitedAt)}
+                        </Text>
+                    </Stack>
+                ),
             },
-            telemetryColumn({
-                countKey: 'citedCount',
-                lastAtKey: 'lastCitedAt',
-                header: 'Cited',
-                sortable: true,
-            }),
-            telemetryColumn({
-                countKey: 'pulledCount',
-                lastAtKey: 'lastPulledAt',
-                header: 'Pulled',
-                sortable: false,
-            }),
             {
                 accessorKey: 'generatedAt',
                 header: 'Generated',
@@ -465,18 +410,20 @@ const AiAgentAdminMemoriesTable = () => {
                 return {};
             }
 
-            const { agent, project, slug } = row.original;
+            const { agent, project, slug, title } = row.original;
             if (!agent) {
                 return {};
             }
 
             return {
                 style: { cursor: 'pointer' },
-                onClick: () => {
-                    void navigate(
-                        `/projects/${project.uuid}/ai-agents/${agent.uuid}/memories/${slug}`,
-                    );
-                },
+                onClick: () =>
+                    setSelectedMemory({
+                        projectUuid: project.uuid,
+                        agentUuid: agent.uuid,
+                        slug,
+                        title,
+                    }),
             };
         },
         mantineTableBodyCellProps: {
@@ -599,7 +546,17 @@ const AiAgentAdminMemoriesTable = () => {
         },
     });
 
-    return <ContentTable table={table} />;
+    return (
+        <>
+            <ContentTable table={table} />
+            {selectedMemory && (
+                <AdminMemoryDetailsModal
+                    selection={selectedMemory}
+                    onClose={() => setSelectedMemory(null)}
+                />
+            )}
+        </>
+    );
 };
 
 export default AiAgentAdminMemoriesTable;

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminMemoriesTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminMemoriesTable.tsx
@@ -1,0 +1,605 @@
+import {
+    type AiAgentAdminMemoryItem,
+    type AiAgentAdminMemorySortField,
+} from '@lightdash/common';
+import {
+    Anchor,
+    Badge,
+    Box,
+    Button,
+    Divider,
+    Group,
+    Stack,
+    Text,
+    Tooltip,
+    useMantineTheme,
+} from '@mantine-8/core';
+import { useDebouncedValue } from '@mantine-8/hooks';
+import {
+    IconArrowDown,
+    IconArrowsSort,
+    IconArrowUp,
+    IconBox,
+    IconBrain,
+    IconCircleDotted,
+    IconClock,
+    IconFileText,
+    IconMessageCircleStar,
+    IconQuote,
+    IconRobotFace,
+    IconTrash,
+    IconUser,
+} from '@tabler/icons-react';
+import { useCallback, useEffect, useMemo, useRef, type UIEvent } from 'react';
+import { Link, useNavigate } from 'react-router';
+import {
+    ContentTable,
+    useContentTable,
+    type ContentTableColumnDef,
+    type ContentTableSortingState,
+} from '../../../../../components/common/ContentTable';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { useInfiniteAiAgentAdminMemories } from '../../hooks/useAiAgentAdmin';
+import { useAiAgentAdminMemoryFilters } from '../../hooks/useAiAgentAdminMemoryFilters';
+import { AgentNamePill } from '../AgentNamePill';
+import styles from './AiAgentAdminMemoriesTable.module.css';
+import { MEMORY_STATUS_COLORS, MEMORY_STATUS_LABELS } from './memoryStatus';
+import MemoryStatusFilter from './MemoryStatusFilter';
+import ProjectsFilter from './ProjectsFilter';
+import { SearchFilter } from './SearchFilter';
+import UsersFilter from './UsersFilter';
+
+const SORTABLE_COLUMNS: AiAgentAdminMemorySortField[] = [
+    'generatedAt',
+    'citedCount',
+];
+
+const isSortableColumn = (id: string): id is AiAgentAdminMemorySortField =>
+    SORTABLE_COLUMNS.includes(id as AiAgentAdminMemorySortField);
+
+const formatDate = (value: string | null) =>
+    value ? new Date(value).toLocaleDateString() : 'Never';
+
+const telemetryColumn = ({
+    countKey,
+    lastAtKey,
+    header,
+    sortable,
+}: {
+    countKey: 'citedCount' | 'pulledCount';
+    lastAtKey: 'lastCitedAt' | 'lastPulledAt';
+    header: string;
+    sortable: boolean;
+}): ContentTableColumnDef<AiAgentAdminMemoryItem> => ({
+    accessorKey: countKey,
+    header,
+    enableSorting: sortable,
+    size: 140,
+    Header: ({ column }) => (
+        <Group gap="two">
+            <MantineIcon icon={IconQuote} color="ldGray.6" />
+            {column.columnDef.header}
+        </Group>
+    ),
+    Cell: ({ row }) => (
+        <Stack gap={2}>
+            <Badge variant="default">{row.original[countKey]}</Badge>
+            <Text fz="xs" c="ldGray.6">
+                {formatDate(row.original[lastAtKey])}
+            </Text>
+        </Stack>
+    ),
+});
+
+const AiAgentAdminMemoriesTable = () => {
+    const theme = useMantineTheme();
+    const navigate = useNavigate();
+
+    const {
+        search,
+        selectedProjectUuids,
+        selectedUserUuids,
+        selectedStatuses,
+        sortField,
+        sortDirection,
+        apiFilters,
+        setSearch,
+        setSelectedProjectUuids,
+        setSelectedUserUuids,
+        setSelectedStatuses,
+        setSorting,
+        hasActiveFilters,
+        resetFilters,
+    } = useAiAgentAdminMemoryFilters();
+
+    // The search input writes to the URL per keystroke; debounce the query so a
+    // body-wide ILIKE doesn't run on every character
+    const [debouncedSearch] = useDebouncedValue(search, 300);
+
+    const { data, isInitialLoading, isFetching, hasNextPage, fetchNextPage } =
+        useInfiniteAiAgentAdminMemories(
+            {
+                pagination: {},
+                filters: { ...apiFilters, search: debouncedSearch },
+                sort: { field: sortField, direction: sortDirection },
+            },
+            { keepPreviousData: true },
+        );
+
+    const tableData = useMemo(
+        () => data?.pages.flatMap((page) => page.data.memories) ?? [],
+        [data],
+    );
+
+    const totalResults =
+        data?.pages[data.pages.length - 1]?.pagination?.totalResults ?? 0;
+
+    const sorting = useMemo<ContentTableSortingState>(
+        () => [{ id: sortField, desc: sortDirection === 'desc' }],
+        [sortField, sortDirection],
+    );
+
+    const handleSortingChange = useCallback(
+        (
+            updaterOrValue:
+                | ContentTableSortingState
+                | ((old: ContentTableSortingState) => ContentTableSortingState),
+        ) => {
+            const newSorting =
+                typeof updaterOrValue === 'function'
+                    ? updaterOrValue(sorting)
+                    : updaterOrValue;
+
+            if (newSorting.length > 0) {
+                const { id, desc } = newSorting[0];
+                setSorting(
+                    isSortableColumn(id) ? id : 'generatedAt',
+                    desc ? 'desc' : 'asc',
+                );
+            }
+        },
+        [sorting, setSorting],
+    );
+
+    const tableContainerRef = useRef<HTMLDivElement>(null);
+
+    const fetchMoreOnBottomReached = useCallback(
+        (containerRefElement?: HTMLDivElement | null) => {
+            if (!containerRefElement) return;
+            const { scrollHeight, scrollTop, clientHeight } =
+                containerRefElement;
+            if (
+                scrollHeight - scrollTop - clientHeight < 200 &&
+                !isFetching &&
+                hasNextPage
+            ) {
+                void fetchNextPage();
+            }
+        },
+        [fetchNextPage, isFetching, hasNextPage],
+    );
+
+    useEffect(() => {
+        fetchMoreOnBottomReached(tableContainerRef.current);
+    }, [fetchMoreOnBottomReached]);
+
+    const getBottomToolbarLabel = () => {
+        if (isFetching) return 'Loading more...';
+        return hasNextPage ? 'Scroll for more results' : 'All results loaded';
+    };
+    const bottomToolbarLabel = getBottomToolbarLabel();
+
+    const columns: ContentTableColumnDef<AiAgentAdminMemoryItem>[] = useMemo(
+        () => [
+            {
+                accessorKey: 'title',
+                header: 'Memory',
+                enableSorting: false,
+                size: 320,
+                Header: ({ column }) => (
+                    <Group gap="two">
+                        <MantineIcon icon={IconBrain} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => {
+                    const memory = row.original;
+                    return (
+                        <Stack gap={2} miw={0}>
+                            <Text fw={600} fz="sm" c="ldGray.9" truncate>
+                                {memory.title}
+                            </Text>
+                            <Text fz="xs" c="ldGray.6" truncate>
+                                {memory.slug}
+                            </Text>
+                        </Stack>
+                    );
+                },
+            },
+            {
+                accessorKey: 'summary',
+                header: 'Summary',
+                enableSorting: false,
+                size: 320,
+                Header: ({ column }) => (
+                    <Group gap="two">
+                        <MantineIcon icon={IconFileText} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => (
+                    <Tooltip
+                        withinPortal
+                        label={row.original.summary}
+                        disabled={!row.original.summary}
+                        multiline
+                        maw={400}
+                    >
+                        <Text fz="sm" c="ldGray.7" lineClamp={2}>
+                            {row.original.summary}
+                        </Text>
+                    </Tooltip>
+                ),
+            },
+            {
+                accessorKey: 'status',
+                header: 'Status',
+                enableSorting: false,
+                size: 120,
+                Header: ({ column }) => (
+                    <Group gap="two">
+                        <MantineIcon icon={IconCircleDotted} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => (
+                    <Badge
+                        variant="light"
+                        radius="sm"
+                        tt="none"
+                        color={MEMORY_STATUS_COLORS[row.original.status]}
+                    >
+                        {MEMORY_STATUS_LABELS[row.original.status]}
+                    </Badge>
+                ),
+            },
+            {
+                accessorKey: 'project.name',
+                header: 'Project',
+                enableSorting: false,
+                size: 180,
+                Header: ({ column }) => (
+                    <Group gap="two">
+                        <MantineIcon icon={IconBox} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => (
+                    <Text c="ldGray.9" fz="sm" truncate>
+                        {row.original.project.name}
+                    </Text>
+                ),
+            },
+            {
+                accessorKey: 'agent.name',
+                header: 'Agent',
+                enableSorting: false,
+                size: 180,
+                Header: ({ column }) => (
+                    <Group gap="two">
+                        <MantineIcon icon={IconRobotFace} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => {
+                    const { agent } = row.original;
+                    if (!agent) {
+                        return (
+                            <Text c="ldGray.5" fz="xs" fs="italic">
+                                Deleted agent
+                            </Text>
+                        );
+                    }
+                    return (
+                        <AgentNamePill
+                            name={agent.name}
+                            imageUrl={agent.imageUrl}
+                        />
+                    );
+                },
+            },
+            {
+                accessorKey: 'user.name',
+                header: 'User',
+                enableSorting: false,
+                size: 180,
+                Header: ({ column }) => (
+                    <Group gap="two">
+                        <MantineIcon icon={IconUser} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => {
+                    const { user } = row.original;
+                    if (!user) {
+                        return (
+                            <Text c="ldGray.5" fz="xs" fs="italic">
+                                Unknown
+                            </Text>
+                        );
+                    }
+                    return (
+                        <Tooltip
+                            withinPortal
+                            label={user.email}
+                            disabled={!user.email}
+                        >
+                            <Text c="ldGray.9" fz="sm" truncate>
+                                {user.name}
+                            </Text>
+                        </Tooltip>
+                    );
+                },
+            },
+            {
+                accessorKey: 'sourceThreadUuid',
+                header: 'Provenance',
+                enableSorting: false,
+                size: 140,
+                Header: ({ column }) => (
+                    <Group gap="two">
+                        <MantineIcon
+                            icon={IconMessageCircleStar}
+                            color="ldGray.6"
+                        />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => {
+                    const { agent, project, sourceThreadUuid } = row.original;
+                    if (!sourceThreadUuid) {
+                        return (
+                            <Text fz="xs" c="ldGray.7" fw={500}>
+                                Consolidated
+                            </Text>
+                        );
+                    }
+                    if (!agent) {
+                        return (
+                            <Text fz="xs" c="ldGray.7" fw={500}>
+                                Thread
+                            </Text>
+                        );
+                    }
+                    return (
+                        <Anchor
+                            component={Link}
+                            fz="xs"
+                            fw={500}
+                            to={`/projects/${project.uuid}/ai-agents/${agent.uuid}/threads/${sourceThreadUuid}`}
+                            onClick={(event) => event.stopPropagation()}
+                        >
+                            Thread
+                        </Anchor>
+                    );
+                },
+            },
+            telemetryColumn({
+                countKey: 'citedCount',
+                lastAtKey: 'lastCitedAt',
+                header: 'Cited',
+                sortable: true,
+            }),
+            telemetryColumn({
+                countKey: 'pulledCount',
+                lastAtKey: 'lastPulledAt',
+                header: 'Pulled',
+                sortable: false,
+            }),
+            {
+                accessorKey: 'generatedAt',
+                header: 'Generated',
+                enableSorting: true,
+                size: 140,
+                Header: ({ column }) => (
+                    <Group gap="two">
+                        <MantineIcon icon={IconClock} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => (
+                    <Text fz="sm" c="ldGray.7">
+                        {formatDate(row.original.generatedAt)}
+                    </Text>
+                ),
+            },
+        ],
+        [],
+    );
+
+    const table = useContentTable({
+        columns,
+        data: tableData,
+        enableColumnResizing: false,
+        enableRowNumbers: false,
+        enablePagination: false,
+        enableFilters: false,
+        enableFullScreenToggle: false,
+        enableDensityToggle: false,
+        enableColumnActions: false,
+        enableColumnFilters: false,
+        enableHiding: false,
+        enableGlobalFilterModes: false,
+        enableSorting: true,
+        manualSorting: true,
+        onSortingChange: handleSortingChange,
+        enableTopToolbar: true,
+        mantinePaperProps: {
+            shadow: undefined,
+            style: {
+                border: `1px solid ${theme.colors.ldGray[2]}`,
+                borderRadius: theme.spacing.sm,
+                boxShadow: theme.shadows.subtle,
+                display: 'flex',
+                flexDirection: 'column',
+            },
+        },
+        mantineTableContainerProps: {
+            ref: tableContainerRef,
+            style: {
+                maxHeight: 'calc(100dvh - 350px)',
+            },
+            onScroll: (event: UIEvent<HTMLDivElement>) =>
+                fetchMoreOnBottomReached(event.target as HTMLDivElement),
+        },
+        mantineTableProps: {
+            highlightOnHover: true,
+        },
+        mantineTableHeadRowProps: {
+            style: {
+                boxShadow: 'none',
+            },
+        },
+        mantineTableBodyRowProps: ({ row, table: mantineTable }) => {
+            if (mantineTable.getState().showSkeletons) {
+                return {};
+            }
+
+            const { agent, project, slug } = row.original;
+            if (!agent) {
+                return {};
+            }
+
+            return {
+                style: { cursor: 'pointer' },
+                onClick: () => {
+                    void navigate(
+                        `/projects/${project.uuid}/ai-agents/${agent.uuid}/memories/${slug}`,
+                    );
+                },
+            };
+        },
+        mantineTableBodyCellProps: {
+            h: 72,
+            style: {
+                padding: `${theme.spacing.md} ${theme.spacing.xl}`,
+                borderRight: 'none',
+                borderLeft: 'none',
+                borderBottom: `1px solid ${theme.colors.ldGray[2]}`,
+                borderTop: 'none',
+            },
+        },
+        renderTopToolbar: () => (
+            <Box>
+                <Group
+                    p={`${theme.spacing.lg} ${theme.spacing.xl}`}
+                    justify="space-between"
+                >
+                    <Group gap="xs">
+                        <SearchFilter
+                            search={search}
+                            setSearch={setSearch}
+                            placeholder="Search memories"
+                        />
+
+                        <Divider
+                            orientation="vertical"
+                            w={1}
+                            h={20}
+                            className={styles.toolbarDivider}
+                        />
+                        <ProjectsFilter
+                            selectedProjectUuids={selectedProjectUuids}
+                            setSelectedProjectUuids={setSelectedProjectUuids}
+                            tooltipLabel="Filter memories by project"
+                            projectScope="all"
+                        />
+                        <UsersFilter
+                            selectedUserUuids={selectedUserUuids}
+                            setSelectedUserUuids={setSelectedUserUuids}
+                        />
+                        <MemoryStatusFilter
+                            selectedStatuses={selectedStatuses}
+                            setSelectedStatuses={setSelectedStatuses}
+                        />
+
+                        {hasActiveFilters && (
+                            <>
+                                <Divider
+                                    orientation="vertical"
+                                    w={1}
+                                    h={20}
+                                    className={styles.toolbarDivider}
+                                />
+                                <Button
+                                    variant="subtle"
+                                    size="xs"
+                                    leftSection={
+                                        <MantineIcon
+                                            icon={IconTrash}
+                                            size="sm"
+                                        />
+                                    }
+                                    onClick={resetFilters}
+                                >
+                                    Clear all filters
+                                </Button>
+                            </>
+                        )}
+                    </Group>
+
+                    <Box
+                        bg="ldGray.1"
+                        c="ldGray.9"
+                        py="sm"
+                        px="xs"
+                        className={styles.resultCount}
+                    >
+                        <Text fz="sm" fw={500}>
+                            {isInitialLoading
+                                ? 'Loading...'
+                                : `${tableData.length} of ${totalResults} ${
+                                      totalResults === 1 ? 'memory' : 'memories'
+                                  }`}
+                        </Text>
+                    </Box>
+                </Group>
+                <Divider color="ldGray.2" />
+            </Box>
+        ),
+        renderBottomToolbar: () => (
+            <Box
+                p={`${theme.spacing.sm} ${theme.spacing.xl} ${theme.spacing.md} ${theme.spacing.xl}`}
+                className={styles.bottomToolbar}
+            >
+                <Text fz="xs" c="ldGray.8">
+                    {bottomToolbarLabel}
+                </Text>
+            </Box>
+        ),
+        icons: {
+            IconArrowsSort: () => (
+                <MantineIcon icon={IconArrowsSort} size="md" color="ldGray.5" />
+            ),
+            IconSortAscending: () => (
+                <MantineIcon icon={IconArrowUp} size="md" color="blue.6" />
+            ),
+            IconSortDescending: () => (
+                <MantineIcon icon={IconArrowDown} size="md" color="blue.6" />
+            ),
+        },
+        state: {
+            sorting,
+            showProgressBars: false,
+            showSkeletons: isInitialLoading,
+            density: 'md',
+        },
+        mantineLoadingOverlayProps: {
+            loaderProps: { color: 'violet' },
+        },
+    });
+
+    return <ContentTable table={table} />;
+};
+
+export default AiAgentAdminMemoriesTable;

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/MemoryStatusFilter.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/MemoryStatusFilter.tsx
@@ -1,0 +1,34 @@
+import type { AiAgentMemoryStatus } from '@lightdash/common';
+import { IconCircleDotted } from '@tabler/icons-react';
+import { type FC } from 'react';
+import FilterFacet, {
+    type FilterFacetOption,
+} from '../../../../../components/common/FilterFacet';
+import { type useAiAgentAdminMemoryFilters } from '../../hooks/useAiAgentAdminMemoryFilters';
+import { MEMORY_STATUS_LABELS } from './memoryStatus';
+
+const OPTIONS: FilterFacetOption[] = (
+    Object.keys(MEMORY_STATUS_LABELS) as AiAgentMemoryStatus[]
+).map((status) => ({ value: status, label: MEMORY_STATUS_LABELS[status] }));
+
+type MemoryStatusFilterProps = Pick<
+    ReturnType<typeof useAiAgentAdminMemoryFilters>,
+    'selectedStatuses' | 'setSelectedStatuses'
+>;
+
+const MemoryStatusFilter: FC<MemoryStatusFilterProps> = ({
+    selectedStatuses,
+    setSelectedStatuses,
+}) => (
+    <FilterFacet
+        label="Status"
+        icon={IconCircleDotted}
+        options={OPTIONS}
+        selected={selectedStatuses}
+        onChange={setSelectedStatuses}
+        tooltipLabel="Filter memories by status"
+        emptyLabel="No statuses available."
+    />
+);
+
+export default MemoryStatusFilter;

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ProjectsFilter.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ProjectsFilter.tsx
@@ -12,19 +12,36 @@ type ProjectsFilterProps = Pick<
     'selectedProjectUuids' | 'setSelectedProjectUuids'
 > & {
     tooltipLabel?: string;
+    // 'with-agents' hides projects that have no agent; 'all' lists every
+    // project, which audit surfaces need since content outlives its agent
+    projectScope?: 'with-agents' | 'all';
 };
 
 const ProjectsFilter: FC<ProjectsFilterProps> = ({
     selectedProjectUuids,
     setSelectedProjectUuids,
     tooltipLabel = 'Filter threads by project',
+    projectScope = 'with-agents',
 }) => {
     const [searchValue, setSearchValue] = useState('');
     const { data: projects, isLoading } = useProjects();
-    const organizationAiAgents = useAiAgentAdminAgents();
+    const organizationAiAgents = useAiAgentAdminAgents({
+        enabled: projectScope === 'with-agents',
+    });
 
     const options = useMemo<FilterFacetOption[]>(() => {
-        if (!projects || !organizationAiAgents.data) return [];
+        if (!projects) return [];
+
+        const toOption = (project: { projectUuid: string; name: string }) => ({
+            value: project.projectUuid,
+            label: project.name,
+        });
+
+        if (projectScope === 'all') {
+            return projects.map(toOption);
+        }
+
+        if (!organizationAiAgents.data) return [];
 
         const projectUuidsWithAgents = new Set(
             organizationAiAgents.data.map((agent) => agent.projectUuid),
@@ -34,11 +51,8 @@ const ProjectsFilter: FC<ProjectsFilterProps> = ({
             .filter((project) =>
                 projectUuidsWithAgents.has(project.projectUuid),
             )
-            .map((project) => ({
-                value: project.projectUuid,
-                label: project.name,
-            }));
-    }, [projects, organizationAiAgents.data]);
+            .map(toOption);
+    }, [projects, organizationAiAgents.data, projectScope]);
 
     const filteredOptions = useMemo<FilterFacetOption[]>(() => {
         const search = searchValue.trim().toLowerCase();
@@ -64,10 +78,18 @@ const ProjectsFilter: FC<ProjectsFilterProps> = ({
             emptyLabel={
                 searchValue
                     ? 'No projects match your search.'
-                    : 'No projects with agents available.'
+                    : 'No projects available.'
             }
-            loading={isLoading || organizationAiAgents.isLoading}
-            helperText="Showing projects with agents only"
+            loading={
+                isLoading ||
+                (projectScope === 'with-agents' &&
+                    organizationAiAgents.isLoading)
+            }
+            helperText={
+                projectScope === 'with-agents'
+                    ? 'Showing projects with agents only'
+                    : undefined
+            }
             searchValue={searchValue}
             onSearchChange={setSearchValue}
             searchPlaceholder="Search projects..."

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/memoryStatus.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/memoryStatus.ts
@@ -1,0 +1,13 @@
+import type { AiAgentMemoryStatus } from '@lightdash/common';
+
+export const MEMORY_STATUS_LABELS: Record<AiAgentMemoryStatus, string> = {
+    active: 'Active',
+    superseded: 'Superseded',
+    retired: 'Retired',
+};
+
+export const MEMORY_STATUS_COLORS: Record<AiAgentMemoryStatus, string> = {
+    active: 'green',
+    superseded: 'yellow',
+    retired: 'gray',
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiMemoriesSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiMemoriesSettingsPage.tsx
@@ -1,0 +1,11 @@
+import { SettingsPage } from '../../../../../../components/common/Settings/SettingsPage';
+import AiAgentAdminMemoriesTable from '../AiAgentAdminMemoriesTable';
+
+export const AiMemoriesSettingsPage = () => (
+    <SettingsPage
+        title="Memories"
+        description="Audit what your AI agents have learned across projects."
+    >
+        <AiAgentAdminMemoriesTable />
+    </SettingsPage>
+);

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
@@ -1,9 +1,12 @@
 import {
     type AiAgentAdminFilters,
+    type AiAgentAdminMemoryFilters,
+    type AiAgentAdminMemorySort,
     type AiAgentAdminSort,
     type AiAgentReviewItemSummary,
     type AiAgentReviewItemStatus,
     type ApiAiAgentAdminConversationsResponse,
+    type ApiAiAgentAdminMemoriesResponse,
     type ApiAiAgentAdminPromptActivityResponse,
     type ApiAiAgentReviewItemActivityResponse,
     type ApiAiAgentReviewItemPrDiffResponse,
@@ -109,6 +112,61 @@ export const useInfiniteAiAgentAdminThreads = (
         ...infinityQueryOpts,
     });
 };
+
+export type AiAgentAdminMemoriesArgs = {
+    filters: AiAgentAdminMemoryFilters;
+    sort: AiAgentAdminMemorySort;
+    pagination: {
+        pageSize?: number;
+        page?: number;
+    };
+};
+
+const getAiAgentAdminMemories = async (
+    args: AiAgentAdminMemoryFilters & {
+        sortField: AiAgentAdminMemorySort['field'];
+        sortDirection: AiAgentAdminMemorySort['direction'];
+    } & {
+        pageSize?: number;
+        page?: number;
+    },
+) => {
+    const params = createQueryString(args);
+    return lightdashApi<ApiAiAgentAdminMemoriesResponse['results']>({
+        version: 'v1',
+        url: `/aiAgents/admin/memories?${params}`,
+        method: 'GET',
+        body: undefined,
+    });
+};
+
+export const useInfiniteAiAgentAdminMemories = (
+    args: AiAgentAdminMemoriesArgs,
+    infinityQueryOpts: UseInfiniteQueryOptions<
+        ApiAiAgentAdminMemoriesResponse['results'],
+        ApiError
+    > = {},
+) =>
+    useInfiniteQuery<ApiAiAgentAdminMemoriesResponse['results'], ApiError>({
+        queryKey: ['ai-agent-admin-memories', args],
+        queryFn: ({ pageParam }) =>
+            getAiAgentAdminMemories({
+                ...args.filters,
+                sortField: args.sort.field,
+                sortDirection: args.sort.direction,
+                ...args.pagination,
+                page: (pageParam as number) ?? 1,
+            }),
+        getNextPageParam: (lastPage) => {
+            if (lastPage.pagination) {
+                return lastPage.pagination.page <
+                    lastPage.pagination.totalPageCount
+                    ? lastPage.pagination.page + 1
+                    : undefined;
+            }
+        },
+        ...infinityQueryOpts,
+    });
 
 const getAiAgentAdminProjectPromptActivity = async ({
     projectUuid,

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdminMemoryFilters.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdminMemoryFilters.test.tsx
@@ -31,19 +31,44 @@ describe('useAiAgentAdminMemoryFilters', () => {
         expect(result.current.apiFilters).toEqual({
             projectUuids: [PROJECT_UUID],
             userUuids: [USER_UUID],
+            statuses: ['active'],
         });
         expect(result.current.hasActiveFilters).toBe(true);
     });
 
-    it('defaults to newest-first with no filters', () => {
+    it('defaults to newest-first, active memories only', () => {
         const { result } = renderHook(() => useAiAgentAdminMemoryFilters(), {
             wrapper: createWrapper(),
         });
 
         expect(result.current.sortField).toBe('generatedAt');
         expect(result.current.sortDirection).toBe('desc');
-        expect(result.current.apiFilters).toEqual({});
+        expect(result.current.selectedStatuses).toEqual(['active']);
+        expect(result.current.apiFilters).toEqual({ statuses: ['active'] });
         expect(result.current.hasActiveFilters).toBe(false);
+    });
+
+    it('treats the "all" status token as no status filter', () => {
+        const { result } = renderHook(() => useAiAgentAdminMemoryFilters(), {
+            wrapper: createWrapper('?statuses=all'),
+        });
+
+        expect(result.current.selectedStatuses).toEqual([]);
+        expect(result.current.apiFilters.statuses).toBeUndefined();
+        expect(result.current.hasActiveFilters).toBe(true);
+    });
+
+    it('round-trips a cleared status filter through the URL', async () => {
+        const { result } = renderHook(() => useAiAgentAdminMemoryFilters(), {
+            wrapper: createWrapper(),
+        });
+
+        act(() => result.current.setSelectedStatuses([]));
+
+        await waitFor(() => {
+            expect(result.current.selectedStatuses).toEqual([]);
+            expect(result.current.apiFilters.statuses).toBeUndefined();
+        });
     });
 
     it('drops unknown statuses from the URL', () => {
@@ -73,6 +98,7 @@ describe('useAiAgentAdminMemoryFilters', () => {
         await waitFor(() => {
             expect(result.current.hasActiveFilters).toBe(false);
             expect(result.current.selectedProjectUuids).toEqual([]);
+            expect(result.current.selectedStatuses).toEqual(['active']);
             expect(result.current.sortField).toBe('generatedAt');
         });
     });

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdminMemoryFilters.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdminMemoryFilters.test.tsx
@@ -1,0 +1,79 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { type PropsWithChildren } from 'react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it } from 'vitest';
+import { useAiAgentAdminMemoryFilters } from './useAiAgentAdminMemoryFilters';
+
+const USER_UUID = '55de7cc5-4d4b-4d09-a441-85eca10ba60a';
+const PROJECT_UUID = '3675b69e-8324-4110-bdca-059031aa8da3';
+
+const createWrapper = (search = '') =>
+    function Wrapper({ children }: PropsWithChildren) {
+        return (
+            <MemoryRouter
+                initialEntries={[`/generalSettings/ai/memories${search}`]}
+            >
+                {children}
+            </MemoryRouter>
+        );
+    };
+
+describe('useAiAgentAdminMemoryFilters', () => {
+    it('loads project and user filters from the URL', () => {
+        const { result } = renderHook(() => useAiAgentAdminMemoryFilters(), {
+            wrapper: createWrapper(
+                `?projects=${PROJECT_UUID}&users=${USER_UUID}`,
+            ),
+        });
+
+        expect(result.current.selectedProjectUuids).toEqual([PROJECT_UUID]);
+        expect(result.current.selectedUserUuids).toEqual([USER_UUID]);
+        expect(result.current.apiFilters).toEqual({
+            projectUuids: [PROJECT_UUID],
+            userUuids: [USER_UUID],
+        });
+        expect(result.current.hasActiveFilters).toBe(true);
+    });
+
+    it('defaults to newest-first with no filters', () => {
+        const { result } = renderHook(() => useAiAgentAdminMemoryFilters(), {
+            wrapper: createWrapper(),
+        });
+
+        expect(result.current.sortField).toBe('generatedAt');
+        expect(result.current.sortDirection).toBe('desc');
+        expect(result.current.apiFilters).toEqual({});
+        expect(result.current.hasActiveFilters).toBe(false);
+    });
+
+    it('drops unknown statuses from the URL', () => {
+        const { result } = renderHook(() => useAiAgentAdminMemoryFilters(), {
+            wrapper: createWrapper('?statuses=active,bogus'),
+        });
+
+        expect(result.current.selectedStatuses).toEqual(['active']);
+        expect(result.current.apiFilters.statuses).toEqual(['active']);
+    });
+
+    it('persists sorting and resets every filter', async () => {
+        const { result } = renderHook(() => useAiAgentAdminMemoryFilters(), {
+            wrapper: createWrapper(`?projects=${PROJECT_UUID}`),
+        });
+
+        act(() => result.current.setSorting('citedCount', 'asc'));
+
+        await waitFor(() => {
+            expect(result.current.sortField).toBe('citedCount');
+            expect(result.current.sortDirection).toBe('asc');
+            expect(result.current.selectedProjectUuids).toEqual([PROJECT_UUID]);
+        });
+
+        act(() => result.current.resetFilters());
+
+        await waitFor(() => {
+            expect(result.current.hasActiveFilters).toBe(false);
+            expect(result.current.selectedProjectUuids).toEqual([]);
+            expect(result.current.sortField).toBe('generatedAt');
+        });
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdminMemoryFilters.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdminMemoryFilters.ts
@@ -1,0 +1,212 @@
+import type {
+    AiAgentAdminMemoryFilters,
+    AiAgentAdminMemorySort,
+    AiAgentAdminMemorySortField,
+    AiAgentMemoryStatus,
+} from '@lightdash/common';
+import { useCallback, useMemo } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+import useSearchParams from '../../../../hooks/useSearchParams';
+
+const MEMORY_STATUSES: AiAgentMemoryStatus[] = [
+    'active',
+    'superseded',
+    'retired',
+];
+
+const isMemoryStatus = (value: string): value is AiAgentMemoryStatus =>
+    MEMORY_STATUSES.includes(value as AiAgentMemoryStatus);
+
+export interface AiAgentAdminMemoryFiltersState {
+    search: AiAgentAdminMemoryFilters['search'];
+    selectedProjectUuids: NonNullable<
+        AiAgentAdminMemoryFilters['projectUuids']
+    >;
+    selectedUserUuids: NonNullable<AiAgentAdminMemoryFilters['userUuids']>;
+    selectedStatuses: AiAgentMemoryStatus[];
+    sortField: AiAgentAdminMemorySortField;
+    sortDirection: AiAgentAdminMemorySort['direction'];
+}
+
+const DEFAULT_FILTERS: AiAgentAdminMemoryFiltersState = {
+    search: undefined,
+    selectedProjectUuids: [],
+    selectedUserUuids: [],
+    selectedStatuses: [],
+    sortField: 'generatedAt',
+    sortDirection: 'desc',
+};
+
+/** URL-persisted filter state for the admin memories table. */
+export const useAiAgentAdminMemoryFilters = () => {
+    const navigate = useNavigate();
+    const { search: locationSearch, pathname } = useLocation();
+
+    const searchParam = useSearchParams<string>('search');
+    const projectsParam = useSearchParams<string>('projects');
+    const usersParam = useSearchParams<string>('users');
+    const statusesParam = useSearchParams<string>('statuses');
+    const sortByParam = useSearchParams<AiAgentAdminMemorySortField>('sortBy');
+    const sortDirectionParam = useSearchParams<'asc' | 'desc'>('sortDirection');
+
+    const currentFilters = useMemo<AiAgentAdminMemoryFiltersState>(
+        () => ({
+            search: searchParam || DEFAULT_FILTERS.search,
+            selectedProjectUuids:
+                projectsParam?.split(',').filter(Boolean) ||
+                DEFAULT_FILTERS.selectedProjectUuids,
+            selectedUserUuids:
+                usersParam?.split(',').filter(Boolean) ||
+                DEFAULT_FILTERS.selectedUserUuids,
+            selectedStatuses:
+                statusesParam?.split(',').filter(isMemoryStatus) ||
+                DEFAULT_FILTERS.selectedStatuses,
+            sortField: sortByParam || DEFAULT_FILTERS.sortField,
+            sortDirection: sortDirectionParam || DEFAULT_FILTERS.sortDirection,
+        }),
+        [
+            searchParam,
+            projectsParam,
+            usersParam,
+            statusesParam,
+            sortByParam,
+            sortDirectionParam,
+        ],
+    );
+
+    const updateUrl = useCallback(
+        (newFilters: AiAgentAdminMemoryFiltersState) => {
+            const searchParams = new URLSearchParams();
+
+            if (newFilters.search) {
+                searchParams.set('search', newFilters.search);
+            }
+            if (newFilters.selectedProjectUuids.length > 0) {
+                searchParams.set(
+                    'projects',
+                    newFilters.selectedProjectUuids.join(','),
+                );
+            }
+            if (newFilters.selectedUserUuids.length > 0) {
+                searchParams.set(
+                    'users',
+                    newFilters.selectedUserUuids.join(','),
+                );
+            }
+            if (newFilters.selectedStatuses.length > 0) {
+                searchParams.set(
+                    'statuses',
+                    newFilters.selectedStatuses.join(','),
+                );
+            }
+            if (newFilters.sortField !== DEFAULT_FILTERS.sortField) {
+                searchParams.set('sortBy', newFilters.sortField);
+            }
+            if (newFilters.sortDirection !== DEFAULT_FILTERS.sortDirection) {
+                searchParams.set('sortDirection', newFilters.sortDirection);
+            }
+
+            const newSearch = searchParams.toString();
+            if (newSearch !== new URLSearchParams(locationSearch).toString()) {
+                void navigate(
+                    { pathname, search: newSearch },
+                    { replace: true },
+                );
+            }
+        },
+        [navigate, pathname, locationSearch],
+    );
+
+    const setSearch = useCallback(
+        (search: AiAgentAdminMemoryFiltersState['search']) => {
+            updateUrl({ ...currentFilters, search: search || undefined });
+        },
+        [updateUrl, currentFilters],
+    );
+
+    const setSelectedProjectUuids = useCallback(
+        (projectUuids: string[]) => {
+            updateUrl({
+                ...currentFilters,
+                selectedProjectUuids: projectUuids,
+            });
+        },
+        [updateUrl, currentFilters],
+    );
+
+    const setSelectedUserUuids = useCallback(
+        (userUuids: string[]) => {
+            updateUrl({ ...currentFilters, selectedUserUuids: userUuids });
+        },
+        [updateUrl, currentFilters],
+    );
+
+    const setSelectedStatuses = useCallback(
+        (statuses: string[]) => {
+            updateUrl({
+                ...currentFilters,
+                selectedStatuses: statuses.filter(isMemoryStatus),
+            });
+        },
+        [updateUrl, currentFilters],
+    );
+
+    const setSorting = useCallback(
+        (
+            sortField: AiAgentAdminMemorySortField,
+            sortDirection: AiAgentAdminMemorySort['direction'],
+        ) => {
+            updateUrl({ ...currentFilters, sortField, sortDirection });
+        },
+        [updateUrl, currentFilters],
+    );
+
+    const resetFilters = useCallback(() => {
+        updateUrl(DEFAULT_FILTERS);
+    }, [updateUrl]);
+
+    // Sorting is deliberately excluded: a plain sort click shouldn't surface
+    // the "Clear all filters" button
+    const hasActiveFilters = useMemo(
+        () =>
+            currentFilters.search !== DEFAULT_FILTERS.search ||
+            currentFilters.selectedProjectUuids.length > 0 ||
+            currentFilters.selectedUserUuids.length > 0 ||
+            currentFilters.selectedStatuses.length > 0,
+        [currentFilters],
+    );
+
+    const apiFilters = useMemo<AiAgentAdminMemoryFilters>(() => {
+        const result: AiAgentAdminMemoryFilters = {};
+
+        if (currentFilters.search) {
+            result.search = currentFilters.search;
+        }
+        if (currentFilters.selectedProjectUuids.length > 0) {
+            result.projectUuids = currentFilters.selectedProjectUuids;
+        }
+        if (currentFilters.selectedUserUuids.length > 0) {
+            result.userUuids = currentFilters.selectedUserUuids;
+        }
+        if (currentFilters.selectedStatuses.length > 0) {
+            result.statuses = currentFilters.selectedStatuses;
+        }
+
+        return result;
+    }, [currentFilters]);
+
+    return {
+        ...currentFilters,
+
+        apiFilters,
+
+        setSearch,
+        setSelectedProjectUuids,
+        setSelectedUserUuids,
+        setSelectedStatuses,
+        setSorting,
+
+        resetFilters,
+        hasActiveFilters,
+    };
+};

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdminMemoryFilters.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdminMemoryFilters.ts
@@ -17,6 +17,10 @@ const MEMORY_STATUSES: AiAgentMemoryStatus[] = [
 const isMemoryStatus = (value: string): value is AiAgentMemoryStatus =>
     MEMORY_STATUSES.includes(value as AiAgentMemoryStatus);
 
+// An absent `statuses` param means the default (active only), so clearing the
+// status filter needs its own token to mean "every status"
+const ALL_STATUSES_PARAM = 'all';
+
 export interface AiAgentAdminMemoryFiltersState {
     search: AiAgentAdminMemoryFilters['search'];
     selectedProjectUuids: NonNullable<
@@ -32,7 +36,7 @@ const DEFAULT_FILTERS: AiAgentAdminMemoryFiltersState = {
     search: undefined,
     selectedProjectUuids: [],
     selectedUserUuids: [],
-    selectedStatuses: [],
+    selectedStatuses: ['active'],
     sortField: 'generatedAt',
     sortDirection: 'desc',
 };
@@ -59,8 +63,10 @@ export const useAiAgentAdminMemoryFilters = () => {
                 usersParam?.split(',').filter(Boolean) ||
                 DEFAULT_FILTERS.selectedUserUuids,
             selectedStatuses:
-                statusesParam?.split(',').filter(isMemoryStatus) ||
-                DEFAULT_FILTERS.selectedStatuses,
+                statusesParam === ALL_STATUSES_PARAM
+                    ? []
+                    : statusesParam?.split(',').filter(isMemoryStatus) ||
+                      DEFAULT_FILTERS.selectedStatuses,
             sortField: sortByParam || DEFAULT_FILTERS.sortField,
             sortDirection: sortDirectionParam || DEFAULT_FILTERS.sortDirection,
         }),
@@ -93,7 +99,12 @@ export const useAiAgentAdminMemoryFilters = () => {
                     newFilters.selectedUserUuids.join(','),
                 );
             }
-            if (newFilters.selectedStatuses.length > 0) {
+            if (newFilters.selectedStatuses.length === 0) {
+                searchParams.set('statuses', ALL_STATUSES_PARAM);
+            } else if (
+                newFilters.selectedStatuses.join(',') !==
+                DEFAULT_FILTERS.selectedStatuses.join(',')
+            ) {
                 searchParams.set(
                     'statuses',
                     newFilters.selectedStatuses.join(','),
@@ -172,7 +183,8 @@ export const useAiAgentAdminMemoryFilters = () => {
             currentFilters.search !== DEFAULT_FILTERS.search ||
             currentFilters.selectedProjectUuids.length > 0 ||
             currentFilters.selectedUserUuids.length > 0 ||
-            currentFilters.selectedStatuses.length > 0,
+            currentFilters.selectedStatuses.join(',') !==
+                DEFAULT_FILTERS.selectedStatuses.join(','),
         [currentFilters],
     );
 

--- a/packages/frontend/src/hooks/settings/types.ts
+++ b/packages/frontend/src/hooks/settings/types.ts
@@ -69,6 +69,7 @@ export type SettingsContext = {
     isServiceAccountsEnabled: boolean;
     isAiCopilotEnabledOrTrial: boolean;
     shouldShowAiAgentReviews: boolean;
+    shouldShowAiAgentMemories: boolean;
     // Org-level AI settings access (router config, org settings, review queue).
     canManageOrgAiAgent: boolean;
     // True when the user can manage org AI settings OR has AI agent access in at

--- a/packages/frontend/src/hooks/settings/useSettingsContext.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsContext.ts
@@ -35,6 +35,11 @@ export const useSettingsContext = (): SettingsContext => {
     const shouldShowAiAgentReviews =
         aiOrganizationSettingsQuery.data?.aiAgentReviewsEnabled === true;
 
+    const { data: aiAgentMemoryFlag } = useServerFeatureFlag(
+        FeatureFlags.AiAgentMemory,
+    );
+    const shouldShowAiAgentMemories = aiAgentMemoryFlag?.enabled ?? false;
+
     const { data: serviceAccountsFlag } = useServerFeatureFlag(
         CommercialFeatureFlags.ServiceAccounts,
     );
@@ -181,6 +186,7 @@ export const useSettingsContext = (): SettingsContext => {
         isServiceAccountsEnabled,
         isAiCopilotEnabledOrTrial,
         shouldShowAiAgentReviews,
+        shouldShowAiAgentMemories,
         canManageOrgAiAgent,
         hasAnyAiAgentAccess,
         isAiOrganizationSettingsLoading:

--- a/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
@@ -473,23 +473,23 @@ export const useSettingsNavigation = (
                 },
             );
 
-            if (shouldShowAiAgentMemories) {
-                aiChildren.push({
-                    label: 'Memories',
-                    to: '/generalSettings/ai/memories',
-                    icon: IconBulb,
-                    keywords: ['memory', 'memories', 'learned', 'knowledge'],
-                    children: [],
-                    exact: true,
-                });
-            }
-
             if (shouldShowAiAgentReviews) {
                 aiChildren.push({
                     label: 'Issues',
                     to: '/generalSettings/ai/issues',
                     icon: IconListCheck,
                     keywords: ['classifier', 'reviews'],
+                    children: [],
+                    exact: true,
+                });
+            }
+
+            if (shouldShowAiAgentMemories) {
+                aiChildren.push({
+                    label: 'Memories',
+                    to: '/generalSettings/ai/memories',
+                    icon: IconBulb,
+                    keywords: ['memory', 'memories', 'learned', 'knowledge'],
                     children: [],
                     exact: true,
                 });

--- a/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
@@ -7,6 +7,7 @@ import {
     IconBrowser,
     IconBrush,
     IconBuildingSkyscraper,
+    IconBulb,
     IconCalendarStats,
     IconChecklist,
     IconClock,
@@ -78,6 +79,7 @@ export const useSettingsNavigation = (
         isServiceAccountsEnabled,
         isAiCopilotEnabledOrTrial,
         shouldShowAiAgentReviews,
+        shouldShowAiAgentMemories,
         canManageOrgAiAgent,
         hasAnyAiAgentAccess,
         embeddingEnabled,
@@ -470,6 +472,17 @@ export const useSettingsNavigation = (
                     exact: true,
                 },
             );
+
+            if (shouldShowAiAgentMemories) {
+                aiChildren.push({
+                    label: 'Memories',
+                    to: '/generalSettings/ai/memories',
+                    icon: IconBulb,
+                    keywords: ['memory', 'memories', 'learned', 'knowledge'],
+                    children: [],
+                    exact: true,
+                });
+            }
 
             if (shouldShowAiAgentReviews) {
                 aiChildren.push({
@@ -866,6 +879,7 @@ export const useSettingsNavigation = (
         isServiceAccountsEnabled,
         isAiCopilotEnabledOrTrial,
         shouldShowAiAgentReviews,
+        shouldShowAiAgentMemories,
         canManageOrgAiAgent,
         hasAnyAiAgentAccess,
         isEmbeddingEnabled,

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -72,6 +72,7 @@ import VerifiedDomainsPanel from '../components/UserSettings/VerifiedDomains/Ver
 import { ReviewRemediationWorkspace } from '../ee/features/aiCopilot/components/Admin/ReviewRemediationWorkspace';
 import { AiAgentsSettingsPage } from '../ee/features/aiCopilot/components/Admin/settings/AiAgentsSettingsPage';
 import { AiGeneralSettingsPage } from '../ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage';
+import { AiMemoriesSettingsPage } from '../ee/features/aiCopilot/components/Admin/settings/AiMemoriesSettingsPage';
 import { AiReviewsSettingsPage } from '../ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage';
 import { AiSettingsProviders } from '../ee/features/aiCopilot/components/Admin/settings/AiSettingsProviders';
 import { AiThreadsSettingsPage } from '../ee/features/aiCopilot/components/Admin/settings/AiThreadsSettingsPage';
@@ -149,6 +150,7 @@ const Settings: FC = () => {
         dataAppsFlag,
         isAiCopilotEnabledOrTrial,
         shouldShowAiAgentReviews,
+        shouldShowAiAgentMemories,
         canManageOrgAiAgent,
         hasAnyAiAgentAccess,
         isAiOrganizationSettingsLoading,
@@ -627,6 +629,16 @@ const Settings: FC = () => {
                     </AiSettingsProviders>
                 ),
             });
+            if (shouldShowAiAgentMemories) {
+                allowedRoutes.push({
+                    path: '/ai/memories',
+                    element: (
+                        <AiSettingsProviders>
+                            <AiMemoriesSettingsPage />
+                        </AiSettingsProviders>
+                    ),
+                });
+            }
             if (shouldShowAiAgentReviews) {
                 allowedRoutes.push({
                     path: '/ai/issues',
@@ -699,6 +711,7 @@ const Settings: FC = () => {
         isLeaveOrganizationEnabled,
         isAiCopilotEnabledOrTrial,
         shouldShowAiAgentReviews,
+        shouldShowAiAgentMemories,
         canManageOrgAiAgent,
         hasAnyAiAgentAccess,
     ]);
@@ -777,6 +790,10 @@ const Settings: FC = () => {
             ) &&
             !matchPath(
                 { path: '/generalSettings/ai/mcp' },
+                location.pathname,
+            ) &&
+            !matchPath(
+                { path: '/generalSettings/ai/memories' },
                 location.pathname,
             ) &&
             !matchPath(


### PR DESCRIPTION
Closes: [ZAP-682](https://linear.app/lightdash/issue/ZAP-682/memory-slice-10-admin-memories-tab)

### Description:

Slice 10/11 of AI Agent Memory v0 — an org-level, read-only audit surface for the memories agents have written.

Adds a **Memories** tab under Settings → Ask AI (`/generalSettings/ai/memories`, with the legacy `/ai-agents/admin/memories` path redirecting to it), modelled on the existing Agents/Threads admin tables.

**Backend**
- `GET /api/v1/aiAgents/admin/memories` — paginated (default 50, capped at 100), sortable by `generatedAt` / `citedCount`.
- Gated on the `ai-agent-memory` feature flag (403 when off) and the existing AI admin read scope (`resolveReadScope`): org admins see everything, project-scoped AI admins are narrowed to their own projects.
- `AiAgentMemoryModel.findAdminMemoriesPaginated` joins project/agent/user for display and truncates the memory body server-side to keep the list payload bounded.
- `AiAgentMemoryStatus` moved into `@lightdash/common` so the backend entity and API share one definition.

**Frontend**
- Columns: memory (title + slug), summary, status, project, agent, user, cited (count + last cited), generated.
- Clicking a row opens the memory in the shared `MemoryDetailsModal` rather than navigating away, so the audit list keeps its scroll position and filters.
- Filters by **project**, **user** and **status** using the existing searchable `FilterFacet` dropdown, plus debounced free-text search over title/slug/body. All filter state is URL-persisted.
- **Defaults to active memories only.** Superseded and retired are reachable via the status filter; clearing it entirely is encoded as `statuses=all` in the URL, since an absent param means the default.

### Notes

- `ProjectsFilter` gains a `projectScope` prop. The threads/agents tabs keep the existing "projects with agents only" behaviour; the memories tab lists all projects, since a memory outlives the agent that wrote it.
- Memories whose agent has been deleted (`agent_uuid` is null) still list, but can't be opened — the memory detail endpoint is agent-scoped. Worth a follow-up if that turns out to matter.
- `pulledCount` / `lastPulledAt` / `sourceThreadUuid` stay in the API response (ZAP-682 asks for pulled telemetry and provenance as part of the audit surface) even though the table no longer renders columns for them. Provenance is still shown inside the detail modal. Happy to strip them from the payload if we'd rather not carry unused fields.

### Validation

- Backend unit tests: `AiAgentAdminService.test.ts` (55 passing, 4 new covering flag-off, non-admin, project scoping, and passthrough of pagination/filters/sort).
- Backend integration: `AiAgentMemoryModel.integration.test.ts` (17 passing, 1 new covering pagination + project/user/status/search filters and ordering).
- Frontend: `useAiAgentAdminMemoryFilters.test.tsx` (6 new, incl. the active-by-default and `statuses=all` round-trip) + existing settings-nav suites — 39 passing.
- Manual API checks against a local stack: filters, sorting (incl. nulls-last), pagination, malformed-uuid rejection (400), flag-off (403), viewer/editor forbidden (403), the active-only default (1 of 3 seeded rows) vs cleared filter (3 of 3), and the detail fetch the modal makes.
- `typecheck:fast` and lint clean on common / backend / frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
