### PR TITLE
fix(charts): persist the chart-level color palette on first save

### DIFF
--- a/packages/api-tests/tests/savedChart.test.ts
+++ b/packages/api-tests/tests/savedChart.test.ts
@@ -196,6 +196,133 @@ describe('Saved chart space selection', () => {
     });
 });
 
+describe('Saved chart color palette on create', () => {
+    const projectUuid = SEED_PROJECT.project_uuid;
+
+    let admin: Awaited<ReturnType<typeof login>>;
+    let colorPaletteUuid: string;
+    const createdChartUuids: string[] = [];
+    const createdDashboardUuids: string[] = [];
+
+    beforeAll(async () => {
+        admin = await login();
+
+        const paletteResp = await admin.post<{
+            results: { colorPaletteUuid: string };
+        }>(`${apiUrl}/org/color-palettes`, {
+            name: uniqueName('Palette for chart create'),
+            // The API requires exactly 20 colors
+            colors: Array.from({ length: 20 }, () => '#112233'),
+        });
+        colorPaletteUuid = paletteResp.body.results.colorPaletteUuid;
+    });
+
+    afterAll(async () => {
+        for (const uuid of createdChartUuids) {
+            await admin
+                .delete(`${apiUrl}/saved/${uuid}`, { failOnStatusCode: false })
+                .catch(() => {});
+        }
+        for (const uuid of createdDashboardUuids) {
+            await admin
+                .delete(`${apiUrl}/dashboards/${uuid}`, {
+                    failOnStatusCode: false,
+                })
+                .catch(() => {});
+        }
+        if (colorPaletteUuid) {
+            await admin
+                .delete(`${apiUrl}/org/color-palettes/${colorPaletteUuid}`, {
+                    failOnStatusCode: false,
+                })
+                .catch(() => {});
+        }
+    });
+
+    it('Should persist the chart-level palette when a chart is first saved to a space', async () => {
+        const body: CreateChartInSpace = {
+            ...chartMock,
+            name: uniqueName('Chart with palette in space'),
+            spaceUuid: undefined,
+            dashboardUuid: null,
+            colorPaletteUuid,
+        };
+
+        const response = await admin.post<{ results: SavedChart }>(
+            `${apiUrl}/projects/${projectUuid}/saved`,
+            body,
+        );
+        expect(response.status).toBe(200);
+        createdChartUuids.push(response.body.results.uuid);
+
+        const getResponse = await admin.get<{ results: SavedChart }>(
+            `${apiUrl}/saved/${response.body.results.uuid}`,
+        );
+        expect(getResponse.status).toBe(200);
+        const fetchedChart = getResponse.body.results;
+        expect(fetchedChart.colorPaletteUuid).toBe(colorPaletteUuid);
+        // Resolving from the chart means the cascade did not override it
+        expect(fetchedChart.resolvedColorPalette.source.type).toBe('chart');
+    });
+
+    it('Should persist the chart-level palette when a chart is first saved to a dashboard', async () => {
+        const dashResp = await admin.post<{ results: Dashboard }>(
+            `${apiUrl}/projects/${projectUuid}/dashboards`,
+            { ...dashboardMock, name: uniqueName('Dashboard for palette') },
+        );
+        const dashboard = dashResp.body.results;
+        createdDashboardUuids.push(dashboard.uuid);
+
+        const body: CreateChartInDashboard = {
+            ...chartMock,
+            name: uniqueName('Chart with palette in dashboard'),
+            dashboardUuid: dashboard.uuid,
+            spaceUuid: null,
+            colorPaletteUuid,
+        };
+
+        const response = await admin.post<{ results: SavedChart }>(
+            `${apiUrl}/projects/${projectUuid}/saved`,
+            body,
+        );
+        expect(response.status).toBe(200);
+        createdChartUuids.push(response.body.results.uuid);
+
+        const getResponse = await admin.get<{ results: SavedChart }>(
+            `${apiUrl}/saved/${response.body.results.uuid}`,
+        );
+        expect(getResponse.status).toBe(200);
+        const fetchedChart = getResponse.body.results;
+        expect(fetchedChart.dashboardUuid).toBe(dashboard.uuid);
+        expect(fetchedChart.colorPaletteUuid).toBe(colorPaletteUuid);
+        expect(fetchedChart.resolvedColorPalette.source.type).toBe('chart');
+    });
+
+    it('Should inherit from the cascade when no palette is given on create', async () => {
+        const body: CreateChartInSpace = {
+            ...chartMock,
+            name: uniqueName('Chart without palette'),
+            spaceUuid: undefined,
+            dashboardUuid: null,
+        };
+
+        const response = await admin.post<{ results: SavedChart }>(
+            `${apiUrl}/projects/${projectUuid}/saved`,
+            body,
+        );
+        expect(response.status).toBe(200);
+        createdChartUuids.push(response.body.results.uuid);
+
+        const getResponse = await admin.get<{ results: SavedChart }>(
+            `${apiUrl}/saved/${response.body.results.uuid}`,
+        );
+        expect(getResponse.status).toBe(200);
+        const fetchedChart = getResponse.body.results;
+        expect(fetchedChart.colorPaletteUuid).toBeNull();
+        expect(fetchedChart.resolvedColorPalette.source.type).not.toBe('chart');
+    });
+});
+
 describe('Saved chart cross-space dashboard permissions', () => {
     const projectUuid = SEED_PROJECT.project_uuid;
     const testPrefix = `test-cross-space-${Date.now()}`;

--- a/packages/backend/src/database/entities/savedCharts.ts
+++ b/packages/backend/src/database/entities/savedCharts.ts
@@ -24,27 +24,23 @@ import { Knex } from 'knex';
 export const SavedChartsTableName = 'saved_queries';
 export const SavedChartVersionsTableName = 'saved_queries_versions';
 
-type InsertChartInSpace = Pick<
+type InsertChartBase = Pick<
     DbSavedChart,
     | 'name'
     | 'description'
     | 'last_version_chart_kind'
     | 'last_version_updated_by_user_uuid'
     | 'slug'
-> & {
+> &
+    Pick<DbSavedChart, 'color_palette_uuid'>;
+
+type InsertChartInSpace = InsertChartBase & {
     project_uuid: string;
     space_id: number;
     dashboard_uuid: null;
 };
 
-type InsertChartInDashboard = Pick<
-    DbSavedChart,
-    | 'name'
-    | 'description'
-    | 'last_version_chart_kind'
-    | 'last_version_updated_by_user_uuid'
-    | 'slug'
-> & {
+type InsertChartInDashboard = InsertChartBase & {
     project_uuid: string;
     space_id: null;
     dashboard_uuid: string;

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -478,6 +478,7 @@ export const createSavedChart = async (
         updatedByUser,
         spaceUuid,
         dashboardUuid,
+        colorPaletteUuid,
         slug,
         forceSlug,
     }: CreateSavedChart & {
@@ -510,6 +511,7 @@ export const createSavedChart = async (
                         ChartKind.VERTICAL_BAR,
                     last_version_updated_by_user_uuid: userUuid,
                     project_uuid: projectUuid,
+                    color_palette_uuid: colorPaletteUuid ?? null,
                     slug: forceSlug
                         ? slug
                         : await generateUniqueSlugScopedToProject(

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -994,14 +994,17 @@ type CreateChartBase = Pick<
     | 'parameters'
 >;
 
+// colorPaletteUuid is on each member to avoid an allOf in the OpenAPI schema.
 export type CreateChartInSpace = CreateChartBase & {
     spaceUuid?: string;
     dashboardUuid?: null;
+    colorPaletteUuid?: string | null;
 };
 
 export type CreateChartInDashboard = CreateChartBase & {
     dashboardUuid: string;
     spaceUuid?: null;
+    colorPaletteUuid?: string | null;
 };
 
 export type CreateSavedChart = CreateChartInSpace | CreateChartInDashboard;

--- a/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
+++ b/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
@@ -257,6 +257,7 @@ const SaveChartButton: FC<{
                 <ChartCreateModal
                     opened={isQueryModalOpen}
                     savedData={unsavedChartVersionForSave}
+                    colorPaletteUuid={stagedColorPaletteUuid}
                     onClose={() => {
                         setIsQueryModalOpen(false);
                         setIsSaveAsModal(false);

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToDashboard.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToDashboard.tsx
@@ -36,6 +36,8 @@ type Props = {
     projectUuid?: string;
     onClose: () => void;
     defaults?: ChartMetadata;
+    /** Chart-level palette chosen before the first save. */
+    colorPaletteUuid?: string | null;
 };
 
 type SaveToDashboardFormValues = { name: string; description: string };
@@ -54,6 +56,7 @@ export const SaveToDashboard: FC<Props> = ({
     projectUuid,
     onClose,
     defaults = DEFAULT_CHART_METADATA,
+    colorPaletteUuid,
 }) => {
     const [dashboardInfoFromStorage, setDashboardInfoFromStorage] = useState({
         name: dashboardName,
@@ -115,6 +118,7 @@ export const SaveToDashboard: FC<Props> = ({
                 ...savedData,
                 name: values.name,
                 description: values.description,
+                colorPaletteUuid,
                 dashboardUuid,
             };
             const chart = await createChart(newChartInDashboard);
@@ -153,6 +157,7 @@ export const SaveToDashboard: FC<Props> = ({
         },
         [
             savedData,
+            colorPaletteUuid,
             dashboardUuid,
             createChart,
             getDashboardActiveTabUuid,

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard.tsx
@@ -98,11 +98,14 @@ type Props = {
     chartMetadata?: ChartMetadata;
     redirectOnSuccess?: boolean;
     showViewChartAction?: boolean;
+    /** Chart-level palette chosen before the first save. */
+    colorPaletteUuid?: string | null;
 };
 
 export const SaveToSpaceOrDashboard: FC<Props> = ({
     projectUuid,
     savedData,
+    colorPaletteUuid,
     defaultSpaceUuid,
     onConfirm,
     onClose,
@@ -354,6 +357,7 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
                     ...savedData,
                     name: values.name,
                     description: values.description ?? undefined,
+                    colorPaletteUuid,
                     spaceUuid: forcedSpaceUuid,
                     dashboardUuid: undefined,
                 });
@@ -375,6 +379,7 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
                     ...savedData,
                     name: values.name,
                     description: values.description ?? undefined,
+                    colorPaletteUuid,
                     dashboardUuid: originatingDashboard.dashboardUuid,
                 };
                 savedQuery = await createChart(newChartInDashboard);
@@ -459,6 +464,7 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
                     ...savedData,
                     name: values.name,
                     description: values.description ?? undefined,
+                    colorPaletteUuid,
                     dashboardUuid: destinationDashboard.uuid,
                 });
                 const firstTab = destinationDashboard.tabs?.[0];
@@ -522,6 +528,7 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
                     ...savedData,
                     name: values.name,
                     description: values.description ?? undefined,
+                    colorPaletteUuid,
                     spaceUuid,
                     dashboardUuid: undefined,
                 });
@@ -545,6 +552,7 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
             selectedDashboard,
             createChart,
             savedData,
+            colorPaletteUuid,
             updateDashboard,
             handleCreateNewSpace,
             onConfirm,

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/index.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/index.tsx
@@ -31,6 +31,8 @@ interface ChartCreateModalProps extends Pick<
     redirectOnSuccess?: boolean;
     showViewChartAction?: boolean;
     forcedSpaceUuid?: string;
+    /** Chart-level palette chosen before the first save. */
+    colorPaletteUuid?: string | null;
 }
 
 enum SaveMode {
@@ -50,6 +52,7 @@ const ChartCreateModal: FC<ChartCreateModalProps> = ({
     redirectOnSuccess = true,
     showViewChartAction = true,
     forcedSpaceUuid,
+    colorPaletteUuid,
 }) => {
     // Store it in the state to avoid losing the param when the user switches between tables
     const [spaceUuid] = useState(defaultSpaceUuid);
@@ -112,6 +115,7 @@ const ChartCreateModal: FC<ChartCreateModalProps> = ({
                     dashboardName={editingDashboardInfo.name}
                     dashboardUuid={editingDashboardInfo.dashboardUuid}
                     savedData={savedData}
+                    colorPaletteUuid={colorPaletteUuid}
                     onClose={onClose}
                     defaults={chartMetadata}
                 />
@@ -121,6 +125,7 @@ const ChartCreateModal: FC<ChartCreateModalProps> = ({
                 <SaveToSpaceOrDashboard
                     projectUuid={projectUuid}
                     savedData={savedData}
+                    colorPaletteUuid={colorPaletteUuid}
                     onConfirm={onConfirm}
                     onClose={onClose}
                     defaultSpaceUuid={spaceUuid}

--- a/packages/frontend/src/features/explorer/store/selectors.test.ts
+++ b/packages/frontend/src/features/explorer/store/selectors.test.ts
@@ -1,0 +1,51 @@
+import { type SavedChart } from '@lightdash/common';
+import { explorerActions, explorerReducer } from './explorerSlice';
+import { selectHasPaletteChanges } from './selectors';
+
+const PALETTE_UUID = '55555555-5555-4555-8555-555555555555';
+
+const savedChartWithPalette = {
+    colorPaletteUuid: PALETTE_UUID,
+} as SavedChart;
+
+describe('selectHasPaletteChanges', () => {
+    it('reports no change for an unsaved chart with the inherited palette', () => {
+        const explorer = explorerReducer(
+            undefined,
+            explorerActions.setColorPaletteUuid(null),
+        );
+
+        expect(selectHasPaletteChanges({ explorer })).toBe(false);
+    });
+
+    it('reports a change for an unsaved chart with a chosen palette', () => {
+        const explorer = explorerReducer(
+            undefined,
+            explorerActions.setColorPaletteUuid(PALETTE_UUID),
+        );
+
+        expect(selectHasPaletteChanges({ explorer })).toBe(true);
+    });
+
+    it('reports no change for a saved chart whose palette is untouched', () => {
+        const explorer = explorerReducer(
+            undefined,
+            explorerActions.setSavedChart(savedChartWithPalette),
+        );
+
+        expect(selectHasPaletteChanges({ explorer })).toBe(false);
+    });
+
+    it('reports a change for a saved chart whose palette was cleared', () => {
+        const withSavedChart = explorerReducer(
+            undefined,
+            explorerActions.setSavedChart(savedChartWithPalette),
+        );
+        const explorer = explorerReducer(
+            withSavedChart,
+            explorerActions.setColorPaletteUuid(null),
+        );
+
+        expect(selectHasPaletteChanges({ explorer })).toBe(true);
+    });
+});

--- a/packages/frontend/src/features/explorer/store/selectors.ts
+++ b/packages/frontend/src/features/explorer/store/selectors.ts
@@ -512,7 +512,8 @@ const hasMapExtentChanged = (
 export const selectHasPaletteChanges = createSelector(
     [selectSavedChart, selectUnsavedColorPaletteUuid],
     (savedChart, unsavedColorPaletteUuid) => {
-        if (!savedChart) return false;
+        // Unsaved chart: any chosen palette is a change.
+        if (!savedChart) return unsavedColorPaletteUuid !== null;
         return unsavedColorPaletteUuid !== savedChart.colorPaletteUuid;
     },
 );


### PR DESCRIPTION
Picking a color palette on a chart before its first save silently lost the selection. The palette could only ever be written on update: the create payload had no field to carry it, `createSavedChart` never wrote `color_palette_uuid`, and the unsaved-chart branch of `selectHasPaletteChanges` reported no change.

This makes create symmetric with update:

- `CreateChartBase` carries an optional `colorPaletteUuid`. Omitting it still means "inherit from the dashboard/space/project/org cascade", which is what create already produced.
- `createSavedChart` persists `color_palette_uuid` on the shared insert, so it covers both charts saved to a space and charts saved into a dashboard.
- `selectHasPaletteChanges` treats a chosen palette on an unsaved chart as a change, and the Explorer passes it through both branches of the create modal (`SaveToSpaceOrDashboard` and `SaveToDashboard`) into the first-save payload.

Affects all chart types, not just data app vizzes.

One knock-on worth calling out: `SavedChartService.duplicate` and `PromoteService` build their create payload by spreading a whole chart, so both now preserve the chart-level palette instead of dropping it. Duplication preserving it is the intent. Promotion is safe because upstream and preview projects are constrained to the same organization and palettes are org-scoped. Content-as-code is unaffected, since `ChartAsCode` doesn't carry the field.

https://linear.app/lightdash/issue/PROD-9288/chart-level-color-palette-is-dropped-when-a-chart-is-first-saved
