### PR TITLE
fix: stacked bar underlying data drops filters for non-plotted dimensions

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -918,19 +918,29 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                     chart.metricQuery.customDimensions,
                 );
 
-                // Filter dimensions from explore that match dimensionNames
-                // Only dimensions should be available for dashboard filtering - metrics are not supported
+                // Filter dimensions from explore that match the clicked item's
+                // columns. Stacked bar tuples only expose the plotted columns
+                // via dimensionNames, so include the resolved dataset row's
+                // columns too. Only dimensions should be available for
+                // dashboard filtering - metrics are not supported
+                const clickedColumnNames = new Set([
+                    ...e.dimensionNames,
+                    ...Object.keys(e.datasetRow ?? {}),
+                ]);
                 const exploreDimensions = allDimensions.filter((dimension) =>
-                    e.dimensionNames.includes(getItemId(dimension)),
+                    clickedColumnNames.has(getItemId(dimension)),
                 );
 
                 // Helper to extract value from click event data
-                // For stacked bars: e.value is an array, e.dimensionNames maps indices to field names
+                // For stacked bars: e.value is an array, e.dimensionNames maps
+                // indices to field names, and the dataset row carries the
+                // non-plotted columns
                 // For other charts: e.data is an object with field names as keys
                 const getValueFromClickData = (fieldId: string) => {
                     if (Array.isArray(e.value) && e.dimensionNames) {
                         const index = e.dimensionNames.indexOf(fieldId);
-                        return index >= 0 ? e.value[index] : undefined;
+                        if (index >= 0) return e.value[index];
+                        return e.datasetRow?.[fieldId];
                     }
                     return (e.data as Record<string, unknown>)[fieldId];
                 };

--- a/packages/frontend/src/components/MetricQueryData/UnderlyingDataFilterBadges.module.css
+++ b/packages/frontend/src/components/MetricQueryData/UnderlyingDataFilterBadges.module.css
@@ -1,0 +1,5 @@
+.target {
+    vertical-align: middle;
+    margin-left: var(--mantine-spacing-xs);
+    cursor: default;
+}

--- a/packages/frontend/src/components/MetricQueryData/UnderlyingDataFilterBadges.tsx
+++ b/packages/frontend/src/components/MetricQueryData/UnderlyingDataFilterBadges.tsx
@@ -1,0 +1,99 @@
+import {
+    getItemId,
+    isFilterableItem,
+    type CustomDimension,
+    type Field,
+    type FilterRule,
+    type TableCalculation,
+} from '@lightdash/common';
+import { Badge, HoverCard, Stack, Text } from '@mantine-8/core';
+import { IconFilter } from '@tabler/icons-react';
+import { type FC } from 'react';
+import { getConditionalRuleLabelFromItem } from '../common/Filters/FilterInputs/utils';
+import MantineIcon from '../common/MantineIcon';
+import classes from './UnderlyingDataFilterBadges.module.css';
+
+type Props = {
+    filterRules: FilterRule[];
+    fields: (Field | TableCalculation | CustomDimension)[];
+};
+
+// Inline filter-count chip + hover card summarising which filters scope the
+// underlying data results, mirroring the dashboard tile filter popover.
+// Rendered inside the modal title (a <p>), so the target must stay inline.
+const UnderlyingDataFilterBadges: FC<Props> = ({ filterRules, fields }) => {
+    const labelledRules = filterRules.flatMap((filterRule) => {
+        const field = fields.find(
+            (f) => getItemId(f) === filterRule.target.fieldId,
+        );
+        if (!field || !isFilterableItem(field)) return [];
+        return [
+            {
+                id: filterRule.id,
+                labels: getConditionalRuleLabelFromItem(filterRule, field),
+            },
+        ];
+    });
+
+    if (labelledRules.length === 0) return null;
+
+    return (
+        <HoverCard
+            withArrow
+            withinPortal
+            shadow="md"
+            position="bottom-start"
+            offset={4}
+            arrowOffset={10}
+        >
+            <HoverCard.Target>
+                <Badge
+                    component="span"
+                    className={classes.target}
+                    variant="default"
+                    c="ldDark.7"
+                    radius="md"
+                    size="lg"
+                    fz="xs"
+                    fw={500}
+                    tt="none"
+                    leftSection={<MantineIcon icon={IconFilter} size="sm" />}
+                >
+                    {labelledRules.length} filter
+                    {labelledRules.length > 1 ? 's' : ''}
+                </Badge>
+            </HoverCard.Target>
+            <HoverCard.Dropdown maw={500}>
+                <Text c="ldGray.7" fw={500} fz="xs" mb="xs">
+                    Underlying data is filtered to:
+                </Text>
+                <Stack gap="xs" align="flex-start">
+                    {labelledRules.map(({ id, labels }) => (
+                        <Badge
+                            key={id}
+                            variant="outline"
+                            color="ldGray.4"
+                            radius="sm"
+                            size="lg"
+                            fz="xs"
+                            fw="normal"
+                            tt="none"
+                        >
+                            <Text fw={600} span inherit c="foreground">
+                                {labels.field}:
+                            </Text>{' '}
+                            <Text span inherit c="foreground">
+                                {labels.operator}
+                            </Text>{' '}
+                            <Text fw={600} span inherit c="foreground">
+                                {labels.value}
+                            </Text>
+                        </Badge>
+                    ))}
+                </Stack>
+            </HoverCard.Dropdown>
+        </HoverCard>
+    );
+};
+
+export default UnderlyingDataFilterBadges;

