### PR TITLE
feat: ask viz-specific clarifying questions for data app vizs

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.clarifyApp.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.clarifyApp.test.ts
@@ -1,0 +1,274 @@
+// Stub the e2b/ai SDKs before importing AppGenerateService so the tests never
+// reach the real sandbox or model client.
+import { DATA_APP_VIZ_TEMPLATE, type DataAppTemplate } from '@lightdash/common';
+import { generateObject } from 'ai';
+import { AppGenerateService } from './AppGenerateService';
+import {
+    CLARIFY_APP_SYSTEM_PROMPT,
+    CLARIFY_VIZ_SYSTEM_PROMPT,
+} from './clarifierPrompts';
+
+vi.mock('e2b', () => ({
+    Sandbox: class {},
+    CommandExitError: class extends Error {},
+    ALL_TRAFFIC: '*',
+}));
+vi.mock('ai', () => ({
+    generateObject: vi.fn(),
+}));
+vi.mock('../ai/models', () => ({
+    getModel: vi.fn(() => ({
+        model: { provider: 'anthropic', modelId: 'claude-sonnet-4-5' },
+        callOptions: {},
+        providerOptions: {},
+        keyManagement: 'lightdash',
+    })),
+    resolveKeyManagement: vi.fn(() => 'lightdash'),
+}));
+vi.mock('../ai/utils/aiCallTelemetry', () => ({
+    getAiCallTelemetry: vi.fn(() => ({ isEnabled: false })),
+    getLanguageModelAttribution: vi.fn(() => ({})),
+}));
+vi.mock('../../../analytics/aiUsage', () => ({
+    emitAiUsage: vi.fn(),
+    languageModelUsageToTokens: vi.fn(() => ({})),
+}));
+
+// `ability`/`abilityRules` are only read by `fromSession`, which the attached
+// -resources path goes through to resolve chart names.
+const USER = {
+    userUuid: 'user-1',
+    organizationUuid: 'org-1',
+    ability: { can: () => true, cannot: () => false },
+    abilityRules: [],
+} as never;
+
+const CATALOG_ITEMS = [
+    {
+        type: 'field',
+        tableName: 'orders',
+        name: 'order_date',
+        fieldType: 'dimension',
+    },
+    {
+        type: 'field',
+        tableName: 'orders',
+        name: 'total_revenue',
+        fieldType: 'metric',
+    },
+];
+
+function buildService() {
+    const getCatalogItemsSummary = vi.fn().mockResolvedValue(CATALOG_ITEMS);
+    const service = new AppGenerateService({
+        lightdashConfig: {
+            appRuntime: { sampleDataEnabled: true },
+        } as never,
+        analytics: { track: vi.fn() } as never,
+        analyticsModel: {} as never,
+        catalogModel: { getCatalogItemsSummary } as never,
+        appModel: {} as never,
+        featureFlagModel: {
+            get: vi.fn().mockResolvedValue({ enabled: true }),
+        } as never,
+        organizationDesignModel: {} as never,
+        pinnedListModel: {} as never,
+        projectModel: {
+            getSummary: vi
+                .fn()
+                .mockResolvedValue({ organizationUuid: 'org-1' }),
+        } as never,
+        projectParametersModel: {} as never,
+        spaceModel: {} as never,
+        schedulerClient: {} as never,
+        savedChartService: {
+            get: vi.fn().mockResolvedValue({
+                name: 'Revenue by month',
+                tableName: 'orders',
+            }),
+        } as never,
+        spacePermissionService: {} as never,
+        dashboardService: {} as never,
+        projectService: {} as never,
+        promoteService: {} as never,
+        externalConnectionModel: {} as never,
+        sandboxRegistryModel: {} as never,
+        orgAiCopilotConfigResolver: {
+            getCopilotConfig: vi
+                .fn()
+                .mockResolvedValue({ defaultProvider: 'anthropic' }),
+        } as never,
+    });
+    // Bypass real CASL — the prompt/context selection is what these tests cover.
+    (
+        service as unknown as { createAuditedAbility: () => unknown }
+    ).createAuditedAbility = () => ({ cannot: () => false });
+    return { service, getCatalogItemsSummary };
+}
+
+const generateObjectMock = vi.mocked(generateObject);
+
+function mockQuestions(questions: string[]) {
+    generateObjectMock.mockResolvedValue({
+        object: { questions },
+        usage: {},
+    } as never);
+}
+
+/** The system + user message the clarifier actually handed to the model. */
+function sentMessages() {
+    const call = generateObjectMock.mock.calls[0][0] as {
+        messages: { role: string; content: string }[];
+    };
+    const system = call.messages.find((m) => m.role === 'system')!.content;
+    const userMessage = call.messages.find((m) => m.role === 'user')!.content;
+    return { system, userMessage };
+}
+
+async function clarify(template: DataAppTemplate | undefined) {
+    const { service, getCatalogItemsSummary } = buildService();
+    const result = await service.clarifyApp(
+        USER,
+        'project-1',
+        'a radial gauge',
+        template,
+    );
+    return { result, getCatalogItemsSummary, ...sentMessages() };
+}
+
+beforeEach(() => {
+    generateObjectMock.mockReset();
+    mockQuestions([]);
+});
+
+describe('AppGenerateService.clarifyApp for the data app viz template', () => {
+    it('never sends catalog context, so no data question can be grounded', async () => {
+        const { getCatalogItemsSummary, userMessage } = await clarify(
+            DATA_APP_VIZ_TEMPLATE,
+        );
+
+        // A data app viz never runs a query — it renders the rows the host
+        // explore hands it — so the catalog is neither fetched nor sent.
+        expect(getCatalogItemsSummary).not.toHaveBeenCalled();
+        expect(userMessage).not.toContain('Available tables and key fields');
+        expect(userMessage).not.toContain('orders');
+        expect(userMessage).not.toContain('total_revenue');
+        // The viz system prompt already fixes the kind.
+        expect(userMessage).not.toContain('App kind');
+        expect(userMessage).toContain('a radial gauge');
+    });
+
+    it('still passes attached resources through as visual reference', async () => {
+        const { service } = buildService();
+
+        await service.clarifyApp(
+            USER,
+            'project-1',
+            'a radial gauge',
+            DATA_APP_VIZ_TEMPLATE,
+            [{ uuid: 'chart-1', includeSampleData: false, linkLive: false }],
+            undefined,
+            ['image-1', 'image-2'],
+        );
+
+        const { userMessage } = sentMessages();
+        expect(userMessage).toContain('Chart: "Revenue by month"');
+        expect(userMessage).toContain('2 images attached as design reference');
+    });
+
+    it('routes to the viz system prompt, not the app one', async () => {
+        const { system } = await clarify(DATA_APP_VIZ_TEMPLATE);
+
+        expect(system).toBe(CLARIFY_VIZ_SYSTEM_PROMPT);
+    });
+
+    it('still caps at 4 questions and drops blank ones', async () => {
+        mockQuestions([
+            'Which chart type do you want?',
+            '  ',
+            'Should it split by a series field?',
+            'Is the value axis one metric?',
+            'Do you want a legend?',
+            'A fifth question that must be dropped?',
+        ]);
+        const { service } = buildService();
+
+        const { questions } = await service.clarifyApp(
+            USER,
+            'project-1',
+            'a radial gauge',
+            DATA_APP_VIZ_TEMPLATE,
+        );
+
+        expect(questions).toEqual([
+            'Which chart type do you want?',
+            'Should it split by a series field?',
+            'Is the value axis one metric?',
+            'Do you want a legend?',
+        ]);
+    });
+
+    it('still falls through to no questions when the model call fails', async () => {
+        generateObjectMock.mockRejectedValue(new Error('provider exploded'));
+        const { service } = buildService();
+
+        await expect(
+            service.clarifyApp(
+                USER,
+                'project-1',
+                'a radial gauge',
+                DATA_APP_VIZ_TEMPLATE,
+            ),
+        ).resolves.toEqual({ questions: [] });
+    });
+});
+
+describe('AppGenerateService.clarifyApp for app templates', () => {
+    it.each<DataAppTemplate | undefined>([
+        'dashboard',
+        'slideshow',
+        'pdf',
+        'custom',
+        undefined,
+    ])('keeps the catalog-grounded app prompt for %s', async (template) => {
+        const { getCatalogItemsSummary, system, userMessage } =
+            await clarify(template);
+
+        expect(getCatalogItemsSummary).toHaveBeenCalledWith('project-1');
+        expect(userMessage).toContain('Available tables and key fields');
+        expect(userMessage).toContain('orders');
+        expect(userMessage).toContain(`App kind: ${template ?? 'custom'}`);
+
+        expect(system).toBe(CLARIFY_APP_SYSTEM_PROMPT);
+    });
+});
+
+// Guards the prompt text itself. A data app viz has no say over the query, so
+// the viz prompt must never invite a question the user cannot answer at build
+// time — these are the assertions that would catch app framing creeping back in.
+describe('CLARIFY_VIZ_SYSTEM_PROMPT', () => {
+    it('keeps the shared bias against asking anything', () => {
+        expect(CLARIFY_VIZ_SYSTEM_PROMPT).toContain(
+            'DEFAULT TO ASKING NOTHING',
+        );
+    });
+
+    it('carries none of the app prompt data or layout guidance', () => {
+        expect(CLARIFY_VIZ_SYSTEM_PROMPT).not.toContain(
+            'Which tables or metrics to query',
+        );
+        expect(CLARIFY_VIZ_SYSTEM_PROMPT).not.toContain(
+            'Default time range, when',
+        );
+        expect(CLARIFY_VIZ_SYSTEM_PROMPT).not.toContain('single-page vs tabs');
+        expect(CLARIFY_VIZ_SYSTEM_PROMPT).not.toContain('layout density');
+        expect(CLARIFY_VIZ_SYSTEM_PROMPT).not.toContain('App kind context');
+    });
+
+    it('scopes the askable set to the component and its declared fields', () => {
+        // The three cases GLITCH-639 calls out as genuinely viz-shaped.
+        expect(CLARIFY_VIZ_SYSTEM_PROMPT).toMatch(/chart type/i);
+        expect(CLARIFY_VIZ_SYSTEM_PROMPT).toMatch(/series\/breakdown/i);
+        expect(CLARIFY_VIZ_SYSTEM_PROMPT).toMatch(/one metric or several/i);
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -161,6 +161,10 @@ import {
 } from './appCode';
 import { contextFile, promptHistoryToMarkdown } from './appContext';
 import {
+    CLARIFY_APP_SYSTEM_PROMPT,
+    CLARIFY_VIZ_SYSTEM_PROMPT,
+} from './clarifierPrompts';
+import {
     classifyClaudeCliFailure,
     ClaudeGenerationError,
 } from './claudeCliFailure';
@@ -4456,6 +4460,10 @@ export class AppGenerateService extends BaseService {
      * Anthropic — mirroring the data-apps sandbox provider switch in
      * `claudeCodeEnv.ts` so the clarifier and code generation use the same
      * provider.
+     *
+     * Branches on template: a data app viz gets a component-scoped prompt and
+     * no catalog context, because it never runs a query. Everything else shares
+     * the cap, timeout and fall-through behaviour. See `clarifierPrompts.ts`.
      */
     async clarifyApp(
         user: SessionUser,
@@ -4502,8 +4510,16 @@ export class AppGenerateService extends BaseService {
             return { questions: [] };
         }
 
+        // A data app viz never runs a query — it renders whatever rows the host
+        // explore hands it — so catalog context would only invite questions
+        // about explores, dimensions and time ranges that nobody can answer at
+        // build time. Skip the summary entirely (and its catalog read).
+        const isVizTemplate = template === DATA_APP_VIZ_TEMPLATE;
+
         const [catalogSummary, attachedResources] = await Promise.all([
-            this.buildCatalogSummaryForClarifier(projectUuid),
+            isVizTemplate
+                ? Promise.resolve(null)
+                : this.buildCatalogSummaryForClarifier(projectUuid),
             this.buildAttachedResourcesForClarifier(charts, dashboard, user),
         ]);
         const imageCount = imageIds?.length ?? 0;
@@ -4512,11 +4528,12 @@ export class AppGenerateService extends BaseService {
         // rejects `maxItems` in the schema. The prompt already pins the
         // 1–4 cap and we slice client-side after the response.
         const clarifySchema = z.object({
-            questions: z
-                .array(z.string())
-                .describe(
-                    '0–4 short clarifying questions, each a single sentence (5–15 words). Default to empty — only include questions whose answers would materially change the app.',
-                ),
+            questions: z.array(z.string()).describe(
+                // Deliberately says "what gets built", not "the app" — this
+                // description reaches the model alongside a system prompt
+                // that may be insisting it is building a viz, not an app.
+                '0–4 short clarifying questions, each a single sentence (5–15 words). Default to empty — only include questions whose answers would materially change what gets built.',
+            ),
         });
 
         // Cap the LLM call so a stalled provider can't pin the chat input
@@ -4533,6 +4550,9 @@ export class AppGenerateService extends BaseService {
             userUuid: user.userUuid,
             ...getLanguageModelAttribution(modelOptions.model),
             keyManagement: modelOptions.keyManagement,
+            // Which prompt variant ran — the two ask for very different things,
+            // so spend and question counts are only comparable within a variant.
+            extra: { template: template ?? 'custom' },
         });
         let result;
         try {
@@ -4546,36 +4566,18 @@ export class AppGenerateService extends BaseService {
                 messages: [
                     {
                         role: 'system',
-                        content: `You help a user scope a React data app on top of their semantic layer before any code is written. Given the user's prompt, the kind of app they're building, and a summary of the available tables, decide whether 0–4 short clarifying questions would materially change what gets built.
-
-DEFAULT TO ASKING NOTHING. Empty is the right answer for most well-formed prompts. Only ask when the answer would meaningfully change the app's structure, content, or scope — never to fine-tune cosmetics or pick between two equally reasonable defaults. If you're unsure whether to ask, don't. Reasonable defaults during the build beat slowing the user down.
-
-Worth asking about (only when the prompt is silent on them):
-- Which tables or metrics to query, when several plausible options exist
-- Default time range, when the prompt doesn't imply one
-- Audience, when it would change the level of detail (executive vs analyst)
-- The shape of the app (single-page vs tabs, drill-down vs flat) when truly ambiguous
-
-App kind context (use to prioritize, not as a checklist):
-- dashboard: audience, key metrics/KPIs, default time range, layout density.
-- slideshow: number of slides, narrative arc, takeaway per slide.
-- pdf: page orientation, audience, what gets exported vs interactive.
-- custom: focus on the most impactful unknowns.
-
-Do NOT ask about:
-- Cosmetic details with reasonable defaults (date format, exact colors, number formatting, axis labels, column widths).
-- Anything already stated in the prompt — even partially.
-- Things you can look up in the catalog (table names, field names).
-- Picking between two readings of a phrase when one is the obvious interpretation.
-- Multi-part or open-ended — each question must be answerable in one short line.
-- Which chart, dashboard, or image to use, when the user has already attached resources — those are listed under "Resources the user attached".
-
-Each question, when asked, must be a single sentence, 5–15 words.`,
+                        content: isVizTemplate
+                            ? CLARIFY_VIZ_SYSTEM_PROMPT
+                            : CLARIFY_APP_SYSTEM_PROMPT,
                     },
                     {
                         role: 'user',
                         content: [
-                            `App kind: ${template ?? 'custom'}`,
+                            // The viz system prompt already fixes the kind, and
+                            // there is no catalog to describe.
+                            ...(isVizTemplate
+                                ? []
+                                : [`App kind: ${template ?? 'custom'}`]),
                             `\nUser prompt:\n${trimmed}`,
                             `\nResources the user attached:\n${
                                 AppGenerateService.formatAttachedResourcesForClarifier(
@@ -4583,16 +4585,21 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                                     imageCount,
                                 ) || '(none)'
                             }`,
-                            `\nAvailable tables and key fields:\n${
-                                catalogSummary || '(no catalog available)'
-                            }`,
+                            ...(isVizTemplate
+                                ? []
+                                : [
+                                      `\nAvailable tables and key fields:\n${
+                                          catalogSummary ||
+                                          '(no catalog available)'
+                                      }`,
+                                  ]),
                         ].join('\n'),
                     },
                 ],
             });
         } catch (err) {
             this.logger.warn(
-                `App clarify failed after ${AppGenerateService.elapsed(start)}ms (project=${projectUuid}, llm=${llmProvider}): ${getErrorMessage(err)}`,
+                `App clarify failed after ${AppGenerateService.elapsed(start)}ms (project=${projectUuid}, template=${template ?? 'custom'}, llm=${llmProvider}): ${getErrorMessage(err)}`,
             );
             return { questions: [] };
         }
@@ -4605,7 +4612,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             .slice(0, 4);
 
         this.logger.info(
-            `App clarify: ${questions.length} question(s) in ${elapsedMs}ms (project=${projectUuid}, llm=${llmProvider})`,
+            `App clarify: ${questions.length} question(s) in ${elapsedMs}ms (project=${projectUuid}, template=${template ?? 'custom'}, llm=${llmProvider})`,
         );
 
         return { questions };

--- a/packages/backend/src/ee/services/AppGenerateService/clarifierPrompts.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/clarifierPrompts.ts
@@ -1,0 +1,59 @@
+/**
+ * System prompts for the pre-build clarifier (`AppGenerateService.clarifyApp`).
+ *
+ * Two variants, because the two things you can build have nothing in common at
+ * clarify time. An app queries the semantic layer, so its open questions are
+ * data questions. A data app viz never queries anything — it is one reusable
+ * chart component that renders the rows a host explore hands it — so its only
+ * open questions are about the component and the fields it declares.
+ */
+
+export const CLARIFY_APP_SYSTEM_PROMPT = `You help a user scope a React data app on top of their semantic layer before any code is written. Given the user's prompt, the kind of app they're building, and a summary of the available tables, decide whether 0–4 short clarifying questions would materially change what gets built.
+
+DEFAULT TO ASKING NOTHING. Empty is the right answer for most well-formed prompts. Only ask when the answer would meaningfully change the app's structure, content, or scope — never to fine-tune cosmetics or pick between two equally reasonable defaults. If you're unsure whether to ask, don't. Reasonable defaults during the build beat slowing the user down.
+
+Worth asking about (only when the prompt is silent on them):
+- Which tables or metrics to query, when several plausible options exist
+- Default time range, when the prompt doesn't imply one
+- Audience, when it would change the level of detail (executive vs analyst)
+- The shape of the app (single-page vs tabs, drill-down vs flat) when truly ambiguous
+
+App kind context (use to prioritize, not as a checklist):
+- dashboard: audience, key metrics/KPIs, default time range, layout density.
+- slideshow: number of slides, narrative arc, takeaway per slide.
+- pdf: page orientation, audience, what gets exported vs interactive.
+- custom: focus on the most impactful unknowns.
+
+Do NOT ask about:
+- Cosmetic details with reasonable defaults (date format, exact colors, number formatting, axis labels, column widths).
+- Anything already stated in the prompt — even partially.
+- Things you can look up in the catalog (table names, field names).
+- Picking between two readings of a phrase when one is the obvious interpretation.
+- Multi-part or open-ended — each question must be answerable in one short line.
+- Which chart, dashboard, or image to use, when the user has already attached resources — those are listed under "Resources the user attached".
+
+Each question, when asked, must be a single sentence, 5–15 words.`;
+
+export const CLARIFY_VIZ_SYSTEM_PROMPT = `You help a user scope a single reusable chart component before any code is written. Given the user's prompt, decide whether 0–4 short clarifying questions would materially change what gets built.
+
+This is a data app visualization, not an app. It never runs a query and never chooses data: Lightdash runs the query, then hands the component the result rows plus a mapping from the field names the component declares to columns in those rows. The same component is reused across many different queries. Which explore, tables, dimensions, metrics, filters or time range are involved is decided later, per query, by whoever applies the visualization — none of it is knowable or decidable here.
+
+DEFAULT TO ASKING NOTHING. Empty is the right answer for most well-formed prompts. Only ask when the answer would meaningfully change how the component renders or which fields it declares — never to fine-tune cosmetics or pick between two equally reasonable defaults. If you're unsure whether to ask, don't. Reasonable defaults during the build beat slowing the user down.
+
+Worth asking about (only when the prompt is silent on them):
+- Chart type, when the prompt describes an outcome without naming a form and several forms genuinely fit
+- Whether it needs a series/breakdown field to split or colour the data, when the prompt names neither a breakdown nor a plainly single-series shape
+- Whether the value axis carries one metric or several, when the prompt names no measure and the chart type doesn't settle it
+
+Most prompts already settle all three. Each of these is worth at most one question, and only when the prompt genuinely leaves it open — asking about a breakdown or a metric count on a prompt that already implies one is the most common way to get this wrong.
+
+Do NOT ask about:
+- Which explore, table, dimension, metric or filter to use, or the time range — the component receives whatever the query returns and never chooses it. Never ask what the chart should display or measure. "What metric should the gauge show?" and "Which value goes on the y-axis?" are always wrong: the component declares named field slots (e.g. \`value\`, \`category\`) and whoever applies the visualization binds real fields to them later.
+- Audience, app structure, navigation, tabs, pages, filters or page layout — this is one chart, not an app.
+- Cosmetic details with reasonable defaults (colours, date format, number formatting, axis labels, legend placement, tooltip contents).
+- Anything already stated in the prompt — even partially. A named chart type answers the chart type question; a stated breakdown ("by region", "per segment", "split by status") answers the series question; a single named measure answers the metric-count question.
+- Picking between two readings of a phrase when one is the obvious interpretation.
+- Multi-part or open-ended — each question must be answerable in one short line.
+- Which chart, dashboard, or image to use, when the user has already attached resources — those are listed under "Resources the user attached".
+
+Each question, when asked, must be a single sentence, 5–15 words.`;


### PR DESCRIPTION
## Problem

Pick the **Data app visualization** template, hit send, and the pre-build clarifier asks app questions: which explore to query, which dimensions, what default time range, who the audience is. None of it applies. A data app viz never runs a query — it receives `rows` plus a `fieldMapping` from `useVizContext()` and renders whatever the host explore hands it. So the first thing you do on every viz build is skip the questions.

`clarifyApp` used a single system prompt for every template. Three parts were wrong for vizs: the "worth asking about" list led with *which tables or metrics to query*; the "App kind context" block enumerated dashboard / slideshow / pdf / custom and let `data_app_viz` fall through with no guidance; and it always pasted a catalog summary into the user message, pointing the model straight at data questions.

## Change

Branch the clarifier on template.

For `data_app_viz`:
- **No catalog summary.** Not sent, and not even fetched — the branch drops a `getCatalogItemsSummary` call from the pre-build path. A question naming your explores or fields now has nothing to ground itself in.
- **A viz-specific system prompt** (`clarifierPrompts.ts`). Keeps the strong "default to asking nothing" bias, and scopes what remains askable to things that change the component or its declared `DataAppVizSchema`: chart type when unnamed, whether a series/breakdown field is needed, whether the value axis carries one metric or several. Each of those has an explicit off-switch so a prompt that already implies one doesn't get asked about it.
- **No `App kind:` line** in the user message — the system prompt already fixes the kind.
- Attached resources are still passed through; an attached chart is a plausible visual reference.

Everything else is shared and unchanged: the 0–4 cap, the 15s timeout, telemetry, and the fall-through-to-empty on any LLM error.

For every other template the prompt and the user message are **byte-for-byte what `main` sent**. The existing prompt was lifted into `clarifierPrompts.ts` as a pure move, which is what makes that claim mechanically checkable rather than a matter of reading the diff carefully.

Also folded in from review: the shared structured-output schema description said questions should "materially change the app", which is app framing riding along with the viz system prompt — it now says "what gets built", which fits both. And the clarify telemetry span and both log lines now carry `template`, so the two variants can be told apart in production.

<img width="419" height="258" alt="CleanShot 2026-07-27 at 12 15 14" src="https://github.com/user-attachments/assets/74a416cb-466c-4c0f-8ffc-b6dce6d7af25" />


Fixes GLITCH-639
