### PR TITLE
fix(pre-aggregates): bundle DuckDB extensions

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,5 +1,10 @@
 # syntax=docker/dockerfile:1.7
 
+# Extensions are ABI-versioned. Keep this pinned image and the destination path
+# below aligned with @duckdb/node-api; the production stage fails if they drift.
+FROM duckdb/duckdb:1.5.2@sha256:5658472bf45cce867048a17201b9d38d4632507e7df4a69994f8236599f69d45 AS duckdb-extensions
+RUN ["/duckdb", "-c", "INSTALL httpfs; INSTALL aws;"]
+
 # -----------------------------
 # Stage 0: pnpm setup base
 # -----------------------------
@@ -400,6 +405,19 @@ COPY --from=prod-builder  /usr/local/dbt1.10 /usr/local/dbt1.10
 COPY --from=prod-builder  /usr/local/dbt1.11 /usr/local/dbt1.11
 COPY --from=prod-builder  /usr/local/dbt1.12 /usr/local/dbt1.12
 COPY --from=build-final /usr/app /usr/app
+
+COPY --from=duckdb-extensions \
+    /root/.duckdb/extensions/v1.5.2/*/*.duckdb_extension \
+    /usr/app/packages/warehouses/dist/duckdbExtensions/v1.5.2/
+
+# Never silently restore production runtime downloads after a DuckDB upgrade.
+RUN duckdb_version="$(cd /usr/app/packages/warehouses && node -e "process.stdout.write(require('@duckdb/node-api').version())")" \
+    && extension_directory="/usr/app/packages/warehouses/dist/duckdbExtensions/${duckdb_version}" \
+    && if [ ! -r "${extension_directory}/httpfs.duckdb_extension" ] \
+        || [ ! -r "${extension_directory}/aws.duckdb_extension" ]; then \
+        echo >&2 "Bundled extensions do not match @duckdb/node-api ${duckdb_version}"; \
+        exit 1; \
+    fi
 
 RUN ln -s /usr/local/dbt1.4/bin/dbt /usr/local/bin/dbt \
     && ln -s /usr/local/dbt1.5/bin/dbt /usr/local/bin/dbt1.5 \

--- a/dockerfile-prs
+++ b/dockerfile-prs
@@ -1,5 +1,10 @@
 # syntax=docker/dockerfile:1.7
 
+# Extensions are ABI-versioned. Keep this pinned image and the destination path
+# below aligned with @duckdb/node-api; the production stage fails if they drift.
+FROM duckdb/duckdb:1.5.2@sha256:5658472bf45cce867048a17201b9d38d4632507e7df4a69994f8236599f69d45 AS duckdb-extensions
+RUN ["/duckdb", "-c", "INSTALL httpfs; INSTALL aws;"]
+
 # Optimized Multi-Stage Build for PR Previews
 # Uses parallel build stages and cache mounts for maximum caching
 # Okteto uses a cluster of buildkit instances to persist caches across PRs
@@ -220,6 +225,19 @@ COPY --from=build-formula /usr/app/packages/formula/dist /usr/app/packages/formu
 COPY --from=build-warehouses /usr/app/packages/warehouses/dist /usr/app/packages/warehouses/dist
 COPY --from=build-backend /usr/app/packages/backend/dist /usr/app/packages/backend/dist
 COPY --from=build-frontend /usr/app/packages/frontend/build /usr/app/packages/frontend/build
+
+COPY --from=duckdb-extensions \
+    /root/.duckdb/extensions/v1.5.2/*/*.duckdb_extension \
+    /usr/app/packages/warehouses/dist/duckdbExtensions/v1.5.2/
+
+# Never silently restore production runtime downloads after a DuckDB upgrade.
+RUN duckdb_version="$(cd /usr/app/packages/warehouses && node -e "process.stdout.write(require('@duckdb/node-api').version())")" \
+    && extension_directory="/usr/app/packages/warehouses/dist/duckdbExtensions/${duckdb_version}" \
+    && if [ ! -r "${extension_directory}/httpfs.duckdb_extension" ] \
+        || [ ! -r "${extension_directory}/aws.duckdb_extension" ]; then \
+        echo >&2 "Bundled extensions do not match @duckdb/node-api ${duckdb_version}"; \
+        exit 1; \
+    fi
 
 EXPOSE 8080
 

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
@@ -73,6 +73,7 @@ vi.mock('@duckdb/node-api', () => ({
     DuckDBInstance: {
         create: (...args: unknown[]) => createInstanceMock(...args),
     },
+    version: () => 'v1.5.2',
 }));
 
 const getMockStreamResult = (
@@ -368,6 +369,85 @@ describe('DuckdbWarehouseClient', () => {
         expect(secretSql).toContain("ENDPOINT 's3.eu-west-1.amazonaws.com'");
         expect(secretSql).not.toContain('KEY_ID');
         expect(secretSql).not.toContain("SECRET '");
+    });
+
+    it('should load bundled extensions without runtime installs', async () => {
+        const accessMock = vi.spyOn(fs, 'access').mockResolvedValue();
+        try {
+            const runMock = vi.fn();
+            const streamMock = vi.fn(async () =>
+                getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+            );
+
+            createInstanceMock.mockResolvedValue(
+                createMockConnection(streamMock, runMock),
+            );
+
+            const client = DuckdbWarehouseClient.createForPreAggregate({
+                type: 'duckdb_s3',
+                s3Config: {
+                    endpoint: 's3.eu-west-1.amazonaws.com',
+                    region: 'eu-west-1',
+                    forcePathStyle: false,
+                    useSsl: true,
+                },
+            });
+
+            await client.runQuery('SELECT 1 AS val');
+
+            expect(runMock).toHaveBeenCalledWith(
+                expect.stringContaining(
+                    "duckdbExtensions/v1.5.2/httpfs.duckdb_extension';",
+                ),
+            );
+            expect(runMock).toHaveBeenCalledWith(
+                expect.stringContaining(
+                    "duckdbExtensions/v1.5.2/aws.duckdb_extension';",
+                ),
+            );
+            expect(runMock).not.toHaveBeenCalledWith('INSTALL httpfs;');
+            expect(runMock).not.toHaveBeenCalledWith('INSTALL aws;');
+        } finally {
+            accessMock.mockRestore();
+        }
+    });
+
+    it('should surface bundled extension load failures', async () => {
+        const accessMock = vi.spyOn(fs, 'access').mockResolvedValue();
+        try {
+            const loadError = new Error('Invalid bundled extension');
+            const runMock = vi.fn(async (sql: string) => {
+                if (sql.includes('httpfs.duckdb_extension')) {
+                    throw loadError;
+                }
+            });
+            const streamMock = vi.fn(async () =>
+                getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+            );
+
+            createInstanceMock.mockResolvedValue(
+                createMockConnection(streamMock, runMock),
+            );
+
+            const client = DuckdbWarehouseClient.createForPreAggregate({
+                type: 'duckdb_s3',
+                s3Config: {
+                    endpoint: 'localhost:9000',
+                    region: 'us-east-1',
+                    accessKey: 'key',
+                    secretKey: 'secret',
+                    forcePathStyle: true,
+                    useSsl: false,
+                },
+            });
+
+            await expect(client.runQuery('SELECT 1 AS val')).rejects.toThrow(
+                loadError,
+            );
+            expect(runMock).not.toHaveBeenCalledWith('INSTALL httpfs;');
+        } finally {
+            accessMock.mockRestore();
+        }
     });
 
     it('should use static DuckDB S3 credentials when configured', async () => {
@@ -1242,7 +1322,7 @@ describe('DuckdbWarehouseClient', () => {
                 /SECRET __lightdash_ducklake\s/.test(s),
             );
             const attachIdx = stmts.findIndex((s) =>
-                /^ATTACH 'ducklake:__lightdash_ducklake'/.test(s),
+                s.startsWith("ATTACH 'ducklake:__lightdash_ducklake'"),
             );
 
             expect(catalogIdx).toBeGreaterThanOrEqual(0);
@@ -1295,8 +1375,8 @@ describe('DuckdbWarehouseClient', () => {
             expect(joined).not.toMatch(/SECRET __lightdash_ducklake\s/);
             expect(
                 stmts.some((s) =>
-                    /^ATTACH 'ducklake:sqlite:\/tmp\/ducklake\.sqlite' AS "ducklake" \(DATA_PATH '\/tmp\/ducklake-data', READ_ONLY\);/.test(
-                        s,
+                    s.startsWith(
+                        "ATTACH 'ducklake:sqlite:/tmp/ducklake.sqlite' AS \"ducklake\" (DATA_PATH '/tmp/ducklake-data', READ_ONLY);",
                     ),
                 ),
             ).toBe(true);

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -1,4 +1,8 @@
-import { DuckDBInstance, DuckDBTypeId } from '@duckdb/node-api';
+import {
+    DuckDBInstance,
+    DuckDBTypeId,
+    version as duckdbVersion,
+} from '@duckdb/node-api';
 import {
     AnyType,
     CreateDuckdbCredentials,
@@ -676,13 +680,56 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         return !(s3Config.accessKey && s3Config.secretKey);
     }
 
-    private static async loadAwsExtensionForCredentialChain(
+    private static async getBundledExtensionPath(
+        extension: 'httpfs' | 'aws',
+    ): Promise<string | undefined> {
+        // Production images bundle signed extensions under the embedded DuckDB
+        // version to avoid runtime downloads. Local development has no bundled
+        // files and intentionally falls back to INSTALL/LOAD below.
+        const extensionPath = path.resolve(
+            __dirname,
+            '..',
+            'duckdbExtensions',
+            duckdbVersion(),
+            `${extension}.duckdb_extension`,
+        );
+
+        try {
+            await fs.access(extensionPath, fsSync.constants.R_OK);
+            return extensionPath;
+        } catch {
+            return undefined;
+        }
+    }
+
+    private async loadExtension(
         db: DuckdbConnection,
-        s3Config?: DuckdbS3SessionConfig,
+        extension: 'httpfs' | 'aws',
     ): Promise<void> {
-        if (s3Config && DuckdbWarehouseClient.usesS3CredentialChain(s3Config)) {
-            await db.run('INSTALL aws;');
-            await db.run('LOAD aws;');
+        const extensionPath =
+            await DuckdbWarehouseClient.getBundledExtensionPath(extension);
+        if (!extensionPath) {
+            await db.run(`INSTALL ${extension};`);
+            await db.run(`LOAD ${extension};`);
+            return;
+        }
+
+        // A bundled file should be valid because Docker verifies the version at
+        // build time. Surface load failures instead of hiding corruption or an
+        // ABI mismatch behind a network install.
+        await db.run(
+            `LOAD '${DuckdbWarehouseClient.escapeDuckdbString(extensionPath)}';`,
+        );
+    }
+
+    private async loadAwsExtensionForCredentialChain(
+        db: DuckdbConnection,
+    ): Promise<void> {
+        if (
+            this.s3Config &&
+            DuckdbWarehouseClient.usesS3CredentialChain(this.s3Config)
+        ) {
+            await this.loadExtension(db, 'aws');
         }
     }
 
@@ -695,12 +742,8 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         if (!client.ducklakeConfig) {
             // For DuckLake mode, httpfs and the ducklake/postgres/mysql/azure
             // extensions are autoloaded by ATTACH — no explicit INSTALL/LOAD.
-            await db.run('INSTALL httpfs;');
-            await db.run('LOAD httpfs;');
-            await DuckdbWarehouseClient.loadAwsExtensionForCredentialChain(
-                db,
-                client.s3Config,
-            );
+            await client.loadExtension(db, 'httpfs');
+            await client.loadAwsExtensionForCredentialChain(db);
         }
         const httpfsMs = performance.now() - httpfsStart;
 
@@ -1242,12 +1285,8 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         tempDir: string,
     ): Promise<void> {
         if (!this.ducklakeConfig) {
-            await db.run('INSTALL httpfs;');
-            await db.run('LOAD httpfs;');
-            await DuckdbWarehouseClient.loadAwsExtensionForCredentialChain(
-                db,
-                this.s3Config,
-            );
+            await this.loadExtension(db, 'httpfs');
+            await this.loadAwsExtensionForCredentialChain(db);
         }
 
         await db.run(`SET temp_directory = '${tempDir}';`);


### PR DESCRIPTION
Closes #26395

Installs signed, version-matched `httpfs` and `aws` extensions during Docker builds using the digest-pinned official DuckDB 1.5.2 image, then copies only the binaries into production images.

The warehouse client loads bundled extensions after an asynchronous file check. Environments without them, including local macOS development, retain the existing `INSTALL`/`LOAD` behavior; bundled extension load failures are surfaced without network fallback.

Verified with a clean monorepo build, warehouse typecheck/tests/lint/format, native ARM64 plus emulated AMD64 Docker builds, and direct bundled-extension loading in the Okteto preview.

test-all