### PR TITLE
feat: collapse secondary memory details

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -129,6 +129,7 @@
         "remark-emoji": "5.0.2",
         "remark-frontmatter": "5.0.0",
         "remark-gfm": "4.0.1",
+        "remark-parse": "11.0.0",
         "reselect": "5.1.1",
         "rudder-sdk-js": "2.9.1",
         "scheduler": "0.23.2",

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.test.tsx
@@ -17,7 +17,17 @@ vi.mock('../../hooks/useAiAgentMemory', () => ({
         data: {
             slug: 'net-revenue-ab12cd34',
             title: 'Net revenue convention',
-            rawMemory: '**Net revenue** excludes refunds.',
+            rawMemory: `## Memory
+
+**Net revenue** excludes refunds.
+
+## Evidence
+
+The user explicitly adopted this definition.
+
+## Apply
+
+Use net revenue for future revenue questions.`,
             terms: ['net revenue'],
             objects: [],
             status: 'active',
@@ -127,10 +137,26 @@ describe('MemoryCitation', () => {
         ).toBeInTheDocument();
         expect(within(dialog).getByText('Memory')).toBeInTheDocument();
         expect(within(dialog).getByText('net revenue')).toBeInTheDocument();
-        expect(within(dialog).getByText('Source')).toBeInTheDocument();
+        const evidenceControl = within(dialog).getByRole('button', {
+            name: /Evidence/,
+        });
+        const applyControl = within(dialog).getByRole('button', {
+            name: /Apply/,
+        });
+        const sourceControl = within(dialog).getByRole('button', {
+            name: /Source/,
+        });
+
+        expect(evidenceControl).toHaveAttribute('aria-expanded', 'false');
+        expect(applyControl).toHaveAttribute('aria-expanded', 'false');
+        expect(sourceControl).toHaveAttribute('aria-expanded', 'false');
         expect(
             within(dialog).getByText('Extracted from one thread'),
         ).toBeInTheDocument();
+
+        fireEvent.click(sourceControl);
+
+        expect(sourceControl).toHaveAttribute('aria-expanded', 'true');
         expect(within(dialog).getByText('Defined')).toHaveAttribute(
             'data-streamdown',
             'strong',
@@ -169,6 +195,8 @@ describe('MemoryCitation', () => {
                 </MantineProvider>
             </MemoryRouter>,
         );
+
+        fireEvent.click(screen.getByRole('button', { name: /Source/ }));
 
         expect(screen.getByText('Source thread')).toBeInTheDocument();
         expect(

--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.module.css
@@ -36,10 +36,65 @@
     font-size: 14px;
 }
 
-.section {
-    margin-top: 32px;
-    padding-top: 26px;
-    border-top: 1px solid var(--mantine-color-ldGray-1);
+.disclosures {
+    margin-top: 28px;
+    border-top: 1px solid var(--mantine-color-ldGray-2);
+}
+
+.disclosureItem {
+    border-bottom-color: var(--mantine-color-ldGray-2);
+}
+
+.disclosureControl {
+    min-height: 60px;
+    padding: 10px 4px;
+    border-radius: 8px;
+}
+
+.disclosureControl:hover {
+    background: light-dark(
+        var(--mantine-color-ldGray-0),
+        var(--mantine-color-dark-6)
+    );
+}
+
+.disclosureLabel {
+    padding: 0;
+}
+
+.disclosureChevron {
+    color: var(--mantine-color-ldGray-5);
+}
+
+.disclosureContent {
+    padding: 2px 28px 20px 4px;
+}
+
+.disclosureTitle {
+    color: var(--mantine-color-ldGray-9);
+    font-size: 13px;
+    font-weight: 550;
+    line-height: 1.4;
+}
+
+.disclosureDescription {
+    margin-top: 2px;
+    color: var(--mantine-color-ldGray-6);
+    font-size: 11.5px;
+    line-height: 1.4;
+}
+
+.disclosureMarkdown {
+    padding-left: 0;
+    color: var(--mantine-color-ldGray-8);
+    font-size: 13px;
+    line-height: 1.6;
+}
+
+.disclosureMarkdown p,
+.disclosureMarkdown li {
+    color: inherit;
+    font-size: inherit;
 }
 
 .sourceList {

--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.tsx
@@ -4,6 +4,7 @@ import type {
     ApiAiAgentMemoryResponse,
 } from '@lightdash/common';
 import {
+    Accordion,
     Alert,
     Anchor,
     Badge,
@@ -23,6 +24,7 @@ import { type FC, type ReactNode } from 'react';
 import { Link } from 'react-router';
 import { AiMarkdown } from '../../../../../components/common/AiMarkdown';
 import MantineModal from '../../../../../components/common/MantineModal';
+import { parseAiAgentMemorySections } from '../../utils/memory';
 import styles from './MemoryDetails.module.css';
 
 type Memory = ApiAiAgentMemoryResponse['results'];
@@ -47,6 +49,16 @@ const RailRow: FC<{ label: string; children: ReactNode }> = ({
         <Text className={styles.railLabel}>{label}</Text>
         <Box className={styles.railValue}>{children}</Box>
     </Group>
+);
+
+const DisclosureLabel: FC<{ title: string; description: string }> = ({
+    title,
+    description,
+}) => (
+    <Box>
+        <Text className={styles.disclosureTitle}>{title}</Text>
+        <Text className={styles.disclosureDescription}>{description}</Text>
+    </Box>
 );
 
 const SourceRow: FC<{
@@ -109,6 +121,13 @@ export const MemoryDetails: FC<MemoryDetailsProps> = ({
         memory.provenance.type === 'source_thread'
             ? [memory.provenance.source]
             : memory.provenance.sources;
+    const sections = parseAiAgentMemorySections(memory.rawMemory);
+    const sourceDescription =
+        memory.provenance.type === 'consolidated'
+            ? sources.length > 0
+                ? `Consolidated from ${sources.length} memories`
+                : 'Consolidated memory'
+            : 'Extracted from one thread';
 
     return (
         <Box className={styles.layout}>
@@ -138,37 +157,84 @@ export const MemoryDetails: FC<MemoryDetailsProps> = ({
                 <Stack gap="md">
                     <Text className={styles.sectionLabel}>Memory</Text>
                     <AiMarkdown className={styles.memoryContent}>
-                        {memory.rawMemory}
+                        {sections.memory}
                     </AiMarkdown>
                 </Stack>
 
-                <Stack gap="md" className={styles.section}>
-                    <Group justify="space-between" align="baseline">
-                        <Text className={styles.sectionLabel}>Source</Text>
-                        <Text size="xs" c="dimmed">
-                            {memory.provenance.type === 'consolidated'
-                                ? sources.length > 0
-                                    ? `Consolidated from ${sources.length} memories`
-                                    : 'Consolidated memory'
-                                : 'Extracted from one thread'}
-                        </Text>
-                    </Group>
-                    <Box className={styles.sourceList}>
-                        {sources.length > 0 ? (
-                            sources.map((source) => (
-                                <SourceRow
-                                    key={source.slug}
-                                    source={source}
-                                    projectUuid={projectUuid}
+                <Accordion
+                    multiple
+                    defaultValue={[]}
+                    className={styles.disclosures}
+                    classNames={{
+                        item: styles.disclosureItem,
+                        control: styles.disclosureControl,
+                        label: styles.disclosureLabel,
+                        chevron: styles.disclosureChevron,
+                        content: styles.disclosureContent,
+                    }}
+                >
+                    {sections.evidence ? (
+                        <Accordion.Item value="evidence">
+                            <Accordion.Control>
+                                <DisclosureLabel
+                                    title="Evidence"
+                                    description="Why this memory was learned"
                                 />
-                            ))
-                        ) : (
-                            <Text size="xs" c="dimmed" p="md">
-                                No source threads recorded
-                            </Text>
-                        )}
-                    </Box>
-                </Stack>
+                            </Accordion.Control>
+                            <Accordion.Panel>
+                                <AiMarkdown
+                                    className={styles.disclosureMarkdown}
+                                >
+                                    {sections.evidence}
+                                </AiMarkdown>
+                            </Accordion.Panel>
+                        </Accordion.Item>
+                    ) : null}
+
+                    {sections.apply ? (
+                        <Accordion.Item value="apply">
+                            <Accordion.Control>
+                                <DisclosureLabel
+                                    title="Apply"
+                                    description="When and how to use it"
+                                />
+                            </Accordion.Control>
+                            <Accordion.Panel>
+                                <AiMarkdown
+                                    className={styles.disclosureMarkdown}
+                                >
+                                    {sections.apply}
+                                </AiMarkdown>
+                            </Accordion.Panel>
+                        </Accordion.Item>
+                    ) : null}
+
+                    <Accordion.Item value="source">
+                        <Accordion.Control>
+                            <DisclosureLabel
+                                title="Source"
+                                description={sourceDescription}
+                            />
+                        </Accordion.Control>
+                        <Accordion.Panel>
+                            <Box className={styles.sourceList}>
+                                {sources.length > 0 ? (
+                                    sources.map((source) => (
+                                        <SourceRow
+                                            key={source.slug}
+                                            source={source}
+                                            projectUuid={projectUuid}
+                                        />
+                                    ))
+                                ) : (
+                                    <Text size="xs" c="dimmed" p="md">
+                                        No source threads recorded
+                                    </Text>
+                                )}
+                            </Box>
+                        </Accordion.Panel>
+                    </Accordion.Item>
+                </Accordion>
             </Stack>
 
             <Divider orientation="vertical" className={styles.divider} />

--- a/packages/frontend/src/ee/features/aiCopilot/utils/memory.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/memory.test.ts
@@ -1,9 +1,95 @@
-import { getAiAgentMemoryPreview } from './memory';
+import { getAiAgentMemoryPreview, parseAiAgentMemorySections } from './memory';
 
 describe('getAiAgentMemoryPreview', () => {
     it('preserves markdown and limits the preview to 256 characters', () => {
         const memory = `**Revenue definition** ${'a'.repeat(300)}`;
 
         expect(getAiAgentMemoryPreview(memory)).toBe(memory.slice(0, 256));
+    });
+});
+
+describe('parseAiAgentMemorySections', () => {
+    it('splits the standard memory markdown sections', () => {
+        expect(
+            parseAiAgentMemorySections(`## Memory
+
+Use completed revenue.
+
+## Evidence
+
+- The user adopted the convention.
+
+## Apply
+
+Use it for future revenue questions.`),
+        ).toEqual({
+            memory: 'Use completed revenue.',
+            evidence: '- The user adopted the convention.',
+            apply: 'Use it for future revenue questions.',
+        });
+    });
+
+    it('preserves unstructured markdown as the memory', () => {
+        const value = '**Net revenue** excludes refunds.';
+
+        expect(parseAiAgentMemorySections(value)).toEqual({
+            memory: value,
+            evidence: null,
+            apply: null,
+        });
+    });
+
+    it('does not parse section-like headings inside code fences', () => {
+        const value = `## Memory
+
+Keep this example:
+
+\`\`\`md
+## Evidence
+Not a real section
+\`\`\``;
+
+        expect(parseAiAgentMemorySections(value)).toEqual({
+            memory: `Keep this example:
+
+\`\`\`md
+## Evidence
+Not a real section
+\`\`\``,
+            evidence: null,
+            apply: null,
+        });
+    });
+
+    it('only closes a fence with the same marker and sufficient length', () => {
+        const value = `## Memory
+
+Keep this example:
+
+\`\`\`\`md
+## Evidence
+Not a real section
+\`\`\`
+## Apply
+Still part of the example
+\`\`\`\`
+
+## Evidence
+
+Actual evidence.`;
+
+        expect(parseAiAgentMemorySections(value)).toEqual({
+            memory: `Keep this example:
+
+\`\`\`\`md
+## Evidence
+Not a real section
+\`\`\`
+## Apply
+Still part of the example
+\`\`\`\``,
+            evidence: 'Actual evidence.',
+            apply: null,
+        });
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/utils/memory.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/memory.ts
@@ -1,1 +1,72 @@
+import remarkParse from 'remark-parse';
+import { unified } from 'unified';
+
 export const getAiAgentMemoryPreview = (value: string) => value.slice(0, 256);
+
+export type AiAgentMemorySections = {
+    memory: string;
+    evidence: string | null;
+    apply: string | null;
+};
+
+const SECTION_NAMES = ['memory', 'evidence', 'apply'] as const;
+type SectionName = (typeof SECTION_NAMES)[number];
+
+const markdownParser = unified().use(remarkParse);
+
+const getSectionName = (heading: string): SectionName | null => {
+    const name = heading
+        .replace(/^ {0,3}#{1,6}[ \t]+/, '')
+        .replace(/[ \t]+#+[ \t]*$/, '')
+        .trim()
+        .toLowerCase();
+
+    return SECTION_NAMES.find((section) => section === name) ?? null;
+};
+
+export const parseAiAgentMemorySections = (
+    value: string,
+): AiAgentMemorySections => {
+    const fallback = {
+        memory: value.trim(),
+        evidence: null,
+        apply: null,
+    };
+    const sections: Record<SectionName, string[]> = {
+        memory: [],
+        evidence: [],
+        apply: [],
+    };
+    const headings = markdownParser.parse(value).children.flatMap((node) => {
+        const start = node.position?.start.offset;
+        const end = node.position?.end.offset;
+        if (node.type !== 'heading' || start === undefined || end === undefined)
+            return [];
+
+        const section = getSectionName(value.slice(start, end));
+        return section ? [{ section, start, end }] : [];
+    });
+
+    if (!headings.some(({ section }) => section === 'memory')) return fallback;
+
+    headings.forEach(({ section, end }, index) => {
+        const nextStart = headings[index + 1]?.start ?? value.length;
+        sections[section].push(value.slice(end, nextStart).trim());
+    });
+
+    const preamble = value.slice(0, headings[0].start).trim();
+    const memory = [preamble, ...sections.memory]
+        .filter(Boolean)
+        .join('\n')
+        .trim();
+    if (!memory) return fallback;
+
+    const evidence = sections.evidence.join('\n').trim();
+    const apply = sections.apply.join('\n').trim();
+
+    return {
+        memory,
+        evidence: evidence || null,
+        apply: apply || null,
+    };
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1371,6 +1371,9 @@ importers:
       remark-gfm:
         specifier: 4.0.1
         version: 4.0.1
+      remark-parse:
+        specifier: 11.0.0
+        version: 11.0.0
       reselect:
         specifier: 5.1.1
         version: 5.1.1


### PR DESCRIPTION
## Summary

- keep the learned memory visible while collapsing Evidence, Apply, and Source by default
- parse standard memory sections with remark while preserving the original Markdown
- preserve a readable fallback for unstructured memories

## Testing

- `pnpm -F frontend test --run src/ee/features/aiCopilot/utils/memory.test.ts src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.test.tsx`
- `pnpm -F frontend linter ...` on changed TypeScript files
- `pnpm exec oxfmt --check ...` on parser files
- `pnpm -F frontend typecheck:fast`
- browser: supporting sections collapsed by default; Evidence expands and collapses independently

Closes: ZAP-705
