### PR TITLE
feat(data-apps): shard the injected catalog into per-model files

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.exploresToModelFiles.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.exploresToModelFiles.test.ts
@@ -1,0 +1,274 @@
+// Stub the e2b/ai SDKs before importing AppGenerateService so this unit test
+// never reaches a real sandbox or model client.
+import { type Explore } from '@lightdash/common';
+import { parse as parseYaml } from 'yaml';
+import { AppGenerateService } from './AppGenerateService';
+
+vi.mock('e2b', () => ({
+    Sandbox: class {},
+    CommandExitError: class extends Error {},
+    ALL_TRAFFIC: '*',
+}));
+vi.mock('ai', () => ({
+    generateObject: vi.fn(),
+}));
+
+type ModelFile = { filename: string; contents: string };
+
+type PrivateAppGenerateService = {
+    exploresToModelFiles: (
+        explores: Explore[],
+        chartUsageByTable: Map<string, number>,
+    ) => {
+        files: ModelFile[];
+        tableCount: number;
+        dimensionCount: number;
+        metricCount: number;
+        totalBytes: number;
+    };
+};
+
+const exploresToModelFiles = (
+    explores: Explore[],
+    chartUsageByTable: Map<string, number> = new Map(),
+) =>
+    (
+        AppGenerateService as unknown as PrivateAppGenerateService
+    ).exploresToModelFiles(explores, chartUsageByTable);
+
+const indexOf = (files: ModelFile[]) =>
+    files.find((file) => file.filename === '_index.md')!.contents;
+
+const modelFilesOf = (files: ModelFile[]) =>
+    files.filter(
+        (file) =>
+            file.filename !== '_index.md' && file.filename !== 'schema.yml',
+    );
+
+const buildExplore = (
+    name: string,
+    dimensionCount: number,
+    options: { descriptionLength?: number } = {},
+): Explore =>
+    ({
+        name,
+        baseTable: name,
+        joinedTables: [],
+        tables: {
+            [name]: {
+                description: options.descriptionLength
+                    ? 'd'.repeat(options.descriptionLength)
+                    : undefined,
+                metrics: {
+                    row_count: { name: 'row_count', type: 'count' },
+                },
+                dimensions: Object.fromEntries(
+                    Array.from({ length: dimensionCount }, (_, i) => [
+                        `dim_${i}`,
+                        {
+                            name: `dim_${i}`,
+                            type: 'string',
+                            description: 'x'.repeat(180),
+                        },
+                    ]),
+                ),
+            },
+        },
+    }) as unknown as Explore;
+
+describe('AppGenerateService.exploresToModelFiles', () => {
+    it('writes one parseable file per model plus an index naming each file', () => {
+        const explore = {
+            name: 'orders',
+            baseTable: 'orders',
+            joinedTables: [
+                {
+                    table: 'customers',
+                    sqlOn: '${orders.customer_id} = ${customers.id}',
+                    relationship: 'many-to-one',
+                },
+            ],
+            tables: {
+                orders: {
+                    description: 'One row per order',
+                    metrics: {
+                        total_revenue: { name: 'total_revenue', type: 'sum' },
+                    },
+                    dimensions: {
+                        status: { name: 'status', type: 'string' },
+                    },
+                },
+                customers: {
+                    metrics: {},
+                    dimensions: {
+                        customer_name: {
+                            name: 'customer_name',
+                            type: 'string',
+                        },
+                    },
+                },
+            },
+        } as unknown as Explore;
+
+        const result = exploresToModelFiles([explore]);
+
+        expect(result).toMatchObject({
+            tableCount: 2,
+            dimensionCount: 2,
+            metricCount: 1,
+        });
+        expect(result.files.map((file) => file.filename).sort()).toEqual([
+            '_index.md',
+            'customers.yml',
+            'orders.yml',
+            'schema.yml',
+        ]);
+
+        const orders = parseYaml(
+            result.files.find((file) => file.filename === 'orders.yml')!
+                .contents,
+        ) as {
+            models: Array<{
+                name: string;
+                meta?: {
+                    metrics?: Record<string, unknown>;
+                    joins?: Array<{ join: string }>;
+                };
+                columns?: Array<{ name: string }>;
+            }>;
+        };
+        expect(orders.models).toHaveLength(1);
+        expect(orders.models[0].name).toBe('orders');
+        expect(orders.models[0].meta?.metrics).toHaveProperty('total_revenue');
+        expect(orders.models[0].meta?.joins?.[0].join).toBe('customers');
+        expect(orders.models[0].columns?.[0].name).toBe('status');
+
+        const index = indexOf(result.files);
+        expect(index).toContain(
+            'orders  orders.yml  dims=1 metrics=1  joins=customers  One row per order',
+        );
+        expect(index).toContain('customers  customers.yml  dims=1 metrics=0');
+    });
+
+    it('orders the index by chart usage so detail is shed from the least-queried models', () => {
+        const explores = [
+            buildExplore('rarely_used', 1),
+            buildExplore('heavily_used', 1),
+        ];
+
+        const index = indexOf(
+            exploresToModelFiles(
+                explores,
+                new Map([
+                    ['rarely_used', 2],
+                    ['heavily_used', 900],
+                ]),
+            ).files,
+        );
+
+        expect(index.indexOf('heavily_used')).toBeLessThan(
+            index.indexOf('rarely_used'),
+        );
+    });
+
+    it('keeps every file under the size the agent Read tool accepts', () => {
+        // One model far wider than the per-file ceiling, forcing a split.
+        const result = exploresToModelFiles([buildExplore('wide', 2_000)]);
+
+        const modelFiles = modelFilesOf(result.files);
+        expect(modelFiles.length).toBeGreaterThan(1);
+        for (const file of result.files) {
+            expect(Buffer.byteLength(file.contents)).toBeLessThan(256_000);
+        }
+
+        const dimensionNames = modelFiles.flatMap((file) => {
+            const parsed = parseYaml(file.contents) as {
+                models: Array<{
+                    name: string;
+                    columns?: Array<{ name: string }>;
+                }>;
+            };
+            expect(parsed.models[0].name).toBe('wide');
+            return (parsed.models[0].columns ?? []).map(
+                (column) => column.name,
+            );
+        });
+        expect(new Set(dimensionNames).size).toBe(2_000);
+
+        expect(modelFiles[0].contents).toContain(
+            `# wide continues in ${modelFiles[1].filename}`,
+        );
+        expect(indexOf(result.files)).toContain('wide  wide.yml');
+    });
+
+    it('writes a file for every model the index names, including unsplittable ones', () => {
+        // Metrics-only and far past the per-file ceiling: there is no column
+        // list to split on, so the model has to be written whole rather than
+        // dropped.
+        const explore = {
+            name: 'metrics_only',
+            baseTable: 'metrics_only',
+            joinedTables: [],
+            tables: {
+                metrics_only: {
+                    metrics: Object.fromEntries(
+                        Array.from({ length: 3_000 }, (_, i) => [
+                            `metric_${i}`,
+                            {
+                                name: `metric_${i}`,
+                                type: 'sum',
+                                description: 'y'.repeat(180),
+                            },
+                        ]),
+                    ),
+                    dimensions: {},
+                },
+            },
+        } as unknown as Explore;
+
+        const result = exploresToModelFiles([explore]);
+
+        const modelFiles = modelFilesOf(result.files);
+        expect(modelFiles).toHaveLength(1);
+        expect(modelFiles[0].filename).toBe('metrics_only.yml');
+        const parsed = parseYaml(modelFiles[0].contents) as {
+            models: Array<{ meta?: { metrics?: Record<string, unknown> } }>;
+        };
+        expect(Object.keys(parsed.models[0].meta?.metrics ?? {})).toHaveLength(
+            3_000,
+        );
+        expect(indexOf(result.files)).toContain(
+            'metrics_only  metrics_only.yml',
+        );
+    });
+
+    it('lists every model in the index even when descriptions no longer fit', () => {
+        const explores = Array.from({ length: 1_500 }, (_, i) =>
+            buildExplore(`model_${i}`, 1, { descriptionLength: 200 }),
+        );
+
+        const index = indexOf(exploresToModelFiles(explores).files);
+
+        expect(Buffer.byteLength(index)).toBeLessThan(256_000);
+        for (const explore of explores) {
+            expect(index).toContain(`${explore.name}  ${explore.name}.yml`);
+        }
+    });
+
+    it('gives colliding model names distinct filenames', () => {
+        const result = exploresToModelFiles([
+            buildExplore('sales/eu', 1),
+            buildExplore('sales_eu', 1),
+        ]);
+
+        const filenames = modelFilesOf(result.files).map(
+            (file) => file.filename,
+        );
+        expect(new Set(filenames).size).toBe(2);
+
+        const index = indexOf(result.files);
+        for (const filename of filenames) {
+            expect(index).toContain(filename);
+        }
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.externalSamples.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.externalSamples.test.ts
@@ -60,7 +60,9 @@ function buildService() {
             lightdashConfig: {} as never,
             analytics: {} as never,
             analyticsModel: {} as never,
-            catalogModel: {} as never,
+            catalogModel: {
+                getChartUsageByTable: async () => new Map<string, number>(),
+            } as never,
             appModel: {} as never,
             featureFlagModel: featureFlagModel as never,
             organizationDesignModel: {} as never,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -300,6 +300,26 @@ type StagedAppFile = {
 
 type NamedStagedFile = StagedAppFile & { sandboxFilename: string };
 
+/**
+ * A compiled table rendered as dbt-style YAML lines. Header (`- name:` through
+ * `meta:`) and column blocks stay separate so a model can be composed into one
+ * document or split across files without re-parsing.
+ */
+type RenderedModel = {
+    name: string;
+    description: string | null;
+    joinedTables: string[];
+    headerLines: string[];
+    columnBlocks: string[][];
+    dimensionCount: number;
+    metricCount: number;
+};
+
+type ModelFile = {
+    filename: string;
+    contents: string;
+};
+
 type DataAppVersionFailureTelemetry = {
     wasResumed?: boolean;
     claudeProvider?: 'anthropic' | 'bedrock';
@@ -2464,18 +2484,24 @@ export class AppGenerateService extends BaseService {
 
         // Source the synthetic schema from the compiled explore cache (not the
         // flattened catalog summary) so it carries joins, real dimension/metric
-        // types, and parameters. See exploresToYaml.
-        const exploresByUuid =
-            await this.projectModel.getAllExploresFromCache(projectUuid);
+        // types, and parameters. See exploresToModelFiles.
+        const [exploresByUuid, chartUsageByTable] = await Promise.all([
+            this.projectModel.getAllExploresFromCache(projectUuid),
+            this.catalogModel.getChartUsageByTable(projectUuid),
+        ]);
         const explores = Object.values(exploresByUuid).filter(
             (explore): explore is Explore => !isExploreError(explore),
         );
         const {
-            yaml: modelYaml,
+            files: modelFiles,
             tableCount,
             dimensionCount,
             metricCount,
-        } = AppGenerateService.exploresToYaml(explores);
+            totalBytes,
+        } = AppGenerateService.exploresToModelFiles(
+            explores,
+            chartUsageByTable,
+        );
 
         // Project-level parameters are global (not attached to any one explore)
         // and live in lightdash.config.yml — the location skill.md already tells
@@ -2489,11 +2515,20 @@ export class AppGenerateService extends BaseService {
         // different ownership (e.g. root-owned after Claude CLI execution),
         // which would cause a permission error on write.
         await sandbox.commands.run(
-            'rm -f /tmp/dbt-repo/models/schema.yml /tmp/dbt-repo/lightdash.config.yml /tmp/prompt.txt 2>/dev/null; rm -rf /tmp/images /tmp/uploads /tmp/metric-queries /tmp/dashboard /tmp/external-data 2>/dev/null; true',
+            'rm -rf /tmp/dbt-repo/models 2>/dev/null; rm -f /tmp/dbt-repo/lightdash.config.yml /tmp/prompt.txt 2>/dev/null; rm -rf /tmp/images /tmp/uploads /tmp/metric-queries /tmp/dashboard /tmp/external-data 2>/dev/null; true',
             { timeoutMs: 10_000 },
         );
 
-        await sandbox.files.write('/tmp/dbt-repo/models/schema.yml', modelYaml);
+        // One round trip per model file would cost minutes on a large project,
+        // so ship the whole directory as a single archive and unpack in place.
+        await sandbox.files.write(
+            '/tmp/dbt-repo/models.tar',
+            await AppGenerateService.packModelFiles(modelFiles),
+        );
+        await sandbox.commands.run(
+            'mkdir -p /tmp/dbt-repo/models && tar -xf /tmp/dbt-repo/models.tar -C /tmp/dbt-repo/models && rm -f /tmp/dbt-repo/models.tar',
+            { timeoutMs: 60_000 },
+        );
         if (configYaml) {
             await sandbox.files.write(
                 '/tmp/dbt-repo/lightdash.config.yml',
@@ -2603,15 +2638,45 @@ export class AppGenerateService extends BaseService {
 
         const durationMs = AppGenerateService.elapsed(start);
         this.logger.info(
-            `App ${appUuid}: model context written (tables=${tableCount}, dimensions=${dimensionCount}, metrics=${metricCount}, yamlBytes=${modelYaml.length}, ${durationMs}ms)`,
+            `App ${appUuid}: model context written (tables=${tableCount}, dimensions=${dimensionCount}, metrics=${metricCount}, files=${modelFiles.length}, yamlBytes=${totalBytes}, ${durationMs}ms)`,
         );
         return {
             durationMs,
             tableCount,
             dimensionCount,
             metricCount,
-            yamlBytes: modelYaml.length,
+            yamlBytes: totalBytes,
         };
+    }
+
+    private static packModelFiles(files: ModelFile[]): Promise<Buffer> {
+        return new Promise<Buffer>((resolve, reject) => {
+            const packer = tarPack();
+            const chunks: Buffer[] = [];
+            packer.on('data', (chunk: Buffer) => chunks.push(chunk));
+            packer.on('end', () => resolve(Buffer.concat(chunks)));
+            packer.on('error', reject);
+
+            const addNext = (index: number): void => {
+                if (index >= files.length) {
+                    packer.finalize();
+                    return;
+                }
+                const file = files[index];
+                packer.entry(
+                    { name: file.filename },
+                    Buffer.from(file.contents, 'utf-8'),
+                    (err) => {
+                        if (err) {
+                            reject(err);
+                            return;
+                        }
+                        addNext(index + 1);
+                    },
+                );
+            };
+            addNext(0);
+        });
     }
 
     /**
@@ -8284,157 +8349,157 @@ export class AppGenerateService extends BaseService {
         return lines;
     }
 
-    /**
-     * Convert compiled explores into the dbt-style YAML that skill.md expects.
-     * One model per explore, keyed by the explore name (the value passed to
-     * `query()`), carrying real metric/dimension types, join relationships
-     * (`meta.joins`), AI hints, and model-level parameters. Joined tables that
-     * aren't themselves a top-level explore (seeds, aliased joins) are inlined
-     * so their dot-notation fields stay discoverable. Hidden fields are
-     * skipped; descriptions are truncated to keep the prompt bounded.
-     */
-    private static exploresToYaml(explores: Explore[]): {
-        yaml: string;
-        tableCount: number;
-        dimensionCount: number;
-        metricCount: number;
-    } {
-        const DESCRIPTION_MAX_LEN = 200;
-        const truncate = (s: string): string =>
-            s.length > DESCRIPTION_MAX_LEN
-                ? `${s.slice(0, DESCRIPTION_MAX_LEN - 1)}…`
-                : s;
+    private static readonly DESCRIPTION_MAX_LEN = 200;
 
-        const lines: string[] = ['models:'];
-        let tableCount = 0;
-        let dimensionCount = 0;
-        let metricCount = 0;
+    private static truncateDescription(s: string): string {
+        return s.length > AppGenerateService.DESCRIPTION_MAX_LEN
+            ? `${s.slice(0, AppGenerateService.DESCRIPTION_MAX_LEN - 1)}…`
+            : s;
+    }
+
+    /**
+     * Render one compiled table as a dbt-style model, carrying real
+     * metric/dimension types, join relationships (`meta.joins`), AI hints, and
+     * model-level parameters. Joins and parameters live on the explore rather
+     * than the table, so they're passed in explicitly. Hidden fields are
+     * skipped; descriptions are truncated to keep the output bounded.
+     */
+    private static renderTableModel(
+        modelName: string,
+        table: CompiledTable,
+        joins: CompiledExploreJoin[],
+        parameters: Record<string, LightdashProjectParameter> | undefined,
+    ): RenderedModel {
+        const truncate = AppGenerateService.truncateDescription;
+        const headerLines: string[] = [`  - name: ${modelName}`];
+        if (table.description) {
+            headerLines.push(
+                `    description: ${AppGenerateService.yamlQuote(truncate(table.description))}`,
+            );
+        }
+
+        const metrics = Object.values(table.metrics).filter((m) => !m.hidden);
+        const dimensions = Object.values(table.dimensions).filter(
+            (d) => !d.hidden,
+        );
+        const parameterEntries = parameters ? Object.entries(parameters) : [];
+
+        if (
+            metrics.length > 0 ||
+            joins.length > 0 ||
+            parameterEntries.length > 0
+        ) {
+            headerLines.push(`    meta:`);
+            if (metrics.length > 0) {
+                headerLines.push(`      metrics:`);
+                for (const m of metrics) {
+                    headerLines.push(`        ${m.name}:`);
+                    headerLines.push(`          type: ${m.type}`);
+                    if (m.label && m.label !== m.name) {
+                        headerLines.push(
+                            `          label: ${AppGenerateService.yamlQuote(m.label)}`,
+                        );
+                    }
+                    if (m.description) {
+                        headerLines.push(
+                            `          description: ${AppGenerateService.yamlQuote(truncate(m.description))}`,
+                        );
+                    }
+                    const aiHints = getEffectiveFieldAiHints(m, table);
+                    if (aiHints) {
+                        headerLines.push(`          ai_hints:`);
+                        for (const aiHint of aiHints) {
+                            headerLines.push(
+                                `            - ${AppGenerateService.yamlQuote(aiHint)}`,
+                            );
+                        }
+                    }
+                }
+            }
+            if (joins.length > 0) {
+                headerLines.push(`      joins:`);
+                for (const j of joins) {
+                    headerLines.push(`        - join: ${j.table}`);
+                    if (j.relationship) {
+                        headerLines.push(
+                            `          relationship: ${j.relationship}`,
+                        );
+                    }
+                    if (j.sqlOn) {
+                        headerLines.push(
+                            `          sql_on: ${AppGenerateService.yamlQuote(j.sqlOn)}`,
+                        );
+                    }
+                }
+            }
+            if (parameterEntries.length > 0) {
+                headerLines.push(`      parameters:`);
+                for (const [key, param] of parameterEntries) {
+                    headerLines.push(
+                        ...AppGenerateService.renderParameterYaml(
+                            key,
+                            param,
+                            '        ',
+                        ),
+                    );
+                }
+            }
+        }
+
+        const columnBlocks = dimensions.map((d) => {
+            const block: string[] = [`      - name: ${d.name}`];
+            if (d.label && d.label !== d.name) {
+                block.push(
+                    `        label: ${AppGenerateService.yamlQuote(d.label)}`,
+                );
+            }
+            if (d.description) {
+                block.push(
+                    `        description: ${AppGenerateService.yamlQuote(truncate(d.description))}`,
+                );
+            }
+            const aiHints = getEffectiveFieldAiHints(d, table);
+            if (aiHints) {
+                block.push(`        ai_hints:`);
+                for (const aiHint of aiHints) {
+                    block.push(
+                        `          - ${AppGenerateService.yamlQuote(aiHint)}`,
+                    );
+                }
+            }
+            block.push(`        meta:`);
+            block.push(`          dimension:`);
+            block.push(`            type: ${d.type}`);
+            return block;
+        });
+
+        return {
+            name: modelName,
+            description: table.description ? truncate(table.description) : null,
+            joinedTables: joins.map((j) => j.table),
+            headerLines,
+            columnBlocks,
+            dimensionCount: dimensions.length,
+            metricCount: metrics.length,
+        };
+    }
+
+    /**
+     * One model per explore, keyed by the explore name (the value passed to
+     * `query()`). Joined tables that aren't themselves a top-level explore
+     * (seeds, aliased joins) are appended so their dot-notation fields stay
+     * discoverable.
+     */
+    private static exploresToRenderedModels(
+        explores: Explore[],
+    ): RenderedModel[] {
+        const models: RenderedModel[] = [];
 
         // Names already emitted as a standalone model, so the join-target
         // fallback (pass 2) only inlines tables that aren't otherwise visible.
         const emittedModelNames = new Set<string>(
             explores.map((explore) => explore.name),
         );
-
-        // Emit one model from a compiled table. Joins and parameters live on
-        // the explore (not the table), so they're passed in explicitly.
-        const emitTableModel = (
-            modelName: string,
-            table: CompiledTable,
-            joins: CompiledExploreJoin[],
-            parameters: Record<string, LightdashProjectParameter> | undefined,
-        ): void => {
-            tableCount += 1;
-            lines.push(`  - name: ${modelName}`);
-            if (table.description) {
-                lines.push(
-                    `    description: ${AppGenerateService.yamlQuote(truncate(table.description))}`,
-                );
-            }
-
-            const metrics = Object.values(table.metrics).filter(
-                (m) => !m.hidden,
-            );
-            const dimensions = Object.values(table.dimensions).filter(
-                (d) => !d.hidden,
-            );
-            const parameterEntries = parameters
-                ? Object.entries(parameters)
-                : [];
-
-            if (
-                metrics.length > 0 ||
-                joins.length > 0 ||
-                parameterEntries.length > 0
-            ) {
-                lines.push(`    meta:`);
-                if (metrics.length > 0) {
-                    lines.push(`      metrics:`);
-                    for (const m of metrics) {
-                        metricCount += 1;
-                        lines.push(`        ${m.name}:`);
-                        lines.push(`          type: ${m.type}`);
-                        if (m.label && m.label !== m.name) {
-                            lines.push(
-                                `          label: ${AppGenerateService.yamlQuote(m.label)}`,
-                            );
-                        }
-                        if (m.description) {
-                            lines.push(
-                                `          description: ${AppGenerateService.yamlQuote(truncate(m.description))}`,
-                            );
-                        }
-                        const aiHints = getEffectiveFieldAiHints(m, table);
-                        if (aiHints) {
-                            lines.push(`          ai_hints:`);
-                            for (const aiHint of aiHints) {
-                                lines.push(
-                                    `            - ${AppGenerateService.yamlQuote(aiHint)}`,
-                                );
-                            }
-                        }
-                    }
-                }
-                if (joins.length > 0) {
-                    lines.push(`      joins:`);
-                    for (const j of joins) {
-                        lines.push(`        - join: ${j.table}`);
-                        if (j.relationship) {
-                            lines.push(
-                                `          relationship: ${j.relationship}`,
-                            );
-                        }
-                        if (j.sqlOn) {
-                            lines.push(
-                                `          sql_on: ${AppGenerateService.yamlQuote(j.sqlOn)}`,
-                            );
-                        }
-                    }
-                }
-                if (parameterEntries.length > 0) {
-                    lines.push(`      parameters:`);
-                    for (const [key, param] of parameterEntries) {
-                        lines.push(
-                            ...AppGenerateService.renderParameterYaml(
-                                key,
-                                param,
-                                '        ',
-                            ),
-                        );
-                    }
-                }
-            }
-
-            if (dimensions.length > 0) {
-                lines.push(`    columns:`);
-                for (const d of dimensions) {
-                    dimensionCount += 1;
-                    lines.push(`      - name: ${d.name}`);
-                    if (d.label && d.label !== d.name) {
-                        lines.push(
-                            `        label: ${AppGenerateService.yamlQuote(d.label)}`,
-                        );
-                    }
-                    if (d.description) {
-                        lines.push(
-                            `        description: ${AppGenerateService.yamlQuote(truncate(d.description))}`,
-                        );
-                    }
-                    const aiHints = getEffectiveFieldAiHints(d, table);
-                    if (aiHints) {
-                        lines.push(`        ai_hints:`);
-                        for (const aiHint of aiHints) {
-                            lines.push(
-                                `          - ${AppGenerateService.yamlQuote(aiHint)}`,
-                            );
-                        }
-                    }
-                    lines.push(`        meta:`);
-                    lines.push(`          dimension:`);
-                    lines.push(`            type: ${d.type}`);
-                }
-            }
-        };
 
         // Pass 1: every explore becomes a model keyed by its queryable name.
         for (const explore of explores) {
@@ -8443,11 +8508,13 @@ export class AppGenerateService extends BaseService {
                 const joins = (explore.joinedTables ?? []).filter(
                     (j) => !j.hidden,
                 );
-                emitTableModel(
-                    explore.name,
-                    baseTable,
-                    joins,
-                    explore.parameters,
+                models.push(
+                    AppGenerateService.renderTableModel(
+                        explore.name,
+                        baseTable,
+                        joins,
+                        explore.parameters,
+                    ),
                 );
             }
         }
@@ -8466,16 +8533,278 @@ export class AppGenerateService extends BaseService {
                     !inlined.has(key)
                 ) {
                     inlined.add(key);
-                    emitTableModel(key, joinedTable, [], undefined);
+                    models.push(
+                        AppGenerateService.renderTableModel(
+                            key,
+                            joinedTable,
+                            [],
+                            undefined,
+                        ),
+                    );
                 }
             }
         }
 
+        return models;
+    }
+
+    private static renderedModelToLines(model: RenderedModel): string[] {
+        return [
+            ...model.headerLines,
+            ...(model.columnBlocks.length > 0 ? ['    columns:'] : []),
+            ...model.columnBlocks.flat(),
+        ];
+    }
+
+    /**
+     * Convert compiled explores into a single dbt-style YAML document. Used for
+     * the app-code download bundle, where the whole semantic layer is expected
+     * in one file; the build sandbox gets the sharded layout instead.
+     */
+    private static exploresToYaml(explores: Explore[]): {
+        yaml: string;
+        tableCount: number;
+        dimensionCount: number;
+        metricCount: number;
+    } {
+        const models = AppGenerateService.exploresToRenderedModels(explores);
+        const lines = [
+            'models:',
+            ...models.flatMap(AppGenerateService.renderedModelToLines),
+        ];
+
         return {
             yaml: lines.join('\n'),
-            tableCount,
-            dimensionCount,
-            metricCount,
+            tableCount: models.length,
+            dimensionCount: models.reduce((n, m) => n + m.dimensionCount, 0),
+            metricCount: models.reduce((n, m) => n + m.metricCount, 0),
+        };
+    }
+
+    static readonly MODELS_INDEX_FILENAME = '_index.md';
+
+    // Iterations resume the previous Claude session, whose history still points
+    // at the single-file layout this replaced. Leave a signpost so a remembered
+    // read lands on instructions rather than a missing file.
+    private static readonly MODELS_LEGACY_POINTER: ModelFile = {
+        filename: 'schema.yml',
+        contents: [
+            '# This project is sharded across one YAML file per model in this directory.',
+            `# Start with ${AppGenerateService.MODELS_INDEX_FILENAME}, then read only the model files you need.`,
+            '',
+        ].join('\n'),
+    };
+
+    // The agent's Read tool refuses files over 256KB outright, so every file we
+    // write has to stay comfortably under it or it is unreadable in the sandbox.
+    private static readonly MODEL_FILE_MAX_BYTES = 200_000;
+
+    private static readonly INDEX_MAX_BYTES = 200_000;
+
+    // Below this, index entries carry joins and a description; past it they
+    // degrade to name/file/counts so every model still gets listed.
+    private static readonly INDEX_DETAIL_MAX_BYTES = 120_000;
+
+    private static readonly INDEX_DESCRIPTION_MAX_LEN = 120;
+
+    /**
+     * The index carries the resolved filename for every model, so sanitizing a
+     * name here never leaves the agent guessing at the path.
+     */
+    private static modelFilenames(models: RenderedModel[]): string[] {
+        const taken = new Set<string>([
+            AppGenerateService.MODELS_INDEX_FILENAME,
+            AppGenerateService.MODELS_LEGACY_POINTER.filename,
+        ]);
+        return models.map((model) => {
+            const safe = model.name.replace(/[^a-zA-Z0-9_-]/g, '_') || 'model';
+            let filename = `${safe}.yml`;
+            let suffix = 2;
+            while (taken.has(filename)) {
+                filename = `${safe}-${suffix}.yml`;
+                suffix += 1;
+            }
+            taken.add(filename);
+            return filename;
+        });
+    }
+
+    /**
+     * One model as one or more YAML files. A model whose columns push it past
+     * the Read ceiling is split across `<name>.yml`, `<name>.part2.yml`, … —
+     * each a standalone-parseable document for the same model.
+     */
+    private static modelToFiles(
+        model: RenderedModel,
+        filename: string,
+    ): ModelFile[] {
+        const whole = `models:\n${AppGenerateService.renderedModelToLines(
+            model,
+        ).join('\n')}\n`;
+        // Columns are the only split point, so a model with none is written
+        // whole however big its metrics make it — an oversized file is still
+        // greppable, whereas a model the index names but never writes is not.
+        if (
+            Buffer.byteLength(whole) <=
+                AppGenerateService.MODEL_FILE_MAX_BYTES ||
+            model.columnBlocks.length === 0
+        ) {
+            return [{ filename, contents: whole }];
+        }
+
+        const base = filename.replace(/\.yml$/, '');
+        const header = `models:\n${model.headerLines.join('\n')}\n    columns:\n`;
+        const files: ModelFile[] = [];
+        let current: string[] = [];
+        let currentBytes = Buffer.byteLength(header);
+
+        const flush = () => {
+            if (current.length === 0) return;
+            const part = files.length + 1;
+            files.push({
+                filename: part === 1 ? filename : `${base}.part${part}.yml`,
+                contents:
+                    part === 1
+                        ? `${header}${current.join('\n')}\n`
+                        : `models:\n  - name: ${model.name}\n    columns:\n${current.join(
+                              '\n',
+                          )}\n`,
+            });
+            current = [];
+            currentBytes = Buffer.byteLength(header);
+        };
+
+        for (const block of model.columnBlocks) {
+            const text = block.join('\n');
+            const blockBytes = Buffer.byteLength(text) + 1;
+            if (
+                current.length > 0 &&
+                currentBytes + blockBytes >
+                    AppGenerateService.MODEL_FILE_MAX_BYTES
+            ) {
+                flush();
+            }
+            current.push(text);
+            currentBytes += blockBytes;
+        }
+        flush();
+
+        return files.map((file, i) => ({
+            ...file,
+            contents:
+                i < files.length - 1
+                    ? `${file.contents}# ${model.name} continues in ${
+                          files[i + 1].filename
+                      }\n`
+                    : file.contents,
+        }));
+    }
+
+    /**
+     * Shard the compiled explores into one YAML file per model plus an index
+     * listing every model, so full fidelity stays on disk without the whole
+     * catalog having to fit in the context window. `chartUsageByTable` ranks
+     * the index, so any detail it sheds comes off the least-queried models.
+     */
+    private static exploresToModelFiles(
+        explores: Explore[],
+        chartUsageByTable: Map<string, number>,
+    ): {
+        files: ModelFile[];
+        tableCount: number;
+        dimensionCount: number;
+        metricCount: number;
+        totalBytes: number;
+    } {
+        const models = AppGenerateService.exploresToRenderedModels(explores);
+        const filenames = AppGenerateService.modelFilenames(models);
+
+        const files = models.flatMap((model, i) =>
+            AppGenerateService.modelToFiles(model, filenames[i]),
+        );
+
+        const ranked = models
+            .map((model, i) => ({
+                model,
+                filename: filenames[i],
+                chartUsage: chartUsageByTable.get(model.name) ?? 0,
+            }))
+            .sort(
+                (a, b) =>
+                    b.chartUsage - a.chartUsage ||
+                    a.model.name.localeCompare(b.model.name),
+            );
+
+        const header = [
+            `# Semantic layer — ${models.length} model${
+                models.length === 1 ? '' : 's'
+            }`,
+            '',
+            'Every model in this project is listed below, most-queried first. Read',
+            'only the model files you need — never the whole directory. To locate a',
+            'field whose model you do not know, Grep this directory for its name.',
+            '',
+            'name  file  dims/metrics  joins  description',
+            '',
+        ].join('\n');
+
+        const detailLine = (entry: (typeof ranked)[number]): string => {
+            const { model, filename } = entry;
+            const joins =
+                model.joinedTables.length > 0
+                    ? model.joinedTables.join(',')
+                    : '-';
+            const description = model.description
+                ? `  ${model.description
+                      .replace(/\s+/g, ' ')
+                      .slice(0, AppGenerateService.INDEX_DESCRIPTION_MAX_LEN)}`
+                : '';
+            return `${model.name}  ${filename}  dims=${model.dimensionCount} metrics=${model.metricCount}  joins=${joins}${description}`;
+        };
+
+        const compactLine = (entry: (typeof ranked)[number]): string =>
+            `${entry.model.name}  ${entry.filename}  dims=${entry.model.dimensionCount} metrics=${entry.model.metricCount}`;
+
+        const lines: string[] = [];
+        let bytes = Buffer.byteLength(header);
+        let detailed = true;
+        let omitted = 0;
+        for (const entry of ranked) {
+            if (detailed && bytes > AppGenerateService.INDEX_DETAIL_MAX_BYTES) {
+                detailed = false;
+            }
+            const line = detailed ? detailLine(entry) : compactLine(entry);
+            const lineBytes = Buffer.byteLength(line) + 1;
+            if (bytes + lineBytes > AppGenerateService.INDEX_MAX_BYTES) {
+                omitted += 1;
+            } else {
+                lines.push(line);
+                bytes += lineBytes;
+            }
+        }
+        if (omitted > 0) {
+            lines.push(
+                `\n(${omitted} rarely-queried models not listed — Glob this directory for *.yml to see them all)`,
+            );
+        }
+
+        files.push(
+            {
+                filename: AppGenerateService.MODELS_INDEX_FILENAME,
+                contents: `${header}${lines.join('\n')}\n`,
+            },
+            AppGenerateService.MODELS_LEGACY_POINTER,
+        );
+
+        return {
+            files,
+            tableCount: models.length,
+            dimensionCount: models.reduce((n, m) => n + m.dimensionCount, 0),
+            metricCount: models.reduce((n, m) => n + m.metricCount, 0),
+            totalBytes: files.reduce(
+                (n, f) => n + Buffer.byteLength(f.contents),
+                0,
+            ),
         };
     }
 

--- a/packages/backend/src/models/CatalogModel/CatalogModel.ts
+++ b/packages/backend/src/models/CatalogModel/CatalogModel.ts
@@ -1215,6 +1215,26 @@ export class CatalogModel {
         }));
     }
 
+    /** Chart usage per table, summed across the table's fields. */
+    async getChartUsageByTable(
+        projectUuid: string,
+    ): Promise<Map<string, number>> {
+        const rows = await this.database(CatalogTableName)
+            .where(`${CatalogTableName}.project_uuid`, projectUuid)
+            .where(`${CatalogTableName}.type`, CatalogType.Field)
+            .groupBy(`${CatalogTableName}.table_name`)
+            .select<{ table_name: string; chart_usage: string }[]>(
+                `${CatalogTableName}.table_name`,
+                this.database.raw(
+                    `COALESCE(SUM(${CatalogTableName}.chart_usage), 0) as chart_usage`,
+                ),
+            );
+
+        return new Map(
+            rows.map((row) => [row.table_name, Number(row.chart_usage)]),
+        );
+    }
+
     async getCatalogItemsWithTags(
         projectUuid: string,
         opts?: {

--- a/sandboxes/data-apps/template/references/chart-references.md
+++ b/sandboxes/data-apps/template/references/chart-references.md
@@ -34,10 +34,10 @@ Each file contains:
 
 **How to use these:**
 1. Read the JSON file(s) to understand what data the user wants in their app
-2. Cross-reference the field IDs against the dbt YAML catalog at
-   `/tmp/dbt-repo/models/schema.yml` for field descriptions, types, and relationships
-   between fields — this helps you understand how the referenced charts connect to the
-   user's overall prompt
+2. Cross-reference the field IDs against the dbt YAML catalog — read
+   `/tmp/dbt-repo/models/<exploreName>.yml` for the referenced explores — for field
+   descriptions, types, and relationships between fields; this helps you understand how
+   the referenced charts connect to the user's overall prompt
 3. Map fields to SDK calls:
    - `chartName` → `query(exploreName).label(chartName)` — **always set the label**
    - `metricQuery.dimensions` → `.dimensions([...])`

--- a/sandboxes/data-apps/template/skill.md
+++ b/sandboxes/data-apps/template/skill.md
@@ -49,7 +49,17 @@ Available at `@/components/ui/<name>`:
 
 ## Semantic Layer (dbt models)
 
-The available data models are defined in dbt YAML files at **`/tmp/dbt-repo/models/`**. Read these to discover every model, dimension, metric, join, and parameter available to you. **Never guess field names** — use only what's in the YAML. When a dimension or metric has `ai_hints`, follow that guidance when deciding which field best matches the user's intent; hints supplement names, labels, and descriptions. (Parameters live in a `parameters:` block under `meta:` / `config.meta:`, or in `lightdash.config.yml` — see [Parameters](#parameters).)
+The available data models are defined in dbt YAML files at **`/tmp/dbt-repo/models/`** — one file per model, plus an index. **Never guess field names** — use only what's in the YAML. When a dimension or metric has `ai_hints`, follow that guidance when deciding which field best matches the user's intent; hints supplement names, labels, and descriptions. (Parameters live in a `parameters:` block under `meta:` / `config.meta:`, or in `lightdash.config.yml` — see [Parameters](#parameters).)
+
+### Finding the right models
+
+Projects range from a handful of models to well over a thousand, so the directory is indexed rather than inlined:
+
+1. **Read `/tmp/dbt-repo/models/_index.md` first.** It lists every model, most-queried first, with its file name, dimension/metric counts, joined tables, and description.
+2. **Read only the model files the app actually needs**, e.g. `Read /tmp/dbt-repo/models/orders.yml`. Each file holds that model's complete dimensions, metrics, joins, and parameters.
+3. **Grep when the index isn't enough.** If you know a field name but not its model, `Grep` the directory for it. A wide model may be split across `<name>.yml`, `<name>.part2.yml`, … — the last line of each part points at the next.
+
+**Never read every model file, and never page through a file with `offset`/`limit`** — pick the model from the index and read that one file whole.
 
 ### Reading dbt YAML
 


### PR DESCRIPTION
The build sandbox got the whole semantic layer as a single `models/schema.yml`. The agent's `Read` tool refuses files over 256KB, so on a large project it works around that — paging the file with `offset`/`limit` and shelling out to `find`/`grep`/`wc` to locate models.

Write one YAML file per model instead, plus an `_index.md` listing every model with its file, dimension/metric counts, joins and description, ranked by chart usage. Per-model fidelity is unchanged — it's addressable now instead of inlined.

- Files stay under the `Read` ceiling: a model past it splits across `<name>.yml`, `<name>.part2.yml`, …; the index degrades to compact entries rather than dropping models.
- The directory ships as one tar and is unpacked in the sandbox — a write per file would cost minutes on a large project.
- `skill.md` now points the agent at the index and tells it not to page files.
- The app-code download bundle still gets the single-document `semantic-layer.yml`; its output is byte-identical.

## Measured

A/B on a synthetic 403-model catalog (611KB as one file), 4 discovery-heavy prompts × 2 reps per arm. The control is this same branch's template with only the catalog section of `skill.md` reverted, so the two arms differ in nothing but the layout and its instructions.

**Correctness is unchanged — it was already at ceiling:**

| rule | control (one file) | this PR (sharded) |
|---|---|---|
| `queries-valid-fields` | 8/8 | 8/8 |
| `renders-clean` | 8/8 | 8/8 |
| `build-passes` | 8/8 | 8/8 |
| `made-metric-queries` | 8/8 | 8/8 |

Even with 400 decoy models in a file it cannot open, the agent picked the right explore and real fields every run. **This is not a correctness fix.**

**The win is cost:**

| | control | this PR |
|---|---|---|
| median duration | 572s | 359s (−37%) |
| median turns | 32 | 10 |
| total tool calls (8 runs) | 308 | 152 |

Catalog interactions across 8 runs go from 17 `Read` + 13 `Grep` + 12 `Bash` + 4 `Glob` — 9 of those reads paged with `offset`/`limit` — to 24 plain `Read`s with no paging, no Bash and no Grep at all.

Caveats: n=2 per cell; one prompt (`pdf-report`) moved only −2%, so the gain isn't uniform. Some other rules improved too (`no-read-back-of-own-writes`, `no-template-lib-reads`) but those concern `/app` files and have no causal link to the catalog — the control arm simply did about twice as much of everything.

The harness changes used to measure this were a one-off and are deliberately not part of this PR.

Closes: GLITCH-513

🤖 Generated with [Claude Code](https://claude.com/claude-code)