### PR TITLE
chore(dead-code): remove unused ParameterError import in Gitlab.ts

### DIFF
--- a/packages/backend/src/clients/gitlab/Gitlab.ts
+++ b/packages/backend/src/clients/gitlab/Gitlab.ts
@@ -5,7 +5,6 @@ import {
     getErrorMessage,
     LightdashError,
     NotFoundError,
-    ParameterError,
     PullRequestState,
     UnexpectedGitError,
 } from '@lightdash/common';


### PR DESCRIPTION
`packages/backend/src/clients/gitlab/Gitlab.ts` imports `ParameterError` from `@lightdash/common` and never uses it. One line, deleted.

## Provenance

The import arrived with the GitLab writeback client in #16643 (2025-09-01) and has **never** had a call site — it was dead on arrival, not stranded by a later removal.

```
$ git log origin/main -S'ParameterError' -- packages/backend/src/clients/gitlab/Gitlab.ts
e37c2a155f feat: gitlab write back (#16643)
```

Exactly one commit ever changed the symbol's presence in this file: the one that added it. At that commit the file already contained a single occurrence — the import itself.

## Why nothing else on that statement goes

Per-symbol anchored counts on `origin/main` (the import line is included in each count, so `1` means "import only"):

| symbol | occurrences |
| --- | --- |
| `AlreadyExistsError` | 3 |
| `AnyType` | 3 |
| `ForbiddenError` | 5 |
| `getErrorMessage` | 6 |
| `LightdashError` | 3 |
| `NotFoundError` | 9 |
| **`ParameterError`** | **1** |
| `PullRequestState` | 7 |
| `UnexpectedGitError` | 7 |

Every other symbol is genuinely used. Counts are anchored on word boundaries (`\bParameterError\b`) so they can't be inflated by a longer identifier that merely contains the name.

## Notes

Strictly subtractive — an unused import has no call sites and no runtime behaviour, so there is nothing to test beyond the typecheck CI runs on this PR.

Surfaced while auditing the merged dead-code PRs. A note on SPK-659 attributed this leftover to #26160; the history above shows that was wrong, and the ticket has been corrected.

Linear: SPK-713