### PR TITLE
fix: prevent BigQuery user-credentials re-auth loop

### DIFF
--- a/packages/backend/src/controllers/authentication/strategies/googleStrategy.ts
+++ b/packages/backend/src/controllers/authentication/strategies/googleStrategy.ts
@@ -68,13 +68,17 @@ export const googleStrategyVerify = async (
                 openIdUser.openId,
             );
 
-            if (hasBigqueryScope) {
+            if (hasBigqueryScope && refreshToken) {
                 Logger.info(
                     `Creating user warehouse credentials for bigquery on Google OAuth`,
                 );
                 await userService.createBigqueryWarehouseCredentials(
                     req.user,
                     refreshToken,
+                );
+            } else if (hasBigqueryScope) {
+                Logger.warn(
+                    `Google OAuth granted the BigQuery scope but returned no refresh token; keeping existing user warehouse credentials for user ${req.user.userUuid}`,
                 );
             }
 
@@ -102,13 +106,17 @@ export const googleStrategyVerify = async (
             );
         }
 
-        if (hasBigqueryScope) {
+        if (hasBigqueryScope && refreshToken) {
             Logger.info(
                 `Creating user warehouse credentials for bigquery on Google OAuth`,
             );
             await userService.createBigqueryWarehouseCredentials(
                 user,
                 refreshToken,
+            );
+        } else if (hasBigqueryScope) {
+            Logger.warn(
+                `Google OAuth granted the BigQuery scope but returned no refresh token; keeping existing user warehouse credentials for user ${user.userUuid}`,
             );
         }
         return done(null, user);

--- a/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.test.ts
+++ b/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.test.ts
@@ -175,6 +175,44 @@ describe('UserWarehouseCredentialsModel', () => {
             ).rejects.toThrow(BigqueryTokenError);
         });
 
