### PR TITLE
fix(ai): recover deep research reports from empty agent turns

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -403,6 +403,7 @@ type GenerateAgentExecutionOptions =
           budget: AiDeepResearchBudget;
           selectedMcpServerUuids: string[];
           abortSignal?: AbortSignal;
+          initialTokenUsage?: number;
           onStepUsage?: (tokens: number) => void | Promise<void>;
           onWarehouseQuery?: () => void | Promise<void>;
           onExecutionContextResolved?: (
@@ -8859,6 +8860,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     responseExecution.budget.maxToolCalls +
                     DEEP_RESEARCH_STEP_HEADROOM,
                 budget: responseExecution.budget,
+                initialTokenUsage: responseExecution.initialTokenUsage ?? 0,
                 onStepUsage: responseExecution.onStepUsage,
                 onExecutionContextResolved:
                     responseExecution.onExecutionContextResolved,

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.test.ts
@@ -295,6 +295,7 @@ describe('AiDeepResearchExecutor', () => {
             report,
             warehouseQueryUuids: [queryUuid],
         });
+        expect(generateAgentThreadResponse).toHaveBeenCalledTimes(1);
         expect(
             aiDeepResearchRunModel.updateExecutionContextSnapshot,
         ).toHaveBeenCalledWith('run-1', executionContextSnapshot);
@@ -472,8 +473,123 @@ describe('AiDeepResearchExecutor', () => {
         });
     });
 