--- a/packages/frontend/src/components/MetricQueryData/UnderlyingDataModal.tsx
+++ b/packages/frontend/src/components/MetricQueryData/UnderlyingDataModal.tsx
@@ -43,6 +43,7 @@ import MantineModal from '../common/MantineModal';
 import { type TableColumn } from '../common/Table/types';
 import ExportResults from '../ExportResults';
 import { getZoomedDimFilter } from './dateZoomFilter';
+import UnderlyingDataFilterBadges from './UnderlyingDataFilterBadges';
 import UnderlyingDataResultsTable from './UnderlyingDataResultsTable';
 import { useMetricQueryDataContext } from './useMetricQueryDataContext';
 
@@ -146,12 +147,15 @@ const UnderlyingDataModalContent: FC = () => {
         [showUnderlyingValues, allFields],
     );
 
-    const filters = useMemo<Filters>(() => {
-        if (!underlyingDataConfig) return {};
+    // Flat rules scoping the results to the clicked chart segment/cell, kept
+    // separate from the grouped explore filters so they can be surfaced in the
+    // header filter summary
+    const filterParts = useMemo(() => {
+        if (!underlyingDataConfig) return null;
         const { item, fieldValues, pivotReference, value, dateZoom } =
             underlyingDataConfig;
 
-        if (item === undefined) return {};
+        if (item === undefined) return null;
 
         // If we are viewing data from a metric or a table calculation, we filter using all existing dimensions in the table
         const dimensionFilters = !isDimension(item)
@@ -239,6 +243,15 @@ const UnderlyingDataModalContent: FC = () => {
                 },
             })) || [];
 
+        return {
+            pointFilterRules: [...dimensionFilters, ...pivotFilter],
+            metricFilterRules: metricFilters,
+        };
+    }, [underlyingDataConfig, allDimensions, resolvedTimezone]);
+
+    const filters = useMemo<Filters>(() => {
+        if (!filterParts) return {};
+
         const exploreFilters =
             metricQuery?.filters?.dimensions !== undefined
                 ? [metricQuery.filters.dimensions]
@@ -246,9 +259,8 @@ const UnderlyingDataModalContent: FC = () => {
 
         const combinedFilters = [
             ...exploreFilters,
-            ...dimensionFilters,
-            ...pivotFilter,
-            ...metricFilters,
+            ...filterParts.pointFilterRules,
+            ...filterParts.metricFilterRules,
         ];
 
         return getFiltersFromGroup(
@@ -258,13 +270,7 @@ const UnderlyingDataModalContent: FC = () => {
             },
             allFields,
         );
-    }, [
-        underlyingDataConfig,
-        metricQuery,
-        allFields,
-        allDimensions,
-        resolvedTimezone,
-    ]);
+    }, [filterParts, metricQuery, allFields]);
 
     const {
         error,
@@ -369,6 +375,23 @@ const UnderlyingDataModalContent: FC = () => {
             }),
         );
 
