### PR TITLE
fix(data-apps): rename New menu item from "App" to "Data App"

### DIFF
--- a/packages/frontend/src/components/NavBar/ExploreMenu.tsx
+++ b/packages/frontend/src/components/NavBar/ExploreMenu.tsx
@@ -138,7 +138,7 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                             >
                                 <LargeMenuItem
                                     component={Link}
-                                    title="App"
+                                    title="Data App"
                                     description="Build an interactive app powered by your data."
                                     to={`/projects/${projectUuid}/apps/generate`}
                                     icon={IconAppWindow}


### PR DESCRIPTION
The **New** dropdown in the navbar listed the item as "App", but everywhere else in the product we call these "data apps" (Space page: "Create new data app", all-apps page: "Create data app" / "All data apps"). Renames the menu item to "Data App" for consistency. Beta badge and description are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)