### PR TITLE
fix(onboarding): route new-onboarding signups to the data source page without EE

### DIFF
--- a/packages/frontend/src/components/AppRoute.test.tsx
+++ b/packages/frontend/src/components/AppRoute.test.tsx
@@ -67,6 +67,10 @@ const renderAppRoute = () =>
                         path="/createProject"
                         element={<div>create project</div>}
                     />
+                    <Route
+                        path="/onboarding/data-source"
+                        element={<div>data source</div>}
+                    />
                 </Routes>
             </MemoryRouter>
         </MantineProvider>,
@@ -87,8 +91,31 @@ describe('AppRoute', () => {
         expect(screen.getByText('get started')).toBeInTheDocument();
     });
 
-    it('sends a copilot-less organization straight to project creation', () => {
+    it('sends a copilot-less organization to the new data source page', () => {
         state.isCopilotEnabled = false;
+        renderAppRoute();
+
+        expect(screen.getByText('data source')).toBeInTheDocument();
+    });
+
+    it('sends an organization without the homepage builder to the new data source page', () => {
+        state.isHomepageBuilderEnabled = false;
+        renderAppRoute();
+
+        expect(screen.getByText('data source')).toBeInTheDocument();
+    });
+
+    it('sends an organization without new onboarding to legacy project creation', () => {
+        state.isNewOnboardingEnabled = false;
+        state.isHomepageBuilderEnabled = false;
+        state.isCopilotEnabled = false;
+        renderAppRoute();
+
+        expect(screen.getByText('create project')).toBeInTheDocument();
+    });
+
+    it('keeps legacy project creation when only the enterprise surfaces are enabled', () => {
+        state.isNewOnboardingEnabled = false;
         renderAppRoute();
 
         expect(screen.getByText('create project')).toBeInTheDocument();
@@ -101,6 +128,7 @@ describe('AppRoute', () => {
 
         expect(screen.queryByText('create project')).toBeNull();
         expect(screen.queryByText('get started')).toBeNull();
+        expect(screen.queryByText('data source')).toBeNull();
     });
 
     it('renders its children once the organization has a project', () => {

--- a/packages/frontend/src/components/AppRoute.tsx
+++ b/packages/frontend/src/components/AppRoute.tsx
@@ -38,20 +38,17 @@ const AppRoute: FC<React.PropsWithChildren> = ({ children }) => {
         ) {
             return <PageSpinner />;
         }
+        const isNewOnboardingEnabled = orgSetupPageFlag.data?.enabled ?? false;
         const showGetStarted =
             homepageBuilderFlag.isEnabled &&
             isCopilotEnabled &&
-            (orgSetupPageFlag.data?.enabled ?? false);
-        return (
-            <Navigate
-                to={{
-                    pathname: showGetStarted
-                        ? '/get-started'
-                        : '/createProject',
-                }}
-                state={{ from: location }}
-            />
-        );
+            isNewOnboardingEnabled;
+        const pathname = showGetStarted
+            ? '/get-started'
+            : isNewOnboardingEnabled
+              ? '/onboarding/data-source'
+              : '/createProject';
+        return <Navigate to={{ pathname }} state={{ from: location }} />;
     }
 
     return <>{children}</>;


### PR DESCRIPTION
The new signup flow could only reach `/onboarding/data-source` through the enterprise day-0 homepage, so instances without enterprise features fell back to the legacy project-creation flow after signup.

Linear: PROD-9303

## The problem

`AppRoute` sends a project-less organization to `/get-started` only when **all three** of `homepage-builder`, copilot and `new-onboarding` are enabled. `/get-started` renders the enterprise `NoProjectHomepage`, whose `connect-warehouse` recommended action is the only post-signup link to `/onboarding/data-source`.

The first two are enterprise-gated, so on self-hosted, OSS and local dev instances a user with `new-onboarding` enabled got the new email-only signup and the new full-page organization setup, and was then handed the **legacy** `SelectWarehouse` → `SelectConnectMethod` flow. The new warehouse-connect experience was unreachable, despite being gated on a flag that says nothing about enterprise.

This was easy to miss because the legacy page also reads "Let's get you set up!" and now carries the "Invite an expert" footer, so it looks like the new page at a glance.

## The change

`new-onboarding` now routes to `/onboarding/data-source` on its own. Precedence:

| homepage-builder + copilot | new-onboarding | destination |
|---|---|---|
| ✅ | ✅ | `/get-started` (unchanged) |
| ❌ | ✅ | `/onboarding/data-source` (**new**) |
| any | ❌ | `/createProject` (unchanged) |

The enterprise day-0 homepage still wins where it is available, so #25679's homepage-first onboarding is untouched. Only the previously-legacy fallback changes, and only when `new-onboarding` is on.

No redirect-loop risk: `AppRoute` wraps `/projects/*` only — `/get-started`, `/onboarding/data-source` and `/createProject` are siblings outside it. `useOnboardingPageGuard` on the destination also checks `new-onboarding`, and we only route there when it is enabled.

## Verification

Browser-verified on a **non-enterprise** instance (`homepage-builder=false`, `ai-copilot=false`, no license key, `new-onboarding=true`): fresh email-only signup → verify → organization setup → lands on `/onboarding/data-source` ("Add a data source"). Before this change the same environment landed on `/createProject`.

Unit tests cover all three branches plus the loading case: `AppRoute.test.tsx` 7 passing. `typecheck:fast` clean, package linter clean on both touched files, react-doctor reports nothing on `AppRoute.tsx`.

## Note

Worth a sanity check from whoever owns the day-0 experience: this assumes the new warehouse-connect flow is *meant* to be available without enterprise. If it is deliberately enterprise-only, the right fix is the opposite one — document the gating and leave routing alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBjoamEJYshNBA7bhfBmhv
