### PR TITLE
feat: distill skips threads whose memory is no longer active

### DIFF
--- a/packages/backend/src/ee/models/AiAgentMemoryModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentMemoryModel.integration.test.ts
@@ -1465,4 +1465,200 @@ describe('AiAgentMemoryModel integration', () => {
             ['orders'],
         );
     });
+
+    it.each(['superseded', 'retired'] as const)(
+        'skips a thread whose memory is %s and keeps it out of the next sweep',
+        async (status) => {
+            const activity = new Date('2026-07-22T05:00:00Z');
+            const threadUuid = await createThread();
+            await createPrompt(threadUuid, activity);
+            const memory = await model.upsertSourceThreadMemory(
+                memoryInput(threadUuid),
+            );
+            await database(AiAgentMemoryTableName)
+                .where('ai_agent_memory_uuid', memory.ai_agent_memory_uuid)
+                .update({ status });
+
+            const distillCall = vi.fn<AiAgentMemoryDistillCall>();
+            const service = buildService(distillCall);
+            await expect(
+                service.distillThread({
+                    organizationUuid: SEED_ORG_1.organization_uuid,
+                    projectUuid: SEED_PROJECT.project_uuid,
+                    userUuid: 'system',
+                    threadUuid,
+                    sweptUpdatedAt: activity.toISOString(),
+                }),
+            ).resolves.toBe('skipped');
+            expect(distillCall).not.toHaveBeenCalled();
+
+            await expect(
+                database(AiAgentThreadDistillTableName)
+                    .where('ai_thread_uuid', threadUuid)
+                    .first(),
+            ).resolves.toMatchObject({
+                outcome: 'skipped',
+                distill_prompt_hash: null,
+                distilled_up_to: activity,
+            });
+            const rows = await database(AiAgentMemoryTableName).where(
+                'source_thread_uuid',
+                threadUuid,
+            );
+            expect(rows).toHaveLength(1);
+            expect(rows[0]).toMatchObject({
+                ai_agent_memory_uuid: memory.ai_agent_memory_uuid,
+                slug: memory.slug,
+                status,
+            });
+
+            const candidates = await model.findThreadsDueForDistill({
+                idleBefore: new Date(activity.getTime() + 6 * 60 * 60 * 1000),
+                activityFloor: new Date(
+                    activity.getTime() - 24 * 60 * 60 * 1000,
+                ),
+            });
+            expect(
+                candidates.some((row) => row.threadUuid === threadUuid),
+            ).toBe(false);
+        },
+    );
+
+    it('re-distills threads with an active memory row or none at all', async () => {
+        const activity = new Date('2026-07-22T05:00:00Z');
+        const citedAt = new Date('2026-07-22T04:00:00Z');
+        const [withMemory, withoutMemory] = await Promise.all([
+            createThread(),
+            createThread(),
+        ]);
+        await Promise.all([
+            createPrompt(withMemory, activity),
+            createPrompt(withoutMemory, activity),
+        ]);
+        const existing = await model.upsertSourceThreadMemory(
+            memoryInput(withMemory),
+        );
+        await database(AiAgentMemoryTableName)
+            .where('ai_agent_memory_uuid', existing.ai_agent_memory_uuid)
+            .update({ cited_count: 4, last_cited_at: citedAt });
+
+        const distillCall = vi
+            .fn<AiAgentMemoryDistillCall>()
+            .mockResolvedValue({
+                result: {
+                    type: 'memory',
+                    thread_summary: 'The user corrected the revenue rule.',
+                    slug: 'gross-revenue',
+                    title: 'Gross revenue convention',
+                    raw_memory: 'Use gross revenue.',
+                    terms: ['gross revenue'],
+                    objects: [],
+                    scope: 'user',
+                },
+            });
+        const service = buildService(distillCall);
+        const payload = {
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            projectUuid: SEED_PROJECT.project_uuid,
+            userUuid: 'system',
+            sweptUpdatedAt: activity.toISOString(),
+        };
+
+        await expect(
+            service.distillThread({ ...payload, threadUuid: withMemory }),
+        ).resolves.toBe('memory');
+        await expect(
+            service.distillThread({ ...payload, threadUuid: withoutMemory }),
+        ).resolves.toBe('memory');
+        expect(distillCall).toHaveBeenCalledTimes(2);
+
+        const kept = await database(AiAgentMemoryTableName).where(
+            'source_thread_uuid',
+            withMemory,
+        );
+        expect(kept).toHaveLength(1);
+        expect(kept[0]).toMatchObject({
+            ai_agent_memory_uuid: existing.ai_agent_memory_uuid,
+            slug: existing.slug,
+            raw_memory: 'Use gross revenue.',
+            status: 'active',
+            cited_count: 4,
+            last_cited_at: citedAt,
+        });
+
+        const created = await database(AiAgentMemoryTableName).where(
+            'source_thread_uuid',
+            withoutMemory,
+        );
+        expect(created).toHaveLength(1);
+        expect(created[0]).toMatchObject({
+            raw_memory: 'Use gross revenue.',
+            status: 'active',
+        });
+    });
+
+    it('re-distills in place when an active row sits beside a superseded one', async () => {
+        const activity = new Date('2026-07-22T05:00:00Z');
+        const threadUuid = await createThread();
+        await createPrompt(threadUuid, activity);
+        const superseded = await model.upsertSourceThreadMemory(
+            memoryInput(threadUuid),
+        );
+        await database(AiAgentMemoryTableName)
+            .where('ai_agent_memory_uuid', superseded.ai_agent_memory_uuid)
+            .update({ status: 'superseded' });
+        const active = await model.upsertSourceThreadMemory(
+            memoryInput(threadUuid),
+        );
+
+        const distillCall = vi
+            .fn<AiAgentMemoryDistillCall>()
+            .mockResolvedValue({
+                result: {
+                    type: 'memory',
+                    thread_summary: 'The user corrected the revenue rule.',
+                    slug: 'gross-revenue',
+                    title: 'Gross revenue convention',
+                    raw_memory: 'Use gross revenue.',
+                    terms: ['gross revenue'],
+                    objects: [],
+                    scope: 'user',
+                },
+            });
+        await expect(
+            buildService(distillCall).distillThread({
+                organizationUuid: SEED_ORG_1.organization_uuid,
+                projectUuid: SEED_PROJECT.project_uuid,
+                userUuid: 'system',
+                threadUuid,
+                sweptUpdatedAt: activity.toISOString(),
+            }),
+        ).resolves.toBe('memory');
+
+        const rows = await database(AiAgentMemoryTableName).where(
+            'source_thread_uuid',
+            threadUuid,
+        );
+        expect(rows).toHaveLength(2);
+        expect(
+            rows.find(
+                (row) =>
+                    row.ai_agent_memory_uuid ===
+                    superseded.ai_agent_memory_uuid,
+            ),
+        ).toMatchObject({
+            status: 'superseded',
+            raw_memory: 'Use net revenue.',
+        });
+        expect(
+            rows.find(
+                (row) =>
+                    row.ai_agent_memory_uuid === active.ai_agent_memory_uuid,
+            ),
+        ).toMatchObject({
+            slug: active.slug,
+            status: 'active',
+            raw_memory: 'Use gross revenue.',
+        });
+    });
 });

