### PR TITLE
chore: slim PR preview runtime payload

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -357,7 +357,7 @@ jobs:
           name: pr-${{ github.event.number }}
           timeout: 15m
           file: okteto.preview.yaml
-          variables: SITE_URL=https://lightdash-preview-pr-${{ github.event.number }}.lightdash.okteto.dev,DB_DIVERT=${{ needs.files-changed.outputs.db_divert }}
+          variables: SITE_URL=https://lightdash-preview-pr-${{ github.event.number }}.lightdash.okteto.dev,DB_DIVERT=${{ needs.files-changed.outputs.db_divert }},TURBO_TEAM=${{ vars.TURBO_TEAM }},TURBO_TOKEN=${{ secrets.TURBO_TOKEN }}
 
       - name: Set preview URL output
         run: echo "url=https://lightdash-preview-pr-${{ github.event.number }}.lightdash.okteto.dev" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/preview-db-snapshot.yml
+++ b/.github/workflows/preview-db-snapshot.yml
@@ -65,6 +65,9 @@ jobs:
 
       - name: Deploy database and seeder
         run: okteto deploy -f docker/docker-compose.db-snapshot.yml --namespace db-snapshot --name db-snapshot --timeout 30m
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
       - name: Snapshot the seeded volume
         run: ./scripts/preview-db-snapshot.sh "${GITHUB_SHA::7}"

--- a/docker/docker-compose.db-snapshot.yml
+++ b/docker/docker-compose.db-snapshot.yml
@@ -10,6 +10,10 @@ volumes:
             class: csi-okteto
             size: 2Gi
 
+secrets:
+    TURBO_TOKEN:
+        environment: TURBO_TOKEN
+
 services:
     # Must be named identically to the preview db service: the seed stores the
     # project's warehouse connection (including this hostname) in the database,
@@ -31,6 +35,10 @@ services:
             target: pr-runner
             context: ..
             dockerfile: dockerfile-prs
+            args:
+                - TURBO_TEAM=$TURBO_TEAM
+            secrets:
+                - TURBO_TOKEN
         restart: always
         depends_on:
             - db-preview

--- a/docker/docker-compose.preview.yml
+++ b/docker/docker-compose.preview.yml
@@ -12,6 +12,10 @@ volumes:
             dev.okteto.com/from-snapshot-name: ${DB_SNAPSHOT_NAME:-}
             dev.okteto.com/from-snapshot-namespace: ${DB_SNAPSHOT_NAMESPACE:-}
 
+secrets:
+    TURBO_TOKEN:
+        environment: TURBO_TOKEN
+
 # Okteto specific
 endpoints:
     - path: /
@@ -41,6 +45,10 @@ services:
             target: pr-runner
             context: ..
             dockerfile: dockerfile-prs
+            args:
+                - TURBO_TEAM=$TURBO_TEAM
+            secrets:
+                - TURBO_TOKEN
         depends_on:
             - db-preview
             - headless-browser

--- a/dockerfile-prs
+++ b/dockerfile-prs
@@ -201,9 +201,9 @@ RUN --mount=type=secret,id=TURBO_TOKEN \
 # output: /usr/app/packages/frontend/build
 
 ############################
-# Build: final build
+# Build: deployment payload
 ############################
-FROM prod-builder AS build-final
+FROM prod-builder AS deploy-builder
 
 # Install Sentry CLI and process sourcemaps if environment variables are set
 ARG SENTRY_AUTH_TOKEN=""
