### PR TITLE
feat(data-apps): sandbox skill mapping SDK features to host-UI names and wiring

### DIFF
--- a/sandboxes/data-apps/template/.claude/skills/sdk-features/SKILL.md
+++ b/sandboxes/data-apps/template/.claude/skills/sdk-features/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: sdk-features
+description: Map Lightdash SDK capabilities to their host-UI names and the app-code wiring each needs. Use when the user asks about a feature by name (Inspect data, drill-down, exports, shareable URLs), when offering newly available features after a template upgrade, or when wiring a host-facing capability into the app.
+---
+
+The `@lightdash/query-sdk` in this workspace declares its capabilities in a
+registry: `node_modules/@lightdash/query-sdk/dist/features.js` (`SDK_FEATURES`,
+each `{ key, label, description, wiring? }`). That registry is the source of
+truth — never invent capabilities from export lists or type definitions. This
+skill adds what the registry can't: how each feature maps to the Lightdash
+host UI and the exact wiring recipe.
+
+## Vocabulary: users speak host-UI, the SDK speaks keys
+
+Users describe features by what they see in the Lightdash editor. Translate:
+
+| User says / host UI | Registry key | Wiring |
+| --- | --- | --- |
+| "Inspect data" (Queries panel button) | `lineage` | required — see below |
+| "select an element", editor element picker | `inspect` | none (automatic) |
+| thumbnails / screenshots / scheduled deliveries | `screenshot` | required — see below |
+| drill down, click into a chart | `drill-down` | app code opt-in |
+| "share this view", URL that restores state | `url-state` | app code opt-in |
+| Google Sheets export | `gsheet-export` | app code opt-in |
+| external API data | `external-fetch` | app code opt-in |
+| runs inside a dashboard tile | `viz-context` | required — see below |
+
+## Automatic (zero wiring — active on any current-SDK bundle)
+
+`createClient()` mounts these itself: the capability **manifest**, the editor
+**element inspector** (`inspect`), and the **lineage runtime**. Core querying
+(`query`, `saved-chart` via `useLightdash`/`savedChart`) is just normal SDK
+usage. If the app calls `createClient()`, these need nothing from you.
+
+## Wiring recipes
+
+### `lineage` — the host's "Inspect data" button
+
+The lineage runtime only announces itself once the DOM contains
+`data-ld-query` stamps; until then the host's Inspect data button stays
+disabled. Spread the `lineage` props returned by `useLightdash` onto the root
+element of every query-bound block:
+
+```jsx
+const { data, lineage } = useLightdash(myQuery);
+return <div {...lineage}>{/* chart rendered from data */}</div>;
+```
+
+Stamp every visualization, not just one — each stamp maps that block to its
+query in the host's Queries panel.
+
+### `screenshot` — thumbnails and scheduled deliveries
+
+Provided by the template file `src/screenshotHandler.js`; `main.jsx` must
+import and call it (`initScreenshotHandler()`). Apps migrated from older
+templates may be missing the file or the call — copy the file from the
+template and add the call rather than reimplementing.
+
+### `viz-context` — apps embedded as dashboard tiles
+
+Wrap the app in `VizContextProvider` (see the template `main.jsx`) and read
+the host-supplied query context with `useVizContext`. Only relevant for
+visualization-style apps meant to run inside dashboards.
+
+### App-code opt-ins (call the API where it fits the app)
+
+- `drill-down`: `drillDown(...)` derives a more detailed query from a clicked
+  result row — wire it to click handlers on charts/rows.
+- `url-state`: `useUrlState(...)` syncs a piece of app state into the page URL
+  so views can be shared and restored.
+- `gsheet-export`: `exportToSheets(...)` sends tabular results to a new
+  Google Sheet — offer it wherever the app renders a table.
+- `external-fetch`: `client.externalFetch(alias, opts)` calls an external
+  connection linked to this app. The connection must already be linked by the
+  host; you cannot add one from app code.
+
+## After a template upgrade
+
+An upgrade rebuilds the app on the current SDK, which turns on the automatic
+capabilities but does NOT add wiring — that is a deliberate rail. When you
+offer newly available features, offer wiring-required ones too (their registry
+entries carry a `wiring` note); implement only when the user asks.


### PR DESCRIPTION
## What

Adds an `sdk-features` skill to the data-app sandbox template so the in-box agent can map Lightdash SDK capabilities to their host-UI names and know the exact app-code wiring each one needs.

## Why

Field-testing the upgrade flow showed the agent cannot connect user vocabulary to SDK capabilities: a user asked "what about inspect data?" (the host UI's name for the `lineage` capability) and the agent had nothing to go on — the sandbox has no docs mapping feature keys → host-UI names → wiring recipes. Without this, wiring-required features (lineage stamps, screenshot handler, viz context) can neither be explained nor implemented on request.

## How

One new skill file in `sandboxes/data-apps/template/.claude/skills/sdk-features/SKILL.md`:

- Vocabulary table: host-UI name ↔ registry key ↔ wiring class.
- Zero-wiring features (`createClient()` auto-mounts: manifest, element inspector, lineage runtime) vs wiring recipes (`lineage` stamps via the `lineage` props from `useLightdash`, `screenshotHandler.js` import, `VizContextProvider`) vs app-code opt-ins (`drillDown`, `useUrlState`, `exportToSheets`, `client.externalFetch`).
- Points at `node_modules/@lightdash/query-sdk/dist/features.js` as the registry source of truth (never invent features).
- Upgrade note: upgrades enable automatic capabilities but never add wiring — offer, implement only on request.

Ships into the sandbox image via the existing `COPY template/.claude/ ./.claude/` step; existing sandboxes pick it up on their next upgrade/cold-start.

Relates: PROD-7614

🤖 Generated with [Claude Code](https://claude.com/claude-code)