### PR TITLE
feat(data-apps): add a typed config-option contract for data app vizzes

### DIFF
--- a/packages/common/src/ee/apps/dataAppVizConfigOptions.ts
+++ b/packages/common/src/ee/apps/dataAppVizConfigOptions.ts
@@ -1,0 +1,54 @@
+// Leaf module: the data app viz config-option vocabulary. Kept free of any
+// import so both `ee/apps/types.ts` and `types/savedCharts.ts` can depend on it
+// without forming a cycle.
+
+export type DataAppVizConfigOptionType =
+    | 'boolean'
+    | 'select'
+    | 'number'
+    | 'text'
+    | 'color';
+
+// A whole-viz config option rendered as a form control; `group` is an optional tab label.
+export type DataAppVizConfigOption =
+    | {
+          type: 'boolean';
+          name: string;
+          label: string;
+          group?: string;
+          default: boolean;
+      }
+    | {
+          type: 'select';
+          name: string;
+          label: string;
+          group?: string;
+          choices: { value: string; label: string }[];
+          default: string;
+      }
+    | {
+          type: 'number';
+          name: string;
+          label: string;
+          group?: string;
+          default: number;
+          min?: number;
+          max?: number;
+      }
+    | {
+          type: 'text';
+          name: string;
+          label: string;
+          group?: string;
+          default: string;
+      }
+    | {
+          type: 'color';
+          name: string;
+          label: string;
+          group?: string;
+          default: string;
+      };
+
+/** A persisted config value; its shape is set by the option's declared `type`. */
+export type DataAppVizOptionValue = boolean | number | string;

--- a/packages/common/src/ee/apps/types.test.ts
+++ b/packages/common/src/ee/apps/types.test.ts
@@ -4,6 +4,7 @@ import {
     getVisibleDataAppClaudeModels,
     resolveDefaultVisibleDataAppClaudeModel,
     type DataAppVizConfigOption,
+    type DataAppVizOptionValue,
 } from './types';
 
 const validFields = {
@@ -116,15 +117,25 @@ describe('dataAppVizSchema', () => {
                     type: 'color',
                     default: '#7262ff',
                 },
-                {
-                    name: 'palette',
-                    label: 'Palette',
-                    type: 'palette',
-                    default: ['#111', '#222'],
-                },
             ],
         });
         expect(r.success).toBe(true);
