### PR TITLE
feat: enable timezone support by default

### DIFF
--- a/docker/docker-compose.preview.yml
+++ b/docker/docker-compose.preview.yml
@@ -114,9 +114,6 @@ services:
             # Preview has no TLS certs; plaintext is fine inside the compose
             # network. Production requires PGWIRE_SSL_CERT_PATH/KEY_PATH.
             PGWIRE_SSL_MODE: disabled
-            # Enables the combined timezone feature (incl. user-level timezone
-            # resolution) so the timezone api-tests pass.
-            LIGHTDASH_ENABLE_TIMEZONE_SUPPORT: true
 
             # Force-enable embedding flag in preview envs so e2e tests work.
             # Picked up via LEGACY_ENABLE_ENV_VARS in parseConfig.ts → unified

--- a/docs/timezones/timezone-handling.md
+++ b/docs/timezones/timezone-handling.md
@@ -29,7 +29,16 @@ A single flag gates timezone behavior:
 | ----------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `EnableTimezoneSupport` | `LIGHTDASH_ENABLE_TIMEZONE_SUPPORT`   | The whole timezone feature: data-timezone warehouse field + session-TZ setup, the "filter inputs in project TZ" toggle, the user-facing timezone pickers (Profile panel, Explorer chart-level), and per-viewer (user-profile) timezone resolution |
 
