### PR TITLE
fix: gate DuckLake local catalog/data paths behind instance config

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -374,6 +374,9 @@ export const lightdashConfigMock: LightdashConfig = {
             region: 'mock_region',
         },
     },
+    ducklake: {
+        localPathsEnabled: true,
+    },
     usageEvents: {
         enabled: false,
         flushIntervalMs: 60000,

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1612,6 +1612,10 @@ export type LightdashConfig = {
         duckdbQueryMemoryLimit: string | null;
         s3?: Omit<S3Config, 'expirationTime'>;
     };
+    ducklake: {
+        /** Allow DuckLake catalog/data paths on the server's local filesystem. Only viable for single-pod deployments, so it defaults to off in cloud mode. */
+        localPathsEnabled: boolean;
+    };
     usageEvents: {
         enabled: boolean;
         flushIntervalMs: number;
@@ -3121,6 +3125,12 @@ export const parseConfig = (): LightdashConfig => {
             duckdbQueryMemoryLimit:
                 process.env.PRE_AGGREGATE_DUCKDB_QUERY_MEMORY_LIMIT ?? null,
             s3: preAggregatesS3,
+        },
+        ducklake: {
+            localPathsEnabled:
+                process.env.DUCKLAKE_LOCAL_PATHS_ENABLED !== undefined
+                    ? process.env.DUCKLAKE_LOCAL_PATHS_ENABLED === 'true'
+                    : mode !== LightdashMode.CLOUD_BETA,
         },
         usageEvents: {
             enabled: usageEventsEnabled,

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -7,6 +7,8 @@ import {
     DimensionType,
     DownloadFileType,
     DuckdbConnectionType,
+    DucklakeCatalogType,
+    DucklakeDataPathType,
     FeatureFlags,
     FilterOperator,
     ForbiddenError,
@@ -3441,5 +3443,70 @@ describe('ProjectService.resolveCompileAdapter (MultiDbtSources regression firew
         await expect(
             projectService.resolveCompileAdapter(baseArgs),
         ).rejects.toThrow(ParameterError);
+    });
+});
+
+describe('validateConfigSecrets - DuckLake local paths', () => {
+    const ducklakeLocalCredentials: CreateWarehouseCredentials = {
+        type: WarehouseTypes.DUCKDB,
+        connectionType: DuckdbConnectionType.DUCKLAKE,
+        schema: 'main',
+        catalog: {
+            type: DucklakeCatalogType.SQLITE,
+            path: '/srv/lightdash/catalog.sqlite',
+        },
+        dataPath: {
+            type: DucklakeDataPathType.LOCAL,
+            path: '/srv/lightdash/data',
+        },
+    };
+
+    const ducklakeRemoteCredentials: CreateWarehouseCredentials = {
+        type: WarehouseTypes.DUCKDB,
+        connectionType: DuckdbConnectionType.DUCKLAKE,
+        schema: 'main',
+        catalog: {
+            type: DucklakeCatalogType.POSTGRES,
+            host: 'db.internal',
+            port: 5432,
+            database: 'ducklake',
+            user: 'ducklake',
+            password: 'secret',
+        },
+        dataPath: {
+            type: DucklakeDataPathType.S3,
+            url: 's3://bucket/ducklake/',
+        },
+    };
+
+    const localPathsDisabledService = getMockedProjectService({
+        ...lightdashConfigMock,
+        ducklake: { localPathsEnabled: false },
+    });
+
+    test('rejects DuckLake credentials with local catalog/data paths when local paths are disabled', () => {
+        expect(() =>
+            localPathsDisabledService.validateConfigSecrets({
+                warehouseConnection: ducklakeLocalCredentials,
+            } as UpdateProject),
+        ).toThrow(ParameterError);
+    });
+
+    test('accepts DuckLake credentials with remote catalog and data paths when local paths are disabled', () => {
+        expect(() =>
+            localPathsDisabledService.validateConfigSecrets({
+                warehouseConnection: ducklakeRemoteCredentials,
+            } as UpdateProject),
+        ).not.toThrow();
+    });
+
+    test('accepts DuckLake credentials with local paths when local paths are enabled', () => {
+        const localPathsEnabledService =
+            getMockedProjectService(lightdashConfigMock);
+        expect(() =>
+            localPathsEnabledService.validateConfigSecrets({
+                warehouseConnection: ducklakeLocalCredentials,
+            } as UpdateProject),
+        ).not.toThrow();
     });
 });

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -64,6 +64,8 @@ import {
     DefaultSupportedDbtVersion,
     DownloadFileType,
     DuckdbConnectionType,
+    DucklakeCatalogType,
+    DucklakeDataPathType,
     EnsurePlaygroundProjectResults,
     Explore,
     ExploreError,
@@ -2406,6 +2408,10 @@ export class ProjectService extends BaseService {
         ProjectService.assertPersistableSnowflakeAuthentication(
             data.warehouseConnection,
         );
+        ProjectService.assertDucklakeLocalPathsAllowed(
+            data.warehouseConnection,
+            this.lightdashConfig.ducklake.localPathsEnabled,
+        );
 
         await this.validateProjectCreationPermissions(user, data);
 
@@ -2460,6 +2466,10 @@ export class ProjectService extends BaseService {
         ProjectService.assertEmbeddedCredentialsAreInternal(
             newProjectData.warehouseConnection,
             internalProvisioning,
+        );
+        ProjectService.assertDucklakeLocalPathsAllowed(
+            newProjectData.warehouseConnection,
+            this.lightdashConfig.ducklake.localPathsEnabled,
         );
 
         const createProject: CreateProjectOptionalCredentials =
@@ -3098,6 +3108,32 @@ export class ProjectService extends BaseService {
     }
 
     /*
+    DuckLake SQLite/DuckDB catalogs and LOCAL data paths reference files on
+    the Lightdash server filesystem, so they are only viable for single-pod
+    deployments and can be disabled via `ducklake.localPathsEnabled`.
+    */
+    private static assertDucklakeLocalPathsAllowed(
+        credentials: CreateWarehouseCredentials | undefined,
+        localPathsEnabled: boolean,
+    ): void {
+        if (
+            localPathsEnabled ||
+            credentials?.type !== WarehouseTypes.DUCKDB ||
+            credentials.connectionType !== DuckdbConnectionType.DUCKLAKE
+        ) {
+            return;
+        }
+        if (
+            credentials.catalog.type !== DucklakeCatalogType.POSTGRES ||
+            credentials.dataPath.type === DucklakeDataPathType.LOCAL
+        ) {
+            throw new ParameterError(
+                'DuckLake catalog and data paths on the local filesystem are not enabled on this instance',
+            );
+        }
+    }
+
+    /*
     Interactive Snowflake authentication types need a browser on every
     connect, so they cannot be used from headless backend/scheduler runs.
     External browser is still allowed when `requireUserCredentials` is set,
@@ -3191,6 +3227,12 @@ export class ProjectService extends BaseService {
                         'Athena access key authentication requires accessKeyId and secretAccessKey',
                     );
                 }
+                break;
+            case WarehouseTypes.DUCKDB:
+                ProjectService.assertDucklakeLocalPathsAllowed(
+                    project.warehouseConnection,
+                    this.lightdashConfig.ducklake.localPathsEnabled,
+                );
                 break;
             default:
                 break;
@@ -3883,6 +3925,10 @@ export class ProjectService extends BaseService {
             }
             ProjectService.assertEmbeddedCredentialsAreInternal(
                 body.credentials,
+            );
+            ProjectService.assertDucklakeLocalPathsAllowed(
+                body.credentials,
+                this.lightdashConfig.ducklake.localPathsEnabled,
             );
             effectiveCredentials = body.credentials;
         }


### PR DESCRIPTION
Adds a `ducklake.localPathsEnabled` config flag (`DUCKLAKE_LOCAL_PATHS_ENABLED`, defaulting to off in cloud mode) and validates DuckLake warehouse credentials against it when saving or previewing project connections.

Linear: SPK-596