### PR TITLE
test(data-apps): remove redundant config tests

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
@@ -161,22 +161,6 @@ describe('DataAppVizConfigTabs', () => {
         ]);
     });
 
-    it('renders no tab strip when the viz declares no options', () => {
-        renderWithProviders(<ConfigTabs />);
-
-        expect(screen.queryByRole('tab')).not.toBeInTheDocument();
-    });
-
-    it('builds one tab per declared group, ungrouped options collapsing into Display', () => {
-        mockSchema(declaredOptions);
-
-        renderWithProviders(<ConfigTabs />);
-
-        expect(
-            screen.getAllByRole('tab').map((tab) => tab.textContent),
-        ).toEqual(['General', 'Style', 'Display']);
-    });
-
     it('renders declared defaults when nothing is stored', async () => {
         const user = userEvent.setup();
         mockSchema(declaredOptions);

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizOptionTabs.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizOptionTabs.test.tsx
@@ -67,15 +67,6 @@ describe('DataAppVizOptionTabs', () => {
         expect(onChange).toHaveBeenCalledWith('showLegend', false);
     });
 
-    it("renders the caller's palette control in the tab the declaration names", async () => {
-        const user = userEvent.setup();
-        renderTabs(options, { group: 'Style' });
-
-        await user.click(screen.getByRole('tab', { name: 'Style' }));
-
-        expect(screen.getByTestId('palette')).toBeInTheDocument();
-    });
-
     it('shows the palette control once, in one tab only', async () => {
         const user = userEvent.setup();
         renderTabs(options, { group: 'Style' });

--- a/packages/frontend/src/features/apps/components/DataAppVizTestPanel.test.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizTestPanel.test.tsx
@@ -351,55 +351,6 @@ describe('DataAppVizTestPanel', () => {
         ).toBeDisabled();
     });
 
-    it('groups declared options into config tabs, defaults applied', async () => {
-        const user = userEvent.setup();
-        renderWithProviders(
-            <DataAppVizTestPanel
-                projectUuid="p1"
-                schema={{
-                    fields: schema.fields,
-                    configOptions: [
-                        {
-                            type: 'boolean',
-                            name: 'showLegend',
-                            label: 'Show legend',
-                            group: 'Style',
-                            default: true,
-                        },
-                    ],
-                    colorPalette: null,
-                }}
-                onContextChange={vi.fn()}
-            />,
-        );
-
-        expect(
-            screen.getAllByRole('tab').map((tab) => tab.textContent),
-        ).toEqual(['General', 'Style']);
-
-        await user.click(screen.getByRole('tab', { name: 'Style' }));
-        expect(screen.getByLabelText('Show legend')).toBeChecked();
-    });
-
-    it('offers the palette picker for a declared palette', async () => {
-        const user = userEvent.setup();
-        renderWithProviders(
-            <DataAppVizTestPanel
-                projectUuid="p1"
-                schema={{
-                    fields: schema.fields,
-                    configOptions: [],
-                    colorPalette: { group: 'Colours' },
-                }}
-                onContextChange={vi.fn()}
-            />,
-        );
-
-        await user.click(screen.getByRole('tab', { name: 'Colours' }));
-
-        expect(screen.getByText('Color palette')).toBeInTheDocument();
-    });
-
     it('republishes option edits after a successful query', async () => {
         const onContextChange = vi.fn();
         renderWithProviders(


### PR DESCRIPTION
## Summary

- remove outer config-tab tests already covered by the shared tab component
- remove a palette placement assertion subsumed by the stronger single-placement test
- keep panel-specific option and palette republishing coverage

## Tests

- pnpm -F frontend test src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizOptionTabs.test.tsx src/features/apps/components/DataAppVizTestPanel.test.tsx