### PR TITLE
docs(pr-skill): PR bodies must never quote Slack/internal-comms content

### DIFF
--- a/.claude/skills/creating-pull-requests/SKILL.md
+++ b/.claude/skills/creating-pull-requests/SKILL.md
@@ -13,9 +13,10 @@ Conventions for every PR body in this repo. Applies regardless of whether the PR
 ## Rules
 
 1. **Never mention client/customer names or their data examples** anywhere in the PR title, description, or commit messages. Redact to generic terms ("a customer", "an org", "example values") even when a Linear ticket or issue references the customer by name.
-2. **Always close or reference a Linear ticket.** Every PR links to a Linear ticket — `Closes: PROD-XXXX` to close it, or `Relates: PROD-XXXX` if it shouldn't auto-close. **If no ticket is provided, do not fabricate one and do not silently omit it** — flag it to the developer and ask for the ticket. Only open the PR without a ticket once they explicitly confirm there isn't one.
-3. **If a GitHub issue exists, reference or close it.** Use `Closes: #XXXXX` to close, `Relates: #XXXXX` otherwise.
-4. **Subticket → parent's GitHub issue is `Relates`, not `Closes`.** A subticket's PR should not close the parent's tracking issue; add it as related.
+2. **Never quote, summarize, or attribute Slack messages or other internal-communication content** anywhere in the PR title, description, or commit messages — even when Slack/internal chatter was used as an investigation or evidence source. Cite only that the signal was checked and what it showed, in generic terms (no channel names, no quoted text, no who-said-what).
+3. **Always close or reference a Linear ticket.** Every PR links to a Linear ticket — `Closes: PROD-XXXX` to close it, or `Relates: PROD-XXXX` if it shouldn't auto-close. **If no ticket is provided, do not fabricate one and do not silently omit it** — flag it to the developer and ask for the ticket. Only open the PR without a ticket once they explicitly confirm there isn't one.
+4. **If a GitHub issue exists, reference or close it.** Use `Closes: #XXXXX` to close, `Relates: #XXXXX` otherwise.
+5. **Subticket → parent's GitHub issue is `Relates`, not `Closes`.** A subticket's PR should not close the parent's tracking issue; add it as related.
 
 ## Footer Format
 
@@ -36,6 +37,7 @@ Relates: #22801
 ## Checklist Before Opening
 
 - [ ] No client/customer name or their data anywhere in the title, body, or commits
+- [ ] No quoted/summarized Slack or internal-communication content anywhere in the title, body, or commits
 - [ ] A `Closes:`/`Relates:` line for a Linear ticket is present, OR the developer explicitly confirmed there's no ticket
 - [ ] If a GitHub issue exists, a `Closes:`/`Relates:` line for it is present
 - [ ] Subtickets relate (not close) the parent's GitHub issue


### PR DESCRIPTION
## Summary
- The `creating-pull-requests` skill's confidentiality rule was implicit ("generic terms"); make it explicit: never quote, summarize, or attribute Slack/internal-communication content in a PR title/description/commit, even when it was used as an investigation/evidence source.
- Adds the same rule to the checklist.

Closes: SPK-691