### PR TITLE
fix(frontend): preserve groupBy as pivotConfig when saving AI dashboard artifacts

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/utils/dashboardChartConverter.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/dashboardChartConverter.ts
@@ -1,4 +1,5 @@
 import {
+    getGroupByDimensions,
     getWebAiChartConfig,
     type AiAgentChartTypeOption,
     type ApiAiAgentThreadMessageVizQuery,
@@ -29,17 +30,23 @@ function convertAiVisualizationToCreateSavedChartVersion(
         aiVizData;
     const { metricQuery } = query;
 
+    const webAiChartConfig = getWebAiChartConfig({
+        vizConfig: dashboardVisualization,
+        metricQuery,
+        maxQueryLimit: options.maxQueryLimit,
+        fieldsMap: aiVizData.query.fields,
+        overrideChartType: selectedChartType ?? undefined,
+    });
+
     // Use expanded chart config if available (user made custom changes to the chart),
     // otherwise generate config from dashboard visualization with chart type override
     const finalChartConfig =
-        expandedChartConfig ??
-        getWebAiChartConfig({
-            vizConfig: dashboardVisualization,
-            metricQuery,
-            maxQueryLimit: options.maxQueryLimit,
-            fieldsMap: aiVizData.query.fields,
-            overrideChartType: selectedChartType ?? undefined,
-        }).echartsConfig;
+        expandedChartConfig ?? webAiChartConfig.echartsConfig;
+
+    // The artifact preview pivots results by the groupBy hint; the saved chart
+    // needs the same dimensions persisted as pivotConfig or its series can't
+    // bind to the un-pivoted results and the chart renders flat.
+    const groupByDimensions = getGroupByDimensions(webAiChartConfig);
 
     // Create table config with proper column order
     const tableConfig = {
@@ -55,6 +62,9 @@ function convertAiVisualizationToCreateSavedChartVersion(
         tableName: metricQuery.exploreName,
         metricQuery,
         chartConfig: finalChartConfig,
+        pivotConfig: groupByDimensions?.length
+            ? { columns: groupByDimensions }
+            : undefined,
         tableConfig,
         dashboardUuid: options.dashboardUuid,
         dashboardName: options.dashboardName,


### PR DESCRIPTION
Saving an AI-generated dashboard artifact dropped the charts' grouping: visualizations specified with `groupBy`/`stackBars` were persisted with no `pivotConfig`, so the saved charts rendered flat even though the artifact preview was correct. The preview path derives pivot columns from the `groupBy` hint (`getGroupByDimensions`), but the client-side save converter built the `CreateSavedChartVersion` without ever replicating that derivation — the persisted series referenced per-group pivot values that the un-pivoted saved query could no longer produce.

The converter now computes the web AI chart config once and derives the pivot columns from it with the same `getGroupByDimensions` helper the preview uses, persisting them as `pivotConfig` when the visualization has a `groupBy` (ungrouped charts stay pivot-free). Verified end-to-end locally: re-saving a grouped stacked-bar dashboard artifact persists `pivot_dimensions` and the saved dashboard renders identically to the preview.

Closes: PROD-9242
Closes: #26183

🤖 Generated with [Claude Code](https://claude.com/claude-code)
