### PR TITLE
chore(dev): add a warm image for Okteto development

### DIFF
--- a/.github/workflows/dev-warm-image.yml
+++ b/.github/workflows/dev-warm-image.yml
@@ -1,0 +1,55 @@
+name: Dev Warm Image
+
+# Bakes the warm base image for Okteto cloud dev environments (the dev-warm
+# target of dockerfile-prs): source at main + installed node_modules +
+# pre-built package dists. okteto.dev.yaml points its dev container at this
+# image so a fresh namespace starts hot-reloading in minutes instead of
+# deriving that state on first `okteto up`. The DB-state twin of
+# preview-db-snapshot.yml.
+
+on:
+  schedule:
+    # Nightly, before European working hours
+    - cron: "0 4 * * *"
+  push:
+    branches: [main]
+    paths:
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "dockerfile-prs"
+      - ".github/workflows/dev-warm-image.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dev-warm-image
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build and push the dev-warm image
+    runs-on: depot-ubuntu-24.04-4
+    timeout-minutes: 45
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Okteto context
+        uses: okteto/context@5212ce5ebf9d3584bafd33f4a295a8521fc5abe7 # latest
+        with:
+          url: ${{ secrets.OKTETO_CONTEXT }}
+          token: ${{ secrets.OKTETO_TOKEN }}
+
+      - name: Build and push
+        run: |
+          start=$(date +%s)
+          # The global registry is readable from every namespace; the build
+          # runs on the shared BuildKit cluster so unchanged layers are cached
+          okteto build -f dockerfile-prs --target dev-warm \
+            -t okteto.global/lightdash-dev-warm:latest .
+          echo "Image build took $(( $(date +%s) - start ))s" | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/dev-warm-image.yml
+++ b/.github/workflows/dev-warm-image.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Install Okteto CLI
         run: |
           curl -sSfL -o okteto https://github.com/okteto/okteto/releases/download/3.21.0/okteto-Linux-x86_64
+          echo "f1fc644e2c2d2285a557577eafc6d4494410dce17b36bac6c3c269fc04c573ef  okteto" | sha256sum --check
           chmod +x okteto
           sudo mv okteto /usr/local/bin/okteto
 

--- a/.github/workflows/dev-warm-image.yml
+++ b/.github/workflows/dev-warm-image.yml
@@ -39,11 +39,14 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Install Okteto CLI
+        run: |
+          curl -sSfL -o okteto https://github.com/okteto/okteto/releases/download/3.21.0/okteto-Linux-x86_64
+          chmod +x okteto
+          sudo mv okteto /usr/local/bin/okteto
+
       - name: Okteto context
-        uses: okteto/context@5212ce5ebf9d3584bafd33f4a295a8521fc5abe7 # latest
-        with:
-          url: ${{ secrets.OKTETO_CONTEXT }}
-          token: ${{ secrets.OKTETO_TOKEN }}
+        run: okteto context use "${{ secrets.OKTETO_CONTEXT }}" --token "${{ secrets.OKTETO_TOKEN }}"
 
       - name: Build and push
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,6 @@ docs/superpowers/
 
 # Playground bundle builder venv
 scripts/playground-bundle/.venv/
+
+# Local pnpm store (also keeps it out of Okteto file sync via .stignore)
+.pnpm-store/

