### PR TITLE
fix: remove memory summary column

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminMemoriesTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminMemoriesTable.tsx
@@ -22,7 +22,6 @@ import {
     IconBrain,
     IconCircleDotted,
     IconClock,
-    IconFileText,
     IconQuote,
     IconRobotFace,
     IconTrash,
@@ -193,31 +192,6 @@ const AiAgentAdminMemoriesTable = () => {
                         </Stack>
                     );
                 },
-            },
-            {
-                accessorKey: 'summary',
-                header: 'Summary',
-                enableSorting: false,
-                size: 320,
-                Header: ({ column }) => (
-                    <Group gap="two">
-                        <MantineIcon icon={IconFileText} color="ldGray.6" />
-                        {column.columnDef.header}
-                    </Group>
-                ),
-                Cell: ({ row }) => (
-                    <Tooltip
-                        withinPortal
-                        label={row.original.summary}
-                        disabled={!row.original.summary}
-                        multiline
-                        maw={400}
-                    >
-                        <Text fz="sm" c="ldGray.7" lineClamp={2}>
-                            {row.original.summary}
-                        </Text>
-                    </Tooltip>
-                ),
             },
             {
                 accessorKey: 'status',


### PR DESCRIPTION
## Summary

- remove the Summary column from the AI memories table
- keep the memory title and slug as the primary row identity
- preserve row-click access to full memory details

## Testing

- `pnpm -F frontend linter src/ee/features/aiCopilot/components/Admin/AiAgentAdminMemoriesTable.tsx`
- `pnpm exec oxfmt --check packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminMemoriesTable.tsx`
- `pnpm -F frontend typecheck:fast`
- browser: Summary header absent, remaining columns aligned, and rows still open memory details
