### PR TITLE
fix(dashboards): apply the current parameter values when exporting

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -601,6 +601,7 @@ export default class SchedulerTask {
         exportOptions?: {
             dashboardFilters?: ExportContentPayload['dashboardFilters'];
             dateZoomGranularity?: ExportContentPayload['dateZoomGranularity'];
+            parameters?: ExportContentPayload['parameters'];
         },
     ): Promise<
         NotificationPayloadBase['page'] & {
@@ -637,9 +638,10 @@ export default class SchedulerTask {
                 : undefined;
 
         const sendNowSchedulerParameters =
-            !schedulerUuid && isDashboardScheduler(scheduler)
+            exportOptions?.parameters ??
+            (!schedulerUuid && isDashboardScheduler(scheduler)
                 ? scheduler.parameters
-                : undefined;
+                : undefined);
 
         const selectedTabs = isDashboardScheduler(scheduler)
             ? scheduler.selectedTabs
@@ -1032,11 +1034,14 @@ export default class SchedulerTask {
                                 ),
                             );
 
-                        // Merge scheduler parameters with dashboard parameters (scheduler parameters override)
-                        const finalParameters: ParametersValuesMap = {
-                            ...convertedDashboardParameters,
-                            ...schedulerParameters,
-                        };
+                        // Ad-hoc exports send the parameter values currently
+                        // applied on the dashboard, which replace the saved
+                        // defaults the same way exported filters do.
+                        const finalParameters: ParametersValuesMap =
+                            exportOptions?.parameters ?? {
+                                ...convertedDashboardParameters,
+                                ...schedulerParameters,
+                            };
 
                         // Sheets are added to the workbook in promise order, so
                         // sort tiles by dashboard layout (tab order, then
@@ -5140,6 +5145,7 @@ export default class SchedulerTask {
                     {
                         dashboardFilters: payload.dashboardFilters,
                         dateZoomGranularity: payload.dateZoomGranularity,
+                        parameters: payload.parameters,
                     },
                 );
 

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -9,6 +9,7 @@ import {
     OrganizationMemberRole,
     PossibleAbilities,
     ProjectMemberRole,
+    SCHEDULER_TASKS,
     SchedulerFormat,
     SessionUser,
     type Account,
@@ -112,6 +113,7 @@ const slackClient = {
 
 const schedulerClient = {
     generateDailyJobsForScheduler: vi.fn(async () => undefined),
+    scheduleTask: vi.fn(async () => ({ jobId: 'jobId' })),
 };
 
 const dashboardChartsResult = {
@@ -218,6 +220,18 @@ describe('DashboardService', () => {
         expect(dashboardModel.getByIdOrSlug).toHaveBeenCalledWith(
             dashboard.uuid,
             { projectUuid: undefined },
+        );
+    });
+
+    test('should forward the applied parameter values when exporting content', async () => {
+        await service.scheduleExportContent(user, dashboard.uuid, {
+            format: SchedulerFormat.IMAGE,
+            parameters: { region: 'APAC' },
+        });
+
+        expect(schedulerClient.scheduleTask).toHaveBeenCalledWith(
+            SCHEDULER_TASKS.EXPORT_CONTENT,
+            expect.objectContaining({ parameters: { region: 'APAC' } }),
         );
     });
 

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -229,6 +229,7 @@ export class DashboardService
             dateZoomGranularity: data.dateZoomGranularity,
             customViewportWidth: data.customViewportWidth,
             selectedTabs: data.selectedTabs ?? null,
+            parameters: data.parameters,
             organizationUuid: dashboard.organizationUuid,
             projectUuid: dashboard.projectUuid,
             userUuid: user.userUuid,

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -856,6 +856,7 @@ export type ExportContentPayload = TraceTaskBase & {
     dateZoomGranularity?: DateGranularity | string;
     customViewportWidth?: number;
     selectedTabs?: string[] | null;
+    parameters?: ParametersValuesMap;
 };
 
 export type ExportContentRequest = {
@@ -865,6 +866,7 @@ export type ExportContentRequest = {
     dateZoomGranularity?: DateGranularity | string;
     customViewportWidth?: number;
     selectedTabs?: string[] | null;
+    parameters?: ParametersValuesMap;
 };
 
 export type DownloadAsyncQueryResultsPayload = TraceTaskBase & {

--- a/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
@@ -58,6 +58,7 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
     const dateZoomGranularity = useDashboardContext(
         (c) => c.dateZoomGranularity,
     );
+    const parameterValues = useDashboardContext((c) => c.parameterValues);
 
     const [previews, setPreviews] = useState<Record<string, string>>({});
     const [previewChoice, setPreviewChoice] = useState<
@@ -92,11 +93,15 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
         );
     }, [allTabsSelected, dashboard.tiles, selectedTabs]);
 
+    // Filters and parameters are part of the key so a cached preview is not
+    // reused after the user changes the dashboard view.
     const getPreviewKey = useCallback(
         (width: string) => {
-            return `${width}-${selectedTabs.join('-')}`;
+            return `${width}-${selectedTabs.join('-')}-${JSON.stringify(
+                dashboardFilters,
+            )}-${JSON.stringify(parameterValues)}`;
         },
-        [selectedTabs],
+        [selectedTabs, dashboardFilters, parameterValues],
     );
 
     const currentPreview = previewChoice
@@ -132,6 +137,7 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
                 exportType === SchedulerFormat.IMAGE ? {} : getCsvOptions(),
             dashboardFilters,
             dateZoomGranularity,
+            parameters: parameterValues,
             customViewportWidth:
                 exportType === SchedulerFormat.IMAGE && previewChoice
                     ? parseInt(previewChoice)
@@ -148,6 +154,7 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
         exportType,
         getCsvOptions,
         onClose,
+        parameterValues,
         previewChoice,
     ]);
 
@@ -168,6 +175,7 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
                 : undefined,
             dashboardFilters,
             dateZoomGranularity,
+            parameters: parameterValues,
             selectedTabs: exportSelectedTabs,
         });
 
