### PR TITLE
feat(analytics): add org to warehouse selection

### DIFF
--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SelectWarehouse.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SelectWarehouse.tsx
@@ -80,6 +80,9 @@ const SelectWarehouse: FC<SelectWarehouseProps> = ({
                                               track({
                                                   name: EventName.ONBOARDING_WAREHOUSE_SELECTED,
                                                   properties: {
+                                                      organizationId:
+                                                          organization?.organizationUuid ??
+                                                          '',
                                                       warehouse: item.key,
                                                       tier:
                                                           item.key ===

--- a/packages/frontend/src/pages/OnboardingDataSource.tsx
+++ b/packages/frontend/src/pages/OnboardingDataSource.tsx
@@ -120,6 +120,7 @@ const DataSourcePicker: FC = () => {
     const navigate = useNavigate();
     const { track } = useTracking();
     const { health } = useApp();
+    const { data: organization } = useOrganization();
     const popularWarehouses = getPopularWarehouses(
         health.data?.auth.google.enabled ?? false,
     );
@@ -130,7 +131,11 @@ const DataSourcePicker: FC = () => {
     ) => {
         track({
             name: EventName.ONBOARDING_WAREHOUSE_SELECTED,
-            properties: { warehouse: String(key), tier },
+            properties: {
+                organizationId: organization?.organizationUuid ?? '',
+                warehouse: String(key),
+                tier,
+            },
         });
         void navigate(getWarehouseRoute(key));
     };

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -655,6 +655,7 @@ type OrganizationBrandDetectedEvent = {
 type OnboardingWarehouseSelectedEvent = {
     name: EventName.ONBOARDING_WAREHOUSE_SELECTED;
     properties: {
+        organizationId: string;
         warehouse: string;
         tier: 'popular' | 'all' | 'other';
     };


### PR DESCRIPTION
## What and why

Adds `organizationId` to `onboarding_warehouse.selected` so the warehouse-connect step can be joined to the organization onboarding funnel. Other onboarding frontend events can receive the same organization key in a follow-up.

## Fix

Extends the event properties type and supplies `organizationId` from the current organization at both existing event emissions.

## Verification

Verified by CI (local checks intentionally skipped).

Linear: SPK-645
Linear: SPK-626