### PR TITLE
perf: optimize project-scoped chart queries

### DIFF
--- a/packages/backend/src/models/SavedChartModel.test.ts
+++ b/packages/backend/src/models/SavedChartModel.test.ts
@@ -626,3 +626,34 @@ describe('moveToSpace', () => {
         expect(tracker.history.update).toHaveLength(0);
     });
 });
+
+describe('findChartsForValidation', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new SavedChartModel({
+        database,
+        lightdashConfig: lightdashConfigMock,
+    });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    test('resolves project ownership once before joining latest chart versions', async () => {
+        const projectUuid = '22222222-2222-4222-8222-222222222222';
+        tracker.on.select(({ sql }) => sql.length > 0).response([]);
+
+        await model.findChartsForValidation(projectUuid);
+
+        const [query] = tracker.history.select;
+        expect(query.bindings).toContain(projectUuid);
+        expect(query.sql).not.toContain('union all');
+        expect(query.sql.match(/spaces/g)).toHaveLength(1);
+        expect(query.sql.match(/dashboards/g)).toHaveLength(1);
+        expect(query.sql).toContain('"sq"."project_uuid"');
+    });
+});

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -1938,52 +1938,21 @@ export class SavedChartModel {
             .groupBy('saved_query_id')
             .as('latest');
 
-        return qb.unionAll([
-            // First part of UNION - charts in space
-            this.database
-                .select({
-                    saved_query_uuid: 'sq.saved_query_uuid',
-                    name: 'sq.name',
-                    saved_queries_version_id: 'latest.max_version_id',
-                    dashboard_uuid: 'sq.dashboard_uuid',
-                })
-                .from(`${SavedChartsTableName} as sq`)
-                .innerJoin(
-                    latestVersions,
-                    'latest.saved_query_id',
-                    'sq.saved_query_id',
-                )
-                .innerJoin(
-                    `${SpaceTableName} as s`,
-                    's.space_id',
-                    'sq.space_id',
-                )
-                .where('sq.project_uuid', projectUuid)
-                .whereNull('sq.deleted_at'),
-
-            // Second part of UNION - charts saved inside dashboards
-            this.database
-                .select({
-                    saved_query_uuid: 'sq.saved_query_uuid',
-                    name: 'sq.name',
-                    saved_queries_version_id: 'latest.max_version_id',
-                    dashboard_uuid: 'sq.dashboard_uuid',
-                })
-                .from(`${SavedChartsTableName} as sq`)
-                .innerJoin(
-                    latestVersions,
-                    'latest.saved_query_id',
-                    'sq.saved_query_id',
-                )
-                .innerJoin(
-                    `${DashboardsTableName} as d`,
-                    'd.dashboard_uuid',
-                    'sq.dashboard_uuid',
-                )
-                .innerJoin(`${SpaceTableName} as s`, 's.space_id', 'd.space_id')
-                .where('sq.project_uuid', projectUuid)
-                .whereNull('sq.deleted_at'),
-        ]);
+        return qb
+            .select({
+                saved_query_uuid: 'sq.saved_query_uuid',
+                name: 'sq.name',
+                saved_queries_version_id: 'latest.max_version_id',
+                dashboard_uuid: 'sq.dashboard_uuid',
+            })
+            .from(`${SavedChartsTableName} as sq`)
+            .innerJoin(
+                latestVersions,
+                'latest.saved_query_id',
+                'sq.saved_query_id',
+            )
+            .where('sq.project_uuid', projectUuid)
+            .whereNull('sq.deleted_at');
     }
 
     async findChartsForValidation(


### PR DESCRIPTION
## Summary

- Uses the authoritative `saved_queries.project_uuid` ownership introduced by the parent PR to collapse the latest-chart-version CTE from two location-specific branches into one direct chart scan.
- Removes two redundant space joins, one redundant dashboard join, and the second-stage `UNION ALL` while retaining the existing active dashboard/space ownership prefilter.
- Leaves space joins in place wherever they return space metadata or enforce deleted-space semantics.

## Performance

Benchmarked with alternating warmed PostgreSQL `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)` runs so execution order and cache warming did not favor either query.

Real local project (91 active charts; 30 measured runs after 5 warmups):

- Median execution: 0.214 ms → 0.127 ms (**40.7% faster**).
- p95 execution: 0.291 ms → 0.160 ms (**45.0% faster**).
- Shared buffer hits: 743 → 375 (**49.5% fewer**).
- Plan nodes: 25 → 14 (**44.0% fewer**).
- Planner cost: 39.41 → 29.32 (**25.6% lower**).

Disposable production-shape fixture (200,000 charts, 600,000 versions; 9 measured runs after 2 warmups):

- Median execution: 372.452 ms → 320.295 ms (**14.0% faster**).
- p95 execution: 441.387 ms → 347.279 ms (**21.3% faster**).
- Temporary block reads: 3,918 → 3,434 (**12.4% fewer**).
- Temporary block writes: 5,031 → 4,547 (**9.6% fewer**).
- Plan nodes: 28 → 15 (**46.4% fewer**).
- Planner cost: 65,620 → 55,010 (**16.2% lower**).

The fixture used session-local temporary tables and was rolled back. These numbers isolate the changed latest-version CTE; end-to-end request improvement will be smaller where unrelated validation or explore-loading work dominates.

An additional unused `projects` left join was evaluated separately. PostgreSQL already eliminated it, producing the same 12-node plan, cost, and buffer usage; that source change was therefore restored and is not part of this PR.

## Validation

Automated:

- Saved chart model tests: 18 passed.
- Backend fast typecheck passed.
- Focused backend lint passed.
- Backend formatting check passed.
- Full `test-all` CI: [22/22 jobs passed with zero skipped](https://github.com/lightdash/lightdash/actions/runs/30259514471), including API, all five app E2E shards, three timezone suites, and all CLI/dbt variants.

Live local stack after applying the parent migration:

- Health check returned HTTP 200.
- Tested against a real project with 91 active charts: 89 direct-space and 2 dashboard-owned.
- Compared the old and new latest-version CTEs in PostgreSQL: both returned 91 identical rows, with zero rows in either side of the symmetric difference.
- Chart validation returned HTTP 200 with zero errors for both a direct-space chart and a dashboard-owned chart.
- Spotlight captured both validation requests with zero errors and confirmed the optimized CTE executes with one ownership space join and no second-stage `UNION ALL`.

CI: `test-all`

Relates: PROD-9106