### PR TITLE
fix(data-apps): link app scheduled deliveries to the app, not /dashboards/null

### DIFF
--- a/packages/frontend/src/components/SchedulersView/SchedulersViewUtils.test.ts
+++ b/packages/frontend/src/components/SchedulersView/SchedulersViewUtils.test.ts
@@ -1,0 +1,149 @@
+import {
+    SchedulerFormat,
+    ThresholdOperator,
+    type AppScheduler,
+    type ChartScheduler,
+    type DashboardScheduler,
+    type SchedulerAndTargets,
+    type SqlChartScheduler,
+} from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { getItemLink, getSchedulerLink } from './SchedulersViewUtils';
+
+const PROJECT_UUID = 'project-1';
+
+/** A scheduler variant plus the targets every SchedulerItem carries. */
+type Fixture<T> = T & Pick<SchedulerAndTargets, 'targets'>;
+
+const base = {
+    schedulerUuid: 'scheduler-1',
+    slug: 'weekly-delivery',
+    name: 'Weekly delivery',
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+    createdBy: 'user-1',
+    createdByName: 'Jane',
+    format: SchedulerFormat.CSV,
+    cron: '0 9 * * 1',
+    savedChartName: null,
+    dashboardName: null,
+    savedSqlName: null,
+    appName: null,
+    options: { formatted: true, limit: 'table' as const },
+    enabled: true,
+    includeLinks: true,
+    projectUuid: PROJECT_UUID,
+    targets: [],
+};
+
+const chartScheduler: Fixture<ChartScheduler> = {
+    ...base,
+    savedChartUuid: 'chart-1',
+    dashboardUuid: null,
+    savedSqlUuid: null,
+    appUuid: null,
+};
+
+const dashboardScheduler: Fixture<DashboardScheduler> = {
+    ...base,
+    savedChartUuid: null,
+    dashboardUuid: 'dashboard-1',
+    savedSqlUuid: null,
+    appUuid: null,
+    selectedTabs: null,
+};
+
+const sqlChartScheduler: Fixture<SqlChartScheduler> = {
+    ...base,
+    savedChartUuid: null,
+    dashboardUuid: null,
+    savedSqlUuid: 'sql-chart-1',
+    appUuid: null,
+};
+
+const appScheduler: Fixture<AppScheduler> = {
+    ...base,
+    savedChartUuid: null,
+    dashboardUuid: null,
+    savedSqlUuid: null,
+    appUuid: 'app-1',
+};
+
+describe('getSchedulerLink', () => {
+    it('links an app scheduler to the app, not the dashboard route', () => {
+        expect(getSchedulerLink(appScheduler)).toBe(
+            `/projects/${PROJECT_UUID}/apps/app-1/view?scheduler_uuid=scheduler-1`,
+        );
+    });
+
+    it('links chart, sql chart and dashboard schedulers to their own routes', () => {
+        expect(getSchedulerLink(chartScheduler)).toBe(
+            `/projects/${PROJECT_UUID}/saved/chart-1/view/?scheduler_uuid=scheduler-1`,
+        );
+        expect(getSchedulerLink(sqlChartScheduler)).toBe(
+            `/projects/${PROJECT_UUID}/sql-runner/sql-chart-1?scheduler_uuid=scheduler-1`,
+        );
+        expect(getSchedulerLink(dashboardScheduler)).toBe(
+            `/projects/${PROJECT_UUID}/dashboards/dashboard-1/view/?scheduler_uuid=scheduler-1`,
+        );
+    });
+
+    it('appends the sync param for Google Sheets app deliveries', () => {
+        expect(
+            getSchedulerLink({
+                ...appScheduler,
+                format: SchedulerFormat.GSHEETS,
+            }),
+        ).toBe(
+            `/projects/${PROJECT_UUID}/apps/app-1/view?scheduler_uuid=scheduler-1&isSync=true`,
+        );
+    });
+
+    it('uses the threshold param for app alerts', () => {
+        expect(
+            getSchedulerLink({
+                ...appScheduler,
+                thresholds: [
+                    {
+                        operator: ThresholdOperator.GREATER_THAN,
+                        fieldId: 'revenue',
+                        value: 1,
+                    },
+                ],
+            }),
+        ).toBe(
+            `/projects/${PROJECT_UUID}/apps/app-1/view?threshold_uuid=scheduler-1`,
+        );
+    });
+
+    it('falls back to the provided project uuid when the item has none', () => {
+        expect(
+            getSchedulerLink(
+                { ...appScheduler, projectUuid: null },
+                'fallback-project',
+            ),
+        ).toBe(
+            `/projects/fallback-project/apps/app-1/view?scheduler_uuid=scheduler-1`,
+        );
+    });
+});
+
+describe('getItemLink', () => {
+    it('links an app scheduler to the app, not the dashboard route', () => {
+        expect(getItemLink(appScheduler)).toBe(
+            `/projects/${PROJECT_UUID}/apps/app-1/view`,
+        );
+    });
+
+    it('links chart, sql chart and dashboard schedulers to their own routes', () => {
+        expect(getItemLink(chartScheduler)).toBe(
+            `/projects/${PROJECT_UUID}/saved/chart-1/view`,
+        );
+        expect(getItemLink(sqlChartScheduler)).toBe(
+            `/projects/${PROJECT_UUID}/sql-runner/sql-chart-1`,
+        );
+        expect(getItemLink(dashboardScheduler)).toBe(
+            `/projects/${PROJECT_UUID}/dashboards/dashboard-1/view`,
+        );
+    });
+});

