### PR TITLE
feat(apps): show a data app viz's build history in the chart config

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -9,6 +9,7 @@ import { MantineProvider, useMantineColorScheme } from '@mantine/core';
 import { memo, useMemo, type FC } from 'react';
 import { useParams } from 'react-router';
 import DataAppVizLibraryPicker from '../../../features/apps/components/DataAppVizLibraryPicker';
+import DataAppVizThread from '../../../features/apps/components/DataAppVizThread';
 import { useDataAppVisualization } from '../../../features/apps/hooks/useDataAppVisualization';
 import {
     autoMapDataAppVizFields,
@@ -152,6 +153,14 @@ export const ConfigTabs: FC = memo(() => {
                 }
                 colorPalette={colorPalette}
                 paletteControl={<ColorPaletteSection />}
+                threadContent={
+                    projectUuid && dataAppVizUuid ? (
+                        <DataAppVizThread
+                            projectUuid={projectUuid}
+                            dataAppVizUuid={dataAppVizUuid}
+                        />
+                    ) : null
+                }
             />
         </MantineProvider>
     );

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizOptionTabs.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizOptionTabs.test.tsx
@@ -35,6 +35,7 @@ const renderTabs = (
             onChange={onChange}
             colorPalette={colorPalette}
             paletteControl={paletteControl}
+            threadContent={null}
         />,
     );
 

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizOptionTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizOptionTabs.tsx
@@ -25,6 +25,11 @@ type Props = {
      * owns the control; this component only places it.
      */
     paletteControl: ReactNode;
+    /**
+     * The viz's conversation. Null when no viz is picked, in which case no
+     * Thread tab is offered — there is nothing to have a history of.
+     */
+    threadContent: ReactNode;
 };
 
 /**
@@ -41,13 +46,17 @@ const DataAppVizOptionTabs: FC<Props> = ({
     onChange,
     colorPalette,
     paletteControl,
+    threadContent,
 }) => {
     const optionGroups = useMemo(
         () => groupDataAppVizOptions(configOptions, colorPalette),
         [configOptions, colorPalette],
     );
 
-    if (optionGroups.length === 0) return <>{generalContent}</>;
+    // Nothing to tab between: no declared options and no viz to have a
+    // history of, so the general content is the whole form.
+    if (optionGroups.length === 0 && !threadContent)
+        return <>{generalContent}</>;
 
     return (
         <Tabs defaultValue="general" keepMounted={false}>
@@ -60,9 +69,18 @@ const DataAppVizOptionTabs: FC<Props> = ({
                         {group.label}
                     </Tabs.Tab>
                 ))}
+                {threadContent && (
+                    <Tabs.Tab px="sm" value="thread">
+                        Thread
+                    </Tabs.Tab>
+                )}
             </Tabs.List>
 
             <Tabs.Panel value="general">{generalContent}</Tabs.Panel>
+
+            {threadContent && (
+                <Tabs.Panel value="thread">{threadContent}</Tabs.Panel>
+            )}
 
             {optionGroups.map((group) => (
                 <Tabs.Panel key={group.id} value={group.id}>

--- a/packages/frontend/src/features/apps/components/DataAppVizTestPanel.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizTestPanel.tsx
@@ -255,6 +255,8 @@ const DataAppVizTestPanel: FC<Props> = ({
                     values={effectiveOptions}
                     onChange={setOption}
                     colorPalette={schema.colorPalette}
+                    // The generator has no host chart, so no viz thread.
+                    threadContent={null}
                     paletteControl={
                         <PalettePicker
                             label="Color palette"

--- a/packages/frontend/src/features/apps/components/DataAppVizThread.test.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizThread.test.tsx
@@ -1,0 +1,155 @@
+import { type ApiAppVersionSummary } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { useGetApp } from '../hooks/useGetApp';
+import DataAppVizThread from './DataAppVizThread';
+
+vi.mock('../hooks/useGetApp', () => ({ useGetApp: vi.fn() }));
+
+const mockedUseGetApp = vi.mocked(useGetApp);
+
+const version = (
+    overrides: Partial<ApiAppVersionSummary> = {},
+): ApiAppVersionSummary => ({
+    version: 1,
+    prompt: 'stacked bars per shipping method',
+    status: 'ready',
+    statusMessage: null,
+    statusHistory: [],
+    error: null,
+    createdAt: new Date('2026-05-15T10:00:00Z'),
+    statusUpdatedAt: new Date('2026-05-15T10:00:52Z'),
+    createdByUser: { userUuid: 'u1', firstName: 'Katie', lastName: 'Jones' },
+    resources: null,
+    ...overrides,
+});
+
+const setVersions = (
+    versions: ApiAppVersionSummary[],
+    extra: { hasNextPage?: boolean; isLoading?: boolean } = {},
+) => {
+    mockedUseGetApp.mockReturnValue({
+        data: {
+            pages: [{ versions, hasMore: false }],
+            pageParams: [undefined],
+        },
+        isLoading: extra.isLoading ?? false,
+        hasNextPage: extra.hasNextPage ?? false,
+        fetchNextPage: vi.fn(),
+        isFetchingNextPage: false,
+    } as unknown as ReturnType<typeof useGetApp>);
+};
+
+const render = () =>
+    renderWithProviders(
+        <DataAppVizThread projectUuid="project-1" dataAppVizUuid="viz-1" />,
+    );
+
+describe('DataAppVizThread', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('shows the request and a receipt for a finished build', () => {
+        setVersions([version()]);
+        render();
+
+        expect(
+            screen.getByText('stacked bars per shipping method'),
+        ).toBeInTheDocument();
+        expect(screen.getByText('Built in 52s')).toBeInTheDocument();
+    });
+
+    it('names the declared slots on the receipt', () => {
+        setVersions([
+            version({
+                resources: {
+                    vizSchema: {
+                        fields: [
+                            {
+                                name: 'x',
+                                label: 'X Axis',
+                                type: 'dimension',
+                                required: true,
+                            },
+                            {
+                                name: 'v',
+                                label: 'Value',
+                                type: 'metric',
+                                required: true,
+                            },
+                        ],
+                    },
+                } as unknown as ApiAppVersionSummary['resources'],
+            }),
+        ]);
+        render();
+
+        expect(
+            screen.getByText('Built in 52s · X Axis, Value'),
+        ).toBeInTheDocument();
+    });
+
+    it('surfaces a failed build as its cause, not a success', () => {
+        setVersions([
+            version({ status: 'error', statusMessage: 'Build failed' }),
+        ]);
+        render();
+
+        expect(screen.getByText('Build failed')).toBeInTheDocument();
+        expect(screen.queryByText(/Built in/)).not.toBeInTheDocument();
+    });
+
+    it('shows no receipt while a build is still running', () => {
+        setVersions([version({ status: 'building', statusUpdatedAt: null })]);
+        render();
+
+        expect(
+            screen.getByText('stacked bars per shipping method'),
+        ).toBeInTheDocument();
+        expect(screen.queryByText(/Built in/)).not.toBeInTheDocument();
+    });
+
+    it('credits the author when the first version is loaded', () => {
+        setVersions([version()]);
+        render();
+
+        expect(screen.getByText(/Built by Katie Jones/)).toBeInTheDocument();
+    });
+
+    it('does not claim origin when earlier versions are still unloaded', () => {
+        setVersions([version({ version: 7 })], { hasNextPage: true });
+        render();
+
+        expect(
+            screen.getByText(/Last updated by Katie Jones/),
+        ).toBeInTheDocument();
+        expect(screen.getByText('Load earlier messages')).toBeInTheDocument();
+    });
+
+    it('offers no "load earlier" once version 1 is held', () => {
+        // The server may still report another page; holding v1 means we have
+        // the whole contiguous history regardless.
+        setVersions([version()], { hasNextPage: true });
+        render();
+
+        expect(
+            screen.queryByText('Load earlier messages'),
+        ).not.toBeInTheDocument();
+    });
+
+    it('labels a prompt-less uploaded version instead of showing a blank', () => {
+        setVersions([version({ prompt: '' })]);
+        render();
+
+        expect(screen.getByText('Uploaded from source')).toBeInTheDocument();
+    });
+
+    it('shows an empty state when the viz has no history', () => {
+        setVersions([]);
+        render();
+
+        expect(
+            screen.getByText('This visualization has no history yet.'),
+        ).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/features/apps/components/DataAppVizThread.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizThread.tsx
@@ -1,0 +1,179 @@
+import { Anchor, Group, Loader, Stack, Text } from '@mantine-8/core';
+import { IconAlertTriangle, IconCheck } from '@tabler/icons-react';
+import { useMemo, type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { useTimeAgo } from '../../../hooks/useTimeAgo';
+import ChatBubbleMeta from '../ChatBubbleMeta';
+import { useGetApp } from '../hooks/useGetApp';
+import { formatBuildDuration } from '../utils/formatBuildDuration';
+import { type ChatMessage } from '../utils/mergeChatMessages';
+import {
+    createChatMessageFallbacks,
+    versionsToChatMessages,
+} from '../utils/versionsToChatMessages';
+
+type Props = {
+    projectUuid: string;
+    dataAppVizUuid: string;
+};
+
+/** One-line summary of what a finished build produced. */
+const receiptLabel = (message: ChatMessage): string => {
+    if (message.status === 'error') return message.content;
+    const built =
+        message.durationMs === null
+            ? 'Built'
+            : `Built in ${formatBuildDuration(message.durationMs)}`;
+    const slots = message.vizSchema?.fields.map((f) => f.label) ?? [];
+    return slots.length > 0 ? `${built} · ${slots.join(', ')}` : built;
+};
+
+const Receipt: FC<{ message: ChatMessage }> = ({ message }) => {
+    const failed = message.status === 'error';
+    return (
+        <Group gap={6} wrap="nowrap" align="flex-start">
+            <MantineIcon
+                icon={failed ? IconAlertTriangle : IconCheck}
+                size={13}
+                color={failed ? 'red.6' : 'green.7'}
+            />
+            <Text size="xs" c={failed ? 'red.7' : 'dimmed'}>
+                {receiptLabel(message)}
+            </Text>
+        </Group>
+    );
+};
+
+const Request: FC<{ message: ChatMessage }> = ({ message }) => (
+    <Stack gap={2}>
+        <ChatBubbleMeta
+            timestamp={message.timestamp}
+            userName={message.userName}
+        />
+        {message.content ? (
+            <Text size="sm">{message.content}</Text>
+        ) : (
+            <Text size="sm" c="dimmed" fs="italic">
+                Uploaded from source
+            </Text>
+        )}
+    </Stack>
+);
+
+/** Author + age of the viz, from the oldest version loaded so far. */
+const Provenance: FC<{
+    authorName: string | null;
+    at: Date;
+    isOrigin: boolean;
+}> = ({ authorName, at, isOrigin }) => {
+    const timeAgo = useTimeAgo(at);
+    const verb = isOrigin ? 'Built' : 'Last updated';
+    return (
+        <Text size="xs" c="dimmed">
+            {authorName
+                ? `${verb} by ${authorName} · ${timeAgo}`
+                : `${verb} ${timeAgo}`}
+        </Text>
+    );
+};
+
+/**
+ * The viz's conversation, read-only: who built it, every request made against
+ * it, and a one-line receipt per finished build. Sourced entirely from the
+ * app's version history, which is already fetched for the chart's preview — so
+ * this adds no request of its own.
+ */
+const DataAppVizThread: FC<Props> = ({ projectUuid, dataAppVizUuid }) => {
+    const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } =
+        useGetApp(projectUuid, dataAppVizUuid);
+
+    const versions = useMemo(
+        () => data?.pages.flatMap((page) => page.versions) ?? [],
+        [data?.pages],
+    );
+
+    const messages = useMemo(
+        () =>
+            versionsToChatMessages(
+                versions,
+                dataAppVizUuid,
+                createChatMessageFallbacks(),
+            ),
+        [versions, dataAppVizUuid],
+    );
+
+    // Versions are 1-indexed and contiguous, so holding version 1 means the
+    // whole history is loaded however many pages the server still offers.
+    const hasOrigin = versions.some((v) => v.version === 1);
+    const hasEarlier = hasNextPage && !hasOrigin;
+    const oldestLoaded = versions.reduce<(typeof versions)[number] | null>(
+        (oldest, v) =>
+            oldest === null || v.version < oldest.version ? v : oldest,
+        null,
+    );
+
+    if (isLoading) {
+        return (
+            <Group justify="center" p="md">
+                <Loader size="sm" />
+            </Group>
+        );
+    }
+
+    if (messages.length === 0) {
+        return (
+            <Text size="sm" c="dimmed">
+                This visualization has no history yet.
+            </Text>
+        );
+    }
+
+    return (
+        <Stack gap="md">
+            {oldestLoaded && (
+                <Provenance
+                    authorName={
+                        oldestLoaded.createdByUser
+                            ? [
+                                  oldestLoaded.createdByUser.firstName,
+                                  oldestLoaded.createdByUser.lastName,
+                              ]
+                                  .filter((s) => s.length > 0)
+                                  .join(' ') || null
+                            : null
+                    }
+                    at={new Date(oldestLoaded.createdAt)}
+                    isOrigin={hasOrigin}
+                />
+            )}
+
+            {hasEarlier && (
+                <Anchor
+                    component="button"
+                    type="button"
+                    size="xs"
+                    disabled={isFetchingNextPage}
+                    onClick={() => void fetchNextPage()}
+                >
+                    {isFetchingNextPage ? 'Loading…' : 'Load earlier messages'}
+                </Anchor>
+            )}
+
+            {messages.map((message, index) =>
+                message.role === 'user' ? (
+                    <Request
+                        key={`${message.timestamp.getTime()}-${index}`}
+                        message={message}
+                    />
+                ) : (
+                    <Receipt
+                        key={`${message.timestamp.getTime()}-${index}`}
+                        message={message}
+                    />
+                ),
+            )}
+        </Stack>
+    );
+};
+
+export default DataAppVizThread;

