### PR TITLE
feat: improve AI memory scope visibility

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminMemoriesTable.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminMemoriesTable.test.tsx
@@ -1,5 +1,5 @@
 import { type AiAgentAdminMemoryItem } from '@lightdash/common';
-import { screen, within } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -77,7 +77,7 @@ describe('AiAgentAdminMemoriesTable', () => {
         vi.clearAllMocks();
     });
 
-    it('renders a scope badge on every row', () => {
+    it('does not render scope as a table column', () => {
         mockMemories([
             makeMemory(),
             makeMemory({
@@ -90,20 +90,9 @@ describe('AiAgentAdminMemoriesTable', () => {
 
         renderTable();
 
-        const scopeColumnIndex = screen
-            .getAllByRole('columnheader')
-            .findIndex((header) => header.textContent?.includes('Scope'));
-        expect(scopeColumnIndex).toBeGreaterThan(-1);
-
-        const scopeCellText = (title: string) => {
-            const row = screen.getByText(title).closest('tr');
-            expect(row).not.toBeNull();
-            return within(row!).getAllByRole('cell')[scopeColumnIndex]
-                .textContent;
-        };
-
-        expect(scopeCellText('Net revenue convention')).toBe('Personal');
-        expect(scopeCellText('Fiscal year offset')).toBe('Project-wide');
+        expect(
+            screen.queryByRole('columnheader', { name: /Scope/ }),
+        ).not.toBeInTheDocument();
     });
 
     it('filters by scope through the scope facet', async () => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminMemoriesTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminMemoriesTable.tsx
@@ -24,7 +24,6 @@ import {
     IconClock,
     IconQuote,
     IconRobotFace,
-    IconTag,
     IconTrash,
     IconUser,
 } from '@tabler/icons-react';
@@ -51,7 +50,6 @@ import {
     type AdminMemorySelection,
 } from './AdminMemoryDetailsModal';
 import styles from './AiAgentAdminMemoriesTable.module.css';
-import { MEMORY_SCOPE_COLORS, MEMORY_SCOPE_LABELS } from './memoryScope';
 import MemoryScopeFilter from './MemoryScopeFilter';
 import { MEMORY_STATUS_COLORS, MEMORY_STATUS_LABELS } from './memoryStatus';
 import MemoryStatusFilter from './MemoryStatusFilter';
@@ -217,28 +215,6 @@ const AiAgentAdminMemoriesTable = () => {
                         color={MEMORY_STATUS_COLORS[row.original.status]}
                     >
                         {MEMORY_STATUS_LABELS[row.original.status]}
-                    </Badge>
-                ),
-            },
-            {
-                accessorKey: 'scope',
-                header: 'Scope',
-                enableSorting: false,
-                size: 120,
-                Header: ({ column }) => (
-                    <Group gap="two">
-                        <MantineIcon icon={IconTag} color="ldGray.6" />
-                        {column.columnDef.header}
-                    </Group>
-                ),
-                Cell: ({ row }) => (
-                    <Badge
-                        variant="light"
-                        radius="sm"
-                        tt="none"
-                        color={MEMORY_SCOPE_COLORS[row.original.scope]}
-                    >
-                        {MEMORY_SCOPE_LABELS[row.original.scope]}
                     </Badge>
                 ),
             },

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/memoryScope.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/memoryScope.ts
@@ -6,8 +6,3 @@ export const MEMORY_SCOPE_LABELS: Record<AiAgentMemoryScope, string> = {
     user: 'Personal',
     project: 'Project-wide',
 };
-
-export const MEMORY_SCOPE_COLORS: Record<AiAgentMemoryScope, string> = {
-    user: 'gray',
-    project: 'indigo',
-};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.test.tsx
@@ -37,6 +37,7 @@ Use net revenue for future revenue questions.`,
             terms: ['net revenue'],
             objects: [],
             status: 'active',
+            scope: 'user',
             generatedAt: '2026-07-22T00:00:00.000Z',
             citedCount: 3,
             provenance: {
@@ -172,7 +173,20 @@ describe('MemoryCitation', () => {
         );
         expect(within(dialog).getByText('Citations')).toBeInTheDocument();
         expect(within(dialog).getByText('3')).toBeInTheDocument();
+        expect(within(dialog).getByText('Scope')).toBeInTheDocument();
+        expect(within(dialog).getByText('Personal').tagName).toBe('P');
         expect(within(dialog).getByText('Open thread')).toBeInTheDocument();
+
+        fireEvent.mouseEnter(
+            within(dialog).getByRole('button', {
+                name: 'About memory scope',
+            }),
+        );
+        expect(
+            await screen.findByText(
+                'Scope guides how the agent uses this memory. All memories remain private to the user by default.',
+            ),
+        ).toBeInTheDocument();
     });
 
     it('changes status from the modal menu without closing it', async () => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.tsx
@@ -5,6 +5,7 @@ import type {
 } from '@lightdash/common';
 import {
     Accordion,
+    ActionIcon,
     Alert,
     Anchor,
     Badge,
@@ -13,17 +14,20 @@ import {
     Group,
     Stack,
     Text,
+    Tooltip,
 } from '@mantine-8/core';
 import {
     IconArrowRight,
     IconExternalLink,
     IconHistory,
+    IconInfoCircle,
 } from '@tabler/icons-react';
 import { type FC, type ReactNode } from 'react';
 import { Link } from 'react-router';
 import { AiMarkdown } from '../../../../../components/common/AiMarkdown';
 import MantineModal from '../../../../../components/common/MantineModal';
 import { parseAiAgentMemorySections } from '../../utils/memory';
+import { MEMORY_SCOPE_LABELS } from '../Admin/memoryScope';
 import styles from './MemoryDetails.module.css';
 import { MemoryStatusAction, MemoryStatusMenu } from './MemoryStatusControls';
 
@@ -41,12 +45,12 @@ const getObjectLabel = (object: AiProjectContextTypedObjectRef) =>
 const getObjectExplore = (object: AiProjectContextTypedObjectRef) =>
     object.type === 'explore' ? object.name : object.explore;
 
-const RailRow: FC<{ label: string; children: ReactNode }> = ({
+const RailRow: FC<{ label: ReactNode; children: ReactNode }> = ({
     label,
     children,
 }) => (
     <Group className={styles.railRow} wrap="nowrap" gap="sm">
-        <Text className={styles.railLabel}>{label}</Text>
+        <Box className={styles.railLabel}>{label}</Box>
         <Box className={styles.railValue}>{children}</Box>
     </Group>
 );
@@ -233,6 +237,32 @@ export const MemoryDetails: FC<MemoryDetailsProps> = ({
                         slug={memory.slug}
                         status={memory.status}
                     />
+                </RailRow>
+                <RailRow
+                    label={
+                        <Group gap="two" wrap="nowrap">
+                            Scope
+                            <Tooltip
+                                label="Scope guides how the agent uses this memory. All memories remain private to the user by default."
+                                multiline
+                                w={260}
+                                withinPortal
+                            >
+                                <ActionIcon
+                                    aria-label="About memory scope"
+                                    color="gray"
+                                    size="xs"
+                                    variant="transparent"
+                                >
+                                    <IconInfoCircle size={13} />
+                                </ActionIcon>
+                            </Tooltip>
+                        </Group>
+                    }
+                >
+                    <Text className={styles.railText}>
+                        {MEMORY_SCOPE_LABELS[memory.scope]}
+                    </Text>
                 </RailRow>
                 <RailRow label="Saved">
                     <Text className={styles.railText}>


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/ZAP-714/clarify-ai-memory-scope-in-memory-details
Relates: https://linear.app/lightdash/issue/ZAP-707/spec-scope-ai-agent-memories-to-the-user

### Description

- Remove the Scope column from the memories table while keeping its filter
- Show Personal or Project-wide scope in the memory details rail
- Explain that scope guides the agent and memories remain private to the user by default

### Validation

- Frontend full suite: 1,573 tests passed across 195 files
- Frontend fast typecheck passed
- Frontend formatting passed across 2,721 files
- Browser verified the table columns, details scope badge, and hover tooltip