### PR TITLE
feat(onboarding): collect "How did you hear about us?" during signup

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -173,6 +173,17 @@ export type UpdateUserEvent = BaseTrack & {
     };
 };
 
+type HearAboutUsSubmittedEvent = BaseTrack & {
+    event: 'hear_about_us.submitted';
+    userId: string;
+    properties: {
+        organizationId: string;
+        onboardingFlow: OnboardingFlow;
+        answered: boolean;
+        answer: string | null;
+    };
+};
+
 function isUserUpdatedEvent(event: BaseTrack): event is UpdateUserEvent {
     return event.event === 'user.updated';
 }
@@ -2887,6 +2898,7 @@ type TypedEvent =
     | TrackSimpleEvent
     | CreateUserEvent
     | UpdateUserEvent
+    | HearAboutUsSubmittedEvent
     | DeleteUserEvent
     | VerifiedUserEvent
     | OneTimePasscodeSentEvent

--- a/packages/backend/src/database/entities/users.ts
+++ b/packages/backend/src/database/entities/users.ts
@@ -17,6 +17,7 @@ export type DbUser = {
     is_internal: boolean;
     timezone: string | null;
     avatar_gradient: string | null;
+    how_did_you_hear_about_us: string | null;
     updated_at: Date;
 };
 
@@ -41,6 +42,7 @@ export type DbUserUpdate = Partial<
         | 'is_active'
         | 'timezone'
         | 'avatar_gradient'
+        | 'how_did_you_hear_about_us'
         | 'updated_at'
     >
 >;

--- a/packages/backend/src/database/migrations/20260728172230_add_how_did_you_hear_about_us_to_users.ts
+++ b/packages/backend/src/database/migrations/20260728172230_add_how_did_you_hear_about_us_to_users.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('users', (table) => {
+        table.text('how_did_you_hear_about_us').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('users', (table) => {
+        table.dropColumn('how_did_you_hear_about_us');
+    });
+}

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -529,6 +529,7 @@ export class UserModel {
             isActive,
             timezone,
             avatarGradient,
+            howDidYouHearAboutUs,
         }: Partial<UpdateUserArgs>,
         isEmailVerified: boolean = false,
     ): Promise<LightdashUser> {
@@ -546,6 +547,7 @@ export class UserModel {
                         : false,
                     timezone,
                     avatar_gradient: avatarGradient,
+                    how_did_you_hear_about_us: howDidYouHearAboutUs,
                     updated_at: new Date(),
                 })
                 .returning('*');

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -355,6 +355,95 @@ describe('UserService', () => {
         });
     });
 
