### PR TITLE
feat(apps): ask a data app viz for changes from the chart config

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -14,6 +14,7 @@ import DataAppVizLibraryPicker from '../../../features/apps/components/DataAppVi
 import DataAppVizPickOrCreate from '../../../features/apps/components/DataAppVizPickOrCreate';
 import { useDataAppVisualization } from '../../../features/apps/hooks/useDataAppVisualization';
 import { useGenerateDataAppViz } from '../../../features/apps/hooks/useGenerateDataAppViz';
+import { useIterateDataAppViz } from '../../../features/apps/hooks/useIterateDataAppViz';
 import {
     autoMapDataAppVizFields,
     reconcileDataAppVizFieldMapping,
@@ -75,6 +76,10 @@ export const ConfigTabs: FC = memo(() => {
         itemsMap: itemsMap ?? {},
         onReady: handleGenerated,
     });
+    const revision = useIterateDataAppViz({
+        projectUuid,
+        dataAppVizUuid: dataAppVizUuid || null,
+    });
 
     if (!isDataAppViz) return null;
 
@@ -133,6 +138,7 @@ export const ConfigTabs: FC = memo(() => {
                     isBuilding={generation.isBuilding}
                     pendingPrompt={generation.pendingPrompt}
                     error={generation.error}
+                    onRetry={null}
                     onSubmit={generation.generate}
                 />
             )}
@@ -193,8 +199,15 @@ export const ConfigTabs: FC = memo(() => {
                         <DataAppVizConversation
                             projectUuid={projectUuid}
                             dataAppVizUuid={dataAppVizUuid}
-                            // Iterating on an existing viz lands next.
-                            composer={null}
+                            composer={{
+                                itemsMap: itemsMap ?? {},
+                                placeholder: 'Ask for a change…',
+                                isBuilding: revision.isBuilding,
+                                pendingPrompt: revision.pendingPrompt,
+                                error: revision.error,
+                                onRetry: revision.retry,
+                                onSubmit: revision.iterate,
+                            }}
                         />
                     ) : null
                 }

--- a/packages/frontend/src/features/apps/components/DataAppVizConversation.test.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizConversation.test.tsx
@@ -1,5 +1,5 @@
 import { type ApiAppVersionSummary } from '@lightdash/common';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../testing/testUtils';
 import { useGetApp } from '../hooks/useGetApp';
@@ -162,6 +162,7 @@ describe('DataAppVizConversation', () => {
                     isBuilding: true,
                     pendingPrompt: 'a donut of orders by status',
                     error: null,
+                    onRetry: null,
                     onSubmit: vi.fn(),
                 }}
             />,
@@ -185,6 +186,7 @@ describe('DataAppVizConversation', () => {
                     isBuilding: false,
                     pendingPrompt: 'a donut of orders by status',
                     error: null,
+                    onRetry: null,
                     onSubmit: vi.fn(),
                 }}
             />,
@@ -194,6 +196,59 @@ describe('DataAppVizConversation', () => {
         expect(screen.getAllByText('a donut of orders by status')).toHaveLength(
             1,
         );
+    });
+
+    it('offers retry on a failed build and leaves the chart alone', () => {
+        setVersions([version()]);
+        const onRetry = vi.fn();
+        renderWithProviders(
+            <DataAppVizConversation
+                projectUuid="project-1"
+                dataAppVizUuid="viz-1"
+                composer={{
+                    itemsMap: {} as never,
+                    placeholder: 'Ask for a change…',
+                    isBuilding: false,
+                    pendingPrompt: null,
+                    error: 'That change could not be built.',
+                    onRetry,
+                    onSubmit: vi.fn(),
+                }}
+            />,
+        );
+
+        expect(
+            screen.getByText('That change could not be built.'),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText('Your query and chart are untouched.'),
+        ).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+        expect(onRetry).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows no retry when there is nothing to re-send', () => {
+        setVersions([version()]);
+        renderWithProviders(
+            <DataAppVizConversation
+                projectUuid="project-1"
+                dataAppVizUuid="viz-1"
+                composer={{
+                    itemsMap: {} as never,
+                    placeholder: 'Ask for a change…',
+                    isBuilding: false,
+                    pendingPrompt: null,
+                    error: 'Something went wrong.',
+                    onRetry: null,
+                    onSubmit: vi.fn(),
+                }}
+            />,
+        );
+
+        expect(
+            screen.queryByRole('button', { name: 'Retry' }),
+        ).not.toBeInTheDocument();
     });
 
     it('renders the composer only when one is supplied', () => {

--- a/packages/frontend/src/features/apps/components/DataAppVizConversation.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizConversation.tsx
@@ -33,6 +33,8 @@ export type VizConversationComposer = {
     /** The request that is in flight, shown optimistically before it lands. */
     pendingPrompt: string | null;
     error: string | null;
+    /** Re-send the request that failed; null when there is nothing to retry. */
+    onRetry: (() => void) | null;
     onSubmit: (description: string, columns: VizPromptColumn[]) => void;
 };
 
@@ -142,6 +144,7 @@ const DataAppVizConversation: FC<Props> = ({
     const pendingPrompt = composer?.pendingPrompt ?? null;
     const isBuilding = composer?.isBuilding ?? false;
     const error = composer?.error ?? null;
+    const onRetry = composer?.onRetry ?? null;
     const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } =
         useGetApp(projectUuid, dataAppVizUuid ?? undefined);
 
@@ -287,9 +290,24 @@ const DataAppVizConversation: FC<Props> = ({
                         size={13}
                         color="red.6"
                     />
-                    <Text size="xs" c="red.7">
-                        {error}
-                    </Text>
+                    <Stack gap={2}>
+                        <Text size="xs" c="red.7">
+                            {error}
+                        </Text>
+                        <Text size="xs" c="dimmed">
+                            Your query and chart are untouched.
+                        </Text>
+                        {onRetry && (
+                            <Anchor
+                                component="button"
+                                type="button"
+                                size="xs"
+                                onClick={onRetry}
+                            >
+                                Retry
+                            </Anchor>
+                        )}
+                    </Stack>
                 </Group>
             )}
 

--- a/packages/frontend/src/features/apps/components/DataAppVizPickOrCreate.test.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizPickOrCreate.test.tsx
@@ -12,6 +12,7 @@ const render = (props: Partial<Parameters<typeof DataAppVizPickOrCreate>[0]>) =>
             itemsMap={{} as ItemsMap}
             isBuilding={false}
             pendingPrompt={null}
+            onRetry={null}
             error={null}
             onSubmit={vi.fn()}
             {...props}

--- a/packages/frontend/src/features/apps/components/DataAppVizPickOrCreate.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizPickOrCreate.tsx
@@ -14,6 +14,7 @@ type Props = {
     isBuilding: boolean;
     pendingPrompt: string | null;
     error: string | null;
+    onRetry: (() => void) | null;
     onSubmit: (description: string, columns: VizPromptColumn[]) => void;
 };
 
@@ -34,6 +35,7 @@ const DataAppVizPickOrCreate: FC<Props> = ({
     isBuilding,
     pendingPrompt,
     error,
+    onRetry,
     onSubmit,
 }) => {
     const [isCreating, setIsCreating] = useState(false);
@@ -85,6 +87,7 @@ const DataAppVizPickOrCreate: FC<Props> = ({
                     isBuilding,
                     pendingPrompt,
                     error,
+                    onRetry,
                     onSubmit,
                 }}
             />

--- a/packages/frontend/src/features/apps/hooks/useAppBuildPoller.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppBuildPoller.test.ts
@@ -1,0 +1,44 @@
+import { type ApiAppVersionSummary } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { mergePolledVersions } from './useAppBuildPoller';
+
+const version = (n: number, status = 'ready'): ApiAppVersionSummary =>
+    ({ version: n, status }) as ApiAppVersionSummary;
+
+describe('mergePolledVersions', () => {
+    it('keeps an already-loaded ready version while a newer one builds', () => {
+        // The regression: replacing the page with the limit=1 poll evicted v1,
+        // leaving the chart with no ready version to render mid-build.
+        const merged = mergePolledVersions(
+            [version(1, 'ready')],
+            [version(2, 'building')],
+        );
+        expect(merged.map((v) => v.version)).toEqual([2, 1]);
+        expect(merged.find((v) => v.status === 'ready')?.version).toBe(1);
+    });
+
+    it('lets the poll win for a version it already knows about', () => {
+        const merged = mergePolledVersions(
+            [version(2, 'building'), version(1, 'ready')],
+            [version(2, 'ready')],
+        );
+        expect(merged).toHaveLength(2);
+        expect(merged[0]).toEqual(version(2, 'ready'));
+    });
+
+    it('orders newest first', () => {
+        const merged = mergePolledVersions(
+            [version(1), version(3)],
+            [version(2)],
+        );
+        expect(merged.map((v) => v.version)).toEqual([3, 2, 1]);
+    });
+
+    it('handles an empty cache', () => {
+        expect(mergePolledVersions([], [version(1)])).toEqual([version(1)]);
+    });
+
+    it('handles an empty poll', () => {
+        expect(mergePolledVersions([version(1)], [])).toEqual([version(1)]);
+    });
+});

--- a/packages/frontend/src/features/apps/hooks/useAppBuildPoller.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppBuildPoller.ts
@@ -38,6 +38,25 @@ async function pollLoop(url, interval) {
 `;
 
 /**
+ * Fold a poll result into the cached first page.
+ *
+ * The poll asks for `limit=1`, so it carries only the newest version.
+ * Overwriting the page with it would evict the already-loaded ready version,
+ * and surfaces that render straight from this cache (the Explorer's data app
+ * viz chart) would lose their last good render for the length of a build.
+ */
+export const mergePolledVersions = (
+    existing: GetAppResult['versions'],
+    polled: GetAppResult['versions'],
+): GetAppResult['versions'] => {
+    const polledNumbers = new Set(polled.map((v) => v.version));
+    return [
+        ...polled,
+        ...existing.filter((v) => !polledNumbers.has(v.version)),
+    ].sort((a, b) => b.version - a.version);
+};
+
+/**
  * Polls the app versions API via a Web Worker while a version is building.
  * Results are fed into the React Query cache so the UI updates reactively.
  *
@@ -77,20 +96,29 @@ export function useAppBuildPoller(
                                   pageParams: unknown[];
                               }
                             | undefined,
-                    ) => ({
-                        // The poll uses limit=1, so its `hasMore` reflects that
-                        // limit rather than the original page size. Keep the
-                        // first page's `hasMore` so pagination stays accurate.
-                        pages: [
-                            {
-                                ...poll,
-                                hasMore:
-                                    old?.pages?.[0]?.hasMore ?? poll.hasMore,
-                            },
-                            ...(old?.pages?.slice(1) ?? []),
-                        ],
-                        pageParams: old?.pageParams ?? [undefined],
-                    }),
+                    ) => {
+                        const versions = mergePolledVersions(
+                            old?.pages?.[0]?.versions ?? [],
+                            poll.versions ?? [],
+                        );
+                        return {
+                            pages: [
+                                {
+                                    ...poll,
+                                    versions,
+                                    // The poll's `hasMore` reflects limit=1
+                                    // rather than the original page size. Keep
+                                    // the first page's so pagination stays
+                                    // accurate.
+                                    hasMore:
+                                        old?.pages?.[0]?.hasMore ??
+                                        poll.hasMore,
+                                },
+                                ...(old?.pages?.slice(1) ?? []),
+                            ],
+                            pageParams: old?.pageParams ?? [undefined],
+                        };
+                    },
                 );
 
                 const latest = poll.versions?.[0];

--- a/packages/frontend/src/features/apps/hooks/useIterateDataAppViz.ts
+++ b/packages/frontend/src/features/apps/hooks/useIterateDataAppViz.ts
@@ -1,0 +1,117 @@
+import { getErrorMessage } from '@lightdash/common';
+import { useCallback, useState } from 'react';
+import {
+    buildVizGenerationPrompt,
+    type VizPromptColumn,
+} from '../utils/buildVizGenerationPrompt';
+import { useAppBuildPoller } from './useAppBuildPoller';
+import { useGetApp } from './useGetApp';
+import { useIterateApp } from './useIterateApp';
+
+type Args = {
+    projectUuid: string | undefined;
+    dataAppVizUuid: string | null;
+};
+
+export type IterateDataAppVizState = {
+    isBuilding: boolean;
+    /** The request in flight, so the conversation can show it immediately. */
+    pendingPrompt: string | null;
+    error: string | null;
+    iterate: (description: string, columns: VizPromptColumn[]) => void;
+    /** Re-send the request that failed; null when there is nothing to retry. */
+    retry: (() => void) | null;
+};
+
+/**
+ * Ask an existing visualization to change.
+ *
+ * The chart needs no rewiring when the build lands: the poller writes into the
+ * same query key the renderer reads, so it swaps to the new version by itself,
+ * and the bindings are reconciled against the new contract at render.
+ *
+ * A revision applies to the shared visualization, so every chart using it
+ * follows. Offering the fork ("update everywhere" vs "save as a copy") needs
+ * the consumer count, which lands separately.
+ */
+export const useIterateDataAppViz = ({
+    projectUuid,
+    dataAppVizUuid,
+}: Args): IterateDataAppVizState => {
+    const [isPolling, setIsPolling] = useState(false);
+    const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
+    const [failed, setFailed] = useState<{
+        message: string;
+        description: string;
+        columns: VizPromptColumn[];
+    } | null>(null);
+    const { mutate: iterateApp, isLoading: isSubmitting } = useIterateApp();
+
+    const { data: appData } = useGetApp(
+        projectUuid,
+        isPolling ? (dataAppVizUuid ?? undefined) : undefined,
+    );
+
+    const handleDone = useCallback(
+        (version: number, status: string) => {
+            setIsPolling(false);
+            const pending = pendingPrompt;
+            setPendingPrompt(null);
+            if (status === 'ready') return;
+            const built = appData?.pages
+                .flatMap((page) => page.versions)
+                .find((v) => v.version === version);
+            setFailed((prev) => ({
+                message:
+                    built?.statusMessage ??
+                    built?.error ??
+                    'That change could not be built. Please try again.',
+                description: pending ?? prev?.description ?? '',
+                columns: prev?.columns ?? [],
+            }));
+        },
+        [appData?.pages, pendingPrompt],
+    );
+
+    useAppBuildPoller(
+        projectUuid,
+        dataAppVizUuid ?? undefined,
+        isPolling,
+        handleDone,
+    );
+
+    const send = useCallback(
+        (description: string, columns: VizPromptColumn[]) => {
+            if (!projectUuid || !dataAppVizUuid || isPolling) return;
+            setFailed(null);
+            setPendingPrompt(description);
+            iterateApp(
+                {
+                    projectUuid,
+                    appUuid: dataAppVizUuid,
+                    prompt: buildVizGenerationPrompt(description, columns),
+                },
+                {
+                    onSuccess: () => setIsPolling(true),
+                    onError: (err) => {
+                        setPendingPrompt(null);
+                        setFailed({
+                            message: getErrorMessage(err),
+                            description,
+                            columns,
+                        });
+                    },
+                },
+            );
+        },
+        [projectUuid, dataAppVizUuid, isPolling, iterateApp],
+    );
+
+    return {
+        isBuilding: isSubmitting || isPolling,
+        pendingPrompt,
+        error: failed?.message ?? null,
+        iterate: send,
+        retry: failed ? () => send(failed.description, failed.columns) : null,
+    };
+};


### PR DESCRIPTION
Adds "ask for a change" to an existing visualization, plus a failure receipt with Retry.

The chart needs no rewiring when the build lands: the poller writes into the same query key the renderer reads, so it swaps to the new version by itself and the bindings reconcile against the new contract at render.

**Also fixes a real defect in shared code.** `useAppBuildPoller` polls with `limit=1` and *replaced* page 0 of the query cache, evicting the already-loaded ready version — so any surface reading that cache directly lost its last good render for the length of a build. `AppGenerate` masks this with its own accumulator; the Explorer's chart does not. The poller now merges by version number, unit-tested.

For v1 a revision applies to the shared visualization and every chart using it follows the latest version.

Relates: GLITCH-630