### PR TITLE
fix: signal screenshot-ready for custom viz empty states

### DIFF
--- a/packages/frontend/src/components/CustomVisualization/index.screenshotReady.test.tsx
+++ b/packages/frontend/src/components/CustomVisualization/index.screenshotReady.test.tsx
@@ -1,0 +1,107 @@
+import { waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../testing/testUtils';
+
+/**
+ * Guards the screenshot-readiness contract for custom (Vega-Lite)
+ * visualizations. Every dashboard tile must eventually call
+ * onScreenshotReady or onScreenshotError — the export's ready indicator
+ * only mounts once all tiles have reported, so a tile that settles into a
+ * rendered empty state ("No data available" / "No visualization loaded")
+ * without signaling makes dashboard exports hang until timeout
+ * (PROD-9255: custom-viz tiles with zero rows stalled exports for 10
+ * minutes and 502'd the sync export API).
+ */
+
+const { mockContext } = vi.hoisted(() => ({
+    mockContext: {
+        current: {} as Record<string, unknown>,
+    },
+}));
+
+vi.mock('react-vega', () => ({
+    VegaEmbed: () => null,
+}));
+
+vi.mock('../LightdashVisualization/types', () => ({
+    isCustomVisualizationConfig: () => true,
+}));
+
+vi.mock('../LightdashVisualization/useVisualizationContext', () => ({
+    useVisualizationContext: () => mockContext.current,
+}));
+
+// eslint-disable-next-line import/first
+import CustomVisualization from './index';
+
+const buildContext = (
+    overrides: Partial<{
+        isLoading: boolean;
+        spec: object | undefined;
+        series: object[];
+    }> = {},
+) => ({
+    isLoading: overrides.isLoading ?? false,
+    visualizationConfig: {
+        chartConfig: {
+            validConfig: {
+                spec: 'spec' in overrides ? overrides.spec : { mark: 'bar' },
+            },
+            series: overrides.series ?? [{ x: 'a', y: 1 }],
+        },
+    },
+    resultsData: { setFetchAll: vi.fn() },
+    containerWidth: 400,
+    containerHeight: 300,
+});
+
+describe('CustomVisualization screenshot readiness (PROD-9255)', () => {
+    beforeEach(() => {
+        mockContext.current = buildContext();
+    });
+
+    it('signals ready when the query returns zero rows', async () => {
+        mockContext.current = buildContext({ series: [] });
+        const onScreenshotReady = vi.fn();
+
+        renderWithProviders(
+            <CustomVisualization onScreenshotReady={onScreenshotReady} />,
+        );
+
+        await waitFor(() => expect(onScreenshotReady).toHaveBeenCalled());
+    });
+
+    it('signals ready when the chart has no Vega spec', async () => {
+        mockContext.current = buildContext({ spec: undefined });
+        const onScreenshotReady = vi.fn();
+
+        renderWithProviders(
+            <CustomVisualization onScreenshotReady={onScreenshotReady} />,
+        );
+
+        await waitFor(() => expect(onScreenshotReady).toHaveBeenCalled());
+    });
+
+    it('does not signal while results are still loading', async () => {
+        mockContext.current = buildContext({ isLoading: true, series: [] });
+        const onScreenshotReady = vi.fn();
+
+        renderWithProviders(
+            <CustomVisualization onScreenshotReady={onScreenshotReady} />,
+        );
+
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        expect(onScreenshotReady).not.toHaveBeenCalled();
+    });
+
+    it('leaves signaling to onEmbed when the chart has data', async () => {
+        const onScreenshotReady = vi.fn();
+
+        renderWithProviders(
+            <CustomVisualization onScreenshotReady={onScreenshotReady} />,
+        );
+
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        expect(onScreenshotReady).not.toHaveBeenCalled();
+    });
+});

--- a/packages/frontend/src/components/CustomVisualization/index.tsx
+++ b/packages/frontend/src/components/CustomVisualization/index.tsx
@@ -73,6 +73,24 @@ const CustomVisualization: FC<Props> = ({
         resultsData?.setFetchAll(true);
     }, [resultsData]);
 
+    // A tile that settles into a rendered empty state (no spec or zero rows)
+    // has finished loading, so it must still report screenshot-ready —
+    // otherwise dashboard exports wait for a Vega embed that will never
+    // happen and time out. Charts that do render signal via onEmbed/onError.
+    useEffect(() => {
+        if (hasSignaledScreenshotReady.current) return;
+        if (!onScreenshotReady && !onScreenshotError) return;
+        if (isLoading || !isCustomVisualizationConfig(visualizationConfig))
+            return;
+
+        const { validConfig, series } =
+            visualizationConfig.chartConfig as CustomVisualizationConfigAndData;
+        if (!validConfig.spec || !series || series.length === 0) {
+            onScreenshotReady?.();
+            hasSignaledScreenshotReady.current = true;
+        }
+    }, [isLoading, visualizationConfig, onScreenshotReady, onScreenshotError]);
+
     if (!isCustomVisualizationConfig(visualizationConfig)) return null;
     const spec = visualizationConfig.chartConfig.validConfig.spec;
 


### PR DESCRIPTION
Closes #26226

Custom (Vega-Lite) visualizations only reported screenshot readiness from Vega's onEmbed/onError, so a tile that settled into a rendered empty state (no spec or zero rows) never signaled. Dashboard exports then waited for the ready indicator until timing out (180s x 6 attempts), surfacing as 502s on the sync export API and 5-minute job timeouts on the async one.

Signal ready from an effect once loading settles into an empty state, matching how SimpleStatistic and SimpleTable handle theirs.