### PR TITLE
feat(ai-memory): show and filter memory scope in the admin memories tab

### DIFF
--- a/packages/backend/src/ee/controllers/AiAgentAdminController.ts
+++ b/packages/backend/src/ee/controllers/AiAgentAdminController.ts
@@ -345,6 +345,7 @@ export class AiAgentAdminController extends BaseController {
         @Query() projectUuids?: AiAgentAdminMemoryFilters['projectUuids'],
         @Query() userUuids?: AiAgentAdminMemoryFilters['userUuids'],
         @Query() statuses?: AiAgentAdminMemoryFilters['statuses'],
+        @Query() scopes?: AiAgentAdminMemoryFilters['scopes'],
         @Query() search?: AiAgentAdminMemoryFilters['search'],
         // Sorting
         @Query() sortField?: AiAgentAdminMemorySort['field'],
@@ -358,6 +359,7 @@ export class AiAgentAdminController extends BaseController {
             ...(projectUuids && { projectUuids }),
             ...(userUuids && { userUuids }),
             ...(statuses && { statuses }),
+            ...(scopes && { scopes }),
             ...(search && { search }),
         };
 

--- a/packages/backend/src/ee/models/AiAgentMemoryModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentMemoryModel.integration.test.ts
@@ -501,7 +501,7 @@ describe('AiAgentMemoryModel integration', () => {
         expect(Number(ledgerCount?.count)).toBe(1);
     });
 
-    it('paginates admin memories with project, user, status and search filters', async () => {
+    it('paginates admin memories with project, user, status, scope and search filters', async () => {
         const [citedThread, uncitedThread, retiredThread] = await Promise.all([
             createThread(),
             createThread(),
@@ -520,6 +520,7 @@ describe('AiAgentMemoryModel integration', () => {
                 title: 'Fiscal year offset',
                 rawMemory: 'The fiscal year starts in February.',
                 userUuid: null,
+                scope: 'project',
                 generatedAt: new Date('2026-07-22T11:00:00Z'),
             }),
         );
@@ -559,6 +560,7 @@ describe('AiAgentMemoryModel integration', () => {
             title: 'Net revenue convention',
             summary: 'Use net revenue for every board report.',
             status: 'active',
+            scope: 'user',
             project: { uuid: SEED_PROJECT.project_uuid },
             citedCount: 4,
             sourceThreadUuid: citedThread,
@@ -599,6 +601,29 @@ describe('AiAgentMemoryModel integration', () => {
                 (memory) => memory.status === 'retired',
             ),
         ).toBe(true);
+
+        const projectScopeOnly = await model.findAdminMemoriesPaginated({
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            paginateArgs: { page: 1, pageSize: 50 },
+            filters: {
+                projectUuids: [SEED_PROJECT.project_uuid],
+                scopes: ['project'],
+            },
+        });
+        const projectScopeUuids = projectScopeOnly.data.memories.map(
+            (memory) => memory.uuid,
+        );
+        expect(projectScopeUuids).toContain(uncited.ai_agent_memory_uuid);
+        expect(projectScopeUuids).not.toContain(cited.ai_agent_memory_uuid);
+        expect(
+            projectScopeOnly.data.memories.every(
+                (memory) => memory.scope === 'project',
+            ),
+        ).toBe(true);
+        // The count query is built from the same filtered base query
+        expect(projectScopeOnly.pagination?.totalResults).toBe(
+            projectScopeUuids.length,
+        );
 
         const firstPage = await model.findAdminMemoriesPaginated({
             organizationUuid: SEED_ORG_1.organization_uuid,

--- a/packages/backend/src/ee/models/AiAgentMemoryModel.ts
+++ b/packages/backend/src/ee/models/AiAgentMemoryModel.ts
@@ -479,6 +479,12 @@ export class AiAgentMemoryModel {
                 filters.statuses,
             );
         }
+        if (filters?.scopes && filters.scopes.length > 0) {
+            void query.whereIn(
+                `${AiAgentMemoryTableName}.scope`,
+                filters.scopes,
+            );
+        }
         if (filters?.search) {
             const pattern = `%${filters.search}%`;
             void query.where((builder) => {
@@ -540,6 +546,7 @@ export class AiAgentMemoryModel {
                     title: string;
                     summary: string;
                     status: DbAiAgentMemory['status'];
+                    scope: DbAiAgentMemory['scope'];
                     project_uuid: string;
                     project_name: string;
                     agent_uuid: string | null;
@@ -564,6 +571,7 @@ export class AiAgentMemoryModel {
                     ADMIN_MEMORY_SUMMARY_MAX_LENGTH,
                 ]),
                 `${AiAgentMemoryTableName}.status`,
+                `${AiAgentMemoryTableName}.scope`,
                 `${AiAgentMemoryTableName}.project_uuid`,
                 `${ProjectTableName}.name as project_name`,
                 `${AiAgentMemoryTableName}.agent_uuid`,
@@ -611,6 +619,7 @@ export class AiAgentMemoryModel {
                     title: row.title,
                     summary: row.summary,
                     status: row.status,
+                    scope: row.scope,
                     project: {
                         uuid: row.project_uuid,
                         name: row.project_name,

--- a/packages/common/src/ee/AiAgent/adminTypes.ts
+++ b/packages/common/src/ee/AiAgent/adminTypes.ts
@@ -1,6 +1,7 @@
 import type { ApiSuccess, KnexPaginatedData } from '../..';
 import type { DataAppModelVisibility } from '../apps/types';
 import type {
+    AiAgentMemoryScope,
     AiAgentMemoryStatus,
     AiAgentSummary,
     AiAgentThreadSummary,
@@ -68,6 +69,7 @@ export type AiAgentAdminMemoryFilters = {
     projectUuids?: string[];
     userUuids?: string[];
     statuses?: AiAgentMemoryStatus[];
+    scopes?: AiAgentMemoryScope[];
     search?: string; // Search by memory title, slug or body
 };
 
@@ -85,6 +87,7 @@ export type AiAgentAdminMemoryItem = {
     // Memory body, truncated server-side for the list view
     summary: string;
     status: AiAgentMemoryStatus;
+    scope: AiAgentMemoryScope;
     project: {
         uuid: string;
         name: string;

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminMemoriesTable.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminMemoriesTable.test.tsx
@@ -1,0 +1,125 @@
+import { type AiAgentAdminMemoryItem } from '@lightdash/common';
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+import AiAgentAdminMemoriesTable from './AiAgentAdminMemoriesTable';
+
+const mockUseInfiniteAiAgentAdminMemories = vi.fn();
+
+vi.mock('../../../../../hooks/useProjects', () => ({
+    useProjects: () => ({ data: [] }),
+}));
+
+vi.mock('../../../../../hooks/useOrganizationUsers', () => ({
+    useInfiniteOrganizationUsers: () => ({ data: undefined }),
+}));
+
+vi.mock('../../hooks/useAiAgentAdmin', () => ({
+    useAiAgentAdminAgents: () => ({ data: [] }),
+    useInfiniteAiAgentAdminMemories: (...args: unknown[]) =>
+        mockUseInfiniteAiAgentAdminMemories(...args),
+}));
+
+const makeMemory = (
+    overrides: Partial<AiAgentAdminMemoryItem> = {},
+): AiAgentAdminMemoryItem => ({
+    uuid: 'memory-1',
+    slug: 'net-revenue-convention',
+    title: 'Net revenue convention',
+    summary: 'Use net revenue for every board report.',
+    status: 'active',
+    scope: 'user',
+    project: { uuid: 'project-1', name: 'Jaffle shop' },
+    agent: { uuid: 'agent-1', name: 'Ana', imageUrl: null },
+    user: { uuid: 'user-1', name: 'Jane Doe', email: 'jane@example.com' },
+    sourceThreadUuid: 'thread-1',
+    citedCount: 2,
+    lastCitedAt: '2026-07-22T12:00:00.000Z',
+    pulledCount: 0,
+    lastPulledAt: null,
+    generatedAt: '2026-07-22T10:00:00.000Z',
+    ...overrides,
+});
+
+const mockMemories = (memories: AiAgentAdminMemoryItem[]) => {
+    mockUseInfiniteAiAgentAdminMemories.mockReturnValue({
+        data: {
+            pages: [
+                {
+                    data: { memories },
+                    pagination: {
+                        page: 1,
+                        pageSize: 50,
+                        totalPageCount: 1,
+                        totalResults: memories.length,
+                    },
+                },
+            ],
+        },
+        isInitialLoading: false,
+        isFetching: false,
+        hasNextPage: false,
+        fetchNextPage: vi.fn(),
+    });
+};
+
+const renderTable = () =>
+    renderWithProviders(
+        <MemoryRouter initialEntries={['/generalSettings/ai/memories']}>
+            <AiAgentAdminMemoriesTable />
+        </MemoryRouter>,
+    );
+
+describe('AiAgentAdminMemoriesTable', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders a scope badge on every row', () => {
+        mockMemories([
+            makeMemory(),
+            makeMemory({
+                uuid: 'memory-2',
+                slug: 'fiscal-year-offset',
+                title: 'Fiscal year offset',
+                scope: 'project',
+            }),
+        ]);
+
+        renderTable();
+
+        const scopeColumnIndex = screen
+            .getAllByRole('columnheader')
+            .findIndex((header) => header.textContent?.includes('Scope'));
+        expect(scopeColumnIndex).toBeGreaterThan(-1);
+
+        const scopeCellText = (title: string) => {
+            const row = screen.getByText(title).closest('tr');
+            expect(row).not.toBeNull();
+            return within(row!).getAllByRole('cell')[scopeColumnIndex]
+                .textContent;
+        };
+
+        expect(scopeCellText('Net revenue convention')).toBe('Personal');
+        expect(scopeCellText('Fiscal year offset')).toBe('Project-wide');
+    });
+
+    it('filters by scope through the scope facet', async () => {
+        const user = userEvent.setup();
+        mockMemories([makeMemory()]);
+
+        renderTable();
+
+        await user.click(screen.getByRole('button', { name: /Scope/ }));
+        await user.click(await screen.findByText('Project-wide'));
+
+        expect(mockUseInfiniteAiAgentAdminMemories).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                filters: expect.objectContaining({ scopes: ['project'] }),
+            }),
+            expect.anything(),
+        );
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminMemoriesTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminMemoriesTable.tsx
@@ -24,6 +24,7 @@ import {
     IconClock,
     IconQuote,
     IconRobotFace,
+    IconTag,
     IconTrash,
     IconUser,
 } from '@tabler/icons-react';
@@ -50,6 +51,8 @@ import {
     type AdminMemorySelection,
 } from './AdminMemoryDetailsModal';
 import styles from './AiAgentAdminMemoriesTable.module.css';
+import { MEMORY_SCOPE_COLORS, MEMORY_SCOPE_LABELS } from './memoryScope';
+import MemoryScopeFilter from './MemoryScopeFilter';
 import { MEMORY_STATUS_COLORS, MEMORY_STATUS_LABELS } from './memoryStatus';
 import MemoryStatusFilter from './MemoryStatusFilter';
 import ProjectsFilter from './ProjectsFilter';
@@ -77,6 +80,7 @@ const AiAgentAdminMemoriesTable = () => {
         selectedProjectUuids,
         selectedUserUuids,
         selectedStatuses,
+        selectedScopes,
         sortField,
         sortDirection,
         apiFilters,
@@ -84,6 +88,7 @@ const AiAgentAdminMemoriesTable = () => {
         setSelectedProjectUuids,
         setSelectedUserUuids,
         setSelectedStatuses,
+        setSelectedScopes,
         setSorting,
         hasActiveFilters,
         resetFilters,
@@ -212,6 +217,28 @@ const AiAgentAdminMemoriesTable = () => {
                         color={MEMORY_STATUS_COLORS[row.original.status]}
                     >
                         {MEMORY_STATUS_LABELS[row.original.status]}
+                    </Badge>
+                ),
+            },
+            {
+                accessorKey: 'scope',
+                header: 'Scope',
+                enableSorting: false,
+                size: 120,
+                Header: ({ column }) => (
+                    <Group gap="two">
+                        <MantineIcon icon={IconTag} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => (
+                    <Badge
+                        variant="light"
+                        radius="sm"
+                        tt="none"
+                        color={MEMORY_SCOPE_COLORS[row.original.scope]}
+                    >
+                        {MEMORY_SCOPE_LABELS[row.original.scope]}
                     </Badge>
                 ),
             },
@@ -442,6 +469,10 @@ const AiAgentAdminMemoriesTable = () => {
                         <MemoryStatusFilter
                             selectedStatuses={selectedStatuses}
                             setSelectedStatuses={setSelectedStatuses}
+                        />
+                        <MemoryScopeFilter
+                            selectedScopes={selectedScopes}
+                            setSelectedScopes={setSelectedScopes}
                         />
 
                         {hasActiveFilters && (

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/MemoryScopeFilter.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/MemoryScopeFilter.tsx
@@ -1,0 +1,34 @@
+import type { AiAgentMemoryScope } from '@lightdash/common';
+import { IconTag } from '@tabler/icons-react';
+import { type FC } from 'react';
+import FilterFacet, {
+    type FilterFacetOption,
+} from '../../../../../components/common/FilterFacet';
+import { type useAiAgentAdminMemoryFilters } from '../../hooks/useAiAgentAdminMemoryFilters';
+import { MEMORY_SCOPE_LABELS } from './memoryScope';
+
+const OPTIONS: FilterFacetOption[] = (
+    Object.keys(MEMORY_SCOPE_LABELS) as AiAgentMemoryScope[]
+).map((scope) => ({ value: scope, label: MEMORY_SCOPE_LABELS[scope] }));
+
+type MemoryScopeFilterProps = Pick<
+    ReturnType<typeof useAiAgentAdminMemoryFilters>,
+    'selectedScopes' | 'setSelectedScopes'
+>;
+
+const MemoryScopeFilter: FC<MemoryScopeFilterProps> = ({
+    selectedScopes,
+    setSelectedScopes,
+}) => (
+    <FilterFacet
+        label="Scope"
+        icon={IconTag}
+        options={OPTIONS}
+        selected={selectedScopes}
+        onChange={setSelectedScopes}
+        tooltipLabel="Filter memories by scope"
+        emptyLabel="No scopes available."
+    />
+);
+
+export default MemoryScopeFilter;

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/memoryScope.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/memoryScope.ts
@@ -1,0 +1,13 @@
+import type { AiAgentMemoryScope } from '@lightdash/common';
+
+// Labelled "Personal"/"Project-wide" rather than "User"/"Project" so the badge
+// can't be read as the adjacent User and Project columns
+export const MEMORY_SCOPE_LABELS: Record<AiAgentMemoryScope, string> = {
+    user: 'Personal',
+    project: 'Project-wide',
+};
+
+export const MEMORY_SCOPE_COLORS: Record<AiAgentMemoryScope, string> = {
+    user: 'gray',
+    project: 'indigo',
+};

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdminMemoryFilters.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdminMemoryFilters.test.tsx
@@ -44,8 +44,52 @@ describe('useAiAgentAdminMemoryFilters', () => {
         expect(result.current.sortField).toBe('generatedAt');
         expect(result.current.sortDirection).toBe('desc');
         expect(result.current.selectedStatuses).toEqual(['active']);
+        expect(result.current.selectedScopes).toEqual([]);
         expect(result.current.apiFilters).toEqual({ statuses: ['active'] });
         expect(result.current.hasActiveFilters).toBe(false);
+    });
+
+    it('loads the scope filter from the URL', () => {
+        const { result } = renderHook(() => useAiAgentAdminMemoryFilters(), {
+            wrapper: createWrapper('?scopes=project'),
+        });
+
+        expect(result.current.selectedScopes).toEqual(['project']);
+        expect(result.current.apiFilters.scopes).toEqual(['project']);
+        expect(result.current.hasActiveFilters).toBe(true);
+    });
+
+    it('drops unknown scopes from the URL', () => {
+        const { result } = renderHook(() => useAiAgentAdminMemoryFilters(), {
+            wrapper: createWrapper('?scopes=project,bogus'),
+        });
+
+        expect(result.current.selectedScopes).toEqual(['project']);
+        expect(result.current.apiFilters.scopes).toEqual(['project']);
+    });
+
+    it('round-trips a scope selection through the URL and clears it', async () => {
+        const { result } = renderHook(() => useAiAgentAdminMemoryFilters(), {
+            wrapper: createWrapper(),
+        });
+
+        act(() => result.current.setSelectedScopes(['user', 'project']));
+
+        await waitFor(() => {
+            expect(result.current.selectedScopes).toEqual(['user', 'project']);
+            expect(result.current.apiFilters.scopes).toEqual([
+                'user',
+                'project',
+            ]);
+        });
+
+        act(() => result.current.setSelectedScopes([]));
+
+        await waitFor(() => {
+            expect(result.current.selectedScopes).toEqual([]);
+            expect(result.current.apiFilters.scopes).toBeUndefined();
+            expect(result.current.hasActiveFilters).toBe(false);
+        });
     });
 
     it('treats the "all" status token as no status filter', () => {
@@ -82,7 +126,7 @@ describe('useAiAgentAdminMemoryFilters', () => {
 
     it('persists sorting and resets every filter', async () => {
         const { result } = renderHook(() => useAiAgentAdminMemoryFilters(), {
-            wrapper: createWrapper(`?projects=${PROJECT_UUID}`),
+            wrapper: createWrapper(`?projects=${PROJECT_UUID}&scopes=project`),
         });
 
         act(() => result.current.setSorting('citedCount', 'asc'));
@@ -99,6 +143,7 @@ describe('useAiAgentAdminMemoryFilters', () => {
             expect(result.current.hasActiveFilters).toBe(false);
             expect(result.current.selectedProjectUuids).toEqual([]);
             expect(result.current.selectedStatuses).toEqual(['active']);
+            expect(result.current.selectedScopes).toEqual([]);
             expect(result.current.sortField).toBe('generatedAt');
         });
     });

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdminMemoryFilters.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdminMemoryFilters.ts
@@ -2,6 +2,7 @@ import type {
     AiAgentAdminMemoryFilters,
     AiAgentAdminMemorySort,
     AiAgentAdminMemorySortField,
+    AiAgentMemoryScope,
     AiAgentMemoryStatus,
 } from '@lightdash/common';
 import { useCallback, useMemo } from 'react';
@@ -21,6 +22,11 @@ const isMemoryStatus = (value: string): value is AiAgentMemoryStatus =>
 // status filter needs its own token to mean "every status"
 const ALL_STATUSES_PARAM = 'all';
 
+const MEMORY_SCOPES: AiAgentMemoryScope[] = ['user', 'project'];
+
+const isMemoryScope = (value: string): value is AiAgentMemoryScope =>
+    MEMORY_SCOPES.includes(value as AiAgentMemoryScope);
+
 export interface AiAgentAdminMemoryFiltersState {
     search: AiAgentAdminMemoryFilters['search'];
     selectedProjectUuids: NonNullable<
@@ -28,6 +34,8 @@ export interface AiAgentAdminMemoryFiltersState {
     >;
     selectedUserUuids: NonNullable<AiAgentAdminMemoryFilters['userUuids']>;
     selectedStatuses: AiAgentMemoryStatus[];
+    // Empty means every scope: unlike statuses, there is no default subset
+    selectedScopes: AiAgentMemoryScope[];
     sortField: AiAgentAdminMemorySortField;
     sortDirection: AiAgentAdminMemorySort['direction'];
 }
@@ -37,6 +45,7 @@ const DEFAULT_FILTERS: AiAgentAdminMemoryFiltersState = {
     selectedProjectUuids: [],
     selectedUserUuids: [],
     selectedStatuses: ['active'],
+    selectedScopes: [],
     sortField: 'generatedAt',
     sortDirection: 'desc',
 };
@@ -50,6 +59,7 @@ export const useAiAgentAdminMemoryFilters = () => {
     const projectsParam = useSearchParams<string>('projects');
     const usersParam = useSearchParams<string>('users');
     const statusesParam = useSearchParams<string>('statuses');
+    const scopesParam = useSearchParams<string>('scopes');
     const sortByParam = useSearchParams<AiAgentAdminMemorySortField>('sortBy');
     const sortDirectionParam = useSearchParams<'asc' | 'desc'>('sortDirection');
 
@@ -67,6 +77,9 @@ export const useAiAgentAdminMemoryFilters = () => {
                     ? []
                     : statusesParam?.split(',').filter(isMemoryStatus) ||
                       DEFAULT_FILTERS.selectedStatuses,
+            selectedScopes:
+                scopesParam?.split(',').filter(isMemoryScope) ||
+                DEFAULT_FILTERS.selectedScopes,
             sortField: sortByParam || DEFAULT_FILTERS.sortField,
             sortDirection: sortDirectionParam || DEFAULT_FILTERS.sortDirection,
         }),
@@ -75,6 +88,7 @@ export const useAiAgentAdminMemoryFilters = () => {
             projectsParam,
             usersParam,
             statusesParam,
+            scopesParam,
             sortByParam,
             sortDirectionParam,
         ],
@@ -109,6 +123,9 @@ export const useAiAgentAdminMemoryFilters = () => {
                     'statuses',
                     newFilters.selectedStatuses.join(','),
                 );
+            }
+            if (newFilters.selectedScopes.length > 0) {
+                searchParams.set('scopes', newFilters.selectedScopes.join(','));
             }
             if (newFilters.sortField !== DEFAULT_FILTERS.sortField) {
                 searchParams.set('sortBy', newFilters.sortField);
@@ -162,6 +179,16 @@ export const useAiAgentAdminMemoryFilters = () => {
         [updateUrl, currentFilters],
     );
 
+    const setSelectedScopes = useCallback(
+        (scopes: string[]) => {
+            updateUrl({
+                ...currentFilters,
+                selectedScopes: scopes.filter(isMemoryScope),
+            });
+        },
+        [updateUrl, currentFilters],
+    );
+
     const setSorting = useCallback(
         (
             sortField: AiAgentAdminMemorySortField,
@@ -184,7 +211,8 @@ export const useAiAgentAdminMemoryFilters = () => {
             currentFilters.selectedProjectUuids.length > 0 ||
             currentFilters.selectedUserUuids.length > 0 ||
             currentFilters.selectedStatuses.join(',') !==
-                DEFAULT_FILTERS.selectedStatuses.join(','),
+                DEFAULT_FILTERS.selectedStatuses.join(',') ||
+            currentFilters.selectedScopes.length > 0,
         [currentFilters],
     );
 
@@ -203,6 +231,9 @@ export const useAiAgentAdminMemoryFilters = () => {
         if (currentFilters.selectedStatuses.length > 0) {
             result.statuses = currentFilters.selectedStatuses;
         }
+        if (currentFilters.selectedScopes.length > 0) {
+            result.scopes = currentFilters.selectedScopes;
+        }
 
         return result;
     }, [currentFilters]);
@@ -216,6 +247,7 @@ export const useAiAgentAdminMemoryFilters = () => {
         setSelectedProjectUuids,
         setSelectedUserUuids,
         setSelectedStatuses,
+        setSelectedScopes,
         setSorting,
 
         resetFilters,


### PR DESCRIPTION
Slice 5 of 5 under ZAP-707 (Scope AI agent memories to the user). Stacked on
ZAP-711.

Memories have carried a scope since slice 3, but an org admin reviewing the
corpus could not see it: the admin memories tab listed every memory as an
undifferentiated row, so finding the project-general ones meant opening each
personal preference in turn. After this PR scope is a visible column and a
filter, so promotion candidates are reviewable without reading through people's
personal preferences.

## What changed

- `AiAgentAdminMemoryItem` gains `scope`, `AiAgentAdminMemoryFilters` gains
  `scopes` - both mirroring `status`/`statuses`.
- The admin list query selects `scope` and filters on it.
- A **Scope** column sits next to Status, rendering the same light `Badge` the
  status column uses.
- A **Scope** facet sits next to the status facet in the toolbar, built on the
  same shared `FilterFacet`.

The badge reads **Personal** / **Project-wide** rather than "User" / "Project".
The stored values and the URL/API params stay `user`/`project`, but a badge
literally reading "Project" sitting one column away from a Project column
showing a project name is ambiguous at a glance, and this table is meant to be
skimmed.

The user filter, the cross-agent listing behaviour, and the read path are
untouched. Reading a memory in the admin tab remains an audit action.

## The scope filter goes inside the query builder, not after the joins

`findAdminMemoriesPaginated` calls `buildAdminMemoriesQuery` **twice**: once for
the page of rows (then joined for display columns) and once un-joined as the
count query. A filter added anywhere other than inside that builder would apply
to the rows but not the count, so `totalResults` would silently disagree with
what the table shows. The `scopes` clause therefore sits alongside the existing
`statuses` clause inside the builder, and the integration test asserts
`totalResults` matches the returned row count under a scope filter.

## No `all` sentinel for scope

The status filter needs an `ALL_STATUSES_PARAM = 'all'` URL token because
statuses **default to `['active']`** - an absent param means the default, so
"cleared" needs its own token to be distinguishable from "absent". Scope has no
default subset: showing everything is the default, so an empty selection simply
omits the param and no sentinel is needed. Copying it would have added a state
that could never be reached.

For the same reason `hasActiveFilters` tests the scope selection on length
rather than the order-sensitive `join(',')` comparison the status default
requires.

## Not in scope

Parent-spec unresolved question 2 - whether scope should also appear on the
read-only memory page - stays open. This PR is admin-only. `scope` is already on
the `AiAgentMemory` detail type from slice 3 and no UI is built for it there.

## Tests

- `useAiAgentAdminMemoryFilters.test.tsx`: URL load, unknown-token drop,
  select/clear round-trip, and the reset case, mirroring the existing status
  coverage.
- `AiAgentAdminMemoriesTable.test.tsx` (new): asserts a scope badge renders on
  every row, and that picking the scope facet reaches the query hook as
  `scopes: ['project']`.
- `AiAgentMemoryModel.integration.test.ts`: the admin-memories filter test now
  seeds a `project`-scoped memory, asserts the returned `scope`, asserts a
  `scopes: ['project']` filter includes it and excludes the user-scoped rows,
  and asserts the count query agrees with the rows.

Closes: ZAP-712
Relates: ZAP-707
