### PR TITLE
feat(data-apps): receive delivery declarations and expose them on the headless render

### DIFF
--- a/packages/common/src/ee/apps/deliveryQueries.test.ts
+++ b/packages/common/src/ee/apps/deliveryQueries.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import {
+    MAX_DELIVERY_QUERIES,
+    parseDeliveryQueries,
+    type DeliveryQuery,
+} from './deliveryQueries';
+
+const metricQuery: DeliveryQuery = {
+    kind: 'query',
+    label: 'Revenue by segment',
+    query: {
+        exploreName: 'orders',
+        dimensions: ['customer_segment'],
+        metrics: ['total_revenue'],
+        filters: [],
+        sorts: [],
+        tableCalculations: [],
+        additionalMetrics: [],
+        customDimensions: [],
+        limit: 500,
+    },
+};
+
+const savedChartQuery: DeliveryQuery = {
+    kind: 'savedChart',
+    label: 'Linked revenue',
+    chartUuid: 'chart-1',
+    limit: 1000,
+};
+
+describe('parseDeliveryQueries', () => {
+    it('accepts a metric-query declaration', () => {
+        expect(parseDeliveryQueries([metricQuery])).toEqual([metricQuery]);
+    });
+
+    it('accepts a saved-chart declaration', () => {
+        expect(parseDeliveryQueries([savedChartQuery])).toEqual([
+            savedChartQuery,
+        ]);
+    });
+
+    it('rejects a non-array payload', () => {
+        expect(parseDeliveryQueries({ kind: 'query' })).toBeNull();
+        expect(parseDeliveryQueries(null)).toBeNull();
+        expect(parseDeliveryQueries('nope')).toBeNull();
+    });
+
+    it('rejects an empty array — the SDK never publishes one', () => {
+        expect(parseDeliveryQueries([])).toBeNull();
+    });
+
+    it('rejects a declaration with an unknown kind', () => {
+        expect(parseDeliveryQueries([{ kind: 'sql', label: null }])).toBeNull();
+    });
+
+    it('rejects a metric query missing its exploreName', () => {
+        expect(
+            parseDeliveryQueries([
+                { kind: 'query', label: null, query: { dimensions: [] } },
+            ]),
+        ).toBeNull();
+    });
+
+    it('rejects a saved chart missing its chartUuid', () => {
+        expect(
+            parseDeliveryQueries([{ kind: 'savedChart', label: null }]),
+        ).toBeNull();
+    });
+
+    it('rejects a declaration with a non-string label', () => {
+        expect(
+            parseDeliveryQueries([{ ...savedChartQuery, label: 42 }]),
+        ).toBeNull();
+    });
+
+    it('rejects more declarations than the cap', () => {
+        const tooMany = Array.from(
+            { length: MAX_DELIVERY_QUERIES + 1 },
+            () => metricQuery,
+        );
+        expect(parseDeliveryQueries(tooMany)).toBeNull();
+    });
+
+    it('accepts exactly the cap', () => {
+        const atCap = Array.from(
+            { length: MAX_DELIVERY_QUERIES },
+            () => metricQuery,
+        );
+        expect(parseDeliveryQueries(atCap)).toHaveLength(MAX_DELIVERY_QUERIES);
+    });
+});

