### PR TITLE
feat: consolidation dry-run mode

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -3017,7 +3017,10 @@ export type AiAgentMemoryConsolidatedEvent = BaseTrack & {
         organizationId: string;
         projectId: string;
         ownerUserId: string;
-        outcome: 'applied' | 'no_operations';
+        // `applied` is impossible on a dry run, so a query that counts curation
+        // stays correct even if it ignores `dryRun`.
+        outcome: 'applied' | 'proposed' | 'no_operations';
+        dryRun: boolean;
         inputCount: number;
         mergeCount: number;
         supersedeCount: number;
@@ -3038,6 +3041,7 @@ export type AiAgentMemoryConsolidationFailedEvent = BaseTrack & {
         organizationId: string;
         projectId: string;
         ownerUserId: string;
+        dryRun: boolean;
         failureStage: 'selection' | 'consolidation' | 'persistence';
         errorType: string;
     };

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -257,6 +257,9 @@ export const lightdashConfigMock: LightdashConfig = {
             toolDescriptionMaxChars: 600,
             defaultEmbeddingModelProvider: 'openai',
         },
+        agentMemory: {
+            consolidationDryRun: false,
+        },
     },
     embedding: {
         enabled: false,

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1442,6 +1442,10 @@ export type LightdashConfig = {
         copilot: AiCopilotConfigSchemaType;
         analyticsProjectUuid?: string;
         analyticsDashboardUuid?: string;
+        agentMemory: {
+            /** Consolidation computes and records its operations, applying none. */
+            consolidationDryRun: boolean;
+        };
     };
     embedding: {
         enabled: boolean;
@@ -2984,6 +2988,11 @@ export const parseConfig = (): LightdashConfig => {
             copilot: copilotConfig,
             analyticsProjectUuid: process.env.AI_ANALYTICS_PROJECT_UUID,
             analyticsDashboardUuid: process.env.AI_ANALYTICS_DASHBOARD_UUID,
+            agentMemory: {
+                consolidationDryRun:
+                    process.env.AI_AGENT_MEMORY_CONSOLIDATION_DRY_RUN ===
+                    'true',
+            },
         },
         embedding: {
             enabled: process.env.EMBEDDING_ENABLED === 'true',

--- a/packages/backend/src/ee/database/entities/aiAgentMemory.ts
+++ b/packages/backend/src/ee/database/entities/aiAgentMemory.ts
@@ -122,6 +122,8 @@ export type DbAiAgentMemoryConsolidationRun = {
     project_uuid: string;
     user_uuid: string;
     status: AiAgentMemoryConsolidationRunStatus;
+    /** A dry run applied nothing: its operation columns hold proposals. */
+    dry_run: boolean;
     prompt_hash: string;
     input_hash: string;
     input_count: number;

--- a/packages/backend/src/ee/database/migrations/20260729090000_add_ai_agent_memory_consolidation_dry_run.ts
+++ b/packages/backend/src/ee/database/migrations/20260729090000_add_ai_agent_memory_consolidation_dry_run.ts
@@ -1,0 +1,24 @@
+import { Knex } from 'knex';
+
+const AiAgentMemoryConsolidationRunTableName =
+    'ai_agent_memory_consolidation_run';
+
+export async function up(knex: Knex): Promise<void> {
+    // Mode, not outcome: a dry run applied nothing whatever its status, so its
+    // operation columns hold proposals and never count as curation.
+    await knex.schema.alterTable(
+        AiAgentMemoryConsolidationRunTableName,
+        (table) => {
+            table.boolean('dry_run').notNullable().defaultTo(false);
+        },
+    );
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(
+        AiAgentMemoryConsolidationRunTableName,
+        (table) => {
+            table.dropColumn('dry_run');
+        },
+    );
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -162,6 +162,9 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     featureFlagService: repository.getFeatureFlagService(),
                     schedulerClient:
                         clients.getSchedulerClient() as CommercialSchedulerClient,
+                    consolidationDryRun:
+                        context.lightdashConfig.ai.agentMemory
+                            .consolidationDryRun,
                     prometheusMetrics,
                     orgAiCopilotConfigResolver: new OrgAiCopilotConfigResolver({
                         lightdashConfig: context.lightdashConfig,

--- a/packages/backend/src/ee/models/AiAgentMemoryModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentMemoryModel.integration.test.ts
@@ -36,6 +36,7 @@ import {
     type DbAiPrompt,
 } from '../database/entities/ai';
 import {
+    AiAgentMemoryConsolidationRunTableName,
     AiAgentMemoryTableName,
     AiAgentThreadDistillTableName,
 } from '../database/entities/aiAgentMemory';
@@ -57,6 +58,7 @@ describe('AiAgentMemoryModel integration', () => {
     const originalFlags = new Map<string, DbFeatureFlag | undefined>();
     const threadUuids = new Set<string>();
     const memoryUuids = new Set<string>();
+    const consolidationRunUuids = new Set<string>();
 
     const setFeatureFlag = async (flagId: string, enabled: boolean) => {
         await database<FeatureFlagsTable>(FeatureFlagsTableName)
@@ -123,6 +125,14 @@ describe('AiAgentMemoryModel integration', () => {
 
     afterEach(async () => {
         await setFeatureFlag(FeatureFlags.AiAgentMemory, true);
+        if (consolidationRunUuids.size > 0) {
+            await database(AiAgentMemoryConsolidationRunTableName)
+                .whereIn('ai_agent_memory_consolidation_run_uuid', [
+                    ...consolidationRunUuids,
+                ])
+                .delete();
+            consolidationRunUuids.clear();
+        }
         if (memoryUuids.size > 0) {
             await database(AiAgentMemoryTableName)
                 .whereIn('ai_agent_memory_uuid', [...memoryUuids])
@@ -269,8 +279,55 @@ describe('AiAgentMemoryModel integration', () => {
             projectModel,
             featureFlagService,
             schedulerClient,
+            consolidationDryRun: false,
             distillCall,
         });
+
+    it('finds the latest consolidation run in the requested mode', async () => {
+        const recordRun = async (dryRun: boolean, inputHash: string) => {
+            const run = await model.recordConsolidationRun({
+                organizationUuid: SEED_ORG_1.organization_uuid,
+                projectUuid: SEED_PROJECT.project_uuid,
+                ownerUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                status: 'succeeded',
+                dryRun,
+                promptHash: 'prompt-hash',
+                inputHash,
+                inputCount: 30,
+                appliedOperations: [],
+                rejectedOperations: [],
+                errorMessage: null,
+                consolidatedUpTo: new Date('2026-07-30T10:00:00Z'),
+            });
+            consolidationRunUuids.add(
+                run.ai_agent_memory_consolidation_run_uuid,
+            );
+            return run;
+        };
+        const live = await recordRun(false, 'live-hash');
+        const dry = await recordRun(true, 'dry-hash');
+
+        await expect(
+            model.findLatestConsolidationRun({
+                projectUuid: SEED_PROJECT.project_uuid,
+                ownerUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                dryRun: false,
+            }),
+        ).resolves.toMatchObject({
+            ai_agent_memory_consolidation_run_uuid:
+                live.ai_agent_memory_consolidation_run_uuid,
+        });
+        await expect(
+            model.findLatestConsolidationRun({
+                projectUuid: SEED_PROJECT.project_uuid,
+                ownerUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                dryRun: true,
+            }),
+        ).resolves.toMatchObject({
+            ai_agent_memory_consolidation_run_uuid:
+                dry.ai_agent_memory_consolidation_run_uuid,
+        });
+    });
 
     it('replaces source-thread content while keeping slug and telemetry', async () => {
         const sourceThreadUuid = await createThread();

--- a/packages/backend/src/ee/models/AiAgentMemoryModel.ts
+++ b/packages/backend/src/ee/models/AiAgentMemoryModel.ts
@@ -161,6 +161,8 @@ export type AiAgentMemoryConsolidationRunInput = {
     projectUuid: UUID;
     ownerUserUuid: UUID;
     status: AiAgentMemoryConsolidationRunStatus;
+    /** Proposals rather than curation: nothing this run named was written. */
+    dryRun: boolean;
     promptHash: string;
     inputHash: string;
     inputCount: number;
@@ -180,6 +182,12 @@ export type AiAgentMemoryConsolidationSelectedRow = {
 export type AiAgentMemoryConsolidationApplyResult = {
     run: DbAiAgentMemoryConsolidationRun;
     applied: AiAgentMemoryConsolidationOperation[];
+    rejected: AiAgentMemoryConsolidationRejection[];
+};
+
+export type AiAgentMemoryConsolidationProposalResult = {
+    run: DbAiAgentMemoryConsolidationRun;
+    proposed: AiAgentMemoryConsolidationOperation[];
     rejected: AiAgentMemoryConsolidationRejection[];
 };
 
@@ -1106,14 +1114,16 @@ export class AiAgentMemoryModel {
     }
 
     async findLatestConsolidationRun(args: {
-        projectUuid: string;
-        ownerUserUuid: string;
+        projectUuid: UUID;
+        ownerUserUuid: UUID;
+        dryRun: boolean;
     }): Promise<DbAiAgentMemoryConsolidationRun | undefined> {
         return this.database<AiAgentMemoryConsolidationRunTable>(
             AiAgentMemoryConsolidationRunTableName,
         )
             .where('project_uuid', args.projectUuid)
             .where('user_uuid', args.ownerUserUuid)
+            .where('dry_run', args.dryRun)
             .orderBy('created_at', 'desc')
             .first();
     }
@@ -1130,6 +1140,7 @@ export class AiAgentMemoryModel {
                 project_uuid: run.projectUuid,
                 user_uuid: run.ownerUserUuid,
                 status: run.status,
+                dry_run: run.dryRun,
                 prompt_hash: run.promptHash,
                 input_hash: run.inputHash,
                 input_count: run.inputCount,
@@ -1255,6 +1266,115 @@ export class AiAgentMemoryModel {
         return { ...args.operation, slug };
     }
 
+    private static async lockAndRevalidateConsolidation(
+        trx: Knex,
+        args: {
+            run: Pick<
+                AiAgentMemoryConsolidationRunInput,
+                'projectUuid' | 'ownerUserUuid'
+            >;
+            selection: AiAgentMemoryConsolidationSelectedRow[];
+            operations: AiAgentMemoryConsolidationOperation[];
+            rejected: AiAgentMemoryConsolidationRejection[];
+        },
+    ): Promise<{
+        accepted: AiAgentMemoryConsolidationOperation[];
+        rejected: AiAgentMemoryConsolidationRejection[];
+        currentBySlug: Map<string, ConsolidationSourceRow>;
+    }> {
+        await trx.raw('SELECT pg_advisory_xact_lock(?, hashtext(?))', [
+            CONSOLIDATION_LOCK_CLASS,
+            `${args.run.projectUuid}:${args.run.ownerUserUuid}`,
+        ]);
+
+        const namedSlugs = [
+            ...new Set(
+                args.operations.flatMap(
+                    getAiAgentMemoryConsolidationOperationSlugs,
+                ),
+            ),
+        ];
+        const currentRows: ConsolidationSourceRow[] =
+            namedSlugs.length === 0
+                ? []
+                : await trx<AiAgentMemoryTable>(AiAgentMemoryTableName)
+                      .where('project_uuid', args.run.projectUuid)
+                      .where('user_uuid', args.run.ownerUserUuid)
+                      .whereIn('slug', namedSlugs)
+                      .forUpdate()
+                      .select(
+                          'ai_agent_memory_uuid',
+                          'slug',
+                          'status',
+                          'generated_at',
+                          'agent_uuid',
+                          'scope',
+                          'cited_count',
+                          'last_cited_at',
+                          'pulled_count',
+                          'last_pulled_at',
+                      );
+        const currentBySlug = new Map(
+            currentRows.map((row) => [row.slug, row]),
+        );
+        const selectedBySlug = new Map(
+            args.selection.map((row) => [row.slug, row]),
+        );
+        const isUnmoved = (slug: string): boolean => {
+            const current = currentBySlug.get(slug);
+            const selected = selectedBySlug.get(slug);
+            return (
+                current !== undefined &&
+                selected !== undefined &&
+                current.ai_agent_memory_uuid === selected.memoryUuid &&
+                current.status === 'active' &&
+                current.generated_at.getTime() ===
+                    selected.generatedAt.getTime()
+            );
+        };
+
+        const accepted: AiAgentMemoryConsolidationOperation[] = [];
+        const rejected = [...args.rejected];
+        for (const operation of args.operations) {
+            if (
+                getAiAgentMemoryConsolidationOperationSlugs(operation).every(
+                    isUnmoved,
+                )
+            ) {
+                accepted.push(operation);
+            } else {
+                rejected.push({ operation, reason: 'row_moved' });
+            }
+        }
+        return { accepted, rejected, currentBySlug };
+    }
+
+    async recordDryRunConsolidation(args: {
+        run: Omit<
+            AiAgentMemoryConsolidationRunInput,
+            'appliedOperations' | 'rejectedOperations' | 'status' | 'dryRun'
+        >;
+        selection: AiAgentMemoryConsolidationSelectedRow[];
+        operations: AiAgentMemoryConsolidationOperation[];
+        rejected: AiAgentMemoryConsolidationRejection[];
+    }): Promise<AiAgentMemoryConsolidationProposalResult> {
+        return this.database.transaction(async (trx) => {
+            const { accepted, rejected } =
+                await AiAgentMemoryModel.lockAndRevalidateConsolidation(
+                    trx,
+                    args,
+                );
+            const run = await AiAgentMemoryModel.insertConsolidationRun(trx, {
+                ...args.run,
+                status: 'succeeded',
+                dryRun: true,
+                appliedOperations: accepted,
+                rejectedOperations: rejected,
+            });
+            return { run, proposed: accepted, rejected };
+        });
+    }
+
     /**
      * Applies operations and writes the run row in one transaction, under a
      * per-partition advisory lock. The slug-to-uuid resolution inside the lock
@@ -1262,9 +1382,10 @@ export class AiAgentMemoryModel {
      * body was rewritten since selection, is rejected instead of applied.
      */
     async applyConsolidation(args: {
+        // A dry run cannot reach this write path.
         run: Omit<
             AiAgentMemoryConsolidationRunInput,
-            'appliedOperations' | 'rejectedOperations' | 'status'
+            'appliedOperations' | 'rejectedOperations' | 'status' | 'dryRun'
         >;
         selection: AiAgentMemoryConsolidationSelectedRow[];
         operations: AiAgentMemoryConsolidationOperation[];
@@ -1273,70 +1394,11 @@ export class AiAgentMemoryModel {
         unresolvedObjectKeys: Set<string>;
     }): Promise<AiAgentMemoryConsolidationApplyResult> {
         return this.database.transaction(async (trx) => {
-            await trx.raw('SELECT pg_advisory_xact_lock(?, hashtext(?))', [
-                CONSOLIDATION_LOCK_CLASS,
-                `${args.run.projectUuid}:${args.run.ownerUserUuid}`,
-            ]);
-
-            const namedSlugs = [
-                ...new Set(
-                    args.operations.flatMap(
-                        getAiAgentMemoryConsolidationOperationSlugs,
-                    ),
-                ),
-            ];
-            const currentRows =
-                namedSlugs.length === 0
-                    ? []
-                    : await trx<AiAgentMemoryTable>(AiAgentMemoryTableName)
-                          .where('project_uuid', args.run.projectUuid)
-                          .where('user_uuid', args.run.ownerUserUuid)
-                          .whereIn('slug', namedSlugs)
-                          .forUpdate()
-                          .select(
-                              'ai_agent_memory_uuid',
-                              'slug',
-                              'status',
-                              'generated_at',
-                              'agent_uuid',
-                              'scope',
-                              'cited_count',
-                              'last_cited_at',
-                              'pulled_count',
-                              'last_pulled_at',
-                          );
-            const currentBySlug = new Map(
-                currentRows.map((row) => [row.slug, row]),
-            );
-            const selectedBySlug = new Map(
-                args.selection.map((row) => [row.slug, row]),
-            );
-            const isUnmoved = (slug: string): boolean => {
-                const current = currentBySlug.get(slug);
-                const selected = selectedBySlug.get(slug);
-                return (
-                    current !== undefined &&
-                    selected !== undefined &&
-                    current.ai_agent_memory_uuid === selected.memoryUuid &&
-                    current.status === 'active' &&
-                    current.generated_at.getTime() ===
-                        selected.generatedAt.getTime()
+            const { accepted, rejected, currentBySlug } =
+                await AiAgentMemoryModel.lockAndRevalidateConsolidation(
+                    trx,
+                    args,
                 );
-            };
-
-            const accepted: AiAgentMemoryConsolidationOperation[] = [];
-            const rejected = [...args.rejected];
-            for (const operation of args.operations) {
-                if (
-                    getAiAgentMemoryConsolidationOperationSlugs(
-                        operation,
-                    ).every(isUnmoved)
-                ) {
-                    accepted.push(operation);
-                } else {
-                    rejected.push({ operation, reason: 'row_moved' });
-                }
-            }
 
             const applied: AiAgentMemoryConsolidationOperation[] = [];
             for (const operation of accepted) {
@@ -1398,6 +1460,7 @@ export class AiAgentMemoryModel {
             const run = await AiAgentMemoryModel.insertConsolidationRun(trx, {
                 ...args.run,
                 status: 'succeeded',
+                dryRun: false,
                 appliedOperations: applied,
                 rejectedOperations: rejected,
             });

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryConsolidation.integration.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryConsolidation.integration.test.ts
@@ -245,7 +245,13 @@ describe('AI agent memory consolidation integration', () => {
 
     const buildService = (
         consolidateCall: AiAgentMemoryConsolidateCall,
-        schedulerClientOverride?: ReturnType<typeof stubSchedulerClient>,
+        {
+            consolidationDryRun = false,
+            schedulerClientOverride,
+        }: {
+            consolidationDryRun?: boolean;
+            schedulerClientOverride?: ReturnType<typeof stubSchedulerClient>;
+        } = {},
     ) =>
         new AiAgentMemoryService({
             analytics,
@@ -255,6 +261,7 @@ describe('AI agent memory consolidation integration', () => {
             projectModel: getTestContext().app.getModels().getProjectModel(),
             featureFlagService,
             schedulerClient: schedulerClientOverride ?? schedulerClient,
+            consolidationDryRun,
             consolidateCall,
         });
 
@@ -1022,6 +1029,137 @@ describe('AI agent memory consolidation integration', () => {
         expect(await runsForOwner(ownerUuid)).toHaveLength(1);
     });
 
+    it('records a full proposal in dry-run mode without touching a memory row', async () => {
+        const slugs = await seedPartition({
+            userUuid: ownerUuid,
+            count: FLOOR,
+            prefix: 'dryrun',
+        });
+        const rowsBefore = await database(AiAgentMemoryTableName)
+            .where('project_uuid', SEED_PROJECT.project_uuid)
+            .where('user_uuid', ownerUuid)
+            .orderBy('slug', 'asc');
+        const operations: AiAgentMemoryConsolidationOperation[] = [
+            {
+                type: 'merge',
+                source_slugs: [slugs[0]!, slugs[1]!],
+                slug: 'consolidation-dryrun-merged',
+                title: 'One convention',
+                memory: 'Revenue always means net revenue.',
+                terms: ['net revenue'],
+                objects: [],
+                reason: 'Both memories state the same convention.',
+            },
+            {
+                type: 'supersede',
+                loser_slug: slugs[2]!,
+                winner_slug: slugs[3]!,
+                reason: 'The winner is the user’s later correction.',
+            },
+            { type: 'retire', slug: slugs[4]!, reason: 'Its explore is gone.' },
+            { type: 'retire', slug: 'never-in-this-input', reason: 'Gone.' },
+        ];
+        const call = cannedCall(operations);
+
+        await buildService(call, {
+            consolidationDryRun: true,
+        }).consolidateScheduledPartition(partitionPayload(ownerUuid));
+
+        // The curator ran; the corpus is byte-for-byte what it was.
+        expect(call).toHaveBeenCalledOnce();
+        const rowsAfter = await database(AiAgentMemoryTableName)
+            .where('project_uuid', SEED_PROJECT.project_uuid)
+            .where('user_uuid', ownerUuid)
+            .orderBy('slug', 'asc');
+        expect(rowsAfter).toEqual(rowsBefore);
+
+        const [run] = await runsForOwner(ownerUuid);
+        expect(run).toMatchObject({
+            status: 'succeeded',
+            dry_run: true,
+            input_count: FLOOR,
+            applied_count: 3,
+            rejected_count: 1,
+            error_message: null,
+        });
+        expect(
+            run!.applied_operations.map((operation) => operation.type),
+        ).toEqual(['merge', 'supersede', 'retire']);
+        expect(run!.rejected_operations[0]!.reason).toBe('unknown_slug');
+
+        // One dry sample per changed corpus: the hash advanced.
+        const second = cannedCall([]);
+        await buildService(second, {
+            consolidationDryRun: true,
+        }).consolidateScheduledPartition(partitionPayload(ownerUuid));
+        expect(second).not.toHaveBeenCalled();
+        expect(await runsForOwner(ownerUuid)).toHaveLength(1);
+    });
+
+    it('rejects a dry-run proposal moved by a concurrent live run', async () => {
+        const slugs = await seedPartition({
+            userUuid: ownerUuid,
+            count: FLOOR,
+            prefix: 'dryrace',
+        });
+        const operation: AiAgentMemoryConsolidationOperation = {
+            type: 'retire',
+            slug: slugs[0]!,
+            reason: 'Its explore is gone.',
+        };
+        let releaseDryRun!: () => void;
+        const liveFinished = new Promise<void>((resolve) => {
+            releaseDryRun = resolve;
+        });
+        const dryCall = vi.fn(async () => {
+            await liveFinished;
+            return { operations: [operation] };
+        });
+        const dryRun = buildService(dryCall, {
+            consolidationDryRun: true,
+        }).consolidateScheduledPartition(partitionPayload(ownerUuid));
+        await vi.waitFor(() => expect(dryCall).toHaveBeenCalledOnce());
+
+        await buildService(
+            cannedCall([operation]),
+        ).consolidateScheduledPartition(partitionPayload(ownerUuid));
+        releaseDryRun();
+        await expect(dryRun).resolves.toBe('dry_run');
+
+        const runs = await runsForOwner(ownerUuid);
+        const preview = runs.find((run) => run.dry_run);
+        expect(preview).toMatchObject({
+            applied_count: 0,
+            rejected_count: 1,
+        });
+        expect(preview!.rejected_operations[0]!.reason).toBe('row_moved');
+    });
+
+    it('still consolidates an unchanged corpus once dry-run mode is turned off', async () => {
+        await seedPartition({
+            userUuid: ownerUuid,
+            count: FLOOR,
+            prefix: 'dryoff',
+        });
+        const preview = cannedCall([]);
+        await buildService(preview, {
+            consolidationDryRun: true,
+        }).consolidateScheduledPartition(partitionPayload(ownerUuid));
+        expect(preview).toHaveBeenCalledOnce();
+
+        // The dry run applied nothing: the first live pass still owes this
+        // corpus its curation, even though the hash has not moved.
+        const live = cannedCall([]);
+        await buildService(live).consolidateScheduledPartition(
+            partitionPayload(ownerUuid),
+        );
+
+        expect(live).toHaveBeenCalledOnce();
+        const runs = await runsForOwner(ownerUuid);
+        expect(runs.map((run) => run.dry_run)).toEqual([true, false]);
+        expect(runs[0]!.input_hash).toBe(runs[1]!.input_hash);
+    });
+
     it('does not retry a failed partition until the corpus changes', async () => {
         await seedPartition({
             userUuid: ownerUuid,
@@ -1063,7 +1201,9 @@ describe('AI agent memory consolidation integration', () => {
         });
         const enqueue = stubSchedulerClient();
         const call = cannedCall([]);
-        const service = buildService(call, enqueue);
+        const service = buildService(call, {
+            schedulerClientOverride: enqueue,
+        });
 
         // The sweep never enqueues a below-floor partition...
         await service.sweepConsolidationPartitions();
@@ -1090,10 +1230,9 @@ describe('AI agent memory consolidation integration', () => {
         });
         const enqueue = stubSchedulerClient();
 
-        const enqueued = await buildService(
-            cannedCall([]),
-            enqueue,
-        ).sweepConsolidationPartitions();
+        const enqueued = await buildService(cannedCall([]), {
+            schedulerClientOverride: enqueue,
+        }).sweepConsolidationPartitions();
 
         expect(enqueued).toBeGreaterThanOrEqual(1);
         expect(enqueue.aiAgentMemoryConsolidatePartition).toHaveBeenCalledWith(
@@ -1214,7 +1353,9 @@ describe('AI agent memory consolidation integration', () => {
         await setFeatureFlag(FeatureFlags.AiAgentMemory, false);
         const enqueue = stubSchedulerClient();
         const call = cannedCall([]);
-        const service = buildService(call, enqueue);
+        const service = buildService(call, {
+            schedulerClientOverride: enqueue,
+        });
 
         // The sweep filters the organization out...
         await service.sweepConsolidationPartitions();

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.consolidateLlm.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.consolidateLlm.test.ts
@@ -87,6 +87,7 @@ const build = () => {
             aiAgentMemoryDistill: vi.fn(),
             aiAgentMemoryConsolidatePartition: vi.fn(),
         },
+        consolidationDryRun: false,
         orgAiCopilotConfigResolver: {
             getCopilotConfig: vi
                 .fn()

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
@@ -145,7 +145,10 @@ describe('AiAgentMemoryService', () => {
         } as AnyType;
     };
 
-    const build = ({ enabledOrganization = 'org-enabled' } = {}) => {
+    const build = ({
+        enabledOrganization = 'org-enabled',
+        consolidationDryRun = false,
+    } = {}) => {
         const getFlag = vi.fn(async ({ user, featureFlagId }) => ({
             id: featureFlagId,
             enabled:
@@ -179,6 +182,13 @@ describe('AiAgentMemoryService', () => {
         const findConsolidationCandidates = vi.fn().mockResolvedValue([]);
         const findLatestConsolidationRun = vi.fn().mockResolvedValue(undefined);
         const recordConsolidationRun = vi.fn().mockResolvedValue({});
+        const recordDryRunConsolidation = vi.fn(
+            async ({ run, operations, rejected }) => ({
+                run: { ...run, status: 'succeeded', dry_run: true },
+                proposed: operations,
+                rejected,
+            }),
+        );
         const applyConsolidation = vi.fn().mockResolvedValue({
             run: {},
             applied: [],
@@ -235,6 +245,7 @@ describe('AiAgentMemoryService', () => {
                 findConsolidationCandidates,
                 findLatestConsolidationRun,
                 recordConsolidationRun,
+                recordDryRunConsolidation,
                 applyConsolidation,
             } as AnyType,
             aiAgentModel: { getAgent, findThreadOwnership } as AnyType,
@@ -248,6 +259,7 @@ describe('AiAgentMemoryService', () => {
                 aiAgentMemoryDistill,
                 aiAgentMemoryConsolidatePartition,
             },
+            consolidationDryRun,
             distillCall,
             consolidateCall,
         });
@@ -268,6 +280,7 @@ describe('AiAgentMemoryService', () => {
             findConsolidationCandidates,
             findLatestConsolidationRun,
             recordConsolidationRun,
+            recordDryRunConsolidation,
             applyConsolidation,
             findExploresFromCache,
             aiAgentMemoryDistill,
@@ -1124,6 +1137,17 @@ describe('AiAgentMemoryService', () => {
         ownerUserUuid: 'owner-1',
     };
 
+    /** Returns the newest eligible canned run-history row. */
+    const latestConsolidationRun =
+        (
+            runs: {
+                input_hash: string;
+                status: 'succeeded' | 'failed';
+                dry_run: boolean;
+            }[],
+        ) =>
+        async ({ dryRun }: { dryRun: boolean }) =>
+            [...runs].reverse().find((run) => run.dry_run === dryRun);
     const activeMemory = (
         overrides: Record<string, unknown> = {},
     ): Record<string, unknown> => ({
@@ -1154,7 +1178,7 @@ describe('AiAgentMemoryService', () => {
 
     // An empty catalog is treated as an unreadable one, so a partition that is
     // meant to be consolidated needs a catalog with something in it.
-    const buildConsolidation = (options?: { enabledOrganization: string }) => {
+    const buildConsolidation = (options?: Parameters<typeof build>[0]) => {
         const context = build(options);
         context.findExploresFromCache.mockResolvedValue({
             orders: { name: 'orders', tables: {}, joinedTables: [] },
@@ -1386,33 +1410,38 @@ describe('AiAgentMemoryService', () => {
         );
     });
 
-    it('skips a partition whose corpus has not changed since the last run', async () => {
-        const { service, findLatestConsolidationRun, applyConsolidation } =
-            buildConsolidation();
+    it.each(['succeeded', 'failed'] as const)(
+        'skips a partition whose corpus has not changed since a %s live run',
+        async (status) => {
+            const { service, findLatestConsolidationRun, applyConsolidation } =
+                buildConsolidation();
 
-        await expect(
-            service.consolidateScheduledPartition(partitionPayload),
-        ).resolves.toBe('consolidated');
-        const { inputHash } = applyConsolidation.mock.calls[0][0].run;
-        expect(findLatestConsolidationRun).toHaveBeenCalledWith({
-            projectUuid: 'project-enabled',
-            ownerUserUuid: 'owner-1',
-        });
+            await expect(
+                service.consolidateScheduledPartition(partitionPayload),
+            ).resolves.toBe('consolidated');
+            const { inputHash } = applyConsolidation.mock.calls[0][0].run;
+            expect(findLatestConsolidationRun).toHaveBeenCalledWith({
+                projectUuid: 'project-enabled',
+                ownerUserUuid: 'owner-1',
+                dryRun: false,
+            });
 
-        const second = buildConsolidation();
-        second.findLatestConsolidationRun.mockResolvedValue({
-            input_hash: inputHash,
-            status: 'failed',
-        });
+            const second = buildConsolidation();
+            second.findLatestConsolidationRun.mockImplementation(
+                latestConsolidationRun([
+                    { input_hash: inputHash, status, dry_run: false },
+                ]),
+            );
 
-        await expect(
-            second.service.consolidateScheduledPartition(partitionPayload),
-        ).resolves.toBe('skipped');
-        expect(second.consolidateCall).not.toHaveBeenCalled();
-        expect(second.applyConsolidation).not.toHaveBeenCalled();
-        // The catalog is read only for a partition that will be attempted.
-        expect(second.findExploresFromCache).not.toHaveBeenCalled();
-    });
+            await expect(
+                second.service.consolidateScheduledPartition(partitionPayload),
+            ).resolves.toBe('skipped');
+            expect(second.consolidateCall).not.toHaveBeenCalled();
+            expect(second.applyConsolidation).not.toHaveBeenCalled();
+            // The catalog is read only for a partition that will be attempted.
+            expect(second.findExploresFromCache).not.toHaveBeenCalled();
+        },
+    );
 
     it('records a failed run carrying the input hash when the call throws', async () => {
         const {
@@ -1452,6 +1481,283 @@ describe('AiAgentMemoryService', () => {
         });
         expect(JSON.stringify(input)).not.toContain('Summary the curator');
         expect(JSON.stringify(input)).not.toContain('uuid-');
+    });
+
+    // The applied audit the transaction returns is what the event reports, so
+    // the canned model echoes back what it was handed.
+    const echoApply = (applyConsolidation: AnyType) =>
+        applyConsolidation.mockImplementation(
+            async ({ operations, rejected }: AnyType) => ({
+                run: {},
+                applied: operations,
+                rejected,
+            }),
+        );
+
+    const mergeOperation = {
+        type: 'merge',
+        source_slugs: ['net-revenue-0', 'net-revenue-1'],
+        slug: 'net-revenue',
+        title: 'Net revenue convention',
+        memory: 'Use net revenue.',
+        terms: ['ARR'],
+        objects: [],
+        reason: 'Both say the same thing.',
+    };
+
+    const consolidationTrackCalls = (track: AnyType) =>
+        track.mock.calls
+            .map(([event]: [{ event: string }]) => event)
+            .filter((event: { event: string }) =>
+                event.event.startsWith('ai_agent_memory.consolidat'),
+            );
+
+    // One merge, one retire the input names, and one retire it does not: enough
+    // for the proposal, the rejection audit and the apply to be told apart.
+    const dryRunOperations = [
+        mergeOperation,
+        {
+            type: 'retire',
+            slug: 'net-revenue-2',
+            reason: 'Its explore no longer resolves.',
+        },
+        {
+            type: 'retire',
+            slug: 'never-seen',
+            reason: 'Its explore no longer resolves.',
+        },
+    ];
+
+    const buildDryRunPartition = (options?: Parameters<typeof build>[0]) => {
+        const context = buildConsolidation(options);
+        context.consolidateCall.mockResolvedValue({
+            operations: dryRunOperations,
+        });
+        return context;
+    };
+
+    it('proposes operations and applies none in dry-run mode', async () => {
+        const { service, applyConsolidation, recordDryRunConsolidation } =
+            buildDryRunPartition({ consolidationDryRun: true });
+
+        // A dry run curated nothing, so it is not a consolidated partition.
+        await expect(
+            service.consolidateScheduledPartition(partitionPayload),
+        ).resolves.toBe('dry_run');
+
+        expect(applyConsolidation).not.toHaveBeenCalled();
+        expect(recordDryRunConsolidation).toHaveBeenCalledExactlyOnceWith(
+            expect.objectContaining({
+                run: expect.objectContaining({
+                    errorMessage: null,
+                    inputCount: 30,
+                }),
+                operations: [
+                    expect.objectContaining({ type: 'merge' }),
+                    expect.objectContaining({ slug: 'net-revenue-2' }),
+                ],
+                rejected: [
+                    {
+                        operation: expect.objectContaining({
+                            slug: 'never-seen',
+                        }),
+                        reason: 'unknown_slug',
+                    },
+                ],
+            }),
+        );
+    });
+
+    it('proposes exactly what a live run over the same input applies', async () => {
+        const dry = buildDryRunPartition({ consolidationDryRun: true });
+        await dry.service.consolidateScheduledPartition(partitionPayload);
+
+        const live = buildDryRunPartition();
+        echoApply(live.applyConsolidation);
+        await live.service.consolidateScheduledPartition(partitionPayload);
+
+        const [{ run: dryRun, operations: proposed, rejected: dryRejected }] =
+            dry.recordDryRunConsolidation.mock.calls[0];
+        const [{ run: liveRun, operations, rejected }] =
+            live.applyConsolidation.mock.calls[0];
+        expect(proposed).toEqual(operations);
+        expect(dryRejected).toEqual(rejected);
+        // Selection, projection and the call itself are untouched by the mode.
+        expect(dryRun.inputHash).toBe(liveRun.inputHash);
+        expect(dryRun.promptHash).toBe(liveRun.promptHash);
+        expect(dry.consolidateCall.mock.calls[0][0].input).toEqual(
+            live.consolidateCall.mock.calls[0][0].input,
+        );
+    });
+
+    it.each(['succeeded', 'failed'] as const)(
+        'does not repeat a dry run on an unchanged corpus after a %s run',
+        async (status) => {
+            const first = buildDryRunPartition({ consolidationDryRun: true });
+            await first.service.consolidateScheduledPartition(partitionPayload);
+            const [
+                {
+                    run: { inputHash },
+                },
+            ] = first.recordDryRunConsolidation.mock.calls[0];
+
+            const second = buildDryRunPartition({ consolidationDryRun: true });
+            second.findLatestConsolidationRun.mockImplementation(
+                latestConsolidationRun([
+                    { input_hash: inputHash, status, dry_run: true },
+                ]),
+            );
+
+            await expect(
+                second.service.consolidateScheduledPartition(partitionPayload),
+            ).resolves.toBe('skipped');
+            // A dry-run pass may settle on its own dry rows...
+            expect(second.findLatestConsolidationRun).toHaveBeenCalledWith(
+                expect.objectContaining({ dryRun: true }),
+            );
+            expect(second.consolidateCall).not.toHaveBeenCalled();
+            expect(second.recordDryRunConsolidation).not.toHaveBeenCalled();
+        },
+    );
+
+    it('ignores dry-run rows once dry-run mode is turned off', async () => {
+        const first = buildDryRunPartition({ consolidationDryRun: true });
+        await first.service.consolidateScheduledPartition(partitionPayload);
+        const [
+            {
+                run: { inputHash },
+            },
+        ] = first.recordDryRunConsolidation.mock.calls[0];
+
+        // ...but a live pass must not: the corpus is still uncurated.
+        const live = buildDryRunPartition();
+        live.findLatestConsolidationRun.mockImplementation(
+            latestConsolidationRun([
+                { input_hash: inputHash, status: 'succeeded', dry_run: true },
+            ]),
+        );
+        echoApply(live.applyConsolidation);
+        await expect(
+            live.service.consolidateScheduledPartition(partitionPayload),
+        ).resolves.toBe('consolidated');
+        expect(live.findLatestConsolidationRun).toHaveBeenCalledWith(
+            expect.objectContaining({ dryRun: false }),
+        );
+    });
+
+    it('ignores live rows when dry-run mode is turned on', async () => {
+        const live = buildDryRunPartition();
+        echoApply(live.applyConsolidation);
+        await live.service.consolidateScheduledPartition(partitionPayload);
+        const [
+            {
+                run: { inputHash },
+            },
+        ] = live.applyConsolidation.mock.calls[0];
+
+        const dry = buildDryRunPartition({ consolidationDryRun: true });
+        dry.findLatestConsolidationRun.mockImplementation(
+            latestConsolidationRun([
+                { input_hash: inputHash, status: 'succeeded', dry_run: false },
+            ]),
+        );
+
+        await expect(
+            dry.service.consolidateScheduledPartition(partitionPayload),
+        ).resolves.toBe('dry_run');
+        expect(dry.findLatestConsolidationRun).toHaveBeenCalledWith(
+            expect.objectContaining({ dryRun: true }),
+        );
+        expect(dry.recordDryRunConsolidation).toHaveBeenCalledOnce();
+    });
+
+    it('records a dry run that failed as a dry run', async () => {
+        const {
+            service,
+            consolidateCall,
+            recordConsolidationRun,
+            prometheusMetrics,
+            track,
+        } = buildDryRunPartition({ consolidationDryRun: true });
+        consolidateCall.mockRejectedValue(new Error('model exploded'));
+
+        await expect(
+            service.consolidateScheduledPartition(partitionPayload),
+        ).resolves.toBe('failed');
+
+        expect(recordConsolidationRun).toHaveBeenCalledExactlyOnceWith(
+            expect.objectContaining({
+                status: 'failed',
+                dryRun: true,
+                errorMessage: 'model exploded',
+                inputHash: expect.any(String),
+                appliedOperations: [],
+            }),
+        );
+        expect(consolidationTrackCalls(track)).toEqual([
+            expect.objectContaining({
+                event: 'ai_agent_memory.consolidation_failed',
+                properties: expect.objectContaining({ dryRun: true }),
+            }),
+        ]);
+        expect(
+            prometheusMetrics.trackAiAgentMemoryConsolidate,
+        ).toHaveBeenCalledExactlyOnceWith('dry_run_failed', expect.any(Number));
+    });
+
+    it('never reports a dry run as curation that happened', async () => {
+        const { service, track } = buildDryRunPartition({
+            consolidationDryRun: true,
+        });
+
+        await service.consolidateScheduledPartition(partitionPayload);
+
+        expect(consolidationTrackCalls(track)).toEqual([
+            expect.objectContaining({
+                event: 'ai_agent_memory.consolidated',
+                properties: expect.objectContaining({
+                    dryRun: true,
+                    outcome: 'proposed',
+                    inputCount: 30,
+                    mergeCount: 1,
+                    retireCount: 1,
+                    rejectedCount: 1,
+                }),
+            }),
+        ]);
+    });
+
+    it('reports a dry run that proposed nothing', async () => {
+        const { service, consolidateCall, track } = buildDryRunPartition({
+            consolidationDryRun: true,
+        });
+        consolidateCall.mockResolvedValue({ operations: [] });
+
+        await service.consolidateScheduledPartition(partitionPayload);
+
+        expect(consolidationTrackCalls(track)).toEqual([
+            expect.objectContaining({
+                properties: expect.objectContaining({
+                    dryRun: true,
+                    outcome: 'no_operations',
+                }),
+            }),
+        ]);
+    });
+
+    it('keeps proposed operations out of the applied-operation metric', async () => {
+        const { service, prometheusMetrics } = buildDryRunPartition({
+            consolidationDryRun: true,
+        });
+
+        await service.consolidateScheduledPartition(partitionPayload);
+
+        expect(
+            prometheusMetrics.trackAiAgentMemoryConsolidate,
+        ).toHaveBeenCalledExactlyOnceWith('dry_run', expect.any(Number));
+        expect(
+            prometheusMetrics.trackAiAgentMemoryConsolidateOperations,
+        ).not.toHaveBeenCalled();
     });
 
     it('returns not found without reading rows when the flag is off', async () => {

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
@@ -151,6 +151,8 @@ type Dependencies = {
     projectModel: Pick<ProjectModel, 'findExploresFromCache' | 'getSummary'>;
     featureFlagService: FeatureFlagService;
     schedulerClient: MemorySchedulerClient;
+    /** Runs consolidation without applying its proposed operations. */
+    consolidationDryRun: boolean;
     prometheusMetrics?: PrometheusMetrics;
     // Each LLM call is independently cannable for tests. A call that is not
     // canned needs the resolver, which is guarded where the call is made.
@@ -174,6 +176,8 @@ export class AiAgentMemoryService extends BaseService {
 
     private readonly schedulerClient: MemorySchedulerClient;
 
+    private readonly consolidationDryRun: boolean;
+
     private readonly prometheusMetrics: PrometheusMetrics | undefined;
 
     private readonly orgAiCopilotConfigResolver:
@@ -193,6 +197,7 @@ export class AiAgentMemoryService extends BaseService {
         this.projectModel = dependencies.projectModel;
         this.featureFlagService = dependencies.featureFlagService;
         this.schedulerClient = dependencies.schedulerClient;
+        this.consolidationDryRun = dependencies.consolidationDryRun;
         this.prometheusMetrics = dependencies.prometheusMetrics;
         this.orgAiCopilotConfigResolver =
             dependencies.orgAiCopilotConfigResolver;
@@ -216,6 +221,7 @@ export class AiAgentMemoryService extends BaseService {
     /** The pass is scheduled work, so the organization is the anonymous actor. */
     private trackConsolidationFailed(
         partition: AiAgentMemoryConsolidationPartition,
+        dryRun: boolean,
         failureStage: ConsolidationFailureStage,
         error: unknown,
     ): void {
@@ -226,6 +232,7 @@ export class AiAgentMemoryService extends BaseService {
                 organizationId: partition.organizationUuid,
                 projectId: partition.projectUuid,
                 ownerUserId: partition.ownerUserUuid,
+                dryRun,
                 failureStage,
                 // Never the message: an AI SDK error quotes the model output.
                 errorType: error instanceof Error ? error.name : 'UnknownError',
@@ -233,26 +240,27 @@ export class AiAgentMemoryService extends BaseService {
         });
     }
 
-    /**
-     * One event per run that reached the apply transaction, and the applied and
-     * rejected operation mix on the metrics. Counts and closed enumerations
-     * only: no memory text, title, term, object name, slug or operation reason.
-     * Swallows its own failures — this runs inside the attempt's try, and an
-     * instrumentation error must not turn an applied run into a failed one.
-     */
-    private recordConsolidationApplied(args: {
+    /** Records operation counts without exposing memory content. */
+    private recordConsolidationOutcome(args: {
         partition: AiAgentMemoryConsolidationPartition;
         input: AiAgentMemoryConsolidationInputEntry[];
-        applied: AiAgentMemoryConsolidationOperation[];
+        /** Applied on a live run, merely proposed on a dry one. */
+        operations: AiAgentMemoryConsolidationOperation[];
         rejected: AiAgentMemoryConsolidationRejection[];
+        dryRun: boolean;
     }): void {
         try {
-            const appliedCounts = countConsolidationOperations(args.applied);
+            const operationCounts = countConsolidationOperations(
+                args.operations,
+            );
             const rejectedCounts = countConsolidationRejections(args.rejected);
-            this.prometheusMetrics?.trackAiAgentMemoryConsolidateOperations({
-                applied: appliedCounts,
-                rejected: rejectedCounts,
-            });
+            // A dry run wrote nothing, so its proposals must never land on the
+            // metric that counts what curation did.
+            if (!args.dryRun) {
+                this.prometheusMetrics?.trackAiAgentMemoryConsolidateOperations(
+                    { applied: operationCounts, rejected: rejectedCounts },
+                );
+            }
             this.track({
                 event: 'ai_agent_memory.consolidated',
                 anonymousId: args.partition.organizationUuid,
@@ -262,16 +270,16 @@ export class AiAgentMemoryService extends BaseService {
                     ownerUserId: args.partition.ownerUserUuid,
                     // A quiet run is not a skipped partition: it read the
                     // corpus, paid for the call and found nothing to do.
-                    outcome:
-                        args.applied.length > 0 ? 'applied' : 'no_operations',
+                    outcome: AiAgentMemoryService.getConsolidationOutcome(args),
+                    dryRun: args.dryRun,
                     inputCount: args.input.length,
-                    mergeCount: appliedCounts.merge,
-                    supersedeCount: appliedCounts.supersede,
-                    retireCount: appliedCounts.retire,
+                    mergeCount: operationCounts.merge,
+                    supersedeCount: operationCounts.supersede,
+                    retireCount: operationCounts.retire,
                     rejectedCount: args.rejected.length,
                     ...countConsolidationScopes({
                         input: args.input,
-                        applied: args.applied,
+                        applied: args.operations,
                     }),
                 },
             });
@@ -281,6 +289,14 @@ export class AiAgentMemoryService extends BaseService {
                 error: getErrorMessage(error),
             });
         }
+    }
+
+    private static getConsolidationOutcome(args: {
+        operations: AiAgentMemoryConsolidationOperation[];
+        dryRun: boolean;
+    }): AiAgentMemoryConsolidatedEvent['properties']['outcome'] {
+        if (args.operations.length === 0) return 'no_operations';
+        return args.dryRun ? 'proposed' : 'applied';
     }
 
     private trackConsolidationSkipped(
@@ -723,7 +739,9 @@ export class AiAgentMemoryService extends BaseService {
             abortSignal,
         );
         this.prometheusMetrics?.trackAiAgentMemoryConsolidate(
-            outcome,
+            outcome === 'failed' && this.consolidationDryRun
+                ? 'dry_run_failed'
+                : outcome,
             Date.now() - startTime,
         );
         return outcome;
@@ -764,6 +782,7 @@ export class AiAgentMemoryService extends BaseService {
                 await this.aiAgentMemoryModel.findLatestConsolidationRun({
                     projectUuid: partition.projectUuid,
                     ownerUserUuid: partition.ownerUserUuid,
+                    dryRun: this.consolidationDryRun,
                 });
             if (latestRun?.input_hash === inputHash) {
                 this.trackConsolidationSkipped(
@@ -814,7 +833,12 @@ export class AiAgentMemoryService extends BaseService {
                 projectUuid: partition.projectUuid,
                 ownerUserUuid: partition.ownerUserUuid,
             });
-            this.trackConsolidationFailed(partition, 'selection', error);
+            this.trackConsolidationFailed(
+                partition,
+                this.consolidationDryRun,
+                'selection',
+                error,
+            );
             return 'failed';
         }
     }
@@ -918,13 +942,35 @@ export class AiAgentMemoryService extends BaseService {
             });
             rejectedOperations = rejected;
             failureStage = 'persistence';
+            const selection = memories.map((memory) => ({
+                memoryUuid: memory.ai_agent_memory_uuid,
+                slug: memory.slug,
+                generatedAt: memory.generated_at,
+            }));
+
+            // Nothing below this line touches a memory row. The hash is stored
+            // all the same, so one dry sample is taken per changed corpus.
+            if (this.consolidationDryRun) {
+                const result =
+                    await this.aiAgentMemoryModel.recordDryRunConsolidation({
+                        run,
+                        selection,
+                        operations: applied,
+                        rejected,
+                    });
+                this.recordConsolidationOutcome({
+                    partition,
+                    input,
+                    operations: result.proposed,
+                    rejected: result.rejected,
+                    dryRun: true,
+                });
+                return 'dry_run';
+            }
+
             const result = await this.aiAgentMemoryModel.applyConsolidation({
                 run,
-                selection: memories.map((memory) => ({
-                    memoryUuid: memory.ai_agent_memory_uuid,
-                    slug: memory.slug,
-                    generatedAt: memory.generated_at,
-                })),
+                selection,
                 operations: applied,
                 rejected,
                 unresolvedObjectKeys: new Set(
@@ -937,11 +983,12 @@ export class AiAgentMemoryService extends BaseService {
             });
             // The apply's own audit, not validation's: it carries the rows the
             // transaction rejected for having moved since selection.
-            this.recordConsolidationApplied({
+            this.recordConsolidationOutcome({
                 partition,
                 input,
-                applied: result.applied,
+                operations: result.applied,
                 rejected: result.rejected,
+                dryRun: false,
             });
             return 'consolidated';
         } catch (error) {
@@ -958,6 +1005,7 @@ export class AiAgentMemoryService extends BaseService {
             await this.aiAgentMemoryModel.recordConsolidationRun({
                 ...run,
                 status: 'failed',
+                dryRun: this.consolidationDryRun,
                 appliedOperations: [],
                 rejectedOperations,
                 errorMessage,
@@ -974,7 +1022,12 @@ export class AiAgentMemoryService extends BaseService {
                 projectUuid: partition.projectUuid,
                 ownerUserUuid: partition.ownerUserUuid,
             });
-            this.trackConsolidationFailed(partition, failureStage, error);
+            this.trackConsolidationFailed(
+                partition,
+                this.consolidationDryRun,
+                failureStage,
+                error,
+            );
             return 'failed';
         }
     }

--- a/packages/backend/src/prometheus/PrometheusMetrics.ts
+++ b/packages/backend/src/prometheus/PrometheusMetrics.ts
@@ -73,6 +73,8 @@ export type AiAgentMemoryDistillOutcome =
 
 export const AI_AGENT_MEMORY_CONSOLIDATE_OUTCOMES = [
     'consolidated',
+    // Proposed and applied nothing: never counted as a consolidated partition.
+    'dry_run',
     'skipped',
     'failed',
     'aborted',
@@ -80,6 +82,14 @@ export const AI_AGENT_MEMORY_CONSOLIDATE_OUTCOMES = [
 
 export type AiAgentMemoryConsolidateOutcome =
     (typeof AI_AGENT_MEMORY_CONSOLIDATE_OUTCOMES)[number];
+
+const AI_AGENT_MEMORY_CONSOLIDATE_METRIC_OUTCOMES = [
+    ...AI_AGENT_MEMORY_CONSOLIDATE_OUTCOMES,
+    'dry_run_failed',
+] as const;
+
+type AiAgentMemoryConsolidateMetricOutcome =
+    (typeof AI_AGENT_MEMORY_CONSOLIDATE_METRIC_OUTCOMES)[number];
 
 export function getQueryContextLabel(
     context: string,
@@ -580,7 +590,7 @@ export default class PrometheusMetrics {
                 // AI agent memory consolidation pass
                 this.aiAgentMemoryConsolidateCounter = new prometheus.Counter({
                     name: 'ai_agent_memory_consolidate_total',
-                    help: 'AI agent memory consolidation runs by outcome (consolidated | skipped | failed | aborted)',
+                    help: 'AI agent memory consolidation runs by outcome (consolidated | dry_run | skipped | failed | dry_run_failed | aborted)',
                     labelNames: ['outcome'],
                     ...rest,
                 });
@@ -786,12 +796,17 @@ export default class PrometheusMetrics {
                         );
                     },
                 );
-                AI_AGENT_MEMORY_CONSOLIDATE_OUTCOMES.forEach((outcome) => {
-                    this.aiAgentMemoryConsolidateCounter?.inc({ outcome }, 0);
-                    this.aiAgentMemoryConsolidateDurationHistogram?.zero({
-                        outcome,
-                    });
-                });
+                AI_AGENT_MEMORY_CONSOLIDATE_METRIC_OUTCOMES.forEach(
+                    (outcome) => {
+                        this.aiAgentMemoryConsolidateCounter?.inc(
+                            { outcome },
+                            0,
+                        );
+                        this.aiAgentMemoryConsolidateDurationHistogram?.zero({
+                            outcome,
+                        });
+                    },
+                );
                 AI_AGENT_MEMORY_CONSOLIDATION_OPERATION_TYPES.forEach(
                     (operation) => {
                         this.aiAgentMemoryConsolidateOperationCounter?.inc(
@@ -1660,7 +1675,7 @@ export default class PrometheusMetrics {
     }
 
     public trackAiAgentMemoryConsolidate(
-        outcome: AiAgentMemoryConsolidateOutcome,
+        outcome: AiAgentMemoryConsolidateMetricOutcome,
         durationMs: number,
     ) {
         this.aiAgentMemoryConsolidateCounter?.inc({ outcome });


### PR DESCRIPTION
## What

Adds a dry-run mode to the AI agent memory consolidation pass: it computes its operations, records them in full on the run row, and applies nothing.

## Why

The parent spec, [ZAP-715](https://linear.app/lightdash/issue/ZAP-715), lists dry-run under *Out of Scope* and tracks it separately here. The motivation is prompt work. Today a consolidation prompt change can only be evaluated by letting it curate real memories and reading the wreckage afterwards, and there is no un-merge or un-retire path short of hand-written SQL. Dry-run makes a prompt change observable before it is destructive: run it against real corpora, read the proposed operations out of run history, compare them against what the previous prompt proposed on the same input.

## Implementation decisions

- **Everything up to the apply transaction runs unchanged** — selection, projection, the LLM call, validation and its rejections. Only the apply is skipped, so a dry run and a live run over the same input produce the same operation set by construction rather than via a parallel code path.
- **`dry_run` is a column on the run row, not a status.** It records the mode, not the outcome: a dry run that failed is still a dry run, so its operation columns hold proposals whatever its status. This keeps "was this curation?" a single predicate.
- **The write path cannot see the flag.** `applyConsolidation` takes `Omit<…, 'dryRun'>` and hardcodes `dryRun: false`, so a dry run is structurally unable to reach the apply rather than merely branching around it.
- **The input hash is still stored**, so a dry run does not repeat daily on an unchanged corpus. Because it applies nothing, the corpus stays unchanged and the partition skips from the next day onward — one dry sample per changed corpus, which is intended rather than a defect.
- **Settable without a deploy** via `AI_AGENT_MEMORY_CONSOLIDATION_DRY_RUN`, threaded through config into the service.
- **Telemetry keeps proposals apart from curation.** The analytics event gains a `proposed` outcome plus a `dryRun` flag — `applied` is impossible on a dry run, so a query that counts curation stays correct even if it ignores the flag. Proposals never land on the Prometheus applied-operations metric, and the consolidate counter gains a `dry_run` outcome.

## Testing

- Unit (`AiAgentMemoryService.test.ts`): proposes operations and applies none; proposes exactly what a live run over the same input applies; does not repeat on an unchanged corpus; a failed dry run is recorded as a dry run; never reported as curation that happened; the proposed-nothing case; proposals kept out of the applied-operation metric.
- Integration against real Postgres (`AiAgentMemoryConsolidation.integration.test.ts`): records a full proposal without touching a memory row.
- Green: `pnpm -F common typecheck:fast`, `pnpm -F backend typecheck:fast`, `pnpm -F backend lint`, `pnpm -F common test`, the full backend unit suite, and all 19 consolidation integration tests.

Closes: ZAP-718
Relates: ZAP-715


---

## Second review pass

- **Prometheus counter help text listed the wrong outcome set.** `ai_agent_memory_consolidate_total` documents its `outcome` label inline, and this PR adds a `dry_run` value to that label without adding it to the help string — so the metric advertised `consolidated | skipped | failed | aborted` while emitting a fifth value. Help text now matches the enum the code can emit.

Re-verified after the change: `pnpm -F common typecheck:fast`, `pnpm -F backend typecheck:fast`, `pnpm -F backend lint` (0 errors), `pnpm -F common test` (3151 passed), `pnpm -F backend test:dev:nowatch` (87 passed), and the memory service / models / scheduler suites (359 passed).
