### PR TITLE
feat: add organization roadmap

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -76,8 +76,6 @@ INTERCOM_APP_ID=zppxyjpp
 # GITHUB_REDIRECT_DOMAIN=
 
 # LIGHTDASH_LICENSE_KEY=
-ROADMAP_URL=http://127.0.0.1:8080/api/v1/roadmap/organizations
-
 # Users who run Lightdash with Docker should use the following settings
 HEADLESS_BROWSER_HOST=headless-browser
 HEADLESS_BROWSER_PORT=3000

--- a/.env.development
+++ b/.env.development
@@ -76,6 +76,7 @@ INTERCOM_APP_ID=zppxyjpp
 # GITHUB_REDIRECT_DOMAIN=
 
 # LIGHTDASH_LICENSE_KEY=
+ROADMAP_URL=http://127.0.0.1:8080/api/v1/roadmap/organizations
 
 # Users who run Lightdash with Docker should use the following settings
 HEADLESS_BROWSER_HOST=headless-browser

--- a/packages/backend/src/ee/controllers/OrgRoadmapController.ts
+++ b/packages/backend/src/ee/controllers/OrgRoadmapController.ts
@@ -1,0 +1,53 @@
+import {
+    assertRegisteredAccount,
+    type ApiErrorPayload,
+    type ApiRoadmapResponse,
+} from '@lightdash/common';
+import {
+    Get,
+    Hidden,
+    Middlewares,
+    OperationId,
+    Query,
+    Request,
+    Response,
+    Route,
+    SuccessResponse,
+} from '@tsoa/runtime';
+import express from 'express';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+} from '../../controllers/authentication';
+import { BaseController } from '../../controllers/baseController';
+import type { RoadmapService } from '../services/RoadmapService/RoadmapService';
+
+@Route('/api/v1/org/roadmap')
+// These endpoints are under development and susceptible to breaking changes.
+// Keep them hidden until the feature is GA.
+@Hidden()
+@Response<ApiErrorPayload>('default', 'Error')
+export class OrgRoadmapController extends BaseController {
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/')
+    @OperationId('getOrgRoadmap')
+    async getOrgRoadmap(
+        @Request() req: express.Request,
+        @Query() page?: number,
+        @Query() pageSize?: number,
+    ): Promise<ApiRoadmapResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+
+        return {
+            status: 'ok',
+            results: await this.services
+                .getRoadmapService<RoadmapService>()
+                .getRoadmap(req.account, {
+                    page,
+                    pageSize,
+                }),
+        };
+    }
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -93,6 +93,7 @@ import { ProjectContextService } from './services/ProjectContextService/ProjectC
 import { ProjectHomepageService } from './services/ProjectHomepageService';
 import { provisionOnboardingHomepage } from './services/ProjectService/provisionOnboardingHomepage';
 import { provisionPlaygroundProject } from './services/ProjectService/provisionPlaygroundProject';
+import { RoadmapService } from './services/RoadmapService/RoadmapService';
 import { SchedulerAiAugmentationService } from './services/SchedulerAiAugmentationService/SchedulerAiAugmentationService';
 import { ScimService } from './services/ScimService/ScimService';
 import { ServiceAccountService } from './services/ServiceAccountService/ServiceAccountService';
@@ -332,6 +333,11 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         featureFlagService: repository.getFeatureFlagService(),
                         aiModelCatalog,
                     }),
