### PR TITLE
feat(ai-memory): scope memories to the thread owner

### DIFF
--- a/packages/backend/src/ee/database/migrations/20260727103000_scope_ai_agent_memory_to_user.ts
+++ b/packages/backend/src/ee/database/migrations/20260727103000_scope_ai_agent_memory_to_user.ts
@@ -1,0 +1,57 @@
+import { Knex } from 'knex';
+
+const AiAgentMemoryTableName = 'ai_agent_memory';
+const OldIndexName = 'ai_agent_memory_injection_ranking';
+const NewIndexName = 'ai_agent_memory_injection_ranking_owner';
+
+// CREATE/DROP INDEX CONCURRENTLY can't run inside a transaction.
+export const config = { transaction: false };
+
+// A crashed CONCURRENTLY build leaves an INVALID index behind that IF NOT EXISTS
+// would then skip, so clear it before rebuilding.
+async function dropInvalidIndex(knex: Knex, indexName: string): Promise<void> {
+    const { rows } = await knex.raw(
+        `SELECT 1 FROM pg_index
+         JOIN pg_class ON pg_class.oid = pg_index.indexrelid
+         WHERE pg_class.relname = ? AND NOT pg_index.indisvalid`,
+        [indexName],
+    );
+    if (rows.length > 0) {
+        await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS ${indexName}`);
+    }
+}
+
+// Injection now ranks within one owner's memories, so the index leads with
+// (project, owner) before the ordering columns. Built under a new name first so
+// the ranking query is never left without a supporting index.
+export async function up(knex: Knex): Promise<void> {
+    // Without a transaction the migration lock isn't released if a timeout kills
+    // the build, leaving operators to unlock knex_migrations_lock by hand.
+    await knex.raw('SET statement_timeout = 0');
+    try {
+        await dropInvalidIndex(knex, NewIndexName);
+        await knex.raw(`
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS ${NewIndexName}
+            ON ${AiAgentMemoryTableName} (project_uuid, user_uuid, last_cited_at DESC NULLS LAST, generated_at DESC)
+            WHERE status = 'active'
+        `);
+        await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS ${OldIndexName}`);
+    } finally {
+        await knex.raw('RESET statement_timeout');
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw('SET statement_timeout = 0');
+    try {
+        await dropInvalidIndex(knex, OldIndexName);
+        await knex.raw(`
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS ${OldIndexName}
+            ON ${AiAgentMemoryTableName} (project_uuid, last_cited_at DESC NULLS LAST, generated_at DESC)
+            WHERE status = 'active'
+        `);
+        await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS ${NewIndexName}`);
+    } finally {
+        await knex.raw('RESET statement_timeout');
+    }
+}

--- a/packages/backend/src/ee/database/migrations/20260727103100_cascade_ai_agent_memory_user_fk.ts
+++ b/packages/backend/src/ee/database/migrations/20260727103100_cascade_ai_agent_memory_user_fk.ts
@@ -1,0 +1,31 @@
+import { Knex } from 'knex';
+
+const AiAgentMemoryTableName = 'ai_agent_memory';
+const UserForeignKeyName = 'ai_agent_memory_user_uuid_foreign';
+
+// A memory is only ever used in its owner's turns, so it should not outlive the
+// owner as an unattributed row. Kept transactional so the constraint swap is
+// atomic — user_uuid is never left without referential integrity.
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`
+        ALTER TABLE ${AiAgentMemoryTableName}
+        DROP CONSTRAINT IF EXISTS ${UserForeignKeyName}
+    `);
+    await knex.raw(`
+        ALTER TABLE ${AiAgentMemoryTableName}
+        ADD CONSTRAINT ${UserForeignKeyName}
+        FOREIGN KEY (user_uuid) REFERENCES users (user_uuid) ON DELETE CASCADE
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`
+        ALTER TABLE ${AiAgentMemoryTableName}
+        DROP CONSTRAINT IF EXISTS ${UserForeignKeyName}
+    `);
+    await knex.raw(`
+        ALTER TABLE ${AiAgentMemoryTableName}
+        ADD CONSTRAINT ${UserForeignKeyName}
+        FOREIGN KEY (user_uuid) REFERENCES users (user_uuid) ON DELETE SET NULL
+    `);
+}

