### PR TITLE
feat(deep-research): show only available MCP sources

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.deepResearch.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.deepResearch.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router';
@@ -72,7 +72,7 @@ describe('AgentChatInput Deep research mode', () => {
         ).not.toBeInTheDocument();
         expect(
             await screen.findByRole('checkbox', { name: /GitHub/ }),
-        ).toBeChecked();
+        ).not.toBeChecked();
 
         await user.click(screen.getByText('High'));
         await user.click(
@@ -82,7 +82,7 @@ describe('AgentChatInput Deep research mode', () => {
         expect(onStartDeepResearch).toHaveBeenCalledWith({
             question: 'Why did enterprise retention fall in Q2?',
             depth: 'deep',
-            mcpServerUuids: ['mcp-1'],
+            mcpServerUuids: [],
         });
         expect(onSubmit).not.toHaveBeenCalled();
     });
@@ -116,7 +116,7 @@ describe('AgentChatInput Deep research mode', () => {
         expect(onStartDeepResearch).toHaveBeenCalledWith({
             question: 'What changed this month?',
             depth: 'standard',
-            mcpServerUuids: ['mcp-1'],
+            mcpServerUuids: [],
         });
         expect(onSubmit).not.toHaveBeenCalled();
     });
@@ -205,13 +205,13 @@ describe('AgentChatInput Deep research mode', () => {
             name: /GitHub/,
         });
         await user.click(serverCheckbox);
-        expect(serverCheckbox).not.toBeChecked();
+        expect(serverCheckbox).toBeChecked();
         await user.click(
             screen.getByRole('button', { name: 'Start research' }),
         );
 
         expect(onStartDeepResearch).toHaveBeenCalledWith(
-            expect.objectContaining({ mcpServerUuids: [] }),
+            expect.objectContaining({ mcpServerUuids: ['mcp-1'] }),
         );
     });
 
@@ -247,12 +247,15 @@ describe('AgentChatInput Deep research mode', () => {
         );
     });
 
