### PR TITLE
fix: scope sqlRunner download file lookup to the requested project

### DIFF
--- a/packages/backend/src/database/entities/downloadFile.ts
+++ b/packages/backend/src/database/entities/downloadFile.ts
@@ -7,6 +7,7 @@ export type DbDownloadFile = {
     path: string;
     type: string;
     created_at: Date;
+    project_uuid: string | null;
 };
 
 type CreateDownloadFile = Omit<DbDownloadFile, 'created_at'>;

--- a/packages/backend/src/database/migrations/20260727170000_add_project_uuid_to_download_files.ts
+++ b/packages/backend/src/database/migrations/20260727170000_add_project_uuid_to_download_files.ts
@@ -1,0 +1,27 @@
+import { Knex } from 'knex';
+
+const DownloadFilesTableName = 'download_files';
+
+export async function up(knex: Knex): Promise<void> {
+    if (
+        !(await knex.schema.hasColumn(DownloadFilesTableName, 'project_uuid'))
+    ) {
+        await knex.schema.alterTable(DownloadFilesTableName, (table) => {
+            table
+                .uuid('project_uuid')
+                .nullable()
+                .references('project_uuid')
+                .inTable('projects')
+                .onDelete('CASCADE')
+                .index();
+        });
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (await knex.schema.hasColumn(DownloadFilesTableName, 'project_uuid')) {
+        await knex.schema.alterTable(DownloadFilesTableName, (table) => {
+            table.dropColumn('project_uuid');
+        });
+    }
+}

--- a/packages/backend/src/models/DownloadFileModel.ts
+++ b/packages/backend/src/models/DownloadFileModel.ts
@@ -27,11 +27,13 @@ export class DownloadFileModel {
         fileId: string,
         path: string,
         type: DownloadFileType,
+        projectUuid?: string,
     ): Promise<void> {
         await this.database(DownloadFileTableName).insert({
             nanoid: fileId,
             path,
             type,
+            project_uuid: projectUuid ?? null,
         });
     }
 
@@ -50,6 +52,7 @@ export class DownloadFileModel {
             path: row.path,
             createdAt: row.created_at,
             type: row.type as DownloadFileType,
+            projectUuid: row.project_uuid,
         };
     }
 
