### PR TITLE
fix(appearance): remove nav banner from brand appearance preview

### DIFF
--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/BrandAppearanceSettings.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/BrandAppearanceSettings.tsx
@@ -302,8 +302,6 @@ const BrandAppearanceForm: FC<{ brand: OrganizationBrand | null }> = ({
                         Preview
                     </Text>
                     <BrandPreview
-                        name={form.values.name}
-                        logos={form.values.logos}
                         colors={form.values.colors}
                         titleFont={titleFont}
                         bodyFont={bodyFont}

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/BrandPreview.module.css
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/BrandPreview.module.css
@@ -41,42 +41,6 @@
     border: 1px solid var(--mantine-color-ldGray-2);
 }
 
-.nav {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--mantine-spacing-md);
-    padding: 12px 18px;
-}
-
-.navLogo {
-    max-height: 22px;
-    max-width: 90px;
-    object-fit: contain;
-}
-
-.navLogoFallback {
-    width: 24px;
-    height: 24px;
-    border-radius: 6px;
-    background-color: var(--mantine-color-white);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-shrink: 0;
-}
-
-.navAvatar {
-    width: 26px;
-    height: 26px;
-    border-radius: 50%;
-    background-color: rgba(255, 255, 255, 0.2);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-shrink: 0;
-}
-
 .body {
     padding: 20px;
     display: flex;

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/BrandPreview.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/BrandPreview.tsx
@@ -1,12 +1,9 @@
 import {
     type OrganizationBrandColor,
     type OrganizationBrandFont,
-    type OrganizationBrandLogo,
 } from '@lightdash/common';
 import { Box, Group, Paper, Stack, Text } from '@mantine-8/core';
-import { IconSearch } from '@tabler/icons-react';
 import { useEffect, type FC } from 'react';
-import MantineIcon from '../../common/MantineIcon';
 import classes from './BrandPreview.module.css';
 
 const DEFAULT_PRIMARY = '#5b3df5';
@@ -59,14 +56,6 @@ const pickPrimaryColor = (colors: OrganizationBrandColor[]): string => {
     );
 };
 
-const pickNavLogo = (logos: OrganizationBrandLogo[]): string | null => {
-    // The nav bar has a coloured (usually dark) background, so prefer the
-    // light/white artwork — which Brandfetch labels `theme: 'light'` — falling
-    // back to any available logo.
-    const light = logos.find((logo) => logo.theme === 'light');
-    return light?.url ?? logos[0]?.url ?? null;
-};
-
 const BAR_VALUES = [55, 78, 48, 88, 60, 96, 72];
 
 const linePath = (points: number[]): string => {
@@ -83,23 +72,17 @@ const linePath = (points: number[]): string => {
 };
 
 type BrandPreviewProps = {
-    name: string | null;
-    logos: OrganizationBrandLogo[];
     colors: OrganizationBrandColor[];
     titleFont: OrganizationBrandFont | null;
     bodyFont: OrganizationBrandFont | null;
 };
 
 export const BrandPreview: FC<BrandPreviewProps> = ({
-    name,
-    logos,
     colors,
     titleFont,
     bodyFont,
 }) => {
     const primary = pickPrimaryColor(colors);
-    const navLogo = pickNavLogo(logos);
-    const displayName = name ?? 'Your company';
     const barColors = [primary, `${primary}59`];
 
     // Apply a brand font family only when we can actually load it, otherwise
@@ -124,41 +107,6 @@ export const BrandPreview: FC<BrandPreviewProps> = ({
                     </Text>
                 </Box>
             </Group>
-
-            <Box className={classes.nav} bg={primary}>
-                <Group gap="sm" wrap="nowrap">
-                    {navLogo ? (
-                        <img
-                            src={navLogo}
-                            alt={displayName}
-                            className={classes.navLogo}
-                        />
-                    ) : (
-                        <Box className={classes.navLogoFallback}>
-                            <Text size="xs" fw={700} c={primary}>
-                                {displayName[0]?.toUpperCase() ?? 'A'}
-                            </Text>
-                        </Box>
-                    )}
-                    <Text size="sm" fw={600} c="white" ff={bodyFamily}>
-                        {displayName}
-                    </Text>
-                </Group>
-                <Group gap="lg" wrap="nowrap" visibleFrom="xs">
-                    <Text size="xs" c="white" ff={bodyFamily}>
-                        Dashboards
-                    </Text>
-                    <Text size="xs" c="white" opacity={0.85} ff={bodyFamily}>
-                        Charts
-                    </Text>
-                    <Text size="xs" c="white" opacity={0.85} ff={bodyFamily}>
-                        SQL runner
-                    </Text>
-                </Group>
-                <Box className={classes.navAvatar}>
-                    <MantineIcon icon={IconSearch} color="white" size={14} />
-                </Box>
-            </Box>
 
             <Box className={classes.body}>
                 <Group justify="space-between" align="flex-start" wrap="nowrap">

--- a/packages/frontend/src/pages/OrganizationSetup.tsx
+++ b/packages/frontend/src/pages/OrganizationSetup.tsx
@@ -492,8 +492,6 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
 
                 <Box className={classes.rightPane}>
                     <OrganizationSetupPreview
-                        name={form.values.organizationName || null}
-                        logos={detectedBrand?.logos ?? []}
                         colors={previewColors}
                         titleFont={titleFont}
                         bodyFont={bodyFont}

--- a/packages/frontend/src/pages/OrganizationSetupPreview.tsx
+++ b/packages/frontend/src/pages/OrganizationSetupPreview.tsx
@@ -1,7 +1,6 @@
 import {
     type OrganizationBrandColor,
     type OrganizationBrandFont,
-    type OrganizationBrandLogo,
 } from '@lightdash/common';
 import { Box, Text } from '@mantine-8/core';
 import { type FC } from 'react';
@@ -9,8 +8,6 @@ import { BrandPreview } from '../components/UserSettings/AppearanceSettingsPanel
 import classes from './OrganizationSetup.module.css';
 
 type OrganizationSetupPreviewProps = {
-    name: string | null;
-    logos: OrganizationBrandLogo[];
     colors: OrganizationBrandColor[];
     titleFont: OrganizationBrandFont | null;
     bodyFont: OrganizationBrandFont | null;
@@ -19,8 +16,6 @@ type OrganizationSetupPreviewProps = {
 };
 
 const OrganizationSetupPreview: FC<OrganizationSetupPreviewProps> = ({
-    name,
-    logos,
     colors,
     titleFont,
     bodyFont,
@@ -48,8 +43,6 @@ const OrganizationSetupPreview: FC<OrganizationSetupPreviewProps> = ({
         )}
 
         <BrandPreview
-            name={name}
-            logos={logos}
             colors={colors}
             titleFont={titleFont}
             bodyFont={bodyFont}


### PR DESCRIPTION
### Description:

Removes the fake nav bar (logo + name + Dashboards/Charts/SQL runner + search avatar) from the Brand appearance preview on the appearance settings page. The brand colour is still exercised by the "+ New chart" button, the line chart and the bars.

Since the nav was the only consumer of the `name` and `logos` props, they're dropped from `BrandPreview` and its callers. `BrandPreview` is also used on the org setup page, so the banner goes away there too. Brand logos are still previewed separately by the light/dark logo tiles next to the form.

Note: I couldn't drive the app in this sandbox (no local stack), so this hasn't been visually verified — it's a JSX/CSS deletion with no logic changes.
