### PR TITLE
fix: hide fields from data app field pickers

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
@@ -1,0 +1,135 @@
+import {
+    ChartType,
+    CustomDimensionType,
+    DimensionType,
+    FieldType,
+    getItemId,
+    MetricType,
+    type CompiledDimension,
+    type CompiledMetric,
+    type CustomSqlDimension,
+    type Item,
+    type TableCalculation,
+} from '@lightdash/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { ConfigTabs } from './DataAppVizConfigTabs';
+
+const { fieldSelectItems } = vi.hoisted(() => ({
+    fieldSelectItems: [] as Item[][],
+}));
+
+vi.mock('../../../features/apps/components/DataAppVizLibraryPicker', () => ({
+    default: () => null,
+}));
+vi.mock('../../../features/apps/hooks/useDataAppVisualization', () => ({
+    useDataAppVisualization: vi.fn(),
+}));
+vi.mock('../../common/FieldSelect', () => ({
+    default: ({ items }: { items: Item[] }) => {
+        fieldSelectItems.push(items);
+        return <div data-testid="field-select" />;
+    },
+}));
+vi.mock('../../LightdashVisualization/useVisualizationContext', () => ({
+    useVisualizationContext: vi.fn(),
+}));
+
+import { useDataAppVisualization } from '../../../features/apps/hooks/useDataAppVisualization';
+import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
+
+const makeDimension = (name: string, hidden: boolean): CompiledDimension => ({
+    compiledSql: '',
+    tablesReferences: [],
+    fieldType: FieldType.DIMENSION,
+    type: DimensionType.STRING,
+    name,
+    label: name,
+    table: 'orders',
+    tableLabel: 'Orders',
+    sql: '',
+    hidden,
+});
+
+const makeMetric = (name: string, hidden: boolean): CompiledMetric => ({
+    compiledSql: '',
+    tablesReferences: [],
+    fieldType: FieldType.METRIC,
+    type: MetricType.COUNT,
+    name,
+    label: name,
+    table: 'orders',
+    tableLabel: 'Orders',
+    sql: '',
+    hidden,
+});
+
+const customDimension: CustomSqlDimension = {
+    id: 'custom-dimension',
+    name: 'custom',
+    table: 'orders',
+    type: CustomDimensionType.SQL,
+    sql: '${orders.visible}',
+    dimensionType: DimensionType.STRING,
+};
+
+const tableCalculation: TableCalculation = {
+    name: 'table_calculation',
+    displayName: 'Table calculation',
+    sql: '${orders_visible_metric}',
+};
+
+describe('DataAppVizConfigTabs', () => {
+    beforeEach(() => {
+        fieldSelectItems.length = 0;
+        vi.mocked(useDataAppVisualization).mockReturnValue({
+            data: {
+                schema: {
+                    fields: [
+                        {
+                            name: 'source',
+                            label: 'Source',
+                            type: 'dimension',
+                            required: true,
+                        },
+                        {
+                            name: 'value',
+                            label: 'Value',
+                            type: 'metric',
+                            required: true,
+                        },
+                    ],
+                    configOptions: [],
+                },
+            },
+        } as unknown as ReturnType<typeof useDataAppVisualization>);
+        vi.mocked(useVisualizationContext).mockReturnValue({
+            itemsMap: {
+                orders_visible: makeDimension('visible', false),
+                orders_hidden: makeDimension('hidden', true),
+                orders_visible_metric: makeMetric('visible_metric', false),
+                orders_hidden_metric: makeMetric('hidden_metric', true),
+                'custom-dimension': customDimension,
+                table_calculation: tableCalculation,
+            },
+            visualizationConfig: {
+                chartType: ChartType.DATA_APP_VIZ,
+                chartConfig: {
+                    dataAppVizUuid: 'data-app-viz-uuid',
+                    fieldMapping: {},
+                    setDataAppVizUuid: vi.fn(),
+                    setField: vi.fn(),
+                },
+            },
+        } as unknown as ReturnType<typeof useVisualizationContext>);
+    });
+
+    it('matches Explorer field visibility', () => {
+        renderWithProviders(<ConfigTabs />);
+
+        expect(fieldSelectItems.map((items) => items.map(getItemId))).toEqual([
+            ['orders_visible', 'custom-dimension'],
+            ['orders_visible_metric', 'table_calculation'],
+        ]);
+    });
+});

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -1,29 +1,16 @@
-import {
-    getItemId,
-    isCustomDimension,
-    isDimension,
-    isMetric,
-    isTableCalculation,
-    type DataAppVizField,
-    type Item,
-} from '@lightdash/common';
+import { getItemId, type DataAppVizField, type Item } from '@lightdash/common';
 import { Stack, Text } from '@mantine-8/core';
 import { MantineProvider, useMantineColorScheme } from '@mantine/core';
 import { memo, useMemo, type FC } from 'react';
 import { useParams } from 'react-router';
 import DataAppVizLibraryPicker from '../../../features/apps/components/DataAppVizLibraryPicker';
 import { useDataAppVisualization } from '../../../features/apps/hooks/useDataAppVisualization';
