### PR TITLE
chore(dead-code): remove two orphaned DuckDB warehouse-client type aliases

### DIFF
--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -127,9 +127,6 @@ export type DuckdbS3Credentials = {
 
 export type DuckdbConnectionCredentials = DuckdbS3Credentials;
 
-// Backwards-compatible alias while this API settles.
-export type DuckdbS3ConnectionConfig = DuckdbS3Credentials;
-
 export type DuckdbWarehouseClientOptions = {
     /** Resource-constrained isolated sessions, used for materialization/parquet conversion and embedded databases. */
     resourceLimits?: DuckdbResourceLimits;
@@ -397,11 +394,6 @@ const resolveEmbeddedDatabasePath = (dataset: string): string => {
     }
 
     return realDatabasePath;
-};
-
-export type DuckdbWarehouseClientArgs = {
-    databasePath?: string;
-    s3Config?: DuckdbS3SessionConfig;
 };
 
 export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMotherduckCredentials> {


### PR DESCRIPTION
Removes two exported type aliases in `packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts` that have never had a reference. 8 deleted lines, one file, type-only — nothing is emitted to JS, so there is no behaviour change.

| Removed | Why it's there |
| -- | -- |
| `DuckdbS3ConnectionConfig = DuckdbS3Credentials` (+ its comment) | Compat alias added by the DuckDB constructor restructure (#21467, 2026-03-27), commented *"Backwards-compatible alias while this API settles"*. No caller ever adopted it. |
| `DuckdbWarehouseClientArgs` | The **old** constructor arg type. #21467 deleted it and changed the constructor to `(credentials?, options?)`. #21558 (2026-03-31, DuckDB/MotherDuck support — branch cut before the restructure) re-added the declaration on merge with no consumer. It now describes a constructor shape the class does not have. |

## Why it's dead

**Static-analysis signal** (this batch was scoped to `packages/warehouses` only):

- `knip@5` — both listed under "Unused exported types".
- `ts-prune@0.10.3 -p packages/warehouses/tsconfig.json` — both listed.

Both runs are workspace-local and over-report (they also flag `DuckdbS3SessionConfig`, `DuckdbResourceLimits`, `SshTunnel`, `warehouseClientFromCredentials`, which **are** imported cross-package). Tool output was used only to generate candidates; the checks below are what decided it.

**1. Repo-wide grep, all file types — not just the package, not just `.ts`:**

```
$ git grep -n -w -E "DuckdbS3ConnectionConfig|DuckdbWarehouseClientArgs" -- .
packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts:131:export type DuckdbS3ConnectionConfig = DuckdbS3Credentials;
packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts:402:export type DuckdbWarehouseClientArgs = {
```

Only the two declarations. No import, no named re-export, no barrel entry, no test, no fixture, no JSON/YAML/doc reference.

**2. In-file use:** each name occurs exactly once in its own file (the declaration). Every *other* exported DuckDB type in that file was checked the same way and each has a real consumer, so they were left alone:

- `DuckdbS3SessionConfig` → `backend/src/clients/ResultsFileStorageClients/LocalParquetUploadStream.ts`, `backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.ts`
- `DuckdbResourceLimits` → `PreAggregationDuckDbClient.ts`
- `DuckdbLogger`, `DuckdbQueryProfileMetrics`, `DuckdbWarehouseClientOptions`, `DuckdbConnectionCredentials`, `DuckdbS3Credentials` → used in-file in constructor/field/method signatures

**3. Dynamic / string dispatch — not applicable.** Both are `type` aliases, fully erased at compile time. There is no runtime value for a registry map, `[key]` access, TSOA route, DI lookup, env-var switch or dbt/YAML key to resolve to.

**4. Unmerged-branch sweep.** Every `refs/remotes/origin` branch with a commit in the last 60 days, excluding dependabot/snyk/renovate — **451 branches** — grepped for both symbols across `packages/**/*.ts(x)`, excluding the defining file: **0 branches with an external reference.** No in-flight work depends on either type.

**5. Verification after removal:**

- `pnpm -F warehouses typecheck:fast` → clean
- `pnpm --filter warehouses run linter src/warehouseClients/DuckdbWarehouseClient.ts` → clean

## Residual risk

`@lightdash/warehouses` is published to npm, so these two names leave its public type surface. Rated low:

- `DuckdbS3ConnectionConfig` was a literal alias of `DuckdbS3Credentials`, which stays exported — an external consumer has an identical drop-in.
- `DuckdbWarehouseClientArgs` describes a constructor signature the class has not had since 2026-03-27, so any external use of it would already be broken.
- The package exists for first-party consumption (`backend`, `cli`); both types were added in 2026-03 and no consumer inside or outside this repo has ever referenced them.

Linear: SPK-694

Draft pending human review, per the agent merge freeze.
