### PR TITLE
feat(data-apps): attach charts and dashboards by pasting a link

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -4429,8 +4429,9 @@ export class AppGenerateService extends BaseService {
      * itself — tabs, tile layout, filters.
      */
     private async resolveDashboardReference(
-        dashboardUuid: string,
+        dashboardUuidOrSlug: string,
         user: SessionUser,
+        projectUuid: string,
     ): Promise<{
         chartUuids: string[];
         dashboardName: string;
@@ -4438,7 +4439,8 @@ export class AppGenerateService extends BaseService {
     }> {
         const dashboard = await this.dashboardService.getByIdOrSlug(
             user,
-            dashboardUuid,
+            dashboardUuidOrSlug,
+            { projectUuid },
         );
         const chartUuids = dashboard.tiles
             .filter(isDashboardChartTileType)
@@ -4462,6 +4464,7 @@ export class AppGenerateService extends BaseService {
         charts: AppChartReference[] | undefined,
         dashboard: AppDashboardReference | undefined,
         user: SessionUser,
+        projectUuid: string,
     ): Promise<{
         refs: AppChartReference[];
         dashboardName: string | null;
@@ -4487,6 +4490,7 @@ export class AppGenerateService extends BaseService {
             const result = await this.resolveDashboardReference(
                 dashboard.uuid,
                 user,
+                projectUuid,
             );
             dashboardName = result.dashboardName;
             dashboardBlueprint = result.blueprint;
@@ -4569,6 +4573,7 @@ export class AppGenerateService extends BaseService {
     private async resolveChartReferences(
         chartRefs: AppChartReference[],
         user: SessionUser,
+        projectUuid: string,
     ): Promise<{
         references: ChartReference[];
         chartResources: AppVersionChartResource[];
@@ -4598,7 +4603,9 @@ export class AppGenerateService extends BaseService {
         const account = fromSession(user);
 
         const chartResults = await Promise.allSettled(
-            uuids.map((uuid) => this.savedChartService.get(uuid, account)),
+            uuids.map((uuid) =>
+                this.savedChartService.get(uuid, account, { projectUuid }),
+            ),
         );
 
         // Kick off sample fetches in parallel, only for charts that resolved
@@ -4744,7 +4751,12 @@ export class AppGenerateService extends BaseService {
             isVizTemplate
                 ? Promise.resolve(null)
                 : this.buildCatalogSummaryForClarifier(projectUuid),
-            this.buildAttachedResourcesForClarifier(charts, dashboard, user),
+            this.buildAttachedResourcesForClarifier(
+                charts,
+                dashboard,
+                user,
+                projectUuid,
+            ),
         ]);
         const imageCount = imageIds?.length ?? 0;
 
@@ -4855,6 +4867,7 @@ export class AppGenerateService extends BaseService {
         charts: AppChartReference[] | undefined,
         dashboard: AppDashboardReference | undefined,
         user: SessionUser,
+        projectUuid: string,
     ): Promise<{
         charts: { name: string; exploreName: string }[];
         dashboard: { name: string; structureSummary: string } | null;
@@ -4870,6 +4883,7 @@ export class AppGenerateService extends BaseService {
                 const result = await this.resolveDashboardReference(
                     dashboard.uuid,
                     user,
+                    projectUuid,
                 );
                 resolvedDashboard = {
                     name: result.dashboardName,
@@ -4889,7 +4903,9 @@ export class AppGenerateService extends BaseService {
         }
         const account = fromSession(user);
         const chartResults = await Promise.allSettled(
-            [...uuids].map((uuid) => this.savedChartService.get(uuid, account)),
+            [...uuids].map((uuid) =>
+                this.savedChartService.get(uuid, account, { projectUuid }),
+            ),
         );
         const resolvedCharts: { name: string; exploreName: string }[] = [];
         for (const result of chartResults) {
@@ -5065,12 +5081,17 @@ export class AppGenerateService extends BaseService {
         );
 
         const { refs, dashboardName, dashboardBlueprint } =
-            await this.collectChartReferences(charts, dashboard, user);
+            await this.collectChartReferences(
+                charts,
+                dashboard,
+                user,
+                projectUuid,
+            );
         const {
             references: chartReferences,
             chartResources,
             sampleStats,
-        } = await this.resolveChartReferences(refs, user);
+        } = await this.resolveChartReferences(refs, user, projectUuid);
         const externalConnectionResources =
             await this.resolveExternalConnectionResources(
                 user,
@@ -5257,12 +5278,17 @@ export class AppGenerateService extends BaseService {
         );
 
         const { refs, dashboardName, dashboardBlueprint } =
-            await this.collectChartReferences(charts, dashboard, user);
+            await this.collectChartReferences(
+                charts,
+                dashboard,
+                user,
+                projectUuid,
+            );
         const {
             references: chartReferences,
             chartResources,
             sampleStats,
-        } = await this.resolveChartReferences(refs, user);
+        } = await this.resolveChartReferences(refs, user, projectUuid);
 
         // Omitted designUuid means a normal content iteration that inherits
         // the app's current theme. Explicit string/null means "change the

--- a/packages/frontend/src/features/apps/AppResourcePicker.tsx
+++ b/packages/frontend/src/features/apps/AppResourcePicker.tsx
@@ -42,7 +42,13 @@ import {
     IconX,
 } from '@tabler/icons-react';
 import uniqBy from 'lodash/uniqBy';
-import { useCallback, useMemo, useState, type FC } from 'react';
+import {
+    useCallback,
+    useMemo,
+    useState,
+    type ClipboardEvent,
+    type FC,
+} from 'react';
 import { useParams } from 'react-router';
 import MantineIcon from '../../components/common/MantineIcon';
 import { ModelSelector } from '../../components/common/ModelSelector/ModelSelector';
@@ -54,6 +60,16 @@ import { useProject } from '../../hooks/useProject';
 import useApp from '../../providers/App/useApp';
 import { useExternalConnections } from '../externalConnections/hooks/useExternalConnections';
 import classes from './AppResourcePicker.module.css';
+import {
+    useAttachResourceLink,
+    type AttachableResourceType,
+    type AttachLinkOutcome,
+} from './hooks/useAttachResourceLink';
+
+type AttachFromLink = (
+    input: string,
+    accepts: AttachableResourceType,
+) => Promise<AttachLinkOutcome>;
 
 export type SelectedChart = {
     uuid: string;
@@ -271,6 +287,26 @@ export const ModelPicker: FC<{
 };
 
 /**
+ * Bound to paste rather than to every keystroke: a half-typed URL is still a
+ * syntactically valid link, so `onChange` would fire lookups for ids that
+ * don't exist yet. Clears the box on success, leaves the text on failure.
+ */
+const useLinkPasteHandler = (
+    attachFromLink: AttachFromLink,
+    accepts: AttachableResourceType,
+    setSearchQuery: (value: string) => void,
+) =>
+    useCallback(
+        async (event: ClipboardEvent<HTMLInputElement>) => {
+            const pasted = event.clipboardData.getData('text');
+            if ((await attachFromLink(pasted, accepts)) === 'attached') {
+                setSearchQuery('');
+            }
+        },
+        [attachFromLink, accepts, setSearchQuery],
+    );
+
+/**
  * Internal: chart list with search. Used inside `AttachButton`'s popover.
  * Selecting a chart adds it to the parent and keeps the picker open so
  * multiple can be added in one flow.
@@ -281,7 +317,17 @@ const QueryPickerView: FC<{
     onDeselect: (uuid: string) => void;
     onDone: () => void;
     enabled: boolean;
-}> = ({ selectedCharts, onSelect, onDeselect, onDone, enabled }) => {
+    attachFromLink: AttachFromLink;
+    isResolvingLink: boolean;
+}> = ({
+    selectedCharts,
+    onSelect,
+    onDeselect,
+    onDone,
+    enabled,
+    attachFromLink,
+    isResolvingLink,
+}) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const [searchQuery, setSearchQuery] = useState('');
     const [debouncedSearch] = useDebouncedValue(searchQuery, 300);
@@ -340,20 +386,27 @@ const QueryPickerView: FC<{
         [onSelect, onDeselect, selectedUuids],
     );
 
+    const handlePasteLink = useLinkPasteHandler(
+        attachFromLink,
+        'chart',
+        setSearchQuery,
+    );
+
     return (
         <>
             <Box px="xs" pb="xs">
                 <TextInput
                     size="xs"
-                    placeholder="Search queries..."
+                    placeholder="Search or paste a link..."
                     leftSection={<MantineIcon icon={IconSearch} size={14} />}
                     rightSection={
-                        isFetching && !isInitialLoading ? (
+                        (isFetching && !isInitialLoading) || isResolvingLink ? (
                             <Loader size={14} />
                         ) : undefined
                     }
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.currentTarget.value)}
+                    onPaste={(e) => void handlePasteLink(e)}
                     autoFocus
                 />
             </Box>
@@ -687,17 +740,27 @@ export const SelectedQuerySection: FC<{
 };
 
 /**
- * Internal: dashboard list with search. Used inside `AttachButton`'s
- * popover. Single-select: clicking a different dashboard replaces the
- * current one (and tells the parent to close the popover); clicking the
- * already-selected dashboard deselects and keeps the popover open.
+ * Internal: dashboard list with search. Interaction-identical to
+ * `QueryPickerView`; only the selection model differs — single-select, so
+ * picking a different dashboard replaces the current one.
  */
 const DashboardPickerView: FC<{
     selectedDashboard: SelectedDashboard | null;
     onSelect: (dashboard: SelectedDashboard) => void;
     onDeselect: () => void;
+    onDone: () => void;
     enabled: boolean;
-}> = ({ selectedDashboard, onSelect, onDeselect, enabled }) => {
+    attachFromLink: AttachFromLink;
+    isResolvingLink: boolean;
+}> = ({
+    selectedDashboard,
+    onSelect,
+    onDeselect,
+    onDone,
+    enabled,
+    attachFromLink,
+    isResolvingLink,
+}) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const [searchQuery, setSearchQuery] = useState('');
     const [debouncedSearch] = useDebouncedValue(searchQuery, 300);
@@ -728,15 +791,25 @@ const DashboardPickerView: FC<{
         [onSelect, onDeselect, selectedDashboard],
     );
 
+    const handlePasteLink = useLinkPasteHandler(
+        attachFromLink,
+        'dashboard',
+        setSearchQuery,
+    );
+
     return (
         <>
             <Box px="xs" pb="xs">
                 <TextInput
                     size="xs"
-                    placeholder="Search dashboards..."
+                    placeholder="Search or paste a link..."
                     leftSection={<MantineIcon icon={IconSearch} size={14} />}
+                    rightSection={
+                        isResolvingLink ? <Loader size={14} /> : undefined
+                    }
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.currentTarget.value)}
+                    onPaste={(e) => void handlePasteLink(e)}
                     autoFocus
                 />
             </Box>
@@ -785,6 +858,11 @@ const DashboardPickerView: FC<{
                     })
                 )}
             </ScrollArea.Autosize>
+            <Box className={classes.attachPickerFooter}>
+                <Button size="compact-xs" radius="md" onClick={onDone}>
+                    Done
+                </Button>
+            </Box>
         </>
     );
 };
@@ -986,6 +1064,7 @@ export const AttachButton: FC<{
     disabled,
     imagesDisabled,
 }) => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
     const [opened, setOpened] = useState(false);
     const [view, setView] = useState<AttachView>('menu');
 
@@ -994,14 +1073,11 @@ export const AttachButton: FC<{
         if (!isOpen) setView('menu');
     }, []);
 
-    const handleSelectDashboard = useCallback(
-        (dashboard: SelectedDashboard) => {
-            onSelectDashboard(dashboard);
-            setOpened(false);
-            setView('menu');
-        },
-        [onSelectDashboard],
-    );
+    const { attachFromLink, isResolvingLink } = useAttachResourceLink({
+        projectUuid,
+        onSelectChart,
+        onSelectDashboard,
+    });
 
     const handleImagesClick = useCallback(() => {
         setOpened(false);
@@ -1160,6 +1236,8 @@ export const AttachButton: FC<{
                                     setView('menu');
                                 }}
                                 enabled={opened}
+                                attachFromLink={attachFromLink}
+                                isResolvingLink={isResolvingLink}
                             />
                         ) : view === 'connections' ? (
                             <ConnectionPickerView
@@ -1175,9 +1253,15 @@ export const AttachButton: FC<{
                         ) : (
                             <DashboardPickerView
                                 selectedDashboard={selectedDashboard}
-                                onSelect={handleSelectDashboard}
+                                onSelect={onSelectDashboard}
                                 onDeselect={onDeselectDashboard}
+                                onDone={() => {
+                                    setOpened(false);
+                                    setView('menu');
+                                }}
                                 enabled={opened}
+                                attachFromLink={attachFromLink}
+                                isResolvingLink={isResolvingLink}
                             />
                         )}
                     </>

--- a/packages/frontend/src/features/apps/hooks/useAttachResourceLink.ts
+++ b/packages/frontend/src/features/apps/hooks/useAttachResourceLink.ts
@@ -1,0 +1,160 @@
+import {
+    ChartKind,
+    assertUnreachable,
+    getChartKind,
+    type ApiError,
+} from '@lightdash/common';
+import { useCallback, useState } from 'react';
+import { getDashboard } from '../../../hooks/dashboard/useDashboard';
+import useToaster from '../../../hooks/toaster/useToaster';
+import { getSavedQuery } from '../../../hooks/useSavedQuery';
+import {
+    type SelectedChart,
+    type SelectedDashboard,
+} from '../AppResourcePicker';
+import { parseResourceLink } from '../utils/parseResourceLink';
+
+/** `not-a-link` is ordinary text the caller should keep treating as a search
+ *  term; `rejected` was a link, and the user has been told why it didn't attach. */
+export type AttachLinkOutcome = 'attached' | 'rejected' | 'not-a-link';
+
+/** Which kind of link the calling picker accepts. */
+export type AttachableResourceType = 'chart' | 'dashboard';
+
+/**
+ * Resolves a pasted Lightdash link into an attachable data-app resource. Goes
+ * by uuid/slug, so it reaches content the pickers' name search cannot — most
+ * notably charts saved inside a dashboard, which content search omits.
+ */
+export const useAttachResourceLink = ({
+    projectUuid,
+    onSelectChart,
+    onSelectDashboard,
+}: {
+    projectUuid: string | undefined;
+    onSelectChart: (chart: SelectedChart) => void;
+    onSelectDashboard: (dashboard: SelectedDashboard) => void;
+}) => {
+    const { showToastError, showToastApiError } = useToaster();
+    const [isResolvingLink, setIsResolvingLink] = useState(false);
+
+    const attachFromLink = useCallback(
+        async (
+            input: string,
+            accepts: AttachableResourceType,
+        ): Promise<AttachLinkOutcome> => {
+            const link = parseResourceLink(input);
+            if (!link || !projectUuid) return 'not-a-link';
+
+            if (
+                (link.type === 'chart' || link.type === 'dashboard') &&
+                link.type !== accepts
+            ) {
+                showToastError({
+                    title:
+                        link.type === 'chart'
+                            ? "That's a chart link"
+                            : "That's a dashboard link",
+                    subtitle: `Attach it from the ${
+                        link.type === 'chart' ? 'Queries' : 'Dashboard'
+                    } menu instead.`,
+                });
+                return 'rejected';
+            }
+
+            switch (link.type) {
+                case 'shortLink':
+                    showToastError({
+                        title: "Short links can't be attached yet",
+                        subtitle:
+                            "Open the chart or dashboard and paste the URL from your browser's address bar instead.",
+                    });
+                    return 'rejected';
+                case 'exploreState':
+                    showToastError({
+                        title: 'That link points to an exploration',
+                        subtitle:
+                            'Only saved charts and dashboards can be attached. Save the chart first, then paste its link.',
+                    });
+                    return 'rejected';
+                case 'chart':
+                    if (link.projectUuid !== projectUuid) {
+                        showToastError({
+                            title: 'That chart is in a different project',
+                            subtitle:
+                                'Data apps can only use content from the project they are built in.',
+                        });
+                        return 'rejected';
+                    }
+                    setIsResolvingLink(true);
+                    try {
+                        const chart = await getSavedQuery(
+                            link.chartUuidOrSlug,
+                            projectUuid,
+                        );
+                        onSelectChart({
+                            uuid: chart.uuid,
+                            name: chart.name,
+                            chartKind:
+                                getChartKind(
+                                    chart.chartConfig.type,
+                                    chart.chartConfig.config,
+                                ) ?? ChartKind.VERTICAL_BAR,
+                            includeSampleData: false,
+                            linkLive: false,
+                        });
+                        return 'attached';
+                    } catch (e) {
+                        showToastApiError({
+                            title: "Couldn't attach that chart",
+                            apiError: (e as ApiError).error,
+                        });
+                        return 'rejected';
+                    } finally {
+                        setIsResolvingLink(false);
+                    }
+                case 'dashboard':
+                    if (link.projectUuid !== projectUuid) {
+                        showToastError({
+                            title: 'That dashboard is in a different project',
+                            subtitle:
+                                'Data apps can only use content from the project they are built in.',
+                        });
+                        return 'rejected';
+                    }
+                    setIsResolvingLink(true);
+                    try {
+                        const dashboard = await getDashboard(
+                            link.dashboardUuidOrSlug,
+                            projectUuid,
+                        );
+                        onSelectDashboard({
+                            uuid: dashboard.uuid,
+                            name: dashboard.name,
+                            includeSampleData: false,
+                        });
+                        return 'attached';
+                    } catch (e) {
+                        showToastApiError({
+                            title: "Couldn't attach that dashboard",
+                            apiError: (e as ApiError).error,
+                        });
+                        return 'rejected';
+                    } finally {
+                        setIsResolvingLink(false);
+                    }
+                default:
+                    return assertUnreachable(link, 'Unknown resource link');
+            }
+        },
+        [
+            projectUuid,
+            onSelectChart,
+            onSelectDashboard,
+            showToastError,
+            showToastApiError,
+        ],
+    );
+
+    return { attachFromLink, isResolvingLink };
+};

--- a/packages/frontend/src/features/apps/utils/parseResourceLink.test.ts
+++ b/packages/frontend/src/features/apps/utils/parseResourceLink.test.ts
@@ -1,0 +1,63 @@
+import { parseResourceLink } from './parseResourceLink';
+
+const PROJECT = '3675b69e-8324-4110-bdca-059031aa8da3';
+const DASHBOARD = '0f254e64-e553-4cfb-90fd-d9779815e75c';
+const CHART = '11263a0c-ff19-4cf4-9b04-3656fdaa5a0f';
+
+it('parses a dashboard link past its tab path and filter params', () => {
+    expect(
+        parseResourceLink(
+            `https://app.lightdash.cloud/projects/${PROJECT}/dashboards/${DASHBOARD}/view/tabs/tab-1?filters=abc`,
+        ),
+    ).toEqual({
+        type: 'dashboard',
+        projectUuid: PROJECT,
+        dashboardUuidOrSlug: DASHBOARD,
+    });
+});
+
+// The only URL a chart saved inside a dashboard has — the case that name
+// search can't reach at all.
+it('parses the edit link of a chart saved within a dashboard', () => {
+    expect(
+        parseResourceLink(
+            `https://app.lightdash.cloud/projects/${PROJECT}/saved/${CHART}/edit?fromDashboard=${DASHBOARD}`,
+        ),
+    ).toEqual({
+        type: 'chart',
+        projectUuid: PROJECT,
+        chartUuidOrSlug: CHART,
+    });
+});
+
+it('parses a bare path and the /minimal variant', () => {
+    expect(parseResourceLink(`/projects/${PROJECT}/saved/${CHART}`)).toEqual({
+        type: 'chart',
+        projectUuid: PROJECT,
+        chartUuidOrSlug: CHART,
+    });
+    expect(
+        parseResourceLink(`/minimal/projects/${PROJECT}/dashboards/my-slug`),
+    ).toEqual({
+        type: 'dashboard',
+        projectUuid: PROJECT,
+        dashboardUuidOrSlug: 'my-slug',
+    });
+});
+
+it('flags links that are recognised but not attachable', () => {
+    expect(
+        parseResourceLink('https://app.lightdash.cloud/share/AbCdEf12'),
+    ).toEqual({ type: 'shortLink' });
+    expect(
+        parseResourceLink(
+            `https://app.lightdash.cloud/projects/${PROJECT}/tables/orders?create_saved_chart_version=%7B%7D`,
+        ),
+    ).toEqual({ type: 'exploreState' });
+});
+
+it('returns null for search terms and for listing pages without an id', () => {
+    expect(parseResourceLink('revenue per payment method')).toBeNull();
+    expect(parseResourceLink('')).toBeNull();
+    expect(parseResourceLink(`/projects/${PROJECT}/dashboards`)).toBeNull();
+});

--- a/packages/frontend/src/features/apps/utils/parseResourceLink.ts
+++ b/packages/frontend/src/features/apps/utils/parseResourceLink.ts
@@ -1,0 +1,54 @@
+/**
+ * Parses a copy-pasted Lightdash URL into the resource it points at. Returns
+ * null for anything else, so callers can fall back to treating it as text.
+ */
+export type ParsedResourceLink =
+    | {
+          type: 'chart';
+          projectUuid: string;
+          chartUuidOrSlug: string;
+      }
+    | {
+          type: 'dashboard';
+          projectUuid: string;
+          dashboardUuidOrSlug: string;
+      }
+    // Recognised but not attachable: a short link needs a server round-trip to
+    // expand, and an explore URL carries unsaved query state, not a chart.
+    | { type: 'shortLink' }
+    | { type: 'exploreState' };
+
+const RESOURCE_PATH =
+    /^(?:\/minimal)?\/projects\/([^/]+)\/(saved|dashboards)\/([^/?#]+)/;
+const EXPLORE_PATH = /^(?:\/minimal)?\/projects\/[^/]+\/tables(?:\/|$)/;
+const SHORT_LINK_PATH = /^\/share\/[^/?#]+/;
+
+// Lets a bare path parse the same way as a link copied from any Lightdash host.
+const PLACEHOLDER_ORIGIN = 'https://lightdash.invalid';
+
+export const parseResourceLink = (input: string): ParsedResourceLink | null => {
+    const trimmed = input.trim();
+    if (!trimmed) return null;
+
+    let pathname: string;
+    try {
+        pathname = new URL(trimmed, PLACEHOLDER_ORIGIN).pathname;
+    } catch {
+        return null;
+    }
+
+    const resource = RESOURCE_PATH.exec(pathname);
+    if (resource) {
+        const [, projectUuid, contentType, uuidOrSlug] = resource;
+        return contentType === 'saved'
+            ? { type: 'chart', projectUuid, chartUuidOrSlug: uuidOrSlug }
+            : {
+                  type: 'dashboard',
+                  projectUuid,
+                  dashboardUuidOrSlug: uuidOrSlug,
+              };
+    }
+    if (EXPLORE_PATH.test(pathname)) return { type: 'exploreState' };
+    if (SHORT_LINK_PATH.test(pathname)) return { type: 'shortLink' };
+    return null;
+};

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -3073,10 +3073,17 @@ const AppGenerate: FC = () => {
                                                     }
                                                     onSelectChart={(chart) =>
                                                         setSelectedCharts(
-                                                            (prev) => [
-                                                                ...prev,
-                                                                chart,
-                                                            ],
+                                                            (prev) =>
+                                                                prev.some(
+                                                                    (c) =>
+                                                                        c.uuid ===
+                                                                        chart.uuid,
+                                                                )
+                                                                    ? prev
+                                                                    : [
+                                                                          ...prev,
+                                                                          chart,
+                                                                      ],
                                                         )
                                                     }
                                                     onDeselectChart={(uuid) =>


### PR DESCRIPTION
Pasting a Lightdash chart or dashboard URL into the data-app attach picker now attaches that resource, instead of only being able to search by name.

Because it resolves by uuid/slug, it also reaches charts saved inside a dashboard — those are missing from the content search the picker lists from.

Attached charts and dashboards are now scoped to the app's project server-side, since a pasted link can point anywhere.

Closes: https://linear.app/lightdash/issue/PROD-8843/data-apps-reference-dashboardscharts-via-copy-pasted-links