### PR TITLE
fix: align memory catalog link icons

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.module.css
@@ -217,6 +217,10 @@
     color: var(--mantine-color-indigo-7);
 }
 
+.objectLinkIcon {
+    flex: none;
+}
+
 @media (max-width: 820px) {
     .layout {
         grid-template-columns: minmax(0, 1fr);

--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.tsx
@@ -319,7 +319,10 @@ export const MemoryDetails: FC<MemoryDetailsProps> = ({
                                                     : 'Explore'}
                                             </Text>
                                         </Box>
-                                        <IconExternalLink size={13} />
+                                        <IconExternalLink
+                                            size={13}
+                                            className={styles.objectLinkIcon}
+                                        />
                                     </Anchor>
                                 );
                             })}


### PR DESCRIPTION
## Summary

- prevent catalog-object external-link icons from shrinking beside long labels
- keep both icons at the existing 13px visual size

## Testing

- `pnpm -F frontend linter src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.tsx`
- `pnpm exec oxfmt --check packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.tsx packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.module.css`
- `pnpm -F frontend typecheck:fast`
- browser: both catalog-object icons measure 13 × 13px with `flex-shrink: 0`
