### PR TITLE
feat(ai): add Deep Research to homepage

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -124,6 +124,11 @@ interface AgentChatInputProps {
     // Shrinks padding/min-heights for a more compact composer.
     dense?: boolean;
     deepResearchControlPlacement?: 'composer' | 'page_header';
+    deepResearchControlVariant?: 'default' | 'compact';
+    deepResearchControlClassNames?: {
+        root?: string;
+        label?: string;
+    };
 }
 
 const extractToolHints = (editor: Editor | null): string[] => {
@@ -170,6 +175,8 @@ export const AgentChatInput = ({
     revealAgentSelectorOnFocus = false,
     dense = false,
     deepResearchControlPlacement = 'composer',
+    deepResearchControlVariant = 'default',
+    deepResearchControlClassNames,
 }: AgentChatInputProps) => {
     const user = useUser(true);
     const [value, setValueState] = useState(defaultValue ?? '');
@@ -569,6 +576,8 @@ export const AgentChatInput = ({
         <DeepResearchModeControl
             mode={composerMode}
             onModeChange={setComposerMode}
+            variant={deepResearchControlVariant}
+            classNames={deepResearchControlClassNames}
         />
     ) : null;
     const deepResearchControl =

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.test.tsx
@@ -78,4 +78,23 @@ describe('DeepResearchModeControl', () => {
             }),
         ).not.toBeInTheDocument();
     });
+
+    it('renders the compact control with reusable toolbar classes', () => {
+        renderWithProviders(
+            <DeepResearchModeControl
+                mode="ask"
+                onModeChange={() => undefined}
+                variant="compact"
+                classNames={{ root: 'toolbar', label: 'toolbar-label' }}
+            />,
+        );
+
+        const control = screen.getByRole('button', {
+            name: 'Deep research',
+        });
+        expect(control).toHaveClass('toolbar');
+        expect(control.querySelector('.toolbar-label')).toHaveTextContent(
+            'Deep research',
+        );
+    });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.tsx
@@ -7,10 +7,39 @@ export type AgentComposerMode = 'ask' | 'deep_research';
 type Props = {
     mode: AgentComposerMode;
     onModeChange: (mode: AgentComposerMode) => void;
+    variant?: 'default' | 'compact';
+    classNames?: {
+        root?: string;
+        label?: string;
+    };
 };
 
