### PR TITLE
feat(apps): bind viz slots to the query's result columns

### DIFF
--- a/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
         current: undefined as
             | {
                   schema: {
+                      fields: Array<never>;
                       configOptions: Array<{
                           type: 'text';
                           name: string;
@@ -83,6 +84,7 @@ describe('DataAppVizRenderer option delivery', () => {
 
         mocks.dataAppViz.current = {
             schema: {
+                fields: [],
                 configOptions: [
                     {
                         type: 'text',

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -11,6 +11,7 @@ import { useAppPreviewToken } from '../../features/apps/hooks/useAppPreviewToken
 import { useDataAppVisualization } from '../../features/apps/hooks/useDataAppVisualization';
 import { useGetApp } from '../../features/apps/hooks/useGetApp';
 import { usePreviewOrigin } from '../../features/apps/previewOrigin';
+import { reconcileDataAppVizFieldMapping } from '../../features/apps/utils/autoMapDataAppVizFields';
 import MantineIcon from '../common/MantineIcon';
 import { isDataAppVizVisualizationConfig } from '../LightdashVisualization/types';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
@@ -31,7 +32,7 @@ const DataAppVizPlaceholder: FC<{ message: string }> = ({ message }) => (
 
 const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
-    const { visualizationConfig, resultsData, colorPalette } =
+    const { visualizationConfig, resultsData, colorPalette, itemsMap } =
         useVisualizationContext();
     const previewOrigin = usePreviewOrigin();
     const hasSignaledScreenshotReady = useRef(false);
@@ -71,6 +72,7 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
         dataAppVizUuid || undefined,
     );
     const configOptions = dataAppViz?.schema?.configOptions;
+    const fields = dataAppViz?.schema?.fields;
 
     // Latest READY version of the chosen data app viz drives the preview.
     const readyVersion = useMemo(() => {
@@ -87,9 +89,16 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
     );
 
     const dataAppVizContext = useMemo<DataAppVizContext | undefined>(() => {
-        if (!rows || !configOptions) return undefined;
+        if (!rows || !configOptions || !fields) return undefined;
         return {
-            fieldMapping: fieldMapping ?? {},
+            // Reconciled against the contract and columns in force now, so a
+            // rebuilt viz never renders through a binding the panel no longer
+            // shows.
+            fieldMapping: reconcileDataAppVizFieldMapping(
+                fields,
+                itemsMap ?? {},
+                fieldMapping ?? {},
+            ),
             rows,
             options: getEffectiveOptionValues(
                 configOptions,
@@ -99,7 +108,15 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
             // corrected by the visualization context.
             colorPalette,
         };
-    }, [fieldMapping, rows, configOptions, optionValues, colorPalette]);
+    }, [
+        fields,
+        itemsMap,
+        fieldMapping,
+        rows,
+        configOptions,
+        optionValues,
+        colorPalette,
+    ]);
 
     if (!projectUuid || !dataAppVizUuid) {
         return (

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
@@ -8,24 +8,35 @@ import {
     type CompiledDimension,
     type CompiledMetric,
     type CustomSqlDimension,
+    type DataAppViz,
     type DataAppVizConfigOption,
     type DataAppVizPaletteDeclaration,
     type DataAppVizField,
     type Item,
+    type ItemsMap,
     type TableCalculation,
 } from '@lightdash/common';
-import { screen } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../testing/testUtils';
 import { ConfigTabs } from './DataAppVizConfigTabs';
 
-const { fieldSelectItems } = vi.hoisted(() => ({
+type PickerProps = {
+    disabled: boolean;
+    onSelect: (dataAppViz: DataAppViz | null) => void;
+};
+
+const { fieldSelectItems, pickerProps } = vi.hoisted(() => ({
     fieldSelectItems: [] as Item[][],
+    pickerProps: [] as PickerProps[],
 }));
 
 vi.mock('../../../features/apps/components/DataAppVizLibraryPicker', () => ({
-    default: () => null,
+    default: (props: PickerProps) => {
+        pickerProps.push(props);
+        return <div data-testid="viz-picker" />;
+    },
 }));
 vi.mock('../../../features/apps/hooks/useDataAppVisualization', () => ({
     useDataAppVisualization: vi.fn(),
@@ -122,34 +133,42 @@ const mockSchema = (
     } as unknown as ReturnType<typeof useDataAppVisualization>);
 };
 
+const queryColumns: ItemsMap = {
+    orders_visible: makeDimension('visible', false),
+    orders_hidden: makeDimension('hidden', true),
+    orders_visible_metric: makeMetric('visible_metric', false),
+    orders_hidden_metric: makeMetric('hidden_metric', true),
+    'custom-dimension': customDimension,
+    table_calculation: tableCalculation,
+};
+
 describe('DataAppVizConfigTabs', () => {
     const setOption = vi.fn();
+    const setDataAppVizUuid = vi.fn();
 
-    beforeEach(() => {
-        fieldSelectItems.length = 0;
-        setOption.mockClear();
-        mockSchema([]);
+    const mockContext = (itemsMap: ItemsMap) =>
         vi.mocked(useVisualizationContext).mockReturnValue({
-            itemsMap: {
-                orders_visible: makeDimension('visible', false),
-                orders_hidden: makeDimension('hidden', true),
-                orders_visible_metric: makeMetric('visible_metric', false),
-                orders_hidden_metric: makeMetric('hidden_metric', true),
-                'custom-dimension': customDimension,
-                table_calculation: tableCalculation,
-            },
+            itemsMap,
             visualizationConfig: {
                 chartType: ChartType.DATA_APP_VIZ,
                 chartConfig: {
                     dataAppVizUuid: 'data-app-viz-uuid',
                     fieldMapping: {},
                     optionValues: {},
-                    setDataAppVizUuid: vi.fn(),
+                    setDataAppVizUuid,
                     setField: vi.fn(),
                     setOption,
                 },
             },
         } as unknown as ReturnType<typeof useVisualizationContext>);
+
+    beforeEach(() => {
+        fieldSelectItems.length = 0;
+        pickerProps.length = 0;
+        setOption.mockClear();
+        setDataAppVizUuid.mockClear();
+        mockSchema([]);
+        mockContext(queryColumns);
     });
 
     it('matches Explorer field visibility', () => {
@@ -184,6 +203,44 @@ describe('DataAppVizConfigTabs', () => {
         await user.click(screen.getByRole('tab', { name: 'Colours' }));
 
         expect(screen.getByTestId('color-palette-section')).toBeInTheDocument();
+    });
+
+    it('binds the picked viz contract to the query columns', () => {
+        renderWithProviders(<ConfigTabs />);
+
+        const picked = {
+            dataAppVizUuid: 'picked-uuid',
+            schema: {
+                fields: [
+                    ...declaredFields,
+                    {
+                        name: 'breakdown',
+                        label: 'Breakdown',
+                        type: 'series',
+                        required: false,
+                    },
+                ],
+                configOptions: [],
+                colorPalette: null,
+            },
+        } as unknown as DataAppViz;
+        act(() => pickerProps[pickerProps.length - 1].onSelect(picked));
+
+        expect(setDataAppVizUuid).toHaveBeenCalledWith('picked-uuid', {
+            source: 'orders_visible',
+            value: 'orders_visible_metric',
+            breakdown: 'custom-dimension',
+        });
+    });
+
+    it('will not offer the picker before the query has columns', () => {
+        mockContext({});
+        renderWithProviders(<ConfigTabs />);
+
+        expect(pickerProps[pickerProps.length - 1].disabled).toBe(true);
+        expect(
+            screen.getByText('Run your query to pick a visualization.'),
+        ).toBeInTheDocument();
     });
 
     it('fires setOption when a control changes', async () => {

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -10,6 +10,11 @@ import { memo, useMemo, type FC } from 'react';
 import { useParams } from 'react-router';
 import DataAppVizLibraryPicker from '../../../features/apps/components/DataAppVizLibraryPicker';
 import { useDataAppVisualization } from '../../../features/apps/hooks/useDataAppVisualization';
+import {
+    autoMapDataAppVizFields,
+    poolKeyForSlot,
+    reconcileDataAppVizFieldMapping,
+} from '../../../features/apps/utils/autoMapDataAppVizFields';
 import { getDataAppVizFieldItems } from '../../../features/apps/utils/getDataAppVizFieldItems';
 import FieldSelect from '../../common/FieldSelect';
 import { isDataAppVizVisualizationConfig } from '../../LightdashVisualization/types';
@@ -38,10 +43,14 @@ export const ConfigTabs: FC = memo(() => {
         dataAppVizUuid || undefined,
     );
 
-    const { dimensions, metrics } = useMemo(
-        () => getDataAppVizFieldItems(itemsMap ?? {}),
-        [itemsMap],
-    );
+    const itemPools = useMemo(() => {
+        const { dimensions, metrics } = getDataAppVizFieldItems(itemsMap ?? {});
+        return { dimension: dimensions, metric: metrics };
+    }, [itemsMap]);
+    // Auto-binding cannot run without columns, and it only runs once, at pick
+    // time — so picking now would leave the slots empty for good.
+    const hasColumns =
+        itemPools.dimension.length > 0 || itemPools.metric.length > 0;
 
     const configOptions = useMemo(
         () => dataAppViz?.schema?.configOptions ?? [],
@@ -50,7 +59,7 @@ export const ConfigTabs: FC = memo(() => {
     const colorPalette = dataAppViz?.schema?.colorPalette ?? null;
 
     const fieldItems = (field: DataAppVizField): Item[] =>
-        field.type === 'metric' ? metrics : dimensions;
+        itemPools[poolKeyForSlot(field)];
 
     if (!isDataAppViz) return null;
 
@@ -66,6 +75,14 @@ export const ConfigTabs: FC = memo(() => {
         configOptions,
         optionValues,
     );
+    // The contract can change under a stable uuid when the viz is rebuilt, so
+    // what the selects show is the saved mapping reconciled against the
+    // contract and columns in force now — the same value the renderer uses.
+    const effectiveMapping = reconcileDataAppVizFieldMapping(
+        fields,
+        itemsMap ?? {},
+        fieldMapping,
+    );
 
     const generalPanel = (
         <Stack>
@@ -76,8 +93,24 @@ export const ConfigTabs: FC = memo(() => {
                         projectUuid={projectUuid ?? ''}
                         selectedDataAppVizUuid={dataAppVizUuid || null}
                         selectedDataAppViz={dataAppViz ?? null}
-                        onSelect={(uuid) => setDataAppVizUuid(uuid ?? '')}
+                        disabled={!hasColumns}
+                        onSelect={(picked) =>
+                            setDataAppVizUuid(
+                                picked?.dataAppVizUuid ?? '',
+                                picked
+                                    ? autoMapDataAppVizFields(
+                                          picked.schema?.fields ?? [],
+                                          itemsMap ?? {},
+                                      )
+                                    : {},
+                            )
+                        }
                     />
+                    {!hasColumns && (
+                        <Text c="dimmed" size="xs">
+                            Run your query to pick a visualization.
+                        </Text>
+                    )}
                 </Config.Section>
             </Config>
 
@@ -89,7 +122,7 @@ export const ConfigTabs: FC = memo(() => {
 
             {fields.map((field) => {
                 const items = fieldItems(field);
-                const selectedId = fieldMapping[field.name];
+                const selectedId = effectiveMapping[field.name];
                 const selectedItem = selectedId
                     ? items.find((i) => getItemId(i) === selectedId)
                     : undefined;

--- a/packages/frontend/src/features/apps/components/DataAppVizLibraryPicker.test.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizLibraryPicker.test.tsx
@@ -40,7 +40,7 @@ const setData = (data: DataAppViz[]) => {
 };
 
 const render = (
-    onSelect: (id: string | null) => void,
+    onSelect: (dataAppViz: DataAppViz | null) => void,
     selected: DataAppViz | null = null,
 ) =>
     renderWithProviders(
@@ -48,6 +48,7 @@ const render = (
             projectUuid="project-1"
             selectedDataAppVizUuid={selected?.dataAppVizUuid ?? null}
             selectedDataAppViz={selected}
+            disabled={false}
             onSelect={onSelect}
         />,
     );
@@ -73,17 +74,21 @@ describe('DataAppVizLibraryPicker', () => {
         expect(screen.getByText('Bar race')).toBeDefined();
     });
 
-    it('returns the selected viz uuid on click', () => {
-        setData([
-            makeDataAppViz({ dataAppVizUuid: 'picked', name: 'Pick me' }),
-        ]);
+    it('returns the whole selected viz on click, contract included', () => {
+        const picked = makeDataAppViz({
+            dataAppVizUuid: 'picked',
+            name: 'Pick me',
+        });
+        setData([picked]);
         const onSelect = vi.fn();
         render(onSelect);
         openDropdown();
 
         fireEvent.click(screen.getByText('Pick me'));
 
-        expect(onSelect).toHaveBeenCalledWith('picked');
+        // The caller binds the contract straight away, so it needs the schema
+        // and not just the uuid.
+        expect(onSelect).toHaveBeenCalledWith(picked);
     });
 
     it('lists the whole library while the input still holds the selected label', () => {

--- a/packages/frontend/src/features/apps/components/DataAppVizLibraryPicker.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizLibraryPicker.tsx
@@ -10,7 +10,11 @@ type Props = {
     projectUuid: string;
     selectedDataAppVizUuid: string | null;
     selectedDataAppViz: DataAppViz | null;
-    onSelect: (dataAppVizUuid: string | null) => void;
+    disabled: boolean;
+    /** Receives the whole viz so the caller can bind its contract straight
+     *  away, without waiting on a fetch for the newly selected uuid, or null
+     *  when the selection is cleared. */
+    onSelect: (dataAppViz: DataAppViz | null) => void;
 };
 
 interface DataAppVizItem extends ComboboxItem {
@@ -35,6 +39,7 @@ const DataAppVizLibraryPicker: FC<Props> = ({
     projectUuid,
     selectedDataAppVizUuid,
     selectedDataAppViz,
+    disabled,
     onSelect,
 }) => {
     const [search, setSearch] = useState('');
@@ -55,6 +60,19 @@ const DataAppVizLibraryPicker: FC<Props> = ({
     const { data, isInitialLoading, isFetching, error } =
         useDataAppVisualizations(projectUuid, debouncedSearch);
 
+    // Keep the fetched rows addressable by uuid so `onChange` can hand the
+    // caller the whole viz (contract included), not just its uuid.
+    const dataAppVizsByUuid = useMemo(() => {
+        const byUuid = new Map<string, DataAppViz>();
+        if (selectedDataAppViz) {
+            byUuid.set(selectedDataAppViz.dataAppVizUuid, selectedDataAppViz);
+        }
+        for (const page of data?.pages ?? []) {
+            for (const viz of page.data) byUuid.set(viz.dataAppVizUuid, viz);
+        }
+        return byUuid;
+    }, [data?.pages, selectedDataAppViz]);
+
     const selectData = useMemo(() => {
         const dataAppVizs = data?.pages.flatMap((page) => page.data) ?? [];
         const items = dataAppVizs.map(toItem);
@@ -72,13 +90,16 @@ const DataAppVizLibraryPicker: FC<Props> = ({
     return (
         <Select
             searchable
+            disabled={disabled}
             value={selectedDataAppVizUuid}
             data={selectData}
             searchValue={search}
             onSearchChange={setSearch}
             // Search is done server-side, so keep every returned option.
             filter={({ options }) => options}
-            onChange={(value) => onSelect(value)}
+            onChange={(value) =>
+                onSelect(value ? (dataAppVizsByUuid.get(value) ?? null) : null)
+            }
             allowDeselect={false}
             clearable
             placeholder="Select a visualization"

--- a/packages/frontend/src/features/apps/utils/autoMapDataAppVizFields.test.ts
+++ b/packages/frontend/src/features/apps/utils/autoMapDataAppVizFields.test.ts
@@ -1,0 +1,264 @@
+import {
+    DimensionType,
+    FieldType,
+    MetricType,
+    type CompiledDimension,
+    type CompiledMetric,
+    type DataAppVizField,
+    type ItemsMap,
+} from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import {
+    autoMapDataAppVizFields,
+    reconcileDataAppVizFieldMapping,
+} from './autoMapDataAppVizFields';
+
+const dimension = (name: string, hidden = false): CompiledDimension => ({
+    compiledSql: '',
+    tablesReferences: [],
+    fieldType: FieldType.DIMENSION,
+    type: DimensionType.STRING,
+    name,
+    label: name,
+    table: 'orders',
+    tableLabel: 'Orders',
+    sql: '',
+    hidden,
+});
+
+const metric = (name: string, hidden = false): CompiledMetric => ({
+    compiledSql: '',
+    tablesReferences: [],
+    fieldType: FieldType.METRIC,
+    type: MetricType.COUNT,
+    name,
+    label: name,
+    table: 'orders',
+    tableLabel: 'Orders',
+    sql: '',
+    hidden,
+});
+
+const itemsMap = (...items: (CompiledDimension | CompiledMetric)[]): ItemsMap =>
+    Object.fromEntries(items.map((i) => [`orders_${i.name}`, i])) as ItemsMap;
+
+const field = (
+    name: string,
+    type: DataAppVizField['type'],
+    required = true,
+): DataAppVizField => ({ name, label: name, type, required });
+
+describe('autoMapDataAppVizFields', () => {
+    it('binds nothing when the contract declares no slots', () => {
+        expect(
+            autoMapDataAppVizFields([], itemsMap(dimension('status'))),
+        ).toEqual({});
+    });
+
+    it('binds nothing when the query has no columns', () => {
+        expect(
+            autoMapDataAppVizFields([field('x', 'dimension')], {} as ItemsMap),
+        ).toEqual({});
+    });
+
+    it('binds each slot to a column of its type', () => {
+        const mapping = autoMapDataAppVizFields(
+            [field('category', 'dimension'), field('value', 'metric')],
+            itemsMap(dimension('status'), metric('count')),
+        );
+        expect(mapping).toEqual({
+            category: 'orders_status',
+            value: 'orders_count',
+        });
+    });
+
+    it('binds a series slot to a dimension, not a metric', () => {
+        const mapping = autoMapDataAppVizFields(
+            [field('breakdown', 'series')],
+            itemsMap(dimension('status'), metric('count')),
+        );
+        expect(mapping).toEqual({ breakdown: 'orders_status' });
+    });
+
+    it('never binds the same column to two slots', () => {
+        const mapping = autoMapDataAppVizFields(
+            [field('category', 'dimension'), field('breakdown', 'series')],
+            itemsMap(dimension('status'), dimension('method')),
+        );
+        expect(mapping).toEqual({
+            category: 'orders_status',
+            breakdown: 'orders_method',
+        });
+    });
+
+    it('leaves a slot unbound when its pool runs dry', () => {
+        const mapping = autoMapDataAppVizFields(
+            [field('category', 'dimension'), field('breakdown', 'series')],
+            itemsMap(dimension('status')),
+        );
+        expect(mapping).toEqual({ category: 'orders_status' });
+        expect(mapping.breakdown).toBeUndefined();
+    });
+
+    it('fills required slots before optional ones', () => {
+        // The optional slot is declared first, but the single dimension has to
+        // land on the required one or the viz cannot render at all.
+        const mapping = autoMapDataAppVizFields(
+            [
+                field('breakdown', 'series', false),
+                field('category', 'dimension', true),
+            ],
+            itemsMap(dimension('status')),
+        );
+        expect(mapping).toEqual({ category: 'orders_status' });
+    });
+
+    it('keeps declared order within the required pass', () => {
+        const mapping = autoMapDataAppVizFields(
+            [field('first', 'dimension'), field('second', 'dimension')],
+            itemsMap(dimension('status'), dimension('method')),
+        );
+        expect(mapping).toEqual({
+            first: 'orders_status',
+            second: 'orders_method',
+        });
+    });
+
+    it('skips hidden columns', () => {
+        const mapping = autoMapDataAppVizFields(
+            [field('category', 'dimension'), field('value', 'metric')],
+            itemsMap(
+                dimension('secret', true),
+                dimension('status'),
+                metric('hidden_count', true),
+                metric('count'),
+            ),
+        );
+        expect(mapping).toEqual({
+            category: 'orders_status',
+            value: 'orders_count',
+        });
+    });
+});
+
+describe('reconcileDataAppVizFieldMapping', () => {
+    it('keeps a binding that is still valid', () => {
+        const mapping = reconcileDataAppVizFieldMapping(
+            [field('category', 'dimension'), field('value', 'metric')],
+            itemsMap(dimension('status'), dimension('method'), metric('count')),
+            { category: 'orders_method', value: 'orders_count' },
+        );
+        expect(mapping).toEqual({
+            category: 'orders_method',
+            value: 'orders_count',
+        });
+    });
+
+    it('drops a binding for a slot the contract no longer declares', () => {
+        const mapping = reconcileDataAppVizFieldMapping(
+            [field('category', 'dimension')],
+            itemsMap(dimension('status')),
+            { category: 'orders_status', departed: 'orders_status' },
+        );
+        expect(mapping).toEqual({ category: 'orders_status' });
+        expect(mapping.departed).toBeUndefined();
+    });
+
+    it('rebinds a required slot whose column left the query', () => {
+        const mapping = reconcileDataAppVizFieldMapping(
+            [field('category', 'dimension')],
+            itemsMap(dimension('method')),
+            { category: 'orders_gone' },
+        );
+        expect(mapping).toEqual({ category: 'orders_method' });
+    });
+
+    it('rebinds a required slot that was retyped by a rebuild', () => {
+        // The slot used to be a dimension and the saved mapping still points
+        // at one; the rebuilt contract declares it a metric.
+        const mapping = reconcileDataAppVizFieldMapping(
+            [field('value', 'metric')],
+            itemsMap(dimension('status'), metric('count')),
+            { value: 'orders_status' },
+        );
+        expect(mapping).toEqual({ value: 'orders_count' });
+    });
+
+    it('fills a required slot a rebuild has newly added', () => {
+        const mapping = reconcileDataAppVizFieldMapping(
+            [field('category', 'dimension'), field('value', 'metric')],
+            itemsMap(dimension('status'), metric('count')),
+            { category: 'orders_status' },
+        );
+        expect(mapping).toEqual({
+            category: 'orders_status',
+            value: 'orders_count',
+        });
+    });
+
+    it('leaves a cleared optional slot cleared', () => {
+        // Refilling here would undo the user's clear on every render.
+        const mapping = reconcileDataAppVizFieldMapping(
+            [
+                field('category', 'dimension'),
+                field('breakdown', 'series', false),
+            ],
+            itemsMap(dimension('status'), dimension('method')),
+            { category: 'orders_status' },
+        );
+        expect(mapping).toEqual({ category: 'orders_status' });
+        expect(mapping.breakdown).toBeUndefined();
+    });
+
+    it('never rebinds a required slot onto a column another slot holds', () => {
+        const mapping = reconcileDataAppVizFieldMapping(
+            [field('category', 'dimension'), field('breakdown', 'series')],
+            itemsMap(dimension('status')),
+            { category: 'orders_status' },
+        );
+        expect(mapping).toEqual({ category: 'orders_status' });
+        expect(mapping.breakdown).toBeUndefined();
+    });
+
+    it('keeps two slots pointed at one column', () => {
+        // Only auto-binding spreads columns; which ones a chart uses is the
+        // user's call, and rebinding here would undo the pick they just made.
+        const mapping = reconcileDataAppVizFieldMapping(
+            [field('category', 'dimension'), field('breakdown', 'series')],
+            itemsMap(dimension('status'), dimension('method')),
+            { category: 'orders_status', breakdown: 'orders_status' },
+        );
+        expect(mapping).toEqual({
+            category: 'orders_status',
+            breakdown: 'orders_status',
+        });
+    });
+
+    it('does not hand a doubled-up column to a slot still waiting to be filled', () => {
+        const mapping = reconcileDataAppVizFieldMapping(
+            [
+                field('category', 'dimension'),
+                field('breakdown', 'series'),
+                field('detail', 'dimension'),
+            ],
+            itemsMap(dimension('status'), dimension('method')),
+            { category: 'orders_status', breakdown: 'orders_status' },
+        );
+        expect(mapping).toEqual({
+            category: 'orders_status',
+            breakdown: 'orders_status',
+            detail: 'orders_method',
+        });
+    });
+
+    it('matches a fresh auto-map when nothing is persisted and all slots are required', () => {
+        const fields = [
+            field('category', 'dimension'),
+            field('value', 'metric'),
+        ];
+        const items = itemsMap(dimension('status'), metric('count'));
+        expect(reconcileDataAppVizFieldMapping(fields, items, {})).toEqual(
+            autoMapDataAppVizFields(fields, items),
+        );
+    });
+});

--- a/packages/frontend/src/features/apps/utils/autoMapDataAppVizFields.ts
+++ b/packages/frontend/src/features/apps/utils/autoMapDataAppVizFields.ts
@@ -1,0 +1,148 @@
+import {
+    assertUnreachable,
+    getItemId,
+    type DataAppVizField,
+    type DataAppVizFieldMapping,
+    type ItemsMap,
+} from '@lightdash/common';
+import { getDataAppVizFieldItems } from './getDataAppVizFieldItems';
+
+/**
+ * Which of the query's column pools a slot draws from. `series` splits or
+ * colours a measure, so it draws from the dimensions. Shared with the config
+ * panel: if the two disagreed, auto-binding could set a column the select
+ * cannot offer.
+ */
+export const poolKeyForSlot = (
+    field: DataAppVizField,
+): 'dimension' | 'metric' => {
+    switch (field.type) {
+        case 'metric':
+            return 'metric';
+        case 'dimension':
+        case 'series':
+            return 'dimension';
+        default:
+            return assertUnreachable(
+                field.type,
+                `Unknown data app viz field type: ${field.type}`,
+            );
+    }
+};
+
+// Column ids of each type, in result order. Ids rather than items, because
+// every binding is compared and stored as an id.
+type Pools = Record<'dimension' | 'metric', string[]>;
+
+const poolsFor = (itemsMap: ItemsMap): Pools => {
+    const { dimensions, metrics } = getDataAppVizFieldItems(itemsMap);
+    return {
+        dimension: dimensions.map(getItemId),
+        metric: metrics.map(getItemId),
+    };
+};
+
+const poolFor = (pools: Pools, field: DataAppVizField): string[] =>
+    pools[poolKeyForSlot(field)];
+
+/**
+ * Give each still-unbound slot the first column of its type that nothing else
+ * has taken. Slots already in `mapping` keep what they have.
+ */
+const fillSlots = (
+    mapping: DataAppVizFieldMapping,
+    taken: Set<string>,
+    pools: Pools,
+    slots: DataAppVizField[],
+): void => {
+    for (const field of slots) {
+        if (mapping[field.name]) continue;
+        const next = poolFor(pools, field).find((id) => !taken.has(id));
+        if (!next) continue;
+        mapping[field.name] = next;
+        taken.add(next);
+    }
+};
+
+/**
+ * Bind a viz contract's declared slots to the query's result columns.
+ *
+ * Each column is used at most once, so a two-dimension contract never binds
+ * the same column twice. Required slots are filled before optional ones so a
+ * scarce column lands where it is needed rather than in whichever slot happens
+ * to be declared first. Within each pass, declared order wins.
+ *
+ * Returns only the slots it could fill; callers treat a missing entry as
+ * unbound.
+ */
+export const autoMapDataAppVizFields = (
+    fields: DataAppVizField[],
+    itemsMap: ItemsMap,
+): DataAppVizFieldMapping => {
+    const pools = poolsFor(itemsMap);
+    const mapping: DataAppVizFieldMapping = {};
+    const taken = new Set<string>();
+
+    fillSlots(
+        mapping,
+        taken,
+        pools,
+        fields.filter((f) => f.required),
+    );
+    fillSlots(
+        mapping,
+        taken,
+        pools,
+        fields.filter((f) => !f.required),
+    );
+
+    return mapping;
+};
+
+/**
+ * Reconcile a saved binding against the contract and columns in force now.
+ *
+ * A viz is edited in place: a new build can add, remove or retype slots under
+ * a uuid that never changes, and the query's columns move independently. Both
+ * leave a saved `fieldMapping` describing a world that no longer exists — a
+ * binding to a departed column, or to a column whose slot is now a metric.
+ * Left alone those render wrong while the panel shows an empty select.
+ *
+ * Bindings that are still valid are kept, including two slots on one column:
+ * which columns a chart uses is the user's call, and only auto-binding spreads
+ * them. Required slots left unbound are filled from what remains. Optional
+ * slots are *not* refilled: an unbound optional slot is indistinguishable from
+ * one the user deliberately cleared, and refilling would undo the clear on
+ * every render.
+ *
+ * Pure and derived — never written back to the saved chart, so opening a chart
+ * cannot dirty it.
+ */
+export const reconcileDataAppVizFieldMapping = (
+    fields: DataAppVizField[],
+    itemsMap: ItemsMap,
+    persisted: DataAppVizFieldMapping,
+): DataAppVizFieldMapping => {
+    const pools = poolsFor(itemsMap);
+    const mapping: DataAppVizFieldMapping = {};
+    const taken = new Set<string>();
+
+    for (const field of fields) {
+        const bound = persisted[field.name];
+        if (!bound) continue;
+        if (!poolFor(pools, field).includes(bound)) continue;
+        mapping[field.name] = bound;
+        taken.add(bound);
+    }
+
+    // Kept bindings are already in `mapping`, so this only reaches slots the
+    // contract requires and nothing valid claimed.
+    fillSlots(
+        mapping,
+        taken,
+        pools,
+        fields.filter((f) => f.required),
+    );
+
+    return mapping;
+};

--- a/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.test.ts
+++ b/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.test.ts
@@ -132,7 +132,7 @@ describe('useDataAppVizVisualizationConfig', () => {
             useDataAppVizVisualizationConfig(initialConfig, onConfigChange),
         );
 
-        act(() => result.current.setDataAppVizUuid('viz-2'));
+        act(() => result.current.setDataAppVizUuid('viz-2', {}));
 
         expect(result.current.optionValues).toEqual({});
         expect(onConfigChange).toHaveBeenCalledWith({
@@ -151,7 +151,7 @@ describe('useDataAppVizVisualizationConfig', () => {
         // The user picks another viz while a debounced control still holds an
         // edit; the control flushes it from its unmount cleanup, after the
         // switch has already committed.
-        act(() => result.current.setDataAppVizUuid('viz-2'));
+        act(() => result.current.setDataAppVizUuid('viz-2', {}));
         onConfigChange.mockClear();
         act(() => result.current.setOption('viz-1', 'title', 'Revenue'));
 

--- a/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.ts
+++ b/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.ts
@@ -1,5 +1,6 @@
 import {
     type DataAppVizChart,
+    type DataAppVizFieldMapping,
     type DataAppVizOptionValue,
     type DataAppVizOptionValues,
 } from '@lightdash/common';
@@ -8,9 +9,17 @@ import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 export interface DataAppVizVisualizationConfigAndData {
     validConfig: DataAppVizChart;
     dataAppVizUuid: string;
-    fieldMapping: Record<string, string>;
+    fieldMapping: DataAppVizFieldMapping;
     optionValues: DataAppVizOptionValues;
-    setDataAppVizUuid: (dataAppVizUuid: string) => void;
+    /**
+     * `fieldMapping` is the caller's binding for the newly selected viz —
+     * computed from its contract and the query's result columns. Passed in
+     * rather than derived here so this hook stays free of server state.
+     */
+    setDataAppVizUuid: (
+        dataAppVizUuid: string,
+        fieldMapping: DataAppVizFieldMapping,
+    ) => void;
     setField: (fieldName: string, fieldId: string | null) => void;
     /** `dataAppVizUuid` is the viz the edited control belonged to. */
     setOption: (
@@ -60,12 +69,13 @@ const useDataAppVizVisualizationConfig = (
     }, []);
 
     const setDataAppVizUuid = useCallback(
-        (newDataAppVizUuid: string) => {
-            // Fields and options are viz-specific, so switching viz drops both
-            // rather than carrying over now-meaningless names.
+        (newDataAppVizUuid: string, fieldMapping: DataAppVizFieldMapping) => {
+            // Options are viz-specific, so switching viz drops them rather
+            // than carrying over now-meaningless names. The mapping is
+            // replaced wholesale by the caller's auto-binding.
             commit({
                 dataAppVizUuid: newDataAppVizUuid,
-                fieldMapping: {},
+                fieldMapping,
                 optionValues: {},
             });
         },


### PR DESCRIPTION
Picking a visualization used to leave every slot empty. Slots are now bound by type at pick time, each column used once, required slots filled first.

A binding also goes stale on its own: a rebuild can add, remove or retype slots under an unchanged uuid, and the query's columns move independently. Both the panel and the renderer read the saved mapping reconciled against the contract and columns in force now. Reconciling is derived and never written back, so opening a chart cannot dirty it.

The two halves were one operation, differing only in whether a still-unbound *optional* slot gets a column: yes on first pick, no on reconcile, where an empty optional slot may be a deliberate clear. They shipped as two PRs at first (#26330, now folded in and closed), which hid the consumer that justified the shared helper shape.

`poolKeyForSlot` is the single rule for which pool a slot draws from, exhaustive over the field types so a new one is a compile error rather than a silent "treat as dimension". The picker is disabled until the query has columns: binding runs once, at pick time, so picking before the first run bound nothing and left optional slots unbound for the life of the chart.

Relates: GLITCH-630