### PR TITLE
perf: cache TSOA generation in PR preview builds

### DIFF
--- a/dockerfile-prs
+++ b/dockerfile-prs
@@ -152,7 +152,7 @@ COPY packages/backend/src/ packages/backend/src/
 
 RUN --mount=type=secret,id=TURBO_TOKEN \
     export TURBO_TOKEN=$(cat /run/secrets/TURBO_TOKEN 2>/dev/null || echo "") && \
-    turbo build:fast --filter=backend
+    turbo build:preview --filter=backend
 
 # output: /usr/app/packages/backend/dist
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -7,11 +7,13 @@
     "scripts": {
         "generate-api": "tsoa spec-and-routes --configuration tsoa.yml",
         "generate-api:build": "pnpm run generate-api && pnpm run formatter --write ./src/generated",
+        "generate-api:preview": "pnpm run generate-api",
         "generate-api-dev": "chokidar './src/**/controllers/**/*.ts' -c 'pnpm run generate-api'",
         "dev": "LIGHTDASH_MODE=development HEADLESS=true tsx watch --clear-screen=false --inspect=0.0.0.0:9229 src/index.ts",
         "dev:fast": "pnpm run dev",
         "build": "pnpm run generate-api:build && tsc6 --build tsconfig.json",
         "build:fast": "pnpm run generate-api:build && tsc --build tsconfig.fast.json && pnpm run postbuild",
+        "build:preview": "tsc --build tsconfig.fast.json && pnpm run postbuild",
         "build:mcp-app": "pnpm -F @lightdash/mcp-chart-app build",
         "build-sourcemaps": "pnpm run generate-api:build && tsc6 --build tsconfig.sentry.json",
         "typecheck": "tsc6 --project tsconfig.json --noEmit",

--- a/turbo.json
+++ b/turbo.json
@@ -14,6 +14,36 @@
       "outputs": ["dist/**", "build/**", "src/grammar/parser.js", "src/generated/routes.ts", "src/generated/swagger.json"],
       "cache": true
     },
+    "backend#generate-api:preview": {
+      "dependsOn": ["^build:fast"],
+      "inputs": [
+        "$TURBO_ROOT$/tsconfig.json",
+        "package.json",
+        "tsoa.yml",
+        "tsconfig.json",
+        "src/**/*.ts",
+        "src/**/*.tsx",
+        "src/**/*.json",
+        "!src/generated/**",
+        "!src/**/*.test.ts",
+        "!src/**/*.spec.ts",
+        "!src/**/__tests__/**",
+        "!src/database/migrations/**",
+        "!src/database/seeds/**",
+        "!src/ee/database/migrations/**",
+        "!src/ee/database/seeds/**",
+        "!src/scripts/**",
+        "!src/ee/repl/scripts/**"
+      ],
+      "outputs": ["src/generated/routes.ts", "src/generated/swagger.json"],
+      "cache": true
+    },
+    "backend#build:preview": {
+      "dependsOn": ["^build:fast", "generate-api:preview"],
+      "inputs": ["$TURBO_DEFAULT$", "!src/generated/**"],
+      "outputs": ["dist/**"],
+      "cache": true
+    },
     "typecheck": {
       "dependsOn": ["^build"],
       "cache": true


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Separates preview TSOA generation into a cached Turbo task and skips formatting generated artifacts in runtime image builds.
Uses scoped inputs that retain controller and transitive API-type sources while excluding tests, migrations, seeds, scripts, and generated outputs.
Keeps normal backend builds unchanged and updates the PR preview Docker build to use the optimized path.

Validation: the rebased preview build passes, and a warm local run restores all five Turbo tasks from cache.

test-backend