@@ -250,15 +250,18 @@ RUN if [ -n "${SENTRY_AUTH_TOKEN}" ] && [ -n "${SENTRY_ORG}" ] && [ -n "${SENTRY
     sentry-cli releases deploys "${SENTRY_RELEASE_VERSION}" new -e "${SENTRY_ENVIRONMENT}" --project "${SENTRY_BACKEND_PROJECT}"; \
     fi
 
-# Cleanup development dependencies
-RUN rm -rf node_modules \
-    && rm -rf packages/*/node_modules
-
-# Install production dependencies
 ENV NODE_ENV=production
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
-    pnpm install --prod --frozen-lockfile --prefer-offline
+    pnpm --filter backend --prod deploy /out/app/packages/backend --legacy
+
+FROM scratch AS deployment
+
+COPY --link --from=deploy-builder /out/app/packages/backend /out/app/packages/backend
+COPY --link --from=deploy-builder /usr/app/packages/frontend/build /out/app/packages/frontend/build
+COPY --link ./examples/full-jaffle-shop-demo/dbt /out/app/dbt
+COPY --link ./examples/full-jaffle-shop-demo/profiles /out/app/profiles
+COPY --link --chmod=755 ./examples/full-jaffle-shop-demo/renderDeployHook.sh /out/bin/renderDeployHook.sh
 
 # -----------------------------
 # Stage 3: execution environment for backend
@@ -288,7 +291,7 @@ RUN ln -s /usr/local/dbt1.11/bin/dbt /usr/local/bin/dbt1.11
 
 # Run backend
 COPY ./docker/prod-entrypoint.sh /usr/bin/prod-entrypoint.sh
-COPY --from=build-final /usr/app /usr/app
+COPY --link --from=deployment /out/app /usr/app
 
 EXPOSE 8080
 
@@ -305,9 +308,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy demo dbt project for E2E testing
-COPY ./examples/full-jaffle-shop-demo/renderDeployHook.sh /usr/bin/renderDeployHook.sh
-COPY ./examples/full-jaffle-shop-demo/dbt /usr/app/dbt
-COPY ./examples/full-jaffle-shop-demo/profiles /usr/app/profiles
-
-RUN chmod +x /usr/bin/renderDeployHook.sh
+COPY --link --from=deployment /out/bin/renderDeployHook.sh /usr/bin/renderDeployHook.sh

--- a/dockerfile-prs
+++ b/dockerfile-prs
@@ -255,14 +255,6 @@ ENV NODE_ENV=production
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm --filter backend --prod deploy /out/app/packages/backend --legacy
 
-FROM scratch AS deployment
-
-COPY --link --from=deploy-builder /out/app/packages/backend /out/app/packages/backend
-COPY --link --from=deploy-builder /usr/app/packages/frontend/build /out/app/packages/frontend/build
-COPY --link ./examples/full-jaffle-shop-demo/dbt /out/app/dbt
-COPY --link ./examples/full-jaffle-shop-demo/profiles /out/app/profiles
-COPY --link --chmod=755 ./examples/full-jaffle-shop-demo/renderDeployHook.sh /out/bin/renderDeployHook.sh
-
 # -----------------------------
 # Stage 3: execution environment for backend
 # -----------------------------
@@ -291,7 +283,8 @@ RUN ln -s /usr/local/dbt1.11/bin/dbt /usr/local/bin/dbt1.11
 
 # Run backend
 COPY ./docker/prod-entrypoint.sh /usr/bin/prod-entrypoint.sh
-COPY --link --from=deployment /out/app /usr/app
+COPY --from=deploy-builder /out/app/packages/backend /usr/app/packages/backend
+COPY --from=deploy-builder /usr/app/packages/frontend/build /usr/app/packages/frontend/build
 
 EXPOSE 8080
 
@@ -308,4 +301,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --link --from=deployment /out/bin/renderDeployHook.sh /usr/bin/renderDeployHook.sh
+COPY ./examples/full-jaffle-shop-demo/dbt /usr/app/dbt
+COPY ./examples/full-jaffle-shop-demo/profiles /usr/app/profiles
+COPY --chmod=755 ./examples/full-jaffle-shop-demo/renderDeployHook.sh /usr/bin/renderDeployHook.sh


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates: #26260

### Description:
Replaces the preview image full-workspace production reinstall with a portable backend-only `pnpm deploy` payload.
Uses linked layers to assemble backend runtime dependencies, compiled packages, the static frontend, and preview seed assets without copying the builder workspace.
Wires the existing Turbo team and token into Okteto preview and snapshot builds so remote caching is enabled.
Validated the YAML structure, Compose build-secret wiring, snapshot Compose configuration, and whitespace checks.