+        test('falls back to a valid credential when the preferred one cannot be decrypted', async () => {
+            const undecryptableRow = {
+                ...makeRow('undecryptable', validBigqueryCredentials),
+                encrypted_credentials: Buffer.from('not-json'),
+            };
+            const model = createModel({
+                preferredRow: undecryptableRow,
+                fallbackRows: [
+                    undecryptableRow,
+                    makeRow('valid', validBigqueryCredentials),
+                ],
+            });
+            const result = await model.findForProjectWithSecrets(
+                'project-1',
+                'user-1',
+                WarehouseTypes.BIGQUERY,
+            );
+            expect(result?.uuid).toEqual('valid');
+        });
+
+        test('returns undefined when every credential is undecryptable', async () => {
+            const undecryptableRow = {
+                ...makeRow('undecryptable', validBigqueryCredentials),
+                encrypted_credentials: Buffer.from('not-json'),
+            };
+            const model = createModel({
+                preferredRow: undecryptableRow,
+                fallbackRows: [undecryptableRow],
+            });
+            await expect(
+                model.findForProjectWithSecrets(
+                    'project-1',
+                    'user-1',
+                    WarehouseTypes.BIGQUERY,
+                ),
+            ).resolves.toBeUndefined();
+        });
+
         test('returns undefined when the user has no credentials', async () => {
             const model = createModel({
                 preferredRow: undefined,

--- a/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.test.ts
+++ b/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.test.ts
@@ -1,0 +1,192 @@
+import {
+    BigqueryAuthenticationType,
+    BigqueryTokenError,
+    WarehouseTypes,
+} from '@lightdash/common';
+import { Knex } from 'knex';
+import { DbUserWarehouseCredentials } from '../../database/entities/userWarehouseCredentials';
+import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
+import { UserWarehouseCredentialsModel } from './UserWarehouseCredentialsModel';
+
+const passthroughEncryption = {
+    encrypt: (value: string) => Buffer.from(value),
+    decrypt: (value: Buffer) => value.toString(),
+} as unknown as EncryptionUtil;
+
+const validBigqueryCredentials = {
+    type: WarehouseTypes.BIGQUERY,
+    authenticationType: BigqueryAuthenticationType.SSO,
+    keyfileContents: {
+        type: 'authorized_user',
+        client_id: 'client-id',
+        client_secret: 'client-secret',
+        refresh_token: 'refresh-token',
+    },
+};
+
+const brokenBigqueryCredentials = {
+    type: WarehouseTypes.BIGQUERY,
+    authenticationType: BigqueryAuthenticationType.SSO,
+    keyfileContents: {},
+};
+
+const makeRow = (
+    uuid: string,
+    credentials: object,
+): DbUserWarehouseCredentials & {
+    project_name: string | null;
+    project_type: null;
+} => ({
+    user_warehouse_credentials_uuid: uuid,
+    user_uuid: 'user-1',
+    name: 'Default',
+    warehouse_type: WarehouseTypes.BIGQUERY,
+    encrypted_credentials: Buffer.from(JSON.stringify(credentials)),
+    created_at: new Date(),
+    updated_at: new Date(),
+    project_uuid: null,
+    project_name: null,
+    project_type: null,
+});
+
+/**
+ * Builds a model whose first database call resolves the preferred-credential
+ * query (`.first()`) and whose second resolves the fallback query (awaited
+ * directly as a row list).
+ */
+const createModel = ({
+    preferredRow,
+    fallbackRows,
+}: {
+    preferredRow: object | undefined;
+    fallbackRows: object[];
+}) => {
+    const makeBuilder = (result: {
+        firstRow?: object;
+        rows?: object[];
+    }): Record<string, unknown> => {
+        const builder: Record<string, unknown> = {};
+        [
+            'leftJoin',
+            'select',
+            'where',
+            'andWhere',
+            'orderByRaw',
+            'orderBy',
+        ].forEach((method) => {
+            builder[method] = vi.fn(() => builder);
+        });
+        builder.first = vi.fn(async () => result.firstRow);
+        builder.then = (
+            resolve: (rows: object[]) => unknown,
+            reject: (error: unknown) => unknown,
+        ) => Promise.resolve(result.rows ?? []).then(resolve, reject);
+        return builder;
+    };
+    const builders = [
+        makeBuilder({ firstRow: preferredRow }),
+        makeBuilder({ rows: fallbackRows }),
+    ];
+    let call = 0;
+    const database = vi.fn(() => {
+        const builder = builders[call];
+        call += 1;
+        return builder;
+    }) as unknown as Knex;
+    return new UserWarehouseCredentialsModel({
+        database,
+        encryptionUtil: passthroughEncryption,
+    });
+};
+
+describe('UserWarehouseCredentialsModel', () => {
+    describe('getQueryTimeValidationError', () => {
+        test('accepts a BigQuery credential with a refresh token', () => {
+            expect(
+                UserWarehouseCredentialsModel.getQueryTimeValidationError(
+                    validBigqueryCredentials as never,
+                ),
+            ).toBeUndefined();
+        });
+
+        test('rejects a BigQuery credential with an empty keyfile', () => {
+            expect(
+                UserWarehouseCredentialsModel.getQueryTimeValidationError(
+                    brokenBigqueryCredentials as never,
+                ),
+            ).toBeInstanceOf(BigqueryTokenError);
+        });
+
+        test('accepts non-SSO credentials without validation', () => {
+            expect(
+                UserWarehouseCredentialsModel.getQueryTimeValidationError({
+                    type: WarehouseTypes.POSTGRES,
+                    user: 'user',
+                    password: 'password',
+                } as never),
+            ).toBeUndefined();
+        });
+    });
+
+    describe('findForProjectWithSecrets', () => {
+        test('returns the preferred credential when it is valid', async () => {
+            const model = createModel({
+                preferredRow: makeRow('preferred', validBigqueryCredentials),
+                fallbackRows: [
+                    makeRow('preferred', validBigqueryCredentials),
+                    makeRow('other', validBigqueryCredentials),
+                ],
+            });
+            const result = await model.findForProjectWithSecrets(
+                'project-1',
+                'user-1',
+                WarehouseTypes.BIGQUERY,
+            );
+            expect(result?.uuid).toEqual('preferred');
+        });
+
+        test('falls back to a valid credential when the preferred one is broken', async () => {
+            const model = createModel({
+                preferredRow: makeRow('broken', brokenBigqueryCredentials),
+                fallbackRows: [
+                    makeRow('broken', brokenBigqueryCredentials),
+                    makeRow('valid', validBigqueryCredentials),
+                ],
+            });
+            const result = await model.findForProjectWithSecrets(
+                'project-1',
+                'user-1',
+                WarehouseTypes.BIGQUERY,
+            );
+            expect(result?.uuid).toEqual('valid');
+        });
+
+        test('throws the validation error when every credential is broken', async () => {
+            const model = createModel({
+                preferredRow: makeRow('broken', brokenBigqueryCredentials),
+                fallbackRows: [makeRow('broken', brokenBigqueryCredentials)],
+            });
+            await expect(
+                model.findForProjectWithSecrets(
+                    'project-1',
+                    'user-1',
+                    WarehouseTypes.BIGQUERY,
+                ),
+            ).rejects.toThrow(BigqueryTokenError);
+        });
+
+        test('returns undefined when the user has no credentials', async () => {
+            const model = createModel({
+                preferredRow: undefined,
+                fallbackRows: [],
+            });
+            await expect(
+                model.findForProjectWithSecrets(
+                    'project-1',
+                    'user-1',
+                    WarehouseTypes.BIGQUERY,
+                ),
+            ).resolves.toBeUndefined();
+        });
+    });
+});

--- a/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.ts
+++ b/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.ts
@@ -448,8 +448,21 @@ export class UserWarehouseCredentialsModel {
 
         let firstError: LightdashError | undefined;
         for (const { row, isPreferred } of candidates) {
-            const credentialsWithSecrets =
-                this.convertToUserWarehouseCredentialsWithSecrets(row);
+            let credentialsWithSecrets: UserWarehouseCredentialsWithSecrets;
+            try {
+                credentialsWithSecrets =
+                    this.convertToUserWarehouseCredentialsWithSecrets(row);
+            } catch (e) {
+                // Undecryptable rows (e.g. encrypted under a rotated secret)
+                // are permanently unusable — skip them so they can't block a
+                // valid credential, and let the user reauthenticate if none is
+                // left rather than surfacing a server error.
+                Logger.warn(
+                    `Skipping undecryptable user warehouse credential ${row.user_warehouse_credentials_uuid} (type: ${warehouseType}, preferred: ${isPreferred}) for user ${userUuid} on project ${projectUuid}`,
+                );
+                // eslint-disable-next-line no-continue
+                continue;
+            }
             const validationError =
                 UserWarehouseCredentialsModel.getQueryTimeValidationError(
                     credentialsWithSecrets.credentials,

--- a/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.ts
+++ b/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.ts
@@ -6,6 +6,7 @@ import {
     DatabricksAuthenticationType,
     databricksOauthU2mUserCredentialsSchema,
     DatabricksTokenError,
+    LightdashError,
     NotFoundError,
     ParameterError,
     ProjectType,
@@ -31,6 +32,7 @@ import {
     ProjectUserWarehouseCredentialPreferenceTableName,
     UserWarehouseCredentialsTableName,
 } from '../../database/entities/userWarehouseCredentials';
+import Logger from '../../logging/logger';
 import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
 
 type UserWarehouseCredentialsModelArguments = {
@@ -274,59 +276,142 @@ export class UserWarehouseCredentialsModel {
         return undefined;
     }
 
+    // Candidates ordered by selection priority: the per-project preference
+    // first, then project-assigned credentials, then unassigned ones (newest
+    // first within each group).
+    private async _findProjectCredentialCandidates(
+        projectUuid: string,
+        userUuid: string,
+        warehouseType: WarehouseTypes,
+    ): Promise<
+        Array<{
+            row: DbUserWarehouseCredentialsWithProject;
+            isPreferred: boolean;
+        }>
+    > {
+        const projectPreferredCredentials: DbUserWarehouseCredentialsWithProject =
+            await this.baseSelectWithProject()
+                .leftJoin(
+                    ProjectUserWarehouseCredentialPreferenceTableName,
+                    `${ProjectUserWarehouseCredentialPreferenceTableName}.user_warehouse_credentials_uuid`,
+                    `${UserWarehouseCredentialsTableName}.user_warehouse_credentials_uuid`,
+                )
+                .where(
+                    `${UserWarehouseCredentialsTableName}.warehouse_type`,
+                    warehouseType,
+                )
+                .andWhere(
+                    `${ProjectUserWarehouseCredentialPreferenceTableName}.project_uuid`,
+                    projectUuid,
+                )
+                .andWhere(
+                    `${ProjectUserWarehouseCredentialPreferenceTableName}.user_uuid`,
+                    userUuid,
+                )
+                .first();
+
+        // Fallback: prefer credential assigned to this project, else unassigned
+        const fallbackRows: DbUserWarehouseCredentialsWithProject[] =
+            await this.baseSelectWithProject()
+                .where(
+                    `${UserWarehouseCredentialsTableName}.warehouse_type`,
+                    warehouseType,
+                )
+                .andWhere(
+                    `${UserWarehouseCredentialsTableName}.user_uuid`,
+                    userUuid,
+                )
+                .andWhere(function assignedOrUnassigned(this) {
+                    void this.where(
+                        `${UserWarehouseCredentialsTableName}.project_uuid`,
+                        projectUuid,
+                    ).orWhereNull(
+                        `${UserWarehouseCredentialsTableName}.project_uuid`,
+                    );
+                })
+                .orderByRaw(
+                    `CASE WHEN ${UserWarehouseCredentialsTableName}.project_uuid = ? THEN 0 ELSE 1 END ASC`,
+                    [projectUuid],
+                )
+                .orderBy(
+                    `${UserWarehouseCredentialsTableName}.created_at`,
+                    'desc',
+                );
+
+        const candidates = projectPreferredCredentials
+            ? [{ row: projectPreferredCredentials, isPreferred: true }]
+            : [];
+        fallbackRows.forEach((row) => {
+            if (
+                row.user_warehouse_credentials_uuid !==
+                projectPreferredCredentials?.user_warehouse_credentials_uuid
+            ) {
+                candidates.push({ row, isPreferred: false });
+            }
+        });
+        return candidates;
+    }
+
     private async _findProjectCredentials(
         projectUuid: string,
         userUuid: string,
         warehouseType: WarehouseTypes,
-    ) {
-        const projectPreferredCredentials = await this.baseSelectWithProject()
-            .leftJoin(
-                ProjectUserWarehouseCredentialPreferenceTableName,
-                `${ProjectUserWarehouseCredentialPreferenceTableName}.user_warehouse_credentials_uuid`,
-                `${UserWarehouseCredentialsTableName}.user_warehouse_credentials_uuid`,
-            )
-            .where(
-                `${UserWarehouseCredentialsTableName}.warehouse_type`,
-                warehouseType,
-            )
-            .andWhere(
-                `${ProjectUserWarehouseCredentialPreferenceTableName}.project_uuid`,
-                projectUuid,
-            )
-            .andWhere(
-                `${ProjectUserWarehouseCredentialPreferenceTableName}.user_uuid`,
-                userUuid,
-            )
-            .first();
+    ): Promise<DbUserWarehouseCredentialsWithProject | undefined> {
+        const candidates = await this._findProjectCredentialCandidates(
+            projectUuid,
+            userUuid,
+            warehouseType,
+        );
+        return candidates[0]?.row;
+    }
 
-        if (projectPreferredCredentials) {
-            return projectPreferredCredentials;
+    // Returns the error this credential would produce at query time, or
+    // undefined if it's usable. SSO-style credentials store refresh tokens
+    // that can be missing/empty (e.g. keyfiles persisted before validation
+    // existed); anything else is assumed usable.
+    static getQueryTimeValidationError(
+        credentials: UserWarehouseCredentialsWithSecrets['credentials'],
+    ): LightdashError | undefined {
+        if (
+            credentials.type === WarehouseTypes.SNOWFLAKE &&
+            credentials.authenticationType === SnowflakeAuthenticationType.SSO
+        ) {
+            const result =
+                snowflakeSsoUserCredentialsSchema.safeParse(credentials);
+            if (!result.success) {
+                return new SnowflakeTokenError(
+                    `Please reauthenticate to access snowflake`,
+                );
+            }
         }
 
-        // Fallback: prefer credential assigned to this project, else unassigned
-        return this.baseSelectWithProject()
-            .where(
-                `${UserWarehouseCredentialsTableName}.warehouse_type`,
-                warehouseType,
-            )
-            .andWhere(
-                `${UserWarehouseCredentialsTableName}.user_uuid`,
-                userUuid,
-            )
-            .andWhere(function assignedOrUnassigned(this) {
-                void this.where(
-                    `${UserWarehouseCredentialsTableName}.project_uuid`,
-                    projectUuid,
-                ).orWhereNull(
-                    `${UserWarehouseCredentialsTableName}.project_uuid`,
+        if (
+            credentials.type === WarehouseTypes.DATABRICKS &&
+            credentials.authenticationType ===
+                DatabricksAuthenticationType.OAUTH_U2M
+        ) {
+            const result =
+                databricksOauthU2mUserCredentialsSchema.safeParse(credentials);
+            if (!result.success) {
+                return new DatabricksTokenError(
+                    `Please reauthenticate to access databricks`,
                 );
-            })
-            .orderByRaw(
-                `CASE WHEN ${UserWarehouseCredentialsTableName}.project_uuid = ? THEN 0 ELSE 1 END ASC`,
-                [projectUuid],
-            )
-            .orderBy(`${UserWarehouseCredentialsTableName}.created_at`, 'desc')
-            .first();
+            }
+        }
+
+        // Per-user BigQuery credentials are always SSO, so the refresh_token
+        // requirement applies to every BigQuery user credential.
+        if (credentials.type === WarehouseTypes.BIGQUERY) {
+            const result =
+                bigquerySsoUserCredentialsSchema.safeParse(credentials);
+            if (!result.success) {
+                return new BigqueryTokenError(
+                    `Please reauthenticate to access BigQuery`,
+                );
+            }
+        }
+
+        return undefined;
     }
 
     async findForProject(
@@ -345,76 +430,50 @@ export class UserWarehouseCredentialsModel {
         return undefined;
     }
 
+    // Returns the highest-priority credential that passes query-time
+    // validation (e.g. a non-empty BigQuery keyfile), so a single broken
+    // credential — even a preferred one — can't lock the user into a
+    // reauthentication loop while a valid credential exists. Throws the
+    // broken credential's error only when no candidate is usable.
     async findForProjectWithSecrets(
         projectUuid: string,
         userUuid: string,
         warehouseType: WarehouseTypes,
     ): Promise<UserWarehouseCredentialsWithSecrets | undefined> {
-        const credentials = await this._findProjectCredentials(
+        const candidates = await this._findProjectCredentialCandidates(
             projectUuid,
             userUuid,
             warehouseType,
         );
 
-        if (credentials) {
+        let firstError: LightdashError | undefined;
+        for (const { row, isPreferred } of candidates) {
             const credentialsWithSecrets =
-                this.convertToUserWarehouseCredentialsWithSecrets(credentials);
-
-            // Validate Snowflake SSO credentials with Zod schema
-            // This ensures refreshToken is present and token field is not allowed
-            if (
-                credentialsWithSecrets.credentials.type ===
-                    WarehouseTypes.SNOWFLAKE &&
-                credentialsWithSecrets.credentials.authenticationType ===
-                    SnowflakeAuthenticationType.SSO
-            ) {
-                const result = snowflakeSsoUserCredentialsSchema.safeParse(
+                this.convertToUserWarehouseCredentialsWithSecrets(row);
+            const validationError =
+                UserWarehouseCredentialsModel.getQueryTimeValidationError(
                     credentialsWithSecrets.credentials,
                 );
-                if (!result.success) {
-                    throw new SnowflakeTokenError(
-                        `Please reauthenticate to access snowflake`,
+            if (!validationError) {
+                if (firstError) {
+                    Logger.warn(
+                        `Using fallback user warehouse credential ${credentialsWithSecrets.uuid} for user ${userUuid} on project ${projectUuid}: a higher-priority ${warehouseType} credential failed validation`,
                     );
                 }
+                return credentialsWithSecrets;
             }
+            Logger.warn(
+                `Skipping invalid user warehouse credential ${
+                    credentialsWithSecrets.uuid
+                } (type: ${warehouseType}, preferred: ${isPreferred}) for user ${userUuid} on project ${projectUuid}: ${
+                    validationError.message
+                }`,
+            );
+            firstError = firstError ?? validationError;
+        }
 
-            if (
-                credentialsWithSecrets.credentials.type ===
-                    WarehouseTypes.DATABRICKS &&
-                credentialsWithSecrets.credentials.authenticationType ===
-                    DatabricksAuthenticationType.OAUTH_U2M
-            ) {
-                const result =
-                    databricksOauthU2mUserCredentialsSchema.safeParse(
-                        credentialsWithSecrets.credentials,
-                    );
-                if (!result.success) {
-                    throw new DatabricksTokenError(
-                        `Please reauthenticate to access databricks`,
-                    );
-                }
-            }
-
-            // Reject empty BigQuery keyfiles before they reach the warehouse
-            // client (where they surface as "does not contain a client_email
-            // field"), so the user is prompted to reauthenticate instead.
-            // Per-user BigQuery credentials are always SSO, so the refresh_token
-            // requirement applies to every BigQuery user credential.
-            if (
-                credentialsWithSecrets.credentials.type ===
-                WarehouseTypes.BIGQUERY
-            ) {
-                const result = bigquerySsoUserCredentialsSchema.safeParse(
-                    credentialsWithSecrets.credentials,
-                );
-                if (!result.success) {
-                    throw new BigqueryTokenError(
-                        `Please reauthenticate to access BigQuery`,
-                    );
-                }
-            }
-
-            return credentialsWithSecrets;
+        if (firstError) {
+            throw firstError;
         }
 
         return undefined;

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1794,6 +1794,9 @@ export class ProjectService extends BaseService {
                 );
                 userWarehouseCredentialsUuid = userWarehouseCredentials.uuid;
             } else if (credentials.requireUserCredentials) {
+                this.logger.warn(
+                    `No ${credentials.type} user warehouse credentials found for user ${userId} on project ${projectUuid} (requireUserCredentials enabled, host mismatch: ${!!hostMismatch})`,
+                );
                 if (credentials.type === WarehouseTypes.DATABRICKS) {
                     throw new DatabricksTokenError(
                         'Please authenticate to access Databricks',

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -3057,6 +3057,14 @@ export class UserService extends BaseService {
         user: SessionUser,
         refreshToken: string,
     ) {
+        // Guard before deleting: an OAuth callback without a refresh token
+        // must not wipe the user's working credentials.
+        if (!refreshToken) {
+            throw new ParameterError(
+                'Cannot create BigQuery user credentials without a Google refresh token',
+            );
+        }
+
         // Remove old BigQuery credentials to prevent duplicates on re-authentication
         await this.userWarehouseCredentialsModel.deleteAllByUserAndWarehouseType(
             user.userUuid,

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.tsx
@@ -26,13 +26,42 @@ import { useGoogleLoginPopup } from '../../../hooks/gdrive/useGdrive';
 import { useDatabricksLoginPopup } from '../../../hooks/useDatabricks';
 import { useProject } from '../../../hooks/useProject';
 import { useRedshiftAwsSsoLoginPopup } from '../../../hooks/useRedshiftAwsSso';
+import { getUserWarehouseCredentials } from '../../../hooks/userWarehouseCredentials/useUserWarehouseCredentials';
 import { useSnowflakeLoginPopup } from '../../../hooks/useSnowflake';
 import MantineIcon from '../../common/MantineIcon';
 import { getSsoLabel } from '../../ProjectConnection/WarehouseForms/util';
 import { WarehouseSsoButton } from './WarehouseSsoButton';
 
-const BigQueryFormInput: FC<{ onClose: () => void }> = ({ onClose }) => {
-    const { mutate: openLoginPopup } = useGoogleLoginPopup('bigquery', onClose);
+const BigQueryFormInput: FC<{
+    onClose: () => void;
+    onSuccess?: (data: UserWarehouseCredentials) => void;
+}> = ({ onClose, onSuccess }) => {
+    const { mutate: openLoginPopup } = useGoogleLoginPopup(
+        'bigquery',
+        async () => {
+            // The credential is created server-side during the OAuth flow, so
+            // fetch it to save the project preference like the form-based path
+            try {
+                const credentials = await getUserWarehouseCredentials();
+                const bigqueryCredential = credentials
+                    .filter(
+                        ({ credentials: c }) =>
+                            c.type === WarehouseTypes.BIGQUERY,
+                    )
+                    .sort(
+                        (a, b) =>
+                            new Date(b.createdAt).getTime() -
+                            new Date(a.createdAt).getTime(),
+                    )[0];
+                if (bigqueryCredential) {
+                    onSuccess?.(bigqueryCredential);
+                }
+            } catch {
+                // Auth itself succeeded; preference is a best-effort extra
+            }
+            onClose();
+        },
+    );
 
     // If this popup happens, it means we don't have warehouse credentials,
     // (aka isAuthenticated is false), so we need to authenticate
@@ -432,7 +461,9 @@ export const WarehouseFormInputs: FC<{
                 </>
             );
         case WarehouseTypes.BIGQUERY:
-            return <BigQueryFormInput onClose={onClose} />;
+            return (
+                <BigQueryFormInput onClose={onClose} onSuccess={onSuccess} />
+            );
         case WarehouseTypes.DATABRICKS:
             return (
                 <DatabricksFormInput

--- a/packages/frontend/src/hooks/userWarehouseCredentials/useUserWarehouseCredentials.ts
+++ b/packages/frontend/src/hooks/userWarehouseCredentials/useUserWarehouseCredentials.ts
@@ -13,7 +13,7 @@ import {
 import { lightdashApi } from '../../api';
 import useToaster from '../toaster/useToaster';
 
-const getUserWarehouseCredentials = async () =>
+export const getUserWarehouseCredentials = async () =>
     lightdashApi<UserWarehouseCredentials[]>({
         url: `/user/warehouseCredentials`,
         method: 'GET',


### PR DESCRIPTION
## Problem

On projects with **"Require users to provide their own credentials"** enabled for BigQuery, a customer reported users being prompted to re-authenticate after almost every action. Re-authenticating never fixed it; manually setting the default connection under *User settings → My warehouse connections* did.

Root cause analysis (see #26408): credential selection resolved a single candidate (per-project preference first, else most recent credential) and **hard-failed** with `BigqueryTokenError` if that one credential failed query-time validation (e.g. an empty keyfile persisted before #23920). A single broken credential — especially one pinned by a stale preference — locked the user into a re-auth loop even when a valid credential existed. Two adjacent gaps made it worse: the BigQuery SSO popup flow never saved the per-project preference nor reloaded errored queries (unlike the form-based flow), and the Google OAuth callback could delete a user's working BigQuery credentials before failing when Google returned no refresh token.

## Changes

**Backend**
- `UserWarehouseCredentialsModel.findForProjectWithSecrets` now iterates candidates in priority order (preference → project-assigned → unassigned, newest first) and returns the first credential that passes query-time validation, skipping broken ones. It only throws the validation error when *no* usable credential exists. Validation logic is extracted into a static `getQueryTimeValidationError` (same schemas/errors as before).
- `googleStrategyVerify` no longer calls `createBigqueryWarehouseCredentials` when Google returns no refresh token (both link and login flows), and `createBigqueryWarehouseCredentials` guards before deleting existing credentials — an empty refresh token can no longer wipe working credentials.
- Undecryptable credential rows (e.g. encrypted under a rotated secret) are also skipped in the same loop instead of throwing `UnexpectedServerError`, so a permanently dead row can't block a valid credential; when none is left the user gets the re-auth prompt instead of a 500.
- Non-sensitive diagnostic logs (uuids/types/booleans only, no secrets): skipped-invalid-credential, skipped-undecryptable-credential and fallback-used warnings in the model, and a warning with user/project/warehouse context when `MissingWarehouseCredentialsError` is about to be thrown.

**Frontend**
- After the BigQuery SSO popup succeeds, the modal now fetches the server-created credential and passes it to `onSuccess`, so the per-project preference is saved and the page reloads — matching the form-based credential flow. Previously errored queries recover without a manual refresh.

## Regression analysis

- Selection order is unchanged when all credentials are valid: the preferred credential still wins, then project-assigned, then unassigned (newest first). The fallback query now always runs (one extra indexed query per warehouse-credential resolution) instead of only when no preference exists.
- The thrown error type/message when no usable credential exists is unchanged (`SnowflakeTokenError`/`DatabricksTokenError`/`BigqueryTokenError`), so the frontend re-auth modal triggers exactly as before.
- `findForProject` (non-secrets variant, used for display) intentionally keeps its previous "first candidate" behaviour — no validation added there.
- The OAuth guard only skips credential creation in a case that previously ended in `ParameterError` *after* deleting the user's credentials; behaviour when a refresh token is present is unchanged.
- Behaviour change for undecryptable rows: a selected credential that failed decryption previously surfaced `UnexpectedServerError` (500) on every query; it is now skipped (fallback or re-auth prompt). Reads of such rows outside this path (e.g. `getByUuid`) still throw as before.

## Testing

- New unit tests for `getQueryTimeValidationError` and the fallback/throw/undefined/undecryptable paths of `findForProjectWithSecrets` (`UserWarehouseCredentialsModel.test.ts`, 9 tests).
- `pnpm -F backend test:dev:nowatch` (299 tests), backend + frontend `typecheck`, backend + frontend lint all pass.

Closes: PROD-9317
Closes: #26408

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AaFq2pb3w4SHfBEqdXzHKx

