### PR TITLE
feat: add UUID-based AI memory status API

### DIFF
--- a/packages/backend/src/ee/controllers/AiAgentMemoryController.ts
+++ b/packages/backend/src/ee/controllers/AiAgentMemoryController.ts
@@ -1,0 +1,64 @@
+import {
+    assertRegisteredAccount,
+    type ApiErrorPayload,
+    type ApiUpdateAiAgentMemoryStatusRequest,
+    type ApiUpdateAiAgentMemoryStatusResponse,
+    type UUID,
+} from '@lightdash/common';
+import {
+    Body,
+    Middlewares,
+    OperationId,
+    Patch,
+    Path,
+    Request,
+    Response,
+    Route,
+    SuccessResponse,
+} from '@tsoa/runtime';
+import express from 'express';
+import { toSessionUser } from '../../auth/account';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    unauthorisedInDemo,
+} from '../../controllers/authentication';
+import { BaseController } from '../../controllers/baseController';
+import { type AiAgentMemoryService } from '../services/AiAgentMemoryService/AiAgentMemoryService';
+
+@Route('/api/v1/projects/{projectUuid}/aiAgentMemories')
+@Response<ApiErrorPayload>('default', 'Error')
+export class AiAgentMemoryController extends BaseController {
+    /**
+     * Changes whether a memory is available to the AI agent.
+     * @summary Update memory status
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Patch('/{memoryUuid}/status')
+    @OperationId('updateAiAgentMemoryStatus')
+    async updateAiAgentMemoryStatus(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Path() memoryUuid: UUID,
+        @Body() body: ApiUpdateAiAgentMemoryStatusRequest,
+    ): Promise<ApiUpdateAiAgentMemoryStatusResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+
+        await this.services
+            .getAiAgentMemoryService<AiAgentMemoryService>()
+            .updateMemoryStatus(
+                toSessionUser(req.account),
+                projectUuid,
+                memoryUuid,
+                body.status,
+            );
+
+        return { status: 'ok', results: undefined };
+    }
+}

--- a/packages/backend/src/ee/models/AiAgentMemoryModel.ts
+++ b/packages/backend/src/ee/models/AiAgentMemoryModel.ts
@@ -779,6 +779,16 @@ export class AiAgentMemoryModel {
         return { memory, sources, replacement };
     }
 
+    async findByProjectAndUuid(args: {
+        projectUuid: string;
+        memoryUuid: string;
+    }): Promise<DbAiAgentMemory | undefined> {
+        return this.database<AiAgentMemoryTable>(AiAgentMemoryTableName)
+            .where('project_uuid', args.projectUuid)
+            .where('ai_agent_memory_uuid', args.memoryUuid)
+            .first();
+    }
+
     async findActiveBySlugs(args: {
         projectUuid: string;
         userUuid: string;
@@ -793,6 +803,32 @@ export class AiAgentMemoryModel {
             .where('status', 'active')
             .whereIn('slug', slugs)
             .select(['slug', 'title']);
+    }
+
+    async findActiveBySourceThread(
+        sourceThreadUuid: string,
+    ): Promise<Pick<DbAiAgentMemory, 'ai_agent_memory_uuid'> | undefined> {
+        return this.database<AiAgentMemoryTable>(AiAgentMemoryTableName)
+            .where('source_thread_uuid', sourceThreadUuid)
+            .where('status', 'active')
+            .first('ai_agent_memory_uuid');
+    }
+
+    async updateStatus(args: {
+        memoryUuid: string;
+        status: 'active' | 'retired';
+    }): Promise<boolean> {
+        const updated = await this.database<AiAgentMemoryTable>(
+            AiAgentMemoryTableName,
+        )
+            .where('ai_agent_memory_uuid', args.memoryUuid)
+            .whereIn('status', ['active', 'retired'])
+            .update({
+                status: args.status,
+                updated_at: this.database.fn.now(),
+            });
+
+        return updated > 0;
     }
 
     async incrementPulledForActiveMemories(args: {

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
@@ -150,6 +150,7 @@ describe('AiAgentMemoryService', () => {
                     featureFlagId === CommercialFeatureFlags.AiCopilot),
         }));
         const findByProjectAndSlug = vi.fn();
+        const findByProjectAndUuid = vi.fn();
         const findThreadsDueForDistill = vi.fn();
         const findThreadForDistill = vi.fn();
         const upsertSourceThreadMemory = vi.fn().mockResolvedValue({
@@ -157,6 +158,8 @@ describe('AiAgentMemoryService', () => {
         });
         const upsertThreadDistill = vi.fn();
         const findActiveForProject = vi.fn().mockResolvedValue([]);
+        const findActiveBySourceThread = vi.fn().mockResolvedValue(undefined);
+        const updateStatus = vi.fn().mockResolvedValue(true);
         const aiAgentMemoryDistill = vi.fn();
         const getAgent = vi.fn().mockResolvedValue({
             uuid: 'agent-1',
@@ -184,11 +187,14 @@ describe('AiAgentMemoryService', () => {
             analytics: { track } as AnyType,
             aiAgentMemoryModel: {
                 findByProjectAndSlug,
+                findByProjectAndUuid,
                 findThreadsDueForDistill,
                 findThreadForDistill,
                 upsertSourceThreadMemory,
                 upsertThreadDistill,
                 findActiveForProject,
+                findActiveBySourceThread,
+                updateStatus,
             } as AnyType,
             aiAgentModel: { getAgent, findThreadOwnership } as AnyType,
             groupsModel: { findUserInGroups } as AnyType,
@@ -204,11 +210,14 @@ describe('AiAgentMemoryService', () => {
             service,
             getFlag,
             findByProjectAndSlug,
+            findByProjectAndUuid,
             findThreadsDueForDistill,
             findThreadForDistill,
             upsertSourceThreadMemory,
             upsertThreadDistill,
             findActiveForProject,
+            findActiveBySourceThread,
+            updateStatus,
             aiAgentMemoryDistill,
             getAgent,
             findThreadOwnership,
@@ -301,6 +310,7 @@ describe('AiAgentMemoryService', () => {
         await expect(
             service.getMemory(user, 'project-enabled', 'net-revenue-ab12cd34'),
         ).resolves.toMatchObject({
+            uuid: 'memory-1',
             slug: 'net-revenue-ab12cd34',
             title: 'Net revenue convention',
             generatedAt: '2026-07-22T10:00:00.000Z',
@@ -356,6 +366,78 @@ describe('AiAgentMemoryService', () => {
                 source: { threadTitle: 'Owner-visible title' },
             },
         });
+    });
+
+    it('lets the owner retire an active memory by UUID', async () => {
+        const { service, findByProjectAndUuid, updateStatus } = build();
+        findByProjectAndUuid.mockResolvedValue(
+            memoryRow({ user_uuid: 'current-user' }),
+        );
+
+        await expect(
+            service.updateMemoryStatus(
+                buildUser(true),
+                'project-enabled',
+                'memory-1',
+                'retired',
+            ),
+        ).resolves.toBeUndefined();
+        expect(findByProjectAndUuid).toHaveBeenCalledWith({
+            projectUuid: 'project-enabled',
+            memoryUuid: 'memory-1',
+        });
+        expect(updateStatus).toHaveBeenCalledWith({
+            memoryUuid: 'memory-1',
+            status: 'retired',
+        });
+    });
+
+    it('does not reactivate a memory when its source has a newer active memory', async () => {
+        const {
+            service,
+            findByProjectAndUuid,
+            findActiveBySourceThread,
+            updateStatus,
+        } = build();
+        findByProjectAndUuid.mockResolvedValue(
+            memoryRow({
+                user_uuid: 'current-user',
+                status: 'retired',
+            }),
+        );
+        findActiveBySourceThread.mockResolvedValue({
+            ai_agent_memory_uuid: 'newer-memory',
+        });
+
+        await expect(
+            service.updateMemoryStatus(
+                buildUser(true),
+                'project-enabled',
+                'memory-1',
+                'active',
+            ),
+        ).rejects.toThrow('A newer memory from this source is already active');
+        expect(updateStatus).not.toHaveBeenCalled();
+    });
+
+    it('keeps superseded memories read-only', async () => {
+        const { service, findByProjectAndUuid, updateStatus } = build();
+        findByProjectAndUuid.mockResolvedValue(
+            memoryRow({
+                user_uuid: 'current-user',
+                status: 'superseded',
+            }),
+        );
+
+        await expect(
+            service.updateMemoryStatus(
+                buildUser(true),
+                'project-enabled',
+                'memory-1',
+                'active',
+            ),
+        ).rejects.toThrow('Superseded memories are read-only');
+        expect(updateStatus).not.toHaveBeenCalled();
     });
 
     it('decides access from the memory row without loading the source thread', async () => {

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
@@ -8,9 +8,11 @@ import {
     getItemId,
     isExploreError,
     NotFoundError,
+    ParameterError,
     ProjectType,
     type AiAgentMemory,
     type AiAgentMemoryDistillJobPayload,
+    type AiAgentMemoryEditableStatus,
     type AiAgentMemorySource,
     type AiProjectContextTypedObjectRef,
     type Explore,
@@ -248,11 +250,11 @@ export class AiAgentMemoryService extends BaseService {
         }
     }
 
-    async getMemory(
+    private async getMemoryAccessContext(
         user: SessionUser,
         projectUuid: string,
-        slug: string,
-    ): Promise<AiAgentMemory> {
+        identifier: string,
+    ): Promise<string> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
         if (
@@ -275,25 +277,59 @@ export class AiAgentMemoryService extends BaseService {
             }),
         ]);
         if (!copilot.enabled || !memoryFlag.enabled) {
-            throw new NotFoundError(`Memory not found: ${slug}`);
+            throw new NotFoundError(`Memory not found: ${identifier}`);
         }
+
+        return organizationUuid;
+    }
+
+    private async requireReadableMemory(
+        user: SessionUser,
+        organizationUuid: string,
+        projectUuid: string,
+        memory: DbAiAgentMemory | undefined,
+        identifier: string,
+    ): Promise<DbAiAgentMemory> {
+        if (
+            !memory ||
+            !(await this.canReadMemory(
+                user,
+                organizationUuid,
+                projectUuid,
+                memory,
+            ))
+        ) {
+            throw new NotFoundError(`Memory not found: ${identifier}`);
+        }
+
+        return memory;
+    }
+
+    async getMemory(
+        user: SessionUser,
+        projectUuid: string,
+        slug: string,
+    ): Promise<AiAgentMemory> {
+        const organizationUuid = await this.getMemoryAccessContext(
+            user,
+            projectUuid,
+            slug,
+        );
 
         const result = await this.aiAgentMemoryModel.findByProjectAndSlug({
             projectUuid,
             slug,
         });
-        if (
-            !result ||
-            !(await this.canReadMemory(
-                user,
-                organizationUuid,
-                projectUuid,
-                result.memory,
-            ))
-        ) {
-            // Same error as a missing row so a reader can't probe for existence
+        if (!result) {
             throw new NotFoundError(`Memory not found: ${slug}`);
         }
+        await this.requireReadableMemory(
+            user,
+            organizationUuid,
+            projectUuid,
+            result.memory,
+            slug,
+        );
 
         // Reading the memory grants its lineage: the check above already covers
         // the whole row, so there is nothing left to redact per source.
@@ -313,6 +349,7 @@ export class AiAgentMemoryService extends BaseService {
         );
 
         const response: AiAgentMemory = {
+            uuid: result.memory.ai_agent_memory_uuid,
             slug: result.memory.slug,
             title: result.memory.title,
             rawMemory: result.memory.raw_memory,
@@ -345,6 +382,57 @@ export class AiAgentMemoryService extends BaseService {
         });
 
         return response;
+    }
+
+    async updateMemoryStatus(
+        user: SessionUser,
+        projectUuid: string,
+        memoryUuid: string,
+        status: AiAgentMemoryEditableStatus,
+    ): Promise<void> {
+        const organizationUuid = await this.getMemoryAccessContext(
+            user,
+            projectUuid,
+            memoryUuid,
+        );
+        const memory = await this.requireReadableMemory(
+            user,
+            organizationUuid,
+            projectUuid,
+            await this.aiAgentMemoryModel.findByProjectAndUuid({
+                projectUuid,
+                memoryUuid,
+            }),
+            memoryUuid,
+        );
+
+        if (memory.status === 'superseded') {
+            throw new ParameterError('Superseded memories are read-only');
+        }
+
+        if (status === 'active' && memory.source_thread_uuid) {
+            const activeMemory =
+                await this.aiAgentMemoryModel.findActiveBySourceThread(
+                    memory.source_thread_uuid,
+                );
+            if (
+                activeMemory &&
+                activeMemory.ai_agent_memory_uuid !==
+                    memory.ai_agent_memory_uuid
+            ) {
+                throw new ParameterError(
+                    'A newer memory from this source is already active',
+                );
+            }
+        }
+
+        const updated = await this.aiAgentMemoryModel.updateStatus({
+            memoryUuid: memory.ai_agent_memory_uuid,
+            status,
+        });
+        if (!updated) {
+            throw new ParameterError('This memory can no longer be changed');
+        }
     }
 
     async sweep(now = new Date()): Promise<number> {

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -347,6 +347,8 @@ export type AiAgentMemorySource = {
 
 export type AiAgentMemoryStatus = 'active' | 'superseded' | 'retired';
 
+export type AiAgentMemoryEditableStatus = 'active' | 'retired';
+
 /**
  * Never affects which memories are recalled: selection, pull, ranking and
  * access all filter on ownership alone. The label IS rendered into the injected
@@ -356,6 +358,7 @@ export type AiAgentMemoryStatus = 'active' | 'superseded' | 'retired';
 export type AiAgentMemoryScope = 'user' | 'project';
 
 export type AiAgentMemory = {
+    uuid: string;
     slug: string;
     title: string;
     rawMemory: string;
@@ -372,6 +375,12 @@ export type AiAgentMemory = {
 };
 
 export type ApiAiAgentMemoryResponse = ApiSuccess<AiAgentMemory>;
+
+export type ApiUpdateAiAgentMemoryStatusRequest = {
+    status: AiAgentMemoryEditableStatus;
+};
+
+export type ApiUpdateAiAgentMemoryStatusResponse = ApiSuccessEmpty;
 
 export type ApiAiAgentAvatarUploadResponse = ApiSuccess<AiAgent>;
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.test.tsx
@@ -173,6 +173,7 @@ describe('MemoryCitation', () => {
                         projectUuid="project-uuid"
                         agentUuid="agent-uuid"
                         memory={{
+                            uuid: 'memory-uuid',
                             slug: 'net-revenue',
                             title: 'Net revenue convention',
                             rawMemory: 'Use net revenue.',


### PR DESCRIPTION
Relates: https://linear.app/lightdash/issue/ZAP-713/allow-users-to-retire-and-reactivate-ai-agent-memories

### Description

- Expose the stable memory UUID in the detail API
- Add a dedicated UUID-based status endpoint at /projects/{projectUuid}/aiAgentMemories/{memoryUuid}/status
- Enforce existing memory access rules and keep superseded memories read-only
- Preserve the single-active-memory-per-source-thread invariant

### Validation

- Backend memory service: 20 tests passed
- Common and backend fast typechecks passed
- TSOA route and OpenAPI generation passed