--- a/docker/docker-compose.okteto-dev.yml
+++ b/docker/docker-compose.okteto-dev.yml
@@ -1,0 +1,99 @@
+volumes:
+    # When DB_SNAPSHOT_NAME is set (see okteto.dev.yaml), Okteto's webhook
+    # diverts this volume to a copy-on-write clone of the pre-seeded preview
+    # snapshot instead of a blank disk. Unlike previews, the volume is kept
+    # across deploys so dev state persists; delete the PVC for a fresh DB.
+    db-data:
+        driver_opts:
+            class: csi-okteto
+            size: 2Gi
+        labels:
+            dev.okteto.com/from-snapshot-name: ${DB_SNAPSHOT_NAME:-}
+            dev.okteto.com/from-snapshot-namespace: ${DB_SNAPSHOT_NAMESPACE:-}
+
+# Okteto specific: route the public endpoint to the Vite dev server, which
+# proxies /api to the backend inside the same container
+endpoints:
+    - path: /
+      service: lightdash-dev
+      port: 3000
+
+services:
+    db-dev:
+        image: pgvector/pgvector:pg18
+        restart: always
+        environment:
+            - POSTGRES_PASSWORD=${PGPASSWORD}
+        ports:
+            - '5432'
+        volumes:
+            - db-data:/var/lib/postgresql
+
+    headless-browser:
+        build:
+            dockerfile: Dockerfile.headless-browser
+        restart: always
+        ports:
+            - '3000'
+
+    lightdash-dev:
+        build:
+            # The dev image is toolchain-only (node, pnpm, dbt): source code
+            # arrives via okteto up file sync, so code changes never rebuild it
+            target: dev
+            context: ..
+            dockerfile: dockerfile-prs
+        depends_on:
+            - db-dev
+            - headless-browser
+        # The base container idles; okteto up swaps it for the dev container
+        # which runs scripts/okteto-dev-up.sh
+        command: ['sleep', 'infinity']
+        ports:
+            - '3000'
+            - '8080'
+        environment:
+            NODE_ENV: development
+            LIGHTDASH_MODE: development
+            PORT: 8080
+            FE_PORT: 3000
+            # Allow the Okteto ingress hostname in the Vite dev server
+            FE_HOST: .okteto.dev
+            SITE_URL: ${SITE_URL}
+
+            PGHOST: db-dev
+            PGPORT: 5432
+            PGDATABASE: postgres
+            PGUSER: postgres
+            PGPASSWORD: ${PGPASSWORD}
+            PGMAXCONNECTIONS: 30
+
+            # Behind the Okteto TLS ingress
+            SECURE_COOKIES: true
+            TRUST_PROXY: true
+
+            # Must match the snapshot builder (docker-compose.db-snapshot.yml):
+            # the seed encrypted warehouse credentials with this secret
+            LIGHTDASH_SECRET: not very secret
+            # EE seed data in the snapshot needs a license key to be usable
+            LIGHTDASH_LICENSE_KEY: ${LIGHTDASH_LICENSE_KEY}
+
+            DBT_DEMO_DIR: /usr/app/examples/full-jaffle-shop-demo
+            # Must match the snapshot builder (docker-compose.db-snapshot.yml)
+            LIGHTDASH_SEED_DBT_VERSION: v1.11
+            SCHEDULER_ENABLED: true
+            GROUPS_ENABLED: true
+            EXTENDED_USAGE_ANALYTICS: true
+
+            HEADLESS_BROWSER_HOST: headless-browser
+            HEADLESS_BROWSER_PORT: 3000
+            INTERNAL_LIGHTDASH_HOST: http://lightdash-dev:3000
+
+            # Set in the okteto admin UI (same bucket previews use)
+            S3_ACCESS_KEY: ${S3_ACCESS_KEY}
+            S3_SECRET_KEY: ${S3_SECRET_KEY}
+            S3_ENDPOINT: ${S3_ENDPOINT}
+            S3_REGION: ${S3_REGION}
+            S3_BUCKET: ${S3_BUCKET}
+
+            LIGHTDASH_LOG_LEVEL: debug

--- a/docker/docker-compose.okteto-dev.yml
+++ b/docker/docker-compose.okteto-dev.yml
@@ -19,7 +19,7 @@ endpoints:
       port: 3000
 
 services:
-    db-dev:
+    db-preview:
         image: pgvector/pgvector:pg18
         restart: always
         environment:
@@ -44,7 +44,7 @@ services:
             context: ..
             dockerfile: dockerfile-prs
         depends_on:
-            - db-dev
+            - db-preview
             - headless-browser
         # The base container idles; okteto up swaps it for the dev container
         # which runs scripts/okteto-dev-up.sh
@@ -61,7 +61,7 @@ services:
             FE_HOST: .okteto.dev
             SITE_URL: ${SITE_URL}
 
-            PGHOST: db-dev
+            PGHOST: db-preview
             PGPORT: 5432
             PGDATABASE: postgres
             PGUSER: postgres