+                }),
+            roadmapService: ({ context, repository }) =>
+                new RoadmapService({
+                    lightdashConfig: context.lightdashConfig,
+                    featureFlagService: repository.getFeatureFlagService(),
                 }),
             embedService: ({ repository, context, models }) =>
                 new EmbedService({

--- a/packages/backend/src/ee/services/RoadmapService/RoadmapService.ts
+++ b/packages/backend/src/ee/services/RoadmapService/RoadmapService.ts
@@ -16,6 +16,8 @@ import type { LightdashConfig } from '../../../config/parseConfig';
 import { BaseService } from '../../../services/BaseService';
 import type { FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
 
+const ROADMAP_URL =
+    'https://roadmap.lightdash.com/api/v1/roadmap/organizations';
 const ROADMAP_REQUEST_TIMEOUT_MS = 10_000;
 
 type Dependencies = {
@@ -65,9 +67,7 @@ export class RoadmapService extends BaseService {
         }
 
         const { licenseKey } = this.lightdashConfig.license;
-        // todo: temporary env var
-        const roadmapUrl = process.env.ROADMAP_URL;
-        if (!licenseKey || !roadmapUrl) {
+        if (!licenseKey) {
             throw new UnexpectedServerError(
                 'Could not load the organization roadmap',
             );
@@ -82,7 +82,7 @@ export class RoadmapService extends BaseService {
 
         let url: URL;
         try {
-            url = new URL(roadmapUrl);
+            url = new URL(ROADMAP_URL);
             const basePath = url.pathname.replace(/\/$/, '');
             url.pathname = `${basePath}/${encodeURIComponent(organizationUuid)}`;
         } catch {

--- a/packages/backend/src/ee/services/RoadmapService/RoadmapService.ts
+++ b/packages/backend/src/ee/services/RoadmapService/RoadmapService.ts
@@ -1,0 +1,154 @@
+import { subject } from '@casl/ability';
+import {
+    assertIsAccountWithOrg,
+    assertRegisteredAccount,
+    FeatureFlags,
+    ForbiddenError,
+    ROADMAP_DEFAULT_PAGE_SIZE,
+    RoadmapQuerySchema,
+    RoadmapResponseSchema,
+    UnexpectedServerError,
+    type Account,
+    type RoadmapQuery,
+    type RoadmapResults,
+} from '@lightdash/common';
+import type { LightdashConfig } from '../../../config/parseConfig';
+import { BaseService } from '../../../services/BaseService';
+import type { FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
+
+const ROADMAP_REQUEST_TIMEOUT_MS = 10_000;
+
+type Dependencies = {
+    lightdashConfig: LightdashConfig;
+    featureFlagService: Pick<FeatureFlagService, 'get'>;
+};
+
+export class RoadmapService extends BaseService {
+    private readonly lightdashConfig: LightdashConfig;
+
+    private readonly featureFlagService: Pick<FeatureFlagService, 'get'>;
+
+    constructor({ lightdashConfig, featureFlagService }: Dependencies) {
+        super();
+        this.lightdashConfig = lightdashConfig;
+        this.featureFlagService = featureFlagService;
+    }
+
+    async getRoadmap(
+        account: Account,
+        query: RoadmapQuery = {},
+    ): Promise<RoadmapResults> {
+        assertRegisteredAccount(account);
+        assertIsAccountWithOrg(account);
+        const { organizationUuid } = account.organization;
+        const roadmapFlag = await this.featureFlagService.get({
+            user: {
+                userUuid: account.user.userUuid,
+                organizationUuid,
+            },
+            featureFlagId: FeatureFlags.OrganizationRoadmap,
+        });
+        const ability = this.createAuditedAbility(account);
+
+        if (
+            !roadmapFlag.enabled ||
+            ability.cannot(
+                'view',
+                subject('Roadmap', {
+                    organizationUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'The organization roadmap is not available',
+            );
+        }
+
+        const { licenseKey } = this.lightdashConfig.license;
+        // todo: temporary env var
+        const roadmapUrl = process.env.ROADMAP_URL;
+        if (!licenseKey || !roadmapUrl) {
+            throw new UnexpectedServerError(
+                'Could not load the organization roadmap',
+            );
+        }
+
+        const parsedQuery = RoadmapQuerySchema.safeParse(query);
+        if (!parsedQuery.success) {
+            throw new UnexpectedServerError(
+                'Could not load the organization roadmap',
+            );
+        }
+
+        let url: URL;
+        try {
+            url = new URL(roadmapUrl);
+            const basePath = url.pathname.replace(/\/$/, '');
+            url.pathname = `${basePath}/${encodeURIComponent(organizationUuid)}`;
+        } catch {
+            throw new UnexpectedServerError(
+                'Could not load the organization roadmap',
+            );
+        }
+        const paginationQuery = {
+            ...parsedQuery.data,
+            pageSize: parsedQuery.data.pageSize ?? ROADMAP_DEFAULT_PAGE_SIZE,
+        };
+        Object.entries(paginationQuery).forEach(([key, value]) => {
+            if (value !== undefined) {
+                url.searchParams.set(key, String(value));
+            }
+        });
+
+        let response: Response;
+        try {
+            response = await fetch(url.toString(), {
+                headers: {
+                    'lightdash-license-key': licenseKey,
+                },
+                signal: AbortSignal.timeout(ROADMAP_REQUEST_TIMEOUT_MS),
+            });
+        } catch (error) {
+            this.logger.warn('Could not reach the roadmap service', {
+                error: error instanceof Error ? error.message : String(error),
+            });
+            throw new UnexpectedServerError(
+                'Could not load the organization roadmap',
+            );
+        }
+
+        if (!response.ok) {
+            this.logger.warn('Roadmap service returned an error', {
+                statusCode: response.status,
+            });
+            throw new UnexpectedServerError(
+                'Could not load the organization roadmap',
+            );
+        }
+
+        let payload: unknown;
+        try {
+            payload = await response.json();
+        } catch {
+            throw new UnexpectedServerError(
+                'Could not load the organization roadmap',
+            );
+        }
+
+        const parsedResponse = RoadmapResponseSchema.safeParse(payload);
+        if (!parsedResponse.success) {
+            this.logger.warn('Roadmap service returned an invalid response', {
+                issueCount: parsedResponse.error.issues.length,
+            });
+            throw new UnexpectedServerError(
+                'Could not load the organization roadmap',
+            );
+        }
+
+        return {
+            data: parsedResponse.data.results,
+            pagination: parsedResponse.data.pagination,
+            facets: parsedResponse.data.facets,
+        };
+    }
+}

--- a/packages/backend/src/ee/services/RoadmapService/RoadmapService.ts
+++ b/packages/backend/src/ee/services/RoadmapService/RoadmapService.ts
@@ -4,6 +4,7 @@ import {
     assertRegisteredAccount,
     FeatureFlags,
     ForbiddenError,
+    ParameterError,
     ROADMAP_DEFAULT_PAGE_SIZE,
     RoadmapQuerySchema,
     RoadmapResponseSchema,
@@ -75,9 +76,10 @@ export class RoadmapService extends BaseService {
 
         const parsedQuery = RoadmapQuerySchema.safeParse(query);
         if (!parsedQuery.success) {
-            throw new UnexpectedServerError(
-                'Could not load the organization roadmap',
-            );
+            this.logger.warn('Could not parse roadmap query', {
+                issues: parsedQuery.error.issues,
+            });
+            throw new ParameterError('Could not load the organization roadmap');
         }
 
         let url: URL;

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -172,6 +172,7 @@ interface ServiceManifest {
     aiOrganizationSettingsService: unknown;
     schedulerAiAugmentationService: unknown;
     projectContextService: unknown;
+    roadmapService: unknown;
     scimService: unknown;
     supportService: unknown;
     cacheService: unknown;
@@ -1428,6 +1429,10 @@ export class ServiceRepository
         ProjectContextServiceImplT,
     >(): ProjectContextServiceImplT {
         return this.getService('projectContextService');
+    }
+
+    public getRoadmapService<RoadmapServiceImplT>(): RoadmapServiceImplT {
+        return this.getService('roadmapService');
     }
 
     public getEmbedService<EmbedServiceImplT>(): EmbedServiceImplT {

--- a/packages/common/src/authorization/organizationMemberAbility.test.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.test.ts
@@ -48,6 +48,38 @@ const defineAbilityForOrganizationMember = (
 };
 
 describe('Organization member permissions', () => {
+    it('allows only admins to view their organization roadmap', () => {
+        const adminAbility =
+            defineAbilityForOrganizationMember(ORGANIZATION_ADMIN);
+        const memberAbility =
+            defineAbilityForOrganizationMember(ORGANIZATION_MEMBER);
+
+        expect(
+            adminAbility.can(
+                'view',
+                subject('Roadmap', {
+                    organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
+                }),
+            ),
+        ).toBe(true);
+        expect(
+            adminAbility.can(
+                'view',
+                subject('Roadmap', {
+                    organizationUuid: 'another-organization',
+                }),
+            ),
+        ).toBe(false);
+        expect(
+            memberAbility.can(
+                'view',
+                subject('Roadmap', {
+                    organizationUuid: ORGANIZATION_MEMBER.organizationUuid,
+                }),
+            ),
+        ).toBe(false);
+    });
+
     describe('Member permissions', () => {
         let ability = defineAbilityForOrganizationMember(ORGANIZATION_VIEWER);
         describe('when user is an organization admin', () => {

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -413,6 +413,10 @@ export const applyOrganizationMemberStaticAbilities: Record<
     admin(member, { can }) {
         applyOrganizationMemberStaticAbilities.developer(member, { can });
 
+        can('view', 'Roadmap', {
+            organizationUuid: member.organizationUuid,
+        });
+
         can('manage', 'DataApp', {
             organizationUuid: member.organizationUuid,
         });

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -188,6 +188,7 @@ const BASE_ROLE_SCOPES = {
         'manage:OrganizationWarehouseCredentials',
         'manage:Organization',
         'manage:OrganizationColorPalette',
+        'view:Roadmap',
         'impersonate:User',
 
         // PAT management. Granted dynamically at runtime via
@@ -283,6 +284,7 @@ export const getNonEnterpriseScopesForRole = (
         'manage:ExternalConnection',
         'view:OrganizationDesign',
         'manage:OrganizationDesign',
+        'view:Roadmap',
         'manage:PersonalAccessToken',
         'manage:PreAggregation',
     ]);

--- a/packages/common/src/authorization/roleToScopeParity.test.ts
+++ b/packages/common/src/authorization/roleToScopeParity.test.ts
@@ -89,6 +89,7 @@ const ENTERPRISE_SUBJECTS = new Set([
     // role-based side so non-enterprise parity stays clean — at runtime
     // the feature is gated by license anyway.
     'OrganizationWarehouseCredentials',
+    'Roadmap',
 ]);
 
 /**
@@ -136,6 +137,7 @@ const PROJECT_PARITY_IGNORE = new Set([
     '*:Organization',
     '*:OrganizationColorPalette',
     '*:OrganizationDesign',
+    '*:Roadmap',
     '*:Group',
     '*:InviteLink',
     '*:GitIntegration',

--- a/packages/common/src/authorization/scopes.level.test.ts
+++ b/packages/common/src/authorization/scopes.level.test.ts
@@ -11,6 +11,7 @@ import {
 const ORG_ONLY_SCOPE_NAMES = [
     'view:Organization',
     'manage:Organization',
+    'view:Roadmap',
     'view:OrganizationMemberProfile',
     'manage:OrganizationMemberProfile',
     'manage:InviteLink',

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -835,6 +835,15 @@ const scopes: Scope[] = [
         getConditions: addDefaultUuidCondition,
     },
     {
+        name: 'view:Roadmap',
+        description: 'View the organization roadmap',
+        isEnterprise: true,
+        group: ScopeGroup.ORGANIZATION_MANAGEMENT,
+        dependencies: [],
+        level: 'organization',
+        getConditions: addDefaultUuidCondition,
+    },
+    {
         name: 'manage:OrganizationColorPalette',
         description:
             'Create, edit, delete, and activate organization color palettes',

--- a/packages/common/src/authorization/serviceAccountAbility.ts
+++ b/packages/common/src/authorization/serviceAccountAbility.ts
@@ -246,6 +246,9 @@ const applyServiceAccountStaticAbilities: Record<
             userUuid,
             builder: { can },
         });
+        can('view', 'Roadmap', {
+            organizationUuid,
+        });
         can('manage', 'PreAggregation', {
             organizationUuid,
         });

--- a/packages/common/src/authorization/types.ts
+++ b/packages/common/src/authorization/types.ts
@@ -61,6 +61,7 @@ export type CaslSubjectNames =
     | 'PinnedItems'
     | 'Project'
     | 'ProjectHomepage'
+    | 'Roadmap'
     | 'SavedChart'
     | 'ScheduledDeliveries'
     | 'SemanticViewer'

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -288,6 +288,7 @@ export * from './types/queryHistory';
 export * from './types/rename';
 export * from './types/resourceViewItem';
 export * from './types/results';
+export * from './types/roadmap';
 export * from './types/roles';
 export * from './types/savedCharts';
 export * from './types/scheduler';

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -270,6 +270,7 @@ import { type QueryHistoryStatus } from './queryHistory';
 import { type ApiRenameFieldsResponse, type ApiRenameResponse } from './rename';
 import { type MostPopularAndRecentlyUpdated } from './resourceViewItem';
 import { type ResultColumns, type ResultRow } from './results';
+import { type ApiRoadmapResponse } from './roadmap';
 import {
     type ApiCustomRoleAsCodeListResponse,
     type ApiCustomRoleAsCodeUpsertResponse,
@@ -1131,6 +1132,7 @@ type ApiResults =
     | SchedulerWithLogs
     | ValidationResponse[]
     | ApiPaginatedValidateResponse['results']
+    | ApiRoadmapResponse['results']
     | ChartHistory
     | ChartVersion
     | DashboardHistory

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -236,6 +236,11 @@ export enum FeatureFlags {
     ProLimits = 'pro-limits',
 
     /**
+     * Show the organization roadmap and enable its read-only API proxy.
+     */
+    OrganizationRoadmap = 'organization-roadmap',
+
+    /**
      * Replace the discoverFields sub-agent with a deterministic grep over an
      * in-memory, annotated view of the project's cached explores (explore =
      * directory, field = file). Connection-agnostic (reads compiled explores,

--- a/packages/common/src/types/roadmap.ts
+++ b/packages/common/src/types/roadmap.ts
@@ -1,0 +1,144 @@
+import { z } from 'zod';
+
+export const ROADMAP_DEFAULT_PAGE_SIZE = 100;
+
+export enum RoadmapItemStatus {
+    BACKLOG = 'Backlog',
+    BUILDING = 'Building',
+    SHIPPED = 'Shipped',
+    CANCELED = 'Canceled',
+}
+
+export enum RoadmapItemPriority {
+    URGENT = 'Urgent',
+    HIGH = 'High',
+    MEDIUM = 'Medium',
+    LOW = 'Low',
+    NO_PRIORITY = 'No priority',
+}
+
+export type RoadmapItem = {
+    ticketId: string;
+    title: string;
+    description: string | null;
+    status: RoadmapItemStatus;
+    priority: RoadmapItemPriority;
+    createdAt: string;
+    updatedAt: string;
+    issueUrl: string | null;
+    pullRequestUrl: string | null;
+};
+
+const githubIssueUrlSchema = z
+    .string()
+    .regex(
+        /^https:\/\/github\.com\/lightdash\/lightdash\/issues\/\d+\/?$/,
+        'Expected a public lightdash/lightdash issue URL',
+    );
+
+const githubPullRequestUrlSchema = z
+    .string()
+    .regex(
+        /^https:\/\/github\.com\/lightdash\/lightdash\/pull\/\d+\/?$/,
+        'Expected a public lightdash/lightdash pull request URL',
+    );
+
+export const RoadmapItemSchema: z.ZodType<RoadmapItem> = z
+    .object({
+        ticketId: z.string().min(1).max(255),
+        title: z.string().min(1),
+        description: z.string().nullable(),
+        status: z.nativeEnum(RoadmapItemStatus),
+        priority: z.nativeEnum(RoadmapItemPriority),
+        createdAt: z.string().datetime({ offset: true }),
+        updatedAt: z.string().datetime({ offset: true }),
+        issueUrl: githubIssueUrlSchema.nullable(),
+        pullRequestUrl: githubPullRequestUrlSchema.nullable(),
+    })
+    .strict();
+
+export const RoadmapQuerySchema = z
+    .object({
+        page: z.number().int().min(1).max(Number.MAX_SAFE_INTEGER).optional(),
+        pageSize: z
+            .number()
+            .int()
+            .min(1)
+            .max(ROADMAP_DEFAULT_PAGE_SIZE)
+            .optional(),
+    })
+    .strict();
+
+export type RoadmapQuery = z.infer<typeof RoadmapQuerySchema>;
+
+export type RoadmapPagination = {
+    page: number;
+    pageSize: number;
+    totalIssues: number;
+    totalPages: number;
+};
+
+export const RoadmapPaginationSchema: z.ZodType<RoadmapPagination> = z
+    .object({
+        page: z.number().int().min(1).max(Number.MAX_SAFE_INTEGER),
+        pageSize: z.number().int().min(1).max(100),
+        totalIssues: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+        totalPages: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+    })
+    .strict();
+
+export type RoadmapFacets = {
+    statusCounts: Record<RoadmapItemStatus, number>;
+    priorityCounts: Record<RoadmapItemPriority, number>;
+};
+
+const roadmapCountSchema = z.number().int().min(0).max(Number.MAX_SAFE_INTEGER);
+
+export const RoadmapFacetsSchema: z.ZodType<RoadmapFacets> = z
+    .object({
+        statusCounts: z
+            .object({
+                [RoadmapItemStatus.BACKLOG]: roadmapCountSchema,
+                [RoadmapItemStatus.BUILDING]: roadmapCountSchema,
+                [RoadmapItemStatus.SHIPPED]: roadmapCountSchema,
+                [RoadmapItemStatus.CANCELED]: roadmapCountSchema,
+            })
+            .strict(),
+        priorityCounts: z
+            .object({
+                [RoadmapItemPriority.URGENT]: roadmapCountSchema,
+                [RoadmapItemPriority.HIGH]: roadmapCountSchema,
+                [RoadmapItemPriority.MEDIUM]: roadmapCountSchema,
+                [RoadmapItemPriority.LOW]: roadmapCountSchema,
+                [RoadmapItemPriority.NO_PRIORITY]: roadmapCountSchema,
+            })
+            .strict(),
+    })
+    .strict();
+
+export type RoadmapResponse = {
+    status: 'ok';
+    results: RoadmapItem[];
+    pagination: RoadmapPagination;
+    facets: RoadmapFacets;
+};
+
+export const RoadmapResponseSchema: z.ZodType<RoadmapResponse> = z
+    .object({
+        status: z.literal('ok'),
+        results: z.array(RoadmapItemSchema),
+        pagination: RoadmapPaginationSchema,
+        facets: RoadmapFacetsSchema,
+    })
+    .strict();
+
+export type RoadmapResults = {
+    data: RoadmapItem[];
+    pagination: RoadmapPagination;
+    facets: RoadmapFacets;
+};
+
+export type ApiRoadmapResponse = {
+    status: 'ok';
+    results: RoadmapResults;
+};

--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -960,6 +960,10 @@ const PRIVATE_ROUTES: RouteObject[] = [
                 },
             },
             {
+                path: '/roadmap',
+                element: <Navigate to="/generalSettings/roadmap" replace />,
+            },
+            {
                 path: '/no-access',
                 handle: { hideAILauncher: true },
                 element: (

--- a/packages/frontend/src/components/common/Settings/SettingsPage.tsx
+++ b/packages/frontend/src/components/common/Settings/SettingsPage.tsx
@@ -1,11 +1,13 @@
 import { Box, Button, Group, Stack, Text, Title } from '@mantine-8/core';
 import { IconExternalLink } from '@tabler/icons-react';
 import { type FC, type PropsWithChildren, type ReactNode } from 'react';
+import { BetaBadge } from '../BetaBadge';
 import MantineIcon from '../MantineIcon';
 import classes from './SettingsPage.module.css';
 
 type SettingsPageProps = {
     title: string;
+    isBeta?: boolean;
     description?: ReactNode;
     actions?: ReactNode;
 };
@@ -39,6 +41,7 @@ const SettingsPageDocumentationLink: FC<{
 
 const SettingsPage: FC<PropsWithChildren<SettingsPageProps>> = ({
     title,
+    isBeta,
     description,
     actions,
     children,
@@ -53,9 +56,12 @@ const SettingsPage: FC<PropsWithChildren<SettingsPageProps>> = ({
                 className={classes.header}
             >
                 <Stack gap={4} className={classes.heading}>
-                    <Title order={4} className={classes.title}>
-                        {title}
-                    </Title>
+                    <Group gap="xs" wrap="nowrap">
+                        <Title order={4} className={classes.title}>
+                            {title}
+                        </Title>
+                        {isBeta ? <BetaBadge /> : null}
+                    </Group>
                     {description ? (
                         <Text
                             fz="sm"

--- a/packages/frontend/src/ee/hooks/useOrgRoadmap.ts
+++ b/packages/frontend/src/ee/hooks/useOrgRoadmap.ts
@@ -1,0 +1,61 @@
+import {
+    ROADMAP_DEFAULT_PAGE_SIZE,
+    type ApiError,
+    type RoadmapQuery,
+    type RoadmapResults,
+} from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../../api';
+
+const buildRoadmapUrl = (query: RoadmapQuery): string => {
+    const searchParams = new URLSearchParams();
+    Object.entries(query).forEach(([key, value]) => {
+        if (value !== undefined) {
+            searchParams.set(key, String(value));
+        }
+    });
+
+    const queryString = searchParams.toString();
+    return `/org/roadmap${queryString ? `?${queryString}` : ''}`;
+};
+
+const getOrgRoadmap = async (query: RoadmapQuery) =>
+    lightdashApi<RoadmapResults>({
+        url: buildRoadmapUrl(query),
+        method: 'GET',
+        body: undefined,
+    });
+
+const getAllOrgRoadmap = async (): Promise<RoadmapResults> => {
+    const firstPage = await getOrgRoadmap({
+        page: 1,
+        pageSize: ROADMAP_DEFAULT_PAGE_SIZE,
+    });
+    const remainingPages = await Promise.all(
+        Array.from(
+            { length: Math.max(0, firstPage.pagination.totalPages - 1) },
+            (_, index) =>
+                getOrgRoadmap({
+                    page: index + 2,
+                    pageSize: ROADMAP_DEFAULT_PAGE_SIZE,
+                }),
+        ),
+    );
+
+    return {
+        data: [
+            ...firstPage.data,
+            ...remainingPages.flatMap((page) => page.data),
+        ],
+        pagination: firstPage.pagination,
+        facets: firstPage.facets,
+    };
+};
+
+export const useAllOrgRoadmap = (enabled = true) =>
+    useQuery<RoadmapResults, ApiError>({
+        queryKey: ['org-roadmap-all'],
+        queryFn: getAllOrgRoadmap,
+        enabled,
+        retry: false,
+    });

--- a/packages/frontend/src/ee/pages/Roadmap.module.css
+++ b/packages/frontend/src/ee/pages/Roadmap.module.css
@@ -1,0 +1,225 @@
+.page {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    gap: var(--mantine-spacing-lg);
+    min-height: 0;
+    width: 100%;
+}
+
+.toolbar {
+    align-items: center;
+}
+
+.results {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    height: calc(100dvh - 300px);
+    min-height: 0;
+}
+
+.board {
+    background: light-dark(
+        var(--mantine-color-gray-0),
+        var(--mantine-color-dark-6)
+    );
+    border: 1px solid
+        light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
+    border-radius: var(--mantine-radius-md);
+    display: flex;
+    flex: 1;
+    gap: var(--mantine-spacing-md);
+    min-height: 0;
+    overflow-x: auto;
+    padding: var(--mantine-spacing-md);
+    width: 100%;
+}
+
+.list {
+    flex: 1;
+    min-height: 0;
+}
+
+.listTitleButton {
+    text-align: left;
+    width: 100%;
+}
+
+.column {
+    display: flex;
+    flex: 1 1 0;
+    flex-direction: column;
+    min-width: 260px;
+    min-height: 0;
+}
+
+.statusDot {
+    border-radius: 3px;
+    flex: none;
+}
+
+.columnCards {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    gap: var(--mantine-spacing-xs);
+    min-height: 0;
+    overflow-y: auto;
+    padding: 2px;
+}
+
+.card {
+    background: var(--mantine-color-body);
+    border: 1px solid
+        light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
+    border-radius: var(--mantine-radius-md);
+    box-shadow: 0 1px 2px rgba(20, 22, 28, 0.04);
+    overflow: hidden;
+    transition:
+        border-color 120ms ease,
+        box-shadow 120ms ease;
+    width: 100%;
+}
+
+.cardBody {
+    cursor: pointer;
+    padding: var(--mantine-spacing-sm);
+    text-align: left;
+    width: 100%;
+}
+
+.updatedAt {
+    flex: none;
+    white-space: nowrap;
+}
+
+.card:hover {
+    border-color: var(--mantine-color-indigo-4);
+    box-shadow: 0 4px 14px rgba(80, 60, 180, 0.1);
+}
+
+.emptyColumn {
+    border: 1px dashed
+        light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
+    border-radius: var(--mantine-radius-md);
+    padding: var(--mantine-spacing-lg) var(--mantine-spacing-sm);
+    text-align: center;
+}
+
+.detailLayout {
+    align-items: stretch;
+    display: grid;
+    gap: 28px;
+    grid-template-columns: minmax(0, 1fr) 1px 232px;
+    height: calc(85vh - 160px);
+}
+
+.detailHeaderTitle {
+    color: var(--mantine-color-ldGray-9);
+    font-size: 16px;
+    font-weight: 550;
+    letter-spacing: -0.014em;
+    line-height: 1.4;
+}
+
+.detailMain {
+    min-width: 0;
+    overflow-y: auto;
+    padding-right: var(--mantine-spacing-xs);
+}
+
+.detailTicketId {
+    color: var(--mantine-color-ldGray-7);
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 11.5px;
+}
+
+.detailSectionLabel {
+    color: var(--mantine-color-ldGray-6);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+}
+
+.detailPropertyDot {
+    border-radius: 50%;
+    flex: none;
+    height: 6px;
+    width: 6px;
+}
+
+.detailDivider {
+    background-color: var(--mantine-color-ldGray-2);
+}
+
+.detailRailColumn {
+    align-self: start;
+    position: sticky;
+    top: 0;
+}
+
+.detailRailRow {
+    min-height: 28px;
+    padding: 3px 0;
+}
+
+.detailRailLabel {
+    color: var(--mantine-color-ldGray-6);
+    flex: none;
+    font-size: 11.5px;
+    font-weight: 400;
+    width: 72px;
+}
+
+.detailRailValue {
+    display: flex;
+    flex: 1;
+    justify-content: flex-start;
+    min-width: 0;
+    text-align: left;
+}
+
+.detailRailText {
+    color: var(--mantine-color-ldGray-9);
+    font-size: 12px;
+    font-weight: 500;
+    overflow-wrap: anywhere;
+}
+
+.detailRailLink {
+    align-items: center;
+    color: var(--mantine-color-ldGray-9);
+    display: inline-flex;
+    font-size: 12px;
+    font-weight: 500;
+    gap: 5px;
+    text-decoration: none;
+}
+
+.detailRailLink:hover {
+    color: light-dark(
+        var(--mantine-color-indigo-7),
+        var(--mantine-color-indigo-4)
+    );
+}
+
+.markdown {
+    & :global(.wmde-markdown) {
+        background-color: inherit;
+        color: inherit;
+    }
+}
+
+@media (max-width: 820px) {
+    .detailLayout {
+        gap: var(--mantine-spacing-xl);
+        grid-template-columns: minmax(0, 1fr);
+        grid-template-rows: minmax(0, 1fr) auto;
+    }
+
+    .detailDivider {
+        display: none;
+    }
+}

--- a/packages/frontend/src/ee/pages/Roadmap.tsx
+++ b/packages/frontend/src/ee/pages/Roadmap.tsx
@@ -1,0 +1,998 @@
+import {
+    RoadmapItemPriority,
+    RoadmapItemStatus,
+    type RoadmapItem,
+    type RoadmapFacets,
+    type RoadmapPagination,
+} from '@lightdash/common';
+import {
+    ActionIcon,
+    Anchor,
+    Badge,
+    Box,
+    Button,
+    CopyButton,
+    Group,
+    SegmentedControl,
+    Stack,
+    Text,
+    Tooltip,
+    UnstyledButton,
+    useMantineTheme,
+} from '@mantine-8/core';
+import { useDebouncedValue } from '@mantine-8/hooks';
+import {
+    IconAlertCircle,
+    IconArrowUpRight,
+    IconBrandGithub,
+    IconCheck,
+    IconCopy,
+    IconFlag,
+    IconGitPullRequest,
+    IconLayoutKanban,
+    IconRoad,
+    IconSearch,
+    IconTable,
+} from '@tabler/icons-react';
+import MarkdownPreview from '@uiw/react-markdown-preview';
+import { useMemo, useState, type FC, type ReactNode } from 'react';
+import rehypeExternalLinks from 'rehype-external-links';
+import rehypeSanitize from 'rehype-sanitize';
+import {
+    ContentTable,
+    ContentTableSearchInput,
+    useContentTable,
+    type ContentTableColumnDef,
+    type ContentTableSortingState,
+} from '../../components/common/ContentTable';
+import EmptyStateLoader from '../../components/common/EmptyStateLoader';
+import FilterFacet from '../../components/common/FilterFacet';
+import MantineIcon from '../../components/common/MantineIcon';
+import MantineModal from '../../components/common/MantineModal';
+import PaginateControl from '../../components/common/PaginateControl';
+import { SettingsPage } from '../../components/common/Settings/SettingsPage';
+import SuboptimalState from '../../components/common/SuboptimalState/SuboptimalState';
+import { useAllOrgRoadmap } from '../hooks/useOrgRoadmap';
+import styles from './Roadmap.module.css';
+import {
+    filterAndSortRoadmapItems,
+    formatRoadmapDate,
+    formatRoadmapDetailDate,
+    getPriorityColor,
+    getRoadmapFacets,
+    getRoadmapSortOption,
+    getStatusColor,
+} from './roadmapUtils';
+
+type RoadmapView = 'board' | 'table';
+
+type RoadmapColumnDefinition = {
+    label: string;
+    statuses: readonly RoadmapItemStatus[];
+    recencyLabel?: string;
+};
+
+const TABLE_PAGE_SIZE = 20;
+const VISIBLE_ITEMS_PER_COLUMN = 10;
+const EMPTY_ROADMAP_ITEMS: RoadmapItem[] = [];
+const DEFAULT_ROADMAP_STATUSES = [
+    RoadmapItemStatus.BACKLOG,
+    RoadmapItemStatus.BUILDING,
+    RoadmapItemStatus.SHIPPED,
+];
+const COLUMN_DEFINITIONS: readonly RoadmapColumnDefinition[] = [
+    {
+        label: 'Backlog',
+        statuses: [RoadmapItemStatus.BACKLOG],
+    },
+    {
+        label: 'Building',
+        statuses: [RoadmapItemStatus.BUILDING],
+    },
+    {
+        label: 'Shipped',
+        statuses: [RoadmapItemStatus.SHIPPED],
+        recencyLabel: 'in the last month',
+    },
+    {
+        label: 'Canceled',
+        statuses: [RoadmapItemStatus.CANCELED],
+        recencyLabel: 'in the last month',
+    },
+] as const;
+
+const RoadmapRailRow: FC<{ label: string; children: ReactNode }> = ({
+    label,
+    children,
+}) => (
+    <Group className={styles.detailRailRow} wrap="nowrap" gap="sm">
+        <Text className={styles.detailRailLabel}>{label}</Text>
+        <Box className={styles.detailRailValue}>{children}</Box>
+    </Group>
+);
+
+const RoadmapDetailsModal: FC<{
+    item: RoadmapItem | null;
+    onClose: () => void;
+}> = ({ item, onClose }) => {
+    const theme = useMantineTheme();
+
+    return (
+        <MantineModal
+            opened={item !== null}
+            onClose={onClose}
+            size="72rem"
+            title={
+                <Text
+                    component="span"
+                    className={styles.detailHeaderTitle}
+                    lineClamp={2}
+                >
+                    {item?.title ?? 'Roadmap request'}
+                </Text>
+            }
+            cancelLabel={false}
+            modalBodyProps={{ py: 'lg' }}
+            bodyScrollAreaMaxHeight="calc(85vh - 120px)"
+        >
+            {item && (
+                <Box className={styles.detailLayout}>
+                    <Stack className={styles.detailMain} gap={0}>
+                        <Stack gap="md">
+                            <Text className={styles.detailSectionLabel}>
+                                Description
+                            </Text>
+                            {item.description ? (
+                                <Box className={styles.markdown}>
+                                    <MarkdownPreview
+                                        source={item.description}
+                                        rehypePlugins={[
+                                            rehypeSanitize,
+                                            [
+                                                rehypeExternalLinks,
+                                                { target: '_blank' },
+                                            ],
+                                        ]}
+                                        style={{
+                                            backgroundColor: 'inherit',
+                                            color: 'inherit',
+                                            fontSize: theme.fontSizes.sm,
+                                        }}
+                                    />
+                                </Box>
+                            ) : (
+                                <Text c="dimmed" fz="sm">
+                                    No further detail is available for this
+                                    request.
+                                </Text>
+                            )}
+                        </Stack>
+                    </Stack>
+
+                    <Box className={styles.detailDivider} />
+
+                    <Stack
+                        gap="sm"
+                        className={styles.detailRailColumn}
+                        component="aside"
+                        aria-label="Roadmap request properties"
+                    >
+                        <Stack gap={2}>
+                            <RoadmapRailRow label="Status">
+                                <Group gap={6} wrap="nowrap">
+                                    <Box
+                                        className={styles.detailPropertyDot}
+                                        bg={`${getStatusColor(item.status)}.6`}
+                                    />
+                                    <Text className={styles.detailRailText}>
+                                        {item.status}
+                                    </Text>
+                                </Group>
+                            </RoadmapRailRow>
+                            <RoadmapRailRow label="Priority">
+                                <Group gap={6} wrap="nowrap">
+                                    <Box
+                                        className={styles.detailPropertyDot}
+                                        bg={`${getPriorityColor(
+                                            item.priority,
+                                        )}.6`}
+                                    />
+                                    <Text className={styles.detailRailText}>
+                                        {item.priority}
+                                    </Text>
+                                </Group>
+                            </RoadmapRailRow>
+                            <RoadmapRailRow label="Ticket ID">
+                                <Group gap={4} wrap="nowrap">
+                                    <Text className={styles.detailTicketId}>
+                                        {item.ticketId}
+                                    </Text>
+                                    <CopyButton value={item.ticketId}>
+                                        {({ copied, copy }) => (
+                                            <Tooltip
+                                                label={
+                                                    copied
+                                                        ? 'Copied'
+                                                        : 'Copy ticket ID'
+                                                }
+                                                withArrow
+                                            >
+                                                <ActionIcon
+                                                    aria-label={
+                                                        copied
+                                                            ? 'Copied'
+                                                            : 'Copy ticket ID'
+                                                    }
+                                                    color="ldGray.6"
+                                                    onClick={copy}
+                                                    size="xs"
+                                                    variant="transparent"
+                                                >
+                                                    <MantineIcon
+                                                        icon={
+                                                            copied
+                                                                ? IconCheck
+                                                                : IconCopy
+                                                        }
+                                                        size={13}
+                                                    />
+                                                </ActionIcon>
+                                            </Tooltip>
+                                        )}
+                                    </CopyButton>
+                                </Group>
+                            </RoadmapRailRow>
+                            <RoadmapRailRow label="Created">
+                                <Text className={styles.detailRailText}>
+                                    {formatRoadmapDetailDate(item.createdAt)}
+                                </Text>
+                            </RoadmapRailRow>
+                            <RoadmapRailRow label="Updated">
+                                <Text className={styles.detailRailText}>
+                                    {formatRoadmapDetailDate(item.updatedAt)}
+                                </Text>
+                            </RoadmapRailRow>
+                            {item.issueUrl && (
+                                <RoadmapRailRow label="Issue">
+                                    <Anchor
+                                        href={item.issueUrl}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className={styles.detailRailLink}
+                                    >
+                                        <MantineIcon
+                                            icon={IconBrandGithub}
+                                            size={14}
+                                        />
+                                        View GitHub issue
+                                        <MantineIcon
+                                            icon={IconArrowUpRight}
+                                            size={13}
+                                        />
+                                    </Anchor>
+                                </RoadmapRailRow>
+                            )}
+                            {item.pullRequestUrl && (
+                                <RoadmapRailRow label="Pull request">
+                                    <Anchor
+                                        href={item.pullRequestUrl}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className={styles.detailRailLink}
+                                    >
+                                        <MantineIcon
+                                            icon={IconGitPullRequest}
+                                            size={14}
+                                        />
+                                        View pull request
+                                        <MantineIcon
+                                            icon={IconArrowUpRight}
+                                            size={13}
+                                        />
+                                    </Anchor>
+                                </RoadmapRailRow>
+                            )}
+                        </Stack>
+                    </Stack>
+                </Box>
+            )}
+        </MantineModal>
+    );
+};
+
+const RoadmapColumn: FC<{
+    label: string;
+    color: string;
+    items: RoadmapItem[];
+    count: number;
+    recencyLabel?: string;
+    onSelect: (item: RoadmapItem) => void;
+}> = ({ label, color, items, count, recencyLabel, onSelect }) => {
+    const [isExpanded, setIsExpanded] = useState(false);
+    const displayedItems =
+        isExpanded || items.length <= VISIBLE_ITEMS_PER_COLUMN
+            ? items
+            : items.slice(0, VISIBLE_ITEMS_PER_COLUMN);
+    const hasMore = items.length > VISIBLE_ITEMS_PER_COLUMN;
+
+    return (
+        <Box
+            className={styles.column}
+            aria-label={`${label} roadmap items`}
+            data-testid={`roadmap-column-${label}`}
+        >
+            <Group className={styles.columnHeader} gap={8} px={4} pb="xs">
+                <Box
+                    w={8}
+                    h={8}
+                    bg={`${color}.5`}
+                    className={styles.statusDot}
+                />
+                <Text fz="sm" fw={650}>
+                    {label}
+                </Text>
+                <Badge color="gray" variant="light" size="sm">
+                    {count}
+                </Badge>
+                {recencyLabel && (
+                    <Text c="dimmed" fz="xs">
+                        {recencyLabel}
+                    </Text>
+                )}
+            </Group>
+
+            <Box className={styles.columnCards}>
+                {items.length === 0 ? (
+                    <Box className={styles.emptyColumn}>
+                        <Text c="dimmed" fz="xs">
+                            No requests
+                        </Text>
+                    </Box>
+                ) : (
+                    displayedItems.map((item) => (
+                        <Box className={styles.card} key={item.ticketId}>
+                            <Box
+                                className={styles.cardBody}
+                                role="button"
+                                tabIndex={0}
+                                onClick={() => onSelect(item)}
+                                onKeyDown={(
+                                    event: React.KeyboardEvent<HTMLDivElement>,
+                                ) => {
+                                    if (
+                                        event.key === 'Enter' ||
+                                        event.key === ' '
+                                    ) {
+                                        event.preventDefault();
+                                        onSelect(item);
+                                    }
+                                }}
+                            >
+                                <Stack gap="sm">
+                                    <Group
+                                        justify="space-between"
+                                        align="flex-start"
+                                        gap="sm"
+                                        wrap="nowrap"
+                                    >
+                                        <Text fw={550} fz="sm" lineClamp={3}>
+                                            {item.title}
+                                        </Text>
+                                        <Text
+                                            component="time"
+                                            dateTime={item.updatedAt}
+                                            c="dimmed"
+                                            fz="xs"
+                                            title={`Last updated ${new Date(
+                                                item.updatedAt,
+                                            ).toLocaleString()}`}
+                                            className={styles.updatedAt}
+                                        >
+                                            {formatRoadmapDate(item.updatedAt)}
+                                        </Text>
+                                    </Group>
+                                    <Group
+                                        justify="space-between"
+                                        align="center"
+                                        gap="xs"
+                                        wrap="nowrap"
+                                    >
+                                        <Badge
+                                            color={getPriorityColor(
+                                                item.priority,
+                                            )}
+                                            size="xs"
+                                            variant="light"
+                                        >
+                                            {item.priority}
+                                        </Badge>
+                                        {(item.issueUrl ||
+                                            item.pullRequestUrl) && (
+                                            <Group gap={4} wrap="nowrap">
+                                                {item.issueUrl && (
+                                                    <Tooltip label="View GitHub issue">
+                                                        <ActionIcon
+                                                            component="a"
+                                                            href={item.issueUrl}
+                                                            target="_blank"
+                                                            rel="noopener noreferrer"
+                                                            aria-label={`Open GitHub issue: ${item.title}`}
+                                                            color="gray"
+                                                            size="sm"
+                                                            variant="subtle"
+                                                            onClick={(event) =>
+                                                                event.stopPropagation()
+                                                            }
+                                                        >
+                                                            <MantineIcon
+                                                                icon={
+                                                                    IconBrandGithub
+                                                                }
+                                                            />
+                                                        </ActionIcon>
+                                                    </Tooltip>
+                                                )}
+                                                {item.pullRequestUrl && (
+                                                    <Tooltip label="View pull request">
+                                                        <ActionIcon
+                                                            component="a"
+                                                            href={
+                                                                item.pullRequestUrl
+                                                            }
+                                                            target="_blank"
+                                                            rel="noopener noreferrer"
+                                                            aria-label={`Open pull request: ${item.title}`}
+                                                            color="gray"
+                                                            size="sm"
+                                                            variant="subtle"
+                                                            onClick={(event) =>
+                                                                event.stopPropagation()
+                                                            }
+                                                        >
+                                                            <MantineIcon
+                                                                icon={
+                                                                    IconGitPullRequest
+                                                                }
+                                                            />
+                                                        </ActionIcon>
+                                                    </Tooltip>
+                                                )}
+                                            </Group>
+                                        )}
+                                    </Group>
+                                </Stack>
+                            </Box>
+                        </Box>
+                    ))
+                )}
+                {hasMore && (
+                    <Button
+                        color="gray"
+                        fullWidth
+                        size="xs"
+                        variant="subtle"
+                        onClick={() => setIsExpanded((expanded) => !expanded)}
+                    >
+                        {isExpanded
+                            ? 'Show less'
+                            : `Show all (${items.length})`}
+                    </Button>
+                )}
+            </Box>
+        </Box>
+    );
+};
+
+const RoadmapState: FC<{
+    items: RoadmapItem[];
+    isLoading: boolean;
+    isError: boolean;
+    hasActiveFilters: boolean;
+    onRetry: () => void;
+    children: ReactNode;
+}> = ({ items, isLoading, isError, hasActiveFilters, onRetry, children }) => {
+    if (isLoading) {
+        return <EmptyStateLoader title="Loading your roadmap" />;
+    }
+
+    if (isError) {
+        return (
+            <SuboptimalState
+                icon={IconAlertCircle}
+                title="Could not load your roadmap"
+                description="Something went wrong fetching your roadmap."
+                action={
+                    <Button variant="default" onClick={onRetry}>
+                        Try again
+                    </Button>
+                }
+            />
+        );
+    }
+
+    if (items.length === 0) {
+        return hasActiveFilters ? (
+            <SuboptimalState
+                icon={IconSearch}
+                title="No matching requests"
+                description="Try adjusting your filters."
+            />
+        ) : (
+            <SuboptimalState
+                icon={IconRoad}
+                title="No roadmap items yet"
+                description="When your organization raises feature requests with Lightdash, they will appear here."
+            />
+        );
+    }
+
+    return children;
+};
+
+type RoadmapContentProps = {
+    items: RoadmapItem[];
+    isLoading: boolean;
+    isError: boolean;
+    hasActiveFilters?: boolean;
+    onRetry: () => void;
+};
+
+type RoadmapKanbanProps = RoadmapContentProps & {
+    statusCounts?: RoadmapFacets['statusCounts'];
+    visibleStatuses?: RoadmapItemStatus[];
+};
+
+const RoadmapKanban: FC<RoadmapKanbanProps> = ({
+    items,
+    statusCounts,
+    visibleStatuses,
+    isLoading,
+    isError,
+    hasActiveFilters = false,
+    onRetry,
+}) => {
+    const [selectedItem, setSelectedItem] = useState<RoadmapItem | null>(null);
+    const columns = useMemo(
+        () =>
+            COLUMN_DEFINITIONS.filter(
+                (column) =>
+                    !visibleStatuses ||
+                    visibleStatuses.length === 0 ||
+                    column.statuses.some((status) =>
+                        visibleStatuses.includes(status),
+                    ),
+            ).map((column) => ({
+                ...column,
+                items: items.filter((item) =>
+                    column.statuses.includes(item.status),
+                ),
+            })),
+        [items, visibleStatuses],
+    );
+
+    return (
+        <RoadmapState
+            items={items}
+            isLoading={isLoading}
+            isError={isError}
+            hasActiveFilters={hasActiveFilters}
+            onRetry={onRetry}
+        >
+            <Box className={styles.results}>
+                <Box className={styles.board}>
+                    {columns.map((column) => (
+                        <RoadmapColumn
+                            key={column.label}
+                            label={column.label}
+                            color={getStatusColor(column.statuses[0])}
+                            items={column.items}
+                            count={
+                                statusCounts?.[column.statuses[0]] ??
+                                column.items.length
+                            }
+                            recencyLabel={column.recencyLabel}
+                            onSelect={setSelectedItem}
+                        />
+                    ))}
+                </Box>
+                <RoadmapDetailsModal
+                    item={selectedItem}
+                    onClose={() => setSelectedItem(null)}
+                />
+            </Box>
+        </RoadmapState>
+    );
+};
+
+type RoadmapTableProps = RoadmapContentProps & {
+    pagination: RoadmapPagination;
+    onPageChange: (page: number) => void;
+    sorting: ContentTableSortingState;
+    onSortingChange: React.Dispatch<
+        React.SetStateAction<ContentTableSortingState>
+    >;
+};
+
+const RoadmapTable: FC<RoadmapTableProps> = ({
+    items,
+    pagination,
+    isLoading,
+    isError,
+    hasActiveFilters = false,
+    onRetry,
+    onPageChange,
+    sorting,
+    onSortingChange,
+}) => {
+    const [selectedItem, setSelectedItem] = useState<RoadmapItem | null>(null);
+    const theme = useMantineTheme();
+    const columns = useMemo<ContentTableColumnDef<RoadmapItem>[]>(
+        () => [
+            {
+                accessorKey: 'title',
+                header: 'Request',
+                size: 520,
+                enableSorting: false,
+                Cell: ({ row }) => (
+                    <UnstyledButton
+                        className={styles.listTitleButton}
+                        onClick={() => setSelectedItem(row.original)}
+                    >
+                        <Text fw={500} fz="sm">
+                            {row.original.title}
+                        </Text>
+                    </UnstyledButton>
+                ),
+            },
+            {
+                accessorKey: 'status',
+                header: 'Status',
+                size: 140,
+                enableSorting: true,
+                sortDescFirst: false,
+                Cell: ({ row }) => (
+                    <Badge
+                        color={getStatusColor(row.original.status)}
+                        variant="light"
+                    >
+                        {row.original.status}
+                    </Badge>
+                ),
+            },
+            {
+                accessorKey: 'priority',
+                header: 'Priority',
+                size: 140,
+                enableSorting: true,
+                sortDescFirst: false,
+                Cell: ({ row }) => (
+                    <Badge
+                        color={getPriorityColor(row.original.priority)}
+                        variant="light"
+                    >
+                        {row.original.priority}
+                    </Badge>
+                ),
+            },
+            {
+                accessorKey: 'createdAt',
+                header: 'Created',
+                size: 140,
+                enableSorting: true,
+                sortDescFirst: true,
+                Cell: ({ row }) => (
+                    <Text fz="sm">
+                        {new Date(row.original.createdAt).toLocaleDateString()}
+                    </Text>
+                ),
+            },
+            {
+                accessorKey: 'updatedAt',
+                header: 'Updated',
+                size: 140,
+                enableSorting: true,
+                sortDescFirst: true,
+                Cell: ({ row }) => (
+                    <Text fz="sm">
+                        {new Date(row.original.updatedAt).toLocaleDateString()}
+                    </Text>
+                ),
+            },
+        ],
+        [],
+    );
+    const table = useContentTable({
+        columns,
+        data: items,
+        enableColumnResizing: false,
+        enableRowNumbers: false,
+        enablePagination: false,
+        enableFilters: false,
+        enableFullScreenToggle: false,
+        enableDensityToggle: false,
+        enableColumnActions: false,
+        enableColumnFilters: false,
+        enableHiding: false,
+        enableGlobalFilterModes: false,
+        enableSorting: true,
+        enableMultiSort: false,
+        manualSorting: true,
+        onSortingChange,
+        enableTopToolbar: false,
+        enableBottomToolbar: false,
+        getRowId: (row) => row.ticketId,
+        mantinePaperProps: {
+            shadow: undefined,
+            sx: {
+                border: `1px solid ${theme.colors.ldGray[2]}`,
+                borderRadius: theme.spacing.sm,
+                boxShadow: theme.shadows.subtle,
+                display: 'flex',
+                flexDirection: 'column',
+            },
+        },
+        mantineTableContainerProps: {
+            sx: {
+                maxHeight: 'calc(100dvh - 370px)',
+            },
+        },
+        mantineTableHeadRowProps: {
+            style: {
+                boxShadow: 'none',
+            },
+        },
+        mantineTableProps: {
+            highlightOnHover: true,
+        },
+        state: {
+            showProgressBars: false,
+            showSkeletons: isLoading,
+            density: 'md',
+            sorting,
+        },
+        mantineLoadingOverlayProps: {
+            loaderProps: {
+                color: 'gray',
+            },
+        },
+    });
+
+    return (
+        <RoadmapState
+            items={items}
+            isLoading={isLoading}
+            isError={isError}
+            hasActiveFilters={hasActiveFilters}
+            onRetry={onRetry}
+        >
+            <Stack className={styles.results} gap="sm">
+                <Box className={styles.list}>
+                    <ContentTable table={table} />
+                </Box>
+
+                <Group justify="space-between">
+                    <Text c="dimmed" fz="xs">
+                        {pagination.totalIssues} requests
+                    </Text>
+                    {pagination.totalPages > 1 && (
+                        <PaginateControl
+                            currentPage={pagination.page}
+                            totalPages={pagination.totalPages}
+                            hasPreviousPage={pagination.page > 1}
+                            hasNextPage={
+                                pagination.page < pagination.totalPages
+                            }
+                            onPreviousPage={() =>
+                                onPageChange(pagination.page - 1)
+                            }
+                            onNextPage={() => onPageChange(pagination.page + 1)}
+                        />
+                    )}
+                </Group>
+
+                <RoadmapDetailsModal
+                    item={selectedItem}
+                    onClose={() => setSelectedItem(null)}
+                />
+            </Stack>
+        </RoadmapState>
+    );
+};
+
+const RoadmapViewSelector: FC<{
+    value: RoadmapView;
+    onChange: (view: RoadmapView) => void;
+}> = ({ value, onChange }) => (
+    <SegmentedControl
+        aria-label="Roadmap view"
+        ml="auto"
+        size="xs"
+        data={[
+            {
+                label: (
+                    <Group gap={6} wrap="nowrap">
+                        <MantineIcon icon={IconLayoutKanban} />
+                        Board
+                    </Group>
+                ),
+                value: 'board',
+            },
+            {
+                label: (
+                    <Group gap={6} wrap="nowrap">
+                        <MantineIcon icon={IconTable} />
+                        Table
+                    </Group>
+                ),
+                value: 'table',
+            },
+        ]}
+        value={value}
+        onChange={(nextValue) => onChange(nextValue as RoadmapView)}
+    />
+);
+
+const Roadmap: FC = () => {
+    const [view, setView] = useState<RoadmapView>('board');
+    const [page, setPage] = useState(1);
+    const [search, setSearch] = useState('');
+    const [debouncedSearch] = useDebouncedValue(search.trim(), 300);
+    const [statuses, setStatuses] = useState<RoadmapItemStatus[]>(
+        DEFAULT_ROADMAP_STATUSES,
+    );
+    const [priorities, setPriorities] = useState<RoadmapItemPriority[]>([]);
+    const [tableSorting, setTableSorting] = useState<ContentTableSortingState>([
+        {
+            id: 'priority',
+            desc: false,
+        },
+    ]);
+    const roadmapQuery = useAllOrgRoadmap();
+    const allItems = roadmapQuery.data?.data ?? EMPTY_ROADMAP_ITEMS;
+    const boardItems = useMemo(
+        () =>
+            filterAndSortRoadmapItems({
+                items: allItems,
+                search: debouncedSearch,
+                statuses,
+                priorities,
+                sortOption: 'priority',
+            }),
+        [allItems, debouncedSearch, priorities, statuses],
+    );
+    const sortedTableItems = useMemo(
+        () =>
+            filterAndSortRoadmapItems({
+                items: allItems,
+                search: debouncedSearch,
+                statuses,
+                priorities,
+                sortOption: getRoadmapSortOption(tableSorting),
+            }),
+        [allItems, debouncedSearch, priorities, statuses, tableSorting],
+    );
+    const tableItems = sortedTableItems.slice(
+        (page - 1) * TABLE_PAGE_SIZE,
+        page * TABLE_PAGE_SIZE,
+    );
+    const totalPages = Math.ceil(boardItems.length / TABLE_PAGE_SIZE);
+    const facets = useMemo(() => getRoadmapFacets(allItems), [allItems]);
+    const statusCounts = useMemo(
+        () => getRoadmapFacets(boardItems).statusCounts,
+        [boardItems],
+    );
+    const hasActiveFilters = Boolean(
+        search.trim() || statuses.length || priorities.length,
+    );
+    const resetPage = () => setPage(1);
+    const handleTableSortingChange: React.Dispatch<
+        React.SetStateAction<ContentTableSortingState>
+    > = (updater) => {
+        setTableSorting((currentSorting) => {
+            const nextSorting =
+                typeof updater === 'function'
+                    ? updater(currentSorting)
+                    : updater;
+
+            return nextSorting.length > 0
+                ? nextSorting.slice(0, 1)
+                : [
+                      {
+                          id: currentSorting[0]?.id ?? 'priority',
+                          desc: false,
+                      },
+                  ];
+        });
+        resetPage();
+    };
+
+    return (
+        <Stack mb="lg" gap="md" className={styles.page}>
+            <SettingsPage
+                title="Roadmap"
+                isBeta
+                description="Feature requests from your organization and where they stand."
+            >
+                <Group className={styles.toolbar} gap="sm" wrap="wrap">
+                    <ContentTableSearchInput
+                        tooltipLabel="Search roadmap"
+                        placeholder="Search roadmap"
+                        value={search}
+                        onChange={(value) => {
+                            setSearch(value);
+                            resetPage();
+                        }}
+                        collapsedWidth={340}
+                        expandedWidth={340}
+                    />
+                    <FilterFacet
+                        label="Status"
+                        icon={IconRoad}
+                        selected={statuses}
+                        onChange={(values) => {
+                            setStatuses(values as RoadmapItemStatus[]);
+                            resetPage();
+                        }}
+                        options={Object.values(RoadmapItemStatus).map(
+                            (value) => ({
+                                value,
+                                label: value,
+                                count: facets?.statusCounts[value],
+                            }),
+                        )}
+                        tooltipLabel="Filter by status"
+                    />
+                    <FilterFacet
+                        label="Priority"
+                        icon={IconFlag}
+                        selected={priorities}
+                        onChange={(values) => {
+                            setPriorities(values as RoadmapItemPriority[]);
+                            resetPage();
+                        }}
+                        options={Object.values(RoadmapItemPriority).map(
+                            (value) => ({
+                                value,
+                                label: value,
+                                count: facets?.priorityCounts[value],
+                            }),
+                        )}
+                        tooltipLabel="Filter by priority"
+                    />
+                    <RoadmapViewSelector value={view} onChange={setView} />
+                </Group>
+
+                {view === 'board' ? (
+                    <RoadmapKanban
+                        items={boardItems}
+                        statusCounts={statusCounts}
+                        visibleStatuses={statuses}
+                        isLoading={roadmapQuery.isInitialLoading}
+                        isError={roadmapQuery.isError}
+                        hasActiveFilters={hasActiveFilters}
+                        onRetry={() => void roadmapQuery.refetch()}
+                    />
+                ) : (
+                    <RoadmapTable
+                        items={tableItems}
+                        pagination={{
+                            page,
+                            pageSize: TABLE_PAGE_SIZE,
+                            totalIssues: boardItems.length,
+                            totalPages,
+                        }}
+                        isLoading={roadmapQuery.isInitialLoading}
+                        isError={roadmapQuery.isError}
+                        hasActiveFilters={hasActiveFilters}
+                        onRetry={() => void roadmapQuery.refetch()}
+                        onPageChange={setPage}
+                        sorting={tableSorting}
+                        onSortingChange={handleTableSortingChange}
+                    />
+                )}
+            </SettingsPage>
+        </Stack>
+    );
+};
+
+export default Roadmap;

--- a/packages/frontend/src/ee/pages/roadmapUtils.ts
+++ b/packages/frontend/src/ee/pages/roadmapUtils.ts
@@ -1,0 +1,201 @@
+import {
+    assertUnreachable,
+    RoadmapItemPriority,
+    RoadmapItemStatus,
+    type RoadmapItem,
+    type RoadmapFacets,
+} from '@lightdash/common';
+import type { ContentTableSortingState } from '../../components/common/ContentTable';
+
+export type RoadmapSortOption =
+    | 'status'
+    | 'status-desc'
+    | 'priority'
+    | 'priority-desc'
+    | 'updated-desc'
+    | 'updated-asc'
+    | 'created-desc'
+    | 'created-asc';
+
+const PRIORITY_ORDER: Record<RoadmapItemPriority, number> = {
+    [RoadmapItemPriority.URGENT]: 0,
+    [RoadmapItemPriority.HIGH]: 1,
+    [RoadmapItemPriority.MEDIUM]: 2,
+    [RoadmapItemPriority.LOW]: 3,
+    [RoadmapItemPriority.NO_PRIORITY]: 4,
+};
+
+const STATUS_ORDER: Record<RoadmapItemStatus, number> = {
+    [RoadmapItemStatus.BACKLOG]: 0,
+    [RoadmapItemStatus.BUILDING]: 1,
+    [RoadmapItemStatus.SHIPPED]: 2,
+    [RoadmapItemStatus.CANCELED]: 3,
+};
+
+export const getStatusColor = (status: RoadmapItemStatus): string => {
+    switch (status) {
+        case RoadmapItemStatus.BUILDING:
+            return 'blue';
+        case RoadmapItemStatus.SHIPPED:
+            return 'green';
+        case RoadmapItemStatus.BACKLOG:
+        case RoadmapItemStatus.CANCELED:
+            return 'ldGray';
+        default:
+            return assertUnreachable(
+                status,
+                `Unknown roadmap status ${status}`,
+            );
+    }
+};
+
+export const getPriorityColor = (priority: RoadmapItemPriority): string => {
+    switch (priority) {
+        case RoadmapItemPriority.URGENT:
+            return 'red';
+        case RoadmapItemPriority.HIGH:
+            return 'orange';
+        case RoadmapItemPriority.MEDIUM:
+            return 'yellow';
+        case RoadmapItemPriority.LOW:
+            return 'blue';
+        case RoadmapItemPriority.NO_PRIORITY:
+            return 'ldGray';
+        default:
+            return assertUnreachable(
+                priority,
+                `Unknown roadmap priority ${priority}`,
+            );
+    }
+};
+
+export const formatRoadmapDate = (date: string): string =>
+    new Intl.DateTimeFormat(undefined, {
+        day: 'numeric',
+        month: 'short',
+    }).format(new Date(date));
+
+export const formatRoadmapDetailDate = (date: string): string =>
+    new Intl.DateTimeFormat(undefined, {
+        day: 'numeric',
+        month: 'short',
+        year: 'numeric',
+    }).format(new Date(date));
+
+export const getRoadmapFacets = (items: RoadmapItem[]): RoadmapFacets => {
+    const facets = {
+        statusCounts: Object.fromEntries(
+            Object.values(RoadmapItemStatus).map((status) => [status, 0]),
+        ),
+        priorityCounts: Object.fromEntries(
+            Object.values(RoadmapItemPriority).map((priority) => [priority, 0]),
+        ),
+    } as RoadmapFacets;
+
+    items.forEach((item) => {
+        facets.statusCounts[item.status] += 1;
+        facets.priorityCounts[item.priority] += 1;
+    });
+
+    return facets;
+};
+
+export const getRoadmapSortOption = (
+    sorting: ContentTableSortingState,
+): RoadmapSortOption => {
+    const [sort] = sorting;
+    if (!sort) {
+        return 'priority';
+    }
+
+    switch (sort.id) {
+        case 'status':
+            return sort.desc ? 'status-desc' : 'status';
+        case 'priority':
+            return sort.desc ? 'priority-desc' : 'priority';
+        case 'createdAt':
+            return sort.desc ? 'created-desc' : 'created-asc';
+        case 'updatedAt':
+            return sort.desc ? 'updated-desc' : 'updated-asc';
+        default:
+            return 'priority';
+    }
+};
+
+export const filterAndSortRoadmapItems = ({
+    items,
+    search,
+    statuses,
+    priorities,
+    sortOption,
+}: {
+    items: RoadmapItem[];
+    search: string;
+    statuses: RoadmapItemStatus[];
+    priorities: RoadmapItemPriority[];
+    sortOption: RoadmapSortOption;
+}): RoadmapItem[] => {
+    const normalizedSearch = search.trim().toLowerCase();
+    const filteredItems = items.filter((item) => {
+        const matchesStatus =
+            statuses.length === 0 || statuses.includes(item.status);
+        const matchesPriority =
+            priorities.length === 0 || priorities.includes(item.priority);
+        const searchableText = [
+            item.title,
+            item.description,
+            item.ticketId,
+            item.status,
+            item.priority,
+        ]
+            .filter(Boolean)
+            .join(' ')
+            .toLowerCase();
+
+        return (
+            matchesStatus &&
+            matchesPriority &&
+            (!normalizedSearch || searchableText.includes(normalizedSearch))
+        );
+    });
+
+    return filteredItems.sort((left, right) => {
+        switch (sortOption) {
+            case 'status':
+                return (
+                    STATUS_ORDER[left.status] - STATUS_ORDER[right.status] ||
+                    Date.parse(right.updatedAt) - Date.parse(left.updatedAt)
+                );
+            case 'status-desc':
+                return (
+                    STATUS_ORDER[right.status] - STATUS_ORDER[left.status] ||
+                    Date.parse(right.updatedAt) - Date.parse(left.updatedAt)
+                );
+            case 'priority':
+                return (
+                    PRIORITY_ORDER[left.priority] -
+                        PRIORITY_ORDER[right.priority] ||
+                    Date.parse(right.updatedAt) - Date.parse(left.updatedAt)
+                );
+            case 'priority-desc':
+                return (
+                    PRIORITY_ORDER[right.priority] -
+                        PRIORITY_ORDER[left.priority] ||
+                    Date.parse(right.updatedAt) - Date.parse(left.updatedAt)
+                );
+            case 'updated-desc':
+                return Date.parse(right.updatedAt) - Date.parse(left.updatedAt);
+            case 'updated-asc':
+                return Date.parse(left.updatedAt) - Date.parse(right.updatedAt);
+            case 'created-desc':
+                return Date.parse(right.createdAt) - Date.parse(left.createdAt);
+            case 'created-asc':
+                return Date.parse(left.createdAt) - Date.parse(right.createdAt);
+            default:
+                return assertUnreachable(
+                    sortOption,
+                    `Unknown sort option ${sortOption}`,
+                );
+        }
+    });
+};

--- a/packages/frontend/src/hooks/settings/types.ts
+++ b/packages/frontend/src/hooks/settings/types.ts
@@ -63,6 +63,8 @@ export type SettingsContext = {
     isLeaveOrganizationEnabled: boolean;
     isCustomRolesEnabled: boolean | undefined;
     isProLimitsEnabled: boolean;
+    isOrganizationRoadmapEnabled: boolean;
+    isOrganizationRoadmapLoading: boolean;
     isSsoOrganizationSettingsEnabled: boolean;
     isEmailWhitelabelEnabled: boolean;
     isScimTokenManagementEnabled: FeatureFlag | undefined;

--- a/packages/frontend/src/hooks/settings/useSettingsContext.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsContext.ts
@@ -87,6 +87,13 @@ export const useSettingsContext = (): SettingsContext => {
     );
     const isProLimitsEnabled = proLimitsFlag?.enabled ?? false;
 
+    const organizationRoadmapFlagQuery = useServerFeatureFlag(
+        FeatureFlags.OrganizationRoadmap,
+    );
+    const { data: organizationRoadmapFlag } = organizationRoadmapFlagQuery;
+    const isOrganizationRoadmapEnabled =
+        organizationRoadmapFlag?.enabled ?? false;
+
     const { data: ssoOrganizationSettingsFlag } = useServerFeatureFlag(
         FeatureFlags.SsoOrganizationSettings,
     );
@@ -180,6 +187,9 @@ export const useSettingsContext = (): SettingsContext => {
         isLeaveOrganizationEnabled,
         isCustomRolesEnabled,
         isProLimitsEnabled,
+        isOrganizationRoadmapEnabled,
+        isOrganizationRoadmapLoading:
+            organizationRoadmapFlagQuery.isInitialLoading,
         isSsoOrganizationSettingsEnabled,
         isEmailWhitelabelEnabled,
         isScimTokenManagementEnabled,

--- a/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
@@ -29,6 +29,7 @@ import {
     IconPlugConnected,
     IconRefresh,
     IconReportAnalytics,
+    IconRoad,
     IconRobotFace,
     IconSettings,
     IconShieldCheck,
@@ -71,6 +72,7 @@ export const useSettingsNavigation = (
         hasSocialLogin,
         isGroupManagementEnabled,
         isProLimitsEnabled,
+        isOrganizationRoadmapEnabled,
         isCustomRolesEnabled,
         isSsoOrganizationSettingsEnabled,
         isEmailWhitelabelEnabled,
@@ -505,6 +507,30 @@ export const useSettingsNavigation = (
             });
         }
 
+        if (
+            isOrganizationRoadmapEnabled &&
+            ability?.can(
+                'view',
+                subject('Roadmap', {
+                    organizationUuid: organization?.organizationUuid,
+                }),
+            )
+        ) {
+            organizationItems.push({
+                label: 'Roadmap',
+                to: '/generalSettings/roadmap',
+                icon: IconRoad,
+                keywords: [
+                    'feature requests',
+                    'planned',
+                    'building',
+                    'shipped',
+                ],
+                children: [],
+                exact: true,
+            });
+        }
+
         const sections: SettingsNavigationSection[] = [
             {
                 id: 'your-settings',
@@ -871,6 +897,7 @@ export const useSettingsNavigation = (
         hasSocialLogin,
         isGroupManagementEnabled,
         isProLimitsEnabled,
+        isOrganizationRoadmapEnabled,
         isCustomRolesEnabled,
         isSsoOrganizationSettingsEnabled,
         isEmailWhitelabelEnabled,

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -83,6 +83,7 @@ import { CustomRoleCreate } from '../ee/pages/customRoles/CustomRoleCreate';
 import { CustomRoleDuplicate } from '../ee/pages/customRoles/CustomRoleDuplicate';
 import { CustomRoleEdit } from '../ee/pages/customRoles/CustomRoleEdit';
 import { CustomRoles } from '../ee/pages/customRoles/CustomRoles';
+import Roadmap from '../ee/pages/Roadmap';
 import DesignListPage from '../features/organizationDesigns/components/DesignListPage';
 import { filterSettingsNavigation } from '../hooks/settings/filterSettingsNavigation';
 import { useSettingsContext } from '../hooks/settings/useSettingsContext';
@@ -158,6 +159,8 @@ const Settings: FC = () => {
         isLeaveOrganizationEnabled,
         isCustomRolesEnabled,
         isProLimitsEnabled,
+        isOrganizationRoadmapEnabled,
+        isOrganizationRoadmapLoading,
         isSsoOrganizationSettingsEnabled,
         isEmailWhitelabelEnabled,
         isServiceAccountsEnabled,
@@ -584,6 +587,25 @@ const Settings: FC = () => {
             });
         }
 
+        if (
+            isOrganizationRoadmapEnabled &&
+            user?.ability.can(
+                'view',
+                subject('Roadmap', {
+                    organizationUuid: organization?.organizationUuid,
+                }),
+            )
+        ) {
+            allowedRoutes.push({
+                path: '/roadmap',
+                element: (
+                    <TrackPage name={PageName.ROADMAP}>
+                        <Roadmap />
+                    </TrackPage>
+                ),
+            });
+        }
+
         if (isAiCopilotEnabledOrTrial && hasAnyAiAgentAccess) {
             allowedRoutes.push({
                 path: '/ai',
@@ -706,6 +728,7 @@ const Settings: FC = () => {
         health?.auth.google.enabled,
         dataAppsFlag?.enabled,
         isProLimitsEnabled,
+        isOrganizationRoadmapEnabled,
         isSsoOrganizationSettingsEnabled,
         isEmailWhitelabelEnabled,
         isLeaveOrganizationEnabled,
@@ -811,7 +834,8 @@ const Settings: FC = () => {
             !matchPath(
                 { path: '/generalSettings/ai/issues/:fingerprint' },
                 location.pathname,
-            )
+            ) &&
+            !matchPath({ path: '/generalSettings/roadmap' }, location.pathname)
         );
     }, [location.pathname]);
 
@@ -822,6 +846,9 @@ const Settings: FC = () => {
     const isAwaitingAiSettingsRoute =
         isAiOrganizationSettingsLoading &&
         Boolean(matchPath('/generalSettings/ai/*', location.pathname));
+    const isAwaitingRoadmapRoute =
+        isOrganizationRoadmapLoading &&
+        Boolean(matchPath('/generalSettings/roadmap', location.pathname));
 
     if (
         isHealthLoading ||
@@ -829,7 +856,8 @@ const Settings: FC = () => {
         isOrganizationLoading ||
         isActiveProjectUuidLoading ||
         isProjectLoading ||
-        isAwaitingAiSettingsRoute
+        isAwaitingAiSettingsRoute ||
+        isAwaitingRoadmapRoute
     ) {
         return <PageSpinner />;
     }

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -63,6 +63,7 @@ export enum PageName {
     CATALOG = 'catalog',
     METRICS_CATALOG = 'metrics_catalog',
     FUNNEL_BUILDER = 'funnel_builder',
+    ROADMAP = 'roadmap',
 }
 
 export enum CategoryName {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: CS-17
Closes: CS-18

### Description:
Adds a feature-flagged, admin-only organization Roadmap page with Board and Table views, client-side search, status and priority filters, sortable columns, and detailed request modals.
Introduces the strict shared roadmap contract and a hidden authenticated backend endpoint that forwards the license key to the external roadmap service while validating permissions and upstream responses.
Integrates Roadmap into organization settings navigation, page analytics, and the standard settings layout.