### PR TITLE
feat(analytics): emit skipped/failed outcomes from onboarding provisioning

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -867,6 +867,35 @@ type OnboardingHomepageProvisionedEvent = BaseTrack & {
         organizationId: string;
         projectId: string;
         homepageUuid: string;
+        onboardingFlow: OnboardingFlow;
+    };
+};
+
+export type OnboardingHomepageSkippedReason =
+    | 'new_onboarding_flag_disabled'
+    | 'homepage_builder_flag_disabled'
+    | 'not_first_project'
+    | 'homepage_already_exists';
+
+type OnboardingHomepageSkippedEvent = BaseTrack & {
+    event: 'onboarding_homepage.skipped';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        onboardingFlow: OnboardingFlow;
+        reason: OnboardingHomepageSkippedReason;
+    };
+};
+
+type OnboardingHomepageFailedEvent = BaseTrack & {
+    event: 'onboarding_homepage.failed';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        onboardingFlow: OnboardingFlow;
+        errorType: string;
     };
 };
 
@@ -877,6 +906,39 @@ type PlaygroundProjectProvisionedEvent = BaseTrack & {
         organizationId: string;
         projectId: string;
         trigger: 'invite_expert';
+        onboardingFlow: OnboardingFlow;
+        catalogIndexErrorType: string | null;
+    };
+};
+
+export type PlaygroundProjectSkippedReason =
+    | 'new_onboarding_flag_disabled'
+    | 'playground_already_exists'
+    | 'organization_has_project'
+    | 'no_project_access'
+    | 'playground_previously_removed';
+
+type PlaygroundProjectSkippedEvent = BaseTrack & {
+    event: 'playground_project.skipped';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string | null;
+        trigger: 'invite_expert';
+        onboardingFlow: OnboardingFlow;
+        reason: PlaygroundProjectSkippedReason;
+    };
+};
+
+type PlaygroundProjectFailedEvent = BaseTrack & {
+    event: 'playground_project.failed';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string | null;
+        trigger: 'invite_expert';
+        onboardingFlow: OnboardingFlow;
+        errorType: string;
     };
 };
 
@@ -2925,7 +2987,11 @@ type TypedEvent =
     | ApiErrorEvent
     | ProjectEvent
     | OnboardingHomepageProvisionedEvent
+    | OnboardingHomepageSkippedEvent
+    | OnboardingHomepageFailedEvent
     | PlaygroundProjectProvisionedEvent
+    | PlaygroundProjectSkippedEvent
+    | PlaygroundProjectFailedEvent
     | ProjectDeletedEvent
     | ProjectCompiledEvent
     | DbtSourceEvent