--- a/packages/frontend/src/features/apps/utils/formatBuildDuration.test.ts
+++ b/packages/frontend/src/features/apps/utils/formatBuildDuration.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { formatBuildDuration } from './formatBuildDuration';
+
+describe('formatBuildDuration', () => {
+    it('renders sub-minute builds in seconds', () => {
+        expect(formatBuildDuration(52_000)).toBe('52s');
+    });
+
+    it('rounds to the nearest second', () => {
+        expect(formatBuildDuration(52_400)).toBe('52s');
+        expect(formatBuildDuration(52_600)).toBe('53s');
+    });
+
+    it('never claims a build took no time', () => {
+        expect(formatBuildDuration(0)).toBe('1s');
+        expect(formatBuildDuration(120)).toBe('1s');
+    });
+
+    it('switches to minutes at a minute', () => {
+        expect(formatBuildDuration(60_000)).toBe('1m');
+        expect(formatBuildDuration(72_000)).toBe('1m 12s');
+        expect(formatBuildDuration(605_000)).toBe('10m 5s');
+    });
+
+    it('omits a zero seconds remainder', () => {
+        expect(formatBuildDuration(180_000)).toBe('3m');
+    });
+});

--- a/packages/frontend/src/features/apps/utils/formatBuildDuration.ts
+++ b/packages/frontend/src/features/apps/utils/formatBuildDuration.ts
@@ -1,0 +1,12 @@
+/**
+ * Render a build duration the way the thread's receipt reads it: seconds up to
+ * a minute, then minutes and seconds. Sub-second builds round up to `1s` rather
+ * than claiming `0s`.
+ */
+export const formatBuildDuration = (durationMs: number): string => {
+    const totalSeconds = Math.max(1, Math.round(durationMs / 1000));
+    if (totalSeconds < 60) return `${totalSeconds}s`;
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return seconds === 0 ? `${minutes}m` : `${minutes}m ${seconds}s`;
+};

