### PR TITLE
feat(data-apps): declare and deliver viz config options

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.clarifyApp.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.clarifyApp.test.ts
@@ -244,33 +244,3 @@ describe('AppGenerateService.clarifyApp for app templates', () => {
         expect(system).toBe(CLARIFY_APP_SYSTEM_PROMPT);
     });
 });
-
-// Guards the prompt text itself. A data app viz has no say over the query, so
-// the viz prompt must never invite a question the user cannot answer at build
-// time — these are the assertions that would catch app framing creeping back in.
-describe('CLARIFY_VIZ_SYSTEM_PROMPT', () => {
-    it('keeps the shared bias against asking anything', () => {
-        expect(CLARIFY_VIZ_SYSTEM_PROMPT).toContain(
-            'DEFAULT TO ASKING NOTHING',
-        );
-    });
-
-    it('carries none of the app prompt data or layout guidance', () => {
-        expect(CLARIFY_VIZ_SYSTEM_PROMPT).not.toContain(
-            'Which tables or metrics to query',
-        );
-        expect(CLARIFY_VIZ_SYSTEM_PROMPT).not.toContain(
-            'Default time range, when',
-        );
-        expect(CLARIFY_VIZ_SYSTEM_PROMPT).not.toContain('single-page vs tabs');
-        expect(CLARIFY_VIZ_SYSTEM_PROMPT).not.toContain('layout density');
-        expect(CLARIFY_VIZ_SYSTEM_PROMPT).not.toContain('App kind context');
-    });
-
-    it('scopes the askable set to the component and its declared fields', () => {
-        // The three cases GLITCH-639 calls out as genuinely viz-shaped.
-        expect(CLARIFY_VIZ_SYSTEM_PROMPT).toMatch(/chart type/i);
-        expect(CLARIFY_VIZ_SYSTEM_PROMPT).toMatch(/series\/breakdown/i);
-        expect(CLARIFY_VIZ_SYSTEM_PROMPT).toMatch(/one metric or several/i);
-    });
-});

--- a/packages/backend/src/ee/services/AppGenerateService/clarifierPrompts.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/clarifierPrompts.ts
@@ -5,7 +5,8 @@
  * clarify time. An app queries the semantic layer, so its open questions are
  * data questions. A data app viz never queries anything — it is one reusable
  * chart component that renders the rows a host explore hands it — so its only
- * open questions are about the component and the fields it declares.
+ * open questions are about the component, the fields it declares, and the
+ * settings it leaves adjustable.
  */
 
 export const CLARIFY_APP_SYSTEM_PROMPT = `You help a user scope a React data app on top of their semantic layer before any code is written. Given the user's prompt, the kind of app they're building, and a summary of the available tables, decide whether 0–4 short clarifying questions would materially change what gets built.
@@ -44,13 +45,14 @@ Worth asking about (only when the prompt is silent on them):
 - Chart type, when the prompt describes an outcome without naming a form and several forms genuinely fit
 - Whether it needs a series/breakdown field to split or colour the data, when the prompt names neither a breakdown nor a plainly single-series shape
 - Whether the value axis carries one metric or several, when the prompt names no measure and the chart type doesn't settle it
+- Whether a display choice the prompt fixes (labels on or off, a layout, a row cap) should stay adjustable from the chart config panel, when the prompt reads as this-time preference rather than a fixed requirement
 
-Most prompts already settle all three. Each of these is worth at most one question, and only when the prompt genuinely leaves it open — asking about a breakdown or a metric count on a prompt that already implies one is the most common way to get this wrong.
+Most prompts already settle the first three. Each of these is worth at most one question, and only when the prompt genuinely leaves it open — asking about a breakdown or a metric count on a prompt that already implies one is the most common way to get this wrong.
 
 Do NOT ask about:
 - Which explore, table, dimension, metric or filter to use, or the time range — the component receives whatever the query returns and never chooses it. Never ask what the chart should display or measure. "What metric should the gauge show?" and "Which value goes on the y-axis?" are always wrong: the component declares named field slots (e.g. \`value\`, \`category\`) and whoever applies the visualization binds real fields to them later.
 - Audience, app structure, navigation, tabs, pages, filters or page layout — this is one chart, not an app.
-- Cosmetic details with reasonable defaults (colours, date format, number formatting, axis labels, legend placement, tooltip contents).
+- The value of a cosmetic detail (colours, date format, number formatting, axis labels, legend placement, tooltip contents) — reasonable defaults exist. Whether one of them stays adjustable is the separate question above.
 - Anything already stated in the prompt — even partially. A named chart type answers the chart type question; a stated breakdown ("by region", "per segment", "split by status") answers the series question; a single named measure answers the metric-count question.
 - Picking between two readings of a phrase when one is the obvious interpretation.
 - Multi-part or open-ended — each question must be answerable in one short line.

--- a/packages/backend/src/ee/services/AppGenerateService/templates.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/templates.ts
@@ -31,38 +31,20 @@ Build a print-optimized report:
 - \`window.print()\` can be a secondary Print action, but do not rely on it for the Download PDF button.
 - Prefer narrative copy with charts as supporting evidence, not a dense dashboard grid.`;
 
