### PR TITLE
fix: preserve data app slugs in preview projects

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -7158,6 +7158,7 @@ export class AppGenerateService extends BaseService {
                     // by their creator inside the preview.
                     created_by_user_uuid: sourceApp.created_by_user_uuid,
                     name: sourceApp.name,
+                    slug: sourceApp.slug,
                     description: sourceApp.description,
                     template: sourceApp.template,
                     space_uuid: previewSpaceUuid,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.vizSchemaCopy.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.vizSchemaCopy.test.ts
@@ -52,6 +52,7 @@ const sourceApp = {
     upstream_app_uuid: null,
     template: 'data_app_viz',
     name: 'My Viz',
+    slug: 'my-viz',
     description: 'A viz',
     created_by_user_uuid: USER_UUID,
     deleted_at: null,
@@ -334,6 +335,7 @@ describe('viz_schema propagation on app copy paths', () => {
             expect.objectContaining({
                 project_uuid: PREVIEW_PROJECT_UUID,
                 template: 'data_app_viz',
+                slug: 'my-viz',
             }),
             expect.anything(),
             'ready',


### PR DESCRIPTION
### Description

Preview-project cloning copied a data app's name but regenerated its slug from that name. This usually produced the same value, but a customized source slug could drift in the preview.

This change passes the source app slug explicitly when creating the preview copy, matching the existing preview behavior for spaces, charts, SQL charts, and dashboards.

This is a separate behavior fix stacked on #26393, which adds explicit slug input support to `AppModel.createWithVersion`.

### Validation

- existing app preview-copy test now asserts the source slug is preserved
- 5 focused app copy tests
- backend fast typecheck
- commit hooks: backend lint/format, unused exports, and secret scan

### Compatibility and security

Only newly cloned preview data apps are affected. Existing apps and preview projects are not backfilled or renamed. No schema, permissions, dependencies, feature flags, or analytics changes.