### PR TITLE
fix: prevent SQL Runner layout jitter

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -637,26 +637,20 @@ export const ContentPanel: FC = () => {
                             shadow="none"
                             radius={0}
                             withBorder={false}
-                            style={{ flex: 1 }}
+                            style={{ flex: 1, position: 'relative' }}
                             className={styles.inputPaper}
                         >
                             <Box
                                 style={{
                                     flex: 1,
                                     position: 'absolute',
+                                    inset: 0,
                                     overflowY: isVizTableConfig(
                                         currentVizConfig,
                                     )
                                         ? 'auto'
                                         : 'hidden',
-                                    height: inputSectionHeight,
-                                    width: inputSectionWidth,
                                 }}
-                                pt={
-                                    activeEditorTab === EditorTabs.SQL
-                                        ? 'md'
-                                        : 0
-                                }
                             >
                                 <ConditionalVisibility
                                     isVisible={


### PR DESCRIPTION
## Summary

Before

https://github.com/user-attachments/assets/3aaa659a-de29-4460-a884-bb52a24175e8


After

<img width="1346" height="1053" alt="CleanShot 2026-07-27 at 14 36 10" src="https://github.com/user-attachments/assets/14535e1b-c1be-4564-8156-0abe40654b9a" />


- prevent the SQL Runner editor container from feeding measured border-box dimensions back into its layout
- anchor the editor content to the panel bounds to avoid scrollbar flicker
- remove redundant wrapper padding so the editor remains aligned below the toolbar

## Testing

- manually verified the flicker is resolved across the affected browser width
- manually verified SQL editor and results panel layout
- formatting and diff checks pass

Closes: PROD-9249
Closes: #26205