### PR TITLE
chore: test frontend preview build optimisations

### DIFF
--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -24,7 +24,10 @@
 
         <title>Lightdash</title>
     </head>
-    <body data-color-mode="light">
+    <body
+        data-color-mode="light"
+        data-preview-build-probe="frontend-optimisations"
+    >
         <noscript>You need to enable JavaScript to run this app.</noscript>
         <div id="root"></div>
 


### PR DESCRIPTION
## Summary

Analysis-only PR to measure the preview build optimisations introduced in #26312. Do not merge.

- adds a behavior-neutral attribute to the built frontend HTML
- invalidates the frontend build input while leaving application behavior unchanged
- exercises the standard preview image build and deployment path

## Analysis

Compare the Deploy Preview job duration, Docker layer cache hits, deployment payload assembly, and image push size with the pre-#26312 path.

## Validation

- `git diff --check`
- HTML parsed successfully with Python standard library
- `pnpm -F frontend build` could not run locally because this workspace has no `node_modules`; CI will run the production build