### PR TITLE
ci: allow manual dispatch of the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: {}
 
 jobs:
   build-and-test:


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` to `Build & Release`'s triggers, alongside the existing `push: branches: [main]`.

## Why
The release job runs `semantic-release`, which only cuts a version when at least one commit since the last tag is a releasable type (`feat`/`fix`/`perf` under the default Angular preset — `chore`/`docs`/etc. don't trigger a bump). Right now the only way to re-run the pipeline is a push to `main`, so there's no way to kick off a release check on demand (e.g. to pick up a `chore` commit as soon as a releasable one lands, without waiting on the next push). Manual dispatch doesn't bypass semantic-release's commit analysis — it just lets the same pipeline be triggered without a push.

Related: PROD-8557 (Node 24 release-day cutover) — the currently-merged Node 24 commit is a `chore:` and won't cut a release on its own.

## Test plan
- [ ] Confirm the "Run workflow" button appears for `Build & Release` in the Actions UI after merge
- [ ] Manually dispatch once and confirm `semantic-release` runs its normal analysis (no-op if still no releasable commit since last tag)