### PR TITLE
fix(apps): reconcile viz field bindings against the live contract

### DIFF
--- a/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
         current: undefined as
             | {
                   schema: {
+                      fields: Array<never>;
                       configOptions: Array<{
                           type: 'text';
                           name: string;
@@ -83,6 +84,7 @@ describe('DataAppVizRenderer option delivery', () => {
 
         mocks.dataAppViz.current = {
             schema: {
+                fields: [],
                 configOptions: [
                     {
                         type: 'text',

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -11,6 +11,7 @@ import { useAppPreviewToken } from '../../features/apps/hooks/useAppPreviewToken
 import { useDataAppVisualization } from '../../features/apps/hooks/useDataAppVisualization';
 import { useGetApp } from '../../features/apps/hooks/useGetApp';
 import { usePreviewOrigin } from '../../features/apps/previewOrigin';
+import { reconcileDataAppVizFieldMapping } from '../../features/apps/utils/autoMapDataAppVizFields';
 import MantineIcon from '../common/MantineIcon';
 import { isDataAppVizVisualizationConfig } from '../LightdashVisualization/types';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
@@ -31,7 +32,7 @@ const DataAppVizPlaceholder: FC<{ message: string }> = ({ message }) => (
 
 const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
-    const { visualizationConfig, resultsData, colorPalette } =
+    const { visualizationConfig, resultsData, colorPalette, itemsMap } =
         useVisualizationContext();
     const previewOrigin = usePreviewOrigin();
     const hasSignaledScreenshotReady = useRef(false);
@@ -71,6 +72,7 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
         dataAppVizUuid || undefined,
     );
     const configOptions = dataAppViz?.schema?.configOptions;
+    const fields = dataAppViz?.schema?.fields;
 
     // Latest READY version of the chosen data app viz drives the preview.
     const readyVersion = useMemo(() => {
@@ -87,9 +89,16 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
     );
 
     const dataAppVizContext = useMemo<DataAppVizContext | undefined>(() => {
-        if (!rows || !configOptions) return undefined;
+        if (!rows || !configOptions || !fields) return undefined;
         return {
-            fieldMapping: fieldMapping ?? {},
+            // Reconciled against the contract and columns in force now, so a
+            // rebuilt viz never renders through a binding the panel no longer
+            // shows.
+            fieldMapping: reconcileDataAppVizFieldMapping(
+                fields,
+                itemsMap ?? {},
+                fieldMapping ?? {},
+            ),
             rows,
             options: getEffectiveOptionValues(
                 configOptions,
@@ -99,7 +108,15 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
             // corrected by the visualization context.
             colorPalette,
         };
-    }, [fieldMapping, rows, configOptions, optionValues, colorPalette]);
+    }, [
+        fields,
+        itemsMap,
+        fieldMapping,
+        rows,
+        configOptions,
+        optionValues,
+        colorPalette,
+    ]);
 
     if (!projectUuid || !dataAppVizUuid) {
         return (

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -10,7 +10,10 @@ import { memo, useMemo, type FC } from 'react';
 import { useParams } from 'react-router';
 import DataAppVizLibraryPicker from '../../../features/apps/components/DataAppVizLibraryPicker';
 import { useDataAppVisualization } from '../../../features/apps/hooks/useDataAppVisualization';
-import { autoMapDataAppVizFields } from '../../../features/apps/utils/autoMapDataAppVizFields';
+import {
+    autoMapDataAppVizFields,
+    reconcileDataAppVizFieldMapping,
+} from '../../../features/apps/utils/autoMapDataAppVizFields';
 import { getDataAppVizFieldItems } from '../../../features/apps/utils/getDataAppVizFieldItems';
 import FieldSelect from '../../common/FieldSelect';
 import { isDataAppVizVisualizationConfig } from '../../LightdashVisualization/types';
@@ -67,6 +70,14 @@ export const ConfigTabs: FC = memo(() => {
         configOptions,
         optionValues,
     );
+    // The contract can change under a stable uuid when the viz is rebuilt, so
+    // what the selects show is the saved mapping reconciled against the
+    // contract and columns in force now — the same value the renderer uses.
+    const effectiveMapping = reconcileDataAppVizFieldMapping(
+        fields,
+        itemsMap ?? {},
+        fieldMapping,
+    );
 
     const generalPanel = (
         <Stack>
@@ -100,7 +111,7 @@ export const ConfigTabs: FC = memo(() => {
 
             {fields.map((field) => {
                 const items = fieldItems(field);
-                const selectedId = fieldMapping[field.name];
+                const selectedId = effectiveMapping[field.name];
                 const selectedItem = selectedId
                     ? items.find((i) => getItemId(i) === selectedId)
                     : undefined;

--- a/packages/frontend/src/features/apps/utils/autoMapDataAppVizFields.test.ts
+++ b/packages/frontend/src/features/apps/utils/autoMapDataAppVizFields.test.ts
@@ -8,7 +8,10 @@ import {
     type ItemsMap,
 } from '@lightdash/common';
 import { describe, expect, it } from 'vitest';
-import { autoMapDataAppVizFields } from './autoMapDataAppVizFields';
+import {
+    autoMapDataAppVizFields,
+    reconcileDataAppVizFieldMapping,
+} from './autoMapDataAppVizFields';
 
 const dimension = (name: string, hidden = false): CompiledDimension => ({
     compiledSql: '',
@@ -135,5 +138,108 @@ describe('autoMapDataAppVizFields', () => {
             category: 'orders_status',
             value: 'orders_count',
         });
+    });
+});
+
+describe('reconcileDataAppVizFieldMapping', () => {
+    it('keeps a binding that is still valid', () => {
+        const mapping = reconcileDataAppVizFieldMapping(
+            [field('category', 'dimension'), field('value', 'metric')],
+            itemsMap(dimension('status'), dimension('method'), metric('count')),
+            { category: 'orders_method', value: 'orders_count' },
+        );
+        expect(mapping).toEqual({
+            category: 'orders_method',
+            value: 'orders_count',
+        });
+    });
+
+    it('drops a binding for a slot the contract no longer declares', () => {
+        const mapping = reconcileDataAppVizFieldMapping(
+            [field('category', 'dimension')],
+            itemsMap(dimension('status')),
+            { category: 'orders_status', departed: 'orders_status' },
+        );
+        expect(mapping).toEqual({ category: 'orders_status' });
+        expect(mapping.departed).toBeUndefined();
+    });
+
+    it('rebinds a required slot whose column left the query', () => {
+        const mapping = reconcileDataAppVizFieldMapping(
+            [field('category', 'dimension')],
+            itemsMap(dimension('method')),
+            { category: 'orders_gone' },
+        );
+        expect(mapping).toEqual({ category: 'orders_method' });
+    });
+
+    it('rebinds a required slot that was retyped by a rebuild', () => {
+        // The slot used to be a dimension and the saved mapping still points
+        // at one; the rebuilt contract declares it a metric.
+        const mapping = reconcileDataAppVizFieldMapping(
+            [field('value', 'metric')],
+            itemsMap(dimension('status'), metric('count')),
+            { value: 'orders_status' },
+        );
+        expect(mapping).toEqual({ value: 'orders_count' });
+    });
+
+    it('fills a required slot a rebuild has newly added', () => {
+        const mapping = reconcileDataAppVizFieldMapping(
+            [field('category', 'dimension'), field('value', 'metric')],
+            itemsMap(dimension('status'), metric('count')),
+            { category: 'orders_status' },
+        );
+        expect(mapping).toEqual({
+            category: 'orders_status',
+            value: 'orders_count',
+        });
+    });
+
+    it('leaves a cleared optional slot cleared', () => {
+        // Refilling here would undo the user's clear on every render.
+        const mapping = reconcileDataAppVizFieldMapping(
+            [
+                field('category', 'dimension'),
+                field('breakdown', 'series', false),
+            ],
+            itemsMap(dimension('status'), dimension('method')),
+            { category: 'orders_status' },
+        );
+        expect(mapping).toEqual({ category: 'orders_status' });
+        expect(mapping.breakdown).toBeUndefined();
+    });
+
+    it('never rebinds a required slot onto a column another slot holds', () => {
+        const mapping = reconcileDataAppVizFieldMapping(
+            [field('category', 'dimension'), field('breakdown', 'series')],
+            itemsMap(dimension('status')),
+            { category: 'orders_status' },
+        );
+        expect(mapping).toEqual({ category: 'orders_status' });
+        expect(mapping.breakdown).toBeUndefined();
+    });
+
+    it('drops a duplicated binding rather than pointing two slots at one column', () => {
+        const mapping = reconcileDataAppVizFieldMapping(
+            [field('category', 'dimension'), field('breakdown', 'series')],
+            itemsMap(dimension('status'), dimension('method')),
+            { category: 'orders_status', breakdown: 'orders_status' },
+        );
+        expect(mapping).toEqual({
+            category: 'orders_status',
+            breakdown: 'orders_method',
+        });
+    });
+
+    it('matches a fresh auto-map when nothing is persisted and all slots are required', () => {
+        const fields = [
+            field('category', 'dimension'),
+            field('value', 'metric'),
+        ];
+        const items = itemsMap(dimension('status'), metric('count'));
+        expect(reconcileDataAppVizFieldMapping(fields, items, {})).toEqual(
+            autoMapDataAppVizFields(fields, items),
+        );
     });
 });

--- a/packages/frontend/src/features/apps/utils/autoMapDataAppVizFields.ts
+++ b/packages/frontend/src/features/apps/utils/autoMapDataAppVizFields.ts
@@ -63,3 +63,50 @@ export const autoMapDataAppVizFields = (
 
     return mapping;
 };
+
+/**
+ * Reconcile a saved binding against the contract and columns in force now.
+ *
+ * A viz is edited in place: a new build can add, remove or retype slots under
+ * a uuid that never changes, and the query's columns move independently. Both
+ * leave a saved `fieldMapping` describing a world that no longer exists — a
+ * binding to a departed column, or to a column whose slot is now a metric.
+ * Left alone those render wrong while the panel shows an empty select.
+ *
+ * Bindings that are still valid are kept. Required slots left unbound are
+ * filled from what remains. Optional slots are *not* refilled: an unbound
+ * optional slot is indistinguishable from one the user deliberately cleared,
+ * and refilling would undo the clear on every render.
+ *
+ * Pure and derived — never written back to the saved chart, so opening a chart
+ * cannot dirty it.
+ */
+export const reconcileDataAppVizFieldMapping = (
+    fields: DataAppVizField[],
+    itemsMap: ItemsMap,
+    persisted: DataAppVizFieldMapping,
+): DataAppVizFieldMapping => {
+    const pools = poolsFor(itemsMap);
+    const validIds = {
+        metric: new Set(pools.metric.map(getItemId)),
+        dimension: new Set(pools.dimension.map(getItemId)),
+    };
+
+    const mapping: DataAppVizFieldMapping = {};
+    const taken = new Set<string>();
+
+    for (const field of fields) {
+        const bound = persisted[field.name];
+        if (!bound || taken.has(bound)) continue;
+        const pool = isMetricSlot(field) ? validIds.metric : validIds.dimension;
+        if (!pool.has(bound)) continue;
+        mapping[field.name] = bound;
+        taken.add(bound);
+    }
+
+    fields
+        .filter((f) => f.required)
+        .forEach((f) => fill(mapping, taken, pools, f));
+
+    return mapping;
+};


### PR DESCRIPTION
A rebuild can add, remove or retype slots under an unchanged uuid, and the query's columns move independently. Either leaves a saved `fieldMapping` describing a world that no longer exists.

`reconcileDataAppVizFieldMapping` keeps valid bindings and refills required slots. Unbound optional slots are left alone — one is indistinguishable from a slot the user deliberately cleared. Derived, never written back, so opening a chart cannot dirty it.

Relates: GLITCH-630
