### PR TITLE
feat(ai): make deep research reports available to chat

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -444,6 +444,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         models.getAiAgentMemoryModel<AiAgentMemoryModel>(),
                     aiAgentDocumentModel:
                         models.getAiAgentDocumentModel<AiAgentDocumentModel>(),
+                    aiDeepResearchRunModel:
+                        models.getAiDeepResearchRunModel<AiDeepResearchRunModel>(),
                     projectContextModel:
                         models.getProjectContextModel<ProjectContextModel>(),
                     catalogModel: models.getCatalogModel(),

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.test.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.test.ts
@@ -91,6 +91,41 @@ describe('AiDeepResearchRunModel', () => {
         ]);
     });
 
+    it('loads conversation runs by prompt within the organization and project', async () => {
+        tracker.on.select(AiDeepResearchRunsTableName).responseOnce([]);
+
+        await model.findByPromptUuidsScoped({
+            promptUuids: ['prompt-1', 'prompt-2'],
+            organizationUuid: 'organization-1',
+            projectUuid: 'project-1',
+        });
+
+        expect(tracker.history.select[0].bindings).toEqual([
+            'prompt-1',
+            'prompt-2',
+            'organization-1',
+            'project-1',
+        ]);
+        expect(tracker.history.select[0].sql).toContain(
+            'select "prompt_uuid", "result_markdown"',
+        );
+        expect(tracker.history.select[0].sql).not.toContain(
+            'result_chart_data',
+        );
+    });
+
+    it('does not query for an empty conversation', async () => {
+        await expect(
+            model.findByPromptUuidsScoped({
+                promptUuids: [],
+                organizationUuid: 'organization-1',
+                projectUuid: 'project-1',
+            }),
+        ).resolves.toEqual([]);
+
+        expect(tracker.history.select).toHaveLength(0);
+    });
+
     it('does not overwrite a cancellation request with completion', async () => {
         tracker.on.update(AiDeepResearchRunsTableName).responseOnce([]);
 

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
@@ -156,6 +156,26 @@ export class AiDeepResearchRunModel {
             .first();
     }
 
+    async findByPromptUuidsScoped(args: {
+        promptUuids: string[];
+        organizationUuid: string;
+        projectUuid: string;
+    }): Promise<
+        Pick<DbAiDeepResearchRun, 'prompt_uuid' | 'result_markdown'>[]
+    > {
+        if (args.promptUuids.length === 0) {
+            return [];
+        }
+
+        return this.database<AiDeepResearchRunsTable>(
+            AiDeepResearchRunsTableName,
+        )
+            .select('prompt_uuid', 'result_markdown')
+            .whereIn('prompt_uuid', args.promptUuids)
+            .where('organization_uuid', args.organizationUuid)
+            .where('project_uuid', args.projectUuid);
+    }
+
     async findByThreadScoped(args: {
         aiThreadUuid: string;
         organizationUuid: string;

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -217,6 +217,7 @@ import { ShareService } from '../../../services/ShareService/ShareService';
 import { SpaceService } from '../../../services/SpaceService/SpaceService';
 import { wrapSentryTransaction } from '../../../utils';
 import { validatePublicHttpUrl } from '../../../utils/ssrfProtection';
+import { type DbAiDeepResearchRun } from '../../database/entities/aiDeepResearch';
 import { AiAgentDocumentModel } from '../../models/AiAgentDocumentModel';
 import { AiAgentMemoryModel } from '../../models/AiAgentMemoryModel';
 import {
@@ -230,6 +231,7 @@ import {
 } from '../../models/AiAgentModel';
 import { AiAgentReviewClassifierModel } from '../../models/AiAgentReviewClassifierModel';
 import { AiAgentReviewNotificationModel } from '../../models/AiAgentReviewNotificationModel';
+import { AiDeepResearchRunModel } from '../../models/AiDeepResearchRunModel';
 import { CommercialSlackAuthenticationModel } from '../../models/CommercialSlackAuthenticationModel';
 import { ProjectContextModel } from '../../models/ProjectContextModel';
 import { CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
@@ -427,6 +429,10 @@ type AiAgentServiceDependencies = {
     aiAgentModel: AiAgentModel;
     aiAgentMemoryModel: AiAgentMemoryModel;
     aiAgentDocumentModel: AiAgentDocumentModel;
+    aiDeepResearchRunModel: Pick<
+        AiDeepResearchRunModel,
+        'findByPromptUuidsScoped'
+    >;
     projectContextModel: ProjectContextModel;
     analytics: LightdashAnalytics;
     asyncQueryService: AsyncQueryService;
@@ -644,6 +650,11 @@ export class AiAgentService extends BaseService {
     private readonly aiAgentMemoryModel: AiAgentMemoryModel;
 
     private readonly aiAgentDocumentModel: AiAgentDocumentModel;
+
+    private readonly aiDeepResearchRunModel: Pick<
+        AiDeepResearchRunModel,
+        'findByPromptUuidsScoped'
+    >;
 
     private readonly githubAppInstallationsModel: GithubAppInstallationsModel;
 
@@ -979,6 +990,7 @@ export class AiAgentService extends BaseService {
         this.aiAgentModel = dependencies.aiAgentModel;
         this.aiAgentMemoryModel = dependencies.aiAgentMemoryModel;
         this.aiAgentDocumentModel = dependencies.aiAgentDocumentModel;
+        this.aiDeepResearchRunModel = dependencies.aiDeepResearchRunModel;
         this.projectContextModel = dependencies.projectContextModel;
         this.analytics = dependencies.analytics;
         this.asyncQueryService = dependencies.asyncQueryService;
@@ -4661,8 +4673,26 @@ export class AiAgentService extends BaseService {
             },
         };
 
-        const serializedInput =
-            Compaction.serializeConversation(messagesToCompact);
+        const promptUuidsToCompact = [
+            ...new Set(messagesToCompact.map((message) => message.uuid)),
+        ];
+        const deepResearchRuns =
+            await this.aiDeepResearchRunModel.findByPromptUuidsScoped({
+                promptUuids: promptUuidsToCompact,
+                organizationUuid: user.organizationUuid,
+                projectUuid: prompt.projectUuid,
+            });
+        const deepResearchReportsByPromptUuid = new Map(
+            deepResearchRuns.flatMap((run) =>
+                run.result_markdown
+                    ? [[run.prompt_uuid, run.result_markdown] as const]
+                    : [],
+            ),
+        );
+        const serializedInput = Compaction.serializeConversation(
+            messagesToCompact,
+            { deepResearchReportsByPromptUuid },
+        );
 
         const summary = await generateCompactionSummary(compactionModel, {
             previousSummary: latestCompaction?.summary,
@@ -6761,6 +6791,23 @@ Use them as a reference, but do all the due dilligence and follow the instructio
         } satisfies UserModelMessage;
     }
 
+    static createDeepResearchContextMessage(
+        run: Pick<DbAiDeepResearchRun, 'result_markdown'> | undefined,
+    ): AssistantModelMessage | null {
+        if (!run?.result_markdown) {
+            return null;
+        }
+
+        return {
+            role: 'assistant',
+            content: [
+                '<deep_research_report>',
+                run.result_markdown,
+                '</deep_research_report>',
+            ].join('\n'),
+        } satisfies AssistantModelMessage;
+    }
+
     static createPinnedContextMessage(
         context: AiPromptContext,
     ): UserModelMessage | null {
@@ -7131,8 +7178,19 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             currentPromptUuid: string;
         },
     ): Promise<ModelMessage[]> {
-        const contextMap = await this.aiAgentModel.getContextForPromptUuids(
-            threadMessages.map((m) => m.ai_prompt_uuid),
+        const promptUuids = threadMessages.map(
+            (message) => message.ai_prompt_uuid,
+        );
+        const [contextMap, deepResearchRuns] = await Promise.all([
+            this.aiAgentModel.getContextForPromptUuids(promptUuids),
+            this.aiDeepResearchRunModel.findByPromptUuidsScoped({
+                promptUuids,
+                organizationUuid: options.organizationUuid,
+                projectUuid: options.projectUuid,
+            }),
+        ]);
+        const deepResearchRunsByPromptUuid = new Map(
+            deepResearchRuns.map((run) => [run.prompt_uuid, run]),
         );
 
         const messagesWithToolCalls = await Promise.all(
@@ -7204,7 +7262,16 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         toolCallsAndResults,
                     );
 
-                if (
+                const deepResearchContextMessage =
+                    AiAgentService.createDeepResearchContextMessage(
+                        deepResearchRunsByPromptUuid.get(
+                            message.ai_prompt_uuid,
+                        ),
+                    );
+
+                if (deepResearchContextMessage) {
+                    messages.push(deepResearchContextMessage);
+                } else if (
                     message.response &&
                     !message.error_message &&
                     (!hasUnresolvedApproval || !isCurrentPrompt)

--- a/packages/backend/src/ee/services/AiAgentService/deepResearchContextMessage.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/deepResearchContextMessage.test.ts
@@ -1,0 +1,137 @@
+import { AiAgentService } from './AiAgentService';
+
+vi.mock('../ai/AiAgentMcpRuntimeClient', () => ({
+    AiAgentMcpRuntimeClient: vi
+        .fn()
+        // eslint-disable-next-line prefer-arrow-callback
+        .mockImplementation(function MockAiAgentMcpRuntimeClient() {
+            return {};
+        }),
+}));
+
+describe('AiAgentService.createDeepResearchContextMessage', () => {
+    it('makes the report Markdown available as assistant context', () => {
+        const message = AiAgentService.createDeepResearchContextMessage({
+            result_markdown: '# Retention report\n\nRetention improved.',
+        });
+
+        expect(message).toEqual({
+            role: 'assistant',
+            content: expect.stringContaining(
+                '# Retention report\n\nRetention improved.',
+            ),
+        });
+    });
+
+    it('does not create context before a report is available', () => {
+        expect(
+            AiAgentService.createDeepResearchContextMessage({
+                result_markdown: null,
+            }),
+        ).toBeNull();
+        expect(
+            AiAgentService.createDeepResearchContextMessage(undefined),
+        ).toBeNull();
+    });
+});
+
+describe('AiAgentService deep research conversation history', () => {
+    it('replays a completed report for a follow-up prompt', async () => {
+        const aiDeepResearchRunModel = {
+            findByPromptUuidsScoped: vi.fn().mockResolvedValue([
+                {
+                    prompt_uuid: 'research-prompt',
+                    result_markdown: '# Retention report',
+                },
+            ]),
+        };
+        const service = new AiAgentService({
+            aiAgentModel: {
+                getContextForPromptUuids: vi.fn().mockResolvedValue(new Map()),
+                getToolCallsAndResultsForPrompt: vi.fn().mockResolvedValue([]),
+            },
+            aiDeepResearchRunModel,
+            lightdashConfig: {},
+        } as unknown as ConstructorParameters<typeof AiAgentService>[0]);
+
+        const history = await service.getChatHistoryFromThreadMessages(
+            [
+                {
+                    ai_prompt_uuid: 'research-prompt',
+                    prompt: 'Research retention',
+                    response: null,
+                    error_message: null,
+                    human_score: null,
+                    human_feedback: null,
+                },
+            ] as never,
+            {
+                organizationUuid: 'organization-1',
+                projectUuid: 'project-1',
+                agentUuid: 'agent-1',
+                retrieveRelevantArtifacts: false,
+                compaction: null,
+                currentPromptUuid: 'follow-up-prompt',
+            },
+        );
+
+        expect(
+            aiDeepResearchRunModel.findByPromptUuidsScoped,
+        ).toHaveBeenCalledWith({
+            promptUuids: ['research-prompt'],
+            organizationUuid: 'organization-1',
+            projectUuid: 'project-1',
+        });
+        expect(history).toEqual([
+            { role: 'user', content: 'Research retention' },
+            {
+                role: 'assistant',
+                content: expect.stringContaining('# Retention report'),
+            },
+        ]);
+    });
+
+    it('keeps the ordinary response when a research report is incomplete', async () => {
+        const service = new AiAgentService({
+            aiAgentModel: {
+                getContextForPromptUuids: vi.fn().mockResolvedValue(new Map()),
+                getToolCallsAndResultsForPrompt: vi.fn().mockResolvedValue([]),
+            },
+            aiDeepResearchRunModel: {
+                findByPromptUuidsScoped: vi.fn().mockResolvedValue([
+                    {
+                        prompt_uuid: 'research-prompt',
+                        result_markdown: null,
+                    },
+                ]),
+            },
+            lightdashConfig: {},
+        } as unknown as ConstructorParameters<typeof AiAgentService>[0]);
+
+        const history = await service.getChatHistoryFromThreadMessages(
+            [
+                {
+                    ai_prompt_uuid: 'research-prompt',
+                    prompt: 'Research retention',
+                    response: 'The ordinary response',
+                    error_message: null,
+                    human_score: null,
+                    human_feedback: null,
+                },
+            ] as never,
+            {
+                organizationUuid: 'organization-1',
+                projectUuid: 'project-1',
+                agentUuid: 'agent-1',
+                retrieveRelevantArtifacts: false,
+                compaction: null,
+                currentPromptUuid: 'follow-up-prompt',
+            },
+        );
+
+        expect(history).toEqual([
+            { role: 'user', content: 'Research retention' },
+            { role: 'assistant', content: 'The ordinary response' },
+        ]);
+    });
+});

--- a/packages/backend/src/ee/services/ai/compaction.test.ts
+++ b/packages/backend/src/ee/services/ai/compaction.test.ts
@@ -101,6 +101,41 @@ describe('AI context compaction helpers', () => {
         expect(serialized).toContain('[truncated 500 chars]');
     });
 
+    it('includes deep research Markdown in the compaction input', () => {
+        const serialized = Compaction.serializeConversation(
+            [
+                {
+                    role: 'assistant',
+                    status: 'idle',
+                    uuid: 'research-prompt',
+                    threadUuid: 'thread-1',
+                    message: null,
+                    errorMessage: null,
+                    interrupted: false,
+                    createdAt: new Date().toISOString(),
+                    humanScore: null,
+                    toolCalls: [],
+                    toolResults: [],
+                    reasoning: [],
+                    savedQueryUuid: null,
+                    artifacts: null,
+                    referencedArtifacts: null,
+                    modelConfig: null,
+                    tokenUsage: null,
+                },
+            ],
+            {
+                deepResearchReportsByPromptUuid: new Map([
+                    ['research-prompt', '# Retention report'],
+                ]),
+            },
+        );
+
+        expect(serialized).toContain(
+            '[Deep research report]: # Retention report',
+        );
+    });
+
     it('serializes a same-named file and repository as distinct, unambiguous lines', () => {
         const serialized = Compaction.serializeConversation([
             {

--- a/packages/backend/src/ee/services/ai/compaction.ts
+++ b/packages/backend/src/ee/services/ai/compaction.ts
@@ -89,7 +89,12 @@ export class Compaction {
         return threadMessages.slice(compactedThroughIndex + 1);
     }
 
-    static serializeConversation(messages: AiAgentMessage[]): string {
+    static serializeConversation(
+        messages: AiAgentMessage[],
+        options?: {
+            deepResearchReportsByPromptUuid?: ReadonlyMap<string, string>;
+        },
+    ): string {
         const lines: string[] = [];
 
         for (const message of messages) {
@@ -101,6 +106,12 @@ export class Compaction {
             } else {
                 if (message.message) {
                     lines.push(`[Assistant]: ${message.message}`);
+                }
+
+                const deepResearchReport =
+                    options?.deepResearchReportsByPromptUuid?.get(message.uuid);
+                if (deepResearchReport) {
+                    lines.push(`[Deep research report]: ${deepResearchReport}`);
                 }
 
                 if (message.toolCalls.length > 0) {


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9160/deep-research-document-should-be-accessible-to-the-chat

## Description:

Makes completed deep-research Markdown available to later chat turns as the prior assistant response. Includes the report in compaction input so follow-up context survives old prompt removal, while chart snapshots stay outside model context.

```text
Research prompt
  ├─ active history ──> report Markdown ──> follow-up
  └─ compaction ──────> report Markdown ──> summary
```

## Test plan:

- `pnpm -F backend exec vitest run --config vitest.config.ts src/ee/models/AiDeepResearchRunModel.test.ts src/ee/services/AiAgentService/deepResearchContextMessage.test.ts src/ee/services/ai/compaction.test.ts`
- `pnpm -F backend typecheck:fast`
- Changed-file ESLint and oxfmt checks