### PR TITLE
feat(ci): remove stale npm-pin comment in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,11 +66,6 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
 
-      # Pinned to the npm 11.x line, not `latest`: npm 12.0.0 raised its engines
-      # requirement to Node >=22.22.2 / >=24.15.0 / >=26.0.0, breaking this step
-      # on our current Node 20 (.nvmrc). npm 11.x still supports Node ^20.17.0
-      # and OIDC/trusted publishing. Temporary until the Node 24 cutover
-      # (PROD-8557, due 2026-07-29) lands and this step can track latest again.
       - name: Upgrade npm for OIDC support
         run: sfw npm install -g npm@11.18.0
 


### PR DESCRIPTION
## Summary
- Removes the comment above the "Upgrade npm for OIDC support" step in `.github/workflows/release.yml` explaining the npm 11.x pin.

## Why
The comment said the pin to npm 11.x (instead of latest) was needed because npm 12.0.0 requires Node >=22.22.2 / >=24.15.0 / >=26.0.0, which the old Node 20 `.nvmrc` couldn't satisfy — and that this was "temporary until the Node 24 cutover (PROD-8557) lands."

That cutover has landed (#26320, merged) and `.nvmrc` is now `24.18`, which satisfies npm 12's `>=24.15.0` floor. The comment's premise no longer holds, so it was stale rather than useful.

The `npm install -g npm@11.18.0` step itself is intentionally left untouched — removing the pin is a separate, riskier change (needs verifying the default npm on this runner still supports OIDC/trusted publishing), not just a comment cleanup.

Related: PROD-8557.

## Test plan
- [ ] N/A — comment-only change, no functional diff