### PR TITLE
feat(data-apps): edit and store one data app viz config option

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizOptionControl.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizOptionControl.test.tsx
@@ -1,0 +1,110 @@
+import { type DataAppVizConfigOption } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import DataAppVizOptionControl from './DataAppVizOptionControl';
+
+const textOption: DataAppVizConfigOption = {
+    name: 'title',
+    label: 'Title',
+    type: 'text',
+    default: 'Untitled',
+};
+
+describe('DataAppVizOptionControl', () => {
+    it('debounces text edits rather than pushing every keystroke', async () => {
+        vi.useFakeTimers();
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        const onChange = vi.fn();
+
+        renderWithProviders(
+            <DataAppVizOptionControl
+                option={textOption}
+                value="Untitled"
+                onChange={onChange}
+            />,
+        );
+
+        await user.clear(screen.getByLabelText('Title'));
+        await user.type(screen.getByLabelText('Title'), 'Revenue');
+
+        expect(onChange).not.toHaveBeenCalledWith('Revenue');
+        await vi.advanceTimersByTimeAsync(250);
+        expect(onChange).toHaveBeenCalledWith('Revenue');
+
+        vi.useRealTimers();
+    });
+
+    it('flushes a pending text edit when the control unmounts', async () => {
+        vi.useFakeTimers();
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        const onChange = vi.fn();
+
+        const { unmount } = renderWithProviders(
+            <DataAppVizOptionControl
+                option={textOption}
+                value="Untitled"
+                onChange={onChange}
+            />,
+        );
+
+        await user.clear(screen.getByLabelText('Title'));
+        await user.type(screen.getByLabelText('Title'), 'Revenue');
+        expect(onChange).not.toHaveBeenCalledWith('Revenue');
+
+        // Closing the config panel mid-edit must not silently drop the change.
+        unmount();
+        expect(onChange).toHaveBeenCalledWith('Revenue');
+
+        vi.useRealTimers();
+    });
+
+    it('shows an externally changed value once the pending edit has landed', async () => {
+        vi.useFakeTimers();
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        const onChange = vi.fn();
+
+        const { rerender } = renderWithProviders(
+            <DataAppVizOptionControl
+                option={textOption}
+                value="Untitled"
+                onChange={onChange}
+            />,
+        );
+
+        await user.clear(screen.getByLabelText('Title'));
+        await user.type(screen.getByLabelText('Title'), 'Revenue');
+        await vi.advanceTimersByTimeAsync(250);
+        expect(onChange).toHaveBeenCalledWith('Revenue');
+
+        // A landed draft must not go on masking what the caller stores next.
+        rerender(
+            <DataAppVizOptionControl
+                option={textOption}
+                value="Reset by the caller"
+                onChange={onChange}
+            />,
+        );
+
+        expect(screen.getByLabelText('Title')).toHaveValue(
+            'Reset by the caller',
+        );
+
+        vi.useRealTimers();
+    });
+
+    it('falls back to the declared default when the stored value has the wrong shape', () => {
+        const onChange = vi.fn();
+
+        renderWithProviders(
+            <DataAppVizOptionControl
+                option={textOption}
+                value={42}
+                onChange={onChange}
+            />,
+        );
+
+        expect(screen.getByLabelText('Title')).toHaveValue('Untitled');
+    });
+});

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizOptionControl.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizOptionControl.tsx
@@ -1,0 +1,194 @@
+import {
+    assertUnreachable,
+    getEffectiveOptionValue,
+    type DataAppVizConfigOption,
+    type DataAppVizOptionValue,
+} from '@lightdash/common';
+import { Select, Switch, TextInput } from '@mantine-8/core';
+import { useDebouncedCallback } from '@mantine-8/hooks';
+import { useState, type FC } from 'react';
+import { NumberInput } from '../../common/NumberInput';
+import ColorSelector from '../ColorSelector';
+import { Config } from '../common/Config';
+
+// Free-text and colour edits fire continuously while typing / dragging, so
+// they're debounced before reaching chart state (and the iframe re-render).
+const OPTION_DEBOUNCE_MS = 200;
+
+type OptionOfType<T extends DataAppVizConfigOption['type']> = Extract<
+    DataAppVizConfigOption,
+    { type: T }
+>;
+
+/**
+ * Holds the in-flight edit while the debounce is pending, then hands back to
+ * the prop once it lands — the same `draft ?? value` discipline ColorSelector
+ * uses, so an externally changed `value` is never masked by a stale draft.
+ */
+const usePendingEdit = <T extends DataAppVizOptionValue>(
+    value: T,
+    onChange: (value: T) => void,
+) => {
+    const [pending, setPending] = useState<T | null>(null);
+    const flushChange = useDebouncedCallback(
+        (next: T) => {
+            onChange(next);
+            setPending(null);
+        },
+        { delay: OPTION_DEBOUNCE_MS, flushOnUnmount: true },
+    );
+
+    return {
+        current: pending ?? value,
+        edit: (next: T) => {
+            setPending(next);
+            flushChange(next);
+        },
+    };
+};
+
+const BooleanOptionControl: FC<{
+    option: OptionOfType<'boolean'>;
+    value: boolean;
+    onChange: (value: boolean) => void;
+}> = ({ option, value, onChange }) => (
+    <Config.Group>
+        <Config.Label>{option.label}</Config.Label>
+        <Switch
+            size="xs"
+            aria-label={option.label}
+            checked={value}
+            onChange={(event) => onChange(event.currentTarget.checked)}
+        />
+    </Config.Group>
+);
+
+const SelectOptionControl: FC<{
+    option: OptionOfType<'select'>;
+    value: string;
+    onChange: (value: string) => void;
+}> = ({ option, value, onChange }) => (
+    <Select
+        size="xs"
+        label={option.label}
+        data={option.choices}
+        value={value}
+        allowDeselect={false}
+        onChange={(next) => onChange(next ?? option.default)}
+    />
+);
+
+const NumberOptionControl: FC<{
+    option: OptionOfType<'number'>;
+    value: number;
+    onChange: (value: number) => void;
+}> = ({ option, value, onChange }) => (
+    <NumberInput
+        size="xs"
+        label={option.label}
+        value={value}
+        min={option.min}
+        max={option.max}
+        decimalScale="unlimited"
+        onNumberChange={(next) => onChange(next ?? option.default)}
+    />
+);
+
+const TextOptionControl: FC<{
+    option: OptionOfType<'text'>;
+    value: string;
+    onChange: (value: string) => void;
+}> = ({ option, value, onChange }) => {
+    const draft = usePendingEdit(value, onChange);
+    return (
+        <TextInput
+            size="xs"
+            label={option.label}
+            value={draft.current}
+            onChange={(event) => draft.edit(event.currentTarget.value)}
+        />
+    );
+};
+
+const ColorOptionControl: FC<{
+    option: OptionOfType<'color'>;
+    value: string;
+    onChange: (value: string) => void;
+}> = ({ option, value, onChange }) => {
+    const draft = usePendingEdit(value, onChange);
+    return (
+        <Config.Group>
+            <Config.Label>{option.label}</Config.Label>
+            <ColorSelector
+                color={draft.current}
+                swatches={[]}
+                ariaLabel={option.label}
+                onColorChange={draft.edit}
+            />
+        </Config.Group>
+    );
+};
+
+type Props = {
+    option: DataAppVizConfigOption;
+    /** Effective value: the stored value, or the declared default. */
+    value: DataAppVizOptionValue;
+    onChange: (value: DataAppVizOptionValue) => void;
+};
+
+/**
+ * Renders one declared config option as a native control. Stored values come
+ * from untyped JSONB, so the same resolver the host pushes into the iframe
+ * decides what each control shows.
+ */
+const DataAppVizOptionControl: FC<Props> = ({ option, value, onChange }) => {
+    switch (option.type) {
+        case 'boolean':
+            return (
+                <BooleanOptionControl
+                    option={option}
+                    value={getEffectiveOptionValue(option, value)}
+                    onChange={onChange}
+                />
+            );
+        case 'select':
+            return (
+                <SelectOptionControl
+                    option={option}
+                    value={getEffectiveOptionValue(option, value)}
+                    onChange={onChange}
+                />
+            );
+        case 'number':
+            return (
+                <NumberOptionControl
+                    option={option}
+                    value={getEffectiveOptionValue(option, value)}
+                    onChange={onChange}
+                />
+            );
+        case 'text':
+            return (
+                <TextOptionControl
+                    option={option}
+                    value={getEffectiveOptionValue(option, value)}
+                    onChange={onChange}
+                />
+            );
+        case 'color':
+            return (
+                <ColorOptionControl
+                    option={option}
+                    value={getEffectiveOptionValue(option, value)}
+                    onChange={onChange}
+                />
+            );
+        default:
+            return assertUnreachable(
+                option,
+                'Unknown data app viz config option type',
+            );
+    }
+};
+
+export default DataAppVizOptionControl;

