### PR TITLE
feat: manage AI agent memory status

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.test.tsx
@@ -1,6 +1,7 @@
 import { MantineProvider } from '@mantine-8/core';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { AiMarkdown } from '../../../../../components/common/AiMarkdown';
 import { MemoryDetails } from '../MemoryDetails/MemoryDetails';
@@ -11,10 +12,15 @@ import {
 import { rehypeAiAgentContentLinks } from './rehypeContentLinks';
 import { rehypeMemoryCitationIndices } from './rehypeMemoryCitations';
 
+const { statusMutationSpy } = vi.hoisted(() => ({
+    statusMutationSpy: vi.fn(),
+}));
+
 vi.mock('../../hooks/useAiAgentMemory', () => ({
     useAiAgentMemory: () => ({
         isLoading: false,
         data: {
+            uuid: 'memory-uuid',
             slug: 'net-revenue-ab12cd34',
             title: 'Net revenue convention',
             rawMemory: `## Memory
@@ -45,6 +51,10 @@ Use net revenue for future revenue questions.`,
             },
             replacementSlug: null,
         },
+    }),
+    useUpdateAiAgentMemoryStatus: () => ({
+        isLoading: false,
+        mutate: statusMutationSpy,
     }),
 }));
 
@@ -163,6 +173,34 @@ describe('MemoryCitation', () => {
         expect(within(dialog).getByText('Citations')).toBeInTheDocument();
         expect(within(dialog).getByText('3')).toBeInTheDocument();
         expect(within(dialog).getByText('Open thread')).toBeInTheDocument();
+    });
+
+    it('changes status from the modal menu without closing it', async () => {
+        statusMutationSpy.mockClear();
+        const user = userEvent.setup();
+        renderMarkdown(
+            'Supported sentence.<ld-mem-cite id="net-revenue"></ld-mem-cite>',
+        );
+
+        fireEvent.click(screen.getByTitle('Memory: net-revenue'));
+        const dialog = await screen.findByRole('dialog');
+
+        await user.click(
+            within(dialog).getByRole('button', {
+                name: 'Change memory status',
+            }),
+        );
+        await user.click(
+            await screen.findByRole('menuitem', { name: 'Retired' }),
+        );
+
+        expect(statusMutationSpy).toHaveBeenCalledWith({
+            projectUuid: 'project-uuid',
+            memoryUuid: 'memory-uuid',
+            slug: 'net-revenue-ab12cd34',
+            status: 'retired',
+        });
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
 
     it('renders a source thread without a link when its agent is gone', () => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.module.css
@@ -190,6 +190,24 @@
     background: var(--mantine-color-teal-6);
 }
 
+.statusTrigger {
+    border-radius: var(--mantine-radius-sm);
+    padding: 3px 5px;
+    margin: -3px -5px;
+}
+
+.statusTrigger:hover {
+    background: light-dark(
+        var(--mantine-color-ldGray-1),
+        var(--mantine-color-dark-5)
+    );
+}
+
+.statusTrigger:focus-visible {
+    outline: 2px solid var(--mantine-color-indigo-5);
+    outline-offset: 2px;
+}
+
 .slug {
     color: var(--mantine-color-ldGray-8);
     font-family: var(--mantine-font-family-monospace);

--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.tsx
@@ -10,7 +10,6 @@ import {
     Badge,
     Box,
     Divider,
-    getDefaultZIndex,
     Group,
     Stack,
     Text,
@@ -26,6 +25,7 @@ import { AiMarkdown } from '../../../../../components/common/AiMarkdown';
 import MantineModal from '../../../../../components/common/MantineModal';
 import { parseAiAgentMemorySections } from '../../utils/memory';
 import styles from './MemoryDetails.module.css';
+import { MemoryStatusAction, MemoryStatusMenu } from './MemoryStatusControls';
 
 type Memory = ApiAiAgentMemoryResponse['results'];
 
@@ -227,13 +227,12 @@ export const MemoryDetails: FC<MemoryDetailsProps> = ({
 
             <Stack className={styles.rail} gap={0}>
                 <RailRow label="Status">
-                    <Group gap={8} wrap="nowrap">
-                        <Box
-                            className={styles.statusDot}
-                            data-status={memory.status}
-                        />
-                        <Text className={styles.railText}>{memory.status}</Text>
-                    </Group>
+                    <MemoryStatusMenu
+                        projectUuid={projectUuid}
+                        memoryUuid={memory.uuid}
+                        slug={memory.slug}
+                        status={memory.status}
+                    />
                 </RailRow>
                 <RailRow label="Saved">
                     <Text className={styles.railText}>
@@ -346,9 +345,16 @@ export const MemoryDetailsModal: FC<MemoryDetailsModalProps> = ({
             </Text>
         }
         cancelLabel={false}
-        modalRootProps={{ zIndex: getDefaultZIndex('overlay') }}
         modalBodyProps={{ py: 'lg' }}
         bodyScrollAreaMaxHeight="calc(85vh - 120px)"
+        headerActions={
+            <MemoryStatusAction
+                projectUuid={projectUuid}
+                memoryUuid={memory.uuid}
+                slug={memory.slug}
+                status={memory.status}
+            />
+        }
     >
         <MemoryDetails
             memory={memory}

--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryStatusControls.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryStatusControls.tsx
@@ -1,0 +1,125 @@
+import type {
+    AiAgentMemoryEditableStatus,
+    AiAgentMemoryStatus,
+} from '@lightdash/common';
+import {
+    Box,
+    Button,
+    Group,
+    Menu,
+    Text,
+    UnstyledButton,
+} from '@mantine-8/core';
+import { IconChevronDown } from '@tabler/icons-react';
+import { type FC } from 'react';
+import { useUpdateAiAgentMemoryStatus } from '../../hooks/useAiAgentMemory';
+import { MEMORY_STATUS_LABELS } from '../Admin/memoryStatus';
+import styles from './MemoryDetails.module.css';
+
+type Props = {
+    projectUuid: string;
+    memoryUuid: string;
+    slug: string;
+    status: AiAgentMemoryStatus;
+};
+
+const editableStatuses: AiAgentMemoryEditableStatus[] = ['active', 'retired'];
+
+export const MemoryStatusMenu: FC<Props> = ({
+    projectUuid,
+    memoryUuid,
+    slug,
+    status,
+}) => {
+    const updateStatus = useUpdateAiAgentMemoryStatus();
+
+    if (status === 'superseded') {
+        return (
+            <Group gap={8} wrap="nowrap">
+                <Box className={styles.statusDot} data-status={status} />
+                <Text className={styles.railText}>
+                    {MEMORY_STATUS_LABELS[status]}
+                </Text>
+            </Group>
+        );
+    }
+
+    return (
+        <Menu width={144} position="bottom-start" shadow="sm" withinPortal>
+            <Menu.Target>
+                <UnstyledButton
+                    className={styles.statusTrigger}
+                    aria-label="Change memory status"
+                    onClick={(event) => event.stopPropagation()}
+                    onPointerDown={(event) => event.stopPropagation()}
+                >
+                    <Group gap={8} wrap="nowrap">
+                        <Box
+                            className={styles.statusDot}
+                            data-status={status}
+                        />
+                        <Text className={styles.railText}>
+                            {MEMORY_STATUS_LABELS[status]}
+                        </Text>
+                        <IconChevronDown size={13} aria-hidden />
+                    </Group>
+                </UnstyledButton>
+            </Menu.Target>
+            <Menu.Dropdown
+                onClick={(event) => event.stopPropagation()}
+                onPointerDown={(event) => event.stopPropagation()}
+            >
+                {editableStatuses.map((nextStatus) => (
+                    <Menu.Item
+                        key={nextStatus}
+                        disabled={
+                            nextStatus === status || updateStatus.isLoading
+                        }
+                        onClick={() =>
+                            updateStatus.mutate({
+                                projectUuid,
+                                memoryUuid,
+                                slug,
+                                status: nextStatus,
+                            })
+                        }
+                    >
+                        {MEMORY_STATUS_LABELS[nextStatus]}
+                    </Menu.Item>
+                ))}
+            </Menu.Dropdown>
+        </Menu>
+    );
+};
+
+export const MemoryStatusAction: FC<Props> = ({
+    projectUuid,
+    memoryUuid,
+    slug,
+    status,
+}) => {
+    const updateStatus = useUpdateAiAgentMemoryStatus();
+
+    if (status === 'superseded') return null;
+
+    const nextStatus = status === 'active' ? 'retired' : 'active';
+    const label = status === 'active' ? 'Retire memory' : 'Reactivate memory';
+
+    return (
+        <Button
+            variant="default"
+            size="xs"
+            loading={updateStatus.isLoading}
+            onClick={() =>
+                updateStatus.mutate({
+                    projectUuid,
+                    memoryUuid,
+                    slug,
+                    status: nextStatus,
+                })
+            }
+        >
+            {label}
+        </Button>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentMemory.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentMemory.ts
@@ -1,6 +1,12 @@
-import type { ApiAiAgentMemoryResponse, ApiError } from '@lightdash/common';
-import { useQuery } from '@tanstack/react-query';
+import type {
+    AiAgentMemoryEditableStatus,
+    ApiAiAgentMemoryResponse,
+    ApiError,
+    ApiUpdateAiAgentMemoryStatusRequest,
+} from '@lightdash/common';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { lightdashApi } from '../../../../api';
+import useToaster from '../../../../hooks/toaster/useToaster';
 import { getAiAgentApiBase } from './aiAgentRouting';
 
 const getAiAgentMemory = (
@@ -33,3 +39,64 @@ export const useAiAgentMemory = ({
         retry: (failureCount, error) =>
             error.error?.statusCode !== 404 && failureCount < 2,
     });
+
+const updateAiAgentMemoryStatus = ({
+    projectUuid,
+    memoryUuid,
+    status,
+}: {
+    projectUuid: string;
+    memoryUuid: string;
+    slug: string;
+    status: AiAgentMemoryEditableStatus;
+}) =>
+    lightdashApi<undefined>({
+        version: 'v1',
+        url: `/projects/${projectUuid}/aiAgentMemories/${memoryUuid}/status`,
+        method: 'PATCH',
+        body: JSON.stringify({
+            status,
+        } satisfies ApiUpdateAiAgentMemoryStatusRequest),
+    });
+
+export const useUpdateAiAgentMemoryStatus = () => {
+    const queryClient = useQueryClient();
+    const { showToastSuccess, showToastApiError } = useToaster();
+
+    return useMutation<
+        undefined,
+        ApiError,
+        {
+            projectUuid: string;
+            memoryUuid: string;
+            slug: string;
+            status: AiAgentMemoryEditableStatus;
+        }
+    >({
+        mutationFn: updateAiAgentMemoryStatus,
+        onSuccess: (_data, { projectUuid, slug, status }) => {
+            queryClient.setQueryData<ApiAiAgentMemoryResponse['results']>(
+                ['aiAgentMemory', projectUuid, slug],
+                (memory) => (memory ? { ...memory, status } : memory),
+            );
+            void queryClient.invalidateQueries({
+                queryKey: ['ai-agent-admin-memories'],
+            });
+            showToastSuccess({
+                title:
+                    status === 'retired'
+                        ? 'Memory retired'
+                        : 'Memory reactivated',
+            });
+        },
+        onError: ({ error }, { status }) => {
+            showToastApiError({
+                title:
+                    status === 'retired'
+                        ? 'Failed to retire memory'
+                        : 'Failed to reactivate memory',
+                apiError: error,
+            });
+        },
+    });
+};

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentMemoryPage.module.css
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentMemoryPage.module.css
@@ -32,6 +32,8 @@
 }
 
 .title {
+    min-width: 0;
+    flex: 1;
     margin: 0;
     color: var(--mantine-color-ldGray-9);
     font-size: 18px;

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentMemoryPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentMemoryPage.tsx
@@ -12,6 +12,7 @@ import { Link, useParams } from 'react-router';
 import ErrorState from '../../../components/common/ErrorState';
 import PageSpinner from '../../../components/PageSpinner';
 import { MemoryDetails } from '../../features/aiCopilot/components/MemoryDetails/MemoryDetails';
+import { MemoryStatusAction } from '../../features/aiCopilot/components/MemoryDetails/MemoryStatusControls';
 import { useAiAgentMemory } from '../../features/aiCopilot/hooks/useAiAgentMemory';
 import styles from './AiAgentMemoryPage.module.css';
 
@@ -38,7 +39,11 @@ const AiAgentMemoryPage = () => {
                 </Anchor>
 
                 <Paper withBorder radius="lg" className={styles.surface}>
-                    <Group className={styles.header} wrap="nowrap">
+                    <Group
+                        className={styles.header}
+                        wrap="nowrap"
+                        justify="space-between"
+                    >
                         <Text
                             component="h1"
                             className={styles.title}
@@ -46,6 +51,12 @@ const AiAgentMemoryPage = () => {
                         >
                             {memoryQuery.data.title}
                         </Text>
+                        <MemoryStatusAction
+                            projectUuid={projectUuid}
+                            memoryUuid={memoryQuery.data.uuid}
+                            slug={memoryQuery.data.slug}
+                            status={memoryQuery.data.status}
+                        />
                     </Group>
                     <Divider />
                     <Box className={styles.body}>


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/ZAP-713/allow-users-to-retire-and-reactivate-ai-agent-memories

### Description

- Add Retire memory and Reactivate memory actions to memory details
- Let admins change status directly between Active and Retired
- Keep Superseded memories read-only
- Use the UUID-based memory status API from the parent PR

### Validation

- Frontend memory citation/details: 8 tests passed
- Frontend fast typecheck passed
- Full stack common, backend, and frontend fast typechecks passed