--- a/packages/frontend/src/components/SchedulersView/SchedulersViewUtils.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersViewUtils.tsx
@@ -1,5 +1,9 @@
 import {
     assertUnreachable,
+    isAppScheduler,
+    isChartScheduler,
+    isDashboardScheduler,
+    isSqlChartScheduler,
     SchedulerFormat,
     SchedulerJobStatus,
     SchedulerResourceType,
@@ -203,14 +207,22 @@ export const getSchedulerLink = (
         return `${resourcePath}?${paramName}=${item.schedulerUuid}${syncParam}`;
     }
 
-    // Handle SchedulerItem (uses savedChartUuid/dashboardUuid/savedSqlUuid)
-    if (item.savedChartUuid) {
+    // Handle SchedulerItem. Dispatch on the resource type guards rather than
+    // truthiness of a uuid field, so a new scheduler resource type fails to
+    // compile here instead of silently falling through to the dashboard URL.
+    if (isChartScheduler(item)) {
         return `/projects/${projectUuid}/saved/${item.savedChartUuid}/view/?${paramName}=${item.schedulerUuid}${syncParam}`;
     }
-    if (item.savedSqlUuid) {
+    if (isSqlChartScheduler(item)) {
         return `/projects/${projectUuid}/sql-runner/${item.savedSqlUuid}?${paramName}=${item.schedulerUuid}${syncParam}`;
     }
-    return `/projects/${projectUuid}/dashboards/${item.dashboardUuid}/view/?${paramName}=${item.schedulerUuid}`;
+    if (isAppScheduler(item)) {
+        return `/projects/${projectUuid}/apps/${item.appUuid}/view?${paramName}=${item.schedulerUuid}${syncParam}`;
+    }
+    if (isDashboardScheduler(item)) {
+        return `/projects/${projectUuid}/dashboards/${item.dashboardUuid}/view/?${paramName}=${item.schedulerUuid}`;
+    }
+    return assertUnreachable(item, 'Unknown scheduler resource type');
 };
 
 export const getItemLink = (
@@ -220,13 +232,19 @@ export const getItemLink = (
     // Use item's projectUuid if available, otherwise fall back to the provided one
     const projectUuid = item.projectUuid ?? fallbackProjectUuid ?? '';
 
-    if (item.savedChartUuid) {
+    if (isChartScheduler(item)) {
         return `/projects/${projectUuid}/saved/${item.savedChartUuid}/view`;
     }
-    if (item.savedSqlUuid) {
+    if (isSqlChartScheduler(item)) {
         return `/projects/${projectUuid}/sql-runner/${item.savedSqlUuid}`;
     }
-    return `/projects/${projectUuid}/dashboards/${item.dashboardUuid}/view`;
+    if (isAppScheduler(item)) {
+        return `/projects/${projectUuid}/apps/${item.appUuid}/view`;
+    }
+    if (isDashboardScheduler(item)) {
+        return `/projects/${projectUuid}/dashboards/${item.dashboardUuid}/view`;
+    }
+    return assertUnreachable(item, 'Unknown scheduler resource type');
 };
 
 export const formatTime = (date: Date) =>


### PR DESCRIPTION
On **Project settings → Syncs & scheduled deliveries**, clicking a scheduled delivery that belongs to a **data app** navigated to `/projects/{projectUuid}/dashboards/null/view/` instead of the app. The row listed fine — only the link was wrong.

App deliveries ship today (image format only) and are already included in the listing via the `schedulerApps` union in `SchedulerModel/index.ts:964`, so this is live. The **Run history** tab was unaffected.

### Root cause

`SchedulersViewUtils.tsx` has two link builders and only one knew about apps.

The `SchedulerRun` branch switches on `SchedulerResourceType` and ends in `assertUnreachable`, so adding `APP` to that enum was a compile error until handled. The `SchedulerItem` branch duck-typed on which uuid field was truthy and fell through to the dashboard URL:

```ts
if (item.savedChartUuid) { ... }
if (item.savedSqlUuid)   { ... }
return `/projects/${projectUuid}/dashboards/${item.dashboardUuid}/view/...`;  // app lands here
```

An app scheduler is mapped with `dashboardUuid: null`, so the template literal interpolated the string `null`. `getItemLink` had the identical fall-through.

### Fix

Both builders now dispatch on the `isChartScheduler` / `isSqlChartScheduler` / `isAppScheduler` / `isDashboardScheduler` guards and end in `assertUnreachable`. The next scheduler resource type will fail to compile here rather than silently resolving to a dashboard URL — the fall-through is what hid this one.

### Tests

New `SchedulersViewUtils.test.ts` covers all four resource types across both builders, plus the sync and threshold params and the project-uuid fallback. Verified it fails without the fix (5 of 7 red, each showing an app row resolving to a dashboard URL).

### Deliberately not changed

The dashboard branch of `getSchedulerLink` omits `syncParam` while the chart and sql-chart branches include it. That looks like a separate oversight affecting dashboard Google Sheets syncs; behaviour is preserved here rather than bundled into a bug fix.

### Follow-ups (pre-existing, not in this PR)

- `resourceType` filter is typed `'chart' | 'dashboard'` (`schedulerController.ts:339`, `useScheduler.ts:420`) — can't filter by app or sql chart, though the model already supports it (`SchedulerModel/index.ts:949`).
- `getSchedulersSummaryByOwner` (`SchedulerModel/index.ts:2751`) unions only chart + dashboard queries, so app and sql-chart schedulers are missing from the owner summary count.

Closes: PROD-9282
Relates: PROD-8374