--- a/dockerfile-prs
+++ b/dockerfile-prs
@@ -121,9 +121,9 @@ COPY . .
 # Pre-build the packages the backend imports as dist; scripts/okteto-dev-up.sh
 # reuses the emitted dists and *.tsbuildinfo for incremental rebuilds
 RUN export NODE_OPTIONS="--max-old-space-size=4096" \
-    && pnpm formula:build:fast \
-    && pnpm common-build:fast \
-    && pnpm warehouses-build:fast
+    && pnpm formula:build \
+    && pnpm common-build \
+    && pnpm warehouses-build
 
 # -----------------------------
 # Stage 2: continue build for production environment

--- a/dockerfile-prs
+++ b/dockerfile-prs
@@ -91,6 +91,29 @@ EXPOSE 3000
 EXPOSE 8080
 
 # -----------------------------
+# Stage 1b: warm development environment
+# -----------------------------
+# Dev image with expensive-to-derive node state baked in: source at main,
+# installed node_modules, and pre-built package dists. Okteto cloud dev
+# environments (okteto.dev.yaml) start from this so a fresh namespace only
+# syncs the branch diff and builds incrementally instead of paying a full
+# install and cold builds. Published nightly by
+# .github/workflows/dev-warm-image.yml.
+FROM dev AS dev-warm
+
+COPY . .
+
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --frozen-lockfile --prefer-offline
+
+# Pre-build the packages the backend imports as dist; scripts/okteto-dev-up.sh
+# reuses the emitted dists and *.tsbuildinfo for incremental rebuilds
+RUN export NODE_OPTIONS="--max-old-space-size=4096" \
+    && pnpm formula:build:fast \
+    && pnpm common-build:fast \
+    && pnpm warehouses-build:fast
+
+# -----------------------------
 # Stage 2: continue build for production environment
 # -----------------------------
 

--- a/dockerfile-prs
+++ b/dockerfile-prs
@@ -90,6 +90,30 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 EXPOSE 3000
 EXPOSE 8080
 
+# Install development dependencies before copying source so source-only changes
+# reuse the node_modules layer.
+FROM dev AS dev-dependencies
+
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json .npmrc .pnpmfile.cjs ./
+COPY packages/api-tests/package.json packages/api-tests/
+COPY packages/backend/package.json packages/backend/
+COPY packages/backend/src/ee/services/McpService/mcp-chart-app/package.json packages/backend/src/ee/services/McpService/mcp-chart-app/
+COPY packages/cli/package.json packages/cli/
+COPY packages/common/package.json packages/common/
+COPY packages/e2e/package.json packages/e2e/
+COPY packages/formula/package.json packages/formula/
+COPY packages/formula-tests/package.json packages/formula-tests/
+COPY packages/frontend/package.json packages/frontend/
+COPY packages/frontend/sdk/package.json packages/frontend/sdk/
+COPY packages/iframe-test-app/package.json packages/iframe-test-app/
+COPY packages/query-sdk/package.json packages/query-sdk/
+COPY packages/sdk-next-test-app/package.json packages/sdk-next-test-app/
+COPY packages/sdk-test-app/package.json packages/sdk-test-app/
+COPY packages/warehouses/package.json packages/warehouses/
+
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --frozen-lockfile --prefer-offline
+
 # -----------------------------
 # Stage 1b: warm development environment
 # -----------------------------
@@ -99,12 +123,9 @@ EXPOSE 8080
 # syncs the branch diff and builds incrementally instead of paying a full
 # install and cold builds. Published nightly by
 # .github/workflows/dev-warm-image.yml.
-FROM dev AS dev-warm
+FROM dev-dependencies AS dev-warm
 
 COPY . .
-
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
-    pnpm install --frozen-lockfile --prefer-offline
 
 # Pre-build the packages the backend imports as dist; scripts/okteto-dev-up.sh
 # reuses the emitted dists and *.tsbuildinfo for incremental rebuilds

--- a/dockerfile-prs
+++ b/dockerfile-prs
@@ -95,24 +95,15 @@ EXPOSE 8080
 FROM dev AS dev-dependencies
 
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json .npmrc .pnpmfile.cjs ./
-COPY packages/api-tests/package.json packages/api-tests/
 COPY packages/backend/package.json packages/backend/
