### PR TITLE
fix(ai): don't let schema-validation failures trip the query retry cap

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -411,11 +411,15 @@ const buildPrepareStep = ({
     dependencies,
     tools,
     logger,
+    invalidToolCallIds,
 }: {
     args: AiAgentArgs;
     dependencies: AiAgentDependencies;
     tools: ToolSet;
     logger: ReturnType<typeof createAiAgentLogger>;
+    // Ids of tool calls the AI SDK dropped for invalid input, recorded by
+    // onStepFinish/onChunk as the turn progresses (shared mutable set).
+    invalidToolCallIds: ReadonlySet<string>;
 }) => {
     const forcedFirstStep = buildForcedFirstStep(args, tools);
     let retryCapPersisted = false;
@@ -437,6 +441,7 @@ const buildPrepareStep = ({
         const retryOverride = buildQueryRetryStepOverride(
             messages,
             Object.keys(tools),
+            invalidToolCallIds,
         );
         if (retryOverride) {
             activeTools = retryOverride.activeTools;
@@ -1165,11 +1170,13 @@ export const generateAgentResponse = async ({
             'Generate Agent Response',
             `Calling generateText with model: ${modelName}`,
         );
+        const invalidToolCallIds = new Set<string>();
         const prepareStep = buildPrepareStep({
             args,
             dependencies,
             tools,
             logger,
+            invalidToolCallIds,
         });
         const telemetry = getAgentTelemetryConfig(
             'generateAgentResponse',
@@ -1241,6 +1248,7 @@ export const generateAgentResponse = async ({
                                 // (replayed into UI/history) and persist them
                                 // in the error table instead.
                                 if (toolCall.invalid) {
+                                    invalidToolCallIds.add(toolCall.toolCallId);
                                     Sentry.captureException(toolCall.error, {
                                         tags: {
                                             errorType: 'AiAgentToolCallInvalid',
@@ -1488,11 +1496,13 @@ export const streamAgentResponse = async ({
             'Stream Agent Response',
             `Calling streamText with model: ${modelName}`,
         );
+        const invalidToolCallIds = new Set<string>();
         const prepareStep = buildPrepareStep({
             args,
             dependencies,
             tools,
             logger,
+            invalidToolCallIds,
         });
         const stopWhenPromptInterrupted = buildStopWhenPromptInterrupted(
             args,
@@ -1552,6 +1562,7 @@ export const streamAgentResponse = async ({
                         });
 
                         if (event.chunk.invalid) {
+                            invalidToolCallIds.add(event.chunk.toolCallId);
                             Sentry.captureException(event.chunk.error, {
                                 tags: {
                                     errorType: 'AiAgentToolCallInvalid',

--- a/packages/backend/src/ee/services/ai/agents/queryRetryCap.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/queryRetryCap.test.ts
@@ -2,195 +2,191 @@ import type { ModelMessage } from 'ai';
 import { describe, expect, it } from 'vitest';
 import {
     buildQueryRetryStepOverride,
-    classifyQueryResult,
-    collectQueryResultClasses,
+    INVALID_INPUT_CAP,
     QUERY_TOOL_NAMES,
-    shouldCapQueryRetries,
+    WAREHOUSE_ERROR_CAP,
+    WAREHOUSE_SLOW_CAP,
 } from './queryRetryCap';
 
-const toolResultMessage = (
-    toolName: string,
-    output: { type: string; value: string },
-): ModelMessage =>
-    ({
-        role: 'tool',
-        content: [{ type: 'tool-result', toolCallId: 'id', toolName, output }],
-    }) as unknown as ModelMessage;
+const QUERY_TOOLS = [...QUERY_TOOL_NAMES];
+const NON_QUERY_TOOL = 'grepFields';
+const ALL_TOOLS = [...QUERY_TOOLS, NON_QUERY_TOOL];
 
-describe('classifyQueryResult', () => {
-    it('treats a non-error result as ok', () => {
-        expect(classifyQueryResult({ type: 'text', value: 'Total\n42' })).toBe(
-            'ok',
+/**
+ * Simulates a turn the way the agent loop sees it: tool results accumulate in
+ * the model messages, and invalid tool calls are recorded by id (as
+ * agentV2's onStepFinish/onChunk handlers do) — never derived from the error
+ * text.
+ */
+const makeTurn = () => {
+    const messages: ModelMessage[] = [];
+    const invalidToolCallIds = new Set<string>();
+    let idCounter = 0;
+
+    const addResult = (
+        toolName: string,
+        output: { type: string; value: string },
+    ) => {
+        idCounter += 1;
+        const toolCallId = `call-${idCounter}`;
+        messages.push({
+            role: 'tool',
+            content: [{ type: 'tool-result', toolCallId, toolName, output }],
+        } as unknown as ModelMessage);
+        return toolCallId;
+    };
+
+    return {
+        success: (toolName = 'runQuery') =>
+            addResult(toolName, { type: 'text', value: 'Total\n42' }),
+        failure: (toolName = 'runQuery', value = 'Error running query. Boom') =>
+            addResult(toolName, { type: 'error-text', value }),
+        invalidInput: (
+            toolName = 'generateVisualization',
+            value = 'the SDK wording for a dropped call, which we must not depend on',
+        ) => {
+            const toolCallId = addResult(toolName, {
+                type: 'error-text',
+                value,
+            });
+            invalidToolCallIds.add(toolCallId);
+            return toolCallId;
+        },
+        override: () =>
+            buildQueryRetryStepOverride(
+                messages,
+                ALL_TOOLS,
+                invalidToolCallIds,
+            ),
+    };
+};
+
+const times = (n: number, fn: () => void) => {
+    for (let i = 0; i < n; i += 1) fn();
+};
+
+describe('query retry cap', () => {
+    it('never caps a turn of successful queries, however many', () => {
+        const turn = makeTurn();
+        times(10, () => turn.success());
+        expect(turn.override()).toBeNull();
+    });
+
+    it('does not count successes toward the failure bounds', () => {
+        const turn = makeTurn();
+        times(10, () => turn.success());
+        times(WAREHOUSE_ERROR_CAP - 1, () => turn.failure());
+        expect(turn.override()).toBeNull();
+    });
+
+    it('ignores failures of non-query tools', () => {
+        const turn = makeTurn();
+        times(WAREHOUSE_ERROR_CAP, () =>
+            turn.failure(NON_QUERY_TOOL, 'Error running query. Timed out'),
         );
+        expect(turn.override()).toBeNull();
     });
 
-    it('classifies a warehouse timeout as warehouse-slow', () => {
-        expect(
-            classifyQueryResult({
-                type: 'error-text',
-                value: 'Error running query. Query polling timed out after 300000ms',
-            }),
-        ).toBe('warehouse-slow');
+    it('removes the query tools once warehouse failures hit their bound', () => {
+        const turn = makeTurn();
+        times(WAREHOUSE_ERROR_CAP, () => turn.failure());
+        const override = turn.override();
+        expect(override?.activeTools).toEqual([NON_QUERY_TOOL]);
+        expect(override?.nudge.toLowerCase()).toContain('do not run it again');
     });
 
-    it('classifies a dropped connection as warehouse-slow', () => {
-        expect(
-            classifyQueryResult({
-                type: 'error-text',
-                value: 'Error running query. Connection terminated unexpectedly',
-            }),
-        ).toBe('warehouse-slow');
-    });
-
-    it('does not bucket warehouse-specific errors — any non-timeout failure is other', () => {
-        // Permission / scan-limit / bad-SQL errors are all treated the same;
-        // we never match warehouse-specific prose.
-        expect(
-            classifyQueryResult({
-                type: 'error-text',
-                value: 'Error running query. Access Denied: User does not have permission to query table',
-            }),
-        ).toBe('other');
-        expect(
-            classifyQueryResult({
-                type: 'error-text',
-                value: 'Error running query. Query exceeded limit for bytesBilledLimitExceeded',
-            }),
-        ).toBe('other');
-        expect(
-            classifyQueryResult({
-                type: 'error-text',
-                value: 'Error running query. Something inexplicable happened',
-            }),
-        ).toBe('other');
-    });
-});
-
-describe('shouldCapQueryRetries', () => {
-    it('does not cap below the thresholds', () => {
-        expect(shouldCapQueryRetries(['ok', 'other']).capped).toBe(false);
-        expect(shouldCapQueryRetries(['warehouse-slow', 'ok']).capped).toBe(
-            false,
+    it('trips sooner on repeated warehouse timeouts', () => {
+        const turn = makeTurn();
+        times(WAREHOUSE_SLOW_CAP, () =>
+            turn.failure(
+                'runQuery',
+                'Error running query. Query polling timed out after 300000ms',
+            ),
         );
+        const override = turn.override();
+        expect(override?.activeTools).toEqual([NON_QUERY_TOOL]);
     });
 
-    it('caps after two warehouse-slow errors', () => {
-        expect(
-            shouldCapQueryRetries(['warehouse-slow', 'warehouse-slow']).capped,
-        ).toBe(true);
-    });
-
-    it('caps after three errors of any kind', () => {
-        expect(shouldCapQueryRetries(['other', 'other', 'other']).capped).toBe(
-            true,
+    it('quotes the warehouse error in the give-up nudge, without the retry-encouraging wrapper', () => {
+        const turn = makeTurn();
+        times(WAREHOUSE_ERROR_CAP, () =>
+            turn.failure(
+                'runSql',
+                'Error running SQL query. Access Denied: User does not have permission to query table my-project:dataset.orders\n\nTry again if you believe the error can be resolved.',
+            ),
         );
-    });
-
-    it('does not count successful (ok) calls toward the cap', () => {
-        expect(
-            shouldCapQueryRetries(['ok', 'ok', 'ok', 'ok', 'other']).capped,
-        ).toBe(false);
-    });
-});
-
-describe('collectQueryResultClasses', () => {
-    it('collects and classifies query-tool results in order', () => {
-        const messages: ModelMessage[] = [
-            toolResultMessage('generateVisualization', {
-                type: 'error-text',
-                value: 'Error running query. Query polling timed out after 300000ms',
-            }),
-            toolResultMessage('grepFields', {
-                type: 'text',
-                value: 'some fields',
-            }),
-            toolResultMessage('runQuery', {
-                type: 'error-text',
-                value: 'Error running query. Invalid custom metric',
-            }),
-        ];
-        expect(collectQueryResultClasses(messages, QUERY_TOOL_NAMES)).toEqual([
-            'warehouse-slow',
-            'other',
-        ]);
-    });
-
-    it('collects runSql results', () => {
-        const messages: ModelMessage[] = [
-            toolResultMessage('runSql', {
-                type: 'error-text',
-                value: 'Error running SQL query. Access Denied: no permission',
-            }),
-        ];
-        expect(collectQueryResultClasses(messages, QUERY_TOOL_NAMES)).toEqual([
-            'other',
-        ]);
-    });
-
-    it('ignores non-query tools', () => {
-        const messages: ModelMessage[] = [
-            toolResultMessage('searchFieldValues', {
-                type: 'error-text',
-                value: 'timed out',
-            }),
-        ];
-        expect(collectQueryResultClasses(messages, QUERY_TOOL_NAMES)).toEqual(
-            [],
-        );
-    });
-});
-
-describe('buildQueryRetryStepOverride', () => {
-    const allTools = [
-        'generateVisualization',
-        'runQuery',
-        'runSql',
-        'grepFields',
-    ];
-
-    it('returns null when the cap has not tripped', () => {
-        const messages: ModelMessage[] = [
-            toolResultMessage('generateVisualization', {
-                type: 'error-text',
-                value: 'Error running query. Invalid custom metric',
-            }),
-        ];
-        expect(buildQueryRetryStepOverride(messages, allTools)).toBeNull();
-    });
-
-    it('drops the query tools and nudges once tripped', () => {
-        const err = {
-            type: 'error-text',
-            value: 'Error running query. Query polling timed out after 300000ms',
-        };
-        const messages: ModelMessage[] = [
-            toolResultMessage('generateVisualization', err),
-            toolResultMessage('generateVisualization', err),
-        ];
-        const override = buildQueryRetryStepOverride(messages, allTools);
-        expect(override?.activeTools).toEqual(['grepFields']);
-        expect(override?.nudge.toLowerCase()).toContain('do not');
-    });
-
-    it('surfaces the warehouse error and instructs the agent to relay it', () => {
-        const err = {
-            type: 'error-text',
-            value: 'Error running SQL query. Access Denied: User does not have permission to query table my-project:dataset.orders\n\nTry again if you believe the error can be resolved.',
-        };
-        const messages: ModelMessage[] = [
-            toolResultMessage('runSql', err),
-            toolResultMessage('runSql', err),
-            toolResultMessage('runSql', err),
-        ];
-        const override = buildQueryRetryStepOverride(messages, allTools);
-        expect(override?.activeTools).not.toContain('runSql');
-        // The wrapping prefix/suffix are stripped; the real warehouse text stays.
+        const override = turn.override();
         expect(override?.nudge).toContain(
             'Access Denied: User does not have permission to query table',
         );
         expect(override?.nudge).not.toContain('Try again if you believe');
         expect(override?.nudge.toLowerCase()).toContain(
             'relay this warehouse error',
+        );
+    });
+
+    it('never removes the query tools for validation failures, however many', () => {
+        const turn = makeTurn();
+        times(INVALID_INPUT_CAP + 3, () => turn.invalidInput());
+        const override = turn.override();
+        expect(override?.activeTools).toEqual(ALL_TOOLS);
+    });
+
+    it('does not count validation failures toward the warehouse bound', () => {
+        const turn = makeTurn();
+        times(WAREHOUSE_ERROR_CAP, () => turn.invalidInput());
+        expect(turn.override()).toBeNull();
+    });
+
+    it('classifies by recorded call id, not by error text', () => {
+        // An invalid call whose SDK message happens to read like a warehouse
+        // timeout must still count as a validation failure.
+        const turn = makeTurn();
+        times(WAREHOUSE_SLOW_CAP, () =>
+            turn.invalidInput(
+                'generateVisualization',
+                'input dropped: the query timed out while validating',
+            ),
+        );
+        expect(turn.override()).toBeNull();
+    });
+
+    it('steers a sustained validation loop toward correcting the input, with tools kept', () => {
+        const turn = makeTurn();
+        times(INVALID_INPUT_CAP - 1, () => turn.invalidInput());
+        expect(turn.override()).toBeNull();
+
+        turn.invalidInput();
+        const override = turn.override();
+        expect(override?.activeTools).toEqual(ALL_TOOLS);
+        expect(override?.nudge.toLowerCase()).toContain('schema validation');
+        expect(override?.nudge.toLowerCase()).toContain('fix the structure');
+    });
+
+    it('gives up rather than steers when warehouse failures also hit their bound', () => {
+        const turn = makeTurn();
+        times(INVALID_INPUT_CAP, () => turn.invalidInput());
+        times(WAREHOUSE_ERROR_CAP, () => turn.failure());
+        const override = turn.override();
+        expect(override?.activeTools).toEqual([NON_QUERY_TOOL]);
+    });
+
+    it('quotes the last warehouse error in the give-up nudge even when a validation failure came after it', () => {
+        const turn = makeTurn();
+        times(WAREHOUSE_ERROR_CAP, () =>
+            turn.failure(
+                'runQuery',
+                'Error running query. Access Denied: no permission on table orders',
+            ),
+        );
+        turn.invalidInput(
+            'generateVisualization',
+            'SDK wording for the dropped call',
+        );
+        const override = turn.override();
+        expect(override?.nudge).toContain('Access Denied: no permission');
+        expect(override?.nudge).not.toContain(
+            'SDK wording for the dropped call',
         );
     });
 });

--- a/packages/backend/src/ee/services/ai/agents/queryRetryCap.ts
+++ b/packages/backend/src/ee/services/ai/agents/queryRetryCap.ts
@@ -1,3 +1,4 @@
+import { assertUnreachable } from '@lightdash/common';
 import type { ModelMessage } from 'ai';
 
 /**
@@ -15,7 +16,17 @@ export const QUERY_TOOL_NAMES: ReadonlySet<string> = new Set([
     'runSql',
 ]);
 
-export type QueryResultClass = 'ok' | 'warehouse-slow' | 'other';
+/** Re-running a heavy scan that already timed out is especially wasteful. */
+export const WAREHOUSE_SLOW_CAP = 2;
+/** Executed-query failures of any kind: the model is looping, not converging. */
+export const WAREHOUSE_ERROR_CAP = 3;
+/**
+ * Schema-validation failures never reach the warehouse and usually converge
+ * after the relayed error, so their bound is later and corrective, not final.
+ */
+export const INVALID_INPUT_CAP = 6;
+
+type QueryResultClass = 'ok' | 'warehouse-slow' | 'invalid-input' | 'other';
 
 // A tool result as it appears in the model messages (see toModelOutput):
 // success → { type: 'text' }, error → { type: 'error-text' }.
@@ -25,60 +36,76 @@ const WAREHOUSE_SLOW =
     /timed out|timeout|polling|connection (terminated|lost)|econnreset/i;
 
 /**
- * Classify a single query-tool result. Only `error-text` outputs count as
- * failures; a successful result is `ok` and never contributes to the cap.
- * We deliberately do NOT try to bucket errors by warehouse-specific meaning
+ * We deliberately do NOT bucket errors by warehouse-specific meaning
  * (permissions, scan limits, bad SQL, ...) — that would mean matching each
  * warehouse's error prose, which is brittle and only ever covers whichever
- * warehouse we hard-coded. Any repeated failure is treated the same, and the
- * actual warehouse message is relayed to the user (see buildQueryRetryStepOverride).
- * The one exception is warehouse-slow (timeouts), which trips sooner because
- * re-running a heavy scan that already timed out is especially wasteful.
+ * warehouse we hard-coded. Invalid input is likewise not detected from the
+ * message text: the caller records the failed calls' ids as the AI SDK
+ * reports them (`toolCall.invalid`), so classification survives SDK rewording.
  */
-export const classifyQueryResult = (
+const classifyQueryResult = (
     output: ToolResultOutput,
+    isInvalidInput: boolean,
 ): QueryResultClass => {
     if (output.type !== 'error-text') return 'ok';
+    if (isInvalidInput) return 'invalid-input';
     if (WAREHOUSE_SLOW.test(output.value)) return 'warehouse-slow';
     return 'other';
 };
+
+const isWarehouseFailure = (c: QueryResultClass): boolean =>
+    c === 'warehouse-slow' || c === 'other';
+
+type QueryRetryCapDecision =
+    | { capped: false }
+    | {
+          capped: true;
+          reason: string;
+          // give-up: remove the query tools, answer with what we have.
+          // correct-input: keep the tools, steer the model to fix its input.
+          kind: 'give-up' | 'correct-input';
+      };
 
 /**
  * Decide whether to stop the agent re-issuing query tools this turn. Trips on
  * repeated *failures* only, so legitimate multi-chart turns (several successful
  * queries) are never capped.
- *  - ≥2 warehouse-slow: re-running a heavy scan that already timed out won't help.
- *  - ≥3 errors total: the model is looping instead of converging.
  */
-export const shouldCapQueryRetries = (
+const shouldCapQueryRetries = (
     classes: QueryResultClass[],
-): { capped: boolean; reason: string } => {
+): QueryRetryCapDecision => {
     const warehouseSlow = classes.filter((c) => c === 'warehouse-slow').length;
-    const errors = classes.filter((c) => c !== 'ok').length;
-    if (warehouseSlow >= 2) {
+    const warehouseErrors = classes.filter(isWarehouseFailure).length;
+    const invalidInputs = classes.filter((c) => c === 'invalid-input').length;
+    if (warehouseSlow >= WAREHOUSE_SLOW_CAP) {
         return {
             capped: true,
             reason: 'the warehouse query timed out repeatedly',
+            kind: 'give-up',
         };
     }
-    if (errors >= 3) {
+    if (warehouseErrors >= WAREHOUSE_ERROR_CAP) {
         return {
             capped: true,
             reason: 'the query failed repeatedly',
+            kind: 'give-up',
         };
     }
-    return { capped: false, reason: '' };
+    if (invalidInputs >= INVALID_INPUT_CAP) {
+        return {
+            capped: true,
+            reason: 'the tool input failed schema validation repeatedly',
+            kind: 'correct-input',
+        };
+    }
+    return { capped: false };
 };
 
 type QueryResult = { class: QueryResultClass; value: string };
 
-/**
- * Walk the model messages and collect every query-tool result, in order, with
- * both its class and the raw error text. Non-query tool results are ignored.
- */
-export const collectQueryResults = (
+const collectQueryResults = (
     messages: ModelMessage[],
-    queryToolNames: ReadonlySet<string>,
+    invalidToolCallIds: ReadonlySet<string>,
 ): QueryResult[] => {
     const results: QueryResult[] = [];
     for (const message of messages) {
@@ -90,12 +117,16 @@ export const collectQueryResults = (
                     'type' in part &&
                     part.type === 'tool-result' &&
                     'toolName' in part &&
-                    queryToolNames.has(part.toolName as string) &&
+                    QUERY_TOOL_NAMES.has(part.toolName as string) &&
+                    'toolCallId' in part &&
                     'output' in part
                 ) {
                     const output = part.output as ToolResultOutput;
                     results.push({
-                        class: classifyQueryResult(output),
+                        class: classifyQueryResult(
+                            output,
+                            invalidToolCallIds.has(part.toolCallId as string),
+                        ),
                         value:
                             typeof output.value === 'string'
                                 ? output.value
@@ -107,16 +138,6 @@ export const collectQueryResults = (
     }
     return results;
 };
-
-/**
- * Walk the model messages and classify every query-tool result, in order.
- * Non-query tool results are ignored.
- */
-export const collectQueryResultClasses = (
-    messages: ModelMessage[],
-    queryToolNames: ReadonlySet<string>,
-): QueryResultClass[] =>
-    collectQueryResults(messages, queryToolNames).map((r) => r.class);
 
 // toolErrorHandler wraps the underlying warehouse error with a fixed prefix and
 // a "Try again..." suffix; strip both so the snippet we relay to the user is
@@ -133,45 +154,72 @@ const cleanWarehouseError = (value: string): string =>
 const MAX_ERROR_SNIPPET_CHARS = 500;
 
 /**
- * Given the current model messages and the full tool set, decide the
- * `prepareStep` override that bounds query-tool retries: returns the reduced
- * `activeTools` (query tools removed) and a nudge message, or null when the cap
- * has not tripped. The nudge carries the actual warehouse error so the agent
- * relays it to the user (permissions / query-size limit) instead of failing
- * silently. Pure so the `prepareStep` wiring stays trivial.
+ * Given the current model messages, the full tool set, and the ids of tool
+ * calls the AI SDK dropped for invalid input, decide the `prepareStep`
+ * override that bounds query-tool retries: returns `activeTools` and a nudge
+ * message, or null when no cap has tripped. Warehouse failures remove the
+ * query tools and relay the actual warehouse error so the agent surfaces it
+ * (permissions / query-size limit) instead of failing silently; validation
+ * loops keep the tools and steer the model to fix its input. Pure so the
+ * `prepareStep` wiring stays trivial.
  */
 export const buildQueryRetryStepOverride = (
     messages: ModelMessage[],
     allToolNames: string[],
+    invalidToolCallIds: ReadonlySet<string>,
 ): { activeTools: string[]; nudge: string } | null => {
-    const results = collectQueryResults(messages, QUERY_TOOL_NAMES);
+    const results = collectQueryResults(messages, invalidToolCallIds);
     const decision = shouldCapQueryRetries(results.map((r) => r.class));
     if (!decision.capped) return null;
 
-    const lastError = [...results]
-        .reverse()
-        .find((r) => r.class !== 'ok')?.value;
-    const snippet = lastError
-        ? cleanWarehouseError(lastError).slice(0, MAX_ERROR_SNIPPET_CHARS)
-        : '';
+    switch (decision.kind) {
+        case 'correct-input':
+            return {
+                activeTools: allToolNames,
+                nudge: [
+                    `Your query tool calls keep failing schema validation (${decision.reason}).`,
+                    'Stop retrying the same input shape.',
+                    'Re-read the validation error and fix the structure of the failing part — a common mistake is wrapping each filter rule in an extra object instead of passing the flat rule the schema asks for.',
+                    'If it still fails, leave the failing part out, run the simpler query, and tell the user which part you dropped so they can refine it.',
+                ].join(' '),
+            };
+        case 'give-up': {
+            const lastError = [...results]
+                .reverse()
+                .find((r) => isWarehouseFailure(r.class))?.value;
+            const snippet = lastError
+                ? cleanWarehouseError(lastError).slice(
+                      0,
+                      MAX_ERROR_SNIPPET_CHARS,
+                  )
+                : '';
 
-    const nudge = [
-        `The data query has repeatedly failed (${decision.reason}).`,
-        'Do not run it again.',
-        ...(snippet
-            ? [
-                  `The warehouse reported: "${snippet}".`,
-                  'Relay this warehouse error to the user in your reply so they can address it (for example a permissions or query-size-limit issue on their side),',
-                  'then answer with whatever information you already have.',
-              ]
-            : [
-                  'Answer using the information you already have,',
-                  'or briefly explain what is blocking the result.',
-              ]),
-    ].join(' ');
+            const nudge = [
+                `The data query has repeatedly failed (${decision.reason}).`,
+                'Do not run it again.',
+                ...(snippet
+                    ? [
+                          `The warehouse reported: "${snippet}".`,
+                          'Relay this warehouse error to the user in your reply so they can address it (for example a permissions or query-size-limit issue on their side),',
+                          'then answer with whatever information you already have.',
+                      ]
+                    : [
+                          'Answer using the information you already have,',
+                          'or briefly explain what is blocking the result.',
+                      ]),
+            ].join(' ');
 
-    return {
-        activeTools: allToolNames.filter((name) => !QUERY_TOOL_NAMES.has(name)),
-        nudge,
-    };
+            return {
+                activeTools: allToolNames.filter(
+                    (name) => !QUERY_TOOL_NAMES.has(name),
+                ),
+                nudge,
+            };
+        }
+        default:
+            return assertUnreachable(
+                decision.kind,
+                'Unknown query retry cap kind',
+            );
+    }
 };


### PR DESCRIPTION
Regression introduced by lightdash/lightdash#24999: the query retry cap was built to stop failing warehouse queries from stacking heavy scans, but it also counts schema-validation failures — tool calls that were dropped before any query ran. After three of those, the cap removes the query tools and tells the model to answer with what it has, so the agent gives up with replies like "the filter kept failing validation" even though a retry would have succeeded.

This fix classifies validation failures separately so they no longer count toward the warehouse cap, keeping the cap's original protections intact for queries that actually executed. Classification comes from the tool-call ids the AI SDK flags as invalid (`toolCall.invalid`, recorded by the same handlers that persist them to `ai_agent_tool_call_error`), not from matching the SDK's error prose, so it survives SDK message rewording. Validation loops get their own more generous bound with a corrective nudge that keeps the tools available and steers the model to fix the input's structure (the recorded failures are mostly valid filter rules wrapped in an extra object) before falling back to simplifying. The give-up nudge also now quotes the last real warehouse error rather than a trailing validation error, and the cap decision is a discriminated union so the give-up/correct-input handling is exhaustively checked. Tests now exercise the public seam (`buildQueryRetryStepOverride`) against simulated turns instead of pinning internal classes and copy.

Relates: lightdash/lightdash#26182<br>Relates: lightdash/lightdash#26182

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)