-The project timezone setting itself is always available. `resolveQueryTimezone` always honors a chart pinned to `user_timezone` — falling back to the project timezone only when the viewer has no stored profile preference. The `EnableTimezoneSupport` flag gates the surrounding pipeline (warehouse session setup, timezone-aware `DATE_TRUNC`, returning `displayTimezone`), so when the flag is off the resolved zone simply isn't applied to the query. The flag can be toggled per-organization (or per-user) via `feature_flag_overrides` in the database, which takes precedence over the env var, so we can roll out gradually without flipping the global switch.
+The project timezone setting itself is always available. `resolveQueryTimezone` always honors a chart pinned to `user_timezone` — falling back to the project timezone only when the viewer has no stored profile preference. The `EnableTimezoneSupport` flag gates the surrounding pipeline (warehouse session setup, timezone-aware `DATE_TRUNC`, returning `displayTimezone`), so when the flag is off the resolved zone simply isn't applied to the query.
+
+**The flag is on by default.** Resolution order (`FeatureFlagModel`):
+
+1. `LIGHTDASH_DISABLE_FEATURE_FLAGS=enable-timezone-support` — instance-wide kill switch.
+2. `LIGHTDASH_ENABLE_TIMEZONE_SUPPORT` — when set to `true`/`false` it pins the flag instance-wide and the database is not consulted.
+3. `feature_flag_overrides` in the database — per-user override, then per-organization override, then the `feature_flags.default_enabled` row. This is how a single organization is opted out.
+4. No opinion anywhere → **enabled**.
+
+A database lookup failure is swallowed (logged as a warning) and falls through to the default, so an outage leaves the flag on rather than silently changing query semantics for everyone.
 
 ### Data timezone (`dataTimezone`)
 

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -18,9 +18,8 @@ process.on('uncaughtException', () => {
 (async () => {
     try {
         const timezoneWarning = getProcessTimezoneWarning({
-            enableTimezoneSupport: Boolean(
-                lightdashConfig.query.enableTimezoneSupport,
-            ),
+            enableTimezoneSupport:
+                lightdashConfig.query.enableTimezoneSupport !== false,
             timezoneOffsetMinutes: new Date().getTimezoneOffset(),
         });
         if (timezoneWarning) {

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
@@ -384,6 +384,71 @@ describe('FeatureFlagModel', () => {
         });
     });
 
+    describe('EnableTimezoneSupport defaults to on', () => {
+        const withTimezoneSupport = (enableTimezoneSupport: boolean) => ({
+            query: { ...lightdashConfigMock.query, enableTimezoneSupport },
+        });
+
+        it('is enabled when neither config nor database has an opinion', async () => {
+            const model = buildModel({}, buildFakeDatabase({}));
+
+            const result = await model.get({
+                featureFlagId: FeatureFlags.EnableTimezoneSupport,
+                user: dbUser,
+            });
+
+            expect(result).toEqual({
+                id: FeatureFlags.EnableTimezoneSupport,
+                enabled: true,
+            });
+        });
+
+        it('is disabled by an organization override', async () => {
+            const model = buildModel(
+                {},
+                buildFakeDatabase({
+                    flag: { default_enabled: null },
+                    orgOverride: { enabled: false },
+                }),
+            );
+
+            const result = await model.get({
+                featureFlagId: FeatureFlags.EnableTimezoneSupport,
+                user: dbUser,
+            });
+
+            expect(result.enabled).toBe(false);
+        });
+
+        it('is disabled by LIGHTDASH_ENABLE_TIMEZONE_SUPPORT=false, ignoring the database', async () => {
+            const model = buildModel(
+                withTimezoneSupport(false),
+                buildFakeDatabase({ flag: { default_enabled: true } }),
+            );
+
+            const result = await model.get({
+                featureFlagId: FeatureFlags.EnableTimezoneSupport,
+                user: dbUser,
+            });
+
+            expect(result.enabled).toBe(false);
+        });
+
+        it('stays enabled when LIGHTDASH_ENABLE_TIMEZONE_SUPPORT=true, ignoring the database', async () => {
+            const model = buildModel(
+                withTimezoneSupport(true),
+                buildFakeDatabase({ orgOverride: { enabled: false } }),
+            );
+
+            const result = await model.get({
+                featureFlagId: FeatureFlags.EnableTimezoneSupport,
+                user: dbUser,
+            });
+
+            expect(result.enabled).toBe(true);
+        });
+    });
+
     describe('database error resilience', () => {
         // Reproduces the embed-account regression: a non-UUID userUuid
         // (e.g. `external::…`) makes Postgres throw 22P02 on the override
@@ -401,6 +466,7 @@ describe('FeatureFlagModel', () => {
         });
 
         it('does not throw when EnableTimezoneSupport DB lookup fails', async () => {
+            // Falls back to the default (on) rather than propagating.
             const model = buildModel({}, throwingDatabase);
 
             const result = await model.get({
@@ -413,7 +479,7 @@ describe('FeatureFlagModel', () => {
 
             expect(result).toEqual({
                 id: FeatureFlags.EnableTimezoneSupport,
-                enabled: false,
+                enabled: true,
             });
             expect(warnSpy).toHaveBeenCalled();
         });

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -98,15 +98,20 @@ export class FeatureFlagModel {
         };
     }
 
+    // On by default. Disable it instance-wide with
+    // LIGHTDASH_ENABLE_TIMEZONE_SUPPORT=false (or LIGHTDASH_DISABLE_FEATURE_FLAGS),
+    // or per organization/user with a `feature_flag_overrides` row.
     private async getEnableTimezoneSupportEnabled(
         args: FeatureFlagLogicArgs,
         options: FeatureFlagQueryOptions = {},
     ): Promise<FeatureFlag> {
-        if (this.lightdashConfig.query.enableTimezoneSupport) {
-            return { id: args.featureFlagId, enabled: true };
+        if (this.lightdashConfig.query.enableTimezoneSupport !== undefined) {
+            return {
+                id: args.featureFlagId,
+                enabled: this.lightdashConfig.query.enableTimezoneSupport,
+            };
         }
-        const dbResult = await this.tryGetFromDatabase(args, options);
-        return dbResult ?? { id: args.featureFlagId, enabled: false };
+        return this.getWithEnvFallback(args, true, options);
     }
 
     private async getEnableDataAppsEnabled(
@@ -121,15 +126,15 @@ export class FeatureFlagModel {
     }
 
     // DB value (user override → org override → flag default) wins. Falls
-    // back to the env-derived value when the flag has no DB row and no
+    // back to the supplied default when the flag has no DB row and no
     // override applies.
     private async getWithEnvFallback(
         args: FeatureFlagLogicArgs,
-        envFallback: boolean,
+        fallback: boolean,
         options: FeatureFlagQueryOptions = {},
     ): Promise<FeatureFlag> {
         const dbResult = await this.tryGetFromDatabase(args, options);
-        return dbResult ?? { id: args.featureFlagId, enabled: envFallback };
+        return dbResult ?? { id: args.featureFlagId, enabled: fallback };
     }
 
     protected async tryGetFromDatabase(

--- a/packages/backend/src/scheduler.ts
+++ b/packages/backend/src/scheduler.ts
@@ -15,9 +15,8 @@ process.on('uncaughtException', () => {
 (async () => {
     if (process.env.CI !== 'true') {
         const timezoneWarning = getProcessTimezoneWarning({
-            enableTimezoneSupport: Boolean(
-                lightdashConfig.query.enableTimezoneSupport,
-            ),
+            enableTimezoneSupport:
+                lightdashConfig.query.enableTimezoneSupport !== false,
             timezoneOffsetMinutes: new Date().getTimezoneOffset(),
         });
         if (timezoneWarning) {


### PR DESCRIPTION
## What

`EnableTimezoneSupport` now defaults to **on**. ( Related to GLITCH-520 ) - this only changes behaviour for deployments with no DB row — self-hosted

## How it resolves now

`FeatureFlagModel`, in order:

1. `LIGHTDASH_DISABLE_FEATURE_FLAGS=enable-timezone-support` — instance-wide kill switch.
2. `LIGHTDASH_ENABLE_TIMEZONE_SUPPORT=true|false` — pins the flag instance-wide, DB not consulted.
3. `feature_flag_overrides` — per-user, then per-org, then the `feature_flags.default_enabled` row. This is how a single org stays opted out.
4. No opinion anywhere → enabled.

So there are three ways to turn it off, one of which (the per-org override) needs no redeploy.

## Behaviour changes

- No config and no DB row: was off, now on.
- `LIGHTDASH_ENABLE_TIMEZONE_SUPPORT=false` used to fall through to the DB (a DB row could still enable it). It is now a hard off, matching how `=true` already behaved.
- A DB lookup failure is still swallowed and logged, but now falls back to enabled rather than disabled — an outage leaves the flag in its default state instead of silently changing query semantics.
- The non-UTC process timezone startup warning follows the same default (warns unless the flag is explicitly disabled).

## Tests

New `FeatureFlagModel` cases cover: default on with no opinion, org override off, `LIGHTDASH_ENABLE_TIMEZONE_SUPPORT=false`, `LIGHTDASH_DISABLE_FEATURE_FLAGS`, and env `true` beating an org override. Existing DB-failure case updated to the new fallback.

https://linear.app/lightdash/issue/GLITCH-520/flip-enabletimezonesupport-default-to-true