### PR TITLE
feat: show enterprise license status in About modal

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -84,6 +84,7 @@ import { EmbedService } from './services/EmbedService/EmbedService';
 import { ExternalConnectionCoderService } from './services/ExternalConnectionCoderService/ExternalConnectionCoderService';
 import { ExternalConnectionService } from './services/ExternalConnectionService/ExternalConnectionService';
 import { GoogleServiceAccountTokenProvider } from './services/ExternalConnectionService/GoogleServiceAccountTokenProvider';
+import { EnterpriseLicenseService } from './services/LicenseService/LicenseService';
 import { ManagedAgentService } from './services/ManagedAgentService/ManagedAgentService';
 import { McpService } from './services/McpService/McpService';
 import { OnboardingAgentService } from './services/OnboardingAgentService/OnboardingAgentService';
@@ -135,6 +136,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
 
     return {
         serviceProviders: {
+            licenseService: () => new EnterpriseLicenseService(),
             aiAgentMemoryService: ({
                 models,
                 clients,

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -1,4 +1,3 @@
-import { ForbiddenError } from '@lightdash/common';
 import express, { Express } from 'express';
 import { AppArguments } from '../App';
 import {
@@ -126,9 +125,10 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
             `Enterprise license for ${lightdashConfig.siteUrl} is valid.`,
         );
     } else {
-        throw new ForbiddenError(
+        Logger.warn(
             `Enterprise license for ${lightdashConfig.siteUrl} ${license.detail} [${license.code}]`,
         );
+        return {};
     }
 
     // Register EE-specific NATS streams
@@ -136,7 +136,10 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
 
     return {
         serviceProviders: {
-            licenseService: () => new EnterpriseLicenseService(),
+            licenseService: () =>
+                new EnterpriseLicenseService({
+                    licenseKey: lightdashConfig.license.licenseKey,
+                }),
             aiAgentMemoryService: ({
                 models,
                 clients,

--- a/packages/backend/src/ee/services/LicenseService/LicenseService.ts
+++ b/packages/backend/src/ee/services/LicenseService/LicenseService.ts
@@ -1,0 +1,5 @@
+import { LicenseService } from '../../../services/LicenseService/LicenseService';
+
+export class EnterpriseLicenseService extends LicenseService {
+    protected override readonly valid: boolean = true;
+}

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -8,6 +8,7 @@ import {
 export const BaseResponse: HealthState = {
     healthy: true,
     license: {
+        hasLicenseKey: false,
         valid: false,
     },
     version: '0.1.0',

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -7,6 +7,9 @@ import {
 
 export const BaseResponse: HealthState = {
     healthy: true,
+    license: {
+        valid: false,
+    },
     version: '0.1.0',
     mode: LightdashMode.DEFAULT,
     isAuthenticated: false,

--- a/packages/backend/src/services/HealthService/HealthService.test.ts
+++ b/packages/backend/src/services/HealthService/HealthService.test.ts
@@ -5,6 +5,7 @@ import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import { MigrationModel } from '../../models/MigrationModel/MigrationModel';
 import { OrganizationModel } from '../../models/OrganizationModel';
 import { OrganizationSettingsModel } from '../../models/OrganizationSettingsModel';
+import { LicenseService } from '../LicenseService/LicenseService';
 import { HealthService } from './HealthService';
 import { BaseResponse, userMock } from './HealthService.mock';
 
@@ -31,10 +32,17 @@ const organizationSettingsModel = {
     get: vi.fn(async () => ({ queryLimit: null, csvCellsLimit: null })),
 };
 
+const licenseService = new LicenseService();
+const validLicenseService = new LicenseService();
+vi.spyOn(validLicenseService, 'getLicenseStatus').mockReturnValue({
+    valid: true,
+});
+
 describe('health', () => {
     const healthService = new HealthService({
         organizationModel: organizationModel as unknown as OrganizationModel,
         lightdashConfig: lightdashConfigMock,
+        licenseService,
         migrationModel: migrationModel as unknown as MigrationModel,
         organizationSettingsModel:
             organizationSettingsModel as unknown as OrganizationSettingsModel,
@@ -84,8 +92,11 @@ describe('health', () => {
                 organizationModel as unknown as OrganizationModel,
             lightdashConfig: {
                 ...lightdashConfigMock,
-                license: { licenseKey: 'test-license-key' },
+                license: {
+                    licenseKey: 'test-license-key',
+                },
             },
+            licenseService,
             migrationModel: migrationModel as unknown as MigrationModel,
             organizationSettingsModel:
                 organizationSettingsModel as unknown as OrganizationSettingsModel,
@@ -95,6 +106,29 @@ describe('health', () => {
                 .hasPlaygroundProjects,
         ).toBe(true);
     });
+    it('returns the enterprise license validation result', async () => {
+        expect((await healthService.getHealthState(undefined)).license).toEqual(
+            {
+                valid: false,
+            },
+        );
+
+        const validatedService = new HealthService({
+            organizationModel:
+                organizationModel as unknown as OrganizationModel,
+            lightdashConfig: lightdashConfigMock,
+            licenseService: validLicenseService,
+            migrationModel: migrationModel as unknown as MigrationModel,
+            organizationSettingsModel:
+                organizationSettingsModel as unknown as OrganizationSettingsModel,
+        });
+
+        expect(
+            (await validatedService.getHealthState(undefined)).license,
+        ).toEqual({
+            valid: true,
+        });
+    });
     it('Should return localDbtEnabled false when in cloud beta mode', async () => {
         const service = new HealthService({
             organizationModel:
@@ -103,6 +137,7 @@ describe('health', () => {
                 ...lightdashConfigMock,
                 mode: LightdashMode.CLOUD_BETA,
             },
+            licenseService,
             migrationModel: migrationModel as unknown as MigrationModel,
             organizationSettingsModel:
                 organizationSettingsModel as unknown as OrganizationSettingsModel,
@@ -181,6 +216,7 @@ describe('health', () => {
                         identityVerificationSecret: testSecret,
                     },
                 },
+                licenseService,
                 migrationModel: migrationModel as unknown as MigrationModel,
                 organizationSettingsModel:
                     organizationSettingsModel as unknown as OrganizationSettingsModel,
@@ -201,6 +237,7 @@ describe('health', () => {
                         identityVerificationSecret: testSecret,
                     },
                 },
+                licenseService,
                 migrationModel: migrationModel as unknown as MigrationModel,
                 organizationSettingsModel:
                     organizationSettingsModel as unknown as OrganizationSettingsModel,

--- a/packages/backend/src/services/HealthService/HealthService.test.ts
+++ b/packages/backend/src/services/HealthService/HealthService.test.ts
@@ -32,9 +32,15 @@ const organizationSettingsModel = {
     get: vi.fn(async () => ({ queryLimit: null, csvCellsLimit: null })),
 };
 
-const licenseService = new LicenseService();
-const validLicenseService = new LicenseService();
+const licenseService = new LicenseService({ licenseKey: null });
+const invalidLicenseService = new LicenseService({
+    licenseKey: 'invalid-license-key',
+});
+const validLicenseService = new LicenseService({
+    licenseKey: 'valid-license-key',
+});
 vi.spyOn(validLicenseService, 'getLicenseStatus').mockReturnValue({
+    hasLicenseKey: true,
     valid: true,
 });
 
@@ -109,9 +115,27 @@ describe('health', () => {
     it('returns the enterprise license validation result', async () => {
         expect((await healthService.getHealthState(undefined)).license).toEqual(
             {
+                hasLicenseKey: false,
                 valid: false,
             },
         );
+
+        const invalidService = new HealthService({
+            organizationModel:
+                organizationModel as unknown as OrganizationModel,
+            lightdashConfig: lightdashConfigMock,
+            licenseService: invalidLicenseService,
+            migrationModel: migrationModel as unknown as MigrationModel,
+            organizationSettingsModel:
+                organizationSettingsModel as unknown as OrganizationSettingsModel,
+        });
+
+        expect(
+            (await invalidService.getHealthState(undefined)).license,
+        ).toEqual({
+            hasLicenseKey: true,
+            valid: false,
+        });
 
         const validatedService = new HealthService({
             organizationModel:
@@ -126,6 +150,7 @@ describe('health', () => {
         expect(
             (await validatedService.getHealthState(undefined)).license,
         ).toEqual({
+            hasLicenseKey: true,
             valid: true,
         });
     });

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -13,10 +13,12 @@ import { OrganizationModel } from '../../models/OrganizationModel';
 import { OrganizationSettingsModel } from '../../models/OrganizationSettingsModel';
 import { VERSION } from '../../version';
 import { BaseService } from '../BaseService';
+import { LicenseService } from '../LicenseService/LicenseService';
 import { resolveOrganizationExportLimits } from '../OrganizationSettingsService/resolveExportLimits';
 
 type HealthServiceArguments = {
     lightdashConfig: LightdashConfig;
+    licenseService: LicenseService;
     organizationModel: OrganizationModel;
     migrationModel: MigrationModel;
     organizationSettingsModel: OrganizationSettingsModel;
@@ -24,6 +26,8 @@ type HealthServiceArguments = {
 
 export class HealthService extends BaseService {
     private readonly lightdashConfig: LightdashConfig;
+
+    private readonly licenseService: LicenseService;
 
     private readonly organizationModel: OrganizationModel;
 
@@ -35,10 +39,12 @@ export class HealthService extends BaseService {
         organizationModel,
         migrationModel,
         lightdashConfig,
+        licenseService,
         organizationSettingsModel,
     }: HealthServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
+        this.licenseService = licenseService;
         this.organizationModel = organizationModel;
         this.migrationModel = migrationModel;
         this.organizationSettingsModel = organizationSettingsModel;
@@ -119,6 +125,7 @@ export class HealthService extends BaseService {
 
         return {
             healthy: true,
+            license: this.licenseService.getLicenseStatus(),
             mode: this.lightdashConfig.mode,
             version: VERSION,
             localDbtEnabled,

--- a/packages/backend/src/services/LicenseService/LicenseService.ts
+++ b/packages/backend/src/services/LicenseService/LicenseService.ts
@@ -1,13 +1,24 @@
 import { BaseService } from '../BaseService';
 
 export type LicenseStatus = {
+    hasLicenseKey: boolean;
     valid: boolean;
 };
 
 export class LicenseService extends BaseService {
     protected readonly valid: boolean = false;
 
+    private readonly hasLicenseKey: boolean;
+
+    constructor({ licenseKey }: { licenseKey: string | null }) {
+        super();
+        this.hasLicenseKey = licenseKey !== null;
+    }
+
     getLicenseStatus(): LicenseStatus {
-        return { valid: this.valid };
+        return {
+            hasLicenseKey: this.hasLicenseKey,
+            valid: this.valid,
+        };
     }
 }

--- a/packages/backend/src/services/LicenseService/LicenseService.ts
+++ b/packages/backend/src/services/LicenseService/LicenseService.ts
@@ -1,0 +1,13 @@
+import { BaseService } from '../BaseService';
+
+export type LicenseStatus = {
+    valid: boolean;
+};
+
+export class LicenseService extends BaseService {
+    protected readonly valid: boolean = false;
+
+    getLicenseStatus(): LicenseStatus {
+        return { valid: this.valid };
+    }
+}

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -41,6 +41,7 @@ import { GitIntegrationService } from './GitIntegrationService/GitIntegrationSer
 import { GitlabAppService } from './GitlabAppService/GitlabAppService';
 import { GroupsService } from './GroupService';
 import { HealthService } from './HealthService/HealthService';
+import { LicenseService } from './LicenseService/LicenseService';
 import { LightdashAnalyticsService } from './LightdashAnalyticsService/LightdashAnalyticsService';
 import { MetricsExplorerService } from './MetricsExplorerService/MetricsExplorerService';
 import { NotificationsService } from './NotificationsService/NotificationsService';
@@ -103,6 +104,7 @@ interface ServiceManifest {
     gdriveService: GdriveService;
     groupService: GroupsService;
     healthService: HealthService;
+    licenseService: LicenseService;
     notificationService: NotificationsService;
     oauthService: OAuthService;
 
@@ -567,6 +569,7 @@ export class ServiceRepository
             () =>
                 new HealthService({
                     lightdashConfig: this.context.lightdashConfig,
+                    licenseService: this.getLicenseService(),
                     organizationModel: this.models.getOrganizationModel(),
                     migrationModel: this.models.getMigrationModel(),
                     organizationSettingsModel:
@@ -1563,6 +1566,10 @@ export class ServiceRepository
                     savedChartModel: this.models.getSavedChartModel(),
                 }),
         );
+    }
+
+    public getLicenseService(): LicenseService {
+        return this.getService('licenseService', () => new LicenseService());
     }
 
     public getCacheService<CacheServiceImplT>(): CacheServiceImplT {

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1569,7 +1569,13 @@ export class ServiceRepository
     }
 
     public getLicenseService(): LicenseService {
-        return this.getService('licenseService', () => new LicenseService());
+        return this.getService(
+            'licenseService',
+            () =>
+                new LicenseService({
+                    licenseKey: this.context.lightdashConfig.license.licenseKey,
+                }),
+        );
     }
 
     public getCacheService<CacheServiceImplT>(): CacheServiceImplT {

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -499,6 +499,7 @@ export enum LightdashMode {
 export type HealthState = {
     healthy: boolean;
     license: {
+        hasLicenseKey: boolean;
         valid: boolean;
     };
     mode: LightdashMode;

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -498,6 +498,9 @@ export enum LightdashMode {
 
 export type HealthState = {
     healthy: boolean;
+    license: {
+        valid: boolean;
+    };
     mode: LightdashMode;
     version: string;
     localDbtEnabled: boolean;

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -498,7 +498,7 @@ export enum LightdashMode {
 
 export type HealthState = {
     healthy: boolean;
-    license: {
+    license?: {
         hasLicenseKey: boolean;
         valid: boolean;
     };

--- a/packages/frontend/src/components/AboutFooter.tsx
+++ b/packages/frontend/src/components/AboutFooter.tsx
@@ -121,7 +121,7 @@ const AboutFooter: FC<{ minimal?: boolean; maxWidth?: number }> = ({
                 onClose={() => setIsOpen(false)}
                 title="About Lightdash"
                 icon={IconInfoCircle}
-                size="sm"
+                size="md"
                 modalBodyProps={{ py: 'lg' }}
             >
                 <TrackPage

--- a/packages/frontend/src/components/AboutFooter.tsx
+++ b/packages/frontend/src/components/AboutFooter.tsx
@@ -8,9 +8,11 @@ import {
     Button,
     Divider,
     Group,
+    Paper,
+    Stack,
     Text,
 } from '@mantine-8/core';
-import { IconBook, IconInfoCircle } from '@tabler/icons-react';
+import { IconBook, IconBrandGithub, IconInfoCircle } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import useApp from '../providers/App/useApp';
 import {
@@ -38,6 +40,7 @@ const AboutFooter: FC<{ minimal?: boolean; maxWidth?: number }> = ({
         healthState.data?.latest.version &&
         healthState.data.version !== healthState.data.latest.version &&
         healthState.data?.mode === LightdashMode.DEFAULT;
+    const isLicenseValid = healthState.data?.license.valid ?? false;
 
     return (
         <TrackSection name={SectionName.PAGE_FOOTER}>
@@ -118,58 +121,117 @@ const AboutFooter: FC<{ minimal?: boolean; maxWidth?: number }> = ({
                 onClose={() => setIsOpen(false)}
                 title="About Lightdash"
                 icon={IconInfoCircle}
-                cancelLabel={false}
-                actions={
-                    <Group gap="sm">
-                        <MantineLinkButton
-                            href="https://docs.lightdash.com/"
-                            target="_blank"
-                            variant="default"
-                        >
-                            Docs
-                        </MantineLinkButton>
-                        <MantineLinkButton
-                            href="https://github.com/lightdash/lightdash"
-                            target="_blank"
-                            variant="default"
-                        >
-                            Github
-                        </MantineLinkButton>
-                    </Group>
-                }
+                size="sm"
+                modalBodyProps={{ py: 'lg' }}
             >
                 <TrackPage
                     name={PageName.ABOUT_LIGHTDASH}
                     type={PageType.MODAL}
                 >
-                    <Text fw={500}>
-                        <b>Version:</b>{' '}
-                        {healthState.data
-                            ? `v${healthState.data.version}`
-                            : 'n/a'}
-                    </Text>
-                    {showUpdateBadge && (
-                        <Alert
-                            title="New version available!"
-                            color="blue"
-                            icon={<IconInfoCircle size={17} />}
-                        >
-                            <Text c="blue">
-                                The version v{healthState.data?.latest.version}{' '}
-                                is now available. Please follow the instructions
-                                in the{' '}
-                                <Anchor
-                                    href="https://docs.lightdash.com/self-host/update-lightdash"
-                                    target="_blank"
-                                    rel="noreferrer"
-                                    underline="always"
+                    <Stack gap="md">
+                        <Text fz="sm" c="ldGray.6">
+                            Instance details and licensing status.
+                        </Text>
+
+                        <Paper withBorder radius="md" p="md">
+                            <Stack gap="md">
+                                <Group justify="space-between" wrap="nowrap">
+                                    <Text fz="sm" c="ldGray.6">
+                                        Version
+                                    </Text>
+                                    <Text fz="sm" fw={600}>
+                                        {healthState.data
+                                            ? `v${healthState.data.version}`
+                                            : 'n/a'}
+                                    </Text>
+                                </Group>
+
+                                <Divider />
+
+                                <Group
+                                    justify="space-between"
+                                    align="center"
+                                    wrap="nowrap"
                                 >
-                                    How to update version
-                                </Anchor>{' '}
-                                documentation.
-                            </Text>
-                        </Alert>
-                    )}
+                                    <Box>
+                                        <Text fz="sm" fw={500}>
+                                            Enterprise license
+                                        </Text>
+                                        <Text fz="xs" c="ldGray.6">
+                                            {isLicenseValid
+                                                ? 'Enterprise features are enabled.'
+                                                : 'This instance has no enterprise license.'}
+                                        </Text>
+                                    </Box>
+                                    <Badge
+                                        color={
+                                            isLicenseValid ? 'green' : 'gray'
+                                        }
+                                        variant="light"
+                                        flex="none"
+                                    >
+                                        {isLicenseValid
+                                            ? 'Valid'
+                                            : 'No license'}
+                                    </Badge>
+                                </Group>
+                            </Stack>
+                        </Paper>
+
+                        {showUpdateBadge && (
+                            <Alert
+                                title="New version available!"
+                                color="blue"
+                                icon={<IconInfoCircle size={17} />}
+                            >
+                                <Text c="blue">
+                                    The version v
+                                    {healthState.data?.latest.version} is now
+                                    available. Please follow the instructions in
+                                    the{' '}
+                                    <Anchor
+                                        href="https://docs.lightdash.com/self-host/update-lightdash"
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        underline="always"
+                                    >
+                                        How to update version
+                                    </Anchor>{' '}
+                                    documentation.
+                                </Text>
+                            </Alert>
+                        )}
+
+                        <Group gap="xs">
+                            <MantineLinkButton
+                                href="https://docs.lightdash.com/"
+                                target="_blank"
+                                variant="subtle"
+                                color="ldGray.7"
+                                size="compact-sm"
+                                leftSection={
+                                    <MantineIcon icon={IconBook} size="sm" />
+                                }
+                            >
+                                Documentation
+                            </MantineLinkButton>
+                            <MantineLinkButton
+                                href="https://github.com/lightdash/lightdash"
+                                target="_blank"
+                                variant="subtle"
+                                color="ldGray.7"
+                                size="compact-sm"
+                                leftSection={
+                                    <MantineIcon
+                                        icon={IconBrandGithub}
+                                        size="sm"
+                                    />
+                                }
+                            >
+                                GitHub
+                            </MantineLinkButton>
+                        </Group>
+                    </Stack>
                 </TrackPage>
             </MantineModal>
         </TrackSection>

--- a/packages/frontend/src/components/AboutFooter.tsx
+++ b/packages/frontend/src/components/AboutFooter.tsx
@@ -40,7 +40,24 @@ const AboutFooter: FC<{ minimal?: boolean; maxWidth?: number }> = ({
         healthState.data?.latest.version &&
         healthState.data.version !== healthState.data.latest.version &&
         healthState.data?.mode === LightdashMode.DEFAULT;
-    const isLicenseValid = healthState.data?.license.valid ?? false;
+    const licenseStatus = healthState.data?.license;
+    const licenseDisplay = licenseStatus?.valid
+        ? {
+              badge: 'Valid',
+              color: 'green',
+              description: 'Enterprise features are enabled.',
+          }
+        : licenseStatus?.hasLicenseKey
+          ? {
+                badge: 'Not valid',
+                color: 'red',
+                description: 'The configured license key is not valid.',
+            }
+          : {
+                badge: 'No license',
+                color: 'gray',
+                description: 'No enterprise license key is configured.',
+            };
 
     return (
         <TrackSection name={SectionName.PAGE_FOOTER}>
@@ -158,21 +175,15 @@ const AboutFooter: FC<{ minimal?: boolean; maxWidth?: number }> = ({
                                             Enterprise license
                                         </Text>
                                         <Text fz="xs" c="ldGray.6">
-                                            {isLicenseValid
-                                                ? 'Enterprise features are enabled.'
-                                                : 'This instance has no enterprise license.'}
+                                            {licenseDisplay.description}
                                         </Text>
                                     </Box>
                                     <Badge
-                                        color={
-                                            isLicenseValid ? 'green' : 'gray'
-                                        }
+                                        color={licenseDisplay.color}
                                         variant="light"
                                         flex="none"
                                     >
-                                        {isLicenseValid
-                                            ? 'Valid'
-                                            : 'No license'}
+                                        {licenseDisplay.badge}
                                     </Badge>
                                 </Group>
                             </Stack>

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -6,6 +6,7 @@ export default function mockHealthResponse(
     return {
         healthy: true,
         license: {
+            hasLicenseKey: false,
             valid: false,
         },
         mode: LightdashMode.CLOUD_BETA,

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -5,6 +5,9 @@ export default function mockHealthResponse(
 ): HealthState {
     return {
         healthy: true,
+        license: {
+            valid: false,
+        },
         mode: LightdashMode.CLOUD_BETA,
         version: '0.0.0',
         localDbtEnabled: true,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Adds open-source and enterprise license services so the health endpoint reports whether a key is configured and whether it passed validation, without exposing the key.
Distinguishes no-license, invalid, and valid states while keeping enterprise services disabled when a configured key fails validation.
Surfaces those states in a redesigned About Lightdash modal alongside version details, update availability, and resource links.

### Screenshots

#### No license
<img width="480" height="354" alt="About Lightdash modal with no enterprise license configured" src="https://github.com/user-attachments/assets/c7e309b2-9709-4fc0-8073-ae48617c60d0" />

#### Not valid
<img width="480" height="354" alt="About Lightdash modal with an invalid enterprise license" src="https://github.com/user-attachments/assets/5e2adcb9-9f0a-4861-a555-496ab2a54ab9" />

#### Valid
<img width="480" height="354" alt="About Lightdash modal with a valid enterprise license" src="https://github.com/user-attachments/assets/ef0befcc-56f1-47d2-b8bf-c732692b729b" />

#### New version available
<img width="480" height="507" alt="About Lightdash modal with a new version available" src="https://github.com/user-attachments/assets/f193d775-eb56-4053-88e4-8475f36444cb" />