### PR TITLE
feat(data-apps): let a viz declare that it colours from the chart palette

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
@@ -77,6 +77,7 @@ const VIZ_SCHEMA = {
         },
     ],
     configOptions: [],
+    colorPalette: null,
 };
 
 const makeDeps = (

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizGeneration.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizGeneration.test.ts
@@ -131,6 +131,7 @@ describe('AppGenerateService.parseSchema', () => {
             { name: 'value', label: 'Value', type: 'metric', required: true },
         ],
         configOptions: [],
+        colorPalette: null,
     };
 
     it('validates a well-formed schema', () => {
@@ -139,7 +140,7 @@ describe('AppGenerateService.parseSchema', () => {
         );
     });
 
-    it('defaults configOptions to [] when omitted', () => {
+    it('defaults configOptions to [] and colorPalette to null when omitted', () => {
         expect(
             AppGenerateService.parseSchema({ fields: validSchema.fields }),
         ).toEqual(validSchema);

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
@@ -28,6 +28,7 @@ const vizSchema: DataAppVizSchema = {
         { name: 'value', label: 'Value', type: 'metric', required: true },
     ],
     configOptions: [],
+    colorPalette: null,
 };
 
 const makeDataAppVizRow = (overrides: Record<string, unknown> = {}) => ({

--- a/packages/common/src/ee/apps/dataAppVizConfigOptions.ts
+++ b/packages/common/src/ee/apps/dataAppVizConfigOptions.ts
@@ -52,3 +52,15 @@ export type DataAppVizConfigOption =
 
 /** A persisted config value; its shape is set by the option's declared `type`. */
 export type DataAppVizOptionValue = boolean | number | string;
+
+/**
+ * Declared by a viz that colours from the resolved Lightdash palette. Not a
+ * config option: it carries no value of its own, it only asks the config panel
+ * for the standard palette picker, whose choice is stored as the chart's
+ * palette and delivered on `colorPalette`. There is one palette per chart, so
+ * a viz either declares this or it does not.
+ */
+export type DataAppVizPaletteDeclaration = {
+    /** Tab to place the picker in, matching a config option `group`. */
+    group?: string;
+};

--- a/packages/common/src/ee/apps/sdkFeatures.ts
+++ b/packages/common/src/ee/apps/sdkFeatures.ts
@@ -80,6 +80,13 @@ export const SDK_FEATURES: SdkFeature[] = [
         description:
             'Receive query context when app visualizations are embedded in dashboards.',
     },
+    {
+        key: 'viz-config-options',
+        label: 'Visualization config options',
+        description:
+            "Let viewers adjust the visualization from the Lightdash config panel — toggles, dropdowns, numbers, text and colours — and take series colours from the chart's palette, without regenerating the app.",
+        wiring: 'Declare configOptions (and colorPalette, if the viz colours series) in the viz schema, then read options[name] and colorPalette from useVizContext().',
+    },
 ];
 
 export const SDK_FEATURE_KEYS: string[] = SDK_FEATURES.map((f) => f.key);

--- a/packages/common/src/ee/apps/types.test.ts
+++ b/packages/common/src/ee/apps/types.test.ts
@@ -21,10 +21,13 @@ const validFields = {
 };
 
 describe('dataAppVizSchema', () => {
-    it('accepts a well-formed fields declaration (configOptions defaults to [])', () => {
+    it('accepts a well-formed fields declaration (configOptions defaults to [], colorPalette to null)', () => {
         const r = dataAppVizSchema.safeParse(validFields);
         expect(r.success).toBe(true);
-        if (r.success) expect(r.data.configOptions).toEqual([]);
+        if (r.success) {
+            expect(r.data.configOptions).toEqual([]);
+            expect(r.data.colorPalette).toBeNull();
+        }
     });
 
     it('accepts an empty field list', () => {
@@ -136,6 +139,24 @@ describe('dataAppVizSchema', () => {
                 ],
             }).success,
         ).toBe(false);
+    });
+
+    it('accepts a colorPalette declaration, with or without a group', () => {
+        const grouped = dataAppVizSchema.safeParse({
+            fields: [],
+            colorPalette: { group: 'Colours' },
+        });
+        expect(grouped.success).toBe(true);
+        if (grouped.success) {
+            expect(grouped.data.colorPalette).toEqual({ group: 'Colours' });
+        }
+
+        const ungrouped = dataAppVizSchema.safeParse({
+            fields: [],
+            colorPalette: {},
+        });
+        expect(ungrouped.success).toBe(true);
+        if (ungrouped.success) expect(ungrouped.data.colorPalette).toEqual({});
     });
 
     it('rejects a boolean option with a non-boolean default', () => {

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -19,12 +19,14 @@ import assertUnreachable from '../../utils/assertUnreachable';
 import {
     type DataAppVizConfigOption,
     type DataAppVizOptionValue,
+    type DataAppVizPaletteDeclaration,
 } from './dataAppVizConfigOptions';
 
 export type {
     DataAppVizConfigOption,
     DataAppVizConfigOptionType,
     DataAppVizOptionValue,
+    DataAppVizPaletteDeclaration,
 } from './dataAppVizConfigOptions';
 
 /**
@@ -645,6 +647,8 @@ export type DataAppVizField = {
 export type DataAppVizSchema = {
     fields: DataAppVizField[];
     configOptions: DataAppVizConfigOption[];
+    /** Null when the viz colours nothing from the resolved palette. */
+    colorPalette: DataAppVizPaletteDeclaration | null;
 };
 
 const uniqueNames = <T extends { name: string }>(arr: T[]): boolean =>
@@ -708,6 +712,10 @@ export const dataAppVizSchema = z.object({
         )
         .default([])
         .refine(uniqueNames, 'duplicate option name'),
+    colorPalette: z
+        .object({ group: z.string().optional() })
+        .nullable()
+        .default(null),
 });
 
 // Compile-time guard: the zod schema's output type must match the explicit
@@ -809,10 +817,14 @@ export const APP_SDK_VIZ_CONTEXT_REQUEST_MESSAGE =
     'lightdash:sdk:viz-context-request';
 
 // Host-owned render context pushed into a data app viz: field name → bound query
-// field id, the host-fetched result rows the renderer reads, and the effective
-// config option values (stored value ?? declared default).
+// field id, the host-fetched result rows the renderer reads, the effective
+// config option values (stored value ?? declared default), and the palette
+// resolved for this chart. `colorPalette` is pushed whether or not the viz
+// declared one, so a viz that colours series never has to check first.
 export type DataAppVizContext = {
     fieldMapping: Record<string, string>;
     rows: ResultRow[];
     options: Record<string, DataAppVizOptionValue>;
+    // Resolved through the same org/project/space/dashboard cascade as native charts.
+    colorPalette: string[];
 };

--- a/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
@@ -60,6 +60,7 @@ vi.mock('../LightdashVisualization/useVisualizationContext', () => ({
             rows: [{ 'orders.category': { value: { raw: 'Hardware' } } }],
             setFetchAll: mocks.setFetchAll,
         },
+        colorPalette: ['#7162FF'],
     }),
 }));
 
@@ -98,6 +99,7 @@ describe('DataAppVizRenderer option delivery', () => {
             expect.objectContaining({
                 dataAppVizContext: expect.objectContaining({
                     options: { title: 'Sales' },
+                    colorPalette: ['#7162FF'],
                 }),
             }),
             undefined,

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -31,7 +31,8 @@ const DataAppVizPlaceholder: FC<{ message: string }> = ({ message }) => (
 
 const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
-    const { visualizationConfig, resultsData } = useVisualizationContext();
+    const { visualizationConfig, resultsData, colorPalette } =
+        useVisualizationContext();
     const previewOrigin = usePreviewOrigin();
     const hasSignaledScreenshotReady = useRef(false);
 
@@ -94,8 +95,11 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
                 configOptions,
                 optionValues ?? {},
             ),
+            // Already resolved through the full palette cascade and dark-mode
+            // corrected by the visualization context.
+            colorPalette,
         };
-    }, [fieldMapping, rows, configOptions, optionValues]);
+    }, [fieldMapping, rows, configOptions, optionValues, colorPalette]);
 
     if (!projectUuid || !dataAppVizUuid) {
         return (

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
@@ -9,6 +9,7 @@ import {
     type CompiledMetric,
     type CustomSqlDimension,
     type DataAppVizConfigOption,
+    type DataAppVizPaletteDeclaration,
     type DataAppVizField,
     type Item,
     type TableCalculation,
@@ -37,6 +38,10 @@ vi.mock('../../common/FieldSelect', () => ({
 }));
 vi.mock('../../LightdashVisualization/useVisualizationContext', () => ({
     useVisualizationContext: vi.fn(),
+}));
+// Self-wiring against the Explorer store, which this panel test doesn't mount.
+vi.mock('../common/ColorPaletteSection', () => ({
+    ColorPaletteSection: () => <div data-testid="color-palette-section" />,
 }));
 
 import { useDataAppVisualization } from '../../../features/apps/hooks/useDataAppVisualization';
@@ -106,9 +111,14 @@ const declaredOptions: DataAppVizConfigOption[] = [
     { type: 'number', name: 'barWidth', label: 'Bar width', default: 8 },
 ];
 
-const mockSchema = (configOptions: DataAppVizConfigOption[]) => {
+const mockSchema = (
+    configOptions: DataAppVizConfigOption[],
+    colorPalette: DataAppVizPaletteDeclaration | null = null,
+) => {
     vi.mocked(useDataAppVisualization).mockReturnValue({
-        data: { schema: { fields: declaredFields, configOptions } },
+        data: {
+            schema: { fields: declaredFields, configOptions, colorPalette },
+        },
     } as unknown as ReturnType<typeof useDataAppVisualization>);
 };
 
@@ -180,6 +190,16 @@ describe('DataAppVizConfigTabs', () => {
         await user.click(screen.getByRole('tab', { name: 'Display' }));
 
         expect(screen.getByLabelText('Bar width')).toHaveValue('8');
+    });
+
+    it('renders the standard palette picker for a declared palette', async () => {
+        const user = userEvent.setup();
+        mockSchema([], { group: 'Colours' });
+        renderWithProviders(<ConfigTabs />);
+
+        await user.click(screen.getByRole('tab', { name: 'Colours' }));
+
+        expect(screen.getByTestId('color-palette-section')).toBeInTheDocument();
     });
 
     it('fires setOption when a control changes', async () => {

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -14,6 +14,7 @@ import { getDataAppVizFieldItems } from '../../../features/apps/utils/getDataApp
 import FieldSelect from '../../common/FieldSelect';
 import { isDataAppVizVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
+import { ColorPaletteSection } from '../common/ColorPaletteSection';
 import { Config } from '../common/Config';
 import { getVizConfigThemeOverride } from '../mantineTheme';
 import DataAppVizOptionTabs from './DataAppVizOptionTabs';
@@ -46,6 +47,8 @@ export const ConfigTabs: FC = memo(() => {
         () => dataAppViz?.schema?.configOptions ?? [],
         [dataAppViz],
     );
+    const colorPalette = dataAppViz?.schema?.colorPalette ?? null;
+
     const fieldItems = (field: DataAppVizField): Item[] =>
         field.type === 'metric' ? metrics : dimensions;
 
@@ -127,6 +130,8 @@ export const ConfigTabs: FC = memo(() => {
                 onChange={(name, value) =>
                     setOption(dataAppVizUuid, name, value)
                 }
+                colorPalette={colorPalette}
+                paletteControl={<ColorPaletteSection />}
             />
         </MantineProvider>
     );

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizOptionTabs.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizOptionTabs.test.tsx
@@ -1,4 +1,7 @@
-import { type DataAppVizConfigOption } from '@lightdash/common';
+import {
+    type DataAppVizConfigOption,
+    type DataAppVizPaletteDeclaration,
+} from '@lightdash/common';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
@@ -6,6 +9,7 @@ import { renderWithProviders } from '../../../testing/testUtils';
 import DataAppVizOptionTabs from './DataAppVizOptionTabs';
 
 const generalContent = <div data-testid="general">General content</div>;
+const paletteControl = <div data-testid="palette">Palette picker</div>;
 
 const options: DataAppVizConfigOption[] = [
     {
@@ -20,6 +24,7 @@ const options: DataAppVizConfigOption[] = [
 
 const renderTabs = (
     configOptions: DataAppVizConfigOption[],
+    colorPalette: DataAppVizPaletteDeclaration | null = null,
     onChange = vi.fn(),
 ) =>
     renderWithProviders(
@@ -28,6 +33,8 @@ const renderTabs = (
             configOptions={configOptions}
             values={{}}
             onChange={onChange}
+            colorPalette={colorPalette}
+            paletteControl={paletteControl}
         />,
     );
 
@@ -51,12 +58,52 @@ describe('DataAppVizOptionTabs', () => {
     it('falls back to each option default and reports changes by name', async () => {
         const user = userEvent.setup();
         const onChange = vi.fn();
-        renderTabs(options, onChange);
+        renderTabs(options, null, onChange);
 
         await user.click(screen.getByRole('tab', { name: 'Style' }));
         expect(screen.getByLabelText('Show legend')).toBeChecked();
 
         await user.click(screen.getByLabelText('Show legend'));
         expect(onChange).toHaveBeenCalledWith('showLegend', false);
+    });
+
+    it("renders the caller's palette control in the tab the declaration names", async () => {
+        const user = userEvent.setup();
+        renderTabs(options, { group: 'Style' });
+
+        await user.click(screen.getByRole('tab', { name: 'Style' }));
+
+        expect(screen.getByTestId('palette')).toBeInTheDocument();
+    });
+
+    it('shows the palette control once, in one tab only', async () => {
+        const user = userEvent.setup();
+        renderTabs(options, { group: 'Style' });
+
+        await user.click(screen.getByRole('tab', { name: 'Style' }));
+        expect(screen.getAllByTestId('palette')).toHaveLength(1);
+
+        await user.click(screen.getByRole('tab', { name: 'Display' }));
+        expect(screen.queryByTestId('palette')).not.toBeInTheDocument();
+    });
+
+    it('renders no palette control when the viz declares none', async () => {
+        const user = userEvent.setup();
+        renderTabs(options, null);
+
+        await user.click(screen.getByRole('tab', { name: 'Style' }));
+        expect(screen.queryByTestId('palette')).not.toBeInTheDocument();
+
+        await user.click(screen.getByRole('tab', { name: 'Display' }));
+        expect(screen.queryByTestId('palette')).not.toBeInTheDocument();
+    });
+
+    it('builds a tab strip for a viz that declares only a palette', async () => {
+        const user = userEvent.setup();
+        renderTabs([], { group: 'Colours' });
+
+        await user.click(screen.getByRole('tab', { name: 'Colours' }));
+
+        expect(screen.getByTestId('palette')).toBeInTheDocument();
     });
 });

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizOptionTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizOptionTabs.tsx
@@ -2,6 +2,7 @@ import {
     type DataAppVizConfigOption,
     type DataAppVizOptionValue,
     type DataAppVizOptionValues,
+    type DataAppVizPaletteDeclaration,
 } from '@lightdash/common';
 import { Stack, Tabs } from '@mantine-8/core';
 import { useMemo, type FC, type ReactNode } from 'react';
@@ -16,23 +17,34 @@ type Props = {
     /** Effective values: the stored value, or the declared default. */
     values: DataAppVizOptionValues;
     onChange: (name: string, value: DataAppVizOptionValue) => void;
+    /** Null when the viz colours nothing from the resolved palette. */
+    colorPalette: DataAppVizPaletteDeclaration | null;
+    /**
+     * Rendered in the tab the declaration names. Picking the chart's Lightdash
+     * palette differs by surface (Explorer store vs local state), so the caller
+     * owns the control; this component only places it.
+     */
+    paletteControl: ReactNode;
 };
 
 /**
  * Tab shell for a data app viz config form: a fixed `General` tab holding the
  * caller's content, then one tab per declared option `group` (ungrouped options
- * collapsing into `Display`). A viz that declares no options gets no tab strip
- * at all — the general content is the whole form.
+ * collapsing into `Display`), with the palette picker in the tab its
+ * declaration names. A viz that declares neither options nor a palette gets no
+ * tab strip at all — the general content is the whole form.
  */
 const DataAppVizOptionTabs: FC<Props> = ({
     generalContent,
     configOptions,
     values,
     onChange,
+    colorPalette,
+    paletteControl,
 }) => {
     const optionGroups = useMemo(
-        () => groupDataAppVizOptions(configOptions),
-        [configOptions],
+        () => groupDataAppVizOptions(configOptions, colorPalette),
+        [configOptions, colorPalette],
     );
 
     if (optionGroups.length === 0) return <>{generalContent}</>;
@@ -68,6 +80,7 @@ const DataAppVizOptionTabs: FC<Props> = ({
                                 </Config.Section>
                             </Config>
                         ))}
+                        {group.hasPalette && paletteControl}
                     </Stack>
                 </Tabs.Panel>
             ))}

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/dataAppVizOptionGroups.test.ts
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/dataAppVizOptionGroups.test.ts
@@ -15,15 +15,14 @@ const option = (name: string, group?: string): DataAppVizConfigOption => ({
 
 describe('groupDataAppVizOptions', () => {
     it('returns no groups for an empty declaration', () => {
-        expect(groupDataAppVizOptions([])).toEqual([]);
+        expect(groupDataAppVizOptions([], null)).toEqual([]);
     });
 
     it('keeps declaration order and merges repeated groups', () => {
-        const groups = groupDataAppVizOptions([
-            option('a', 'Style'),
-            option('b', 'Axes'),
-            option('c', 'Style'),
-        ]);
+        const groups = groupDataAppVizOptions(
+            [option('a', 'Style'), option('b', 'Axes'), option('c', 'Style')],
+            null,
+        );
 
         expect(groups.map((g) => g.label)).toEqual(['Style', 'Axes']);
         expect(groups[0].options.map((o) => o.name)).toEqual(['a', 'c']);
@@ -31,16 +30,55 @@ describe('groupDataAppVizOptions', () => {
     });
 
     it('collapses every ungrouped option into a single Display group', () => {
-        const groups = groupDataAppVizOptions([
-            option('a'),
-            option('b', 'Style'),
-            option('c'),
-        ]);
+        const groups = groupDataAppVizOptions(
+            [option('a'), option('b', 'Style'), option('c')],
+            null,
+        );
 
         expect(groups.map((g) => g.label)).toEqual([
             UNGROUPED_OPTIONS_LABEL,
             'Style',
         ]);
         expect(groups[0].options.map((o) => o.name)).toEqual(['a', 'c']);
+    });
+
+    it('marks no group as holding the palette when none is declared', () => {
+        const groups = groupDataAppVizOptions([option('a', 'Style')], null);
+
+        expect(groups.every((g) => !g.hasPalette)).toBe(true);
+    });
+
+    it('places a declared palette in the group it names', () => {
+        const groups = groupDataAppVizOptions(
+            [option('a', 'Style'), option('b', 'Axes')],
+            { group: 'Style' },
+        );
+
+        expect(groups.map((g) => g.label)).toEqual(['Style', 'Axes']);
+        expect(groups.map((g) => g.hasPalette)).toEqual([true, false]);
+    });
+
+    it('puts an ungrouped palette in the Display group', () => {
+        const groups = groupDataAppVizOptions([option('a')], {});
+
+        expect(groups.map((g) => g.label)).toEqual([UNGROUPED_OPTIONS_LABEL]);
+        expect(groups[0].hasPalette).toBe(true);
+    });
+
+    it('creates a group for a palette whose tab no option shares', () => {
+        const groups = groupDataAppVizOptions([option('a', 'Style')], {
+            group: 'Colours',
+        });
+
+        expect(groups.map((g) => g.label)).toEqual(['Style', 'Colours']);
+        expect(groups[1].options).toEqual([]);
+        expect(groups[1].hasPalette).toBe(true);
+    });
+
+    it('gives a viz that declares only a palette a single group', () => {
+        const groups = groupDataAppVizOptions([], { group: 'Colours' });
+
+        expect(groups.map((g) => g.label)).toEqual(['Colours']);
+        expect(groups[0].hasPalette).toBe(true);
     });
 });

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/dataAppVizOptionGroups.ts
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/dataAppVizOptionGroups.ts
@@ -1,4 +1,7 @@
-import { type DataAppVizConfigOption } from '@lightdash/common';
+import {
+    type DataAppVizConfigOption,
+    type DataAppVizPaletteDeclaration,
+} from '@lightdash/common';
 
 /** Label for the tab collecting every option that declared no `group`. */
 export const UNGROUPED_OPTIONS_LABEL = 'Display';
@@ -8,15 +11,19 @@ export type DataAppVizOptionGroup = {
     id: string;
     label: string;
     options: DataAppVizConfigOption[];
+    /** Whether the palette picker belongs in this tab. */
+    hasPalette: boolean;
 };
 
 /**
  * Buckets declared options into config tabs: one per distinct `group`, with
  * every ungrouped option collapsing into a single `Display` tab. Groups keep
- * the order in which they first appear in the declaration.
+ * the order in which they first appear in the declaration. A declared palette
+ * joins the group it names, creating that tab if no option shares it.
  */
 export const groupDataAppVizOptions = (
     configOptions: DataAppVizConfigOption[],
+    colorPalette: DataAppVizPaletteDeclaration | null,
 ): DataAppVizOptionGroup[] => {
     const buckets = new Map<string, DataAppVizConfigOption[]>();
     configOptions.forEach((option) => {
@@ -26,9 +33,17 @@ export const groupDataAppVizOptions = (
         else buckets.set(label, [option]);
     });
 
+    const paletteLabel = colorPalette
+        ? (colorPalette.group ?? UNGROUPED_OPTIONS_LABEL)
+        : null;
+    if (paletteLabel !== null && !buckets.has(paletteLabel)) {
+        buckets.set(paletteLabel, []);
+    }
+
     return [...buckets.entries()].map(([label, options], index) => ({
         id: `option-group-${index}`,
         label,
         options,
+        hasPalette: label === paletteLabel,
     }));
 };

--- a/packages/frontend/src/features/apps/components/DataAppVizLibraryPicker.test.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizLibraryPicker.test.tsx
@@ -21,6 +21,7 @@ const makeDataAppViz = (overrides: Partial<DataAppViz>): DataAppViz => ({
     schema: {
         fields: [{ name: 'v', label: 'V', type: 'metric', required: true }],
         configOptions: [],
+        colorPalette: null,
     },
     createdAt: new Date('2026-06-30'),
     createdByUserUuid: 'user-1',

--- a/packages/frontend/src/features/apps/components/DataAppVizResultCard.test.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizResultCard.test.tsx
@@ -10,6 +10,7 @@ const schema: DataAppVizSchema = {
         { name: 'value', label: 'Value', type: 'metric', required: false },
     ],
     configOptions: [],
+    colorPalette: null,
 };
 
 describe('DataAppVizResultCard', () => {
@@ -30,7 +31,9 @@ describe('DataAppVizResultCard', () => {
 
     it('renders gracefully with an empty fields array', () => {
         renderWithProviders(
-            <DataAppVizResultCard schema={{ fields: [], configOptions: [] }} />,
+            <DataAppVizResultCard
+                schema={{ fields: [], configOptions: [], colorPalette: null }}
+            />,
         );
 
         expect(screen.getByText('Visualization ready')).toBeInTheDocument();

--- a/packages/frontend/src/features/apps/components/DataAppVizTestPanel.test.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizTestPanel.test.tsx
@@ -48,6 +48,7 @@ const schema: DataAppVizSchema = {
         { name: 'value', label: 'Value', type: 'metric', required: true },
     ],
     configOptions: [],
+    colorPalette: null,
 };
 
 const makeDimension = (name: string, hidden: boolean): CompiledDimension => ({
@@ -247,6 +248,7 @@ describe('DataAppVizTestPanel', () => {
                         },
                     ],
                     configOptions: [],
+                    colorPalette: null,
                 }}
                 onContextChange={vi.fn()}
             />,

--- a/packages/frontend/src/features/apps/components/DataAppVizTestPanel.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizTestPanel.tsx
@@ -1,4 +1,5 @@
 import {
+    ECHARTS_DEFAULT_COLORS,
     getEffectiveOptionValues,
     getErrorMessage,
     getItemId,
@@ -9,9 +10,11 @@ import {
     type DataAppVizSchema,
 } from '@lightdash/common';
 import { Button, Card, Group, Select, Stack, Text } from '@mantine-8/core';
+import { useMantineColorScheme } from '@mantine/core';
 import { useEffect, useMemo, useState, type FC } from 'react';
 import Callout from '../../../components/common/Callout';
 import FieldSelect from '../../../components/common/FieldSelect';
+import { useProjectColorPalette } from '../../../hooks/appearance/useProjectColorPalette';
 import { useExploreByProjectUuid } from '../../../hooks/useExplore';
 import { useExplores } from '../../../hooks/useExplores';
 import { type QueryResultsProps } from '../../../hooks/useQueryResults';
@@ -70,6 +73,16 @@ const DataAppVizTestPanel: FC<Props> = ({
         [schema.configOptions],
     );
 
+    const { colorScheme } = useMantineColorScheme();
+    const { data: projectPalette } = useProjectColorPalette(projectUuid);
+    const colorPalette = useMemo(() => {
+        if (!projectPalette) return ECHARTS_DEFAULT_COLORS;
+        if (colorScheme === 'dark' && projectPalette.darkColors) {
+            return projectPalette.darkColors;
+        }
+        return projectPalette.colors;
+    }, [projectPalette, colorScheme]);
+
     const rows = queryResults.rows;
     // Notify the parent once the run's rows arrive (external async → parent).
     // Only push rows belonging to this run's query — on a re-run the executor
@@ -87,6 +100,7 @@ const DataAppVizTestPanel: FC<Props> = ({
                 fieldMapping: run.mapping,
                 rows,
                 options: effectiveOptions,
+                colorPalette,
             });
         }
     }, [
@@ -95,6 +109,7 @@ const DataAppVizTestPanel: FC<Props> = ({
         runQueryUuid,
         queryResults.queryUuid,
         effectiveOptions,
+        colorPalette,
         onContextChange,
     ]);
     // Clear the preview when this panel unmounts (e.g. a newer version lands).

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
@@ -1015,6 +1015,7 @@ describe('data-app-viz-context push', () => {
             },
         ],
         options: { showLegend: true, barColor: '#ff0000' },
+        colorPalette: ['#7162FF', '#1A1B1E'],
     };
 
     function renderWithDataAppVizContext(ctx: DataAppVizContext | undefined) {
@@ -1041,6 +1042,7 @@ describe('data-app-viz-context push', () => {
                 fieldMapping: dataAppVizContext.fieldMapping,
                 rows: dataAppVizContext.rows,
                 options: dataAppVizContext.options,
+                colorPalette: dataAppVizContext.colorPalette,
             }),
             '*',
         );
@@ -1075,6 +1077,40 @@ describe('data-app-viz-context push', () => {
                 fieldMapping: dataAppVizContext.fieldMapping,
                 rows: dataAppVizContext.rows,
                 options: { showLegend: false },
+            }),
+            '*',
+        );
+    });
+
+    it('re-pushes the context when only the color palette changes', () => {
+        const postSpy = vi.spyOn(window, 'postMessage');
+        const iframeRef = {
+            current: { contentWindow: window } as unknown as HTMLIFrameElement,
+        } as RefObject<HTMLIFrameElement | null>;
+        const { rerender } = renderHook(
+            ({ ctx }: { ctx: DataAppVizContext }) =>
+                useAppSdkBridge({
+                    iframeRef,
+                    expectedPreviewOrigin: window.location.origin,
+                    projectUuid: PROJECT_UUID,
+                    appUuid: APP_UUID,
+                    dataAppVizContext: ctx,
+                }),
+            { initialProps: { ctx: dataAppVizContext } },
+        );
+        postSpy.mockClear();
+
+        rerender({
+            ctx: { ...dataAppVizContext, colorPalette: ['#F2C94C'] },
+        });
+
+        expect(postSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: APP_SDK_DATA_APP_VIZ_CONTEXT_MESSAGE,
+                fieldMapping: dataAppVizContext.fieldMapping,
+                rows: dataAppVizContext.rows,
+                options: dataAppVizContext.options,
+                colorPalette: ['#F2C94C'],
             }),
             '*',
         );

--- a/packages/query-sdk/src/features.ts
+++ b/packages/query-sdk/src/features.ts
@@ -80,6 +80,13 @@ export const SDK_FEATURES: SdkFeature[] = [
         description:
             'Receive query context when app visualizations are embedded in dashboards.',
     },
+    {
+        key: 'viz-config-options',
+        label: 'Visualization config options',
+        description:
+            "Let viewers adjust the visualization from the Lightdash config panel — toggles, dropdowns, numbers, text and colours — and take series colours from the chart's palette, without regenerating the app.",
+        wiring: 'Declare configOptions (and colorPalette, if the viz colours series) in the viz schema, then read options[name] and colorPalette from useVizContext().',
+    },
 ];
 
 export const SDK_FEATURE_KEYS: string[] = SDK_FEATURES.map((f) => f.key);

--- a/packages/query-sdk/src/vizContext.test.ts
+++ b/packages/query-sdk/src/vizContext.test.ts
@@ -46,12 +46,16 @@ const hostPayloadIsAcceptedBySdk: Assert<
 const inboundOptionsRemainOptional: Assert<
     IsOptional<DataAppVizContextMessage, 'options'>
 > = true;
+const inboundPaletteRemainsOptional: Assert<
+    IsOptional<DataAppVizContextMessage, 'colorPalette'>
+> = true;
 void [
     messageKeysMatchHost,
     messageTypeMatchesHost,
     optionValueTypesMatchHost,
     hostPayloadIsAcceptedBySdk,
     inboundOptionsRemainOptional,
+    inboundPaletteRemainsOptional,
 ];
 
 const row: VizContextRow = {
@@ -158,6 +162,29 @@ describe('toVizContextState', () => {
         });
     });
 
+    it('carries the host-resolved palette through', () => {
+        expect(
+            toVizContextState(message({ colorPalette: ['#111', '#222'] }))
+                .colorPalette,
+        ).toEqual(['#111', '#222']);
+    });
+
+    it('falls back to an empty palette when the host omits or malforms it', () => {
+        expect(
+            toVizContextState(message({ colorPalette: undefined }))
+                .colorPalette,
+        ).toEqual([]);
+        expect(
+            toVizContextState(message({ colorPalette: 'nope' as never }))
+                .colorPalette,
+        ).toEqual([]);
+        expect(
+            toVizContextState(
+                message({ colorPalette: ['#111', null as never, '#222'] }),
+            ).colorPalette,
+        ).toEqual(['#111', '#222']);
+    });
+
     it('still normalises fieldMapping and rows', () => {
         expect(
             toVizContextState(
@@ -170,6 +197,7 @@ describe('toVizContextState', () => {
             fieldMapping: {},
             rows: [],
             options: {},
+            colorPalette: [],
         });
     });
 });

--- a/packages/query-sdk/src/vizContext.ts
+++ b/packages/query-sdk/src/vizContext.ts
@@ -34,6 +34,7 @@ export type VizContextRow = Record<string, VizContextCell | undefined>;
 /**
  * A config option value. Its shape follows the option's declared type:
  * `boolean` → boolean, `number` → number, `select`/`text`/`color` → string.
+ * Series colours are not an option — they arrive on `colorPalette`.
  */
 export type VizContextOptionValue = boolean | number | string;
 
@@ -41,7 +42,9 @@ export type VizContextOptionValue = boolean | number | string;
  * Pushed by the host into the iframe. `fieldMapping` maps each field name the
  * renderer declared to the query field id it resolves to; `rows` are the
  * host-fetched result rows keyed by field id; `options` holds the current
- * value of each config option the renderer declared.
+ * value of each config option the renderer declared; `colorPalette` is the
+ * Lightdash palette resolved for this chart, pushed whether or not the
+ * renderer declared one.
  */
 export type DataAppVizContextMessage = {
     type: 'lightdash:sdk:data-app-viz-context';
@@ -49,6 +52,8 @@ export type DataAppVizContextMessage = {
     rows: VizContextRow[];
     /** Absent when the installed host predates config-option delivery. */
     options?: Record<string, VizContextOptionValue>;
+    /** Absent when the installed host predates palette delivery. */
+    colorPalette?: string[];
 };
 
 /** Posted by the iframe on mount so the host pushes the current context. */
@@ -84,6 +89,13 @@ export type VizContext = {
     rows: VizContextRow[];
     /** Config option name → current value (the user's choice, else the declared default). */
     options: Record<string, VizContextOptionValue>;
+    /**
+     * Ordered series colours resolved from the Lightdash palette the viewer
+     * picked. Colour multi-series charts with
+     * `colorPalette[i % colorPalette.length]`. Empty only when the host
+     * resolved no palette; keep a fallback array in your own code for that.
+     */
+    colorPalette: string[];
     /** False until the first context arrives — render a placeholder while false. */
     ready: boolean;
 };
@@ -92,6 +104,7 @@ type VizContextValue = {
     fieldMapping: Record<string, string>;
     rows: VizContextRow[];
     options: Record<string, VizContextOptionValue>;
+    colorPalette: string[];
 };
 
 type VizContextState = VizContextValue | null;
@@ -123,8 +136,9 @@ const normalizeOptions = (
 
 /**
  * Normalises an inbound host message into provider state. The payload crosses a
- * postMessage boundary so every key is treated as untrusted; `options` is also
- * absent from hosts predating it, and falls back to `{}`.
+ * postMessage boundary so every key is treated as untrusted; `options` and
+ * `colorPalette` are also absent from hosts predating them, and fall back to
+ * `{}` / `[]`.
  */
 export function toVizContextState(
     message: DataAppVizContextMessage,
@@ -133,6 +147,11 @@ export function toVizContextState(
         fieldMapping: message.fieldMapping ?? {},
         rows: Array.isArray(message.rows) ? message.rows : [],
         options: normalizeOptions(message.options),
+        colorPalette: Array.isArray(message.colorPalette)
+            ? message.colorPalette.filter(
+                  (color): color is string => typeof color === 'string',
+              )
+            : [],
     };
 }
 
@@ -197,7 +216,7 @@ export function VizContextProvider({ children }: { children: ReactNode }) {
  * still works standalone. Re-renders whenever the host pushes (on load, on
  * mapping change, on query change). Resolve a declared field to its bound cell
  * with `fieldMapping[name]` then `getFormatted`/`getRaw`; read a declared
- * config option with `options[name]`.
+ * config option with `options[name]`, and colour series from `colorPalette`.
  */
 export function useVizContext(): VizContext {
     const fromProvider = useContext(VizContextContext);
@@ -215,6 +234,7 @@ export function useVizContext(): VizContext {
         fieldMapping: context?.fieldMapping ?? {},
         rows: context?.rows ?? [],
         options: context?.options ?? {},
+        colorPalette: context?.colorPalette ?? [],
         ready: context !== null,
     };
 }


### PR DESCRIPTION
Lets a viz say it colours from the chart's palette.

`colorPalette` is a top-level key on the declaration rather than a sixth option type. There's one palette per chart and it carries no value of its own, so the option union stays five uniform types, every one of which produces a value on `options`.

Declaring it puts the standard palette picker in the config tab it names, and delivers the resolved colours on the render context. The colours come through the same org/project/space/dashboard cascade as native charts, so a viz on a dashboard matches the charts beside it. The palette is pushed whether or not the viz declared one, so a viz that colours series never has to check first.

Nothing new is persisted: the choice is stored as the chart's existing `color_palette_uuid`.

Registers `viz-config-options` in the SDK capability manifest so existing apps get offered the feature. Staleness is a key-set diff, so a new key is the only thing that surfaces it.

https://linear.app/lightdash/issue/GLITCH-563/generated-config-form-viz-declares-typed-config-options-colours-layout