### PR TITLE
fix(ai): render inline deep research charts without Explore lookup

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
@@ -76,6 +76,7 @@ type Props = {
     headerContent?: ReactNode;
     displayFields?: boolean;
     displayFilters?: boolean;
+    loadExplore?: boolean;
 };
 
 export const AiVisualizationRenderer: FC<Props> = ({
@@ -89,6 +90,7 @@ export const AiVisualizationRenderer: FC<Props> = ({
     headerContent,
     displayFields = true,
     displayFilters: displayFiltersProp = true,
+    loadExplore = true,
 }) => {
     const { data: health } = useHealth();
     const { projectUuid } = useParams<{ projectUuid: string }>();
@@ -111,7 +113,7 @@ export const AiVisualizationRenderer: FC<Props> = ({
 
     const { metricQuery, fields, resolvedTimezone } = vizQueryData.query;
     const tableName = metricQuery?.exploreName;
-    const { data: explore } = useExplore(tableName);
+    const { data: explore } = useExplore(loadExplore ? tableName : undefined);
 
     const [echartsClickEvent, setEchartsClickEvent] =
         useState<EchartsSeriesClickEvent | null>(null);

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchChartTile.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchChartTile.test.tsx
@@ -23,15 +23,18 @@ vi.mock('../ChatElements/AiVisualizationRenderer', () => ({
         headerContent,
         displayFields,
         displayFilters,
+        loadExplore,
     }: {
         headerContent: ReactNode;
         displayFields?: boolean;
         displayFilters?: boolean;
+        loadExplore?: boolean;
     }) => (
         <div
             data-testid="visualization"
             data-display-fields={String(displayFields)}
             data-display-filters={String(displayFilters)}
+            data-load-explore={String(loadExplore)}
         >
             {headerContent}
             <div>Rendered query data</div>
@@ -154,6 +157,10 @@ describe('DeepResearchChartTile', () => {
             'data-display-filters',
             'false',
         );
+        expect(screen.getByTestId('visualization')).toHaveAttribute(
+            'data-load-explore',
+            'true',
+        );
     });
 
     it('shows the applied filters as read-only pills in the header', () => {
@@ -205,6 +212,10 @@ describe('DeepResearchChartTile', () => {
         expect(
             screen.queryByRole('button', { name: 'View live data' }),
         ).not.toBeInTheDocument();
+        expect(screen.getByTestId('visualization')).toHaveAttribute(
+            'data-load-explore',
+            'false',
+        );
     });
 
     it('shows the live error state even while a page fetch is marked in-flight', () => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchChartTile.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchChartTile.tsx
@@ -216,6 +216,7 @@ export const DeepResearchChartTile = ({
                         selectedChartType={chart.chartConfig.defaultVizType}
                         displayFields={false}
                         displayFilters={false}
+                        loadExplore={chart.source === 'warehouse'}
                         headerContent={
                             displayFilterPills ? (
                                 <AgentVisualizationFilters


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9163/explore-inline-does-not-exist

## Summary

Opening a completed Deep Research report with agent-computed charts shows an `Explore \"inline\" does not exist` error. Warehouse-backed report charts are unaffected.

## Root cause

Deep Research stores agent-computed chart snapshots with the synthetic Explore name `inline`. The shared visualization renderer unconditionally loads Explore metadata, even though inline charts already contain the fields and rows needed to render.

```ts
const { data: explore } = useExplore(tableName);
```

The metadata request reaches `/explores/inline`, which returns 404 and displays the error toast.

## Fix

Makes Explore metadata loading optional and disables it for agent-computed Deep Research charts. Warehouse-backed charts keep the existing lookup and live-data behavior.

- `AiVisualizationRenderer` accepts an opt-out for Explore metadata loading.
- `DeepResearchChartTile` opts out when the chart source is `inline`.
- The chart-tile test covers both inline and warehouse-backed behavior.

## Before

```text
Inline snapshot ──> useExplore(\"inline\") ──> GET /explores/inline ──> 404 toast
```

## After

```text
Inline snapshot  ──> embedded fields + rows ──> rendered chart
Warehouse chart ──> useExplore(real name)   ──> rendered chart
```

## Test plan

- [x] `pnpm -F @lightdash/frontend exec vitest run src/ee/features/aiCopilot/components/DeepResearch/DeepResearchChartTile.test.tsx` — 7 tests pass
- [x] `pnpm -F @lightdash/frontend typecheck:fast`
- [x] Changed-file lint, formatting, and `git diff --check`
- [ ] Manual: open an inline-chart Deep Research report and confirm it renders without an Explore error
- [ ] Manual: switch a warehouse-backed report chart between snapshot and live data