### PR TITLE
fix: simplify memory citation popover

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.module.css
@@ -37,30 +37,17 @@
     border-color: var(--mantine-color-gray-3);
 }
 
-.preview {
-    max-height: 156px;
-    overflow: hidden;
-    padding-left: 0;
-    color: var(--mantine-color-ldGray-7);
-}
-
-.preview p,
-.preview li {
-    color: var(--mantine-color-ldGray-7);
-    font-size: 13px;
-}
-
 .detailsButton {
     display: inline-flex;
     align-items: center;
     gap: 4px;
-    color: var(--mantine-color-indigo-6);
-    font-size: 12px;
-    font-weight: 600;
+    color: var(--mantine-color-ldGray-6);
+    font-size: 11.5px;
+    font-weight: 500;
 }
 
 .detailsButton:hover {
-    color: var(--mantine-color-indigo-8);
+    color: var(--mantine-color-ldGray-8);
 }
 
 .detailsButton:focus-visible {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.test.tsx
@@ -99,19 +99,18 @@ describe('MemoryCitation', () => {
         );
     });
 
-    it('shows memory details on hover', async () => {
+    it('shows only the memory title on hover', async () => {
         renderMarkdown(
             'Supported sentence.<ld-mem-cite id="net-revenue"></ld-mem-cite>',
         );
 
         fireEvent.mouseEnter(screen.getByTitle('Memory: net-revenue'));
 
-        const emphasizedText = await screen.findByText('Net revenue', {
-            selector: '[data-streamdown="strong"]',
-        });
-        expect(emphasizedText).toHaveAttribute('data-streamdown', 'strong');
-        expect(screen.getByText('Net revenue convention')).toBeInTheDocument();
-        expect(screen.getByText('View details')).toBeInTheDocument();
+        expect(
+            await screen.findByText('Net revenue convention'),
+        ).toBeInTheDocument();
+        expect(screen.queryByText('Net revenue')).not.toBeInTheDocument();
+        expect(screen.getByText('View memory')).toBeInTheDocument();
     });
 
     it('opens full memory details in a modal', async () => {
@@ -120,7 +119,7 @@ describe('MemoryCitation', () => {
         );
 
         fireEvent.mouseEnter(screen.getByTitle('Memory: net-revenue'));
-        fireEvent.click(await screen.findByText('View details'));
+        fireEvent.click(await screen.findByText('View memory'));
 
         const dialog = await screen.findByRole('dialog');
         expect(

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.tsx
@@ -13,9 +13,7 @@ import { useDisclosure } from '@mantine-8/hooks';
 import { IconArrowRight } from '@tabler/icons-react';
 import { useState } from 'react';
 import { useParams } from 'react-router';
-import { AiMarkdown } from '../../../../../components/common/AiMarkdown';
 import { useAiAgentMemory } from '../../hooks/useAiAgentMemory';
-import { getAiAgentMemoryPreview } from '../../utils/memory';
 import { MemoryDetailsModal } from '../MemoryDetails/MemoryDetails';
 import styles from './MemoryCitation.module.css';
 
@@ -93,11 +91,6 @@ export const MemoryCitation = ({
                                     </Badge>
                                 ) : null}
                             </Group>
-                            <AiMarkdown className={styles.preview}>
-                                {getAiAgentMemoryPreview(
-                                    memoryQuery.data.rawMemory,
-                                )}
-                            </AiMarkdown>
                             <Divider />
                             <Group justify="space-between" wrap="nowrap">
                                 <Text size="xs" c="dimmed">
@@ -111,8 +104,8 @@ export const MemoryCitation = ({
                                     className={styles.detailsButton}
                                     onClick={openDetails}
                                 >
-                                    View details
-                                    <IconArrowRight size={13} />
+                                    View memory
+                                    <IconArrowRight size={12} />
                                 </UnstyledButton>
                             </Group>
                         </Stack>


### PR DESCRIPTION
### Description

- Show only the persisted title in memory citation popovers.
- Rename the drill-down action to "View memory" and reduce its visual prominence.
- Update focused tests for the title-only popover.

### Verification

- `direnv exec . pnpm -F frontend test --run src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.test.tsx` (7 passed)
- Focused frontend lint and formatting checks
- Manual verification in the local app
