### PR TITLE
fix(sql-runner): apply the current parameter values when downloading results

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -416,15 +416,14 @@ export const ContentPanel: FC = () => {
                     downloadLimit === null
                         ? MAX_SAFE_INTEGER
                         : (downloadLimit ?? limit),
-                    // TODO: pass parameterValues (same as handleRunQuery)
-                    undefined,
+                    parameterValues,
                     true,
                 );
                 return newQuery.queryUuid;
             }
             return queryUuid;
         },
-        [sql, projectUuid, limit, queryUuid],
+        [sql, projectUuid, limit, queryUuid, parameterValues],
     );
 
     const getDownloadPivotQueryUuid = useCallback(async () => {

--- a/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlChartResults.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlChartResults.tsx
@@ -281,6 +281,7 @@ export const useSavedSqlChartResults = (
                         savedSqlUuid: chartQuery.data.savedSqlUuid,
                         context: context as QueryExecutionContext,
                         limit: limit ?? MAX_SAFE_INTEGER,
+                        parameters,
                     });
                 }
                 queryUuidToDownload = queryForDownload.queryUuid;


### PR DESCRIPTION
Part 2 of 2, stacked on #26399. That PR fixes dashboard-level export; this one fixes the same defect on SQL chart and SQL runner downloads. The two are independent — this one touches only frontend query-argument plumbing.

## Problem

Downloading results from a **saved SQL chart** or from the **SQL runner** ignored the parameter values applied on screen and used the saved defaults instead. The file contains the wrong rows with no visual cue.

## Root cause

These downloads reuse the query already executed for the view **only when the requested download limit matches the limit that view ran with**; otherwise they re-execute. Both re-execution paths built a fresh set of query arguments and omitted the parameter values:

- `useSavedSqlChartResults.getDownloadQueryUuid` — the embed and dashboard branches passed `parameters`; the standalone saved-chart branch did not.
- `ContentPanel.getDownloadQueryUuid` — passed `undefined`, with a pre-existing `TODO: pass parameterValues`.

In practice almost every download re-executes — including the default "Table rows" option, whose limit is the row count rather than the chart's saved limit — so the standalone SQL chart download was effectively always wrong, not just on an edge case.

## Change

Pass the parameter values on both re-execution paths. Both receiving functions (`getSqlChartPivotChartData`, `executeSqlQuery`) already accepted the argument; the call sites simply omitted it. `parameterValues` was already in scope in `ContentPanel` — it is the same value `handleRunQuery` uses to run the visible query, which is what the TODO pointed at.

## Regression analysis

- The added argument only reaches queries that were **already being re-executed**; the reuse branch is untouched.
- The download now runs with exactly the parameters the visible query ran with, so downloaded data matches the screen by construction rather than by coincidence.
- No change to the embed or dashboard-tile branches, which already passed `parameters`.
- No API, type, or backend change — the values travel on an existing request field that the interactive path already populates, so there is no new server-side input surface.

## Testing

Verified end-to-end in a local instance against a real warehouse, driving the browser.

Rig: a saved SQL chart whose SQL is `SELECT ${lightdash.parameters.metric_type} AS chosen_metric, 1 AS n`, with the project default for `metric_type` being `count`, switched in the UI to `revenue` so the chart on screen showed `revenue`.

| | before | after |
|---|---|---|
| download, "All results" | `count` | `revenue` |
| download, "Table rows" (default) | `count` | `revenue` |

**Explore downloads checked as a control** (not changed by this PR): using the seeded parameterised dimension `orders.date_dim_param_test` with `date_dim_parameter` set to `2025-01-01` (default `2025-07-06`), the screen showed `90 / 61` and the exported file contained `90 / 61` — the applied value, not the default. Cross-checked against the warehouse: 61 orders have `order_date <= 2025-01-01`. That path spreads the original query args into the download query, so parameters ride along by construction.

`pnpm -F frontend typecheck:fast` and frontend lint pass.

Note: the saved-chart download was exercised in the browser. The `ContentPanel` edit-mode download is the same one-line change against the same function signature but was not separately exercised.

Closes: PROD-9315
Closes: #26398