-export const DeepResearchModeControl = ({ mode, onModeChange }: Props) => {
+export const DeepResearchModeControl = ({
+    mode,
+    onModeChange,
+    variant = 'default',
+    classNames,
+}: Props) => {
     const isDeepResearch = mode === 'deep_research';
+    const toggleMode = () =>
+        onModeChange(isDeepResearch ? 'ask' : 'deep_research');
+
+    if (variant === 'compact') {
+        return (
+            <button
+                type="button"
+                className={classNames?.root}
+                onClick={toggleMode}
+                aria-label="Deep research"
+                aria-pressed={isDeepResearch}
+            >
+                <MantineIcon icon={IconTelescope} size={15} stroke={1.8} />
+                <span className={classNames?.label} aria-hidden="true">
+                    Deep research
+                </span>
+            </button>
+        );
+    }
 
     return (
         <Button
@@ -20,9 +49,7 @@ export const DeepResearchModeControl = ({ mode, onModeChange }: Props) => {
             leftSection={
                 <MantineIcon icon={IconTelescope} size={14} stroke={1.8} />
             }
-            onClick={() =>
-                onModeChange(isDeepResearch ? 'ask' : 'deep_research')
-            }
+            onClick={toggleMode}
             aria-label="Deep research"
             aria-pressed={isDeepResearch}
         >

--- a/packages/frontend/src/ee/features/homepageBuilder/AdminHomepageControls.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/AdminHomepageControls.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import { type PropsWithChildren } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { AdminHomepageControls } from './AdminHomepageControls';
+
+vi.mock('react-router', () => ({
+    useNavigate: () => vi.fn(),
+}));
+
+vi.mock('../../../providers/Ability', () => ({
+    Can: ({ children }: PropsWithChildren) => children,
+}));
+
+describe('AdminHomepageControls', () => {
+    it('provides a Deep Research target beside the homepage controls', () => {
+        const { container } = render(
+            <AdminHomepageControls
+                projectUuid="project-1"
+                organizationUuid="organization-1"
+            />,
+        );
+
+        expect(
+            container.querySelector('[data-deep-research-control-target]'),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: 'Customize homepage' }),
+        ).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/AdminHomepageControls.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/AdminHomepageControls.test.tsx
@@ -20,11 +20,19 @@ describe('AdminHomepageControls', () => {
             />,
         );
 
+        const customizeButton = screen.getByRole('button', {
+            name: 'Customize homepage',
+        });
+        const deepResearchTarget = container.querySelector(
+            '[data-deep-research-control-target]',
+        );
+
+        expect(deepResearchTarget).toBeInTheDocument();
+        if (!deepResearchTarget) {
+            throw new Error('Deep Research target was not rendered');
+        }
         expect(
-            container.querySelector('[data-deep-research-control-target]'),
-        ).toBeInTheDocument();
-        expect(
-            screen.getByRole('button', { name: 'Customize homepage' }),
-        ).toBeInTheDocument();
+            customizeButton.compareDocumentPosition(deepResearchTarget),
+        ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     });
 });

--- a/packages/frontend/src/ee/features/homepageBuilder/AdminHomepageControls.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/AdminHomepageControls.tsx
@@ -22,10 +22,6 @@ export const AdminHomepageControls: FC<Props> = ({
     const navigate = useNavigate();
     return (
         <div className={classes.corner}>
-            <div
-                className={classes.deepResearchTarget}
-                data-deep-research-control-target
-            />
             <Can
                 I="manage"
                 this={subject('ProjectHomepage', {
@@ -64,6 +60,10 @@ export const AdminHomepageControls: FC<Props> = ({
                     </span>
                 </button>
             </Can>
+            <div
+                className={classes.deepResearchTarget}
+                data-deep-research-control-target
+            />
         </div>
     );
 };

--- a/packages/frontend/src/ee/features/homepageBuilder/AdminHomepageControls.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/AdminHomepageControls.tsx
@@ -21,11 +21,18 @@ export const AdminHomepageControls: FC<Props> = ({
 }) => {
     const navigate = useNavigate();
     return (
-        <Can
-            I="manage"
-            this={subject('ProjectHomepage', { organizationUuid, projectUuid })}
-        >
-            <div className={classes.corner}>
+        <div className={classes.corner}>
+            <div
+                className={classes.deepResearchTarget}
+                data-deep-research-control-target
+            />
+            <Can
+                I="manage"
+                this={subject('ProjectHomepage', {
+                    organizationUuid,
+                    projectUuid,
+                })}
+            >
                 {showNewHomepage && (
                     <button
                         type="button"
@@ -56,7 +63,7 @@ export const AdminHomepageControls: FC<Props> = ({
                         Customize homepage
                     </span>
                 </button>
-            </div>
-        </Can>
+            </Can>
+        </div>
     );
 };

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.test.tsx
@@ -1,0 +1,213 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, render } from '@testing-library/react';
+import { type ComponentProps } from 'react';
+import type * as ReactRouter from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentChatInput } from '../aiCopilot/components/ChatElements/AgentChatInput';
+import { DayOneAskInput } from './DayOneAskInput';
+
+type AgentChatInputModule = {
+    AgentChatInput: typeof AgentChatInput;
+};
+
+const {
+    agentChatInputProps,
+    agents,
+    createAgentThread,
+    deepResearchEnabled,
+    navigate,
+    startDeepResearch,
+} = vi.hoisted(() => ({
+    agentChatInputProps: {
+        current: undefined as ComponentProps<typeof AgentChatInput> | undefined,
+    },
+    agents: {
+        current: [
+            {
+                uuid: 'agent-1',
+                name: 'Data agent',
+            },
+        ],
+    },
+    createAgentThread: vi.fn(),
+    deepResearchEnabled: { current: true },
+    navigate: vi.fn(),
+    startDeepResearch: vi.fn(),
+}));
+
+vi.mock('react-router', async (importOriginal) => ({
+    ...(await importOriginal<typeof ReactRouter>()),
+    useNavigate: () => navigate,
+}));
+
+vi.mock('../../../hooks/useProject', () => ({
+    useProject: () => ({ data: undefined }),
+}));
+
+vi.mock('../../../hooks/useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: () => ({
+        data: { enabled: deepResearchEnabled.current },
+    }),
+}));
+
+vi.mock('../../../providers/App/useApp', () => ({
+    default: () => ({
+        user: {
+            data: {
+                organizationUuid: 'organization-1',
+                ability: { can: () => true },
+            },
+        },
+    }),
+}));
+
+vi.mock('../../../providers/Tracking/useTracking', () => ({
+    default: () => ({
+        track: vi.fn(),
+        data: { rudder: true },
+    }),
+}));
+
+vi.mock(
+    '../aiCopilot/components/PendingPromptContext/PendingPromptContext',
+    () => ({
+        usePendingPrompt: () => ({ setPendingPrompt: vi.fn() }),
+    }),
+);
+
+vi.mock('../aiCopilot/hooks/useAgentSuggestions', () => ({
+    useAgentSuggestions: () => ({
+        data: undefined,
+        isLoading: false,
+    }),
+}));
+
+vi.mock('../aiCopilot/hooks/useAiAgentPermission', () => ({
+    useCanCreateAiAgentThread: () => true,
+}));
+
+vi.mock('../aiCopilot/hooks/useAiAgentSqlModeAvailable', () => ({
+    useAiAgentSqlModeAvailable: () => false,
+}));
+
+vi.mock('../aiCopilot/hooks/useDeepResearch', () => ({
+    useStartDeepResearchForThreadMutation: () => ({
+        mutateAsync: startDeepResearch,
+    }),
+}));
+
+vi.mock('../aiCopilot/hooks/useProjectAiAgents', () => ({
+    useCreateAgentThreadMutation: () => ({
+        mutateAsync: createAgentThread,
+        isLoading: false,
+    }),
+    useProjectAiAgents: () => ({
+        data: agents.current,
+        isInitialLoading: false,
+    }),
+}));
+
+vi.mock('../aiCopilot/hooks/useUserAgentPreferences', () => ({
+    useGetUserAgentPreferences: () => ({
+        data: undefined,
+        isInitialLoading: false,
+    }),
+}));
+
+vi.mock(
+    '../aiCopilot/components/ChatElements/AgentChatInput',
+    async (importOriginal) => {
+        const original = await importOriginal<AgentChatInputModule>();
+        return {
+            ...original,
+            AgentChatInput: (
+                props: ComponentProps<typeof original.AgentChatInput>,
+            ) => {
+                agentChatInputProps.current = props;
+                return <div data-testid="agent-chat-input" />;
+            },
+        };
+    },
+);
+
+const renderInput = (routerEnabled = false) => {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    queryClient.setQueryData(['ai-router'], { enabled: routerEnabled });
+
+    return render(
+        <QueryClientProvider client={queryClient}>
+            <DayOneAskInput projectUuid="project-1" hideSuggestions />
+        </QueryClientProvider>,
+    );
+};
+
+describe('DayOneAskInput', () => {
+    beforeEach(() => {
+        agentChatInputProps.current = undefined;
+        agents.current = [{ uuid: 'agent-1', name: 'Data agent' }];
+        createAgentThread.mockReset();
+        createAgentThread.mockResolvedValue({
+            uuid: 'thread-1',
+            firstMessage: { uuid: 'prompt-1' },
+        });
+        deepResearchEnabled.current = true;
+        startDeepResearch.mockReset();
+        startDeepResearch.mockResolvedValue(undefined);
+    });
+
+    it('starts Deep Research with a new thread for the selected agent', async () => {
+        renderInput();
+
+        expect(agentChatInputProps.current?.agentUuid).toBe('agent-1');
+        expect(agentChatInputProps.current?.onStartDeepResearch).toBeDefined();
+
+        await act(async () => {
+            await agentChatInputProps.current?.onStartDeepResearch?.({
+                question: 'Research churn',
+                depth: 'deep',
+                mcpServerUuids: ['mcp-1'],
+            });
+        });
+
+        expect(createAgentThread).toHaveBeenCalledWith({
+            agentUuid: 'agent-1',
+            prompt: 'Research churn',
+            skipAgentResponse: true,
+        });
+        expect(startDeepResearch).toHaveBeenCalledWith({
+            question: 'Research churn',
+            depth: 'deep',
+            agentUuid: 'agent-1',
+            threadUuid: 'thread-1',
+            promptUuid: 'prompt-1',
+            mcpServerUuids: ['mcp-1'],
+        });
+    });
+
+    it('hides Deep Research when Auto routing is selected', () => {
+        agents.current = [
+            { uuid: 'agent-1', name: 'Data agent' },
+            { uuid: 'agent-2', name: 'Finance agent' },
+        ];
+
+        renderInput(true);
+
+        expect(agentChatInputProps.current?.selectedAgent).toBe('auto');
+        expect(agentChatInputProps.current?.agentUuid).toBeUndefined();
+        expect(
+            agentChatInputProps.current?.onStartDeepResearch,
+        ).toBeUndefined();
+    });
+
+    it('hides Deep Research when the feature flag is disabled', () => {
+        deepResearchEnabled.current = false;
+
+        renderInput();
+
+        expect(
+            agentChatInputProps.current?.onStartDeepResearch,
+        ).toBeUndefined();
+    });
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.test.tsx
@@ -165,6 +165,15 @@ describe('DayOneAskInput', () => {
         expect(agentChatInputProps.current?.deepResearchControlPlacement).toBe(
             'page_header',
         );
+        expect(agentChatInputProps.current?.deepResearchControlVariant).toBe(
+            'compact',
+        );
+        expect(
+            agentChatInputProps.current?.deepResearchControlClassNames,
+        ).toEqual({
+            root: expect.any(String),
+            label: expect.any(String),
+        });
 
         await act(async () => {
             await agentChatInputProps.current?.onStartDeepResearch?.({

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.test.tsx
@@ -162,6 +162,9 @@ describe('DayOneAskInput', () => {
 
         expect(agentChatInputProps.current?.agentUuid).toBe('agent-1');
         expect(agentChatInputProps.current?.onStartDeepResearch).toBeDefined();
+        expect(agentChatInputProps.current?.deepResearchControlPlacement).toBe(
+            'page_header',
+        );
 
         await act(async () => {
             await agentChatInputProps.current?.onStartDeepResearch?.({

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.tsx
@@ -1,6 +1,7 @@
 import { subject } from '@casl/ability';
 import {
     DbtProjectType,
+    FeatureFlags,
     type AgentSuggestion,
     type AiPromptContextInput,
     type AiPromptContextItem,
@@ -9,10 +10,11 @@ import {
 import { Anchor, Skeleton, Text } from '@mantine-8/core';
 import { IconArrowUpRight } from '@tabler/icons-react';
 import { useQueryClient } from '@tanstack/react-query';
-import { useEffect, useRef, useState, type FC } from 'react';
+import { useCallback, useEffect, useRef, useState, type FC } from 'react';
 import { useNavigate } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useProject } from '../../../hooks/useProject';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../providers/App/useApp';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
@@ -22,9 +24,11 @@ import {
 } from '../aiCopilot/components/AgentSelector/AgentSelectorUtils';
 import { AgentChatInput } from '../aiCopilot/components/ChatElements/AgentChatInput';
 import { usePendingPrompt } from '../aiCopilot/components/PendingPromptContext/PendingPromptContext';
+import { type StartDeepResearchArgs } from '../aiCopilot/deepResearch/types';
 import { useAgentSuggestions } from '../aiCopilot/hooks/useAgentSuggestions';
 import { useCanCreateAiAgentThread } from '../aiCopilot/hooks/useAiAgentPermission';
 import { useAiAgentSqlModeAvailable } from '../aiCopilot/hooks/useAiAgentSqlModeAvailable';
+import { useStartDeepResearchForThreadMutation } from '../aiCopilot/hooks/useDeepResearch';
 import {
     useCreateAgentThreadMutation,
     useProjectAiAgents,
@@ -143,6 +147,9 @@ const DayOneAskInputInner: FC<Props> = ({
     const routerEnabled = useAiRouterEnabledFromCache();
     const { mutateAsync: createAgentThread, isLoading: isCreatingThread } =
         useCreateAgentThreadMutation(projectUuid ?? '');
+    const { mutateAsync: startDeepResearch } =
+        useStartDeepResearchForThreadMutation(projectUuid ?? '');
+    const deepResearchFlag = useServerFeatureFlag(FeatureFlags.AiDeepResearch);
 
     const showAutoOption = (agents?.length ?? 0) > 1 && routerEnabled === true;
     const validDefaultAgent = agents?.find(
@@ -154,6 +161,8 @@ const DayOneAskInputInner: FC<Props> = ({
     const activeSelection =
         validDefaultAgent ?? (showAutoOption ? 'auto' : agents?.[0]);
     const referenceAgent = validDefaultAgent ?? agents?.[0];
+    const selectedAgent =
+        activeSelection === 'auto' ? undefined : activeSelection;
 
     const { data: project } = useProject(projectUuid ?? undefined);
     const sqlModeAvailable = useAiAgentSqlModeAvailable(
@@ -228,6 +237,28 @@ const DayOneAskInputInner: FC<Props> = ({
         });
         submitPrompt(prompt, toolHints, context, optimisticContext);
     };
+
+    const handleStartDeepResearch = useCallback(
+        async ({ question, depth, mcpServerUuids }: StartDeepResearchArgs) => {
+            if (!projectUuid || !selectedAgent) {
+                return;
+            }
+            const thread = await createAgentThread({
+                agentUuid: selectedAgent.uuid,
+                prompt: question,
+                skipAgentResponse: true,
+            });
+            await startDeepResearch({
+                question,
+                depth,
+                agentUuid: selectedAgent.uuid,
+                threadUuid: thread.uuid,
+                promptUuid: thread.firstMessage.uuid,
+                mcpServerUuids,
+            });
+        },
+        [createAgentThread, projectUuid, selectedAgent, startDeepResearch],
+    );
 
     const handleChipPick = (chip: AgentSuggestion, index: number) => {
         const organizationId = user.data?.organizationUuid;
@@ -304,6 +335,7 @@ const DayOneAskInputInner: FC<Props> = ({
         <div className={classes.composer} inert={preview}>
             <AgentChatInput
                 projectUuid={projectUuid ?? undefined}
+                agentUuid={selectedAgent?.uuid}
                 agents={agents}
                 selectedAgent={activeSelection ?? agents?.[0]}
                 placeholder={
@@ -314,6 +346,11 @@ const DayOneAskInputInner: FC<Props> = ({
                           : 'Ask anything about your data…'
                 }
                 onSubmit={handleSubmit}
+                onStartDeepResearch={
+                    selectedAgent && deepResearchFlag.data?.enabled
+                        ? handleStartDeepResearch
+                        : undefined
+                }
                 loading={isCreatingThread}
                 showSuggestions={false}
                 fullWidth

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.tsx
@@ -34,6 +34,7 @@ import {
     useProjectAiAgents,
 } from '../aiCopilot/hooks/useProjectAiAgents';
 import { useGetUserAgentPreferences } from '../aiCopilot/hooks/useUserAgentPreferences';
+import homepageControlClasses from './adminHomepageControls.module.css';
 import blockClasses from './blocks/blockStyles.module.css';
 import classes from './DayOneAskInput.module.css';
 
@@ -352,6 +353,11 @@ const DayOneAskInputInner: FC<Props> = ({
                         : undefined
                 }
                 deepResearchControlPlacement="page_header"
+                deepResearchControlVariant="compact"
+                deepResearchControlClassNames={{
+                    root: homepageControlClasses.tbBtn,
+                    label: homepageControlClasses.tbBtnLabel,
+                }}
                 loading={isCreatingThread}
                 showSuggestions={false}
                 fullWidth

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.tsx
@@ -351,6 +351,7 @@ const DayOneAskInputInner: FC<Props> = ({
                         ? handleStartDeepResearch
                         : undefined
                 }
+                deepResearchControlPlacement="page_header"
                 loading={isCreatingThread}
                 showSuggestions={false}
                 fullWidth

--- a/packages/frontend/src/ee/features/homepageBuilder/adminHomepageControls.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/adminHomepageControls.module.css
@@ -39,6 +39,11 @@
     gap: 6px;
 }
 
+.tbBtn[aria-pressed='true'] {
+    background: var(--mantine-color-blue-light);
+    color: var(--mantine-color-blue-light-color);
+}
+
 .tbBtnLabel {
     display: inline-block;
     max-width: 0;

--- a/packages/frontend/src/ee/features/homepageBuilder/adminHomepageControls.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/adminHomepageControls.module.css
@@ -8,6 +8,10 @@
     gap: 8px;
 }
 
+.deepResearchTarget {
+    display: contents;
+}
+
 .tbBtn {
     border: 1px solid var(--mantine-color-ldGray-2);
     background: light-dark(#fff, var(--mantine-color-dark-6));


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9200/add-ability-to-run-deep-research-from-home-page

## Description:

Adds a Deep Research telescope action to the homepage’s top-right controls beside Customize. It matches the existing toolbar behavior: icon-only at rest, expanding its label on hover or keyboard focus, with an active state when research mode is selected.

```text
Top-right telescope (beside Customize)
        │
        ▼
Homepage composer enters Deep Research mode
        │
        ▼
Create thread (skip agent response)
        │
        ▼
Start Deep Research with thread + prompt IDs
```

Auto routing keeps the action hidden because Deep Research must inherit a concrete agent's model, instructions, tools, and permissions.

Tests: 14 focused homepage/shared-composer tests, frontend fast typecheck, lint, formatting, and diff checks.
