### PR TITLE
refactor: render AI memory scope as text

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/memoryScope.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/memoryScope.ts
@@ -6,8 +6,3 @@ export const MEMORY_SCOPE_LABELS: Record<AiAgentMemoryScope, string> = {
     user: 'Personal',
     project: 'Project-wide',
 };
-
-export const MEMORY_SCOPE_COLORS: Record<AiAgentMemoryScope, string> = {
-    user: 'gray',
-    project: 'indigo',
-};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.test.tsx
@@ -173,7 +173,7 @@ describe('MemoryCitation', () => {
         expect(within(dialog).getByText('Citations')).toBeInTheDocument();
         expect(within(dialog).getByText('3')).toBeInTheDocument();
         expect(within(dialog).getByText('Scope')).toBeInTheDocument();
-        expect(within(dialog).getByText('Personal')).toBeInTheDocument();
+        expect(within(dialog).getByText('Personal').tagName).toBe('P');
         expect(within(dialog).getByText('Open thread')).toBeInTheDocument();
 
         fireEvent.mouseEnter(

--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.tsx
@@ -27,7 +27,7 @@ import { Link } from 'react-router';
 import { AiMarkdown } from '../../../../../components/common/AiMarkdown';
 import MantineModal from '../../../../../components/common/MantineModal';
 import { parseAiAgentMemorySections } from '../../utils/memory';
-import { MEMORY_SCOPE_COLORS, MEMORY_SCOPE_LABELS } from '../Admin/memoryScope';
+import { MEMORY_SCOPE_LABELS } from '../Admin/memoryScope';
 import styles from './MemoryDetails.module.css';
 import { MemoryStatusAction, MemoryStatusMenu } from './MemoryStatusControls';
 
@@ -260,14 +260,9 @@ export const MemoryDetails: FC<MemoryDetailsProps> = ({
                         </Group>
                     }
                 >
-                    <Badge
-                        variant="light"
-                        radius="sm"
-                        tt="none"
-                        color={MEMORY_SCOPE_COLORS[memory.scope]}
-                    >
+                    <Text className={styles.railText}>
                         {MEMORY_SCOPE_LABELS[memory.scope]}
-                    </Badge>
+                    </Text>
                 </RailRow>
                 <RailRow label="Saved">
                     <Text className={styles.railText}>


### PR DESCRIPTION
Relates: https://linear.app/lightdash/issue/ZAP-714/clarify-ai-memory-scope-in-memory-details
Relates: https://linear.app/lightdash/issue/ZAP-707/spec-scope-ai-agent-memories-to-the-user

### Description

- Render the memory scope value as normal text instead of a badge
- Remove the unused scope color mapping
- Keep the explanatory privacy tooltip unchanged

### Validation

- Frontend full suite: 1,573 tests passed across 195 files
- Frontend fast typecheck passed
- Browser verified a plain text element with transparent background and no border radius
- Standards and spec reviews found no issues