### PR TITLE
feat: circuit breaker for preview DB snapshot diverts

### DIFF
--- a/.github/workflows/preview-db-guard.yml
+++ b/.github/workflows/preview-db-guard.yml
@@ -1,0 +1,68 @@
+name: Preview DB Guard
+
+# Circuit breaker for preview database snapshot diverts: when diverted
+# preview deploys keep failing (e.g. GCP throttling snapshot restores),
+# delete the snapshots so every preview — including branches with older
+# manifests — falls back to the full migrate + seed path, and alert Slack.
+# Snapshots are republished by the next Preview DB Snapshot run.
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: preview-db-guard
+  cancel-in-progress: false
+
+jobs:
+  guard:
+    name: Check diverted preview deploys
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Count recent diverted deploy failures
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./scripts/preview-db-guard.sh
+
+      - name: Install Okteto CLI
+        if: steps.check.outputs.tripped == 'true'
+        run: |
+          curl -sSfL -o okteto https://github.com/okteto/okteto/releases/download/3.21.0/okteto-Linux-x86_64
+          chmod +x okteto
+          sudo mv okteto /usr/local/bin/okteto
+
+      - name: Trip the breaker
+        id: breaker
+        if: steps.check.outputs.tripped == 'true'
+        run: |
+          okteto context use "${{ secrets.OKTETO_CONTEXT }}" --token "${{ secrets.OKTETO_TOKEN }}"
+          okteto kubeconfig
+          deleted=$(kubectl -n db-snapshot get volumesnapshots -o name | wc -l | tr -d ' ')
+          kubectl -n db-snapshot delete volumesnapshots --all --ignore-not-found
+          echo "deleted=${deleted}" >> "$GITHUB_OUTPUT"
+          echo "Deleted ${deleted} snapshot(s); previews now fall back to full migrate + seed"
+
+      # Only alert when the breaker actually removed snapshots, so a
+      # still-tripped check on the next schedule doesn't re-alert
+      - name: Alert Slack
+        if: steps.check.outputs.tripped == 'true' && steps.breaker.outputs.deleted != '0'
+        run: |
+          curl -sf -X POST -H 'Content-type: application/json' \
+            --data "{
+              \"username\": \"Preview DB Guard\",
+              \"text\": \":rotating_light: Preview DB snapshot circuit breaker tripped: ${{ steps.check.outputs.failures }} diverted preview deploys failed in the last 90 minutes. Snapshots deleted — previews now build their database from scratch (slower but reliable). Affected PRs just need their checks re-run. Snapshots republish on the next <${{ github.server_url }}/${{ github.repository }}/actions/workflows/preview-db-snapshot.yml|Preview DB Snapshot> run; investigate before dispatching one manually.\\n\\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Guard run details>\"
+            }" \
+            ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -9,6 +9,13 @@ preview environments can divert from it instead of migrating + seeding from
 scratch. Run by `.github/workflows/preview-db-snapshot.yml` on merges to main
 that change migrations, seeds, or the jaffle demo project.
 
+### `preview-db-guard.sh`
+
+Circuit breaker for snapshot diverts: counts recent Deploy Preview failures
+that had diverted from a DB snapshot. Run every 30 minutes by
+`.github/workflows/preview-db-guard.yml`, which deletes the snapshots when the
+threshold trips (previews fall back to full migrate + seed) and alerts Slack.
+
 ### `okteto-ssh.sh <pr_number>`
 
 SSH into a preview environment pod.

--- a/scripts/preview-db-guard.sh
+++ b/scripts/preview-db-guard.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -euo pipefail
+
+# Circuit breaker for preview database snapshot diverts (see
+# okteto.preview.yaml). Counts recent Deploy Preview failures whose deploy
+# actually diverted from a snapshot; past the threshold something systemic is
+# wrong (e.g. GCP throttling restores from the snapshot), and the caller
+# deletes the snapshots so every preview falls back to the full
+# migrate + seed path — including branches with older manifests.
+# Runs from .github/workflows/preview-db-guard.yml.
+
+LOOKBACK_MINUTES=90
+THRESHOLD=3
+REPO="${GITHUB_REPOSITORY:-lightdash/lightdash}"
+
+since=$(date -u -d "-${LOOKBACK_MINUTES} minutes" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
+    date -u -v "-${LOOKBACK_MINUTES}M" +%Y-%m-%dT%H:%M:%SZ)
+
+failures=0
+for run_id in $(gh run list -R "$REPO" --workflow=pr.yml --created ">${since}" \
+    --limit 50 --json databaseId --jq '.[].databaseId'); do
+    job_id=$(gh run view "$run_id" -R "$REPO" --json jobs \
+        --jq '.jobs[] | select(.name == "Deploy Preview" and .conclusion == "failure") | .databaseId' \
+        2>/dev/null || true)
+    [ -n "$job_id" ] || continue
+    if gh api "repos/${REPO}/actions/jobs/${job_id}/logs" 2>/dev/null |
+        grep -aq "Diverting preview database"; then
+        failures=$((failures + 1))
+        echo "diverted deploy failure: run ${run_id}"
+    fi
+done
+
+echo "Diverted deploy failures in the last ${LOOKBACK_MINUTES} minutes: ${failures} (threshold ${THRESHOLD})"
+{
+    echo "failures=${failures}"
+    if [ "$failures" -ge "$THRESHOLD" ]; then
+        echo "tripped=true"
+    else
+        echo "tripped=false"
+    fi
+} >> "${GITHUB_OUTPUT:-/dev/null}"


### PR DESCRIPTION
Today's GCP snapshot-restore throttling failed preview deploys **silently for ~6 hours** (35 deploys across ~26 branches). Two structural facts made it worse: diverted deploys *hung* rather than failed, and okteto reads `okteto.preview.yaml` from the raw PR branch — so manifest-level fallbacks don't protect branches that haven't updated from main. The one lever that reaches every branch is server-side: **delete the snapshots**, and every deploy's discovery comes up empty → blank volume → full migrate + seed.

This automates that lever:

- `scripts/preview-db-guard.sh` — counts Deploy Preview failures in the last 90 minutes whose logs show the deploy diverted from a snapshot (validated against today's incident data — correctly identifies the failures).
- `.github/workflows/preview-db-guard.yml` — runs it every 30 minutes; at ≥3 such failures it deletes all snapshots in `db-snapshot` and posts to Slack (`SLACK_WEBHOOK_URL`, same pattern as the AI agent tests). Alerts only when it actually deleted something, so a still-tripped state doesn't re-alert every half hour. Snapshots republish on the next Preview DB Snapshot run (next data-affecting merge to main or manual dispatch), which naturally closes the breaker.

Worst case with the full stack in place (#26343 spread + #26348 bounded attempt + this): a throttling event costs affected PRs one slow preview or one re-run, and the team hears about it within ~30 minutes instead of finding out at standup.

Relates: SPK-297

https://claude.ai/code/session_01RmebrVJwigL6JnggGwpzQR