### PR TITLE
chore: standardize Okteto previews on dbt 1.11

### DIFF
--- a/docker/docker-compose.db-snapshot.yml
+++ b/docker/docker-compose.db-snapshot.yml
@@ -34,6 +34,7 @@ services:
         environment:
             NODE_ENV: production
             DBT_DEMO_DIR: /usr/app
+            LIGHTDASH_SEED_DBT_VERSION: v1.11
             # Must match the preview LIGHTDASH_SECRET in
             # docker-compose.preview.yml: the seed encrypts warehouse
             # credentials with it, and a diverted preview must decrypt them

--- a/docker/docker-compose.preview.yml
+++ b/docker/docker-compose.preview.yml
@@ -58,6 +58,7 @@ services:
             IS_PULL_REQUEST: true
             LIGHTDASH_MODE: pr
             DBT_DEMO_DIR: /usr/app
+            LIGHTDASH_SEED_DBT_VERSION: v1.11
             INTERNAL_LIGHTDASH_HOST: http://lightdash-preview:8080
 
             # This must be set in the GitHub Actions workflow

--- a/dockerfile-prs
+++ b/dockerfile-prs
@@ -46,93 +46,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     tar \
     libsystemd0
 
-# Installing multiple versions of dbt
-# dbt 1.4 is the default
-# Use pip cache to speed up subsequent builds
+# Okteto previews only execute the latest fully supported dbt version.
 RUN --mount=type=cache,target=/root/.cache/pip \
-    python3 -m venv /usr/local/dbt1.4 \
-    && /usr/local/dbt1.4/bin/pip install \
-    "dbt-postgres~=1.4.0" \
-    "dbt-redshift~=1.4.0" \
-    "dbt-snowflake~=1.4.0" \
-    "dbt-bigquery~=1.4.0" \
-    "dbt-databricks~=1.4.0" \
-    "dbt-trino~=1.4.0" \
-    "dbt-clickhouse~=1.4.0" \
-    "psycopg2-binary==2.9.6"
-
-RUN --mount=type=cache,target=/root/.cache/pip \
-    ln -s /usr/local/dbt1.4/bin/dbt /usr/local/bin/dbt\
-    && python3 -m venv /usr/local/dbt1.5 \
-    && /usr/local/dbt1.5/bin/pip install \
-    "dbt-postgres~=1.5.0" \
-    "dbt-redshift~=1.5.0" \
-    "dbt-snowflake~=1.5.0" \
-    "dbt-bigquery~=1.5.0" \
-    "dbt-databricks~=1.5.0" \
-    "dbt-trino==1.5.0" \
-    "dbt-clickhouse~=1.5.0" \
-    "psycopg2-binary==2.9.6" \
-    && ln -s /usr/local/dbt1.5/bin/dbt /usr/local/bin/dbt1.5\
-    && python3 -m venv /usr/local/dbt1.6 \
-    && /usr/local/dbt1.6/bin/pip install \
-    "dbt-postgres~=1.6.0" \
-    "dbt-redshift~=1.6.0" \
-    "dbt-snowflake~=1.6.0" \
-    "dbt-bigquery~=1.6.0" \
-    "dbt-databricks~=1.6.0" \
-    "dbt-trino==1.6.0" \
-    "dbt-clickhouse~=1.6.0" \
-    "psycopg2-binary==2.9.6"\
-    && ln -s /usr/local/dbt1.6/bin/dbt /usr/local/bin/dbt1.6 \
-    && python3 -m venv /usr/local/dbt1.7 \
-    && /usr/local/dbt1.7/bin/pip install \
-    "dbt-postgres~=1.7.0" \
-    "dbt-redshift~=1.7.0" \
-    "dbt-snowflake~=1.7.0" \
-    "dbt-bigquery~=1.7.0" \
-    "dbt-databricks~=1.7.0" \
-    "dbt-trino==1.7.0" \
-    "dbt-clickhouse~=1.7.0" \
-    "psycopg2-binary==2.9.6" \
-    && ln -s /usr/local/dbt1.7/bin/dbt /usr/local/bin/dbt1.7 \
-    && python3 -m venv /usr/local/dbt1.8 \
-    && /usr/local/dbt1.8/bin/pip install \
-    # from 1.8, dbt-core needs to be explicitly installed
-    "dbt-core~=1.8.0" \
-    "dbt-postgres~=1.8.0" \
-    "dbt-redshift~=1.8.0" \
-    "dbt-snowflake~=1.8.0" \
-    "dbt-bigquery~=1.8.0" \
-    "dbt-databricks~=1.8.0" \
-    "dbt-trino~=1.8.0" \
-    "dbt-clickhouse~=1.8.0" \
-    && ln -s /usr/local/dbt1.8/bin/dbt /usr/local/bin/dbt1.8 \
-    && python3 -m venv /usr/local/dbt1.9 \
-    && /usr/local/dbt1.9/bin/pip install \
-    "dbt-core~=1.9.0" \
-    "dbt-postgres~=1.9.0" \
-    "dbt-redshift~=1.9.0" \
-    "dbt-snowflake~=1.9.0" \
-    "dbt-bigquery~=1.9.0" \
-    "dbt-databricks~=1.9.0" \
-    "dbt-trino~=1.9.0" \
-    "dbt-clickhouse~=1.9.0" \
-    "dbt-athena~=1.9.0" \
-    && ln -s /usr/local/dbt1.9/bin/dbt /usr/local/bin/dbt1.9 \
-    && python3 -m venv /usr/local/dbt1.10 \
-    && /usr/local/dbt1.10/bin/pip install \
-    "dbt-core~=1.10.0" \
-    "dbt-postgres~=1.10.0" \
-    "dbt-redshift~=1.10.0" \
-    "dbt-snowflake~=1.10.0" \
-    "dbt-bigquery~=1.10.0" \
-    "dbt-databricks~=1.10.0" \
-    "dbt-trino~=1.10.0" \
-    "dbt-clickhouse~=1.9.0" \
-    "dbt-athena~=1.10.0" \
-    && ln -s /usr/local/dbt1.10/bin/dbt /usr/local/bin/dbt1.10 \
-    && python3 -m venv /usr/local/dbt1.11 \
+    python3 -m venv /usr/local/dbt1.11 \
     && /usr/local/dbt1.11/bin/pip install \
     "dbt-core~=1.11.0" \
     "dbt-postgres~=1.10.0" \
