### PR TITLE
feat: consolidation analytics events and prometheus metrics

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -2897,11 +2897,65 @@ export type AiAgentMemoryViewedEvent = BaseTrack & {
     };
 };
 
+/**
+ * The consolidation pass is scheduled work, so the organization is the actor.
+ * Memory text, titles, terms, object names, slugs and operation reasons never
+ * leave the process: only identifiers, counts and closed enumerations do.
+ */
+export type AiAgentMemoryConsolidatedEvent = BaseTrack & {
+    event: 'ai_agent_memory.consolidated';
+    anonymousId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        ownerUserId: string;
+        outcome: 'applied' | 'no_operations';
+        inputCount: number;
+        mergeCount: number;
+        supersedeCount: number;
+        retireCount: number;
+        rejectedCount: number;
+        // Promotion nominations: how many `project`-scope rows curation saw, how
+        // many merges kept that scope, and how many merges silently dropped it.
+        projectScopeInputCount: number;
+        projectScopeMergeCount: number;
+        scopeDowngradedMergeCount: number;
+    };
+};
+
+export type AiAgentMemoryConsolidationFailedEvent = BaseTrack & {
+    event: 'ai_agent_memory.consolidation_failed';
+    anonymousId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        ownerUserId: string;
+        failureStage: 'selection' | 'consolidation' | 'persistence';
+        errorType: string;
+    };
+};
+
+/** A partition that never reached the curator, kept apart from an empty run. */
+export type AiAgentMemoryConsolidationSkippedEvent = BaseTrack & {
+    event: 'ai_agent_memory.consolidation_skipped';
+    anonymousId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        ownerUserId: string;
+        reason: 'clean' | 'catalog_unavailable' | 'objects_unresolved';
+        inputCount: number;
+    };
+};
+
 export type AiAgentMemoryEvent =
     | AiAgentMemoryGeneratedEvent
     | AiAgentMemoryGenerationFailedEvent
     | AiAgentMemoryCitedEvent