--- a/packages/common/src/ee/apps/deliveryQueries.ts
+++ b/packages/common/src/ee/apps/deliveryQueries.ts
@@ -1,0 +1,70 @@
+/**
+ * Queries a data app declares for scheduled delivery, as received from the
+ * sandboxed iframe SDK.
+ *
+ * Keep in sync with `DeliveryQuery` in packages/query-sdk/src/delivery.ts. The
+ * frontend and backend cannot import the SDK — deployment images don't include
+ * it — so this is the copy they read, mirroring the SDK_FEATURES arrangement.
+ */
+
+/** Declarations beyond this are rejected: a delivery with more tabs than this
+ *  is a runaway app, not a report. */
+export const MAX_DELIVERY_QUERIES = 50;
+
+export type DeliveryQuery =
+    | {
+          kind: 'query';
+          label: string | null;
+          // Deliberately loose: duplicating the SDK's full QueryDefinition here
+          // would create a second shape to keep in sync for no gain. Validation
+          // only needs enough to reject garbage; the delivery packaging does the
+          // real conversion, against the same body the bridge already POSTs to
+          // /query/metric-query.
+          query: Record<string, unknown> & { exploreName: string };
+      }
+    | {
+          kind: 'savedChart';
+          label: string | null;
+          chartUuid: string;
+          limit?: number;
+          parameters?: Record<string, unknown>;
+          filters?: unknown[];
+      };
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isLabel = (value: unknown): value is string | null =>
+    value === null || typeof value === 'string';
+
+const isDeliveryQuery = (value: unknown): value is DeliveryQuery => {
+    if (!isPlainObject(value) || !isLabel(value.label)) return false;
+    if (value.kind === 'query') {
+        return (
+            isPlainObject(value.query) &&
+            typeof value.query.exploreName === 'string' &&
+            value.query.exploreName.length > 0
+        );
+    }
+    if (value.kind === 'savedChart') {
+        return (
+            typeof value.chartUuid === 'string' && value.chartUuid.length > 0
+        );
+    }
+    return false;
+};
+
+/**
+ * Validate an untrusted delivery-queries payload.
+ * Returns null for anything that isn't a non-empty array of valid
+ * declarations within the cap — callers warn on null rather than treating it
+ * as "declared nothing", which is a different (and normal) state.
+ */
+export const parseDeliveryQueries = (
+    value: unknown,
+): DeliveryQuery[] | null => {
+    if (!Array.isArray(value)) return null;
+    if (value.length === 0 || value.length > MAX_DELIVERY_QUERIES) return null;
+    if (!value.every(isDeliveryQuery)) return null;
+    return value;
+};

--- a/packages/common/src/ee/index.ts
+++ b/packages/common/src/ee/index.ts
@@ -6,6 +6,7 @@ export * from './aiWriteback/types';
 export * from './externalConnections/coder';
 export * from './externalConnections/types';
 export * from './AiRouter';
+export * from './apps/deliveryQueries';
 export * from './apps/sdkFeatures';
 export * from './apps/types';
 export * from './apps/code';

