### PR TITLE
feat(appearance): generate chart palette from brand colors

### DIFF
--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/BrandAppearanceSettings.module.css
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/BrandAppearanceSettings.module.css
@@ -49,7 +49,7 @@
     display: flex;
     align-items: center;
     border: 1px solid var(--mantine-color-default-border);
-    border-radius: var(--mantine-radius-sm);
+    border-radius: var(--mantine-radius-md);
     background-color: var(--mantine-color-default);
     overflow: hidden;
 }
@@ -83,6 +83,13 @@
 
 .addColor {
     border-style: dashed;
+}
+
+.paletteSwatch {
+    width: 20px;
+    height: 20px;
+    border-radius: var(--mantine-radius-sm);
+    border: 1px solid var(--mantine-color-ldGray-2);
 }
 
 .footer {

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/BrandAppearanceSettings.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/BrandAppearanceSettings.tsx
@@ -10,7 +10,6 @@ import {
     Button,
     ColorInput,
     Group,
-    Select,
     Skeleton,
     Stack,
     Text,
@@ -22,9 +21,14 @@ import {
     IconPlus,
     IconRefresh,
     IconTrash,
+    IconWand,
     IconWorld,
 } from '@tabler/icons-react';
-import { type FC } from 'react';
+import { useState, type FC } from 'react';
+import {
+    useColorPalettes,
+    useCreateColorPalette,
+} from '../../../hooks/appearance/useOrganizationAppearance';
 import useHealth from '../../../hooks/health/useHealth';
 import {
     useFetchOrganizationBrand,
@@ -35,8 +39,11 @@ import MantineIcon from '../../common/MantineIcon';
 import { SettingsCard } from '../../common/Settings/SettingsCard';
 import classes from './BrandAppearanceSettings.module.css';
 import { BrandPreview } from './BrandPreview';
+import { generateBrandPalette } from './generateBrandPalette';
+import { PaletteModalBase } from './PaletteModalBase';
 
-const BRAND_COLOR_TYPES = ['accent', 'brand', 'dark', 'light', 'other'];
+// TODO: re-enable color role editing once roles have a consumer
+// const BRAND_COLOR_TYPES = ['accent', 'brand', 'dark', 'light', 'other'];
 
 type BrandFormValues = {
     domain: string;
@@ -56,46 +63,54 @@ const brandToForm = (brand: OrganizationBrand | null): BrandFormValues => ({
     fonts: brand?.fonts ?? [],
 });
 
-const capitalize = (value: string) =>
-    value.length > 0 ? value.charAt(0).toUpperCase() + value.slice(1) : value;
+// TODO: re-enable color role editing once roles have a consumer
+// const capitalize = (value: string) =>
+//     value.length > 0 ? value.charAt(0).toUpperCase() + value.slice(1) : value;
+//
+// const getColorTypeOptions = (currentType: string) =>
+//     (BRAND_COLOR_TYPES.includes(currentType)
+//         ? BRAND_COLOR_TYPES
+//         : [...BRAND_COLOR_TYPES, currentType]
+//     ).map((type) => ({ value: type, label: capitalize(type) }));
 
-const getColorTypeOptions = (currentType: string) =>
-    (BRAND_COLOR_TYPES.includes(currentType)
-        ? BRAND_COLOR_TYPES
-        : [...BRAND_COLOR_TYPES, currentType]
-    ).map((type) => ({ value: type, label: capitalize(type) }));
-
-const LogoTile: FC<{
-    label: string;
-    dark: boolean;
-    logo: OrganizationBrandLogo | undefined;
-    name: string;
-}> = ({ label, dark, logo, name }) => (
-    <Stack gap="two" align="center">
-        <Box className={dark ? classes.logoTileDark : classes.logoTile}>
-            {logo ? (
-                <img
-                    src={logo.url}
-                    alt={`${name} ${label} logo`}
-                    className={classes.logoImage}
-                />
-            ) : (
-                <Text size="sm" c="dimmed">
-                    No logo
-                </Text>
-            )}
-        </Box>
-        <Text size="xs" c="dimmed">
-            {label}
-        </Text>
-    </Stack>
-);
+// TODO: re-enable logo tiles once logos have a consumer
+// const LogoTile: FC<{
+//     label: string;
+//     dark: boolean;
+//     logo: OrganizationBrandLogo | undefined;
+//     name: string;
+// }> = ({ label, dark, logo, name }) => (
+//     <Stack gap="two" align="center">
+//         <Box className={dark ? classes.logoTileDark : classes.logoTile}>
+//             {logo ? (
+//                 <img
+//                     src={logo.url}
+//                     alt={`${name} ${label} logo`}
+//                     className={classes.logoImage}
+//                 />
+//             ) : (
+//                 <Text size="sm" c="dimmed">
+//                     No logo
+//                 </Text>
+//             )}
+//         </Box>
+//         <Text size="xs" c="dimmed">
+//             {label}
+//         </Text>
+//     </Stack>
+// );
 
 const BrandAppearanceForm: FC<{ brand: OrganizationBrand | null }> = ({
     brand,
 }) => {
     const fetchMutation = useFetchOrganizationBrand();
     const saveMutation = useSaveOrganizationBrand();
+    const [generatedPalette, setGeneratedPalette] = useState<string[] | null>(
+        null,
+    );
+    const [isPaletteModalOpen, setIsPaletteModalOpen] = useState(false);
+    const { data: palettes = [] } = useColorPalettes();
+    const createColorPalette = useCreateColorPalette();
 
     const form = useForm<BrandFormValues>({
         initialValues: brandToForm(brand),
@@ -124,17 +139,28 @@ const BrandAppearanceForm: FC<{ brand: OrganizationBrand | null }> = ({
         });
     };
 
+    const handleGeneratePalette = () => {
+        const palette = generateBrandPalette(
+            form.values.colors.map((color) => color.hex),
+        );
+        setGeneratedPalette(palette);
+        if (palette.length > 0) {
+            setIsPaletteModalOpen(true);
+        }
+    };
+
+    // TODO: re-enable logo tiles once logos have a consumer
     // Brandfetch's logo `theme` describes the artwork colour, not the
     // background it belongs on: `light` is a light/white logo (meant for dark
     // backgrounds) and `dark` is a dark logo (meant for light backgrounds).
     // Pair each with a contrasting tile so neither disappears into it.
-    const logoForLightBg =
-        form.values.logos.find((logo) => logo.theme === 'dark') ??
-        form.values.logos.find((logo) => logo.theme === null) ??
-        form.values.logos[0];
-    const logoForDarkBg =
-        form.values.logos.find((logo) => logo.theme === 'light') ??
-        form.values.logos[0];
+    // const logoForLightBg =
+    //     form.values.logos.find((logo) => logo.theme === 'dark') ??
+    //     form.values.logos.find((logo) => logo.theme === null) ??
+    //     form.values.logos[0];
+    // const logoForDarkBg =
+    //     form.values.logos.find((logo) => logo.theme === 'light') ??
+    //     form.values.logos[0];
 
     const titleFont =
         form.values.fonts.find((font) => font.type === 'title') ?? null;
@@ -148,6 +174,7 @@ const BrandAppearanceForm: FC<{ brand: OrganizationBrand | null }> = ({
                     <TextInput
                         label="Brand domain"
                         placeholder="acme.com"
+                        radius="md"
                         leftSection={<MantineIcon icon={IconWorld} />}
                         {...form.getInputProps('domain')}
                         rightSection={
@@ -168,6 +195,7 @@ const BrandAppearanceForm: FC<{ brand: OrganizationBrand | null }> = ({
                         }
                     />
 
+                    {/* TODO: re-enable logo tiles once logos have a consumer
                     <Stack gap="xs">
                         <Text size="sm" fw={500}>
                             Logo
@@ -187,7 +215,9 @@ const BrandAppearanceForm: FC<{ brand: OrganizationBrand | null }> = ({
                             />
                         </Group>
                     </Stack>
+                    */}
 
+                    {/* TODO: re-enable font selects once fonts have a consumer
                     <Group gap="sm" grow align="flex-start">
                         <Select
                             label="Title font"
@@ -204,6 +234,7 @@ const BrandAppearanceForm: FC<{ brand: OrganizationBrand | null }> = ({
                             disabled
                         />
                     </Group>
+                    */}
 
                     <Stack gap="xs">
                         <Box>
@@ -211,8 +242,8 @@ const BrandAppearanceForm: FC<{ brand: OrganizationBrand | null }> = ({
                                 Brand colors
                             </Text>
                             <Text size="xs" c="dimmed">
-                                Roles are auto-classified by Brandfetch. Edit
-                                any value or role.
+                                Colors are auto-detected from your brand. Edit
+                                any value.
                             </Text>
                         </Box>
 
@@ -239,6 +270,7 @@ const BrandAppearanceForm: FC<{ brand: OrganizationBrand | null }> = ({
                                             withEyeDropper={false}
                                             className={classes.colorInput}
                                         />
+                                        {/* TODO: re-enable color role editing once roles have a consumer
                                         <Select
                                             data={getColorTypeOptions(
                                                 color.type,
@@ -256,6 +288,7 @@ const BrandAppearanceForm: FC<{ brand: OrganizationBrand | null }> = ({
                                             variant="unstyled"
                                             className={classes.colorTypeSelect}
                                         />
+                                        */}
                                     </Box>
                                     <Tooltip
                                         label="Remove color"
@@ -281,6 +314,7 @@ const BrandAppearanceForm: FC<{ brand: OrganizationBrand | null }> = ({
 
                             <Button
                                 variant="default"
+                                radius="md"
                                 leftSection={<MantineIcon icon={IconPlus} />}
                                 className={classes.addColor}
                                 onClick={() =>
@@ -295,6 +329,69 @@ const BrandAppearanceForm: FC<{ brand: OrganizationBrand | null }> = ({
                             </Button>
                         </Stack>
                     </Stack>
+
+                    <Stack gap="xs">
+                        <Box>
+                            <Text size="sm" fw={500}>
+                                Chart palette
+                            </Text>
+                            <Text size="xs" c="dimmed">
+                                Expand your brand colors into a full chart
+                                palette.
+                            </Text>
+                        </Box>
+                        <Button
+                            variant="default"
+                            radius="md"
+                            fullWidth
+                            leftSection={<MantineIcon icon={IconWand} />}
+                            onClick={handleGeneratePalette}
+                            disabled={form.values.colors.length === 0}
+                        >
+                            Generate palette
+                        </Button>
+                        {generatedPalette && generatedPalette.length > 0 && (
+                            <Group gap={4}>
+                                {generatedPalette.map((hex, index) => (
+                                    <Tooltip
+                                        key={`${hex}-${index}`}
+                                        label={hex}
+                                        position="top"
+                                    >
+                                        <Box
+                                            className={classes.paletteSwatch}
+                                            bg={hex}
+                                        />
+                                    </Tooltip>
+                                ))}
+                            </Group>
+                        )}
+                        {generatedPalette && generatedPalette.length > 0 && (
+                            <PaletteModalBase
+                                key={generatedPalette.join('-')}
+                                opened={isPaletteModalOpen}
+                                onClose={() => setIsPaletteModalOpen(false)}
+                                onSubmit={(values) => {
+                                    if (!values.name) return;
+                                    createColorPalette.mutate({
+                                        name: values.name,
+                                        colors: values.colors,
+                                        darkColors: values.darkColors,
+                                    });
+                                }}
+                                isLoading={createColorPalette.isLoading}
+                                initialValues={{
+                                    name: '',
+                                    colors: generatedPalette,
+                                }}
+                                title="Chart palette from your brand"
+                                submitButtonText="Create palette"
+                                existingPaletteNames={palettes.map(
+                                    (palette) => palette.name,
+                                )}
+                            />
+                        )}
+                    </Stack>
                 </Stack>
 
                 <Stack gap="xs">
@@ -307,6 +404,7 @@ const BrandAppearanceForm: FC<{ brand: OrganizationBrand | null }> = ({
                         colors={form.values.colors}
                         titleFont={titleFont}
                         bodyFont={bodyFont}
+                        paletteColors={generatedPalette}
                     />
                 </Stack>
             </Box>

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/BrandPreview.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/BrandPreview.tsx
@@ -4,9 +4,10 @@ import {
     type OrganizationBrandLogo,
 } from '@lightdash/common';
 import { Box, Group, Paper, Stack, Text } from '@mantine-8/core';
-import { IconSearch } from '@tabler/icons-react';
 import { useEffect, type FC } from 'react';
-import MantineIcon from '../../common/MantineIcon';
+// TODO: re-enable browser chrome + nav header preview
+// import { IconSearch } from '@tabler/icons-react';
+// import MantineIcon from '../../common/MantineIcon';
 import classes from './BrandPreview.module.css';
 
 const DEFAULT_PRIMARY = '#5b3df5';
@@ -59,15 +60,39 @@ const pickPrimaryColor = (colors: OrganizationBrandColor[]): string => {
     );
 };
 
-const pickNavLogo = (logos: OrganizationBrandLogo[]): string | null => {
-    // The nav bar has a coloured (usually dark) background, so prefer the
-    // light/white artwork — which Brandfetch labels `theme: 'light'` — falling
-    // back to any available logo.
-    const light = logos.find((logo) => logo.theme === 'light');
-    return light?.url ?? logos[0]?.url ?? null;
-};
+// TODO: re-enable browser chrome + nav header preview
+// const pickNavLogo = (logos: OrganizationBrandLogo[]): string | null => {
+//     // The nav bar has a coloured (usually dark) background, so prefer the
+//     // light/white artwork — which Brandfetch labels `theme: 'light'` — falling
+//     // back to any available logo.
+//     const light = logos.find((logo) => logo.theme === 'light');
+//     return light?.url ?? logos[0]?.url ?? null;
+// };
 
 const BAR_VALUES = [55, 78, 48, 88, 60, 96, 72];
+
+const PIE_VALUES = [32, 24, 18, 14, 12];
+
+const pieSlicePaths = (
+    values: number[],
+    cx: number,
+    cy: number,
+    radius: number,
+): string[] => {
+    const total = values.reduce((sum, value) => sum + value, 0);
+    let angle = -Math.PI / 2;
+    return values.map((value) => {
+        const start = angle;
+        const end = start + (value / total) * Math.PI * 2;
+        angle = end;
+        const x0 = cx + radius * Math.cos(start);
+        const y0 = cy + radius * Math.sin(start);
+        const x1 = cx + radius * Math.cos(end);
+        const y1 = cy + radius * Math.sin(end);
+        const largeArc = end - start > Math.PI ? 1 : 0;
+        return `M ${cx} ${cy} L ${x0} ${y0} A ${radius} ${radius} 0 ${largeArc} 1 ${x1} ${y1} Z`;
+    });
+};
 
 const linePath = (points: number[]): string => {
     const width = 300;
@@ -88,19 +113,24 @@ type BrandPreviewProps = {
     colors: OrganizationBrandColor[];
     titleFont: OrganizationBrandFont | null;
     bodyFont: OrganizationBrandFont | null;
+    // Optional so existing call sites (onboarding) keep working without it
+    paletteColors?: string[] | null;
 };
 
 export const BrandPreview: FC<BrandPreviewProps> = ({
-    name,
-    logos,
     colors,
     titleFont,
     bodyFont,
+    paletteColors,
 }) => {
     const primary = pickPrimaryColor(colors);
-    const navLogo = pickNavLogo(logos);
-    const displayName = name ?? 'Your company';
-    const barColors = [primary, `${primary}59`];
+    // TODO: re-enable browser chrome + nav header preview
+    // const navLogo = pickNavLogo(logos);
+    // const displayName = name ?? 'Your company';
+    const chartColors =
+        paletteColors && paletteColors.length > 0
+            ? paletteColors
+            : [primary, `${primary}59`];
 
     // Apply a brand font family only when we can actually load it, otherwise
     // fall back to the app font.
@@ -112,6 +142,7 @@ export const BrandPreview: FC<BrandPreviewProps> = ({
 
     return (
         <Paper withBorder radius="md" className={classes.window}>
+            {/* TODO: re-enable browser chrome header preview
             <Group className={classes.chrome} gap="xs" wrap="nowrap">
                 <Group gap={6} wrap="nowrap">
                     <Box className={classes.dotRed} />
@@ -124,7 +155,9 @@ export const BrandPreview: FC<BrandPreviewProps> = ({
                     </Text>
                 </Box>
             </Group>
+            */}
 
+            {/* TODO: re-enable nav header preview (uses brand logo)
             <Box className={classes.nav} bg={primary}>
                 <Group gap="sm" wrap="nowrap">
                     {navLogo ? (
@@ -159,6 +192,7 @@ export const BrandPreview: FC<BrandPreviewProps> = ({
                     <MantineIcon icon={IconSearch} color="white" size={14} />
                 </Box>
             </Box>
+            */}
 
             <Box className={classes.body}>
                 <Group justify="space-between" align="flex-start" wrap="nowrap">
@@ -175,11 +209,13 @@ export const BrandPreview: FC<BrandPreviewProps> = ({
                             Performance across every channel this quarter.
                         </Text>
                     </Stack>
+                    {/* TODO: re-enable "+ New chart" button preview
                     <Box className={classes.primaryButton} bg={primary}>
                         <Text size="xs" fw={600} c="white">
                             + New chart
                         </Text>
                     </Box>
+                    */}
                 </Group>
 
                 <Group gap="sm" grow align="stretch" wrap="nowrap">
@@ -211,21 +247,45 @@ export const BrandPreview: FC<BrandPreviewProps> = ({
                     </Paper>
                 </Group>
 
-                <Paper withBorder radius="md" className={classes.card}>
-                    <Text size="xs" c="dimmed" mb="xs" ff={bodyFamily}>
-                        Revenue by channel
-                    </Text>
-                    <Box className={classes.barsRow}>
-                        {BAR_VALUES.map((value, index) => (
-                            <Box
-                                key={`bar-${index}`}
-                                className={classes.bar}
-                                h={`${value}%`}
-                                bg={barColors[index % barColors.length]}
-                            />
-                        ))}
-                    </Box>
-                </Paper>
+                <Group gap="sm" grow align="stretch" wrap="nowrap">
+                    <Paper withBorder radius="md" className={classes.card}>
+                        <Text size="xs" c="dimmed" mb="xs" ff={bodyFamily}>
+                            Revenue by channel
+                        </Text>
+                        <Box className={classes.barsRow}>
+                            {BAR_VALUES.map((value, index) => (
+                                <Box
+                                    key={`bar-${index}`}
+                                    className={classes.bar}
+                                    h={`${value}%`}
+                                    bg={chartColors[index % chartColors.length]}
+                                />
+                            ))}
+                        </Box>
+                    </Paper>
+                    <Paper withBorder radius="md" className={classes.card}>
+                        <Text size="xs" c="dimmed" mb="xs" ff={bodyFamily}>
+                            Revenue share
+                        </Text>
+                        <svg viewBox="0 0 100 100" width="100%" height={90}>
+                            {pieSlicePaths(PIE_VALUES, 50, 50, 46).map(
+                                (path, index) => (
+                                    <path
+                                        key={`slice-${index}`}
+                                        d={path}
+                                        fill={
+                                            chartColors[
+                                                index % chartColors.length
+                                            ]
+                                        }
+                                        stroke="var(--mantine-color-body)"
+                                        strokeWidth={1.5}
+                                    />
+                                ),
+                            )}
+                        </svg>
+                    </Paper>
+                </Group>
             </Box>
         </Paper>
     );

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/generateBrandPalette.ts
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/generateBrandPalette.ts
@@ -1,0 +1,45 @@
+import Color from 'colorjs.io';
+
+const BRAND_PALETTE_SIZE = 20;
+
+const isValidHexColor = (hex: string): boolean =>
+    /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(hex);
+
+const clamp = (value: number, min: number, max: number): number =>
+    Math.min(max, Math.max(min, value));
+
+/**
+ * Expands a handful of brand colors into a full categorical chart palette.
+ * Seeds come first, then variants are derived in OKLCH (perceptually uniform)
+ * by rotating hue and alternating lightness so neighbours stay distinct.
+ */
+export const generateBrandPalette = (
+    hexes: string[],
+    size: number = BRAND_PALETTE_SIZE,
+): string[] => {
+    const seeds = [
+        ...new Set(
+            hexes.filter(isValidHexColor).map((hex) => hex.toLowerCase()),
+        ),
+    ];
+    if (seeds.length === 0) return [];
+
+    const palette = seeds.slice(0, size);
+    let variant = 0;
+    while (palette.length < size) {
+        const seed = seeds[variant % seeds.length];
+        const round = Math.floor(variant / seeds.length) + 1;
+        const color = new Color(seed).to('oklch');
+        color.set(
+            'oklch.h',
+            (h) => ((Number.isNaN(h) ? 0 : h) + round * 33) % 360,
+        );
+        color.set('oklch.l', (l) =>
+            clamp(l + (round % 2 === 0 ? 0.12 : -0.08), 0.45, 0.8),
+        );
+        color.set('oklch.c', (c) => Math.max(c, 0.12));
+        palette.push(color.to('srgb').toGamut().toString({ format: 'hex' }));
+        variant += 1;
+    }
+    return palette;
+};


### PR DESCRIPTION
## Summary

Closes the loop on the Brand appearance section's promise ("Your brand can be used to generate color palettes"): brand colors can now actually generate an organization chart palette.

- **Palette generator**: new "Generate palette" button in Brand appearance expands the brand colors into a 20-color chart palette using `colorjs.io` (already a dependency). Seeds come first; variants are derived in OKLCH by rotating hue and alternating lightness so neighbours stay distinct.
- **Save as org palette**: generating opens the existing `PaletteModalBase` pre-filled with the generated colors — editable hex codes, light/dark tabs, live bar/line/pie preview — and saves through the existing create-palette mutation.
- **Preview**: added a "Revenue share" pie card next to the bar chart; both use the generated palette once one exists (fallback: primary brand color tints).
- **Hidden-not-deleted UI**: logo tiles, title/body font selects, per-color role select, the fake browser chrome/nav header, and the "+ New chart" mock button are commented out with `TODO:` markers (grep one phrase to restore a feature — data flow, props, and CSS all left intact).
- **Layout fixes**: "Generate palette" button is full-width (it clipped in the 360px column), inputs consistently use `radius="md"`.

## Regression analysis

- `BrandPreview` is shared with onboarding (`OrganizationSetup.tsx`): the new `paletteColors` prop is optional and the existing prop contract is unchanged, so onboarding renders as before (minus the commented-out chrome/nav, which onboarding also displayed).
- The brand save/fetch flow is untouched — logos, fonts, and color roles are still fetched from Brandfetch and persisted; only their editing UI is hidden.
- Palette creation goes through the existing `useCreateColorPalette` mutation and `PaletteModalBase` validation (unique name, hex format), identical to the "Add palette" path.

## Test

- Verified in the local app: fetch brand → edit colors → generate → modal opens with 20 hexes → create palette appears in the palette list.
- `pnpm -F frontend run linter` and `pnpm -F frontend typecheck:fast` pass.

Closes: PROD-9283

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CfDZUbLAFAeduceav8bp4H