### PR TITLE
fix: fall back to a blank preview DB volume when a diverted deploy fails

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -355,7 +355,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           name: pr-${{ github.event.number }}
-          timeout: 15m
+          # Generous enough for a failed snapshot divert plus the blank-volume
+          # retry with a full migrate + seed (see okteto.preview.yaml)
+          timeout: 30m
           file: okteto.preview.yaml
           variables: SITE_URL=https://lightdash-preview-pr-${{ github.event.number }}.lightdash.okteto.dev,DB_DIVERT=${{ needs.files-changed.outputs.db_divert }}
 

--- a/okteto.preview.yaml
+++ b/okteto.preview.yaml
@@ -46,4 +46,20 @@ deploy:
         # entrypoint always re-runs against the recreated database
         kubectl delete deployment lightdash-preview --ignore-not-found --wait
     - name: Deploying compose...
-      command: okteto deploy -f docker/docker-compose.preview.yml
+      command: |
+        set -e
+        if [ -n "${DB_SNAPSHOT_NAME:-}" ]; then
+          # Divert must never break preview creation: cloning can fail at
+          # deploy time (e.g. GCP throttles disk creation per source snapshot
+          # when several previews deploy at once). Recreate the volume blank
+          # and take the full migrate + seed path instead.
+          if ! okteto deploy -f docker/docker-compose.preview.yml; then
+            echo "Diverted deploy failed: retrying with a blank database volume"
+            kubectl delete statefulset db-preview --ignore-not-found --wait
+            kubectl delete pvc db-data --ignore-not-found --wait
+            export DB_SNAPSHOT_NAME="" DB_SNAPSHOT_NAMESPACE=""
+            okteto deploy -f docker/docker-compose.preview.yml
+          fi
+        else
+          okteto deploy -f docker/docker-compose.preview.yml
+        fi


### PR DESCRIPTION
A preview deploy [failed](https://github.com/lightdash/lightdash/actions/runs/30370182039/job/90323773770) with GCP `RESOURCE_OPERATION_RATE_EXCEEDED`: GCP throttles disk-creation operations per **source snapshot**, so several previews cloning the pre-seeded snapshot within a short window can fail at volume-provision time — and that failure took the whole preview deploy down, breaking the "divert must never break preview creation" guarantee.

Fix: when a *diverted* deploy fails, delete the half-provisioned volume and redeploy with a blank one, taking the existing full migrate + seed path (slow but green). Non-diverted deploys are unchanged — no blanket retry that would mask genuine app failures twice as slowly. The okteto `deploy-preview` timeout goes from 15m to 30m so the fallback attempt fits in the window.

The original failure is transient — re-running the affected PR's checks succeeds — but bursty deploy traffic will keep tripping the per-snapshot rate limit occasionally, so the deploy needs to self-heal.

Relates: SPK-297

https://claude.ai/code/session_01RmebrVJwigL6JnggGwpzQR