### PR TITLE
feat(homepage): taller standalone resources cards

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
@@ -333,6 +333,7 @@ type BlockCardProps = {
     onChange: (updated: HomepageBlock) => void;
     justPlaced: boolean;
     itemSpan: number | null;
+    standalone: boolean;
 };
 
 const BlockCard: FC<BlockCardProps> = ({
@@ -348,6 +349,7 @@ const BlockCard: FC<BlockCardProps> = ({
     onChange,
     justPlaced,
     itemSpan,
+    standalone,
 }) => {
     const {
         attributes,
@@ -438,6 +440,7 @@ const BlockCard: FC<BlockCardProps> = ({
                 projectUuid={projectUuid}
                 onChange={onChange}
                 itemSpan={itemSpan}
+                standalone={standalone}
             />
         </div>
     );
@@ -1051,6 +1054,14 @@ export const HomepageEditor: FC<Props> = ({
                                                                                     blockIndex
                                                                                 ]
                                                                                     .itemSpan
+                                                                            }
+                                                                            standalone={
+                                                                                resolvedRows[
+                                                                                    rowIndex
+                                                                                ]
+                                                                                    .columns
+                                                                                    .length ===
+                                                                                1
                                                                             }
                                                                             block={
                                                                                 block

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
@@ -23,7 +23,15 @@ const BlockRenderer: FC<{
     personalPlaceholders: boolean;
     presentation?: BlockPresentation;
     itemSpan: number | null;
-}> = ({ block, projectUuid, personalPlaceholders, presentation, itemSpan }) => {
+    standalone: boolean;
+}> = ({
+    block,
+    projectUuid,
+    personalPlaceholders,
+    presentation,
+    itemSpan,
+    standalone,
+}) => {
     const definition = getBlockDefinition(block.type);
     if (!definition) return null;
     if (personalPlaceholders && PERSONAL_BLOCK_TYPES.includes(block.type)) {
@@ -48,6 +56,7 @@ const BlockRenderer: FC<{
             projectUuid={projectUuid}
             presentation={presentation}
             itemSpan={itemSpan}
+            standalone={standalone}
         />
     );
 };
@@ -76,6 +85,7 @@ const RowRenderer: FC<{
                     projectUuid={projectUuid}
                     personalPlaceholders={personalPlaceholders}
                     itemSpan={column.itemSpan}
+                    standalone={row.columns.length === 1}
                 />
             </Box>
         ))}
@@ -127,6 +137,7 @@ export const PublishedHomepage: FC<Props> = ({
                             personalPlaceholders={personalPlaceholders}
                             presentation="hero"
                             itemSpan={hero.row.columns[0].itemSpan}
+                            standalone={hero.row.columns.length === 1}
                         />
                     </div>
                 </div>

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
@@ -278,17 +278,20 @@ const itemHref = (item: HomepageResourceItem, projectUuid: string): string =>
         ? dataAppHref(projectUuid, item.appUuid)
         : item.url;
 
-const ResourceCard: FC<{ item: HomepageResourceItem; projectUuid: string }> = ({
-    item,
-    projectUuid,
-}) => {
+const ResourceCard: FC<{
+    item: HomepageResourceItem;
+    projectUuid: string;
+    standalone: boolean;
+}> = ({ item, projectUuid, standalone }) => {
     const dataApp = isDataApp(item);
     return (
         <a
             href={itemHref(item, projectUuid)}
             target={dataApp ? undefined : '_blank'}
             rel={dataApp ? undefined : 'noopener noreferrer'}
-            className={`${classes.mediaCard} ${classes.cardUnit1} ${classes.clickable} ${classes.plainLink}`}
+            className={`${classes.mediaCard} ${classes.cardUnit1} ${
+                standalone ? classes.mediaCardTall : ''
+            } ${classes.clickable} ${classes.plainLink}`}
         >
             {!dataApp && (
                 <MantineIcon
@@ -349,6 +352,7 @@ export const ResourcesBlockView: FC<BlockComponentProps> = ({
     block,
     itemSpan,
     projectUuid,
+    standalone = false,
 }) => {
     if (block.type !== 'resources' || block.config.items.length === 0) {
         return null;
@@ -364,6 +368,7 @@ export const ResourcesBlockView: FC<BlockComponentProps> = ({
                             <ResourceCard
                                 item={item}
                                 projectUuid={projectUuid}
+                                standalone={standalone}
                             />
                         </PageGridItem>
                     ))}
@@ -449,8 +454,18 @@ const KindControl: FC<{
         <KindSelect value={item.kind} onChange={onChange} />
     );
 
-const BuildCard: FC<EditProps> = ({ item, projectUuid, onPatch, onRemove }) => (
-    <div className={classes.mediaCard}>
+const BuildCard: FC<EditProps & { standalone: boolean }> = ({
+    item,
+    projectUuid,
+    standalone,
+    onPatch,
+    onRemove,
+}) => (
+    <div
+        className={`${classes.mediaCard} ${
+            standalone ? classes.mediaCardTall : ''
+        }`}
+    >
         <CardThumb item={item} projectUuid={projectUuid} />
         <div className={classes.mediaBody}>
             <Group gap={4} justify="space-between" wrap="nowrap">
@@ -539,6 +554,7 @@ export const ResourcesBlockBuild: FC<BuildComponentProps> = ({
     projectUuid,
     onChange,
     itemSpan,
+    standalone = false,
 }) => {
     const [pasteValue, setPasteValue] = useState('');
     const [batch, setBatch] = useState<BatchEntry[]>([]);
@@ -681,6 +697,7 @@ export const ResourcesBlockBuild: FC<BuildComponentProps> = ({
                             <BuildCard
                                 item={item}
                                 projectUuid={projectUuid}
+                                standalone={standalone}
                                 onPatch={(patch) => patchItem(i, patch)}
                                 onRemove={() => removeItem(i)}
                             />
@@ -691,6 +708,7 @@ export const ResourcesBlockBuild: FC<BuildComponentProps> = ({
                             <ResourceCard
                                 item={e.item}
                                 projectUuid={projectUuid}
+                                standalone={standalone}
                             />
                         </PageGridItem>
                     ))}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -423,6 +423,15 @@ a .hoverCard:hover,
     transition: all 0.18s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
+/* A resources block alone in its row has the full page width to itself, so its
+ * cards can grow taller — the extra height goes to the thumb band (flex: 1),
+ * showing more of a 16:9 still (e.g. a YouTube thumbnail) before object-fit:
+ * cover crops it. The double-class keeps it winning the --card-unit cascade
+ * regardless of source order. */
+.mediaCard.mediaCardTall {
+    --card-unit: 200px;
+}
+
 .mediaCard.clickable:hover {
     box-shadow: var(--mantine-shadow-heavy);
     transform: translateY(-2px);

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/types.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/types.ts
@@ -14,6 +14,11 @@ export type BlockComponentProps = {
     // silently omits it renders every card full width, and that failed once
     // already — the compiler now catches it instead of a reviewer.
     itemSpan: number | null;
+    // True when the block is the only one in its row. The resources card grid
+    // uses it to render taller cards so wide 16:9 thumbnails (e.g. YouTube
+    // stills) aren't cropped as hard. Other blocks ignore it. Optional because
+    // omitting it (the default, non-standalone) is the safe current behaviour.
+    standalone?: boolean;
 };
 
 export type BuildComponentProps = BlockComponentProps & {


### PR DESCRIPTION
Resource thumbnails looked stretched and cropped badly for wide 16:9 stills (e.g. YouTube). When a Resources block is alone in its row it has the full page width to itself, so its cards can now grow taller — the extra height goes to the thumb band, showing more of the image before `object-fit: cover` crops it.

- Threads a `standalone` flag (block owns its row) from the layout resolver through both the published page and the editor canvas.
- Standalone resource cards bump `--card-unit` from 140px → 200px via a `mediaCardTall` modifier; shared-row cards are unchanged.
- `object-fit: cover` (Gio's suggestion) was already applied to the thumbnail `<img>`, so no change was needed there.

Applies to both card-layout view and the builder preview.