+    it('retries once with forced report submission when generation ends without a report', async () => {
+        const generateAgentThreadResponse = vi.fn(
+            async (
+                _user: SessionUser,
+                options: {
+                    execution: {
+                        onStepUsage: (tokens: number) => void;
+                    };
+                },
+            ) => {
+                if (generateAgentThreadResponse.mock.calls.length === 1) {
+                    options.execution.onStepUsage(600);
+                }
+            },
+        );
+        const { executor, aiAgentModel } = buildExecutor({
+            generateAgentThreadResponse,
+            provenance: [],
+        });
+        aiAgentModel.getToolCallsAndResultsForPrompt
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce([reportSubmission()]);
+
+        await expect(
+            executor.execute(run(), {
+                signal: new AbortController().signal,
+            }),
+        ).resolves.toEqual({
+            status: 'completed',
+            report,
+            warehouseQueryUuids: [],
+        });
+        expect(generateAgentThreadResponse).toHaveBeenCalledTimes(2);
+        expect(generateAgentThreadResponse).toHaveBeenNthCalledWith(
+            2,
+            expect.anything(),
+            expect.objectContaining({
+                toolHints: [AI_DEEP_RESEARCH_REPORT_TOOL_NAME],
+                forceToolHints: true,
+                execution: expect.objectContaining({
+                    initialTokenUsage: 600,
+                }),
+            }),
+        );
+    });
+
+    it.each([
+        {
+            budgetName: 'maxTokens',
+            budget: { ...budget, maxTokens: 1 },
+            consumeBudget: async (options: AnyType, _attempt: number) => {
+                await options.execution.onStepUsage(1);
+            },
+        },
+        {
+            budgetName: 'maxToolCalls',
+            budget: { ...budget, maxToolCalls: 1 },
+            consumeBudget: async (options: AnyType, attempt: number) => {
+                await options.onStepProgress(
+                    'Reading content',
+                    'readContent',
+                    `content-${attempt}`,
+                );
+            },
+        },
+        {
+            budgetName: 'maxWarehouseQueries',
+            budget: { ...budget, maxWarehouseQueries: 1 },
+            consumeBudget: async (options: AnyType, _attempt: number) => {
+                await options.execution.onWarehouseQuery();
+            },
+        },
+    ])(
+        'enforces the cumulative $budgetName budget across report recovery',
+        async ({ budget: recoveryBudget, consumeBudget }) => {
+            let attempt = 0;
+            const generateAgentThreadResponse = vi.fn(
+                async (_user: SessionUser, options: AnyType) => {
+                    attempt += 1;
+                    await consumeBudget(options, attempt);
+                },
+            );
+            const { executor } = buildExecutor({
+                generateAgentThreadResponse,
+                provenance: [],
+            });
+
+            const result = await executor.execute(
+                run({ budget_snapshot: recoveryBudget }),
+                { signal: new AbortController().signal },
+            );
+
+            expect(result.status).toBe('partially_completed');
+            expect(generateAgentThreadResponse).toHaveBeenCalledTimes(2);
+        },
+    );
+
+    it('does not recover after the run is aborted between agent calls', async () => {
+        const controller = new AbortController();
+        const generateAgentThreadResponse = vi.fn(async () => {
+            controller.abort();
+        });
+        const { executor } = buildExecutor({
+            generateAgentThreadResponse,
+            provenance: [],
+        });
+
+        await expect(
+            executor.execute(run(), { signal: controller.signal }),
+        ).resolves.toEqual({ status: 'cancelled' });
+        expect(generateAgentThreadResponse).toHaveBeenCalledTimes(1);
+    });
+
     it('fails when execution ends without a valid submitted report', async () => {
-        const { executor } = buildExecutor({ provenance: [] });
+        const { executor, generateAgentThreadResponse } = buildExecutor({
+            provenance: [],
+        });
 
         await expect(
             executor.execute(run(), {
@@ -483,6 +599,7 @@ describe('AiDeepResearchExecutor', () => {
             status: 'failed',
             errorMessage: 'Deep Research finished without submitting a report',
         });
+        expect(generateAgentThreadResponse).toHaveBeenCalledTimes(2);
     });
 
     it('does not start an already cancelled run', async () => {

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.ts
@@ -368,70 +368,79 @@ export class AiDeepResearchExecutor {
             ]);
         };
 
-        let executionError: unknown = null;
-        try {
-            await this.dependencies.aiAgentService.generateAgentThreadResponse(
-                user,
-                {
-                    agentUuid: run.agent_uuid,
-                    threadUuid: run.ai_thread_uuid,
-                    promptUuid: run.prompt_uuid,
-                    autoApproveSql: true,
-                    execution: {
-                        mode: 'deep_research',
-                        budget: run.budget_snapshot,
-                        selectedMcpServerUuids: run.selected_mcp_server_uuids,
-                        abortSignal: runSignal,
-                        onStepUsage: (stepTokens) => {
-                            tokens += stepTokens;
-                            if (tokens > run.budget_snapshot.maxTokens) {
-                                budgetExceeded = 'maxTokens';
-                                controller.abort(
-                                    new Error(
-                                        'Deep Research exceeded its token budget',
-                                    ),
-                                );
-                                throw new Error(
+        const generateReport = (forceReportSubmission = false) =>
+            this.dependencies.aiAgentService.generateAgentThreadResponse(user, {
+                agentUuid: run.agent_uuid,
+                threadUuid: run.ai_thread_uuid,
+                promptUuid: run.prompt_uuid,
+                autoApproveSql: true,
+                ...(forceReportSubmission
+                    ? {
+                          toolHints: [AI_DEEP_RESEARCH_REPORT_TOOL_NAME],
+                          forceToolHints: true,
+                      }
+                    : {}),
+                execution: {
+                    mode: 'deep_research',
+                    budget: run.budget_snapshot,
+                    selectedMcpServerUuids: run.selected_mcp_server_uuids,
+                    abortSignal: runSignal,
+                    initialTokenUsage: tokens,
+                    onStepUsage: (stepTokens) => {
+                        tokens += stepTokens;
+                        if (tokens > run.budget_snapshot.maxTokens) {
+                            budgetExceeded = 'maxTokens';
+                            controller.abort(
+                                new Error(
                                     'Deep Research exceeded its token budget',
-                                );
-                            }
-                        },
-                        onWarehouseQuery: () => {
-                            warehouseQueries += 1;
-                            if (
-                                warehouseQueries >
-                                run.budget_snapshot.maxWarehouseQueries
-                            ) {
-                                budgetExceeded = 'maxWarehouseQueries';
-                                const error = new Error(
-                                    'Deep Research exceeded its warehouse-query budget',
-                                );
-                                controller.abort(error);
-                                throw error;
-                            }
-                        },
-                        onExecutionContextResolved: (snapshot) =>
-                            this.dependencies.aiDeepResearchRunModel.updateExecutionContextSnapshot(
-                                run.ai_deep_research_run_uuid,
-                                snapshot,
-                            ),
-                    },
-                    onStepProgress: async (
-                        _progress,
-                        toolName,
-                        toolCallId,
-                        status = 'in_progress',
-                    ) => {
-                        if (
-                            status === 'in_progress' &&
-                            toolName &&
-                            toolCallId
-                        ) {
-                            await recordProgress(toolName, toolCallId);
+                                ),
+                            );
+                            throw new Error(
+                                'Deep Research exceeded its token budget',
+                            );
                         }
                     },
+                    onWarehouseQuery: () => {
+                        warehouseQueries += 1;
+                        if (
+                            warehouseQueries >
+                            run.budget_snapshot.maxWarehouseQueries
+                        ) {
+                            budgetExceeded = 'maxWarehouseQueries';
+                            const error = new Error(
+                                'Deep Research exceeded its warehouse-query budget',
+                            );
+                            controller.abort(error);
+                            throw error;
+                        }
+                    },
+                    onExecutionContextResolved: (snapshot) =>
+                        this.dependencies.aiDeepResearchRunModel.updateExecutionContextSnapshot(
+                            run.ai_deep_research_run_uuid,
+                            snapshot,
+                        ),
                 },
+                onStepProgress: async (
+                    _progress,
+                    toolName,
+                    toolCallId,
+                    status = 'in_progress',
+                ) => {
+                    if (status === 'in_progress' && toolName && toolCallId) {
+                        await recordProgress(toolName, toolCallId);
+                    }
+                },
+            });
+
+        let executionError: unknown = null;
+        try {
+            await generateReport();
+            const initialReport = getLatestReport(
+                await this.getProvenance(run.prompt_uuid),
             );
+            if (!initialReport && !runSignal.aborted) {
+                await generateReport(true);
+            }
         } catch (error) {
             executionError = error;
         } finally {

--- a/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
@@ -2,12 +2,35 @@ import type { ModelMessage } from 'ai';
 import type { AiAgentArgs, AiAgentDependencies } from '../types/aiAgent';
 import {
     buildDeepResearchExecutionContextSnapshot,
+    buildForcedFirstStep,
     buildMessagesWithMemoryBlock,
     getAgentTools,
     normalizeToolOutput,
     withEarlyToolProgress,
     type AgentMcpToolSetup,
 } from './agentV2';
+
+describe('buildForcedFirstStep', () => {
+    it('forces the hinted report tool on only the opening step', () => {
+        const prepareStep = buildForcedFirstStep(
+            {
+                forceToolHints: true,
+                toolHints: ['submitResearchReport'],
+            } as AiAgentArgs,
+            {
+                submitResearchReport: {} as never,
+            },
+        );
+
+        expect(prepareStep?.({ stepNumber: 0 })).toEqual({
+            toolChoice: {
+                type: 'tool',
+                toolName: 'submitResearchReport',
+            },
+        });
+        expect(prepareStep?.({ stepNumber: 1 })).toEqual({});
+    });
+});
 
 describe('buildDeepResearchExecutionContextSnapshot', () => {
     it('captures the effective runtime without secret-bearing fields', () => {
@@ -343,6 +366,7 @@ describe('getAgentTools workstream tool gate', () => {
                 maxWarehouseQueries: 10,
                 maxResultRows: 1_000,
             },
+            initialTokenUsage: 0,
         };
         const tools = getAgentTools(
             args,

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -396,7 +396,7 @@ const buildStopWhenPromptInterrupted =
  * to guarantee the agent opens a PR via editDbtProject rather than just
  * discussing the fix. No-op if the forced tool isn't in the registered set.
  */
-const buildForcedFirstStep = (args: AiAgentArgs, tools: ToolSet) => {
+export const buildForcedFirstStep = (args: AiAgentArgs, tools: ToolSet) => {
     if (!args.forceToolHints) return undefined;
     const forcedTool = args.toolHints[0];
     if (!forcedTool || !(forcedTool in tools)) return undefined;
@@ -1125,7 +1125,10 @@ export const generateAgentResponse = async ({
     );
     const startTime = Date.now();
     const modelName = getAiAgentModelName(args.model);
-    let generatedTokenUsage = 0;
+    let generatedTokenUsage =
+        args.execution.mode === 'deep_research'
+            ? args.execution.initialTokenUsage
+            : 0;
 
     try {
         const [availableExplores, memoryBlock] = await Promise.all([

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -118,6 +118,7 @@ export type AiAgentExecutionConfig =
           mode: 'deep_research';
           maxSteps: number;
           budget: AiDeepResearchBudget;
+          initialTokenUsage: number;
           onStepUsage?: (tokens: number) => void | Promise<void>;
           onExecutionContextResolved?: (
               snapshot: AiDeepResearchExecutionContextSnapshot,


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9243/ai-agent-turn-can-finish-with-an-empty-message-and-status-idle-no

## Summary

Deep Research no longer discards a completed investigation when the agent finishes without submitting its report. It makes one bounded recovery turn that forces report submission while preserving cancellation and the original run budgets.

## Root cause

AgentV2 can finish normally with an empty response after completing its tool work. Deep Research only accepts a persisted `submitResearchReport` tool call, so that normal agent completion reached the executor's terminal no-report branch.

```ts
if (!report) {
    return {
        status: 'failed',
        errorMessage: 'Deep Research finished without submitting a report',
    };
}
```

The AgentV2 migration in #26106 exposed this existing empty-turn behavior on Deep Research because the report tool is mandatory on that path.

## Fix

The executor checks provenance after the initial investigation and, only when no report exists, makes one recovery call that forces `submitResearchReport` as its first tool. The recovery uses the same abort signal and cumulative token, tool-call, and warehouse-query budgets.

- `AiDeepResearchExecutor` — adds the bounded recovery turn.
- Agent execution config — carries prior token usage into recovery so persisted prompt usage remains cumulative.
- Executor and AgentV2 tests — cover forced tool choice, bounded retry, cancellation, and cumulative budgets.
- Frontend progress counters and telemetry warnings remain out of scope because they do not cause the failed run.

## Before

```text
Agent investigation
       │
       ├─ tools and queries complete
       │
       └─ empty final turn
                │
                └─ no report → failed run
```

## After

```text
Agent investigation
       │
       ├─ report submitted ────────────────→ complete
       │
       └─ no report
              │
              └─ force submitResearchReport once
                         ├─ report ─────────→ complete
                         └─ no report ──────→ existing failure
```

## Test plan

- [x] Focused Vitest: 2 files, 30 tests passed.
- [x] Regression matrix: initial report, recovery success, bounded failure, cancellation, cumulative token/tool/query budgets, and forced first-step tool choice.
- [x] `pnpm -F backend typecheck:fast`
- [x] Changed-file formatting and ESLint.
- [x] Full backend unit suite: 336 files passed, 4,864 tests passed, 1 skipped.
