### PR TITLE
feat(apps): attach files to the viz composer

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -175,8 +175,8 @@ export const ConfigTabs: FC = memo(() => {
                         }
                         footer={
                             <DataAppVizComposer
-                                // Slate reads its placeholder only on mount.
-                                key={dataAppVizUuid ? 'revise' : 'create'}
+                                projectUuid={projectUuid}
+                                appUuid={dataAppVizUuid || build.draftAppUuid}
                                 placeholder={
                                     dataAppVizUuid
                                         ? 'Ask for a change…'

--- a/packages/frontend/src/features/apps/components/DataAppVizComposer.test.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizComposer.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { useAppFileUpload } from '../hooks/useAppFileUpload';
+import DataAppVizComposer from './DataAppVizComposer';
+
+vi.mock('../hooks/useAppFileUpload', () => ({ useAppFileUpload: vi.fn() }));
+vi.mock(
+    '../../../components/common/PromptComposer/PromptComposer',
+    async () => {
+        const React = await import('react');
+
+        return {
+            default: React.forwardRef<
+                { getText: () => string; clear: () => void },
+                {
+                    attachments?: React.ReactNode;
+                    toolbarLeft?: React.ReactNode;
+                }
+            >(({ attachments, toolbarLeft }, ref) => {
+                React.useImperativeHandle(ref, () => ({
+                    getText: () => '',
+                    clear: vi.fn(),
+                }));
+
+                return (
+                    <div>
+                        {attachments}
+                        {toolbarLeft}
+                    </div>
+                );
+            }),
+        };
+    },
+);
+
+describe('DataAppVizComposer', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(useAppFileUpload).mockReturnValue({
+            mutateAsync: vi.fn().mockResolvedValue({ fileId: 'file-1' }),
+        } as unknown as ReturnType<typeof useAppFileUpload>);
+        URL.createObjectURL = vi.fn(() => 'blob:chart');
+        URL.revokeObjectURL = vi.fn();
+    });
+
+    it('drops app-scoped attachments when the selected app changes', async () => {
+        const props = {
+            projectUuid: 'project-1',
+            placeholder: 'Describe a visualization',
+            isBuilding: false,
+            onSubmit: vi.fn(),
+        };
+        const { container, rerender } = renderWithProviders(
+            <DataAppVizComposer {...props} appUuid="app-1" />,
+        );
+        const input = container.querySelector('input[type="file"]');
+
+        fireEvent.change(input!, {
+            target: {
+                files: [
+                    new File(['image'], 'chart.png', { type: 'image/png' }),
+                ],
+            },
+        });
+
+        expect(await screen.findByAltText('Attached')).toBeInTheDocument();
+
+        rerender(<DataAppVizComposer {...props} appUuid="app-2" />);
+
+        expect(screen.queryByAltText('Attached')).not.toBeInTheDocument();
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:chart');
+    });
+});

