### PR TITLE
feat(analytics): instrument the Snowflake CLI SSO connect experience

### DIFF
--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeCliSsoPanel.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeCliSsoPanel.tsx
@@ -22,6 +22,7 @@ import {
 } from '@mantine-8/core';
 import { IconAlertTriangle, IconCheck, IconCopy } from '@tabler/icons-react';
 import { useEffect, useState, type FC, type ReactNode } from 'react';
+import { useLocation } from 'react-router';
 import {
     useMintWarehouseConnectCode,
     useWarehouseConnectCodeClaim,
@@ -146,6 +147,10 @@ const SnowflakeCliSsoPanel: FC<Props> = ({
 }) => {
     const { health } = useApp();
     const { track } = useTracking();
+    const { pathname } = useLocation();
+    const onboardingFlow = pathname.startsWith('/onboarding/')
+        ? 'new'
+        : 'legacy';
     const form = useFormContext();
     const siteUrl = health.data?.siteUrl ?? '';
     const mint = useMintWarehouseConnectCode();
@@ -171,6 +176,10 @@ const SnowflakeCliSsoPanel: FC<Props> = ({
             setClaimed(true);
             setInventory(claim.data.inventory);
             onDeposited(claim.data.credentials);
+            track({
+                name: EventName.SNOWFLAKE_CLI_SSO_CONNECT_COMPLETED,
+                properties: { success: true, onboardingFlow },
+            });
             const depositedInventory = claim.data.inventory;
             const selectedDatabase =
                 claim.data.credentials.database ??
@@ -198,15 +207,19 @@ const SnowflakeCliSsoPanel: FC<Props> = ({
                 }
             }
         }
-    }, [claimed, claim.data, onDeposited, form]);
+    }, [claimed, claim.data, onDeposited, form, track, onboardingFlow]);
 
     useEffect(() => {
         if (claim.error) {
             sessionStorage.removeItem(STORED_CODE_KEY);
             setCode(null);
             setSecondsRemaining(null);
+            track({
+                name: EventName.SNOWFLAKE_CLI_SSO_CONNECT_COMPLETED,
+                properties: { success: false, onboardingFlow },
+            });
         }
-    }, [claim.error]);
+    }, [claim.error, track, onboardingFlow]);
 
     useEffect(() => {
         if (secondsRemaining === null || secondsRemaining <= 0)
@@ -441,6 +454,7 @@ const SnowflakeCliSsoPanel: FC<Props> = ({
                             onCopy={() =>
                                 track({
                                     name: EventName.SNOWFLAKE_CLI_SSO_COMMAND_COPIED,
+                                    properties: { onboardingFlow },
                                 })
                             }
                         />

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -77,7 +77,6 @@ type GenericEvent = {
         | EventName.METRICS_CATALOG_TREES_EDGE_REMOVED
         | EventName.METRICS_CATALOG_TREES_CANVAS_MODE_CLICKED
         | EventName.BIGQUERY_SSO_SIGNIN_CLICKED
-        | EventName.SNOWFLAKE_CLI_SSO_COMMAND_COPIED
         | EventName.AGENT_SETUP_PROMPT_COPIED;
     properties?: {};
 };
@@ -687,6 +686,21 @@ type BigquerySsoSigninCompletedEvent = {
     };
 };
 
+type SnowflakeCliSsoCommandCopiedEvent = {
+    name: EventName.SNOWFLAKE_CLI_SSO_COMMAND_COPIED;
+    properties: {
+        onboardingFlow: 'legacy' | 'new';
+    };
+};
+
+type SnowflakeCliSsoConnectCompletedEvent = {
+    name: EventName.SNOWFLAKE_CLI_SSO_CONNECT_COMPLETED;
+    properties: {
+        success: boolean;
+        onboardingFlow: 'legacy' | 'new';
+    };
+};
+
 type OnboardingProjectReadyStartExploringClickedEvent = {
     name: EventName.ONBOARDING_PROJECT_READY_START_EXPLORING_CLICKED;
     properties: {
@@ -740,6 +754,8 @@ export type EventData =
     | OrganizationBrandDetectedEvent
     | OnboardingWarehouseSelectedEvent
     | BigquerySsoSigninCompletedEvent
+    | SnowflakeCliSsoCommandCopiedEvent
+    | SnowflakeCliSsoConnectCompletedEvent
     | OnboardingProjectReadyStartExploringClickedEvent
     | HomepageAskSubmittedEvent
     | HomepageRecommendedActionImpressionEvent

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -201,6 +201,7 @@ export enum EventName {
     BIGQUERY_SSO_SIGNIN_CLICKED = 'bigquery_sso.signin_clicked',
     BIGQUERY_SSO_SIGNIN_COMPLETED = 'bigquery_sso.signin_completed',
     SNOWFLAKE_CLI_SSO_COMMAND_COPIED = 'snowflake_cli_sso.command_copied',
+    SNOWFLAKE_CLI_SSO_CONNECT_COMPLETED = 'snowflake_cli_sso.connect_completed',
     SETUP_INVITE_SENT = 'setup_invite.sent',
     PLAYGROUND_PROJECT_ENTERED = 'playground_project.entered',
     PLAYGROUND_PROJECT_SETUP_FAILED = 'playground_project.setup_failed',


### PR DESCRIPTION
The dashboard question "how many people use the Snowflake or BigQuery SSO experience to connect their warehouse?" is only half answerable today. BigQuery has `bigquery_sso.signin_clicked` → `bigquery_sso.signin_completed{success}`, so a started SSO flow can be told from a finished one. Snowflake CLI SSO has a single copy-the-command event carrying **no properties at all**, so the two warehouses aren't comparable and neither can be sliced by rollout arm.

Both events were already wired — `snowflake_cli_sso.command_copied` fires from a real `onCopy` handler. The absence of a shredded table downstream means nobody has copied that command in production yet, not that the emitter is missing.

### What changed

- **`snowflake_cli_sso.command_copied` now carries `onboardingFlow`.** It moves out of the property-less `GenericEvent` union into its own type, same shape and same `pathname.startsWith('/onboarding/')` derivation as #26341.
- **New `snowflake_cli_sso.connect_completed{success, onboardingFlow}`**, so a started CLI SSO flow can be told from a finished one.

### What the completion event does and does not prove

Completion here isn't a browser redirect: the user copies a command and runs it in their own terminal, so there's no OAuth return trip to hook the way BigQuery has. The nearest honest signal is the one the panel already acts on — the browser polls `/warehouse-connect/claim` every 2s, and the CLI's credentials coming back is what flips the panel to "Connected as … ✓". That's what the event reports.

**`success: true` means:** the CLI ran, completed its Snowflake SSO sign-in, deposited credentials, and this browser tab picked them up. That is a genuine end-to-end completion of the connect handshake — not an inference.

**It does not mean** the project was created or that the warehouse ever ran a query. Those are later steps, already covered by `create_project_button.click` / `create_project.failed`.

**`success: false` means** the browser's wait ended with the connect code rejected — expired, invalidated, or an API error while polling (the query uses `retry: false`, so a single transient 5xx counts). It is a signal that the wait ended badly, **not** a measured failure of the user's SSO attempt.

**The biggest blind spot is silent abandonment.** Copy the command, never run it, close the tab — no completion event of either kind. So `command_copied` → `connect_completed` is a conversion rate among people who stayed on the page, not among everyone who started. Reads of the funnel should treat missing completions as "unknown", not as failures.

### On `create_project_cli_sso_option.click`

Named in the ticket as another event that has never fired. It **is** wired (`SnowflakeForm.tsx`), but it is effectively unreachable on the default path: when the flag is on, an effect puts the form into CLI SSO mode automatically, so the user never selects the option that fires the event. It only fires if someone switches to a different auth type and then switches back. It is therefore not a usable measure of CLI SSO entry, and this PR does not try to make it one — `snowflake_cli_sso.command_copied` is the entry signal. Left as-is deliberately rather than silently.

### Overlap with existing backend events

`WarehouseConnectService` already emits `warehouse_connect_code.created`, `warehouse_connect.deposited` and `warehouse_connect.claimed`. Those are server-side and can't know `onboardingFlow` (no request pathname), and they don't sit in the `snowflake_cli_sso.*` family, so they can't be joined symmetrically against `bigquery_sso.*` in the journey mart. The frontend pair added here is what makes the two warehouses directly comparable; the backend events remain useful as a cross-check on whether a deposit happened when the browser tab was already gone.

### Verification

- `pnpm -F frontend typecheck` — passes clean.
- `pnpm --filter frontend run linter <the 3 touched paths>` — 0 warnings, 0 errors.
- react-doctor, scoped to the touched directory and diffed against the same run on `main`: **no new diagnostics**. The 7 findings on `SnowflakeCliSsoPanel.tsx` are identical before and after, only line-shifted (giant component, `onDeposited` prop-callback-in-effect, state adjustment in effect, chained iterations). All pre-existing; fixing them means restructuring the claim-polling architecture, which doesn't belong in a telemetry PR.
- **No runtime verification — these events have not been observed firing.** Both local dev-env slots were occupied by other worktrees, and a true `success: true` needs a real Snowflake SSO round trip through the CLI, which the available test account can't perform. The change is type-checked and follows the existing emitter pattern, but treat "fires in production" as unproven until the smoke run covers it.

Linear: SPK-680