+// The viz build contract (the hook, the declaration, the option vocabulary, the
+// final pass) lives in the sandbox's `reusable-visualization` skill, so it sits alongside
+// the app-focused sandbox skill it overrides instead of competing with it from
+// the user prompt. This prompt only orients the request and loads that skill by
+// path — `Read(//app/**)` is allowlisted for every generation, so reading it
+// does not depend on the Skill tool being permitted.
 const DATA_APP_VIZ_INSTRUCTIONS = `[Data app viz]
 You are building ONE reusable chart component. You do NOT fetch data or run queries: Lightdash runs the query, then gives you the result rows plus a mapping from your field names to the columns in those rows. The same component is reused across many different queries, so never hardcode column names — just render whatever data you are handed.
 
-Three requirements, all mandatory:
+Before you write any code, read \`/app/.claude/skills/reusable-visualization/SKILL.md\` with the Read tool — the \`reusable-visualization\` skill. It is the contract for this build: the \`useVizContext()\` hook you take your data and settings from, the fields and config options you declare as structured output, the exact option vocabulary, the palette rule, and the final pass you run before you finish. Where it and the sandbox skill disagree, it wins. Follow it as written.
 
-1. Build ONE chart visualization component whose job is to make the mapped data easy to read at a glance. Build the chart type the user asked for; only if they didn't specify one, pick what best fits the fields (bars to compare categories, a line for a trend over time, etc.). Either way, get the fundamentals right: clear axes and labels, readable spacing, and a tooltip on hover. This is a single reusable visualization, not an app: no dashboard, navigation, multiple panels, filters, or page chrome. Recharts, echarts, D3, or plain SVG all work.
-   Fill the viewport: give your root element \`height: 100vh\` (or \`position: fixed; inset: 0\`), NOT \`height: 100%\` — that collapses to a 0-height invisible box unless every ancestor also sets a height. This gives auto-sizing charts like recharts \`<ResponsiveContainer>\` a real height to measure. Confirm the chart actually renders and isn't a blank box.
+Build the chart type the user asked for; only if they did not name one, pick what best fits the fields (bars to compare categories, a line for a trend over time).
 
-2. Get your data from the \`useVizContext()\` hook — do not add a message listener or fetch anything yourself:
-
-   import { useVizContext, getFormatted, getRaw } from '@lightdash/query-sdk';
-
-   function Chart() {
-     const { fieldMapping, rows, ready } = useVizContext();
-     if (!ready) return <Placeholder />;            // data hasn't arrived yet
-     const catField = fieldMapping['category'];     // your field name -> column id
-     const valField = fieldMapping['value'];
-     const data = rows.map((row) => ({
-       label: getFormatted(row, catField),          // display text, e.g. "Completed"
-       value: Number(getRaw(row, valField) ?? 0),   // raw number
-     }));
-     // ...render \`data\`
-   }
-
-   Show a clearly visible placeholder (readable, good contrast — never near-white on white) while \`!ready\`, when a field is unmapped, or when there are no rows.
-
-3. Declare the fields your component reads. This is collected as structured output (do NOT write a file); Lightdash uses it to build the field-mapping UI, so the component is unusable without it. For each field:
-   - \`name\`: the key you read from \`fieldMapping\` (unique, no spaces) — must match what you used above.
-   - \`label\`: human label shown in the mapping UI.
-   - \`type\`: \`dimension\` (category/grouping), \`metric\` (number), or \`series\` (a dimension used to split/colour).
-   - \`required\`: false only if the chart still renders without it.
-   Declare exactly what you read — no more, no less. e.g. "category" (dimension, required) + "value" (metric, required).`;
+You are done when the chart renders for real and the declaration you emit is the one that skill describes: every field and every config option the component reads, and nothing a viewer would plausibly want different left hardcoded.`;
 
 export const getTemplateInstructions = (
     template: DataAppTemplate,

--- a/packages/common/src/ee/apps/types.test.ts
+++ b/packages/common/src/ee/apps/types.test.ts
@@ -1,4 +1,6 @@
 import {
+    dataAppVizGenerationSchema,
+    dataAppVizJsonSchema,
     dataAppVizSchema,
     getEffectiveOptionValues,
     getVisibleDataAppClaudeModels,
@@ -355,5 +357,65 @@ describe('resolveDefaultVisibleDataAppClaudeModel', () => {
                 haiku: false,
             }),
         ).toBeNull();
+    });
+});
+
+describe('dataAppVizGenerationSchema', () => {
+    it('requires configOptions and colorPalette, unlike the persistence schema', () => {
+        expect(dataAppVizGenerationSchema.safeParse(validFields).success).toBe(
+            false,
+        );
+        expect(
+            dataAppVizGenerationSchema.safeParse({
+                ...validFields,
+                configOptions: [],
+            }).success,
+        ).toBe(false);
+        expect(
+            dataAppVizGenerationSchema.safeParse({
+                ...validFields,
+                configOptions: [],
+                colorPalette: null,
+            }).success,
+        ).toBe(true);
+    });
+
+    it('accepts the same vocabulary the persistence schema does', () => {
+        const declaration = {
+            ...validFields,
+            configOptions: [
+                {
+                    name: 'accent',
+                    label: 'Accent',
+                    type: 'color',
+                    default: '#7162FF',
+                },
+            ],
+            colorPalette: { group: 'Colours' },
+        };
+        expect(dataAppVizGenerationSchema.safeParse(declaration).success).toBe(
+            true,
+        );
+        expect(dataAppVizSchema.safeParse(declaration).success).toBe(true);
+    });
+});
+
+describe('dataAppVizJsonSchema', () => {
+    // What the generator CLI receives via --json-schema.
+    const jsonSchema = dataAppVizJsonSchema as {
+        required?: string[];
+        properties?: Record<string, { description?: string }>;
+    };
+
+    it('makes fields, configOptions and colorPalette required', () => {
+        expect(jsonSchema.required).toEqual(
+            expect.arrayContaining(['fields', 'configOptions', 'colorPalette']),
+        );
+    });
+
+    it('describes what each top-level property is for', () => {
+        expect(jsonSchema.properties?.fields.description).toBeTruthy();
+        expect(jsonSchema.properties?.configOptions.description).toBeTruthy();
+        expect(jsonSchema.properties?.colorPalette.description).toBeTruthy();
     });
 });

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -655,67 +655,140 @@ const uniqueNames = <T extends { name: string }>(arr: T[]): boolean =>
     new Set(arr.map((a) => a.name)).size === arr.length;
 
 const optionBase = {
-    name: z.string().min(1),
-    label: z.string(),
-    group: z.string().optional(),
+    name: z
+        .string()
+        .min(1)
+        .describe(
+            'Key the component reads from `options`. Unique across options, no spaces.',
+        ),
+    label: z
+        .string()
+        .describe('Human label shown next to the control in the config panel.'),
+    group: z
+        .string()
+        .optional()
+        .describe(
+            'Optional tab name. Options sharing a group are rendered in the same config tab; ungrouped options share a default tab.',
+        ),
 };
 
-// Runtime validator for the untrusted generated declaration. Also the source
-// for the JSON Schema embedded in the generation prompt.
+const vizFields = z
+    .array(
+        z.object({
+            name: z
+                .string()
+                .min(1)
+                .describe(
+                    'Key the component reads from `fieldMapping`. Unique across fields, no spaces.',
+                ),
+            label: z
+                .string()
+                .describe('Human label shown in the field-mapping UI.'),
+            type: z
+                .enum(['dimension', 'metric', 'series'])
+                .describe(
+                    'dimension = a category/grouping column, metric = a numeric measure, series = a dimension used to split or colour the chart.',
+                ),
+            required: z
+                .boolean()
+                .describe(
+                    'false only when the chart still renders with this field unmapped.',
+                ),
+        }),
+    )
+    .describe(
+        'Every data column the component reads. Declare exactly what you read — no more, no less.',
+    );
+
+const vizConfigOptions = z.array(
+    z.discriminatedUnion('type', [
+        z.object({
+            ...optionBase,
+            type: z.literal('boolean'),
+            default: z
+                .boolean()
+                .describe('Value used until the viewer changes it.'),
+        }),
+        z.object({
+            ...optionBase,
+            type: z.literal('select'),
+            choices: z
+                .array(
+                    z.object({
+                        value: z
+                            .string()
+                            .describe('Value delivered on `options`.'),
+                        label: z.string().describe('Human label in the list.'),
+                    }),
+                )
+                .min(1)
+                .describe('The selectable choices; at least one.'),
+            default: z
+                .string()
+                .describe('One of the declared choice `value`s.'),
+        }),
+        z.object({
+            ...optionBase,
+            type: z.literal('number'),
+            default: z
+                .number()
+                .describe('Value used until the viewer changes it.'),
+            min: z.number().optional().describe('Optional lower bound.'),
+            max: z.number().optional().describe('Optional upper bound.'),
+        }),
+        z.object({
+            ...optionBase,
+            type: z.literal('text'),
+            default: z
+                .string()
+                .describe('Value used until the viewer changes it.'),
+        }),
+        z.object({
+            ...optionBase,
+            type: z.literal('color'),
+            default: z
+                .string()
+                .describe('Hex colour used until the viewer changes it.'),
+        }),
+    ]),
+);
+
+const vizColorPalette = z
+    .object({
+        group: z
+            .string()
+            .optional()
+            .describe(
+                'Optional tab name, matching a config option `group`. The picker gets its own tab when no option shares it.',
+            ),
+    })
+    .nullable()
+    .describe(
+        'Declare this when the component colours anything from `colorPalette`. It surfaces the standard Lightdash palette picker, so the viz inherits the same colours as the charts around it. Not a config option: the chosen colours arrive on `colorPalette`, never on `options`. Null when the component colours nothing.',
+    );
+
+// Runtime validator for the untrusted generated declaration, and for schemas
+// round-tripped through an app manifest. `configOptions` defaults to `[]` so a
+// declaration persisted before config options existed still parses.
 export const dataAppVizSchema = z.object({
-    fields: z
-        .array(
-            z.object({
-                name: z.string().min(1),
-                label: z.string(),
-                type: z.enum(['dimension', 'metric', 'series']),
-                required: z.boolean(),
-            }),
-        )
-        .refine(uniqueNames, 'duplicate field name'),
-    configOptions: z
-        .array(
-            z.discriminatedUnion('type', [
-                z.object({
-                    ...optionBase,
-                    type: z.literal('boolean'),
-                    default: z.boolean(),
-                }),
-                z.object({
-                    ...optionBase,
-                    type: z.literal('select'),
-                    choices: z
-                        .array(
-                            z.object({ value: z.string(), label: z.string() }),
-                        )
-                        .min(1),
-                    default: z.string(),
-                }),
-                z.object({
-                    ...optionBase,
-                    type: z.literal('number'),
-                    default: z.number(),
-                    min: z.number().optional(),
-                    max: z.number().optional(),
-                }),
-                z.object({
-                    ...optionBase,
-                    type: z.literal('text'),
-                    default: z.string(),
-                }),
-                z.object({
-                    ...optionBase,
-                    type: z.literal('color'),
-                    default: z.string(),
-                }),
-            ]),
-        )
+    fields: vizFields.refine(uniqueNames, 'duplicate field name'),
+    configOptions: vizConfigOptions
         .default([])
         .refine(uniqueNames, 'duplicate option name'),
-    colorPalette: z
-        .object({ group: z.string().optional() })
-        .nullable()
-        .default(null),
+    colorPalette: vizColorPalette.default(null),
+});
+
+// The stricter contract handed to the generator CLI: `configOptions` and
+// `colorPalette` are required, so an empty declaration is a deliberate answer
+// rather than the shape of the schema's defaults.
+export const dataAppVizGenerationSchema = z.object({
+    fields: vizFields.refine(uniqueNames, 'duplicate field name'),
+    configOptions: vizConfigOptions
+        .refine(uniqueNames, 'duplicate option name')
+        .describe(
+            'Every setting the viewer can change from the chart config panel without regenerating the viz — one per literal the component would otherwise hardcode: what it shows or hides, which variant it picked, and the numbers and labels it wrote in. Each `name` must be a key the component reads from `options`. Series colours are not among them: declare `colorPalette` instead. Empty is only right for a component that hardcodes nothing a viewer would want different.',
+        ),
+    colorPalette: vizColorPalette,
 });
 
 // Compile-time guard: the zod schema's output type must match the explicit
@@ -725,16 +798,24 @@ type AssertMutuallyAssignable<A, B> = [A] extends [B]
         ? true
         : never
     : never;
+type AssertAssignable<A, B> = [A] extends [B] ? true : never;
 const dataAppVizSchemaMatchesApiType: AssertMutuallyAssignable<
     z.infer<typeof dataAppVizSchema>,
     DataAppVizSchema
 > = true;
 void dataAppVizSchemaMatchesApiType;
 
-// JSON Schema form of `dataAppVizSchema` for the generator CLI's `--json-schema`
-// flag. Refinements (e.g. unique names) don't survive the conversion and stay
-// enforced by the runtime `safeParse`.
-export const dataAppVizJsonSchema = zodToJsonSchema(dataAppVizSchema);
+// Whatever the generator emits must be persistable without a second shape.
+const dataAppVizGenerationSchemaIsPersistable: AssertAssignable<
+    z.infer<typeof dataAppVizGenerationSchema>,
+    DataAppVizSchema
+> = true;
+void dataAppVizGenerationSchemaIsPersistable;
+
+// JSON Schema form of the generation contract for the generator CLI's
+// `--json-schema` flag. Refinements (e.g. unique names) don't survive the
+// conversion and stay enforced by the runtime `safeParse`.
+export const dataAppVizJsonSchema = zodToJsonSchema(dataAppVizGenerationSchema);
 
 /** Whether a stored value still has the shape the option declares. */
 const matchesDeclaredType = (
@@ -819,12 +900,12 @@ export const APP_SDK_VIZ_CONTEXT_REQUEST_MESSAGE =
 // Host-owned render context pushed into a data app viz: field name → bound query
 // field id, the host-fetched result rows the renderer reads, the effective
 // config option values (stored value ?? declared default), and the palette
-// resolved for this chart. `colorPalette` is pushed whether or not the viz
-// declared one, so a viz that colours series never has to check first.
+// resolved for this chart (org → project → space → dashboard → chart, dark-mode
+// corrected). `colorPalette` is pushed whether or not the viz declared one, so a
+// viz that colours series never has to check first.
 export type DataAppVizContext = {
     fieldMapping: Record<string, string>;
     rows: ResultRow[];
     options: Record<string, DataAppVizOptionValue>;
-    // Resolved through the same org/project/space/dashboard cascade as native charts.
     colorPalette: string[];
 };

--- a/sandboxes/data-apps/e2b.Dockerfile
+++ b/sandboxes/data-apps/e2b.Dockerfile
@@ -42,8 +42,9 @@ RUN npx shadcn@2.3.0 add --overwrite --yes \
 # raw `var(--x)` + complete oklch colors is the single convention.
 COPY template/tailwind.config.js ./tailwind.config.js
 
-# Vendored Claude Code skills (e.g. frontend-design @ Apache-2.0). Auto-discovered
-# from /app/.claude/skills/ when Claude Code starts in the sandbox.
+# Claude Code skills — first-party plus vendored (frontend-design @ Apache-2.0).
+# The whole directory is copied, so a new skill needs no change here. Read from
+# /app/.claude/skills/ inside the sandbox.
 COPY template/.claude/ ./.claude/
 
 # E2B sandbox runs as 'user' — make /app writable

--- a/sandboxes/data-apps/template/.claude/skills/reusable-visualization/SKILL.md
+++ b/sandboxes/data-apps/template/.claude/skills/reusable-visualization/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: reusable-visualization
+description: Build ONE reusable chart visualization component that receives its data and its settings from the host application instead of fetching them, and declares the fields and config options the host exposes to viewers. Use this whenever a single chart component is reused across many different queries rather than built for one — in Lightdash, the `data_app_viz` app template, also called a "viz". Covers the `useVizContext()` hook, the declaration contract, the config-option vocabulary, and series colours.
+---
+
+# Reusable visualization
+
+This is ONE reusable chart component, not an app. It runs no query and owns no explore.
+Lightdash runs the query, then hands the component the result rows plus a mapping from the
+field names the component declared to the columns in those rows. The same component is
+reused across many different queries — every contract below follows from that: it cannot
+hardcode column names, so it declares a field mapping; it cannot hardcode display choices
+for queries it has never seen, so it declares config options.
+
+No dashboard, navigation, multiple panels, filters or page chrome. Recharts, echarts, D3 or
+plain SVG all work.
+
+Everything the viewer can reach later exists only because the component declared it: the
+columns they map, and every control in the chart's config panel. A literal hardcoded
+instead stays frozen until somebody regenerates the whole viz.
+
+## The hook
+
+`useVizContext()` from `@lightdash/query-sdk` is the only source of data and settings. Do
+not add a message listener and do not fetch anything.
+
+```tsx
+const { fieldMapping, rows, options, colorPalette, ready } = useVizContext();
+```
+
+- `fieldMapping` — `Record<string, string>`: the field name you declared → the query field
+  id it is bound to. Read cells with `getFormatted(row, fieldId)` (display text) and
+  `getRaw(row, fieldId)` (raw value).
+- `rows` — the host-fetched result rows, keyed by query field id.
+- `options` — `Record<string, boolean | number | string>`: the current value of each config
+  option you declared (the viewer's choice, else your declared `default`).
+- `colorPalette` — `string[]`: the Lightdash palette resolved for this chart. Always pushed,
+  whether or not you declared `colorPalette`. Empty only when the host resolved none.
+- `ready` — false until the first context arrives.
+
+Read all five. Ignoring `options` and `colorPalette` is the most common way to build a viz
+nobody can configure.
+
+### These app-level APIs do not apply to a viz
+
+The sandbox skill (`/app/skill.md`) is written for data apps, which do run queries. A
+reusable visualization does not. Do **not** use `useLightdash()`, `filtersFor(EXPLORE)`,
+`addFilter({...})`, or `format(row, fieldName)` — there is no explore to query or filter,
+and formatting arrives pre-computed via `getFormatted`. Where this skill and the sandbox
+skill differ, this skill wins for a viz. Everything else in the sandbox skill (React,
+shadcn, charting, theming, floating surfaces, screenshots) still applies.
+
+## Rendering rules
+
+- **Fill the viewport.** Give the root element `height: 100vh` (or `position: fixed; inset: 0`),
+  NOT `height: 100%` — that collapses to a 0-height invisible box unless every ancestor also
+  sets a height, leaving auto-sizing charts like recharts `<ResponsiveContainer>` nothing to
+  measure. Confirm the chart actually renders and isn't a blank box.
+- **Placeholder.** Show a clearly visible placeholder (readable, good contrast — never
+  near-white on white) while `!ready`, when a required field is unmapped, or when there are
+  no rows.
+- **Fundamentals.** Clear axes and labels, readable spacing, a tooltip on hover.
+  Give every axis a `tickFormatter` (compact numbers, shortened labels) or `hide`
+  it — raw ticks overflow and overlap on a chart the viewer can resize.
+
+## Series colours
+
+Never hardcode series hex values and never hand-pick a palette of your own. Colour series
+with `colorPalette[i % colorPalette.length]`, and declare `colorPalette` in your output so
+the viewer gets the palette picker. Keep a small fallback array in your own code for the
+case where `colorPalette` is empty.
+
+This is the same rule as the sandbox skill's "chart series colors must come from
+`CHART_COLORS`" and `references/d3.md`'s "never hand-pick palettes" — the same Lightdash
+palette, delivered differently. An app imports `CHART_COLORS`; a viz reads the resolved
+colours off the hook, because the viewer picks the palette per chart. In a viz, use the
+hook, not `CHART_COLORS`.
+
+## The declaration
+
+Alongside the component you emit one structured declaration — as **structured output, not a
+file**. It has three parts: `fields`, `configOptions` and `colorPalette`. Lightdash builds
+the field-mapping UI and the chart config panel from it, so the component is unusable
+without it.
+
+The correspondence is exact in both directions: **every key read from `fieldMapping` or
+`options` is declared, and everything declared is read.** A declared option nothing reads is
+a dead control the viewer can move with no effect.
+
+### `fields`
+
+One entry per data column the component reads:
+
+- `name` — the key read from `fieldMapping`. Unique, no spaces.
+- `label` — human label shown in the mapping UI.
+- `type` — `dimension` (a category/grouping column), `metric` (a numeric measure), or
+  `series` (a dimension used to split or colour the chart).
+- `required` — `false` only when the chart still renders with this field unmapped.
+
+### `configOptions`
+
+One entry per setting the viewer can change without regenerating the viz. Every option is a
+whole-viz value applying to the entire chart — there is no per-series option. To colour
+series individually, index into `colorPalette` by series position.
+
+Every option has:
+
+- `name` — the key read from `options`. Unique, no spaces.
+- `label` — human label shown next to the control.
+- `group` — optional tab name. Options sharing a `group` are rendered in the same config
+  tab; ungrouped options share a default tab.
+- `default` — REQUIRED on every option. The value the viz uses until the viewer changes it;
+  its shape follows `type`. Use the value you would otherwise have hardcoded.
+- `type` — exactly one of these five, no others:
+
+| `type` | control | `default` | extra keys |
+|---|---|---|---|
+| `boolean` | switch | `true` / `false` | — |
+| `select` | dropdown | one of the declared choice `value`s (a string) | `choices`: array of `{ "value": "...", "label": "..." }`, at least one entry |
+| `number` | number input | a number | `min`, `max` — both optional numbers |
+| `text` | single-line text input | a string | — |
+| `color` | single colour | a hex string, e.g. `"#7162FF"` | — |
+
+Series colours are not in this list. They are declared separately, on `colorPalette`.
+
+### `colorPalette`
+
+Whether the viewer gets the standard Lightdash palette picker. Declare
+`{ "group": "..." }` when your component colours anything from `colorPalette`, or `null`
+when it colours nothing. `group` is optional and works like an option's: the picker joins
+that tab, and gets a tab of its own when no option shares the name.
+
+This is not a config option. There is one palette per chart, it has no `name` and no
+`default`, and its colours arrive on `colorPalette` — never on `options`.
+
+## Worked example
+
+Component and declaration lining up. Your chart will differ; the correspondence must not.
+
+```tsx
+import { useVizContext, getFormatted, getRaw } from '@lightdash/query-sdk';
+import { Bar, BarChart, Cell, LabelList, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+
+function Chart() {
+  const { fieldMapping, rows, options, colorPalette, ready } = useVizContext();
+  if (!ready) return <div style={{ height: '100vh' }}>Loading…</div>;
+  const catField = fieldMapping['category'];            // your field name -> column id
+  const valField = fieldMapping['value'];
+  const showLabels = options['showLabels'] as boolean;  // your option name -> current value
+  const maxBars = options['maxBars'] as number;
+  const colors = colorPalette.length ? colorPalette : ['#7162FF', '#1A1B1E'];
+  const data = rows.slice(0, maxBars).map((row) => ({
+    label: getFormatted(row, catField),                 // display text, e.g. "Completed"
+    value: Number(getRaw(row, valField) ?? 0),          // raw number
+  }));
+  return (
+    // The root fills the viewport, so ResponsiveContainer has a height to measure.
+    <div style={{ height: '100vh' }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data}>
+          <XAxis
+            dataKey="label"
+            tickFormatter={(v) => (v.length > 12 ? `${v.slice(0, 11)}…` : v)}
+          />
+          <YAxis tickFormatter={(v) => v.toLocaleString()} />
+          <Tooltip />
+          <Bar dataKey="value">
+            {data.map((d, i) => <Cell key={d.label} fill={colors[i % colors.length]} />)}
+            {showLabels && <LabelList dataKey="value" position="top" />}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+```
+
+The declaration that component emits is exactly:
+
+```
+fields: [{ "name": "category", "label": "Category", "type": "dimension", "required": true },
+         { "name": "value", "label": "Value", "type": "metric", "required": true }]
+configOptions: [{ "name": "showLabels", "label": "Show value labels", "group": "Labels", "type": "boolean", "default": true },
+                { "name": "maxBars", "label": "Max bars", "type": "number", "default": 10, "min": 1, "max": 50 }]
+colorPalette: {}
+```
+
+## Final pass, before you finish
+
+Re-read the component you just wrote and list every literal in it: each colour, each
+true/false you chose, each number, each string you typed into the chart. Take the list one
+entry at a time and ask "would a viewer plausibly want this different?". This is the
+minimum, not a menu:
+
+- every element you chose to show or hide (value labels, legend, gridlines, an axis) → `boolean`
+- every variant you picked between (vertical/horizontal, grouped/stacked, curve style) → `select`
+- every number you chose (bar width, max rows, decimal places, a threshold) → `number`
+- every string you wrote into the chart (title, axis label, empty-state text) → `text`
+- every accent colour that is not a series colour (a target line, a highlight) → `color`
+- the series colours, whenever the chart draws more than one series → `colorPalette`
+
+Where the answer is yes, make that literal the option's `default`, declare the option, and
+read the option in its place. Leave it hardcoded only where changing it would break the
+chart.
+
+Then check both directions: every key you read from `options` is declared, and every option
+you declared is read somewhere. `colorPalette` is declared when you colour from
+`colorPalette` — it is never read from `options`.

--- a/sandboxes/data-apps/template/skill.md
+++ b/sandboxes/data-apps/template/skill.md
@@ -2,6 +2,8 @@
 
 You are building a React data app that queries the Lightdash semantic layer. This file is your reference for the environment, SDK, and data model.
 
+**Building a single reusable chart rather than an app?** Read `.claude/skills/reusable-visualization/SKILL.md` before writing any code. A reusable visualization runs no query of its own — the host hands it rows, a field mapping, config option values and a colour palette — so the data and filter APIs below do not apply to it. That skill is the contract for those builds and overrides this guide wherever the two differ. Everything else here (environment, components, visual design) still applies.
+
 ## Iteration mindset
 
 This pipeline is built for iteration — the user refines the app with follow-up prompts, and you have the full conversation history on every iteration. **Favor a responsive first build over upfront perfection.** Hit the core ask and ship; let the user tell you what to add.


### PR DESCRIPTION
Stacked on #26207. This half gets the model to declare config options and gives the viz what it needs to read them.

**The prompt alone was not enough.** Three rounds of rewriting the generation prompt changed nothing — six consecutive live generations declared zero options and hardcoded their colours. The viz contract sat in the user prompt, competing with a large app-focused system prompt that teaches APIs a viz cannot use. So it moved into a `reusable-visualization` skill, and the app skill points at it the same way it already points at `frontend-design`.

**What the skill measurably buys.** Three benchmark arms, same two prompts, three reps each:

| | wall clock | output tokens | turns | rummages through template lib |
|---|---|---|---|---|
| skill read | 77s / 122s | 6.7k / 9.7k | 8, 7 | 2/6 |
| skill present, never read | 91s / 132s | 8.9k / 10.9k | 7, 10 | 3/6 |
| skill deleted | 206s / 280s | 17.5k / 21k | 21, 29 | 0/6 |

Roughly 2.5x faster and half the tokens, and without it the model explores the template to reconstruct the contract. Most of that comes from the skill's description, which is auto-loaded, rather than from reading the body.

**What it does not buy, stated honestly.** With the skill deleted from the image entirely, `declares-config-options`, `reads-every-declared-option`, `reads-color-palette`, `no-hardcoded-series-colors` and `does-not-use-app-data-apis` still pass 6/6. The declaration contract survives without it, so the correctness win belongs to the slimmed prompt and the generation schema rather than to the skill. Which of those two carries it is not isolated: the benchmark can only vary the sandbox image, not the prompt text, and all three changed together. Six samples per arm, and this behaviour is stochastic.

**Also here**

- The generation and persistence schemas are now separate. Generation asks for the `configOptions` key and carries descriptions read at sampling time; persistence is unchanged and still validates what gets stored. Nothing enforces a minimum — a viz with nothing worth configuring can still declare none.
- `useVizContext()` returns `options` and `colorPalette`. Both reach generated apps only on a sandbox image rebuild, which is why they ship with the prompt change.
- The clarifier can ask whether a display choice should stay adjustable.

**Verification.** The tests here pin what is sent to the model and cannot show it works; that is how the first three attempts shipped green while broken. Every number above comes from live generations scored by the benchmark in #26268.

**Series colours are not a config option.** `colorPalette` is a top-level key on the declaration rather than a sixth option type. It has no `name` and no `default`, because there is one palette per chart and the picker renders its own label, so the option vocabulary stays five uniform types, every one of which produces a value on `options`. The skill's option table shrank to five rows and gained a separate `colorPalette` section; its optional `group` places the picker in a named config tab.

A/B over the skill text alone, same image otherwise, two viz prompts, three reps (medians, ranked-bars / multi-series):

| | total | output tokens | declares-color-palette | palette given a `group` |
|---|---|---|---|---|
| skill as it was | 119s / 166s | 10.3k / 15.5k | 6/6 | 0/6 |
| skill rewritten | 81s / 109s | 7.4k / 9.9k | 6/6 | 4/6 |

Every correctness rule is 6/6 in both arms, and no run in either arm declared a `palette` config option. That the old skill also reached 6/6 on `declares-color-palette` is the same lesson as above: the generation schema is what carries the contract, and the skill prose buys speed and the tab placement.

Unrelated to this change but worth recording, because both arms score identically: `ran-pnpm-check` is 0/6 and `no-template-lib-reads` is 1/6. The verification loop the skill asks for is not running at all right now.

https://linear.app/lightdash/issue/GLITCH-563/generated-config-form-viz-declares-typed-config-options-colours-layout