--- a/packages/frontend/src/features/apps/components/DataAppVizComposer.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizComposer.tsx
@@ -1,12 +1,18 @@
-import { IconArrowUp } from '@tabler/icons-react';
+import { ActionIcon, Tooltip } from '@mantine-8/core';
+import { IconArrowUp, IconPaperclip } from '@tabler/icons-react';
 import { useRef, useState, type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
 import { ComposerSubmitButton } from '../../../components/common/PromptComposer/ComposerSubmitButton';
 import PromptComposer, {
     type PromptComposerHandle,
 } from '../../../components/common/PromptComposer/PromptComposer';
+import { SelectedAttachmentSection } from '../AppResourcePicker';
 import { type VizBuildRequest } from '../hooks/useDataAppVizBuild';
+import { useVizComposerAttachments } from '../hooks/useVizComposerAttachments';
 
 type Props = {
+    projectUuid: string | undefined;
+    appUuid: string;
     placeholder: string;
     /** True while a build is running: keep typing, block sending. */
     isBuilding: boolean;
@@ -16,23 +22,31 @@ type Props = {
 /**
  * Describe-a-visualization input for the chart config panel.
  *
- * Only the author's words are sent. The visualization is handed its rows and a
- * mapping from its own field names to the query's columns at render, so it is
- * built to fit whatever query it is dropped into — not just this one.
+ * Only the author's words and any files they attach are sent. The visualization
+ * is handed its rows and a mapping from its own field names to the query's
+ * columns at render, so it is built to fit whatever query it is dropped into —
+ * not just this one.
  */
-const DataAppVizComposer: FC<Props> = ({
+const DataAppVizComposerContent: FC<Props> = ({
+    projectUuid,
+    appUuid,
     placeholder,
     isBuilding,
     onSubmit,
 }) => {
+    const attachments = useVizComposerAttachments({ projectUuid, appUuid });
     const composerRef = useRef<PromptComposerHandle>(null);
+    const fileInputRef = useRef<HTMLInputElement>(null);
     const [isEmpty, setIsEmpty] = useState(true);
+
+    const canSend = !isBuilding && !attachments.isUploading;
 
     const handleSubmit = () => {
         const description = composerRef.current?.getText().trim() ?? '';
-        if (!description || isBuilding) return;
+        if (!description || !canSend) return;
         composerRef.current?.clear();
-        onSubmit({ description });
+        onSubmit({ description, fileIds: attachments.fileIds });
+        attachments.clear();
     };
 
     return (
@@ -40,15 +54,52 @@ const DataAppVizComposer: FC<Props> = ({
             ref={composerRef}
             size="md"
             placeholder={placeholder}
-            submitDisabled={isBuilding}
+            submitDisabled={!canSend}
             onEmptyChange={setIsEmpty}
             onSubmit={handleSubmit}
+            attachments={
+                <SelectedAttachmentSection
+                    attachments={attachments.attachments.map((a) => ({
+                        id: a.key,
+                        previewUrl: a.previewUrl,
+                        filename: a.filename,
+                    }))}
+                    onRemove={attachments.remove}
+                    disabled={isBuilding}
+                />
+            }
+            toolbarLeft={
+                <>
+                    <input
+                        ref={fileInputRef}
+                        type="file"
+                        multiple
+                        hidden
+                        onChange={(e) => {
+                            attachments.add(Array.from(e.target.files ?? []));
+                            e.target.value = '';
+                        }}
+                    />
+                    <Tooltip withArrow label="Attach an image or file">
+                        <ActionIcon
+                            variant="subtle"
+                            color="gray"
+                            size="sm"
+                            disabled={isBuilding}
+                            aria-label="Attach"
+                            onClick={() => fileInputRef.current?.click()}
+                        >
+                            <MantineIcon icon={IconPaperclip} />
+                        </ActionIcon>
+                    </Tooltip>
+                </>
+            }
             toolbarRight={
                 <ComposerSubmitButton
                     icon={IconArrowUp}
                     label="Send"
                     size="sm"
-                    disabled={isEmpty || isBuilding}
+                    disabled={isEmpty || !canSend}
                     loading={isBuilding}
                     onClick={handleSubmit}
                 />
@@ -56,5 +107,9 @@ const DataAppVizComposer: FC<Props> = ({
         />
     );
 };
+
+const DataAppVizComposer: FC<Props> = (props) => (
+    <DataAppVizComposerContent key={props.appUuid} {...props} />
+);
 
 export default DataAppVizComposer;

--- a/packages/frontend/src/features/apps/hooks/useDataAppVizBuild.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useDataAppVizBuild.test.ts
@@ -112,7 +112,10 @@ describe('useDataAppVizBuild', () => {
         const { result } = setup();
 
         act(() =>
-            result.current.send({ description: 'a donut of orders by status' }),
+            result.current.send({
+                description: 'a donut of orders by status',
+                fileIds: [],
+            }),
         );
 
         expect(result.current.pendingPrompt).toBe(
@@ -126,7 +129,12 @@ describe('useDataAppVizBuild', () => {
         // the same tick, so the cache is still a render behind here.
         const { result, onCreated } = setup();
 
-        act(() => result.current.send({ description: 'a donut' }));
+        act(() =>
+            result.current.send({
+                description: 'a donut',
+                fileIds: [],
+            }),
+        );
         const handlers = generate.mock.lastCall?.[1] as GenerateHandlers;
         act(() => handlers.onSuccess({ appUuid: 'viz-1', version: 1 }));
         finishBuild(finishedVersion());
@@ -138,7 +146,12 @@ describe('useDataAppVizBuild', () => {
     it('reports why a build failed and stops building', () => {
         const { result, onCreated } = setup();
 
-        act(() => result.current.send({ description: 'a donut' }));
+        act(() =>
+            result.current.send({
+                description: 'a donut',
+                fileIds: [],
+            }),
+        );
         const handlers = generate.mock.lastCall?.[1] as GenerateHandlers;
         act(() => handlers.onSuccess({ appUuid: 'viz-1', version: 1 }));
         finishBuild(
@@ -156,7 +169,7 @@ describe('useDataAppVizBuild', () => {
     it('does not replace a visualization picked while creation runs', () => {
         const { result, rerender, onCreated } = setup();
 
-        act(() => result.current.send({ description: 'a donut' }));
+        act(() => result.current.send({ description: 'a donut', fileIds: [] }));
         const handlers = generate.mock.lastCall?.[1] as GenerateHandlers;
         act(() => handlers.onSuccess({ appUuid: 'viz-1', version: 1 }));
 
@@ -169,7 +182,12 @@ describe('useDataAppVizBuild', () => {
     it('retries a request the server never accepted, as it was sent', () => {
         const { result } = setup();
 
-        act(() => result.current.send({ description: 'a donut' }));
+        act(() =>
+            result.current.send({
+                description: 'a donut',
+                fileIds: [],
+            }),
+        );
         const handlers = generate.mock.lastCall?.[1] as GenerateHandlers;
         act(() => handlers.onError(new Error('Network error')));
 
@@ -184,7 +202,12 @@ describe('useDataAppVizBuild', () => {
     it('revises the selected visualization instead of making another', () => {
         const { result, onCreated } = setup('viz-1');
 
-        act(() => result.current.send({ description: 'make the bars teal' }));
+        act(() =>
+            result.current.send({
+                description: 'make the bars teal',
+                fileIds: [],
+            }),
+        );
 
         expect(generate).not.toHaveBeenCalled();
         expect(iterate.mock.lastCall?.[0]).toMatchObject({
@@ -203,7 +226,12 @@ describe('useDataAppVizBuild', () => {
     it('does not offer a revision as a draft', () => {
         const { result } = setup('viz-1');
 
-        act(() => result.current.send({ description: 'make the bars teal' }));
+        act(() =>
+            result.current.send({
+                description: 'make the bars teal',
+                fileIds: [],
+            }),
+        );
         const handlers = iterate.mock.lastCall?.[1] as GenerateHandlers;
         act(() => handlers.onSuccess({ appUuid: 'viz-1', version: 2 }));
 
@@ -214,7 +242,12 @@ describe('useDataAppVizBuild', () => {
     it('cancels a revision without deleting its app', () => {
         const { result } = setup('viz-1');
 
-        act(() => result.current.send({ description: 'make the bars teal' }));
+        act(() =>
+            result.current.send({
+                description: 'make the bars teal',
+                fileIds: [],
+            }),
+        );
         const iterateHandlers = iterate.mock.lastCall?.[1] as GenerateHandlers;
         act(() => iterateHandlers.onSuccess({ appUuid: 'viz-1', version: 2 }));
         act(() => result.current.cancel?.());
@@ -239,7 +272,12 @@ describe('useDataAppVizBuild', () => {
     it('retries a revision that failed to build, as it was sent', () => {
         const { result } = setup('viz-1');
 
-        act(() => result.current.send({ description: 'make the bars teal' }));
+        act(() =>
+            result.current.send({
+                description: 'make the bars teal',
+                fileIds: [],
+            }),
+        );
         const handlers = iterate.mock.lastCall?.[1] as GenerateHandlers;
         act(() => handlers.onSuccess({ appUuid: 'viz-1', version: 2 }));
         finishBuild(
@@ -254,10 +292,20 @@ describe('useDataAppVizBuild', () => {
     it('refuses a second request while one is in flight', () => {
         const { result } = setup();
 
-        act(() => result.current.send({ description: 'a donut' }));
+        act(() =>
+            result.current.send({
+                description: 'a donut',
+                fileIds: [],
+            }),
+        );
         const handlers = generate.mock.lastCall?.[1] as GenerateHandlers;
         act(() => handlers.onSuccess({ appUuid: 'viz-1', version: 1 }));
-        act(() => result.current.send({ description: 'actually a bar chart' }));
+        act(() =>
+            result.current.send({
+                description: 'actually a bar chart',
+                fileIds: [],
+            }),
+        );
 
         expect(generate).toHaveBeenCalledTimes(1);
     });
@@ -265,7 +313,7 @@ describe('useDataAppVizBuild', () => {
     it('cancels a draft before deleting its app', () => {
         const { result } = setup();
 
-        act(() => result.current.send({ description: 'a donut' }));
+        act(() => result.current.send({ description: 'a donut', fileIds: [] }));
         const generateHandlers = generate.mock
             .lastCall?.[1] as GenerateHandlers;
         act(() => generateHandlers.onSuccess({ appUuid: 'viz-1', version: 1 }));

--- a/packages/frontend/src/features/apps/hooks/useDataAppVizBuild.ts
+++ b/packages/frontend/src/features/apps/hooks/useDataAppVizBuild.ts
@@ -6,6 +6,7 @@ import {
     type ItemsMap,
 } from '@lightdash/common';
 import { useCallback, useState } from 'react';
+import { v4 as uuid4 } from 'uuid';
 import { autoMapDataAppVizFields } from '../utils/autoMapDataAppVizFields';
 import { useAppBuildPoller } from './useAppBuildPoller';
 import { useCancelAppVersion } from './useCancelAppVersion';
@@ -29,6 +30,7 @@ type Args = {
 /** What was asked for, kept so a failure can be retried as it was sent. */
 export type VizBuildRequest = {
     description: string;
+    fileIds: string[];
 };
 
 /** The app claimed by a build before it has a renderable version. */
@@ -41,6 +43,8 @@ export type DataAppVizDraft = {
 type RunningBuild = DataAppVizDraft & { isNew: boolean };
 
 export type DataAppVizBuildState = {
+    /** Pre-generated uuid used to scope uploads for the next new app. */
+    draftAppUuid: string;
     /**
      * The app the build in flight claimed; null when nothing is building. Its
      * versions are the session, so the dock reads history from it while the
@@ -89,6 +93,7 @@ export const useDataAppVizBuild = ({
     // The request in flight, and the app it is building — both null when idle.
     const [inFlight, setInFlight] = useState<VizBuildRequest | null>(null);
     const [building, setBuilding] = useState<RunningBuild | null>(null);
+    const [draftAppUuid, setDraftAppUuid] = useState(() => uuid4());
     const [failed, setFailed] = useState<{
         message: string;
         request: VizBuildRequest | null;
@@ -122,7 +127,8 @@ export const useDataAppVizBuild = ({
                     version.statusMessage ??
                     version.error ??
                     'That build could not be completed. Please try again.',
-                request,
+                // A new app cannot retry with its already-claimed uuid.
+                request: target?.isNew ? null : request,
             });
         },
         [building, inFlight, itemsMap, dataAppVizUuid, onCreated],
@@ -141,6 +147,8 @@ export const useDataAppVizBuild = ({
             setFailed(null);
             setInFlight(request);
             const prompt = request.description;
+            const files =
+                request.fileIds.length > 0 ? request.fileIds : undefined;
             const onError = (err: unknown) => {
                 setInFlight(null);
                 setFailed({ message: getErrorMessage(err), request });
@@ -148,22 +156,35 @@ export const useDataAppVizBuild = ({
 
             if (dataAppVizUuid === null) {
                 generateApp(
-                    { projectUuid, prompt, template: DATA_APP_VIZ_TEMPLATE },
                     {
-                        onSuccess: ({ appUuid, version }) =>
+                        projectUuid,
+                        prompt,
+                        template: DATA_APP_VIZ_TEMPLATE,
+                        appUuid: draftAppUuid,
+                        fileIds: files,
+                    },
+                    {
+                        onSuccess: ({ appUuid, version }) => {
+                            setDraftAppUuid(uuid4());
                             setBuilding({
                                 appUuid,
                                 version,
                                 startedAt: new Date(),
                                 isNew: true,
-                            }),
+                            });
+                        },
                         onError,
                     },
                 );
                 return;
             }
             iterateApp(
-                { projectUuid, appUuid: dataAppVizUuid, prompt },
+                {
+                    projectUuid,
+                    appUuid: dataAppVizUuid,
+                    prompt,
+                    fileIds: files,
+                },
                 {
                     onSuccess: ({ version }) =>
                         setBuilding({
@@ -176,13 +197,21 @@ export const useDataAppVizBuild = ({
                 },
             );
         },
-        [projectUuid, dataAppVizUuid, building, generateApp, iterateApp],
+        [
+            projectUuid,
+            dataAppVizUuid,
+            building,
+            draftAppUuid,
+            generateApp,
+            iterateApp,
+        ],
     );
 
     const failedRequest = failed?.request ?? null;
     const draft = building?.isNew ? building : null;
 
     return {
+        draftAppUuid,
         appUuid: building?.appUuid ?? null,
         draft,
         startedAt: building?.startedAt ?? null,

--- a/packages/frontend/src/features/apps/hooks/useVizComposerAttachments.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useVizComposerAttachments.test.ts
@@ -1,0 +1,139 @@
+import { MAX_APP_FILES_PER_VERSION } from '@lightdash/common';
+import { act, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHookWithProviders } from '../../../testing/testUtils';
+import { useAppFileUpload } from './useAppFileUpload';
+import { useVizComposerAttachments } from './useVizComposerAttachments';
+
+vi.mock('./useAppFileUpload', () => ({ useAppFileUpload: vi.fn() }));
+
+const showToastError = vi.fn();
+const showToastWarning = vi.fn();
+vi.mock('../../../hooks/toaster/useToaster', () => ({
+    default: () => ({ showToastError, showToastWarning }),
+}));
+
+const mockedUpload = vi.mocked(useAppFileUpload);
+
+const file = (name: string, size = 10, type = 'image/png'): File => {
+    const f = new File(['x'], name, { type });
+    Object.defineProperty(f, 'size', { value: size });
+    return f;
+};
+
+const setup = (uploadFile: ReturnType<typeof vi.fn>) => {
+    mockedUpload.mockReturnValue({
+        mutateAsync: uploadFile,
+    } as unknown as ReturnType<typeof useAppFileUpload>);
+    return renderHookWithProviders(() =>
+        useVizComposerAttachments({
+            projectUuid: 'project-1',
+            appUuid: 'app-1',
+        }),
+    );
+};
+
+describe('useVizComposerAttachments', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        // jsdom has no object URL support.
+        URL.createObjectURL = vi.fn((value) => `blob:${(value as File).name}`);
+        URL.revokeObjectURL = vi.fn();
+    });
+
+    it('uploads on attach and carries the id once it lands', async () => {
+        const uploadFile = vi.fn().mockResolvedValue({ fileId: 'f1' });
+        const { result } = setup(uploadFile);
+
+        act(() => result.current.add([file('chart.png')]));
+
+        // Listed immediately, but not sendable until the upload lands: only
+        // uploaded ids can travel with the request.
+        expect(result.current.attachments).toHaveLength(1);
+        expect(result.current.isUploading).toBe(true);
+        expect(result.current.fileIds).toEqual([]);
+
+        await waitFor(() => expect(result.current.fileIds).toEqual(['f1']));
+        expect(result.current.isUploading).toBe(false);
+        expect(uploadFile.mock.lastCall?.[0]).toMatchObject({
+            projectUuid: 'project-1',
+            appUuid: 'app-1',
+        });
+    });
+
+    it('refuses a file over the size limit without uploading it', () => {
+        const uploadFile = vi.fn();
+        const { result } = setup(uploadFile);
+
+        act(() => result.current.add([file('huge.png', 11 * 1024 * 1024)]));
+
+        expect(result.current.attachments).toEqual([]);
+        expect(uploadFile).not.toHaveBeenCalled();
+        expect(showToastError).toHaveBeenCalledTimes(1);
+    });
+
+    it('takes what fits and warns once for a batch over the cap', () => {
+        const uploadFile = vi.fn().mockResolvedValue({ fileId: 'f' });
+        const { result } = setup(uploadFile);
+
+        const batch = Array.from(
+            { length: MAX_APP_FILES_PER_VERSION + 2 },
+            (_, i) => file(`f${i}.png`),
+        );
+        act(() => result.current.add(batch));
+
+        expect(result.current.attachments).toHaveLength(
+            MAX_APP_FILES_PER_VERSION,
+        );
+        // One warning for the batch, not one per rejected file.
+        expect(showToastWarning).toHaveBeenCalledTimes(1);
+    });
+
+    it('drops an attachment whose upload failed', async () => {
+        const uploadFile = vi.fn().mockRejectedValue(new Error('nope'));
+        const { result } = setup(uploadFile);
+
+        act(() => result.current.add([file('chart.png')]));
+
+        await waitFor(() => expect(result.current.attachments).toEqual([]));
+        expect(showToastError).toHaveBeenCalledWith({
+            title: 'Upload failed',
+            subtitle: 'Please try again or contact support.',
+        });
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:chart.png');
+    });
+
+    it('releases an image preview when its attachment is removed', async () => {
+        const uploadFile = vi.fn().mockResolvedValue({ fileId: 'f1' });
+        const { result } = setup(uploadFile);
+
+        act(() => result.current.add([file('chart.png')]));
+        await waitFor(() => expect(result.current.fileIds).toEqual(['f1']));
+        act(() => result.current.remove('0'));
+
+        expect(result.current.attachments).toEqual([]);
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:chart.png');
+    });
+
+    it('releases every image preview when attachments are cleared', () => {
+        const uploadFile = vi.fn().mockResolvedValue({ fileId: 'f1' });
+        const { result } = setup(uploadFile);
+
+        act(() => result.current.add([file('one.png'), file('two.png')]));
+        act(() => result.current.clear());
+
+        expect(result.current.attachments).toEqual([]);
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:one.png');
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:two.png');
+    });
+
+    it('releases image previews on unmount', () => {
+        const uploadFile = vi.fn().mockResolvedValue({ fileId: 'f1' });
+        const { result, unmount } = setup(uploadFile);
+
+        act(() => result.current.add([file('chart.png')]));
+        unmount();
+
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:chart.png');
+    });
+});

--- a/packages/frontend/src/features/apps/hooks/useVizComposerAttachments.ts
+++ b/packages/frontend/src/features/apps/hooks/useVizComposerAttachments.ts
@@ -1,0 +1,143 @@
+import { MAX_APP_FILES_PER_VERSION } from '@lightdash/common';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import useToaster from '../../../hooks/toaster/useToaster';
+import { useAppFileUpload } from './useAppFileUpload';
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024;
+
+export type VizAttachment = {
+    fileId: string | null;
+    filename: string;
+    previewUrl: string | null;
+    key: string;
+};
+
+type Args = {
+    projectUuid: string | undefined;
+    appUuid: string;
+};
+
+export type VizComposerAttachments = {
+    attachments: VizAttachment[];
+    isUploading: boolean;
+    add: (files: File[]) => void;
+    remove: (key: string) => void;
+    clear: () => void;
+    fileIds: string[];
+};
+
+export const useVizComposerAttachments = ({
+    projectUuid,
+    appUuid,
+}: Args): VizComposerAttachments => {
+    const [attachments, setAttachments] = useState<VizAttachment[]>([]);
+    const { mutateAsync: uploadFile } = useAppFileUpload();
+    const { showToastError, showToastWarning } = useToaster();
+    const nextKey = useRef(0);
+    const previewUrls = useRef(new Map<string, string>());
+
+    const revokePreview = useCallback((key: string) => {
+        const url = previewUrls.current.get(key);
+        if (!url) return;
+
+        URL.revokeObjectURL(url);
+        previewUrls.current.delete(key);
+    }, []);
+
+    const releasePreviews = useCallback(() => {
+        previewUrls.current.forEach((url) => URL.revokeObjectURL(url));
+        previewUrls.current.clear();
+    }, []);
+
+    useEffect(() => () => releasePreviews(), [releasePreviews]);
+
+    const add = useCallback(
+        (files: File[]) => {
+            if (!projectUuid) return;
+            const withinSize = files.filter((file) => {
+                if (file.size <= MAX_FILE_SIZE) return true;
+                showToastError({
+                    title: 'File too large',
+                    subtitle: `${file.name} exceeds the 10MB limit.`,
+                });
+                return false;
+            });
+            // Computing this outside the updater prevents duplicate toasts.
+            const room = Math.max(
+                0,
+                MAX_APP_FILES_PER_VERSION - attachments.length,
+            );
+            if (withinSize.length > room) {
+                showToastWarning({
+                    title: 'Attachment limit reached',
+                    subtitle: `You can attach up to ${MAX_APP_FILES_PER_VERSION} files per message.`,
+                });
+            }
+
+            withinSize.slice(0, room).forEach((file) => {
+                const key = String(nextKey.current++);
+                const previewUrl = file.type.startsWith('image/')
+                    ? URL.createObjectURL(file)
+                    : null;
+                if (previewUrl) previewUrls.current.set(key, previewUrl);
+
+                setAttachments((prev) => [
+                    ...prev,
+                    { fileId: null, filename: file.name, previewUrl, key },
+                ]);
+
+                void uploadFile({ projectUuid, appUuid, file })
+                    .then(({ fileId }) =>
+                        setAttachments((prev) =>
+                            prev.map((a) =>
+                                a.key === key ? { ...a, fileId } : a,
+                            ),
+                        ),
+                    )
+                    .catch(() => {
+                        revokePreview(key);
+                        setAttachments((prev) =>
+                            prev.filter((a) => a.key !== key),
+                        );
+                        showToastError({
+                            title: 'Upload failed',
+                            subtitle: 'Please try again or contact support.',
+                        });
+                    });
+            });
+        },
+        [
+            projectUuid,
+            appUuid,
+            attachments.length,
+            uploadFile,
+            showToastError,
+            showToastWarning,
+            revokePreview,
+        ],
+    );
+
+    const remove = useCallback(
+        (key: string) => {
+            revokePreview(key);
+            setAttachments((prev) => prev.filter((a) => a.key !== key));
+        },
+        [revokePreview],
+    );
+
+    const clear = useCallback(() => {
+        releasePreviews();
+        setAttachments([]);
+    }, [releasePreviews]);
+
+    return {
+        attachments,
+        isUploading: attachments.some((a) => a.fileId === null),
+        add,
+        remove,
+        clear,
+        fileIds: attachments
+            .map((a) => a.fileId)
+            .filter((id): id is string => id !== null),
+    };
+};

--- a/packages/frontend/src/features/apps/testing/dataAppVizBuildStub.ts
+++ b/packages/frontend/src/features/apps/testing/dataAppVizBuildStub.ts
@@ -5,6 +5,7 @@ import { type DataAppVizBuildState } from '../hooks/useDataAppVizBuild';
 export const buildStub = (
     overrides: Partial<DataAppVizBuildState> = {},
 ): DataAppVizBuildState => ({
+    draftAppUuid: 'draft-app-1',
     appUuid: null,
     draft: null,
     startedAt: null,


### PR DESCRIPTION
Screenshots to imitate, a sketch of the chart you want. Files upload on attach against the visualization being revised, or against the uuid the next new one will claim.

That uuid becomes the app's primary key, so it is rotated once a build claims it. A creation that fails *after* claiming its app cannot retry — its uploads are stranded under that uuid — so Cancel is the way out.

Relates: GLITCH-630

