### PR TITLE
chore(deps): upgrade pnpm 10.33.0 -> 11.17.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,7 @@ pnpm -F backend rollback-last
 
 ## Development Workflow
 
-1. **Package Management**: Use `pnpm` (v9.15.5+) - never use npm or yarn
+1. **Package Management**: Use `pnpm` (v11.17.0+, pinned via `packageManager` in the root `package.json` — let Corepack pick it up) - never use npm or yarn
 2. **Database**: Uses Knex.js for migrations and query building
 3. **API**: TSOA generates OpenAPI specs from TypeScript controllers
 4. **Authentication**: CASL-based authorization with multiple auth providers
@@ -238,12 +238,12 @@ This applies to any install Claude runs in this repo — lockfile regeneration, 
 
 ### Dependency Install Scripts — Blocked by Default
 
-Dependency lifecycle scripts (`preinstall`/`install`/`postinstall`) are blocked by pnpm and enforced in CI via `strictDepBuilds: true` in `pnpm-workspace.yaml`. With it set, `pnpm install` (which every CI job runs) **fails** if any dependency has a build script that isn't reviewed in one of two lists in `pnpm-workspace.yaml`:
+Dependency lifecycle scripts (`preinstall`/`install`/`postinstall`) are blocked by pnpm and enforced in CI via `strictDepBuilds: true` in `pnpm-workspace.yaml`. With it set, `pnpm install` (which every CI job runs) **fails** if any dependency has a build script that isn't reviewed in the `allowBuilds` map in `pnpm-workspace.yaml`:
 
-- `onlyBuiltDependencies` — packages allowed to run their build scripts (native addons we depend on).
-- `ignoredBuiltDependencies` — packages whose build scripts we intentionally do NOT run (each entry documents why).
+- `allowBuilds: { <package>: true }` — allowed to run its build script (native addons we depend on).
+- `allowBuilds: { <package>: false }` — build script we intentionally do NOT run (each entry documents why).
 
-This matters because these scripts also run on `npm install` for downstream consumers of our published packages (e.g. `@lightdash/cli`). When CI fails with `ERR_PNPM_IGNORED_BUILDS`, either remove/replace the dependency, add it to `ignoredBuiltDependencies` (with a reason) if its script is safe to skip, or `onlyBuiltDependencies` if the script must run. (pnpm 11 replaces these three settings with a single `allowBuilds` map.)
+This matters because these scripts also run on `npm install` for downstream consumers of our published packages (e.g. `@lightdash/cli`). When CI fails on an unreviewed build script, either remove/replace the dependency, add it as `false` (with a reason) if its script is safe to skip, or `true` if the script must run.
 
 ### Warehouse Credentials Protection
 

--- a/agent-harness/cloud/cloud-init.yml
+++ b/agent-harness/cloud/cloud-init.yml
@@ -146,13 +146,13 @@ runcmd:
       fnm default 24.18
     '
 
-  # -- Install pnpm 10.33.0 ---------------------------------------------------
+  # -- Install pnpm 11.17.0 ---------------------------------------------------
   - |
     su - lightdash -c '
       export PATH="/home/lightdash/.local/share/fnm:$PATH"
       eval "$(fnm env --shell bash)"
       corepack enable
-      corepack prepare pnpm@10.33.0 --activate
+      corepack prepare pnpm@11.17.0 --activate
     '
 
   # -- Install PM2 globally ----------------------------------------------------

--- a/dockerfile
+++ b/dockerfile
@@ -16,7 +16,7 @@ ENV PATH="$PNPM_HOME:$PATH"
 ENV COREPACK_HOME="/usr/local/corepack"
 RUN npm i -g corepack@latest
 RUN corepack enable
-RUN corepack prepare pnpm@10.33.0 --activate && chmod -R a+rX "$COREPACK_HOME"
+RUN corepack prepare pnpm@11.17.0 --activate && chmod -R a+rX "$COREPACK_HOME"
 RUN pnpm config set store-dir /pnpm/store
 
 WORKDIR /usr/app

--- a/dockerfile-prs
+++ b/dockerfile-prs
@@ -20,7 +20,7 @@ ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN npm i -g corepack@latest
 RUN corepack enable
-RUN corepack prepare pnpm@10.33.0 --activate
+RUN corepack prepare pnpm@11.17.0 --activate
 RUN pnpm config set store-dir /pnpm/store
 
 WORKDIR /usr/app

--- a/package.json
+++ b/package.json
@@ -194,5 +194,5 @@
             "pnpm -F formula run formatter"
         ]
     },
-    "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
+    "packageManager": "pnpm@11.17.0+sha512.cca3cea332ad254bb84145f966d19f4879615210346fc92c79a047f23a0d7b3cca3c3792f0076ba1f1831d277efbcf0a9119b31a9a60eca7fb3d6231f331ef72"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -97,39 +97,37 @@ minimumReleaseAgeExclude:
 # attack/breakage vector — they also run on `npm install` for downstream consumers
 # of our published packages (e.g. @lightdash/cli). pnpm blocks them by default;
 # strictDepBuilds makes `pnpm install` FAIL (instead of warn) when a dependency has
-# a build script that isn't reviewed in one of the two lists below. This blocks
-# un-vetted install scripts from landing in CI.
-# Note: in pnpm 11 these three settings are replaced by a single `allowBuilds` map.
+# a build script that isn't reviewed in the `allowBuilds` map below. This blocks
+# un-vetted install scripts from landing in CI. (Default since pnpm 11; kept
+# explicit so the intent survives a future default change.)
 strictDepBuilds: true
 