-    it('blocks preflight while a selected MCP server needs reconnection', async () => {
+    it('only shows MCP servers that are available to use', async () => {
         const user = userEvent.setup();
         useAgentAiMcpServersMock.mockReturnValue({
             data: [
+                connectedMcpServer,
                 {
                     ...connectedMcpServer,
+                    uuid: 'mcp-2',
+                    name: 'Attio',
                     connectionStatus: 'not_connected',
                     hasCredentials: false,
                 },
@@ -280,10 +283,71 @@ describe('AgentChatInput Deep research mode', () => {
         await user.click(screen.getByRole('button', { name: 'Deep research' }));
 
         expect(
-            await screen.findByText('connection required'),
-        ).toBeInTheDocument();
+            await screen.findByRole('checkbox', { name: /GitHub/ }),
+        ).not.toBeChecked();
+        expect(
+            screen.queryByRole('checkbox', { name: /Attio/ }),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByText('connection required'),
+        ).not.toBeInTheDocument();
         expect(
             screen.getByRole('button', { name: 'Start research' }),
-        ).toBeDisabled();
+        ).toBeEnabled();
+    });
+
+    it('removes a selected MCP when it becomes unavailable', async () => {
+        const user = userEvent.setup();
+        const onStartDeepResearch = vi.fn().mockResolvedValue(undefined);
+        const renderInput = () => (
+            <Provider store={store}>
+                <MemoryRouter>
+                    <AgentChatInput
+                        onSubmit={vi.fn()}
+                        onStartDeepResearch={onStartDeepResearch}
+                        projectUuid="project-1"
+                        agentUuid="agent-1"
+                        defaultValue="Investigate churn"
+                        showSuggestions={false}
+                    />
+                </MemoryRouter>
+            </Provider>
+        );
+        const rendered = renderWithProviders(renderInput());
+
+        await user.click(screen.getByRole('button', { name: 'Deep research' }));
+        await user.click(
+            await screen.findByRole('checkbox', { name: /GitHub/ }),
+        );
+
+        useAgentAiMcpServersMock.mockReturnValue({
+            data: [
+                {
+                    ...connectedMcpServer,
+                    connectionStatus: 'not_connected',
+                    hasCredentials: false,
+                },
+            ],
+            isLoading: false,
+            isError: false,
+            error: null,
+        });
+        rendered.rerender(renderInput());
+
+        await waitFor(() => {
+            expect(
+                screen.queryByRole('checkbox', { name: /GitHub/ }),
+            ).not.toBeInTheDocument();
+            expect(
+                screen.getByRole('button', { name: 'Start research' }),
+            ).toBeEnabled();
+        });
+
+        await user.click(
+            screen.getByRole('button', { name: 'Start research' }),
+        );
+        expect(onStartDeepResearch).toHaveBeenCalledWith(
+            expect.objectContaining({ mcpServerUuids: [] }),
+        );
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchMcpSelector.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchMcpSelector.tsx
@@ -1,21 +1,8 @@
 import { type AiMcpServer } from '@lightdash/common';
-import {
-    Alert,
-    Checkbox,
-    Group,
-    Loader,
-    Stack,
-    Text,
-    ThemeIcon,
-} from '@mantine-8/core';
-import {
-    IconAlertCircle,
-    IconDatabase,
-    IconPlugConnected,
-} from '@tabler/icons-react';
+import { Alert, Checkbox, Group, Loader, Stack, Text } from '@mantine-8/core';
+import { IconAlertCircle, IconPlugConnected } from '@tabler/icons-react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { isDeepResearchMcpServerReady } from '../../deepResearch/mcpServerReady';
-import styles from './DeepResearchPreflight.module.css';
 
 type Props = {
     mcpServers: AiMcpServer[];
@@ -32,11 +19,7 @@ export const DeepResearchMcpSelector = ({
     isLoading,
     error,
 }: Props) => {
-    const unavailableSelectedServers = mcpServers.filter(
-        (server) =>
-            selectedMcpServerUuids.includes(server.uuid) &&
-            !isDeepResearchMcpServerReady(server),
-    );
+    const availableMcpServers = mcpServers.filter(isDeepResearchMcpServerReady);
 
     const handleServerChange = (serverUuid: string, checked: boolean) => {
         onSelectedMcpServerUuidsChange(
@@ -60,16 +43,6 @@ export const DeepResearchMcpSelector = ({
                     actions, can run unattended.
                 </Text>
             </Stack>
-            <Group gap="xs">
-                <Group gap={6} className={styles.source} data-available>
-                    <ThemeIcon variant="light" color="indigo" size={22}>
-                        <MantineIcon icon={IconDatabase} size={12} />
-                    </ThemeIcon>
-                    <Text size="11px" lh={1.35}>
-                        Agent context and project data
-                    </Text>
-                </Group>
-            </Group>
             {isLoading ? (
                 <Group gap="xs">
                     <Loader size="xs" />
@@ -85,9 +58,9 @@ export const DeepResearchMcpSelector = ({
                 >
                     {error}
                 </Alert>
-            ) : mcpServers.length > 0 ? (
+            ) : availableMcpServers.length > 0 ? (
                 <Stack gap="xs">
-                    {mcpServers.map((server) => (
+                    {availableMcpServers.map((server) => (
                         <Checkbox
                             key={server.uuid}
                             checked={selectedMcpServerUuids.includes(
@@ -108,11 +81,6 @@ export const DeepResearchMcpSelector = ({
                                     <Text span size="11px">
                                         {server.name}
                                     </Text>
-                                    {!isDeepResearchMcpServerReady(server) && (
-                                        <Text span size="10px" c="red">
-                                            connection required
-                                        </Text>
-                                    )}
                                 </Group>
                             }
                         />
@@ -120,21 +88,8 @@ export const DeepResearchMcpSelector = ({
                 </Stack>
             ) : (
                 <Text size="11px" c="dimmed">
-                    This agent has no MCP servers attached.
+                    This agent has no MCP servers available.
                 </Text>
-            )}
-            {unavailableSelectedServers.length > 0 && (
-                <Alert
-                    color="orange"
-                    icon={<MantineIcon icon={IconAlertCircle} />}
-                    p="xs"
-                >
-                    Connect or disable{' '}
-                    {unavailableSelectedServers
-                        .map((server) => server.name)
-                        .join(', ')}{' '}
-                    before starting.
-                </Alert>
             )}
         </Stack>
     );

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.test.tsx
@@ -58,10 +58,10 @@ describe('DeepResearchModeControl', () => {
         ).toBeInTheDocument();
         expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
         expect(
-            screen.getByText('Agent context and project data'),
-        ).toBeInTheDocument();
+            screen.queryByText('Agent context and project data'),
+        ).not.toBeInTheDocument();
         expect(
-            screen.getByText('This agent has no MCP servers attached.'),
+            screen.getByText('This agent has no MCP servers available.'),
         ).toBeInTheDocument();
         expect(
             screen.queryByRole('button', { name: 'Start research' }),

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.module.css
@@ -41,20 +41,6 @@
     }
 }
 
-.source {
-    padding: rem(3px) rem(6px);
-    border: 1px solid var(--mantine-color-indigo-2);
-    border-radius: var(--mantine-radius-sm);
-
-    @mixin light {
-        background-color: rgba(255, 255, 255, 0.56);
-    }
-
-    &[data-available='false'] {
-        border-style: dashed;
-    }
-}
-
 @media (max-width: 48em) {
     .root {
         padding-right: var(--mantine-spacing-sm);

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearchComposer.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearchComposer.ts
@@ -35,16 +35,28 @@ export const useDeepResearchComposer = ({
             setSelectedMcpServerUuids([]);
             return;
         }
-        if (
-            !mcpServersQuery.data ||
-            initializedSelectionKeyRef.current === selectionKey
-        ) {
+        if (!mcpServersQuery.data) {
             return;
         }
-        initializedSelectionKeyRef.current = selectionKey;
-        setSelectedMcpServerUuids(
-            mcpServersQuery.data.map((server) => server.uuid),
+        if (initializedSelectionKeyRef.current !== selectionKey) {
+            initializedSelectionKeyRef.current = selectionKey;
+            setSelectedMcpServerUuids([]);
+            return;
+        }
+
+        const availableMcpServerUuids = new Set(
+            mcpServersQuery.data
+                .filter(isDeepResearchMcpServerReady)
+                .map((server) => server.uuid),
         );
+        setSelectedMcpServerUuids((selectedUuids) => {
+            const availableSelectedUuids = selectedUuids.filter((uuid) =>
+                availableMcpServerUuids.has(uuid),
+            );
+            return availableSelectedUuids.length === selectedUuids.length
+                ? selectedUuids
+                : availableSelectedUuids;
+        });
     }, [selectionKey, mcpServersQuery.data]);
 
     const hasUnavailableSelection = (mcpServersQuery.data ?? []).some(


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9251/only-preselect-mcps-that-are-available-to-use

## Summary

Deep Research now starts with no MCP sources selected and only offers sources whose credentials are ready to use. The preflight also removes the connection warning and the static agent context/project data pill.

## MCP source preflight

```text
Before
  Attached MCPs  -> all selected
  Unavailable    -> visible + blocking warning
  Context        -> static pill

After
  Ready MCPs     -> visible + unchecked
  Unavailable    -> omitted
  Context        -> inherited without a pill
```

A selected MCP that becomes unavailable during a query refetch is removed from the per-run selection, so a hidden stale UUID cannot silently block Start or reach backend validation.

## Regression analysis

- **Explicit MCP selection** — ready sources still submit their UUIDs when checked.
- **Preflight readiness** — loading and query errors still block Start.
- **Backend validation** — selected-server membership and credential checks remain unchanged.
- **Ask and research controls** — Ask remains the default; depth, busy-thread, embedded-route, and retry behavior are unchanged.
- No backend or API surface is touched.

## Test plan

- [x] Ready MCP sources render unchecked and an empty selection submits `mcpServerUuids: []`.
- [x] Explicitly checking a ready source submits its UUID.
- [x] Unavailable sources, connection-required copy, and the context pill do not render.
- [x] A selected source that becomes unavailable after refetch is removed and Start stays enabled.
- [x] No-available-source, Ask mode, depth, busy, embedded, and failed-start paths remain covered.
- [x] Frontend typecheck, lint, formatting, and `git diff --check` pass.
- [x] Full frontend suite passes: 201 files and 1,613 tests.