### PR TITLE
fix(apps): keep loaded versions when the build poller refreshes

### DIFF
--- a/packages/frontend/src/features/apps/hooks/useAppBuildPoller.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppBuildPoller.test.ts
@@ -1,0 +1,44 @@
+import { type ApiAppVersionSummary } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { mergePolledVersions } from './useAppBuildPoller';
+
+const version = (n: number, status = 'ready'): ApiAppVersionSummary =>
+    ({ version: n, status }) as ApiAppVersionSummary;
+
+describe('mergePolledVersions', () => {
+    it('keeps an already-loaded ready version while a newer one builds', () => {
+        // The regression: replacing the page with the limit=1 poll evicted v1,
+        // leaving the chart with no ready version to render mid-build.
+        const merged = mergePolledVersions(
+            [version(1, 'ready')],
+            [version(2, 'building')],
+        );
+        expect(merged.map((v) => v.version)).toEqual([2, 1]);
+        expect(merged.find((v) => v.status === 'ready')?.version).toBe(1);
+    });
+
+    it('lets the poll win for a version it already knows about', () => {
+        const merged = mergePolledVersions(
+            [version(2, 'building'), version(1, 'ready')],
+            [version(2, 'ready')],
+        );
+        expect(merged).toHaveLength(2);
+        expect(merged[0]).toEqual(version(2, 'ready'));
+    });
+
+    it('orders newest first', () => {
+        const merged = mergePolledVersions(
+            [version(1), version(3)],
+            [version(2)],
+        );
+        expect(merged.map((v) => v.version)).toEqual([3, 2, 1]);
+    });
+
+    it('handles an empty cache', () => {
+        expect(mergePolledVersions([], [version(1)])).toEqual([version(1)]);
+    });
+
+    it('handles an empty poll', () => {
+        expect(mergePolledVersions([version(1)], [])).toEqual([version(1)]);
+    });
+});

--- a/packages/frontend/src/features/apps/hooks/useAppBuildPoller.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppBuildPoller.ts
@@ -1,5 +1,6 @@
 import {
     APP_VERSION_TERMINAL_STATUSES,
+    type ApiAppVersionSummary,
     type ApiGetAppResponse,
 } from '@lightdash/common';
 import { useQueryClient } from '@tanstack/react-query';
@@ -38,16 +39,37 @@ async function pollLoop(url, interval) {
 `;
 
 /**
+ * Fold a poll result into the cached first page.
+ *
+ * The poll asks for `limit=1`, so it carries only the newest version.
+ * Overwriting the page with it would evict the already-loaded ready version,
+ * and surfaces that render straight from this cache (the Explorer's data app
+ * viz chart) would lose their last good render for the length of a build.
+ */
+export const mergePolledVersions = (
+    existing: GetAppResult['versions'],
+    polled: GetAppResult['versions'],
+): GetAppResult['versions'] => {
+    const polledNumbers = new Set(polled.map((v) => v.version));
+    return [
+        ...polled,
+        ...existing.filter((v) => !polledNumbers.has(v.version)),
+    ].sort((a, b) => b.version - a.version);
+};
+
+/**
  * Polls the app versions API via a Web Worker while a version is building.
  * Results are fed into the React Query cache so the UI updates reactively.
  *
- * Calls `onDone(version, status)` once when the build finishes.
+ * Calls `onDone` once when the build finishes, with the version the poll just
+ * fetched — callers must not read it back out of the query cache, which is
+ * still a render behind at that point.
  */
 export function useAppBuildPoller(
     projectUuid: string | undefined,
     appUuid: string | undefined,
     isBuilding: boolean,
-    onDone: (version: number, status: string) => void,
+    onDone: (version: ApiAppVersionSummary) => void,
 ) {
     const queryClient = useQueryClient();
     const onDoneRef = useRef(onDone);
@@ -77,20 +99,29 @@ export function useAppBuildPoller(
                                   pageParams: unknown[];
                               }
                             | undefined,
-                    ) => ({
-                        // The poll uses limit=1, so its `hasMore` reflects that
-                        // limit rather than the original page size. Keep the
-                        // first page's `hasMore` so pagination stays accurate.
-                        pages: [
-                            {
-                                ...poll,
-                                hasMore:
-                                    old?.pages?.[0]?.hasMore ?? poll.hasMore,
-                            },
-                            ...(old?.pages?.slice(1) ?? []),
-                        ],
-                        pageParams: old?.pageParams ?? [undefined],
-                    }),
+                    ) => {
+                        const versions = mergePolledVersions(
+                            old?.pages?.[0]?.versions ?? [],
+                            poll.versions ?? [],
+                        );
+                        return {
+                            pages: [
+                                {
+                                    ...poll,
+                                    versions,
+                                    // The poll's `hasMore` reflects limit=1
+                                    // rather than the original page size. Keep
+                                    // the first page's so pagination stays
+                                    // accurate.
+                                    hasMore:
+                                        old?.pages?.[0]?.hasMore ??
+                                        poll.hasMore,
+                                },
+                                ...(old?.pages?.slice(1) ?? []),
+                            ],
+                            pageParams: old?.pageParams ?? [undefined],
+                        };
+                    },
                 );
 
                 const latest = poll.versions?.[0];
@@ -100,10 +131,7 @@ export function useAppBuildPoller(
                         APP_VERSION_TERMINAL_STATUSES as readonly string[]
                     ).includes(latest.status)
                 ) {
-                    onDoneRef.current(
-                        latest.version as number,
-                        latest.status as string,
-                    );
+                    onDoneRef.current(latest);
                 }
             }
         };

--- a/packages/frontend/src/features/apps/hooks/useBuildNotification.ts
+++ b/packages/frontend/src/features/apps/hooks/useBuildNotification.ts
@@ -1,7 +1,8 @@
+import { type ApiAppVersionSummary } from '@lightdash/common';
 import { useCallback, useEffect, useRef } from 'react';
 
 /**
- * Returns a `notify(version, status)` function that shows an OS notification
+ * Returns a `notify(version)` function that shows an OS notification
  * when a build completes — but only when the tab is in the background.
  *
  * Automatically requests notification permission when `shouldRequestPermission`
@@ -22,7 +23,7 @@ export function useBuildNotification(
     const notifiedVersionRef = useRef<number | null>(null);
 
     return useCallback(
-        (version: number, status: string) => {
+        ({ version, status }: ApiAppVersionSummary) => {
             if (notifiedVersionRef.current === version) return;
             notifiedVersionRef.current = version;
 


### PR DESCRIPTION
The poller fetches `limit=1` and replaced page 0 of the cache with it, so any surface reading the cache directly lost its already-loaded ready version for the length of a build — the Explorer chart fell back to "still generating" mid-build. `AppGenerate` never noticed because it keeps its own accumulator.

`onDone` now hands back the version it fetched rather than its number. Callers were re-finding it in the cache, which is a render behind: the poll writes the cache and calls back in the same tick.

Relates: GLITCH-630
