### PR TITLE
feat: enforce project-scoped data app slugs

### DIFF
--- a/packages/backend/src/database/entities/apps.ts
+++ b/packages/backend/src/database/entities/apps.ts
@@ -22,6 +22,7 @@ export type DbApp = {
     name: string;
     description: string;
     project_uuid: string;
+    slug: string;
     space_uuid: string | null;
     // Stable, registry-owned sandbox id (`sandbox_registry.sandbox_uuid`). Null
     // until the app's first generation creates a sandbox. The provider's own
@@ -46,7 +47,7 @@ export type DbApp = {
 
 export type AppsTable = Knex.CompositeTableType<
     DbApp,
-    Pick<DbApp, 'project_uuid' | 'created_by_user_uuid'> &
+    Pick<DbApp, 'project_uuid' | 'created_by_user_uuid' | 'slug'> &
         Partial<
             Pick<
                 DbApp,

--- a/packages/backend/src/database/migrations/20260727140000_enforce_app_project_slug_contract.ts
+++ b/packages/backend/src/database/migrations/20260727140000_enforce_app_project_slug_contract.ts
@@ -1,0 +1,489 @@
+import { Knex } from 'knex';
+
+export const config = { transaction: false };
+
+const AppsTableName = 'apps';
+const ProjectForeignKey = 'apps_project_uuid_foreign';
+const ProjectNotNullCheck = 'apps_project_uuid_not_null';
+const SlugNotNullCheck = 'apps_slug_not_null';
+const ProjectSlugUniqueConstraint = 'apps_project_uuid_slug_unique';
+const ProjectSlugLookupIndex = 'apps_project_uuid_slug_migration_idx';
+const AppSlugSequence = 'apps_slug_sequence';
+const BackfillBatchSize = 10000;
+const RepairBatchSize = 1000;
+const MaxGeneratedSlugLength = 255;
+const LockTimeout = '5s';
+
+/**
+ * Adds the direct project-scoped slug contract for data apps.
+ *
+ * apps.project_uuid has been a NOT NULL project FK since the table was created.
+ * This migration validates that historical ownership contract, then:
+ *
+ * 1. Adds a nullable slug with a sequence default for rolling compatibility.
+ * 2. Backfills missing slugs from names, with an app sequence fallback.
+ * 3. Adds a NOT VALID non-null check and backfills again.
+ * 4. Repairs same-project duplicates in bounded batches.
+ * 5. Builds the unique index concurrently and attaches it as a constraint.
+ * 6. Validates and promotes the slug non-null check.
+ *
+ * Active apps win duplicate ties, but deleted apps still participate because
+ * they can be restored. Every phase is idempotent and safe to resume after the
+ * Knex migration lock has been released.
+ */
+
+const logProgress = (message: string): void => {
+    // eslint-disable-next-line no-console
+    console.log(`  ${AppsTableName}: ${message}`);
+};
+
+const getRowCount = (result: { rowCount?: number }): number =>
+    result.rowCount ?? 0;
+
+const isUniqueViolation = (error: unknown): boolean =>
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    error.code === '23505';
+
+async function withLockTimeout<T>(
+    knex: Knex,
+    callback: (trx: Knex.Transaction) => Promise<T>,
+): Promise<T> {
+    return knex.transaction(async (trx) => {
+        await trx.raw(`SET LOCAL lock_timeout = '${LockTimeout}'`);
+        return callback(trx);
+    });
+}
+
+async function constraintExists(
+    knex: Knex,
+    constraintName: string,
+    constraintType?: 'f' | 'u',
+): Promise<boolean> {
+    const result = await knex.raw<{ rowCount: number }>(
+        `SELECT 1
+         FROM pg_constraint
+         WHERE conname = ?
+           AND conrelid = ?::regclass
+           ${constraintType ? 'AND contype = ?' : ''}`,
+        constraintType
+            ? [constraintName, AppsTableName, constraintType]
+            : [constraintName, AppsTableName],
+    );
+    return getRowCount(result) > 0;
+}
+
+async function isColumnNotNull(
+    knex: Knex,
+    columnName: 'project_uuid' | 'slug',
+): Promise<boolean> {
+    const result = await knex.raw<{ rows: Array<{ attnotnull: boolean }> }>(
+        `SELECT attnotnull
+         FROM pg_attribute
+         WHERE attrelid = ?::regclass
+           AND attname = ?
+           AND NOT attisdropped`,
+        [AppsTableName, columnName],
+    );
+    return result.rows[0]?.attnotnull ?? false;
+}
+
+async function ensureSlugColumn(knex: Knex): Promise<void> {
+    await knex.raw(`CREATE SEQUENCE IF NOT EXISTS ${AppSlugSequence}`);
+
+    if (!(await knex.schema.hasColumn(AppsTableName, 'slug'))) {
+        logProgress('adding the slug column');
+        await withLockTimeout(knex, async (trx) => {
+            await trx.raw(`
+                ALTER TABLE ${AppsTableName}
+                ADD COLUMN IF NOT EXISTS slug text
+            `);
+        });
+    }
+
+    // Older pods omit slug during a rolling deploy. The sequence keeps those
+    // temporary slugs readable and collision-free.
+    await withLockTimeout(knex, async (trx) => {
+        await trx.raw(`
+            ALTER TABLE ${AppsTableName}
+            ALTER COLUMN slug
+            SET DEFAULT ('app-' || nextval('${AppSlugSequence}')::text)
+        `);
+    });
+}
+
+async function ensureProjectContract(knex: Knex): Promise<void> {
+    if (!(await isColumnNotNull(knex, 'project_uuid'))) {
+        if (!(await constraintExists(knex, ProjectNotNullCheck))) {
+            logProgress('adding the project UUID not-null check');
+            await withLockTimeout(knex, async (trx) => {
+                await trx.raw(`
+                    ALTER TABLE ${AppsTableName}
+                    ADD CONSTRAINT ${ProjectNotNullCheck}
+                    CHECK (project_uuid IS NOT NULL)
+                    NOT VALID
+                `);
+            });
+        }
+
+        logProgress('validating project UUID non-nullability');
+        await withLockTimeout(knex, async (trx) => {
+            await trx.raw(`
+                ALTER TABLE ${AppsTableName}
+                VALIDATE CONSTRAINT ${ProjectNotNullCheck}
+            `);
+        });
+        await withLockTimeout(knex, async (trx) => {
+            await trx.raw(`
+                ALTER TABLE ${AppsTableName}
+                ALTER COLUMN project_uuid SET NOT NULL,
+                DROP CONSTRAINT IF EXISTS ${ProjectNotNullCheck}
+            `);
+        });
+    }
+
+    if (!(await constraintExists(knex, ProjectForeignKey, 'f'))) {
+        logProgress('adding the project foreign key without validation');
+        await withLockTimeout(knex, async (trx) => {
+            await trx.raw(`
+                ALTER TABLE ${AppsTableName}
+                ADD CONSTRAINT ${ProjectForeignKey}
+                FOREIGN KEY (project_uuid)
+                REFERENCES projects(project_uuid)
+                ON DELETE CASCADE
+                NOT VALID
+            `);
+        });
+    }
+
+    logProgress('validating the project foreign key');
+    await withLockTimeout(knex, async (trx) => {
+        await trx.raw(`
+            ALTER TABLE ${AppsTableName}
+            VALIDATE CONSTRAINT ${ProjectForeignKey}
+        `);
+    });
+}
+
+async function backfillMissingSlugs(knex: Knex): Promise<void> {
+    let totalUpdated = 0;
+    for (;;) {
+        // eslint-disable-next-line no-await-in-loop
+        const result = await withLockTimeout(knex, async (trx) =>
+            trx.raw<{ rowCount: number }>(`
+                WITH batch AS (
+                    SELECT
+                        app_id,
+                        LEFT(
+                            CASE
+                                WHEN TRIM(
+                                    BOTH '-' FROM REGEXP_REPLACE(
+                                        LOWER(name),
+                                        '[^a-z0-9]+',
+                                        '-',
+                                        'g'
+                                    )
+                                ) = ''
+                                    THEN 'app-' ||
+                                        nextval('${AppSlugSequence}')::text
+                                ELSE TRIM(
+                                    BOTH '-' FROM REGEXP_REPLACE(
+                                        LOWER(name),
+                                        '[^a-z0-9]+',
+                                        '-',
+                                        'g'
+                                    )
+                                )
+                            END,
+                            ${MaxGeneratedSlugLength}
+                        ) AS slug
+                    FROM ${AppsTableName}
+                    WHERE slug IS NULL OR slug = ''
+                    ORDER BY app_id
+                    LIMIT ${BackfillBatchSize}
+                )
+                UPDATE ${AppsTableName} AS apps
+                SET slug = batch.slug
+                FROM batch
+                WHERE apps.app_id = batch.app_id
+                  AND (apps.slug IS NULL OR apps.slug = '')
+            `),
+        );
+        const updated = getRowCount(result);
+        if (updated === 0) break;
+        totalUpdated += updated;
+        logProgress(`backfilled slug for ${totalUpdated} rows`);
+    }
+}
+
+async function addSlugNotNullCheck(knex: Knex): Promise<void> {
+    if (
+        (await isColumnNotNull(knex, 'slug')) ||
+        (await constraintExists(knex, SlugNotNullCheck))
+    ) {
+        return;
+    }
+
+    logProgress('adding the slug not-null check');
+    await withLockTimeout(knex, async (trx) => {
+        await trx.raw(`
+            ALTER TABLE ${AppsTableName}
+            ADD CONSTRAINT ${SlugNotNullCheck}
+            CHECK (slug IS NOT NULL)
+            NOT VALID
+        `);
+    });
+}
+
+async function deduplicateSlugs(knex: Knex): Promise<void> {
+    let totalUpdated = 0;
+    for (;;) {
+        // eslint-disable-next-line no-await-in-loop
+        const result = await withLockTimeout(knex, async (trx) =>
+            trx.raw<{ rowCount: number }>(`
+                WITH ranked AS (
+                    SELECT
+                        app_id,
+                        project_uuid,
+                        slug,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY project_uuid, slug
+                            ORDER BY
+                                (deleted_at IS NULL) DESC,
+                                created_at,
+                                app_id
+                        ) AS duplicate_number
+                    FROM ${AppsTableName}
+                ), duplicate_rows AS (
+                    SELECT app_id, project_uuid, slug
+                    FROM ranked
+                    WHERE duplicate_number > 1
+                    ORDER BY project_uuid, slug, app_id
+                    LIMIT ${RepairBatchSize}
+                ), replacements AS (
+                    SELECT
+                        duplicate_rows.app_id,
+                        duplicate_rows.project_uuid,
+                        duplicate_rows.slug AS original_slug,
+                        replacement.candidate
+                    FROM duplicate_rows
+                    CROSS JOIN LATERAL (
+                        WITH RECURSIVE candidate_numbers(candidate_number) AS (
+                            SELECT nextval('${AppSlugSequence}')::text
+                            UNION ALL
+                            SELECT nextval('${AppSlugSequence}')::text
+                            FROM candidate_numbers
+                            WHERE EXISTS (
+                                SELECT 1
+                                FROM ${AppsTableName} AS existing
+                                WHERE existing.project_uuid =
+                                        duplicate_rows.project_uuid
+                                  AND existing.slug =
+                                        LEFT(
+                                            duplicate_rows.slug,
+                                            GREATEST(
+                                                0,
+                                                ${MaxGeneratedSlugLength} - 1 -
+                                                CHAR_LENGTH(
+                                                    candidate_numbers.candidate_number
+                                                )
+                                            )
+                                        ) || '-' ||
+                                        candidate_numbers.candidate_number
+                                  AND existing.app_id <>
+                                        duplicate_rows.app_id
+                            )
+                        )
+                        SELECT
+                            LEFT(
+                                duplicate_rows.slug,
+                                GREATEST(
+                                    0,
+                                    ${MaxGeneratedSlugLength} - 1 -
+                                    CHAR_LENGTH(
+                                        candidate_numbers.candidate_number
+                                    )
+                                )
+                            ) || '-' ||
+                            candidate_numbers.candidate_number AS candidate
+                        FROM candidate_numbers
+                        WHERE NOT EXISTS (
+                            SELECT 1
+                            FROM ${AppsTableName} AS existing
+                            WHERE existing.project_uuid =
+                                    duplicate_rows.project_uuid
+                              AND existing.slug =
+                                    LEFT(
+                                        duplicate_rows.slug,
+                                        GREATEST(
+                                            0,
+                                            ${MaxGeneratedSlugLength} - 1 -
+                                            CHAR_LENGTH(
+                                                candidate_numbers.candidate_number
+                                            )
+                                        )
+                                    ) || '-' ||
+                                    candidate_numbers.candidate_number
+                              AND existing.app_id <> duplicate_rows.app_id
+                        )
+                        LIMIT 1
+                    ) AS replacement
+                )
+                UPDATE ${AppsTableName} AS apps
+                SET slug = replacements.candidate
+                FROM replacements
+                WHERE apps.app_id = replacements.app_id
+                  AND apps.project_uuid = replacements.project_uuid
+                  AND apps.slug = replacements.original_slug
+            `),
+        );
+        const updated = getRowCount(result);
+        if (updated === 0) break;
+        totalUpdated += updated;
+        logProgress(`deduplicated slug for ${totalUpdated} rows`);
+    }
+}
+
+async function dropInvalidIndex(knex: Knex, indexName: string): Promise<void> {
+    const invalidIndex = await knex.raw<{ rowCount: number }>(
+        `SELECT 1
+         FROM pg_class
+         JOIN pg_index ON pg_index.indexrelid = pg_class.oid
+         WHERE pg_class.relname = ?
+           AND pg_index.indrelid = ?::regclass
+           AND NOT pg_index.indisvalid`,
+        [indexName, AppsTableName],
+    );
+    if (getRowCount(invalidIndex) > 0) {
+        logProgress(`dropping invalid index ${indexName} from a prior run`);
+        await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS ${indexName}`);
+    }
+}
+
+async function ensureProjectSlugLookupIndex(knex: Knex): Promise<void> {
+    await dropInvalidIndex(knex, ProjectSlugLookupIndex);
+    logProgress(
+        'building the temporary project slug lookup index concurrently',
+    );
+    await knex.raw(`
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS ${ProjectSlugLookupIndex}
+        ON ${AppsTableName} (project_uuid, slug)
+    `);
+}
+
+async function dropProjectSlugLookupIndex(knex: Knex): Promise<void> {
+    await knex.raw(
+        `DROP INDEX CONCURRENTLY IF EXISTS ${ProjectSlugLookupIndex}`,
+    );
+}
+
+async function createProjectSlugConstraint(knex: Knex): Promise<void> {
+    if (await constraintExists(knex, ProjectSlugUniqueConstraint, 'u')) {
+        await dropProjectSlugLookupIndex(knex);
+        return;
+    }
+
+    await ensureProjectSlugLookupIndex(knex);
+
+    for (;;) {
+        // eslint-disable-next-line no-await-in-loop
+        await dropInvalidIndex(knex, ProjectSlugUniqueConstraint);
+        // eslint-disable-next-line no-await-in-loop
+        await deduplicateSlugs(knex);
+
+        try {
+            logProgress('building the project slug unique index concurrently');
+            // eslint-disable-next-line no-await-in-loop
+            await knex.raw(`
+                CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS
+                    ${ProjectSlugUniqueConstraint}
+                ON ${AppsTableName} (project_uuid, slug)
+            `);
+            break;
+        } catch (error) {
+            if (!isUniqueViolation(error)) throw error;
+            logProgress(
+                'a concurrent duplicate appeared during index creation; retrying',
+            );
+        }
+    }
+
+    await withLockTimeout(knex, async (trx) => {
+        if (!(await constraintExists(trx, ProjectSlugUniqueConstraint, 'u'))) {
+            logProgress('attaching the project slug unique constraint');
+            await trx.raw(`
+                ALTER TABLE ${AppsTableName}
+                ADD CONSTRAINT ${ProjectSlugUniqueConstraint}
+                UNIQUE USING INDEX ${ProjectSlugUniqueConstraint}
+            `);
+        }
+    });
+    await dropProjectSlugLookupIndex(knex);
+}
+
+async function enforceSlugNotNull(knex: Knex): Promise<void> {
+    if (await isColumnNotNull(knex, 'slug')) {
+        await withLockTimeout(knex, async (trx) => {
+            await trx.raw(`
+                ALTER TABLE ${AppsTableName}
+                DROP CONSTRAINT IF EXISTS ${SlugNotNullCheck}
+            `);
+        });
+        return;
+    }
+
+    logProgress('validating slug non-nullability');
+    await withLockTimeout(knex, async (trx) => {
+        await trx.raw(`
+            ALTER TABLE ${AppsTableName}
+            VALIDATE CONSTRAINT ${SlugNotNullCheck}
+        `);
+    });
+
+    logProgress('setting slug NOT NULL');
+    await withLockTimeout(knex, async (trx) => {
+        await trx.raw(`
+            ALTER TABLE ${AppsTableName}
+            ALTER COLUMN slug SET NOT NULL,
+            DROP CONSTRAINT IF EXISTS ${SlugNotNullCheck}
+        `);
+    });
+}
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw('SET statement_timeout = 0');
+    try {
+        await ensureSlugColumn(knex);
+        await ensureProjectContract(knex);
+        await backfillMissingSlugs(knex);
+        await addSlugNotNullCheck(knex);
+        await backfillMissingSlugs(knex);
+        await createProjectSlugConstraint(knex);
+        await enforceSlugNotNull(knex);
+        logProgress('project-scoped data app slug contract complete');
+    } finally {
+        await knex.raw('RESET statement_timeout');
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await withLockTimeout(knex, async (trx) => {
+        await trx.raw(`
+            ALTER TABLE ${AppsTableName}
+            DROP CONSTRAINT IF EXISTS ${ProjectSlugUniqueConstraint},
+            DROP CONSTRAINT IF EXISTS ${SlugNotNullCheck}
+        `);
+    });
+    await knex.raw(
+        `DROP INDEX CONCURRENTLY IF EXISTS ${ProjectSlugUniqueConstraint}`,
+    );
+    await dropProjectSlugLookupIndex(knex);
+    await withLockTimeout(knex, async (trx) => {
+        await trx.raw(`
+            ALTER TABLE ${AppsTableName}
+            DROP COLUMN IF EXISTS slug
+        `);
+    });
+    await knex.raw(`DROP SEQUENCE IF EXISTS ${AppSlugSequence}`);
+}

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -1,6 +1,7 @@
 import {
     APP_VERSION_CANCELLED_BY_USER,
     DATA_APP_VIZ_TEMPLATE,
+    generateSlug,
     NotFoundError,
     ProjectType,
     type AppVersionDependencies,
@@ -10,6 +11,7 @@ import {
     type KnexPaginatedData,
 } from '@lightdash/common';
 import { Knex } from 'knex';
+import { v4 as uuidv4 } from 'uuid';
 import {
     APP_VERSION_TERMINAL_STATUSES,
     AppsTableName,
@@ -31,10 +33,16 @@ import { ProjectTableName } from '../database/entities/projects';
 import { SpaceTableName } from '../database/entities/spaces';
 import { UserTableName } from '../database/entities/users';
 import KnexPaginate from '../database/pagination';
+import {
+    acquireProjectSlugLock,
+    generateUniqueSlugScopedToProject,
+} from '../utils/SlugUtils';
 
 type AppModelArguments = {
     database: Knex;
 };
+
+const AppSlugSequence = 'apps_slug_sequence';
 
 export class AppModel {
     private readonly database: Knex;
@@ -63,8 +71,31 @@ export class AppModel {
         vizSchema?: DataAppVizSchema,
     ): Promise<{ app: DbApp; version: DbAppVersion }> {
         return this.database.transaction(async (trx) => {
+            const appId = app.app_id ?? uuidv4();
+            const appName = app.name ?? '';
+            const hasSlugName = /[a-z0-9]/i.test(appName);
+            const slugSource = hasSlugName
+                ? appName
+                : (
+                      await trx.raw<{ rows: Array<{ slug: string }> }>(
+                          `SELECT 'app-' || nextval(?)::text AS slug`,
+                          [AppSlugSequence],
+                      )
+                  ).rows[0].slug;
+            const baseSlug = generateSlug(slugSource).slice(0, 255);
+            await acquireProjectSlugLock(trx, app.project_uuid, baseSlug);
+            const slug = await generateUniqueSlugScopedToProject(
+                trx,
+                app.project_uuid,
+                AppsTableName,
+                baseSlug,
+            );
             const [appRow] = await trx(AppsTableName)
-                .insert(app)
+                .insert({
+                    ...app,
+                    app_id: appId,
+                    slug,
+                })
                 .returning('*');
             const [versionRow] = await trx(AppVersionsTableName)
                 .insert({

--- a/packages/backend/src/utils/SlugUtils.test.ts
+++ b/packages/backend/src/utils/SlugUtils.test.ts
@@ -1,5 +1,6 @@
 import knex from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import { AppsTableName } from '../database/entities/apps';
 import { DashboardsTableName } from '../database/entities/dashboards';
 import { ProjectTableName } from '../database/entities/projects';
 import { SavedChartsTableName } from '../database/entities/savedCharts';
@@ -35,18 +36,34 @@ describe('generateUniqueSlugScopedToProject', () => {
         },
     );
 
-    it('uses native project ownership for saved SQL charts', async () => {
-        tracker.on.select(SavedSqlTableName).responseOnce([]);
+    it.each([SavedSqlTableName, AppsTableName] as const)(
+        'uses native project ownership for %s',
+        async (tableName) => {
+            tracker.on.select(tableName).responseOnce([]);
 
-        await generateUniqueSlugScopedToProject(
+            await generateUniqueSlugScopedToProject(
+                database,
+                '22222222-2222-4222-8222-222222222222',
+                tableName,
+                'Orders',
+            );
+
+            const [query] = tracker.history.select;
+            expect(query.sql).toContain(`"${tableName}"."project_uuid"`);
+            expect(query.sql).not.toContain(`join "${ProjectTableName}"`);
+        },
+    );
+
+    it('caps generated app slugs at 255 characters', async () => {
+        tracker.on.select(AppsTableName).responseOnce([]);
+
+        const slug = await generateUniqueSlugScopedToProject(
             database,
             '22222222-2222-4222-8222-222222222222',
-            SavedSqlTableName,
-            'Orders',
+            AppsTableName,
+            'a'.repeat(300),
         );
 
-        const [query] = tracker.history.select;
-        expect(query.sql).toContain(`"${SavedSqlTableName}"."project_uuid"`);
-        expect(query.sql).not.toContain(`join "${ProjectTableName}"`);
+        expect(slug).toHaveLength(255);
     });
 });

--- a/packages/backend/src/utils/SlugUtils.ts
+++ b/packages/backend/src/utils/SlugUtils.ts
@@ -1,6 +1,7 @@
 import { assertUnreachable, generateSlug } from '@lightdash/common';
 import { Knex } from 'knex';
 import { customAlphabet as createCustomNanoid } from 'nanoid';
+import { AppsTableName } from '../database/entities/apps';
 import { DashboardsTableName } from '../database/entities/dashboards';
 import { ProjectTableName } from '../database/entities/projects';
 import { SavedChartsTableName } from '../database/entities/savedCharts';
@@ -8,6 +9,7 @@ import { SavedSqlTableName } from '../database/entities/savedSql';
 import { SpaceTableName } from '../database/entities/spaces';
 
 type SlugTables =
+    | typeof AppsTableName
     | typeof SavedChartsTableName
     | typeof SavedSqlTableName
     | typeof DashboardsTableName
@@ -104,7 +106,11 @@ export const generateUniqueSlugScopedToProject = async (
     tableName: SlugTables,
     name: string,
 ) => {
-    const baseSlug = generateSlug(name);
+    const generatedSlug = generateSlug(name);
+    const baseSlug =
+        tableName === AppsTableName
+            ? generatedSlug.slice(0, 255)
+            : generatedSlug;
     let matchingSlugs: string[];
     switch (tableName) {
         case SavedChartsTableName:
@@ -161,6 +167,13 @@ export const generateUniqueSlugScopedToProject = async (
                 .where(`${SavedSqlTableName}.slug`, 'like', `${baseSlug}%`)
                 .pluck(`${SavedSqlTableName}.slug`);
             break;
+        case AppsTableName:
+            matchingSlugs = await trx(AppsTableName)
+                .where(`${AppsTableName}.project_uuid`, projectUuid)
+                .select(`${AppsTableName}.slug`)
+                .where(`${AppsTableName}.slug`, 'like', `${baseSlug}%`)
+                .pluck(`${AppsTableName}.slug`);
+            break;
         case SpaceTableName:
             throw new Error('Not implemented');
         default:
@@ -170,11 +183,15 @@ export const generateUniqueSlugScopedToProject = async (
             );
     }
 
-    let slug = generateSlug(name);
+    let slug = baseSlug;
     let inc = 0;
     while (matchingSlugs.includes(slug)) {
         inc += 1;
-        slug = `${baseSlug}-${inc}`; // generate new slug with number suffix
+        const suffix = `-${inc}`;
+        slug =
+            tableName === AppsTableName
+                ? `${baseSlug.slice(0, 255 - suffix.length)}${suffix}`
+                : `${baseSlug}${suffix}`;
     }
     return slug;
 };


### PR DESCRIPTION
## What

- adds a stable `slug` to data apps and generates project-scoped slugs in the central app creation transaction
- validates the existing `project_uuid` foreign key and `NOT NULL` ownership contract
- backfills missing slugs, repairs same-project duplicates, and keeps deleted apps in the uniqueness set
- enforces `slug NOT NULL` and `UNIQUE (project_uuid, slug)`
- uses a PostgreSQL sequence for readable unnamed and conflict slugs such as `app-12` and `my-app-13`

## Slug behavior

- named apps use the normalized app name
- concurrent same-name app creation uses the existing project-scoped numeric suffix convention
- unnamed apps use `app-<sequence>`
- migration-time duplicate repairs use `<existing-slug>-<sequence>`
- occupied numeric candidates are skipped without changing the natural slug that already owns them
- sequence gaps after failed, rolled-back, or deleted creations are expected and preserve concurrency safety
- slugs remain stable when an app is renamed

## Migration safety

- adds the column as nullable before backfilling in 10,000-row committed batches
- gives old pods a sequence-backed database default when they omit `slug`
- adds and validates `NOT VALID` checks before metadata-only `SET NOT NULL`
- uses a temporary concurrent lookup index for efficient duplicate repair
- builds the final unique index concurrently, then attaches it as a constraint
- applies a 5-second lock timeout to blocking DDL
- detects invalid concurrent indexes left by an interrupted run and safely rebuilds them
- active apps retain the original slug; deleted apps remain unique because they can be restored

## Live migration matrix

| Scenario | Result |
| --- | --- |
| active and deleted apps share a slug | active app retained the base slug; other rows received sequence suffixes |
| same slug in different projects | preserved in both projects |
| empty and punctuation-only names | received readable `app-<sequence>` slugs |
| long generated slug | capped at 255 characters |
| next sequence suffix already belongs to a natural slug | occupied suffixes were skipped and natural slugs were preserved |
| migrate → rollback → migrate | clean; rollback removed the slug column and sequence while preserving project ownership |
| old-code insert omitting slug | database default produced a non-null sequence slug |
| explicit null, same-project duplicate, unknown project | rejected by database constraints |
| ten concurrent unnamed model creates | produced ten distinct sequential `app-<sequence>` slugs |
| five concurrent same-name model creates | produced the base slug followed by `-1` through `-4` |

A 100,017-row synthetic cold run with 95,002 duplicate repairs completed in **24.3 seconds** locally. The final state had zero null/empty/UUID slugs, zero duplicate groups, valid FK/unique constraints, and no temporary index left behind.

## Checks

- backend fast typecheck
- targeted backend ESLint and formatter
- `SlugUtils.test.ts` (5 tests)
- live model and PostgreSQL migrate/rollback/reapply scenarios above

Closes: PROD-9252
Relates: PROD-8968