### PR TITLE
feat(data-apps): manifest-aware Inspect-data tooltip advice

### DIFF
--- a/packages/frontend/src/features/apps/AppInspectorPanel.tsx
+++ b/packages/frontend/src/features/apps/AppInspectorPanel.tsx
@@ -44,6 +44,10 @@ type Props = {
      *  When `onToggleLineage` is omitted, the toggle is hidden. */
     lineageEnabled?: boolean;
     lineageAvailable?: boolean;
+    /** The bundle's manifest reports the lineage capability — so an
+     *  unavailable toggle means missing app wiring, not a stale SDK, and the
+     *  tooltip advises asking the agent instead of upgrading. */
+    lineageSupportedBySdk?: boolean;
     onToggleLineage?: () => void;
     /** External-connection fetches for the "Requests" tab. The tab is always
      *  shown (even at zero) so it survives a clear and surfaces the feature. */
@@ -98,6 +102,7 @@ const AppInspectorPanel: FC<Props> = ({
     focusedQueryUuid,
     lineageEnabled,
     lineageAvailable,
+    lineageSupportedBySdk,
     onToggleLineage,
     externalRequests,
     onClearExternalRequests,
@@ -233,7 +238,9 @@ const AppInspectorPanel: FC<Props> = ({
                             <Tooltip
                                 label={
                                     !lineageAvailable
-                                        ? 'Inspect data is not available in this app version — upgrade the app (regenerate it) to enable it'
+                                        ? lineageSupportedBySdk
+                                            ? "Inspect data isn't wired into this app yet — ask the agent to add it"
+                                            : 'Inspect data is not available in this app version — upgrade the app to enable it'
                                         : lineageEnabled
                                           ? 'Inspect data: on'
                                           : 'Inspect data'

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -3527,6 +3527,11 @@ const AppGenerate: FC = () => {
                                         focusedQueryUuid={focusedQueryUuid}
                                         lineageEnabled={lineageEnabled}
                                         lineageAvailable={lineageAvailable}
+                                        lineageSupportedBySdk={
+                                            sdkUpgradeOffer.reportedFeatures?.includes(
+                                                'lineage',
+                                            ) ?? false
+                                        }
                                         onToggleLineage={handleToggleLineage}
                                     />
                                 )}


### PR DESCRIPTION
## What

Makes the Queries-panel "Inspect data" tooltip give correct advice now that the host knows the bundle's SDK manifest, and drops the "(regenerate it)" phrasing.

## Why

The old copy — "Inspect data is not available in this app version — upgrade the app (regenerate it) to enable it" — predates the upgrade flow and is wrong advice for an already-upgraded app: lineage needs `data-ld-query` stamps in app code, which an upgrade deliberately does not add. Field-testing hit exactly this: an upgraded app still showed "upgrade to enable it" with nothing left to upgrade.

## How

- `AppInspectorPanel` gains an optional `lineageSupportedBySdk` prop.
- When the toggle is unavailable but the bundle's manifest reports the `lineage` capability, the tooltip now says: "Inspect data isn't wired into this app yet — ask the agent to add it".
- When the manifest doesn't report it (legacy/stale bundle), the upgrade copy remains, minus "(regenerate it)": "…upgrade the app to enable it".
- The builder (`AppGenerate`) derives the prop from the SDK upgrade offer's `reportedFeatures`; the viewer surface passes nothing and keeps the fallback copy.

Relates: PROD-7614

🤖 Generated with [Claude Code](https://claude.com/claude-code)