### PR TITLE
feat(data-apps): track upgrades in pipeline analytics

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1485,6 +1485,10 @@ export type DataAppUpgradeRequestedEvent = BaseTrack & {
         /** What the app's bundle self-reported; null for legacy bundles. */
         reportedSdkVersion: string | null;
         reportedFeatureCount: number | null;
+        /** Feature keys the frontend computed as possibly-new — what this
+         *  upgrade can newly enable. Compare with the app's next
+         *  reportedFeatures to measure adoption. Null for older clients. */
+        candidateFeatureKeys: string[] | null;
     };
 };
 
@@ -1510,6 +1514,7 @@ export type DataAppVersionCompletedEvent = BaseTrack & {
         appUuid: string;
         version: number;
         isIteration: boolean;
+        isUpgrade: boolean;
         claudeModel: DataAppClaudeModel;
         claudeProvider: 'anthropic' | 'bedrock';
         schedulerWaitMs: number;
@@ -1563,6 +1568,7 @@ export type DataAppVersionFailedEvent = BaseTrack & {
         appUuid: string;
         version: number;
         isIteration: boolean;
+        isUpgrade: boolean;
         claudeModel: DataAppClaudeModel;
         claudeProvider?: 'anthropic' | 'bedrock';
         schedulerWaitMs?: number;

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -1577,6 +1577,7 @@ export class AppGenerateService extends BaseService {
                 appUuid: payload.appUuid,
                 version: payload.version,
                 isIteration: payload.isIteration,
+                isUpgrade: payload.isUpgrade ?? false,
                 claudeModel,
                 claudeProvider: telemetry.claudeProvider,
                 schedulerWaitMs: telemetry.schedulerWaitMs,
@@ -4382,6 +4383,7 @@ export class AppGenerateService extends BaseService {
                 appUuid,
                 version,
                 isIteration: payload.isIteration,
+                isUpgrade: payload.isUpgrade ?? false,
                 claudeModel,
                 claudeProvider,
                 schedulerWaitMs,
@@ -5559,6 +5561,8 @@ export class AppGenerateService extends BaseService {
                 version: newVersion,
                 reportedSdkVersion: body.reportedSdkVersion ?? null,
                 reportedFeatureCount: body.reportedFeatures?.length ?? null,
+                candidateFeatureKeys:
+                    body.candidateFeatures?.map((f) => f.key) ?? null,
             },
         });
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.upgrade.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.upgrade.test.ts
@@ -168,6 +168,7 @@ describe('upgradeApp', () => {
                     version: 5,
                     reportedSdkVersion: '0.3400.0',
                     reportedFeatureCount: 2,
+                    candidateFeatureKeys: ['drill-down', 'lineage'],
                 }),
             }),
         );


### PR DESCRIPTION
## What

Adds upgrade dimensions to the existing data-app pipeline analytics rather than new events:

- `data_app.version.completed` + `data_app.version.failed` gain `isUpgrade: boolean` (from the pipeline payload flag) — every existing timing/usage property (`totalDurationMs`, stage breakdowns, token usage, failure stage) can now be segmented by upgrade runs.
- `data_app.upgrade_requested` gains `candidateFeatureKeys: string[] | null` — the possibly-new feature keys the frontend computed and sent with the request.

## Why

Upgrades were only observable at request time. With `isUpgrade` on the completion/failure events we can measure upgrade duration, failure rate, and cost against normal iterations with zero new instrumentation. `candidateFeatureKeys` records what each upgrade could newly enable; comparing it against the same app's `reportedFeatures` on a later `upgrade_requested` measures which features actually made it into deployed bundles ("added" tracking without any client-side eventing — deliberately skipping a client event for verified-active features, since the backend never sees the manifest).

Relates: PROD-7614

🤖 Generated with [Claude Code](https://claude.com/claude-code)