-    | AiAgentMemoryViewedEvent;
+    | AiAgentMemoryViewedEvent
+    | AiAgentMemoryConsolidatedEvent
+    | AiAgentMemoryConsolidationFailedEvent
+    | AiAgentMemoryConsolidationSkippedEvent;
 
 export type AiRouterConfigUpdatedEvent = BaseTrack & {
     event: 'ai_router.config_updated';

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.consolidateLlm.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.consolidateLlm.test.ts
@@ -47,7 +47,9 @@ const retryableApiFailure = () =>
 // The real consolidateWithLlm path: no canned consolidateCall injected.
 const build = () => {
     const recordConsolidationRun = vi.fn().mockResolvedValue({});
-    const applyConsolidation = vi.fn().mockResolvedValue({});
+    const applyConsolidation = vi
+        .fn()
+        .mockResolvedValue({ run: {}, applied: [], rejected: [] });
     const service = new AiAgentMemoryService({
         analytics: { track: vi.fn() } as AnyType,
         aiAgentMemoryModel: {

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
@@ -198,8 +198,16 @@ describe('AiAgentMemoryService', () => {
         const distillCall = vi.fn();
         const consolidateCall = vi.fn().mockResolvedValue({ operations: [] });
         const track = vi.fn();
+        const prometheusMetrics = {
+            trackAiAgentMemoryDistill: vi.fn(),
+            incrementAiAgentMemorySweepEnqueued: vi.fn(),
+            trackAiAgentMemoryConsolidate: vi.fn(),
+            trackAiAgentMemoryConsolidateOperations: vi.fn(),
+            incrementAiAgentMemoryEligiblePartitions: vi.fn(),
+        };
         const service = new AiAgentMemoryService({
             analytics: { track } as AnyType,
+            prometheusMetrics: prometheusMetrics as AnyType,
             aiAgentMemoryModel: {
                 findByProjectAndSlug,
                 findByProjectAndUuid,
@@ -255,6 +263,7 @@ describe('AiAgentMemoryService', () => {
             distillCall,
             consolidateCall,
             track,
+            prometheusMetrics,
         };
     };
 

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
@@ -11,6 +11,7 @@ import {
     type AiAgentMemory,
     type AiAgentMemoryConsolidatePartitionJobPayload,
     type AiAgentMemoryConsolidationInputEntry,
+    type AiAgentMemoryConsolidationOperation,
     type AiAgentMemoryConsolidationRejection,
     type AiAgentMemoryDistillJobPayload,
     type AiAgentMemoryEditableStatus,
@@ -26,6 +27,9 @@ import { createHash, randomBytes } from 'crypto';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import {
+    type AiAgentMemoryConsolidatedEvent,
+    type AiAgentMemoryConsolidationFailedEvent,
+    type AiAgentMemoryConsolidationSkippedEvent,
     type AiAgentMemoryGeneratedEvent,
     type AiAgentMemoryGenerationFailedEvent,
     type AiAgentMemoryViewedEvent,
@@ -34,7 +38,10 @@ import {
 import { type GroupsModel } from '../../../models/GroupsModel';
 import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import type PrometheusMetrics from '../../../prometheus/PrometheusMetrics';
-import { type AiAgentMemoryDistillOutcome } from '../../../prometheus/PrometheusMetrics';
+import {
+    type AiAgentMemoryConsolidateOutcome,
+    type AiAgentMemoryDistillOutcome,
+} from '../../../prometheus/PrometheusMetrics';
 import { BaseService } from '../../../services/BaseService';
 import { type FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
 import { type DbAiAgentMemory } from '../../database/entities/aiAgentMemory';
@@ -59,6 +66,9 @@ import {
     buildConsolidationInput,
     buildConsolidationUserMessage,
     computeConsolidationInputHash,
+    countConsolidationOperations,
+    countConsolidationRejections,
+    countConsolidationScopes,
     validateConsolidationOperations,
     type AiAgentMemoryConsolidationPartition,
 } from './consolidation';
@@ -105,11 +115,7 @@ export type AiAgentMemoryConsolidateCall = (args: {
     abortSignal?: AbortSignal;
 }) => Promise<ConsolidationOutput>;
 
-export type AiAgentMemoryConsolidateOutcome =
-    | 'consolidated'
-    | 'skipped'
-    | 'failed'
-    | 'aborted';
+export { type AiAgentMemoryConsolidateOutcome };
 
 type MemorySchedulerClient = {
     aiAgentMemoryDistill: (
@@ -123,7 +129,16 @@ type MemorySchedulerClient = {
 type MemoryServiceAnalyticsEvent =
     | AiAgentMemoryGeneratedEvent
     | AiAgentMemoryGenerationFailedEvent
-    | AiAgentMemoryViewedEvent;
+    | AiAgentMemoryViewedEvent
+    | AiAgentMemoryConsolidatedEvent
+    | AiAgentMemoryConsolidationFailedEvent
+    | AiAgentMemoryConsolidationSkippedEvent;
+
+type ConsolidationFailureStage =
+    AiAgentMemoryConsolidationFailedEvent['properties']['failureStage'];
+
+type ConsolidationSkipReason =
+    AiAgentMemoryConsolidationSkippedEvent['properties']['reason'];
 
 type Dependencies = {
     analytics: LightdashAnalytics;
@@ -193,6 +208,94 @@ export class AiAgentMemoryService extends BaseService {
                 error: getErrorMessage(error),
             });
         }
+    }
+
+    /** The pass is scheduled work, so the organization is the anonymous actor. */
+    private trackConsolidationFailed(
+        partition: AiAgentMemoryConsolidationPartition,
+        failureStage: ConsolidationFailureStage,
+        error: unknown,
+    ): void {
+        this.track({
+            event: 'ai_agent_memory.consolidation_failed',
+            anonymousId: partition.organizationUuid,
+            properties: {
+                organizationId: partition.organizationUuid,
+                projectId: partition.projectUuid,
+                ownerUserId: partition.ownerUserUuid,
+                failureStage,
+                // Never the message: an AI SDK error quotes the model output.
+                errorType: error instanceof Error ? error.name : 'UnknownError',
+            },
+        });
+    }
+
+    /**
+     * One event per run that reached the apply transaction, and the applied and
+     * rejected operation mix on the metrics. Counts and closed enumerations
+     * only: no memory text, title, term, object name, slug or operation reason.
+     * Swallows its own failures — this runs inside the attempt's try, and an
+     * instrumentation error must not turn an applied run into a failed one.
+     */
+    private recordConsolidationApplied(args: {
+        partition: AiAgentMemoryConsolidationPartition;
+        input: AiAgentMemoryConsolidationInputEntry[];
+        applied: AiAgentMemoryConsolidationOperation[];
+        rejected: AiAgentMemoryConsolidationRejection[];
+    }): void {
+        try {
+            const appliedCounts = countConsolidationOperations(args.applied);
+            const rejectedCounts = countConsolidationRejections(args.rejected);
+            this.prometheusMetrics?.trackAiAgentMemoryConsolidateOperations({
+                applied: appliedCounts,
+                rejected: rejectedCounts,
+            });
+            this.track({
+                event: 'ai_agent_memory.consolidated',
+                anonymousId: args.partition.organizationUuid,
+                properties: {
+                    organizationId: args.partition.organizationUuid,
+                    projectId: args.partition.projectUuid,
+                    ownerUserId: args.partition.ownerUserUuid,
+                    // A quiet run is not a skipped partition: it read the
+                    // corpus, paid for the call and found nothing to do.
+                    outcome:
+                        args.applied.length > 0 ? 'applied' : 'no_operations',
+                    inputCount: args.input.length,
+                    mergeCount: appliedCounts.merge,
+                    supersedeCount: appliedCounts.supersede,
+                    retireCount: appliedCounts.retire,
+                    rejectedCount: args.rejected.length,
+                    ...countConsolidationScopes({
+                        input: args.input,
+                        applied: args.applied,
+                    }),
+                },
+            });
+        } catch (error) {
+            this.logger.warn('Unable to record AI agent consolidation run', {
+                projectUuid: args.partition.projectUuid,
+                error: getErrorMessage(error),
+            });
+        }
+    }
+
+    private trackConsolidationSkipped(
+        partition: AiAgentMemoryConsolidationPartition,
+        reason: ConsolidationSkipReason,
+        inputCount: number,
+    ): void {
+        this.track({
+            event: 'ai_agent_memory.consolidation_skipped',
+            anonymousId: partition.organizationUuid,
+            properties: {
+                organizationId: partition.organizationUuid,
+                projectId: partition.projectUuid,
+                ownerUserId: partition.ownerUserUuid,
+                reason,
+                inputCount,
+            },
+        });
     }
 
     /**
@@ -510,6 +613,9 @@ export class AiAgentMemoryService extends BaseService {
                 AI_AGENT_MEMORY_CONSOLIDATION_MIN_ACTIVE_ROWS,
             );
         const due = await this.filterByEnabledOrganizations(candidates);
+        this.prometheusMetrics?.incrementAiAgentMemoryEligiblePartitions(
+            due.length,
+        );
 
         await Promise.all(
             due.map((candidate) =>
@@ -531,6 +637,22 @@ export class AiAgentMemoryService extends BaseService {
      * skip, never a failure.
      */
     async consolidateScheduledPartition(
+        payload: AiAgentMemoryConsolidatePartitionJobPayload,
+        abortSignal?: AbortSignal,
+    ): Promise<AiAgentMemoryConsolidateOutcome> {
+        const startTime = Date.now();
+        const outcome = await this.runConsolidateScheduledPartition(
+            payload,
+            abortSignal,
+        );
+        this.prometheusMetrics?.trackAiAgentMemoryConsolidate(
+            outcome,
+            Date.now() - startTime,
+        );
+        return outcome;
+    }
+
+    private async runConsolidateScheduledPartition(
         payload: AiAgentMemoryConsolidatePartitionJobPayload,
         abortSignal?: AbortSignal,
     ): Promise<AiAgentMemoryConsolidateOutcome> {
@@ -566,14 +688,28 @@ export class AiAgentMemoryService extends BaseService {
                     projectUuid: partition.projectUuid,
                     ownerUserUuid: partition.ownerUserUuid,
                 });
-            if (latestRun?.input_hash === inputHash) return 'skipped';
+            if (latestRun?.input_hash === inputHash) {
+                this.trackConsolidationSkipped(
+                    partition,
+                    'clean',
+                    memories.length,
+                );
+                return 'skipped';
+            }
 
             // Read only for a partition that will be attempted: the common
             // all-skipped day must not read a single cached_explores blob.
             const explores = await this.loadConsolidationCatalog(
                 partition.projectUuid,
             );
-            if (explores === null) return 'skipped';
+            if (explores === null) {
+                this.trackConsolidationSkipped(
+                    partition,
+                    'catalog_unavailable',
+                    memories.length,
+                );
+                return 'skipped';
+            }
 
             return await this.consolidatePartition({
                 partition,
@@ -601,6 +737,7 @@ export class AiAgentMemoryService extends BaseService {
                 projectUuid: partition.projectUuid,
                 ownerUserUuid: partition.ownerUserUuid,
             });
+            this.trackConsolidationFailed(partition, 'selection', error);
             return 'failed';
         }
     }
@@ -662,6 +799,11 @@ export class AiAgentMemoryService extends BaseService {
                 'Skipping AI agent memory consolidation: no object resolves',
                 { projectUuid: partition.projectUuid },
             );
+            this.trackConsolidationSkipped(
+                partition,
+                'objects_unresolved',
+                input.length,
+            );
             return 'skipped';
         }
 
@@ -678,6 +820,7 @@ export class AiAgentMemoryService extends BaseService {
 
         // What curation tried and was not allowed to do survives a failed apply.
         let rejectedOperations: AiAgentMemoryConsolidationRejection[] = [];
+        let failureStage: ConsolidationFailureStage = 'consolidation';
         try {
             args.abortSignal?.throwIfAborted();
             const output = await this.consolidateCall({
@@ -697,7 +840,8 @@ export class AiAgentMemoryService extends BaseService {
                 input,
             });
             rejectedOperations = rejected;
-            await this.aiAgentMemoryModel.applyConsolidation({
+            failureStage = 'persistence';
+            const result = await this.aiAgentMemoryModel.applyConsolidation({
                 run,
                 selection: memories.map((memory) => ({
                     memoryUuid: memory.ai_agent_memory_uuid,
@@ -713,6 +857,14 @@ export class AiAgentMemoryService extends BaseService {
                             getAiProjectContextObjectKey(object.object),
                         ),
                 ),
+            });
+            // The apply's own audit, not validation's: it carries the rows the
+            // transaction rejected for having moved since selection.
+            this.recordConsolidationApplied({
+                partition,
+                input,
+                applied: result.applied,
+                rejected: result.rejected,
             });
             return 'consolidated';
         } catch (error) {
@@ -745,6 +897,7 @@ export class AiAgentMemoryService extends BaseService {
                 projectUuid: partition.projectUuid,
                 ownerUserUuid: partition.ownerUserUuid,
             });
+            this.trackConsolidationFailed(partition, failureStage, error);
             return 'failed';
         }
     }

--- a/packages/backend/src/ee/services/AiAgentMemoryService/consolidation.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/consolidation.ts
@@ -4,7 +4,9 @@ import {
     getAiProjectContextObjectKey,
     type AiAgentMemoryConsolidationInputEntry,
     type AiAgentMemoryConsolidationOperation,
+    type AiAgentMemoryConsolidationOperationType,
     type AiAgentMemoryConsolidationRejection,
+    type AiAgentMemoryConsolidationRejectionReason,
     type Explore,
     type ExploreError,
 } from '@lightdash/common';
@@ -223,6 +225,85 @@ export const validateConsolidationOperations = (args: {
     }
 
     return { applied, rejected };
+};
+
+export type ConsolidationOperationCounts = Record<
+    AiAgentMemoryConsolidationOperationType,
+    number
+>;
+
+export type ConsolidationRejectionCounts = Record<
+    AiAgentMemoryConsolidationRejectionReason,
+    number
+>;
+
+/** Exhaustive by construction: a new operation type fails to compile here. */
+export const countConsolidationOperations = (
+    operations: AiAgentMemoryConsolidationOperation[],
+): ConsolidationOperationCounts => {
+    const counts: ConsolidationOperationCounts = {
+        merge: 0,
+        supersede: 0,
+        retire: 0,
+    };
+    operations.forEach((operation) => {
+        counts[operation.type] += 1;
+    });
+    return counts;
+};
+
+export const countConsolidationRejections = (
+    rejections: AiAgentMemoryConsolidationRejection[],
+): ConsolidationRejectionCounts => {
+    const counts: ConsolidationRejectionCounts = {
+        unknown_slug: 0,
+        duplicate_target: 0,
+        self_supersede: 0,
+        insufficient_sources: 0,
+        row_moved: 0,
+    };
+    rejections.forEach((rejection) => {
+        counts[rejection.reason] += 1;
+    });
+    return counts;
+};
+
+/**
+ * The promotion-nomination mix. A mixed-scope merge downgrades to `user` and
+ * erases a nomination with no rejection recorded, so the loss is counted here
+ * rather than being invisible.
+ */
+export const countConsolidationScopes = (args: {
+    input: AiAgentMemoryConsolidationInputEntry[];
+    applied: AiAgentMemoryConsolidationOperation[];
+}): {
+    projectScopeInputCount: number;
+    projectScopeMergeCount: number;
+    scopeDowngradedMergeCount: number;
+} => {
+    const scopeBySlug = new Map(
+        args.input.map((entry) => [entry.id, entry.scope]),
+    );
+    const merges = args.applied.filter(
+        (operation) => operation.type === 'merge',
+    );
+    const sourceScopes = merges.map((merge) =>
+        merge.source_slugs.map((slug) => scopeBySlug.get(slug) ?? 'user'),
+    );
+
+    return {
+        projectScopeInputCount: args.input.filter(
+            (entry) => entry.scope === 'project',
+        ).length,
+        projectScopeMergeCount: sourceScopes.filter((scopes) =>
+            scopes.every((scope) => scope === 'project'),
+        ).length,
+        scopeDowngradedMergeCount: sourceScopes.filter(
+            (scopes) =>
+                scopes.some((scope) => scope === 'project') &&
+                !scopes.every((scope) => scope === 'project'),
+        ).length,
+    };
 };
 
 export const buildConsolidationUserMessage = (

--- a/packages/backend/src/prometheus/PrometheusMetrics.ts
+++ b/packages/backend/src/prometheus/PrometheusMetrics.ts
@@ -1,8 +1,12 @@
 import {
+    AI_AGENT_MEMORY_CONSOLIDATION_OPERATION_TYPES,
+    AI_AGENT_MEMORY_CONSOLIDATION_REJECTION_REASONS,
     AnyType,
     PreAggregateMissReason,
     QueryExecutionContext,
     QueryHistoryStatus,
+    type AiAgentMemoryConsolidationOperationType,
+    type AiAgentMemoryConsolidationRejectionReason,
     type WarehousePhaseTimings,
 } from '@lightdash/common';
 import { EventEmitter } from 'events';
@@ -67,6 +71,16 @@ export const AI_AGENT_MEMORY_DISTILL_OUTCOMES = [
 export type AiAgentMemoryDistillOutcome =
     (typeof AI_AGENT_MEMORY_DISTILL_OUTCOMES)[number];
 
+export const AI_AGENT_MEMORY_CONSOLIDATE_OUTCOMES = [
+    'consolidated',
+    'skipped',
+    'failed',
+    'aborted',
+] as const;
+
+export type AiAgentMemoryConsolidateOutcome =
+    (typeof AI_AGENT_MEMORY_CONSOLIDATE_OUTCOMES)[number];
+
 export function getQueryContextLabel(
     context: string,
 ): 'interactive' | 'scheduled' {
@@ -118,6 +132,22 @@ export default class PrometheusMetrics {
     public aiAgentMemorySweepEnqueuedCounter: prometheus.Counter | null = null;
 
     public aiAgentMemoryUnknownToolPolicyCounter: prometheus.Counter | null =
+        null;
+
+    // AI agent memory consolidation pass (daily cron)
+    public aiAgentMemoryConsolidateCounter: prometheus.Counter<'outcome'> | null =
+        null;
+
+    public aiAgentMemoryConsolidateDurationHistogram: prometheus.Histogram<'outcome'> | null =
+        null;
+
+    public aiAgentMemoryConsolidateOperationCounter: prometheus.Counter<'operation'> | null =
+        null;
+
+    public aiAgentMemoryConsolidateRejectedCounter: prometheus.Counter<'reason'> | null =
+        null;
+
+    public aiAgentMemoryEligiblePartitionsCounter: prometheus.Counter | null =
         null;
 
     // repoShell (read-only repo VFS) GitHub API latency
@@ -528,6 +558,51 @@ export default class PrometheusMetrics {
                         ...rest,
                     });
 
+                // AI agent memory consolidation pass
+                this.aiAgentMemoryConsolidateCounter = new prometheus.Counter({
+                    name: 'ai_agent_memory_consolidate_total',
+                    help: 'AI agent memory consolidation runs by outcome (consolidated | skipped | failed | aborted)',
+                    labelNames: ['outcome'],
+                    ...rest,
+                });
+
+                this.aiAgentMemoryConsolidateDurationHistogram =
+                    new prometheus.Histogram({
+                        name: 'ai_agent_memory_consolidate_duration_ms',
+                        help: 'AI agent memory consolidation run duration in ms by outcome',
+                        labelNames: ['outcome'],
+                        // A reasoning call on the org's default model, so the
+                        // tail runs minutes rather than seconds.
+                        buckets: [
+                            100, 500, 1000, 5000, 15000, 30000, 60000, 120000,
+                            300000, 600000,
+                        ],
+                        ...rest,
+                    });
+
+                this.aiAgentMemoryConsolidateOperationCounter =
+                    new prometheus.Counter({
+                        name: 'ai_agent_memory_consolidate_operations_total',
+                        help: 'AI agent memory consolidation operations applied by type (merge | supersede | retire)',
+                        labelNames: ['operation'],
+                        ...rest,
+                    });
+
+                this.aiAgentMemoryConsolidateRejectedCounter =
+                    new prometheus.Counter({
+                        name: 'ai_agent_memory_consolidate_rejected_total',
+                        help: 'AI agent memory consolidation operations rejected by reason',
+                        labelNames: ['reason'],
+                        ...rest,
+                    });
+
+                this.aiAgentMemoryEligiblePartitionsCounter =
+                    new prometheus.Counter({
+                        name: 'ai_agent_memory_eligible_partitions_total',
+                        help: 'Partitions eligible for memory consolidation, counted per cron tick',
+                        ...rest,
+                    });
+
                 // repoShell GitHub API latency (per-request round-trips)
                 const githubRequestBuckets = [
                     25, 50, 100, 150, 200, 300, 500, 750, 1000, 2000, 5000,
@@ -683,6 +758,29 @@ export default class PrometheusMetrics {
                 });
                 this.aiAgentMemorySweepEnqueuedCounter?.inc(0);
                 this.aiAgentMemoryUnknownToolPolicyCounter?.inc(0);
+                AI_AGENT_MEMORY_CONSOLIDATE_OUTCOMES.forEach((outcome) => {
+                    this.aiAgentMemoryConsolidateCounter?.inc({ outcome }, 0);
+                    this.aiAgentMemoryConsolidateDurationHistogram?.zero({
+                        outcome,
+                    });
+                });
+                AI_AGENT_MEMORY_CONSOLIDATION_OPERATION_TYPES.forEach(
+                    (operation) => {
+                        this.aiAgentMemoryConsolidateOperationCounter?.inc(
+                            { operation },
+                            0,
+                        );
+                    },
+                );
+                AI_AGENT_MEMORY_CONSOLIDATION_REJECTION_REASONS.forEach(
+                    (reason) => {
+                        this.aiAgentMemoryConsolidateRejectedCounter?.inc(
+                            { reason },
+                            0,
+                        );
+                    },
+                );
+                this.aiAgentMemoryEligiblePartitionsCounter?.inc(0);
 
                 // Initialize pre-aggregate metrics
                 this.preAggregateMatchCounter = new prometheus.Counter({
@@ -1520,6 +1618,43 @@ export default class PrometheusMetrics {
 
     public incrementAiAgentMemoryUnknownToolPolicy() {
         this.aiAgentMemoryUnknownToolPolicyCounter?.inc();
+    }
+
+    public trackAiAgentMemoryConsolidate(
+        outcome: AiAgentMemoryConsolidateOutcome,
+        durationMs: number,
+    ) {
+        this.aiAgentMemoryConsolidateCounter?.inc({ outcome });
+        this.aiAgentMemoryConsolidateDurationHistogram?.observe(
+            { outcome },
+            durationMs,
+        );
+    }
+
+    public trackAiAgentMemoryConsolidateOperations(args: {
+        applied: Record<AiAgentMemoryConsolidationOperationType, number>;
+        rejected: Record<AiAgentMemoryConsolidationRejectionReason, number>;
+    }) {
+        Object.entries(args.applied).forEach(([operation, count]) => {
+            if (count > 0) {
+                this.aiAgentMemoryConsolidateOperationCounter?.inc(
+                    { operation },
+                    count,
+                );
+            }
+        });
+        Object.entries(args.rejected).forEach(([reason, count]) => {
+            if (count > 0) {
+                this.aiAgentMemoryConsolidateRejectedCounter?.inc(
+                    { reason },
+                    count,
+                );
+            }
+        });
+    }
+
+    public incrementAiAgentMemoryEligiblePartitions(count: number) {
+        this.aiAgentMemoryEligiblePartitionsCounter?.inc(count);
     }
 
     public observeAiWritebackSandboxCreateDuration(durationMs: number) {

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -418,6 +418,12 @@ export type AiAgentMemoryConsolidationOperation =
           reason: string;
       };
 
+export type AiAgentMemoryConsolidationOperationType =
+    AiAgentMemoryConsolidationOperation['type'];
+
+export const AI_AGENT_MEMORY_CONSOLIDATION_OPERATION_TYPES: ReadonlyArray<AiAgentMemoryConsolidationOperationType> =
+    ['merge', 'supersede', 'retire'];
+
 /** The one operation that creates a row. */
 export type AiAgentMemoryConsolidationMergeOperation = Extract<
     AiAgentMemoryConsolidationOperation,
@@ -444,12 +450,17 @@ export const getAiAgentMemoryConsolidationOperationSlugs = (
     }
 };
 
+/** Enumerable and content-free, so both the run audit and metrics can label by it. */
+export const AI_AGENT_MEMORY_CONSOLIDATION_REJECTION_REASONS = [
+    'unknown_slug',
+    'duplicate_target',
+    'self_supersede',
+    'insufficient_sources',
+    'row_moved',
+] as const;
+
 export type AiAgentMemoryConsolidationRejectionReason =
-    | 'unknown_slug'
-    | 'duplicate_target'
-    | 'self_supersede'
-    | 'insufficient_sources'
-    | 'row_moved';
+    (typeof AI_AGENT_MEMORY_CONSOLIDATION_REJECTION_REASONS)[number];
 
 export type AiAgentMemoryConsolidationRejection = {
     operation: AiAgentMemoryConsolidationOperation;


### PR DESCRIPTION
Makes the consolidation pass visible outside the database. Today its only record is the run-history table, which answers "what happened in this partition" but not "is curation working across the fleet" — how often partitions become eligible, how often runs find nothing, how the operation mix shifts as the prompt changes, and whether failures cluster. Spec lists this under *Out of Scope* on ZAP-715 ("Analytics events and Prometheus metrics for consolidation. Tracked as its own slice; run history is DB-backed in the meantime").

Follows the shape of the two write-path slices that already instrumented distill (#26143 for analytics, #26149 for Prometheus), so both pipelines read off one dashboard.

## What changed

**Three analytics events**, named to the existing memory family and emitted after the durable action:

- `ai_agent_memory.consolidated` — one per run that reached the apply transaction. Carries org, project, owner, outcome, input count, applied counts per operation type, and rejected count.
- `ai_agent_memory.consolidation_failed` — failure stage (`selection | consolidation | persistence`) and error type.
- `ai_agent_memory.consolidation_skipped` — reason (`clean | catalog_unavailable | objects_unresolved`) and input count.

**A quiet run is not a skipped partition.** A run that read the corpus, paid for the LLM call and emitted nothing reports `outcome: 'no_operations'` on the *consolidated* event; a partition whose input hash was unchanged never reaches the curator and reports `reason: 'clean'` on the *skipped* event. These are different facts and had to stay distinguishable.

**Nothing content-bearing leaves the process.** Only identifiers, counts and closed enumerations. No memory text, title, terms, object names, operation reasons — and no slugs, which are excluded deliberately because they are derived from memory content. `errorType` is the error *name*, never the message: an AI SDK schema-validation error quotes the raw model output in its message.

**Scope mix is carried on the completed event** — `projectScopeInputCount`, `projectScopeMergeCount`, `scopeDowngradedMergeCount`. The spec accepts that a mixed-scope merge downgrades to `user` and silently erases a promotion nomination, with observability as the agreed mitigation; this makes the loss a metric rather than a query against the run audit.

**Prometheus**, named alongside the existing distill and sweep metrics:

- `ai_agent_memory_consolidate_total{outcome}` and `ai_agent_memory_consolidate_duration_ms{outcome}` — buckets run to 10 min, since this is a reasoning call on the org's default model rather than the fast one.
- `ai_agent_memory_consolidate_operations_total{operation}`
- `ai_agent_memory_consolidate_rejected_total{reason}`
- `ai_agent_memory_eligible_partitions_total` — per cron tick.

All label combinations are zero-initialised at registration, so a dashboard shows `0` rather than a gap before the first run.

## Implementation notes

- **The completed event reads the apply's own audit, not validation's.** `applyConsolidation` returns what the transaction actually applied and what it rejected inside the lock for having moved since selection, so a row that changed during the LLM call is counted as rejected rather than applied.
- **Tracking is swallowed and logged.** The whole record-applied path sits inside the attempt's `try`, so an instrumentation throw would otherwise turn an applied run into a `failed` one. Covered by a test.
- **Rejection reasons and operation types became const arrays in `common`**, with the existing union types derived from them. Prometheus needs to enumerate the labels to zero them, and the count helpers need exhaustive records — a new operation type now fails to compile rather than silently going uncounted.
- **The failure stage is tracked as the run progresses** rather than inferred in the catch, so a persistence failure is not reported as a curator failure.
- Loop-level failures (a partition dropped before its run row exists) report stage `selection` and still increment the `failed` run counter with its elapsed duration.

## Testing

12 new cases in `AiAgentMemoryService.test.ts` and 3 in `consolidation.test.ts`, all asserting observable output rather than call sequences:

- A completed run reports counts per operation type; a quiet run is distinguishable from a clean skip; both skip reasons are named.
- Every consolidation event is scanned for memory bodies, titles, terms, object names and slugs.
- The promotion-nomination mix survives a merge — all-project merge counted as kept, mixed-scope merge counted as downgraded.
- A failure reports a stage and error type and no raw message; a failed apply is separated from a failed curator call; a partition dropped before the curator is reported.
- Operations still apply when tracking throws.
- Eligible-partition, run-outcome and applied-operation counters, including a failed partition.

Also run: `pnpm -F common typecheck:fast`, `pnpm -F backend typecheck:fast`, `pnpm -F backend lint`, `pnpm -F common test`, `pnpm -F backend test:dev:nowatch`.

Linear: https://linear.app/lightdash/issue/ZAP-717
Spec: https://linear.app/lightdash/issue/ZAP-715

Relates: ZAP-715
Closes: ZAP-717
