### PR TITLE
fix: spread preview DB restores across several snapshot copies

### DIFF
--- a/okteto.preview.yaml
+++ b/okteto.preview.yaml
@@ -18,11 +18,19 @@ deploy:
         # (DB_DIVERT=false, computed from changed files in pr.yml).
         SNAPSHOT=""
         if [ "${DB_DIVERT:-true}" = "true" ]; then
-          SNAPSHOT=$(kubectl get volumesnapshots -n db-snapshot \
+          # The refresh workflow publishes several identical copies; pick one
+          # at random so concurrent previews spread their restores across GCP
+          # snapshot resources (GCP rate-limits disk creation per snapshot),
+          # and a retried deploy naturally lands on a different copy
+          CANDIDATES=$(kubectl get volumesnapshots -n db-snapshot \
             -l app.kubernetes.io/part-of=lightdash-preview-db \
             --sort-by=.metadata.creationTimestamp \
             -o jsonpath='{range .items[?(@.status.readyToUse==true)]}{.metadata.name}{"\n"}{end}' \
-            2>/dev/null | tail -n 1 || true)
+            2>/dev/null | tail -n 3 || true)
+          COUNT=$(echo "$CANDIDATES" | grep -c . || true)
+          if [ "$COUNT" -gt 0 ]; then
+            SNAPSHOT=$(echo "$CANDIDATES" | sed -n "$(( $(date +%s) % COUNT + 1 ))p")
+          fi
         fi
         if [ -n "$SNAPSHOT" ]; then
           echo "Diverting preview database to snapshot db-snapshot/$SNAPSHOT"

--- a/scripts/preview-db-snapshot.sh
+++ b/scripts/preview-db-snapshot.sh
@@ -8,8 +8,12 @@ set -euo pipefail
 # .github/workflows/preview-db-snapshot.yml.
 
 NAMESPACE="${DB_SNAPSHOT_NAMESPACE:-db-snapshot}"
-SNAPSHOT_NAME="preview-db-${1:?usage: preview-db-snapshot.sh <suffix, e.g. short sha>}"
-KEEP=3
+SUFFIX="${1:?usage: preview-db-snapshot.sh <suffix, e.g. short sha>}"
+# GCP rate-limits disk creation per source snapshot, so publish several
+# identical copies and let previews spread their restores across them
+# (okteto.preview.yaml picks one at random). Keep two generations.
+COPIES=3
+KEEP=6
 
 is_seeded() {
     [ "$(kubectl -n "$NAMESPACE" exec statefulset/db-preview -- psql -U postgres -tAc \
@@ -34,7 +38,12 @@ done
 # Flush to disk so the snapshot restores without WAL replay
 kubectl -n "$NAMESPACE" exec statefulset/db-preview -- psql -U postgres -c "CHECKPOINT;"
 
-kubectl -n "$NAMESPACE" apply -f - <<EOF
+# Sequential creation (waiting for ready between copies) also spaces the
+# snapshot-create operations, which GCP rate-limits per source disk
+ready_count=0
+for i in $(seq 1 "$COPIES"); do
+    SNAPSHOT_NAME="preview-db-${SUFFIX}-${i}"
+    kubectl -n "$NAMESPACE" apply -f - <<EOF
 apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshot
 metadata:
@@ -47,21 +56,29 @@ spec:
     persistentVolumeClaimName: db-data
 EOF
 
-echo "Waiting for ${SNAPSHOT_NAME} to be ready..."
-ready=""
-for _ in $(seq 1 60); do
-    if [ "$(kubectl -n "$NAMESPACE" get volumesnapshot "$SNAPSHOT_NAME" -o jsonpath='{.status.readyToUse}' 2>/dev/null)" = "true" ]; then
-        ready=true
-        break
+    echo "Waiting for ${SNAPSHOT_NAME} to be ready..."
+    ready=""
+    for _ in $(seq 1 60); do
+        if [ "$(kubectl -n "$NAMESPACE" get volumesnapshot "$SNAPSHOT_NAME" -o jsonpath='{.status.readyToUse}' 2>/dev/null)" = "true" ]; then
+            ready=true
+            break
+        fi
+        sleep 10
+    done
+    if [ -n "$ready" ]; then
+        ready_count=$((ready_count + 1))
+        echo "Snapshot ${NAMESPACE}/${SNAPSHOT_NAME} is ready"
+    else
+        # Previews only consider readyToUse snapshots, so a straggler is
+        # harmless; delete it and carry on with the copies that worked
+        echo "Timed out waiting for ${SNAPSHOT_NAME}; removing it"
+        kubectl -n "$NAMESPACE" delete volumesnapshot "$SNAPSHOT_NAME" --ignore-not-found
     fi
-    sleep 10
 done
-[ -n "$ready" ] || {
-    echo "Timed out waiting for the snapshot to be ready"
-    kubectl -n "$NAMESPACE" get volumesnapshot "$SNAPSHOT_NAME" -o yaml || true
+[ "$ready_count" -gt 0 ] || {
+    echo "No snapshot copy became ready"
     exit 1
 }
-echo "Snapshot ${NAMESPACE}/${SNAPSHOT_NAME} is ready"
 
 # Previews always divert from the newest ready snapshot; keep a few for safety
 snapshots=$(kubectl -n "$NAMESPACE" get volumesnapshots \


### PR DESCRIPTION
Preview deploys kept failing with GCP `RESOURCE_OPERATION_RATE_EXCEEDED` even after the blank-volume fallback (#26318): with a single snapshot, **every preview clone in the cluster restores from the same GCP snapshot resource**, and once a burst trips the per-snapshot rate limit, the Pending PVCs across namespaces keep retrying against it — the combined retry traffic never lets the limit drain (thundering herd). PR #25503 hit this repeatedly this afternoon.

Fix, per GCP's guidance for fan-out from one source:

- `scripts/preview-db-snapshot.sh` publishes **3 identical copies** per refresh (`preview-db-<sha>-1..3`), created sequentially with a ready-wait between each — which also spaces out GCP's per-disk snapshot-*creation* limit. A copy that never goes ready is deleted and tolerated; at least one must succeed. Retention keeps two generations (6).
- `okteto.preview.yaml` discovery picks **one of the newest 3 ready copies at random** instead of always the newest — concurrent previews spread across 3 GCP resources, and a retried deploy naturally lands on a different copy.

**Current state**: I've deleted the existing snapshots (kill switch), so previews are on the full-seed fallback and green. Merging this re-triggers the snapshot workflow, which publishes the first 3-copy generation and re-enables divert.

Note on rollout: okteto reads `okteto.preview.yaml` from the raw PR branch, so open PRs pick up new deploy behaviour (divert, fallback, spread) only after updating from main.

Relates: SPK-297

https://claude.ai/code/session_01RmebrVJwigL6JnggGwpzQR