### PR TITLE
chore: exercise backend and frontend preview build

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -6,7 +6,7 @@ import knexConfig from './knexfile';
 import Logger from './logging/logger';
 import { getProcessTimezoneWarning } from './utils/processTimezone';
 
-// trigger BE tests
+// Trigger backend preview build.
 
 // Winston (handleExceptions/handleRejections in winston.ts) owns structured logging
 // for both events. Logger uses exitOnError: false so rejections are tolerated.

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -41,6 +41,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
+// Trigger frontend preview build.
 const container = document.getElementById('root');
 if (!container) throw new Error('Root element not found!');
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates: #26312

### Description:
This is an intentionally no-op backend and frontend change created to trigger deploy-preview and measure the preview build after the runtime payload and remote-cache optimizations in #26312.

Do not merge. Use the preview deployment logs and duration for analysis.