### PR TITLE
feat(ai): use telescope icon for Deep Research

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -17,7 +17,7 @@ import { RichTextEditor } from '@mantine-8/tiptap';
 import {
     IconArrowUp,
     IconPlayerStop,
-    IconReportSearch,
+    IconTelescope,
     IconTerminal2,
 } from '@tabler/icons-react';
 import Mention from '@tiptap/extension-mention';
@@ -747,7 +747,7 @@ export const AgentChatInput = ({
                                     className={styles.minimalResearchIndicator}
                                 >
                                     <MantineIcon
-                                        icon={IconReportSearch}
+                                        icon={IconTelescope}
                                         size={15}
                                         stroke={1.8}
                                     />
@@ -853,7 +853,7 @@ export const AgentChatInput = ({
                                 <MantineIcon
                                     icon={
                                         composerMode === 'deep_research'
-                                            ? IconReportSearch
+                                            ? IconTelescope
                                             : IconArrowUp
                                     }
                                     color="ldGray.0"
@@ -925,7 +925,7 @@ export const AgentChatInput = ({
                         aria-label="Deep research mode"
                     >
                         <MantineIcon
-                            icon={IconReportSearch}
+                            icon={IconTelescope}
                             size={15}
                             stroke={1.8}
                         />
@@ -1064,7 +1064,7 @@ export const AgentChatInput = ({
                                 <MantineIcon
                                     icon={
                                         composerMode === 'deep_research'
-                                            ? IconReportSearch
+                                            ? IconTelescope
                                             : IconArrowUp
                                     }
                                     color="ldGray.0"

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.tsx
@@ -1,5 +1,5 @@
 import { Badge, Button, Group } from '@mantine-8/core';
-import { IconReportSearch } from '@tabler/icons-react';
+import { IconTelescope } from '@tabler/icons-react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 
 export type AgentComposerMode = 'ask' | 'deep_research';
@@ -18,7 +18,7 @@ export const DeepResearchModeControl = ({ mode, onModeChange }: Props) => {
             variant={isDeepResearch ? 'light' : 'subtle'}
             color="blue"
             leftSection={
-                <MantineIcon icon={IconReportSearch} size={14} stroke={1.8} />
+                <MantineIcon icon={IconTelescope} size={14} stroke={1.8} />
             }
             onClick={() =>
                 onModeChange(isDeepResearch ? 'ask' : 'deep_research')

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
@@ -19,7 +19,7 @@ import {
     IconFileSearch,
     IconPlayerStop,
     IconPlugConnected,
-    IconReportSearch,
+    IconTelescope,
 } from '@tabler/icons-react';
 import { useEffect, useState } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
@@ -143,7 +143,7 @@ export const DeepResearchRunCard = ({
                 <Group justify="space-between" align="flex-start" wrap="nowrap">
                     <Group align="flex-start" wrap="nowrap">
                         <ThemeIcon color="indigo" variant="light" radius="md">
-                            <MantineIcon icon={IconReportSearch} size={18} />
+                            <MantineIcon icon={IconTelescope} size={18} />
                         </ThemeIcon>
                         <Stack gap={3}>
                             <Group gap="xs">


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9201/change-deep-research-icon-to-telescope

## Summary

Replaces the report-search glyph with a telescope across the existing Deep Research AI-chat experience. The mode control, compact and regular composer states, start actions, and run card now share the requested visual identity.

### AI-chat surface

- **Mode control** — uses the telescope when entering or leaving Deep Research mode.
- **Composer** — uses the telescope in both compact and regular active-mode indicators and start-research actions.
- **Run card** — uses the telescope in the header for queued, active, completed, partial, failed, and cancelled runs.

## Visual change

Before:
  `IconReportSearch` → 6 Deep Research render sites

After:
  `IconTelescope` → the same 6 render sites at the existing 14px, 15px, 18px, and 20px sizes

## Regression analysis

- **Deep Research behavior** — callbacks, mode state, labels, settings, and run lifecycle remain unchanged.
- **Presentation** — icon sizes, strokes, colors, accessible labels, and `MantineIcon` wrappers remain unchanged.
- **Scope** — normal Ask submission and other run-card icons remain unchanged, with no backend or API surface touched.

## Test plan

- [x] Run the focused Deep Research component tests: 3 files and 19 tests pass.
- [x] Run `pnpm -F frontend typecheck:fast`.
- [x] Run `pnpm -F frontend lint`.
- [x] Confirm no `IconReportSearch` reference remains in the three owning components.
- [x] Confirm exactly six Deep Research `IconTelescope` render sites.
- [ ] Verify the telescope visually in compact and regular composers plus the run card, in light and dark modes.
