### PR TITLE
fix: bump pinned okteto CLI so the snapshot builder parses compose secrets

### DIFF
--- a/.github/workflows/preview-db-snapshot.yml
+++ b/.github/workflows/preview-db-snapshot.yml
@@ -42,7 +42,7 @@ jobs:
       # only; the run steps below need the CLI on the runner itself
       - name: Install Okteto CLI
         run: |
-          curl -sSfL -o okteto https://github.com/okteto/okteto/releases/download/3.7.0/okteto-Linux-x86_64
+          curl -sSfL -o okteto https://github.com/okteto/okteto/releases/download/3.21.0/okteto-Linux-x86_64
           chmod +x okteto
           sudo mv okteto /usr/local/bin/okteto
 


### PR DESCRIPTION
The Preview DB Snapshot workflow has failed since #26312 added a top-level `secrets:` block (TURBO_TOKEN build secret) to the builder compose: the workflow's pinned okteto CLI **3.7.0** predates compose `secrets:` support, misclassifies the file as an okteto manifest, and errors with `field 'volumes' is not a property of the okteto manifest`. Previews are unaffected because they deploy through okteto's server-side pipeline, which runs a current parser — that's why the identical block works in `docker-compose.preview.yml`.

Bump the pin to **3.21.0** (current stable). Verified locally: 3.21.0 validates the exact compose from main, including the secrets block.

Merging re-triggers the workflow, which publishes the first 3-copy snapshot generation from #26343 — superseding the manually created `preview-db-manual-*` single snapshot currently serving diverts.

Relates: SPK-297

https://claude.ai/code/session_01RmebrVJwigL6JnggGwpzQR