### PR TITLE
fix: include all tabs in scheduled dashboard image exports

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -17,6 +17,7 @@ import {
     DimensionType,
     DownloadFileType,
     EmailNotificationPayload,
+    expandSelectedTabs,
     ExportContentPayload,
     ExportCsvDashboardPayload,
     FeatureFlags,
@@ -550,8 +551,15 @@ export default class SchedulerTask {
 
             const queryParams = new URLSearchParams();
             if (schedulerUuid) queryParams.set('schedulerUuid', schedulerUuid);
-            if (selectedTabs)
-                queryParams.set('selectedTabs', JSON.stringify(selectedTabs));
+            const selectedTabsList = expandSelectedTabs(
+                selectedTabs,
+                dashboard.tiles,
+            );
+            if (selectedTabsList.length > 0)
+                queryParams.set(
+                    'selectedTabs',
+                    JSON.stringify(selectedTabsList),
+                );
             if (context) queryParams.set('context', context);
 
             return {

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -6,6 +6,7 @@ import {
     ChartType,
     DashboardTileTypes,
     DownloadFileType,
+    expandSelectedTabs,
     EXPORT_TAB_PAGE_CLASS,
     ForbiddenError,
     getErrorMessage,
@@ -44,7 +45,6 @@ import {
 import { StringIndexed } from '@slack/bolt/dist/types/helpers';
 import { WebClient } from '@slack/web-api';
 import * as fsPromise from 'fs/promises';
-import { uniq } from 'lodash';
 import { nanoid as useNanoid } from 'nanoid';
 import fetch from 'node-fetch';
 import playwright, { type ElementHandle, type Page } from 'playwright';
@@ -894,15 +894,11 @@ export class UnfurlService extends BaseService {
 
         validateSelectedTabs(selectedTabs, dashboard.tiles);
 
-        // Create a new URLSearchParams object for query filters.
-        // When selectedTabs is null we forward every tab UUID present on the
-        // dashboard (and `null` for orphan tiles) so the frontend's
-        // `schedulerTabsSelected.includes(tile.tabUuid)` filter keeps orphans
-        // in the aggregated screenshot. See PROD-2505.
         const selectedTabsParams = new URLSearchParams();
-        const selectedTabsList: (string | null)[] =
-            selectedTabs ??
-            uniq(dashboard.tiles.map((tile) => tile.tabUuid ?? null));
+        const selectedTabsList = expandSelectedTabs(
+            selectedTabs,
+            dashboard.tiles,
+        );
 
         if (selectedTabsList.length > 0)
             selectedTabsParams.set(

--- a/packages/common/src/utils/dashboard.test.ts
+++ b/packages/common/src/utils/dashboard.test.ts
@@ -1,6 +1,10 @@
 import { type DashboardTile } from '../types/dashboard';
 import { ParameterError } from '../types/errors';
-import { isTileInSelectedTabs, validateSelectedTabs } from './dashboard';
+import {
+    expandSelectedTabs,
+    isTileInSelectedTabs,
+    validateSelectedTabs,
+} from './dashboard';
 
 describe('validateSelectedTabs', () => {
     // Simple mock that focuses on just the tabUuid property
@@ -81,5 +85,38 @@ describe('isTileInSelectedTabs', () => {
     it('excludes non-orphan tiles when selectedTabs is empty', () => {
         expect(isTileInSelectedTabs({ tabUuid: 'tab1' }, [])).toBe(false);
         expect(isTileInSelectedTabs({ tabUuid: null }, [])).toBe(true);
+    });
+});
+
+describe('expandSelectedTabs', () => {
+    it('returns the explicit selection unchanged', () => {
+        expect(
+            expandSelectedTabs(['tab1'], [{ tabUuid: 'tab1' }]),
+        ).toStrictEqual(['tab1']);
+        expect(expandSelectedTabs([], [{ tabUuid: 'tab1' }])).toStrictEqual([]);
+    });
+
+    it('expands null into every tab UUID present on the tiles, deduplicated', () => {
+        expect(
+            expandSelectedTabs(null, [
+                { tabUuid: 'tab1' },
+                { tabUuid: 'tab2' },
+                { tabUuid: 'tab1' },
+            ]),
+        ).toStrictEqual(['tab1', 'tab2']);
+    });
+
+    it('includes a null sentinel for orphan tiles', () => {
+        expect(
+            expandSelectedTabs(null, [
+                { tabUuid: 'tab1' },
+                { tabUuid: null },
+                { tabUuid: undefined },
+            ]),
+        ).toStrictEqual(['tab1', null]);
+    });
+
+    it('returns an empty list for a dashboard without tiles', () => {
+        expect(expandSelectedTabs(null, [])).toStrictEqual([]);
     });
 });

--- a/packages/common/src/utils/dashboard.ts
+++ b/packages/common/src/utils/dashboard.ts
@@ -34,6 +34,19 @@ export const isTileInSelectedTabs = (
     !selectedTabs || !tile.tabUuid || selectedTabs.includes(tile.tabUuid);
 
 /**
+ * Expands a null ("all tabs") selection into the explicit list the minimal
+ * dashboard render expects in its `selectedTabs` URL param: every tab UUID
+ * present on the tiles, plus a `null` sentinel for orphan (no-tab) tiles.
+ * Without the explicit list the minimal render falls back to showing only the
+ * active (first) tab. See PROD-2505.
+ */
+export const expandSelectedTabs = (
+    selectedTabs: string[] | null,
+    tiles: { tabUuid?: string | null }[],
+): (string | null)[] =>
+    selectedTabs ?? [...new Set(tiles.map((tile) => tile.tabUuid ?? null))];
+
+/**
  * Validates that selected tabs exist in the dashboard tiles.
  * If selectedTabs is provided and not empty, ensures at least one selected tab exists in dashboard tabs.
  * @param selectedTabs - Array of selected tab UUIDs or null


### PR DESCRIPTION
Exporting a dashboard with "Include all tabs" (`selectedTabs: null`) only rendered the first tab: the scheduler built the minimal-render URL without a `selectedTabs` param, so the page fell back to the active (first) tab. This affected async exports and scheduled deliveries.

Adds a shared `expandSelectedTabs` helper that expands the null selection into every tab UUID on the dashboard tiles (plus a `null` sentinel for orphan tiles), and uses it in both `SchedulerTask` and `UnfurlService` so the two export paths stay in sync.

Closes: PROD-9219