### PR TITLE
chore(ci): bump pinned npm to 12.0.1 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
           cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Upgrade npm for OIDC support
-        run: sfw npm install -g npm@11.18.0
+        run: sfw npm install -g npm@12.0.1
 
       - name: Install dependencies
         run: sfw pnpm install --frozen-lockfile --prefer-offline --prod=false


### PR DESCRIPTION
## Summary
- Bumps the pinned npm version in the release job's "Upgrade npm for OIDC support" step from `11.18.0` to `12.0.1` (npm's current published version).

## Why
This pin existed because npm 12.0.0 raised its engines requirement to Node `>=22.22.2 / >=24.15.0 / >=26.0.0`, which the repo's old Node 20 `.nvmrc` couldn't satisfy (see the explanatory comment removed in #26396).

`.nvmrc` is now `24.18`, which satisfies npm 12's `>=24.15.0` floor, so the pin can move forward.

Related: PROD-8557 (Node 24 release-day cutover).

## Test plan
- [ ] CI passes on this branch
- [ ] The release job's npm install/publish steps succeed under npm 12.0.1 (OIDC/trusted publishing still works)