### PR TITLE
chore: remove deprecated AI agent feature flag

### DIFF
--- a/packages/common/src/featureFlags/previewFeatureFlags.ts
+++ b/packages/common/src/featureFlags/previewFeatureFlags.ts
@@ -24,8 +24,6 @@ const PREVIEW_EXCLUDED_FEATURE_FLAGS: ReadonlySet<string> = new Set<string>([
     // Off pending a security review, or only meaningful for eval orgs.
     FeatureFlags.SsoOrganizationSettings,
     FeatureFlags.AiReviewReplayCapture,
-    // Deprecated, kept only for persisted config.
-    FeatureFlags.AiAgentRevamp,
     // Derived from instance configuration: left to their config handler so a
     // preview never advertises a feature whose backend isn't configured.
     CommercialFeatureFlags.AiCopilot,

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -142,11 +142,6 @@ export enum FeatureFlags {
     AiAgentMemory = 'ai-agent-memory',
 
     /**
-     * @deprecated Rolled out to all customers. Keep for persisted feature flag config only.
-     */
-    AiAgentRevamp = 'ai-agent-revamp',
-
-    /**
      * Enable the Hexbin (H3 hexagonal binning) layer type for Map charts.
      * Gates the option in the Map Type segmented control. Existing charts
      * already saved with the hexbin layer continue to render either way.


### PR DESCRIPTION
## Summary

- Remove `AiAgentRevamp` from the active feature flag registry.
- Remove its stale preview-environment exclusion.

## Persisted configuration

Persisted flags remain safe: `FeatureFlagModel.get` accepts string IDs and resolves database-only flags without enum membership. This change does not delete feature flag rows or overrides. No runtime code checks `ai-agent-revamp`.

## Validation

- `pnpm --filter common typecheck`
- `pnpm exec vitest run --config vitest.config.ts src/models/FeatureFlagModel/FeatureFlagModel.test.ts` — 36 tests passed
- `git diff --check`

Relates: SPK-697