### PR TITLE
fix(data-apps): open move-to-space modal when favoriting a space-less app from lists

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -29,6 +29,7 @@ import {
 import { type FC, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
 import { AskAiAgentMenuItem } from '../../../ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem';
+import { FavoritePersonalDataAppModal } from '../../../features/apps/components/DataAppFavoriteMenuItem';
 import { PromoteAppModal } from '../../../features/apps/components/PromoteAppModal';
 import { useDuplicateApp } from '../../../features/apps/hooks/useDuplicateApp';
 import { PromotionConfirmDialog } from '../../../features/promotion/components/PromotionConfirmDialog';
@@ -86,6 +87,8 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const { data: project } = useProject(projectUuid);
     const [isPromoteAppOpen, setIsPromoteAppOpen] = useState(false);
+    const [isFavoriteSpaceModalOpen, setIsFavoriteSpaceModalOpen] =
+        useState(false);
     const { mutate: duplicateApp } = useDuplicateApp();
     const organizationUuid = user.data?.organizationUuid;
     const { data: spaces = [] } = useSpaceSummaries(projectUuid, true, {});
@@ -352,6 +355,12 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                                 )
                             }
                             onClick={() => {
+                                // Space-less apps can't be favorited — offer
+                                // the same move-to-space flow as the app header
+                                if (isPersonalDataApp && !isFavorited) {
+                                    setIsFavoriteSpaceModalOpen(true);
+                                    return;
+                                }
                                 favoritesContext.toggleFavorite(
                                     item.type,
                                     item.data.uuid,
@@ -737,6 +746,16 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                         appUuid={item.data.uuid}
                         opened
                         onClose={() => setIsPromoteAppOpen(false)}
+                    />
+                )}
+            {isFavoriteSpaceModalOpen &&
+                projectUuid &&
+                item.type === ResourceViewItemType.DATA_APP && (
+                    <FavoritePersonalDataAppModal
+                        projectUuid={projectUuid}
+                        app={item.data}
+                        opened
+                        onClose={() => setIsFavoriteSpaceModalOpen(false)}
                     />
                 )}
         </>


### PR DESCRIPTION
Favoriting a data app that isn't in a space worked from the app view/build header (it opens a move-to-space modal) but failed with an error toast from the all-data-apps list, because `ResourceActionMenu` toggled the favorite without intercepting the space-less case.

Reuse the header's `FavoritePersonalDataAppModal` in `ResourceActionMenu` so both surfaces offer the same move-and-favorite flow.

No Linear ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)