### PR TITLE
feat(settings): add Data apps org settings section

### DIFF
--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -938,6 +938,15 @@ const PRIVATE_ROUTES: RouteObject[] = [
                 },
             },
             {
+                // Themes moved under the Data apps settings section. Redirect
+                // here rather than inside Settings so the sidebar mounts on the
+                // new path and expands the group.
+                path: '/generalSettings/themes',
+                element: (
+                    <Navigate to="/generalSettings/dataApps/themes" replace />
+                ),
+            },
+            {
                 path: '/roadmap',
                 element: <Navigate to="/generalSettings/roadmap" replace />,
             },

--- a/packages/frontend/src/features/organizationDesigns/components/ThemePicker.tsx
+++ b/packages/frontend/src/features/organizationDesigns/components/ThemePicker.tsx
@@ -211,7 +211,9 @@ export const ThemePicker: FC<Props> = ({
                 <Menu.Divider />
                 <Menu.Item
                     leftSection={<MantineIcon icon={IconSettings} size={14} />}
-                    onClick={() => void navigate('/generalSettings/themes')}
+                    onClick={() =>
+                        void navigate('/generalSettings/dataApps/themes')
+                    }
                 >
                     <Text size="xs">Manage themes</Text>
                 </Menu.Item>

--- a/packages/frontend/src/hooks/settings/types.ts
+++ b/packages/frontend/src/hooks/settings/types.ts
@@ -79,6 +79,7 @@ export type SettingsContext = {
     hasAnyAiAgentAccess: boolean;
     isAiOrganizationSettingsLoading: boolean;
     dataAppsFlag: FeatureFlag | undefined;
+    isDataAppsFlagLoading: boolean;
     embeddingEnabled: FeatureFlag | undefined;
     allowPasswordAuthentication: boolean;
     hasSocialLogin: boolean | undefined;

--- a/packages/frontend/src/hooks/settings/useSettingsContext.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsContext.ts
@@ -78,9 +78,8 @@ export const useSettingsContext = (): SettingsContext => {
         FeatureFlags.UserGroupsEnabled,
     );
 
-    const { data: dataAppsFlag } = useServerFeatureFlag(
-        FeatureFlags.EnableDataApps,
-    );
+    const dataAppsFlagQuery = useServerFeatureFlag(FeatureFlags.EnableDataApps);
+    const { data: dataAppsFlag } = dataAppsFlagQuery;
 
     const { data: proLimitsFlag } = useServerFeatureFlag(
         FeatureFlags.ProLimits,
@@ -202,6 +201,7 @@ export const useSettingsContext = (): SettingsContext => {
         isAiOrganizationSettingsLoading:
             aiOrganizationSettingsQuery.isInitialLoading,
         dataAppsFlag,
+        isDataAppsFlagLoading: dataAppsFlagQuery.isInitialLoading,
         embeddingEnabled,
         allowPasswordAuthentication,
         hasSocialLogin,

--- a/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
@@ -286,15 +286,29 @@ export const useSettingsNavigation = (
             });
         }
 
-        if (isDataAppsEnabled && ability?.can('view', 'OrganizationDesign')) {
-            organizationItems.push({
-                label: 'Themes',
-                to: '/generalSettings/themes',
-                icon: IconBrush,
-                keywords: ['design', 'colors', 'charts'],
-                children: [],
-                exact: true,
-            });
+        if (isDataAppsEnabled) {
+            const dataAppChildren: SettingsNavigationItem[] = [];
+
+            if (ability?.can('view', 'OrganizationDesign')) {
+                dataAppChildren.push({
+                    label: 'Themes',
+                    to: '/generalSettings/dataApps/themes',
+                    icon: IconBrush,
+                    keywords: ['design', 'colors', 'charts'],
+                    children: [],
+                    exact: true,
+                });
+            }
+
+            if (dataAppChildren.length > 0) {
+                organizationItems.push({
+                    label: 'Data apps',
+                    to: '/generalSettings/dataApps',
+                    icon: IconAppWindow,
+                    keywords: ['apps', 'data apps'],
+                    children: dataAppChildren,
+                });
+            }
         }
 
         if (ability?.can('manage', 'Organization')) {

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -150,6 +150,7 @@ const Settings: FC = () => {
         project,
         isScimTokenManagementEnabled,
         dataAppsFlag,
+        isDataAppsFlagLoading,
         isAiCopilotEnabledOrTrial,
         shouldShowAiAgentReviews,
         shouldShowAiAgentMemories,
@@ -491,7 +492,13 @@ const Settings: FC = () => {
             user?.ability.can('view', 'OrganizationDesign')
         ) {
             allowedRoutes.push({
-                path: '/themes',
+                path: '/dataApps',
+                element: (
+                    <Navigate to="/generalSettings/dataApps/themes" replace />
+                ),
+            });
+            allowedRoutes.push({
+                path: '/dataApps/themes',
                 element: <DesignListPage />,
             });
         }
@@ -862,6 +869,9 @@ const Settings: FC = () => {
     const isAwaitingRoadmapRoute =
         isOrganizationRoadmapLoading &&
         Boolean(matchPath('/generalSettings/roadmap', location.pathname));
+    const isAwaitingDataAppsRoute =
+        isDataAppsFlagLoading &&
+        Boolean(matchPath('/generalSettings/dataApps/*', location.pathname));
 
     if (
         isHealthLoading ||
@@ -870,7 +880,8 @@ const Settings: FC = () => {
         isActiveProjectUuidLoading ||
         isProjectLoading ||
         isAwaitingAiSettingsRoute ||
-        isAwaitingRoadmapRoute
+        isAwaitingRoadmapRoute ||
+        isAwaitingDataAppsRoute
     ) {
         return <PageSpinner />;
     }


### PR DESCRIPTION
Adds a **Data apps** section to Organization settings and moves **Themes** under it. The org-level activity log lands here as a second sub-page.

`/generalSettings/themes` → `/generalSettings/dataApps/themes`, with a redirect for the old path.

Also fixes a pre-existing race where cold-loading the themes URL bounced to Profile — the routes memo ran before the data-apps feature flag resolved. Same guard the file already uses for AI and roadmap routes.

Closes: PROD-9311
Relates: #26197