### PR TITLE
fix(query-sdk): post the capability manifest with wildcard targetOrigin

### DIFF
--- a/packages/query-sdk/src/features.test.ts
+++ b/packages/query-sdk/src/features.test.ts
@@ -93,12 +93,12 @@ describe('announceSdkManifest', () => {
             }),
         );
 
-    it('posts the manifest immediately, targeted at the serving origin', () => {
+    it('posts the manifest immediately with a wildcard target (cloud serves bundles cross-origin)', () => {
         const targetWindow = { postMessage: vi.fn() } as unknown as Window;
         cleanup = announceSdkManifest(targetWindow);
         expect(targetWindow.postMessage).toHaveBeenCalledWith(
             expectedMessage,
-            window.location.origin,
+            '*',
         );
     });
 

--- a/packages/query-sdk/src/manifest.ts
+++ b/packages/query-sdk/src/manifest.ts
@@ -23,11 +23,13 @@ export function announceSdkManifest(targetWindow: Window): () => void {
         sdkVersion: SDK_VERSION,
         features: SDK_FEATURE_KEYS,
     };
-    // Bundles are served from the host page's own origin, and location.origin
-    // is URL-derived so it survives the sandboxed (opaque-origin) iframe.
-    const { origin } = window.location;
-    const targetOrigin = origin && origin !== 'null' ? origin : '*';
-    const post = () => targetWindow.postMessage(message, targetOrigin);
+    // Wildcard on purpose — do NOT "fix" this to an origin. Cloud serves
+    // bundles from {customer}.lightdash.app while the host page runs on
+    // {customer}.lightdash.cloud, so the bundle cannot derive the parent's
+    // origin, and a mismatched targetOrigin silently drops the manifest
+    // (every app then shows as legacy/upgradeable). Matches every other
+    // bridge message; the payload is public constants from this package.
+    const post = () => targetWindow.postMessage(message, '*');
     activeCleanup?.();
     const handler = (event: MessageEvent) => {
         if (event.source !== targetWindow) return;


### PR DESCRIPTION
## Problem

On cloud, every data app shows the upgrade badge — including brand-new and just-upgraded apps — because the host never receives the SDK capability manifest.

`announceSdkManifest` posts with `targetOrigin = window.location.origin` (added in #26038 responding to a review suggestion). That assumption holds in local dev (Vite proxies `/api` so the bundle iframe is same-origin), but cloud deliberately serves app bundles from `{customer}.lightdash.app` while the host page runs on `{customer}.lightdash.cloud`. With a mismatched targetOrigin the browser silently drops the message, the host's 5s legacy timeout fires, and every bundle classifies as legacy.

Verified on a test instance: the deployed bundle contains the new SDK (manifest + stampCount literals present), the message just never arrives.

## Fix

Post the manifest with `'*'`, matching every other message in this iframe bridge (transport fetch, inspector, lineage announces — all wildcard, because the sandboxed iframe's opaque origin makes origin-targeting unusable in this protocol anyway). The payload is public constants from the npm package. A comment now documents why this must stay wildcard so it doesn't get "fixed" again.

## Note

Bundles built while the broken SDK was in the template (the current test-instance builds) need one rebuild/upgrade after this lands in the template image to start announcing.

Relates: PROD-7614

🤖 Generated with [Claude Code](https://claude.com/claude-code)