--- a/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.test.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.test.ts
@@ -148,6 +148,16 @@ describe('provisionOnboardingHomepage', () => {
         expect(mocks.listHomepages).not.toHaveBeenCalled();
         expect(mocks.createHomepage).not.toHaveBeenCalled();
         expect(mocks.publishHomepage).not.toHaveBeenCalled();
+        expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
+            event: 'onboarding_homepage.skipped',
+            userId: USER_UUID,
+            properties: {
+                organizationId: ORGANIZATION_UUID,
+                projectId: PROJECT_UUID,
+                onboardingFlow: 'new',
+                reason: 'homepage_builder_flag_disabled',
+            },
+        });
     });
 
     it('skips provisioning when the organization setup page flag is disabled', async () => {
@@ -163,6 +173,16 @@ describe('provisionOnboardingHomepage', () => {
         expect(mocks.listHomepages).not.toHaveBeenCalled();
         expect(mocks.createHomepage).not.toHaveBeenCalled();
         expect(mocks.publishHomepage).not.toHaveBeenCalled();
+        expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
+            event: 'onboarding_homepage.skipped',
+            userId: USER_UUID,
+            properties: {
+                organizationId: ORGANIZATION_UUID,
+                projectId: PROJECT_UUID,
+                onboardingFlow: 'legacy',
+                reason: 'new_onboarding_flag_disabled',
+            },
+        });
     });
 
     it('skips provisioning when the project already has a homepage', async () => {
@@ -173,6 +193,16 @@ describe('provisionOnboardingHomepage', () => {
 
         expect(mocks.createHomepage).not.toHaveBeenCalled();
         expect(mocks.publishHomepage).not.toHaveBeenCalled();
+        expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
+            event: 'onboarding_homepage.skipped',
+            userId: USER_UUID,
+            properties: {
+                organizationId: ORGANIZATION_UUID,
+                projectId: PROJECT_UUID,
+                onboardingFlow: 'new',
+                reason: 'homepage_already_exists',
+            },
+        });
     });
 
     it('skips provisioning when this is not the organization first project', async () => {
@@ -187,6 +217,71 @@ describe('provisionOnboardingHomepage', () => {
         expect(mocks.listHomepages).not.toHaveBeenCalled();
         expect(mocks.createHomepage).not.toHaveBeenCalled();
         expect(mocks.publishHomepage).not.toHaveBeenCalled();
+        expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
+            event: 'onboarding_homepage.skipped',
+            userId: USER_UUID,
+            properties: {
+                organizationId: ORGANIZATION_UUID,
+                projectId: PROJECT_UUID,
+                onboardingFlow: 'new',
+                reason: 'not_first_project',
+            },
+        });
+    });
+
+    it('emits no event for non-default projects', async () => {
+        const mocks = buildArguments();
+
+        await provisionOnboardingHomepage({
+            ...mocks.args,
+            projectType: ProjectType.PREVIEW,
+        });
+
+        expect(mocks.getFeatureFlag).not.toHaveBeenCalled();
+        expect(mocks.track).not.toHaveBeenCalled();
+    });
+
+    it('tracks a failure and rethrows when homepage creation fails', async () => {
+        const mocks = buildArguments();
+        mocks.createHomepage.mockRejectedValue(
+            new Error('Homepage creation failed'),
+        );
+
+        await expect(provisionOnboardingHomepage(mocks.args)).rejects.toThrow(
+            'Homepage creation failed',
+        );
+
+        expect(mocks.publishHomepage).not.toHaveBeenCalled();
+        expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
+            event: 'onboarding_homepage.failed',
+            userId: USER_UUID,
+            properties: {
+                organizationId: ORGANIZATION_UUID,
+                projectId: PROJECT_UUID,
+                onboardingFlow: 'new',
+                errorType: 'Error',
+            },
+        });
+    });
+
+    it('tracks a failure and rethrows when publishing fails', async () => {
+        const mocks = buildArguments();
+        mocks.publishHomepage.mockRejectedValue(new Error('Publish failed'));
+
+        await expect(provisionOnboardingHomepage(mocks.args)).rejects.toThrow(
+            'Publish failed',
+        );
+
+        expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
+            event: 'onboarding_homepage.failed',
+            userId: USER_UUID,
+            properties: {
+                organizationId: ORGANIZATION_UUID,
+                projectId: PROJECT_UUID,
+                onboardingFlow: 'new',
+                errorType: 'Error',
+            },
+        });
     });
 
     it('creates and publishes the onboarding homepage for the first project', async () => {
@@ -215,13 +310,14 @@ describe('provisionOnboardingHomepage', () => {
         expect(mocks.publishHomepage).toHaveBeenCalledWith(HOMEPAGE_UUID, {
             type: 'everyone',
         });
-        expect(mocks.track).toHaveBeenCalledWith({
+        expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
             event: 'onboarding_homepage.provisioned',
             userId: USER_UUID,
             properties: {
                 organizationId: ORGANIZATION_UUID,
                 projectId: PROJECT_UUID,
                 homepageUuid: HOMEPAGE_UUID,
+                onboardingFlow: 'new',
             },
         });
     });

--- a/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.ts
@@ -5,7 +5,11 @@ import {
     ProjectType,
     type SessionUser,
 } from '@lightdash/common';
-import { type LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
+import {
+    type LightdashAnalytics,
+    type OnboardingFlow,
+    type OnboardingHomepageSkippedReason,
+} from '../../../analytics/LightdashAnalytics';
 import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { type FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
 import { type ProjectHomepageModel } from '../../models/ProjectHomepageModel';
@@ -32,7 +36,8 @@ export const provisionOnboardingHomepage = async ({
     projectHomepageModel,
     analytics,
 }: ProvisionOnboardingHomepageArguments): Promise<void> => {
-    if (projectType !== ProjectType.DEFAULT || !user.organizationUuid) {
+    const { organizationUuid } = user;
+    if (projectType !== ProjectType.DEFAULT || !organizationUuid) {
         return;
     }
 
@@ -46,41 +51,77 @@ export const provisionOnboardingHomepage = async ({
             featureFlagId: CommercialFeatureFlags.HomepageBuilder,
         }),
     ]);
-    if (!orgSetupPageFlag.enabled || !homepageBuilderFlag.enabled) {
+    const onboardingFlow: OnboardingFlow = orgSetupPageFlag.enabled
+        ? 'new'
+        : 'legacy';
+    const trackSkipped = (reason: OnboardingHomepageSkippedReason) => {
+        analytics.track({
+            event: 'onboarding_homepage.skipped',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+                onboardingFlow,
+                reason,
+            },
+        });
+    };
+    if (!orgSetupPageFlag.enabled) {
+        trackSkipped('new_onboarding_flag_disabled');
+        return;
+    }
+    if (!homepageBuilderFlag.enabled) {
+        trackSkipped('homepage_builder_flag_disabled');
         return;
     }
 
-    const organizationProjects = await projectModel.getAllByOrganizationUuid(
-        user.organizationUuid,
-    );
-    if (
-        organizationProjects.length !== 1 ||
-        organizationProjects[0].projectUuid !== projectUuid
-    ) {
-        return;
-    }
+    try {
+        const organizationProjects =
+            await projectModel.getAllByOrganizationUuid(organizationUuid);
+        if (
+            organizationProjects.length !== 1 ||
+            organizationProjects[0].projectUuid !== projectUuid
+        ) {
+            trackSkipped('not_first_project');
+            return;
+        }
 
-    const existingHomepages = await projectHomepageModel.list(projectUuid);
-    if (existingHomepages.length > 0) {
-        return;
-    }
+        const existingHomepages = await projectHomepageModel.list(projectUuid);
+        if (existingHomepages.length > 0) {
+            trackSkipped('homepage_already_exists');
+            return;
+        }
 
-    const homepage = await projectHomepageModel.create({
-        projectUuid,
-        name: 'Getting started',
-        draftConfig: buildOnboardingHomepageConfig(),
-        createdByUserUuid: user.userUuid,
-    });
-    await projectHomepageModel.publish(homepage.homepageUuid, {
-        type: 'everyone',
-    });
-    analytics.track({
-        event: 'onboarding_homepage.provisioned',
-        userId: user.userUuid,
-        properties: {
-            organizationId: user.organizationUuid,
-            projectId: projectUuid,
-            homepageUuid: homepage.homepageUuid,
-        },
-    });
+        const homepage = await projectHomepageModel.create({
+            projectUuid,
+            name: 'Getting started',
+            draftConfig: buildOnboardingHomepageConfig(),
+            createdByUserUuid: user.userUuid,
+        });
+        await projectHomepageModel.publish(homepage.homepageUuid, {
+            type: 'everyone',
+        });
+        analytics.track({
+            event: 'onboarding_homepage.provisioned',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+                homepageUuid: homepage.homepageUuid,
+                onboardingFlow,
+            },
+        });
+    } catch (error) {
+        analytics.track({
+            event: 'onboarding_homepage.failed',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+                onboardingFlow,
+                errorType: error instanceof Error ? error.name : 'Unknown',
+            },
+        });
+        throw error;
+    }
 };

--- a/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.test.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.test.ts
@@ -70,7 +70,9 @@ const buildArguments = () => {
         catalogFieldMap: {},
         numberOfCategoriesApplied: 0,
     }));
