### PR TITLE
feat: enable dashboard filter requirements by default

### DIFF
--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
@@ -331,6 +331,53 @@ describe('FeatureFlagModel', () => {
         });
     });
 
+    describe('DashboardFilterRequirements default', () => {
+        it('defaults to enabled when the DB has no opinion', async () => {
+            const model = buildModel({}, buildFakeDatabase({}));
+
+            const result = await model.get({
+                featureFlagId: FeatureFlags.DashboardFilterRequirements,
+                user: dbUser,
+            });
+
+            expect(result).toEqual({
+                id: FeatureFlags.DashboardFilterRequirements,
+                enabled: true,
+            });
+        });
+
+        it('an org override of false beats the enabled default', async () => {
+            const model = buildModel(
+                {},
+                buildFakeDatabase({
+                    flag: { default_enabled: null },
+                    orgOverride: { enabled: false },
+                }),
+            );
+
+            const result = await model.get({
+                featureFlagId: FeatureFlags.DashboardFilterRequirements,
+                user: dbUser,
+            });
+
+            expect(result.enabled).toBe(false);
+        });
+
+        it('LIGHTDASH_DISABLE_FEATURE_FLAGS forces it off', async () => {
+            const model = buildModel({
+                disabledFeatureFlags: new Set([
+                    FeatureFlags.DashboardFilterRequirements,
+                ]),
+            });
+
+            const result = await model.get({
+                featureFlagId: FeatureFlags.DashboardFilterRequirements,
+            });
+
+            expect(result.enabled).toBe(false);
+        });
+    });
+
     describe('database error resilience', () => {
         // Reproduces the embed-account regression: a non-UUID userUuid
         // (e.g. `external::…`) makes Postgres throw 22P02 on the override

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -46,6 +46,8 @@ export class FeatureFlagModel {
                     this.lightdashConfig.results.cacheEnabled,
                     options,
                 ),
+            [FeatureFlags.DashboardFilterRequirements]: (flagArgs, options) =>
+                this.getWithEnvFallback(flagArgs, true, options),
         };
     }
 


### PR DESCRIPTION
## Summary

Dashboard filter requirements (requirement groups + the guided locked-dashboard setup) has been released and verified, so the `dashboard-filter-requirements` feature flag now defaults to **on**.

The flag is resolved through the existing `getWithEnvFallback` handler pattern in `FeatureFlagModel`, so the usual escape hatches still apply:

- user/org overrides in the `feature_flag_overrides` table win over the default
- a `default_enabled` value on the flag's DB row wins over the fallback
- `LIGHTDASH_DISABLE_FEATURE_FLAGS=dashboard-filter-requirements` still works as a self-hosted kill switch

## Testing

- Added unit tests covering the enabled-by-default resolution, org override precedence, and the env kill switch (`FeatureFlagModel.test.ts`, 20 tests passing)

Relates: PROD-8661
Relates: #25095