+    describe('completeUserSetup', () => {
+        test('persists and tracks a trimmed answer', async () => {
+            await userService.completeUserSetup(sessionUser, {
+                jobTitle: '',
+                howDidYouHearAboutUs: '  A podcast  ',
+                enableEmailDomainAccess: false,
+                isMarketingOptedIn: true,
+                isTrackingAnonymized: false,
+            });
+
+            expect(vi.mocked(userModel.updateUser)).toHaveBeenCalledWith(
+                sessionUser.userUuid,
+                undefined,
+                {
+                    isSetupComplete: true,
+                    isTrackingAnonymized: false,
+                    isMarketingOptedIn: true,
+                    howDidYouHearAboutUs: 'A podcast',
+                },
+            );
+            expect(vi.mocked(analyticsMock.track)).toHaveBeenCalledWith({
+                event: 'hear_about_us.submitted',
+                userId: sessionUser.userUuid,
+                properties: {
+                    organizationId: sessionUser.organizationUuid,
+                    onboardingFlow: 'legacy',
+                    answered: true,
+                    answer: 'A podcast',
+                },
+            });
+        });
+
+        test('persists and tracks a skipped answer', async () => {
+            await userService.completeUserSetup(sessionUser, {
+                jobTitle: '',
+                howDidYouHearAboutUs: '',
+                enableEmailDomainAccess: false,
+                isMarketingOptedIn: true,
+                isTrackingAnonymized: false,
+            });
+
+            expect(vi.mocked(userModel.updateUser)).toHaveBeenCalledWith(
+                sessionUser.userUuid,
+                undefined,
+                {
+                    isSetupComplete: true,
+                    isTrackingAnonymized: false,
+                    isMarketingOptedIn: true,
+                    howDidYouHearAboutUs: '',
+                },
+            );
+            expect(vi.mocked(analyticsMock.track)).toHaveBeenCalledWith({
+                event: 'hear_about_us.submitted',
+                userId: sessionUser.userUuid,
+                properties: {
+                    organizationId: sessionUser.organizationUuid,
+                    onboardingFlow: 'legacy',
+                    answered: false,
+                    answer: null,
+                },
+            });
+        });
+
+        test('does not track an absent answer', async () => {
+            await userService.completeUserSetup(sessionUser, {
+                jobTitle: '',
+                enableEmailDomainAccess: false,
+                isMarketingOptedIn: true,
+                isTrackingAnonymized: false,
+            });
+
+            expect(vi.mocked(userModel.updateUser)).toHaveBeenCalledWith(
+                sessionUser.userUuid,
+                undefined,
+                {
+                    isSetupComplete: true,
+                    isTrackingAnonymized: false,
+                    isMarketingOptedIn: true,
+                    howDidYouHearAboutUs: undefined,
+                },
+            );
+            expect(vi.mocked(analyticsMock.track)).not.toHaveBeenCalledWith(
+                expect.objectContaining({
+                    event: 'hear_about_us.submitted',
+                }),
+            );
+        });
+    });
+
     describe('delete', () => {
         const orglessActor: SessionUser = {
             ...sessionUser,

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -1397,6 +1397,7 @@ export class UserService extends BaseService {
             isTrackingAnonymized,
             isMarketingOptedIn,
             enableEmailDomainAccess,
+            howDidYouHearAboutUs,
         }: CompleteUserArgs,
     ): Promise<LightdashUser> {
         if (!isUserWithOrg(user)) {
@@ -1452,6 +1453,10 @@ export class UserService extends BaseService {
                 );
             }
         }
+        const answer =
+            typeof howDidYouHearAboutUs === 'string'
+                ? howDidYouHearAboutUs.trim().slice(0, 1000)
+                : undefined;
         const completeUser = await this.userModel.updateUser(
             user.userUuid,
             undefined,
@@ -1459,8 +1464,23 @@ export class UserService extends BaseService {
                 isSetupComplete: true,
                 isTrackingAnonymized,
                 isMarketingOptedIn,
+                howDidYouHearAboutUs: answer,
             },
         );
+
+        if (answer !== undefined) {
+            const onboardingFlow = await this.getOnboardingFlow(user);
+            this.analytics.track({
+                event: 'hear_about_us.submitted',
+                userId: completeUser.userUuid,
+                properties: {
+                    organizationId: user.organizationUuid,
+                    onboardingFlow,
+                    answered: answer.length > 0,
+                    answer: answer.length > 0 ? answer : null,
+                },
+            });
+        }
 
         this.identifyUser(completeUser);
         this.analytics.track({

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -603,6 +603,7 @@ export const hasSpecialCharacters = (text: string) => /[^a-zA-Z ]/g.test(text);
 export const CompleteUserSchema = z.object({
     organizationName: getOrganizationNameSchema().optional(),
     jobTitle: z.string().min(0),
+    howDidYouHearAboutUs: z.string().trim().max(1000).optional(),
     enableEmailDomainAccess: z.boolean().default(false),
     isMarketingOptedIn: z.boolean().default(true),
     isTrackingAnonymized: z.boolean().default(false),

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -1002,6 +1002,7 @@ export type UpdateUserArgs = {
     timezone: string | null;
     /* Explicit gradient placeholder override; null falls back to the deterministic gradient. */
     avatarGradient: UserAvatarColorValue | null;
+    howDidYouHearAboutUs: string;
 };
 
 export type ApiUserAvatarResponse = {

--- a/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.test.tsx
+++ b/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.test.tsx
@@ -246,6 +246,7 @@ describe('UserCompletionModal', () => {
             .patch('/api/v1/user/me/complete', {
                 organizationName: 'test organization',
                 jobTitle: 'Software Engineer',
+                howDidYouHearAboutUs: '',
                 enableEmailDomainAccess: false,
                 isMarketingOptedIn: false,
                 isTrackingAnonymized: true,
@@ -301,6 +302,7 @@ describe('UserCompletionModal', () => {
         const scope = nock(BASE_API_URL)
             .patch('/api/v1/user/me/complete', {
                 jobTitle: 'Software Engineer',
+                howDidYouHearAboutUs: '',
                 enableEmailDomainAccess: false,
                 isMarketingOptedIn: true,
                 isTrackingAnonymized: false,
@@ -311,6 +313,61 @@ describe('UserCompletionModal', () => {
         await user.click(submitButton);
 
         // wait for api call to be made
+        scope.done();
+        await waitFor(() => expect(scope.isDone()).toBe(true));
+    });
+
+    it('should render the how did you hear about us input', async () => {
+        renderModal({
+            user: {
+                isSetupComplete: false,
+                organizationName: 'test organization',
+            },
+        });
+
+        const welcomeModal = await screen.findByRole('dialog');
+        expect(
+            within(welcomeModal).getByLabelText('How did you hear about us?'),
+        ).toBeInTheDocument();
+    });
+
+    it('should submit the trimmed how did you hear about us answer', async () => {
+        const user = userEvent.setup();
+
+        renderModal({
+            user: {
+                isSetupComplete: false,
+                organizationName: 'test organization',
+            },
+        });
+
+        const submitButton = await screen.findByRole('button', {
+            name: 'Next',
+        });
+
+        const roleSelect =
+            await screen.findByPlaceholderText('Select your role');
+        await user.click(roleSelect);
+        const roleOption = await screen.findByText('Software Engineer');
+        await user.click(roleOption);
+
+        const referralInput = await screen.findByLabelText(
+            'How did you hear about us?',
+        );
+        await user.type(referralInput, '  a podcast  ');
+
+        const scope = nock(BASE_API_URL)
+            .patch('/api/v1/user/me/complete', {
+                jobTitle: 'Software Engineer',
+                howDidYouHearAboutUs: 'a podcast',
+                enableEmailDomainAccess: false,
+                isMarketingOptedIn: true,
+                isTrackingAnonymized: false,
+            })
+            .reply(200);
+
+        await user.click(submitButton);
+
         scope.done();
         await waitFor(() => expect(scope.isDone()).toBe(true));
     });

--- a/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.tsx
+++ b/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.tsx
@@ -39,6 +39,7 @@ const UserCompletionModal: FC = () => {
         initialValues: {
             organizationName: '',
             jobTitle: '',
+            howDidYouHearAboutUs: '',
             enableEmailDomainAccess: false,
             isMarketingOptedIn: true,
             isTrackingAnonymized: false,
@@ -49,11 +50,15 @@ const UserCompletionModal: FC = () => {
     const { isLoading, mutate, isSuccess } = useUserCompleteMutation();
 
     const handleSubmit = form.onSubmit((data) => {
+        const payload = {
+            ...data,
+            howDidYouHearAboutUs: data.howDidYouHearAboutUs?.trim() ?? '',
+        };
         if (user.data?.organizationName) {
-            const { organizationName, ...rest } = data;
+            const { organizationName, ...rest } = payload;
             mutate(rest);
         } else {
-            mutate(data);
+            mutate(payload);
         }
     });
 
@@ -138,6 +143,13 @@ const UserCompletionModal: FC = () => {
                         required
                         placeholder="Select your role"
                         {...form.getInputProps('jobTitle')}
+                    />
+
+                    <TextInput
+                        label="How did you hear about us?"
+                        placeholder="Google, a colleague, a podcast..."
+                        disabled={isLoading}
+                        {...form.getInputProps('howDidYouHearAboutUs')}
                     />
 
                     <Stack gap="xs">

--- a/packages/frontend/src/pages/OrganizationSetup.test.tsx
+++ b/packages/frontend/src/pages/OrganizationSetup.test.tsx
@@ -1,0 +1,146 @@
+import { LightdashMode } from '@lightdash/common';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BASE_API_URL } from '../api';
+import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
+import { renderWithProviders } from '../testing/testUtils';
+import OrganizationSetup from './OrganizationSetup';
+
+vi.mock('../hooks/useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: vi.fn(),
+}));
+
+const renderSetupPage = (mocks?: Parameters<typeof renderWithProviders>[1]) =>
+    renderWithProviders(
+        <MemoryRouter initialEntries={['/organization-setup']}>
+            <Routes>
+                <Route
+                    path="/organization-setup"
+                    element={<OrganizationSetup />}
+                />
+                <Route path="/" element={<div>Home page</div>} />
+            </Routes>
+        </MemoryRouter>,
+        mocks,
+    );
+
+const selectRole = async (user: ReturnType<typeof userEvent.setup>) => {
+    const roleSelect = await screen.findByPlaceholderText('Select your role');
+    await user.click(roleSelect);
+    const roleOption = await screen.findByText('Software Engineer');
+    await user.click(roleOption);
+};
+
+describe('OrganizationSetup', () => {
+    beforeEach(() => {
+        vi.mocked(useServerFeatureFlag).mockReturnValue({
+            data: { id: 'organization-setup-page', enabled: true },
+            isLoading: false,
+        } as ReturnType<typeof useServerFeatureFlag>);
+    });
+
+    it('submits an empty referral answer when a user joining an existing organization skips it', async () => {
+        const user = userEvent.setup();
+
+        renderSetupPage({
+            user: {
+                isSetupComplete: false,
+                organizationName: 'test organization',
+                email: 'demo@lightdash.com',
+            },
+            health: {
+                mode: LightdashMode.DEFAULT,
+            },
+        });
+
+        expect(
+            await screen.findByText('Tell us about you'),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByPlaceholderText('Acme Analytics'),
+        ).not.toBeInTheDocument();
+
+        const referralInput = await screen.findByLabelText(
+            'How did you hear about us?',
+        );
+        expect(referralInput).toBeInTheDocument();
+
+        const submitButton = await screen.findByRole('button', {
+            name: 'Finish',
+        });
+        expect(submitButton).toBeDisabled();
+
+        await selectRole(user);
+
+        expect(submitButton).toBeEnabled();
+
+        const scope = nock(BASE_API_URL)
+            .patch('/api/v1/user/me/complete', {
+                jobTitle: 'Software Engineer',
+                howDidYouHearAboutUs: '',
+                enableEmailDomainAccess: false,
+                isMarketingOptedIn: true,
+                isTrackingAnonymized: false,
+            })
+            .reply(200);
+
+        await user.click(submitButton);
+
+        await waitFor(() => expect(scope.isDone()).toBe(true));
+    });
+
+    it('submits the trimmed referral answer when a user creating an organization answers it', async () => {
+        const user = userEvent.setup();
+
+        renderSetupPage({
+            user: {
+                isSetupComplete: false,
+                organizationName: '',
+                email: 'demo@lightdash.com',
+            },
+            health: {
+                mode: LightdashMode.DEFAULT,
+            },
+        });
+
+        const nameInput = await screen.findByPlaceholderText('Acme Analytics');
+        await user.clear(nameInput);
+        await user.type(nameInput, 'test organization');
+        await user.click(
+            await screen.findByRole('button', { name: 'Continue' }),
+        );
+
+        expect(
+            await screen.findByText('Tell us about you'),
+        ).toBeInTheDocument();
+
+        await selectRole(user);
+
+        const referralInput = await screen.findByLabelText(
+            'How did you hear about us?',
+        );
+        await user.type(referralInput, '  a podcast  ');
+
+        const scope = nock(BASE_API_URL)
+            .patch('/api/v1/user/me/complete', {
+                organizationName: 'test organization',
+                jobTitle: 'Software Engineer',
+                howDidYouHearAboutUs: 'a podcast',
+                enableEmailDomainAccess: true,
+                isMarketingOptedIn: true,
+                isTrackingAnonymized: false,
+            })
+            .reply(200);
+        const brandScope = nock(BASE_API_URL)
+            .put('/api/v1/org/brand', () => true)
+            .reply(200, { status: 'ok', results: null });
+
+        await user.click(await screen.findByRole('button', { name: 'Finish' }));
+
+        await waitFor(() => expect(scope.isDone()).toBe(true));
+        await waitFor(() => expect(brandScope.isDone()).toBe(true));
+    });
+});

--- a/packages/frontend/src/pages/OrganizationSetup.tsx
+++ b/packages/frontend/src/pages/OrganizationSetup.tsx
@@ -105,6 +105,7 @@ const buildBrandColors = (
 type OrganizationSetupFormValues = {
     organizationName: string;
     jobTitle: string;
+    howDidYouHearAboutUs: string;
     enableEmailDomainAccess: boolean;
     isMarketingOptedIn: boolean;
     isTrackingAnonymized: boolean;
@@ -136,6 +137,7 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
                     ? inferOrganizationName(emailDomain)
                     : '',
             jobTitle: '',
+            howDidYouHearAboutUs: '',
             enableEmailDomainAccess: canEnableEmailDomainAccess,
             isMarketingOptedIn: true,
             isTrackingAnonymized: false,
@@ -249,6 +251,7 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
             // rights to change), so don't attempt to save it.
             completeMutation.mutate({
                 jobTitle: values.jobTitle,
+                howDidYouHearAboutUs: values.howDidYouHearAboutUs.trim(),
                 enableEmailDomainAccess: values.enableEmailDomainAccess,
                 isMarketingOptedIn: values.isMarketingOptedIn,
                 isTrackingAnonymized: values.isTrackingAnonymized,
@@ -259,6 +262,7 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
         completeMutation.mutate({
             organizationName: values.organizationName,
             jobTitle: values.jobTitle,
+            howDidYouHearAboutUs: values.howDidYouHearAboutUs.trim(),
             enableEmailDomainAccess: values.enableEmailDomainAccess,
             isMarketingOptedIn: values.isMarketingOptedIn,
             isTrackingAnonymized: values.isTrackingAnonymized,
@@ -435,6 +439,15 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
                                     size="md"
                                     required
                                     {...form.getInputProps('jobTitle')}
+                                />
+
+                                <TextInput
+                                    label="How did you hear about us?"
+                                    placeholder="Google, a colleague, a podcast..."
+                                    size="md"
+                                    {...form.getInputProps(
+                                        'howDidYouHearAboutUs',
+                                    )}
                                 />
 
                                 <Stack gap="xs">


### PR DESCRIPTION
Adds an optional, free-text **"How did you hear about us?"** field to signup, collected once per user at setup completion.

Linear: PROD-9296

## What changed

- **Both onboarding arms** get the field on their existing setup-completion form:
  - new flow: the "About you" step of `/organization-setup` (`OrganizationSetup.tsx`)
  - legacy flow: the `UserCompletionModal`
- New nullable `users.how_did_you_hear_about_us` text column (migration tested up **and** down: `migrate` → `rollback-last` → `migrate`).
- `UserService.completeUserSetup` persists the trimmed answer (capped at 1000 chars, runtime-guarded since this express route has no schema validation) and fires a dedicated `hear_about_us.submitted` analytics event.
- Tests: new `completeUserSetup` describe block (backend), new `OrganizationSetup.test.tsx`, extended `UserCompletionModal.test.tsx` payload-contract tests.

## Design decisions

1. **Which surface?** The new flow's signup screen is deliberately email-only, so the field lives on the org-setup "About you" step instead; the legacy arm uses the completion modal. Both submit through the same `PATCH /user/me/complete`, so the backend change is shared.
2. **Both arms, not new-only.** Shipping it on one arm would make the field a confound in the new-onboarding rollout comparison — a conversion effect from the field itself would be indistinguishable from the flow's own effect.
3. **Optional and skippable.** Free text on a conversion-critical screen is a drop-off risk, so it never gates the submit button. The payload contract distinguishes three states: `undefined` = field never shown (old clients / pre-feature users, column stays NULL), `''` = shown and skipped, text = answered. "Declined to answer" and "never saw it" are therefore distinguishable in both the DB and the event stream.
4. **Storage: DB column + dedicated event.** `jobTitle` precedent is analytics-only, but a downstream sync contract (SPK-683) consumes this field, so the value is persisted on `users` as well as emitted. A dedicated event is used rather than piggybacking `user.updated` because that event's properties are allowlisted in `LightdashAnalytics.track()` and extra properties would be silently dropped. The event fires on **both submit and skip** with `{ answered, answer, onboardingFlow, organizationId }`, so the field's own drop-off cost is measurable.

## Funnel impact

**No step-count change on either arm.** The field is embedded in existing steps; `ORGANIZATION_SETUP_STEP_COMPLETED` events and step labels are untouched.

## Verification

- Browser-verified on both arms locally: new flow (answered → trimmed value in DB and in the PATCH payload), legacy modal (skipped → `''` in DB), plus a full fresh email → OTP → org-setup → warehouse-select pass with the flag on. Pre-existing users keep `NULL`.
- `typecheck:fast` clean on common/backend/frontend; package linters clean on all touched paths; backend `UserService.test.ts` 108 passing; frontend suites 20 passing.
- react-doctor on touched files: no diagnostics on lines this PR adds. Two pre-existing findings in `OrganizationSetup.tsx` (brand-detection effect passes data upward; component size) predate this PR and are intentionally not refactored here — this page is conversion-critical the day before the flag flip.

## Notes

- Verification environment note (not caused by this PR): the new warehouse-connect step is reached via the EE day-0 homepage, so on a non-EE instance `new-onboarding` signups finish org setup and land on legacy `/createProject`. Tracked as PROD-9303 (confirm whether that gating is intended).
- The response of `PATCH /user/me/complete` does not expose the new column (`LightdashUser` unchanged).
- Open text will produce unnormalised answers; categorisation (dropdown or post-hoc classification) is a deliberate non-goal here, per the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBjoamEJYshNBA7bhfBmhv


