### PR TITLE
fix(onboarding): don't save brand when joining an existing org

### DIFF
--- a/packages/frontend/src/pages/OrganizationSetup.tsx
+++ b/packages/frontend/src/pages/OrganizationSetup.tsx
@@ -244,21 +244,25 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
         });
 
         if (user.organizationName) {
+            // Joining an existing org: no org name to set, and the brand
+            // belongs to the org (which a joiner — often a viewer — has no
+            // rights to change), so don't attempt to save it.
             completeMutation.mutate({
                 jobTitle: values.jobTitle,
                 enableEmailDomainAccess: values.enableEmailDomainAccess,
                 isMarketingOptedIn: values.isMarketingOptedIn,
                 isTrackingAnonymized: values.isTrackingAnonymized,
             });
-        } else {
-            completeMutation.mutate({
-                organizationName: values.organizationName,
-                jobTitle: values.jobTitle,
-                enableEmailDomainAccess: values.enableEmailDomainAccess,
-                isMarketingOptedIn: values.isMarketingOptedIn,
-                isTrackingAnonymized: values.isTrackingAnonymized,
-            });
+            return;
         }
+
+        completeMutation.mutate({
+            organizationName: values.organizationName,
+            jobTitle: values.jobTitle,
+            enableEmailDomainAccess: values.enableEmailDomainAccess,
+            isMarketingOptedIn: values.isMarketingOptedIn,
+            isTrackingAnonymized: values.isTrackingAnonymized,
+        });
 
         const brandDomain =
             detectedBrand?.domain ?? (isCompanyDomain ? emailDomain : null);


### PR DESCRIPTION
## What

When completing the org-setup **"About you"** step, `OrganizationSetup.tsx` fired `saveBrand.mutate(...)` whenever the user's email was a "company" domain (or a brand was detected) — gated only on the domain, **not** on whether the user can manage the org. A user **joining an existing org** (via allowed email-domain match, or an invite) comes in as a **viewer**, so the brand save 403'd and surfaced a spurious toast:

> Failed to save brand — You don't have access to this resource or action

Onboarding still completed (they reached the home), but with a scary permission error.

## Fix

Brand is set from the **workspace step**, which only the org *creator* ever sees. So only run `saveBrand` in the create-org branch; a joiner returns right after saving their profile (no org name, no brand). Net: one fewer (failing) request for every join, and no error toast.

## Testing

- `pnpm -F frontend typecheck:fast` + lint clean.
- Verified live on a local EE dev instance: registered a fresh `@<company-domain>` user → domain-join → finished the "About you" step → lands on the org home **with no "Failed to save brand" toast** (previously it fired every time). Creating a new org still saves brand as before.

Refs: PROD-9294

🤖 Generated with [Claude Code](https://claude.com/claude-code)