--- a/packages/backend/src/ee/models/AiAgentMemoryModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentMemoryModel.integration.test.ts
@@ -4,6 +4,8 @@ import {
     ProjectType,
     SEED_ORG_1,
     SEED_ORG_1_ADMIN,
+    SEED_ORG_1_EDITOR,
+    SEED_ORG_1_VIEWER,
     SEED_PROJECT,
     type AiAgentMemoryDistillJobPayload,
     type AiThreadCreatedFrom,
@@ -187,6 +189,7 @@ describe('AiAgentMemoryModel integration', () => {
         createdAt: Date,
         successful = true,
         hidden = false,
+        createdByUserUuid: string | null = null,
     ) => {
         const [prompt] = await database<
             Pick<
@@ -203,7 +206,7 @@ describe('AiAgentMemoryModel integration', () => {
         >(AiPromptTableName)
             .insert({
                 ai_thread_uuid: threadUuid,
-                created_by_user_uuid: null,
+                created_by_user_uuid: createdByUserUuid,
                 prompt: 'Question',
                 response: successful ? 'Answer' : null,
                 error_message: successful ? null : 'failed',
@@ -227,7 +230,7 @@ describe('AiAgentMemoryModel integration', () => {
         organizationUuid: SEED_ORG_1.organization_uuid,
         projectUuid: SEED_PROJECT.project_uuid,
         agentUuid: null,
-        userUuid: null,
+        userUuid: SEED_ORG_1_ADMIN.user_uuid,
         sourceThreadUuid,
         slug: `memory-${crypto.randomUUID().slice(0, 8)}`,
         title: 'Net revenue convention',
@@ -326,6 +329,7 @@ describe('AiAgentMemoryModel integration', () => {
         const before = new Date();
         await model.incrementPulledForActiveMemories({
             projectUuid: SEED_PROJECT.project_uuid,
+            userUuid: SEED_ORG_1_ADMIN.user_uuid,
             slugs: [memory.slug, memory.slug],
         });
         const updated = await database(AiAgentMemoryTableName)
@@ -358,6 +362,7 @@ describe('AiAgentMemoryModel integration', () => {
 
         await model.incrementCitedForActiveMemories({
             projectUuid: SEED_PROJECT.project_uuid,
+            userUuid: SEED_ORG_1_ADMIN.user_uuid,
             slugs: [active.slug, active.slug, retired.slug, 'unknown-memory'],
         });
 
@@ -412,6 +417,7 @@ describe('AiAgentMemoryModel integration', () => {
 
         const rows = await model.findActiveForProject({
             projectUuid: SEED_PROJECT.project_uuid,
+            userUuid: SEED_ORG_1_ADMIN.user_uuid,
         });
         const testMemorySlugs = new Set([older.slug, newer.slug, cited.slug]);
 
@@ -509,6 +515,7 @@ describe('AiAgentMemoryModel integration', () => {
             memoryInput(uncitedThread, {
                 title: 'Fiscal year offset',
                 rawMemory: 'The fiscal year starts in February.',
+                userUuid: null,
                 generatedAt: new Date('2026-07-22T11:00:00Z'),
             }),
         );
@@ -641,6 +648,7 @@ describe('AiAgentMemoryModel integration', () => {
 
         const rows = await model.findActiveForProject({
             projectUuid: SEED_PROJECT.project_uuid,
+            userUuid: SEED_ORG_1_ADMIN.user_uuid,
         });
 
         expect(rows.map((row) => row.ai_agent_memory_uuid)).toEqual([
@@ -648,6 +656,151 @@ describe('AiAgentMemoryModel integration', () => {
             second.ai_agent_memory_uuid,
             third.ai_agent_memory_uuid,
         ]);
+    });
+
+    it('scopes reads, slug lookups and telemetry to the memory owner', async () => {
+        const [ownerThread, otherThread, unownedThread] = await Promise.all([
+            createThread(),
+            createThread(),
+            createThread(),
+        ]);
+        const owned = await model.upsertSourceThreadMemory(
+            memoryInput(ownerThread, {
+                userUuid: SEED_ORG_1_ADMIN.user_uuid,
+            }),
+        );
+        const otherUsers = await model.upsertSourceThreadMemory(
+            memoryInput(otherThread, {
+                userUuid: SEED_ORG_1_EDITOR.user_uuid,
+            }),
+        );
+        const unowned = await model.upsertSourceThreadMemory(
+            memoryInput(unownedThread, { userUuid: null }),
+        );
+        const allSlugs = [owned.slug, otherUsers.slug, unowned.slug];
+
+        const ownerRows = await model.findActiveForProject({
+            projectUuid: SEED_PROJECT.project_uuid,
+            userUuid: SEED_ORG_1_ADMIN.user_uuid,
+        });
+        expect(
+            ownerRows
+                .filter((row) => allSlugs.includes(row.slug))
+                .map((row) => row.slug),
+        ).toEqual([owned.slug]);
+
+        await expect(
+            model.findActiveBySlugs({
+                projectUuid: SEED_PROJECT.project_uuid,
+                userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                slugs: allSlugs,
+            }),
+        ).resolves.toEqual([{ slug: owned.slug, title: owned.title }]);
+
+        await model.incrementPulledForActiveMemories({
+            projectUuid: SEED_PROJECT.project_uuid,
+            userUuid: SEED_ORG_1_ADMIN.user_uuid,
+            slugs: allSlugs,
+        });
+        await expect(
+            model.incrementCitedForActiveMemories({
+                projectUuid: SEED_PROJECT.project_uuid,
+                userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                slugs: allSlugs,
+            }),
+        ).resolves.toEqual([
+            { memoryId: owned.ai_agent_memory_uuid, slug: owned.slug },
+        ]);
+
+        const rows = await database(AiAgentMemoryTableName)
+            .whereIn('slug', allSlugs)
+            .select('slug', 'pulled_count', 'cited_count');
+        expect(rows.sort((a, b) => a.slug.localeCompare(b.slug))).toEqual(
+            [
+                { slug: owned.slug, pulled_count: 1, cited_count: 1 },
+                { slug: otherUsers.slug, pulled_count: 0, cited_count: 0 },
+                { slug: unowned.slug, pulled_count: 0, cited_count: 0 },
+            ].sort((a, b) => a.slug.localeCompare(b.slug)),
+        );
+    });
+
+    it('returns nothing for a user who owns no memories in the project', async () => {
+        const threadUuid = await createThread();
+        const memory = await model.upsertSourceThreadMemory(
+            memoryInput(threadUuid, { userUuid: SEED_ORG_1_ADMIN.user_uuid }),
+        );
+
+        await expect(
+            model.findActiveForProject({
+                projectUuid: SEED_PROJECT.project_uuid,
+                userUuid: SEED_ORG_1_VIEWER.user_uuid,
+            }),
+        ).resolves.toEqual([]);
+        await expect(
+            model.findActiveBySlugs({
+                projectUuid: SEED_PROJECT.project_uuid,
+                userUuid: SEED_ORG_1_VIEWER.user_uuid,
+                slugs: [memory.slug],
+            }),
+        ).resolves.toEqual([]);
+        await expect(
+            model.incrementCitedForActiveMemories({
+                projectUuid: SEED_PROJECT.project_uuid,
+                userUuid: SEED_ORG_1_VIEWER.user_uuid,
+                slugs: [memory.slug],
+            }),
+        ).resolves.toEqual([]);
+    });
+
+    it('attributes a distilled slack memory to the thread owner, not the last prompter', async () => {
+        const threadUuid = await createThread('slack');
+        const firstActivity = new Date('2026-07-22T05:00:00Z');
+        await createPrompt(
+            threadUuid,
+            firstActivity,
+            true,
+            false,
+            SEED_ORG_1_EDITOR.user_uuid,
+        );
+        const lastActivity = new Date('2026-07-22T05:30:00Z');
+        await createPrompt(
+            threadUuid,
+            lastActivity,
+            true,
+            false,
+            SEED_ORG_1_ADMIN.user_uuid,
+        );
+        const distillCall = vi
+            .fn<AiAgentMemoryDistillCall>()
+            .mockResolvedValue({
+                result: {
+                    type: 'memory',
+                    thread_summary: 'The users agreed a revenue rule.',
+                    slug: 'shared-thread-revenue',
+                    title: 'Shared thread revenue convention',
+                    raw_memory: 'Use net revenue.',
+                    terms: ['net revenue'],
+                    objects: [],
+                },
+            });
+
+        await expect(
+            buildService(distillCall).distillThread({
+                organizationUuid: SEED_ORG_1.organization_uuid,
+                projectUuid: SEED_PROJECT.project_uuid,
+                userUuid: 'system',
+                threadUuid,
+                sweptUpdatedAt: lastActivity.toISOString(),
+            }),
+        ).resolves.toBe('memory');
+
+        await expect(
+            database(AiAgentMemoryTableName)
+                .where('source_thread_uuid', threadUuid)
+                .first(),
+        ).resolves.toMatchObject({
+            user_uuid: SEED_ORG_1_EDITOR.user_uuid,
+        });
     });
 
     it('reads distilled and nested consolidated provenance with the final replacement', async () => {

--- a/packages/backend/src/ee/models/AiAgentMemoryModel.ts
+++ b/packages/backend/src/ee/models/AiAgentMemoryModel.ts
@@ -92,7 +92,6 @@ export type AiAgentMemoryThreadCandidate = {
 export type AiAgentMemoryThread = AiAgentMemoryThreadCandidate & {
     distilledUpTo: Date | null;
     agentUuid: UUID | null;
-    userUuid: UUID | null;
     title: string | null;
     createdFrom: AiThreadCreatedFrom;
     projectType: ProjectType;
@@ -212,7 +211,6 @@ export class AiAgentMemoryModel {
                     distilledUpTo: Date | null;
                     promptUuid: UUID;
                     createdAt: Date;
-                    userUuid: UUID | null;
                     userText: string;
                     assistantText: string | null;
                     errorMessage: string | null;
@@ -232,7 +230,6 @@ export class AiAgentMemoryModel {
                 distilledUpTo: 'distill.distilled_up_to',
                 promptUuid: 'prompt.ai_prompt_uuid',
                 createdAt: 'prompt.created_at',
-                userUuid: 'prompt.created_by_user_uuid',
                 userText: 'prompt.prompt',
                 assistantText: 'prompt.response',
                 errorMessage: 'prompt.error_message',
@@ -298,9 +295,6 @@ export class AiAgentMemoryModel {
             organizationUuid: first.organizationUuid,
             projectUuid: first.projectUuid,
             agentUuid: first.agentUuid,
-            userUuid:
-                promptRows.findLast((row) => row.userUuid !== null)?.userUuid ??
-                null,
             title: first.title,
             createdFrom: first.createdFrom,
             projectType: first.projectType,
@@ -429,12 +423,16 @@ export class AiAgentMemoryModel {
         return row;
     }
 
+    // Memories are owned by a single user; a null-owner row is nobody's, so
+    // callers must resolve a real owner before asking for a set.
     async findActiveForProject(args: {
         projectUuid: string;
+        userUuid: string;
         limit?: number;
     }): Promise<DbAiAgentMemory[]> {
         const query = this.database<AiAgentMemoryTable>(AiAgentMemoryTableName)
             .where('project_uuid', args.projectUuid)
+            .where('user_uuid', args.userUuid)
             .where('status', 'active')
             .orderBy('last_cited_at', 'desc', 'last')
             .orderBy('generated_at', 'desc');
@@ -768,6 +766,7 @@ export class AiAgentMemoryModel {
 
     async findActiveBySlugs(args: {
         projectUuid: string;
+        userUuid: string;
         slugs: string[];
     }): Promise<Array<{ slug: string; title: string }>> {
         const slugs = [...new Set(args.slugs)];
@@ -775,6 +774,7 @@ export class AiAgentMemoryModel {
 
         return this.database<AiAgentMemoryTable>(AiAgentMemoryTableName)
             .where('project_uuid', args.projectUuid)
+            .where('user_uuid', args.userUuid)
             .where('status', 'active')
             .whereIn('slug', slugs)
             .select(['slug', 'title']);
@@ -782,6 +782,7 @@ export class AiAgentMemoryModel {
 
     async incrementPulledForActiveMemories(args: {
         projectUuid: string;
+        userUuid: string;
         slugs: string[];
     }): Promise<void> {
         const slugs = [...new Set(args.slugs)];
@@ -789,6 +790,7 @@ export class AiAgentMemoryModel {
 
         await this.database<AiAgentMemoryTable>(AiAgentMemoryTableName)
             .where('project_uuid', args.projectUuid)
+            .where('user_uuid', args.userUuid)
             .where('status', 'active')
             .whereIn('slug', slugs)
             .update({
@@ -799,6 +801,7 @@ export class AiAgentMemoryModel {
 
     async incrementCitedForActiveMemories(args: {
         projectUuid: string;
+        userUuid: string;
         slugs: string[];
     }): Promise<Array<{ memoryId: string; slug: string }>> {
         const slugs = [...new Set(args.slugs)];
@@ -808,6 +811,7 @@ export class AiAgentMemoryModel {
             AiAgentMemoryTableName,
         )
             .where('project_uuid', args.projectUuid)
+            .where('user_uuid', args.userUuid)
             .where('status', 'active')
             .whereIn('slug', slugs)
             .update({

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
@@ -4,6 +4,7 @@ import {
     DimensionType,
     FeatureFlags,
     FieldType,
+    ProjectType,
     SupportedDbtAdapter,
     type AnyType,
     type Explore,
@@ -121,6 +122,12 @@ describe('AiAgentMemoryService', () => {
         }));
         const findByProjectAndSlug = vi.fn();
         const findThreadsDueForDistill = vi.fn();
+        const findThreadForDistill = vi.fn();
+        const upsertSourceThreadMemory = vi.fn().mockResolvedValue({
+            ai_agent_memory_uuid: 'memory-1',
+        });
+        const upsertThreadDistill = vi.fn();
+        const findActiveForProject = vi.fn().mockResolvedValue([]);
         const aiAgentMemoryDistill = vi.fn();
         const getAgent = vi.fn().mockResolvedValue({
             uuid: 'agent-1',
@@ -142,29 +149,69 @@ describe('AiAgentMemoryService', () => {
             organizationUuid:
                 projectUuid === 'project-other' ? 'org-other' : 'org-enabled',
         }));
+        const distillCall = vi.fn();
         const service = new AiAgentMemoryService({
             analytics: { track: vi.fn() } as AnyType,
             aiAgentMemoryModel: {
                 findByProjectAndSlug,
                 findThreadsDueForDistill,
+                findThreadForDistill,
+                upsertSourceThreadMemory,
+                upsertThreadDistill,
+                findActiveForProject,
             } as AnyType,
             aiAgentModel: { getAgent, findThreadOwnership } as AnyType,
             groupsModel: { findUserInGroups } as AnyType,
-            projectModel: { getSummary: getProjectSummary } as AnyType,
+            projectModel: {
+                getSummary: getProjectSummary,
+                findExploresFromCache: vi.fn().mockResolvedValue({}),
+            } as AnyType,
             featureFlagService: { get: getFlag } as AnyType,
             schedulerClient: { aiAgentMemoryDistill },
-            distillCall: vi.fn(),
+            distillCall,
         });
         return {
             service,
             getFlag,
             findByProjectAndSlug,
             findThreadsDueForDistill,
+            findThreadForDistill,
+            upsertSourceThreadMemory,
+            upsertThreadDistill,
+            findActiveForProject,
             aiAgentMemoryDistill,
             getAgent,
             findThreadOwnership,
+            distillCall,
         };
     };
+
+    const memoryRow = (
+        overrides: Record<string, unknown> = {},
+    ): Record<string, unknown> => ({
+        ai_agent_memory_uuid: 'memory-1',
+        slug: 'net-revenue-ab12cd34',
+        title: 'Net revenue convention',
+        raw_memory: 'Use net revenue.',
+        terms: [],
+        objects: [],
+        status: 'active',
+        agent_uuid: 'agent-1',
+        user_uuid: 'source-user',
+        source_thread_uuid: 'thread-enabled',
+        generated_at: new Date('2026-07-22T10:00:00Z'),
+        cited_count: 3,
+        ...overrides,
+    });
+
+    const lineageSource = (overrides: Record<string, unknown> = {}) => ({
+        slug: 'net-revenue-ab12cd34',
+        agent_uuid: 'agent-1',
+        source_thread_uuid: 'thread-enabled',
+        thread_summary: '**The user** established the convention.',
+        thread_title: 'Revenue definitions',
+        ...overrides,
+    });
 
     it('enqueues the exact activity watermark selected by the sweep', async () => {
         const { service, findThreadsDueForDistill, aiAgentMemoryDistill } =
@@ -192,14 +239,10 @@ describe('AiAgentMemoryService', () => {
         });
     });
 
-    it('returns a project-visible memory with source provenance', async () => {
+    it('returns full source provenance to an agent manager', async () => {
         const { service, findByProjectAndSlug, getAgent } = build();
         findByProjectAndSlug.mockResolvedValue({
-            memory: {
-                slug: 'net-revenue-ab12cd34',
-                title: 'Net revenue convention',
-                raw_memory: 'Use net revenue.',
-                terms: ['net revenue'],
+            memory: memoryRow({
                 objects: [
                     {
                         type: 'field',
@@ -207,20 +250,9 @@ describe('AiAgentMemoryService', () => {
                         fieldId: 'orders_net_revenue',
                     },
                 ],
-                status: 'active',
-                source_thread_uuid: 'thread-enabled',
-                generated_at: new Date('2026-07-22T10:00:00Z'),
-                cited_count: 3,
-            },
-            sources: [
-                {
-                    slug: 'net-revenue-ab12cd34',
-                    agent_uuid: 'agent-1',
-                    source_thread_uuid: 'thread-enabled',
-                    thread_summary: '**The user** established the convention.',
-                    thread_title: 'Revenue definitions',
-                },
-            ],
+                terms: ['net revenue'],
+            }),
+            sources: [lineageSource()],
             replacement: null,
         });
         getAgent.mockResolvedValue({
@@ -244,134 +276,84 @@ describe('AiAgentMemoryService', () => {
             provenance: {
                 type: 'source_thread',
                 source: {
-                    hasThreadAccess: true,
+                    slug: 'net-revenue-ab12cd34',
                     agentUuid: 'agent-1',
                     threadUuid: 'thread-enabled',
                     threadTitle: 'Revenue definitions',
+                    threadSummary: '**The user** established the convention.',
                 },
             },
         });
     });
 
-    it('redacts source thread details from users without thread access', async () => {
+    it('hides another user’s memory from a project viewer without thread access', async () => {
         const { service, findByProjectAndSlug } = build();
         findByProjectAndSlug.mockResolvedValue({
-            memory: {
-                slug: 'net-revenue-ab12cd34',
-                title: 'Net revenue convention',
-                raw_memory: 'Use net revenue.',
-                terms: ['net revenue'],
-                objects: [],
-                status: 'active',
-                source_thread_uuid: 'thread-enabled',
-                generated_at: new Date('2026-07-22T10:00:00Z'),
-                cited_count: 3,
-            },
-            sources: [
-                {
-                    slug: 'net-revenue-ab12cd34',
-                    agent_uuid: 'agent-1',
-                    source_thread_uuid: 'thread-enabled',
-                    thread_summary: 'Private thread summary.',
-                    thread_title: 'Private thread title',
-                },
-            ],
+            memory: memoryRow(),
+            sources: [lineageSource()],
             replacement: null,
         });
 
-        const memory = await service.getMemory(
-            buildUser(true),
-            'project-enabled',
-            'net-revenue-ab12cd34',
-        );
+        await expect(
+            service.getMemory(
+                buildUser(true),
+                'project-enabled',
+                'net-revenue-ab12cd34',
+            ),
+        ).rejects.toThrow('Memory not found: net-revenue-ab12cd34');
+    });
 
-        expect(memory.provenance).toEqual({
-            type: 'source_thread',
-            source: {
-                slug: 'net-revenue-ab12cd34',
-                hasThreadAccess: false,
+    it('returns the memory to its owner without manage access', async () => {
+        const { service, findByProjectAndSlug } = build();
+        findByProjectAndSlug.mockResolvedValue({
+            memory: memoryRow({ user_uuid: 'current-user' }),
+            sources: [lineageSource({ thread_title: 'Owner-visible title' })],
+            replacement: null,
+        });
+
+        await expect(
+            service.getMemory(
+                buildUser(true),
+                'project-enabled',
+                'net-revenue-ab12cd34',
+            ),
+        ).resolves.toMatchObject({
+            provenance: {
+                type: 'source_thread',
+                source: { threadTitle: 'Owner-visible title' },
             },
         });
     });
 
-    it('returns source details to the thread owner without manage access', async () => {
+    it('decides access from the memory row without loading the source thread', async () => {
         const { service, findByProjectAndSlug, findThreadOwnership } = build();
         findByProjectAndSlug.mockResolvedValue({
-            memory: {
-                slug: 'net-revenue-ab12cd34',
-                title: 'Net revenue convention',
-                raw_memory: 'Use net revenue.',
-                terms: [],
-                objects: [],
-                status: 'active',
-                source_thread_uuid: 'thread-enabled',
-                generated_at: new Date('2026-07-22T10:00:00Z'),
-                cited_count: 3,
-            },
-            sources: [
-                {
-                    slug: 'net-revenue-ab12cd34',
-                    agent_uuid: 'agent-1',
-                    source_thread_uuid: 'thread-enabled',
-                    thread_summary: 'Owner-visible summary.',
-                    thread_title: 'Owner-visible title',
-                },
-            ],
+            memory: memoryRow({
+                user_uuid: 'current-user',
+                source_thread_uuid: null,
+            }),
+            sources: [],
             replacement: null,
         });
-        findThreadOwnership.mockResolvedValue({
-            threadUuid: 'thread-enabled',
-            projectUuid: 'project-enabled',
-            agentUuid: 'agent-1',
-            ownerUserUuid: 'current-user',
-        });
 
-        const memory = await service.getMemory(
-            buildUser(true),
-            'project-enabled',
-            'net-revenue-ab12cd34',
-        );
-
-        expect(memory.provenance).toMatchObject({
-            type: 'source_thread',
-            source: {
-                hasThreadAccess: true,
-                threadTitle: 'Owner-visible title',
-            },
+        await expect(
+            service.getMemory(
+                buildUser(true),
+                'project-enabled',
+                'net-revenue-ab12cd34',
+            ),
+        ).resolves.toMatchObject({
+            provenance: { type: 'consolidated', sources: [] },
         });
+        expect(findThreadOwnership).not.toHaveBeenCalled();
     });
 
-    it('redacts source details when the owner loses agent access', async () => {
-        const { service, findByProjectAndSlug, findThreadOwnership, getAgent } =
-            build();
+    it('hides the memory from its owner when the owner loses agent access', async () => {
+        const { service, findByProjectAndSlug, getAgent } = build();
         findByProjectAndSlug.mockResolvedValue({
-            memory: {
-                slug: 'net-revenue-ab12cd34',
-                title: 'Net revenue convention',
-                raw_memory: 'Use net revenue.',
-                terms: [],
-                objects: [],
-                status: 'active',
-                source_thread_uuid: 'thread-enabled',
-                generated_at: new Date('2026-07-22T10:00:00Z'),
-                cited_count: 3,
-            },
-            sources: [
-                {
-                    slug: 'net-revenue-ab12cd34',
-                    agent_uuid: 'agent-1',
-                    source_thread_uuid: 'thread-enabled',
-                    thread_summary: 'Private summary.',
-                    thread_title: 'Private title',
-                },
-            ],
+            memory: memoryRow({ user_uuid: 'current-user' }),
+            sources: [lineageSource()],
             replacement: null,
-        });
-        findThreadOwnership.mockResolvedValue({
-            threadUuid: 'thread-enabled',
-            projectUuid: 'project-enabled',
-            agentUuid: 'agent-1',
-            ownerUserUuid: 'current-user',
         });
         getAgent.mockResolvedValue({
             uuid: 'agent-1',
@@ -383,19 +365,211 @@ describe('AiAgentMemoryService', () => {
             userAccess: [],
         });
 
-        const memory = await service.getMemory(
-            buildUser(true),
-            'project-enabled',
-            'net-revenue-ab12cd34',
-        );
+        await expect(
+            service.getMemory(
+                buildUser(true),
+                'project-enabled',
+                'net-revenue-ab12cd34',
+            ),
+        ).rejects.toThrow('Memory not found: net-revenue-ab12cd34');
+    });
 
-        expect(memory.provenance).toEqual({
-            type: 'source_thread',
-            source: {
-                slug: 'net-revenue-ab12cd34',
-                hasThreadAccess: false,
+    it('exposes an unowned memory only to an agent manager', async () => {
+        const { service, findByProjectAndSlug } = build();
+        findByProjectAndSlug.mockResolvedValue({
+            memory: memoryRow({ user_uuid: null }),
+            sources: [lineageSource()],
+            replacement: null,
+        });
+
+        await expect(
+            service.getMemory(
+                buildUser(true),
+                'project-enabled',
+                'net-revenue-ab12cd34',
+            ),
+        ).rejects.toThrow('Memory not found: net-revenue-ab12cd34');
+        await expect(
+            service.getMemory(
+                buildUser(true, { canManageAgents: true }),
+                'project-enabled',
+                'net-revenue-ab12cd34',
+            ),
+        ).resolves.toMatchObject({ slug: 'net-revenue-ab12cd34' });
+    });
+
+    it('hides a memory whose agent is gone from everyone', async () => {
+        const { service, findByProjectAndSlug, getAgent } = build();
+        findByProjectAndSlug.mockResolvedValue({
+            memory: memoryRow({ agent_uuid: null, user_uuid: 'current-user' }),
+            sources: [lineageSource()],
+            replacement: null,
+        });
+
+        await expect(
+            service.getMemory(
+                buildUser(true, { canManageAgents: true }),
+                'project-enabled',
+                'net-revenue-ab12cd34',
+            ),
+        ).rejects.toThrow('Memory not found: net-revenue-ab12cd34');
+        expect(getAgent).not.toHaveBeenCalled();
+    });
+
+    it('keeps reading a memory separate from injecting it into the reader’s context', async () => {
+        const { service, findByProjectAndSlug, findActiveForProject } = build();
+        findByProjectAndSlug.mockResolvedValue({
+            memory: memoryRow(),
+            sources: [lineageSource()],
+            replacement: null,
+        });
+
+        await expect(
+            service.getMemory(
+                buildUser(true, { canManageAgents: true }),
+                'project-enabled',
+                'net-revenue-ab12cd34',
+            ),
+        ).resolves.toMatchObject({ slug: 'net-revenue-ab12cd34' });
+        expect(findActiveForProject).not.toHaveBeenCalled();
+    });
+
+    it('attributes a distilled memory to the thread owner, not the last prompter', async () => {
+        const {
+            service,
+            findThreadForDistill,
+            findThreadOwnership,
+            upsertSourceThreadMemory,
+            distillCall,
+        } = build();
+        const activity = new Date('2026-07-22T05:00:00.000Z');
+        findThreadForDistill.mockResolvedValue({
+            threadUuid: 'thread-enabled',
+            organizationUuid: 'org-enabled',
+            projectUuid: 'project-enabled',
+            agentUuid: 'agent-1',
+            title: 'Revenue definitions',
+            createdFrom: 'slack',
+            projectType: ProjectType.DEFAULT,
+            latestActivity: activity,
+            distilledUpTo: null,
+            turns: [
+                {
+                    promptUuid: 'prompt-1',
+                    createdAt: new Date('2026-07-22T04:00:00.000Z'),
+                    userText: 'First user asks',
+                    assistantText: 'Answer',
+                    errorMessage: null,
+                    respondedAt: new Date('2026-07-22T04:01:00.000Z'),
+                    interrupted: false,
+                    tools: [],
+                },
+                {
+                    promptUuid: 'prompt-2',
+                    createdAt: activity,
+                    userText: 'Second user asks last',
+                    assistantText: 'Answer',
+                    errorMessage: null,
+                    respondedAt: activity,
+                    interrupted: false,
+                    tools: [],
+                },
+            ],
+        });
+        findThreadOwnership.mockResolvedValue({
+            threadUuid: 'thread-enabled',
+            projectUuid: 'project-enabled',
+            agentUuid: 'agent-1',
+            ownerUserUuid: 'first-prompter',
+        });
+        distillCall.mockResolvedValue({
+            result: {
+                type: 'memory',
+                thread_summary: 'The users agreed a convention.',
+                slug: 'net-revenue',
+                title: 'Net revenue convention',
+                raw_memory: 'Use net revenue.',
+                terms: ['net revenue'],
+                objects: [],
             },
         });
+
+        await expect(
+            service.distillThread({
+                organizationUuid: 'org-enabled',
+                projectUuid: 'project-enabled',
+                userUuid: 'system',
+                threadUuid: 'thread-enabled',
+                sweptUpdatedAt: activity.toISOString(),
+            }),
+        ).resolves.toBe('memory');
+
+        expect(findThreadOwnership).toHaveBeenCalledWith({
+            organizationUuid: 'org-enabled',
+            threadUuid: 'thread-enabled',
+        });
+        expect(upsertSourceThreadMemory).toHaveBeenCalledWith(
+            expect.objectContaining({ userUuid: 'first-prompter' }),
+        );
+    });
+
+    it('writes a null owner rather than a placeholder when the thread has none', async () => {
+        const {
+            service,
+            findThreadForDistill,
+            findThreadOwnership,
+            upsertSourceThreadMemory,
+            distillCall,
+        } = build();
+        const activity = new Date('2026-07-22T05:00:00.000Z');
+        findThreadForDistill.mockResolvedValue({
+            threadUuid: 'thread-enabled',
+            organizationUuid: 'org-enabled',
+            projectUuid: 'project-enabled',
+            agentUuid: 'agent-1',
+            title: null,
+            createdFrom: 'slack',
+            projectType: ProjectType.DEFAULT,
+            latestActivity: activity,
+            distilledUpTo: null,
+            turns: [
+                {
+                    promptUuid: 'prompt-1',
+                    createdAt: activity,
+                    userText: 'Anonymous ask',
+                    assistantText: 'Answer',
+                    errorMessage: null,
+                    respondedAt: activity,
+                    interrupted: false,
+                    tools: [],
+                },
+            ],
+        });
+        findThreadOwnership.mockResolvedValue(undefined);
+        distillCall.mockResolvedValue({
+            result: {
+                type: 'memory',
+                thread_summary: 'A convention.',
+                slug: 'net-revenue',
+                title: 'Net revenue convention',
+                raw_memory: 'Use net revenue.',
+                terms: [],
+                objects: [],
+            },
+        });
+
+        await expect(
+            service.distillThread({
+                organizationUuid: 'org-enabled',
+                projectUuid: 'project-enabled',
+                userUuid: 'system',
+                threadUuid: 'thread-enabled',
+                sweptUpdatedAt: activity.toISOString(),
+            }),
+        ).resolves.toBe('memory');
+        expect(upsertSourceThreadMemory).toHaveBeenCalledWith(
+            expect.objectContaining({ userUuid: null }),
+        );
     });
 
     it('returns not found without reading rows when the flag is off', async () => {

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
@@ -11,6 +11,7 @@ import {
     ProjectType,
     type AiAgentMemory,
     type AiAgentMemoryDistillJobPayload,
+    type AiAgentMemorySource,
     type AiProjectContextTypedObjectRef,
     type Explore,
     type ExploreError,
@@ -33,10 +34,10 @@ import type PrometheusMetrics from '../../../prometheus/PrometheusMetrics';
 import { type AiAgentMemoryDistillOutcome } from '../../../prometheus/PrometheusMetrics';
 import { BaseService } from '../../../services/BaseService';
 import { type FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
+import { type DbAiAgentMemory } from '../../database/entities/aiAgentMemory';
 import {
     AI_AGENT_MEMORY_THREAD_SOURCES,
     AiAgentMemoryModel,
-    type AiAgentMemoryLineageSource,
     type AiAgentMemoryThread,
 } from '../../models/AiAgentMemoryModel';
 import { type AiAgentModel } from '../../models/AiAgentModel';
@@ -176,43 +177,29 @@ export class AiAgentMemoryService extends BaseService {
         }
     }
 
-    private async canViewSourceThread(
+    /**
+     * Decided from the memory row alone — never loads the source thread, so a
+     * memory outlives the thread it came from. Same predicate that gates thread
+     * access: agent access AND (owns the memory OR can manage the agent).
+     */
+    private async canReadMemory(
         user: SessionUser,
         organizationUuid: string,
         projectUuid: string,
-        source: AiAgentMemoryLineageSource,
+        memory: Pick<DbAiAgentMemory, 'agent_uuid' | 'user_uuid'>,
     ): Promise<boolean> {
-        if (!source.agent_uuid) return false;
+        if (!memory.agent_uuid) return false;
 
-        const [agent, ownership] = await Promise.all([
-            this.aiAgentModel.getAgent({
-                organizationUuid,
-                agentUuid: source.agent_uuid,
-            }),
-            this.aiAgentModel.findThreadOwnership({
-                organizationUuid,
-                threadUuid: source.source_thread_uuid ?? '',
-            }),
-        ]);
-        if (
-            !agent ||
-            agent.projectUuid !== projectUuid ||
-            !ownership ||
-            ownership.projectUuid !== projectUuid ||
-            ownership.agentUuid !== source.agent_uuid
-        ) {
-            return false;
-        }
+        const agent = await this.aiAgentModel.getAgent({
+            organizationUuid,
+            agentUuid: memory.agent_uuid,
+        });
+        if (!agent || agent.projectUuid !== projectUuid) return false;
 
-        return canAccessAiAgentThread(
-            user,
-            agent,
-            ownership.ownerUserUuid ?? '',
-            {
-                auditedAbility: this.createAuditedAbility(user),
-                groupsModel: this.groupsModel,
-            },
-        );
+        return canAccessAiAgentThread(user, agent, memory.user_uuid ?? '', {
+            auditedAbility: this.createAuditedAbility(user),
+            groupsModel: this.groupsModel,
+        });
     }
 
     private async isEnabled(organizationUuid: UUID): Promise<boolean> {
@@ -295,39 +282,35 @@ export class AiAgentMemoryService extends BaseService {
             projectUuid,
             slug,
         });
-        if (!result) {
+        if (
+            !result ||
+            !(await this.canReadMemory(
+                user,
+                organizationUuid,
+                projectUuid,
+                result.memory,
+            ))
+        ) {
+            // Same error as a missing row so a reader can't probe for existence
             throw new NotFoundError(`Memory not found: ${slug}`);
         }
 
-        const sources = (
-            await Promise.all(
-                result.sources.map(async (source) => {
-                    if (!source.source_thread_uuid || !source.thread_summary) {
-                        return null;
-                    }
-
-                    const hasThreadAccess = await this.canViewSourceThread(
-                        user,
-                        organizationUuid,
-                        projectUuid,
-                        source,
-                    );
-                    return hasThreadAccess
-                        ? {
+        // Reading the memory grants its lineage: the check above already covers
+        // the whole row, so there is nothing left to redact per source.
+        const sources = result.sources.flatMap(
+            (source): AiAgentMemorySource[] =>
+                source.source_thread_uuid && source.thread_summary
+                    ? [
+                          {
                               slug: source.slug,
-                              hasThreadAccess: true as const,
                               agentUuid: source.agent_uuid,
                               threadUuid: source.source_thread_uuid,
                               threadTitle: source.thread_title,
                               threadSummary: source.thread_summary,
-                          }
-                        : {
-                              slug: source.slug,
-                              hasThreadAccess: false as const,
-                          };
-                }),
-            )
-        ).filter((source) => source !== null);
+                          },
+                      ]
+                    : [],
+        );
 
         const response: AiAgentMemory = {
             slug: result.memory.slug,
@@ -511,12 +494,18 @@ export class AiAgentMemoryService extends BaseService {
             );
             abortSignal?.throwIfAborted();
             failureStage = 'persistence';
+            // The memory belongs to the thread's owner (its first prompter),
+            // not whoever happened to prompt last in a shared Slack thread.
+            const ownership = await this.aiAgentModel.findThreadOwnership({
+                organizationUuid: thread.organizationUuid,
+                threadUuid: thread.threadUuid,
+            });
             const memory =
                 await this.aiAgentMemoryModel.upsertSourceThreadMemory({
                     organizationUuid: thread.organizationUuid,
                     projectUuid: thread.projectUuid,
                     agentUuid: thread.agentUuid,
-                    userUuid: thread.userUuid,
+                    userUuid: ownership?.ownerUserUuid ?? null,
                     sourceThreadUuid: thread.threadUuid,
                     slug: `${output.result.slug}-${randomBytes(4).toString('hex')}`,
                     title: output.result.title,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -7647,6 +7647,40 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         }
     }
 
+    /**
+     * A memory belongs to the owner of the thread it came from, so every memory
+     * read in a turn resolves to that owner rather than the current prompter.
+     * Null means the thread has no owner — such a thread sees no memories.
+     */
+    private async findThreadMemoryOwnerUuid(args: {
+        organizationUuid: string;
+        projectUuid: string;
+        threadUuid: string;
+    }): Promise<string | null> {
+        // findThreadOwnership only filters by organization, so the project has
+        // to be asserted here before the owner is trusted.
+        const ownership = await this.aiAgentModel.findThreadOwnership({
+            organizationUuid: args.organizationUuid,
+            threadUuid: args.threadUuid,
+        });
+        return ownership?.projectUuid === args.projectUuid
+            ? ownership.ownerUserUuid
+            : null;
+    }
+
+    // Memoizes the owner lookup for the life of one agent run.
+    private createThreadMemoryOwnerResolver(args: {
+        organizationUuid: string;
+        projectUuid: string;
+        threadUuid: string;
+    }): () => Promise<string | null> {
+        let ownerPromise: Promise<string | null> | undefined;
+        return () => {
+            ownerPromise ??= this.findThreadMemoryOwnerUuid(args);
+            return ownerPromise;
+        };
+    }
+
     // Defines the functions that AI Agent tools can use to interact with the Lightdash backend or slack
     // This is scoped to the project, user and prompt (closure)
     private async getAiAgentDependencies(
@@ -7693,11 +7727,23 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
 
         const getProjectContextDocument: AiAgentDependencies['getProjectContextDocument'] =
             () => this.projectContextModel.getDocument(projectUuid);
+        // Memories are scoped to the thread's owner, so a Slack thread keeps one
+        // memory context for its whole life no matter who prompts in a turn.
+        // Resolved lazily and once per run — a memory-disabled run never asks.
+        const resolveThreadMemoryOwnerUuid =
+            this.createThreadMemoryOwnerResolver({
+                organizationUuid,
+                projectUuid,
+                threadUuid: prompt.threadUuid,
+            });
         const getAiAgentMemoryContextEntries: AiAgentDependencies['getAiAgentMemoryContextEntries'] =
             async () => {
+                const ownerUserUuid = await resolveThreadMemoryOwnerUuid();
+                if (!ownerUserUuid) return [];
                 const memories =
                     await this.aiAgentMemoryModel.findActiveForProject({
                         projectUuid,
+                        userUuid: ownerUserUuid,
                     });
                 const now = Date.now();
                 return memories.map((memory) => ({
@@ -7715,13 +7761,19 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 }));
             };
         const incrementAiAgentMemoryPulls: AiAgentDependencies['incrementAiAgentMemoryPulls'] =
-            (entries) =>
-                this.aiAgentMemoryModel.incrementPulledForActiveMemories({
+            async (entries) => {
+                const slugs = entries
+                    .filter((entry) => entry.source === 'memory')
+                    .map((entry) => entry.id);
+                if (slugs.length === 0) return;
+                const ownerUserUuid = await resolveThreadMemoryOwnerUuid();
+                if (!ownerUserUuid) return;
+                await this.aiAgentMemoryModel.incrementPulledForActiveMemories({
                     projectUuid,
-                    slugs: entries
-                        .filter((entry) => entry.source === 'memory')
-                        .map((entry) => entry.id),
+                    userUuid: ownerUserUuid,
+                    slugs,
                 });
+            };
 
         const updateProgress: UpdateProgressFn = (
             progress,
@@ -8291,6 +8343,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             getProjectContextDocument,
             getAiAgentMemoryContextEntries,
             incrementAiAgentMemoryPulls,
+            resolveThreadMemoryOwnerUuid,
             getExplore: toolsRuntime.getExplore,
             listContent: toolsRuntime.listContent,
             findContent: toolsRuntime.findContent,
@@ -8493,6 +8546,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             getProjectContextDocument,
             getAiAgentMemoryContextEntries,
             incrementAiAgentMemoryPulls,
+            resolveThreadMemoryOwnerUuid,
             getExplore,
             listContent,
             findContent,
@@ -9080,10 +9134,14 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                               if (slugs.length === 0) return;
 
                               try {
+                                  const ownerUserUuid =
+                                      await resolveThreadMemoryOwnerUuid();
+                                  if (!ownerUserUuid) return;
                                   const citedMemories =
                                       await this.aiAgentMemoryModel.incrementCitedForActiveMemories(
                                           {
                                               projectUuid: prompt.projectUuid,
+                                              userUuid: ownerUserUuid,
                                               slugs,
                                           },
                                       );
@@ -9536,8 +9594,15 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         if (slugs.length === 0) return [];
 
         try {
+            const ownerUserUuid = await this.findThreadMemoryOwnerUuid({
+                organizationUuid: slackPrompt.organizationUuid,
+                projectUuid: slackPrompt.projectUuid,
+                threadUuid: slackPrompt.threadUuid,
+            });
+            if (!ownerUserUuid) return [];
             const memories = await this.aiAgentMemoryModel.findActiveBySlugs({
                 projectUuid: slackPrompt.projectUuid,
+                userUuid: ownerUserUuid,
                 slugs,
             });
             const memoriesBySlug = new Map(

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -339,16 +339,11 @@ export type ApiAiAgentResponse = {
 
 export type AiAgentMemorySource = {
     slug: string;
-} & (
-    | { hasThreadAccess: false }
-    | {
-          hasThreadAccess: true;
-          agentUuid: string | null;
-          threadUuid: string;
-          threadTitle: string | null;
-          threadSummary: string;
-      }
-);
+    agentUuid: string | null;
+    threadUuid: string;
+    threadTitle: string | null;
+    threadSummary: string;
+};
 
 export type AiAgentMemoryStatus = 'active' | 'superseded' | 'retired';
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.test.tsx
@@ -37,7 +37,6 @@ Use net revenue for future revenue questions.`,
                 type: 'source_thread',
                 source: {
                     slug: 'net-revenue',
-                    hasThreadAccess: true,
                     threadUuid: 'thread-uuid',
                     agentUuid: 'agent-uuid',
                     threadTitle: 'Revenue conventions',
@@ -166,7 +165,7 @@ describe('MemoryCitation', () => {
         expect(within(dialog).getByText('Open thread')).toBeInTheDocument();
     });
 
-    it('does not render restricted source thread details', () => {
+    it('renders a source thread without a link when its agent is gone', () => {
         render(
             <MemoryRouter>
                 <MantineProvider>
@@ -186,7 +185,10 @@ describe('MemoryCitation', () => {
                                 type: 'source_thread',
                                 source: {
                                     slug: 'net-revenue',
-                                    hasThreadAccess: false,
+                                    agentUuid: null,
+                                    threadUuid: 'thread-uuid',
+                                    threadTitle: 'Revenue conventions',
+                                    threadSummary: 'Defined net revenue.',
                                 },
                             },
                             replacementSlug: null,
@@ -198,16 +200,8 @@ describe('MemoryCitation', () => {
 
         fireEvent.click(screen.getByRole('button', { name: /Source/ }));
 
-        expect(screen.getByText('Source thread')).toBeInTheDocument();
-        expect(
-            screen.getByText(
-                'Thread details are only visible to its owner and agent managers.',
-            ),
-        ).toBeInTheDocument();
+        expect(screen.getByText('Revenue conventions')).toBeInTheDocument();
         expect(screen.queryByText('Open thread')).not.toBeInTheDocument();
-        expect(
-            screen.queryByText('Private thread title'),
-        ).not.toBeInTheDocument();
     });
 
     it('opens details without navigating when the marker is clicked', async () => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.tsx
@@ -65,20 +65,6 @@ const SourceRow: FC<{
     source: AiAgentMemorySource;
     projectUuid: string;
 }> = ({ source, projectUuid }) => {
-    if (!source.hasThreadAccess) {
-        return (
-            <Box className={styles.sourceRow}>
-                <Text fw={550} size="sm">
-                    Source thread
-                </Text>
-                <Text size="xs" c="dimmed" mt={4}>
-                    Thread details are only visible to its owner and agent
-                    managers.
-                </Text>
-            </Box>
-        );
-    }
-
     const threadPath = source.agentUuid
         ? `/projects/${projectUuid}/ai-agents/${source.agentUuid}/threads/${source.threadUuid}`
         : null;


### PR DESCRIPTION
Slice 1 of 5 under ZAP-707 (Scope AI agent memories to the user).

AI agent memory shipped project-shared: one store per project, injected into
every user's agent context. Because AI queries execute under the prompting
user's own account, a memory distilled from one user's thread is grounded in
results only that user was entitled to see - and was then injected into
everyone else's context. The read-only memory page also required only
project-view, so any project viewer could read any memory body by slug.

After this PR a memory belongs to exactly one user - the owner of the thread it
came from - and is only ever used in that user's own turns.

## Write

A new memory is attributed to its thread's owner (the first prompt's creator,
falling back to the web-app thread's user) via the existing
`AiAgentModel.findThreadOwnership`, which already gates thread access. This
replaces attribution by *last* prompter, which in a multi-user Slack thread
assigned the memory to whoever happened to speak last. The competing
`promptRows.findLast(...)` derivation is deleted, so there is now one owner
definition rather than two. Multi-prompter Slack threads are still distilled
normally - not skipped, not split per prompter.

## Read

The injected memory block, project-context pull hits, and the cited/pulled
counter bumps all resolve to the current thread's owner and see only that
owner's memories. The owner lookup is memoized once per agent run, so a Slack
thread keeps one stable memory context for its whole life regardless of who is
prompting in a given turn, and a memory-disabled run issues no extra query. A
null owner is treated as nobody: the query is skipped entirely rather than
matching `user_uuid IS NULL`. Ordering, budget, truncation hint and the 30-row
cap are unchanged. The admin memories tab deliberately stays cross-user - it is
an audit surface.

## Access

Reading a memory now requires agent access AND either owning the memory or
being able to manage the agent - the same predicate that gates thread access,
evaluated from the memory row alone. Access never loads the source thread, so a
memory whose source thread was deleted is still readable by its owner. This
tightens the previous project-view-only rule. Read and inject remain separate
queries: an admin reading someone else's memory never pulls it into their own
context.

Because that check now governs the whole memory rather than just the thread
summary, the per-source `hasThreadAccess` redaction became vacuous and was
removed rather than left as a permanently-true flag.

## Schema

Two migrations, no data backfill:

- the injection ranking index is rebuilt as
  `(project_uuid, user_uuid, last_cited_at DESC NULLS LAST, generated_at DESC)
  WHERE status = 'active'`. Built `CONCURRENTLY` under a new name before the old
  one is dropped, so the ranking query is never left unsupported, with an
  INVALID-index guard so a crashed build is resumable.
- the `user_uuid` FK moves from `ON DELETE SET NULL` to `ON DELETE CASCADE`, so
  deleting a user deletes the memories they own. Kept in its own transactional
  migration so the constraint swap stays atomic - splitting it from the
  concurrent index build is why there are two files.

Existing rows keep their current owner: the feature is flagged on for our
internal instance only, so the handful of last-prompter attributions are not
worth a backfill. Slug uniqueness stays per project; access is enforced by
authorization, not by key partitioning.

## Testing

Service-level coverage for owner attribution (including a Slack thread where a
second user sends the final prompt) and the full read-authorization matrix:
owner, agent manager, project viewer with no thread access, deleted source
thread, and unowned memory. Model-level real-Postgres integration coverage for
owner-filtered reads, owner-filtered slug resolution, owner-filtered telemetry,
and non-owner queries returning nothing. Both migrations verified up, down and
up again against a real database.

## Note for reviewers

`AiAgentMemorySource` drops the required `hasThreadAccess` field, which is a
breaking change to the memory API response shape. It is the direct consequence
of "access never loads the source thread" and is intended.

Closes: ZAP-708
Relates: ZAP-707
