### PR TITLE
fix(filters): hide stale date value on 'is null' / 'is not null' badges

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/utils.test.ts
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/utils.test.ts
@@ -85,6 +85,31 @@ describe('getConditionalRuleLabel', () => {
         expect(result.value).toBe('a');
     });
 
+    it('should not show a value for is null / is not null operators even with stale values', () => {
+        const nullRule: BaseFilterRule = {
+            id: 'test-rule-id',
+            operator: FilterOperator.NULL,
+            values: ['2024-01-01'],
+        };
+        const notNullRule: BaseFilterRule = {
+            id: 'test-rule-id',
+            operator: FilterOperator.NOT_NULL,
+            values: ['2024-01-01'],
+        };
+
+        expect(
+            getConditionalRuleLabel(nullRule, FilterType.DATE, 'Created At'),
+        ).toEqual({
+            field: 'Created At',
+            operator: 'is null',
+            value: undefined,
+        });
+        expect(
+            getConditionalRuleLabel(notNullRule, FilterType.DATE, 'Created At')
+                .value,
+        ).toBeUndefined();
+    });
+
     it('should return correct labels for a number filter', () => {
         // Arrange
         const rule: BaseFilterRule = {

--- a/packages/frontend/src/components/common/Filters/FilterInputs/utils.ts
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/utils.ts
@@ -146,6 +146,14 @@ const getValueAsString = (
     const firstValue = values?.[0];
     const secondValue = values?.[1];
 
+    // Null operators take no value; ignore any stale values on the rule
+    if (
+        operator === FilterOperator.NULL ||
+        operator === FilterOperator.NOT_NULL
+    ) {
+        return undefined;
+    }
+
     switch (filterType) {
         case FilterType.STRING:
         case FilterType.NUMBER:
@@ -203,8 +211,6 @@ const getValueAsString = (
                     if (!isFilterRule(rule)) throw new Error('Invalid rule');
 
                     return rule.settings?.unitOfTime?.slice(0, -1) ?? 'day';
-                case FilterOperator.NULL:
-                case FilterOperator.NOT_NULL:
                 case FilterOperator.EQUALS:
                 case FilterOperator.NOT_EQUALS:
                 case FilterOperator.STARTS_WITH:

--- a/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.tsx
+++ b/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.tsx
@@ -31,7 +31,6 @@ import {
 } from '@tabler/icons-react';
 import { useCallback, useMemo, type FC, type MouseEvent } from 'react';
 import {
-    formatDisplayValue,
     getConditionalRuleLabel,
     getConditionalRuleLabelFromItem,
     getFilterRuleTables,
@@ -46,6 +45,7 @@ import FilterConfiguration from '../FilterConfiguration';
 import { useFilterBarPopovers } from '../FilterRequirements/useFilterBarPopovers';
 import { useFilterChipRequirementState } from '../FilterRequirements/useFilterChipRequirementState';
 import classes from './Filter.module.css';
+import { getTruncatedValuesDisplay } from './utils';
 
 type Props = {
     isEditMode: boolean;
@@ -216,39 +216,15 @@ const Filter: FC<Props> = ({
     }, [field?.type, filterRule.target.fallbackType]);
 
     // Truncated values display - show max 2 values with "+N" badge
-    // Skip for date filters since their values include units (e.g., "2 months")
-    const MAX_DISPLAYED_VALUES = 2;
-    const truncatedValuesDisplay = useMemo(() => {
-        // Don't use truncated display for date filters - they have formatted values
-        if (isDateFilter) {
-            return {
-                displayedValues: [],
-                additionalValues: [],
-                hasMore: false,
-            };
-        }
-
-        const values = filterRule.values;
-        if (!values || values.length === 0) {
-            return {
-                displayedValues: [],
-                additionalValues: [],
-                hasMore: false,
-            };
-        }
-
-        const formattedValues = values.map((v) =>
-            formatDisplayValue(String(v)),
-        );
-        const displayedValues = formattedValues.slice(0, MAX_DISPLAYED_VALUES);
-        const additionalValues = formattedValues.slice(MAX_DISPLAYED_VALUES);
-
-        return {
-            displayedValues,
-            additionalValues,
-            hasMore: additionalValues.length > 0,
-        };
-    }, [filterRule.values, isDateFilter]);
+    const truncatedValuesDisplay = useMemo(
+        () =>
+            getTruncatedValuesDisplay(
+                filterRule.values,
+                isDateFilter,
+                filterRule.operator,
+            ),
+        [filterRule.values, filterRule.operator, isDateFilter],
+    );
 
     const {
         showRequirementIcon,

--- a/packages/frontend/src/features/dashboardFilters/ActiveFilters/utils.test.ts
+++ b/packages/frontend/src/features/dashboardFilters/ActiveFilters/utils.test.ts
@@ -1,0 +1,74 @@
+import { FilterOperator } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { getTruncatedValuesDisplay } from './utils';
+
+const EMPTY = {
+    displayedValues: [],
+    additionalValues: [],
+    hasMore: false,
+};
+
+describe('getTruncatedValuesDisplay', () => {
+    it('should show no values for null operators that carry stale values', () => {
+        expect(
+            getTruncatedValuesDisplay(['42'], false, FilterOperator.NULL),
+        ).toEqual(EMPTY);
+        expect(
+            getTruncatedValuesDisplay(
+                ['completed', 'shipped'],
+                false,
+                FilterOperator.NOT_NULL,
+            ),
+        ).toEqual(EMPTY);
+    });
+
+    it('should show no values for date filters', () => {
+        expect(
+            getTruncatedValuesDisplay(
+                ['2024-01-01'],
+                true,
+                FilterOperator.EQUALS,
+            ),
+        ).toEqual(EMPTY);
+    });
+
+    it('should show no values when the rule has none', () => {
+        expect(
+            getTruncatedValuesDisplay([], false, FilterOperator.EQUALS),
+        ).toEqual(EMPTY);
+        expect(
+            getTruncatedValuesDisplay(undefined, false, FilterOperator.EQUALS),
+        ).toEqual(EMPTY);
+    });
+
+    it('should show up to two values without a "+N" badge', () => {
+        expect(
+            getTruncatedValuesDisplay(['1', '2'], false, FilterOperator.EQUALS),
+        ).toEqual({
+            displayedValues: ['1', '2'],
+            additionalValues: [],
+            hasMore: false,
+        });
+    });
+
+    it('should move values beyond the first two into additionalValues', () => {
+        expect(
+            getTruncatedValuesDisplay(
+                ['1', '2', '3', '4'],
+                false,
+                FilterOperator.EQUALS,
+            ),
+        ).toEqual({
+            displayedValues: ['1', '2'],
+            additionalValues: ['3', '4'],
+            hasMore: true,
+        });
+    });
+
+    it('should make leading and trailing whitespace visible', () => {
+        expect(
+            getTruncatedValuesDisplay([' a '], false, FilterOperator.EQUALS)
+                .displayedValues,
+        ).toEqual(['␣a␣']);
+    });
+});

--- a/packages/frontend/src/features/dashboardFilters/ActiveFilters/utils.ts
+++ b/packages/frontend/src/features/dashboardFilters/ActiveFilters/utils.ts
@@ -1,0 +1,43 @@
+import { FilterOperator, type DashboardFilterRule } from '@lightdash/common';
+import { formatDisplayValue } from '../../../components/common/Filters/FilterInputs/utils';
+
+const MAX_DISPLAYED_VALUES = 2;
+
+export type TruncatedValuesDisplay = {
+    displayedValues: string[];
+    additionalValues: string[];
+    hasMore: boolean;
+};
+
+const EMPTY_DISPLAY: TruncatedValuesDisplay = {
+    displayedValues: [],
+    additionalValues: [],
+    hasMore: false,
+};
+
+// Date values carry units (e.g. "2 months") and null operators take no value at
+// all, so both defer to the rule label instead of listing raw values.
+export const getTruncatedValuesDisplay = (
+    values: DashboardFilterRule['values'],
+    isDateFilter: boolean,
+    operator: FilterOperator,
+): TruncatedValuesDisplay => {
+    if (
+        isDateFilter ||
+        operator === FilterOperator.NULL ||
+        operator === FilterOperator.NOT_NULL
+    ) {
+        return EMPTY_DISPLAY;
+    }
+
+    if (!values || values.length === 0) return EMPTY_DISPLAY;
+
+    const formattedValues = values.map((v) => formatDisplayValue(String(v)));
+    const additionalValues = formattedValues.slice(MAX_DISPLAYED_VALUES);
+
+    return {
+        displayedValues: formattedValues.slice(0, MAX_DISPLAYED_VALUES),
+        additionalValues,
+        hasMore: additionalValues.length > 0,
+    };
+};


### PR DESCRIPTION
The `is null` / `is not null` operators take no value, but a leftover `values` array on the rule (e.g. after switching an existing date filter's operator to `is null`/`is not null`) was still formatted and shown in the filter badge/tooltip.

`getValueAsString` now returns no value for `NULL`/`NOT_NULL` operators regardless of any stale values, so badges show only the field name and operator.

Added a unit test covering a null-operator date rule that still carries a stale value.