### PR TITLE
feat(data-apps): accept linked saved charts in useDelivery

### DIFF
--- a/packages/query-sdk/src/delivery.test.ts
+++ b/packages/query-sdk/src/delivery.test.ts
@@ -9,7 +9,7 @@ import {
     unregisterDeliveryQuery,
     type DeliveryQuery,
 } from './delivery';
-import { query } from './query';
+import { query, type QueryBuilder } from './query';
 import { savedChart } from './savedChart';
 
 describe('toDeliveryQuery', () => {
@@ -36,9 +36,37 @@ describe('toDeliveryQuery', () => {
         expect(toDeliveryQuery(query('orders'))?.label).toBeNull();
     });
 
-    it('skips a saved chart with a warning rather than throwing', () => {
+    it('builds a declaration from a linked saved chart, carrying run overrides', () => {
+        const chart = savedChart('chart-1', 'Linked revenue')
+            .limit(1000)
+            .parameters({ region: 'EMEA' });
+
+        expect(toDeliveryQuery(chart)).toEqual({
+            kind: 'savedChart',
+            label: 'Linked revenue',
+            chartUuid: 'chart-1',
+            limit: 1000,
+            parameters: { region: 'EMEA' },
+            filters: undefined,
+        });
+    });
+
+    it('prefers an explicit name over a linked chart label', () => {
+        expect(
+            toDeliveryQuery(savedChart('chart-1', 'From chart'), 'From argument')
+                ?.label,
+        ).toBe('From argument');
+    });
+
+    it('falls back to a null label when the linked chart has none', () => {
+        expect(toDeliveryQuery(savedChart('chart-1'))?.label).toBeNull();
+    });
+
+    it('skips an unrecognised query shape with a warning rather than throwing', () => {
         const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-        expect(toDeliveryQuery(savedChart('chart-1'))).toBeNull();
+        expect(
+            toDeliveryQuery({ notAQuery: true } as unknown as QueryBuilder),
+        ).toBeNull();
         expect(warn).toHaveBeenCalled();
         warn.mockRestore();
     });

--- a/packages/query-sdk/src/delivery.ts
+++ b/packages/query-sdk/src/delivery.ts
@@ -7,14 +7,26 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { QueryBuilder } from './query';
 import { savedChartQueryKey, type SavedChartQuery } from './savedChart';
-import type { QueryDefinition } from './types';
+import type {
+    InternalFilterDefinition,
+    ParametersValuesMap,
+    QueryDefinition,
+} from './types';
 
-export type DeliveryQuery = {
-    kind: 'query';
-    /** Tab/file name in the delivery. Null falls back to a positional name. */
-    label: string | null;
-    query: QueryDefinition;
-};
+/**
+ * A query declared for scheduled delivery. `label` is the tab/file name in the
+ * delivery; null falls back to a positional name.
+ */
+export type DeliveryQuery =
+    | { kind: 'query'; label: string | null; query: QueryDefinition }
+    | {
+          kind: 'savedChart';
+          label: string | null;
+          chartUuid: string;
+          limit?: number;
+          parameters?: ParametersValuesMap;
+          filters?: InternalFilterDefinition[];
+      };
 
 export function toDeliveryQuery(
     query: QueryBuilder | SavedChartQuery,
@@ -28,11 +40,21 @@ export function toDeliveryQuery(
             query: built,
         };
     }
+    if (query?.kind === 'savedChart') {
+        return {
+            kind: 'savedChart',
+            label: name ?? query.labelText ?? null,
+            chartUuid: query.chartUuid,
+            limit: query.limitValue,
+            parameters: query.parameterValues,
+            filters: query.filterValues,
+        };
+    }
     // Skip rather than throw: generated apps chain builder methods freely, and
     // a delivery primitive that throws takes the whole app down.
     // eslint-disable-next-line no-console
     console.warn(
-        '[lightdash] useDelivery does not support linked saved charts yet — skipping this query.',
+        '[lightdash] useDelivery expects a query() or savedChart() — skipping this declaration.',
     );
     return null;
 }


### PR DESCRIPTION
Stacked on #26324. Still ships dark.

The first PR made `useDelivery(savedChart(...))` warn and skip, so apps built around linked charts were safe but couldn't declare anything for delivery. Linked charts are a first-class app pattern — `savedChart` is in `SDK_FEATURES` and `skill.md` has a section on linked charts taking global filters — so excluding them would have left a real class of app unable to use data deliveries at all.

### What this adds

`DeliveryQuery` gains a `savedChart` variant carrying the chart uuid plus the run overrides `savedChart()` already captures:

```ts
| {
      kind: 'savedChart';
      label: string | null;
      chartUuid: string;
      limit?: number;
      parameters?: ParametersValuesMap;
      filters?: InternalFilterDefinition[];
  }
```

The structural methods (`dimensions`, `metrics`, `sorts`, …) are deliberately absent — a saved chart's structure is governed by the chart, which is the same contract `savedChart.ts` documents and `/query/chart` enforces.

Cheap on the backend when the resolver lands: `executeSavedChartQueryAndGetResults` already exists and is exactly what the gsheets chart path uses (`SchedulerTask.ts:3501`).

### Dispatch is explicit, not `else`

`toDeliveryQuery` now checks `query?.kind === 'savedChart'` rather than treating "not a `QueryBuilder`" as implicitly a saved chart. Without that, an unexpected value would have produced a declaration with an `undefined` chartUuid that only failed later, at delivery time. Anything unrecognised warns and is skipped — keeping the crash-safety rule from the top of `savedChart.ts`, since generated apps chain builder methods freely and a throw here takes the whole app down.

### Tests

88 passed across 10 files (up from 85). New coverage for the saved-chart variant, explicit-name precedence, null label fallback, and the unrecognised-shape skip.

Closes: PROD-9287
Relates: PROD-8374
