### PR TITLE
fix: enforce project view permission on custom metrics endpoint

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -2892,6 +2892,39 @@ describe('ProjectService', () => {
         });
     });
 
+    describe('getCustomMetrics', () => {
+        test('returns custom metrics when the user can view the project', async () => {
+            (
+                savedChartModel.find as import('vitest').Mock
+            ).mockResolvedValueOnce([]);
+
+            const result = await service.getCustomMetrics(
+                user,
+                defaultProject.projectUuid,
+            );
+
+            expect(result).toEqual([]);
+            expect(savedChartModel.find).toHaveBeenCalledWith({
+                projectUuid: defaultProject.projectUuid,
+            });
+        });
+
+        test('throws ForbiddenError without querying charts when the user cannot view the project', async () => {
+            const restrictedUser = {
+                ...user,
+                ability: new Ability<PossibleAbilities>([]),
+            } as unknown as SessionUser;
+
+            await expect(
+                service.getCustomMetrics(
+                    restrictedUser,
+                    defaultProject.projectUuid,
+                ),
+            ).rejects.toThrow(ForbiddenError);
+            expect(savedChartModel.find).not.toHaveBeenCalled();
+        });
+    });
+
     describe('getUserAttributes', () => {
         // vi.clearAllMocks() in the outer afterEach does not drain
         // mockImplementationOnce queues — reset the email mock per test so

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -9094,7 +9094,19 @@ export class ProjectService extends BaseService {
             chartUrl: string;
         }[]
     > {
-        // TODO implement permissions
+        const project = await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('Project', {
+                    organizationUuid: project.organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
         const chartSummaries = await this.savedChartModel.find({
             projectUuid,
         });


### PR DESCRIPTION
Add the standard project view permission check to ProjectService.getCustomMetrics before any chart data is read, and cover it with unit tests.

Linear: SPK-591