--- a/packages/backend/src/ee/models/AiAgentMemoryModel.ts
+++ b/packages/backend/src/ee/models/AiAgentMemoryModel.ts
@@ -122,6 +122,8 @@ export type AiAgentMemoryLineageSource = Pick<
     thread_title: string | null;
 };
 
+export type AiAgentMemorySourceThreadState = 'none' | 'active' | 'inactive';
+
 export type AiAgentMemoryWithLineage = {
     memory: DbAiAgentMemory;
     sources: AiAgentMemoryLineageSource[];
@@ -812,6 +814,26 @@ export class AiAgentMemoryModel {
             .where('source_thread_uuid', sourceThreadUuid)
             .where('status', 'active')
             .first('ai_agent_memory_uuid');
+    }
+
+    /**
+     * `inactive` means the thread produced memory that is no longer live —
+     * consolidated away or retired. An active row wins over stale siblings,
+     * because the one-active-row index leaves older rows behind.
+     */
+    async resolveSourceThreadMemoryState(
+        sourceThreadUuid: string,
+    ): Promise<AiAgentMemorySourceThreadState> {
+        const rows = await this.database<AiAgentMemoryTable>(
+            AiAgentMemoryTableName,
+        )
+            .where('source_thread_uuid', sourceThreadUuid)
+            .distinct('status');
+
+        if (rows.length === 0) return 'none';
+        return rows.some((row) => row.status === 'active')
+            ? 'active'
+            : 'inactive';
     }
 
     async updateStatus(args: {

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
@@ -159,6 +159,9 @@ describe('AiAgentMemoryService', () => {
         const upsertThreadDistill = vi.fn();
         const findActiveForProject = vi.fn().mockResolvedValue([]);
         const findActiveBySourceThread = vi.fn().mockResolvedValue(undefined);
+        const resolveSourceThreadMemoryState = vi
+            .fn()
+            .mockResolvedValue('none');
         const updateStatus = vi.fn().mockResolvedValue(true);
         const aiAgentMemoryDistill = vi.fn();
         const getAgent = vi.fn().mockResolvedValue({
@@ -194,6 +197,7 @@ describe('AiAgentMemoryService', () => {
                 upsertThreadDistill,
                 findActiveForProject,
                 findActiveBySourceThread,
+                resolveSourceThreadMemoryState,
                 updateStatus,
             } as AnyType,
             aiAgentModel: { getAgent, findThreadOwnership } as AnyType,
@@ -217,6 +221,7 @@ describe('AiAgentMemoryService', () => {
             upsertThreadDistill,
             findActiveForProject,
             findActiveBySourceThread,
+            resolveSourceThreadMemoryState,
             updateStatus,
             aiAgentMemoryDistill,
             getAgent,
@@ -777,6 +782,124 @@ describe('AiAgentMemoryService', () => {
             'scope',
             'unresolvedObjectCount',
         ]);
+    });
+
+    it('skips a thread whose memory is no longer active without an LLM call', async () => {
+        const activity = new Date('2026-07-22T05:00:00.000Z');
+        const payload = {
+            organizationUuid: 'org-enabled',
+            projectUuid: 'project-enabled',
+            userUuid: 'system',
+            threadUuid: 'thread-enabled',
+            sweptUpdatedAt: activity.toISOString(),
+        };
+
+        const {
+            service,
+            findThreadForDistill,
+            resolveSourceThreadMemoryState,
+            upsertThreadDistill,
+            distillCall,
+        } = build();
+        findThreadForDistill.mockResolvedValue(distillableThread(activity));
+        resolveSourceThreadMemoryState.mockResolvedValue('inactive');
+
+        await expect(service.distillThread(payload)).resolves.toBe('skipped');
+
+        expect(distillCall).not.toHaveBeenCalled();
+        expect(upsertThreadDistill).toHaveBeenCalledExactlyOnceWith({
+            aiThreadUuid: 'thread-enabled',
+            outcome: 'skipped',
+            distillPromptHash: null,
+            distilledUpTo: activity,
+        });
+    });
+
+    it('distills a thread whose memory is still active or absent', async () => {
+        const activity = new Date('2026-07-22T05:00:00.000Z');
+        const payload = {
+            organizationUuid: 'org-enabled',
+            projectUuid: 'project-enabled',
+            userUuid: 'system',
+            threadUuid: 'thread-enabled',
+            sweptUpdatedAt: activity.toISOString(),
+        };
+        const distillOutput = {
+            result: {
+                type: 'no_op',
+                reason: 'no_positive_evidence',
+            },
+        };
+
+        const active = build();
+        active.findThreadForDistill.mockResolvedValue(
+            distillableThread(activity, { distilledUpTo: null }),
+        );
+        active.resolveSourceThreadMemoryState.mockResolvedValue('active');
+        active.distillCall.mockResolvedValue(distillOutput);
+        await expect(active.service.distillThread(payload)).resolves.toBe(
+            'no_op',
+        );
+        expect(active.distillCall).toHaveBeenCalledOnce();
+
+        const none = build();
+        none.findThreadForDistill.mockResolvedValue(
+            distillableThread(activity, { distilledUpTo: null }),
+        );
+        none.resolveSourceThreadMemoryState.mockResolvedValue('none');
+        none.distillCall.mockResolvedValue(distillOutput);
+        await expect(none.service.distillThread(payload)).resolves.toBe(
+            'no_op',
+        );
+        expect(none.distillCall).toHaveBeenCalledOnce();
+    });
+
+    it('skips without writing when the memory stops being active mid-distill', async () => {
+        const activity = new Date('2026-07-22T05:00:00.000Z');
+        const {
+            service,
+            findThreadForDistill,
+            resolveSourceThreadMemoryState,
+            upsertSourceThreadMemory,
+            upsertThreadDistill,
+            distillCall,
+        } = build();
+        findThreadForDistill.mockResolvedValue(
+            distillableThread(activity, { distilledUpTo: null }),
+        );
+        resolveSourceThreadMemoryState
+            .mockResolvedValueOnce('active')
+            .mockResolvedValueOnce('inactive');
+        distillCall.mockResolvedValue({
+            result: {
+                type: 'memory',
+                thread_summary: 'The users agreed a convention.',
+                slug: 'net-revenue',
+                title: 'Net revenue convention',
+                raw_memory: 'Use net revenue.',
+                terms: ['net revenue'],
+                objects: [],
+                scope: 'user',
+            },
+        });
+
+        await expect(
+            service.distillThread({
+                organizationUuid: 'org-enabled',
+                projectUuid: 'project-enabled',
+                userUuid: 'system',
+                threadUuid: 'thread-enabled',
+                sweptUpdatedAt: activity.toISOString(),
+            }),
+        ).resolves.toBe('skipped');
+
+        expect(upsertSourceThreadMemory).not.toHaveBeenCalled();
+        expect(upsertThreadDistill).toHaveBeenCalledExactlyOnceWith({
+            aiThreadUuid: 'thread-enabled',
+            outcome: 'skipped',
+            distillPromptHash: null,
+            distilledUpTo: activity,
+        });
     });
 
     it('returns not found without reading rows when the flag is off', async () => {

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
@@ -489,6 +489,20 @@ export class AiAgentMemoryService extends BaseService {
         return outcome;
     }
 
+    /** Single definition site for the ledger row every skip cause writes. */
+    private async recordSkip(
+        threadUuid: string,
+        distilledUpTo: Date,
+    ): Promise<'skipped'> {
+        await this.aiAgentMemoryModel.upsertThreadDistill({
+            aiThreadUuid: threadUuid,
+            outcome: 'skipped',
+            distillPromptHash: null,
+            distilledUpTo,
+        });
+        return 'skipped';
+    }
+
     private async runDistillThread(
         payload: AiAgentMemoryDistillJobPayload,
         abortSignal?: AbortSignal,
@@ -544,13 +558,18 @@ export class AiAgentMemoryService extends BaseService {
                     turn.assistantText !== null,
             )
         ) {
-            await this.aiAgentMemoryModel.upsertThreadDistill({
-                aiThreadUuid: thread.threadUuid,
-                outcome: 'skipped',
-                distillPromptHash: null,
-                distilledUpTo: sweptUpdatedAt,
-            });
-            return 'skipped';
+            return this.recordSkip(thread.threadUuid, sweptUpdatedAt);
+        }
+
+        // A thread whose memory was consolidated away or retired stops feeding
+        // memory: the one-active-row index would let a re-distill insert a
+        // second active row beside the row that replaced it.
+        const memoryState =
+            await this.aiAgentMemoryModel.resolveSourceThreadMemoryState(
+                thread.threadUuid,
+            );
+        if (memoryState === 'inactive') {
+            return this.recordSkip(thread.threadUuid, sweptUpdatedAt);
         }
 
         let failureStage: AiAgentMemoryGenerationFailedEvent['properties']['failureStage'] =
@@ -589,6 +608,15 @@ export class AiAgentMemoryService extends BaseService {
                 organizationUuid: thread.organizationUuid,
                 threadUuid: thread.threadUuid,
             });
+            // Re-read: the status can flip while the LLM call is in flight, and
+            // the upsert would then insert a second active row.
+            if (
+                (await this.aiAgentMemoryModel.resolveSourceThreadMemoryState(
+                    thread.threadUuid,
+                )) === 'inactive'
+            ) {
+                return await this.recordSkip(thread.threadUuid, sweptUpdatedAt);
+            }
             const memory =
                 await this.aiAgentMemoryModel.upsertSourceThreadMemory({
                     organizationUuid: thread.organizationUuid,


### PR DESCRIPTION
Slice 1 of the AI agent memory consolidation stack.

A thread whose memory row is no longer `active` must stop feeding memory. The distill task now checks the thread's memory state alongside the other eligibility checks, and on a non-active row records a `skipped` ledger row and returns before any LLM call.

### What changed

- `AiAgentMemoryModel.resolveSourceThreadMemoryState(sourceThreadUuid)` — returns `'none' | 'active' | 'inactive'` from one `DISTINCT status` query on `ai_agent_memory`. An active row wins over stale siblings, because the one-active-row partial index leaves older non-active rows behind.
- `AiAgentMemoryService.runDistillThread` consults it inside the task body (after the cheap in-memory eligibility block, before the LLM call). On `'inactive'` it writes a `skipped` ledger row echoing the swept watermark (`distilledUpTo: sweptUpdatedAt`, `distillPromptHash: null`) and returns `'skipped'` — no LLM call.
- The status is re-read immediately before `upsertSourceThreadMemory`, so a flip that lands while the LLM call is in flight does not insert a second active row beside the row that replaced it.
- Both skip causes now share one `recordSkip` helper, so the ledger row has a single definition site.

Nothing was added to the sweep's SQL predicate — the ledger row is what stops the 3-hourly sweep re-enqueueing the thread, asserted directly against `findThreadsDueForDistill`.

### Behaviour

- Threads with an `active` memory row still re-distill in place (same uuid, same slug, telemetry preserved).
- Threads with no memory row still distill normally.
- Threads whose memory is `superseded` or `retired` are skipped permanently — the accepted consequence agreed in the spec.

This ships **inert** for consolidation: nothing produces a `superseded` row until the consolidation pass exists. The one live behaviour change today is for admin-retired memories, which now stop being re-distilled.

### Tests

- 3 unit tests on the service suite (skip path, active/none path, mid-distill status flip).
- 4 real-pg tests on the existing memory-model integration suite: `superseded` and `retired` via `it.each`, the active/no-row control, and a mixed active-beside-superseded case that pins the tie-break.

Verification: `pnpm -F backend typecheck:fast`, lint on the changed files, unit tests (23 passed), integration suite (24 passed against real pg).

Closes: ZAP-716
Relates: ZAP-715
