### PR TITLE
fix(explorer): deselect custom dimension from results table instead of deleting it

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -338,7 +338,7 @@ const ContextMenu: FC<ContextMenuProps> = ({
                             color="red"
                             onClick={() => {
                                 dispatch(
-                                    explorerActions.removeField(
+                                    explorerActions.toggleDimension(
                                         getItemId(item),
                                     ),
                                 );

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -23,6 +23,7 @@ import {
     IconCopy,
     IconDots,
     IconFilter,
+    IconMinus,
     IconPencil,
     IconTimelineEvent,
     IconTrash,
@@ -334,8 +335,7 @@ const ContextMenu: FC<ContextMenuProps> = ({
                         <Menu.Divider />
 
                         <Menu.Item
-                            leftSection={<MantineIcon icon={IconTrash} />}
-                            color="red"
+                            leftSection={<MantineIcon icon={IconMinus} />}
                             onClick={() => {
                                 dispatch(
                                     explorerActions.toggleDimension(
@@ -345,6 +345,20 @@ const ContextMenu: FC<ContextMenuProps> = ({
                             }}
                         >
                             Remove
+                        </Menu.Item>
+
+                        <Menu.Item
+                            leftSection={<MantineIcon icon={IconTrash} />}
+                            color="red"
+                            onClick={() => {
+                                dispatch(
+                                    explorerActions.removeCustomDimension(
+                                        getItemId(item),
+                                    ),
+                                );
+                            }}
+                        >
+                            Delete custom dimension
                         </Menu.Item>
                     </>
                 )}

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -255,15 +255,44 @@ const ContextMenu: FC<ContextMenuProps> = ({
                     </Menu.Item>
                 ) : null}
 
-                <Menu.Item
-                    leftSection={<MantineIcon icon={IconTrash} />}
-                    color="red"
-                    onClick={() => {
-                        dispatch(explorerActions.removeField(itemFieldId));
-                    }}
-                >
-                    Remove
-                </Menu.Item>
+                {isItemAdditionalMetric && !isPopAdditionalMetric ? (
+                    <>
+                        <Menu.Item
+                            leftSection={<MantineIcon icon={IconMinus} />}
+                            onClick={() => {
+                                dispatch(
+                                    explorerActions.toggleMetric(itemFieldId),
+                                );
+                            }}
+                        >
+                            Remove
+                        </Menu.Item>
+
+                        <Menu.Item
+                            leftSection={<MantineIcon icon={IconTrash} />}
+                            color="red"
+                            onClick={() => {
+                                dispatch(
+                                    explorerActions.removeAdditionalMetric(
+                                        itemFieldId,
+                                    ),
+                                );
+                            }}
+                        >
+                            Delete custom metric
+                        </Menu.Item>
+                    </>
+                ) : (
+                    <Menu.Item
+                        leftSection={<MantineIcon icon={IconTrash} />}
+                        color="red"
+                        onClick={() => {
+                            dispatch(explorerActions.removeField(itemFieldId));
+                        }}
+                    >
+                        Remove
+                    </Menu.Item>
+                )}
             </>
         );
     } else if (meta?.isInvalidItem) {


### PR DESCRIPTION
## Problem

In the explore results table, the "Remove" option in the column-header menu for **custom dimensions** and **custom metrics** permanently deleted the definition from the explore, rather than just deselecting the column from the results. This is inconsistent with regular dimensions/metrics (where "Remove" only deselects) and with the sidebar toggle, and forced users to recreate the custom field if they wanted to keep using it in filters.

The root cause: the "Remove" handlers dispatched `removeField`, which additionally strips the definition out of `metricQuery.customDimensions` / `metricQuery.additionalMetrics`. For a warehouse field that's a harmless no-op, but for a custom dimension or custom metric it's the only place the definition lives — so it gets deleted.

## Fix

The column-header menu for custom dimensions and custom metrics now offers both actions explicitly:

- **Remove** (neutral, minus icon) — deselects the column via `toggleDimension` / `toggleMetric`, leaving the definition untouched. Matches the behaviour of the sidebar node-toggle and of regular fields.
- **Delete custom dimension / Delete custom metric** (red, trash icon) — dispatches `removeCustomDimension` / `removeAdditionalMetric`, the same destructive actions as the sidebar tree's "Remove custom dimension/metric". The custom-dimension delete is gated by the same custom-SQL authoring permission check as the sidebar.

Regular fields and period-over-period comparison metrics keep the single destructive-safe "Remove" (for a regular field `removeField`'s extra filtering is a no-op; for a PoP metric deselecting would just orphan the definition).

## How to test

1. In an explore, create a custom dimension and a custom metric and add both to the results table.
2. Open the column-header menu on each and click "Remove" — the column leaves the results, but the field is still listed in the sidebar and usable in filters.
3. Re-add them, open the menu again and click "Delete custom dimension" / "Delete custom metric" — the definition is removed entirely (gone from the sidebar and filters).
