### PR TITLE
fix: reduce memory status callout font size

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.module.css
@@ -9,6 +9,10 @@
     min-width: 0;
 }
 
+.statusCalloutText {
+    font-size: var(--mantine-font-size-xs);
+}
+
 .modalTitle {
     color: var(--mantine-color-ldGray-9);
     font-size: 16px;

--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.tsx
@@ -6,7 +6,6 @@ import type {
 import {
     Accordion,
     ActionIcon,
-    Alert,
     Anchor,
     Badge,
     Box,
@@ -25,6 +24,7 @@ import {
 import { type FC, type ReactNode } from 'react';
 import { Link } from 'react-router';
 import { AiMarkdown } from '../../../../../components/common/AiMarkdown';
+import Callout from '../../../../../components/common/Callout';
 import MantineModal from '../../../../../components/common/MantineModal';
 import { parseAiAgentMemorySections } from '../../utils/memory';
 import { MEMORY_SCOPE_LABELS } from '../Admin/memoryScope';
@@ -123,17 +123,23 @@ export const MemoryDetails: FC<MemoryDetailsProps> = ({
         <Box className={styles.layout}>
             <Stack className={styles.main} gap={0}>
                 {memory.status !== 'active' ? (
-                    <Alert
+                    <Callout
                         mb="xl"
                         color="gray"
-                        variant="light"
+                        variant="info"
                         title={`This memory is ${memory.status}`}
                         icon={<IconHistory size={17} />}
+                        classNames={{
+                            title: styles.statusCalloutText,
+                            message: styles.statusCalloutText,
+                        }}
                     >
                         {replacementPath ? (
                             <Anchor
                                 component={Link}
                                 to={replacementPath}
+                                c="ldGray.8"
+                                fz="xs"
                                 fw={600}
                             >
                                 View the current memory
@@ -141,7 +147,7 @@ export const MemoryDetails: FC<MemoryDetailsProps> = ({
                         ) : (
                             'It remains available for audit history.'
                         )}
-                    </Alert>
+                    </Callout>
                 ) : null}
 
                 <Stack gap="md">


### PR DESCRIPTION
## Summary

- use the shared Lightdash `Callout` component for the superseded-memory notice
- align the callout with the Review items UI 12px typography
- render the replacement-memory link in neutral gray instead of blue

## Verification

- `pnpm --filter @lightdash/frontend typecheck:fast`
- `pnpm --filter @lightdash/frontend exec vitest run src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.test.tsx`
- focused oxlint, oxfmt, and `git diff --check`
- browser: title and link both compute to 12px; link computes to `rgb(52, 58, 64)`