### PR TITLE
feat(homepage): rework day-0 for projects without an AI hero

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.test.tsx
@@ -1,0 +1,84 @@
+import { MantineProvider } from '@mantine-8/core';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DayOneHomepage } from './DayOneHomepage';
+
+const { aiState } = vi.hoisted(() => ({
+    aiState: { current: { canAskAi: true } },
+}));
+
+vi.mock('./hooks/useHomepageAiState', () => ({
+    useHomepageAiState: () => ({ isLoading: false, ...aiState.current }),
+}));
+
+vi.mock('../../../providers/App/useApp', () => ({
+    default: () => ({
+        user: { data: { firstName: 'Ada' } },
+    }),
+}));
+
+vi.mock('./blocks/AskAiHeroBlock', () => ({
+    AskAiHero: () => <div data-testid="ask-ai-hero" />,
+}));
+
+vi.mock('./blocks/QuickActionsBlock', () => ({
+    QuickActionCards: () => <div data-testid="quick-actions" />,
+}));
+
+vi.mock('./blocks/FavoritesBlock', () => ({
+    PersonalFavoritesBar: () => <div data-testid="favorites-bar" />,
+}));
+
+vi.mock('./blocks/ContentCard', () => ({
+    ContentCard: () => <div data-testid="pinned-card" />,
+}));
+
+vi.mock('./hooks/useCollectionContent', () => ({
+    useCollectionContent: () => ({ data: [{ uuid: 'pinned-1' }] }),
+}));
+
+vi.mock('./blocks/RecentBlock', () => ({
+    RecentList: () => <div data-testid="recent-list" />,
+}));
+
+const renderHomepage = () =>
+    render(
+        <MantineProvider>
+            <MemoryRouter>
+                <DayOneHomepage projectUuid="project-1" pinnedItems={[]} />
+            </MemoryRouter>
+        </MantineProvider>,
+    );
+
+describe('DayOneHomepage', () => {
+    beforeEach(() => {
+        aiState.current = { canAskAi: true };
+    });
+
+    it('shows the Ask AI hero when AI agents are available', () => {
+        renderHomepage();
+
+        expect(screen.getByTestId('ask-ai-hero')).toBeInTheDocument();
+        expect(screen.queryByText(/Good \w+, Ada/)).toBeNull();
+        // Recently viewed is for everyone, agents or not
+        expect(screen.getByTestId('recent-list')).toBeInTheDocument();
+        expect(screen.getByTestId('favorites-bar')).toBeInTheDocument();
+        expect(screen.getByTestId('pinned-card')).toBeInTheDocument();
+    });
+
+    it('shows the welcome variant with quick actions and recently viewed when AI is unavailable', () => {
+        aiState.current = { canAskAi: false };
+        renderHomepage();
+
+        expect(screen.queryByTestId('ask-ai-hero')).toBeNull();
+        expect(screen.getByText(/Good \w+, Ada/)).toBeInTheDocument();
+        expect(screen.getByTestId('quick-actions')).toBeInTheDocument();
+        expect(screen.getByTestId('recent-list')).toBeInTheDocument();
+        expect(screen.getByTestId('favorites-bar')).toBeInTheDocument();
+        expect(screen.getByTestId('pinned-card')).toBeInTheDocument();
+        expect(
+            screen.queryByRole('link', { name: /Set up an AI agent/ }),
+        ).toBeNull();
+    });
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.tsx
@@ -1,40 +1,65 @@
-import { type FavoriteItems, type PinnedItems } from '@lightdash/common';
-import { Box, Button, Group, Stack, Text } from '@mantine-8/core';
-import { IconSquareRoundedPlus } from '@tabler/icons-react';
+import { type PinnedItems } from '@lightdash/common';
+import { Box, Stack, Text } from '@mantine-8/core';
+import { IconClock, IconPin } from '@tabler/icons-react';
 import { type FC } from 'react';
-import { Link } from 'react-router';
-import MantineIcon from '../../../components/common/MantineIcon';
-import FavoritesPanel from '../../../components/FavoritesPanel';
-import PinnedItemsPanel from '../../../components/PinnedItemsPanel';
 import useApp from '../../../providers/App/useApp';
 import { AskAiHero } from './blocks/AskAiHeroBlock';
+import { BlockHeader } from './blocks/BlockShell';
+import { ContentCard } from './blocks/ContentCard';
+import { PersonalFavoritesBar } from './blocks/FavoritesBlock';
 import { getDefaultQuickActions } from './blocks/quickActionDefaults';
 import { QuickActionCards } from './blocks/QuickActionsBlock';
+import { RecentList } from './blocks/RecentBlock';
 import classes from './DayOneHomepage.module.css';
+import { getGreeting } from './greeting';
 import layout from './homepageLayout.module.css';
+import { useCollectionContent } from './hooks/useCollectionContent';
 import { useHomepageAiState } from './hooks/useHomepageAiState';
 
 type Props = {
     projectUuid: string;
-    projectName: string;
     pinnedItems: PinnedItems;
-    favoriteItems: FavoriteItems;
-    pinnedIsEnabled: boolean;
 };
 
-export const DayOneHomepage: FC<Props> = ({
-    projectUuid,
-    projectName,
-    pinnedItems,
-    favoriteItems,
-    pinnedIsEnabled,
-}) => {
+/** Pinned content rendered in the same card language as the collection block,
+ * so day-0 doesn't mix a legacy panel in with the builder's blocks. */
+const PinnedCollection: FC<{
+    projectUuid: string;
+    pinnedItems: PinnedItems;
+}> = ({ projectUuid, pinnedItems }) => {
+    const uuids = pinnedItems.map((item) => item.data.uuid);
+    const { data: contents } = useCollectionContent(projectUuid, uuids);
+
+    if (!contents || contents.length === 0) return null;
+
+    return (
+        <Box>
+            <BlockHeader icon={IconPin} title="Pinned" />
+            <Stack gap={8}>
+                {contents.map((content) => (
+                    <ContentCard
+                        key={content.uuid}
+                        content={content}
+                        projectUuid={projectUuid}
+                    />
+                ))}
+            </Stack>
+        </Box>
+    );
+};
+
+export const DayOneHomepage: FC<Props> = ({ projectUuid, pinnedItems }) => {
     const { user } = useApp();
     const { canAskAi } = useHomepageAiState(projectUuid);
 
     return (
         <div className={layout.page}>
-            <div className={layout.heroSection}>
+            {/* Same favourites strip the published homepage puts above its
+                blocks — day-0 opens the same way */}
+            <PersonalFavoritesBar projectUuid={projectUuid} />
+            {/* Body rows always follow, so the hero yields part of the
+                viewport and Recently viewed peeks above the fold */}
+            <div className={layout.heroSection} data-presentation="shared">
                 {canAskAi ? (
                     <div className={layout.hero}>
                         <AskAiHero
@@ -44,57 +69,42 @@ export const DayOneHomepage: FC<Props> = ({
                         />
                     </div>
                 ) : (
-                    <div className={classes.welcome}>
-                        <Group
-                            justify="space-between"
-                            align="flex-end"
-                            wrap="nowrap"
-                            mb={26}
-                        >
-                            <Box>
-                                <Text
-                                    component="h1"
-                                    fz={30}
-                                    fw={600}
-                                    lts="-0.02em"
-                                    m={0}
-                                >
-                                    Welcome to {projectName},{' '}
-                                    {user.data?.firstName}
-                                </Text>
-                                <Text c="dimmed" fz={15} mt={6}>
-                                    Nothing’s here yet — start exploring, or
-                                    your data team can curate this page.
-                                </Text>
-                            </Box>
-                            <Button
-                                component={Link}
-                                to={`/projects/${projectUuid}/tables`}
-                                leftSection={
-                                    <MantineIcon icon={IconSquareRoundedPlus} />
-                                }
-                                flex="0 0 auto"
+                    // Same hero shell and type scale as the Ask AI variant, so
+                    // both day-0 openings sit identically in the fold
+                    <Stack className={layout.hero} gap={16} align="center">
+                        <Box ta="center">
+                            <Text
+                                component="h1"
+                                fz={23}
+                                fw={600}
+                                lts="-0.02em"
+                                lh={1.2}
+                                m={0}
                             >
-                                New
-                            </Button>
-                        </Group>
+                                {getGreeting(user.data?.firstName)}
+                            </Text>
+                            <Text c="dimmed" fz={15} mt={8}>
+                                Pick up where you left off, or start something
+                                new.
+                            </Text>
+                        </Box>
                         <QuickActionCards
                             actions={getDefaultQuickActions(false)}
                             projectUuid={projectUuid}
                         />
-                    </div>
+                    </Stack>
                 )}
             </div>
 
             <div className={classes.secondary}>
                 <Stack gap="xl">
-                    <FavoritesPanel
-                        favoriteItems={favoriteItems}
-                        showEmptyState
-                    />
-                    <PinnedItemsPanel
+                    <Box>
+                        <BlockHeader icon={IconClock} title="Recently viewed" />
+                        <RecentList projectUuid={projectUuid} />
+                    </Box>
+                    <PinnedCollection
+                        projectUuid={projectUuid}
                         pinnedItems={pinnedItems}
-                        isEnabled={pinnedIsEnabled}
                     />
                 </Stack>
             </div>

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/RecentBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/RecentBlock.tsx
@@ -77,7 +77,7 @@ const RecentRow: FC<{
     );
 };
 
-const RecentList: FC<{ projectUuid: string }> = ({ projectUuid }) => {
+export const RecentList: FC<{ projectUuid: string }> = ({ projectUuid }) => {
     const { data: recents, isInitialLoading } = useRecentlyViewed(projectUuid);
     const uuids = (recents ?? [])
         .slice(0, MAX_RECENT_ITEMS)

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -144,15 +144,7 @@ const Home: FC = () => {
                     >
                         <DayOneHomepage
                             projectUuid={project.data.projectUuid}
-                            projectName={project.data.name}
                             pinnedItems={pinnedItems.data ?? []}
-                            favoriteItems={favorites.data ?? []}
-                            pinnedIsEnabled={Boolean(
-                                mostPopularAndRecentlyUpdated?.mostPopular
-                                    .length ||
-                                mostPopularAndRecentlyUpdated?.recentlyUpdated
-                                    .length,
-                            )}
                         />
                     </PinnedItemsProvider>
                 </FavoritesProvider>


### PR DESCRIPTION
Part 3 of 5 — stacked on #26361.

## What

The non-AI day-0 was a left-aligned welcome header with **centred** quick-action chips beneath it, a `+ New` button floating far right, all suspended in a full-viewport band, above a legacy pinned panel. Several visual languages on one page, and a lot of dead space.

## How

It now opens the way the Ask AI variant does:

- the favourites strip on top, then a **centred greeting** on the same hero shell and type scale (23px, same gap) as the Ask AI hero,
- quick actions centred beneath it,
- **Recently viewed**, then pinned content as collection cards rather than the legacy `PinnedItemsPanel`.

Both variants use the fold-aware hero height, so Recently viewed peeks above the fold instead of the hero owning the whole opening view.

Smaller things: `+ New` is gone (it pointed at `/tables`, exactly like the "Run a query" chip beside it), the project name is out of the greeting since it's already in the nav, and the copy no longer says "nothing's here yet" above a page full of favourites and recent content.

## Regression analysis

Day-0 only — the published homepage renderer is untouched. Two changes reach **existing agent users**, since day-0 is shared:

1. **Recently viewed now renders for them too.** It was previously gated to the non-AI variant.
2. **The hero is now 66vh rather than full-viewport**, so their opening view is shorter and Recently viewed peeks in. Measured at an 862px viewport: Recently viewed sits at y=777 (agents) / y=745 (no agents).

Pinned content also switches from the legacy panel to collection cards, and loses the old `isEnabled` gate that tied it to most-popular content existing — so pins now show whenever they resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KedCujEdGmuSsgY6ieWgh9