### PR TITLE
fix: Google Sheets sync on Trino fails with "tag.replace is not a function"

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -62,11 +62,9 @@ describe('buildSchedulerLogContext', () => {
     });
 
     it('stringifies a jobId that arrives as a BigInt at runtime', () => {
-        // graphile-worker types job.id as string, but the global pg INT8
-        // parser override makes it a BigInt at runtime
         expect(
             buildSchedulerLogContext({
-                jobId: BigInt(4482031) as unknown as string,
+                jobId: BigInt(4482031),
             }),
         ).toEqual({ job_id: '4482031' });
     });

--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -61,6 +61,16 @@ describe('buildSchedulerLogContext', () => {
         });
     });
 
+    it('stringifies a jobId that arrives as a BigInt at runtime', () => {
+        // graphile-worker types job.id as string, but the global pg INT8
+        // parser override makes it a BigInt at runtime
+        expect(
+            buildSchedulerLogContext({
+                jobId: BigInt(4482031) as unknown as string,
+            }),
+        ).toEqual({ job_id: '4482031' });
+    });
+
     it('omits a null savedSqlUuid', () => {
         expect(
             buildSchedulerLogContext({

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -249,7 +249,9 @@ export type SchedulerTaskArguments = {
  * the ExecutionContext write.
  */
 export function buildSchedulerLogContext(args: {
-    jobId?: string;
+    // graphile-worker types job.id as string but the global pg INT8 parser
+    // override (PostgresWarehouseClient) makes it a BigInt at runtime
+    jobId?: string | bigint;
     schedulerUuid?: string;
     schedulerName?: string;
     savedSqlUuid?: string | null;
@@ -258,8 +260,6 @@ export function buildSchedulerLogContext(args: {
     if (args.schedulerUuid) schedulerCtx.scheduler_uuid = args.schedulerUuid;
     if (args.schedulerName) schedulerCtx.scheduler_name = args.schedulerName;
     if (args.savedSqlUuid) schedulerCtx.saved_sql_uuid = args.savedSqlUuid;
-    // graphile-worker types job.id as string but the global pg INT8 parser
-    // override (PostgresWarehouseClient) makes it a BigInt at runtime
     if (args.jobId) schedulerCtx.job_id = String(args.jobId);
     return Object.keys(schedulerCtx).length === 0 ? null : schedulerCtx;
 }

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -258,7 +258,9 @@ export function buildSchedulerLogContext(args: {
     if (args.schedulerUuid) schedulerCtx.scheduler_uuid = args.schedulerUuid;
     if (args.schedulerName) schedulerCtx.scheduler_name = args.schedulerName;
     if (args.savedSqlUuid) schedulerCtx.saved_sql_uuid = args.savedSqlUuid;
-    if (args.jobId) schedulerCtx.job_id = args.jobId;
+    // graphile-worker types job.id as string but the global pg INT8 parser
+    // override (PostgresWarehouseClient) makes it a BigInt at runtime
+    if (args.jobId) schedulerCtx.job_id = String(args.jobId);
     return Object.keys(schedulerCtx).length === 0 ? null : schedulerCtx;
 }
 

--- a/packages/warehouses/src/utils/coerceTagToString.ts
+++ b/packages/warehouses/src/utils/coerceTagToString.ts
@@ -1,0 +1,22 @@
+// Query tags are typed as strings, but values can drift at runtime — e.g.
+// scheduler job ids arrive as BigInt via the global pg INT8 parser override.
+export type DriftedTagValue =
+    | string
+    | number
+    | bigint
+    | boolean
+    | null
+    | undefined;
+
+export const coerceTagToString = (
+    tag: DriftedTagValue,
+    context: { caller: string; key: string | null },
+): string => {
+    if (typeof tag === 'string') return tag;
+    if (tag === null || tag === undefined) return '';
+    console.warn(`${context.caller}: coerced non-string tag value`, {
+        ...(context.key === null ? {} : { key: context.key }),
+        valueType: typeof tag,
+    });
+    return String(tag);
+};

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
@@ -395,7 +395,7 @@ describe('BigqueryWarehouseClient.sanitizeLabelsWithValues', () => {
         });
         expect(result).toEqual({ job_id: '224187' });
         expect(warnSpy).toHaveBeenCalledWith(
-            expect.stringContaining('coerced non-string label value'),
+            expect.stringContaining('coerced non-string tag value'),
             { key: 'job_id', valueType: 'number' },
         );
     });

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
@@ -44,6 +44,7 @@ import {
     WarehouseExecuteAsyncQueryArgs,
     WarehouseTableSchema,
 } from '../types';
+import { coerceTagToString } from '../utils/coerceTagToString';
 import {
     DEFAULT_BATCH_SIZE,
     processPromisesInBatches,
@@ -308,25 +309,15 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
         return Object.fromEntries(
             orderedEntries
                 .slice(0, BigqueryWarehouseClient.MAX_LABELS)
-                .map(([key, value]) => {
-                    const safeKey = typeof key === 'string' ? key : String(key);
-                    let safeValue: string;
-                    if (typeof value === 'string') {
-                        safeValue = value;
-                    } else if (value === null || value === undefined) {
-                        safeValue = '';
-                    } else {
-                        console.warn(
-                            'BigqueryWarehouseClient.sanitizeLabelsWithValues: coerced non-string label value',
-                            { key: safeKey, valueType: typeof value },
-                        );
-                        safeValue = String(value);
-                    }
-                    return [
-                        sanitizeQueryTagKey(safeKey),
-                        sanitizeQueryTagValue(safeValue),
-                    ];
-                }),
+                .map(([key, value]) => [
+                    sanitizeQueryTagKey(key),
+                    sanitizeQueryTagValue(
+                        coerceTagToString(value, {
+                            caller: 'BigqueryWarehouseClient.sanitizeLabelsWithValues',
+                            key,
+                        }),
+                    ),
+                ]),
         );
     }
 

--- a/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.test.ts
@@ -128,6 +128,32 @@ describe('TrinoWarehouseClient', () => {
             );
         });
 
+        it('coerces non-string tag values instead of throwing', async () => {
+            const warehouse = new TrinoWarehouseClient(credentials);
+            queryResultMock.mockReturnValue({
+                next: vi
+                    .fn()
+                    .mockResolvedValue({ done: true, value: queryResponse }),
+            });
+
+            // graphile-worker job ids arrive as BigInt at runtime despite the
+            // Record<string, string> type (global pg INT8 parser override)
+            await warehouse.runQuery('SELECT 1', {
+                job_id: BigInt(4482031),
+                query_context:
+                    QueryExecutionContext.SCHEDULED_GSHEETS_DASHBOARD,
+            } as unknown as Record<string, string>);
+
+            expect(queryResultMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    extraHeaders: {
+                        'X-Trino-Client-Tags':
+                            'job_id=4482031,query_context=scheduledGsheetsDashboard',
+                    },
+                }),
+            );
+        });
+
         it('sends query as plain string (no extraHeaders) when no tags are provided', async () => {
             const warehouse = new TrinoWarehouseClient(credentials);
             queryResultMock.mockReturnValue({

--- a/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
@@ -34,9 +34,24 @@ import WarehouseBaseSqlBuilder from './WarehouseBaseSqlBuilder';
 const TRINO_CLIENT_TAGS_HEADER = 'X-Trino-Client-Tags';
 
 // Trino splits the header on commas and Node rejects non-latin1 header values,
-// so tag keys/values are restricted to a safe charset
-const sanitizeClientTag = (tag: string): string =>
-    tag.replace(/[^a-zA-Z0-9_-]/g, '_').substring(0, 60);
+// so tag keys/values are restricted to a safe charset. Values typed as string
+// can be non-string at runtime (e.g. BigInt scheduler job ids), so coerce
+// instead of crashing the query — mirrors BigqueryWarehouseClient labels.
+const sanitizeClientTag = (tag: unknown): string => {
+    let safeTag: string;
+    if (typeof tag === 'string') {
+        safeTag = tag;
+    } else if (tag === null || tag === undefined) {
+        safeTag = '';
+    } else {
+        console.warn(
+            'TrinoWarehouseClient.sanitizeClientTag: coerced non-string tag',
+            { valueType: typeof tag },
+        );
+        safeTag = String(tag);
+    }
+    return safeTag.replace(/[^a-zA-Z0-9_-]/g, '_').substring(0, 60);
+};
 
 export enum TrinoTypes {
     BOOLEAN = 'boolean',
@@ -314,8 +329,12 @@ export class TrinoWarehouseClient extends WarehouseBaseClient<CreateTrinoCredent
         try {
             let alteredQuery = sql;
             if (options?.tags) {
+                // tags can carry BigInt values at runtime; plain
+                // JSON.stringify would throw without the app-level toJSON patch
                 alteredQuery = `${alteredQuery}\n-- ${JSON.stringify(
                     options?.tags,
+                    (_key, value) =>
+                        typeof value === 'bigint' ? value.toString() : value,
                 )}`;
             }
             if (options?.timezone) {

--- a/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
@@ -23,6 +23,7 @@ import {
     Trino,
 } from 'trino-client';
 import { WarehouseCatalog } from '../types';
+import { coerceTagToString, DriftedTagValue } from '../utils/coerceTagToString';
 import {
     DEFAULT_BATCH_SIZE,
     processPromisesInBatches,
@@ -34,24 +35,14 @@ import WarehouseBaseSqlBuilder from './WarehouseBaseSqlBuilder';
 const TRINO_CLIENT_TAGS_HEADER = 'X-Trino-Client-Tags';
 
 // Trino splits the header on commas and Node rejects non-latin1 header values,
-// so tag keys/values are restricted to a safe charset. Values typed as string
-// can be non-string at runtime (e.g. BigInt scheduler job ids), so coerce
-// instead of crashing the query — mirrors BigqueryWarehouseClient labels.
-const sanitizeClientTag = (tag: unknown): string => {
-    let safeTag: string;
-    if (typeof tag === 'string') {
-        safeTag = tag;
-    } else if (tag === null || tag === undefined) {
-        safeTag = '';
-    } else {
-        console.warn(
-            'TrinoWarehouseClient.sanitizeClientTag: coerced non-string tag',
-            { valueType: typeof tag },
-        );
-        safeTag = String(tag);
-    }
-    return safeTag.replace(/[^a-zA-Z0-9_-]/g, '_').substring(0, 60);
-};
+// so tag keys/values are restricted to a safe charset
+const sanitizeClientTag = (tag: DriftedTagValue): string =>
+    coerceTagToString(tag, {
+        caller: 'TrinoWarehouseClient.sanitizeClientTag',
+        key: null,
+    })
+        .replace(/[^a-zA-Z0-9_-]/g, '_')
+        .substring(0, 60);
 
 export enum TrinoTypes {
     BOOLEAN = 'boolean',


### PR DESCRIPTION
Closes #26122 · Linear: PROD-9218

## Problem

Google Sheets syncs on Trino projects fail with `tag.replace is not a function`. Any scheduler-context query on Trino is affected — GSheets syncs are just where it surfaces, because they run through `AsyncQueryService`, which merges scheduler attribution into warehouse query tags.

## Root cause

`queryTags.job_id` is a **BigInt** at runtime, despite being typed `string`, via a three-part interaction:

1. `PostgresWarehouseClient` sets a **process-global** pg type parser (`INT8 → BigInt`, #12710). pnpm resolves a single shared `pg` instance, so the override also applies to graphile-worker's connection — its `jobs.id` is `bigserial`, so `helpers.job.id` is a BigInt even though graphile types it `string`.
2. #23250 flows `helpers.job.id` → `buildSchedulerLogContext` → ExecutionContext → `getSchedulerQueryTags()` → query tags on every scheduler-context async query.
3. #25020 added the `X-Trino-Client-Tags` header: `sanitizeClientTag` calls `.replace()` on each tag value → TypeError on the BigInt. (The `JSON.stringify(tags)` SQL-comment line earlier in `streamQuery` only survives in prod because of the app-level `BigInt.prototype.toJSON` patch.)

BigQuery already warn-and-coerces non-string label values — Trino was the only client calling `.replace` per value with no guard.

## Changes

- **Source fix**: `buildSchedulerLogContext` stringifies `jobId`, correcting every consumer at once (query tags, structured logs, delivery-failure `?ref=` links).
- **Defense**: Trino's `sanitizeClientTag` coerces non-string values with a warn log, mirroring the BigQuery label sanitizer.
- **Latent crash**: the Trino SQL-comment `JSON.stringify` now uses a BigInt-safe replacer so the warehouses package doesn't depend on the app-level `toJSON` monkey-patch.

## Testing

- New unit test: `buildSchedulerLogContext` with a runtime-BigInt `jobId` → string `job_id`.
- New unit test: Trino client tag header with a BigInt tag value → coerced header, no throw (failed with the exact production error before the fix).
- `pnpm -F @lightdash/warehouses test` 284 passed · backend modified-file suites 300 passed · typecheck + lint clean on both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lci2npAvQUvGqKL7X2rtDg