### PR TITLE
perf: optimize dashboard parameter project filtering

### DIFF
--- a/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
@@ -216,6 +216,34 @@ describe('DashboardModel', () => {
         expect(tracker.history.select).toHaveLength(2);
     });
 
+    test('should get dashboard parameters using the dashboard project uuid', async () => {
+        const dashboardUuid = '11111111-1111-4111-8111-111111111111';
+        const parameters = {
+            test_parameter: 'test value',
+        };
+        tracker.on.select(DashboardsTableName).response([{ parameters }]);
+
+        const result = await model.getDashboardParametersByIdOrSlug(
+            dashboardUuid,
+            projectUuid,
+        );
+
+        expect(result).toEqual(parameters);
+        expect(tracker.history.select).toHaveLength(1);
+        expect(tracker.history.select[0].sql).toContain(
+            '"dashboards"."project_uuid"',
+        );
+        expect(tracker.history.select[0].sql).not.toContain(
+            'inner join "spaces"',
+        );
+        expect(tracker.history.select[0].sql).not.toContain(
+            'inner join "projects"',
+        );
+        expect(tracker.history.select[0].bindings).toEqual(
+            expect.arrayContaining([projectUuid, dashboardUuid]),
+        );
+    });
+
     test('should check if saved chart exists in dashboard', async () => {
         const testProjectUuid = 'test-project-uuid';
         const testDashboardUuid = 'test-dashboard-uuid';

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -1343,20 +1343,10 @@ export class DashboardModel {
                 `${DashboardVersionsTableName}.dashboard_version_id`,
                 `${DashboardViewsTableName}.dashboard_version_id`,
             )
-            .innerJoin(
-                SpaceTableName,
-                `${DashboardsTableName}.space_id`,
-                `${SpaceTableName}.space_id`,
-            )
-            .innerJoin(
-                ProjectTableName,
-                `${ProjectTableName}.project_id`,
-                `${SpaceTableName}.project_id`,
-            )
             .select<{ parameters: DashboardParameters | null } | undefined>(
                 `${DashboardViewsTableName}.parameters`,
             )
-            .where(`${ProjectTableName}.project_uuid`, projectUuid)
+            .where(`${DashboardsTableName}.project_uuid`, projectUuid)
             .whereNull(`${DashboardsTableName}.deleted_at`)
             .orderBy(`${DashboardVersionsTableName}.created_at`, 'desc')
             .orderBy(`${DashboardViewsTableName}.created_at`, 'desc');


### PR DESCRIPTION
## Summary

- filter dashboard parameters directly by `dashboards.project_uuid`
- remove the unnecessary `spaces` and `projects` joins
- add a regression test for the generated project-scoped query

## Performance

On the local API database (289 active dashboards), 60 warmed `EXPLAIN (ANALYZE, BUFFERS)` runs against a dashboard with 34 versions/views:

- mean execution: 0.255 ms → 0.225 ms (11.7% faster)
- median execution: 0.228 ms → 0.206 ms (9.6% faster)
- plan: two fewer joins and 5 fewer shared buffer hits

The absolute saving is modest (~0.030 ms per call), but this method is used on dashboard chart execution and the implementation change is narrowly scoped.

## Validation

- all backend unit tests: 5,070 passed, 1 skipped
- focused SQL regression verifies no `spaces` or `projects` join
- backend ESLint passed for both changed files
- live dashboard-chart request returned HTTP 200 and a query UUID after resolving dashboard parameters

CI: test-all

Relates: PROD-9106