+import { getDataAppVizFieldItems } from '../../../features/apps/utils/getDataAppVizFieldItems';
 import FieldSelect from '../../common/FieldSelect';
 import { isDataAppVizVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
 import { Config } from '../common/Config';
 import { getVizConfigThemeOverride } from '../mantineTheme';
-
-const isDimensionItem = (item: Item): boolean =>
-    isDimension(item) || isCustomDimension(item);
-
-const isMetricItem = (item: Item): boolean =>
-    isMetric(item) || isTableCalculation(item);
 
 export const ConfigTabs: FC = memo(() => {
     const { colorScheme } = useMantineColorScheme();
@@ -44,12 +31,10 @@ export const ConfigTabs: FC = memo(() => {
         dataAppVizUuid || undefined,
     );
 
-    const allItems = useMemo(() => Object.values(itemsMap ?? {}), [itemsMap]);
-    const dimensions = useMemo(
-        () => allItems.filter(isDimensionItem),
-        [allItems],
+    const { dimensions, metrics } = useMemo(
+        () => getDataAppVizFieldItems(itemsMap ?? {}),
+        [itemsMap],
     );
-    const metrics = useMemo(() => allItems.filter(isMetricItem), [allItems]);
 
     const fieldItems = (field: DataAppVizField): Item[] =>
         field.type === 'metric' ? metrics : dimensions;

--- a/packages/frontend/src/features/apps/components/DataAppVizTestPanel.test.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizTestPanel.test.tsx
@@ -1,10 +1,32 @@
-import { type DataAppVizSchema } from '@lightdash/common';
+import {
+    DimensionType,
+    FieldType,
+    getItemId,
+    MetricType,
+    SupportedDbtAdapter,
+    type CompiledDimension,
+    type CompiledMetric,
+    type DataAppVizSchema,
+    type Explore,
+    type Item,
+} from '@lightdash/common';
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../testing/testUtils';
 import DataAppVizTestPanel from './DataAppVizTestPanel';
 import { buildTestMetricQuery, isMappingComplete } from './dataAppVizTestQuery';
 
+const { fieldSelectItems } = vi.hoisted(() => ({
+    fieldSelectItems: [] as Item[][],
+}));
+
+vi.mock('../../../components/common/FieldSelect', () => ({
+    default: ({ items }: { items: Item[] }) => {
+        fieldSelectItems.push(items);
+        return <div data-testid="field-select" />;
+    },
+}));
 vi.mock('../../../hooks/useExplores', () => ({
     useExplores: vi.fn(),
 }));
@@ -26,6 +48,59 @@ const schema: DataAppVizSchema = {
         { name: 'value', label: 'Value', type: 'metric', required: true },
     ],
     configOptions: [],
+};
+
+const makeDimension = (name: string, hidden: boolean): CompiledDimension => ({
+    compiledSql: '',
+    tablesReferences: [],
+    fieldType: FieldType.DIMENSION,
+    type: DimensionType.STRING,
+    name,
+    label: name,
+    table: 'orders',
+    tableLabel: 'Orders',
+    sql: '',
+    hidden,
+});
+
+const makeMetric = (name: string, hidden: boolean): CompiledMetric => ({
+    compiledSql: '',
+    tablesReferences: [],
+    fieldType: FieldType.METRIC,
+    type: MetricType.COUNT,
+    name,
+    label: name,
+    table: 'orders',
+    tableLabel: 'Orders',
+    sql: '',
+    hidden,
+});
+
+const exploreWithHiddenFields: Explore = {
+    name: 'orders',
+    label: 'Orders',
+    tags: [],
+    baseTable: 'orders',
+    joinedTables: [],
+    tables: {
+        orders: {
+            name: 'orders',
+            label: 'Orders',
+            database: '',
+            schema: '',
+            sqlTable: 'orders',
+            dimensions: {
+                visible: makeDimension('visible', false),
+                hidden: makeDimension('hidden', true),
+            },
+            metrics: {
+                visible_metric: makeMetric('visible_metric', false),
+                hidden_metric: makeMetric('hidden_metric', true),
+            },
+            lineageGraph: {},
+        },
+    },
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
 };
 
 describe('isMappingComplete', () => {
@@ -79,6 +154,7 @@ describe('buildTestMetricQuery', () => {
 
 describe('DataAppVizTestPanel', () => {
     beforeEach(() => {
+        fieldSelectItems.length = 0;
         vi.mocked(useExplores).mockReturnValue({
             data: [
                 { name: 'orders', label: 'Orders' },
@@ -120,6 +196,18 @@ describe('DataAppVizTestPanel', () => {
         expect(screen.getByText('Value')).toBeInTheDocument();
     });
 
+    it('requests the same filtered Explore list as Explorer', () => {
+        renderWithProviders(
+            <DataAppVizTestPanel
+                projectUuid="p1"
+                schema={schema}
+                onContextChange={vi.fn()}
+            />,
+        );
+
+        expect(useExplores).toHaveBeenCalledWith('p1', true);
+    });
+
     it('hides the run action until an explore is selected', () => {
         renderWithProviders(
             <DataAppVizTestPanel
@@ -132,5 +220,44 @@ describe('DataAppVizTestPanel', () => {
         expect(
             screen.queryByRole('button', { name: /run test query/i }),
         ).not.toBeInTheDocument();
+    });
+
+    it('matches Explorer field visibility', async () => {
+        const user = userEvent.setup();
+        vi.mocked(useExploreByProjectUuid).mockReturnValue({
+            data: exploreWithHiddenFields,
+        } as unknown as ReturnType<typeof useExploreByProjectUuid>);
+
+        renderWithProviders(
+            <DataAppVizTestPanel
+                projectUuid="p1"
+                schema={{
+                    fields: [
+                        {
+                            name: 'source',
+                            label: 'Source',
+                            type: 'dimension',
+                            required: true,
+                        },
+                        {
+                            name: 'value',
+                            label: 'Value',
+                            type: 'metric',
+                            required: true,
+                        },
+                    ],
+                    configOptions: [],
+                }}
+                onContextChange={vi.fn()}
+            />,
+        );
+
+        await user.click(screen.getByPlaceholderText('Select an explore'));
+        await user.click(await screen.findByText('Orders'));
+
+        expect(fieldSelectItems.map((items) => items.map(getItemId))).toEqual([
+            ['orders_visible'],
+            ['orders_visible_metric'],
+        ]);
     });
 });

--- a/packages/frontend/src/features/apps/components/DataAppVizTestPanel.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizTestPanel.tsx
@@ -2,15 +2,10 @@ import {
     getErrorMessage,
     getItemId,
     getItemMap,
-    isCustomDimension,
-    isDimension,
-    isMetric,
     isSummaryExploreError,
-    isTableCalculation,
     QueryExecutionContext,
     type DataAppVizContext,
     type DataAppVizSchema,
-    type Item,
 } from '@lightdash/common';
 import { Button, Card, Group, Select, Stack, Text } from '@mantine-8/core';
 import { useEffect, useMemo, useState, type FC } from 'react';
@@ -20,6 +15,7 @@ import { useExploreByProjectUuid } from '../../../hooks/useExplore';
 import { useExplores } from '../../../hooks/useExplores';
 import { type QueryResultsProps } from '../../../hooks/useQueryResults';
 import { useQueryExecutor } from '../../../providers/Explorer/useQueryExecutor';
+import { getDataAppVizFieldItems } from '../utils/getDataAppVizFieldItems';
 import DataAppVizFieldTypeBadge from './DataAppVizFieldTypeBadge';
 import { buildTestMetricQuery, isMappingComplete } from './dataAppVizTestQuery';
 
@@ -47,7 +43,7 @@ const DataAppVizTestPanel: FC<Props> = ({
     // the query so nothing fires while the user is still picking fields.
     const [run, setRun] = useState<Run | null>(null);
 
-    const explores = useExplores(projectUuid);
+    const explores = useExplores(projectUuid, true);
     const explore = useExploreByProjectUuid(
         exploreName ?? undefined,
         projectUuid,
@@ -57,20 +53,9 @@ const DataAppVizTestPanel: FC<Props> = ({
         () => (explore.data ? getItemMap(explore.data) : {}),
         [explore.data],
     );
-    const allItems = useMemo(() => Object.values(itemsMap), [itemsMap]);
-    const dimensions = useMemo(
-        () =>
-            allItems.filter(
-                (i) => isDimension(i as Item) || isCustomDimension(i as Item),
-            ),
-        [allItems],
-    );
-    const metrics = useMemo(
-        () =>
-            allItems.filter(
-                (i) => isMetric(i as Item) || isTableCalculation(i as Item),
-            ),
-        [allItems],
+    const { dimensions, metrics } = useMemo(
+        () => getDataAppVizFieldItems(itemsMap),
+        [itemsMap],
     );
 
     const [{ query, queryResults }] = useQueryExecutor(

--- a/packages/frontend/src/features/apps/utils/getDataAppVizFieldItems.ts
+++ b/packages/frontend/src/features/apps/utils/getDataAppVizFieldItems.ts
@@ -1,0 +1,20 @@
+import {
+    getDimensionsFromItemsMap,
+    getMetricsFromItemsMap,
+    getTableCalculationsFromItemsMap,
+    isField,
+    type Item,
+    type ItemsMap,
+} from '@lightdash/common';
+
+const isVisibleField = (item: Item): boolean => !isField(item) || !item.hidden;
+
+export const getDataAppVizFieldItems = (itemsMap: ItemsMap) => ({
+    dimensions: Object.values(getDimensionsFromItemsMap(itemsMap)).filter(
+        isVisibleField,
+    ),
+    metrics: [
+        ...Object.values(getMetricsFromItemsMap(itemsMap, isVisibleField)),
+        ...Object.values(getTableCalculationsFromItemsMap(itemsMap)),
+    ],
+});


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes #25359

### Description

- Matches Explorer field visibility by excluding hidden compiled dimensions and metrics from Data App field mapping.
- Keeps custom dimensions and table calculations available.
- Shares the field selector between the Explorer config and App Generator test panel using the established visualization item-map helpers.
- Makes the App Generator test panel request the same project-filtered Explore list as Explorer, so Explores excluded by project table selection are not offered.
- Continues to rely on the backend-filtered Explore payload for project permissions and user-attribute restrictions on Explores, joined tables, dimensions, and metrics.
- Adds component-boundary regression coverage for both pickers and the filtered Explore request.

Linear: [GLITCH-607](https://linear.app/lightdash/issue/GLITCH-607/data-app-visualizations-field-picker-shows-hidden-dimensions-when)

### Tests

- `pnpm -F frontend exec vitest run src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx src/features/apps/components/DataAppVizTestPanel.test.tsx` (2 files, 9 tests)
- `pnpm -F frontend typecheck:fast`
- focused frontend lint and format checks
- `git diff --check`