### PR TITLE
fix(analytics): gate the verified onboarding step on the onboarding context

### DIFF
--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -1186,6 +1186,83 @@ describe('UserService', () => {
                 });
             });
         });
+
+        describe('onboarding step gating', () => {
+            const verifyEmailAs = async (user: SessionUser) => {
+                const service = createUserService(lightdashConfigMock, {
+                    featureFlagModel: createFeatureFlagModel(true),
+                });
+                const emailStatus = activeOtp();
+                emailModel.getPrimaryEmailStatusByUserAndOtp.mockResolvedValueOnce(
+                    emailStatus,
+                );
+                emailModel.verifyUserEmailIfExists.mockResolvedValueOnce([
+                    { email: emailStatus.email },
+                ]);
+
+                await service.getPrimaryEmailStatus(user, '123456');
+
+                return emailStatus;
+            };
+
+            test('emits the verified step when verifying during onboarding', async () => {
+                const onboardingUser: SessionUser = {
+                    ...sessionUser,
+                    isSetupComplete: false,
+                };
+
+                const emailStatus = await verifyEmailAs(onboardingUser);
+
+                expect(analyticsMock.track).toHaveBeenCalledWith({
+                    userId: onboardingUser.userUuid,
+                    event: 'user.verified',
+                    properties: {
+                        email: emailStatus.email,
+                        location: 'onboarding',
+                        isTrackingAnonymized:
+                            onboardingUser.isTrackingAnonymized,
+                        method: 'otp',
+                        onboardingFlow: 'new',
+                    },
+                });
+                expect(analyticsMock.track).toHaveBeenCalledWith({
+                    userId: onboardingUser.userUuid,
+                    event: 'onboarding.step_completed',
+                    properties: {
+                        step: 'verified',
+                        stepIndex: 2,
+                        onboardingFlow: 'new',
+                        organizationId: onboardingUser.organizationUuid,
+                    },
+                });
+            });
+
+            test('does not emit the verified step when verifying from settings', async () => {
+                const settingsUser: SessionUser = {
+                    ...sessionUser,
+                    isSetupComplete: true,
+                };
+
+                const emailStatus = await verifyEmailAs(settingsUser);
+
+                expect(analyticsMock.track).toHaveBeenCalledWith({
+                    userId: settingsUser.userUuid,
+                    event: 'user.verified',
+                    properties: {
+                        email: emailStatus.email,
+                        location: 'settings',
+                        isTrackingAnonymized: settingsUser.isTrackingAnonymized,
+                        method: 'otp',
+                        onboardingFlow: 'new',
+                    },
+                });
+                expect(analyticsMock.track).not.toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        event: 'onboarding.step_completed',
+                    }),
+                );
+            });
+        });
     });
 
     describe('resetPassword', () => {

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -382,27 +382,30 @@ export class UserService extends BaseService {
         );
         if (updatedEmails.length > 0) {
             const onboardingFlow = await this.getOnboardingFlow(user);
+            const location = user.isSetupComplete ? 'settings' : 'onboarding';
             this.analytics.track({
                 userId: user.userUuid,
                 event: 'user.verified',
                 properties: {
                     email,
-                    location: user.isSetupComplete ? 'settings' : 'onboarding',
+                    location,
                     isTrackingAnonymized: user.isTrackingAnonymized,
                     method,
                     onboardingFlow,
                 },
             });
-            this.analytics.track({
-                userId: user.userUuid,
-                event: 'onboarding.step_completed',
-                properties: {
-                    step: 'verified',
-                    stepIndex: 2,
-                    onboardingFlow,
-                    organizationId: user.organizationUuid,
-                },
-            });
+            if (location === 'onboarding') {
+                this.analytics.track({
+                    userId: user.userUuid,
+                    event: 'onboarding.step_completed',
+                    properties: {
+                        step: 'verified',
+                        stepIndex: 2,
+                        onboardingFlow,
+                        organizationId: user.organizationUuid,
+                    },
+                });
+            }
         }
     }
 


### PR DESCRIPTION
## What

`UserService.tryVerifyUserEmail` emitted `onboarding.step_completed{ step: 'verified' }` on every successful email verification, with no check on where the verification happened. Email verification also happens from Settings, long after setup is complete, so the `verified` funnel stage counted people who were never in an onboarding journey at all — it sits well above the `signup` stage it is meant to follow.

This gates the onboarding step emission on the onboarding context. `user.verified` is untouched: it still fires for both locations with the same `location` property, so its consumers are unaffected.

## How

`location` — already computed as `user.isSetupComplete ? 'settings' : 'onboarding'` — is hoisted to a local and reused as the gate, so the funnel gate cannot drift from the location reported on `user.verified`. There is no caller-supplied location to key off: the only caller-supplied argument is `method` (`'otp' | 'link' | 'sso'`), which describes how the email was verified, not where.

## Why now

Ahead of the new-onboarding rollout. With the step ungated, a legacy-vs-new signup→verified comparison is skewed from the first hour of traffic: the legacy arm's numerator is inflated by established users re-verifying an email in Settings, which makes the new flow look worse for purely mechanical reasons.

## Testing

Two unit tests in `UserService.test.ts` (`email OTP login > onboarding step gating`):

- verifying during onboarding still emits both `user.verified` and `onboarding.step_completed`
- verifying from Settings emits `user.verified` only

The Settings test was confirmed to fail against the previous behaviour and pass with the gate in place.

- `pnpm -F backend run test src/services/UserService.test.ts` → 107 passed
- `pnpm -F backend typecheck` → clean
- `pnpm --filter backend run linter packages/backend/src/services/UserService{,.test}.ts` → clean

Linear: SPK-674