--- a/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.test.ts
+++ b/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.test.ts
@@ -1,0 +1,216 @@
+import { type DataAppVizChart } from '@lightdash/common';
+import { act, renderHook } from '@testing-library/react';
+import { StrictMode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import useDataAppVizVisualizationConfig from './useDataAppVizVisualizationConfig';
+
+const initialConfig: DataAppVizChart = {
+    dataAppVizUuid: 'viz-1',
+    fieldMapping: { category: 'orders_status' },
+    optionValues: { showLegend: false },
+};
+
+describe('useDataAppVizVisualizationConfig', () => {
+    it('starts from the saved option values', () => {
+        const { result } = renderHook(() =>
+            useDataAppVizVisualizationConfig(initialConfig),
+        );
+
+        expect(result.current.optionValues).toEqual({ showLegend: false });
+        expect(result.current.validConfig.optionValues).toEqual({
+            showLegend: false,
+        });
+    });
+
+    it('defaults to an empty option map when nothing is saved', () => {
+        const { result } = renderHook(() =>
+            useDataAppVizVisualizationConfig({
+                dataAppVizUuid: 'viz-1',
+                fieldMapping: {},
+            }),
+        );
+
+        expect(result.current.optionValues).toEqual({});
+    });
+
+    it('stores only explicitly set options and pushes them up', () => {
+        const onConfigChange = vi.fn();
+        const { result } = renderHook(() =>
+            useDataAppVizVisualizationConfig(initialConfig, onConfigChange),
+        );
+
+        act(() => result.current.setOption('viz-1', 'barColor', '#ff0000'));
+
+        expect(result.current.optionValues).toEqual({
+            showLegend: false,
+            barColor: '#ff0000',
+        });
+        expect(onConfigChange).toHaveBeenCalledWith({
+            dataAppVizUuid: 'viz-1',
+            fieldMapping: { category: 'orders_status' },
+            optionValues: { showLegend: false, barColor: '#ff0000' },
+        });
+    });
+
+    it('keeps both option edits when two controls flush in the same commit', () => {
+        const onConfigChange = vi.fn();
+        const { result } = renderHook(() =>
+            useDataAppVizVisualizationConfig(initialConfig, onConfigChange),
+        );
+
+        // Closing the config panel flushes every pending debounced control
+        // synchronously, with no re-render between them.
+        act(() => {
+            result.current.setOption('viz-1', 'barColor', '#ff0000');
+            result.current.setOption('viz-1', 'title', 'Revenue');
+        });
+
+        expect(result.current.optionValues).toEqual({
+            showLegend: false,
+            barColor: '#ff0000',
+            title: 'Revenue',
+        });
+        expect(onConfigChange).toHaveBeenLastCalledWith({
+            dataAppVizUuid: 'viz-1',
+            fieldMapping: { category: 'orders_status' },
+            optionValues: {
+                showLegend: false,
+                barColor: '#ff0000',
+                title: 'Revenue',
+            },
+        });
+    });
+
+    it('keeps both field edits when two selects change in the same commit', () => {
+        const onConfigChange = vi.fn();
+        const { result } = renderHook(() =>
+            useDataAppVizVisualizationConfig(initialConfig, onConfigChange),
+        );
+
+        act(() => {
+            result.current.setField('value', 'orders_count');
+            result.current.setField('series', 'orders_channel');
+        });
+
+        expect(result.current.fieldMapping).toEqual({
+            category: 'orders_status',
+            value: 'orders_count',
+            series: 'orders_channel',
+        });
+        expect(onConfigChange).toHaveBeenLastCalledWith({
+            dataAppVizUuid: 'viz-1',
+            fieldMapping: {
+                category: 'orders_status',
+                value: 'orders_count',
+                series: 'orders_channel',
+            },
+            optionValues: { showLegend: false },
+        });
+    });
+
+    it('keeps option values when only a field mapping changes', () => {
+        const onConfigChange = vi.fn();
+        const { result } = renderHook(() =>
+            useDataAppVizVisualizationConfig(initialConfig, onConfigChange),
+        );
+
+        act(() => result.current.setField('value', 'orders_count'));
+
+        expect(onConfigChange).toHaveBeenCalledWith({
+            dataAppVizUuid: 'viz-1',
+            fieldMapping: {
+                category: 'orders_status',
+                value: 'orders_count',
+            },
+            optionValues: { showLegend: false },
+        });
+    });
+
+    it('clears option values when the viz is switched', () => {
+        const onConfigChange = vi.fn();
+        const { result } = renderHook(() =>
+            useDataAppVizVisualizationConfig(initialConfig, onConfigChange),
+        );
+
+        act(() => result.current.setDataAppVizUuid('viz-2'));
+
+        expect(result.current.optionValues).toEqual({});
+        expect(onConfigChange).toHaveBeenCalledWith({
+            dataAppVizUuid: 'viz-2',
+            fieldMapping: {},
+            optionValues: {},
+        });
+    });
+
+    it('drops a late option edit belonging to a viz that is no longer selected', () => {
+        const onConfigChange = vi.fn();
+        const { result } = renderHook(() =>
+            useDataAppVizVisualizationConfig(initialConfig, onConfigChange),
+        );
+
+        // The user picks another viz while a debounced control still holds an
+        // edit; the control flushes it from its unmount cleanup, after the
+        // switch has already committed.
+        act(() => result.current.setDataAppVizUuid('viz-2'));
+        onConfigChange.mockClear();
+        act(() => result.current.setOption('viz-1', 'title', 'Revenue'));
+
+        expect(result.current.optionValues).toEqual({});
+        expect(onConfigChange).not.toHaveBeenCalled();
+    });
+
+    it('drops a late option edit once this config no longer owns the chart', () => {
+        const onConfigChange = vi.fn();
+        const { result, unmount } = renderHook(() =>
+            useDataAppVizVisualizationConfig(initialConfig, onConfigChange),
+        );
+        const { setOption } = result.current;
+
+        // Switching chart type unmounts this config; a control flushing after
+        // that must not write a data-app-viz config back over the new one.
+        unmount();
+        act(() => setOption('viz-1', 'title', 'Revenue'));
+
+        expect(onConfigChange).not.toHaveBeenCalled();
+    });
+
+    it('still writes options after a StrictMode remount', () => {
+        const onConfigChange = vi.fn();
+        // StrictMode runs setup → cleanup → setup on mount, so ownership has
+        // to survive a remount, not just be dropped on unmount.
+        const { result } = renderHook(
+            () =>
+                useDataAppVizVisualizationConfig(initialConfig, onConfigChange),
+            { wrapper: StrictMode },
+        );
+
+        act(() => result.current.setOption('viz-1', 'barColor', '#ff0000'));
+
+        expect(result.current.optionValues).toEqual({
+            showLegend: false,
+            barColor: '#ff0000',
+        });
+        expect(onConfigChange).toHaveBeenCalledWith({
+            dataAppVizUuid: 'viz-1',
+            fieldMapping: { category: 'orders_status' },
+            optionValues: { showLegend: false, barColor: '#ff0000' },
+        });
+    });
+
+    it('round-trips the emitted config back into a fresh hook', () => {
+        const onConfigChange = vi.fn();
+        const { result } = renderHook(() =>
+            useDataAppVizVisualizationConfig(initialConfig, onConfigChange),
+        );
+
+        act(() => result.current.setOption('viz-1', 'barCount', 12));
+        const emitted = onConfigChange.mock
+            .calls[0][0] as unknown as DataAppVizChart;
+
+        const reloaded = renderHook(() =>
+            useDataAppVizVisualizationConfig(emitted),
+        );
+
+        expect(reloaded.result.current.validConfig).toEqual(emitted);
+    });
+});

--- a/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.ts
+++ b/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.ts
@@ -1,61 +1,120 @@
-import { type DataAppVizChart } from '@lightdash/common';
-import { useCallback, useState } from 'react';
+import {
+    type DataAppVizChart,
+    type DataAppVizOptionValue,
+    type DataAppVizOptionValues,
+} from '@lightdash/common';
+import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 
 export interface DataAppVizVisualizationConfigAndData {
     validConfig: DataAppVizChart;
     dataAppVizUuid: string;
     fieldMapping: Record<string, string>;
+    optionValues: DataAppVizOptionValues;
     setDataAppVizUuid: (dataAppVizUuid: string) => void;
     setField: (fieldName: string, fieldId: string | null) => void;
+    /** `dataAppVizUuid` is the viz the edited control belonged to. */
+    setOption: (
+        dataAppVizUuid: string,
+        optionName: string,
+        value: DataAppVizOptionValue,
+    ) => void;
 }
 
-// Local state for a data-app-viz chart (selected viz + field mapping); setters
-// push each change up via `onConfigChange`. Mirrors useCustomVisualizationConfig.
+// Local state for a data-app-viz chart (selected viz + field mapping + config
+// option values); setters push each change up via `onConfigChange`. Mirrors
+// useCustomVisualizationConfig. Only options the user explicitly changed are
+// stored — declared defaults are resolved at render time.
 const useDataAppVizVisualizationConfig = (
     initialChartConfig: DataAppVizChart | undefined,
     onConfigChange?: (config: DataAppVizChart) => void,
 ): DataAppVizVisualizationConfigAndData => {
-    const [dataAppVizUuid, setDataAppVizUuidState] = useState<string>(
-        initialChartConfig?.dataAppVizUuid ?? '',
+    const [config, setConfigState] = useState<Required<DataAppVizChart>>(
+        () => ({
+            dataAppVizUuid: initialChartConfig?.dataAppVizUuid ?? '',
+            fieldMapping: initialChartConfig?.fieldMapping ?? {},
+            optionValues: initialChartConfig?.optionValues ?? {},
+        }),
     );
-    const [fieldMapping, setFieldMappingState] = useState<
-        Record<string, string>
-    >(initialChartConfig?.fieldMapping ?? {});
+
+    // Track the committed config in a ref so setters called within a single
+    // commit (debounced controls all flushing as the panel closes) build on
+    // each other instead of on a stale render closure.
+    const configRef = useRef(config);
+    const onConfigChangeRef = useRef(onConfigChange);
+    onConfigChangeRef.current = onConfigChange;
+
+    // Cleared in the mutation phase, so it is already false by the time the
+    // passive cleanups of the same commit (a debounced control's flush) run.
+    const isOwningChartConfigRef = useRef(true);
+    useLayoutEffect(() => {
+        isOwningChartConfigRef.current = true;
+        return () => {
+            isOwningChartConfigRef.current = false;
+        };
+    }, []);
+
+    const commit = useCallback((next: Required<DataAppVizChart>) => {
+        configRef.current = next;
+        setConfigState(next);
+        onConfigChangeRef.current?.(next);
+    }, []);
 
     const setDataAppVizUuid = useCallback(
         (newDataAppVizUuid: string) => {
-            // Fields are viz-specific, so switching viz drops the old mapping
-            // rather than carrying over now-meaningless field names.
-            setDataAppVizUuidState(newDataAppVizUuid);
-            setFieldMappingState({});
-            onConfigChange?.({
+            // Fields and options are viz-specific, so switching viz drops both
+            // rather than carrying over now-meaningless names.
+            commit({
                 dataAppVizUuid: newDataAppVizUuid,
                 fieldMapping: {},
+                optionValues: {},
             });
         },
-        [onConfigChange],
+        [commit],
     );
 
     const setField = useCallback(
         (fieldName: string, fieldId: string | null) => {
-            const nextMapping = { ...fieldMapping };
+            const nextMapping = { ...configRef.current.fieldMapping };
             if (fieldId === null) {
                 delete nextMapping[fieldName];
             } else {
                 nextMapping[fieldName] = fieldId;
             }
-            setFieldMappingState(nextMapping);
-            onConfigChange?.({ dataAppVizUuid, fieldMapping: nextMapping });
+            commit({ ...configRef.current, fieldMapping: nextMapping });
         },
-        [dataAppVizUuid, fieldMapping, onConfigChange],
+        [commit],
+    );
+
+    const setOption = useCallback(
+        (
+            dataAppVizUuid: string,
+            optionName: string,
+            value: DataAppVizOptionValue,
+        ) => {
+            // A debounced control flushes from its unmount cleanup, by which
+            // point the edit can belong to a config that no longer owns the
+            // chart, or to a viz the user has switched away from.
+            if (!isOwningChartConfigRef.current) return;
+            if (dataAppVizUuid !== configRef.current.dataAppVizUuid) return;
+            commit({
+                ...configRef.current,
+                optionValues: {
+                    ...configRef.current.optionValues,
+                    [optionName]: value,
+                },
+            });
+        },
+        [commit],
     );
 
     return {
-        validConfig: { dataAppVizUuid, fieldMapping },
-        dataAppVizUuid,
-        fieldMapping,
+        validConfig: config,
+        dataAppVizUuid: config.dataAppVizUuid,
+        fieldMapping: config.fieldMapping,
+        optionValues: config.optionValues,
         setDataAppVizUuid,
         setField,
+        setOption,
     };
 };
 


### PR DESCRIPTION
Renders one config option as a form control, and holds the values for a chart.

Text and colour edits are debounced and flushed when the control unmounts, so closing the config panel mid-edit doesn't drop the change. The config hook guards that late flush: an edit arriving after the user switched viz, or after this config stopped owning the chart, is dropped rather than written over the new one.

Both halves of that hazard are here on purpose. Nothing renders the control yet.

https://linear.app/lightdash/issue/GLITCH-563/generated-config-form-viz-declares-typed-config-options-colours-layout