@@ -185,6 +193,7 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
         exportPreviewMutation,
         exportSelectedTabs,
         getPreviewKey,
+        parameterValues,
         previewChoice,
     ]);
 

--- a/packages/frontend/src/hooks/dashboard/useDashboard.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.ts
@@ -13,6 +13,7 @@ import {
     type DashboardVersion,
     type DateGranularity,
     type ExportContentFormat,
+    type ParametersValuesMap,
     type SavedChartsInfoForDashboardAvailableFilters,
     type SchedulerCsvOptions,
     type SchedulerImageOptions,
@@ -218,6 +219,7 @@ const exportDashboardContent = async (
         dateZoomGranularity?: DateGranularity | string;
         customViewportWidth?: number;
         selectedTabs?: string[] | null;
+        parameters?: ParametersValuesMap;
     },
 ) =>
     lightdashApi<ApiJobScheduledResponse['results']>({
@@ -253,6 +255,7 @@ export const useExportDashboardContent = () => {
             dateZoomGranularity?: DateGranularity | string;
             customViewportWidth?: number;
             selectedTabs?: string[] | null;
+            parameters?: ParametersValuesMap;
         }
     >(
         (data) =>
@@ -263,6 +266,7 @@ export const useExportDashboardContent = () => {
                 dateZoomGranularity: data.dateZoomGranularity,
                 customViewportWidth: data.customViewportWidth,
                 selectedTabs: data.selectedTabs,
+                parameters: data.parameters,
             }),
         {
             mutationKey: ['export_dashboard_content'],
@@ -356,6 +360,7 @@ export const useExportDashboardContentPreview = () => {
             dateZoomGranularity?: DateGranularity | string;
             customViewportWidth?: number;
             selectedTabs?: string[] | null;
+            parameters?: ParametersValuesMap;
         }
     >(
         async (data) => {
@@ -366,6 +371,7 @@ export const useExportDashboardContentPreview = () => {
                 dateZoomGranularity: data.dateZoomGranularity,
                 customViewportWidth: data.customViewportWidth,
                 selectedTabs: data.selectedTabs,
+                parameters: data.parameters,
             });
             const details = (await pollJobStatus(
                 job.jobId,


### PR DESCRIPTION
Part 1 of 2. Follow-up: the same defect on SQL chart / SQL runner downloads.

## Problem

Exporting a dashboard from the **Export dashboard** modal (image, `.csv` or `.xlsx`) ignored the parameter values applied on the dashboard and used the saved defaults instead.

Applied **filters** were already respected, so a single export could combine current filters with stale parameters. For `.csv` / `.xlsx` this is silent — the file contains data for the wrong parameter values with no visual cue.

Scheduled deliveries were not affected: they carry explicit parameter overrides and apply them correctly.

## Root cause

`ExportContentRequest` / `ExportContentPayload` had no `parameters` field, so the selected values never left the browser, and both export paths fell back to the saved values:

- **csv / xlsx** — `finalParameters` was built from `dashboard.parameters` merged with `scheduler.parameters`; an ad-hoc export has no scheduler, so only the saved defaults applied. Filters, on the line directly above, already had an export-time override (`exportOptions?.dashboardFilters ?? dashboard.filters`).
- **image** — the synthetic scheduler in `exportContent` set `filters` from the payload but never `parameters`, so `sendNowSchedulerParameters` was `undefined`, nothing was written to session storage for the headless render, and `MinimalDashboard` fell back to the saved values.

## Change

Carry the applied values through the existing export plumbing:

- `parameters` added to `ExportContentRequest` / `ExportContentPayload`.
- `DashboardExportModal` reads `parameterValues` from the dashboard context and sends it on both the export and the preview request.
- `DashboardService.scheduleExportContent` puts it on the scheduler payload.
- `SchedulerTask` lets it replace the saved defaults on both paths — `finalParameters` for csv/xlsx, and `sendNowSchedulerParameters` for the headless image render, which reuses the session-storage mechanism that already exists for send-now deliveries. No `UnfurlService` or `MinimalDashboard` change was needed.

Also included: the image-preview cache key now incorporates the filters and parameters, so a preview generated before changing the view is no longer reused for a later export. That staleness already affected filters.

## Regression analysis

`parameters` is optional throughout, and both call sites use replace-if-present semantics (`exportOptions?.parameters ?? <existing behaviour>`), mirroring how `dashboardFilters` already works:

- **Scheduled deliveries** — unchanged. They never populate `exportOptions`, so `finalParameters` and `sendNowSchedulerParameters` resolve exactly as before, including the dashboard-defaults-merged-with-scheduler-overrides precedence.
- **Older clients / other API callers** that omit `parameters` — unchanged, same fallback to saved defaults.
- **Replace rather than merge** was chosen deliberately: `parameterValues` already contains the saved values seeded at load plus any user edits, and strips cleared values. Merging over the saved defaults would resurrect a parameter the user had explicitly cleared.

## Security

The new field is client-controlled input reaching server-side query construction, so it was checked explicitly rather than assumed:

- **Type boundary** — TSOA validates values against `string | number | string[] | number[]`. Verified live: nested objects, booleans and arrays-of-objects are rejected with 422, so the escaping layer only ever sees scalars.
- **SQL injection** — the export path calls the same `executeAsyncDashboardChartQuery` / `executeAsyncDashboardSqlChartQuery` the interactive path already calls with client-supplied parameters, so substitution goes through `safeReplaceParameters` with warehouse-specific escaping and quoting. Verified live: `x' UNION SELECT table_name, 1 FROM information_schema.tables --` came back as a single literal cell, not executed.
- **Authorization** — unchanged. The export job runs as the requesting user (`getAccountByUserUuid`), and each tile's query re-checks `view SavedChart` with the space access context. Parameters grant no capability the user doesn't already have interactively on the same dashboard.

## Testing

Verified end-to-end in a local instance against a real warehouse, driving the browser.

Rig: a SQL chart whose SQL is `SELECT ${lightdash.parameters.metric_type} AS chosen_metric, 1 AS n`, on a dashboard whose saved default for `metric_type` is `count`, switched in the UI to `revenue`. Exporting through the modal produced a request body carrying `"parameters":{"metric_type":"revenue"}`, and the downloaded file contained `"revenue","1"`.

The endpoint was then called twice against the same backend, with and without `parameters`:

| Request | `.csv` contents | image render |
|---|---|---|
| with `parameters: {metric_type: "revenue"}` | `revenue` | `revenue` |
| without `parameters` | `count` | `count` |

The second row is the reported bug reproduced, and confirms the fallback for callers that omit the field is untouched. The image row went through the real headless-browser render.

Also run: new unit test asserting the applied parameter values reach the scheduler payload from `scheduleExportContent`; `pnpm -F backend typecheck:fast`, `pnpm -F frontend typecheck:fast`, package lints, and the `DashboardService` suite (35 tests) all pass.

Relates: PROD-9315
Relates: #26398
