### PR TITLE
refactor(homepage): one favourites presentation, shared by strip and block

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/FavoritesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/FavoritesBlock.tsx
@@ -13,6 +13,7 @@ import { useState, type FC, type MouseEvent } from 'react';
 import { Link } from 'react-router';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { getResourceUrl } from '../../../../components/common/ResourceView/resourceUtils';
+import TruncatedText from '../../../../components/common/TruncatedText';
 import { useFavoriteMutation } from '../../../../hooks/favorites/useFavoriteMutation';
 import { useFavorites } from '../../../../hooks/favorites/useFavorites';
 import layout from '../homepageLayout.module.css';
@@ -20,7 +21,9 @@ import { BlockHeader } from './BlockShell';
 import classes from './blockStyles.module.css';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
-const FAVORITES_DEFAULT_VISIBLE = 8;
+// Kept to one row by default — the rest are a click away behind "+N more",
+// so favorites never eat the fold above the hero
+const FAVORITES_DEFAULT_VISIBLE = 5;
 
 const FAVORITE_ICONS: Partial<Record<ResourceViewItemType, Icon>> = {
     [ResourceViewItemType.CHART]: IconChartBar,
@@ -82,9 +85,15 @@ const FavoritePills: FC<{
                         size={15}
                         color="ldGray.6"
                     />
-                    <span className={classes.favPillName}>
+                    <TruncatedText
+                        maxWidth={160}
+                        inline
+                        fz={13}
+                        fw={500}
+                        c="inherit"
+                    >
                         {item.data.name}
-                    </span>
+                    </TruncatedText>
                     {isInteractive ? (
                         <MantineIcon
                             icon={IconStarFilled}
@@ -116,8 +125,32 @@ const FavoritePills: FC<{
     );
 };
 
-/** Compact one-line favorites bar pinned above the hero. Hides itself entirely
- * when the user has no favorites. */
+/** The one favorites presentation — shared by the strip above the hero and the
+ * favorites block, so the two never drift apart. */
+const FavoritesSection: FC<{
+    projectUuid: string;
+    title: string;
+    isInteractive: boolean;
+    emptyText: string | null;
+}> = ({ projectUuid, title, isInteractive, emptyText }) => (
+    <Stack gap={0}>
+        <BlockHeader
+            icon={IconStar}
+            title={title}
+            pill="Only you see this"
+            centered
+        />
+        <FavoritePills
+            projectUuid={projectUuid}
+            isInteractive={isInteractive}
+            justify="center"
+            emptyText={emptyText}
+        />
+    </Stack>
+);
+
+/** Favorites pinned above the hero. Hides itself entirely when the user has no
+ * favorites — day-0 shouldn't open with an empty shelf. */
 export const PersonalFavoritesBar: FC<{ projectUuid: string }> = ({
     projectUuid,
 }) => {
@@ -129,15 +162,11 @@ export const PersonalFavoritesBar: FC<{ projectUuid: string }> = ({
 
     return (
         <div className={layout.favBar}>
-            <div className={layout.favBarLabel}>
-                <MantineIcon icon={IconStar} size={14} color="ldGray.6" />
-                <span className={layout.favBarLabelText}>Favorites</span>
-            </div>
-            <FavoritePills
+            <FavoritesSection
                 projectUuid={projectUuid}
+                title="My favorites"
                 isInteractive
                 emptyText={null}
-                wrap="nowrap"
             />
         </div>
     );
@@ -149,20 +178,12 @@ export const FavoritesBlockView: FC<BlockComponentProps> = ({
 }) => {
     if (block.type !== 'favorites') return null;
     return (
-        <Stack gap={0}>
-            <BlockHeader
-                icon={IconStar}
-                title={block.config.title}
-                pill="Only you see this"
-                centered
-            />
-            <FavoritePills
-                projectUuid={projectUuid}
-                isInteractive
-                justify="center"
-                emptyText="Star any dashboard or chart to keep it here — each person sees their own favorites."
-            />
-        </Stack>
+        <FavoritesSection
+            projectUuid={projectUuid}
+            title={block.config.title}
+            isInteractive
+            emptyText="Star any dashboard or chart to keep it here — each person sees their own favorites."
+        />
     );
 };
 

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/RecentBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/RecentBlock.tsx
@@ -14,6 +14,7 @@ import { useQuery } from '@tanstack/react-query';
 import { type FC } from 'react';
 import { Link } from 'react-router';
 import { lightdashApi } from '../../../../api';
+import TruncatedText from '../../../../components/common/TruncatedText';
 import { useTimeAgo } from '../../../../hooks/useTimeAgo';
 import { useCollectionContent } from '../hooks/useCollectionContent';
 import { BlockHeader } from './BlockShell';
@@ -60,7 +61,11 @@ const RecentRow: FC<{
                 )}
             </div>
             <div className={classes.flexFill}>
-                <div className={classes.rowName}>{content.name}</div>
+                <div className={classes.rowName}>
+                    <TruncatedText maxWidth="100%" inline fz="inherit">
+                        {content.name}
+                    </TruncatedText>
+                </div>
                 <div className={classes.rowMeta}>
                     {isDashboard ? 'Dashboard' : 'Chart'}
                 </div>

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -211,6 +211,12 @@ a .hoverCard:hover,
     white-space: nowrap;
 }
 
+/* Icons are flex children, so a long name squeezed them instead of itself —
+ * the name owns all the shrinking. */
+.favPill > svg {
+    flex-shrink: 0;
+}
+
 .favPillMore {
     display: inline-flex;
     align-items: center;

--- a/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
@@ -4,7 +4,7 @@
  * section below. */
 
 .page {
-    --homepage-favbar-height: 48px;
+    --homepage-favbar-height: 78px;
     /* Read by anything positioned relative to the hero — see HomepageStars. */
     --homepage-hero-width: 720px;
     --homepage-page-padding-x: 24px;
@@ -55,29 +55,10 @@
 }
 
 .favBar {
-    display: flex;
-    align-items: center;
-    gap: 12px;
     width: 100%;
     max-width: 1000px;
     min-height: var(--homepage-favbar-height);
     margin: 0 auto;
-    overflow-x: auto;
-}
-
-.favBarLabel {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    flex-shrink: 0;
-}
-
-.favBarLabelText {
-    font-size: 11px;
-    font-weight: 600;
-    letter-spacing: 0.07em;
-    text-transform: uppercase;
-    color: var(--mantine-color-ldGray-6);
 }
 
 .hero {


### PR DESCRIPTION
Part 1 of 5 — stacked on #26353.

## What

Favourites rendered **two different ways** depending on where they appeared:

- **As the strip above the hero**: an inline uppercase `FAVORITES` label, one nowrap row, horizontally scrolled — which sliced the last pill mid-word with no affordance that more existed.
- **As the favourites block**: a centred "My favorites" header with a pill, wrapping — eight favourites sprawled over three rows and ate the fold.

Same data, same feature, two visual languages.

## How

Both now render one `FavoritesSection`: centred header, a single row of pills, and `+N more` to reveal the rest. The default visible count drops from 8 to 5 so the row stays one line.

Two smaller fixes in the same area:

- **Pill icons were being squashed by long names.** They're flex children, so they shrank instead of the text. The name now owns all the shrinking (`flex-shrink: 0` on the icons) — verified icons hold 15px/13px on every pill including a long-titled one.
- Truncated names in both the pills and the recent list now use `TruncatedText`, so hovering shows the full name.

## Regression analysis

This is presentation-only — no data, permissions or query changes. It does change the look for **existing users with a published favourites block or the personal strip**: fewer pills visible at once (5 + `+N more` instead of all 8 wrapping), and the strip gains a header rather than an inline label. `--homepage-favbar-height` moves 48px → 78px to match, which slightly changes hero centring on pages that render the strip.

The trade-off is deliberate: two rows of pills above the hero is better than three, and a `+N more` affordance is better than a name sliced mid-word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KedCujEdGmuSsgY6ieWgh9