### PR TITLE
feat: report memory distill and consolidation failures to Sentry

### DIFF
--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
@@ -67,6 +67,7 @@ import {
     type ConsolidationOutput,
 } from './consolidationSchema';
 import { distillOutputSchema, type DistillOutput } from './distillSchema';
+import { reportAiAgentMemoryFailure } from './failureReporting';
 import { validateMemoryObjects } from './memoryObjects';
 import { sanitizeThread } from './transcriptSanitizer';
 import { serializeTranscript } from './transcriptSerializer';
@@ -592,6 +593,14 @@ export class AiAgentMemoryService extends BaseService {
                     error: getErrorMessage(error),
                 },
             );
+            reportAiAgentMemoryFailure({
+                pipeline: 'consolidate',
+                error,
+                abortSignal: abortSignal ?? null,
+                organizationUuid: partition.organizationUuid,
+                projectUuid: partition.projectUuid,
+                ownerUserUuid: partition.ownerUserUuid,
+            });
             return 'failed';
         }
     }
@@ -727,6 +736,14 @@ export class AiAgentMemoryService extends BaseService {
             this.logger.warn('Dropping AI agent memory consolidation', {
                 projectUuid: partition.projectUuid,
                 error: errorMessage,
+            });
+            reportAiAgentMemoryFailure({
+                pipeline: 'consolidate',
+                error,
+                abortSignal: args.abortSignal ?? null,
+                organizationUuid: partition.organizationUuid,
+                projectUuid: partition.projectUuid,
+                ownerUserUuid: partition.ownerUserUuid,
             });
             return 'failed';
         }
