### PR TITLE
ci: bump helm chart version on release

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -477,7 +477,33 @@ jobs:
           git push origin main
 
   # ============================================================================
-  # Job 4: Publish versioned E2B templates
+  # Job 4: Update Helm chart default version
+  # ============================================================================
+  update-helm-chart:
+    name: Update Helm Chart Version
+    needs: build-and-push-images
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      # Dispatches the existing version-bump workflow in lightdash/helm-charts,
+      # which bumps Chart.yaml (appVersion + chart patch version) and maintains
+      # a rolling PR against that repo.
+      - name: Trigger helm-charts version bump
+        env:
+          GH_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+          gh workflow run increment-lightdash-app-version.yml \
+            --repo lightdash/helm-charts \
+            -f lightdash-version="$VERSION"
+
+  # ============================================================================
+  # Job 5: Publish versioned E2B templates
   # ============================================================================
   e2b-templates:
     name: Publish ${{ matrix.template.display_name }} (${{ matrix.region }})

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -489,18 +489,50 @@ jobs:
         with:
           egress-policy: audit
 
-      # Dispatches the existing version-bump workflow in lightdash/helm-charts,
-      # which bumps Chart.yaml (appVersion + chart patch version) and maintains
-      # a rolling PR against that repo.
-      - name: Trigger helm-charts version bump
-        env:
-          GH_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+      # The push must use a PAT (not GITHUB_TOKEN): pushes made with the
+      # default token don't trigger workflows, and the chart is published by
+      # helm-charts' ci-release workflow on push to main.
+      - name: Checkout helm-charts
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: lightdash/helm-charts
+          token: ${{ secrets.CI_GITHUB_TOKEN }}
+          path: helm-charts
+
+      - name: Bump chart version and appVersion
+        working-directory: helm-charts
         run: |
           TAG="${{ github.event.release.tag_name }}"
           VERSION="${TAG#v}"
-          gh workflow run increment-lightdash-app-version.yml \
-            --repo lightdash/helm-charts \
-            -f lightdash-version="$VERSION"
+          CHART=charts/lightdash/Chart.yaml
+
+          CURRENT_CHART_VERSION=$(awk '/^version:/{print $2}' "$CHART")
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_CHART_VERSION"
+          NEW_CHART_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
+
+          sed -i "s/^version: .*/version: $NEW_CHART_VERSION/" "$CHART"
+          sed -i "s/^appVersion: .*/appVersion: $VERSION/" "$CHART"
+
+          echo "Chart version: $CURRENT_CHART_VERSION -> $NEW_CHART_VERSION, appVersion -> $VERSION"
+
+      # Same helm-docs version as helm-charts' own generate-helm-docs workflow,
+      # which only runs on PRs and so won't cover a direct push to main
+      - name: Regenerate chart README
+        run: |
+          docker run --rm -v "$PWD/helm-charts:/helm-docs" jnorwood/helm-docs:v1.7.0
+
+      - name: Commit and push to main
+        working-directory: helm-charts
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add charts/lightdash/Chart.yaml charts/lightdash/README.md
+          git commit -m "chore(release): update Lightdash to $VERSION"
+          git push origin main
 
   # ============================================================================
   # Job 5: Publish versioned E2B templates


### PR DESCRIPTION
## Summary

Adds an `update-helm-chart` job to `post-release.yml` that keeps the helm chart's default version in sync with every Lightdash release. It checks out `lightdash/helm-charts`, bumps `Chart.yaml` (`appVersion` = release version, chart patch version +1), regenerates the chart README with helm-docs, and pushes straight to `main` — same cross-repo pattern as the Homebrew formula job.

- Pushes with `CI_GITHUB_TOKEN` (a PAT) deliberately: default-token pushes don't trigger workflows, and the chart is published by helm-charts' `ci-release` workflow on push to main
- Commits directly to main rather than opening a bot PR nobody reviews
- Runs after `build-and-push-images` so the Docker image exists before the chart references it
- `continue-on-error: true` so it can never block a release; a failed bump self-heals on the next release

Companion PR: lightdash/helm-charts#137 (removes the old manual `workflow_dispatch` bump workflow this replaces).
