### PR TITLE
fix: scheduled delivery links never end in a dangling ? and edit-modal send-now links to the delivery

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -1,5 +1,6 @@
 import {
     AnyType,
+    appendUuidQueryParam,
     applyDimensionOverrides,
     assertUnreachable,
     CompileProjectPayload,
@@ -40,6 +41,7 @@ import {
     getRequestMethod,
     getSchedulerResourceTypeAndId,
     getSchedulerUuid,
+    getSourceSchedulerUuid,
     GoogleSheetsQuotaError,
     GoogleSheetsTransientError,
     GsheetsNotificationPayload,
@@ -89,7 +91,6 @@ import {
     SchedulerLog,
     SchedulerResourceType,
     SessionUser,
-    setUuidParam,
     SlackInstallationNotFoundError,
     SlackNotificationPayload,
     sleep,
@@ -651,18 +652,19 @@ export default class SchedulerTask {
             appUuid,
         );
 
-        const schedulerUuidParam = setUuidParam(
-            'scheduler_uuid',
-            schedulerUuid,
-        );
         let deliveryUrl: string;
         if (appUuid) {
-            deliveryUrl = `${this.lightdashConfig.siteUrl}/projects/${projectUuid}/apps/${appUuid}/view?${schedulerUuidParam}`;
+            deliveryUrl = `${this.lightdashConfig.siteUrl}/projects/${projectUuid}/apps/${appUuid}/view`;
         } else if (savedChartUuid) {
-            deliveryUrl = `${this.lightdashConfig.siteUrl}/projects/${projectUuid}/saved/${savedChartUuid}/view?${schedulerUuidParam}`;
+            deliveryUrl = `${this.lightdashConfig.siteUrl}/projects/${projectUuid}/saved/${savedChartUuid}/view`;
         } else {
-            deliveryUrl = `${this.lightdashConfig.siteUrl}/projects/${projectUuid}/dashboards/${dashboardUuid}/view?${schedulerUuidParam}`;
+            deliveryUrl = `${this.lightdashConfig.siteUrl}/projects/${projectUuid}/dashboards/${dashboardUuid}/view`;
         }
+        deliveryUrl = appendUuidQueryParam(
+            deliveryUrl,
+            'scheduler_uuid',
+            schedulerUuid ?? getSourceSchedulerUuid(scheduler),
+        );
         const minimalRenderUrl = new URL(minimalUrl);
         if (exportOptions?.dateZoomGranularity) {
             minimalRenderUrl.searchParams.set(
@@ -679,9 +681,9 @@ export default class SchedulerTask {
         if (appState) {
             const encodedAppState = JSON.stringify(appState);
             minimalRenderUrl.searchParams.set('state', encodedAppState);
-            deliveryUrl += `${
-                deliveryUrl.endsWith('?') ? '' : '&'
-            }state=${encodeURIComponent(encodedAppState)}`;
+            const deliveryUrlObj = new URL(deliveryUrl);
+            deliveryUrlObj.searchParams.set('state', encodedAppState);
+            deliveryUrl = deliveryUrlObj.toString();
         }
 
         switch (format) {
@@ -1525,9 +1527,10 @@ export default class SchedulerTask {
             const showExpirationWarning = format !== SchedulerFormat.IMAGE;
             const slackExpirationDays = Math.ceil(slackExpiration / 86400);
             const schedulerFooter = includeLinks
-                ? `<${url}?${setUuidParam(
+                ? `<${appendUuidQueryParam(
+                      url,
                       'scheduler_uuid',
-                      schedulerUuid,
+                      schedulerUuid ?? getSourceSchedulerUuid(scheduler),
                   )}|scheduled delivery>`
                 : 'scheduled delivery';
             const getBlocksArgs = {
@@ -1562,9 +1565,11 @@ export default class SchedulerTask {
                             title: name,
                         });
                     const thresholdFooter = includeLinks
-                        ? `<${url}?${setUuidParam(
+                        ? `<${appendUuidQueryParam(
+                              url,
                               'threshold_uuid',
-                              schedulerUuid,
+                              schedulerUuid ??
+                                  getSourceSchedulerUuid(scheduler),
                           )}|data alert>`
                         : 'data alert';
 
@@ -3055,10 +3060,11 @@ export default class SchedulerTask {
                     ? await this.getImageBufferFromStorage(imageS3Key)
                     : undefined;
 
-            const schedulerUrl = `${url}?${setUuidParam(
+            const schedulerUrl = appendUuidQueryParam(
+                url,
                 'scheduler_uuid',
-                schedulerUuid,
-            )}`;
+                schedulerUuid ?? getSourceSchedulerUuid(scheduler),
+            );
 
             const defaultSchedulerTimezone =
                 await this.schedulerService.getSchedulerDefaultTimezone(
@@ -3481,11 +3487,6 @@ export default class SchedulerTask {
                 scheduler.createdBy,
             );
 
-            const schedulerUuidParam = setUuidParam(
-                'scheduler_uuid',
-                schedulerUuid,
-            );
-
             if (format !== SchedulerFormat.GSHEETS) {
                 throw new UnexpectedServerError(
                     `Unable to process format ${format} on sendGdriveNotification`,
@@ -3495,7 +3496,11 @@ export default class SchedulerTask {
                     await this.schedulerService.savedChartModel.get(
                         savedChartUuid,
                     );
-                deliveryUrl = `${this.lightdashConfig.siteUrl}/projects/${chart.projectUuid}/saved/${savedChartUuid}/view?${schedulerUuidParam}&isSync=true`;
+                deliveryUrl = appendUuidQueryParam(
+                    `${this.lightdashConfig.siteUrl}/projects/${chart.projectUuid}/saved/${savedChartUuid}/view?isSync=true`,
+                    'scheduler_uuid',
+                    schedulerUuid,
+                );
 
                 const defaultSchedulerTimezone =
                     await this.schedulerService.getSchedulerDefaultTimezone(
@@ -3542,7 +3547,11 @@ export default class SchedulerTask {
                     scheduler.createdBy,
                 );
 
-                const reportUrl = `${this.lightdashConfig.siteUrl}/projects/${chart.projectUuid}/saved/${chart.uuid}/view?${schedulerUuidParam}&isSync=true`;
+                const reportUrl = appendUuidQueryParam(
+                    `${this.lightdashConfig.siteUrl}/projects/${chart.projectUuid}/saved/${chart.uuid}/view?isSync=true`,
+                    'scheduler_uuid',
+                    schedulerUuid,
+                );
                 await this.googleDriveClient.uploadMetadata(
                     refreshToken,
                     gdriveId,
@@ -3606,7 +3615,11 @@ export default class SchedulerTask {
                     sessionUser,
                     dashboardUuid,
                 );
-                deliveryUrl = `${this.lightdashConfig.siteUrl}/projects/${dashboard.projectUuid}/dashboards/${dashboardUuid}/view?${schedulerUuidParam}&isSync=true`;
+                deliveryUrl = appendUuidQueryParam(
+                    `${this.lightdashConfig.siteUrl}/projects/${dashboard.projectUuid}/dashboards/${dashboardUuid}/view?isSync=true`,
+                    'scheduler_uuid',
+                    schedulerUuid,
+                );
 
                 const defaultSchedulerTimezone =
                     await this.schedulerService.getSchedulerDefaultTimezone(
@@ -3776,7 +3789,11 @@ export default class SchedulerTask {
                         scheduler.savedSqlUuid,
                         {},
                     );
-                deliveryUrl = `${this.lightdashConfig.siteUrl}/projects/${sqlChart.project.projectUuid}/sql-runner/${sqlChart.slug}?${schedulerUuidParam}&isSync=true`;
+                deliveryUrl = appendUuidQueryParam(
+                    `${this.lightdashConfig.siteUrl}/projects/${sqlChart.project.projectUuid}/sql-runner/${sqlChart.slug}?isSync=true`,
+                    'scheduler_uuid',
+                    schedulerUuid,
+                );
 
                 const defaultSchedulerTimezone =
                     await this.schedulerService.getSchedulerDefaultTimezone(
@@ -4599,22 +4616,22 @@ export default class SchedulerTask {
                     scheduler.createdBy,
                 );
                 if (user.email) {
-                    const schedulerUrlParam = setUuidParam(
-                        'scheduler_uuid',
-                        schedulerUuid,
-                    );
                     const schedulerUrl =
                         scheduler.savedChartUuid || scheduler.dashboardUuid
-                            ? `${this.lightdashConfig.siteUrl}/projects/${
-                                  schedulerPayload.projectUuid
-                              }/${
-                                  scheduler.savedChartUuid
-                                      ? 'saved'
-                                      : 'dashboards'
-                              }/${
-                                  scheduler.savedChartUuid ||
-                                  scheduler.dashboardUuid
-                              }/view?${schedulerUrlParam}`
+                            ? appendUuidQueryParam(
+                                  `${this.lightdashConfig.siteUrl}/projects/${
+                                      schedulerPayload.projectUuid
+                                  }/${
+                                      scheduler.savedChartUuid
+                                          ? 'saved'
+                                          : 'dashboards'
+                                  }/${
+                                      scheduler.savedChartUuid ||
+                                      scheduler.dashboardUuid
+                                  }/view`,
+                                  'scheduler_uuid',
+                                  schedulerUuid,
+                              )
                             : this.lightdashConfig.siteUrl;
 
                     await this.emailClient.sendScheduledDeliveryFailureEmail(
@@ -5615,11 +5632,6 @@ export default class SchedulerTask {
                 return;
             }
 
-            const schedulerUrlParam = setUuidParam(
-                'scheduler_uuid',
-                scheduler.schedulerUuid,
-            );
-
             const resourceUuid =
                 scheduler.savedChartUuid || scheduler.dashboardUuid;
             const resourceType = scheduler.savedChartUuid
@@ -5628,7 +5640,11 @@ export default class SchedulerTask {
 
             let schedulerUrl = this.lightdashConfig.siteUrl;
             if (resourceUuid && projectUuid) {
-                schedulerUrl = `${this.lightdashConfig.siteUrl}/projects/${projectUuid}/${resourceType}/${resourceUuid}/view?${schedulerUrlParam}`;
+                schedulerUrl = appendUuidQueryParam(
+                    `${this.lightdashConfig.siteUrl}/projects/${projectUuid}/${resourceType}/${resourceUuid}/view`,
+                    'scheduler_uuid',
+                    scheduler.schedulerUuid,
+                );
             }
 
             const failedTargets = batchResult.results

--- a/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
@@ -2,11 +2,13 @@ import { Ability, RawRuleOf } from '@casl/ability';
 import {
     ForbiddenError,
     OrganizationMemberRole,
+    ParameterError,
     PossibleAbilities,
     SchedulerAndTargets,
     SchedulerFormat,
     SessionUser,
     type ChartScheduler,
+    type CreateSchedulerAndTargets,
 } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import EmailClient from '../../clients/EmailClient/EmailClient';
@@ -134,6 +136,10 @@ const schedulerClient = {
     addScheduledDeliveryJob: vi.fn(async () => ({})),
 };
 
+const slackClient = {
+    joinChannels: vi.fn(async () => {}),
+};
+
 const buildUser = (
     abilities: RawRuleOf<Ability<PossibleAbilities>>[],
 ): SessionUser =>
@@ -157,7 +163,7 @@ const buildService = () =>
         appModel: {} as AppModel,
         projectModel: {} as ProjectModel,
         schedulerClient: schedulerClient as unknown as SchedulerClient,
-        slackClient: {} as SlackClient,
+        slackClient: slackClient as unknown as SlackClient,
         emailClient: {} as EmailClient,
         userModel: {} as UserModel,
         googleDriveClient: {} as GoogleDriveClient,
@@ -186,6 +192,81 @@ describe('SchedulerService', () => {
             expect(
                 schedulerClient.addScheduledDeliveryJob,
             ).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('sendScheduler', () => {
+        const sendNowPayload = {
+            name: 'send now delivery',
+            format: SchedulerFormat.CSV,
+            cron: '0 0 * * *',
+            options: { formatted: true, limit: 'table' },
+            savedChartUuid,
+            dashboardUuid: null,
+            savedSqlUuid: null,
+            appUuid: null,
+            createdBy: 'userUuid',
+            enabled: true,
+            includeLinks: true,
+            targets: [{ recipient: 'recipient@example.com' }],
+        } as unknown as CreateSchedulerAndTargets;
+
+        const userWhoCanSend = buildUser([
+            { subject: 'ScheduledDeliveries', action: ['create'] },
+            { subject: 'SavedChart', action: ['view'] },
+            { subject: 'Dashboard', action: ['view'] },
+        ]);
+
+        test('passes sourceSchedulerUuid to the delivery job when it matches the saved scheduler resource', async () => {
+            await service.sendScheduler(userWhoCanSend, {
+                ...sendNowPayload,
+                sourceSchedulerUuid: chartSchedulerInPrivateSpace.schedulerUuid,
+            });
+
+            expect(schedulerModel.getScheduler).toHaveBeenCalledWith(
+                chartSchedulerInPrivateSpace.schedulerUuid,
+            );
+            expect(
+                schedulerClient.addScheduledDeliveryJob,
+            ).toHaveBeenCalledWith(
+                expect.any(Date),
+                expect.objectContaining({
+                    sourceSchedulerUuid:
+                        chartSchedulerInPrivateSpace.schedulerUuid,
+                }),
+                undefined,
+            );
+        });
+
+        test('throws ParameterError when sourceSchedulerUuid belongs to a different resource', async () => {
+            await expect(
+                service.sendScheduler(userWhoCanSend, {
+                    ...sendNowPayload,
+                    savedChartUuid: null,
+                    dashboardUuid: 'dashboardUuid',
+                    sourceSchedulerUuid:
+                        chartSchedulerInPrivateSpace.schedulerUuid,
+                }),
+            ).rejects.toThrowError(ParameterError);
+
+            expect(
+                schedulerClient.addScheduledDeliveryJob,
+            ).not.toHaveBeenCalled();
+        });
+
+        test('does not look up a saved scheduler when no sourceSchedulerUuid is given', async () => {
+            await service.sendScheduler(userWhoCanSend, sendNowPayload);
+
+            expect(schedulerModel.getScheduler).not.toHaveBeenCalled();
+            expect(
+                schedulerClient.addScheduledDeliveryJob,
+            ).toHaveBeenCalledWith(
+                expect.any(Date),
+                expect.not.objectContaining({
+                    sourceSchedulerUuid: expect.anything(),
+                }),
+                undefined,
+            );
         });
     });
 

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -1573,6 +1573,24 @@ export class SchedulerService extends BaseService {
             throw new ForbiddenError();
         }
 
+        // The body is client-supplied: only trust sourceSchedulerUuid for
+        // delivery links if it resolves to a scheduler on the same resource.
+        if (scheduler.sourceSchedulerUuid) {
+            const sourceScheduler = await this.schedulerModel.getScheduler(
+                scheduler.sourceSchedulerUuid,
+            );
+            if (
+                sourceScheduler.savedChartUuid !== scheduler.savedChartUuid ||
+                sourceScheduler.dashboardUuid !== scheduler.dashboardUuid ||
+                sourceScheduler.savedSqlUuid !== scheduler.savedSqlUuid ||
+                sourceScheduler.appUuid !== scheduler.appUuid
+            ) {
+                throw new ParameterError(
+                    'sourceSchedulerUuid does not belong to the delivery resource',
+                );
+            }
+        }
+
         const slackChannels = scheduler.targets
             .filter(isCreateSchedulerSlackTarget)
             .map((target) => target.channel);

--- a/packages/common/src/types/scheduler.test.ts
+++ b/packages/common/src/types/scheduler.test.ts
@@ -1,0 +1,48 @@
+import {
+    getSchedulerUuid,
+    getSourceSchedulerUuid,
+    type CreateSchedulerAndTargets,
+    type Scheduler,
+} from './scheduler';
+
+describe('getSourceSchedulerUuid', () => {
+    it('returns the transient uuid from a send-now payload', () => {
+        const payload = {
+            name: 'delivery',
+            targets: [],
+            sourceSchedulerUuid: 'source-uuid',
+        } as unknown as CreateSchedulerAndTargets;
+
+        expect(getSourceSchedulerUuid(payload)).toBe('source-uuid');
+    });
+
+    it('returns undefined when the payload has no source scheduler', () => {
+        const payload = {
+            name: 'delivery',
+            targets: [],
+        } as unknown as CreateSchedulerAndTargets;
+
+        expect(getSourceSchedulerUuid(payload)).toBeUndefined();
+    });
+
+    it('returns undefined for saved scheduler payloads', () => {
+        const saved = {
+            schedulerUuid: 'saved-uuid',
+            name: 'delivery',
+        } as unknown as Scheduler;
+
+        expect(getSourceSchedulerUuid(saved)).toBeUndefined();
+    });
+});
+
+describe('getSchedulerUuid', () => {
+    it('does not fall back to the transient source uuid', () => {
+        const payload = {
+            name: 'delivery',
+            targets: [],
+            sourceSchedulerUuid: 'source-uuid',
+        } as unknown as CreateSchedulerAndTargets;
+
+        expect(getSchedulerUuid(payload)).toBeUndefined();
+    });
+});

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -343,6 +343,11 @@ export type CreateSchedulerAndTargets = Omit<
     // worker can run it without a persisted row. Never written to the scheduler
     // table (persisted separately via the ai-augmentation sub-resource).
     aiAugmentation?: SchedulerAiAugmentation | null;
+    // Transient: "send now" from the edit modal of a saved scheduler carries
+    // that scheduler's uuid so delivery links can open the delivery. Only used
+    // for link building — must not reclassify the payload as a saved scheduler
+    // (send-now filter/batch semantics key off schedulerUuid being absent).
+    sourceSchedulerUuid?: string;
 };
 
 export type CreateSchedulerAndTargetsWithoutIds = Omit<
@@ -636,6 +641,11 @@ export const getSchedulerUuid = (
     data: CreateSchedulerAndTargets | Pick<Scheduler, 'schedulerUuid'>,
 ): string | undefined =>
     'schedulerUuid' in data ? data.schedulerUuid : undefined;
+
+export const getSourceSchedulerUuid = (
+    data: CreateSchedulerAndTargets | Pick<Scheduler, 'schedulerUuid'>,
+): string | undefined =>
+    'sourceSchedulerUuid' in data ? data.sourceSchedulerUuid : undefined;
 
 export enum LightdashPage {
     DASHBOARD = 'dashboard',

--- a/packages/common/src/utils/searchParams.test.ts
+++ b/packages/common/src/utils/searchParams.test.ts
@@ -1,0 +1,59 @@
+import { appendUuidQueryParam } from './searchParams';
+
+const VALID_UUID = '4f5b6c7d-8e9f-4a1b-b2c3-d4e5f6a7b8c9';
+
+describe('appendUuidQueryParam', () => {
+    it('appends the param when the uuid is valid', () => {
+        expect(
+            appendUuidQueryParam(
+                'https://app.lightdash.com/dashboards/abc/view',
+                'scheduler_uuid',
+                VALID_UUID,
+            ),
+        ).toBe(
+            `https://app.lightdash.com/dashboards/abc/view?scheduler_uuid=${VALID_UUID}`,
+        );
+    });
+
+    it('returns the url unchanged when the uuid is undefined', () => {
+        expect(
+            appendUuidQueryParam(
+                'https://app.lightdash.com/dashboards/abc/view',
+                'scheduler_uuid',
+                undefined,
+            ),
+        ).toBe('https://app.lightdash.com/dashboards/abc/view');
+    });
+
+    it('returns the url unchanged when the uuid is null', () => {
+        expect(
+            appendUuidQueryParam(
+                'https://app.lightdash.com/dashboards/abc/view',
+                'scheduler_uuid',
+                null,
+            ),
+        ).toBe('https://app.lightdash.com/dashboards/abc/view');
+    });
+
+    it('returns the url unchanged when the uuid is invalid', () => {
+        expect(
+            appendUuidQueryParam(
+                'https://app.lightdash.com/dashboards/abc/view',
+                'scheduler_uuid',
+                'not-a-uuid',
+            ),
+        ).toBe('https://app.lightdash.com/dashboards/abc/view');
+    });
+
+    it('preserves an existing query string', () => {
+        expect(
+            appendUuidQueryParam(
+                'https://app.lightdash.com/dashboards/abc/view?foo=bar',
+                'scheduler_uuid',
+                VALID_UUID,
+            ),
+        ).toBe(
+            `https://app.lightdash.com/dashboards/abc/view?foo=bar&scheduler_uuid=${VALID_UUID}`,
+        );
+    });
+});

--- a/packages/common/src/utils/searchParams.ts
+++ b/packages/common/src/utils/searchParams.ts
@@ -1,8 +1,14 @@
 import { validate as validateUuid } from 'uuid';
 
-export function setUuidParam(key: string, value?: string | null) {
-    if (value && validateUuid(value)) {
-        return `${key}=${value}`;
+export function appendUuidQueryParam(
+    url: string,
+    key: string,
+    value?: string | null,
+): string {
+    if (!value || !validateUuid(value)) {
+        return url;
     }
-    return '';
+    const parsed = new URL(url);
+    parsed.searchParams.set(key, value);
+    return parsed.toString();
 }

--- a/packages/frontend/src/features/scheduler/hooks/useSchedulerFormModal.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useSchedulerFormModal.ts
@@ -427,6 +427,9 @@ export const useSchedulerFormModal = ({
             createdBy: user.userUuid,
             // Carry the (possibly unsaved) AI settings so send-now runs them.
             aiAugmentation: form.values.aiAugmentation,
+            // In edit mode, carry the saved scheduler's uuid so delivery
+            // links can open the delivery.
+            sourceSchedulerUuid: isEditMode ? schedulerUuid : undefined,
         };
 
         track({ name: EventName.SCHEDULER_SEND_NOW_BUTTON });
@@ -442,6 +445,7 @@ export const useSchedulerFormModal = ({
         track,
         sendNow,
         formResource?.type,
+        schedulerUuid,
     ]);
 
     const isMutating = isEditMode


### PR DESCRIPTION
Closes #26124 (PROD-9220)

## Problem

The "scheduled delivery" link in delivery emails and Slack footers sometimes ends in a bare `view?` with no `scheduler_uuid`, so it opens the resource without opening the delivery.

Two defects compound:

1. **The scheduler modal's "Send now" never sends the scheduler uuid — even in edit mode.** `useSchedulerFormModal` posts unsaved form state (`CreateSchedulerAndTargets`, no uuid) to `POST /schedulers/send` in both create and edit mode. Only the list-row "Send now" uses `POST /schedulers/{uuid}/send`. That's the "sometimes".
2. **The link template hardcodes `?` around a conditionally-empty param.** All delivery-link call sites build `${url}?${setUuidParam('scheduler_uuid', uuid)}`, and `setUuidParam` returns `''` for a missing/invalid uuid (#14252), leaving the dangling `?`.

## Fix

- **New `appendUuidQueryParam(url, key, value)`** in common: appends the param via the URL API only when the value is a valid uuid, otherwise returns the url unchanged. Replaces `setUuidParam` (now removed) at every call site in `SchedulerTask.ts`, including the gsheets `isSync` URLs and the app-state `state` param append (which previously assumed a trailing `?`).
- **Edit-modal send-now links to the saved delivery**: the payload carries a transient `sourceSchedulerUuid` (same pattern as the transient `aiAugmentation`), used only for link building. `schedulerUuid` stays absent so send-now semantics are unchanged — filter/parameter overrides, individual (non-batch) jobs, and `sendNow` analytics all still key off it. The backend validates the uuid resolves to a scheduler on the same resource before trusting it (client-supplied body).
- Create-mode send-now legitimately has no uuid: the link is now a clean resource URL with no dangling `?`.

## Testing

- Unit tests for `appendUuidQueryParam` (valid/missing/invalid uuid, existing query string)
- Unit tests for `getSourceSchedulerUuid` and `getSchedulerUuid` non-fallback
- `SchedulerService.sendScheduler` tests: passes matching `sourceSchedulerUuid` through, rejects mismatched resource with `ParameterError`, skips lookup when absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019JMhHkRVusJ27FRmFA4Xfx