### PR TITLE
fix: bound the diverted preview deploy so the blank-volume retry always runs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -355,9 +355,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           name: pr-${{ github.event.number }}
-          # Generous enough for a failed snapshot divert plus the blank-volume
+          # Covers a bounded diverted attempt (18m) plus the blank-volume
           # retry with a full migrate + seed (see okteto.preview.yaml)
-          timeout: 30m
+          timeout: 40m
           file: okteto.preview.yaml
           variables: SITE_URL=https://lightdash-preview-pr-${{ github.event.number }}.lightdash.okteto.dev,DB_DIVERT=${{ needs.files-changed.outputs.db_divert }},TURBO_TEAM=${{ vars.TURBO_TEAM }},TURBO_TOKEN=${{ secrets.TURBO_TOKEN }}
 

--- a/okteto.preview.yaml
+++ b/okteto.preview.yaml
@@ -59,14 +59,16 @@ deploy:
         if [ -n "${DB_SNAPSHOT_NAME:-}" ]; then
           # Divert must never break preview creation: cloning can fail at
           # deploy time (e.g. GCP throttles disk creation per source snapshot
-          # when several previews deploy at once). Recreate the volume blank
-          # and take the full migrate + seed path instead.
-          if ! okteto deploy -f docker/docker-compose.preview.yml; then
+          # when several previews deploy at once). The explicit timeout keeps
+          # a clone that hangs in Pending from eating the whole pipeline
+          # window, so the fallback below always gets its turn: recreate the
+          # volume blank and take the full migrate + seed path instead.
+          if ! okteto deploy -f docker/docker-compose.preview.yml --timeout 18m; then
             echo "Diverted deploy failed: retrying with a blank database volume"
             kubectl delete statefulset db-preview --ignore-not-found --wait
             kubectl delete pvc db-data --ignore-not-found --wait
             export DB_SNAPSHOT_NAME="" DB_SNAPSHOT_NAMESPACE=""
-            okteto deploy -f docker/docker-compose.preview.yml
+            okteto deploy -f docker/docker-compose.preview.yml --timeout 20m
           fi
         else
           okteto deploy -f docker/docker-compose.preview.yml


### PR DESCRIPTION
During today's snapshot-throttling incident, diverted deploys didn't *fail* — they **hung** with the PVC in Pending while GCP throttled the clone, waited out the entire pipeline window, and the blank-volume fallback from #26318 never got a chance to run.

Fix: give the diverted attempt an explicit `--timeout 18m` (headroom for the image build + a healthy divert, which lands well under 10m) so a stuck clone fails fast, give the blank-volume retry `--timeout 20m` (full migrate + seed with a warm image cache), and widen the `deploy-preview` window to 40m to fit the worst case of both.

Second layer of the don't-let-this-happen-again work; pairs with #26343 (spread restores across snapshot copies) and the upcoming automatic circuit breaker.

Relates: SPK-297

https://claude.ai/code/session_01RmebrVJwigL6JnggGwpzQR