@@ -58,6 +61,7 @@ export class DownloadFileModel {
         urlPrefix: string,
         callback: (writer: (data: ResultRow) => void) => Promise<void>,
         fileStorageClient?: FileStorageClient,
+        projectUuid?: string,
     ): Promise<string> {
         const downloadFileId = nanoid();
         const passThrough = new PassThrough();
@@ -87,6 +91,7 @@ export class DownloadFileModel {
             downloadFileId,
             s3FileId,
             DownloadFileType.S3_JSONL,
+            projectUuid,
         );
         Logger.debug('File has been uploaded to S3.');
 
@@ -95,15 +100,37 @@ export class DownloadFileModel {
     }
 
     // TODO: consider removing in milestone #212
-    streamFunction(fileStorageClient: FileStorageClient) {
+    streamFunction(fileStorageClient: FileStorageClient, projectUuid: string) {
         return fileStorageClient.isEnabled()
-            ? this.streamResultsToCloudStorage.bind(this)
-            : this.streamResultsToLocalFile.bind(this);
+            ? (
+                  urlPrefix: string,
+                  callback: (
+                      writer: (data: ResultRow) => void,
+                  ) => Promise<void>,
+              ) =>
+                  this.streamResultsToCloudStorage(
+                      urlPrefix,
+                      callback,
+                      fileStorageClient,
+                      projectUuid,
+                  )
+            : (
+                  urlPrefix: string,
+                  callback: (
+                      writer: (data: ResultRow) => void,
+                  ) => Promise<void>,
+              ) =>
+                  this.streamResultsToLocalFile(
+                      urlPrefix,
+                      callback,
+                      projectUuid,
+                  );
     }
 
     async streamResultsToLocalFile(
         urlPrefix: string,
         callback: (writer: (data: ResultRow) => void) => Promise<void>,
+        projectUuid?: string,
     ): Promise<string> {
         const downloadFileId = nanoid(); // Creates a new nanoid for the download file because the jobId is already exposed
         const filePath = `/tmp/${downloadFileId}.jsonl`;
@@ -112,6 +139,7 @@ export class DownloadFileModel {
             downloadFileId,
             filePath,
             DownloadFileType.JSONL,
+            projectUuid,
         );
         const writeStream = fs.createWriteStream(filePath, {
             encoding: 'utf8',

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -4,6 +4,7 @@ import {
     DbtVersionOptionLatest,
     defineUserAbility,
     DimensionType,
+    DownloadFileType,
     DuckdbConnectionType,
     FeatureFlags,
     FilterOperator,
@@ -23,10 +24,12 @@ import {
     WarehouseTypes,
     type ChartSummary,
     type CreateWarehouseCredentials,
+    type DownloadFile,
     type Explore,
     type PossibleAbilities,
     type RegisteredAccount,
 } from '@lightdash/common';
+import { Readable } from 'stream';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { S3CacheClient } from '../../clients/Aws/S3CacheClient';
 import EmailClient from '../../clients/EmailClient/EmailClient';
@@ -282,7 +285,9 @@ const getMockedProjectService = (
     overrides: Partial<
         Pick<
             ConstructorParameters<typeof ProjectService>[0],
-            'spacePermissionService' | 'provisionPlaygroundProject'
+            | 'spacePermissionService'
+            | 'provisionPlaygroundProject'
+            | 'downloadFileModel'
         >
     > = {},
 ) =>
@@ -311,7 +316,8 @@ const getMockedProjectService = (
         warehouseAvailableTablesModel: {} as WarehouseAvailableTablesModel,
         emailModel: emailModel as unknown as EmailModel,
         schedulerClient: schedulerClient as unknown as SchedulerClient,
-        downloadFileModel: {} as unknown as DownloadFileModel,
+        downloadFileModel:
+            overrides.downloadFileModel ?? ({} as unknown as DownloadFileModel),
         fileStorageClient: {} as FileStorageClient,
         groupsModel: {} as GroupsModel,
         tagsModel: tagsModel as unknown as TagsModel,
@@ -3100,6 +3106,69 @@ describe('ProjectService', () => {
                     credentials,
                 }),
             ).rejects.toThrowError(ForbiddenError);
+        });
+    });
+
+    describe('getFileStream', () => {
+        const getServiceWithDownloadFile = (downloadFile: DownloadFile) =>
+            getMockedProjectService(lightdashConfigMock, {
+                downloadFileModel: {
+                    getDownloadFile: vi.fn(async () => downloadFile),
+                } as unknown as DownloadFileModel,
+            });
+
+        it('returns a stream when the file belongs to the requested project', async () => {
+            const serviceWithFile = getServiceWithDownloadFile({
+                nanoid: 'file-id',
+                path: __filename,
+                createdAt: new Date(),
+                type: DownloadFileType.JSONL,
+                projectUuid: projectSummary.projectUuid,
+            });
+
+            const stream = await serviceWithFile.getFileStream(
+                user,
+                projectSummary.projectUuid,
+                'file-id',
+            );
+
+            expect(stream).toBeInstanceOf(Readable);
+        });
+
+        it('throws NotFoundError when the file belongs to a different project', async () => {
+            const serviceWithFile = getServiceWithDownloadFile({
+                nanoid: 'file-id',
+                path: '/tmp/file-id.jsonl',
+                createdAt: new Date(),
+                type: DownloadFileType.JSONL,
+                projectUuid: 'another-project-uuid',
+            });
+
+            await expect(
+                serviceWithFile.getFileStream(
+                    user,
+                    projectSummary.projectUuid,
+                    'file-id',
+                ),
+            ).rejects.toThrowError(NotFoundError);
+        });
+
+        it('throws NotFoundError when the file has no owning project', async () => {
+            const serviceWithFile = getServiceWithDownloadFile({
+                nanoid: 'file-id',
+                path: '/tmp/file-id.jsonl',
+                createdAt: new Date(),
+                type: DownloadFileType.JSONL,
+                projectUuid: null,
+            });
+
+            await expect(
+                serviceWithFile.getFileStream(
+                    user,
+                    projectSummary.projectUuid,
+                    'file-id',
+                ),
+            ).rejects.toThrowError(NotFoundError);
         });
     });
 });

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -5847,6 +5847,7 @@ export class ProjectService extends BaseService {
 
         const fileUrl = await this.downloadFileModel.streamFunction(
             this.fileStorageClient,
+            projectUuid,
         )(
             `${this.lightdashConfig.siteUrl}/api/v1/projects/${projectUuid}/sqlRunner/results`,
             async (writer) => {
@@ -5870,7 +5871,6 @@ export class ProjectService extends BaseService {
                     },
                 );
             },
-            this.fileStorageClient,
         );
 
         await sshTunnel.disconnect();
@@ -5958,6 +5958,7 @@ export class ProjectService extends BaseService {
 
         const fileUrl = await this.downloadFileModel.streamFunction(
             this.fileStorageClient,
+            projectUuid,
         )(
             `${this.lightdashConfig.siteUrl}/api/v1/projects/${projectUuid}/sqlRunner/results`,
             async (writer) => {
@@ -6051,7 +6052,6 @@ export class ProjectService extends BaseService {
                     writer(currentTransformedRow);
                 }
             },
-            this.fileStorageClient,
         );
 
         await sshTunnel.disconnect();
@@ -6099,6 +6099,9 @@ export class ProjectService extends BaseService {
 
         const downloadFile =
             await this.downloadFileModel.getDownloadFile(fileId);
+        if (downloadFile.projectUuid !== projectUuid) {
+            throw new NotFoundError('Cannot find file');
+        }
         switch (downloadFile.type) {
             case DownloadFileType.JSONL:
                 return fs.createReadStream(downloadFile.path);

--- a/packages/common/src/types/downloadFile.ts
+++ b/packages/common/src/types/downloadFile.ts
@@ -14,6 +14,7 @@ export type DownloadFile = {
     path: string;
     createdAt: Date;
     type: DownloadFileType;
+    projectUuid: string | null;
 };
 
 /**


### PR DESCRIPTION
Records the owning project on sqlRunner download files and only serves a file through the results endpoint of the project that created it; mismatched or legacy (unowned) files return 404.

Linear: SPK-592