### PR TITLE
refactor(apps): extract version to chat-message converter

### DIFF
--- a/packages/frontend/src/features/apps/utils/chatMessage.test.ts
+++ b/packages/frontend/src/features/apps/utils/chatMessage.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { mergeChatMessages, type ChatMessage } from './mergeChatMessages';
+import { mergeChatMessages, type ChatMessage } from './chatMessage';
 
 const baseMessage: ChatMessage = {
     role: 'user',
+    status: null,
     content: '',
     imagePreviewUrls: [],
     imageResourceIds: [],
@@ -11,7 +12,6 @@ const baseMessage: ChatMessage = {
     externalConnections: [],
     dashboardName: null,
     clarifications: [],
-    appUuid: null,
     version: null,
     timestamp: new Date('2026-05-15T10:00:00Z'),
     userName: 'Test User',

--- a/packages/frontend/src/features/apps/utils/chatMessage.ts
+++ b/packages/frontend/src/features/apps/utils/chatMessage.ts
@@ -23,6 +23,11 @@ export type ChatAttachedFile = {
 
 export type ChatMessage = {
     role: 'user' | 'assistant';
+    /**
+     * Outcome of an assistant bubble; `null` on user bubbles. The only signal
+     * renderers use to tell success from failure.
+     */
+    status: 'ready' | 'error' | null;
     content: string;
     imagePreviewUrls: string[];
     imageResourceIds: string[];
@@ -31,7 +36,6 @@ export type ChatMessage = {
     externalConnections: ChatConnection[];
     dashboardName: string | null;
     clarifications: AppClarification[];
-    appUuid: string | null;
     version: number | null;
     timestamp: Date;
     userName: string | null;
@@ -52,6 +56,31 @@ export type ChatMessage = {
     // current latest, so the comparison hasn't tripped yet.
     submittedAtVersion?: number;
 };
+
+/**
+ * Every field a message can carry, at its "nothing here" value, so a literal
+ * only has to state what it actually has. A function rather than a constant so
+ * no two messages share an array.
+ */
+export const emptyChatMessage = (): Omit<
+    ChatMessage,
+    'role' | 'timestamp'
+> => ({
+    status: null,
+    content: '',
+    imagePreviewUrls: [],
+    imageResourceIds: [],
+    files: [],
+    charts: [],
+    externalConnections: [],
+    dashboardName: null,
+    clarifications: [],
+    version: null,
+    userName: null,
+    vizSchema: null,
+    reasoning: [],
+    activity: [],
+});
 
 /**
  * Merge server-side history with the optimistic local message queue, dropping

--- a/packages/frontend/src/features/apps/utils/versionsToChatMessages.test.ts
+++ b/packages/frontend/src/features/apps/utils/versionsToChatMessages.test.ts
@@ -1,0 +1,216 @@
+import { type ApiAppVersionSummary } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import {
+    versionNarrationTexts,
+    versionsToChatMessages,
+    type ChatMessageFallbacks,
+} from './versionsToChatMessages';
+
+const emptyFallbacks = (): ChatMessageFallbacks => ({
+    charts: new Map(),
+    connections: new Map(),
+    imagePreviewUrls: new Map(),
+    files: new Map(),
+    dashboardName: new Map(),
+});
+
+const version = (
+    overrides: Partial<ApiAppVersionSummary> = {},
+): ApiAppVersionSummary => ({
+    version: 1,
+    prompt: 'stacked bars per shipping method',
+    status: 'ready',
+    statusMessage: null,
+    statusHistory: [],
+    error: null,
+    createdAt: new Date('2026-05-15T10:00:00Z'),
+    statusUpdatedAt: new Date('2026-05-15T10:00:52Z'),
+    createdByUser: {
+        userUuid: 'u1',
+        firstName: 'Katie',
+        lastName: 'Jones',
+    },
+    resources: null,
+    ...overrides,
+});
+
+const convert = (versions: ApiAppVersionSummary[]) =>
+    versionsToChatMessages(versions);
+
+describe('versionsToChatMessages', () => {
+    it('returns nothing for no versions', () => {
+        expect(convert([])).toEqual([]);
+    });
+
+    it('pairs each version with a user bubble and a receipt', () => {
+        const [user, assistant] = convert([version()]);
+
+        expect(user.role).toBe('user');
+        expect(user.status).toBeNull();
+        expect(user.content).toBe('stacked bars per shipping method');
+        expect(user.userName).toBe('Katie Jones');
+
+        expect(assistant.role).toBe('assistant');
+        expect(assistant.status).toBe('ready');
+        expect(assistant.version).toBe(1);
+    });
+
+    it('orders oldest first regardless of input order', () => {
+        const messages = convert([
+            version({ version: 3, prompt: 'third' }),
+            version({ version: 1, prompt: 'first' }),
+            version({ version: 2, prompt: 'second' }),
+        ]);
+        expect(
+            messages.filter((m) => m.role === 'user').map((m) => m.content),
+        ).toEqual(['first', 'second', 'third']);
+    });
+
+    it('marks failures with status error and no version', () => {
+        const [, assistant] = convert([
+            version({
+                status: 'error',
+                statusMessage: 'Build failed',
+                error: 'stack trace',
+            }),
+        ]);
+
+        expect(assistant.status).toBe('error');
+        expect(assistant.content).toBe('Build failed');
+        // A deps chip renders off `version`; a failed build has no artifacts.
+        expect(assistant.version).toBeNull();
+    });
+
+    it('falls back to the detailed error when there is no status message', () => {
+        const [, assistant] = convert([
+            version({ status: 'error', statusMessage: null, error: 'boom' }),
+        ]);
+        expect(assistant.content).toBe('boom');
+    });
+
+    it('emits only a user bubble while a version is still building', () => {
+        const messages = convert([version({ status: 'building' })]);
+        expect(messages).toHaveLength(1);
+        expect(messages[0].role).toBe('user');
+    });
+
+    it('dates the receipt to when the build finished', () => {
+        const [user, assistant] = convert([version()]);
+        expect(user.timestamp).toEqual(new Date('2026-05-15T10:00:00Z'));
+        expect(assistant.timestamp).toEqual(new Date('2026-05-15T10:00:52Z'));
+    });
+
+    it('falls back to createdAt when the version never recorded a transition', () => {
+        const [, assistant] = convert([version({ statusUpdatedAt: null })]);
+        expect(assistant.timestamp).toEqual(new Date('2026-05-15T10:00:00Z'));
+    });
+
+    it('derives the ready message for prompt-less uploaded versions', () => {
+        const [, first] = convert([
+            version({ prompt: '', statusMessage: 'stale leftover' }),
+        ]);
+        expect(first.content).toBe('Your app is ready!');
+
+        const [, later] = convert([
+            version({
+                version: 4,
+                prompt: '',
+                statusMessage: 'stale leftover',
+            }),
+        ]);
+        expect(later.content).toBe('Version 4 is ready!');
+    });
+
+    it('prefers the version status message for prompted versions', () => {
+        const [, assistant] = convert([version({ statusMessage: 'All done' })]);
+        expect(assistant.content).toBe('All done');
+    });
+
+    it('reads attachments from server resources when present', () => {
+        const [user] = versionsToChatMessages([
+            version({
+                resources: {
+                    charts: [
+                        {
+                            chartUuid: 'c1',
+                            chartName: 'Orders',
+                            linkLive: true,
+                        },
+                    ],
+                    images: [],
+                    clarifications: [],
+                } as unknown as ApiAppVersionSummary['resources'],
+            }),
+        ]);
+        expect(user.charts).toEqual([
+            {
+                name: 'Orders',
+                uuid: 'c1',
+                chartKind: undefined,
+                linkLive: true,
+            },
+        ]);
+    });
+
+    it('falls back to session attachments for versions with no resources', () => {
+        const fallbacks = emptyFallbacks();
+        fallbacks.charts.set('stacked bars per shipping method', [
+            { name: 'Orders', uuid: 'c1' },
+        ]);
+        fallbacks.dashboardName.set(
+            'stacked bars per shipping method',
+            'Ops dashboard',
+        );
+
+        const [user] = versionsToChatMessages([version()], fallbacks);
+        expect(user.charts).toEqual([{ name: 'Orders', uuid: 'c1' }]);
+        expect(user.dashboardName).toBe('Ops dashboard');
+    });
+
+    it('attaches narration to the receipt, not the prompt', () => {
+        const [user, assistant] = convert([
+            version({
+                statusHistory: [
+                    { kind: 'thinking', message: 'Considering layout' },
+                    { kind: 'tool', message: 'Creating App.tsx' },
+                ] as ApiAppVersionSummary['statusHistory'],
+            }),
+        ]);
+        expect(user.reasoning).toEqual([]);
+        expect(assistant.reasoning).toEqual(['Considering layout']);
+        expect(assistant.activity).toEqual(['Creating App.tsx']);
+    });
+
+    it('handles a missing author', () => {
+        const [user] = convert([version({ createdByUser: null })]);
+        expect(user.userName).toBeNull();
+    });
+});
+
+describe('versionNarrationTexts', () => {
+    it('returns nothing when there is no history', () => {
+        expect(versionNarrationTexts(undefined, 'thinking')).toEqual([]);
+    });
+
+    it('collapses consecutive duplicates from a restarted stream', () => {
+        const history = [
+            { kind: 'thinking', message: 'a' },
+            { kind: 'thinking', message: 'a' },
+            { kind: 'thinking', message: 'b' },
+            { kind: 'thinking', message: 'a' },
+        ] as ApiAppVersionSummary['statusHistory'];
+        expect(versionNarrationTexts(history, 'thinking')).toEqual([
+            'a',
+            'b',
+            'a',
+        ]);
+    });
+
+    it('keeps only the requested kind', () => {
+        const history = [
+            { kind: 'thinking', message: 'thought' },
+            { kind: 'tool', message: 'action' },
+        ] as ApiAppVersionSummary['statusHistory'];
+        expect(versionNarrationTexts(history, 'tool')).toEqual(['action']);
+    });
+});

--- a/packages/frontend/src/features/apps/utils/versionsToChatMessages.ts
+++ b/packages/frontend/src/features/apps/utils/versionsToChatMessages.ts
@@ -1,0 +1,175 @@
+import {
+    type ApiAppVersionSummary,
+    type AppVersionStatusHistoryEntry,
+    type AppVersionStatusHistoryEntryKind,
+} from '@lightdash/common';
+import { getAppVersionFailureMessage } from '../getAppVersionFailureMessage';
+import {
+    emptyChatMessage,
+    type ChatAttachedFile,
+    type ChatChart,
+    type ChatConnection,
+    type ChatMessage,
+} from './chatMessage';
+
+// The null guard exists because the poll worker feeds raw fetch JSON into
+// the query cache; the consecutive dedupe because a retry can restart the
+// generation stream and re-emit the same entry.
+export function versionNarrationTexts(
+    history: AppVersionStatusHistoryEntry[] | undefined,
+    kind: AppVersionStatusHistoryEntryKind,
+): string[] {
+    return (history ?? [])
+        .filter((entry) => entry.kind === kind)
+        .map((entry) => entry.message)
+        .filter((message, index, all) => message !== all[index - 1]);
+}
+
+/**
+ * Session-only attachment fallbacks, keyed by prompt text. Versions persisted
+ * before server-side resource capture carry no `resources`, so a surface that
+ * submitted the prompt itself can supply what it sent. Surfaces that only read
+ * history omit them.
+ */
+export type ChatMessageFallbacks = {
+    charts: Map<string, ChatChart[]>;
+    connections: Map<string, ChatConnection[]>;
+    imagePreviewUrls: Map<string, string[]>;
+    files: Map<string, ChatAttachedFile[]>;
+    dashboardName: Map<string, string>;
+};
+
+// Read-only, so one shared instance serves every caller that has none.
+const NO_FALLBACKS: ChatMessageFallbacks = {
+    charts: new Map(),
+    connections: new Map(),
+    imagePreviewUrls: new Map(),
+    files: new Map(),
+    dashboardName: new Map(),
+};
+
+const authorNameOf = (version: ApiAppVersionSummary): string | null => {
+    if (!version.createdByUser) return null;
+    return (
+        [version.createdByUser.firstName, version.createdByUser.lastName]
+            .filter((s) => s.length > 0)
+            .join(' ') || null
+    );
+};
+
+/**
+ * Convert fetched app versions into chat messages, oldest first. Each version
+ * yields a user bubble (the prompt) plus, once terminal, an assistant bubble
+ * carrying the outcome. Versions still building yield only the user bubble —
+ * their progress is rendered live by the caller.
+ */
+export function versionsToChatMessages(
+    versions: ApiAppVersionSummary[],
+    fallbacks: ChatMessageFallbacks = NO_FALLBACKS,
+): ChatMessage[] {
+    if (versions.length === 0) return [];
+    const sorted = [...versions].sort((a, b) => a.version - b.version);
+
+    return sorted.flatMap((v) => {
+        // Prefer server-side resources; fall back to session maps.
+        const serverCharts: ChatChart[] =
+            v.resources?.charts.map((c) => ({
+                name: c.chartName,
+                uuid: c.chartUuid,
+                chartKind: undefined,
+                linkLive: c.linkLive,
+            })) ?? [];
+        const charts =
+            serverCharts.length > 0
+                ? serverCharts
+                : (fallbacks.charts.get(v.prompt) ?? []);
+
+        const serverConnections: ChatConnection[] =
+            v.resources?.externalConnections?.map((c) => ({
+                externalConnectionUuid: c.externalConnectionUuid,
+                name: c.name,
+                alias: c.alias,
+            })) ?? [];
+        const externalConnections =
+            serverConnections.length > 0
+                ? serverConnections
+                : (fallbacks.connections.get(v.prompt) ?? []);
+
+        const imageResourceIds =
+            v.resources?.images.map((img) => img.imageId) ?? [];
+        const imagePreviewUrls = fallbacks.imagePreviewUrls.get(v.prompt) ?? [];
+        const files: ChatAttachedFile[] =
+            v.resources?.files?.map((f) => ({ filename: f.filename })) ??
+            fallbacks.files.get(v.prompt) ??
+            [];
+        const dashboardName =
+            v.resources?.dashboardName ??
+            fallbacks.dashboardName.get(v.prompt) ??
+            null;
+        const clarifications = v.resources?.clarifications ?? [];
+
+        // Assistant reply is dated to when the build actually finished; fall
+        // back to createdAt for old rows persisted before the column started
+        // being written, or for rows still mid-build.
+        const replyTimestamp = v.statusUpdatedAt ?? v.createdAt;
+        // Uploaded-from-source versions (`lightdash upload`) are the only ones
+        // created without a prompt. Their build pipeline stores no completion
+        // message either, so derive the assistant bubble from the version row
+        // rather than trusting a leftover statusMessage.
+        const isUploadedVersion = v.prompt === '';
+        const readyMessage =
+            v.version === 1
+                ? 'Your app is ready!'
+                : `Version ${v.version} is ready!`;
+        const reasoning = versionNarrationTexts(v.statusHistory, 'thinking');
+        const activity = versionNarrationTexts(v.statusHistory, 'tool');
+
+        const msgs: ChatMessage[] = [
+            {
+                ...emptyChatMessage(),
+                role: 'user',
+                content: v.prompt,
+                imagePreviewUrls,
+                imageResourceIds,
+                files,
+                charts,
+                externalConnections,
+                dashboardName,
+                clarifications,
+                timestamp: new Date(v.createdAt),
+                userName: authorNameOf(v),
+            },
+        ];
+
+        if (v.status === 'ready') {
+            msgs.push({
+                ...emptyChatMessage(),
+                role: 'assistant',
+                status: 'ready',
+                content: isUploadedVersion
+                    ? readyMessage
+                    : (v.statusMessage ?? readyMessage),
+                version: v.version,
+                timestamp: new Date(replyTimestamp),
+                vizSchema: v.resources?.vizSchema ?? null,
+                reasoning,
+                activity,
+            });
+        } else if (v.status === 'error') {
+            msgs.push({
+                ...emptyChatMessage(),
+                role: 'assistant',
+                status: 'error',
+                content: getAppVersionFailureMessage(v),
+                // `version` stays null: a deps chip renders off it, and a
+                // failed build has no artifacts to describe.
+                timestamp: new Date(replyTimestamp),
+                reasoning,
+                activity,
+            });
+        }
+        // 'building' status yields no assistant bubble — the caller renders it
+        // as a live progress indicator instead.
+        return msgs;
+    });
+}

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -14,8 +14,6 @@ import {
     type AppDashboardReference,
     type AppExternalConnectionReference,
     type AppVersionDependencyEntry,
-    type AppVersionStatusHistoryEntry,
-    type AppVersionStatusHistoryEntryKind,
     type DataAppClaudeModel,
     type DataAppTemplate,
     type DataAppVizContext,
@@ -117,7 +115,6 @@ import AppSpaceChip from '../features/apps/components/AppSpaceChip';
 import DataAppVizResultCard from '../features/apps/components/DataAppVizResultCard';
 import DataAppVizTestPanel from '../features/apps/components/DataAppVizTestPanel';
 import LoadingDots from '../features/apps/components/LoadingDots';
-import { getAppVersionFailureMessage } from '../features/apps/getAppVersionFailureMessage';
 import { useAppBuildPoller } from '../features/apps/hooks/useAppBuildPoller';
 import { useAppFileUpload } from '../features/apps/hooks/useAppFileUpload';
 import { useAppImageUrl } from '../features/apps/hooks/useAppImageUrl';
@@ -141,12 +138,17 @@ import { useTrackedExternalRequests } from '../features/apps/hooks/useTrackedExt
 import { usePreviewOrigin } from '../features/apps/previewOrigin';
 import { getTemplate } from '../features/apps/templates';
 import {
+    emptyChatMessage,
     mergeChatMessages,
     type ChatAttachedFile,
     type ChatChart,
     type ChatConnection,
     type ChatMessage,
-} from '../features/apps/utils/mergeChatMessages';
+} from '../features/apps/utils/chatMessage';
+import {
+    versionNarrationTexts,
+    versionsToChatMessages,
+} from '../features/apps/utils/versionsToChatMessages';
 import { useAppExternalConnections } from '../features/externalConnections/hooks/useAppExternalConnections';
 import { ThemePicker } from '../features/organizationDesigns/components/ThemePicker';
 import { useOrganizationDesigns } from '../features/organizationDesigns/hooks/useOrganizationDesigns';
@@ -178,19 +180,6 @@ function parseElementRefLabel(label: string): ElementRef | null {
     return { tag: m[1] ?? '', text: m[2] ?? '', loc: m[3] ?? '' };
 }
 
-// The null guard exists because the poll worker feeds raw fetch JSON into
-// the query cache; the consecutive dedupe because a retry can restart the
-// generation stream and re-emit the same entry.
-function versionNarrationTexts(
-    history: AppVersionStatusHistoryEntry[] | undefined,
-    kind: AppVersionStatusHistoryEntryKind,
-): string[] {
-    return (history ?? [])
-        .filter((entry) => entry.kind === kind)
-        .map((entry) => entry.message)
-        .filter((message, index, all) => message !== all[index - 1]);
-}
-
 // Run a layout-changing state update inside a native View Transition so the
 // browser cross-fades/morphs the before/after frames (used for the
 // centered-composer → split-sidebar handoff). flushSync forces React to
@@ -207,7 +196,7 @@ function withViewTransition(update: () => void): void {
     }
 }
 
-// ChatChart and ChatMessage are imported from `features/apps/utils/mergeChatMessages`
+// ChatChart and ChatMessage are imported from `features/apps/utils/chatMessage`
 // alongside the merge helper, so the type and the merge logic stay collocated.
 
 const AppResourceImage: FC<{
@@ -927,136 +916,17 @@ const AppGenerate: FC = () => {
     }, [serverVersionCount]);
 
     // Convert fetched versions into chat messages (oldest first)
-    const historyMessages = useMemo<ChatMessage[]>(() => {
-        if (allVersions.length === 0) return [];
-        const sorted = [...allVersions].sort((a, b) => a.version - b.version);
-        return sorted.flatMap((v) => {
-            // Prefer server-side resources; fall back to session refs
-            const serverCharts: ChatChart[] =
-                v.resources?.charts.map((c) => ({
-                    name: c.chartName,
-                    uuid: c.chartUuid,
-                    chartKind: undefined,
-                    linkLive: c.linkLive,
-                })) ?? [];
-            const charts =
-                serverCharts.length > 0
-                    ? serverCharts
-                    : (sentChartsByPrompt.current.get(v.prompt) ?? []);
-            const serverConnections: ChatConnection[] =
-                v.resources?.externalConnections?.map((c) => ({
-                    externalConnectionUuid: c.externalConnectionUuid,
-                    name: c.name,
-                    alias: c.alias,
-                })) ?? [];
-            const externalConnections =
-                serverConnections.length > 0
-                    ? serverConnections
-                    : (sentConnectionsByPrompt.current.get(v.prompt) ?? []);
-            const imageResourceIds =
-                v.resources?.images.map((img) => img.imageId) ?? [];
-            const imagePreviewUrls =
-                sentImagesByPrompt.current.get(v.prompt) ?? [];
-            // Old rows carry no `files` — fall back to the session map so an
-            // optimistic bubble's chips survive the local→server transition.
-            const files: ChatAttachedFile[] =
-                v.resources?.files?.map((f) => ({ filename: f.filename })) ??
-                sentFilesByPrompt.current.get(v.prompt) ??
-                [];
-            const dashboardName =
-                v.resources?.dashboardName ??
-                sentDashboardByPrompt.current.get(v.prompt) ??
-                null;
-            const clarifications = v.resources?.clarifications ?? [];
-            const authorName = v.createdByUser
-                ? [v.createdByUser.firstName, v.createdByUser.lastName]
-                      .filter((s) => s.length > 0)
-                      .join(' ') || null
-                : null;
-            // Assistant reply is dated to when the build actually finished;
-            // fall back to createdAt for old rows persisted before the column
-            // started being written, or for rows still mid-build.
-            const replyTimestamp = v.statusUpdatedAt ?? v.createdAt;
-            // Uploaded-from-source versions (`lightdash upload`) are the only
-            // ones created without a prompt. Their build pipeline stores no
-            // completion message either, so derive the assistant bubble from
-            // the version row rather than trusting a leftover statusMessage.
-            const isUploadedVersion = v.prompt === '';
-            const readyMessage =
-                v.version === 1
-                    ? 'Your app is ready!'
-                    : `Version ${v.version} is ready!`;
-            const reasoning = versionNarrationTexts(
-                v.statusHistory,
-                'thinking',
-            );
-            const activity = versionNarrationTexts(v.statusHistory, 'tool');
-            const msgs: ChatMessage[] = [
-                {
-                    role: 'user',
-                    content: v.prompt,
-                    imagePreviewUrls,
-                    imageResourceIds,
-                    files,
-                    charts,
-                    externalConnections,
-                    dashboardName,
-                    clarifications,
-                    appUuid: null,
-                    version: null,
-                    timestamp: new Date(v.createdAt),
-                    userName: authorName,
-                    vizSchema: null,
-                    reasoning: [],
-                    activity: [],
-                },
-            ];
-            if (v.status === 'ready') {
-                msgs.push({
-                    role: 'assistant',
-                    content: isUploadedVersion
-                        ? readyMessage
-                        : (v.statusMessage ?? readyMessage),
-                    imagePreviewUrls: [],
-                    imageResourceIds: [],
-                    files: [],
-                    charts: [],
-                    externalConnections: [],
-                    dashboardName: null,
-                    clarifications: [],
-                    appUuid: activeAppUuid ?? null,
-                    version: v.version,
-                    timestamp: new Date(replyTimestamp),
-                    userName: null,
-                    vizSchema: v.resources?.vizSchema ?? null,
-                    reasoning,
-                    activity,
-                });
-            } else if (v.status === 'error') {
-                msgs.push({
-                    role: 'assistant',
-                    content: getAppVersionFailureMessage(v),
-                    imagePreviewUrls: [],
-                    imageResourceIds: [],
-                    files: [],
-                    charts: [],
-                    externalConnections: [],
-                    dashboardName: null,
-                    clarifications: [],
-                    appUuid: null,
-                    version: null,
-                    timestamp: new Date(replyTimestamp),
-                    userName: null,
-                    vizSchema: null,
-                    reasoning,
-                    activity,
-                });
-            }
-            // 'building' status is not rendered as a history message —
-            // it's shown as a live progress indicator below
-            return msgs;
-        });
-    }, [allVersions, activeAppUuid]);
+    const historyMessages = useMemo<ChatMessage[]>(
+        () =>
+            versionsToChatMessages(allVersions, {
+                charts: sentChartsByPrompt.current,
+                connections: sentConnectionsByPrompt.current,
+                imagePreviewUrls: sentImagesByPrompt.current,
+                files: sentFilesByPrompt.current,
+                dashboardName: sentDashboardByPrompt.current,
+            }),
+        [allVersions],
+    );
 
     // Lookup table: version number → full version summary. Used to retrieve
     // declared-dependency metadata when rendering assistant bubbles.
@@ -1247,25 +1117,14 @@ const AppGenerate: FC = () => {
             setLocalMessages((prev) => [
                 ...prev,
                 {
+                    ...emptyChatMessage(),
                     role: 'user',
                     content: prompt,
-                    imagePreviewUrls: [],
-                    imageResourceIds: [],
-                    files: [],
-                    charts: [],
-                    externalConnections: [],
-                    dashboardName: null,
-                    clarifications: [],
-                    appUuid: null,
-                    version: null,
                     timestamp: new Date(),
                     userName:
                         [user.data?.firstName, user.data?.lastName]
                             .filter((s): s is string => !!s && s.length > 0)
                             .join(' ') || null,
-                    vizSchema: null,
-                    reasoning: [],
-                    activity: [],
                     submittedAtVersion: maxHistoryVersion,
                 },
             ]);
@@ -1294,22 +1153,11 @@ const AppGenerate: FC = () => {
                         setLocalMessages((prev) => [
                             ...prev,
                             {
+                                ...emptyChatMessage(),
                                 role: 'assistant',
+                                status: 'error',
                                 content: themeErrorMessage,
-                                imagePreviewUrls: [],
-                                imageResourceIds: [],
-                                files: [],
-                                charts: [],
-                                externalConnections: [],
-                                dashboardName: null,
-                                clarifications: [],
-                                appUuid: null,
-                                version: null,
                                 timestamp: new Date(),
-                                userName: null,
-                                vizSchema: null,
-                                reasoning: [],
-                                activity: [],
                             },
                         ]);
                     },
@@ -1793,22 +1641,11 @@ const AppGenerate: FC = () => {
             setLocalMessages((prev) => [
                 ...prev,
                 {
+                    ...emptyChatMessage(),
                     role: 'assistant' as const,
+                    status: 'error' as const,
                     content: errorMessage,
-                    imagePreviewUrls: [],
-                    imageResourceIds: [],
-                    files: [],
-                    charts: [],
-                    externalConnections: [],
-                    dashboardName: null,
-                    clarifications: [],
-                    appUuid: null,
-                    version: null,
                     timestamp: new Date(),
-                    userName: null,
-                    vizSchema: null,
-                    reasoning: [],
-                    activity: [],
                 },
             ]);
         },
@@ -1953,25 +1790,19 @@ const AppGenerate: FC = () => {
             setLocalMessages((prev) => [
                 ...prev,
                 {
+                    ...emptyChatMessage(),
                     role: 'user',
                     content: trimmed,
                     imagePreviewUrls: sentImageUrls,
-                    imageResourceIds: [],
                     files: sentFiles,
                     charts: sentCharts,
                     externalConnections: sentConnections,
                     dashboardName: sentDashboardName,
-                    clarifications: [],
-                    appUuid: null,
-                    version: null,
                     timestamp: new Date(),
                     userName:
                         [user.data?.firstName, user.data?.lastName]
                             .filter((s): s is string => !!s && s.length > 0)
                             .join(' ') || null,
-                    vizSchema: null,
-                    reasoning: [],
-                    activity: [],
                     // Snapshot the highest server version known at submit time.
                     // Once history catches up past this number the optimistic
                     // bubble is dropped by `mergeChatMessages` — even if the
@@ -2611,7 +2442,8 @@ const AppGenerate: FC = () => {
                                                             }
                                                             userName={null}
                                                             version={
-                                                                msg.appUuid &&
+                                                                msg.status ===
+                                                                    'ready' &&
                                                                 msg.version !==
                                                                     null
                                                                     ? buildBubbleVersionInfo(
@@ -2672,7 +2504,8 @@ const AppGenerate: FC = () => {
                                                                     }
                                                                 />
                                                             )
-                                                        ) : msg.appUuid ? (
+                                                        ) : msg.status !==
+                                                          'error' ? (
                                                             <AiMarkdown>
                                                                 {msg.content}
                                                             </AiMarkdown>


### PR DESCRIPTION
Extracts the `app_versions[] → ChatMessage[]` converter out of `AppGenerate.tsx` so another surface can render a data app's history, and so it can be unit-tested.

Assistant bubbles used a null `appUuid` to mean "failed", which rendered a successful message as an error whenever the uuid happened to be absent. Now an explicit `status`.

Pure refactor.

Relates: GLITCH-630