+    const modalTitle = (
+        <>
+            View underlying data
+            <UnderlyingDataFilterBadges
+                filterRules={
+                    filterParts
+                        ? [
+                              ...filterParts.pointFilterRules,
+                              ...filterParts.metricFilterRules,
+                          ]
+                        : []
+                }
+                fields={allFields}
+            />
+        </>
+    );
+
     const headerActions = (
         <Group gap="sm">
             {canExportCsv && (
@@ -429,7 +452,7 @@ const UnderlyingDataModalContent: FC = () => {
             opened={isUnderlyingDataModalOpen}
             icon={IconStack}
             onClose={closeUnderlyingDataModal}
-            title="View underlying data"
+            title={modalTitle}
             fullScreen
             headerActions={headerActions}
             cancelLabel={false}

--- a/packages/frontend/src/components/MetricQueryData/utils.test.ts
+++ b/packages/frontend/src/components/MetricQueryData/utils.test.ts
@@ -1,0 +1,178 @@
+/// <reference types="vitest/globals" />
+import {
+    DimensionType,
+    FieldType,
+    MetricType,
+    type CompiledDimension,
+    type CompiledMetric,
+    type EChartsSeries,
+    type ItemsMap,
+} from '@lightdash/common';
+import { type EchartsSeriesClickEvent } from '../SimpleChart';
+import { getDataFromChartClick } from './utils';
+
+const weekDimension: CompiledDimension = {
+    fieldType: FieldType.DIMENSION,
+    type: DimensionType.DATE,
+    name: 'order_date_week',
+    label: 'Order date week',
+    table: 'orders',
+    tableLabel: 'Orders',
+    sql: '',
+    compiledSql: '',
+    tablesReferences: ['orders'],
+    hidden: false,
+};
+
+const priorityDimension: CompiledDimension = {
+    fieldType: FieldType.DIMENSION,
+    type: DimensionType.STRING,
+    name: 'order_priority',
+    label: 'Order priority',
+    table: 'orders',
+    tableLabel: 'Orders',
+    sql: '',
+    compiledSql: '',
+    tablesReferences: ['orders'],
+    hidden: false,
+};
+
+const countMetric: CompiledMetric = {
+    fieldType: FieldType.METRIC,
+    type: MetricType.COUNT_DISTINCT,
+    name: 'unique_order_count',
+    label: 'Unique order count',
+    table: 'orders',
+    tableLabel: 'Orders',
+    sql: '',
+    compiledSql: '',
+    tablesReferences: ['orders'],
+    hidden: false,
+};
+
+const itemsMap: ItemsMap = {
+    orders_order_date_week: weekDimension,
+    orders_order_priority: priorityDimension,
+    orders_unique_order_count: countMetric,
+};
+
+const series: EChartsSeries[] = [
+    {
+        type: 'bar',
+        encode: {
+            x: 'orders_order_date_week',
+            y: 'orders_unique_order_count',
+            tooltip: [],
+            seriesName: 'orders_unique_order_count',
+        },
+    } as unknown as EChartsSeries,
+];
+
+const baseClickEvent = {
+    componentType: 'series' as const,
+    seriesIndex: 0,
+    dataIndex: 0,
+    dimensionNames: ['orders_order_date_week', 'orders_unique_order_count'],
+    event: { event: {} as MouseEvent },
+} as EchartsSeriesClickEvent;
+
+describe('getDataFromChartClick', () => {
+    test('tuple-mode click restores non-plotted columns from the dataset row', () => {
+        const result = getDataFromChartClick(
+            {
+                ...baseClickEvent,
+                value: ['2024-12-30', 4],
+                data: { value: ['2024-12-30', 4] },
+                datasetRow: {
+                    orders_order_date_week: '2024-12-30',
+                    orders_order_priority: 'urgent',
+                    orders_unique_order_count: 4,
+                },
+            },
+            itemsMap,
+            series,
+        );
+
+        expect(result.fieldValues.orders_order_date_week?.raw).toBe(
+            '2024-12-30',
+        );
+        expect(result.fieldValues.orders_order_priority?.raw).toBe('urgent');
+        expect(result.item).toBe(countMetric);
+        expect(result.value.raw).toBe(4);
+    });
+
+    test('tuple values win over dataset row values for plotted columns', () => {
+        const result = getDataFromChartClick(
+            {
+                ...baseClickEvent,
+                value: ['2024-12-30', 4],
+                data: { value: ['2024-12-30', 4] },
+                datasetRow: {
+                    orders_order_date_week: 'some-other-week',
+                    orders_unique_order_count: 999,
+                },
+            },
+            itemsMap,
+            series,
+        );
+
+        expect(result.fieldValues.orders_order_date_week?.raw).toBe(
+            '2024-12-30',
+        );
+        expect(result.value.raw).toBe(4);
+    });
+
+    test('tuple-mode click without a dataset row keeps plotted columns only', () => {
+        const result = getDataFromChartClick(
+            {
+                ...baseClickEvent,
+                value: ['2024-12-30', 4],
+                data: { value: ['2024-12-30', 4] },
+            },
+            itemsMap,
+            series,
+        );
+
+        expect(result.fieldValues.orders_order_date_week?.raw).toBe(
+            '2024-12-30',
+        );
+        expect(result.fieldValues.orders_order_priority).toBeUndefined();
+    });
+
+    test('converts ∅ placeholders to null in dataset row values', () => {
+        const result = getDataFromChartClick(
+            {
+                ...baseClickEvent,
+                value: ['2024-12-30', 4],
+                data: { value: ['2024-12-30', 4] },
+                datasetRow: {
+                    orders_order_date_week: '2024-12-30',
+                    orders_order_priority: '∅',
+                },
+            },
+            itemsMap,
+            series,
+        );
+
+        expect(result.fieldValues.orders_order_priority?.raw).toBeNull();
+    });
+
+    test('object-mode click (non-stacked) reads fields from event data', () => {
+        const result = getDataFromChartClick(
+            {
+                ...baseClickEvent,
+                value: 4,
+                data: {
+                    orders_order_date_week: '2024-12-30',
+                    orders_order_priority: 'urgent',
+                    orders_unique_order_count: 4,
+                },
+            },
+            itemsMap,
+            series,
+        );
+
+        expect(result.fieldValues.orders_order_priority?.raw).toBe('urgent');
+        expect(result.value.raw).toBe(4);
+    });
+});

--- a/packages/frontend/src/components/MetricQueryData/utils.ts
+++ b/packages/frontend/src/components/MetricQueryData/utils.ts
@@ -26,10 +26,24 @@ const extractFieldValuesFromClickEvent = (
         e.dimensionNames.forEach((dimName, index) => {
             if (dimName && index < valueArray.length) {
                 const val = valueArray[index];
+                // Sparse tuple slots (e.g. padded gap rows) carry no value for
+                // this column — skip them instead of building a broken filter
+                if (val === undefined) return;
                 const raw = val === '∅' ? null : val; // convert ∅ values back to null. Echarts doesn't support null formatting https://github.com/apache/echarts/issues/15821
                 fieldValues[dimName] = { raw, formatted: String(val ?? '') };
             }
         });
+        // Stacked bar tuples only carry the plotted columns, so restore the
+        // clicked row's remaining ones (e.g. non-plotted dimensions) from the
+        // dataset row — without them their filters get silently dropped.
+        // Tuple values win: they are the clicked item.
+        if (e.datasetRow) {
+            Object.entries(e.datasetRow).forEach(([key, val]) => {
+                if (fieldValues[key] !== undefined || val === undefined) return;
+                const raw = val === '∅' ? null : val;
+                fieldValues[key] = { raw, formatted: String(val ?? '') };
+            });
+        }
         return fieldValues;
     }
 

--- a/packages/frontend/src/components/SimpleChart/index.tsx
+++ b/packages/frontend/src/components/SimpleChart/index.tsx
@@ -57,6 +57,10 @@ export type EchartsSeriesClickEvent = EchartsBaseClickEvent & {
     // encode maps x/y axes to indices in dimensionNames (e.g., {x: [0], y: [1]})
     encode?: { x?: number[]; y?: number[] };
     pivotReference?: PivotReference;
+    // Full dataset row for the clicked item, resolved via dataIndex before the
+    // event is forwarded. Stacked bar series carry sparse [x, y] tuples, so
+    // this is the only way consumers can see the row's remaining columns.
+    datasetRow?: Record<string, unknown>;
 };
 
 type EchartsClickEvent = EchartsSeriesClickEvent | EchartsBaseClickEvent;
@@ -262,8 +266,13 @@ const SimpleChart: FC<SimpleChartProps> = memo(
                             e.seriesIndex
                         ];
                         if (series && series.encode) {
+                            // Stacked bar series carry sparse [x, y] tuples,
+                            // so resolve the full dataset row via dataIndex
+                            // for consumers that need the remaining columns
+                            const datasetRow =
+                                eChartsOptions?.dataset?.source?.[e.dataIndex];
                             onSeriesContextMenu(
-                                e,
+                                { ...e, datasetRow },
                                 eChartsOptions?.series || [],
                             );
                         }


### PR DESCRIPTION
## Problem

"View underlying data" on a **stacked** bar chart returns too many rows whenever the query contains a dimension that isn't plotted on the x-axis or used as the group — e.g. `week + status + priority`, grouped by `status`, stacked. Clicking a segment produced filters for the week and the group only; the `priority` filter was silently dropped, so the modal showed all rows for that week+status instead of just the clicked segment's rows. The same chart **unstacked** filtered correctly, which is exactly the asymmetry users reported ("regular bar chart is correct, stacked shows all the line items").

This is the surviving tail of #18730: the earlier fix (#18754) taught the click handler to read tuple-mode payloads, but it couldn't recover columns that were never in the tuple to begin with.

## Root cause

Stacked bar series don't read from the shared ECharts dataset. `applyRoundedCornersToStackData` rebuilds each stacked series with per-item `{value: [x, y]}` tuples and a two-entry `dimensions` list, so the click event's `dimensionNames`/`value` only carry the x category and the clicked metric. Any other dataset column (extra dimensions) never reaches `getDataFromChartClick`, and `UnderlyingDataModal` can't build a filter for it. The group filter survives independently via `series.pivotReference`, which is why simple x+group charts looked fine and this hid for so long.

## Fix

Resolve the clicked item's **full dataset row via `e.dataIndex`** at click time — zero extra chart payload, no changes to series data or to `common`:

- **`SimpleChart/index.tsx`** — before forwarding a series click, attach `datasetRow = eChartsOptions.dataset.source[e.dataIndex]` to the event (a reference to an existing row, resolved once per click). Tuple-mode series data is built with `rows.map(...)` from the same array that backs `dataset.source`, so `dataIndex` aligns in both dataset mode and tuple mode.
- **`MetricQueryData/utils.ts`** — after mapping tuple values via `dimensionNames`, fill in the *missing* columns from `datasetRow`. Tuple values always win — they are the clicked item — so plotted x/metric extraction is byte-for-byte unchanged.
- **`DashboardChartTile.tsx`** — the right-click "filter dashboard to…" options and their values also consider `datasetRow` columns, restoring parity with non-stacked charts.

## UI: filter summary in the modal

The modal previously gave no indication of its scoping, which is why this bug was only detectable by counting rows. This PR adds an inline "N filters" chip after the "View underlying data" title with a hovercard listing the applied segment filters as badges (same visual language as the dashboard tile filter popover, reusing `getConditionalRuleLabelFromItem`):

- New `UnderlyingDataFilterBadges` component (+ CSS module). The modal title renders inside a `<p>`, so the hover target is a span-based `Badge`.
- `UnderlyingDataModal` filter memo split into `filterParts` (flat point + metric rules) and the derived grouped `filters` — the chip and the query are built from the same rules, so if a filter were ever dropped from the query it would visibly disappear from the chip too.

## Regression analysis

- **No data-shape changes**: series tuples, `series.dimensions`, and the dataset are untouched (`packages/common` is not modified). All rendering, tooltip, and label code paths see identical inputs.
- **Click extraction is strictly additive**: tuple-mapped values are computed exactly as before and take precedence; `datasetRow` only contributes columns that were previously absent (and were therefore dropped). `datasetRow` is optional on the event type — any path that doesn't set it behaves as before.
- **`dataIndex` alignment**: tuple series data is `rows.map(...)` over the same `paddedSortedResults` array that becomes `dataset.source` (rounded corners are skipped for 100% stacking, which stays in dataset mode), so the resolved row is the row the tuple was built from — including padded gap rows.
- Dashboard right-click "Filter dashboard to…" options gain the extra dimensions as a side effect — parity with non-stacked charts, not a regression.
- Verified unchanged behaviour in the browser on: explorer (frontend pivot), dashboard tiles (backend SQL pivot `_any_` columns), saved chart page, 100% stacking, flipped axes, string x-axis; pivot metric columns present in the dataset row do **not** leak into filters (only dimensions become filters).
- Verified the fix end-to-end: a 3-dimension stacked chart segment with value 2 now sends `week + priority + status` filters and returns exactly 2 rows (previously 4 with the priority filter missing) — on both vertical and flipped stacked bars.
- Unit tests added for `getDataFromChartClick`: dataset-row merge, tuple precedence, missing-row fallback, `∅`→null conversion, and object-mode behaviour.

## Screenshot

The new filter summary on the fixed chart:

_"View underlying data [⧩ 3 filters]" → hovercard: "Order date week: is 2024-12-30 · Order priority: is urgent · Status: is placed"_

Closes: PROD-1183
Closes: #18730

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017f11doH5Ff8sbFV7r9ygRq