--- a/packages/frontend/src/features/apps/utils/mergeChatMessages.test.ts
+++ b/packages/frontend/src/features/apps/utils/mergeChatMessages.test.ts
@@ -4,6 +4,7 @@ import { mergeChatMessages, type ChatMessage } from './mergeChatMessages';
 const baseMessage: ChatMessage = {
     role: 'user',
     status: null,
+    durationMs: null,
     content: '',
     imagePreviewUrls: [],
     imageResourceIds: [],

--- a/packages/frontend/src/features/apps/utils/mergeChatMessages.ts
+++ b/packages/frontend/src/features/apps/utils/mergeChatMessages.ts
@@ -30,6 +30,11 @@ export type ChatMessage = {
      * happens to be absent.
      */
     status: 'ready' | 'error' | null;
+    /**
+     * How long the build took, for the thread's "built in 52s" receipt. Null on
+     * user bubbles and on versions predating completion-time capture.
+     */
+    durationMs: number | null;
     content: string;
     imagePreviewUrls: string[];
     imageResourceIds: string[];

--- a/packages/frontend/src/features/apps/utils/versionsToChatMessages.test.ts
+++ b/packages/frontend/src/features/apps/utils/versionsToChatMessages.test.ts
@@ -189,6 +189,21 @@ describe('versionsToChatMessages', () => {
         expect(assistant.activity).toEqual(['Creating App.tsx']);
     });
 
+    it('survives a resources blob missing its optional collections', () => {
+        // `resources` is JSONB; a viz-only version can carry just a vizSchema.
+        // Dereferencing charts/images unguarded took out the whole panel.
+        const [user, assistant] = convert([
+            version({
+                resources: {
+                    vizSchema: { fields: [], configOptions: [] },
+                } as unknown as ApiAppVersionSummary['resources'],
+            }),
+        ]);
+        expect(user.charts).toEqual([]);
+        expect(user.imageResourceIds).toEqual([]);
+        expect(assistant.vizSchema).toEqual({ fields: [], configOptions: [] });
+    });
+
     it('handles a missing author', () => {
         const [user] = convert([version({ createdByUser: null })]);
         expect(user.userName).toBeNull();

--- a/packages/frontend/src/features/apps/utils/versionsToChatMessages.ts
+++ b/packages/frontend/src/features/apps/utils/versionsToChatMessages.ts
@@ -72,7 +72,7 @@ export function versionsToChatMessages(
     return sorted.flatMap((v) => {
         // Prefer server-side resources; fall back to session maps.
         const serverCharts: ChatChart[] =
-            v.resources?.charts.map((c) => ({
+            v.resources?.charts?.map((c) => ({
                 name: c.chartName,
                 uuid: c.chartUuid,
                 chartKind: undefined,
@@ -95,7 +95,7 @@ export function versionsToChatMessages(
                 : (fallbacks.connections.get(v.prompt) ?? []);
 
         const imageResourceIds =
-            v.resources?.images.map((img) => img.imageId) ?? [];
+            v.resources?.images?.map((img) => img.imageId) ?? [];
         const imagePreviewUrls = fallbacks.imagePreviewUrls.get(v.prompt) ?? [];
         const files: ChatAttachedFile[] =
             v.resources?.files?.map((f) => ({ filename: f.filename })) ??
@@ -120,6 +120,12 @@ export function versionsToChatMessages(
             v.version === 1
                 ? 'Your app is ready!'
                 : `Version ${v.version} is ready!`;
+        // Null rather than 0 when the version never recorded a transition:
+        // an unknown duration is not a zero-second build.
+        const durationMs = v.statusUpdatedAt
+            ? new Date(v.statusUpdatedAt).getTime() -
+              new Date(v.createdAt).getTime()
+            : null;
         const reasoning = versionNarrationTexts(v.statusHistory, 'thinking');
         const activity = versionNarrationTexts(v.statusHistory, 'tool');
 
@@ -127,6 +133,7 @@ export function versionsToChatMessages(
             {
                 role: 'user',
                 status: null,
+                durationMs: null,
                 content: v.prompt,
                 imagePreviewUrls,
                 imageResourceIds,
@@ -149,6 +156,7 @@ export function versionsToChatMessages(
             msgs.push({
                 role: 'assistant',
                 status: 'ready',
+                durationMs,
                 content: isUploadedVersion
                     ? readyMessage
                     : (v.statusMessage ?? readyMessage),
@@ -171,6 +179,7 @@ export function versionsToChatMessages(
             msgs.push({
                 role: 'assistant',
                 status: 'error',
+                durationMs,
                 content: getAppVersionFailureMessage(v),
                 imagePreviewUrls: [],
                 imageResourceIds: [],

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -1118,6 +1118,7 @@ const AppGenerate: FC = () => {
                 {
                     role: 'user',
                     status: null,
+                    durationMs: null,
                     content: prompt,
                     imagePreviewUrls: [],
                     imageResourceIds: [],
@@ -1166,6 +1167,7 @@ const AppGenerate: FC = () => {
                             {
                                 role: 'assistant',
                                 status: 'error',
+                                durationMs: null,
                                 content: themeErrorMessage,
                                 imagePreviewUrls: [],
                                 imageResourceIds: [],
@@ -1666,6 +1668,7 @@ const AppGenerate: FC = () => {
                 {
                     role: 'assistant' as const,
                     status: 'error' as const,
+                    durationMs: null,
                     content: errorMessage,
                     imagePreviewUrls: [],
                     imageResourceIds: [],
@@ -1827,6 +1830,7 @@ const AppGenerate: FC = () => {
                 {
                     role: 'user',
                     status: null,
+                    durationMs: null,
                     content: trimmed,
                     imagePreviewUrls: sentImageUrls,
                     imageResourceIds: [],


### PR DESCRIPTION
Adds the visualization's build history to the chart config: who built it, every request made against it, and a one-line receipt per finished build.

Sourced entirely from the app's version history, which is already fetched for the chart's preview — no new endpoint, no new query. Durations come from `statusUpdatedAt - createdAt`, declared slots from the version's `vizSchema`.

Also hardens a latent crash inherited from `AppGenerate.tsx`: `v.resources?.charts.map(...)` optional-chains `resources` then dereferences `.charts` unguarded. `resources` is a JSONB blob whose sibling keys carry back-compat markers, and a viz-only version can carry just a `vizSchema`. Reachable from the Explorer, where a throw takes out the whole config panel.

Relates: GLITCH-630