### PR TITLE
feat: show agent reasoning and activity history in data app builds

### DIFF
--- a/packages/backend/src/database/entities/apps.ts
+++ b/packages/backend/src/database/entities/apps.ts
@@ -2,6 +2,7 @@ import {
     type AppVersionDependencies,
     type AppVersionResources,
     type AppVersionStatus,
+    type AppVersionStatusHistoryEntry,
     type DataAppTemplate,
     type DataAppVizSchema,
 } from '@lightdash/common';
@@ -84,6 +85,8 @@ export type DbAppVersion = {
     status: AppVersionStatus;
     error: string | null;
     status_message: string | null;
+    // Append-only build narration log; defaults to [] on insert.
+    status_history: AppVersionStatusHistoryEntry[];
     status_updated_at: Date | null;
     resources: AppVersionResources | null;
     // Declared-dependency summary for the version's build; null = template set.
@@ -112,6 +115,7 @@ export type AppVersionsTable = Knex.CompositeTableType<
             | 'status'
             | 'error'
             | 'status_message'
+            | 'status_history'
             | 'status_updated_at'
             | 'viz_schema'
         >

--- a/packages/backend/src/database/migrations/20260727104818_add_status_history_to_app_versions.ts
+++ b/packages/backend/src/database/migrations/20260727104818_add_status_history_to_app_versions.ts
@@ -1,0 +1,13 @@
+import { type Knex } from 'knex';
+
+export const up = async (knex: Knex): Promise<void> => {
+    await knex.schema.alterTable('app_versions', (table) => {
+        table.jsonb('status_history').notNullable().defaultTo('[]');
+    });
+};
+
+export const down = async (knex: Knex): Promise<void> => {
+    await knex.schema.alterTable('app_versions', (table) => {
+        table.dropColumn('status_history');
+    });
+};

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.buildFromSource.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.buildFromSource.test.ts
@@ -74,6 +74,7 @@ function buildService(
         updateVersionStatusIfInProgress: vi.fn().mockResolvedValue(true),
         updateSandboxUuid: vi.fn().mockResolvedValue(undefined),
         updateStatusMessage: vi.fn().mockResolvedValue(undefined),
+        recordBuildNarration: vi.fn().mockResolvedValue(undefined),
         getVersion: vi
             .fn()
             .mockResolvedValue(

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.statusHistory.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.statusHistory.test.ts
@@ -1,0 +1,62 @@
+import { type AppVersionStatusHistoryEntry } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { AppGenerateService } from './AppGenerateService';
+
+// Private static — accessed via index so the filter's contract stays covered
+// without widening the service's public surface.
+const filter = (
+    history: AppVersionStatusHistoryEntry[],
+    status: 'generating' | 'ready',
+    statusMessage: string | null,
+) =>
+    // eslint-disable-next-line @typescript-eslint/dot-notation
+    AppGenerateService['filterStatusHistoryForApi'](
+        history,
+        status,
+        statusMessage,
+    );
+
+const entry = (
+    kind: AppVersionStatusHistoryEntry['kind'],
+    message: string,
+): AppVersionStatusHistoryEntry => ({
+    kind,
+    message,
+    timestamp: '2026-07-27T10:00:00.000Z',
+});
+
+describe('filterStatusHistoryForApi', () => {
+    it('drops reasoning entries restated in the final message on terminal versions', () => {
+        const history = [
+            entry('thinking', 'I will start with the KPI row.'),
+            entry('tool', 'Creating App.tsx'),
+            // Final text block streams through the snippet pipeline, so its
+            // sentences land in the history with different whitespace.
+            entry('thinking', 'Built a dashboard with a KPI row.'),
+        ];
+        const result = filter(
+            history,
+            'ready',
+            'Built a dashboard\nwith a KPI row. The build step will surface issues.',
+        );
+        expect(result.map((e) => e.message)).toEqual([
+            'I will start with the KPI row.',
+            'Creating App.tsx',
+        ]);
+    });
+
+    it('keeps all non-stage entries while the version is in progress', () => {
+        const history = [
+            entry('stage', 'Setting up build environment'),
+            entry('thinking', 'Planning the layout.'),
+            entry('tool', 'Reading schema.yml'),
+        ];
+        // Live statusMessage often equals the newest snippet — it must not
+        // suppress that entry mid-build.
+        const result = filter(history, 'generating', 'Planning the layout.');
+        expect(result.map((e) => e.message)).toEqual([
+            'Planning the layout.',
+            'Reading schema.yml',
+        ]);
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -54,6 +54,8 @@ import {
     type AppVersionDependencyEntry,
     type AppVersionExternalConnectionResource,
     type AppVersionResources,
+    type AppVersionStatusHistoryEntry,
+    type AppVersionStatusHistoryEntryKind,
     type ChartConfig,
     type ChartReference,
     type ChartSampleData,
@@ -2461,7 +2463,12 @@ export class AppGenerateService extends BaseService {
      * Convert an internal tool description (e.g. "Write /app/src/Dashboard.tsx")
      * into a user-friendly status message (e.g. "Creating Dashboard.tsx").
      */
-    private static toolDescriptionToStatusMessage(description: string): string {
+    /** Human-readable status for a recognized tool; null for tools we have
+     *  no meaningful description for (the caller shows a coding phrase as
+     *  the live status instead, without recording it in the history). */
+    private static toolDescriptionToStatusMessage(
+        description: string,
+    ): string | null {
         const parts = description.split(' ');
         const tool = parts[0];
         const filePath = parts.slice(1).join(' ');
@@ -2480,7 +2487,7 @@ export class AppGenerateService extends BaseService {
             case 'TodoWrite':
                 return 'Updating TODOs';
             default:
-                return AppGenerateService.randomCodingPhrase();
+                return null;
         }
     }
 
@@ -2667,10 +2674,13 @@ export class AppGenerateService extends BaseService {
                                         this.logger.info(
                                             `App ${appUuid}: claude turn #${event.turn}: thinking`,
                                         );
+                                        // Live-status placeholder only — not
+                                        // worth keeping in the transcript.
                                         this.updateAppStatus(
                                             appUuid,
                                             version,
                                             'Thinking',
+                                            null,
                                         );
                                         break;
                                     case 'thinking_snippet':
@@ -2678,6 +2688,7 @@ export class AppGenerateService extends BaseService {
                                             appUuid,
                                             version,
                                             event.snippet,
+                                            'thinking',
                                         );
                                         break;
                                     case 'tool_use': {
@@ -2689,12 +2700,18 @@ export class AppGenerateService extends BaseService {
                                         // use only the first tool for the status.
                                         const firstTool =
                                             event.description.split(', ')[0];
+                                        const toolStatus =
+                                            AppGenerateService.toolDescriptionToStatusMessage(
+                                                firstTool,
+                                            );
+                                        // Unknown tools get a fun live status
+                                        // but stay out of the transcript.
                                         this.updateAppStatus(
                                             appUuid,
                                             version,
-                                            AppGenerateService.toolDescriptionToStatusMessage(
-                                                firstTool,
-                                            ),
+                                            toolStatus ??
+                                                AppGenerateService.randomCodingPhrase(),
+                                            toolStatus ? 'tool' : null,
                                         );
                                         break;
                                     }
@@ -2845,15 +2862,17 @@ export class AppGenerateService extends BaseService {
     /**
      * Fire-and-forget app status message update. Logs (but does not propagate)
      * failures so transient DB errors during a long generation don't kill the
-     * pipeline.
+     * pipeline. `kind` tags the entry in the narration history; `null` shows
+     * the message as the live status without recording it.
      */
     private updateAppStatus(
         appUuid: string,
         version: number,
         message: string,
+        kind: AppVersionStatusHistoryEntryKind | null = 'stage',
     ): void {
         void this.appModel
-            .updateStatusMessage(appUuid, version, message)
+            .recordBuildNarration(appUuid, version, message, kind)
             .catch((e) => {
                 this.logger.warn(
                     `App ${appUuid}: failed to update status message: ${getErrorMessage(e)}`,
@@ -3067,10 +3086,11 @@ export class AppGenerateService extends BaseService {
             );
 
             try {
-                await this.appModel.updateStatusMessage(
+                await this.appModel.recordBuildNarration(
                     appUuid,
                     version,
                     isBuildError ? 'Fixing build errors' : 'Fixing blank app',
+                    'stage',
                 );
             } catch (e) {
                 this.logger.warn(
@@ -3136,10 +3156,11 @@ export class AppGenerateService extends BaseService {
             fixUsage = addClaudeUsage(fixUsage, generation.usage);
 
             try {
-                await this.appModel.updateStatusMessage(
+                await this.appModel.recordBuildNarration(
                     appUuid,
                     version,
                     'Rebuilding',
+                    'stage',
                 );
             } catch (e) {
                 this.logger.warn(
@@ -4008,10 +4029,11 @@ export class AppGenerateService extends BaseService {
                 // the Vite build. Skipped for template-only versions.
                 if (versionDeps !== null) {
                     try {
-                        await this.appModel.updateStatusMessage(
+                        await this.appModel.recordBuildNarration(
                             appUuid,
                             version,
                             'Installing dependencies',
+                            'stage',
                         );
                     } catch (e) {
                         this.logger.warn(
@@ -4058,10 +4080,11 @@ export class AppGenerateService extends BaseService {
                         return;
                     }
                     try {
-                        await this.appModel.updateStatusMessage(
+                        await this.appModel.recordBuildNarration(
                             appUuid,
                             version,
                             'Packaging your app',
+                            'stage',
                         );
                     } catch (e) {
                         this.logger.warn(
@@ -6610,6 +6633,38 @@ export class AppGenerateService extends BaseService {
         }
     }
 
+    /**
+     * Narration entries as served to the chat UI. Stage labels are always
+     * dropped (transient progress the live status line already showed). On
+     * terminal versions, reasoning entries restated in the final completion
+     * message are dropped too — the snippet stream can't tell Claude's
+     * closing response apart from mid-run narration, so its sentences also
+     * land in the history. Snippets are verbatim extracts, so a normalized
+     * substring check identifies them exactly.
+     */
+    private static filterStatusHistoryForApi(
+        history: AppVersionStatusHistoryEntry[] | null,
+        status: AppVersionStatus,
+        statusMessage: string | null,
+    ): AppVersionStatusHistoryEntry[] {
+        const normalize = (s: string) => s.replace(/\s+/g, ' ').trim();
+        const finalText =
+            !isAppVersionInProgress(status) && statusMessage
+                ? normalize(statusMessage)
+                : null;
+        return (history ?? []).filter((entry) => {
+            if (entry.kind === 'stage') return false;
+            if (
+                finalText &&
+                entry.kind === 'thinking' &&
+                finalText.includes(normalize(entry.message))
+            ) {
+                return false;
+            }
+            return true;
+        });
+    }
+
     async getAppVersions(
         user: SessionUser,
         projectUuid: string,
@@ -6630,6 +6685,7 @@ export class AppGenerateService extends BaseService {
             prompt: string;
             status: AppVersionStatus;
             statusMessage: string | null;
+            statusHistory: AppVersionStatusHistoryEntry[];
             error: string | null;
             createdAt: Date;
             statusUpdatedAt: Date | null;
@@ -6686,6 +6742,11 @@ export class AppGenerateService extends BaseService {
                 prompt: v.prompt,
                 status: v.status,
                 statusMessage: v.status_message,
+                statusHistory: AppGenerateService.filterStatusHistoryForApi(
+                    v.status_history,
+                    v.status,
+                    v.status_message,
+                ),
                 error: v.error,
                 // Attach `vizSchema` even when `resources` JSONB is null (a
                 // viz with no other attachments) — never drop existing
@@ -8650,10 +8711,11 @@ export class AppGenerateService extends BaseService {
             // package.json + lockfile and run pnpm install before the build.
             if (versionDeps !== null) {
                 try {
-                    await this.appModel.updateStatusMessage(
+                    await this.appModel.recordBuildNarration(
                         appUuid,
                         version,
                         'Installing dependencies',
+                        'stage',
                     );
                 } catch (e) {
                     this.logger.warn(

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.vizSchemaCopy.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.vizSchemaCopy.test.ts
@@ -89,6 +89,7 @@ function buildService() {
         setUpstreamAppUuid: vi.fn().mockResolvedValue(undefined),
         syncPromotedApp: vi.fn().mockResolvedValue(undefined),
         updateStatusMessage: vi.fn().mockResolvedValue(undefined),
+        recordBuildNarration: vi.fn().mockResolvedValue(undefined),
         listAppsByProject: vi.fn().mockResolvedValue([sourceApp]),
         remapPreviewDashboardTileApps: vi.fn().mockResolvedValue(undefined),
     };

--- a/packages/backend/src/ee/services/AppGenerateService/ClaudeStreamProcessor.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/ClaudeStreamProcessor.ts
@@ -121,22 +121,14 @@ const SNIPPET_SENTENCES = 1;
 
 /**
  * Return the most recent `n` complete sentences from `buf` as a single
- * paragraph: whitespace collapsed to single spaces, trailing periods
- * stripped (so they don't visually merge with the UI's animated "..."
- * indicator — `!` and `?` stay since they read distinctly), text-in-progress
- * after the last terminator dropped. Returns `''` while no complete sentence
+ * paragraph: whitespace collapsed to single spaces, text-in-progress after
+ * the last terminator dropped. Returns `''` while no complete sentence
  * exists yet — the caller skips empty updates so the status holds at
  * "Thinking".
  *
  * A sentence terminator is `[.!?]` followed by either whitespace + a capital
  * letter (which skips abbreviations like "e.g." that are followed by a
  * lowercase word) or end-of-string.
- *
- * Invariant for the frontend: the snippet collapses whitespace to a single
- * space, so it is always a single paragraph. The chat UI's `<p>` override
- * that injects `<LoadingDots />` inside the rendered paragraph relies on
- * this — if you change the snippet to preserve `\n\n`, the override needs
- * to learn about "last paragraph only".
  */
 function lastSentencesSnippet(buf: string, n: number): string {
     const flat = buf.replace(/\s+/g, ' ').trim();
@@ -151,10 +143,7 @@ function lastSentencesSnippet(buf: string, n: number): string {
     const end = positions[positions.length - 1];
     const sliceStart =
         positions.length > n ? positions[positions.length - n - 1] + 1 : 0;
-    return flat
-        .slice(sliceStart, end + 1)
-        .trim()
-        .replace(/\.+$/, '');
+    return flat.slice(sliceStart, end + 1).trim();
 }
 
 /**

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -5,6 +5,7 @@ import {
     ProjectType,
     type AppVersionDependencies,
     type AppVersionResources,
+    type AppVersionStatusHistoryEntryKind,
     type DataAppVizSchema,
     type KnexPaginateArgs,
     type KnexPaginatedData,
@@ -99,6 +100,31 @@ export class AppModel {
         });
     }
 
+    /**
+     * Cap on status_history entries per version. Snippet updates are
+     * throttled to one per ~3s upstream, so normal builds stay well under
+     * this; the cap only guards pathological runs (long retries against the
+     * 55-min sandbox timeout) from growing the row without bound. Once hit,
+     * new messages still update status_message but stop being recorded.
+     */
+    private static readonly MAX_STATUS_HISTORY_ENTRIES = 500;
+
+    /** SQL expression appending one entry to status_history, respecting the cap. */
+    private statusHistoryAppend(
+        message: string,
+        kind: AppVersionStatusHistoryEntryKind,
+    ): DbAppVersion['status_history'] {
+        return this.database.raw(
+            `CASE WHEN jsonb_array_length(status_history) < ? THEN status_history || ?::jsonb ELSE status_history END`,
+            [
+                AppModel.MAX_STATUS_HISTORY_ENTRIES,
+                JSON.stringify([
+                    { message, timestamp: new Date().toISOString(), kind },
+                ]),
+            ],
+        ) as unknown as DbAppVersion['status_history'];
+    }
+
     async updateVersionStatus(
         appId: string,
         version: number,
@@ -120,6 +146,11 @@ export class AppModel {
      * Update version status only if it is currently in progress.
      * Returns true if the update was applied, false if the version was
      * already in a terminal state (e.g. cancelled by the user).
+     *
+     * Stage messages for non-terminal transitions are also appended to the
+     * status_history narration log. Terminal messages are not — the final
+     * completion message lives in status_message and is rendered as the
+     * assistant reply, not as part of the build narration.
      */
     async updateVersionStatusIfInProgress(
         appId: string,
@@ -135,11 +166,24 @@ export class AppModel {
                 status,
                 error: error ?? null,
                 status_message: statusMessage ?? null,
+                ...(statusMessage && isAppVersionInProgress(status)
+                    ? {
+                          status_history: this.statusHistoryAppend(
+                              statusMessage,
+                              'stage',
+                          ),
+                      }
+                    : {}),
                 status_updated_at: this.database.fn.now() as unknown as Date,
             });
         return updatedRows > 0;
     }
 
+    /**
+     * Plain status_message setter with no in-progress guard — used by flows
+     * that stamp a message on an already-terminal version (restore, promote,
+     * duplicate). Build pipelines must use `recordBuildNarration` instead.
+     */
     async updateStatusMessage(
         appId: string,
         version: number,
@@ -149,6 +193,38 @@ export class AppModel {
             .where({ app_id: appId, version })
             .update({
                 status_message: statusMessage,
+                status_updated_at: this.database.fn.now() as unknown as Date,
+            });
+    }
+
+    /**
+     * Record a live narration message for an in-progress build: overwrites
+     * status_message and (when `kind` is non-null) appends to the
+     * status_history log. `kind: null` is for transient placeholders (e.g.
+     * "Thinking") that should show as the live status but aren't worth
+     * keeping in the transcript. No-ops once the version reached a terminal
+     * state, so a late fire-and-forget write from the generation stream
+     * can't clobber the final completion message.
+     */
+    async recordBuildNarration(
+        appId: string,
+        version: number,
+        statusMessage: string,
+        kind: AppVersionStatusHistoryEntryKind | null,
+    ): Promise<void> {
+        await this.database(AppVersionsTableName)
+            .where({ app_id: appId, version })
+            .whereNotIn('status', [...APP_VERSION_TERMINAL_STATUSES])
+            .update({
+                status_message: statusMessage,
+                ...(kind
+                    ? {
+                          status_history: this.statusHistoryAppend(
+                              statusMessage,
+                              kind,
+                          ),
+                      }
+                    : {}),
                 status_updated_at: this.database.fn.now() as unknown as Date,
             });
     }

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -359,11 +359,30 @@ export type ApiAppThumbnailUrlResponse = ApiSuccess<{
     thumbnailUrl: string;
 }>;
 
+// What produced a narration entry: a pipeline stage label, a summarized
+// thinking snippet from the generation stream, or a tool-activity status.
+// The chat UI renders 'thinking' (Reasoning row) and 'tool' (Activity row);
+// 'stage' entries are stored but filtered out of API responses.
+export type AppVersionStatusHistoryEntryKind = 'stage' | 'thinking' | 'tool';
+
+// One narration message recorded while a version was building. Persisted on
+// app_versions.status_history (jsonb) so the full chain survives the poll
+// cadence and page reloads.
+export type AppVersionStatusHistoryEntry = {
+    message: string;
+    // ISO-8601, stamped when the message was recorded.
+    timestamp: string;
+    kind: AppVersionStatusHistoryEntryKind;
+};
+
 export type ApiAppVersionSummary = {
     version: number;
     prompt: string;
     status: AppVersionStatus;
     statusMessage: string | null;
+    // Accumulated build narration, oldest first — live and after completion.
+    // Server-filtered before serving; see filterStatusHistoryForApi.
+    statusHistory: AppVersionStatusHistoryEntry[];
     // Detailed failure reason (e.g. the build's stderr) when `status` is
     // `error`; null otherwise. `statusMessage` carries the short user-facing
     // line (e.g. "Build failed"); this carries the why.

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.module.css
@@ -430,6 +430,9 @@
     text-align: left;
     border-radius: 10px;
     padding: 7px 12px;
+    /* <button> doesn't inherit font — without this the preview renders in
+     * the UA sans-serif, whose metrics sit visibly off against the label. */
+    font-family: var(--mantine-font-family);
 }
 
 .reasoningIcon {
@@ -443,11 +446,13 @@
     animation: livePulse 1.6s ease-in-out infinite;
 }
 
+/* Label and preview must share the default line-height — mismatched
+ * line-heights (or the -webkit-box a lineClamp creates) center their boxes
+ * but visibly misalign the glyphs against each other. Font-family comes
+ * from .reasoningHeader so label and preview always share metrics. */
 .reasoningLabel {
     flex-shrink: 0;
-    line-height: 1;
     color: var(--mantine-color-ldGray-8);
-    font-family: var(--mantine-font-family);
     font-weight: 500;
     letter-spacing: -0.005em;
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.tsx
@@ -14,7 +14,11 @@ import {
     Text,
     UnstyledButton,
 } from '@mantine-8/core';
-import { IconChevronRight, IconNotes } from '@tabler/icons-react';
+import {
+    IconChevronRight,
+    IconNotes,
+    type Icon as TablerIconType,
+} from '@tabler/icons-react';
 import { useEffect, useState, type FC } from 'react';
 import { AiMarkdown } from '../../../../../../components/common/AiMarkdown';
 import MantineIcon from '../../../../../../components/common/MantineIcon';
@@ -174,7 +178,11 @@ const McpSummaryIconStack: FC<{
 export const ReasoningHistoryRow: FC<{
     texts: string[];
     isLive: boolean;
-}> = ({ texts, isLive }) => {
+    /** Row identity overrides so other surfaces (e.g. data-app builds) can
+     *  reuse the collapsed-history pattern for non-reasoning content. */
+    icon?: TablerIconType;
+    label?: string;
+}> = ({ texts, isLive, icon = IconNotes, label = 'Reasoning' }) => {
     const [open, setOpen] = useState(false);
     const combined = texts.join('\n\n');
     // While streaming, the preview is the *latest* reasoning chunk (it rolls
@@ -198,7 +206,7 @@ export const ReasoningHistoryRow: FC<{
                     {isLive ? (
                         <Box className={styles.iconChip} data-live="true">
                             <MantineIcon
-                                icon={IconNotes}
+                                icon={icon}
                                 size={12}
                                 stroke={1.7}
                                 className={styles.reasoningIcon}
@@ -207,7 +215,7 @@ export const ReasoningHistoryRow: FC<{
                         </Box>
                     ) : (
                         <MantineIcon
-                            icon={IconNotes}
+                            icon={icon}
                             size={13}
                             stroke={1.6}
                             className={styles.reasoningIcon}
@@ -218,12 +226,12 @@ export const ReasoningHistoryRow: FC<{
                         className={styles.reasoningLabel}
                         data-live={isLive ? 'true' : 'false'}
                     >
-                        Reasoning
+                        {label}
                     </Text>
                     <Text
                         size="xs"
                         c="dimmed"
-                        lineClamp={1}
+                        truncate
                         fs="italic"
                         className={styles.reasoningPreview}
                     >

--- a/packages/frontend/src/features/apps/ChatBubbleMeta.tsx
+++ b/packages/frontend/src/features/apps/ChatBubbleMeta.tsx
@@ -33,6 +33,9 @@ type Props = {
      * elsewhere on the bubble — not in this meta row.
      */
     version?: VersionInfo;
+    /** Extra class for the row — used to align the meta with sibling
+     *  content whose inset this component can't know about. */
+    className?: string;
 };
 
 /**
@@ -41,7 +44,12 @@ type Props = {
  * to a ready version); the right slot holds the relative timestamp with a
  * tooltip for the absolute date.
  */
-const ChatBubbleMeta: FC<Props> = ({ timestamp, userName, version }) => {
+const ChatBubbleMeta: FC<Props> = ({
+    timestamp,
+    userName,
+    version,
+    className,
+}) => {
     const timeAgo = useTimeAgo(timestamp);
     // Only user bubbles split (name left, timestamp right) — that pattern
     // anchors the sender's name to the bubble edge. Assistant bubbles keep
@@ -53,7 +61,7 @@ const ChatBubbleMeta: FC<Props> = ({ timestamp, userName, version }) => {
             gap="xs"
             wrap="nowrap"
             justify={justify}
-            className={classes.meta}
+            className={[classes.meta, className].filter(Boolean).join(' ')}
         >
             {userName && (
                 <Text fz="xs" fw={600} className={classes.name} truncate>

--- a/packages/frontend/src/features/apps/components/LoadingDots.module.css
+++ b/packages/frontend/src/features/apps/components/LoadingDots.module.css
@@ -1,0 +1,40 @@
+.loadingDots {
+    display: inline-flex;
+    gap: 4px;
+    align-items: center;
+}
+
+.loadingDot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    animation: dotPulse 1.4s ease-in-out infinite;
+
+    @mixin light {
+        background-color: var(--mantine-color-ldGray-5);
+    }
+    @mixin dark {
+        background-color: var(--mantine-color-ldDark-8);
+    }
+}
+
+.loadingDot:nth-child(2) {
+    animation-delay: 0.2s;
+}
+
+.loadingDot:nth-child(3) {
+    animation-delay: 0.4s;
+}
+
+@keyframes dotPulse {
+    0%,
+    80%,
+    100% {
+        opacity: 0.3;
+        transform: scale(0.8);
+    }
+    40% {
+        opacity: 1;
+        transform: scale(1);
+    }
+}

--- a/packages/frontend/src/features/apps/components/LoadingDots.tsx
+++ b/packages/frontend/src/features/apps/components/LoadingDots.tsx
@@ -1,0 +1,13 @@
+import { type FC } from 'react';
+import classes from './LoadingDots.module.css';
+
+/** Three-dot pulse trailing an in-progress status line. */
+const LoadingDots: FC = () => (
+    <span className={classes.loadingDots}>
+        <span className={classes.loadingDot} />
+        <span className={classes.loadingDot} />
+        <span className={classes.loadingDot} />
+    </span>
+);
+
+export default LoadingDots;

--- a/packages/frontend/src/features/apps/utils/mergeChatMessages.test.ts
+++ b/packages/frontend/src/features/apps/utils/mergeChatMessages.test.ts
@@ -15,6 +15,8 @@ const baseMessage: ChatMessage = {
     timestamp: new Date('2026-05-15T10:00:00Z'),
     userName: 'Test User',
     vizSchema: null,
+    reasoning: [],
+    activity: [],
 };
 
 describe('mergeChatMessages', () => {

--- a/packages/frontend/src/features/apps/utils/mergeChatMessages.ts
+++ b/packages/frontend/src/features/apps/utils/mergeChatMessages.ts
@@ -30,6 +30,13 @@ export type ChatMessage = {
     timestamp: Date;
     userName: string | null;
     vizSchema: DataAppVizSchema | null;
+    // Thinking snippets accumulated while the version generated; shown as a
+    // collapsed Reasoning row on assistant bubbles. Empty for user bubbles
+    // and versions predating reasoning capture.
+    reasoning: string[];
+    // Tool actions ("Creating App.tsx") from the same narration history;
+    // shown as a collapsed Activity row on assistant bubbles.
+    activity: string[];
     // For optimistic (local) user bubbles only. Records the latest server
     // version number known at submit time. The bubble is dropped from the
     // merged view once the server has produced a higher version — that's the

--- a/packages/frontend/src/pages/AppGenerate.module.css
+++ b/packages/frontend/src/pages/AppGenerate.module.css
@@ -271,10 +271,16 @@
     color: var(--mantine-color-dimmed) !important;
 }
 
-/* Align the "continue building" hint with the status text above it, which is
- * rendered via AiMarkdown and carries the shared 7px markdown padding-left. */
-.buildingHint {
-    padding-left: 7px;
+/* Matches the Reasoning/Activity rows' 12px horizontal padding so the
+ * working line's text starts flush with their icon chips. */
+.workingLine {
+    padding-left: 12px;
+}
+
+/* Same 12px inset for the assistant meta row (version chip + timestamp) so
+ * the chip lines up with the Reasoning/Activity icon chips below it. */
+.assistantBubbleMeta {
+    padding-left: 12px;
 }
 
 .chatInputArea {
@@ -383,47 +389,6 @@
     }
     @mixin dark {
         color: var(--mantine-color-ldDark-8);
-    }
-}
-
-.loadingDots {
-    display: inline-flex;
-    gap: 4px;
-    align-items: center;
-}
-
-.loadingDot {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    animation: dotPulse 1.4s ease-in-out infinite;
-
-    @mixin light {
-        background-color: var(--mantine-color-ldGray-5);
-    }
-    @mixin dark {
-        background-color: var(--mantine-color-ldDark-8);
-    }
-}
-
-.loadingDot:nth-child(2) {
-    animation-delay: 0.2s;
-}
-
-.loadingDot:nth-child(3) {
-    animation-delay: 0.4s;
-}
-
-@keyframes dotPulse {
-    0%,
-    80%,
-    100% {
-        opacity: 0.3;
-        transform: scale(0.8);
-    }
-    40% {
-        opacity: 1;
-        transform: scale(1);
     }
 }
 

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -13,6 +13,8 @@ import {
     type AppDashboardReference,
     type AppExternalConnectionReference,
     type AppVersionDependencyEntry,
+    type AppVersionStatusHistoryEntry,
+    type AppVersionStatusHistoryEntryKind,
     type DataAppClaudeModel,
     type DataAppTemplate,
     type DataAppVizContext,
@@ -38,6 +40,7 @@ import {
     IconCheck,
     IconArrowUp,
     IconBrush,
+    IconHammer,
     IconExternalLink,
     IconArrowBackUp,
     IconLayoutDashboard,
@@ -79,6 +82,7 @@ import {
 } from '../components/common/PromptComposer';
 import { getChartIcon } from '../components/common/ResourceIcon/utils';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
+import { ReasoningHistoryRow } from '../ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard';
 import { useAiOrganizationSettings } from '../ee/features/aiCopilot/hooks/useAiOrganizationSettings';
 import AppIframePreview, {
     type AppIframePreviewHandle,
@@ -110,6 +114,7 @@ import AppHeaderActions from '../features/apps/components/AppHeaderActions';
 import AppSpaceChip from '../features/apps/components/AppSpaceChip';
 import DataAppVizResultCard from '../features/apps/components/DataAppVizResultCard';
 import DataAppVizTestPanel from '../features/apps/components/DataAppVizTestPanel';
+import LoadingDots from '../features/apps/components/LoadingDots';
 import { getAppVersionFailureMessage } from '../features/apps/getAppVersionFailureMessage';
 import { useAppBuildPoller } from '../features/apps/hooks/useAppBuildPoller';
 import { useAppImageUpload } from '../features/apps/hooks/useAppImageUpload';
@@ -166,6 +171,19 @@ function parseElementRefLabel(label: string): ElementRef | null {
         );
     if (!m) return null;
     return { tag: m[1] ?? '', text: m[2] ?? '', loc: m[3] ?? '' };
+}
+
+// The null guard exists because the poll worker feeds raw fetch JSON into
+// the query cache; the consecutive dedupe because a retry can restart the
+// generation stream and re-emit the same entry.
+function versionNarrationTexts(
+    history: AppVersionStatusHistoryEntry[] | undefined,
+    kind: AppVersionStatusHistoryEntryKind,
+): string[] {
+    return (history ?? [])
+        .filter((entry) => entry.kind === kind)
+        .map((entry) => entry.message)
+        .filter((message, index, all) => message !== all[index - 1]);
 }
 
 // Run a layout-changing state update inside a native View Transition so the
@@ -313,14 +331,6 @@ const AppPreview = forwardRef<AppIframePreviewHandle, AppPreviewProps>(
 );
 
 AppPreview.displayName = 'AppPreview';
-
-const LoadingDots: FC = () => (
-    <span className={classes.loadingDots}>
-        <span className={classes.loadingDot} />
-        <span className={classes.loadingDot} />
-        <span className={classes.loadingDot} />
-    </span>
-);
 
 const TemplateChip: FC<{ template: DataAppTemplate }> = ({ template }) => {
     const t = getTemplate(template);
@@ -861,6 +871,20 @@ const AppGenerate: FC = () => {
         return null;
     }, [appData]);
     const isBuilding = latestBuildingVersion !== null;
+    // Accumulated narration for the live build's Reasoning / Activity rows.
+    const reasoningTexts = useMemo<string[]>(
+        () =>
+            versionNarrationTexts(
+                latestBuildingVersion?.statusHistory,
+                'thinking',
+            ),
+        [latestBuildingVersion],
+    );
+    const activityTexts = useMemo<string[]>(
+        () =>
+            versionNarrationTexts(latestBuildingVersion?.statusHistory, 'tool'),
+        [latestBuildingVersion],
+    );
     // Clarifying counts as loading for the chat input (disable send; typing
     // stays enabled so the next prompt can be drafted), and a pending
     // unanswered clarification keeps send disabled until the user clicks
@@ -944,6 +968,11 @@ const AppGenerate: FC = () => {
                 v.version === 1
                     ? 'Your app is ready!'
                     : `Version ${v.version} is ready!`;
+            const reasoning = versionNarrationTexts(
+                v.statusHistory,
+                'thinking',
+            );
+            const activity = versionNarrationTexts(v.statusHistory, 'tool');
             const msgs: ChatMessage[] = [
                 {
                     role: 'user',
@@ -959,6 +988,8 @@ const AppGenerate: FC = () => {
                     timestamp: new Date(v.createdAt),
                     userName: authorName,
                     vizSchema: null,
+                    reasoning: [],
+                    activity: [],
                 },
             ];
             if (v.status === 'ready') {
@@ -978,6 +1009,8 @@ const AppGenerate: FC = () => {
                     timestamp: new Date(replyTimestamp),
                     userName: null,
                     vizSchema: v.resources?.vizSchema ?? null,
+                    reasoning,
+                    activity,
                 });
             } else if (v.status === 'error') {
                 msgs.push({
@@ -994,6 +1027,8 @@ const AppGenerate: FC = () => {
                     timestamp: new Date(replyTimestamp),
                     userName: null,
                     vizSchema: null,
+                    reasoning,
+                    activity,
                 });
             }
             // 'building' status is not rendered as a history message —
@@ -1207,6 +1242,8 @@ const AppGenerate: FC = () => {
                             .filter((s): s is string => !!s && s.length > 0)
                             .join(' ') || null,
                     vizSchema: null,
+                    reasoning: [],
+                    activity: [],
                     submittedAtVersion: maxHistoryVersion,
                 },
             ]);
@@ -1248,6 +1285,8 @@ const AppGenerate: FC = () => {
                                 timestamp: new Date(),
                                 userName: null,
                                 vizSchema: null,
+                                reasoning: [],
+                                activity: [],
                             },
                         ]);
                     },
@@ -1702,6 +1741,8 @@ const AppGenerate: FC = () => {
                     timestamp: new Date(),
                     userName: null,
                     vizSchema: null,
+                    reasoning: [],
+                    activity: [],
                 },
             ]);
         },
@@ -1853,6 +1894,8 @@ const AppGenerate: FC = () => {
                             .filter((s): s is string => !!s && s.length > 0)
                             .join(' ') || null,
                     vizSchema: null,
+                    reasoning: [],
+                    activity: [],
                     // Snapshot the highest server version known at submit time.
                     // Once history catches up past this number the optimistic
                     // bubble is dropped by `mergeChatMessages` — even if the
@@ -2452,11 +2495,36 @@ const AppGenerate: FC = () => {
                                                                       )
                                                                     : undefined
                                                             }
+                                                            className={
+                                                                classes.assistantBubbleMeta
+                                                            }
                                                         />
                                                         {msg.version !== null &&
                                                             renderVersionDepsChip(
                                                                 msg.version,
                                                             )}
+                                                        {msg.reasoning.length >
+                                                            0 && (
+                                                            <ReasoningHistoryRow
+                                                                texts={
+                                                                    msg.reasoning
+                                                                }
+                                                                isLive={false}
+                                                            />
+                                                        )}
+                                                        {msg.activity.length >
+                                                            0 && (
+                                                            <ReasoningHistoryRow
+                                                                texts={
+                                                                    msg.activity
+                                                                }
+                                                                isLive={false}
+                                                                icon={
+                                                                    IconHammer
+                                                                }
+                                                                label="Activity"
+                                                            />
+                                                        )}
                                                         {msg.vizSchema ? (
                                                             msg.version !==
                                                                 null &&
@@ -2602,64 +2670,90 @@ const AppGenerate: FC = () => {
                                                                 starting{' '}
                                                                 <LoadingDots />
                                                             </Text>
-                                                        ) : latestBuildingVersion?.statusMessage ? (
-                                                            <AiMarkdown
-                                                                className={
-                                                                    classes.statusMarkdown
-                                                                }
-                                                                components={{
-                                                                    p: ({
-                                                                        node: _node,
-                                                                        children,
-                                                                        ...rest
-                                                                    }) => (
-                                                                        <p
-                                                                            {...rest}
-                                                                        >
-                                                                            {
-                                                                                children
-                                                                            }{' '}
-                                                                            <LoadingDots />
-                                                                        </p>
-                                                                    ),
-                                                                }}
-                                                            >
-                                                                {
-                                                                    latestBuildingVersion.statusMessage
-                                                                }
-                                                            </AiMarkdown>
                                                         ) : (
-                                                            <Text
-                                                                size="sm"
-                                                                c="dimmed"
-                                                            >
-                                                                Generating your
-                                                                app{' '}
-                                                                <LoadingDots />
-                                                            </Text>
+                                                            <>
+                                                                {reasoningTexts.length >
+                                                                    0 && (
+                                                                    <ReasoningHistoryRow
+                                                                        texts={
+                                                                            reasoningTexts
+                                                                        }
+                                                                        isLive
+                                                                    />
+                                                                )}
+                                                                {activityTexts.length >
+                                                                    0 && (
+                                                                    <ReasoningHistoryRow
+                                                                        texts={
+                                                                            activityTexts
+                                                                        }
+                                                                        isLive
+                                                                        icon={
+                                                                            IconHammer
+                                                                        }
+                                                                        label="Activity"
+                                                                    />
+                                                                )}
+                                                                {latestBuildingVersion?.status ===
+                                                                'generating' ? (
+                                                                    // A status line here would duplicate the live
+                                                                    // previews of the Reasoning/Activity rows above.
+                                                                    <Text
+                                                                        size="sm"
+                                                                        c="dimmed"
+                                                                        className={
+                                                                            classes.workingLine
+                                                                        }
+                                                                    >
+                                                                        Working
+                                                                        on your
+                                                                        app —
+                                                                        feel
+                                                                        free to
+                                                                        switch
+                                                                        tabs or
+                                                                        close
+                                                                        this one{' '}
+                                                                        <LoadingDots />
+                                                                    </Text>
+                                                                ) : latestBuildingVersion?.statusMessage ? (
+                                                                    <AiMarkdown
+                                                                        className={
+                                                                            classes.statusMarkdown
+                                                                        }
+                                                                        components={{
+                                                                            p: ({
+                                                                                node: _node,
+                                                                                children,
+                                                                                ...rest
+                                                                            }) => (
+                                                                                <p
+                                                                                    {...rest}
+                                                                                >
+                                                                                    {
+                                                                                        children
+                                                                                    }{' '}
+                                                                                    <LoadingDots />
+                                                                                </p>
+                                                                            ),
+                                                                        }}
+                                                                    >
+                                                                        {
+                                                                            latestBuildingVersion.statusMessage
+                                                                        }
+                                                                    </AiMarkdown>
+                                                                ) : (
+                                                                    <Text
+                                                                        size="sm"
+                                                                        c="dimmed"
+                                                                    >
+                                                                        Generating
+                                                                        your app{' '}
+                                                                        <LoadingDots />
+                                                                    </Text>
+                                                                )}
+                                                            </>
                                                         )}
-                                                        {!isClarifying &&
-                                                            latestBuildingVersion?.status ===
-                                                                'generating' && (
-                                                                <Text
-                                                                    className={
-                                                                        classes.buildingHint
-                                                                    }
-                                                                    fz={11}
-                                                                    c="dimmed"
-                                                                    mt={6}
-                                                                >
-                                                                    I'll
-                                                                    continue
-                                                                    building in
-                                                                    the
-                                                                    background —
-                                                                    feel free to
-                                                                    switch tabs
-                                                                    or close
-                                                                    this one.
-                                                                </Text>
-                                                            )}
                                                     </Box>
                                                 </Box>
                                             </Box>


### PR DESCRIPTION
Persists the agent's build narration (thinking snippets + tool activity) on app versions and renders it as collapsible Reasoning/Activity rows in the data app chat — live during generation and on completed versions.


### Screenshots:
#### Collapsed while working
<img width="763" height="221" alt="Screenshot 2026-07-27 at 16 12 46" src="https://github.com/user-attachments/assets/f2a8993f-f3b3-442f-9d32-e5332ce9c421" />


#### Expanded while working
<img width="763" height="420" alt="Screenshot 2026-07-27 at 16 12 40" src="https://github.com/user-attachments/assets/3b760f79-b006-4cb2-9f4f-ab8c293f825b" />

#### After it finished building (collapsed)
<img width="754" height="208" alt="image" src="https://github.com/user-attachments/assets/d3c934ab-0263-4130-944d-202ce340f48a" />


#### After it finished building (expanded)
<img width="763" height="1268" alt="Screenshot 2026-07-27 at 15 59 17" src="https://github.com/user-attachments/assets/606b011e-0292-4a16-882e-fe0775b73917" />

Closes: https://linear.app/lightdash/issue/PROD-8190/data-apps-show-accumulated-agent-reasoningstatus-history-during-app