### PR TITLE
fix(data-apps): fix app viz picker search and add clear button

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -76,7 +76,7 @@ export const ConfigTabs: FC = memo(() => {
                         projectUuid={projectUuid ?? ''}
                         selectedDataAppVizUuid={dataAppVizUuid || null}
                         selectedDataAppViz={dataAppViz ?? null}
-                        onSelect={setDataAppVizUuid}
+                        onSelect={(uuid) => setDataAppVizUuid(uuid ?? '')}
                     />
                 </Config.Section>
             </Config>

--- a/packages/frontend/src/features/apps/components/DataAppVizLibraryPicker.test.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizLibraryPicker.test.tsx
@@ -1,6 +1,5 @@
 import { type DataAppViz } from '@lightdash/common';
-import { fireEvent, screen } from '@testing-library/react';
-import { type ReactElement } from 'react';
+import { act, fireEvent, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../testing/testUtils';
 import { useDataAppVisualizations } from '../hooks/useDataAppVisualizations';
@@ -40,15 +39,18 @@ const setData = (data: DataAppViz[]) => {
     } as unknown as ReturnType<typeof useDataAppVisualizations>);
 };
 
-const render = (onSelect: (id: string) => void): ReactElement =>
+const render = (
+    onSelect: (id: string | null) => void,
+    selected: DataAppViz | null = null,
+) =>
     renderWithProviders(
         <DataAppVizLibraryPicker
             projectUuid="project-1"
-            selectedDataAppVizUuid={null}
-            selectedDataAppViz={null}
+            selectedDataAppVizUuid={selected?.dataAppVizUuid ?? null}
+            selectedDataAppViz={selected}
             onSelect={onSelect}
         />,
-    ) as unknown as ReactElement;
+    );
 
 // Options live in the Select dropdown, which only mounts once opened.
 const openDropdown = () =>
@@ -82,6 +84,54 @@ describe('DataAppVizLibraryPicker', () => {
         fireEvent.click(screen.getByText('Pick me'));
 
         expect(onSelect).toHaveBeenCalledWith('picked');
+    });
+
+    it('lists the whole library while the input still holds the selected label', () => {
+        vi.useFakeTimers();
+        try {
+            const selected = makeDataAppViz({
+                dataAppVizUuid: 'a',
+                name: 'Radial gauge',
+            });
+            setData([
+                selected,
+                makeDataAppViz({ dataAppVizUuid: 'b', name: 'Bar race' }),
+            ]);
+            render(vi.fn(), selected);
+            // Mantine fills the input with the selected label on mount; let the
+            // search debounce settle so a real query would have been issued.
+            act(() => {
+                vi.advanceTimersByTime(500);
+            });
+            openDropdown();
+
+            expect(mockedUseDataAppVisualizations).toHaveBeenLastCalledWith(
+                'project-1',
+                '',
+            );
+            expect(screen.getByText('Bar race')).toBeDefined();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('clears the selection with the clear button', () => {
+        const selected = makeDataAppViz({
+            dataAppVizUuid: 'a',
+            name: 'Radial gauge',
+        });
+        setData([selected]);
+        const onSelect = vi.fn();
+        const { container } = render(onSelect, selected);
+
+        // Mantine's clear button is aria-hidden, so it isn't role-queryable.
+        const clearButton = container.querySelector(
+            '.mantine-8-InputClearButton-root',
+        );
+        expect(clearButton).not.toBeNull();
+        fireEvent.click(clearButton!);
+
+        expect(onSelect).toHaveBeenCalledWith(null);
     });
 
     it('shows an empty state when there are no bindable vizs', () => {

--- a/packages/frontend/src/features/apps/components/DataAppVizLibraryPicker.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizLibraryPicker.tsx
@@ -10,7 +10,7 @@ type Props = {
     projectUuid: string;
     selectedDataAppVizUuid: string | null;
     selectedDataAppViz: DataAppViz | null;
-    onSelect: (dataAppVizUuid: string) => void;
+    onSelect: (dataAppVizUuid: string | null) => void;
 };
 
 interface DataAppVizItem extends ComboboxItem {
@@ -38,7 +38,19 @@ const DataAppVizLibraryPicker: FC<Props> = ({
     onSelect,
 }) => {
     const [search, setSearch] = useState('');
-    const [debouncedSearch] = useDebouncedValue(search, 300);
+    const selectedLabel = selectedDataAppViz
+        ? getAppDisplayName(
+              selectedDataAppViz.name,
+              selectedDataAppViz.dataAppVizUuid,
+          )
+        : null;
+    // Mantine puts the selected option's label in the input, which is not a
+    // query the user typed. Mirror Mantine's own `filterOptions` rule so the
+    // whole library stays listed until they actually type something else.
+    const [debouncedSearch] = useDebouncedValue(
+        search === selectedLabel ? '' : search,
+        300,
+    );
 
     const { data, isInitialLoading, isFetching, error } =
         useDataAppVisualizations(projectUuid, debouncedSearch);
@@ -66,10 +78,9 @@ const DataAppVizLibraryPicker: FC<Props> = ({
             onSearchChange={setSearch}
             // Search is done server-side, so keep every returned option.
             filter={({ options }) => options}
-            onChange={(value) => {
-                if (value) onSelect(value);
-            }}
+            onChange={(value) => onSelect(value)}
             allowDeselect={false}
+            clearable
             placeholder="Select a visualization"
             nothingFoundMessage={
                 error


### PR DESCRIPTION
Two fixes to the **Data app visualization** picker in the Explorer chart config.

### 1. Selecting a viz collapsed the dropdown to just that viz

Mantine puts the selected option's label into the input and internally treats "search text == selected label" as *not* a search (`filterOptions: searchable && selectedOption?.label !== search`) — which is why client-filtered selects look fine. This picker searches server-side, so it was passing that label straight to the list endpoint as `search` and getting back only the one matching app. You had to manually clear the text to browse the library again.

The picker now mirrors Mantine's own rule: when the search text equals the selected label, the query goes out empty. Typing still narrows normally.

### 2. No clear button

Added `clearable`, matching `FieldSelect` — the field selects directly below it in the same panel already have an X. `onSelect` now takes `string | null`, and `DataAppVizConfigTabs` maps null to the empty uuid the config already uses for "nothing selected". Clearing drops the field mapping and the chart falls back to its existing "Pick a data app visualization to render." placeholder.

### Testing

Two new cases in `DataAppVizLibraryPicker.test.tsx`. The search one uses fake timers so the debounce actually fires — verified it fails when the fix is reverted.

Manually verified in the Explorer: with a viz selected, reopening the dropdown lists the whole library; searching narrows correctly; the X clears back to the placeholder state.

Closes: GLITCH-640
