### PR TITLE
feat(scim): provision organization custom roles

### DIFF
--- a/packages/backend/src/ee/services/ScimService/ScimService.mock.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.mock.ts
@@ -103,6 +103,18 @@ export const mockProjects = [
     },
 ];
 
+export const mockOrganizationCustomRole: Role = {
+    roleUuid: 'custom-organization-role-uuid',
+    name: 'Custom Organization Role',
+    description: 'Custom organization role',
+    level: 'organization',
+    organizationUuid: 'org-uuid',
+    ownerType: 'user',
+    createdBy: 'test-user-uuid',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+};
+
 // Mock custom roles for testing
 export const mockCustomRoles: Role[] = [
     {
@@ -127,6 +139,7 @@ export const mockCustomRoles: Role[] = [
         createdAt: new Date(),
         updatedAt: new Date(),
     },
+    mockOrganizationCustomRole,
 ];
 
 // Mock organization member profile model

--- a/packages/backend/src/ee/services/ScimService/ScimService.test.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.test.ts
@@ -25,6 +25,17 @@ describe('ScimService', () => {
         type: 'Organization',
         primary: true,
     };
+    const organizationCustomRoleUser: LightdashUser = {
+        ...mockUser,
+        userId: 1,
+        roleUuid: mockOrganizationCustomRole.roleUuid,
+        isTrackingAnonymized: false,
+        isMarketingOptedIn: false,
+        isSetupComplete: true,
+        createdAt: mockUser.userCreatedAt,
+        updatedAt: mockUser.userUpdatedAt,
+        timezone: null,
+    };
 
     beforeEach(() => {
         vi.clearAllMocks();
@@ -300,9 +311,12 @@ describe('ScimService', () => {
         });
 
         test('should create user with an organization-level custom role', async () => {
-            const { rolesModel } = ScimServiceArgumentsMock;
+            const { rolesModel, userModel } = ScimServiceArgumentsMock;
+            vi.mocked(userModel.getUserDetailsByUuid).mockResolvedValueOnce(
+                organizationCustomRoleUser,
+            );
 
-            await service.createUser({
+            const result = await service.createUser({
                 account: mockScimAccount,
                 user: {
                     schemas: [ScimSchemaType.USER],
@@ -330,6 +344,50 @@ describe('ScimService', () => {
                 [],
                 true,
             );
+            expect(result.roles).toContainEqual(organizationCustomScimRole);
+        });
+
+        test('should reject a bare no-role value before creating a user', async () => {
+            const { organizationMemberProfileModel, userModel } =
+                ScimServiceArgumentsMock;
+
+            await expect(
+                service.createUser({
+                    account: mockScimAccount,
+                    user: {
+                        schemas: [ScimSchemaType.USER],
+                        userName: 'new-user@example.com',
+                        name: {
+                            givenName: 'New',
+                            familyName: 'User',
+                        },
+                        active: true,
+                        emails: [
+                            {
+                                value: 'new-user@example.com',
+                                primary: true,
+                            },
+                        ],
+                        roles: [
+                            {
+                                value: 'no-role',
+                                type: 'Organization',
+                                primary: true,
+                            },
+                        ],
+                    },
+                    organizationUuid: 'org-uuid',
+                }),
+            ).rejects.toMatchObject({
+                detail: 'Invalid role values: no-role',
+                status: '400',
+                scimType: 'invalidValue',
+            });
+
+            expect(userModel.createUser).not.toHaveBeenCalled();
+            expect(
+                organizationMemberProfileModel.createOrganizationMembershipByUuid,
+            ).not.toHaveBeenCalled();
         });
 
         test('should adopt orphan user (verified email but no organization) instead of creating', async () => {
@@ -763,6 +821,102 @@ describe('ScimService', () => {
             });
         });
 
+        test.each(['no-role', 'invalid-no-role'])(
+            'should reject invalid bare organization role value %s before updating the user',
+            async (roleValue) => {
+                const { rolesModel, userModel } = ScimServiceArgumentsMock;
+
+                await expect(
+                    service.updateUser({
+                        account: mockScimAccount,
+                        user: {
+                            schemas: [ScimSchemaType.USER],
+                            userName: mockUser.email,
+                            name: {
+                                givenName: mockUser.firstName,
+                                familyName: mockUser.lastName,
+                            },
+                            active: mockUser.isActive,
+                            emails: [
+                                {
+                                    value: mockUser.email,
+                                    primary: true,
+                                },
+                            ],
+                            roles: [
+                                {
+                                    value: roleValue,
+                                    type: 'Organization',
+                                    primary: true,
+                                },
+                            ],
+                        },
+                        userUuid: mockUser.userUuid,
+                        organizationUuid: mockUser.organizationUuid,
+                    }),
+                ).rejects.toMatchObject({
+                    detail: `Invalid role values: ${roleValue}`,
+                    status: '400',
+                    scimType: 'invalidValue',
+                });
+
+                expect(userModel.updateUser).not.toHaveBeenCalled();
+                expect(
+                    rolesModel.setUserOrgAndProjectRoles,
+                ).not.toHaveBeenCalled();
+            },
+        );
+
+        test.each([
+            ['omitted', undefined],
+            ['empty', [] as ScimUserRole[]],
+        ])(
+            'should preserve existing roles when the roles array is %s',
+            async (_case, roles) => {
+                const {
+                    organizationMemberProfileModel,
+                    rolesModel,
+                    userModel,
+                } = ScimServiceArgumentsMock;
+                vi.mocked(
+                    organizationMemberProfileModel.getOrganizationMemberByUuid,
+                ).mockResolvedValueOnce({
+                    ...mockUser,
+                    roleUuid: mockOrganizationCustomRole.roleUuid,
+                });
+                vi.mocked(userModel.getUserDetailsByUuid).mockResolvedValueOnce(
+                    organizationCustomRoleUser,
+                );
+
+                const result = await service.updateUser({
+                    account: mockScimAccount,
+                    user: {
+                        schemas: [ScimSchemaType.USER],
+                        userName: mockUser.email,
+                        name: {
+                            givenName: mockUser.firstName,
+                            familyName: mockUser.lastName,
+                        },
+                        active: mockUser.isActive,
+                        emails: [
+                            {
+                                value: mockUser.email,
+                                primary: true,
+                            },
+                        ],
+                        ...(roles === undefined ? {} : { roles }),
+                    },
+                    userUuid: mockUser.userUuid,
+                    organizationUuid: mockUser.organizationUuid,
+                });
+
+                expect(
+                    rolesModel.setUserOrgAndProjectRoles,
+                ).not.toHaveBeenCalled();
+                expect(result.roles).toContainEqual(organizationCustomScimRole);
+            },
+        );
+
         test('should handle organization-only roles in roles array via unified method', async () => {
             const { organizationMemberProfileModel, rolesModel } =
                 ScimServiceArgumentsMock;
@@ -919,6 +1073,35 @@ describe('ScimService', () => {
                 [],
                 true,
             );
+        });
+
+        test('should reject a bare no-role value in a patch', async () => {
+            const { rolesModel, userModel } = ScimServiceArgumentsMock;
+
+            await expect(
+                service.patchUser({
+                    account: mockScimAccount,
+                    userUuid: mockUser.userUuid,
+                    organizationUuid: mockUser.organizationUuid,
+                    patchOp: {
+                        schemas: [ScimSchemaType.PATCH],
+                        Operations: [
+                            {
+                                op: 'Replace',
+                                path: 'roles[primary eq true].value',
+                                value: 'no-role',
+                            },
+                        ],
+                    },
+                }),
+            ).rejects.toMatchObject({
+                detail: 'Invalid role values: no-role',
+                status: '400',
+                scimType: 'invalidValue',
+            });
+
+            expect(userModel.updateUser).not.toHaveBeenCalled();
+            expect(rolesModel.setUserOrgAndProjectRoles).not.toHaveBeenCalled();
         });
     });
 
@@ -1277,7 +1460,7 @@ describe('ScimService', () => {
             );
         });
 
-        test('should allow roles ending with NO_ROLE_KEYWORD', () => {
+        test('should allow the exact project no-role sentinel', () => {
             const roles = [
                 {
                     value: 'admin',
@@ -1297,6 +1480,25 @@ describe('ScimService', () => {
                 ScimService.validateRolesArray(roles, validRoleValues);
             }).not.toThrow();
         });
+
+        test.each(['no-role', 'invalid-no-role', ':no-role'])(
+            'should reject invalid no-role value %s',
+            (roleValue) => {
+                expect(() => {
+                    ScimService.validateRolesArray(
+                        [
+                            {
+                                value: roleValue,
+                                display: 'Invalid no-role value',
+                                type: 'Organization',
+                                primary: true,
+                            },
+                        ],
+                        validRoleValues,
+                    );
+                }).toThrow(`Invalid role values: ${roleValue}`);
+            },
+        );
     });
 
     describe('parseRoleId and generateRoleId integration', () => {

--- a/packages/backend/src/ee/services/ScimService/ScimService.test.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.test.ts
@@ -11,6 +11,7 @@ import {
 import { ScimPatch } from 'scim-patch';
 import { ScimService } from './ScimService';
 import {
+    mockOrganizationCustomRole,
     mockScimAccount,
     mockUser,
     ScimServiceArgumentsMock,
@@ -18,6 +19,12 @@ import {
 
 describe('ScimService', () => {
     const service = new ScimService(ScimServiceArgumentsMock);
+    const organizationCustomScimRole: ScimUserRole = {
+        value: mockOrganizationCustomRole.roleUuid,
+        display: mockOrganizationCustomRole.name,
+        type: 'Organization',
+        primary: true,
+    };
 
     beforeEach(() => {
         vi.clearAllMocks();
@@ -193,6 +200,26 @@ describe('ScimService', () => {
         });
     });
 
+    describe('getUser', () => {
+        test('should return an organization-level custom role', async () => {
+            const { organizationMemberProfileModel } = ScimServiceArgumentsMock;
+            vi.mocked(
+                organizationMemberProfileModel.getOrganizationMemberByUuid,
+            ).mockResolvedValueOnce({
+                ...mockUser,
+                roleUuid: mockOrganizationCustomRole.roleUuid,
+            });
+
+            const result = await service.getUser({
+                account: mockScimAccount,
+                userUuid: mockUser.userUuid,
+                organizationUuid: mockUser.organizationUuid,
+            });
+
+            expect(result.roles).toContainEqual(organizationCustomScimRole);
+        });
+    });
+
     describe('createUser', () => {
         test('should create user with default role when no role is provided', async () => {
             // Create a SCIM user without a role in the extension schema
@@ -270,6 +297,39 @@ describe('ScimService', () => {
                 userUuid: mockUser.userUuid,
                 role: OrganizationMemberRole.ADMIN, // Provided role
             });
+        });
+
+        test('should create user with an organization-level custom role', async () => {
+            const { rolesModel } = ScimServiceArgumentsMock;
+
+            await service.createUser({
+                account: mockScimAccount,
+                user: {
+                    schemas: [ScimSchemaType.USER],
+                    userName: 'new-user@example.com',
+                    name: {
+                        givenName: 'New',
+                        familyName: 'User',
+                    },
+                    active: true,
+                    emails: [
+                        {
+                            value: 'new-user@example.com',
+                            primary: true,
+                        },
+                    ],
+                    roles: [organizationCustomScimRole],
+                },
+                organizationUuid: 'org-uuid',
+            });
+
+            expect(rolesModel.setUserOrgAndProjectRoles).toHaveBeenCalledWith(
+                'org-uuid',
+                mockUser.userUuid,
+                mockOrganizationCustomRole.roleUuid,
+                [],
+                true,
+            );
         });
 
         test('should adopt orphan user (verified email but no organization) instead of creating', async () => {
@@ -425,25 +485,63 @@ describe('ScimService', () => {
                 organizationUuid: mockUser.organizationUuid,
             });
 
-            // Org role downgraded to MEMBER
-            expect(
-                organizationMemberProfileModel.updateOrganizationMember,
-            ).toHaveBeenCalledWith(
+            expect(rolesModel.setUserOrgAndProjectRoles).toHaveBeenCalledWith(
                 mockUser.organizationUuid,
                 mockUser.userUuid,
-                { role: OrganizationMemberRole.MEMBER },
+                OrganizationMemberRole.MEMBER,
+                [],
+                false,
             );
-
-            // Removed from all projects
-            expect(
-                rolesModel.removeUserAccessFromAllProjects,
-            ).toHaveBeenCalledWith(mockUser.userUuid);
 
             // Removed from all groups in org
             expect(groupsModel.removeUserFromAllGroups).toHaveBeenCalledWith({
                 organizationUuid: mockUser.organizationUuid,
                 userUuid: mockUser.userUuid,
             });
+        });
+
+        test('should clear a custom organization role when deactivating user', async () => {
+            const { organizationMemberProfileModel, rolesModel } =
+                ScimServiceArgumentsMock;
+            vi.mocked(
+                organizationMemberProfileModel.getOrganizationMemberByUuid,
+            ).mockResolvedValueOnce({
+                ...mockUser,
+                roleUuid: mockOrganizationCustomRole.roleUuid,
+            });
+
+            await service.updateUser({
+                account: mockScimAccount,
+                user: {
+                    schemas: [ScimSchemaType.USER],
+                    userName: mockUser.email,
+                    name: {
+                        givenName: mockUser.firstName,
+                        familyName: mockUser.lastName,
+                    },
+                    active: false,
+                    emails: [
+                        {
+                            value: mockUser.email,
+                            primary: true,
+                        },
+                    ],
+                    roles: [organizationCustomScimRole],
+                },
+                userUuid: mockUser.userUuid,
+                organizationUuid: mockUser.organizationUuid,
+            });
+
+            expect(rolesModel.setUserOrgAndProjectRoles).toHaveBeenCalledTimes(
+                1,
+            );
+            expect(rolesModel.setUserOrgAndProjectRoles).toHaveBeenCalledWith(
+                mockUser.organizationUuid,
+                mockUser.userUuid,
+                OrganizationMemberRole.MEMBER,
+                [],
+                false,
+            );
         });
 
         test('should throw error when an invalid role is provided', async () => {
@@ -595,6 +693,76 @@ describe('ScimService', () => {
             );
         });
 
+        test('should update user with an organization-level custom role', async () => {
+            const { rolesModel } = ScimServiceArgumentsMock;
+
+            await service.updateUser({
+                account: mockScimAccount,
+                user: {
+                    schemas: [ScimSchemaType.USER],
+                    userName: mockUser.email,
+                    name: {
+                        givenName: mockUser.firstName,
+                        familyName: mockUser.lastName,
+                    },
+                    active: mockUser.isActive,
+                    emails: [
+                        {
+                            value: mockUser.email,
+                            primary: true,
+                        },
+                    ],
+                    roles: [organizationCustomScimRole],
+                },
+                userUuid: mockUser.userUuid,
+                organizationUuid: mockUser.organizationUuid,
+            });
+
+            expect(rolesModel.setUserOrgAndProjectRoles).toHaveBeenCalledWith(
+                mockUser.organizationUuid,
+                mockUser.userUuid,
+                mockOrganizationCustomRole.roleUuid,
+                [],
+                true,
+            );
+        });
+
+        test('should reject a bare project-level custom role UUID', async () => {
+            await expect(
+                service.updateUser({
+                    account: mockScimAccount,
+                    user: {
+                        schemas: [ScimSchemaType.USER],
+                        userName: mockUser.email,
+                        name: {
+                            givenName: mockUser.firstName,
+                            familyName: mockUser.lastName,
+                        },
+                        active: mockUser.isActive,
+                        emails: [
+                            {
+                                value: mockUser.email,
+                                primary: true,
+                            },
+                        ],
+                        roles: [
+                            {
+                                value: 'custom-role-1-uuid',
+                                type: 'Organization',
+                                primary: true,
+                            },
+                        ],
+                    },
+                    userUuid: mockUser.userUuid,
+                    organizationUuid: mockUser.organizationUuid,
+                }),
+            ).rejects.toMatchObject({
+                detail: 'Invalid role values: custom-role-1-uuid',
+                status: '400',
+                scimType: 'invalidValue',
+            });
+        });
+
         test('should handle organization-only roles in roles array via unified method', async () => {
             const { organizationMemberProfileModel, rolesModel } =
                 ScimServiceArgumentsMock;
@@ -724,6 +892,34 @@ describe('ScimService', () => {
                 );
             },
         );
+
+        test('should replace the organization role with a custom role', async () => {
+            const { rolesModel } = ScimServiceArgumentsMock;
+
+            await service.patchUser({
+                account: mockScimAccount,
+                userUuid: mockUser.userUuid,
+                organizationUuid: mockUser.organizationUuid,
+                patchOp: {
+                    schemas: [ScimSchemaType.PATCH],
+                    Operations: [
+                        {
+                            op: 'Replace',
+                            path: 'roles[primary eq true].value',
+                            value: mockOrganizationCustomRole.roleUuid,
+                        },
+                    ],
+                },
+            });
+
+            expect(rolesModel.setUserOrgAndProjectRoles).toHaveBeenCalledWith(
+                mockUser.organizationUuid,
+                mockUser.userUuid,
+                mockOrganizationCustomRole.roleUuid,
+                [],
+                true,
+            );
+        });
     });
 
     describe('updateGroup', () => {
@@ -1387,7 +1583,7 @@ describe('ScimService', () => {
 
                 expect(result).toEqual({
                     schemas: [ScimSchemaType.LIST_RESPONSE],
-                    totalResults: 20, // 6 org system + 7 per project (2 projects) = 6+14 = 20
+                    totalResults: 21,
                     itemsPerPage: 100,
                     startIndex: 1,
                     Resources: expect.arrayContaining([
@@ -1408,7 +1604,7 @@ describe('ScimService', () => {
                 });
 
                 // Verify we have the expected number of roles
-                expect(result.Resources).toHaveLength(20);
+                expect(result.Resources).toHaveLength(21);
 
                 // Verify some specific role values
                 const roleValues = result.Resources.map((role) => role.value);
@@ -1423,6 +1619,12 @@ describe('ScimService', () => {
                 expect(roleValues).toContain(
                     'project-2-uuid:custom-role-2-uuid',
                 ); // project-level custom role
+                expect(roleValues).toContain(
+                    mockOrganizationCustomRole.roleUuid,
+                );
+                expect(roleValues).not.toContain(
+                    `project-1-uuid:${mockOrganizationCustomRole.roleUuid}`,
+                );
 
                 // Verify we don't have preview project roles
                 const previewRoles = roleValues.filter((value) =>
@@ -1452,6 +1654,30 @@ describe('ScimService', () => {
                         lastModified: undefined, // System roles don't have modification dates
                         location: expect.stringContaining(
                             '/api/v1/scim/v2/Roles/admin',
+                        ),
+                    },
+                });
+            });
+
+            test('should return an organization-level custom role by UUID', async () => {
+                const result = await service.getRole(
+                    'test-org-uuid',
+                    mockOrganizationCustomRole.roleUuid,
+                );
+
+                expect(result).toEqual({
+                    schemas: [ScimSchemaType.ROLE],
+                    id: mockOrganizationCustomRole.roleUuid,
+                    value: mockOrganizationCustomRole.roleUuid,
+                    display: mockOrganizationCustomRole.name,
+                    type: 'Organization',
+                    supported: true,
+                    meta: {
+                        resourceType: 'Role',
+                        created: mockOrganizationCustomRole.createdAt,
+                        lastModified: mockOrganizationCustomRole.updatedAt,
+                        location: expect.stringContaining(
+                            `/api/v1/scim/v2/Roles/${mockOrganizationCustomRole.roleUuid}`,
                         ),
                     },
                 });

--- a/packages/backend/src/ee/services/ScimService/ScimService.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.ts
@@ -596,6 +596,10 @@ export class ScimService extends BaseService {
                 roles: dedupedRoles,
             });
 
+            const finalUser = await this.userModel.getUserDetailsByUuid(
+                dbUser.userUuid,
+            );
+
             // verify user email on create if coming from scim
             await this.emailModel.verifyUserEmailIfExists(
                 dbUser.userUuid,
@@ -620,10 +624,13 @@ export class ScimService extends BaseService {
             });
 
             // Get user project roles
-            const userRoles = await this.getUserScimRoles(dbUser, allScimRoles);
+            const userRoles = await this.getUserScimRoles(
+                finalUser,
+                allScimRoles,
+            );
 
             // Construct SCIM-compliant response
-            return this.convertLightdashUserToScimUser(dbUser, userRoles);
+            return this.convertLightdashUserToScimUser(finalUser, userRoles);
         } catch (error) {
             if (error instanceof ParameterError) {
                 throw new ScimError({
@@ -726,33 +733,34 @@ export class ScimService extends BaseService {
 
             // Update user's organization role if provided in the extension schema
             const extensionData = user[ScimSchemaType.LIGHTDASH_USER_EXTENSION];
-            if (extensionData?.role && extensionData.role !== dbUser.role) {
-                // Validate that the role is a valid OrganizationMemberRole
-                if (!isOrganizationMemberRole(extensionData.role)) {
+            const extensionRole = extensionData?.role;
+            if (extensionRole) {
+                if (!isOrganizationMemberRole(extensionRole)) {
                     throw new ParameterError(
-                        `Invalid role: ${
-                            extensionData.role
-                        }. Role must be one of: ${Object.values(
+                        `Invalid role: ${extensionRole}. Role must be one of: ${Object.values(
                             OrganizationMemberRole,
                         ).join(', ')}`,
                     );
                 }
 
-                await this.organizationMemberProfileModel.updateOrganizationMember(
-                    organizationUuid,
-                    userUuid,
-                    {
-                        role: extensionData.role,
-                    },
-                );
+                if (user.active !== false && extensionRole !== dbUser.role) {
+                    await this.organizationMemberProfileModel.updateOrganizationMember(
+                        organizationUuid,
+                        userUuid,
+                        {
+                            role: extensionRole,
+                        },
+                    );
+                }
             }
 
-            // Update user org and project roles
-            await this.upsertUserRoles({
-                organizationUuid,
-                userUuid,
-                roles: dedupedRoles,
-            });
+            if (user.active !== false) {
+                await this.upsertUserRoles({
+                    organizationUuid,
+                    userUuid,
+                    roles: dedupedRoles,
+                });
+            }
 
             // If active status changes, either true or false
             // We delete all openid identities for the user's email and user uuid
@@ -769,51 +777,20 @@ export class ScimService extends BaseService {
 
             // If setting user to inactive, drop org role to MEMBER and remove project roles
             if (user.active === false) {
-                try {
-                    if (dbUser.role !== OrganizationMemberRole.MEMBER) {
-                        await this.organizationMemberProfileModel.updateOrganizationMember(
-                            organizationUuid,
-                            userUuid,
-                            {
-                                role: OrganizationMemberRole.MEMBER,
-                            },
-                        );
-                        this.logger.info(
-                            'SCIM: Updated user organisation role to MEMBER',
-                            {
-                                userUuid,
-                                organizationUuid,
-                                role: OrganizationMemberRole.MEMBER,
-                            },
-                        );
-                    }
-                } catch (e) {
-                    this.logger.error(
-                        `Failed to drop organization role for inactive user ${userUuid} to MEMBER: ${getErrorMessage(
-                            e,
-                        )}`,
-                    );
-                }
-                try {
-                    const projectsCount =
-                        await this.rolesModel.removeUserAccessFromAllProjects(
-                            dbUser.userUuid,
-                        );
-                    this.logger.info(
-                        'SCIM: Removed user roles from all projects',
-                        {
-                            userUuid,
-                            organizationUuid,
-                            projectsCount,
-                        },
-                    );
-                } catch (e) {
-                    this.logger.error(
-                        `Failed to remove project roles for inactive user ${userUuid}: ${getErrorMessage(
-                            e,
-                        )}`,
-                    );
-                }
+                await this.rolesModel.setUserOrgAndProjectRoles(
+                    organizationUuid,
+                    userUuid,
+                    OrganizationMemberRole.MEMBER,
+                    [],
+                    false,
+                );
+                this.logger.info(
+                    'SCIM: Reset organization and project roles for inactive user',
+                    {
+                        userUuid,
+                        organizationUuid,
+                    },
+                );
 
                 // Remove user from all groups in the organization when deactivated
                 try {
@@ -923,7 +900,7 @@ export class ScimService extends BaseService {
                 projectUuid: string;
                 roleId: string;
             }> = [];
-            let desiredOrgRoleUuid: OrganizationMemberRole | undefined;
+            let desiredOrgRoleUuid: string | undefined;
 
             for (const role of roles) {
                 const { roleUuid, projectUuid } = ScimService.parseRoleId(
@@ -938,7 +915,7 @@ export class ScimService extends BaseService {
                             roleId: roleUuid,
                         });
                     }
-                } else if (isOrganizationMemberRole(roleUuid)) {
+                } else {
                     desiredOrgRoleUuid = roleUuid;
                 }
             }
@@ -2002,6 +1979,12 @@ export class ScimService extends BaseService {
             organizationUuid,
             'user',
         );
+        const organizationCustomRoles = customRoles.filter(
+            (role) => role.level === 'organization',
+        );
+        const projectCustomRoles = customRoles.filter(
+            (role) => role.level === 'project',
+        );
 
         // Get all projects for the organization, ignoring preview projects
         const allProjects = await wrapSentryTransaction(
@@ -2025,6 +2008,9 @@ export class ScimService extends BaseService {
                 }),
             );
         });
+        organizationCustomRoles.forEach((role) => {
+            allScimRoles.push(this.convertLightdashRoleToScimRole(role));
+        });
 
         // For each project, add system roles and custom roles
         nonPreviewProjects.forEach((project) => {
@@ -2039,7 +2025,7 @@ export class ScimService extends BaseService {
             });
 
             // Add project-level custom roles
-            customRoles.forEach((role) => {
+            projectCustomRoles.forEach((role) => {
                 allScimRoles.push(
                     this.convertLightdashRoleToScimRole(role, {
                         projectUuid: project.projectUuid,
@@ -2057,16 +2043,17 @@ export class ScimService extends BaseService {
     }
 
     private async getUserScimRoles(
-        user: Pick<LightdashUser, 'userUuid' | 'role'>,
+        user: Pick<LightdashUser, 'userUuid' | 'role' | 'roleUuid'>,
         availableScimRoles: ScimRole[],
     ): Promise<ScimUserRole[]> {
         try {
             const allRoles: ScimUserRole[] = [];
+            const organizationRoleId = user.roleUuid ?? user.role;
 
             // Add organization role if present
-            if (user?.role) {
+            if (organizationRoleId) {
                 const scimRole = availableScimRoles.find(
-                    (role) => role.value === user.role,
+                    (role) => role.value === organizationRoleId,
                 );
                 if (scimRole) {
                     allRoles.push({

--- a/packages/backend/src/ee/services/ScimService/ScimService.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.ts
@@ -1879,11 +1879,15 @@ export class ScimService extends BaseService {
         // Check for invalid role values
         const invalidRoles = roles
             .map((role) => role.value)
-            .filter(
-                (roleValue) =>
-                    !validRoleValues.includes(roleValue) &&
-                    !roleValue.toLowerCase().endsWith(NO_ROLE_KEYWORD),
-            );
+            .filter((roleValue) => {
+                const { projectUuid, roleUuid } =
+                    ScimService.parseRoleId(roleValue);
+                const isProjectNoRole =
+                    Boolean(projectUuid) &&
+                    roleUuid.toLowerCase() === NO_ROLE_KEYWORD;
+
+                return !validRoleValues.includes(roleValue) && !isProjectNoRole;
+            });
 
         if (invalidRoles.length > 0) {
             throw new ParameterError(

--- a/packages/backend/src/models/RolesModel.ts
+++ b/packages/backend/src/models/RolesModel.ts
@@ -937,7 +937,7 @@ export class RolesModel {
 
     /**
      * Set a user's organization and project roles to exactly match the provided values.
-     * - Organization role is REQUIRED and must be a valid system organization role id (no custom role allowed).
+     * - Organization role is REQUIRED and can be a system or custom organization role id.
      * - Project roles: adds or updates roles for listed projects; removes memberships for projects not present.
      * - If projectRoles is an empty array, all existing project memberships for the user are removed.
      * - If excludeProjectPreviews is true, preview projects are excluded from removal operations.
@@ -946,7 +946,7 @@ export class RolesModel {
     async setUserOrgAndProjectRoles(
         organizationUuid: string,
         userUuid: string,
-        orgRoleId: OrganizationMemberRole,
+        orgRoleId: string,
         projectRoles: Array<{ projectUuid: string; roleId: string }>,
         excludeProjectPreviews: boolean = false,
         tx?: Knex.Transaction,


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9277/scim-permissions-support-provisioning-organization-level-custom-roles

## Summary

SCIM rejected bare UUIDs for organization-level custom roles, so organizations using custom organization access could not fully automate user provisioning. This change accepts and discovers organization custom roles across user POST, PUT, PATCH, and GET flows while keeping group-level organization role assignment out of scope.

Docs: https://github.com/lightdash/mintlify-docs/pull/1054

## Root cause

SCIM recognized a colonless value as an organization role only when it matched the built-in enum. Role discovery also mapped every custom role onto every project without checking the role level, and user responses ignored the persisted organization `roleUuid`.

```ts
} else if (isOrganizationMemberRole(roleUuid)) {
    desiredOrgRoleUuid = roleUuid;
}
```

The organization membership model already persists custom role UUIDs. The missing support was confined to SCIM discovery, validation, assignment typing, and serialization.

## Fix

Organization custom roles are now exposed as bare UUIDs with `type: "Organization"`, while project custom roles remain `<project_uuid>:<custom_role_uuid>`. The validated organization value flows through the existing transactional writer, and SCIM user responses prefer the persisted custom `roleUuid`.

- `ScimService` partitions custom roles by level and handles custom organization IDs across discovery and user writes.
- `RolesModel` reflects its existing ability to persist either a system or custom organization role ID.
- Deactivation authoritatively resets the user to `member`, clears `role_uuid`, and removes project access even if the request contains custom roles.
- The Okta compatibility sentinel accepts only an exact project-scoped `<project_uuid>:no-role` value, so malformed bare and suffix values fail before any user write.
- Regression coverage includes POST, PUT, PATCH, GET, discovery, invalid values, role preservation, and deactivation cleanup.
- Group-level organization custom-role assignment remains out of scope.

## Before

```text
roles.value: <custom_role_uuid>
                 │
                 ▼
        400 invalidValue
```

## After

```text
roles.value: <custom_role_uuid>
                 │
                 ▼
organization_memberships.role_uuid
```

## Test plan

- [x] `pnpm -F backend typecheck:fast`
- [x] Targeted ESLint across all four changed TypeScript files
- [x] Focused `ScimService` suite — 65 tests pass
- [x] Full backend suite — 5,005 tests pass, 1 skipped
- [x] Targeted `oxfmt --check` across the updated service and test files
- [x] Live SCIM discovery, POST, PUT, PATCH, invalid-value, and GET checks
- [x] Live bare `no-role` POST — `400 invalidValue` with zero persisted user rows
- [x] Postgres verification of custom-role persistence and deactivation cleanup
- [x] Cleanup verification for the ephemeral user, role, token, session, and DB records