-COPY packages/backend/src/ee/services/McpService/mcp-chart-app/package.json packages/backend/src/ee/services/McpService/mcp-chart-app/
-COPY packages/cli/package.json packages/cli/
 COPY packages/common/package.json packages/common/
-COPY packages/e2e/package.json packages/e2e/
 COPY packages/formula/package.json packages/formula/
-COPY packages/formula-tests/package.json packages/formula-tests/
 COPY packages/frontend/package.json packages/frontend/
-COPY packages/frontend/sdk/package.json packages/frontend/sdk/
-COPY packages/iframe-test-app/package.json packages/iframe-test-app/
-COPY packages/query-sdk/package.json packages/query-sdk/
-COPY packages/sdk-next-test-app/package.json packages/sdk-next-test-app/
-COPY packages/sdk-test-app/package.json packages/sdk-test-app/
 COPY packages/warehouses/package.json packages/warehouses/
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
-    pnpm install --frozen-lockfile --prefer-offline
+    pnpm --filter . --filter backend... --filter @lightdash/frontend... \
+    install --frozen-lockfile --prefer-offline
 
 # -----------------------------
 # Stage 1b: warm development environment

--- a/okteto.dev.yaml
+++ b/okteto.dev.yaml
@@ -1,0 +1,67 @@
+# Cloud development environment: a preview-like environment with hot reloading.
+#
+#   okteto deploy -f okteto.dev.yaml --wait   # create/update the environment
+#   okteto up -f okteto.dev.yaml              # sync code + start dev servers
+#
+# The public endpoint is https://lightdash-<namespace>.lightdash.okteto.dev
+# (named after the dev environment, "lightdash") and serves the Vite dev
+# server, so synced changes hot-reload in the browser.
+deploy:
+    commands:
+        - name: Configuring database...
+          command: |
+              set -e
+              # Stable password shared with the snapshot builder
+              # (docker/docker-compose.db-snapshot.yml): a database diverted
+              # from a snapshot keeps the password it was initialised with
+              echo "PGPASSWORD=not-very-secret-preview-db" >> "$OKTETO_ENV"
+
+              # Boot the database from the newest pre-seeded snapshot so the
+              # environment starts with demo data and no migrate/seed wait.
+              # Only on first deploy: the volume is kept afterwards.
+              SNAPSHOT=""
+              if ! kubectl get pvc db-data >/dev/null 2>&1; then
+                SNAPSHOT=$(kubectl get volumesnapshots -n db-snapshot \
+                  -l app.kubernetes.io/part-of=lightdash-preview-db \
+                  --sort-by=.metadata.creationTimestamp \
+                  -o jsonpath='{range .items[?(@.status.readyToUse==true)]}{.metadata.name}{"\n"}{end}' \
+                  2>/dev/null | tail -n 1 || true)
+              fi
+              if [ -n "$SNAPSHOT" ]; then
+                echo "Booting dev database from snapshot db-snapshot/$SNAPSHOT"
+                echo "DB_SNAPSHOT_NAME=$SNAPSHOT" >> "$OKTETO_ENV"
+                echo "DB_SNAPSHOT_NAMESPACE=db-snapshot" >> "$OKTETO_ENV"
+              else
+                echo "Reusing existing database volume (or starting blank if no snapshot is ready)"
+              fi
+
+              echo "SITE_URL=https://lightdash-${OKTETO_NAMESPACE}.${OKTETO_DOMAIN}" >> "$OKTETO_ENV"
+        - name: Deploying compose...
+          command: okteto deploy -f docker/docker-compose.okteto-dev.yml
+
+dev:
+    lightdash-dev:
+        # Nightly-baked warm image (see .github/workflows/dev-warm-image.yml):
+        # source at main + node_modules + pre-built dists, so a fresh namespace
+        # only syncs the branch diff and builds incrementally
+        image: okteto.global/lightdash-dev-warm:latest
+        command: bash scripts/okteto-dev-up.sh
+        sync:
+            - .:/usr/app
+        resources:
+            requests:
+                cpu: '1'
+                memory: 4Gi
+            # Cluster LimitRange max is 2 CPU / 8Gi per container
+            limits:
+                cpu: '2'
+                memory: 8Gi
+        forward:
+            # Node.js debugger (tsx watch --inspect). Local 9230 because a
+            # local dev stack usually holds 9229 already
+            - 9230:9229
+        # No persistent volume: it would shadow the warm image's baked
+        # /usr/app. A pod restart re-syncs (~1 min) — acceptable for
+        # ephemeral dev namespaces
+        persistentVolume:
+            enabled: false

