### PR TITLE
chore(deps): upgrade pnpm 10.33.0 -> 11.17.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
+# npm CLI only. pnpm 11 reads settings from pnpm-workspace.yaml (`savePrefix`).
 save-exact=true
 # npm CLI 11.10+ supply-chain cooldown: refuse to install package versions
 # published less than 3 days ago. Older npm versions silently ignore this.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,7 @@ pnpm -F backend rollback-last
 
 ## Development Workflow
 
-1. **Package Management**: Use `pnpm` (v9.15.5+) - never use npm or yarn
+1. **Package Management**: Use `pnpm` (v11.17.0+, pinned via `packageManager` in the root `package.json` — let Corepack pick it up) - never use npm or yarn
 2. **Database**: Uses Knex.js for migrations and query building
 3. **API**: TSOA generates OpenAPI specs from TypeScript controllers
 4. **Authentication**: CASL-based authorization with multiple auth providers
@@ -238,12 +238,12 @@ This applies to any install Claude runs in this repo — lockfile regeneration, 
 
 ### Dependency Install Scripts — Blocked by Default
 
-Dependency lifecycle scripts (`preinstall`/`install`/`postinstall`) are blocked by pnpm and enforced in CI via `strictDepBuilds: true` in `pnpm-workspace.yaml`. With it set, `pnpm install` (which every CI job runs) **fails** if any dependency has a build script that isn't reviewed in one of two lists in `pnpm-workspace.yaml`:
+Dependency lifecycle scripts (`preinstall`/`install`/`postinstall`) are blocked by pnpm and enforced in CI via `strictDepBuilds: true` in `pnpm-workspace.yaml`. With it set, `pnpm install` (which every CI job runs) **fails** if any dependency has a build script that isn't reviewed in the `allowBuilds` map in `pnpm-workspace.yaml`:
 
-- `onlyBuiltDependencies` — packages allowed to run their build scripts (native addons we depend on).
-- `ignoredBuiltDependencies` — packages whose build scripts we intentionally do NOT run (each entry documents why).
+- `allowBuilds: { <package>: true }` — allowed to run its build script (native addons we depend on).
+- `allowBuilds: { <package>: false }` — build script we intentionally do NOT run (each entry documents why).
 
-This matters because these scripts also run on `npm install` for downstream consumers of our published packages (e.g. `@lightdash/cli`). When CI fails with `ERR_PNPM_IGNORED_BUILDS`, either remove/replace the dependency, add it to `ignoredBuiltDependencies` (with a reason) if its script is safe to skip, or `onlyBuiltDependencies` if the script must run. (pnpm 11 replaces these three settings with a single `allowBuilds` map.)
+This matters because these scripts also run on `npm install` for downstream consumers of our published packages (e.g. `@lightdash/cli`). When CI fails on an unreviewed build script, either remove/replace the dependency, add it as `false` (with a reason) if its script is safe to skip, or `true` if the script must run.
 
 ### Warehouse Credentials Protection
 

--- a/dockerfile
+++ b/dockerfile
@@ -11,7 +11,7 @@ ENV PATH="$PNPM_HOME:$PATH"
 ENV COREPACK_HOME="/usr/local/corepack"
 RUN npm i -g corepack@latest
 RUN corepack enable
-RUN corepack prepare pnpm@10.33.0 --activate && chmod -R a+rX "$COREPACK_HOME"
+RUN corepack prepare pnpm@11.17.0 --activate && chmod -R a+rX "$COREPACK_HOME"
 RUN pnpm config set store-dir /pnpm/store
 
 WORKDIR /usr/app

--- a/dockerfile-prs
+++ b/dockerfile-prs
@@ -15,7 +15,7 @@ ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN npm i -g corepack@latest
 RUN corepack enable
-RUN corepack prepare pnpm@10.33.0 --activate
+RUN corepack prepare pnpm@11.17.0 --activate
 RUN pnpm config set store-dir /pnpm/store
 
 WORKDIR /usr/app

--- a/package.json
+++ b/package.json
@@ -11,42 +11,6 @@
         "packages/*",
         "packages/frontend/sdk"
     ],
