### PR TITLE
fix(homepage): hide Ask AI blocks when no agent is configured

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility.ts
@@ -6,11 +6,21 @@ import { useAiAgentPermission } from './useAiAgentPermission';
 import { useAiOrganizationSettings } from './useAiOrganizationSettings';
 import { useProjectAiAgents } from './useProjectAiAgents';
 
+type AiAgentVisibility = {
+    /** AI surfaces may be shown — true for anyone who can manage agents, even
+     * when none exist yet. */
+    isVisible: boolean;
+    /** At least one agent is configured in the active project. */
+    hasAgents: boolean;
+    isLoading: boolean;
+};
+
 /**
- * This hook is used to determine if the ai agent button should be visible
- * @returns true if the ai agent button should be visible
+ * Resolves whether AI agent surfaces should be shown, and whether an agent is
+ * actually configured — callers that can't render anything useful without one
+ * (see `useHomepageAiEnabled`) need to tell those two cases apart.
  */
-export const useAiAgentButtonVisibility = () => {
+export const useAiAgentVisibility = (): AiAgentVisibility => {
     const activeProjectQuery = useActiveProject();
     const projectUuid = activeProjectQuery.data ?? undefined;
 
@@ -41,6 +51,8 @@ export const useAiAgentButtonVisibility = () => {
         CommercialFeatureFlags.AiCopilot,
     );
 
+    const hasAgents = !!agentsQuery.data && agentsQuery.data.length > 0;
+
     if (
         agentsQuery.isLoading ||
         aiOrganizationSettingsQuery.isLoading ||
@@ -48,25 +60,28 @@ export const useAiAgentButtonVisibility = () => {
         appQuery.health.isLoading ||
         aiCopilotFlagQuery.isLoading
     ) {
-        return false;
+        return { isVisible: false, hasAgents, isLoading: true };
     }
 
-    const hasAgents = agentsQuery.data && agentsQuery.data.length > 0;
     const canViewButton = (canViewAiAgents && hasAgents) || canManageAiAgents;
     const isAiAgentEnabled = aiOrganizationSettingsQuery.data?.aiAgentsVisible;
     const isAiCopilotEnabledOrTrial =
         aiCopilotFlagQuery.data?.enabled ||
         aiOrganizationSettingsQuery.data?.isTrial;
 
-    if (
-        !canViewButton ||
-        !canViewAiAgents ||
-        !isAiAgentEnabled ||
-        !projectUuid ||
-        !isAiCopilotEnabledOrTrial
-    ) {
-        return false;
-    }
+    const isVisible =
+        !!canViewButton &&
+        !!canViewAiAgents &&
+        !!isAiAgentEnabled &&
+        !!projectUuid &&
+        !!isAiCopilotEnabledOrTrial;
 
-    return true;
+    return { isVisible, hasAgents, isLoading: false };
 };
+
+/**
+ * This hook is used to determine if the ai agent button should be visible
+ * @returns true if the ai agent button should be visible
+ */
+export const useAiAgentButtonVisibility = () =>
+    useAiAgentVisibility().isVisible;

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.tsx
@@ -7,12 +7,12 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import FavoritesPanel from '../../../components/FavoritesPanel';
 import PinnedItemsPanel from '../../../components/PinnedItemsPanel';
 import useApp from '../../../providers/App/useApp';
-import { useAiAgentButtonVisibility } from '../aiCopilot/hooks/useAiAgentsButtonVisibility';
 import { AskAiHero } from './blocks/AskAiHeroBlock';
 import { getDefaultQuickActions } from './blocks/quickActionDefaults';
 import { QuickActionCards } from './blocks/QuickActionsBlock';
 import classes from './DayOneHomepage.module.css';
 import layout from './homepageLayout.module.css';
+import { useHomepageAiEnabled } from './hooks/useHomepageAiEnabled';
 
 type Props = {
     projectUuid: string;
@@ -30,7 +30,7 @@ export const DayOneHomepage: FC<Props> = ({
     pinnedIsEnabled,
 }) => {
     const { user } = useApp();
-    const isAiEnabled = useAiAgentButtonVisibility();
+    const isAiEnabled = useHomepageAiEnabled();
 
     return (
         <div className={layout.page}>

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageBuilderPage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageBuilderPage.tsx
@@ -14,8 +14,10 @@ import ForbiddenPanel from '../../../components/ForbiddenPanel';
 import PageSpinner from '../../../components/PageSpinner';
 import useApp from '../../../providers/App/useApp';
 import { useIsCopilotEnabled } from '../aiCopilot/hooks/useIsCopilotEnabled';
+import { getDefaultQuickActions } from './blocks/quickActionDefaults';
 import { CreateHomepageModal } from './CreateHomepageModal';
 import { HomepageEditor } from './HomepageEditor';
+import { useHomepageAiState } from './hooks/useHomepageAiEnabled';
 import {
     useCreateHomepageWithDraft,
     useHomepageBuilderFlag,
@@ -39,6 +41,7 @@ export const HomepageBuilderPage: FC = () => {
         useHomepageBuilderFlag();
     const { isCopilotEnabled, isLoading: isCopilotLoading } =
         useIsCopilotEnabled();
+    const { isAiEnabled, isLoading: isAiStateLoading } = useHomepageAiState();
     const homepage = useHomepageForBuilder(projectUuid, {
         enabled: isFlagEnabled,
         homepageUuid: selectedHomepageUuid,
@@ -73,6 +76,9 @@ export const HomepageBuilderPage: FC = () => {
     const shouldAutoCreate =
         isFlagEnabled &&
         isCopilotEnabled &&
+        // The seed depends on whether an agent is configured, so don't create
+        // until that is known.
+        !isAiStateLoading &&
         canManage &&
         !!projectUuid &&
         homepage.isFetchedAfterMount &&
@@ -91,11 +97,23 @@ export const HomepageBuilderPage: FC = () => {
                         {
                             id: uuidv4(),
                             blocks: [
-                                {
-                                    id: uuidv4(),
-                                    type: 'ask-ai-hero',
-                                    config: { showGreeting: true },
-                                },
+                                // Without a configured agent the Ask AI hero
+                                // isn't offered at all, so seed the next best
+                                // starting point.
+                                isAiEnabled
+                                    ? {
+                                          id: uuidv4(),
+                                          type: 'ask-ai-hero',
+                                          config: { showGreeting: true },
+                                      }
+                                    : {
+                                          id: uuidv4(),
+                                          type: 'quick-actions',
+                                          config: {
+                                              actions:
+                                                  getDefaultQuickActions(false),
+                                          },
+                                      },
                             ],
                         },
                     ],
@@ -103,7 +121,7 @@ export const HomepageBuilderPage: FC = () => {
             },
             { onSuccess: openHomepage },
         );
-    }, [shouldAutoCreate, createFirstHomepage, openHomepage]);
+    }, [shouldAutoCreate, createFirstHomepage, openHomepage, isAiEnabled]);
 
     if (isFlagLoading || isCopilotLoading) {
         return <PageSpinner />;

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
@@ -60,7 +60,6 @@ import { Fragment, useEffect, useMemo, useRef, useState, type FC } from 'react';
 import { useNavigate } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
 import MantineModal from '../../../components/common/MantineModal';
-import { useAiAgentButtonVisibility } from '../aiCopilot/hooks/useAiAgentsButtonVisibility';
 import { TIER_CLASS, traitFor } from './blockLayout';
 import { IconSquare } from './blocks/BlockShell';
 import {
@@ -86,6 +85,7 @@ import {
 } from './configOps';
 import classes from './HomepageEditor.module.css';
 import layout from './homepageLayout.module.css';
+import { useHomepageAiEnabled } from './hooks/useHomepageAiEnabled';
 import {
     useDeleteHomepage,
     useDiscardHomepageDraft,
@@ -483,7 +483,7 @@ export const HomepageEditor: FC<Props> = ({
     const [isDiscardModalOpen, setIsDiscardModalOpen] = useState(false);
     const [isPublishModalOpen, setIsPublishModalOpen] = useState(false);
 
-    const isAiEnabled = useAiAgentButtonVisibility();
+    const isAiEnabled = useHomepageAiEnabled();
 
     const [draft, setDraft] = useState<HomepageConfig>(() =>
         migrateHomepageConfig(homepage.draftConfig),

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.test.tsx
@@ -7,6 +7,20 @@ import { PublishedHomepage } from './PublishedHomepage';
 vi.mock('../../../providers/App/useApp', () => ({
     default: () => ({ user: { data: { firstName: 'Test' } } }),
 }));
+const mockIsAiEnabled = vi.hoisted(() => ({ value: true }));
+vi.mock('./hooks/useHomepageAiEnabled', () => ({
+    useHomepageAiEnabled: () => mockIsAiEnabled.value,
+}));
+vi.mock('./DayOneAskInput', () => ({
+    DayOneAskInput: () => <div data-testid="ask-input" />,
+}));
+vi.mock('./blocks/useRecommendedActions', () => ({
+    useRecommendedActions: () => ({ hasPendingActions: false }),
+}));
+
+afterEach(() => {
+    mockIsAiEnabled.value = true;
+});
 
 const config: HomepageConfig = {
     version: 1,
@@ -30,5 +44,35 @@ it('renders markdown blocks', () => {
             <PublishedHomepage config={config} projectUuid="p1" />
         </MantineProvider>,
     );
+    expect(screen.getByText(/Hello team/)).toBeInTheDocument();
+});
+
+it('leaves no empty hero behind when no agent is configured', () => {
+    mockIsAiEnabled.value = false;
+    const { container } = render(
+        <MantineProvider>
+            <PublishedHomepage
+                config={{
+                    version: 1,
+                    rows: [
+                        {
+                            id: 'r1',
+                            blocks: [
+                                {
+                                    id: 'b1',
+                                    type: 'ask-ai-hero',
+                                    config: { showGreeting: false },
+                                },
+                            ],
+                        },
+                        ...config.rows,
+                    ],
+                }}
+                projectUuid="p1"
+            />
+        </MantineProvider>,
+    );
+    expect(screen.queryByTestId('ask-input')).toBeNull();
+    expect(container.querySelectorAll('[data-presentation]')).toHaveLength(0);
     expect(screen.getByText(/Hello team/)).toBeInTheDocument();
 });

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
@@ -4,15 +4,17 @@ import {
     type HomepageConfig,
 } from '@lightdash/common';
 import { Box, Paper, Text } from '@mantine-8/core';
-import { type FC, type ReactNode } from 'react';
+import { useMemo, type FC, type ReactNode } from 'react';
 import { TIER_CLASS } from './blockLayout';
 import { getBlockDefinition } from './blocks/registry';
 import { type BlockPresentation } from './blocks/types';
 import layout from './homepageLayout.module.css';
+import { useHomepageAiEnabled } from './hooks/useHomepageAiEnabled';
 import {
     resolveHomepageLayout,
     type ResolvedRow,
 } from './resolveHomepageLayout';
+import { stripUnavailableAiBlocks } from './stripAiBlocks';
 
 const PERSONAL_BLOCK_TYPES: HomepageBlock['type'][] = ['favorites', 'recent'];
 
@@ -108,7 +110,13 @@ export const PublishedHomepage: FC<Props> = ({
     personalPlaceholders = false,
     topBar = null,
 }) => {
-    const { hero, rows } = resolveHomepageLayout(migrateHomepageConfig(config));
+    const isAiEnabled = useHomepageAiEnabled();
+    const { hero, rows } = useMemo(() => {
+        const migrated = migrateHomepageConfig(config);
+        return resolveHomepageLayout(
+            isAiEnabled ? migrated : stripUnavailableAiBlocks(migrated),
+        );
+    }, [config, isAiEnabled]);
 
     return (
         <div className={layout.page}>

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.test.tsx
@@ -6,8 +6,9 @@ import { AskAiHeroBlockBuild, AskAiHeroBlockView } from './AskAiHeroBlock';
 vi.mock('../DayOneAskInput', () => ({
     DayOneAskInput: () => <div data-testid="ask-input" />,
 }));
-vi.mock('../../aiCopilot/hooks/useAiAgentsButtonVisibility', () => ({
-    useAiAgentButtonVisibility: () => true,
+const mockIsAiEnabled = vi.hoisted(() => ({ value: true }));
+vi.mock('../hooks/useHomepageAiEnabled', () => ({
+    useHomepageAiEnabled: () => mockIsAiEnabled.value,
 }));
 vi.mock('../../../../providers/App/useApp', () => ({
     default: () => ({ user: { data: { firstName: 'Test' } } }),
@@ -65,6 +66,40 @@ describe('AskAiHeroBlockView', () => {
         );
         expect(screen.queryByText(/What do you want to know/)).toBeNull();
         expect(screen.getByTestId('ask-input')).toBeInTheDocument();
+    });
+
+    describe('without a configured agent', () => {
+        beforeEach(() => {
+            mockIsAiEnabled.value = false;
+        });
+        afterEach(() => {
+            mockIsAiEnabled.value = true;
+        });
+
+        it('keeps the greeting as a plain header, without the composer', () => {
+            wrap(
+                <AskAiHeroBlockView
+                    itemSpan={null}
+                    block={block}
+                    projectUuid="p1"
+                />,
+            );
+            expect(screen.getByText(/^Good /)).toBeInTheDocument();
+            expect(screen.queryByText(/What do you want to know/)).toBeNull();
+            expect(screen.queryByTestId('ask-input')).toBeNull();
+        });
+
+        it('renders nothing when the greeting is off', () => {
+            wrap(
+                <AskAiHeroBlockView
+                    itemSpan={null}
+                    block={{ ...block, config: { showGreeting: false } }}
+                    projectUuid="p1"
+                />,
+            );
+            expect(screen.queryByRole('heading')).toBeNull();
+            expect(screen.queryByTestId('ask-input')).toBeNull();
+        });
     });
 });
 

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.tsx
@@ -1,12 +1,26 @@
 import { Box, Stack, Switch, Text } from '@mantine-8/core';
 import { type FC } from 'react';
 import useApp from '../../../../providers/App/useApp';
-import { useAiAgentButtonVisibility } from '../../aiCopilot/hooks/useAiAgentsButtonVisibility';
 import { DayOneAskInput } from '../DayOneAskInput';
 import { getGreeting } from '../greeting';
+import { useHomepageAiEnabled } from '../hooks/useHomepageAiEnabled';
 import { RecommendedActionsChecklist } from './RecommendedActionsChecklist';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 import { useRecommendedActions } from './useRecommendedActions';
+
+export const HeroHeading: FC<{ children: string }> = ({ children }) => (
+    <Text
+        component="h1"
+        fz={23}
+        fw={600}
+        lts="-0.02em"
+        lh={1.2}
+        ta="center"
+        m={0}
+    >
+        {children}
+    </Text>
+);
 
 // The day-0 hero, as a reusable unit: greeting + the real agent chat
 // composer with live suggestions. Shared between DayOneHomepage (always
@@ -31,18 +45,9 @@ export const AskAiHero: FC<{
     return (
         <Stack gap={16} align="center" w="100%">
             {showGreeting && (
-                <Text
-                    component="h1"
-                    fz={23}
-                    fw={600}
-                    lts="-0.02em"
-                    lh={1.2}
-                    ta="center"
-                    m={0}
-                >
-                    {getGreeting(user.data?.firstName)}. What do you want to
-                    know?
-                </Text>
+                <HeroHeading>{`${getGreeting(
+                    user.data?.firstName,
+                )}. What do you want to know?`}</HeroHeading>
             )}
             <Box w="100%">
                 <DayOneAskInput projectUuid={projectUuid} preview={preview} />
@@ -61,8 +66,17 @@ export const AskAiHeroBlockView: FC<BlockComponentProps> = ({
     block,
     projectUuid,
 }) => {
-    const isAiEnabled = useAiAgentButtonVisibility();
-    if (block.type !== 'ask-ai-hero' || !isAiEnabled) return null;
+    const { user } = useApp();
+    const isAiEnabled = useHomepageAiEnabled();
+    if (block.type !== 'ask-ai-hero') return null;
+    // No agent to talk to: keep the greeting as a plain page header and drop
+    // the composer. Greeting-less heroes never reach here — stripAiBlocks
+    // removes them from the config before the layout is resolved.
+    if (!isAiEnabled) {
+        return block.config.showGreeting ? (
+            <HeroHeading>{getGreeting(user.data?.firstName)}</HeroHeading>
+        ) : null;
+    }
     // The greeting follows its toggle regardless of the block's position; it
     // still renders inline mid-page rather than only in the hero slot.
     return (

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/QuickActionsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/QuickActionsBlock.tsx
@@ -30,7 +30,7 @@ import MantineModal from '../../../../components/common/MantineModal';
 import { useInfiniteContent } from '../../../../hooks/useContent';
 import useTracking from '../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../types/Events';
-import { useAiAgentButtonVisibility } from '../../aiCopilot/hooks/useAiAgentsButtonVisibility';
+import { useHomepageAiEnabled } from '../hooks/useHomepageAiEnabled';
 import classes from './blockStyles.module.css';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
@@ -92,7 +92,7 @@ export const QuickActionCards: FC<{
     projectUuid: string;
 }> = ({ actions, projectUuid }) => {
     const { track } = useTracking();
-    const isAiEnabled = useAiAgentButtonVisibility();
+    const isAiEnabled = useHomepageAiEnabled();
     const visibleActions = actions.filter(
         (action) => action.type !== 'ask-ai' || isAiEnabled,
     );
@@ -210,6 +210,7 @@ export const QuickActionsBlockBuild: FC<BuildComponentProps> = ({
     onChange,
 }) => {
     const [isDashboardPickerOpen, setIsDashboardPickerOpen] = useState(false);
+    const isAiEnabled = useHomepageAiEnabled();
     if (block.type !== 'quick-actions') return null;
 
     const setActions = (actions: HomepageQuickAction[]) =>
@@ -226,7 +227,9 @@ export const QuickActionsBlockBuild: FC<BuildComponentProps> = ({
     const missingStatics = (
         Object.keys(STATIC_ACTIONS) as Array<keyof typeof STATIC_ACTIONS>
     ).filter(
-        (type) => !block.config.actions.some((action) => action.type === type),
+        (type) =>
+            (type !== 'ask-ai' || isAiEnabled) &&
+            !block.config.actions.some((action) => action.type === type),
     );
 
     return (

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useHomepageAiEnabled.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useHomepageAiEnabled.ts
@@ -1,0 +1,21 @@
+import { useAiAgentVisibility } from '../../aiCopilot/hooks/useAiAgentsButtonVisibility';
+
+type HomepageAiState = {
+    /** The homepage should surface its Ask AI blocks. */
+    isAiEnabled: boolean;
+    isLoading: boolean;
+};
+
+/**
+ * Stricter than `useAiAgentButtonVisibility`, which is also true for anyone who
+ * can *manage* agents when none exist — good enough for a nav button, but on the
+ * homepage that turns the hero into an empty composer nudging admins to go set
+ * an agent up. Here an agent has to actually be configured.
+ */
+export const useHomepageAiState = (): HomepageAiState => {
+    const { isVisible, hasAgents, isLoading } = useAiAgentVisibility();
+    return { isAiEnabled: isVisible && hasAgents, isLoading };
+};
+
+export const useHomepageAiEnabled = (): boolean =>
+    useHomepageAiState().isAiEnabled;

--- a/packages/frontend/src/ee/features/homepageBuilder/stripAiBlocks.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/stripAiBlocks.test.ts
@@ -1,0 +1,109 @@
+import { type HomepageConfig } from '@lightdash/common';
+import { stripUnavailableAiBlocks } from './stripAiBlocks';
+
+const config = (rows: HomepageConfig['rows']): HomepageConfig => ({
+    version: 1,
+    rows,
+});
+
+it('keeps a hero that still greets, drops one that only composes', () => {
+    const greeting = stripUnavailableAiBlocks(
+        config([
+            {
+                id: 'r1',
+                blocks: [
+                    {
+                        id: 'b1',
+                        type: 'ask-ai-hero',
+                        config: { showGreeting: true },
+                    },
+                ],
+            },
+        ]),
+    );
+    expect(greeting.rows).toHaveLength(1);
+
+    const composerOnly = stripUnavailableAiBlocks(
+        config([
+            {
+                id: 'r1',
+                blocks: [
+                    {
+                        id: 'b1',
+                        type: 'ask-ai-hero',
+                        config: { showGreeting: false },
+                    },
+                ],
+            },
+        ]),
+    );
+    expect(composerOnly.rows).toEqual([]);
+});
+
+it('drops the ask-ai quick action but keeps the rest', () => {
+    const result = stripUnavailableAiBlocks(
+        config([
+            {
+                id: 'r1',
+                blocks: [
+                    {
+                        id: 'b1',
+                        type: 'quick-actions',
+                        config: {
+                            actions: [
+                                { type: 'ask-ai' },
+                                { type: 'run-query' },
+                            ],
+                        },
+                    },
+                ],
+            },
+        ]),
+    );
+    expect(result.rows[0].blocks[0]).toEqual({
+        id: 'b1',
+        type: 'quick-actions',
+        config: { actions: [{ type: 'run-query' }] },
+    });
+});
+
+it('drops a quick-actions block left with nothing to show', () => {
+    const result = stripUnavailableAiBlocks(
+        config([
+            {
+                id: 'r1',
+                blocks: [
+                    {
+                        id: 'b1',
+                        type: 'quick-actions',
+                        config: { actions: [{ type: 'ask-ai' }] },
+                    },
+                ],
+            },
+            {
+                id: 'r2',
+                blocks: [
+                    {
+                        id: 'b2',
+                        type: 'markdown',
+                        config: { content: '# Hello' },
+                    },
+                ],
+            },
+        ]),
+    );
+    expect(result.rows.map((row) => row.id)).toEqual(['r2']);
+});
+
+it('leaves non-AI blocks untouched', () => {
+    const rows: HomepageConfig['rows'] = [
+        {
+            id: 'r1',
+            blocks: [
+                { id: 'b1', type: 'markdown', config: { content: '# Hi' } },
+                { id: 'b2', type: 'favorites', config: { title: 'Favorites' } },
+            ],
+        },
+    ];
+    expect(stripUnavailableAiBlocks(config(rows)).rows).toEqual(rows);
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/stripAiBlocks.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/stripAiBlocks.ts
@@ -1,0 +1,37 @@
+import { type HomepageBlock, type HomepageConfig } from '@lightdash/common';
+
+// With no agent configured the Ask AI surfaces have nothing to talk to, so they
+// are dropped from the config before the layout is resolved — otherwise the
+// resolver hoists a block that renders nothing into the hero slot, leaving a
+// blank first screen. A hero that still greets is kept: the greeting alone is a
+// valid page header (see AskAiHeroBlockView).
+const stripBlock = (block: HomepageBlock): HomepageBlock | null => {
+    switch (block.type) {
+        case 'ask-ai-hero':
+            return block.config.showGreeting ? block : null;
+        case 'quick-actions': {
+            const actions = block.config.actions.filter(
+                (action) => action.type !== 'ask-ai',
+            );
+            return actions.length > 0
+                ? { ...block, config: { ...block.config, actions } }
+                : null;
+        }
+        default:
+            return block;
+    }
+};
+
+export const stripUnavailableAiBlocks = (
+    config: HomepageConfig,
+): HomepageConfig => ({
+    ...config,
+    rows: config.rows
+        .map((row) => ({
+            ...row,
+            blocks: row.blocks
+                .map(stripBlock)
+                .filter((block): block is HomepageBlock => block !== null),
+        }))
+        .filter((row) => row.blocks.length > 0),
+});


### PR DESCRIPTION
### Description:

The homepage treated "copilot enabled" as "AI is usable", so an org with the flag on but no agent created got a full-viewport hero that rendered nothing (or, for admins, a dashed *"set up an AI agent"* box), plus an `ask-ai` quick action that was filtered out at render leaving a blank column.

The signal is now `useHomepageAiEnabled` — AI surfaces visible **and** at least one agent actually configured — used everywhere the homepage touches AI. `useAiAgentButtonVisibility` is unchanged for its other callers; it's refactored into `useAiAgentVisibility`, which also reports `hasAgents` and `isLoading`.

With no agent configured:
- Ask AI surfaces are stripped from the config *before* the layout is resolved (`stripAiBlocks.ts`), so the resolver never hoists an empty hero and no blank column is left behind. A hero with its greeting toggle on keeps the greeting as a plain page header.
- The Ask AI block and the `ask-ai` quick action are no longer offered in the builder.
- The first auto-created homepage seeds a quick-actions block instead of an Ask AI hero.
- `DayOneHomepage` now falls into its existing no-AI welcome variant for admins too, rather than showing the agent-setup nudge inside a viewport-height hero.

No backend change: the day-1 provisioned config still contains the Ask AI hero, so it starts working as soon as an agent is created.

Verified with unit tests (new coverage for `stripAiBlocks`, the no-agent hero, and the empty-hero case), typecheck and lint — this sandbox has no dev server or database, so the pages weren't driven in a browser.
