### PR TITLE
fix: don't flash the "Finish setting up" checklist while its status queries load

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.test.tsx
@@ -149,6 +149,34 @@ describe('useRecommendedActions', () => {
         ).toBeNull();
     });
 
+    describe('new-onboarding gate', () => {
+        it('has no pending actions while new-onboarding is disabled', () => {
+            const { result } = renderHook(() =>
+                useRecommendedActions('project-uuid'),
+            );
+
+            expect(result.current.visibleActions).toContain(
+                'connect-warehouse',
+            );
+            expect(result.current.hasPendingActions).toBe(false);
+        });
+
+        it('has pending actions once new-onboarding is enabled', () => {
+            vi.mocked(useServerFeatureFlag).mockImplementation(
+                (flag) =>
+                    ({
+                        data: { enabled: flag === FeatureFlags.NewOnboarding },
+                    }) as ReturnType<typeof useServerFeatureFlag>,
+            );
+
+            const { result } = renderHook(() =>
+                useRecommendedActions('project-uuid'),
+            );
+
+            expect(result.current.hasPendingActions).toBe(true);
+        });
+    });
+
     describe('on a playground project', () => {
         beforeEach(() => {
             vi.mocked(useOrganization).mockReturnValue({

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.test.tsx
@@ -103,6 +103,27 @@ describe('useRecommendedActions', () => {
         });
     });
 
+    it('reports no pending actions while source control is still loading', () => {
+        vi.mocked(useApp).mockReturnValue({
+            health: { data: { hasGithub: true } },
+            user: {
+                data: {
+                    ability: { can: () => true },
+                },
+            },
+        } as unknown as ReturnType<typeof useApp>);
+        vi.mocked(useGithubConfig).mockReturnValue({
+            data: undefined,
+            isInitialLoading: true,
+        } as ReturnType<typeof useGithubConfig>);
+
+        const { result } = renderHook(() =>
+            useRecommendedActions('project-uuid'),
+        );
+
+        expect(result.current.hasPendingActions).toBe(false);
+    });
+
     it('shows no source-control annotation when nothing is connected', () => {
         vi.mocked(useApp).mockReturnValue({
             health: { data: { hasGitlab: true } },

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
@@ -150,6 +150,7 @@ const useActionStatuses = (
 export const useRecommendedActions = (projectUuid: string | null) => {
     const { user } = useApp();
     const { statuses, isLoading } = useActionStatuses(projectUuid);
+    const newOnboardingFlag = useServerFeatureFlag(FeatureFlags.NewOnboarding);
     const { data: project } = useProject(projectUuid ?? undefined);
     const isPlaygroundProject = isPlaygroundProvisioningSource(
         project?.provisioningSource,
@@ -177,6 +178,7 @@ export const useRecommendedActions = (projectUuid: string | null) => {
         ? []
         : RECOMMENDED_ACTION_KEYS.filter((key) => statuses[key].isVisible);
     const hasPendingActions =
+        newOnboardingFlag.data?.enabled === true &&
         !isLoading &&
         canManageProject &&
         visibleActions.some(

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
@@ -36,13 +36,21 @@ export type ActionStatus = {
 
 const useActionStatuses = (
     projectUuid: string | null,
-): Record<HomepageRecommendedActionKey, ActionStatus> => {
+): {
+    statuses: Record<HomepageRecommendedActionKey, ActionStatus>;
+    isLoading: boolean;
+} => {
     const { health } = useApp();
-    const { data: organization } = useOrganization();
-    const { data: project } = useProject(projectUuid ?? undefined);
-    const { data: projects } = useProjects();
-    const { data: githubConfig } = useGithubConfig();
-    const { data: slack, isSuccess: isSlackSuccess } = useGetSlack();
+    const organizationQuery = useOrganization();
+    const projectQuery = useProject(projectUuid ?? undefined);
+    const projectsQuery = useProjects();
+    const githubConfigQuery = useGithubConfig();
+    const slackQuery = useGetSlack();
+    const { data: organization } = organizationQuery;
+    const { data: project } = projectQuery;
+    const { data: projects } = projectsQuery;
+    const { data: githubConfig } = githubConfigQuery;
+    const { data: slack, isSuccess: isSlackSuccess } = slackQuery;
     const newOnboardingFlag = useServerFeatureFlag(FeatureFlags.NewOnboarding);
     const codingAgentOnboardingFlag = useServerFeatureFlag(
         FeatureFlags.CodingAgentOnboarding,
@@ -53,10 +61,22 @@ const useActionStatuses = (
 
     const hasGithub = !!health.data?.hasGithub;
     const hasGitlab = !!health.data?.hasGitlab;
-    const { isSuccess: isGitlabConnected } = useGitlabRepositories({
+    const gitlabQuery = useGitlabRepositories({
         enabled: hasGitlab,
     });
+    const { isSuccess: isGitlabConnected } = gitlabQuery;
     const isGithubConnected = githubConfig?.enabled === true;
+
+    // Every step defaults to incomplete, so rendering before these have
+    // settled flashes steps that are already done
+    const isLoading =
+        health.isInitialLoading ||
+        organizationQuery.isInitialLoading ||
+        projectQuery.isInitialLoading ||
+        projectsQuery.isInitialLoading ||
+        (hasGithub && githubConfigQuery.isInitialLoading) ||
+        (hasGitlab && gitlabQuery.isInitialLoading) ||
+        (!!health.data?.hasSlack && slackQuery.isInitialLoading);
 
     const dbtConnection = project?.dbtConnection;
     const hasSemanticLayer =
@@ -81,50 +101,55 @@ const useActionStatuses = (
             : undefined;
 
     return {
-        'connect-warehouse': {
-            isVisible: true,
-            isComplete: hasRealWarehouseProject,
-            annotation: warehouseType ? getWarehouseLabel(warehouseType) : null,
-            doneIcon: warehouseType
-                ? getWarehouseIcon(warehouseType, 'sm')
-                : null,
-            url: '/onboarding/data-source',
-        },
-        'add-semantic-layer': {
-            isVisible: !!projectUuid,
-            isComplete: hasSemanticLayer,
-            annotation: dbtConnection
-                ? DbtProjectTypeLabels[dbtConnection.type]
-                : null,
-            doneIcon: null,
-            url: hasAgentSemanticLayerEntry
-                ? `/projects/${projectUuid}/onboarding/agent`
-                : `/generalSettings/projectManagement/${projectUuid}/settings`,
-        },
-        'connect-source-control': {
-            isVisible: hasGithub || hasGitlab,
-            isComplete: isGithubConnected || isGitlabConnected,
-            annotation: isGithubConnected
-                ? 'GitHub'
-                : isGitlabConnected
-                  ? 'GitLab'
-                  : null,
-            doneIcon: null,
-            url: '/generalSettings/integrations',
-        },
-        'connect-slack': {
-            isVisible: !!health.data?.hasSlack,
-            isComplete: isSlackConnected,
-            annotation: slack?.slackTeamName ?? 'Connected',
-            doneIcon: null,
-            url: '/generalSettings/integrations',
+        isLoading,
+        statuses: {
+            'connect-warehouse': {
+                isVisible: true,
+                isComplete: hasRealWarehouseProject,
+                annotation: warehouseType
+                    ? getWarehouseLabel(warehouseType)
+                    : null,
+                doneIcon: warehouseType
+                    ? getWarehouseIcon(warehouseType, 'sm')
+                    : null,
+                url: '/onboarding/data-source',
+            },
+            'add-semantic-layer': {
+                isVisible: !!projectUuid,
+                isComplete: hasSemanticLayer,
+                annotation: dbtConnection
+                    ? DbtProjectTypeLabels[dbtConnection.type]
+                    : null,
+                doneIcon: null,
+                url: hasAgentSemanticLayerEntry
+                    ? `/projects/${projectUuid}/onboarding/agent`
+                    : `/generalSettings/projectManagement/${projectUuid}/settings`,
+            },
+            'connect-source-control': {
+                isVisible: hasGithub || hasGitlab,
+                isComplete: isGithubConnected || isGitlabConnected,
+                annotation: isGithubConnected
+                    ? 'GitHub'
+                    : isGitlabConnected
+                      ? 'GitLab'
+                      : null,
+                doneIcon: null,
+                url: '/generalSettings/integrations',
+            },
+            'connect-slack': {
+                isVisible: !!health.data?.hasSlack,
+                isComplete: isSlackConnected,
+                annotation: slack?.slackTeamName ?? 'Connected',
+                doneIcon: null,
+                url: '/generalSettings/integrations',
+            },
         },
     };
 };
 
 export const useRecommendedActions = (projectUuid: string | null) => {
     const { user } = useApp();
-    const statuses = useActionStatuses(projectUuid);
+    const { statuses, isLoading } = useActionStatuses(projectUuid);
     const { data: project } = useProject(projectUuid ?? undefined);
     const isPlaygroundProject = isPlaygroundProvisioningSource(
         project?.provisioningSource,
@@ -152,6 +177,7 @@ export const useRecommendedActions = (projectUuid: string | null) => {
         ? []
         : RECOMMENDED_ACTION_KEYS.filter((key) => statuses[key].isVisible);
     const hasPendingActions =
+        !isLoading &&
         canManageProject &&
         visibleActions.some(
             (key) => !statuses[key].isComplete && !skippedActions.includes(key),


### PR DESCRIPTION
### Description:

Every recommended action in the homepage setup checklist defaults to incomplete, so the block rendered as soon as `/health` resolved — before the GitHub/GitLab/Slack/project/org queries had settled — and then hid itself once those resolved as already done. That's the flash in the recording.

`useActionStatuses` now also reports an `isLoading` flag (initial load of the queries that feed `isVisible`/`isComplete`, skipping integrations the instance doesn't have), and `hasPendingActions` stays `false` until they've settled.

The checklist is also now gated on the `new-onboarding` feature flag — with the flag off it never renders (including while the flag query is in flight), so the only surfaces showing it are the ones new-onboarding already owns.
