### PR TITLE
feat: consolidation merge operation creates the merged memory row

### DIFF
--- a/packages/backend/src/ee/database/entities/aiAgentMemory.ts
+++ b/packages/backend/src/ee/database/entities/aiAgentMemory.ts
@@ -66,6 +66,7 @@ export type AiAgentMemoryTable = Knex.CompositeTableType<
         | 'created_at'
         | 'updated_at'
     > &
+        AiAgentMemoryJsonbWrite &
         Partial<
             Pick<
                 DbAiAgentMemory,

--- a/packages/backend/src/ee/models/AiAgentMemoryModel.ts
+++ b/packages/backend/src/ee/models/AiAgentMemoryModel.ts
@@ -1,13 +1,15 @@
 import {
     assertUnreachable,
+    getAiAgentMemoryConsolidationOperationSlugs,
+    getAiProjectContextObjectKey,
     ProjectType,
     type AiAgentAdminMemoriesSummary,
     type AiAgentAdminMemoryFilters,
     type AiAgentAdminMemorySort,
+    type AiAgentMemoryConsolidationMergeOperation,
     type AiAgentMemoryConsolidationOperation,
     type AiAgentMemoryConsolidationRejection,
     type AiAgentMemoryConsolidationRunStatus,
-    type AiAgentMemoryConsolidationStatusFlipOperation,
     type AiAgentMemoryScope,
     type AiProjectContextTypedObjectRef,
     type AiThreadCreatedFrom,
@@ -15,6 +17,7 @@ import {
     type KnexPaginatedData,
     type UUID,
 } from '@lightdash/common';
+import { randomBytes } from 'crypto';
 import { Knex } from 'knex';
 import { EmailTableName } from '../../database/entities/emails';
 import { ProjectTableName } from '../../database/entities/projects';
@@ -171,9 +174,24 @@ export type AiAgentMemoryConsolidationSelectedRow = {
 
 export type AiAgentMemoryConsolidationApplyResult = {
     run: DbAiAgentMemoryConsolidationRun;
-    applied: AiAgentMemoryConsolidationStatusFlipOperation[];
+    applied: AiAgentMemoryConsolidationOperation[];
     rejected: AiAgentMemoryConsolidationRejection[];
 };
+
+/** A source row as the apply transaction re-reads it, inside the lock. */
+type ConsolidationSourceRow = Pick<
+    DbAiAgentMemory,
+    | 'ai_agent_memory_uuid'
+    | 'slug'
+    | 'status'
+    | 'generated_at'
+    | 'agent_uuid'
+    | 'scope'
+    | 'cited_count'
+    | 'last_cited_at'
+    | 'pulled_count'
+    | 'last_pulled_at'
+>;
 
 const CONSOLIDATION_LOCK_CLASS = 4;
 
@@ -1041,7 +1059,110 @@ export class AiAgentMemoryModel {
     }
 
     /**
-     * Applies status flips and writes the run row in one transaction, under a
+     * A merged row is a new row that inherits what its sources earned: summed
+     * counts, the newest telemetry stamps, and the newest `generated_at` — never
+     * the merge time, which would reset the injection fence's staleness read.
+     * It carries no source thread and no thread summary, which is what routes
+     * the memory page to its consolidated-provenance lineage walk.
+     */
+    private static async applyMerge(
+        trx: Knex,
+        args: {
+            operation: AiAgentMemoryConsolidationMergeOperation;
+            organizationUuid: UUID;
+            projectUuid: UUID;
+            ownerUserUuid: UUID;
+            sources: ConsolidationSourceRow[];
+            unresolvedObjectKeys: Set<string>;
+        },
+    ): Promise<AiAgentMemoryConsolidationMergeOperation> {
+        const { sources } = args;
+        const maxTime = (dates: Array<Date | null>): Date | null => {
+            const times = dates.flatMap((date) =>
+                date ? [date.getTime()] : [],
+            );
+            return times.length === 0 ? null : new Date(Math.max(...times));
+        };
+        // Newest source first, slug as the tie-break so the inherited agent is
+        // deterministic; a row with no agent is unreadable on the memory page.
+        const newestFirst = [...sources].sort(
+            (a, b) =>
+                b.generated_at.getTime() - a.generated_at.getTime() ||
+                a.slug.localeCompare(b.slug),
+        );
+        // The curator's handle is not unique across a project; the suffix keeps
+        // a second merge from failing the whole run on the slug constraint.
+        const slug = `${args.operation.slug}-${randomBytes(4).toString('hex')}`;
+
+        const [merged] = await trx<AiAgentMemoryTable>(AiAgentMemoryTableName)
+            .insert({
+                organization_uuid: args.organizationUuid,
+                project_uuid: args.projectUuid,
+                agent_uuid:
+                    newestFirst.find((source) => source.agent_uuid !== null)
+                        ?.agent_uuid ?? null,
+                user_uuid: args.ownerUserUuid,
+                source_thread_uuid: null,
+                slug,
+                title: args.operation.title,
+                raw_memory: args.operation.memory,
+                thread_summary: null,
+                terms: JSON.stringify(args.operation.terms),
+                objects: JSON.stringify(args.operation.objects),
+                // This run re-resolved every object against the live catalog, so
+                // the merged row records present fact, not a source's snapshot.
+                unresolved_objects: JSON.stringify(
+                    args.operation.objects.filter((object) =>
+                        args.unresolvedObjectKeys.has(
+                            getAiProjectContextObjectKey(object),
+                        ),
+                    ),
+                ),
+                // Scope never widens: a single `user` source narrows the result.
+                scope: sources.every((source) => source.scope === 'project')
+                    ? 'project'
+                    : 'user',
+                generated_at: new Date(
+                    Math.max(
+                        ...sources.map((source) =>
+                            source.generated_at.getTime(),
+                        ),
+                    ),
+                ),
+                cited_count: sources.reduce(
+                    (total, source) => total + source.cited_count,
+                    0,
+                ),
+                last_cited_at: maxTime(
+                    sources.map((source) => source.last_cited_at),
+                ),
+                pulled_count: sources.reduce(
+                    (total, source) => total + source.pulled_count,
+                    0,
+                ),
+                last_pulled_at: maxTime(
+                    sources.map((source) => source.last_pulled_at),
+                ),
+            })
+            .returning('ai_agent_memory_uuid');
+
+        await trx<AiAgentMemoryTable>(AiAgentMemoryTableName)
+            .whereIn(
+                'ai_agent_memory_uuid',
+                sources.map((source) => source.ai_agent_memory_uuid),
+            )
+            .update({
+                status: 'superseded',
+                superseded_by_uuid: merged.ai_agent_memory_uuid,
+                updated_at: trx.fn.now(),
+            });
+
+        // The audit carries the slug the row actually got, not the handle asked for.
+        return { ...args.operation, slug };
+    }
+
+    /**
+     * Applies operations and writes the run row in one transaction, under a
      * per-partition advisory lock. The slug-to-uuid resolution inside the lock
      * doubles as the movement check: a row that is no longer active, or whose
      * body was rewritten since selection, is rejected instead of applied.
@@ -1052,8 +1173,10 @@ export class AiAgentMemoryModel {
             'appliedOperations' | 'rejectedOperations' | 'status'
         >;
         selection: AiAgentMemoryConsolidationSelectedRow[];
-        operations: AiAgentMemoryConsolidationStatusFlipOperation[];
+        operations: AiAgentMemoryConsolidationOperation[];
         rejected: AiAgentMemoryConsolidationRejection[];
+        /** Object keys this run resolved against the live catalog and did not find. */
+        unresolvedObjectKeys: Set<string>;
     }): Promise<AiAgentMemoryConsolidationApplyResult> {
         return this.database.transaction(async (trx) => {
             await trx.raw('SELECT pg_advisory_xact_lock(?, hashtext(?))', [
@@ -1063,10 +1186,8 @@ export class AiAgentMemoryModel {
 
             const namedSlugs = [
                 ...new Set(
-                    args.operations.flatMap((operation) =>
-                        operation.type === 'supersede'
-                            ? [operation.loser_slug, operation.winner_slug]
-                            : [operation.slug],
+                    args.operations.flatMap(
+                        getAiAgentMemoryConsolidationOperationSlugs,
                     ),
                 ),
             ];
@@ -1083,6 +1204,12 @@ export class AiAgentMemoryModel {
                               'slug',
                               'status',
                               'generated_at',
+                              'agent_uuid',
+                              'scope',
+                              'cited_count',
+                              'last_cited_at',
+                              'pulled_count',
+                              'last_pulled_at',
                           );
             const currentBySlug = new Map(
                 currentRows.map((row) => [row.slug, row]),
@@ -1103,22 +1230,38 @@ export class AiAgentMemoryModel {
                 );
             };
 
-            const applied: AiAgentMemoryConsolidationStatusFlipOperation[] = [];
+            const accepted: AiAgentMemoryConsolidationOperation[] = [];
             const rejected = [...args.rejected];
             for (const operation of args.operations) {
-                const slugs =
-                    operation.type === 'supersede'
-                        ? [operation.loser_slug, operation.winner_slug]
-                        : [operation.slug];
-                if (slugs.every(isUnmoved)) {
-                    applied.push(operation);
+                if (
+                    getAiAgentMemoryConsolidationOperationSlugs(
+                        operation,
+                    ).every(isUnmoved)
+                ) {
+                    accepted.push(operation);
                 } else {
                     rejected.push({ operation, reason: 'row_moved' });
                 }
             }
 
-            for (const operation of applied) {
+            const applied: AiAgentMemoryConsolidationOperation[] = [];
+            for (const operation of accepted) {
                 switch (operation.type) {
+                    case 'merge':
+                        applied.push(
+                            // eslint-disable-next-line no-await-in-loop
+                            await AiAgentMemoryModel.applyMerge(trx, {
+                                operation,
+                                organizationUuid: args.run.organizationUuid,
+                                projectUuid: args.run.projectUuid,
+                                ownerUserUuid: args.run.ownerUserUuid,
+                                sources: operation.source_slugs.map(
+                                    (slug) => currentBySlug.get(slug)!,
+                                ),
+                                unresolvedObjectKeys: args.unresolvedObjectKeys,
+                            }),
+                        );
+                        break;
                     case 'supersede':
                         // eslint-disable-next-line no-await-in-loop
                         await trx<AiAgentMemoryTable>(AiAgentMemoryTableName)
@@ -1134,6 +1277,7 @@ export class AiAgentMemoryModel {
                                 )!.ai_agent_memory_uuid,
                                 updated_at: this.database.fn.now(),
                             });
+                        applied.push(operation);
                         break;
                     case 'retire':
                         // eslint-disable-next-line no-await-in-loop
@@ -1147,6 +1291,7 @@ export class AiAgentMemoryModel {
                                 status: 'retired',
                                 updated_at: this.database.fn.now(),
                             });
+                        applied.push(operation);
                         break;
                     default:
                         assertUnreachable(

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryConsolidation.integration.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryConsolidation.integration.test.ts
@@ -6,6 +6,7 @@ import {
     type AiAgentMemoryConsolidationOperation,
     type AiProjectContextTypedObjectRef,
 } from '@lightdash/common';
+import { randomUUID } from 'crypto';
 import type { Knex } from 'knex';
 import { vi } from 'vitest';
 import { LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
@@ -18,6 +19,8 @@ import {
 import { UserTableName } from '../../../database/entities/users';
 import { FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
 import { getTestContext } from '../../../vitest.setup.integration';
+import { AiThreadTableName } from '../../database/entities/ai';
+import { AiAgentTableName } from '../../database/entities/aiAgent';
 import {
     AiAgentMemoryConsolidationRunTableName,
     AiAgentMemoryTableName,
@@ -44,9 +47,11 @@ describe('AI agent memory consolidation integration', () => {
     let analytics: LightdashAnalytics;
     let ownerUuid: string;
     let otherOwnerUuid: string;
+    let agentUuid: string;
     let resolvableExploreName: string;
     const originalFlags = new Map<string, DbFeatureFlag | undefined>();
     const createdUserUuids: string[] = [];
+    const createdThreadUuids: string[] = [];
 
     const setFeatureFlag = async (flagId: string, enabled: boolean) => {
         await database<FeatureFlagsTable>(FeatureFlagsTableName)
@@ -122,6 +127,28 @@ describe('AI agent memory consolidation integration', () => {
         ownerUuid = await createUser('Owner');
         otherOwnerUuid = await createUser('Other');
 
+        const [agent] = await database(AiAgentTableName)
+            .insert({
+                organization_uuid: SEED_ORG_1.organization_uuid,
+                project_uuid: SEED_PROJECT.project_uuid,
+                name: 'Consolidation agent',
+                slug: `consolidation-agent-${randomUUID().slice(0, 8)}`,
+                description: null,
+                image_url: null,
+                image_url_source: null,
+                tags: null,
+                enable_data_access: false,
+                enable_self_improvement: false,
+                enable_content_tools: false,
+                enable_user_context: false,
+                admin_only: false,
+                model_config: null,
+                is_system: false,
+                version: 1,
+            })
+            .returning<Array<{ ai_agent_uuid: string }>>('ai_agent_uuid');
+        agentUuid = agent.ai_agent_uuid;
+
         const explores = await getTestContext()
             .app.getModels()
             .getProjectModel()
@@ -146,9 +173,18 @@ describe('AI agent memory consolidation integration', () => {
                     .orWhereILike('slug', 'consolidation-%');
             })
             .delete();
+        if (createdThreadUuids.length > 0) {
+            await database(AiThreadTableName)
+                .whereIn('ai_thread_uuid', createdThreadUuids)
+                .delete();
+            createdThreadUuids.length = 0;
+        }
     });
 
     afterAll(async () => {
+        await database(AiAgentTableName)
+            .where('ai_agent_uuid', agentUuid)
+            .delete();
         await database(UserTableName)
             .whereIn('user_uuid', createdUserUuids)
             .delete();
@@ -242,6 +278,37 @@ describe('AI agent memory consolidation integration', () => {
         return row;
     };
 
+    /** The row a merge created: its stored slug carries a uniqueness suffix. */
+    const mergedRow = async (handle: string): Promise<DbAiAgentMemory> => {
+        const row = await database(AiAgentMemoryTableName)
+            .where('project_uuid', SEED_PROJECT.project_uuid)
+            .whereILike('slug', `${handle}-%`)
+            .first<DbAiAgentMemory>();
+        if (!row) throw new Error(`Missing merged memory for ${handle}`);
+        return row;
+    };
+
+    /** Gives a seeded row the distill-time provenance a real memory has. */
+    const attachSourceThread = async (slug: string): Promise<string> => {
+        const [thread] = await database(AiThreadTableName)
+            .insert({
+                organization_uuid: SEED_ORG_1.organization_uuid,
+                project_uuid: SEED_PROJECT.project_uuid,
+                created_from: 'web_app',
+                agent_uuid: agentUuid,
+            })
+            .returning<Array<{ ai_thread_uuid: string }>>('ai_thread_uuid');
+        createdThreadUuids.push(thread.ai_thread_uuid);
+        await database(AiAgentMemoryTableName)
+            .where('project_uuid', SEED_PROJECT.project_uuid)
+            .where('slug', slug)
+            .update({
+                source_thread_uuid: thread.ai_thread_uuid,
+                agent_uuid: agentUuid,
+            });
+        return thread.ai_thread_uuid;
+    };
+
     const runsForOwner = async (
         userUuid: string,
     ): Promise<DbAiAgentMemoryConsolidationRun[]> =>
@@ -309,6 +376,333 @@ describe('AI agent memory consolidation integration', () => {
         ).toEqual(['supersede', 'retire']);
     });
 
+    it('merges into one active row that inherits what its sources earned', async () => {
+        const slugs = await seedPartition({
+            userUuid: ownerUuid,
+            count: FLOOR,
+            prefix: 'merge',
+        });
+        const [first, second] = [slugs[0]!, slugs[1]!];
+        const exploreObject = {
+            type: 'explore' as const,
+            name: resolvableExploreName,
+        };
+        const fieldObject = {
+            type: 'field' as const,
+            explore: resolvableExploreName,
+            fieldId: `${resolvableExploreName}_status`,
+        };
+        await Promise.all([
+            attachSourceThread(first),
+            attachSourceThread(second),
+        ]);
+        await database(AiAgentMemoryTableName)
+            .where('project_uuid', SEED_PROJECT.project_uuid)
+            .where('slug', first)
+            .update({
+                scope: 'project',
+                objects: JSON.stringify([exploreObject]),
+                cited_count: 4,
+                last_cited_at: new Date('2026-07-25T10:00:00Z'),
+                pulled_count: 6,
+                last_pulled_at: new Date('2026-07-26T10:00:00Z'),
+            });
+        await database(AiAgentMemoryTableName)
+            .where('project_uuid', SEED_PROJECT.project_uuid)
+            .where('slug', second)
+            .update({
+                objects: JSON.stringify([fieldObject]),
+                cited_count: 3,
+                last_cited_at: new Date('2026-07-27T10:00:00Z'),
+                pulled_count: 1,
+                last_pulled_at: null,
+            });
+        const sources = await Promise.all([
+            memoryBySlug(first),
+            memoryBySlug(second),
+        ]);
+
+        await buildService(
+            cannedCall([
+                {
+                    type: 'merge',
+                    source_slugs: [first, second],
+                    slug: 'consolidation-merged',
+                    title: 'One revenue convention',
+                    memory: 'Revenue always means net revenue after refunds.',
+                    terms: ['net revenue'],
+                    objects: [
+                        exploreObject,
+                        fieldObject,
+                        { type: 'explore', name: 'no_source_named_this' },
+                    ],
+                    reason: 'Both memories state the same convention.',
+                },
+            ]),
+        ).consolidateScheduledPartition(partitionPayload(ownerUuid));
+
+        const merged = await mergedRow('consolidation-merged');
+        expect(merged).toMatchObject({
+            status: 'active',
+            user_uuid: ownerUuid,
+            // No source thread and no summary: this is what routes the memory
+            // page to its consolidated-provenance branch.
+            source_thread_uuid: null,
+            thread_summary: null,
+            agent_uuid: agentUuid,
+            title: 'One revenue convention',
+            raw_memory: 'Revenue always means net revenue after refunds.',
+            // Objects stay a subset of the union of the sources' objects.
+            objects: [exploreObject, fieldObject],
+            // Mixed scope narrows; it never widens to project.
+            scope: 'user',
+            cited_count: 7,
+            last_cited_at: new Date('2026-07-27T10:00:00Z'),
+            pulled_count: 7,
+            last_pulled_at: new Date('2026-07-26T10:00:00Z'),
+            // The newest evidence behind it, never the merge time.
+            generated_at: sources[0]!.generated_at,
+        });
+        // The row's real insert time is the created-at column, not generated_at.
+        expect(merged.created_at.getTime()).toBeGreaterThan(
+            merged.generated_at.getTime(),
+        );
+
+        const [supersededFirst, supersededSecond] = await Promise.all([
+            memoryBySlug(first),
+            memoryBySlug(second),
+        ]);
+        expect(supersededFirst).toMatchObject({
+            status: 'superseded',
+            superseded_by_uuid: merged.ai_agent_memory_uuid,
+            raw_memory: sources[0]!.raw_memory,
+        });
+        expect(supersededSecond).toMatchObject({
+            status: 'superseded',
+            superseded_by_uuid: merged.ai_agent_memory_uuid,
+            raw_memory: sources[1]!.raw_memory,
+        });
+
+        // Consolidated provenance: the memory page's lineage branch, and a
+        // replacement pointer that leads a citation of a merged-away memory
+        // somewhere useful.
+        const reader = buildService(cannedCall([]));
+        const page = await reader.getMemory(
+            getTestContext().testUser,
+            SEED_PROJECT.project_uuid,
+            merged.slug,
+        );
+        expect(page.provenance.type).toBe('consolidated');
+        expect(
+            page.provenance.type === 'consolidated'
+                ? page.provenance.sources.map((source) => source.slug).sort()
+                : [],
+        ).toEqual([first, second].sort());
+        expect(page.replacementSlug).toBeNull();
+        await expect(
+            reader
+                .getMemory(
+                    getTestContext().testUser,
+                    SEED_PROJECT.project_uuid,
+                    first,
+                )
+                .then((source) => source.replacementSlug),
+        ).resolves.toBe(merged.slug);
+
+        // Injection renders the merged row and neither of its sources.
+        const active = await model.findActiveForProject({
+            projectUuid: SEED_PROJECT.project_uuid,
+            userUuid: ownerUuid,
+        });
+        const activeSlugs = active.map((memory) => memory.slug);
+        expect(activeSlugs).toContain(merged.slug);
+        expect(activeSlugs).not.toContain(first);
+        expect(activeSlugs).not.toContain(second);
+        // Inherited citations, not the merge time, decide where it ranks.
+        expect(activeSlugs[0]).toBe(merged.slug);
+        const block = renderMemoryBlock(
+            active.map((memory) => ({
+                slug: memory.slug,
+                content: memory.raw_memory,
+                scope: memory.scope,
+                objects: memory.objects,
+                ageDays: 1,
+            })),
+        );
+        expect(block).toContain(`id="${merged.slug}"`);
+        expect(block).not.toContain(`id="${first}"`);
+        expect(block).not.toContain(`id="${second}"`);
+
+        const [run] = await runsForOwner(ownerUuid);
+        expect(run).toMatchObject({ applied_count: 1, rejected_count: 0 });
+        expect(run!.applied_operations[0]).toMatchObject({
+            type: 'merge',
+            slug: merged.slug,
+            objects: [exploreObject, fieldObject],
+        });
+    });
+
+    it('keeps a merged row at project scope only when every source is', async () => {
+        const slugs = await seedPartition({
+            userUuid: ownerUuid,
+            count: FLOOR,
+            prefix: 'scope',
+        });
+        await database(AiAgentMemoryTableName)
+            .where('project_uuid', SEED_PROJECT.project_uuid)
+            .whereIn('slug', [slugs[0]!, slugs[1]!])
+            .update({ scope: 'project' });
+
+        await buildService(
+            cannedCall([
+                {
+                    type: 'merge',
+                    source_slugs: [slugs[0]!, slugs[1]!],
+                    slug: 'consolidation-scoped',
+                    title: 'Project knowledge',
+                    memory: 'One claim.',
+                    terms: [],
+                    objects: [],
+                    reason: 'Both memories state the same convention.',
+                },
+            ]),
+        ).consolidateScheduledPartition(partitionPayload(ownerUuid));
+
+        expect(await mergedRow('consolidation-scoped')).toMatchObject({
+            scope: 'project',
+        });
+    });
+
+    it('flags the merged row’s objects from the live catalog, not its sources’ snapshots', async () => {
+        const exploreObject = {
+            type: 'explore' as const,
+            name: resolvableExploreName,
+        };
+        const missingObject = {
+            type: 'explore' as const,
+            name: 'no_such_explore_exists',
+        };
+        const slugs = await seedPartition({
+            userUuid: ownerUuid,
+            count: FLOOR,
+            prefix: 'staleflags',
+            objects: [exploreObject, missingObject],
+        });
+        // A distill-time snapshot the live catalog has since contradicted.
+        await database(AiAgentMemoryTableName)
+            .where('project_uuid', SEED_PROJECT.project_uuid)
+            .whereIn('slug', [slugs[0]!, slugs[1]!])
+            .update({ unresolved_objects: JSON.stringify([exploreObject]) });
+
+        await buildService(
+            cannedCall([
+                {
+                    type: 'merge',
+                    source_slugs: [slugs[0]!, slugs[1]!],
+                    slug: 'consolidation-flags',
+                    title: 'Merged',
+                    memory: 'One claim.',
+                    terms: [],
+                    objects: [exploreObject, missingObject],
+                    reason: 'Both memories state the same convention.',
+                },
+            ]),
+        ).consolidateScheduledPartition(partitionPayload(ownerUuid));
+
+        expect(await mergedRow('consolidation-flags')).toMatchObject({
+            unresolved_objects: [missingObject],
+        });
+    });
+
+    it('never merges across two owners', async () => {
+        const slugs = await seedPartition({
+            userUuid: ownerUuid,
+            count: FLOOR,
+            prefix: 'mergeowner',
+        });
+        const [otherSlug] = await seedPartition({
+            userUuid: otherOwnerUuid,
+            count: 1,
+            prefix: 'mergeotherowner',
+        });
+
+        await buildService(
+            cannedCall([
+                {
+                    type: 'merge',
+                    source_slugs: [slugs[0]!, otherSlug!],
+                    slug: 'consolidation-crossowner',
+                    title: 'Merged across owners',
+                    memory: 'One claim.',
+                    terms: [],
+                    objects: [],
+                    reason: 'Same claim twice.',
+                },
+            ]),
+        ).consolidateScheduledPartition(partitionPayload(ownerUuid));
+
+        const [run] = await runsForOwner(ownerUuid);
+        expect(run).toMatchObject({ applied_count: 0, rejected_count: 1 });
+        expect(run!.rejected_operations[0]!.reason).toBe('unknown_slug');
+        await expect(mergedRow('consolidation-crossowner')).rejects.toThrow();
+        expect(await memoryBySlug(otherSlug!)).toMatchObject({
+            status: 'active',
+        });
+        expect(await memoryBySlug(slugs[0]!)).toMatchObject({
+            status: 'active',
+        });
+    });
+
+    it('shows a second pass the merged row instead of its sources', async () => {
+        // One row above the floor, so folding two into one keeps the
+        // partition eligible for the verification pass.
+        const slugs = await seedPartition({
+            userUuid: ownerUuid,
+            count: FLOOR + 1,
+            prefix: 'secondpass',
+        });
+        await buildService(
+            cannedCall([
+                {
+                    type: 'merge',
+                    source_slugs: [slugs[0]!, slugs[1]!],
+                    slug: 'consolidation-secondpass',
+                    title: 'Merged',
+                    memory: 'One claim.',
+                    terms: [],
+                    objects: [],
+                    reason: 'Both memories state the same convention.',
+                },
+            ]),
+        ).consolidateScheduledPartition(partitionPayload(ownerUuid));
+        const merged = await mergedRow('consolidation-secondpass');
+
+        // The corpus moved, so the pass runs again; the curator finding nothing
+        // left to do is a successful no-op run.
+        const second = cannedCall([]);
+        await buildService(second).consolidateScheduledPartition(
+            partitionPayload(ownerUuid),
+        );
+
+        const [{ input }] = second.mock.calls[0] as [
+            { input: Array<{ id: string }> },
+        ];
+        const ids = input.map((entry) => entry.id);
+        expect(ids).toContain(merged.slug);
+        expect(ids).not.toContain(slugs[0]);
+        expect(ids).not.toContain(slugs[1]);
+
+        const third = cannedCall([]);
+        await buildService(third).consolidateScheduledPartition(
+            partitionPayload(ownerUuid),
+        );
+        expect(third).not.toHaveBeenCalled();
+        expect(await mergedRow('consolidation-secondpass')).toMatchObject({
+            ai_agent_memory_uuid: merged.ai_agent_memory_uuid,
+            status: 'active',
+        });
+    });
+
     it('records rejected operations with reasons and still succeeds', async () => {
         const slugs = await seedPartition({
             userUuid: ownerUuid,
@@ -324,13 +718,13 @@ describe('AI agent memory consolidation integration', () => {
                 },
                 {
                     type: 'merge',
-                    source_slugs: [slugs[0]!, slugs[1]!],
+                    source_slugs: [slugs[0]!, slugs[0]!],
                     slug: 'consolidation-merged',
                     title: 'Merged',
                     memory: 'One claim.',
                     terms: [],
                     objects: [],
-                    reason: 'Same claim twice.',
+                    reason: 'A merge that names one memory twice.',
                 },
                 {
                     type: 'retire',
@@ -352,7 +746,7 @@ describe('AI agent memory consolidation integration', () => {
         });
         expect(
             run!.rejected_operations.map((rejection) => rejection.reason),
-        ).toEqual(['unknown_slug', 'unsupported_operation']);
+        ).toEqual(['unknown_slug', 'insufficient_sources']);
         expect(run!.rejected_operations[0]!.operation).toMatchObject({
             type: 'retire',
             slug: 'consolidation-not-in-input',
@@ -396,10 +790,14 @@ describe('AI agent memory consolidation integration', () => {
         );
 
         const [run] = await runsForOwner(ownerUuid);
-        expect(run).toMatchObject({ applied_count: 0, rejected_count: 2 });
+        expect(run).toMatchObject({ applied_count: 1, rejected_count: 1 });
         expect(
             run!.rejected_operations.map((rejection) => rejection.reason),
-        ).toEqual(['unsupported_operation', 'unknown_slug']);
+        ).toEqual(['unknown_slug']);
+        // The merged row exists, but under a slug no operation could have named.
+        expect(await mergedRow('consolidation-merged')).toMatchObject({
+            status: 'active',
+        });
     });
 
     it('rejects a row that changed status or generated_at between selection and apply', async () => {
@@ -421,6 +819,10 @@ describe('AI agent memory consolidation integration', () => {
                     raw_memory: 'Rewritten by a resumed thread.',
                     generated_at: new Date('2026-07-27T10:00:00Z'),
                 });
+            await database(AiAgentMemoryTableName)
+                .where('project_uuid', SEED_PROJECT.project_uuid)
+                .where('slug', slugs[4]!)
+                .update({ status: 'retired' });
             return {
                 operations: [
                     {
@@ -433,6 +835,16 @@ describe('AI agent memory consolidation integration', () => {
                         loser_slug: slugs[1]!,
                         winner_slug: slugs[2]!,
                         reason: 'Replaced by a later correction.',
+                    },
+                    {
+                        type: 'merge',
+                        source_slugs: [slugs[4]!, slugs[5]!],
+                        slug: 'consolidation-moved-merge',
+                        title: 'Merged',
+                        memory: 'One claim.',
+                        terms: [],
+                        objects: [],
+                        reason: 'Same claim twice.',
                     },
                     {
                         type: 'retire',
@@ -451,12 +863,19 @@ describe('AI agent memory consolidation integration', () => {
         expect(run).toMatchObject({
             status: 'succeeded',
             applied_count: 1,
-            rejected_count: 2,
+            rejected_count: 3,
         });
         expect(
             run!.rejected_operations.map((rejection) => rejection.reason),
-        ).toEqual(['row_moved', 'row_moved']);
+        ).toEqual(['row_moved', 'row_moved', 'row_moved']);
         expect(await memoryBySlug(slugs[1]!)).toMatchObject({
+            status: 'active',
+            superseded_by_uuid: null,
+        });
+        // A rejected merge creates no row, so its unmoved source stays active
+        // rather than pointing at a merged row nothing can reconcile.
+        await expect(mergedRow('consolidation-moved-merge')).rejects.toThrow();
+        expect(await memoryBySlug(slugs[5]!)).toMatchObject({
             status: 'active',
             superseded_by_uuid: null,
         });
@@ -563,6 +982,7 @@ describe('AI agent memory consolidation integration', () => {
                     },
                 ],
                 rejected: [],
+                unresolvedObjectKeys: new Set<string>(),
             });
 
         const results = await Promise.all([applyOnce(), applyOnce()]);

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
@@ -3,6 +3,7 @@ import {
     CommercialFeatureFlags,
     FeatureFlags,
     ForbiddenError,
+    getAiProjectContextObjectKey,
     getErrorMessage,
     NotFoundError,
     ParameterError,
@@ -696,6 +697,13 @@ export class AiAgentMemoryService extends BaseService {
                 })),
                 operations: applied,
                 rejected,
+                unresolvedObjectKeys: new Set(
+                    projectedObjects
+                        .filter((object) => !object.resolved)
+                        .map((object) =>
+                            getAiProjectContextObjectKey(object.object),
+                        ),
+                ),
             });
             return 'consolidated';
         } catch (error) {

--- a/packages/backend/src/ee/services/AiAgentMemoryService/consolidation.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/consolidation.test.ts
@@ -91,15 +91,34 @@ const memoryRow = (
     ...overrides,
 });
 
-const inputEntry = (id: string): AiAgentMemoryConsolidationInputEntry => ({
+const inputEntry = (
+    id: string,
+    objects: AiAgentMemoryConsolidationInputEntry['objects'] = [],
+): AiAgentMemoryConsolidationInputEntry => ({
     id,
     title: 'A memory',
     memory: 'Body',
     terms: [],
-    objects: [],
+    objects,
     scope: 'user',
     age_days: 1,
     generated_at: '2026-07-27T10:00:00.000Z',
+});
+
+const mergeOperation = (
+    overrides: Partial<
+        Extract<AiAgentMemoryConsolidationOperation, { type: 'merge' }>
+    > = {},
+): AiAgentMemoryConsolidationOperation => ({
+    type: 'merge',
+    source_slugs: ['a', 'b'],
+    slug: 'merged-memory',
+    title: 'Merged',
+    memory: 'Body',
+    terms: [],
+    objects: [],
+    reason: 'One claim.',
+    ...overrides,
 });
 
 describe('consolidation eligibility floor', () => {
@@ -327,7 +346,9 @@ describe('consolidationOutputSchema', () => {
         ).toBe(false);
     });
 
-    it('rejects a merge with fewer than two sources', () => {
+    // Merge arity is a validation rejection, not a parse failure: a one-source
+    // merge must cost itself rather than discard the run's other operations.
+    it('parses a merge with fewer than two sources', () => {
         expect(
             consolidationOutputSchema.safeParse({
                 operations: [
@@ -343,7 +364,7 @@ describe('consolidationOutputSchema', () => {
                     },
                 ],
             }).success,
-        ).toBe(false);
+        ).toBe(true);
     });
 });
 
@@ -386,16 +407,7 @@ describe('validateConsolidationOperations', () => {
 
     it('rejects an operation naming a slug this same run would create', () => {
         const { applied, rejected } = validate([
-            {
-                type: 'merge',
-                source_slugs: ['a', 'b'],
-                slug: 'merged-memory',
-                title: 'Merged',
-                memory: 'Body',
-                terms: [],
-                objects: [],
-                reason: 'One claim.',
-            },
+            mergeOperation(),
             {
                 type: 'retire',
                 slug: 'merged-memory',
@@ -403,11 +415,8 @@ describe('validateConsolidationOperations', () => {
             },
         ]);
 
-        expect(applied).toEqual([]);
-        expect(rejected.map((entry) => entry.reason)).toEqual([
-            'unsupported_operation',
-            'unknown_slug',
-        ]);
+        expect(applied.map((operation) => operation.type)).toEqual(['merge']);
+        expect(rejected.map((entry) => entry.reason)).toEqual(['unknown_slug']);
     });
 
     it('rejects a self-supersede', () => {
@@ -494,42 +503,101 @@ describe('validateConsolidationOperations', () => {
         expect(rejected).toEqual([]);
     });
 
-    it('records a well-formed merge as unsupported without failing the run', () => {
+    it('keeps a well-formed merge alongside a status flip', () => {
         const { applied, rejected } = validate([
-            {
-                type: 'merge',
-                source_slugs: ['a', 'b'],
-                slug: 'merged-memory',
-                title: 'Merged',
-                memory: 'Body',
-                terms: [],
-                objects: [],
-                reason: 'One claim.',
-            },
+            mergeOperation(),
             { type: 'retire', slug: 'c', reason: 'Explore is gone.' },
         ]);
 
-        expect(rejected).toEqual([
-            { operation: expect.anything(), reason: 'unsupported_operation' },
+        expect(rejected).toEqual([]);
+        expect(applied.map((operation) => operation.type)).toEqual([
+            'merge',
+            'retire',
         ]);
-        expect(applied).toHaveLength(1);
     });
 
-    it('rejects a merge with duplicate sources before calling it unsupported', () => {
+    it('rejects a merge naming a single source, keeping the run’s other work', () => {
+        const { applied, rejected } = validate([
+            mergeOperation({ source_slugs: ['a'] }),
+            { type: 'retire', slug: 'c', reason: 'Explore is gone.' },
+        ]);
+
+        expect(applied.map((operation) => operation.type)).toEqual(['retire']);
+        expect(rejected.map((entry) => entry.reason)).toEqual([
+            'insufficient_sources',
+        ]);
+    });
+
+    it('rejects a merge whose sources collapse to fewer than two', () => {
         expect(
             validate([
-                {
-                    type: 'merge',
-                    source_slugs: ['a', 'a'],
-                    slug: 'merged-memory',
-                    title: 'Merged',
-                    memory: 'Body',
-                    terms: [],
-                    objects: [],
-                    reason: 'One claim.',
-                },
+                mergeOperation({ source_slugs: ['a', 'a'] }),
             ]).rejected.map((entry) => entry.reason),
         ).toEqual(['insufficient_sources']);
+    });
+
+    it('de-duplicates a merge’s sources so telemetry is inherited once', () => {
+        const { applied } = validate([
+            mergeOperation({ source_slugs: ['a', 'b', 'a'] }),
+        ]);
+
+        expect(applied[0]).toMatchObject({
+            type: 'merge',
+            source_slugs: ['a', 'b'],
+        });
+    });
+
+    it('narrows merged objects to the union of the sources’ objects', () => {
+        const orders = { type: 'explore' as const, name: 'orders' };
+        const customers = { type: 'explore' as const, name: 'customers' };
+        const status = {
+            type: 'field' as const,
+            explore: 'orders',
+            fieldId: 'orders_status',
+        };
+        const { applied } = validateConsolidationOperations({
+            operations: [
+                mergeOperation({
+                    objects: [
+                        orders,
+                        status,
+                        customers,
+                        { ...orders },
+                        { type: 'explore', name: 'invented' },
+                    ],
+                }),
+            ],
+            input: [
+                inputEntry('a', [{ object: orders, resolved: true }]),
+                inputEntry('b', [{ object: status, resolved: false }]),
+                inputEntry('c', [{ object: customers, resolved: true }]),
+            ],
+        });
+
+        // `customers` belongs to a memory this merge does not name.
+        expect(applied[0]).toMatchObject({ objects: [orders, status] });
+    });
+
+    it('rejects a merge whose source an earlier operation already targets', () => {
+        const { applied, rejected } = validate([
+            { type: 'retire', slug: 'a', reason: 'Explore is gone.' },
+            mergeOperation({ source_slugs: ['a', 'b'] }),
+        ]);
+
+        expect(applied.map((operation) => operation.type)).toEqual(['retire']);
+        expect(rejected.map((entry) => entry.reason)).toEqual([
+            'duplicate_target',
+        ]);
+    });
+
+    it('records the operation as the curator wrote it when rejecting', () => {
+        const { rejected } = validate([
+            mergeOperation({ source_slugs: ['a', 'a'] }),
+        ]);
+
+        expect(rejected[0]!.operation).toMatchObject({
+            source_slugs: ['a', 'a'],
+        });
     });
 });
 

--- a/packages/backend/src/ee/services/AiAgentMemoryService/consolidation.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/consolidation.ts
@@ -1,9 +1,10 @@
 import {
     assertUnreachable,
+    getAiAgentMemoryConsolidationOperationSlugs,
+    getAiProjectContextObjectKey,
     type AiAgentMemoryConsolidationInputEntry,
     type AiAgentMemoryConsolidationOperation,
     type AiAgentMemoryConsolidationRejection,
-    type AiAgentMemoryConsolidationStatusFlipOperation,
     type Explore,
     type ExploreError,
 } from '@lightdash/common';
@@ -89,21 +90,6 @@ export const computeConsolidationInputHash = (
         )
         .digest('hex');
 
-const operationSlugs = (
-    operation: AiAgentMemoryConsolidationOperation,
-): string[] => {
-    switch (operation.type) {
-        case 'merge':
-            return operation.source_slugs;
-        case 'supersede':
-            return [operation.loser_slug, operation.winner_slug];
-        case 'retire':
-            return [operation.slug];
-        default:
-            return assertUnreachable(operation, 'Unknown consolidation op');
-    }
-};
-
 /** Slugs whose status this operation would change. */
 const operationTargets = (
     operation: AiAgentMemoryConsolidationOperation,
@@ -139,17 +125,46 @@ const collidesWithClaims = (
         (slug) => claims.targets.has(slug) || claims.winners.has(slug),
     ) || operationWinners(operation).some((slug) => claims.targets.has(slug));
 
-const isStatusFlipOperation = (
+/**
+ * A merge applies with distinct sources and objects the sources actually named:
+ * duplicated sources would double the inherited telemetry, and an invented
+ * object would hand the merged row a claim no source made.
+ */
+const normalizeOperation = (
     operation: AiAgentMemoryConsolidationOperation,
-): operation is AiAgentMemoryConsolidationStatusFlipOperation =>
-    operation.type !== 'merge';
+    entriesBySlug: Map<string, AiAgentMemoryConsolidationInputEntry>,
+): AiAgentMemoryConsolidationOperation => {
+    if (operation.type !== 'merge') return operation;
+
+    const sourceSlugs = [...new Set(operation.source_slugs)];
+    const sourceObjectKeys = new Set(
+        sourceSlugs.flatMap((slug) =>
+            (entriesBySlug.get(slug)?.objects ?? []).map((entry) =>
+                getAiProjectContextObjectKey(entry.object),
+            ),
+        ),
+    );
+    const seen = new Set<string>();
+    const objects = operation.objects.filter((object) => {
+        const key = getAiProjectContextObjectKey(object);
+        if (!sourceObjectKeys.has(key) || seen.has(key)) return false;
+        seen.add(key);
+        return true;
+    });
+
+    return { ...operation, source_slugs: sourceSlugs, objects };
+};
 
 const rejectionReason = (
     operation: AiAgentMemoryConsolidationOperation,
     inputSlugs: Set<string>,
     claims: ConsolidationClaims,
 ): AiAgentMemoryConsolidationRejection['reason'] | null => {
-    if (operationSlugs(operation).some((slug) => !inputSlugs.has(slug))) {
+    if (
+        getAiAgentMemoryConsolidationOperationSlugs(operation).some(
+            (slug) => !inputSlugs.has(slug),
+        )
+    ) {
         return 'unknown_slug';
     }
     if (
@@ -167,11 +182,6 @@ const rejectionReason = (
     if (collidesWithClaims(operation, claims)) {
         return 'duplicate_target';
     }
-    // Row creation lands with the merge operation; until then a well-formed
-    // merge is recorded as rejected rather than silently dropped.
-    if (operation.type === 'merge') {
-        return 'unsupported_operation';
-    }
     return null;
 };
 
@@ -184,32 +194,31 @@ export const validateConsolidationOperations = (args: {
     operations: AiAgentMemoryConsolidationOperation[];
     input: AiAgentMemoryConsolidationInputEntry[];
 }): {
-    applied: AiAgentMemoryConsolidationStatusFlipOperation[];
+    applied: AiAgentMemoryConsolidationOperation[];
     rejected: AiAgentMemoryConsolidationRejection[];
 } => {
-    const inputSlugs = new Set(args.input.map((entry) => entry.id));
+    const entriesBySlug = new Map(args.input.map((entry) => [entry.id, entry]));
+    const inputSlugs = new Set(entriesBySlug.keys());
     const claims: ConsolidationClaims = {
         targets: new Set<string>(),
         winners: new Set<string>(),
     };
-    const applied: AiAgentMemoryConsolidationStatusFlipOperation[] = [];
+    const applied: AiAgentMemoryConsolidationOperation[] = [];
     const rejected: AiAgentMemoryConsolidationRejection[] = [];
 
     for (const operation of args.operations) {
-        const reason = rejectionReason(operation, inputSlugs, claims);
-        if (reason !== null || !isStatusFlipOperation(operation)) {
-            rejected.push({
-                operation,
-                reason: reason ?? 'unsupported_operation',
-            });
+        const normalized = normalizeOperation(operation, entriesBySlug);
+        const reason = rejectionReason(normalized, inputSlugs, claims);
+        if (reason !== null) {
+            rejected.push({ operation, reason });
         } else {
-            operationTargets(operation).forEach((slug) =>
+            operationTargets(normalized).forEach((slug) =>
                 claims.targets.add(slug),
             );
-            operationWinners(operation).forEach((slug) =>
+            operationWinners(normalized).forEach((slug) =>
                 claims.winners.add(slug),
             );
-            applied.push(operation);
+            applied.push(normalized);
         }
     }
 

--- a/packages/backend/src/ee/services/AiAgentMemoryService/consolidationSchema.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/consolidationSchema.ts
@@ -11,11 +11,13 @@ const slugSchema = z.string().min(1).max(120);
 const mergeOperationSchema = z
     .object({
         type: z.literal('merge'),
+        // Arity is owned by validation, not the schema: providers do not enforce
+        // `minItems` at generation time, so a one-source merge must land in the
+        // rejected-operations audit rather than throw away the whole run.
         source_slugs: z
             .array(slugSchema)
-            .min(2)
             .max(10)
-            .describe('Ids of the memories this merge replaces.'),
+            .describe('At least two ids of the memories this merge replaces.'),
         slug: z
             .string()
             .min(1)

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -15,6 +15,7 @@ import type {
     ToolTimeSeriesArgs,
     ToolVerticalBarArgs,
 } from '../..';
+import assertUnreachable from '../../utils/assertUnreachable';
 import { type AiEvalRunResultAssessment } from './aiEvalAssessment';
 import { type AiProjectContextTypedObjectRef } from './projectContext';
 import {
@@ -417,18 +418,37 @@ export type AiAgentMemoryConsolidationOperation =
           reason: string;
       };
 
-/** The operations that are pure status flips — no row is created. */
-export type AiAgentMemoryConsolidationStatusFlipOperation = Extract<
+/** The one operation that creates a row. */
+export type AiAgentMemoryConsolidationMergeOperation = Extract<
     AiAgentMemoryConsolidationOperation,
-    { type: 'supersede' | 'retire' }
+    { type: 'merge' }
 >;
+
+/**
+ * Every existing row an operation names — a merge's sources included. Validation
+ * and the apply transaction's locking share it, so the set of rows an operation
+ * is checked against can never drift from the set it locks.
+ */
+export const getAiAgentMemoryConsolidationOperationSlugs = (
+    operation: AiAgentMemoryConsolidationOperation,
+): string[] => {
+    switch (operation.type) {
+        case 'merge':
+            return operation.source_slugs;
+        case 'supersede':
+            return [operation.loser_slug, operation.winner_slug];
+        case 'retire':
+            return [operation.slug];
+        default:
+            return assertUnreachable(operation, 'Unknown consolidation op');
+    }
+};
 
 export type AiAgentMemoryConsolidationRejectionReason =
     | 'unknown_slug'
     | 'duplicate_target'
     | 'self_supersede'
     | 'insufficient_sources'
-    | 'unsupported_operation'
     | 'row_moved';
 
 export type AiAgentMemoryConsolidationRejection = {

--- a/packages/common/src/ee/AiAgent/projectContext.ts
+++ b/packages/common/src/ee/AiAgent/projectContext.ts
@@ -44,6 +44,23 @@ export const aiProjectContextTypedObjectRefSchema: z.ZodType<AiProjectContextTyp
 export const aiProjectContextObjectRefSchema: z.ZodType<AiProjectContextObjectRef> =
     z.union([z.string().min(1), aiProjectContextTypedObjectRefSchema]);
 
+/** Identity of an object reference, for set membership and de-duplication. */
+export const getAiProjectContextObjectKey = (
+    object: AiProjectContextTypedObjectRef,
+): string => {
+    switch (object.type) {
+        case 'explore':
+            return `explore:${object.name}`;
+        case 'field':
+            return `field:${object.explore}:${object.fieldId}`;
+        default:
+            return assertUnreachable(
+                object,
+                'Unknown AI project context object ref type',
+            );
+    }
+};
+
 const typedProjectContextObjectRefsSchema = z.array(
     aiProjectContextTypedObjectRefSchema,
 );


### PR DESCRIPTION
Third slice of the AI agent memory consolidation pass. Adds the one curation operation that creates a row: `merge`.

Everything else in the pass — selection, projection, prompt, validation, advisory lock, apply transaction, run history, input-hash skip — landed in ZAP-678. This slice replaces the `unsupported_operation` placeholder rejection with a real apply path.

## What changed

**Row creation.** `AiAgentMemoryModel.applyMerge` inserts one active row inside the same transaction as the status flips, then points every source at it with `status = 'superseded'`. The merged row carries no source thread and no thread summary, which is what routes the memory page to its consolidated-provenance lineage walk — a branch that has been dead since it shipped.

**Inheritance.** Summed cited/pulled counts, MAX last-cited/last-pulled, and `generated_at = MAX(source.generated_at)` so the injection fence reads the age of the evidence rather than the merge time. Scope is `project` only when every source is `project`. Objects are narrowed to the union of the named sources' objects. `unresolved_objects` is written from this run's fresh catalog resolution, not from the sources' distill-time snapshots.

**Validation.** A new `normalizeOperation` step de-duplicates a merge's `source_slugs` (duplicates would double the inherited telemetry) and drops objects no source named. Merge arity is owned by the validator, not the output schema: providers do not enforce `minItems` at generation time, so a one-source merge lands in `rejected_operations` as `insufficient_sources` instead of throwing away the whole run's valid work.

**Slug.** The curator's handle gets a random suffix, because `(project_uuid, slug)` is UNIQUE and a colliding handle would fail the entire run. The applied-operation audit records the slug the row actually got.

## Notes

- The slug set an operation names is now a single exported helper shared by validation and by the apply transaction's `SELECT ... FOR UPDATE`, so the rows an operation is checked against cannot drift from the rows it locks.
- The merged row inherits an `agent_uuid` from its newest source that has one; a null agent makes the memory page 404. ZAP-715 supersedes the lineage-based read predicate in favour of a row-local one, so this is deliberately not a lineage walk.

## Testing

- Real-Postgres integration coverage for merge apply, telemetry and `generated_at` inheritance, scope narrowing, object subsetting, live-catalog unresolved flags, the movement-rejection path on a merge source, cross-owner refusal, the consolidated-provenance page, replacement-slug resolution, injection, and the idempotent second pass.
- Unit coverage for merge normalization, single-source rejection, and the operations schema.

Relates: ZAP-715
Closes: ZAP-679