-    const getByOrganizationUuid = vi.fn(async () => ({
+    const getByOrganizationUuid = vi.fn<
+        ProvisionPlaygroundProjectArguments['onboardingModel']['getByOrganizationUuid']
+    >(async () => ({
         ranQueryAt: null,
         shownSuccessAt: null,
         playgroundProjectDeletedAt: null,
@@ -133,6 +135,17 @@ describe('provisionPlaygroundProject', () => {
             'Playground projects are not available',
         );
         expect(mocks.getAllByOrganizationUuid).not.toHaveBeenCalled();
+        expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
+            event: 'playground_project.skipped',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: null,
+                trigger: 'invite_expert',
+                onboardingFlow: 'legacy',
+                reason: 'new_onboarding_flag_disabled',
+            },
+        });
     });
 
     it('repairs an existing playground cache idempotently', async () => {
@@ -149,6 +162,17 @@ describe('provisionPlaygroundProject', () => {
             projectUuid,
             expect.any(Array),
         );
+        expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
+            event: 'playground_project.skipped',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+                trigger: 'invite_expert',
+                onboardingFlow: 'new',
+                reason: 'playground_already_exists',
+            },
+        });
     });
 
     it('returns an existing real project without creating a playground', async () => {
@@ -159,6 +183,17 @@ describe('provisionPlaygroundProject', () => {
             created: false,
         });
         expect(mocks.createWithoutCompile).not.toHaveBeenCalled();
+        expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
+            event: 'playground_project.skipped',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+                trigger: 'invite_expert',
+                onboardingFlow: 'new',
+                reason: 'organization_has_project',
+            },
+        });
     });
 
     it('does not disclose an existing project the user cannot view', async () => {
@@ -171,6 +206,42 @@ describe('provisionPlaygroundProject', () => {
             'User does not have permission to view an existing project',
         );
         expect(mocks.createWithoutCompile).not.toHaveBeenCalled();
+        expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
+            event: 'playground_project.skipped',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: null,
+                trigger: 'invite_expert',
+                onboardingFlow: 'new',
+                reason: 'no_project_access',
+            },
+        });
+    });
+
+    it('skips provisioning when the playground was previously removed', async () => {
+        const mocks = buildArguments();
+        mocks.args.onboardingModel.getByOrganizationUuid.mockResolvedValue({
+            ranQueryAt: null,
+            shownSuccessAt: null,
+            playgroundProjectDeletedAt: now,
+        });
+
+        await expect(provisionPlaygroundProject(mocks.args)).rejects.toThrow(
+            'Playground project was previously removed',
+        );
+        expect(mocks.createWithoutCompile).not.toHaveBeenCalled();
+        expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
+            event: 'playground_project.skipped',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: null,
+                trigger: 'invite_expert',
+                onboardingFlow: 'new',
+                reason: 'playground_previously_removed',
+            },
+        });
     });
 
     it('creates the playground and caches bundled explores', async () => {
@@ -201,11 +272,17 @@ describe('provisionPlaygroundProject', () => {
             organizationUuid,
             expect.any(Function),
         );
-        expect(mocks.track).toHaveBeenCalledWith(
-            expect.objectContaining({
-                event: 'playground_project.provisioned',
-            }),
-        );
+        expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
+            event: 'playground_project.provisioned',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+                trigger: 'invite_expert',
+                onboardingFlow: 'new',
+                catalogIndexErrorType: null,
+            },
+        });
         expect(mocks.validatePlaygroundDatabase).toHaveBeenCalledWith(
             path.resolve(
                 __dirname,
@@ -244,7 +321,7 @@ describe('provisionPlaygroundProject', () => {
         );
     });
 
-    it('still provisions when catalog indexing fails', async () => {
+    it('still provisions when catalog indexing fails, tracking the error type', async () => {
         const mocks = buildArguments();
         mocks.indexCatalog.mockRejectedValue(new Error('Catalog unavailable'));
 
@@ -252,7 +329,17 @@ describe('provisionPlaygroundProject', () => {
             projectUuid,
             created: true,
         });
-        expect(mocks.track).toHaveBeenCalledOnce();
+        expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
+            event: 'playground_project.provisioned',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+                trigger: 'invite_expert',
+                onboardingFlow: 'new',
+                catalogIndexErrorType: 'Error',
+            },
+        });
     });
 
     it('does not create a project when bundle validation fails', async () => {
@@ -265,6 +352,17 @@ describe('provisionPlaygroundProject', () => {
             'Invalid DuckDB bundle',
         );
         expect(mocks.createWithoutCompile).not.toHaveBeenCalled();
+        expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
+            event: 'playground_project.failed',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: null,
+                trigger: 'invite_expert',
+                onboardingFlow: 'new',
+                errorType: 'Error',
+            },
+        });
     });
 
     it('removes a newly created project when explore caching fails', async () => {
@@ -277,6 +375,16 @@ describe('provisionPlaygroundProject', () => {
             'Cache unavailable',
         );
         expect(mocks.deleteProject).toHaveBeenCalledWith(projectUuid);
-        expect(mocks.track).not.toHaveBeenCalled();
+        expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
+            event: 'playground_project.failed',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+                trigger: 'invite_expert',
+                onboardingFlow: 'new',
+                errorType: 'Error',
+            },
+        });
     });
 });