--- a/okteto.dev.yaml
+++ b/okteto.dev.yaml
@@ -16,6 +16,10 @@ deploy:
               # from a snapshot keeps the password it was initialised with
               echo "PGPASSWORD=not-very-secret-preview-db" >> "$OKTETO_ENV"
 
+              # Retire the old workload without deleting its persistent data.
+              kubectl delete statefulset db-dev --ignore-not-found --wait
+              kubectl delete deployment db-dev --ignore-not-found --wait
+
               # Boot the database from the newest pre-seeded snapshot so the
               # environment starts with demo data and no migrate/seed wait.
               # Only on first deploy: the volume is kept afterwards.

--- a/okteto.dev.yaml
+++ b/okteto.dev.yaml
@@ -65,7 +65,7 @@ dev:
         # Nightly-baked warm image (see .github/workflows/dev-warm-image.yml):
         # source at main + node_modules + pre-built dists, so a fresh namespace
         # only syncs the branch diff and builds incrementally
-        image: okteto.global/lightdash-dev-warm:latest
+        image: ${DEV_WARM_IMAGE:-okteto.global/lightdash-dev-warm:latest}
         command: bash scripts/okteto-dev-up.sh
         sync:
             - .:/usr/app

--- a/okteto.dev.yaml
+++ b/okteto.dev.yaml
@@ -25,11 +25,15 @@ deploy:
               # Only on first deploy: the volume is kept afterwards.
               SNAPSHOT=""
               if ! kubectl get pvc db-data >/dev/null 2>&1; then
-                SNAPSHOT=$(kubectl get volumesnapshots -n db-snapshot \
+                CANDIDATES=$(kubectl get volumesnapshots -n db-snapshot \
                   -l app.kubernetes.io/part-of=lightdash-preview-db \
                   --sort-by=.metadata.creationTimestamp \
                   -o jsonpath='{range .items[?(@.status.readyToUse==true)]}{.metadata.name}{"\n"}{end}' \
-                  2>/dev/null | tail -n 1 || true)
+                  2>/dev/null | tail -n 3 || true)
+                COUNT=$(echo "$CANDIDATES" | grep -c . || true)
+                if [ "$COUNT" -gt 0 ]; then
+                  SNAPSHOT=$(echo "$CANDIDATES" | sed -n "$(( $(date +%s) % COUNT + 1 ))p")
+                fi
               fi
               if [ -n "$SNAPSHOT" ]; then
                 echo "Booting dev database from snapshot db-snapshot/$SNAPSHOT"
@@ -41,7 +45,20 @@ deploy:
 
               echo "SITE_URL=https://lightdash-${OKTETO_NAMESPACE}.${OKTETO_DOMAIN}" >> "$OKTETO_ENV"
         - name: Deploying compose...
-          command: okteto deploy -f docker/docker-compose.okteto-dev.yml
+          command: |
+              set -e
+              if [ -n "${DB_SNAPSHOT_NAME:-}" ]; then
+                if ! okteto deploy -f docker/docker-compose.okteto-dev.yml --timeout 18m; then
+                  echo "Snapshot restore failed: retrying with a blank database volume"
+                  kubectl delete statefulset db-preview --ignore-not-found --wait
+                  kubectl delete deployment db-preview --ignore-not-found --wait
+                  kubectl delete pvc db-data --ignore-not-found --wait
+                  export DB_SNAPSHOT_NAME="" DB_SNAPSHOT_NAMESPACE=""
+                  okteto deploy -f docker/docker-compose.okteto-dev.yml --timeout 20m
+                fi
+              else
+                okteto deploy -f docker/docker-compose.okteto-dev.yml
+              fi
 
 dev:
     lightdash-dev:

