### PR TITLE
test(data-apps): give the generation benchmark viz coverage

### DIFF
--- a/sandboxes/data-apps/benchmark/README.md
+++ b/sandboxes/data-apps/benchmark/README.md
@@ -31,6 +31,11 @@ benchmark leans on two better ones:
      no exceptions"). String-category axes without a formatter render fine
      and are the common failure — a fail here is contract drift, not
      necessarily a user-visible bug.
+   - Some rules don't apply to every template. `multiple-source-files` is
+     dropped for a `data_app_viz` prompt (a viz is ONE component by
+     contract), as are the query render rules (the host owns the query).
+     Dropped ≠ failed: the summary counts each rule only over the runs it
+     applies to.
 2. **Stream-timing buckets** (`stream.ts`, mirrors the backend's
    `ClaudeStreamProcessor`) — apiLatency / thinking / text / toolInput /
    toolExec, plus tokens and turns. Compare medians per bucket, paired by
@@ -108,14 +113,72 @@ pnpm bench:render runs/<timestamp>/   # re-render + refresh gallery
 pnpm bench:gallery runs/<timestamp>/  # regenerate gallery.html only
 ```
 
+## Data app viz coverage
+
+Two prompts — `viz-multi-series` and `viz-ranked-bars` — carry
+`"template": "data_app_viz"`. A templated prompt mirrors the viz pipeline:
+the template instructions lead the prompt, and the run collects its
+declaration (`fields` + `configOptions`) as CLI structured output via
+`--json-schema`, the same channel the backend persists to
+`app_versions.viz_schema`. The declaration lands on
+`analysis.structuredOutput` in `results.json`, so a suspicious rule can be
+read back per run.
+
+Viz subset only:
+
+```bash
+pnpm bench --variant candidate=lightdash-data-app:latest \
+    --prompts viz-multi-series,viz-ranked-bars --reps 3
+```
+
+Six generations exercise the current checkout's prompt and schema. Add a
+second template variant only when comparing sandbox-image or skill changes:
+template variants do not vary these checkout-owned inputs.
+
+Its objective declaration rules are deliberately small:
+
+- `emits-valid-viz-declaration` — the structured output has the field, option,
+  default, uniqueness, and palette shape the persisted contract accepts.
+- `declares-fields` — at least one data-binding field is present.
+- `declares-config-options` — the emitted declaration has a non-empty
+  `configOptions`. Zero options is the headline failure: a viz whose config
+  panel is empty, frozen until somebody regenerates it.
+- `declares-color-palette` — the declaration's `colorPalette` is non-null.
+
+The prompts describe the chart wanted and never mention config options,
+colours or the config panel. A prompt that asked for options would make these
+rules pass without proving anything — don't reword them that way.
+
+The render gate maps the declaration onto deterministic orders fields, pushes
+rows, declared defaults, and a sentinel palette through the real
+`viz-context-request` handshake, and requires the mounted root to change after
+delivery. This proves the built component receives and responds to a real viz
+context; the screenshot gallery is the human check for whether the requested
+chart, options, and colours are actually good. The harness makes no semantic
+claims from regexes over generated source.
+
+`fixtures/data-app-viz-instructions.txt` and
+`fixtures/data-app-viz-output-schema.json` are byte-stable copies of the
+pipeline's `getTemplateInstructions('data_app_viz')` and
+`dataAppVizJsonSchema`. They are explicit benchmark inputs, not assertions over
+production source paths; refresh them deliberately when evaluating a changed
+prompt or schema.
+
+Focused harness checks:
+
+```bash
+pnpm bench:rules   # tsx --test benchmark/assertions.test.ts
+```
+
 ## Fixtures
 
 - `fixtures/schema.yml` — byte-stable catalog (3 models, joins, grains) so
   catalog size/content never confounds a comparison. Don't point the
   benchmark at a live project.
 - `prompts.json` — the suite. Each prompt declares `mustRead` /
-  `mustNotRead` reference files (progressive-disclosure discipline) and can
-  ship extra sandbox files (e.g. the chart-reference fixture) plus a prompt
+  `mustNotRead` reference files (progressive-disclosure discipline), an
+  optional `template` (absent = the default generation), and can ship extra
+  sandbox files (e.g. the chart-reference fixture) plus a prompt
   prepend mirroring the pipeline's format. Note the prepends encode the
   **current** pipeline wording — on templates predating the references/
   layout, the chart-reference prompt tells the model to read a file that
@@ -144,4 +207,5 @@ pnpm bench:gallery runs/<timestamp>/  # regenerate gallery.html only
 ## Costs
 
 Every run is a real sandbox + real Claude generation (~$0.5–1.5 per run on
-sonnet). A 2-variant × 6-prompt × 3-rep matrix is 36 generations.
+sonnet). The suite is 8 prompts, so a 2-variant × 3-rep full matrix is 48
+generations; `--prompts` a subset when you only changed one contract.

--- a/sandboxes/data-apps/benchmark/assertions.test.ts
+++ b/sandboxes/data-apps/benchmark/assertions.test.ts
@@ -1,0 +1,251 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { parseVizDeclaration, vizDeclarationRules } from './assertions.ts';
+import { renderRules, type RenderResult } from './renderGate.ts';
+import { analyzeStream } from './stream.ts';
+
+const validDeclaration = {
+    fields: [
+        {
+            name: 'category',
+            label: 'Category',
+            type: 'dimension',
+            required: true,
+        },
+        {
+            name: 'value',
+            label: 'Value',
+            type: 'metric',
+            required: true,
+        },
+    ],
+    configOptions: [
+        {
+            name: 'showLabels',
+            label: 'Show labels',
+            type: 'boolean',
+            default: true,
+        },
+        {
+            name: 'maxBars',
+            label: 'Maximum bars',
+            type: 'number',
+            default: 12,
+        },
+    ],
+    colorPalette: { group: 'Appearance' },
+};
+
+test('valid viz structured output produces objective declaration rules', () => {
+    const declaration = parseVizDeclaration(validDeclaration);
+    assert.deepEqual(declaration, {
+        fields: validDeclaration.fields,
+        configOptions: [
+            { name: 'showLabels', type: 'boolean', default: true },
+            { name: 'maxBars', type: 'number', default: 12 },
+        ],
+        colorPalette: { group: 'Appearance' },
+    });
+    assert.deepEqual(vizDeclarationRules(declaration), {
+        'emits-valid-viz-declaration': true,
+        'declares-fields': true,
+        'declares-config-options': true,
+        'declares-color-palette': true,
+    });
+});
+
+test('declaration rules report missing product capabilities separately', () => {
+    const declaration = parseVizDeclaration({
+        fields: [],
+        configOptions: [],
+        colorPalette: null,
+    });
+    assert.deepEqual(vizDeclarationRules(declaration), {
+        'emits-valid-viz-declaration': true,
+        'declares-fields': false,
+        'declares-config-options': false,
+        'declares-color-palette': false,
+    });
+    assert.deepEqual(vizDeclarationRules(null), {
+        'emits-valid-viz-declaration': false,
+        'declares-fields': false,
+        'declares-config-options': false,
+        'declares-color-palette': false,
+    });
+});
+
+test('parseVizDeclaration rejects shapes the persisted contract rejects', () => {
+    assert.equal(parseVizDeclaration(null), null);
+    assert.equal(parseVizDeclaration('{}'), null);
+    assert.equal(parseVizDeclaration({ fields: [] }), null);
+    assert.equal(
+        parseVizDeclaration({
+            ...validDeclaration,
+            fields: [validDeclaration.fields[0], validDeclaration.fields[0]],
+        }),
+        null,
+    );
+    assert.equal(
+        parseVizDeclaration({
+            ...validDeclaration,
+            configOptions: [
+                {
+                    name: 'showLabels',
+                    label: 'Show labels',
+                    type: 'boolean',
+                    default: 'yes',
+                },
+            ],
+        }),
+        null,
+    );
+    assert.equal(
+        parseVizDeclaration({ ...validDeclaration, colorPalette: 'default' }),
+        null,
+    );
+    assert.equal(
+        parseVizDeclaration({
+            ...validDeclaration,
+            configOptions: [
+                {
+                    name: 'showLabels',
+                    type: 'boolean',
+                    default: true,
+                },
+            ],
+        }),
+        null,
+    );
+    assert.equal(
+        parseVizDeclaration({
+            ...validDeclaration,
+            configOptions: [
+                {
+                    name: 'orientation',
+                    label: 'Orientation',
+                    type: 'select',
+                    choices: [],
+                    default: 'horizontal',
+                },
+            ],
+        }),
+        null,
+    );
+    assert.equal(
+        parseVizDeclaration({
+            ...validDeclaration,
+            configOptions: [
+                {
+                    name: 'maxBars',
+                    label: 'Maximum bars',
+                    type: 'number',
+                    default: 12,
+                    min: 'one',
+                },
+            ],
+        }),
+        null,
+    );
+});
+
+test('parseVizDeclaration accepts select choices and numeric bounds', () => {
+    const declaration = parseVizDeclaration({
+        ...validDeclaration,
+        configOptions: [
+            {
+                name: 'orientation',
+                label: 'Orientation',
+                group: 'Layout',
+                type: 'select',
+                choices: [
+                    { value: 'horizontal', label: 'Horizontal' },
+                    { value: 'vertical', label: 'Vertical' },
+                ],
+                default: 'horizontal',
+            },
+            {
+                name: 'maxBars',
+                label: 'Maximum bars',
+                type: 'number',
+                default: 12,
+                min: 1,
+                max: 50,
+            },
+        ],
+    });
+
+    assert.deepEqual(declaration?.configOptions, [
+        { name: 'orientation', type: 'select', default: 'horizontal' },
+        { name: 'maxBars', type: 'number', default: 12 },
+    ]);
+});
+
+const renderResult = (): Omit<RenderResult, 'rules'> => ({
+    cell: 'variant__fixture__r1',
+    error: null,
+    settled: true,
+    durationMs: 0,
+    pageErrors: [],
+    consoleErrors: [],
+    fatalMarker: false,
+    boundaryMarker: false,
+    rootChildren: 3,
+    rootTextLength: 42,
+    vizContextRequests: 1,
+    vizContextChanged: true,
+    queries: [],
+    blockedFetches: [],
+    exports: [],
+    screenshot: null,
+});
+
+test('viz render rules require the SDK handshake and a changed root', () => {
+    assert.deepEqual(renderRules(renderResult(), 'data_app_viz'), {
+        'renders-clean': true,
+        'received-viz-context': true,
+        'renders-with-viz-context': true,
+    });
+    assert.equal(
+        renderRules(
+            { ...renderResult(), vizContextChanged: false },
+            'data_app_viz',
+        )['renders-with-viz-context'],
+        false,
+    );
+    assert.equal(
+        renderRules(
+            { ...renderResult(), vizContextRequests: 0 },
+            'data_app_viz',
+        )['received-viz-context'],
+        false,
+    );
+});
+
+test('query render rules still apply only to full data apps', () => {
+    assert.deepEqual(Object.keys(renderRules(renderResult(), null)), [
+        'renders-clean',
+        'made-metric-queries',
+        'queries-valid-fields',
+    ]);
+});
+
+test('the declaration is read from the same CLI result event as production', () => {
+    const analysis = analyzeStream([
+        {
+            atMs: 0,
+            line: JSON.stringify({
+                type: 'result',
+                result: 'done',
+                structured_output: validDeclaration,
+            }),
+        },
+    ]);
+    assert.deepEqual(analysis.structuredOutput, validDeclaration);
+    assert.notEqual(parseVizDeclaration(analysis.structuredOutput), null);
+    assert.equal(
+        analyzeStream([
+            { atMs: 0, line: JSON.stringify({ type: 'result', result: 'x' }) },
+        ]).structuredOutput,
+        null,
+    );
+});

--- a/sandboxes/data-apps/benchmark/assertions.ts
+++ b/sandboxes/data-apps/benchmark/assertions.ts
@@ -7,9 +7,18 @@
  */
 import type { StreamAnalysis } from './stream.ts';
 
+/**
+ * Generation template, mirroring the backend's `DataAppTemplate`. A template
+ * adds its instructions to the prompt and, for a viz, collects the run's
+ * declaration as CLI structured output.
+ */
+export type PromptTemplate = 'data_app_viz';
+
 export type PromptSpec = {
     id: string;
     prompt: string;
+    /** Absent = today's behaviour: no template instructions, no declaration. */
+    template?: PromptTemplate;
     prepend?: string;
     sandboxFiles?: Record<string, string>;
     mustRead: string[];
@@ -72,7 +81,11 @@ export function transcriptRules(
         // Multi-file / no-monolith contract
         'no-rewrite-of-written-file': !rewrote,
         'no-read-back-of-own-writes': !readBack,
-        'multiple-source-files': writtenPaths.length >= 2,
+        // A viz is ONE component by contract, so the no-monolith rule doesn't
+        // apply to it — omitted rather than failed.
+        ...(spec.template === 'data_app_viz'
+            ? {}
+            : { 'multiple-source-files': writtenPaths.length >= 2 }),
         // Template-lib cheat sheet: those files are documented — neither Read
         // nor inspected via Bash (cat/sed/grep on src/lib counts too)
         'no-template-lib-reads':
@@ -138,5 +151,172 @@ export function sourceRules(files: Record<string, string>): RuleResults {
             : false,
         'no-oversized-files': oversized.length === 0,
         'axes-have-tick-formatters': axesOk,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Data app viz
+// ---------------------------------------------------------------------------
+
+/**
+ * The generation run's structured output (the viz declaration the backend
+ * persists to `app_versions.viz_schema`), narrowed to what the rubric reads:
+ * fields and option defaults needed by the render fixture. This deliberately
+ * checks only declaration structure; whether generated code actually reacts to
+ * the context is measured by the browser render gate.
+ */
+export type VizDeclaration = {
+    fields: {
+        name: string;
+        label: string;
+        type: 'dimension' | 'metric' | 'series';
+        required: boolean;
+    }[];
+    configOptions: {
+        name: string;
+        type: 'boolean' | 'select' | 'number' | 'text' | 'color';
+        default: boolean | number | string;
+    }[];
+    /** Null when the run declared no palette, or declared it as null. */
+    colorPalette: { group?: string } | null;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const FIELD_TYPES = new Set(['dimension', 'metric', 'series']);
+const OPTION_TYPES = new Set(['boolean', 'select', 'number', 'text', 'color']);
+
+const hasUniqueNames = (entries: { name: string }[]): boolean =>
+    new Set(entries.map(({ name }) => name)).size === entries.length;
+
+const hasValidOptionBase = (
+    option: Record<string, unknown>,
+): option is Record<string, unknown> & {
+    name: string;
+    label: string;
+    group?: string;
+    type: string;
+} =>
+    typeof option.name === 'string' &&
+    option.name.length > 0 &&
+    typeof option.label === 'string' &&
+    (option.group === undefined || typeof option.group === 'string') &&
+    typeof option.type === 'string' &&
+    OPTION_TYPES.has(option.type);
+
+const hasValidSelectChoices = (value: unknown): boolean =>
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every(
+        (choice) =>
+            isRecord(choice) &&
+            typeof choice.value === 'string' &&
+            typeof choice.label === 'string',
+    );
+
+const hasValidOptionValueShape = (option: Record<string, unknown>): boolean => {
+    switch (option.type) {
+        case 'boolean':
+            return typeof option.default === 'boolean';
+        case 'select':
+            return (
+                typeof option.default === 'string' &&
+                hasValidSelectChoices(option.choices)
+            );
+        case 'number':
+            return (
+                typeof option.default === 'number' &&
+                Number.isFinite(option.default) &&
+                (option.min === undefined ||
+                    (typeof option.min === 'number' &&
+                        Number.isFinite(option.min))) &&
+                (option.max === undefined ||
+                    (typeof option.max === 'number' &&
+                        Number.isFinite(option.max)))
+            );
+        case 'text':
+        case 'color':
+            return typeof option.default === 'string';
+        default:
+            return false;
+    }
+};
+
+export function parseVizDeclaration(value: unknown): VizDeclaration | null {
+    if (!isRecord(value)) return null;
+    if (!Array.isArray(value.fields) || !Array.isArray(value.configOptions)) {
+        return null;
+    }
+
+    const fields: VizDeclaration['fields'] = [];
+    for (const field of value.fields) {
+        if (
+            !isRecord(field) ||
+            typeof field.name !== 'string' ||
+            field.name.length === 0 ||
+            typeof field.label !== 'string' ||
+            typeof field.type !== 'string' ||
+            !FIELD_TYPES.has(field.type) ||
+            typeof field.required !== 'boolean'
+        ) {
+            return null;
+        }
+        fields.push({
+            name: field.name,
+            label: field.label,
+            type: field.type as VizDeclaration['fields'][number]['type'],
+            required: field.required,
+        });
+    }
+
+    const configOptions: VizDeclaration['configOptions'] = [];
+    for (const option of value.configOptions) {
+        if (
+            !isRecord(option) ||
+            !hasValidOptionBase(option) ||
+            !hasValidOptionValueShape(option)
+        ) {
+            return null;
+        }
+        configOptions.push({
+            name: option.name,
+            type: option.type as VizDeclaration['configOptions'][number]['type'],
+            default: option.default as boolean | number | string,
+        });
+    }
+
+    if (!hasUniqueNames(fields) || !hasUniqueNames(configOptions)) return null;
+
+    const declared = value.colorPalette;
+    if (declared !== null && !isRecord(declared)) return null;
+    if (
+        isRecord(declared) &&
+        declared.group !== undefined &&
+        typeof declared.group !== 'string'
+    ) {
+        return null;
+    }
+    const colorPalette = isRecord(declared)
+        ? typeof declared.group === 'string'
+            ? { group: declared.group }
+            : {}
+        : null;
+    return { fields, configOptions, colorPalette };
+}
+
+/**
+ * Objective declaration checks for a data-app-viz generation. These make no
+ * claim about how the source uses the declaration; the render gate owns that
+ * behavioral check by pushing a real context into the built component.
+ */
+export function vizDeclarationRules(
+    declaration: VizDeclaration | null,
+): RuleResults {
+    return {
+        'emits-valid-viz-declaration': declaration !== null,
+        'declares-fields': (declaration?.fields.length ?? 0) > 0,
+        'declares-config-options': (declaration?.configOptions.length ?? 0) > 0,
+        'declares-color-palette': declaration?.colorPalette != null,
     };
 }

--- a/sandboxes/data-apps/benchmark/fixtures/data-app-viz-instructions.txt
+++ b/sandboxes/data-apps/benchmark/fixtures/data-app-viz-instructions.txt
@@ -1,0 +1,8 @@
+[Data app viz]
+You are building ONE reusable chart component. You do NOT fetch data or run queries: Lightdash runs the query, then gives you the result rows plus a mapping from your field names to the columns in those rows. The same component is reused across many different queries, so never hardcode column names — just render whatever data you are handed.
+
+Before you write any code, read `/app/.claude/skills/reusable-visualization/SKILL.md` with the Read tool — the `reusable-visualization` skill. It is the contract for this build: the `useVizContext()` hook you take your data and settings from, the fields and config options you declare as structured output, the exact option vocabulary, the palette rule, and the final pass you run before you finish. Where it and the sandbox skill disagree, it wins. Follow it as written.
+
+Build the chart type the user asked for; only if they did not name one, pick what best fits the fields (bars to compare categories, a line for a trend over time).
+
+You are done when the chart renders for real and the declaration you emit is the one that skill describes: every field and every config option the component reads, and nothing a viewer would plausibly want different left hardcoded.

--- a/sandboxes/data-apps/benchmark/fixtures/data-app-viz-output-schema.json
+++ b/sandboxes/data-apps/benchmark/fixtures/data-app-viz-output-schema.json
@@ -1,0 +1,257 @@
+{
+    "type": "object",
+    "properties": {
+        "fields": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Key the component reads from `fieldMapping`. Unique across fields, no spaces."
+                    },
+                    "label": {
+                        "type": "string",
+                        "description": "Human label shown in the field-mapping UI."
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "dimension",
+                            "metric",
+                            "series"
+                        ],
+                        "description": "dimension = a category/grouping column, metric = a numeric measure, series = a dimension used to split or colour the chart."
+                    },
+                    "required": {
+                        "type": "boolean",
+                        "description": "false only when the chart still renders with this field unmapped."
+                    }
+                },
+                "required": [
+                    "name",
+                    "label",
+                    "type",
+                    "required"
+                ],
+                "additionalProperties": false
+            },
+            "description": "Every data column the component reads. Declare exactly what you read — no more, no less."
+        },
+        "configOptions": {
+            "type": "array",
+            "items": {
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "minLength": 1,
+                                "description": "Key the component reads from `options`. Unique across options, no spaces."
+                            },
+                            "label": {
+                                "type": "string",
+                                "description": "Human label shown next to the control in the config panel."
+                            },
+                            "group": {
+                                "type": "string",
+                                "description": "Optional tab name. Options sharing a group are rendered in the same config tab; ungrouped options share a default tab."
+                            },
+                            "type": {
+                                "type": "string",
+                                "const": "boolean"
+                            },
+                            "default": {
+                                "type": "boolean",
+                                "description": "Value used until the viewer changes it."
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "label",
+                            "type",
+                            "default"
+                        ],
+                        "additionalProperties": false
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "$ref": "#/properties/configOptions/items/anyOf/0/properties/name"
+                            },
+                            "label": {
+                                "$ref": "#/properties/configOptions/items/anyOf/0/properties/label"
+                            },
+                            "group": {
+                                "$ref": "#/properties/configOptions/items/anyOf/0/properties/group"
+                            },
+                            "type": {
+                                "type": "string",
+                                "const": "select"
+                            },
+                            "choices": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "value": {
+                                            "type": "string",
+                                            "description": "Value delivered on `options`."
+                                        },
+                                        "label": {
+                                            "type": "string",
+                                            "description": "Human label in the list."
+                                        }
+                                    },
+                                    "required": [
+                                        "value",
+                                        "label"
+                                    ],
+                                    "additionalProperties": false
+                                },
+                                "minItems": 1,
+                                "description": "The selectable choices; at least one."
+                            },
+                            "default": {
+                                "type": "string",
+                                "description": "One of the declared choice `value`s."
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "label",
+                            "type",
+                            "choices",
+                            "default"
+                        ],
+                        "additionalProperties": false
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "$ref": "#/properties/configOptions/items/anyOf/0/properties/name"
+                            },
+                            "label": {
+                                "$ref": "#/properties/configOptions/items/anyOf/0/properties/label"
+                            },
+                            "group": {
+                                "$ref": "#/properties/configOptions/items/anyOf/0/properties/group"
+                            },
+                            "type": {
+                                "type": "string",
+                                "const": "number"
+                            },
+                            "default": {
+                                "type": "number",
+                                "description": "Value used until the viewer changes it."
+                            },
+                            "min": {
+                                "type": "number",
+                                "description": "Optional lower bound."
+                            },
+                            "max": {
+                                "type": "number",
+                                "description": "Optional upper bound."
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "label",
+                            "type",
+                            "default"
+                        ],
+                        "additionalProperties": false
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "$ref": "#/properties/configOptions/items/anyOf/0/properties/name"
+                            },
+                            "label": {
+                                "$ref": "#/properties/configOptions/items/anyOf/0/properties/label"
+                            },
+                            "group": {
+                                "$ref": "#/properties/configOptions/items/anyOf/0/properties/group"
+                            },
+                            "type": {
+                                "type": "string",
+                                "const": "text"
+                            },
+                            "default": {
+                                "type": "string",
+                                "description": "Value used until the viewer changes it."
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "label",
+                            "type",
+                            "default"
+                        ],
+                        "additionalProperties": false
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "$ref": "#/properties/configOptions/items/anyOf/0/properties/name"
+                            },
+                            "label": {
+                                "$ref": "#/properties/configOptions/items/anyOf/0/properties/label"
+                            },
+                            "group": {
+                                "$ref": "#/properties/configOptions/items/anyOf/0/properties/group"
+                            },
+                            "type": {
+                                "type": "string",
+                                "const": "color"
+                            },
+                            "default": {
+                                "type": "string",
+                                "description": "Hex colour used until the viewer changes it."
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "label",
+                            "type",
+                            "default"
+                        ],
+                        "additionalProperties": false
+                    }
+                ]
+            },
+            "description": "Every setting the viewer can change from the chart config panel without regenerating the viz — one per literal the component would otherwise hardcode: what it shows or hides, which variant it picked, and the numbers and labels it wrote in. Each `name` must be a key the component reads from `options`. Series colours are not among them: declare `colorPalette` instead. Empty is only right for a component that hardcodes nothing a viewer would want different."
+        },
+        "colorPalette": {
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "group": {
+                            "type": "string",
+                            "description": "Optional tab name, matching a config option `group`. The picker gets its own tab when no option shares it."
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Declare this when the component colours anything from `colorPalette`. It surfaces the standard Lightdash palette picker, so the viz inherits the same colours as the charts around it. Not a config option: the chosen colours arrive on `colorPalette`, never on `options`. Null when the component colours nothing."
+        }
+    },
+    "required": [
+        "fields",
+        "configOptions",
+        "colorPalette"
+    ],
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/sandboxes/data-apps/benchmark/gallery.ts
+++ b/sandboxes/data-apps/benchmark/gallery.ts
@@ -116,6 +116,8 @@ function collectRows(runDir: string): GalleryRow[] {
         const rules = { ...buildRules.get(cell), ...render?.rules };
         if (rules['build-passes'] === false) badges.push('build ✗');
         if (rules['renders-clean'] === false) badges.push('render ✗');
+        if (rules['renders-with-viz-context'] === false)
+            badges.push('viz context ✗');
         if (rules['queries-valid-fields'] === false) badges.push('queries ✗');
         if (rules['made-metric-queries'] === false) badges.push('no queries');
         if (!hasScreenshot) badges.push('no screenshot');

--- a/sandboxes/data-apps/benchmark/harness.js
+++ b/sandboxes/data-apps/benchmark/harness.js
@@ -23,6 +23,8 @@ var state = {
     exports: [],
     externalFetches: [],
     fetchCount: 0,
+    vizContextRequests: 0,
+    vizContextInitialRoot: null,
     activityAt: Date.now(),
 };
 window.__bench = state;
@@ -520,6 +522,42 @@ function postToApp(message) {
     }
 }
 
+function appRootHtml() {
+    try {
+        var root =
+            iframe && iframe.contentDocument
+                ? iframe.contentDocument.getElementById('root')
+                : null;
+        return root ? root.innerHTML : null;
+    } catch (err) {
+        return null;
+    }
+}
+
+function pushVizContext() {
+    var fixture = CONFIG.vizContext;
+    if (!fixture) return;
+    state.vizContextRequests += 1;
+    if (state.vizContextInitialRoot === null) {
+        state.vizContextInitialRoot = appRootHtml();
+    }
+    var synthesized = synthesizeRows(
+        'orders',
+        fixture.dimensions || [],
+        fixture.metrics || [],
+        120,
+        [],
+    );
+    postToApp({
+        type: 'lightdash:sdk:data-app-viz-context',
+        fieldMapping: fixture.fieldMapping || {},
+        rows: synthesized.rows,
+        options: fixture.options || {},
+        colorPalette: fixture.colorPalette || [],
+    });
+    touch();
+}
+
 window.addEventListener('message', function onMessage(event) {
     if (!iframe || !iframe.contentWindow || event.source !== iframe.contentWindow) {
         return;
@@ -530,7 +568,9 @@ window.addEventListener('message', function onMessage(event) {
     }
     touch();
 
-    if (data.type === 'lightdash:sdk:fetch') {
+    if (data.type === 'lightdash:sdk:viz-context-request') {
+        pushVizContext();
+    } else if (data.type === 'lightdash:sdk:fetch') {
         state.fetchCount += 1;
         var response;
         try {

--- a/sandboxes/data-apps/benchmark/mockHost.ts
+++ b/sandboxes/data-apps/benchmark/mockHost.ts
@@ -8,6 +8,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import YAML from 'yaml';
+import type { PromptTemplate, VizDeclaration } from './assertions.ts';
 
 const BENCH_DIR = path.dirname(fileURLToPath(import.meta.url));
 
@@ -36,6 +37,14 @@ export type ChartFixture = {
     metricQuery: Record<string, unknown>;
 };
 
+type VizContextFixture = {
+    fieldMapping: Record<string, string>;
+    dimensions: string[];
+    metrics: string[];
+    options: Record<string, boolean | number | string>;
+    colorPalette: string[];
+};
+
 type SchemaColumn = {
     name: string;
     description?: string;
@@ -61,7 +70,9 @@ type SchemaModel = {
  * "Order status: placed, shipped, completed, returned." so synthesized rows
  * carry the values generated apps expect to see (and filter on).
  */
-function extractCategoryValues(description: string | undefined): string[] | null {
+function extractCategoryValues(
+    description: string | undefined,
+): string[] | null {
     if (!description) return null;
     const colon = description.lastIndexOf(':');
     const candidate = colon === -1 ? description : description.slice(colon + 1);
@@ -144,7 +155,9 @@ export function parseCatalog(schemaYmlPath: string): Catalog {
         ].filter((t) => tableFields.has(t));
         const fields: Record<string, CatalogFieldMeta> = {};
         for (const table of tables) {
-            for (const [name, meta] of Object.entries(tableFields.get(table)!)) {
+            for (const [name, meta] of Object.entries(
+                tableFields.get(table)!,
+            )) {
                 fields[`${table}_${name}`] = meta;
             }
         }
@@ -196,13 +209,94 @@ export function loadChartFixtures(
     return charts;
 }
 
+/** The prompt's generation template; null for the default template. */
+export function loadPromptTemplate(
+    promptsJsonPath: string,
+    promptId: string,
+): PromptTemplate | null {
+    const suite = JSON.parse(fs.readFileSync(promptsJsonPath, 'utf-8')) as {
+        prompts: { id: string; template?: PromptTemplate }[];
+    };
+    return suite.prompts.find((p) => p.id === promptId)?.template ?? null;
+}
+
+const chooseVizField = (
+    field: VizDeclaration['fields'][number],
+    used: Set<string>,
+): string => {
+    const hint = `${field.name} ${field.label}`.toLowerCase();
+    const candidates =
+        field.type === 'metric'
+            ? [
+                  'orders_total_revenue',
+                  'orders_order_count',
+                  'orders_average_order_value',
+              ]
+            : /date|time|month|year|week|day|trend/.test(hint)
+              ? [
+                    'orders_order_date_month',
+                    'orders_order_date_day',
+                    'orders_customer_segment',
+                ]
+              : field.type === 'series'
+                ? ['orders_customer_segment', 'orders_region', 'orders_status']
+                : [
+                      'orders_customer_segment',
+                      'orders_region',
+                      'orders_status',
+                      'orders_order_date_month',
+                  ];
+    return (
+        candidates.find((candidate) => !used.has(candidate)) ?? candidates[0]
+    );
+};
+
+const buildVizContextFixture = (
+    declaration: VizDeclaration | null,
+): VizContextFixture | null => {
+    if (!declaration) return null;
+    const used = new Set<string>();
+    const fieldMapping: Record<string, string> = {};
+    const dimensions: string[] = [];
+    const metrics: string[] = [];
+
+    for (const field of declaration.fields) {
+        const fieldId = chooseVizField(field, used);
+        used.add(fieldId);
+        fieldMapping[field.name] = fieldId;
+        (field.type === 'metric' ? metrics : dimensions).push(fieldId);
+    }
+
+    return {
+        fieldMapping,
+        dimensions,
+        metrics,
+        options: Object.fromEntries(
+            declaration.configOptions.map((option) => [
+                option.name,
+                option.default,
+            ]),
+        ),
+        colorPalette: ['#FF3B30', '#007AFF', '#34C759', '#AF52DE'],
+    };
+};
+
 export function buildHarnessHtml(
     catalog: Catalog,
     charts: Record<string, ChartFixture>,
     projectUuid: string,
+    vizDeclaration: VizDeclaration | null = null,
 ): string {
-    const harnessJs = fs.readFileSync(path.join(BENCH_DIR, 'harness.js'), 'utf-8');
-    const config = { projectUuid, explores: catalog.explores, charts };
+    const harnessJs = fs.readFileSync(
+        path.join(BENCH_DIR, 'harness.js'),
+        'utf-8',
+    );
+    const config = {
+        projectUuid,
+        explores: catalog.explores,
+        charts,
+        vizContext: buildVizContextFixture(vizDeclaration),
+    };
     // <-escape so a stray "</script>" inside config can't break the page.
     const configJson = JSON.stringify(config).replace(/</g, '\\u003c');
     // Target the assignment specifically — the docblock also mentions the

--- a/sandboxes/data-apps/benchmark/prompts.json
+++ b/sandboxes/data-apps/benchmark/prompts.json
@@ -54,6 +54,34 @@
                 "/app/references/sheets-export.md",
                 "/app/references/pdf-downloads.md"
             ]
+        },
+        {
+            "id": "viz-multi-series",
+            "template": "data_app_viz",
+            "prompt": "Build a line chart that plots a metric over time with one line per category, so several categories can be compared at once.",
+            "mustRead": [
+                "/app/.claude/skills/reusable-visualization/SKILL.md"
+            ],
+            "mustNotRead": [
+                "/app/references/sheets-export.md",
+                "/app/references/pdf-downloads.md",
+                "/app/references/chart-references.md",
+                "/app/references/external-apis.md"
+            ]
+        },
+        {
+            "id": "viz-ranked-bars",
+            "template": "data_app_viz",
+            "prompt": "Build a horizontal bar chart that ranks categories by a single metric, biggest first, with the value written at the end of each bar.",
+            "mustRead": [
+                "/app/.claude/skills/reusable-visualization/SKILL.md"
+            ],
+            "mustNotRead": [
+                "/app/references/sheets-export.md",
+                "/app/references/pdf-downloads.md",
+                "/app/references/chart-references.md",
+                "/app/references/external-apis.md"
+            ]
         }
     ]
 }

--- a/sandboxes/data-apps/benchmark/renderGate.ts
+++ b/sandboxes/data-apps/benchmark/renderGate.ts
@@ -15,10 +15,16 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { chromium, type Browser } from 'playwright';
+import {
+    parseVizDeclaration,
+    type PromptTemplate,
+    type VizDeclaration,
+} from './assertions.ts';
 import { writeGallery } from './gallery.ts';
 import {
     buildHarnessHtml,
     loadChartFixtures,
+    loadPromptTemplate,
     parseCatalog,
 } from './mockHost.ts';
 
@@ -48,6 +54,8 @@ export type RenderResult = {
     boundaryMarker: boolean;
     rootChildren: number;
     rootTextLength: number;
+    vizContextRequests: number;
+    vizContextChanged: boolean;
     queries: IssuedQuery[];
     blockedFetches: string[];
     exports: unknown[];
@@ -57,14 +65,29 @@ export type RenderResult = {
 
 export function renderRules(
     result: Omit<RenderResult, 'rules'>,
+    template: PromptTemplate | null,
 ): Record<string, boolean> {
-    return {
+    const rules: Record<string, boolean> = {
         'renders-clean':
             result.error === null &&
             result.pageErrors.length === 0 &&
             !result.fatalMarker &&
             !result.boundaryMarker &&
+            result.settled &&
             result.rootChildren > 0,
+    };
+    // A viz issues no queries — the host owns the query and pushes the rows —
+    // so the query rules don't apply to it and are omitted, not failed.
+    if (template === 'data_app_viz') {
+        return {
+            ...rules,
+            'received-viz-context': result.vizContextRequests > 0,
+            'renders-with-viz-context':
+                result.vizContextRequests > 0 && result.vizContextChanged,
+        };
+    }
+    return {
+        ...rules,
         'made-metric-queries': result.queries.some(
             (q) => q.kind === 'metric' || q.kind === 'chart',
         ),
@@ -102,6 +125,7 @@ async function renderCell(
     runDir: string,
     cell: string,
     harnessHtml: string,
+    template: PromptTemplate | null,
 ): Promise<RenderResult> {
     const distDir = path.join(runDir, 'dist', cell);
     const screenshotDir = path.join(runDir, 'screenshots');
@@ -120,6 +144,8 @@ async function renderCell(
         boundaryMarker: false,
         rootChildren: 0,
         rootTextLength: 0,
+        vizContextRequests: 0,
+        vizContextChanged: false,
         queries: [],
         blockedFetches: [],
         exports: [],
@@ -174,7 +200,9 @@ async function renderCell(
         const page = await context.newPage();
         page.on('pageerror', (err) => {
             if (result.pageErrors.length < 20) {
-                result.pageErrors.push(String(err.message ?? err).slice(0, 300));
+                result.pageErrors.push(
+                    String(err.message ?? err).slice(0, 300),
+                );
             }
         });
         page.on('console', (msg) => {
@@ -208,15 +236,14 @@ async function renderCell(
                 const bench = w.__bench ?? {};
                 let rootChildren = 0;
                 let rootTextLength = 0;
+                let rootHtml: string | null = null;
                 try {
-                    const frame = document.getElementById(
-                        'app-frame',
-                    ) as any;
-                    const root =
-                        frame?.contentDocument?.getElementById('root');
+                    const frame = document.getElementById('app-frame') as any;
+                    const root = frame?.contentDocument?.getElementById('root');
                     if (root) {
                         rootChildren = root.childElementCount;
                         rootTextLength = (root.innerText ?? '').length;
+                        rootHtml = root.innerHTML;
                     }
                 } catch {
                     // cross-origin shouldn't happen; treat as unmounted
@@ -228,6 +255,10 @@ async function renderCell(
                     exports: bench.exports ?? [],
                     rootChildren,
                     rootTextLength,
+                    vizContextRequests: bench.vizContextRequests ?? 0,
+                    vizContextChanged:
+                        typeof bench.vizContextInitialRoot === 'string' &&
+                        rootHtml !== bench.vizContextInitialRoot,
                 };
                 /* eslint-enable @typescript-eslint/no-explicit-any */
             });
@@ -238,6 +269,8 @@ async function renderCell(
             const s = await readState();
             result.rootChildren = s.rootChildren;
             result.rootTextLength = s.rootTextLength;
+            result.vizContextRequests = s.vizContextRequests;
+            result.vizContextChanged = s.vizContextChanged;
             if (
                 Date.now() - startedAt > 5_000 &&
                 Date.now() - s.activityAt > 3_000 &&
@@ -254,6 +287,8 @@ async function renderCell(
         const final = await readState();
         result.rootChildren = final.rootChildren;
         result.rootTextLength = final.rootTextLength;
+        result.vizContextRequests = final.vizContextRequests;
+        result.vizContextChanged = final.vizContextChanged;
         result.queries = final.queries as IssuedQuery[];
         result.blockedFetches = final.blocked as string[];
         result.exports = final.exports as unknown[];
@@ -284,7 +319,10 @@ async function renderCell(
     }
     result.durationMs = Date.now() - startedAt;
 
-    const full: RenderResult = { ...result, rules: renderRules(result) };
+    const full: RenderResult = {
+        ...result,
+        rules: renderRules(result, template),
+    };
     fs.writeFileSync(
         path.join(renderDir, `${cell}.json`),
         JSON.stringify(full, null, 2),
@@ -310,20 +348,39 @@ export async function renderRun(
         path.join(BENCH_DIR, 'fixtures', 'schema.yml'),
     );
     const promptsJsonPath = path.join(BENCH_DIR, 'prompts.json');
-    const harnessByPrompt = new Map<string, string>();
+    const declarations = new Map<string, VizDeclaration | null>();
+    const resultsPath = path.join(runDir, 'results.json');
+    if (fs.existsSync(resultsPath)) {
+        const runResults = JSON.parse(
+            fs.readFileSync(resultsPath, 'utf-8'),
+        ) as {
+            variant: string;
+            promptId: string;
+            rep: number;
+            analysis: { structuredOutput?: unknown } | null;
+        }[];
+        for (const result of runResults) {
+            declarations.set(
+                `${result.variant}__${result.promptId}__r${result.rep}`,
+                parseVizDeclaration(result.analysis?.structuredOutput),
+            );
+        }
+    }
+    const harnessByCell = new Map<string, string>();
     const harnessFor = (cell: string): string => {
         const promptId = promptIdOfCell(cell) ?? '';
-        if (!harnessByPrompt.has(promptId)) {
-            harnessByPrompt.set(
-                promptId,
+        if (!harnessByCell.has(cell)) {
+            harnessByCell.set(
+                cell,
                 buildHarnessHtml(
                     catalog,
                     loadChartFixtures(promptsJsonPath, promptId),
                     'bench-project-uuid',
+                    declarations.get(cell) ?? null,
                 ),
             );
         }
-        return harnessByPrompt.get(promptId)!;
+        return harnessByCell.get(cell)!;
     };
 
     const browser = await chromium.launch();
@@ -340,6 +397,10 @@ export async function renderRun(
                     runDir,
                     cell,
                     harnessFor(cell),
+                    loadPromptTemplate(
+                        promptsJsonPath,
+                        promptIdOfCell(cell) ?? '',
+                    ),
                 );
             }
         },

--- a/sandboxes/data-apps/benchmark/run.ts
+++ b/sandboxes/data-apps/benchmark/run.ts
@@ -20,9 +20,12 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
+    parseVizDeclaration,
     sourceRules,
     transcriptRules,
+    vizDeclarationRules,
     type PromptSpec,
+    type PromptTemplate,
     type RuleResults,
 } from './assertions.ts';
 import { writeGallery } from './gallery.ts';
@@ -35,6 +38,30 @@ const BENCH_DIR = path.dirname(fileURLToPath(import.meta.url));
 // benchmark measures the production configuration, not a lookalike.
 const ALLOWED_TOOLS =
     'Read(//app/**),Read(//tmp/dbt-repo/**),Read(//tmp/images/**),Read(//tmp/metric-queries/**),Read(//tmp/external-data/**),Write(//app/src/**),Edit(//app/src/**),Glob(//app/**),Glob(//tmp/dbt-repo/**),Glob(//tmp/metric-queries/**),Glob(//tmp/external-data/**),Grep(//app/**),Grep(//tmp/dbt-repo/**),Grep(//tmp/external-data/**),Bash(pnpm check),Bash(pnpm check:*)';
+
+/**
+ * Per-template generation config, mirroring AppGenerateService: the template's
+ * instructions are prepended to the prompt, and a template that declares an
+ * output schema collects the run's declaration as CLI structured output
+ * (`--json-schema`, the channel the backend persists to `viz_schema`).
+ *
+ * Both files are byte-stable copies of the pipeline's current wording —
+ * `getTemplateInstructions()` and `dataAppVizJsonSchema` in the repo. Re-copy
+ * them when either changes, or the benchmark measures a prompt production no
+ * longer sends.
+ */
+const TEMPLATE_FIXTURES: Record<
+    PromptTemplate,
+    { instructions: string; outputSchema: string }
+> = {
+    data_app_viz: {
+        instructions: 'fixtures/data-app-viz-instructions.txt',
+        outputSchema: 'fixtures/data-app-viz-output-schema.json',
+    },
+};
+
+const readFixture = (relPath: string): string =>
+    fs.readFileSync(path.join(BENCH_DIR, relPath), 'utf-8');
 
 // ---------------------------------------------------------------------------
 // Config
@@ -157,8 +184,7 @@ function parseArgs(argv: string[]): Config {
     if (config.variants.length === 0) {
         config.variants.push({
             name: 'default',
-            templateRef:
-                process.env.E2B_TEMPLATE_NAME || 'lightdash-data-app',
+            templateRef: process.env.E2B_TEMPLATE_NAME || 'lightdash-data-app',
             effort: null,
             envs: {},
         });
@@ -232,9 +258,26 @@ async function runOne(
                 fs.readFileSync(path.join(BENCH_DIR, localRel), 'utf-8'),
             );
         }
+        // Template instructions lead the prompt and the output schema is
+        // spliced in as a single literal arg — same composition as the
+        // pipeline's writeCatalogAndPrompt / runClaudeGeneration.
+        const templateFixtures = spec.template
+            ? TEMPLATE_FIXTURES[spec.template]
+            : null;
+        const instructions = templateFixtures
+            ? `${readFixture(templateFixtures.instructions).trimEnd()}\n\n`
+            : '';
+        let jsonSchemaFlag = '';
+        if (templateFixtures) {
+            await sandbox.files.write(
+                '/tmp/output-schema.json',
+                readFixture(templateFixtures.outputSchema),
+            );
+            jsonSchemaFlag = '--json-schema "$(cat /tmp/output-schema.json)" ';
+        }
         await sandbox.files.write(
             '/tmp/prompt.txt',
-            `${spec.prepend ?? ''}${spec.prompt}\n`,
+            `${instructions}${spec.prepend ?? ''}${spec.prompt}\n`,
         );
 
         // Generation — flags mirror the production pipeline.
@@ -259,6 +302,7 @@ async function runOne(
                     (variant.effort ? `--effort ${variant.effort} ` : '') +
                     `--verbose --output-format stream-json --include-partial-messages ` +
                     `--allowedTools "${ALLOWED_TOOLS}" ` +
+                    jsonSchemaFlag +
                     `--append-system-prompt-file /app/skill.md`,
                 { cwd: '/app', timeoutMs: 20 * 60 * 1000, onStdout },
             );
@@ -335,6 +379,14 @@ async function runOne(
             files[path.relative(srcDir, full)] = fs.readFileSync(full, 'utf-8');
         }
         Object.assign(result.rules, sourceRules(files));
+        if (spec.template === 'data_app_viz') {
+            Object.assign(
+                result.rules,
+                vizDeclarationRules(
+                    parseVizDeclaration(result.analysis.structuredOutput),
+                ),
+            );
+        }
     } catch (err) {
         result.error = err instanceof Error ? err.message : String(err);
     } finally {
@@ -391,9 +443,9 @@ function summarize(results: RunResult[], config: Config): string {
                     seconds(m((r) => r.analysis!.timings.toolExecMs)).padEnd(
                         8,
                     ) +
-                    String(m((r) => r.analysis!.usage?.outputTokens ?? 0)).padEnd(
-                        8,
-                    ) +
+                    String(
+                        m((r) => r.analysis!.usage?.outputTokens ?? 0),
+                    ).padEnd(8) +
                     String(m((r) => r.analysis!.turns)),
             );
         }
@@ -418,7 +470,9 @@ function summarize(results: RunResult[], config: Config): string {
     if (config.variants.length > 1) {
         const baseline = config.variants[0].name;
         for (const variant of config.variants.slice(1)) {
-            lines.push(`\n=== ${variant.name} vs ${baseline} (median deltas) ===`);
+            lines.push(
+                `\n=== ${variant.name} vs ${baseline} (median deltas) ===`,
+            );
             const promptIds = [...new Set(ok.map((r) => r.promptId))];
             for (const promptId of promptIds) {
                 const pick = (v: string, f: (r: RunResult) => number) =>
@@ -532,6 +586,13 @@ async function main() {
         },
     );
     await Promise.all(workers);
+
+    // Write once before rendering so the standalone render path and this inline
+    // path both load viz declarations from the same artifact.
+    fs.writeFileSync(
+        path.join(config.outDir, 'results.json'),
+        JSON.stringify(results, null, 2),
+    );
 
     // Render gate: run every built app under the local mock host and fold
     // the runtime rules (renders-clean, query validity) into the rubric.

--- a/sandboxes/data-apps/benchmark/stream.ts
+++ b/sandboxes/data-apps/benchmark/stream.ts
@@ -30,6 +30,13 @@ export type StreamAnalysis = {
     /** Subset of toolErrors that look like permission denials. */
     deniedTools: string[];
     resultText: string | null;
+    /**
+     * The run's `--json-schema` structured output, as the CLI emits it on the
+     * result event. Null for runs that declared no schema. This is the same
+     * channel the backend reads the viz declaration from before persisting it
+     * to `app_versions.viz_schema`.
+     */
+    structuredOutput: unknown;
     usage: {
         inputTokens: number;
         outputTokens: number;
@@ -66,6 +73,7 @@ export function analyzeStream(events: Timestamped[]): StreamAnalysis {
         toolErrors: [],
         deniedTools: [],
         resultText: null,
+        structuredOutput: null,
         usage: null,
     };
 
@@ -181,6 +189,7 @@ export function analyzeStream(events: Timestamped[]): StreamAnalysis {
             }
             analysis.resultText =
                 typeof event.result === 'string' ? event.result : null;
+            analysis.structuredOutput = event.structured_output ?? null;
             const usage = (event.usage ?? {}) as Record<string, unknown>;
             analysis.usage = {
                 inputTokens: num(usage.input_tokens),

--- a/sandboxes/data-apps/package.json
+++ b/sandboxes/data-apps/package.json
@@ -5,6 +5,7 @@
         "build": "tsx build-sandbox.ts",
         "test": "tsx test-generate.ts",
         "bench": "tsx benchmark/run.ts",
+        "bench:rules": "tsx --test benchmark/assertions.test.ts",
         "bench:render": "tsx benchmark/renderGate.ts",
         "bench:gallery": "tsx benchmark/gallery.ts"
     },


### PR DESCRIPTION
A prompt test can prove what is sent to the model, but not what the model generates. This adds focused `data_app_viz` coverage to the existing generation benchmark without treating source-text matches as behavioral evidence.

## What this adds

- Two neutrally worded visualization prompts. They do not mention config options, colours, or the config panel.
- The checkout's data-app-viz instructions and structured-output schema as explicit benchmark inputs.
- Structured declaration checks for validity, fields, non-empty config options, and palette declaration.
- Capture of `structured_output` from the Claude CLI result event, matching the backend channel.
- A real SDK viz-context render path: the mock host answers the component's context request with deterministic field mappings, rows, declared defaults, and a sentinel palette.
- Runtime rules that require the SDK handshake and a mounted-root change after context delivery, plus the existing screenshot gallery for semantic/visual review.

The source-regex rules and generated-source fixtures were removed. They could pass when a component merely mentioned an option or palette without using it. The focused test suite uses in-memory inputs only; it does not read production files by path or compare prompt/schema fixture contents.

## Boundaries

- Checkout-owned prompt and schema inputs are a single-version acceptance run. Template variants isolate sandbox-image or skill changes; they do not A/B backend prompt/schema text.
- The browser gate proves that the built component requests and responds to real viz context. The gallery remains the check for whether the requested chart and styling are semantically good.
- Fixtures are refreshed deliberately when evaluating a prompt/schema change.
- No CI wiring is included.

## Verification

- `pnpm --dir sandboxes/data-apps bench:rules` — 6/6
- focused benchmark TypeScript compile
- formatting and `git diff --check`
- Playwright re-render of the stored 12-cell run: candidate requested context and changed the mounted root 6/6, with no page or console errors; screenshots contain populated charts rather than loading placeholders

The browser pass found and fixed a real harness bug: it initially sent the synthesizer's wrapper object as `rows`, producing `No data`; it now sends the row array.

https://linear.app/lightdash/issue/GLITCH-563/generated-config-form-viz-declares-typed-config-options-colours-layout
