### PR TITLE
chore: exercise backend preview build

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -6,7 +6,7 @@ import knexConfig from './knexfile';
 import Logger from './logging/logger';
 import { getProcessTimezoneWarning } from './utils/processTimezone';
 
-// trigger BE tests
+// Trigger backend preview build.
 
 // Winston (handleExceptions/handleRejections in winston.ts) owns structured logging
 // for both events. Logger uses exitOnError: false so rejections are tolerated.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates: #26312

### Description:
This is an intentionally no-op backend change created to trigger deploy-preview and measure the preview build after the backend-only runtime payload and remote-cache optimizations in #26312.

Do not merge. Use the preview deployment logs and duration for analysis.