@@ -996,6 +1013,14 @@ export class AiAgentMemoryService extends BaseService {
             this.logger.warn('Dropping AI agent memory distill', {
                 threadUuid: thread.threadUuid,
                 error: errorMessage,
+            });
+            reportAiAgentMemoryFailure({
+                pipeline: 'distill',
+                error,
+                abortSignal: abortSignal ?? null,
+                organizationUuid: thread.organizationUuid,
+                projectUuid: thread.projectUuid,
+                threadUuid: thread.threadUuid,
             });
             if (!memoryGenerated) {
                 this.track({

--- a/packages/backend/src/ee/services/AiAgentMemoryService/failureReporting.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/failureReporting.ts
@@ -1,0 +1,106 @@
+import { assertUnreachable } from '@lightdash/common';
+import * as Sentry from '@sentry/node';
+import { AISDKError } from 'ai';
+
+/** Groups memory pipeline drops apart from the generic scheduler bucket. */
+const AI_AGENT_MEMORY_FINGERPRINT = 'ai_agent_memory';
+
+/** AI SDK messages quote the raw model output, so they are never reported. */
+const WITHHELD_AI_SDK_MESSAGE = 'AI SDK error (message withheld)';
+
+type AiAgentMemoryFailureBase = {
+    error: unknown;
+    /** The job-level signal, so an aborted job is not reported twice. */
+    abortSignal: AbortSignal | null;
+    organizationUuid: string;
+    projectUuid: string;
+};
+
+export type AiAgentMemoryFailure = AiAgentMemoryFailureBase &
+    (
+        | { pipeline: 'distill'; threadUuid: string }
+        | { pipeline: 'consolidate'; ownerUserUuid: string }
+    );
+
+const getFailureTags = (
+    failure: AiAgentMemoryFailure,
+): Record<string, string> => {
+    const common = {
+        'organization.uuid': failure.organizationUuid,
+        'project.uuid': failure.projectUuid,
+    };
+    switch (failure.pipeline) {
+        case 'distill':
+            return {
+                ...common,
+                'ai_agent_memory.thread_uuid': failure.threadUuid,
+            };
+        case 'consolidate':
+            return {
+                ...common,
+                'ai_agent_memory.owner_user_uuid': failure.ownerUserUuid,
+            };
+        default:
+            return assertUnreachable(failure, 'Unknown memory pipeline');
+    }
+};
+
+const getErrorName = (error: unknown): string =>
+    error instanceof Error ? error.name : 'UnknownError';
+
+/**
+ * Only an aborted job is silent: the job timeout already reports where it
+ * fires, and a partition it never reached records nothing. A call-level
+ * timeout is a real drop nothing else reports, so it is not suppressed here.
+ */
+const isAbortFailure = (failure: AiAgentMemoryFailure): boolean =>
+    failure.abortSignal?.aborted === true;
+
+const getStackFrames = (error: Error): string =>
+    (error.stack ?? '')
+        .split('\n')
+        .filter((line) => line.trimStart().startsWith('at '))
+        .join('\n');
+
+/**
+ * Sentry's linked-errors integration walks `cause`, and the AI SDK hangs the
+ * raw model output off it — memory bodies, terms and objects. Report a clone
+ * carrying the name, a content-free message and the original frames only.
+ */
+const toReportableError = (error: unknown): unknown => {
+    if (!(error instanceof Error)) return error;
+    const message = AISDKError.isInstance(error)
+        ? WITHHELD_AI_SDK_MESSAGE
+        : error.message;
+    const reportable = new Error(message);
+    reportable.name = error.name;
+    reportable.stack = [`${error.name}: ${message}`, getStackFrames(error)]
+        .filter((part) => part.length > 0)
+        .join('\n');
+    return reportable;
+};
+
+/**
+ * Both memory pipelines drop their failures by design — a failed job would
+ * retry the LLM call — so the failure is reported explicitly here instead. Only
+ * identifiers are attached: no memory, thread, term or object content.
+ */
+export const reportAiAgentMemoryFailure = (
+    failure: AiAgentMemoryFailure,
+): void => {
+    try {
+        if (isAbortFailure(failure)) return;
+        Sentry.withScope((scope) => {
+            scope.setFingerprint([
+                AI_AGENT_MEMORY_FINGERPRINT,
+                failure.pipeline,
+                getErrorName(failure.error),
+            ]);
+            scope.setTags(getFailureTags(failure));
+            Sentry.captureException(toReportableError(failure.error));
+        });
+    } catch {
+        // Reporting must never affect the ledger, the run history, or what the
+        // pass applied.
+    }
+};


### PR DESCRIPTION
Reports memory pipeline failures to Sentry. Both distill and consolidation drop their errors by design, so a pipeline failing on every thread or every partition in an org currently produces no Sentry signal at all — Prometheus shows a failure *rate*, but there is no stack, message or payload to debug it with.

Rethrowing is not an option: it would mark the graphile job failed and retry the LLM call, breaking the drop-on-error contract that ZAP-715 relies on (a failed consolidation run stores its input hash and is terminal until the corpus actually changes; a failed distill records a `failed` ledger outcome and returns).

## What changed

**One shared helper.** `failureReporting.ts` takes a discriminated union on `pipeline`, so distill supplies a thread and consolidation supplies an owner — no optional identifiers and no duck typing. Both call sites are fire-and-forget.

**Fingerprint.** `['ai_agent_memory', <pipeline>, <error name>]`, so the two pipelines group separately from each other and from the generic scheduler bucket the task tracer would otherwise put them in.

**Tags are identifiers only.** Organization and project on both, plus thread for distill and owner for consolidation. No memory body, thread text, terms or object names.

**AI SDK errors are cloned before reporting.** `NoObjectGeneratedError` quotes the whole raw model output in its message and hangs a `TypeValidationError` carrying the parsed value off `cause` — and Sentry's linked-errors integration walks `cause`. The helper reports a clone that keeps the error name and the original stack frames but carries a content-free message and no `cause`, so a schema-validation failure is still a usable signal without leaking a memory body into the report.

**Abort suppression is narrow.** A job-level abort is skipped, because the job-timeout helper already reports where it fires and a partition the loop never reached records nothing. A call-level timeout inside the job budget is *not* suppressed — nothing else reports that drop and, for consolidation, the run is terminal until the corpus moves.

**Reporting failures are swallowed.** The whole helper is wrapped, so a Sentry outage can never affect the ledger, the run history, or what a run applied.

## Notes

- Consolidation reports from two places: the per-partition catch, and the loop-level catch that covers a partition dropped before its run row exists (e.g. selection or catalog fetch throwing). The run row is written first where it exists, so the report never replaces the audit trail.
- The distill call site sits after the existing ledger write, so the reported failure and the recorded `failed` outcome cannot diverge.
- The per-partition consolidation catch already returns early on a job abort, so the helper's own abort check is a second line of defence covering the loop-level catch as well.

## Testing

New `AiAgentMemoryService.failureReporting.test.ts`, asserting observable behaviour rather than call sequences:

- A failed distill reports the error, resolves `failed`, and still writes the `failed` ledger row.
- Tags and fingerprints for both pipelines.
- The ledger is still written when `captureException` itself throws.
- An aborted distill and an aborted consolidation are not reported, and the aborted consolidation writes no run row.
- A consolidation partition failure reports with its owner and records a `failed` run.
- A partition dropped before its run row exists is reported with no run row written.
- A schema-validation failure surviving `maxRetries: 1` is reported (two `generateObject` calls) under its own error name.
- The raw model output the AI SDK hangs off the error is absent from the reported message, stack and `cause`.
- A call-level timeout is reported and still records a `failed` run.

Also run: `pnpm -F common typecheck:fast`, `pnpm -F backend typecheck:fast`, `pnpm -F backend lint`, `pnpm -F common test`, `pnpm -F backend test:dev:nowatch`.

Linear: https://linear.app/lightdash/issue/ZAP-720
Spec: https://linear.app/lightdash/issue/ZAP-715

Relates: ZAP-715
Closes: ZAP-720