--- a/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.ts
@@ -18,7 +18,11 @@ import { DuckdbWarehouseClient } from '@lightdash/warehouses';
 import * as Sentry from '@sentry/node';
 import fs from 'fs/promises';
 import path from 'path';
-import { type LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
+import {
+    type LightdashAnalytics,
+    type OnboardingFlow,
+    type PlaygroundProjectSkippedReason,
+} from '../../../analytics/LightdashAnalytics';
 import Logger from '../../../logging/logger';
 import { type OnboardingModel } from '../../../models/OnboardingModel/OnboardingModel';
 import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
@@ -71,6 +75,9 @@ const loadPlaygroundBundle = async (
     return explores as (Explore | ExploreError)[];
 };
 
+const getErrorType = (error: unknown): string =>
+    error instanceof Error ? error.name : 'Unknown';
+
 export const provisionPlaygroundProject = async ({
     user,
     featureFlagService,
@@ -92,119 +99,190 @@ export const provisionPlaygroundProject = async ({
         user,
         featureFlagId: FeatureFlags.NewOnboarding,
     });
+    const onboardingFlow: OnboardingFlow = featureFlag.enabled
+        ? 'new'
+        : 'legacy';
+    let outcomeTracked = false;
+    const trackSkipped = (
+        reason: PlaygroundProjectSkippedReason,
+        projectId: string | null,
+    ) => {
+        outcomeTracked = true;
+        analytics.track({
+            event: 'playground_project.skipped',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId,
+                trigger: 'invite_expert',
+                onboardingFlow,
+                reason,
+            },
+        });
+    };
     if (!featureFlag.enabled) {
+        trackSkipped('new_onboarding_flag_disabled', null);
         throw new NotFoundError('Playground projects are not available');
     }
 
-    return onboardingModel.runInPlaygroundProvisioningLock(
-        organizationUuid,
-        async () => {
-            const dataDirectory = path.resolve(
-                playgroundDataDirectory ??
-                    process.env.PLAYGROUND_DATA_DIR ??
-                    path.join(__dirname, '../../../../assets/playground'),
-            );
-            const projects =
-                await projectModel.getAllByOrganizationUuid(organizationUuid);
-            const accessibleProjects = projects.filter(canViewProject);
-            const playground = accessibleProjects.find(
-                (project) => project.provisioningSource === 'playground',
-            );
-            if (playground) {
+    let lastKnownProjectUuid: string | null = null;
+    try {
+        return await onboardingModel.runInPlaygroundProvisioningLock(
+            organizationUuid,
+            async () => {
+                const dataDirectory = path.resolve(
+                    playgroundDataDirectory ??
+                        process.env.PLAYGROUND_DATA_DIR ??
+                        path.join(__dirname, '../../../../assets/playground'),
+                );
+                const projects =
+                    await projectModel.getAllByOrganizationUuid(
+                        organizationUuid,
+                    );
+                const accessibleProjects = projects.filter(canViewProject);
+                const playground = accessibleProjects.find(
+                    (project) => project.provisioningSource === 'playground',
+                );
+                if (playground) {
+                    lastKnownProjectUuid = playground.projectUuid;
+                    const explores = await loadPlaygroundBundle(
+                        dataDirectory,
+                        validatePlaygroundDatabase,
+                    );
+                    await projectModel.saveExploresToCache(
+                        playground.projectUuid,
+                        explores,
+                    );
+                    trackSkipped(
+                        'playground_already_exists',
+                        playground.projectUuid,
+                    );
+                    return {
+                        projectUuid: playground.projectUuid,
+                        created: false,
+                    };
+                }
+                if (projects.length > 0) {
+                    const existingProject = accessibleProjects[0];
+                    if (!existingProject) {
+                        trackSkipped('no_project_access', null);
+                        throw new ForbiddenError(
+                            'User does not have permission to view an existing project',
+                        );
+                    }
+                    trackSkipped(
+                        'organization_has_project',
+                        existingProject.projectUuid,
+                    );
+                    return {
+                        projectUuid: existingProject.projectUuid,
+                        created: false,
+                    };
+                }
+
+                const onboarding =
+                    await onboardingModel.getByOrganizationUuid(
+                        organizationUuid,
+                    );
+                if (onboarding.playgroundProjectDeletedAt) {
+                    trackSkipped('playground_previously_removed', null);
+                    throw new NotFoundError(
+                        'Playground project was previously removed',
+                    );
+                }
+
                 const explores = await loadPlaygroundBundle(
                     dataDirectory,
                     validatePlaygroundDatabase,
                 );
-                await projectModel.saveExploresToCache(
-                    playground.projectUuid,
-                    explores,
-                );
-                return {
-                    projectUuid: playground.projectUuid,
-                    created: false,
-                };
-            }
-            if (projects.length > 0) {
-                const existingProject = accessibleProjects[0];
-                if (!existingProject) {
-                    throw new ForbiddenError(
-                        'User does not have permission to view an existing project',
-                    );
-                }
-                return {
-                    projectUuid: existingProject.projectUuid,
-                    created: false,
-                };
-            }
 
-            const onboarding =
-                await onboardingModel.getByOrganizationUuid(organizationUuid);
-            if (onboarding.playgroundProjectDeletedAt) {
-                throw new NotFoundError(
-                    'Playground project was previously removed',
-                );
-            }
-
-            const explores = await loadPlaygroundBundle(
-                dataDirectory,
-                validatePlaygroundDatabase,
-            );
-
-            const creation = await projectService.createWithoutCompile(
-                user,
-                {
-                    name: 'Playground (sample data)',
-                    type: ProjectType.DEFAULT,
-                    dbtConnection: { type: DbtProjectType.NONE },
-                    dbtVersion: DefaultSupportedDbtVersion,
-                    warehouseConnection: {
-                        type: WarehouseTypes.DUCKDB,
-                        connectionType: DuckdbConnectionType.EMBEDDED,
-                        dataset: 'jaffle_shop',
+                const creation = await projectService.createWithoutCompile(
+                    user,
+                    {
+                        name: 'Playground (sample data)',
+                        type: ProjectType.DEFAULT,
+                        dbtConnection: { type: DbtProjectType.NONE },
+                        dbtVersion: DefaultSupportedDbtVersion,
+                        warehouseConnection: {
+                            type: WarehouseTypes.DUCKDB,
+                            connectionType: DuckdbConnectionType.EMBEDDED,
+                            dataset: 'jaffle_shop',
+                        },
                     },
-                },
-                RequestMethod.BACKEND,
-                { source: 'playground' },
-            );
-            const { projectUuid } = creation.project;
+                    RequestMethod.BACKEND,
+                    { source: 'playground' },
+                );
+                const { projectUuid } = creation.project;
+                lastKnownProjectUuid = projectUuid;
 
-            try {
-                await projectModel.saveExploresToCache(projectUuid, explores);
-            } catch (error) {
-                await projectModel.delete(projectUuid).catch((cleanupError) => {
-                    Sentry.captureException(cleanupError);
+                try {
+                    await projectModel.saveExploresToCache(
+                        projectUuid,
+                        explores,
+                    );
+                } catch (error) {
+                    await projectModel
+                        .delete(projectUuid)
+                        .catch((cleanupError) => {
+                            Sentry.captureException(cleanupError);
+                            Logger.error(
+                                `Failed to remove incomplete playground project ${projectUuid}: ${
+                                    cleanupError instanceof Error
+                                        ? cleanupError.message
+                                        : String(cleanupError)
+                                }`,
+                            );
+                        });
+                    throw error;
+                }
+
+                let catalogIndexErrorType: string | null = null;
+                try {
+                    await catalogService.indexCatalog(
+                        projectUuid,
+                        user.userUuid,
+                    );
+                } catch (error) {
+                    Sentry.captureException(error);
                     Logger.error(
-                        `Failed to remove incomplete playground project ${projectUuid}: ${
-                            cleanupError instanceof Error
-                                ? cleanupError.message
-                                : String(cleanupError)
+                        `Failed to index playground catalog for project ${projectUuid}: ${
+                            error instanceof Error
+                                ? error.message
+                                : String(error)
                         }`,
                     );
+                    catalogIndexErrorType = getErrorType(error);
+                }
+
+                outcomeTracked = true;
+                analytics.track({
+                    event: 'playground_project.provisioned',
+                    userId: user.userUuid,
+                    properties: {
+                        organizationId: organizationUuid,
+                        projectId: projectUuid,
+                        trigger: 'invite_expert',
+                        onboardingFlow,
+                        catalogIndexErrorType,
+                    },
                 });
-                throw error;
-            }
-
-            try {
-                await catalogService.indexCatalog(projectUuid, user.userUuid);
-            } catch (error) {
-                Sentry.captureException(error);
-                Logger.error(
-                    `Failed to index playground catalog for project ${projectUuid}: ${
-                        error instanceof Error ? error.message : String(error)
-                    }`,
-                );
-            }
-
+                return { projectUuid, created: true };
+            },
+        );
+    } catch (error) {
+        if (!outcomeTracked) {
             analytics.track({
-                event: 'playground_project.provisioned',
+                event: 'playground_project.failed',
                 userId: user.userUuid,
                 properties: {
                     organizationId: organizationUuid,
-                    projectId: projectUuid,
+                    projectId: lastKnownProjectUuid,
                     trigger: 'invite_expert',
+                    onboardingFlow,
+                    errorType: getErrorType(error),
                 },
             });
-            return { projectUuid, created: true };
-        },
-    );
+        }
+        throw error;
+    }
 };

--- a/packages/frontend/src/pages/OnboardingInviteExpert.test.tsx
+++ b/packages/frontend/src/pages/OnboardingInviteExpert.test.tsx
@@ -190,6 +190,7 @@ describe('OnboardingInviteExpert', () => {
         });
         expect(mocks.track).toHaveBeenCalledWith({
             name: EventName.PLAYGROUND_PROJECT_ENTERED,
+            properties: { organizationId: 'org-1' },
         });
     });
 
@@ -275,6 +276,18 @@ describe('OnboardingInviteExpert', () => {
         expect(
             screen.queryByRole('button', { name: /try again/i }),
         ).not.toBeInTheDocument();
+        expect(mocks.track).toHaveBeenCalledWith({
+            name: EventName.PLAYGROUND_PROJECT_SETUP_FAILED,
+            properties: {
+                organizationId: 'org-1',
+                failureType: 'unavailable',
+            },
+        });
+        expect(mocks.track).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                name: EventName.PLAYGROUND_PROJECT_ENTERED,
+            }),
+        );
     });
 
     it('offers a retry for unrecognised failures', async () => {
@@ -292,6 +305,13 @@ describe('OnboardingInviteExpert', () => {
         expect(
             await screen.findByText(/something went wrong while preparing/i),
         ).toBeInTheDocument();
+        expect(mocks.track).toHaveBeenCalledWith({
+            name: EventName.PLAYGROUND_PROJECT_SETUP_FAILED,
+            properties: {
+                organizationId: 'org-1',
+                failureType: 'unknown',
+            },
+        });
 
         mocks.ensurePlayground.mockResolvedValue({ projectUuid: 'p1' });
         await userEvent.click(

--- a/packages/frontend/src/pages/OnboardingInviteExpert.tsx
+++ b/packages/frontend/src/pages/OnboardingInviteExpert.tsx
@@ -170,10 +170,23 @@ const OnboardingInviteExpert: FC = () => {
     const preparePlayground = async () => {
         try {
             const { projectUuid } = await ensurePlaygroundAsync();
-            track({ name: EventName.PLAYGROUND_PROJECT_ENTERED });
+            track({
+                name: EventName.PLAYGROUND_PROJECT_ENTERED,
+                properties: {
+                    organizationId: organization?.organizationUuid ?? '',
+                },
+            });
             void navigate(`/projects/${projectUuid}/home`);
         } catch (error) {
-            setPlaygroundFailure(getPlaygroundSetupFailure(error));
+            const failureType = getPlaygroundSetupFailure(error);
+            setPlaygroundFailure(failureType);
+            track({
+                name: EventName.PLAYGROUND_PROJECT_SETUP_FAILED,
+                properties: {
+                    organizationId: organization?.organizationUuid ?? '',
+                    failureType,
+                },
+            });
             captureException(error, {
                 tags: { feature: 'playground-onboarding' },
             });

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -7,6 +7,7 @@ import {
     type WarehouseTypes,
 } from '@lightdash/common';
 import type * as rudderSDK from 'rudder-sdk-js';
+import { type PlaygroundSetupFailure } from '../../components/ProjectConnection/ProjectConnectFlow/playgroundSetupFailure';
 import {
     type CategoryName,
     type EventName,
@@ -77,7 +78,6 @@ type GenericEvent = {
         | EventName.METRICS_CATALOG_TREES_CANVAS_MODE_CLICKED
         | EventName.BIGQUERY_SSO_SIGNIN_CLICKED
         | EventName.SNOWFLAKE_CLI_SSO_COMMAND_COPIED
-        | EventName.PLAYGROUND_PROJECT_ENTERED
         | EventName.AGENT_SETUP_PROMPT_COPIED;
     properties?: {};
 };
@@ -86,6 +86,21 @@ type SetupInviteSentEvent = {
     name: EventName.SETUP_INVITE_SENT;
     properties: {
         organizationId: string;
+    };
+};
+
+type PlaygroundProjectEnteredEvent = {
+    name: EventName.PLAYGROUND_PROJECT_ENTERED;
+    properties: {
+        organizationId: string;
+    };
+};
+
+type PlaygroundProjectSetupFailedEvent = {
+    name: EventName.PLAYGROUND_PROJECT_SETUP_FAILED;
+    properties: {
+        organizationId: string;
+        failureType: PlaygroundSetupFailure;
     };
 };
 
@@ -712,6 +727,8 @@ type CreateProjectColumnsDefinedButtonClickedEvent = {
 export type EventData =
     | GenericEvent
     | SetupInviteSentEvent
+    | PlaygroundProjectEnteredEvent
+    | PlaygroundProjectSetupFailedEvent
     | CreateProjectButtonClickedEvent
     | CreateProjectFailedEvent
     | SignupFormSubmittedEvent

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -203,6 +203,7 @@ export enum EventName {
     SNOWFLAKE_CLI_SSO_COMMAND_COPIED = 'snowflake_cli_sso.command_copied',
     SETUP_INVITE_SENT = 'setup_invite.sent',
     PLAYGROUND_PROJECT_ENTERED = 'playground_project.entered',
+    PLAYGROUND_PROJECT_SETUP_FAILED = 'playground_project.setup_failed',
     ONBOARDING_PROJECT_READY_START_EXPLORING_CLICKED = 'onboarding_project_ready.start_exploring_clicked',
     HOMEPAGE_ASK_SUBMITTED = 'homepage_ask.submitted',
     HOMEPAGE_RECOMMENDED_ACTION_IMPRESSION = 'homepage_recommended_action.impression',


### PR DESCRIPTION
Ahead of the new-onboarding rollout, `onboarding_homepage.provisioned` and `playground_project.provisioned` were the only signals from the two provisioning paths, and every skip/failure branch was silent — so "not provisioned" was indistinguishable from "not instrumented". This makes each provisioning invocation emit exactly one outcome event.

## Backend

**`onboarding_homepage.*`** (per default-project creation, from `provisionOnboardingHomepage`):
- `onboarding_homepage.provisioned` — now also carries `onboardingFlow`.
- `onboarding_homepage.skipped` — new, with `reason`: `new_onboarding_flag_disabled` | `homepage_builder_flag_disabled` | `not_first_project` | `homepage_already_exists`.
- `onboarding_homepage.failed` — new, with `errorType` (error class name); emitted on any throw after the flag checks, then rethrown so the existing fire-and-forget catch in `runPostProjectCreationProvisioning` still Sentry-logs it. Project creation still cannot fail from this path.

The early guard (non-default project type / no organization) stays silent on purpose: previews would flood the event with non-onboarding invocations, so the funnel denominator is default-project creations.

**`playground_project.*`** (per `ensurePlaygroundProject` invocation, from `provisionPlaygroundProject`):
- `playground_project.provisioned` — now also carries `onboardingFlow` and `catalogIndexErrorType: string | null`. Catalog-index failure is non-fatal (the project is still handed to the user), so it is a property on the success event rather than a competing `.failed` event — this keeps provisioned/skipped/failed mutually exclusive per invocation.
- `playground_project.skipped` — new, with `reason`: `new_onboarding_flag_disabled` | `playground_already_exists` | `organization_has_project` | `no_project_access` | `playground_previously_removed`. Emitted before the corresponding denial throw where one exists, so the API behaviour is unchanged.
- `playground_project.failed` — new, with `errorType` and nullable `projectId`; emitted on fatal aborts (bundle load, project creation, explore-cache write, lock errors), then rethrown.

All events carry `organizationId`, `onboardingFlow` (`new`/`legacy`, from the flag actually checked), and — for playground — the existing `trigger`.

## Frontend

- `playground_project.setup_failed` — new, emitted in the `OnboardingInviteExpert` catch with `failureType` (`unavailable` | `previously-removed` | `forbidden` | `unknown`, the existing classification) and `organizationId`.
- `playground_project.entered` now carries `organizationId` so the entered/failed pair joins to the backend events.

## Tests

- `provisionOnboardingHomepage.test.ts`: every skip branch asserts its skipped event + reason, new failure tests for create/publish throws, success asserts `onboardingFlow`; each case asserts exactly one emission.
- `provisionPlaygroundProject.test.ts`: same treatment, plus a new previously-removed case and catalog-failure asserting `catalogIndexErrorType`.
- `OnboardingInviteExpert.test.tsx`: failure paths assert the `setup_failed` event and that `entered` is not emitted.

Note: the analytics vocabulary-freeze test was removed in #25974, so there is no freeze file to update.

Linear: SPK-678
Closes: SPK-678

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNfRnNKUzYvcmLA5fYxsKU