@@ -143,20 +59,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     "dbt-trino~=1.10.0" \
     "dbt-clickhouse~=1.9.0" \
     "dbt-athena~=1.10.0" \
-    && ln -s /usr/local/dbt1.11/bin/dbt /usr/local/bin/dbt1.11 \
-    && python3 -m venv /usr/local/dbt1.12 \
-# dbt 1.12 has no stable PyPI release yet: pin latest pre-releases, and skip
-# dbt-databricks (no release compatible with dbt-core 1.12)
-    && /usr/local/dbt1.12/bin/pip install \
-    "dbt-core==1.12.0rc1" \
-    "dbt-postgres~=1.10.0" \
-    "dbt-redshift~=1.10.0" \
-    "dbt-snowflake==1.12.0b2" \
-    "dbt-bigquery==1.12.0b1" \
-    "dbt-trino~=1.10.0" \
-    "dbt-clickhouse~=1.9.0" \
-    "dbt-athena~=1.10.0" \
-    && ln -s /usr/local/dbt1.12/bin/dbt /usr/local/bin/dbt1.12
+    "dbt-duckdb~=1.10.0"
 
 # -----------------------------
 # Stage 1: Development environment
@@ -352,7 +255,7 @@ RUN rm -rf node_modules \
     && rm -rf packages/*/node_modules
 
 # Install production dependencies
-ENV NODE_ENV production
+ENV NODE_ENV=production
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install --prod --frozen-lockfile --prefer-offline
@@ -363,7 +266,7 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
 
 FROM pnpm-base AS prod
 
-ENV NODE_ENV production
+ENV NODE_ENV=production
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
@@ -379,25 +282,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=prod-builder  /usr/local/dbt1.4 /usr/local/dbt1.4
-COPY --from=prod-builder  /usr/local/dbt1.5 /usr/local/dbt1.5
-COPY --from=prod-builder  /usr/local/dbt1.6 /usr/local/dbt1.6
-COPY --from=prod-builder  /usr/local/dbt1.7 /usr/local/dbt1.7
-COPY --from=prod-builder  /usr/local/dbt1.8 /usr/local/dbt1.8
-COPY --from=prod-builder  /usr/local/dbt1.9 /usr/local/dbt1.9
-COPY --from=prod-builder  /usr/local/dbt1.10 /usr/local/dbt1.10
 COPY --from=prod-builder  /usr/local/dbt1.11 /usr/local/dbt1.11
-COPY --from=prod-builder  /usr/local/dbt1.12 /usr/local/dbt1.12
 
-RUN ln -s /usr/local/dbt1.4/bin/dbt /usr/local/bin/dbt \
-    && ln -s /usr/local/dbt1.5/bin/dbt /usr/local/bin/dbt1.5 \
-    && ln -s /usr/local/dbt1.6/bin/dbt /usr/local/bin/dbt1.6 \
-    && ln -s /usr/local/dbt1.7/bin/dbt /usr/local/bin/dbt1.7 \
-    && ln -s /usr/local/dbt1.8/bin/dbt /usr/local/bin/dbt1.8 \
-    && ln -s /usr/local/dbt1.9/bin/dbt /usr/local/bin/dbt1.9 \
-    && ln -s /usr/local/dbt1.10/bin/dbt /usr/local/bin/dbt1.10 \
-    && ln -s /usr/local/dbt1.11/bin/dbt /usr/local/bin/dbt1.11 \
-    && ln -s /usr/local/dbt1.12/bin/dbt /usr/local/bin/dbt1.12
+RUN ln -s /usr/local/dbt1.11/bin/dbt /usr/local/bin/dbt1.11
 
 # Run backend
 COPY ./docker/prod-entrypoint.sh /usr/bin/prod-entrypoint.sh

--- a/examples/full-jaffle-shop-demo/renderDeployHook.sh
+++ b/examples/full-jaffle-shop-demo/renderDeployHook.sh
@@ -22,10 +22,16 @@ if is_seeded; then
 else
     echo "Database not pre-seeded: running full dbt + migrate + seed"
 
-    # Idempotent dbt commands
-    dbt1.7 deps --project-dir /usr/app/dbt --profiles-dir /usr/app/profiles
-    dbt1.7 seed --project-dir /usr/app/dbt --profiles-dir /usr/app/profiles --full-refresh
-    dbt1.7 run --project-dir /usr/app/dbt --profiles-dir /usr/app/profiles --full-refresh
+    seed_dbt_version="${LIGHTDASH_SEED_DBT_VERSION:-v1.7}"
+    seed_dbt_command="dbt${seed_dbt_version#v}"
+    if ! command -v "$seed_dbt_command" >/dev/null; then
+        echo "Missing dbt executable: $seed_dbt_command"
+        exit 1
+    fi
+
+    "$seed_dbt_command" deps --project-dir /usr/app/dbt --profiles-dir /usr/app/profiles
+    "$seed_dbt_command" seed --project-dir /usr/app/dbt --profiles-dir /usr/app/profiles --full-refresh
+    "$seed_dbt_command" run --project-dir /usr/app/dbt --profiles-dir /usr/app/profiles --full-refresh
 
     # Rollback all migrations and seed
     pnpm -F backend rollback-all-production

--- a/packages/api-tests/helpers/projects.ts
+++ b/packages/api-tests/helpers/projects.ts
@@ -178,7 +178,7 @@ export async function createProject(
             type: 'dbt',
             project_dir: process.env.DBT_PROJECT_DIR || '/usr/app/dbt',
         },
-        dbtVersion: 'v1.7',
+        dbtVersion: 'v1.11',
         warehouseConnection,
     });
     expect(resp.status).toBe(200);

--- a/packages/api-tests/tests/promotion.test.ts
+++ b/packages/api-tests/tests/promotion.test.ts
@@ -41,7 +41,7 @@ async function createProject(
                 type: 'dbt',
                 project_dir: process.env.DBT_PROJECT_DIR,
             },
-            dbtVersion: 'v1.7',
+            dbtVersion: 'v1.11',
             warehouseConnection: warehouseConfig,
         },
     );

--- a/packages/api-tests/tests/savedChartGet.test.ts
+++ b/packages/api-tests/tests/savedChartGet.test.ts
@@ -86,7 +86,7 @@ async function createAndRefreshProject(
             type: 'dbt',
             project_dir: process.env.DBT_PROJECT_DIR || '/usr/app/dbt',
         },
-        dbtVersion: 'v1.7',
+        dbtVersion: 'v1.11',
         warehouseConnection: postgresWarehouseConfig,
     });
     expect(projectResp.status).toBe(200);

--- a/packages/backend/src/database/seeds/development/01_initial_user.ts
+++ b/packages/backend/src/database/seeds/development/01_initial_user.ts
@@ -193,7 +193,7 @@ export async function seed(knex: Knex): Promise<void> {
             ...SEED_PROJECT,
             organization_id: organizationId,
             dbt_connection: encryptedProjectSettings,
-            dbt_version: SupportedDbtVersions.V1_7,
+            dbt_version: SupportedDbtVersions.V1_11,
             created_by_user_uuid: user.user_uuid,
         })
         .returning(['project_id', 'project_uuid']);
@@ -266,7 +266,7 @@ export async function seed(knex: Knex): Promise<void> {
                 warehouseCatalog: undefined,
                 onWarehouseCatalogChange: () => {},
             },
-            SupportedDbtVersions.V1_7,
+            SupportedDbtVersions.V1_11,
         );
         const explores = await adapter.compileAllExplores({
             userUuid: user.user_uuid,

--- a/packages/e2e/cypress/support/commands.ts
+++ b/packages/e2e/cypress/support/commands.ts
@@ -464,7 +464,7 @@ Cypress.Commands.add(
                     type: 'dbt',
                     project_dir: Cypress.env('DBT_PROJECT_DIR'),
                 },
-                dbtVersion: 'v1.7',
+                dbtVersion: 'v1.11',
                 warehouseConnection: warehouseConfig || {
                     host: Cypress.env('PGHOST') || 'localhost',
                     user: 'postgres',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A (no Linear ticket)

### Description:
Okteto PR images now install and expose only dbt Core 1.11 with the supported warehouse adapters, substantially reducing the preview image dependency matrix.
Preview and snapshot hooks select `dbt1.11`, while seeded projects and preview-facing API/E2E project helpers are pinned to `v1.11`; the production Dockerfile and CLI workflows are unchanged.
Validation covered Dockerfile checks, the dbt dependency layer, all 46 Jaffle seeds and 63 models, and a backend production build; final local image export was blocked by Docker Desktop disk capacity.