--- a/packages/frontend/src/features/apps/AppIframePreview.tsx
+++ b/packages/frontend/src/features/apps/AppIframePreview.tsx
@@ -1,6 +1,7 @@
 import {
     type DataAppVizContext,
     type DashboardFilters,
+    type DeliveryQuery,
 } from '@lightdash/common';
 import {
     forwardRef,
@@ -43,6 +44,8 @@ type Props = {
      *  Inspect/Screenshot buttons don't flicker off-then-back-on each time. */
     identityKey: string;
     onQueryEvent?: (event: QueryEvent) => void;
+    /** Fires with the app's declared scheduled-delivery queries. */
+    onDeliveryQueries?: (queries: DeliveryQuery[]) => void;
     /** Reports external-connection fetches for the external-requests inspector
      *  tab. Left undefined by hosts that don't surface the inspector (embed,
      *  dashboard tiles). */
@@ -134,6 +137,7 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
             appUuid,
             identityKey,
             onQueryEvent,
+            onDeliveryQueries,
             onExternalRequestEvent,
             onElementSelected,
             inspectorEnabled,
@@ -192,6 +196,7 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
             projectUuid,
             appUuid,
             onQueryEvent,
+            onDeliveryQueries,
             onElementSelected,
             onInspectorAvailable: handleInspectorAnnounce,
             onScreenshotAvailable: handleScreenshotAnnounce,

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
@@ -5,6 +5,7 @@ import {
     LightdashAppUuidHeader,
     type DashboardFilters,
     type DataAppVizContext,
+    type DeliveryQuery,
 } from '@lightdash/common';
 import { renderHook } from '@testing-library/react';
 import { type RefObject } from 'react';
@@ -1154,5 +1155,74 @@ describe('data-app-viz-context push', () => {
             }),
             '*',
         );
+    });
+});
+
+function renderBridgeWithDelivery(
+    onDeliveryQueries: (queries: DeliveryQuery[]) => void,
+) {
+    const iframeRef = {
+        current: { contentWindow: window } as unknown as HTMLIFrameElement,
+    } as RefObject<HTMLIFrameElement | null>;
+    renderHook(() =>
+        useAppSdkBridge({
+            iframeRef,
+            expectedPreviewOrigin: window.location.origin,
+            projectUuid: PROJECT_UUID,
+            appUuid: APP_UUID,
+            onDeliveryQueries,
+        }),
+    );
+}
+
+const DELIVERY_DECLARATION = {
+    kind: 'query',
+    label: 'Revenue',
+    query: { exploreName: 'orders', dimensions: [], metrics: [], limit: 500 },
+};
+
+describe('delivery query declarations', () => {
+    it('forwards a valid declared set', () => {
+        const received: DeliveryQuery[][] = [];
+        renderBridgeWithDelivery((queries) => received.push(queries));
+
+        dispatchFetchMessage({
+            type: 'lightdash:delivery:available',
+            queries: [DELIVERY_DECLARATION],
+        });
+
+        expect(received).toHaveLength(1);
+        expect(received[0]).toEqual([DELIVERY_DECLARATION]);
+    });
+
+    it('replaces the previous set rather than accumulating', () => {
+        const received: DeliveryQuery[][] = [];
+        renderBridgeWithDelivery((queries) => received.push(queries));
+
+        dispatchFetchMessage({
+            type: 'lightdash:delivery:available',
+            queries: [DELIVERY_DECLARATION],
+        });
+        dispatchFetchMessage({
+            type: 'lightdash:delivery:available',
+            queries: [DELIVERY_DECLARATION, DELIVERY_DECLARATION],
+        });
+
+        expect(received[1]).toHaveLength(2);
+    });
+
+    it('ignores an invalid payload and warns', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const received: DeliveryQuery[][] = [];
+        renderBridgeWithDelivery((queries) => received.push(queries));
+
+        dispatchFetchMessage({
+            type: 'lightdash:delivery:available',
+            queries: [{ kind: 'nonsense' }],
+        });
+
+        expect(received).toHaveLength(0);
+        expect(warn).toHaveBeenCalled();
+        warn.mockRestore();
     });
 });

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -3,8 +3,10 @@ import {
     APP_SDK_VIZ_CONTEXT_REQUEST_MESSAGE,
     JWT_HEADER_NAME,
     LightdashAppUuidHeader,
+    parseDeliveryQueries,
     type DataAppVizContext,
     type DashboardFilters,
+    type DeliveryQuery,
 } from '@lightdash/common';
 import { useCallback, useEffect, useRef, type RefObject } from 'react';
 import { lightdashApi } from '../../../api';