-    "pnpm": {
-        "overrides": {
-            "react-is": "19.2.0",
-            "@types/react": "19.2.2",
-            "@types/react-dom": "19.2.2",
-            "linkifyjs": "4.3.2",
-            "axios": "1.16.0",
-            "form-data@2.5.3": "2.5.5",
-            "form-data@3.0.1": "3.0.5",
-            "form-data@4.0.0": "4.0.6",
-            "form-data@4.0.2": "4.0.6",
-            "validator": "13.15.23",
-            "node-forge": "1.4.0",
-            "glob@>=10.2.0 <10.5.0": "10.5.0",
-            "jws": "4.0.1",
-            "qs": "6.15.2",
-            "hono": "4.12.27",
-            "tar": "7.5.21",
-            "eslint": "8.57.1",
-            "canvas": "3.2.1",
-            "ssh2": "1.17.0",
-            "cpu-features": "0.0.10",
-            "nan": "2.27.0",
-            "express-rate-limit": "8.3.0",
-            "@hapi/content": "6.0.1",
-            "undici": "6.27.0",
-            "handlebars": "4.7.9",
-            "basic-ftp": "5.3.1",
-            "vite@>=7.0.0 <7.3.2": "7.3.5",
-            "systeminformation": "5.31.6",
-            "path-to-regexp@0.1.12": "0.1.13",
-            "ajv@<6.14.0": "6.15.0",
-            "ajv@>=8.0.0 <8.18.0": "8.18.0",
-            "postcss@<8.5.10": "8.5.10"
-        }
-    },
     "dependencies": {
         "tslib": "2.8.1"
     },
@@ -226,5 +190,5 @@
             "pnpm -F formula run formatter"
         ]
     },
-    "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
+    "packageManager": "pnpm@11.17.0+sha512.cca3cea332ad254bb84145f966d19f4879615210346fc92c79a047f23a0d7b3cca3c3792f0076ba1f1831d277efbcf0a9119b31a9a60eca7fb3d6231f331ef72"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,45 @@ packages:
   - 'packages/frontend/sdk'
   - 'packages/backend/src/ee/services/McpService/mcp-chart-app'
 
+# Exact versions on `pnpm add` (pnpm 11 no longer reads `save-exact` from .npmrc).
+savePrefix: ''
+
+# Moved from package.json#pnpm.overrides — pnpm 11 no longer reads the `pnpm`
+# field in package.json.
+overrides:
+  react-is: 19.2.0
+  '@types/react': 19.2.2
+  '@types/react-dom': 19.2.2
+  linkifyjs: 4.3.2
+  axios: 1.16.0
+  form-data@2.5.3: 2.5.5
+  form-data@3.0.1: 3.0.5
+  form-data@4.0.0: 4.0.6
+  form-data@4.0.2: 4.0.6
+  validator: 13.15.23
+  node-forge: 1.4.0
+  'glob@>=10.2.0 <10.5.0': 10.5.0
+  jws: 4.0.1
+  qs: 6.15.2
+  hono: 4.12.27
+  tar: 7.5.21
+  eslint: 8.57.1
+  canvas: 3.2.1
+  ssh2: 1.17.0
+  cpu-features: 0.0.10
+  nan: 2.27.0
+  express-rate-limit: 8.3.0
+  '@hapi/content': 6.0.1
+  undici: 6.27.0
+  handlebars: 4.7.9
+  basic-ftp: 5.3.1
+  'vite@>=7.0.0 <7.3.2': 7.3.5
+  systeminformation: 5.31.6
+  path-to-regexp@0.1.12: 0.1.13
+  'ajv@<6.14.0': 6.15.0
+  'ajv@>=8.0.0 <8.18.0': 8.18.0
+  'postcss@<8.5.10': 8.5.10
+
 minimumReleaseAge: 4320 # 3 days — supply chain protection (matches .npmrc min-release-age)
 minimumReleaseAgeExclude:
   # Renovate security update: hono@4.12.18 || 4.12.21 || 4.12.25 || 4.12.27
@@ -60,39 +99,37 @@ minimumReleaseAgeExclude:
 # attack/breakage vector — they also run on `npm install` for downstream consumers
 # of our published packages (e.g. @lightdash/cli). pnpm blocks them by default;
 # strictDepBuilds makes `pnpm install` FAIL (instead of warn) when a dependency has
-# a build script that isn't reviewed in one of the two lists below. This blocks
-# un-vetted install scripts from landing in CI.
-# Note: in pnpm 11 these three settings are replaced by a single `allowBuilds` map.
+# a build script that isn't reviewed in the `allowBuilds` map below. This blocks
+# un-vetted install scripts from landing in CI. (Default since pnpm 11; kept
+# explicit so the intent survives a future default change.)
 strictDepBuilds: true
 
