### PR TITLE
feat(analytics): stamp onboardingFlow on webapp onboarding funnel events

### DIFF
--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectSuccess.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectSuccess.tsx
@@ -68,7 +68,10 @@ const ConnectSuccess: FC<ConnectSuccessProps> = ({ projectUuid }) => {
                         onClick={() => {
                             track({
                                 name: EventName.ONBOARDING_PROJECT_READY_START_EXPLORING_CLICKED,
-                                properties: { projectId: projectUuid },
+                                properties: {
+                                    projectId: projectUuid,
+                                    onboardingFlow: 'legacy',
+                                },
                             });
                         }}
                     >

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SelectWarehouse.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SelectWarehouse.tsx
@@ -89,6 +89,7 @@ const SelectWarehouse: FC<SelectWarehouseProps> = ({
                                                           OtherWarehouse.Other
                                                               ? 'other'
                                                               : 'all',
+                                                      onboardingFlow: 'legacy',
                                                   },
                                               });
                                               onSelect(item.key);

--- a/packages/frontend/src/pages/OnboardingDataSource.tsx
+++ b/packages/frontend/src/pages/OnboardingDataSource.tsx
@@ -135,6 +135,7 @@ const DataSourcePicker: FC = () => {
                 organizationId: organization?.organizationUuid ?? '',
                 warehouse: String(key),
                 tier,
+                onboardingFlow: 'new',
             },
         });
         void navigate(getWarehouseRoute(key));

--- a/packages/frontend/src/pages/OnboardingProjectReady.tsx
+++ b/packages/frontend/src/pages/OnboardingProjectReady.tsx
@@ -200,7 +200,10 @@ const OnboardingProjectReadyContent: FC<{ projectUuid: string }> = ({
                         onClick={() => {
                             track({
                                 name: EventName.ONBOARDING_PROJECT_READY_START_EXPLORING_CLICKED,
-                                properties: { projectId: projectUuid },
+                                properties: {
+                                    projectId: projectUuid,
+                                    onboardingFlow: 'new',
+                                },
                             });
                             void navigate(`/projects/${projectUuid}/home`);
                         }}

--- a/packages/frontend/src/pages/Register.tsx
+++ b/packages/frontend/src/pages/Register.tsx
@@ -116,7 +116,10 @@ const Register: FC = () => {
                 onSubmit={(data: CreateEmailOnlyUserArgs) => {
                     track({
                         name: EventName.SIGNUP_FORM_SUBMITTED,
-                        properties: { variant: 'email_only' },
+                        properties: {
+                            variant: 'email_only',
+                            onboardingFlow: 'new',
+                        },
                     });
                     mutate(data);
                 }}
@@ -127,7 +130,10 @@ const Register: FC = () => {
                 onSubmit={(data: CreateUserArgs) => {
                     track({
                         name: EventName.SIGNUP_FORM_SUBMITTED,
-                        properties: { variant: 'password' },
+                        properties: {
+                            variant: 'password',
+                            onboardingFlow: 'legacy',
+                        },
                     });
                     mutate(data);
                 }}

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -620,6 +620,7 @@ type SignupFormSubmittedEvent = {
     name: EventName.SIGNUP_FORM_SUBMITTED;
     properties: {
         variant: 'email_only' | 'password';
+        onboardingFlow: 'legacy' | 'new';
     };
 };
 
@@ -658,6 +659,7 @@ type OnboardingWarehouseSelectedEvent = {
         organizationId: string;
         warehouse: string;
         tier: 'popular' | 'all' | 'other';
+        onboardingFlow: 'legacy' | 'new';
     };
 };
 
@@ -672,6 +674,7 @@ type OnboardingProjectReadyStartExploringClickedEvent = {
     name: EventName.ONBOARDING_PROJECT_READY_START_EXPLORING_CLICKED;
     properties: {
         projectId: string;
+        onboardingFlow: 'legacy' | 'new';
     };
 };
 


### PR DESCRIPTION
Linear: [SPK-665](https://linear.app/lightdash/issue/SPK-665/stamp-onboardingflow-on-webapp-onboarding-funnel-events-at-journey)

## What

Adds an `onboardingFlow: 'legacy' | 'new'` property to the three webapp onboarding funnel events, derived from the UI surface the user actually saw:

| Event | `new` fires from | `legacy` fires from |
|---|---|---|
| `signup_form.submitted` | Register email-only branch (NewOnboarding flag) | Register password branch |
| `onboarding_warehouse.selected` | OnboardingDataSource page | ProjectConnectFlow/SelectWarehouse |
| `onboarding_project_ready.start_exploring_clicked` | OnboardingProjectReady page | ProjectConnectFlow/ConnectSuccess |

## Why

Today `onboarding_flow` is only stamped on server-side `onboarding_step_completed` events, so journeys that drop off before emitting any step have unknown flow — a survivorship bias that makes legacy-vs-new funnel comparison unsafe (a flow with worse early drop-off looks better because its failures are unlabeled). Stamping flow at journey entry fixes the comparison at the source. Exposure can't be labeled retroactively, so this should land before the NewOnboarding flag reaches real traffic.

Frontend-only; no API or event-name changes — one additional typed property on three existing events.

## Verification

`pnpm -F frontend typecheck:fast` clean; touched-path lint clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lc4SYE2fxRrRrpsmCQcgMZ