@@ -238,6 +240,13 @@ export type UseAppSdkBridgeParams = {
     onLineageAvailable?: () => void;
     onLineageSelected?: (event: { queryUuid: string }) => void;
     /**
+     * Fires when the iframe SDK declares which queries belong in a scheduled
+     * delivery (`lightdash:delivery:available`). The SDK republishes the full
+     * set on change, so each call carries the complete list, not a delta.
+     * Left undefined, the message is ignored.
+     */
+    onDeliveryQueries?: (queries: DeliveryQuery[]) => void;
+    /**
      * Fires when the iframe SDK reports its capability manifest
      * (`lightdash:sdk:manifest`) — sent by SDKs new enough to have a feature
      * registry. Old bundles never send it; the parent owns the "no manifest
@@ -273,6 +282,7 @@ export function useAppSdkBridge({
     capabilities,
     onLineageAvailable,
     onLineageSelected,
+    onDeliveryQueries,
     onExternalRequestEvent,
     dataAppVizContext,
     onUrlStateChange,
@@ -390,6 +400,22 @@ export function useAppSdkBridge({
                 if (typeof stampCount === 'number' && stampCount > 0) {
                     onLineageAvailable?.();
                 }
+                return;
+            }
+
+            if (data?.type === 'lightdash:delivery:available') {
+                if (!onDeliveryQueries) return;
+                const queries = parseDeliveryQueries(data.queries);
+                if (!queries) {
+                    // Untrusted app payload: warn rather than drop silently — a
+                    // silent drop looks like the app declared nothing, which is
+                    // a legitimate state and would hide the bug.
+                    console.warn(
+                        '[lightdash] Ignoring app delivery declarations: invalid payload',
+                    );
+                    return;
+                }
+                onDeliveryQueries(queries);
                 return;
             }
 
@@ -932,6 +958,7 @@ export function useAppSdkBridge({
             capabilities,
             onLineageAvailable,
             onLineageSelected,
+            onDeliveryQueries,
             onExternalRequestEvent,
             pushDataAppVizContext,
             onUrlStateChange,

--- a/packages/frontend/src/pages/MinimalApp.deliveryQueries.test.ts
+++ b/packages/frontend/src/pages/MinimalApp.deliveryQueries.test.ts
@@ -1,0 +1,33 @@
+import { type DeliveryQuery } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import {
+    DELIVERY_QUERIES_GLOBAL,
+    publishDeliveryQueriesToWindow,
+    readDeliveryQueriesFromWindow,
+} from './MinimalApp.deliveryQueries';
+
+const declaration: DeliveryQuery = {
+    kind: 'savedChart',
+    label: 'Linked revenue',
+    chartUuid: 'chart-1',
+};
+
+describe('MinimalApp delivery query exposure', () => {
+    it('reads back an empty list before anything is published', () => {
+        delete (window as unknown as Record<string, unknown>)[
+            DELIVERY_QUERIES_GLOBAL
+        ];
+        expect(readDeliveryQueriesFromWindow()).toEqual([]);
+    });
+
+    it('exposes published declarations on the window global', () => {
+        publishDeliveryQueriesToWindow([declaration]);
+        expect(readDeliveryQueriesFromWindow()).toEqual([declaration]);
+    });
+
+    it('replaces the previous set on republish', () => {
+        publishDeliveryQueriesToWindow([declaration]);
+        publishDeliveryQueriesToWindow([]);
+        expect(readDeliveryQueriesFromWindow()).toEqual([]);
+    });
+});

--- a/packages/frontend/src/pages/MinimalApp.deliveryQueries.ts
+++ b/packages/frontend/src/pages/MinimalApp.deliveryQueries.ts
@@ -1,0 +1,22 @@
+import { type DeliveryQuery } from '@lightdash/common';
+
+/**
+ * Where the headless render publishes the app's declared delivery queries.
+ * Read by UnfurlService via page.evaluate — keep the name in sync with the
+ * backend resolver.
+ */
+export const DELIVERY_QUERIES_GLOBAL = '__lightdashAppDeliveryQueries';
+
+export function publishDeliveryQueriesToWindow(queries: DeliveryQuery[]): void {
+    if (typeof window === 'undefined') return;
+    (window as unknown as Record<string, unknown>)[DELIVERY_QUERIES_GLOBAL] =
+        queries;
+}
+
+export function readDeliveryQueriesFromWindow(): DeliveryQuery[] {
+    if (typeof window === 'undefined') return [];
+    const value = (window as unknown as Record<string, unknown>)[
+        DELIVERY_QUERIES_GLOBAL
+    ];
+    return Array.isArray(value) ? (value as DeliveryQuery[]) : [];
+}

--- a/packages/frontend/src/pages/MinimalApp.tsx
+++ b/packages/frontend/src/pages/MinimalApp.tsx
@@ -1,4 +1,4 @@
-import { FeatureFlags } from '@lightdash/common';
+import { FeatureFlags, type DeliveryQuery } from '@lightdash/common';
 import { Box, Loader, Stack, Text } from '@mantine-8/core';
 import { useDebouncedValue } from '@mantine-8/hooks';
 import { IconAppsOff } from '@tabler/icons-react';
@@ -13,6 +13,7 @@ import { type QueryEvent } from '../features/apps/hooks/useAppSdkBridge';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
 import { usePreviewOrigin } from '../features/apps/previewOrigin';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
+import { publishDeliveryQueriesToWindow } from './MinimalApp.deliveryQueries';
 
 /**
  * How long the app must be quiet (SDK alive, zero in-flight queries) before
@@ -76,6 +77,14 @@ export default function MinimalApp() {
 
     const handleScreenshotAvailable = useCallback((available: boolean) => {
         setSdkAlive(available);
+    }, []);
+
+    const handleDeliveryQueries = useCallback((queries: DeliveryQuery[]) => {
+        // Written here, not in an effect keyed on readiness: this runs well
+        // before `isReady` flips (debounced APP_QUIET_DEBOUNCE_MS behind the
+        // last query settling), and UnfurlService waits on the ready
+        // indicator — so the global is always in place before it looks.
+        publishDeliveryQueriesToWindow(queries);
     }, []);
 
     const handleQueryEvent = useCallback((event: QueryEvent) => {
@@ -196,6 +205,7 @@ export default function MinimalApp() {
                 identityKey={`${appUuid}:${latestReadyVersion}`}
                 onIframeLoad={handleIframeLoad}
                 onQueryEvent={handleQueryEvent}
+                onDeliveryQueries={handleDeliveryQueries}
                 onScreenshotAvailabilityChange={handleScreenshotAvailable}
                 // Seeds the app from ?state= so scheduled deliveries with a
                 // saved app state screenshot that view, not the default one.

--- a/packages/query-sdk/src/delivery.ts
+++ b/packages/query-sdk/src/delivery.ts
@@ -16,6 +16,10 @@ import type {
 /**
  * A query declared for scheduled delivery. `label` is the tab/file name in the
  * delivery; null falls back to a positional name.
+ *
+ * Keep in sync with `DeliveryQuery` in
+ * packages/common/src/ee/apps/deliveryQueries.ts — the host and backend read
+ * that copy, because deployment images don't include this package.
  */
 export type DeliveryQuery =
     | { kind: 'query'; label: string | null; query: QueryDefinition }


### PR DESCRIPTION
Stacked on #26325. Still ships dark — nothing consumes the exposed set until the resolver lands, and there are no UI changes.

The SDK declares delivery queries and announces them (#26324). This PR is the host half: receive that announcement, validate it, and put the settled set where the backend resolver can read it.

### The type has to live in common

`useAppSdkBridge` can't import `DeliveryQuery` from the SDK — neither `packages/frontend` nor `packages/backend` depends on `@lightdash/query-sdk`, with zero imports in either, because deployment images don't ship it. So `DeliveryQuery` + `parseDeliveryQueries()` go in `packages/common/src/ee/apps/deliveryQueries.ts`, which the bridge reads now and the resolver and delivery packaging will read later. Same arrangement as the `SDK_FEATURES` mirror; the SDK carries a `Keep in sync with …` comment pointing back, matching the existing `MAX_URL_STATE_CHARS` precedent.

`query` is typed loosely there (`Record<string, unknown> & { exploreName: string }`) rather than duplicating the SDK's full `QueryDefinition`. That's deliberate and commented — validation only needs enough structure to reject garbage, and duplicating the whole definition would create a second shape to keep in sync for no gain. The real conversion happens where the query is handed to the query engine, against the same body the bridge already POSTs to `/query/metric-query`.

### Untrusted input

The payload comes from a sandboxed, opaque-origin frame running generated code, so it's validated like `lightdash:sdk:url-state-change` is: shape-checked, capped at 50 declarations, and rejected with a `console.warn` rather than dropped silently. A silent drop would be indistinguishable from "the app declared nothing", which is a legitimate state — that's also why `parseDeliveryQueries` returns `null` rather than `[]`.

No new network surface: `ALLOWED_ROUTES` is untouched, asserted in the checklist below.

### Ordering

`MinimalApp` publishes to `window.__lightdashAppDeliveryQueries` from the bridge callback, not from an effect keyed on readiness. That callback runs well before `isReady` flips — it's debounced `APP_QUIET_DEBOUNCE_MS` behind the last query settling — and `UnfurlService` blocks on the ready indicator. So the resolver can never observe a ready page with a stale set. The comment in `MinimalApp.tsx` says so, because moving this into a readiness-keyed effect would invert it and fail silently.

### Verification

- common: 3161 passed, 1 skipped (117 files)
- frontend `src/features/apps` + `src/pages`: 112 passed (15 files) — 3 new bridge tests, 3 new exposure tests, 10 new validator tests
- `typecheck:fast` clean on both
- lint: 4 warnings, byte-identical to `main`
- `git diff main -- useAppSdkBridge.ts | grep -c ALLOWED_ROUTES` → 0

Closes: PROD-9297
Relates: PROD-8374