+    });
+
+    it('rejects an option whose type is outside the declared vocabulary', () => {
+        expect(
+            dataAppVizSchema.safeParse({
+                fields: [],
+                configOptions: [
+                    {
+                        name: 'series',
+                        label: 'Series colours',
+                        type: 'palette',
+                        default: ['#111', '#222'],
+                    },
+                ],
+            }).success,
+        ).toBe(false);
     });
 
     it('rejects a boolean option with a non-boolean default', () => {
@@ -188,6 +199,71 @@ describe('getEffectiveOptionValues', () => {
                 { gone: 5, a: true },
             ),
         ).toEqual({ a: true });
+    });
+
+    it('ignores a stored value whose shape no longer matches the declared type', () => {
+        const declared: DataAppVizConfigOption[] = [
+            {
+                name: 'showLegend',
+                label: 'Show legend',
+                type: 'boolean',
+                default: true,
+            },
+            { name: 'maxBars', label: 'Max bars', type: 'number', default: 10 },
+            { name: 'title', label: 'Title', type: 'text', default: 'Sales' },
+            {
+                name: 'barColor',
+                label: 'Bar colour',
+                type: 'color',
+                default: '#7162FF',
+            },
+            {
+                name: 'layout',
+                label: 'Layout',
+                type: 'select',
+                choices: [
+                    { value: 'vertical', label: 'Vertical' },
+                    { value: 'horizontal', label: 'Horizontal' },
+                ],
+                default: 'vertical',
+            },
+        ];
+
+        // Each stored value was written under the same name by a declaration
+        // that gave the option a different type.
+        expect(
+            getEffectiveOptionValues(declared, {
+                showLegend: 'yes',
+                maxBars: '24',
+                title: 12,
+                // Stored values are untyped JSONB, so a shape the value type no
+                // longer allows can still be sitting in the column.
+                barColor: ['#7162FF'] as unknown as DataAppVizOptionValue,
+                layout: 24,
+            }),
+        ).toEqual({
+            showLegend: true,
+            maxBars: 10,
+            title: 'Sales',
+            barColor: '#7162FF',
+            layout: 'vertical',
+        });
+    });
+
+    it('ignores a stored select value that is no longer a declared choice', () => {
+        const declared: DataAppVizConfigOption[] = [
+            {
+                name: 'layout',
+                label: 'Layout',
+                type: 'select',
+                choices: [{ value: 'vertical', label: 'Vertical' }],
+                default: 'vertical',
+            },
+        ];
+
+        expect(
+            getEffectiveOptionValues(declared, { layout: 'horizontal' }),
+        ).toEqual({ layout: 'vertical' });
     });
 });
 

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -14,6 +14,17 @@ import {
 import { type MetricQuery } from '../../types/metricQuery';
 import { type DashboardParameters } from '../../types/parameters';
 import { type ChartConfig, type SavedChart } from '../../types/savedCharts';
+import assertUnreachable from '../../utils/assertUnreachable';
+import {
+    type DataAppVizConfigOption,
+    type DataAppVizOptionValue,
+} from './dataAppVizConfigOptions';
+
+export type {
+    DataAppVizConfigOption,
+    DataAppVizConfigOptionType,
+    DataAppVizOptionValue,
+} from './dataAppVizConfigOptions';
 
 /**
  * Ordered pipeline stages. Index position determines progression — used to
@@ -593,65 +604,6 @@ export type DataAppVizField = {
     required: boolean;
 };
 
-export type DataAppVizConfigOptionType =
-    | 'boolean'
-    | 'select'
-    | 'number'
-    | 'text'
-    | 'color'
-    | 'palette';
-
-// A whole-viz config option rendered as a form control; `group` is an optional tab label.
-export type DataAppVizConfigOption =
-    | {
-          type: 'boolean';
-          name: string;
-          label: string;
-          group?: string;
-          default: boolean;
-      }
-    | {
-          type: 'select';
-          name: string;
-          label: string;
-          group?: string;
-          choices: { value: string; label: string }[];
-          default: string;
-      }
-    | {
-          type: 'number';
-          name: string;
-          label: string;
-          group?: string;
-          default: number;
-          min?: number;
-          max?: number;
-      }
-    | {
-          type: 'text';
-          name: string;
-          label: string;
-          group?: string;
-          default: string;
-      }
-    | {
-          type: 'color';
-          name: string;
-          label: string;
-          group?: string;
-          default: string;
-      }
-    | {
-          type: 'palette';
-          name: string;
-          label: string;
-          group?: string;
-          default: string[];
-      };
-
-/** A persisted config value; its shape is set by the option's declared `type`. */
-export type DataAppVizOptionValue = boolean | number | string | string[];
-
 /** The full declaration a data app viz emits: data-binding fields + config form. */
 export type DataAppVizSchema = {
     fields: DataAppVizField[];
@@ -715,11 +667,6 @@ export const dataAppVizSchema = z.object({
                     type: z.literal('color'),
                     default: z.string(),
                 }),
-                z.object({
-                    ...optionBase,
-                    type: z.literal('palette'),
-                    default: z.array(z.string()),
-                }),
             ]),
         )
         .default([])
@@ -744,13 +691,54 @@ void dataAppVizSchemaMatchesApiType;
 // enforced by the runtime `safeParse`.
 export const dataAppVizJsonSchema = zodToJsonSchema(dataAppVizSchema);
 
-/** Effective option values = stored value ?? declared default (derive, never seed). */
+/** Whether a stored value still has the shape the option declares. */
+const matchesDeclaredType = (
+    option: DataAppVizConfigOption,
+    value: DataAppVizOptionValue,
+): boolean => {
+    switch (option.type) {
+        case 'boolean':
+            return typeof value === 'boolean';
+        case 'number':
+            return typeof value === 'number';
+        case 'select':
+            // A choice dropped by a regeneration is as stale as a wrong type.
+            return option.choices.some((choice) => choice.value === value);
+        case 'text':
+        case 'color':
+            return typeof value === 'string';
+        default:
+            return assertUnreachable(
+                option,
+                'Unknown data app viz config option type',
+            );
+    }
+};
+
+/**
+ * Effective value of one option: the stored value, or the declared default when
+ * nothing is stored or the stored value no longer matches the declared type —
+ * stored values are untyped JSONB and a regeneration can change an option's
+ * type (derive, never seed).
+ */
+export const getEffectiveOptionValue = <T extends DataAppVizConfigOption>(
+    option: T,
+    storedValue: DataAppVizOptionValue | undefined,
+): T['default'] =>
+    storedValue !== undefined && matchesDeclaredType(option, storedValue)
+        ? (storedValue as T['default'])
+        : option.default;
+
+/** Effective values for every declared option. */
 export const getEffectiveOptionValues = (
     configOptions: DataAppVizConfigOption[],
     optionValues: Record<string, DataAppVizOptionValue>,
 ): Record<string, DataAppVizOptionValue> =>
     Object.fromEntries(
-        configOptions.map((o) => [o.name, optionValues[o.name] ?? o.default]),
+        configOptions.map((o) => [
+            o.name,
+            getEffectiveOptionValue(o, optionValues[o.name]),
+        ]),
     );
 
 // A reusable, by-reference data app viz: a single-tile data app that declares a