-# Packages allowed to run their build scripts (native addons we depend on).
-onlyBuiltDependencies:
-  - '@sentry-internal/node-cpu-profiler'
-  - '@sentry/cli'
-  - '@swc/core'
-  - bcrypt
-  - canvas
-  - core-js
-  - core-js-pure
-  - cypress
-  - duckdb
-  - esbuild
-  - lz4
-  - msgpackr-extract
-  - protobufjs
-  - sharp
-  - ssh2
-
-# Packages that ship build scripts we intentionally do NOT run. Each entry must
-# explain why skipping the script is safe.
-ignoredBuiltDependencies:
+# Reviewed build scripts. `true` = allowed to run (native addons we depend on);
+# `false` = script intentionally NOT run, with a reason. pnpm 11 replaced
+# onlyBuiltDependencies/ignoredBuiltDependencies with this single map.
+allowBuilds:
+  '@sentry-internal/node-cpu-profiler': true
+  '@sentry/cli': true
+  '@swc/core': true
+  bcrypt: true
+  canvas: true
+  core-js: true
+  core-js-pure: true
+  cypress: true
+  duckdb: true
+  esbuild: true
+  lz4: true
+  msgpackr-extract: true
+  protobufjs: true
+  sharp: true
+  ssh2: true
   # Optional native Zstandard addon, pulled in transitively via just-bash → backend.
   # Not compiled; the backend runs without the native build.
-  - '@mongodb-js/zstd'
+  '@mongodb-js/zstd': false
   # Optional native liblzma/XZ addon, pulled in transitively via just-bash → backend.
   # Not compiled; the backend runs without the native build.
-  - node-liblzma
-  - cpu-features
+  node-liblzma: false
+  cpu-features: false
 
 packageExtensions:
   '@mastra/schema-compat@0.11.2':


### PR DESCRIPTION
### Description:

Upgrades the pinned package manager from **pnpm 10.33.0 → 11.17.0**.

**Linear: PROD-8816**

This is the switch PR of a Graphite stack. Everything pnpm-10-compatible was split into the PRs below it; this PR contains only the changes that require (or effect) the version switch itself.

#### The stack (bottom → top)

1. #26473 — move all `package.json#pnpm` config to `pnpm-workspace.yaml` (pnpm 11 stops reading the `pnpm` field; done below the switch in pnpm-10-compatible syntax, lockfile byte-identical)
2. #26468 — agent-harness cloud-init Node 24.18
3. #26472 — CI exact-version guard reads `pnpm-workspace.yaml` overrides; post-release cache keyed on `packageManager`
4. #26469 — data-apps template settings dual-compat (pnpm 10 + 11)
5. #26477 — Gitpod toolchain pin (Node 24.18 + corepack)
6. #26488 — pnpm/action-setup → v6.0.9 (pre-fix pin fails pnpm 11 OIDC publish, pnpm/pnpm#11513)
7. **this PR — the switch**
8. #26470 — e2b sandbox image → pnpm 11
9. #26471 — docs cleanup
10. #26478 — release workflow npm rationale (pnpm 11 publishes natively)

#### What changed (this PR only)

| Change | Why |
|---|---|
| `packageManager` repinned to `pnpm@11.17.0` **with its sha512 integrity hash** | Corepack verifies the hash on every install; an unhashed pin loses that check |
| `onlyBuiltDependencies` / `ignoredBuiltDependencies` → a single **`allowBuilds`** map (`true` = build script allowed, `false` = intentionally skipped) | Both settings are removed in pnpm 11. The reviewed package set and the "why we skip this one" comments are preserved verbatim |
| `corepack prepare pnpm@…` bumped in `dockerfile` and `dockerfile-prs` | Production and PR-preview images pin pnpm independently of `packageManager` |
| `corepack prepare pnpm@11.17.0` in `agent-harness/cloud/cloud-init.yml` | Completes PROD-9333: the harness VM gets Node 24.18 below this PR and the matching pnpm here |
| `CLAUDE.md` updated | Documented pnpm floor was stale (v9.15.5), and the build-script section described the removed settings |

`strictDepBuilds: true` is now the pnpm 11 default but is kept explicit so the intent survives a future default change.

#### Notes

- **`pnpm-lock.yaml` is unchanged.** The overrides move happened in #26473 with byte-identical resolution; this PR does not touch resolution at all (lockfile format stays 9.0).
- No CI workflow changes needed: every `pnpm/action-setup` use in `.github/` omits the `version:` input and therefore reads `packageManager` directly.
- pnpm 11 requires **Node ≥ 22.13** (it uses `node:sqlite`); the repo is already on Node 24, so this is unblocked.
- The new `blockExoticSubdeps: true` default is a no-op here — the lockfile has zero git/tarball dependencies.
- This supersedes the Renovate PR #24842, which failed on all of the above.

#### Verification

Run locally on Node 24.18.0 / pnpm 11.17.0 (against the pre-slice all-in-one branch, whose end state equals this stack's):

| Check | Result |
|---|---|
| `pnpm install --frozen-lockfile` (the exact path CI and the Docker build use) | pass |
| build: `formula`, `common`, `warehouses` | pass |
| typecheck: `common`, `warehouses`, `backend`, `frontend` | pass |
| lint: `common`, `backend` | pass |
| `pnpm -F common test` | pass |

Native build scripts (`lz4`, `bcrypt`, `duckdb`, …) compiled under the new `allowBuilds` map, confirming the allowlist migrated correctly.

---

test-all

<sub>Forcing the full suite: a config-only diff would otherwise skip the preview deploy, which is what builds `dockerfile-prs` with the new `corepack prepare pnpm@11.17.0` pin.</sub>
