### PR TITLE
fix: use replaceAll in parseTableField to handle nested references

### DIFF
--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -210,7 +210,7 @@ export class ValidationService extends BaseService {
     ): string[] {
         const parseTableField = (field: string) =>
             // Transform ${table.field} references on table calculation to table_field
-            field.replace('${', '').replace('}', '').replace('.', '_');
+            field.replaceAll('${', '').replaceAll('}', '').replaceAll('.', '_');
 
         const tableCalculationFieldsInSql: string[] = tableCalculations.reduce<
             string[]


### PR DESCRIPTION
## Summary

Fixed `parseTableField()` in `ValidationService.ts` to replace all occurrences of `${`, `}`, and `.` instead of only the first.

## Changes

**`packages/backend/src/services/ValidationService/ValidationService.ts`** (line 213)

`.replace()` → `.replaceAll()` for all three string replacements.

JavaScript's `.replace()` with a string argument only replaces the **first** occurrence. For table calculation fields with nested references like `${table.nested.field}`:

| | Before (bug) | After (fix) |
|---|---|---|
| Input | `${table.nested.field}` | `${table.nested.field}` |
| Output | `table_nested.field` | `table_nested_field` |

Only the first `.` was replaced, causing validation to fail for multi-level field references.

## Test plan

- [x] Verified `.replaceAll()` correctly transforms all dots in nested field references
- [x] No behavioral change for simple (single-dot) field references