--- a/packages/frontend/src/features/users/components/LoginLanding.tsx
+++ b/packages/frontend/src/features/users/components/LoginLanding.tsx
@@ -304,7 +304,7 @@ const Login: FC<{}> = () => {
             </Box>
             <Card id={LOGIN_PAGE_ID} p="xl" radius="xs" withBorder shadow="xs">
                 <Title order={3} ta="center" mb="md">
-                    Sign in
+                    banana
                 </Title>
                 <form
                     name="login"

--- a/packages/frontend/src/features/users/components/LoginLanding.tsx
+++ b/packages/frontend/src/features/users/components/LoginLanding.tsx
@@ -304,7 +304,7 @@ const Login: FC<{}> = () => {
             </Box>
             <Card id={LOGIN_PAGE_ID} p="xl" radius="xs" withBorder shadow="xs">
                 <Title order={3} ta="center" mb="md">
-                    banana
+                    Sign in
                 </Title>
                 <form
                     name="login"

--- a/scripts/okteto-dev-up.sh
+++ b/scripts/okteto-dev-up.sh
@@ -19,9 +19,9 @@ pnpm --filter . --filter backend... --filter @lightdash/frontend... \
     install --prefer-offline
 
 echo "--- Building formula, common, warehouses (incremental)"
-pnpm formula:build:fast
-pnpm common-build:fast
-pnpm warehouses-build:fast
+pnpm formula:build
+pnpm common-build
+pnpm warehouses-build
 
 echo "--- Running database migrations"
 # The preview snapshot was migrated from compiled dist ('.js' filenames); dev
@@ -41,7 +41,4 @@ fi
 ALLOW_MISSING_MIGRATIONS=true pnpm -F backend migrate
 
 echo "--- Starting dev servers"
-# dev:fast shares tsconfigs with the build:fast pre-build above; plain `dev`
-# uses the full tsconfigs and would recompile everything in watch mode,
-# restarting the backend on every emitted file
-exec pnpm dev:fast
+exec pnpm dev

--- a/scripts/okteto-dev-up.sh
+++ b/scripts/okteto-dev-up.sh
@@ -36,7 +36,8 @@ else
     echo "WARNING: blank database (no preview snapshot was available)."
     echo "WARNING: migrating from scratch; there will be no demo data or demo login."
 fi
-pnpm -F backend migrate
+# The snapshot can contain migrations added to main after this branch diverged.
+ALLOW_MISSING_MIGRATIONS=true pnpm -F backend migrate
 
 echo "--- Starting dev servers"
 # dev:fast shares tsconfigs with the build:fast pre-build above; plain `dev`

--- a/scripts/okteto-dev-up.sh
+++ b/scripts/okteto-dev-up.sh
@@ -15,7 +15,8 @@ if [ ! -e /usr/app/profiles ] && [ ! -L /usr/app/profiles ]; then
 fi
 
 echo "--- Installing dependencies"
-pnpm install --prefer-offline
+pnpm --filter . --filter backend... --filter @lightdash/frontend... \
+    install --prefer-offline
 
 echo "--- Building formula, common, warehouses (incremental)"
 pnpm formula:build:fast

--- a/scripts/okteto-dev-up.sh
+++ b/scripts/okteto-dev-up.sh
@@ -1,11 +1,18 @@
 #!/bin/bash
 # Runs inside the Okteto dev container (see okteto.dev.yaml). Installs
 # dependencies, builds the packages the backend imports as dist, migrates the
-# database, then starts the same watchers as local dev. node_modules and
-# incremental build state live on the dev container's persistent volume, so
-# only the first run pays the full cost.
+# database, then starts the same watchers as local dev. The warm image provides
+# node_modules and incremental build state; each pod restart starts from it.
 set -euo pipefail
 cd /usr/app
+
+# Snapshotted project settings use the paths from the preview image.
+if [ ! -e /usr/app/dbt ] && [ ! -L /usr/app/dbt ]; then
+    ln -s /usr/app/examples/full-jaffle-shop-demo/dbt /usr/app/dbt
+fi
+if [ ! -e /usr/app/profiles ] && [ ! -L /usr/app/profiles ]; then
+    ln -s /usr/app/examples/full-jaffle-shop-demo/profiles /usr/app/profiles
+fi
 
 echo "--- Installing dependencies"
 pnpm install --prefer-offline

--- a/scripts/okteto-dev-up.sh
+++ b/scripts/okteto-dev-up.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Runs inside the Okteto dev container (see okteto.dev.yaml). Installs
+# dependencies, builds the packages the backend imports as dist, migrates the
+# database, then starts the same watchers as local dev. node_modules and
+# incremental build state live on the dev container's persistent volume, so
+# only the first run pays the full cost.
+set -euo pipefail
+cd /usr/app
+
+echo "--- Installing dependencies"
+pnpm install --prefer-offline
+
+echo "--- Building formula, common, warehouses (incremental)"
+pnpm formula:build:fast
+pnpm common-build:fast
+pnpm warehouses-build:fast
+
+echo "--- Running database migrations"
+# The preview snapshot was migrated from compiled dist ('.js' filenames); dev
+# runs migrations from src ('.ts'). Align the records or knex refuses to run.
+# A blank database (no snapshot was ready at deploy time) has no
+# knex_migrations table yet: skip the rename and warn — the app boots without
+# demo data and users must register manually.
+if [ "$(psql -h "$PGHOST" -p "${PGPORT:-5432}" -U "$PGUSER" -d "$PGDATABASE" -tAc \
+    "SELECT to_regclass('knex_migrations') IS NOT NULL")" = "t" ]; then
+    psql -h "$PGHOST" -p "${PGPORT:-5432}" -U "$PGUSER" -d "$PGDATABASE" \
+        -c "UPDATE knex_migrations SET name = regexp_replace(name, '\.js$', '.ts') WHERE name LIKE '%.js';"
+else
+    echo "WARNING: blank database (no preview snapshot was available)."
+    echo "WARNING: migrating from scratch; there will be no demo data or demo login."
+fi
+pnpm -F backend migrate
+
+echo "--- Starting dev servers"
+# dev:fast shares tsconfigs with the build:fast pre-build above; plain `dev`
+# uses the full tsconfigs and would recompile everything in watch mode,
+# restarting the backend on every emitted file
+exec pnpm dev:fast


### PR DESCRIPTION
Adds a warm base image for standalone Okteto development environments used by developers and remote agents. The image bakes in the expensive Node dependency and package-build state so a new namespace can reach the hot-reload workflow sooner.

## Why this remains separate from previews

Okteto development environments and PR previews serve different workflows:

- A development environment must be available directly from a local branch, before a PR exists, so developers and agents can start working immediately.
- A PR preview is a deterministic, push-driven environment used for review, QA, and e2e checks.

Keeping them separate avoids making development startup depend on opening a PR and waiting for the preview pipeline. This PR focuses on making the standalone development environment fast enough to create on demand.

## What's in this PR

- **`dockerfile-prs`**: adds a Node 24 `dev-warm` target with the required workspace dependencies plus pre-built `formula`, `common`, and `warehouses` output using the TypeScript 7 build scripts.
- **`.github/workflows/dev-warm-image.yml`**: builds and publishes `okteto.global/lightdash-dev-warm:latest` nightly, when its dependency inputs change, and on manual dispatch.
- **`okteto.dev.yaml`**: uses the warm image, supports `DEV_WARM_IMAGE` overrides for isolated testing, and restores the development database from a recent ready snapshot. Snapshot restoration has a timeout and retries with a clean blank volume if restoration fails.
- **Database migration**: renames the development database service to `db-preview`, removes the legacy `db-dev` workload while retaining its PVC, and preserves compatibility with the preview database snapshot.
- **`scripts/okteto-dev-up.sh`**: restores the dbt and profiles paths expected by snapshotted project settings, reconciles dependencies, performs incremental package builds, handles compiled migration filenames and newer snapshot migrations, then starts the standard development watchers.
- **`docker/docker-compose.okteto-dev.yml`**: provides the preview-compatible database and Lightdash services used by the standalone development manifest.

The development container intentionally has persistence disabled because a mounted `/usr/app` volume would hide the state baked into the warm image. Source synchronization applies the local branch changes over that image.

## Validation

- Rebased onto the Node 24 and TypeScript 7 version of `main`.
- Built the complete `dev-warm` Docker target using `node:24-bookworm-slim`.
- Validated the Okteto manifest, YAML files, startup shell script, and Git diff.

Relates: SPK-565