-# Packages allowed to run their build scripts (native addons we depend on).
-onlyBuiltDependencies:
-  - '@sentry-internal/node-cpu-profiler'
-  - '@sentry/cli'
-  - '@swc/core'
-  - bcrypt
-  - canvas
-  - core-js
-  - core-js-pure
-  - cypress
-  - duckdb
-  - esbuild
-  - lz4
-  - msgpackr-extract
-  - protobufjs
-  - sharp
-  - ssh2
-
-# Packages that ship build scripts we intentionally do NOT run. Each entry must
-# explain why skipping the script is safe.
-ignoredBuiltDependencies:
+# Reviewed build scripts. `true` = allowed to run (native addons we depend on);
+# `false` = script intentionally NOT run, with a reason. pnpm 11 replaced
+# onlyBuiltDependencies/ignoredBuiltDependencies with this single map.
+allowBuilds:
+  '@sentry-internal/node-cpu-profiler': true
+  '@sentry/cli': true
+  '@swc/core': true
+  bcrypt: true
+  canvas: true
+  core-js: true
+  core-js-pure: true
+  cypress: true
+  duckdb: true
+  esbuild: true
+  lz4: true
+  msgpackr-extract: true
+  protobufjs: true
+  sharp: true
+  ssh2: true
   # Optional native Zstandard addon, pulled in transitively via just-bash → backend.
   # Not compiled; the backend runs without the native build.
-  - '@mongodb-js/zstd'
+  '@mongodb-js/zstd': false
   # Optional native liblzma/XZ addon, pulled in transitively via just-bash → backend.
   # Not compiled; the backend runs without the native build.
-  - node-liblzma
-  - cpu-features
+  node-liblzma: false
+  cpu-features: false
 
 packageExtensions:
   '@mastra/schema-compat@0.11.2':


### PR DESCRIPTION
Closes: <!-- PROD-8816 -->

### Description:

Upgrades the pinned package manager from **pnpm 10.33.0 → 11.17.0**.

pnpm 11 changes *how configuration is read*, so this is a hand-written migration rather than a version-string bump. Each item below is a breaking change that would silently degrade the repo if it were only the version that moved.

**Linear: PROD-8816**

#### What changed

| Change | Why |
|---|---|
| `packageManager` repinned to `pnpm@11.17.0` **with its sha512 integrity hash** | Corepack verifies the hash on every install; an unhashed pin loses that check |
| All **32 dependency overrides** moved from `package.json#pnpm.overrides` → `overrides:` in `pnpm-workspace.yaml` | pnpm 11 **no longer reads the `pnpm` field in `package.json`**. Left in place they'd be silently ignored, un-pinning axios, undici, form-data, node-forge, qs, validator, handlebars and the rest |
| `onlyBuiltDependencies` / `ignoredBuiltDependencies` → a single **`allowBuilds`** map (`true` = build script allowed, `false` = intentionally skipped) | Both settings are removed in pnpm 11. The reviewed package set and the "why we skip this one" comments are preserved verbatim |
| `save-exact=true` expressed as `savePrefix: ''` in `pnpm-workspace.yaml` | pnpm 11 reads only auth/registry settings from `.npmrc`. The `.npmrc` entries are kept for the npm CLI |
| `corepack prepare pnpm@…` bumped in `dockerfile` and `dockerfile-prs` | Production and PR-preview images pin pnpm independently of `packageManager` |
| `CLAUDE.md` updated | Documented pnpm floor was stale (v9.15.5), and the build-script section described the removed settings |

`strictDepBuilds: true` is now the pnpm 11 default but is kept explicit so the intent survives a future default change.

#### Notes

- **`pnpm-lock.yaml` is unchanged.** Resolution is byte-identical after the overrides move, and the lockfile's `overrides` section still lists all 32 entries — that's the check that this migration didn't quietly drop a pin.
- No CI workflow changes needed: every `pnpm/action-setup` use in `.github/` omits the `version:` input and therefore reads `packageManager` directly.
- pnpm 11 requires **Node ≥ 22.13** (it uses `node:sqlite`); the repo is already on Node 24, so this is unblocked.
- The new `blockExoticSubdeps: true` default is a no-op here — the lockfile has zero git/tarball dependencies.
- This supersedes the Renovate PR #24842, which failed on all of the above.

#### Verification

Run locally on Node 24.18.0 / pnpm 11.17.0:

| Check | Result |
|---|---|
| `pnpm install --frozen-lockfile` (the exact path CI and the Docker build use) | pass |
| build: `formula`, `common`, `warehouses` | pass |
| typecheck: `common`, `warehouses`, `backend`, `frontend` | pass |
| lint: `common`, `backend` | pass |
| `pnpm -F common test` | pass |

Native build scripts (`lz4`, `bcrypt`, `duckdb`, …) compiled under the new `allowBuilds` map, confirming the allowlist migrated correctly.
