### PR TITLE
feat(analytics): stamp onboardingFlow on the shared connection-form events

### DIFF
--- a/packages/frontend/src/components/ProjectConnection/CreateProjectconnection.tsx
+++ b/packages/frontend/src/components/ProjectConnection/CreateProjectconnection.tsx
@@ -10,7 +10,7 @@ import { Button } from '@mantine-8/core';
 import { useQueryClient } from '@tanstack/react-query';
 import confetti from 'canvas-confetti';
 import { useEffect, useMemo, useRef, useState, type FC } from 'react';
-import { useNavigate } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import { getProject, useCreateMutation } from '../../hooks/useProject';
 import useActiveJob from '../../providers/ActiveJob/useActiveJob';
 import useApp from '../../providers/App/useApp';
@@ -45,6 +45,10 @@ const CreateProjectConnection: FC<CreateProjectConnectionProps> = ({
     celebrateOnSuccess = false,
 }) => {
     const navigate = useNavigate();
+    const { pathname } = useLocation();
+    const onboardingFlow = pathname.startsWith('/onboarding/')
+        ? 'new'
+        : 'legacy';
     const queryClient = useQueryClient();
     const { user, health } = useApp();
     const [createProjectJobId, setCreateProjectJobId] = useState<string>();
@@ -99,6 +103,7 @@ const CreateProjectConnection: FC<CreateProjectConnectionProps> = ({
                         ? warehouseConnection.authenticationType
                         : undefined,
                 warehouseOnly,
+                onboardingFlow,
             },
         });
         if (selectedWarehouse) {
@@ -222,6 +227,7 @@ const CreateProjectConnection: FC<CreateProjectConnectionProps> = ({
                     warehouse: selectedWarehouse ?? form.values.warehouse.type,
                     errorType: failedStep?.stepType ?? 'unknown',
                     warehouseOnly,
+                    onboardingFlow,
                 },
             });
         }
@@ -230,6 +236,7 @@ const CreateProjectConnection: FC<CreateProjectConnectionProps> = ({
         createProjectJobId,
         selectedWarehouse,
         warehouseOnly,
+        onboardingFlow,
         track,
         form.values.warehouse.type,
     ]);

--- a/packages/frontend/src/hooks/useProject.ts
+++ b/packages/frontend/src/hooks/useProject.ts
@@ -19,6 +19,7 @@ import {
     useQueryClient,
     type UseQueryOptions,
 } from '@tanstack/react-query';
+import { useLocation } from 'react-router';
 import { lightdashApi } from '../api';
 import useActiveJob from '../providers/ActiveJob/useActiveJob';
 import useTracking from '../providers/Tracking/useTracking';
@@ -134,6 +135,10 @@ export const useCreateMutation = (options?: {
     const { setActiveJobId, setQuietActiveJobId } = useActiveJob();
     const { showToastApiError } = useToaster();
     const { track } = useTracking();
+    const { pathname } = useLocation();
+    const onboardingFlow = pathname.startsWith('/onboarding/')
+        ? 'new'
+        : 'legacy';
     return useMutation<ApiJobStartedResults, ApiError, CreateProject>(
         (data) => createProject(data),
         {
@@ -153,6 +158,7 @@ export const useCreateMutation = (options?: {
                         warehouse: data.warehouseConnection.type,
                         errorType: error.name,
                         warehouseOnly: options?.warehouseOnly,
+                        onboardingFlow,
                     },
                 });
                 showToastApiError({

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -604,6 +604,7 @@ type CreateProjectButtonClickedEvent = {
         warehouse: WarehouseTypes;
         authenticationType?: string;
         warehouseOnly?: boolean;
+        onboardingFlow: 'legacy' | 'new';
     };
 };
 
@@ -613,6 +614,7 @@ type CreateProjectFailedEvent = {
         warehouse: WarehouseTypes;
         errorType: string;
         warehouseOnly?: boolean;
+        onboardingFlow: 'legacy' | 'new';
     };
 };
 


### PR DESCRIPTION
Linear: SPK-675

## Problem

The new onboarding flow (`OnboardingDataSource`) and the legacy `/createProject/warehouse` route render the **same** `ConnectManuallyStep2` → `CreateProjectConnection` component with the **same** `warehouseOnly` prop. That makes `create_project_button.click` and `create_project.failed` byte-identical across the two arms, so the connection step is the one point in the funnel where exposure can't be attributed to a flow.

`warehouseOnly` is not a usable discriminator: it separates *manual-with-dbt* (`/createProject/manual`) from *warehouse-only*, which cuts across the legacy/new axis rather than along it. Both `/createProject/warehouse` and `/onboarding/data-source/:warehouse` pass it.

Every step either side of this one already carries `onboardingFlow` after #26298. This closes the gap in the middle, ahead of the new-onboarding rollout — exposure can't be labelled retroactively.

## Change

Adds `onboardingFlow: 'legacy' | 'new'` to `create_project_button.click` and `create_project.failed`, plus the corresponding event types.

The value is derived from the route the form is mounted on:

```ts
const { pathname } = useLocation();
const onboardingFlow = pathname.startsWith('/onboarding/') ? 'new' : 'legacy';
```

`CreateProjectConnection` only ever mounts under `/createProject/*` (legacy) or `/onboarding/data-source/*` (new), so the prefix is unambiguous.

**Why the route and not the feature flag** — this matches how #26298 derived the value: label the surface the user actually saw. It's also strictly more accurate here. An org with the flag enabled that adds a *subsequent* project still goes through `/createProject`; the flag would mislabel that journey `new`, while the route correctly reports `legacy`. Reading the route is also synchronous, so `create_project.failed` — which fires from a `useEffect` — can never emit an undefined value while a flag query is still loading.

## Also stamped: the other half of `create_project.failed`

`create_project.failed` has a second emitter, `useCreateMutation`'s `onError` in `hooks/useProject.ts`. The two are halves of the same submit: the component's effect catches **async job** failures (the warehouse adapter test runs inside the background job), while the hook catches **synchronous API** errors. Labelling only one would have left the same unattributable hole this change exists to close. That hook has exactly one caller — `CreateProjectConnection` — so it derives the value the same way, with no signature change.

The property is required (not optional) on both event types, matching #26298, so a future emitter can't silently omit it.

## Verification

- `pnpm -F frontend typecheck:fast` — clean
- `pnpm --filter frontend run linter <touched paths>` — 0 warnings, 0 errors
- `oxfmt --check <touched paths>` — correctly formatted
- `vitest run OnboardingDataSource.test.tsx Register.test.tsx AppRoute.test.tsx` — 3 files, 8 tests passed

No tests exist for the touched files. No behaviour changes — analytics properties only.