--- a/packages/common/src/schemas/json/chart-as-code-1.0.json
+++ b/packages/common/src/schemas/json/chart-as-code-1.0.json
@@ -1068,6 +1068,10 @@
                 },
                 "fieldMapping": {
                     "$ref": "#/$defs/DataAppVizFieldMapping"
+                },
+                "optionValues": {
+                    "$ref": "#/$defs/DataAppVizOptionValues",
+                    "description": "Only options the user explicitly changed — declared defaults are never\nseeded here, they're resolved at render time. Absent on charts saved\nbefore config options shipped."
                 }
             },
             "required": ["fieldMapping", "dataAppVizUuid"],
@@ -1090,6 +1094,25 @@
         "DataAppVizFieldMapping": {
             "$ref": "#/$defs/Record_string.string_",
             "description": "Maps a data app viz's field name → the host query field id bound to it."
+        },
+        "DataAppVizOptionValue": {
+            "anyOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "format": "double",
+                    "type": "number"
+                },
+                {
+                    "type": "string"
+                }
+            ],
+            "description": "A persisted config value; its shape is set by the option's declared `type`."
+        },
+        "DataAppVizOptionValues": {
+            "$ref": "#/$defs/Record_string.DataAppVizOptionValue_",
+            "description": "Maps a declared config option's name → the value the user chose for it."
         },
         "DimensionOverrides": {
             "additionalProperties": {
@@ -2581,6 +2604,14 @@
         "Record_string.ColumnProperties_": {
             "additionalProperties": {
                 "$ref": "#/$defs/ColumnProperties"
+            },
+            "description": "Construct a type with a set of properties K of type T",
+            "properties": {},
+            "type": "object"
+        },
+        "Record_string.DataAppVizOptionValue_": {
+            "additionalProperties": {
+                "$ref": "#/$defs/DataAppVizOptionValue"
             },
             "description": "Construct a type with a set of properties K of type T",
             "properties": {},

--- a/packages/common/src/types/savedCharts.test.ts
+++ b/packages/common/src/types/savedCharts.test.ts
@@ -158,6 +158,7 @@ describe('ChartType.DATA_APP_VIZ variant', () => {
         config: {
             dataAppVizUuid: 'data-app-viz-1',
             fieldMapping: { category: 'orders_status', value: 'orders_count' },
+            optionValues: { showLegend: false, barColor: '#ff0000' },
         },
     };
 
@@ -174,6 +175,15 @@ describe('ChartType.DATA_APP_VIZ variant', () => {
         expect(isDataAppVizChart(dataAppVizConfig.config)).toBe(true);
         expect(isDataAppVizChart({ spec: {} })).toBe(false);
         expect(isDataAppVizChart(undefined)).toBe(false);
+    });
+
+    it('isDataAppVizChart still matches charts saved without optionValues', () => {
+        expect(
+            isDataAppVizChart({
+                dataAppVizUuid: 'data-app-viz-1',
+                fieldMapping: {},
+            }),
+        ).toBe(true);
     });
 
     it('is not misclassified as a table config', () => {

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -1,3 +1,4 @@
+import { type DataAppVizOptionValue } from '../ee/apps/dataAppVizConfigOptions';
 import assertUnreachable from '../utils/assertUnreachable';
 import { type ViewStatistics } from './analytics';
 import { type DateZoom } from './api/paginatedQuery';
@@ -785,10 +786,19 @@ export type CustomVis = {
 /** Maps a data app viz's field name → the host query field id bound to it. */
 export type DataAppVizFieldMapping = Record<string, string>;
 
+/** Maps a declared config option's name → the value the user chose for it. */
+export type DataAppVizOptionValues = Record<string, DataAppVizOptionValue>;
+
 export type DataAppVizChart = {
     /** The reusable data app viz this chart renders with (by reference). */
     dataAppVizUuid: string;
     fieldMapping: DataAppVizFieldMapping;
+    /**
+     * Only options the user explicitly changed — declared defaults are never
+     * seeded here, they're resolved at render time. Absent on charts saved
+     * before config options shipped.
+     */
+    optionValues?: DataAppVizOptionValues;
 };
 
 export type CartesianChart = {


### PR DESCRIPTION
The typed vocabulary a data app viz uses to declare its config options, plus where the chosen values are stored on a chart.

Five option types: boolean, select, number, text, colour. Values live on `optionValues` next to `fieldMapping` in the existing `chart_config` JSONB, so there's no migration.

Only options the user explicitly changed are stored. Declared defaults resolve at render time, which is what makes regeneration latest-wins for free: a stored value whose shape no longer matches its declared type falls back to the default.

Types and pure functions only. Nothing renders or stores an option yet.

https://linear.app/lightdash/issue/GLITCH-563/generated-config-form-viz-declares-typed-config-options-colours-layout