### PR TITLE
fix(homepage): keep dashboard tiles out of Recently viewed

### DIFF
--- a/packages/backend/src/database/entities/analytics.ts
+++ b/packages/backend/src/database/entities/analytics.ts
@@ -34,7 +34,8 @@ export type AnalyticsDashboardViews = Knex.CompositeTableType<
 
 export type AnalyticsChartViews = Knex.CompositeTableType<
     DbAnalyticsChartViews,
-    Pick<DbAnalyticsChartViews, 'chart_uuid' | 'user_uuid'>
+    Pick<DbAnalyticsChartViews, 'chart_uuid' | 'user_uuid'> &
+        Partial<Pick<DbAnalyticsChartViews, 'context'>>
 >;
 
 export type AnalyticsAppViews = Knex.CompositeTableType<

--- a/packages/backend/src/ee/models/ProjectHomepageModel.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.ts
@@ -201,6 +201,19 @@ export class ProjectHomepageModel {
                   AND p.project_uuid = :projectUuid
                   AND sq.deleted_at IS NULL
                   AND s.deleted_at IS NULL
+                  -- Opening a dashboard records a view for every tile on it,
+                  -- which would bury the dashboard the user actually opened.
+                  -- Tiles are tagged where we can, but several code paths
+                  -- write untagged rows, so also drop chart views that land
+                  -- in the moments around one of this user's dashboard views.
+                  AND (acv.context ->> 'source') IS DISTINCT FROM 'dashboard'
+                  AND NOT EXISTS (
+                      SELECT 1
+                      FROM analytics_dashboard_views tile_dv
+                      WHERE tile_dv.user_uuid = acv.user_uuid
+                        AND acv.timestamp BETWEEN tile_dv.timestamp - interval '2 seconds'
+                                              AND tile_dv.timestamp + interval '15 seconds'
+                  )
                 UNION ALL
                 SELECT 'dashboard' AS content_type,
                        adv.dashboard_uuid AS content_uuid,

--- a/packages/backend/src/models/AnalyticsModel.ts
+++ b/packages/backend/src/models/AnalyticsModel.ts
@@ -84,11 +84,15 @@ export class AnalyticsModel {
     async addChartViewEvent(
         chartUuid: string,
         userUuid: string | null,
+        /** Set when the chart was rendered as a dashboard tile rather than
+         * opened on its own — recently-viewed excludes those. */
+        context?: { source: 'dashboard'; dashboardUuid: string },
     ): Promise<void> {
         await this.database.transaction(async (trx) => {
             await trx(AnalyticsChartViewsTableName).insert({
                 chart_uuid: chartUuid,
                 user_uuid: userUuid,
+                context: context ?? null,
             });
             await trx(SavedChartsTableName)
                 .update({

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -5294,6 +5294,12 @@ export class AsyncQueryService extends ProjectService {
             .addChartViewEvent(
                 savedChart.uuid,
                 account.isRegisteredUser() ? account.user.id : null,
+                resolvedDashboardUuid
+                    ? {
+                          source: 'dashboard',
+                          dashboardUuid: resolvedDashboardUuid,
+                      }
+                    : undefined,
             )
             .catch((e) =>
                 this.logger.warn('Failed to track chart view event', {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -5008,6 +5008,7 @@ export class ProjectService extends BaseService {
         await this.analyticsModel.addChartViewEvent(
             savedChart.uuid,
             account.user.id,
+            dashboardUuid ? { source: 'dashboard', dashboardUuid } : undefined,
         );
 
         const availableFieldIds = getAvailableFilterFieldIds(explore);


### PR DESCRIPTION
## What

Opening a dashboard records a chart view for **every tile on it**, timestamped a fraction of a second *after* the dashboard's own view. A six-tile dashboard therefore pushed itself out of the top four of "Recently viewed" — you'd open a dashboard, go home, and see its tiles instead of the dashboard.

Reproduced on a 6-tile dashboard: 6 chart rows at `17:39:10` and one dashboard row at `17:39:09`, putting the dashboard at position 7.

## How

Two layers, because one wasn't enough:

1. `addChartViewEvent` takes an optional `{ source: 'dashboard', dashboardUuid }` context, passed at the call sites where the dashboard uuid is in scope. The recently-viewed query drops those rows.
2. **Not every path is taggable.** `AsyncQueryService.executeAsyncSavedChartQuery` and `SavedChartService.get` also record a view per tile and have no dashboard uuid in scope — verified by seeing 6 tagged *and* 6 untagged rows land at the same millisecond. So the query also skips chart views falling in a window (−2s/+15s) around one of the same user's dashboard views.

## Regression analysis

The behaviour change is scoped to the homepage's recently-viewed list. `views_count`, `first_viewed_at` and the analytics tables themselves are untouched, so view statistics, "most popular" and unused-content reporting are unaffected. The new `context` column value is additive — historical rows are all `NULL` and keep behaving exactly as before.

The time window is a **heuristic and the weak point**: if someone opens a dashboard and clicks into a chart within 15 seconds, that chart view is dropped from their recently-viewed. The principled fix is to thread dashboard context into the two remaining call sites and delete the window; I'd treat this as a stopgap rather than the end state.

## Testing

Verified against a running backend:
- Open a 6-tile dashboard → it now ranks **#1**, above its own tiles.
- Open a chart directly → it ranks **#1**, so direct chart views are not swallowed.
- Confirmed in the DB that tile views carry the dashboard context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KedCujEdGmuSsgY6ieWgh9