### PR TITLE
feat(apps): ask a data app viz to change

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -171,18 +171,20 @@ export const ConfigTabs: FC = memo(() => {
                         onCancelBuild={
                             build.draft !== null && !dataAppVizUuid
                                 ? build.discard
-                                : null
+                                : build.cancel
                         }
                         footer={
-                            // Asking a saved visualization to change is not
-                            // wired up yet; the composer only authors new ones.
-                            dataAppVizUuid ? null : (
-                                <DataAppVizComposer
-                                    placeholder="Describe a new visualization…"
-                                    isBuilding={build.isBuilding}
-                                    onSubmit={build.send}
-                                />
-                            )
+                            <DataAppVizComposer
+                                // Slate reads its placeholder only on mount.
+                                key={dataAppVizUuid ? 'revise' : 'create'}
+                                placeholder={
+                                    dataAppVizUuid
+                                        ? 'Ask for a change…'
+                                        : 'Describe a new visualization…'
+                                }
+                                isBuilding={build.isBuilding}
+                                onSubmit={build.send}
+                            />
                         }
                     />
                 )}

--- a/packages/frontend/src/features/apps/components/DataAppVizDock.test.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizDock.test.tsx
@@ -211,7 +211,7 @@ describe('DataAppVizDock', () => {
 
     it('leaves the footer out when the panel supplies none', async () => {
         setVersions([version()]);
-        render();
+        render('viz-1', buildStub(), null);
 
         await userEvent.click(
             screen.getByRole('button', { name: 'Show versions' }),

--- a/packages/frontend/src/features/apps/hooks/useDataAppVizBuild.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useDataAppVizBuild.test.ts
@@ -7,13 +7,16 @@ import { useCancelAppVersion } from './useCancelAppVersion';
 import { useDataAppVizBuild } from './useDataAppVizBuild';
 import { useDeleteApp } from './useDeleteApp';
 import { useGenerateApp } from './useGenerateApp';
+import { useIterateApp } from './useIterateApp';
 
 vi.mock('./useGenerateApp', () => ({ useGenerateApp: vi.fn() }));
+vi.mock('./useIterateApp', () => ({ useIterateApp: vi.fn() }));
 vi.mock('./useAppBuildPoller', () => ({ useAppBuildPoller: vi.fn() }));
 vi.mock('./useCancelAppVersion', () => ({ useCancelAppVersion: vi.fn() }));
 vi.mock('./useDeleteApp', () => ({ useDeleteApp: vi.fn() }));
 
 const mockedGenerate = vi.mocked(useGenerateApp);
+const mockedIterate = vi.mocked(useIterateApp);
 const mockedPoller = vi.mocked(useAppBuildPoller);
 const mockedCancel = vi.mocked(useCancelAppVersion);
 const mockedDelete = vi.mocked(useDeleteApp);
@@ -63,12 +66,14 @@ describe('useDataAppVizBuild', () => {
     let generate: ReturnType<typeof vi.fn>;
     let cancelVersion: ReturnType<typeof vi.fn>;
     let deleteApp: ReturnType<typeof vi.fn>;
+    let iterate: ReturnType<typeof vi.fn>;
 
     beforeEach(() => {
         vi.clearAllMocks();
         generate = vi.fn();
         cancelVersion = vi.fn();
         deleteApp = vi.fn();
+        iterate = vi.fn();
         mockedGenerate.mockReturnValue({
             mutate: generate,
             isLoading: false,
@@ -79,9 +84,16 @@ describe('useDataAppVizBuild', () => {
         mockedDelete.mockReturnValue({
             mutate: deleteApp,
         } as unknown as ReturnType<typeof useDeleteApp>);
+        mockedIterate.mockReturnValue({
+            mutate: iterate,
+            isLoading: false,
+        } as unknown as ReturnType<typeof useIterateApp>);
     });
 
-    const setup = (onCreated = vi.fn()) => {
+    const setup = (
+        initialDataAppVizUuid: string | null = null,
+        onCreated = vi.fn(),
+    ) => {
         const rendered = renderHookWithProviders(
             ({ dataAppVizUuid }: { dataAppVizUuid: string | null }) =>
                 useDataAppVizBuild({
@@ -91,7 +103,7 @@ describe('useDataAppVizBuild', () => {
                     onCreated,
                 }),
             undefined,
-            { initialProps: { dataAppVizUuid: null as string | null } },
+            { initialProps: { dataAppVizUuid: initialDataAppVizUuid } },
         );
         return { ...rendered, onCreated };
     };
@@ -167,6 +179,76 @@ describe('useDataAppVizBuild', () => {
         act(() => result.current.retry?.());
         expect(generate).toHaveBeenCalledTimes(2);
         expect(result.current.pendingPrompt).toBe('a donut');
+    });
+
+    it('revises the selected visualization instead of making another', () => {
+        const { result, onCreated } = setup('viz-1');
+
+        act(() => result.current.send({ description: 'make the bars teal' }));
+
+        expect(generate).not.toHaveBeenCalled();
+        expect(iterate.mock.lastCall?.[0]).toMatchObject({
+            projectUuid: 'project-1',
+            appUuid: 'viz-1',
+        });
+
+        const handlers = iterate.mock.lastCall?.[1] as GenerateHandlers;
+        act(() => handlers.onSuccess({ appUuid: 'viz-1', version: 2 }));
+        finishBuild(finishedVersion({ version: 2 }));
+
+        expect(onCreated).not.toHaveBeenCalled();
+        expect(result.current.isBuilding).toBe(false);
+    });
+
+    it('does not offer a revision as a draft', () => {
+        const { result } = setup('viz-1');
+
+        act(() => result.current.send({ description: 'make the bars teal' }));
+        const handlers = iterate.mock.lastCall?.[1] as GenerateHandlers;
+        act(() => handlers.onSuccess({ appUuid: 'viz-1', version: 2 }));
+
+        expect(result.current.draft).toBeNull();
+        expect(result.current.discard).toBeNull();
+    });
+
+    it('cancels a revision without deleting its app', () => {
+        const { result } = setup('viz-1');
+
+        act(() => result.current.send({ description: 'make the bars teal' }));
+        const iterateHandlers = iterate.mock.lastCall?.[1] as GenerateHandlers;
+        act(() => iterateHandlers.onSuccess({ appUuid: 'viz-1', version: 2 }));
+        act(() => result.current.cancel?.());
+
+        expect(cancelVersion).toHaveBeenCalledWith(
+            {
+                projectUuid: 'project-1',
+                appUuid: 'viz-1',
+                version: 2,
+            },
+            expect.anything(),
+        );
+        expect(deleteApp).not.toHaveBeenCalled();
+
+        const cancelHandlers = cancelVersion.mock.lastCall?.[1] as {
+            onSuccess: () => void;
+        };
+        act(() => cancelHandlers.onSuccess());
+        expect(result.current.isBuilding).toBe(false);
+    });
+
+    it('retries a revision that failed to build, as it was sent', () => {
+        const { result } = setup('viz-1');
+
+        act(() => result.current.send({ description: 'make the bars teal' }));
+        const handlers = iterate.mock.lastCall?.[1] as GenerateHandlers;
+        act(() => handlers.onSuccess({ appUuid: 'viz-1', version: 2 }));
+        finishBuild(
+            finishedVersion({ version: 2, status: 'error', error: 'Nope' }),
+        );
+
+        expect(result.current.error).toBe('Nope');
+        act(() => result.current.retry?.());
+        expect(iterate).toHaveBeenCalledTimes(2);
     });
 
     it('refuses a second request while one is in flight', () => {

--- a/packages/frontend/src/features/apps/hooks/useDataAppVizBuild.ts
+++ b/packages/frontend/src/features/apps/hooks/useDataAppVizBuild.ts
@@ -11,13 +11,15 @@ import { useAppBuildPoller } from './useAppBuildPoller';
 import { useCancelAppVersion } from './useCancelAppVersion';
 import { useDeleteApp } from './useDeleteApp';
 import { useGenerateApp } from './useGenerateApp';
+import { useIterateApp } from './useIterateApp';
 
 type Args = {
     projectUuid: string | undefined;
     itemsMap: ItemsMap;
-    /** The visualization the chart points at; null while it points at none. */
+    /** The visualization being revised; null while authoring a new one. */
     dataAppVizUuid: string | null;
-    /** Called once a new visualization lands ready, with its contract bound. */
+    /** Called once a new visualization lands ready with the chart still
+     *  pointing at nothing, with its contract bound. */
     onCreated: (
         dataAppVizUuid: string,
         fieldMapping: DataAppVizFieldMapping,
@@ -36,7 +38,7 @@ export type DataAppVizDraft = {
     startedAt: Date;
 };
 
-type RunningBuild = DataAppVizDraft;
+type RunningBuild = DataAppVizDraft & { isNew: boolean };
 
 export type DataAppVizBuildState = {
     /**
@@ -61,12 +63,15 @@ export type DataAppVizBuildState = {
     send: (request: VizBuildRequest) => void;
     /** Re-send the request that failed; null when there is nothing to retry. */
     retry: (() => void) | null;
+    /** Cancels a revision without deleting its app. */
+    cancel: (() => void) | null;
     /** Cancels the build and deletes its draft app. */
     discard: (() => void) | null;
 };
 
 /**
- * Build a visualization for the chart from its own query.
+ * Build the chart's visualization from its own query: generate one when none
+ * is selected, ask the selected one to change when there is.
  *
  * The chart needs no rewiring when the build lands: the poller writes into the
  * same query key the renderer reads, so it picks up the new version by itself,
@@ -89,6 +94,7 @@ export const useDataAppVizBuild = ({
         request: VizBuildRequest | null;
     } | null>(null);
     const { mutate: generateApp } = useGenerateApp();
+    const { mutate: iterateApp } = useIterateApp();
     const { mutate: cancelVersion } = useCancelAppVersion();
     const { mutate: deleteApp } = useDeleteApp();
 
@@ -99,9 +105,8 @@ export const useDataAppVizBuild = ({
             setBuilding(null);
             setInFlight(null);
             if (version.status === 'ready') {
-                // Picking a visualization while creation runs is a newer user
-                // decision, so a late completion must not replace it.
-                if (target && dataAppVizUuid === null) {
+                // Only new visualizations need selecting; later picker choices win.
+                if (target?.isNew && dataAppVizUuid === null) {
                     onCreated(
                         target.appUuid,
                         autoMapDataAppVizFields(
@@ -135,31 +140,47 @@ export const useDataAppVizBuild = ({
             if (!projectUuid || building !== null) return;
             setFailed(null);
             setInFlight(request);
-            generateApp(
+            const prompt = request.description;
+            const onError = (err: unknown) => {
+                setInFlight(null);
+                setFailed({ message: getErrorMessage(err), request });
+            };
+
+            if (dataAppVizUuid === null) {
+                generateApp(
+                    { projectUuid, prompt, template: DATA_APP_VIZ_TEMPLATE },
+                    {
+                        onSuccess: ({ appUuid, version }) =>
+                            setBuilding({
+                                appUuid,
+                                version,
+                                startedAt: new Date(),
+                                isNew: true,
+                            }),
+                        onError,
+                    },
+                );
+                return;
+            }
+            iterateApp(
+                { projectUuid, appUuid: dataAppVizUuid, prompt },
                 {
-                    projectUuid,
-                    prompt: request.description,
-                    template: DATA_APP_VIZ_TEMPLATE,
-                },
-                {
-                    onSuccess: ({ appUuid, version }) =>
+                    onSuccess: ({ version }) =>
                         setBuilding({
-                            appUuid,
+                            appUuid: dataAppVizUuid,
                             version,
                             startedAt: new Date(),
+                            isNew: false,
                         }),
-                    onError: (err) => {
-                        setInFlight(null);
-                        setFailed({ message: getErrorMessage(err), request });
-                    },
+                    onError,
                 },
             );
         },
-        [projectUuid, building, generateApp],
+        [projectUuid, dataAppVizUuid, building, generateApp, iterateApp],
     );
 
     const failedRequest = failed?.request ?? null;
-    const draft = building;
+    const draft = building?.isNew ? building : null;
 
     return {
         appUuid: building?.appUuid ?? null,
@@ -174,6 +195,25 @@ export const useDataAppVizBuild = ({
         error: failed?.message ?? null,
         send,
         retry: failedRequest ? () => send(failedRequest) : null,
+        cancel:
+            projectUuid && building && !building.isNew
+                ? () => {
+                      cancelVersion(
+                          {
+                              projectUuid,
+                              appUuid: building.appUuid,
+                              version: building.version,
+                          },
+                          {
+                              onSuccess: () => {
+                                  setBuilding(null);
+                                  setInFlight(null);
+                                  setFailed(null);
+                              },
+                          },
+                      );
+                  }
+                : null,
         discard:
             projectUuid && draft
                 ? () => {

--- a/packages/frontend/src/features/apps/testing/dataAppVizBuildStub.ts
+++ b/packages/frontend/src/features/apps/testing/dataAppVizBuildStub.ts
@@ -14,6 +14,7 @@ export const buildStub = (
     error: null,
     send: vi.fn(),
     retry: null,
+    cancel: null,
     discard: null,
     ...overrides,
 });


### PR DESCRIPTION
The same composer now revises the selected visualization instead of creating another one — the panel picks the endpoint by whether one is selected, so there is one composer and no mode to enter or leave.

The chart keeps rendering the last good version while a revision builds, and bindings reconcile against the new contract at render. For v1 the latest version wins for every chart using it.

Relates: GLITCH-630
