### PR TITLE
feat(data-apps): give the generator preview the same config form

### DIFF
--- a/packages/frontend/src/features/apps/components/DataAppVizTestPanel.test.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizTestPanel.test.tsx
@@ -9,8 +9,9 @@ import {
     type DataAppVizSchema,
     type Explore,
     type Item,
+    type ResultRow,
 } from '@lightdash/common';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../testing/testUtils';
@@ -22,10 +23,45 @@ const { fieldSelectItems } = vi.hoisted(() => ({
 }));
 
 vi.mock('../../../components/common/FieldSelect', () => ({
-    default: ({ items }: { items: Item[] }) => {
+    default: ({
+        items,
+        onChange,
+        placeholder,
+    }: {
+        items: Item[];
+        onChange: (item: Item | undefined) => void;
+        placeholder: string;
+    }) => {
         fieldSelectItems.push(items);
-        return <div data-testid="field-select" />;
+        return (
+            <button
+                type="button"
+                data-testid="field-select"
+                onClick={() => onChange(items[0])}
+            >
+                {placeholder}
+            </button>
+        );
     },
+}));
+vi.mock('../../../components/common/PalettePicker/PalettePicker', () => ({
+    PalettePicker: ({
+        label,
+        onChange,
+    }: {
+        label: string;
+        onChange: (value: string | null) => void;
+    }) => (
+        <button type="button" onClick={() => onChange('ocean-palette')}>
+            {label}
+        </button>
+    ),
+}));
+vi.mock('../../../hooks/appearance/useOrganizationAppearance', () => ({
+    useColorPalettes: vi.fn(),
+}));
+vi.mock('../../../hooks/appearance/useProjectColorPalette', () => ({
+    useProjectColorPalette: vi.fn(),
 }));
 vi.mock('../../../hooks/useExplores', () => ({
     useExplores: vi.fn(),
@@ -37,6 +73,8 @@ vi.mock('../../../providers/Explorer/useQueryExecutor', () => ({
     useQueryExecutor: vi.fn(),
 }));
 
+import { useColorPalettes } from '../../../hooks/appearance/useOrganizationAppearance';
+import { useProjectColorPalette } from '../../../hooks/appearance/useProjectColorPalette';
 import { useExploreByProjectUuid } from '../../../hooks/useExplore';
 import { useExplores } from '../../../hooks/useExplores';
 import { useQueryExecutor } from '../../../providers/Explorer/useQueryExecutor';
@@ -104,6 +142,35 @@ const exploreWithHiddenFields: Explore = {
     targetDatabase: SupportedDbtAdapter.POSTGRES,
 };
 
+const configurableSchema: DataAppVizSchema = {
+    fields: [
+        {
+            name: 'source',
+            label: 'Source',
+            type: 'dimension',
+            required: true,
+        },
+    ],
+    configOptions: [
+        {
+            type: 'boolean',
+            name: 'showLegend',
+            label: 'Show legend',
+            group: 'Style',
+            default: true,
+        },
+    ],
+    colorPalette: { group: 'Style' },
+};
+
+const resultRows: ResultRow[] = [
+    {
+        orders_visible: {
+            value: { raw: 'Retail', formatted: 'Retail' },
+        },
+    },
+];
+
 describe('isMappingComplete', () => {
     it('is false until every required field is mapped', () => {
         expect(isMappingComplete(schema, {})).toBe(false);
@@ -165,6 +232,28 @@ describe('DataAppVizTestPanel', () => {
         vi.mocked(useExploreByProjectUuid).mockReturnValue({
             data: undefined,
         } as unknown as ReturnType<typeof useExploreByProjectUuid>);
+        vi.mocked(useColorPalettes).mockReturnValue({
+            data: [
+                {
+                    colorPaletteUuid: 'ocean-palette',
+                    organizationUuid: 'org-1',
+                    name: 'Ocean',
+                    colors: ['#123456', '#abcdef'],
+                    darkColors: null,
+                    createdAt: new Date('2026-01-01T00:00:00Z'),
+                    isActive: false,
+                },
+            ],
+        } as unknown as ReturnType<typeof useColorPalettes>);
+        vi.mocked(useProjectColorPalette).mockReturnValue({
+            data: {
+                colors: ['#111111'],
+                darkColors: null,
+                paletteUuid: null,
+                paletteName: null,
+                source: { type: 'default' },
+            },
+        } as unknown as ReturnType<typeof useProjectColorPalette>);
         vi.mocked(useQueryExecutor).mockReturnValue([
             {
                 query: { isFetching: false, error: null },
@@ -178,6 +267,38 @@ describe('DataAppVizTestPanel', () => {
         ] as unknown as ReturnType<typeof useQueryExecutor>);
     });
 
+    const runSuccessfulPreviewQuery = async () => {
+        const user = userEvent.setup();
+        vi.mocked(useExploreByProjectUuid).mockReturnValue({
+            data: exploreWithHiddenFields,
+        } as unknown as ReturnType<typeof useExploreByProjectUuid>);
+        vi.mocked(useQueryExecutor).mockReturnValue([
+            {
+                query: {
+                    data: { queryUuid: 'query-1' },
+                    isFetching: false,
+                    error: null,
+                },
+                queryResults: {
+                    rows: resultRows,
+                    queryUuid: 'query-1',
+                    isFetchingFirstPage: false,
+                    error: null,
+                },
+            },
+            vi.fn(),
+        ] as unknown as ReturnType<typeof useQueryExecutor>);
+
+        await user.click(screen.getByPlaceholderText('Select an explore'));
+        await user.click(await screen.findByText('Orders'));
+        await user.click(screen.getByRole('button', { name: 'Select source' }));
+        await user.click(
+            screen.getByRole('button', { name: /run test query/i }),
+        );
+
+        return user;
+    };
+
     it('lists the declared fields and the explore picker up-front', () => {
         renderWithProviders(
             <DataAppVizTestPanel
@@ -187,8 +308,6 @@ describe('DataAppVizTestPanel', () => {
             />,
         );
 
-        expect(screen.getByText('Visualization ready')).toBeInTheDocument();
-        expect(screen.getByText('Test with data')).toBeInTheDocument();
         expect(
             screen.getByPlaceholderText('Select an explore'),
         ).toBeInTheDocument();
@@ -209,7 +328,8 @@ describe('DataAppVizTestPanel', () => {
         expect(useExplores).toHaveBeenCalledWith('p1', true);
     });
 
-    it('hides the run action until an explore is selected', () => {
+    it('hides the run action until an explore is selected', async () => {
+        const user = userEvent.setup();
         renderWithProviders(
             <DataAppVizTestPanel
                 projectUuid="p1"
@@ -221,6 +341,129 @@ describe('DataAppVizTestPanel', () => {
         expect(
             screen.queryByRole('button', { name: /run test query/i }),
         ).not.toBeInTheDocument();
+
+        await user.click(screen.getByPlaceholderText('Select an explore'));
+        await user.click(await screen.findByText('Orders'));
+
+        // Still disabled — no field is mapped yet.
+        expect(
+            screen.getByRole('button', { name: /run test query/i }),
+        ).toBeDisabled();
+    });
+
+    it('groups declared options into config tabs, defaults applied', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(
+            <DataAppVizTestPanel
+                projectUuid="p1"
+                schema={{
+                    fields: schema.fields,
+                    configOptions: [
+                        {
+                            type: 'boolean',
+                            name: 'showLegend',
+                            label: 'Show legend',
+                            group: 'Style',
+                            default: true,
+                        },
+                    ],
+                    colorPalette: null,
+                }}
+                onContextChange={vi.fn()}
+            />,
+        );
+
+        expect(
+            screen.getAllByRole('tab').map((tab) => tab.textContent),
+        ).toEqual(['General', 'Style']);
+
+        await user.click(screen.getByRole('tab', { name: 'Style' }));
+        expect(screen.getByLabelText('Show legend')).toBeChecked();
+    });
+
+    it('offers the palette picker for a declared palette', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(
+            <DataAppVizTestPanel
+                projectUuid="p1"
+                schema={{
+                    fields: schema.fields,
+                    configOptions: [],
+                    colorPalette: { group: 'Colours' },
+                }}
+                onContextChange={vi.fn()}
+            />,
+        );
+
+        await user.click(screen.getByRole('tab', { name: 'Colours' }));
+
+        expect(screen.getByText('Color palette')).toBeInTheDocument();
+    });
+
+    it('republishes option edits after a successful query', async () => {
+        const onContextChange = vi.fn();
+        renderWithProviders(
+            <DataAppVizTestPanel
+                projectUuid="p1"
+                schema={configurableSchema}
+                onContextChange={onContextChange}
+            />,
+        );
+
+        const user = await runSuccessfulPreviewQuery();
+        await waitFor(() =>
+            expect(onContextChange).toHaveBeenLastCalledWith({
+                fieldMapping: { source: 'orders_visible' },
+                rows: resultRows,
+                options: { showLegend: true },
+                colorPalette: ['#111111'],
+            }),
+        );
+
+        await user.click(screen.getByRole('tab', { name: 'Style' }));
+        await user.click(screen.getByLabelText('Show legend'));
+
+        await waitFor(() =>
+            expect(onContextChange).toHaveBeenLastCalledWith({
+                fieldMapping: { source: 'orders_visible' },
+                rows: resultRows,
+                options: { showLegend: false },
+                colorPalette: ['#111111'],
+            }),
+        );
+    });
+
+    it('republishes palette edits after a successful query', async () => {
+        const onContextChange = vi.fn();
+        renderWithProviders(
+            <DataAppVizTestPanel
+                projectUuid="p1"
+                schema={configurableSchema}
+                onContextChange={onContextChange}
+            />,
+        );
+
+        const user = await runSuccessfulPreviewQuery();
+        await waitFor(() =>
+            expect(onContextChange).toHaveBeenLastCalledWith({
+                fieldMapping: { source: 'orders_visible' },
+                rows: resultRows,
+                options: { showLegend: true },
+                colorPalette: ['#111111'],
+            }),
+        );
+
+        await user.click(screen.getByRole('tab', { name: 'Style' }));
+        await user.click(screen.getByRole('button', { name: 'Color palette' }));
+
+        await waitFor(() =>
+            expect(onContextChange).toHaveBeenLastCalledWith({
+                fieldMapping: { source: 'orders_visible' },
+                rows: resultRows,
+                options: { showLegend: true },
+                colorPalette: ['#123456', '#abcdef'],
+            }),
+        );
     });
 
     it('matches Explorer field visibility', async () => {

--- a/packages/frontend/src/features/apps/components/DataAppVizTestPanel.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizTestPanel.tsx
@@ -7,13 +7,18 @@ import {
     isSummaryExploreError,
     QueryExecutionContext,
     type DataAppVizContext,
+    type DataAppVizOptionValue,
+    type DataAppVizOptionValues,
     type DataAppVizSchema,
 } from '@lightdash/common';
 import { Button, Card, Group, Select, Stack, Text } from '@mantine-8/core';
 import { useMantineColorScheme } from '@mantine/core';
-import { useEffect, useMemo, useState, type FC } from 'react';
+import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import Callout from '../../../components/common/Callout';
 import FieldSelect from '../../../components/common/FieldSelect';
+import { PalettePicker } from '../../../components/common/PalettePicker/PalettePicker';
+import DataAppVizOptionTabs from '../../../components/VisualizationConfigs/DataAppVizConfig/DataAppVizOptionTabs';
+import { useColorPalettes } from '../../../hooks/appearance/useOrganizationAppearance';
 import { useProjectColorPalette } from '../../../hooks/appearance/useProjectColorPalette';
 import { useExploreByProjectUuid } from '../../../hooks/useExplore';
 import { useExplores } from '../../../hooks/useExplores';
@@ -32,8 +37,9 @@ type Props = {
 };
 
 // Interactive panel below the viz result card: pick an explore, map each
-// declared field to a dimension/metric, run one query, and push the resulting
-// rows into the generator preview via `onContextChange`. Fields only.
+// declared field to a dimension/metric, set any declared config option, run one
+// query, and push the resulting context into the generator preview via
+// `onContextChange`.
 const DataAppVizTestPanel: FC<Props> = ({
     projectUuid,
     schema,
@@ -42,6 +48,15 @@ const DataAppVizTestPanel: FC<Props> = ({
     const [exploreName, setExploreName] = useState<string | null>(null);
     const [fieldMapping, setFieldMapping] = useState<Record<string, string>>(
         {},
+    );
+    // Only what the user explicitly changed; defaults resolve at push time.
+    const [optionValues, setOptionValues] = useState<DataAppVizOptionValues>(
+        {},
+    );
+    // Palette chosen here only for the preview — nothing is saved until the
+    // viz is used on a chart, which then owns the palette the normal way.
+    const [colorPaletteUuid, setColorPaletteUuid] = useState<string | null>(
+        null,
     );
     // Snapshot of the query + mapping captured when the user clicks Run. Gates
     // the query so nothing fires while the user is still picking fields.
@@ -69,22 +84,29 @@ const DataAppVizTestPanel: FC<Props> = ({
     );
 
     const effectiveOptions = useMemo(
-        () => getEffectiveOptionValues(schema.configOptions, {}),
-        [schema.configOptions],
+        () => getEffectiveOptionValues(schema.configOptions, optionValues),
+        [schema.configOptions, optionValues],
     );
 
     const { colorScheme } = useMantineColorScheme();
+    const { data: palettes = [] } = useColorPalettes();
     const { data: projectPalette } = useProjectColorPalette(projectUuid);
+    const selectedPalette = useMemo(
+        () => palettes.find((p) => p.colorPaletteUuid === colorPaletteUuid),
+        [palettes, colorPaletteUuid],
+    );
     const colorPalette = useMemo(() => {
-        if (!projectPalette) return ECHARTS_DEFAULT_COLORS;
-        if (colorScheme === 'dark' && projectPalette.darkColors) {
-            return projectPalette.darkColors;
+        const source = selectedPalette ?? projectPalette;
+        if (!source) return ECHARTS_DEFAULT_COLORS;
+        if (colorScheme === 'dark' && source.darkColors) {
+            return source.darkColors;
         }
-        return projectPalette.colors;
-    }, [projectPalette, colorScheme]);
+        return source.colors;
+    }, [selectedPalette, projectPalette, colorScheme]);
 
     const rows = queryResults.rows;
-    // Notify the parent once the run's rows arrive (external async → parent).
+    // Notify the parent once the run's rows arrive (external async → parent),
+    // and again whenever an option changes so the preview re-renders live.
     // Only push rows belonging to this run's query — on a re-run the executor
     // transiently re-exposes the previous query's cached page before the new
     // queryUuid lands.
@@ -136,6 +158,13 @@ const DataAppVizTestPanel: FC<Props> = ({
         clearRun();
     };
 
+    const setOption = useCallback(
+        (name: string, value: DataAppVizOptionValue) => {
+            setOptionValues((prev) => ({ ...prev, [name]: value }));
+        },
+        [],
+    );
+
     const handleRun = () => {
         if (!exploreName || !isMappingComplete(schema, fieldMapping)) return;
         setRun({
@@ -159,63 +188,84 @@ const DataAppVizTestPanel: FC<Props> = ({
         Boolean(run) && (query.isFetching || queryResults.isFetchingFirstPage);
     const error = query.error ?? queryResults.error;
 
+    const generalContent = (
+        <Stack gap="xs">
+            <Select
+                size="xs"
+                label="Test with data"
+                placeholder="Select an explore"
+                searchable
+                data={exploreOptions}
+                value={exploreName}
+                onChange={handleExploreChange}
+            />
+
+            <Stack gap="xs">
+                {schema.fields.map((field) => {
+                    const items =
+                        field.type === 'metric' ? metrics : dimensions;
+                    const selectedId = fieldMapping[field.name];
+                    const selectedItem = selectedId
+                        ? items.find((i) => getItemId(i) === selectedId)
+                        : undefined;
+                    return (
+                        <Stack key={field.name} gap={2}>
+                            <Group gap="xs">
+                                <Text size="xs" fw={500}>
+                                    {field.label}
+                                </Text>
+                                <DataAppVizFieldTypeBadge type={field.type} />
+                            </Group>
+                            {exploreName && (
+                                <FieldSelect
+                                    size="xs"
+                                    placeholder={`Select ${field.label.toLowerCase()}`}
+                                    disabled={items.length === 0}
+                                    item={selectedItem}
+                                    items={items}
+                                    onChange={(newField) =>
+                                        setField(
+                                            field.name,
+                                            newField
+                                                ? getItemId(newField)
+                                                : null,
+                                        )
+                                    }
+                                    clearable={!field.required}
+                                    hasGrouping
+                                />
+                            )}
+                        </Stack>
+                    );
+                })}
+            </Stack>
+        </Stack>
+    );
+
     return (
         <Card withBorder radius="md" p="sm">
             <Stack gap="xs">
                 <Text size="sm" fw={600}>
                     Visualization ready
                 </Text>
-                <Select
-                    size="xs"
-                    label="Test with data"
-                    placeholder="Select an explore"
-                    searchable
-                    data={exploreOptions}
-                    value={exploreName}
-                    onChange={handleExploreChange}
-                />
 
-                <Stack gap="xs">
-                    {schema.fields.map((field) => {
-                        const items =
-                            field.type === 'metric' ? metrics : dimensions;
-                        const selectedId = fieldMapping[field.name];
-                        const selectedItem = selectedId
-                            ? items.find((i) => getItemId(i) === selectedId)
-                            : undefined;
-                        return (
-                            <Stack key={field.name} gap={2}>
-                                <Group gap="xs">
-                                    <Text size="xs" fw={500}>
-                                        {field.label}
-                                    </Text>
-                                    <DataAppVizFieldTypeBadge
-                                        type={field.type}
-                                    />
-                                </Group>
-                                {exploreName && (
-                                    <FieldSelect
-                                        size="xs"
-                                        placeholder={`Select ${field.label.toLowerCase()}`}
-                                        disabled={items.length === 0}
-                                        item={selectedItem}
-                                        items={items}
-                                        onChange={(newField) =>
-                                            setField(
-                                                field.name,
-                                                newField
-                                                    ? getItemId(newField)
-                                                    : null,
-                                            )
-                                        }
-                                        clearable={!field.required}
-                                        hasGrouping
-                                    />
-                                )}
-                            </Stack>
-                        );
-                    })}
-                </Stack>
+                <DataAppVizOptionTabs
+                    generalContent={generalContent}
+                    configOptions={schema.configOptions}
+                    values={effectiveOptions}
+                    onChange={setOption}
+                    colorPalette={schema.colorPalette}
+                    paletteControl={
+                        <PalettePicker
+                            label="Color palette"
+                            value={colorPaletteUuid}
+                            onChange={setColorPaletteUuid}
+                            palettes={palettes}
+                            parentLabel="Project default"
+                            showPreview={false}
+                        />
+                    }
+                />
 
                 {error && (
                     <Callout variant="danger">{getErrorMessage(error)}</Callout>


### PR DESCRIPTION
The generator preview gets the same config form as a chart.

The test panel reuses the chart config's tab shell, so a viz author sees its declared options and palette exactly as a viewer will, and the preview re-renders as they change.

Palette choice here is preview-only. Nothing is saved until the viz is used on a chart, which then owns the palette the normal way.

https://linear.app/lightdash/issue/GLITCH-563/generated-config-form-viz-declares-typed-config-options-colours-layout