### PR TITLE
feat(data-apps): render declared config options as chart config tabs

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
@@ -8,9 +8,13 @@ import {
     type CompiledDimension,
     type CompiledMetric,
     type CustomSqlDimension,
+    type DataAppVizConfigOption,
+    type DataAppVizField,
     type Item,
     type TableCalculation,
 } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../testing/testUtils';
 import { ConfigTabs } from './DataAppVizConfigTabs';
@@ -79,30 +83,42 @@ const tableCalculation: TableCalculation = {
     sql: '${orders_visible_metric}',
 };
 
+const declaredFields: DataAppVizField[] = [
+    { name: 'source', label: 'Source', type: 'dimension', required: true },
+    { name: 'value', label: 'Value', type: 'metric', required: true },
+];
+
+const declaredOptions: DataAppVizConfigOption[] = [
+    {
+        type: 'boolean',
+        name: 'showLegend',
+        label: 'Show legend',
+        group: 'Style',
+        default: true,
+    },
+    {
+        type: 'text',
+        name: 'title',
+        label: 'Title',
+        group: 'Style',
+        default: 'Sales',
+    },
+    { type: 'number', name: 'barWidth', label: 'Bar width', default: 8 },
+];
+
+const mockSchema = (configOptions: DataAppVizConfigOption[]) => {
+    vi.mocked(useDataAppVisualization).mockReturnValue({
+        data: { schema: { fields: declaredFields, configOptions } },
+    } as unknown as ReturnType<typeof useDataAppVisualization>);
+};
+
 describe('DataAppVizConfigTabs', () => {
+    const setOption = vi.fn();
+
     beforeEach(() => {
         fieldSelectItems.length = 0;
-        vi.mocked(useDataAppVisualization).mockReturnValue({
-            data: {
-                schema: {
-                    fields: [
-                        {
-                            name: 'source',
-                            label: 'Source',
-                            type: 'dimension',
-                            required: true,
-                        },
-                        {
-                            name: 'value',
-                            label: 'Value',
-                            type: 'metric',
-                            required: true,
-                        },
-                    ],
-                    configOptions: [],
-                },
-            },
-        } as unknown as ReturnType<typeof useDataAppVisualization>);
+        setOption.mockClear();
+        mockSchema([]);
         vi.mocked(useVisualizationContext).mockReturnValue({
             itemsMap: {
                 orders_visible: makeDimension('visible', false),
@@ -117,8 +133,10 @@ describe('DataAppVizConfigTabs', () => {
                 chartConfig: {
                     dataAppVizUuid: 'data-app-viz-uuid',
                     fieldMapping: {},
+                    optionValues: {},
                     setDataAppVizUuid: vi.fn(),
                     setField: vi.fn(),
+                    setOption,
                 },
             },
         } as unknown as ReturnType<typeof useVisualizationContext>);
@@ -131,5 +149,51 @@ describe('DataAppVizConfigTabs', () => {
             ['orders_visible', 'custom-dimension'],
             ['orders_visible_metric', 'table_calculation'],
         ]);
+    });
+
+    it('renders no tab strip when the viz declares no options', () => {
+        renderWithProviders(<ConfigTabs />);
+
+        expect(screen.queryByRole('tab')).not.toBeInTheDocument();
+    });
+
+    it('builds one tab per declared group, ungrouped options collapsing into Display', () => {
+        mockSchema(declaredOptions);
+
+        renderWithProviders(<ConfigTabs />);
+
+        expect(
+            screen.getAllByRole('tab').map((tab) => tab.textContent),
+        ).toEqual(['General', 'Style', 'Display']);
+    });
+
+    it('renders declared defaults when nothing is stored', async () => {
+        const user = userEvent.setup();
+        mockSchema(declaredOptions);
+        renderWithProviders(<ConfigTabs />);
+
+        await user.click(screen.getByRole('tab', { name: 'Style' }));
+
+        expect(screen.getByLabelText('Show legend')).toBeChecked();
+        expect(screen.getByLabelText('Title')).toHaveValue('Sales');
+
+        await user.click(screen.getByRole('tab', { name: 'Display' }));
+
+        expect(screen.getByLabelText('Bar width')).toHaveValue('8');
+    });
+
+    it('fires setOption when a control changes', async () => {
+        const user = userEvent.setup();
+        mockSchema(declaredOptions);
+        renderWithProviders(<ConfigTabs />);
+
+        await user.click(screen.getByRole('tab', { name: 'Style' }));
+        await user.click(screen.getByLabelText('Show legend'));
+
+        expect(setOption).toHaveBeenCalledWith(
+            'data-app-viz-uuid',
+            'showLegend',
+            false,
+        );
     });
 });

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -1,4 +1,9 @@
-import { getItemId, type DataAppVizField, type Item } from '@lightdash/common';
+import {
+    getEffectiveOptionValues,
+    getItemId,
+    type DataAppVizField,
+    type Item,
+} from '@lightdash/common';
 import { Stack, Text } from '@mantine-8/core';
 import { MantineProvider, useMantineColorScheme } from '@mantine/core';
 import { memo, useMemo, type FC } from 'react';
@@ -11,6 +16,7 @@ import { isDataAppVizVisualizationConfig } from '../../LightdashVisualization/ty
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
 import { Config } from '../common/Config';
 import { getVizConfigThemeOverride } from '../mantineTheme';
+import DataAppVizOptionTabs from './DataAppVizOptionTabs';
 
 export const ConfigTabs: FC = memo(() => {
     const { colorScheme } = useMantineColorScheme();
@@ -36,67 +42,92 @@ export const ConfigTabs: FC = memo(() => {
         [itemsMap],
     );
 
+    const configOptions = useMemo(
+        () => dataAppViz?.schema?.configOptions ?? [],
+        [dataAppViz],
+    );
     const fieldItems = (field: DataAppVizField): Item[] =>
         field.type === 'metric' ? metrics : dimensions;
 
     if (!isDataAppViz) return null;
 
-    const { setDataAppVizUuid, setField, fieldMapping } =
-        visualizationConfig.chartConfig;
+    const {
+        setDataAppVizUuid,
+        setField,
+        setOption,
+        fieldMapping,
+        optionValues,
+    } = visualizationConfig.chartConfig;
     const fields = dataAppViz?.schema?.fields ?? [];
+    const effectiveValues = getEffectiveOptionValues(
+        configOptions,
+        optionValues,
+    );
+
+    const generalPanel = (
+        <Stack>
+            <Config>
+                <Config.Section>
+                    <Config.Heading>Data app visualization</Config.Heading>
+                    <DataAppVizLibraryPicker
+                        projectUuid={projectUuid ?? ''}
+                        selectedDataAppVizUuid={dataAppVizUuid || null}
+                        selectedDataAppViz={dataAppViz ?? null}
+                        onSelect={setDataAppVizUuid}
+                    />
+                </Config.Section>
+            </Config>
+
+            {dataAppVizUuid && fields.length === 0 && (
+                <Text c="dimmed" size="sm">
+                    This visualization has no fields to map.
+                </Text>
+            )}
+
+            {fields.map((field) => {
+                const items = fieldItems(field);
+                const selectedId = fieldMapping[field.name];
+                const selectedItem = selectedId
+                    ? items.find((i) => getItemId(i) === selectedId)
+                    : undefined;
+                return (
+                    <Config key={field.name}>
+                        <Config.Section>
+                            <Config.Heading>{field.label}</Config.Heading>
+                            <FieldSelect
+                                placeholder={`Select ${field.label.toLowerCase()}`}
+                                disabled={items.length === 0}
+                                item={selectedItem}
+                                items={items}
+                                onChange={(newField) =>
+                                    setField(
+                                        field.name,
+                                        newField ? getItemId(newField) : null,
+                                    )
+                                }
+                                clearable={!field.required}
+                                hasGrouping
+                            />
+                        </Config.Section>
+                    </Config>
+                );
+            })}
+        </Stack>
+    );
 
     return (
         <MantineProvider inherit theme={themeOverride}>
-            <Stack>
-                <Config>
-                    <Config.Section>
-                        <Config.Heading>Data app visualization</Config.Heading>
-                        <DataAppVizLibraryPicker
-                            projectUuid={projectUuid ?? ''}
-                            selectedDataAppVizUuid={dataAppVizUuid || null}
-                            selectedDataAppViz={dataAppViz ?? null}
-                            onSelect={setDataAppVizUuid}
-                        />
-                    </Config.Section>
-                </Config>
-
-                {dataAppVizUuid && fields.length === 0 && (
-                    <Text c="dimmed" size="sm">
-                        This visualization has no fields to map.
-                    </Text>
-                )}
-
-                {fields.map((field) => {
-                    const items = fieldItems(field);
-                    const selectedId = fieldMapping[field.name];
-                    const selectedItem = selectedId
-                        ? items.find((i) => getItemId(i) === selectedId)
-                        : undefined;
-                    return (
-                        <Config key={field.name}>
-                            <Config.Section>
-                                <Config.Heading>{field.label}</Config.Heading>
-                                <FieldSelect
-                                    placeholder={`Select ${field.label.toLowerCase()}`}
-                                    disabled={items.length === 0}
-                                    item={selectedItem}
-                                    items={items}
-                                    onChange={(newField) =>
-                                        setField(
-                                            field.name,
-                                            newField
-                                                ? getItemId(newField)
-                                                : null,
-                                        )
-                                    }
-                                    clearable={!field.required}
-                                    hasGrouping
-                                />
-                            </Config.Section>
-                        </Config>
-                    );
-                })}
-            </Stack>
+            <DataAppVizOptionTabs
+                // Remount on a viz switch so no control keeps the previous
+                // viz's draft edit.
+                key={dataAppVizUuid}
+                generalContent={generalPanel}
+                configOptions={configOptions}
+                values={effectiveValues}
+                onChange={(name, value) =>
+                    setOption(dataAppVizUuid, name, value)
+                }
+            />
         </MantineProvider>
     );
 });

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizOptionTabs.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizOptionTabs.test.tsx
@@ -1,0 +1,62 @@
+import { type DataAppVizConfigOption } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import DataAppVizOptionTabs from './DataAppVizOptionTabs';
+
+const generalContent = <div data-testid="general">General content</div>;
+
+const options: DataAppVizConfigOption[] = [
+    {
+        type: 'boolean',
+        name: 'showLegend',
+        label: 'Show legend',
+        group: 'Style',
+        default: true,
+    },
+    { type: 'number', name: 'barWidth', label: 'Bar width', default: 8 },
+];
+
+const renderTabs = (
+    configOptions: DataAppVizConfigOption[],
+    onChange = vi.fn(),
+) =>
+    renderWithProviders(
+        <DataAppVizOptionTabs
+            generalContent={generalContent}
+            configOptions={configOptions}
+            values={{}}
+            onChange={onChange}
+        />,
+    );
+
+describe('DataAppVizOptionTabs', () => {
+    it('renders the general content bare when no options are declared', () => {
+        renderTabs([]);
+
+        expect(screen.getByTestId('general')).toBeInTheDocument();
+        expect(screen.queryByRole('tab')).not.toBeInTheDocument();
+    });
+
+    it('keeps the general content in its own tab alongside the option groups', () => {
+        renderTabs(options);
+
+        expect(
+            screen.getAllByRole('tab').map((tab) => tab.textContent),
+        ).toEqual(['General', 'Style', 'Display']);
+        expect(screen.getByTestId('general')).toBeInTheDocument();
+    });
+
+    it('falls back to each option default and reports changes by name', async () => {
+        const user = userEvent.setup();
+        const onChange = vi.fn();
+        renderTabs(options, onChange);
+
+        await user.click(screen.getByRole('tab', { name: 'Style' }));
+        expect(screen.getByLabelText('Show legend')).toBeChecked();
+
+        await user.click(screen.getByLabelText('Show legend'));
+        expect(onChange).toHaveBeenCalledWith('showLegend', false);
+    });
+});

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizOptionTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizOptionTabs.tsx
@@ -1,0 +1,78 @@
+import {
+    type DataAppVizConfigOption,
+    type DataAppVizOptionValue,
+    type DataAppVizOptionValues,
+} from '@lightdash/common';
+import { Stack, Tabs } from '@mantine-8/core';
+import { useMemo, type FC, type ReactNode } from 'react';
+import { Config } from '../common/Config';
+import DataAppVizOptionControl from './DataAppVizOptionControl';
+import { groupDataAppVizOptions } from './dataAppVizOptionGroups';
+
+type Props = {
+    /** First tab's content — the caller's own viz picker / field mapping. */
+    generalContent: ReactNode;
+    configOptions: DataAppVizConfigOption[];
+    /** Effective values: the stored value, or the declared default. */
+    values: DataAppVizOptionValues;
+    onChange: (name: string, value: DataAppVizOptionValue) => void;
+};
+
+/**
+ * Tab shell for a data app viz config form: a fixed `General` tab holding the
+ * caller's content, then one tab per declared option `group` (ungrouped options
+ * collapsing into `Display`). A viz that declares no options gets no tab strip
+ * at all — the general content is the whole form.
+ */
+const DataAppVizOptionTabs: FC<Props> = ({
+    generalContent,
+    configOptions,
+    values,
+    onChange,
+}) => {
+    const optionGroups = useMemo(
+        () => groupDataAppVizOptions(configOptions),
+        [configOptions],
+    );
+
+    if (optionGroups.length === 0) return <>{generalContent}</>;
+
+    return (
+        <Tabs defaultValue="general" keepMounted={false}>
+            <Tabs.List mb="sm">
+                <Tabs.Tab px="sm" value="general">
+                    General
+                </Tabs.Tab>
+                {optionGroups.map((group) => (
+                    <Tabs.Tab key={group.id} px="sm" value={group.id}>
+                        {group.label}
+                    </Tabs.Tab>
+                ))}
+            </Tabs.List>
+
+            <Tabs.Panel value="general">{generalContent}</Tabs.Panel>
+
+            {optionGroups.map((group) => (
+                <Tabs.Panel key={group.id} value={group.id}>
+                    <Stack>
+                        {group.options.map((option) => (
+                            <Config key={option.name}>
+                                <Config.Section>
+                                    <DataAppVizOptionControl
+                                        option={option}
+                                        value={values[option.name]}
+                                        onChange={(value) =>
+                                            onChange(option.name, value)
+                                        }
+                                    />
+                                </Config.Section>
+                            </Config>
+                        ))}
+                    </Stack>
+                </Tabs.Panel>
+            ))}
+        </Tabs>
+    );
+};
+
+export default DataAppVizOptionTabs;

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/dataAppVizOptionGroups.test.ts
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/dataAppVizOptionGroups.test.ts
@@ -1,0 +1,46 @@
+import { type DataAppVizConfigOption } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import {
+    groupDataAppVizOptions,
+    UNGROUPED_OPTIONS_LABEL,
+} from './dataAppVizOptionGroups';
+
+const option = (name: string, group?: string): DataAppVizConfigOption => ({
+    type: 'boolean',
+    name,
+    label: name,
+    default: true,
+    ...(group ? { group } : {}),
+});
+
+describe('groupDataAppVizOptions', () => {
+    it('returns no groups for an empty declaration', () => {
+        expect(groupDataAppVizOptions([])).toEqual([]);
+    });
+
+    it('keeps declaration order and merges repeated groups', () => {
+        const groups = groupDataAppVizOptions([
+            option('a', 'Style'),
+            option('b', 'Axes'),
+            option('c', 'Style'),
+        ]);
+
+        expect(groups.map((g) => g.label)).toEqual(['Style', 'Axes']);
+        expect(groups[0].options.map((o) => o.name)).toEqual(['a', 'c']);
+        expect(groups[1].options.map((o) => o.name)).toEqual(['b']);
+    });
+
+    it('collapses every ungrouped option into a single Display group', () => {
+        const groups = groupDataAppVizOptions([
+            option('a'),
+            option('b', 'Style'),
+            option('c'),
+        ]);
+
+        expect(groups.map((g) => g.label)).toEqual([
+            UNGROUPED_OPTIONS_LABEL,
+            'Style',
+        ]);
+        expect(groups[0].options.map((o) => o.name)).toEqual(['a', 'c']);
+    });
+});

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/dataAppVizOptionGroups.ts
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/dataAppVizOptionGroups.ts
@@ -1,0 +1,34 @@
+import { type DataAppVizConfigOption } from '@lightdash/common';
+
+/** Label for the tab collecting every option that declared no `group`. */
+export const UNGROUPED_OPTIONS_LABEL = 'Display';
+
+export type DataAppVizOptionGroup = {
+    /** Stable tab value, derived from position rather than the label. */
+    id: string;
+    label: string;
+    options: DataAppVizConfigOption[];
+};
+
+/**
+ * Buckets declared options into config tabs: one per distinct `group`, with
+ * every ungrouped option collapsing into a single `Display` tab. Groups keep
+ * the order in which they first appear in the declaration.
+ */
+export const groupDataAppVizOptions = (
+    configOptions: DataAppVizConfigOption[],
+): DataAppVizOptionGroup[] => {
+    const buckets = new Map<string, DataAppVizConfigOption[]>();
+    configOptions.forEach((option) => {
+        const label = option.group ?? UNGROUPED_OPTIONS_LABEL;
+        const existing = buckets.get(label);
+        if (existing) existing.push(option);
+        else buckets.set(label, [option]);
+    });
+
+    return [...buckets.entries()].map(([label, options], index) => ({
+        id: `option-group-${index}`,
+        label,
+        options,
+    }));
+};


### PR DESCRIPTION
Puts the declared options into the chart config panel.

One tab per declared `group`, with ungrouped options collapsing into a single Display tab. The existing viz picker and field mapping move into a General tab.

A viz that declares no options gets no tab strip and the panel looks exactly as it does today.

https://linear.app/lightdash/issue/GLITCH-563/generated-config-form-viz-declares-typed-config-options-colours-layout