### PR TITLE
feat(apps): build a data app viz from the chart config

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -1,12 +1,20 @@
-import { getEffectiveOptionValues, type ItemsMap } from '@lightdash/common';
+import {
+    getEffectiveOptionValues,
+    type DataAppVizFieldMapping,
+    type ItemsMap,
+} from '@lightdash/common';
 import { Box } from '@mantine-8/core';
 import { MantineProvider, useMantineColorScheme } from '@mantine/core';
-import { memo, useMemo, type FC } from 'react';
+import { memo, useCallback, useMemo, type FC } from 'react';
 import { useParams } from 'react-router';
+import DataAppVizBuildStatus from '../../../features/apps/components/DataAppVizBuildStatus';
+import DataAppVizComposer from '../../../features/apps/components/DataAppVizComposer';
 import DataAppVizDock from '../../../features/apps/components/DataAppVizDock';
 import { useCanCreateDataApp } from '../../../features/apps/hooks/useCanCreateDataApp';
 import { useCanEditDataApp } from '../../../features/apps/hooks/useCanEditDataApp';
 import { useDataAppVisualization } from '../../../features/apps/hooks/useDataAppVisualization';
+import { useDataAppVizBuild } from '../../../features/apps/hooks/useDataAppVizBuild';
+import { useElapsedClock } from '../../../features/apps/hooks/useElapsedClock';
 import {
     autoMapDataAppVizFields,
     reconcileDataAppVizFieldMapping,
@@ -47,16 +55,32 @@ export const ConfigTabs: FC = memo(() => {
     );
     const colorPalette = dataAppViz?.schema?.colorPalette ?? null;
 
+    // Held in a ref-free callback so the build hook can commit straight into
+    // the chart config once a new visualization lands.
+    const setDataAppVizUuidRef = isDataAppViz
+        ? visualizationConfig.chartConfig.setDataAppVizUuid
+        : undefined;
+    const handleCreated = useCallback(
+        (uuid: string, mapping: DataAppVizFieldMapping) =>
+            setDataAppVizUuidRef?.(uuid, mapping),
+        [setDataAppVizUuidRef],
+    );
+    const build = useDataAppVizBuild({
+        projectUuid,
+        itemsMap: itemsMap ?? {},
+        dataAppVizUuid: dataAppVizUuid || null,
+        onCreated: handleCreated,
+    });
+    const elapsed = useElapsedClock(build.startedAt);
     const canCreateApp = useCanCreateDataApp(projectUuid);
     const canEditSelected = useCanEditDataApp(projectUuid, {
         spaceUuid: dataAppViz?.spaceUuid ?? null,
         createdByUserUuid: dataAppViz?.createdByUserUuid ?? null,
     });
-    // The dock is authoring end to end — the version log's restores, the way
-    // into the builder — so it is offered on the same rules as the builder
-    // page: creating a new visualization, or managing the one selected.
-    // Without either, the panel is the picker and the settings. The create
-    // arm only becomes reachable once the dock renders with nothing selected.
+    // The dock is authoring end to end — the composer, the version log's
+    // restores, the way into the builder — so it is offered on the same rules
+    // as the builder page: creating a new visualization, or managing the one
+    // selected. Without either, the panel is the picker and the settings.
     const canAuthor = dataAppVizUuid ? canEditSelected : canCreateApp;
 
     if (!isDataAppViz) return null;
@@ -124,10 +148,33 @@ export const ConfigTabs: FC = memo(() => {
                     />
                 </Box>
 
-                {dataAppVizUuid && canAuthor && (
+                {canAuthor && (
                     <DataAppVizDock
                         projectUuid={projectUuid ?? ''}
-                        dataAppVizUuid={dataAppVizUuid}
+                        // A build claims its app before the chart points at it,
+                        // so the versions on show are that one's until it lands.
+                        dataAppVizUuid={dataAppVizUuid || build.appUuid}
+                        build={build}
+                        elapsed={elapsed}
+                        status={
+                            build.isBuilding ? (
+                                <DataAppVizBuildStatus
+                                    build={build}
+                                    elapsed={elapsed}
+                                />
+                            ) : undefined
+                        }
+                        footer={
+                            // Asking a saved visualization to change is not
+                            // wired up yet; the composer only authors new ones.
+                            dataAppVizUuid ? null : (
+                                <DataAppVizComposer
+                                    placeholder="Describe a new visualization…"
+                                    isBuilding={build.isBuilding}
+                                    onSubmit={build.send}
+                                />
+                            )
+                        }
                     />
                 )}
             </Box>

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizSettings.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizSettings.tsx
@@ -31,7 +31,8 @@ type Props = {
 /**
  * What the chart is pointing at, and what each of its slots is bound to.
  *
- * Changes here are free and instant — no build, no request.
+ * Changes here are free and instant — no build, no request. That is what
+ * separates them from the build session docked below.
  */
 const DataAppVizSettings: FC<Props> = ({
     projectUuid,

--- a/packages/frontend/src/features/apps/components/DataAppVizBuildStatus.test.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizBuildStatus.test.tsx
@@ -1,0 +1,44 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { buildStub } from '../testing/dataAppVizBuildStub';
+import DataAppVizBuildStatus from './DataAppVizBuildStatus';
+
+describe('DataAppVizBuildStatus', () => {
+    it('reports what was asked for and how long it has been going', () => {
+        renderWithProviders(
+            <DataAppVizBuildStatus
+                build={buildStub({
+                    isBuilding: true,
+                    pendingPrompt: 'make the bars horizontal',
+                    claimedVersion: 2,
+                })}
+                elapsed="0:14"
+            />,
+        );
+
+        expect(screen.getByText('Building v2')).toBeInTheDocument();
+        expect(
+            screen.getByText('make the bars horizontal'),
+        ).toBeInTheDocument();
+        expect(screen.getByText('· 0:14')).toBeInTheDocument();
+    });
+
+    // The version is claimed a beat after the send, so the first render of a
+    // build has no number to show yet.
+    it('names the build alone until it has claimed a version', () => {
+        renderWithProviders(
+            <DataAppVizBuildStatus
+                build={buildStub({
+                    isBuilding: true,
+                    pendingPrompt: 'a donut of orders by status',
+                    claimedVersion: null,
+                })}
+                elapsed={null}
+            />,
+        );
+
+        expect(screen.getByText('Building')).toBeInTheDocument();
+        expect(screen.queryByText(/· /)).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/features/apps/components/DataAppVizBuildStatus.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizBuildStatus.tsx
@@ -1,0 +1,33 @@
+import { Text } from '@mantine-8/core';
+import { type FC } from 'react';
+import { type DataAppVizBuildState } from '../hooks/useDataAppVizBuild';
+
+type Props = {
+    build: DataAppVizBuildState;
+    /** Ticking `0:12` while the build runs. */
+    elapsed: string | null;
+};
+
+/**
+ * What the dock's resting bar reports while a build is in flight, in place of
+ * the provenance line: what was asked for, and how long it has been going.
+ */
+const DataAppVizBuildStatus: FC<Props> = ({ build, elapsed }) => (
+    <>
+        <Text size="xs" fw={500}>
+            {build.claimedVersion === null
+                ? 'Building'
+                : `Building v${build.claimedVersion}`}
+        </Text>
+        <Text size="xs" c="dimmed" truncate="end">
+            {build.pendingPrompt}
+        </Text>
+        {elapsed && (
+            <Text size="xs" c="dimmed" fw={500}>
+                {`· ${elapsed}`}
+            </Text>
+        )}
+    </>
+);
+
+export default DataAppVizBuildStatus;

--- a/packages/frontend/src/features/apps/components/DataAppVizComposer.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizComposer.tsx
@@ -1,0 +1,60 @@
+import { IconArrowUp } from '@tabler/icons-react';
+import { useRef, useState, type FC } from 'react';
+import { ComposerSubmitButton } from '../../../components/common/PromptComposer/ComposerSubmitButton';
+import PromptComposer, {
+    type PromptComposerHandle,
+} from '../../../components/common/PromptComposer/PromptComposer';
+import { type VizBuildRequest } from '../hooks/useDataAppVizBuild';
+
+type Props = {
+    placeholder: string;
+    /** True while a build is running: keep typing, block sending. */
+    isBuilding: boolean;
+    onSubmit: (request: VizBuildRequest) => void;
+};
+
+/**
+ * Describe-a-visualization input for the chart config panel.
+ *
+ * Only the author's words are sent. The visualization is handed its rows and a
+ * mapping from its own field names to the query's columns at render, so it is
+ * built to fit whatever query it is dropped into — not just this one.
+ */
+const DataAppVizComposer: FC<Props> = ({
+    placeholder,
+    isBuilding,
+    onSubmit,
+}) => {
+    const composerRef = useRef<PromptComposerHandle>(null);
+    const [isEmpty, setIsEmpty] = useState(true);
+
+    const handleSubmit = () => {
+        const description = composerRef.current?.getText().trim() ?? '';
+        if (!description || isBuilding) return;
+        composerRef.current?.clear();
+        onSubmit({ description });
+    };
+
+    return (
+        <PromptComposer
+            ref={composerRef}
+            size="md"
+            placeholder={placeholder}
+            submitDisabled={isBuilding}
+            onEmptyChange={setIsEmpty}
+            onSubmit={handleSubmit}
+            toolbarRight={
+                <ComposerSubmitButton
+                    icon={IconArrowUp}
+                    label="Send"
+                    size="sm"
+                    disabled={isEmpty || isBuilding}
+                    loading={isBuilding}
+                    onClick={handleSubmit}
+                />
+            }
+        />
+    );
+};
+
+export default DataAppVizComposer;

--- a/packages/frontend/src/features/apps/components/DataAppVizDock.module.css
+++ b/packages/frontend/src/features/apps/components/DataAppVizDock.module.css
@@ -18,6 +18,14 @@
     flex: 0 1 auto;
 }
 
+/* No versions to divide the composer from, so no rule — and the dock hugs
+   what it has rather than claiming half the panel. */
+.dockBare {
+    flex: 0 0 auto;
+    padding-top: 0;
+    border-top: none;
+}
+
 .sheetHeader {
     flex: 0 0 auto;
 }
@@ -41,6 +49,33 @@
     align-items: center;
     gap: var(--mantine-spacing-xs);
     min-height: 22px;
+}
+
+/* Rides the dock's top edge while a build runs, so a collapsed dock still
+   reports it. Indeterminate: a build's length is not knowable up front. */
+.progress {
+    position: absolute;
+    top: -1px;
+    left: 0;
+    right: 0;
+    height: 2px;
+    overflow: hidden;
+}
+
+.progressBar {
+    width: 40%;
+    height: 100%;
+    background-color: var(--mantine-color-violet-5);
+    animation: dockProgress 1.6s ease-in-out infinite;
+}
+
+@keyframes dockProgress {
+    from {
+        transform: translateX(-100%);
+    }
+    to {
+        transform: translateX(350%);
+    }
 }
 
 /* The whole status line opens the dock, so the target is the sentence rather

--- a/packages/frontend/src/features/apps/components/DataAppVizDock.test.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizDock.test.tsx
@@ -1,17 +1,22 @@
 import { type ApiAppVersionSummary } from '@lightdash/common';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { type ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../testing/testUtils';
+import { useAppBuildPoller } from '../hooks/useAppBuildPoller';
+import { type DataAppVizBuildState } from '../hooks/useDataAppVizBuild';
 import { useGetApp } from '../hooks/useGetApp';
 import {
     appVersion,
     appVersionsPage,
     appVersionsUnreadable,
 } from '../testing/appVersionHistory';
+import { buildStub } from '../testing/dataAppVizBuildStub';
 import DataAppVizDock from './DataAppVizDock';
 
 vi.mock('../hooks/useGetApp', () => ({ useGetApp: vi.fn() }));
+vi.mock('../hooks/useAppBuildPoller', () => ({ useAppBuildPoller: vi.fn() }));
 vi.mock('../hooks/useRestoreAppVersion', () => ({
     useRestoreAppVersion: () => ({
         mutate: vi.fn(),
@@ -22,6 +27,7 @@ vi.mock('../hooks/useRestoreAppVersion', () => ({
 }));
 
 const mockedUseGetApp = vi.mocked(useGetApp);
+const mockedUseAppBuildPoller = vi.mocked(useAppBuildPoller);
 
 const version = appVersion;
 
@@ -34,9 +40,23 @@ const setVersions = (
     );
 };
 
-const render = () =>
+// The panel hands the composer down as the footer, so these tests stand in for
+// it the same way: what the dock owes is a place to put it under its versions.
+const composerSlot = <button type="button">Send</button>;
+
+const render = (
+    dataAppVizUuid: string | null = 'viz-1',
+    build: DataAppVizBuildState = buildStub(),
+    footer: ReactNode = dataAppVizUuid === null ? composerSlot : null,
+) =>
     renderWithProviders(
-        <DataAppVizDock projectUuid="project-1" dataAppVizUuid="viz-1" />,
+        <DataAppVizDock
+            projectUuid="project-1"
+            dataAppVizUuid={dataAppVizUuid}
+            build={build}
+            elapsed={build.isBuilding ? '0:14' : null}
+            footer={footer}
+        />,
     );
 
 describe('DataAppVizDock', () => {
@@ -48,38 +68,6 @@ describe('DataAppVizDock', () => {
 
         expect(screen.getByText(/Built by Katie Jones/)).toBeInTheDocument();
         expect(screen.getByText('v2')).toBeInTheDocument();
-    });
-
-    // The badge names what the chart is rendering. Reading it off the newest
-    // version instead would claim a build that failed is on screen.
-    it('badges the last good build, not a newer one that failed', () => {
-        setVersions([version(), version({ version: 2, status: 'error' })]);
-        render();
-
-        expect(screen.getByText('v1')).toBeInTheDocument();
-        expect(screen.queryByText('v2')).not.toBeInTheDocument();
-    });
-
-    it('badges the last good build while a newer one is running', () => {
-        setVersions([version(), version({ version: 2, status: 'building' })]);
-        render();
-
-        expect(screen.getByText('v1')).toBeInTheDocument();
-        expect(screen.queryByText('v2')).not.toBeInTheDocument();
-    });
-
-    it('badges the rendered version even when it is older than the page', () => {
-        setVersions([version({ version: 9, status: 'error' })], 4);
-        render();
-
-        expect(screen.getByText('v4')).toBeInTheDocument();
-    });
-
-    it('shows no version badge before anything has built successfully', () => {
-        setVersions([version({ status: 'building' })]);
-        render();
-
-        expect(screen.queryByText(/^v\d+$/)).not.toBeInTheDocument();
     });
 
     it('does not claim origin when earlier versions are still unloaded', () => {
@@ -164,49 +152,193 @@ describe('DataAppVizDock', () => {
         ).toHaveAttribute('href', '/projects/project-1/apps/viz-1');
     });
 
-    // The dock is a shell: what else belongs against the panel's bottom edge
-    // is the caller's business, so these are slots rather than branches here.
-    it('takes over the resting line when the caller supplies a status', () => {
-        setVersions([version()]);
-        renderWithProviders(
-            <DataAppVizDock
-                projectUuid="project-1"
-                dataAppVizUuid="viz-1"
-                status={<span>Building v2</span>}
-            />,
-        );
+    it('is the footer alone before a visualization exists', () => {
+        setVersions([]);
+        render(null);
 
-        expect(screen.getByText('Building v2')).toBeInTheDocument();
         expect(
-            screen.queryByText(/Built by Katie Jones/),
+            screen.getByRole('button', { name: 'Send' }),
+        ).toBeInTheDocument();
+        // Nothing to collapse yet, so no version chrome to collapse it with.
+        expect(screen.queryByText('Versions')).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: 'Show versions' }),
         ).not.toBeInTheDocument();
     });
 
-    // Resting, the dock is one line of provenance. The footer belongs to the
-    // versions it sits under, so it comes and goes with them.
-    it('holds the footer back until the versions are open', async () => {
-        setVersions([version()]);
-        renderWithProviders(
-            <DataAppVizDock
-                projectUuid="project-1"
-                dataAppVizUuid="viz-1"
-                footer={<span>footer slot</span>}
-            />,
+    it('shows a failed create before a visualization exists', async () => {
+        const retry = vi.fn();
+        setVersions([]);
+        render(
+            null,
+            buildStub({
+                error: 'The sandbox ran out of memory',
+                retry,
+            }),
         );
 
-        expect(screen.queryByText('footer slot')).not.toBeInTheDocument();
+        expect(
+            screen.getByText('The sandbox ran out of memory'),
+        ).toBeInTheDocument();
+        await userEvent.click(screen.getByRole('button', { name: 'Retry' }));
+        expect(retry).toHaveBeenCalledOnce();
+    });
+
+    it('keeps a first build bare — the build, then the footer', () => {
+        setVersions([version({ status: 'generating', statusUpdatedAt: null })]);
+        // The panel resolves the draft's app before handing it down.
+        render(
+            'draft-app',
+            buildStub({
+                isBuilding: true,
+                appUuid: 'draft-app',
+                claimedVersion: 1,
+                pendingPrompt: 'a donut of orders by status',
+            }),
+            composerSlot,
+        );
+
+        expect(screen.getByText('Building')).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: 'Send' }),
+        ).toBeInTheDocument();
+        // Nothing has landed, so there is no version chrome to wrap it in.
+        expect(screen.queryByText('Versions')).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole('link', { name: /Open in builder/ }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('leaves the footer out when the panel supplies none', async () => {
+        setVersions([version()]);
+        render();
 
         await userEvent.click(
             screen.getByRole('button', { name: 'Show versions' }),
         );
 
-        expect(screen.getByText('footer slot')).toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: 'Send' }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('rides a build in flight on the dock’s top edge', () => {
+        setVersions([version()]);
+        render('viz-1', buildStub({ isBuilding: true, claimedVersion: 2 }));
+
+        expect(
+            screen.getByRole('progressbar', { name: 'Build in progress' }),
+        ).toHaveAttribute('aria-valuetext', '0:14');
+    });
+
+    it('polls a build that started outside the chart config', () => {
+        setVersions([
+            version(),
+            version({
+                version: 2,
+                status: 'generating',
+                statusUpdatedAt: null,
+            }),
+        ]);
+        render();
+
+        expect(mockedUseAppBuildPoller).toHaveBeenLastCalledWith(
+            'project-1',
+            'viz-1',
+            true,
+            expect.any(Function),
+        );
+    });
+
+    it('does not add a second poller for a locally owned build', () => {
+        setVersions([
+            version(),
+            version({
+                version: 2,
+                status: 'generating',
+                statusUpdatedAt: null,
+            }),
+        ]);
+        render(
+            'viz-1',
+            buildStub({
+                isBuilding: true,
+                appUuid: 'viz-1',
+                claimedVersion: 2,
+            }),
+        );
+
+        expect(mockedUseAppBuildPoller).toHaveBeenLastCalledWith(
+            'project-1',
+            'viz-1',
+            false,
+            expect.any(Function),
+        );
+    });
+
+    // The badge names what the chart is rendering. Reading it off the newest
+    // version instead would claim a build that failed is on screen.
+    it('badges the last good build, not a newer one that failed', () => {
+        setVersions([version(), version({ version: 2, status: 'error' })]);
+        render();
+
+        expect(screen.getByText('v1')).toBeInTheDocument();
+        expect(screen.queryByText('v2')).not.toBeInTheDocument();
+    });
+
+    it('badges the rendered version even when it is older than the page', () => {
+        setVersions(
+            [version({ version: 9, status: 'error' }), version({ version: 5 })],
+            4,
+        );
+        render();
+
+        expect(screen.getByText('v4')).toBeInTheDocument();
+    });
+
+    it('takes over the resting line when the panel supplies a status', () => {
+        setVersions([version()]);
+        renderWithProviders(
+            <DataAppVizDock
+                projectUuid="project-1"
+                dataAppVizUuid="viz-1"
+                build={buildStub()}
+                elapsed={null}
+                status={<span>Restoring…</span>}
+            />,
+        );
+
+        expect(screen.getByText('Restoring…')).toBeInTheDocument();
+        expect(
+            screen.queryByText(/Built by Katie Jones/),
+        ).not.toBeInTheDocument();
+    });
+
+    // Resting, the dock is one line of provenance. The composer belongs to the
+    // versions it sits under, so it comes and goes with them.
+    it('holds the footer back until the versions are open', async () => {
+        setVersions([version()]);
+        render('viz-1', buildStub(), composerSlot);
+
+        expect(
+            screen.queryByRole('button', { name: 'Send' }),
+        ).not.toBeInTheDocument();
+
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Show versions' }),
+        );
+
+        expect(
+            screen.getByRole('button', { name: 'Send' }),
+        ).toBeInTheDocument();
 
         await userEvent.click(
             screen.getByRole('button', { name: 'Hide versions' }),
         );
 
-        expect(screen.queryByText('footer slot')).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: 'Send' }),
+        ).not.toBeInTheDocument();
     });
 
     it('closes back down to the bar', async () => {
@@ -222,5 +354,6 @@ describe('DataAppVizDock', () => {
 
         expect(screen.queryByText('Versions')).not.toBeInTheDocument();
         expect(screen.getByText(/Built by Katie Jones/)).toBeInTheDocument();
+        expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
     });
 });

--- a/packages/frontend/src/features/apps/components/DataAppVizDock.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizDock.tsx
@@ -1,3 +1,4 @@
+import { isAppVersionInProgress } from '@lightdash/common';
 import { Badge, Box, Button, Group, Text, Tooltip } from '@mantine-8/core';
 import { useDisclosure } from '@mantine-8/hooks';
 import {
@@ -9,10 +10,14 @@ import {
 import { type FC, type ReactNode } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useTimeAgo } from '../../../hooks/useTimeAgo';
+import { useAppBuildPoller } from '../hooks/useAppBuildPoller';
 import { useAppVersionHistory } from '../hooks/useAppVersionHistory';
+import { type DataAppVizBuildState } from '../hooks/useDataAppVizBuild';
 import { getVersionAuthorName } from '../utils/versionsToChatMessages';
 import classes from './DataAppVizDock.module.css';
 import DataAppVizVersionLog from './DataAppVizVersionLog';
+
+const ignoreExternalBuildDone = () => undefined;
 
 const Provenance: FC<{
     authorName: string | null;
@@ -34,11 +39,11 @@ const Provenance: FC<{
 
 type Props = {
     projectUuid: string;
-    /**
-     * The visualization whose versions are on show, already resolved by the
-     * caller. The dock does not work out which one that is.
-     */
-    dataAppVizUuid: string;
+    /** The visualization the chart points at; null when it points at none. */
+    dataAppVizUuid: string | null;
+    build: DataAppVizBuildState;
+    /** Ticking `0:12` while a build runs; null when nothing is running. */
+    elapsed: string | null;
     /** Replaces the provenance line on the resting bar while it is present. */
     status?: ReactNode;
     /** Sits under the log wherever there is one. A resting dock has none, so
@@ -50,21 +55,39 @@ type Props = {
  * The visualization's versions, docked to the bottom of the config panel.
  *
  * Resting it is a slim bar: where this visualization came from, and the way in.
- * Expanded it is every version it has had, and the way out to the full builder.
- * The settings above it never move.
+ * Expanded it is every version it has had, the composer to ask for the next
+ * one, and the way out to the full builder. The settings above it never move.
  *
  * What the bar reports and what sits under the log are the caller's business,
  * so the status line and the footer are slots rather than branches here.
+ *
+ * Before anything exists there are no versions to hide, so the dock is the
+ * composer alone — collapsing an empty panel is not worth offering.
  */
 const DataAppVizDock: FC<Props> = ({
     projectUuid,
     dataAppVizUuid,
+    build,
+    elapsed,
     status,
     footer,
 }) => {
-    const [isExpanded, { toggle }] = useDisclosure(false);
-    const { latest, oldest, hasOrigin, latestReadyVersion, isError } =
+    // Open on arrival when there is nothing selected: describing one is the
+    // only thing to do here.
+    const [isExpanded, { toggle }] = useDisclosure(dataAppVizUuid === null);
+    const { versions, latest, oldest, hasOrigin, latestReadyVersion, isError } =
         useAppVersionHistory(projectUuid, dataAppVizUuid);
+    const isLatestVersionBuilding =
+        latest !== null && isAppVersionInProgress(latest.status);
+    const isOwnedByPanel = build.isBuilding && build.appUuid === dataAppVizUuid;
+    // A build started in the app builder has no local build state to own its
+    // worker. Keep the shared app cache moving until that version is terminal.
+    useAppBuildPoller(
+        projectUuid,
+        dataAppVizUuid ?? undefined,
+        isLatestVersionBuilding && !isOwnedByPanel,
+        ignoreExternalBuildDone,
+    );
     // With the origin loaded the line reports where the visualization came
     // from; without it the verb flips to "Last updated", which is the newest
     // version rather than the oldest page we happen to hold.
@@ -77,6 +100,30 @@ const DataAppVizDock: FC<Props> = ({
             {`v${latestReadyVersion}`}
         </Badge>
     );
+
+    // Version chrome needs versions. A first build in flight has claimed one
+    // but landed none, so there is nothing yet to collapse, label or open in
+    // the builder — just the build, and the composer under it.
+    // Knowing there are none is not the same as failing to find out, so a
+    // failed history keeps the bar that can say so.
+    const hasLandedVersion =
+        versions.some((v) => v.status === 'ready') || isError;
+
+    if (dataAppVizUuid === null || !hasLandedVersion) {
+        return (
+            <Box className={`${classes.dock} ${classes.dockBare}`}>
+                {(dataAppVizUuid !== null || build.error !== null) && (
+                    <DataAppVizVersionLog
+                        projectUuid={projectUuid}
+                        dataAppVizUuid={dataAppVizUuid}
+                        build={build}
+                        elapsed={elapsed}
+                    />
+                )}
+                {footer && <Box className={classes.footer}>{footer}</Box>}
+            </Box>
+        );
+    }
 
     const toggleButton = (
         <Tooltip
@@ -140,6 +187,8 @@ const DataAppVizDock: FC<Props> = ({
                     <DataAppVizVersionLog
                         projectUuid={projectUuid}
                         dataAppVizUuid={dataAppVizUuid}
+                        build={build}
+                        elapsed={elapsed}
                     />
                 </Box>
 
@@ -150,6 +199,16 @@ const DataAppVizDock: FC<Props> = ({
 
     return (
         <Box className={classes.dock}>
+            {build.isBuilding && (
+                <Box
+                    className={classes.progress}
+                    role="progressbar"
+                    aria-label="Build in progress"
+                    aria-valuetext={elapsed ?? 'Starting'}
+                >
+                    <Box className={classes.progressBar} />
+                </Box>
+            )}
             <Box className={classes.bar}>
                 <button
                     type="button"

--- a/packages/frontend/src/features/apps/components/DataAppVizVersionLog.test.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizVersionLog.test.tsx
@@ -3,6 +3,7 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../testing/testUtils';
+import { type DataAppVizBuildState } from '../hooks/useDataAppVizBuild';
 import { useGetApp } from '../hooks/useGetApp';
 import { useRestoreAppVersion } from '../hooks/useRestoreAppVersion';
 import {
@@ -10,6 +11,7 @@ import {
     appVersionsPage,
     appVersionsUnreadable,
 } from '../testing/appVersionHistory';
+import { buildStub } from '../testing/dataAppVizBuildStub';
 import DataAppVizVersionLog from './DataAppVizVersionLog';
 
 vi.mock('../hooks/useGetApp', () => ({ useGetApp: vi.fn() }));
@@ -32,9 +34,14 @@ const setVersions = (
     );
 };
 
-const render = () =>
+const render = (build: DataAppVizBuildState = buildStub()) =>
     renderWithProviders(
-        <DataAppVizVersionLog projectUuid="project-1" dataAppVizUuid="viz-1" />,
+        <DataAppVizVersionLog
+            projectUuid="project-1"
+            dataAppVizUuid="viz-1"
+            build={build}
+            elapsed={build.isBuilding ? '0:14' : null}
+        />,
     );
 
 describe('DataAppVizVersionLog', () => {
@@ -156,6 +163,89 @@ describe('DataAppVizVersionLog', () => {
         expect(
             screen.getByText(/Could not load this visualization's versions/),
         ).toBeInTheDocument();
+    });
+
+    it('writes the request in flight as its own row, with the clock', () => {
+        setVersions([version()]);
+        render(
+            buildStub({
+                isBuilding: true,
+                pendingPrompt: 'make the bars horizontal',
+                claimedVersion: 2,
+            }),
+        );
+
+        expect(
+            screen.getByText('make the bars horizontal'),
+        ).toBeInTheDocument();
+        expect(screen.getByText('Building')).toBeInTheDocument();
+        expect(screen.getByText('0:14')).toBeInTheDocument();
+        expect(screen.getByText('v2')).toBeInTheDocument();
+    });
+
+    it('drops the live row once the version it claimed reaches history', () => {
+        setVersions([version(), version({ version: 2 })]);
+        render(
+            buildStub({
+                isBuilding: true,
+                pendingPrompt: 'make the bars horizontal',
+                claimedVersion: 2,
+            }),
+        );
+
+        expect(screen.queryByText('Building')).not.toBeInTheDocument();
+    });
+
+    it('reports progress on any stage before a version lands', () => {
+        setVersions([
+            version(),
+            version({
+                version: 2,
+                status: 'generating',
+                statusUpdatedAt: null,
+                prompt: 'make the bars horizontal',
+            }),
+        ]);
+        render(
+            buildStub({
+                isBuilding: true,
+                pendingPrompt: 'make the bars horizontal',
+                claimedVersion: 2,
+            }),
+        );
+
+        // One row, not a live row on top of the history row for the same build.
+        expect(screen.getAllByText('make the bars horizontal')).toHaveLength(1);
+        expect(screen.getByText('Building')).toBeInTheDocument();
+        expect(screen.getByText('0:14')).toBeInTheDocument();
+    });
+
+    it('keeps the last finished version current while the next one builds', () => {
+        setVersions([
+            version(),
+            version({
+                version: 2,
+                status: 'generating',
+                statusUpdatedAt: null,
+            }),
+        ]);
+        render(buildStub({ isBuilding: true, claimedVersion: 2 }));
+
+        // v1 is what the chart still renders, so it is not restorable.
+        expect(screen.getByText('current')).toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: 'Restore' }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('offers to re-send a request the server never accepted', async () => {
+        const retry = vi.fn();
+        setVersions([version()]);
+        render(buildStub({ error: 'The builder is busy', retry }));
+
+        expect(screen.getByText('The builder is busy')).toBeInTheDocument();
+        await userEvent.click(screen.getByRole('button', { name: 'Retry' }));
+        expect(retry).toHaveBeenCalled();
     });
 
     it('restores only once the consequence is confirmed', async () => {

--- a/packages/frontend/src/features/apps/components/DataAppVizVersionLog.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizVersionLog.tsx
@@ -1,4 +1,7 @@
-import { type ApiAppVersionSummary } from '@lightdash/common';
+import {
+    isAppVersionInProgress,
+    type ApiAppVersionSummary,
+} from '@lightdash/common';
 import { Anchor, Badge, Group, Loader, Stack, Text } from '@mantine-8/core';
 import { IconAlertTriangle, IconCheck, IconRestore } from '@tabler/icons-react';
 import { useMemo, useState, type FC } from 'react';
@@ -7,11 +10,13 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import MantineModal from '../../../components/common/MantineModal';
 import { useTimeAgo } from '../../../hooks/useTimeAgo';
 import { useAppVersionHistory } from '../hooks/useAppVersionHistory';
+import { type DataAppVizBuildState } from '../hooks/useDataAppVizBuild';
 import { useRestoreAppVersion } from '../hooks/useRestoreAppVersion';
 import { type ChatMessage } from '../utils/chatMessage';
 import { formatBuildDuration } from '../utils/formatBuildDuration';
 import { versionsToChatMessages } from '../utils/versionsToChatMessages';
 import classes from './DataAppVizVersionLog.module.css';
+import LoadingDots from './LoadingDots';
 
 /** One exchange: what was asked for, and what the build made of it. */
 type LogEntry = {
@@ -61,12 +66,32 @@ const Prompt: FC<{ message: ChatMessage }> = ({ message }) =>
         </Text>
     );
 
+const Building: FC<{ elapsed: string | null }> = ({ elapsed }) => (
+    <Group gap={6} wrap="nowrap">
+        <Text size="xs" c="dimmed">
+            Building
+        </Text>
+        <LoadingDots />
+        {elapsed && (
+            <Text size="xs" c="dimmed" fw={500}>
+                {elapsed}
+            </Text>
+        )}
+    </Group>
+);
+
 const LogRow: FC<{
     entry: LogEntry;
     /** The version every chart using this visualization renders right now. */
     isCurrent: boolean;
+    /** Ticking clock, when this row is the build in flight. */
+    elapsed: string | null;
     onRestore: (version: number) => void;
-}> = ({ entry, isCurrent, onRestore }) => {
+}> = ({ entry, isCurrent, elapsed, onRestore }) => {
+    // A version the poller has written but not yet finished — any of the seven
+    // stages before it lands. Its own row reports the progress, so the build
+    // never needs a second one.
+    const isBuilding = isAppVersionInProgress(entry.status);
     return (
         <Group
             className={classes.row}
@@ -78,7 +103,7 @@ const LogRow: FC<{
             <Badge
                 size="xs"
                 variant="light"
-                color={isCurrent ? 'violet' : 'gray'}
+                color={isCurrent || isBuilding ? 'violet' : 'gray'}
                 className={classes.versionBadge}
             >
                 {`v${entry.version}`}
@@ -86,7 +111,11 @@ const LogRow: FC<{
 
             <Stack gap={2} className={classes.rowBody}>
                 <Prompt message={entry.request} />
-                {entry.receipt && <Receipt message={entry.receipt} />}
+                {isBuilding ? (
+                    <Building elapsed={elapsed} />
+                ) : (
+                    entry.receipt && <Receipt message={entry.receipt} />
+                )}
             </Stack>
 
             {isCurrent && (
@@ -109,10 +138,74 @@ const LogRow: FC<{
     );
 };
 
+/**
+ * The request in flight, shown from the moment it is sent — its version log
+ * row is written by the build itself, not by history.
+ */
+const LiveRow: FC<{
+    build: DataAppVizBuildState;
+    elapsed: string | null;
+}> = ({ build, elapsed }) => (
+    <Group className={classes.row} gap="xs" wrap="nowrap" align="flex-start">
+        <Badge
+            size="xs"
+            variant="light"
+            color="violet"
+            className={classes.versionBadge}
+        >
+            {build.claimedVersion === null ? '···' : `v${build.claimedVersion}`}
+        </Badge>
+
+        <Stack gap={2} className={classes.rowBody}>
+            <Text size="xs" lineClamp={1}>
+                {build.pendingPrompt}
+            </Text>
+            <Building elapsed={elapsed} />
+        </Stack>
+    </Group>
+);
+
+/** A send that never became a version: nothing to receipt, only to retry. */
+const FailedRow: FC<{ error: string; retry: (() => void) | null }> = ({
+    error,
+    retry,
+}) => (
+    <Group className={classes.row} gap="xs" wrap="nowrap" align="flex-start">
+        <MantineIcon
+            icon={IconAlertTriangle}
+            size={12}
+            color="red.6"
+            className={classes.versionBadge}
+        />
+        <Stack gap={2} className={classes.rowBody}>
+            <Text size="xs" c="red.7">
+                {error}
+            </Text>
+            <Text size="xs" c="dimmed">
+                Your query and chart are untouched.
+            </Text>
+        </Stack>
+        {retry && (
+            <Anchor
+                component="button"
+                type="button"
+                size="xs"
+                className={classes.rowAction}
+                onClick={retry}
+            >
+                Retry
+            </Anchor>
+        )}
+    </Group>
+);
+
 type Props = {
     projectUuid: string;
-    /** The visualization whose history this is. */
-    dataAppVizUuid: string;
+    /** The visualization whose history this is; null before one exists. */
+    dataAppVizUuid: string | null;
+    build: DataAppVizBuildState;
+    /** Ticking `0:12` while a build runs; null when nothing is running. */
+    elapsed: string | null;
 };
 
 /**
@@ -123,7 +216,12 @@ type Props = {
  * new version. The newest version that finished is what every chart using this
  * visualization renders, so a restore reaches all of them.
  */
-const DataAppVizVersionLog: FC<Props> = ({ projectUuid, dataAppVizUuid }) => {
+const DataAppVizVersionLog: FC<Props> = ({
+    projectUuid,
+    dataAppVizUuid,
+    build,
+    elapsed,
+}) => {
     const {
         versions,
         latestReadyVersion,
@@ -170,9 +268,16 @@ const DataAppVizVersionLog: FC<Props> = ({ projectUuid, dataAppVizUuid }) => {
         );
     }
 
+    // The build writes its own row until the version it claimed reaches
+    // history, where the same request appears as a stored prompt.
+    const isClaimedInHistory =
+        build.claimedVersion !== null &&
+        versions.some((v) => v.version === build.claimedVersion);
+
     // Only when the failure left nothing to read — a page that fails partway
-    // should not throw away the versions already on screen.
-    if (isError && entries.length === 0) {
+    // should not throw away the versions already on screen, and a build in
+    // flight still has a row of its own to write.
+    if (isError && entries.length === 0 && !build.isBuilding && !build.error) {
         return (
             <Text size="xs" c="dimmed" px="xs" py={6}>
                 Could not load this visualization's versions.
@@ -183,11 +288,20 @@ const DataAppVizVersionLog: FC<Props> = ({ projectUuid, dataAppVizUuid }) => {
     return (
         <>
             <Stack gap={0}>
+                {build.isBuilding && !isClaimedInHistory && (
+                    <LiveRow build={build} elapsed={elapsed} />
+                )}
+
+                {build.error && (
+                    <FailedRow error={build.error} retry={build.retry} />
+                )}
+
                 {entries.map((entry) => (
                     <LogRow
                         key={entry.version}
                         entry={entry}
                         isCurrent={entry.version === latestReadyVersion}
+                        elapsed={elapsed}
                         onRestore={setRestoreTarget}
                     />
                 ))}
@@ -207,7 +321,7 @@ const DataAppVizVersionLog: FC<Props> = ({ projectUuid, dataAppVizUuid }) => {
                 )}
             </Stack>
 
-            {restoreTarget !== null && (
+            {restoreTarget !== null && dataAppVizUuid && (
                 <MantineModal
                     opened
                     onClose={() => {

--- a/packages/frontend/src/features/apps/hooks/useDataAppVizBuild.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useDataAppVizBuild.test.ts
@@ -1,0 +1,166 @@
+import { type ApiAppVersionSummary } from '@lightdash/common';
+import { act } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHookWithProviders } from '../../../testing/testUtils';
+import { useAppBuildPoller } from './useAppBuildPoller';
+import { useDataAppVizBuild } from './useDataAppVizBuild';
+import { useGenerateApp } from './useGenerateApp';
+
+vi.mock('./useGenerateApp', () => ({ useGenerateApp: vi.fn() }));
+vi.mock('./useAppBuildPoller', () => ({ useAppBuildPoller: vi.fn() }));
+
+const mockedGenerate = vi.mocked(useGenerateApp);
+const mockedPoller = vi.mocked(useAppBuildPoller);
+
+type GenerateHandlers = {
+    onSuccess: (result: { appUuid: string; version: number }) => void;
+    onError: (error: unknown) => void;
+};
+
+/** The last `onDone` the hook handed the poller. */
+const finishBuild = (version: Partial<ApiAppVersionSummary>) => {
+    const onDone = mockedPoller.mock.lastCall?.[3];
+    act(() => onDone?.(version as ApiAppVersionSummary));
+};
+
+const finishedVersion = (
+    overrides: Partial<ApiAppVersionSummary> = {},
+): Partial<ApiAppVersionSummary> => ({
+    version: 1,
+    status: 'ready',
+    statusMessage: null,
+    error: null,
+    resources: {
+        vizSchema: {
+            fields: [
+                { name: 'x', label: 'X', type: 'dimension', required: true },
+            ],
+        },
+    } as unknown as ApiAppVersionSummary['resources'],
+    ...overrides,
+});
+
+const itemsMap = {
+    orders_status: {
+        name: 'status',
+        table: 'orders',
+        label: 'Status',
+        fieldType: 'dimension',
+        type: 'string',
+        tableLabel: 'Orders',
+        sql: '',
+        hidden: false,
+    },
+} as never;
+
+describe('useDataAppVizBuild', () => {
+    let generate: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        generate = vi.fn();
+        mockedGenerate.mockReturnValue({
+            mutate: generate,
+            isLoading: false,
+        } as unknown as ReturnType<typeof useGenerateApp>);
+    });
+
+    const setup = (onCreated = vi.fn()) => {
+        const rendered = renderHookWithProviders(
+            ({ dataAppVizUuid }: { dataAppVizUuid: string | null }) =>
+                useDataAppVizBuild({
+                    projectUuid: 'project-1',
+                    itemsMap,
+                    dataAppVizUuid,
+                    onCreated,
+                }),
+            undefined,
+            { initialProps: { dataAppVizUuid: null as string | null } },
+        );
+        return { ...rendered, onCreated };
+    };
+
+    it('shows the request in flight while building', () => {
+        const { result } = setup();
+
+        act(() =>
+            result.current.send({ description: 'a donut of orders by status' }),
+        );
+
+        expect(result.current.pendingPrompt).toBe(
+            'a donut of orders by status',
+        );
+        expect(result.current.isBuilding).toBe(true);
+    });
+
+    it('binds the contract off the version the poller hands back', () => {
+        // Not off the query cache: the poll writes the cache and calls back in
+        // the same tick, so the cache is still a render behind here.
+        const { result, onCreated } = setup();
+
+        act(() => result.current.send({ description: 'a donut' }));
+        const handlers = generate.mock.lastCall?.[1] as GenerateHandlers;
+        act(() => handlers.onSuccess({ appUuid: 'viz-1', version: 1 }));
+        finishBuild(finishedVersion());
+
+        expect(onCreated).toHaveBeenCalledWith('viz-1', { x: 'orders_status' });
+        expect(result.current.isBuilding).toBe(false);
+    });
+
+    it('reports why a build failed and stops building', () => {
+        const { result, onCreated } = setup();
+
+        act(() => result.current.send({ description: 'a donut' }));
+        const handlers = generate.mock.lastCall?.[1] as GenerateHandlers;
+        act(() => handlers.onSuccess({ appUuid: 'viz-1', version: 1 }));
+        finishBuild(
+            finishedVersion({
+                status: 'error',
+                statusMessage: 'The sandbox ran out of memory',
+            }),
+        );
+
+        expect(result.current.error).toBe('The sandbox ran out of memory');
+        expect(result.current.isBuilding).toBe(false);
+        expect(onCreated).not.toHaveBeenCalled();
+    });
+
+    it('does not replace a visualization picked while creation runs', () => {
+        const { result, rerender, onCreated } = setup();
+
+        act(() => result.current.send({ description: 'a donut' }));
+        const handlers = generate.mock.lastCall?.[1] as GenerateHandlers;
+        act(() => handlers.onSuccess({ appUuid: 'viz-1', version: 1 }));
+
+        rerender({ dataAppVizUuid: 'picked-viz' });
+        finishBuild(finishedVersion());
+
+        expect(onCreated).not.toHaveBeenCalled();
+    });
+
+    it('retries a request the server never accepted, as it was sent', () => {
+        const { result } = setup();
+
+        act(() => result.current.send({ description: 'a donut' }));
+        const handlers = generate.mock.lastCall?.[1] as GenerateHandlers;
+        act(() => handlers.onError(new Error('Network error')));
+
+        expect(result.current.pendingPrompt).toBeNull();
+        expect(result.current.retry).not.toBeNull();
+
+        act(() => result.current.retry?.());
+        expect(generate).toHaveBeenCalledTimes(2);
+        expect(result.current.pendingPrompt).toBe('a donut');
+    });
+
+    it('refuses a second request while one is in flight', () => {
+        const { result } = setup();
+
+        act(() => result.current.send({ description: 'a donut' }));
+        const handlers = generate.mock.lastCall?.[1] as GenerateHandlers;
+        act(() => handlers.onSuccess({ appUuid: 'viz-1', version: 1 }));
+        act(() => result.current.send({ description: 'actually a bar chart' }));
+
+        expect(generate).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/frontend/src/features/apps/hooks/useDataAppVizBuild.ts
+++ b/packages/frontend/src/features/apps/hooks/useDataAppVizBuild.ts
@@ -1,0 +1,171 @@
+import {
+    DATA_APP_VIZ_TEMPLATE,
+    getErrorMessage,
+    type ApiAppVersionSummary,
+    type DataAppVizFieldMapping,
+    type ItemsMap,
+} from '@lightdash/common';
+import { useCallback, useState } from 'react';
+import { autoMapDataAppVizFields } from '../utils/autoMapDataAppVizFields';
+import { useAppBuildPoller } from './useAppBuildPoller';
+import { useGenerateApp } from './useGenerateApp';
+
+type Args = {
+    projectUuid: string | undefined;
+    itemsMap: ItemsMap;
+    /** The visualization the chart points at; null while it points at none. */
+    dataAppVizUuid: string | null;
+    /** Called once a new visualization lands ready, with its contract bound. */
+    onCreated: (
+        dataAppVizUuid: string,
+        fieldMapping: DataAppVizFieldMapping,
+    ) => void;
+};
+
+/** What was asked for, kept so a failure can be retried as it was sent. */
+export type VizBuildRequest = {
+    description: string;
+};
+
+/**
+ * A build in flight, once the server has accepted it. It is a real app
+ * already — the request creates it — but it has no ready version yet, so it is
+ * not worth pointing a chart at.
+ */
+type RunningBuild = {
+    appUuid: string;
+    version: number;
+    startedAt: Date;
+};
+
+export type DataAppVizBuildState = {
+    /**
+     * The app the build in flight claimed; null when nothing is building. Its
+     * versions are the session, so the dock reads history from it while the
+     * chart still points at nothing.
+     */
+    appUuid: string | null;
+    /** When the build in flight started, for the panel's clock. */
+    startedAt: Date | null;
+    /**
+     * The version the build in flight claimed; null until the server accepts
+     * it. What tells a surface that its live row now lives in history.
+     */
+    claimedVersion: number | null;
+    isBuilding: boolean;
+    /** The request in flight, so the log can show it immediately. */
+    pendingPrompt: string | null;
+    /** Why the last attempt failed, for the log's error row. */
+    error: string | null;
+    send: (request: VizBuildRequest) => void;
+    /** Re-send the request that failed; null when there is nothing to retry. */
+    retry: (() => void) | null;
+};
+
+/**
+ * Build a visualization for the chart from its own query.
+ *
+ * The chart needs no rewiring when the build lands: the poller writes into the
+ * same query key the renderer reads, so it picks up the new version by itself,
+ * and the bindings are reconciled against the contract at render.
+ *
+ * Nothing is sent for the space: an Explorer-authored viz is personal, exactly
+ * as one created in the generator is, and is filed into a space afterwards.
+ */
+export const useDataAppVizBuild = ({
+    projectUuid,
+    itemsMap,
+    dataAppVizUuid,
+    onCreated,
+}: Args): DataAppVizBuildState => {
+    // The request in flight, and the app it is building — both null when idle.
+    const [inFlight, setInFlight] = useState<VizBuildRequest | null>(null);
+    const [building, setBuilding] = useState<RunningBuild | null>(null);
+    const [failed, setFailed] = useState<{
+        message: string;
+        request: VizBuildRequest | null;
+    } | null>(null);
+    const { mutate: generateApp } = useGenerateApp();
+
+    const handleDone = useCallback(
+        (version: ApiAppVersionSummary) => {
+            const target = building;
+            const request = inFlight;
+            setBuilding(null);
+            setInFlight(null);
+            if (version.status === 'ready') {
+                // Picking a visualization while creation runs is a newer user
+                // decision, so a late completion must not replace it.
+                if (target && dataAppVizUuid === null) {
+                    onCreated(
+                        target.appUuid,
+                        autoMapDataAppVizFields(
+                            version.resources?.vizSchema?.fields ?? [],
+                            itemsMap,
+                        ),
+                    );
+                }
+                return;
+            }
+            setFailed({
+                message:
+                    version.statusMessage ??
+                    version.error ??
+                    'That build could not be completed. Please try again.',
+                request,
+            });
+        },
+        [building, inFlight, itemsMap, dataAppVizUuid, onCreated],
+    );
+
+    useAppBuildPoller(
+        projectUuid,
+        building?.appUuid,
+        building !== null,
+        handleDone,
+    );
+
+    const send = useCallback(
+        (request: VizBuildRequest) => {
+            if (!projectUuid || building !== null) return;
+            setFailed(null);
+            setInFlight(request);
+            generateApp(
+                {
+                    projectUuid,
+                    prompt: request.description,
+                    template: DATA_APP_VIZ_TEMPLATE,
+                },
+                {
+                    onSuccess: ({ appUuid, version }) =>
+                        setBuilding({
+                            appUuid,
+                            version,
+                            startedAt: new Date(),
+                        }),
+                    onError: (err) => {
+                        setInFlight(null);
+                        setFailed({ message: getErrorMessage(err), request });
+                    },
+                },
+            );
+        },
+        [projectUuid, building, generateApp],
+    );
+
+    const failedRequest = failed?.request ?? null;
+
+    return {
+        appUuid: building?.appUuid ?? null,
+        startedAt: building?.startedAt ?? null,
+        claimedVersion: building?.version ?? null,
+        // A request is in flight from the moment it is sent until the build
+        // lands or the send fails — the mutation's own loading flag covers
+        // only the submit itself.
+        isBuilding: inFlight !== null,
+        pendingPrompt: inFlight?.description ?? null,
+        error: failed?.message ?? null,
+        send,
+        retry: failedRequest ? () => send(failedRequest) : null,
+    };
+};

--- a/packages/frontend/src/features/apps/hooks/useElapsedClock.ts
+++ b/packages/frontend/src/features/apps/hooks/useElapsedClock.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+import { formatElapsedClock } from '../utils/formatElapsedClock';
+
+/**
+ * A ticking `0:12` for a build in flight; null when nothing is running.
+ *
+ * The clock is what makes a draft read as in progress rather than stuck — a
+ * static "Building…" says nothing about whether it moved.
+ */
+export const useElapsedClock = (startedAt: Date | null): string | null => {
+    const [now, setNow] = useState(() => Date.now());
+
+    useEffect(() => {
+        if (startedAt === null) return;
+        setNow(Date.now());
+        const id = setInterval(() => setNow(Date.now()), 1000);
+        return () => clearInterval(id);
+    }, [startedAt]);
+
+    if (startedAt === null) return null;
+    return formatElapsedClock(now - startedAt.getTime());
+};

--- a/packages/frontend/src/features/apps/testing/dataAppVizBuildStub.ts
+++ b/packages/frontend/src/features/apps/testing/dataAppVizBuildStub.ts
@@ -1,0 +1,17 @@
+import { vi } from 'vitest';
+import { type DataAppVizBuildState } from '../hooks/useDataAppVizBuild';
+
+/** An idle build, for surfaces under test that only read its state. */
+export const buildStub = (
+    overrides: Partial<DataAppVizBuildState> = {},
+): DataAppVizBuildState => ({
+    appUuid: null,
+    startedAt: null,
+    claimedVersion: null,
+    isBuilding: false,
+    pendingPrompt: null,
+    error: null,
+    send: vi.fn(),
+    retry: null,
+    ...overrides,
+});

--- a/packages/frontend/src/features/apps/utils/formatElapsedClock.test.ts
+++ b/packages/frontend/src/features/apps/utils/formatElapsedClock.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { formatElapsedClock } from './formatElapsedClock';
+
+describe('formatElapsedClock', () => {
+    it('counts from zero rather than rounding up to a second', () => {
+        // A duration reads "1s" at the start; a clock has to read 0:00 or it
+        // looks like it has already been running.
+        expect(formatElapsedClock(0)).toBe('0:00');
+        expect(formatElapsedClock(400)).toBe('0:00');
+    });
+
+    it('pads seconds', () => {
+        expect(formatElapsedClock(9_000)).toBe('0:09');
+        expect(formatElapsedClock(12_000)).toBe('0:12');
+    });
+
+    it('rolls into minutes', () => {
+        expect(formatElapsedClock(60_000)).toBe('1:00');
+        expect(formatElapsedClock(95_000)).toBe('1:35');
+        expect(formatElapsedClock(3_600_000)).toBe('60:00');
+    });
+
+    it('never goes backwards past zero', () => {
+        expect(formatElapsedClock(-5_000)).toBe('0:00');
+    });
+});

--- a/packages/frontend/src/features/apps/utils/formatElapsedClock.ts
+++ b/packages/frontend/src/features/apps/utils/formatElapsedClock.ts
@@ -1,0 +1,11 @@
+/**
+ * A running build's elapsed time, as a clock rather than a duration: `0:12`.
+ * Counts up, so it reads as something still happening — a finished build gets
+ * `formatBuildDuration` ("44s") instead.
+ */
+export const formatElapsedClock = (elapsedMs: number): string => {
+    const totalSeconds = Math.max(0, Math.floor(elapsedMs / 1000));
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return `${minutes}:${String(seconds).padStart(2, '0')}`;
+};


### PR DESCRIPTION
The dock gains a composer. Only what the author typed is sent — the visualization is handed its rows and a field mapping at render, so it is built to fit whatever query it is dropped into, not this one. (There is no first-class way to attach a query to a generation request today; `charts` needs a saved chart.)

Before anything exists there is no dock chrome, just the composer. A build reports itself on its own version row, and on the collapsed bar, so collapsing never loses sight of it.

A visualization is created personal, exactly as one created in the generator is, and filed into a space afterwards.

Relates: GLITCH-630
