### PR TITLE
test: make CLI version assertion version-agnostic

### DIFF
--- a/packages/e2e/cypress/cli/api/commands.cy.ts
+++ b/packages/e2e/cypress/cli/api/commands.cy.ts
@@ -13,7 +13,7 @@ describe('version', () => {
     it('Should get version', () => {
         cy.exec(`${cliCommand} --version`)
             .its('stdout')
-            .should('contain', '0.');
+            .should('match', /\d+\.\d+\.\d+/);
     });
 });
 


### PR DESCRIPTION
The "CLI: Without dbt" e2e job is failing on every PR since the CLI version moved to 1.x: the `Should get version` test in `packages/e2e/cypress/cli/api/commands.cy.ts` asserted that `lightdash --version` output contains the literal string `'0.'`, which was only ever true while the CLI was on a `0.x` version.

This replaces the hardcoded prefix check with a semver-shaped regex match (`/\d+\.\d+\.\d+/`), so the assertion keeps validating that the command prints a version without coupling the test to any particular major version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)