### PR TITLE
chore(dead-code): drop redundant exports in the CLI package, dedupe the job poller

### DIFF
--- a/packages/cli/src/analytics/analytics.ts
+++ b/packages/cli/src/analytics/analytics.ts
@@ -637,5 +637,3 @@ export class LightdashAnalytics {
         }
     }
 }
-
-export const analytics: LightdashAnalytics = new LightdashAnalytics();

--- a/packages/cli/src/analytics/analytics.ts
+++ b/packages/cli/src/analytics/analytics.ts
@@ -464,6 +464,7 @@ type CliRenameCompleted = BaseTrack & {
         chartsUpdated: number;
         dashboardsUpdated: number;
         durationMs: number;
+        validationStatus: 'skipped' | 'passed' | 'failed';
     };
 };
 type CliRenameError = BaseTrack & {

--- a/packages/cli/src/dbt/manifest.ts
+++ b/packages/cli/src/dbt/manifest.ts
@@ -15,9 +15,7 @@ export type LoadManifestArgs = {
 const getManifestPath = async (targetDir: string): Promise<string> =>
     path.join(targetDir, 'manifest.json');
 
-const loadManifestFromFile = async (
-    filename: string,
-): Promise<DbtManifest> => {
+const loadManifestFromFile = async (filename: string): Promise<DbtManifest> => {
     globalState.debug(`> Loading dbt manifest from ${filename}`);
     try {
         const manifest = JSON.parse(
@@ -50,9 +48,7 @@ export const isHttpUrl = (value: string): boolean => {
     }
 };
 
-const loadManifestFromUrl = async (
-    url: string,
-): Promise<DbtManifest> => {
+const loadManifestFromUrl = async (url: string): Promise<DbtManifest> => {
     globalState.debug(`> Loading dbt manifest from ${url}`);
     try {
         const response = await fetch(url);

--- a/packages/cli/src/dbt/manifest.ts
+++ b/packages/cli/src/dbt/manifest.ts
@@ -12,10 +12,10 @@ export type LoadManifestArgs = {
     targetDir: string;
 };
 
-export const getManifestPath = async (targetDir: string): Promise<string> =>
+const getManifestPath = async (targetDir: string): Promise<string> =>
     path.join(targetDir, 'manifest.json');
 
-export const loadManifestFromFile = async (
+const loadManifestFromFile = async (
     filename: string,
 ): Promise<DbtManifest> => {
     globalState.debug(`> Loading dbt manifest from ${filename}`);
@@ -50,7 +50,7 @@ export const isHttpUrl = (value: string): boolean => {
     }
 };
 
-export const loadManifestFromUrl = async (
+const loadManifestFromUrl = async (
     url: string,
 ): Promise<DbtManifest> => {
     globalState.debug(`> Loading dbt manifest from ${url}`);

--- a/packages/cli/src/dbt/targets/Bigquery/index.ts
+++ b/packages/cli/src/dbt/targets/Bigquery/index.ts
@@ -26,7 +26,7 @@ type BigqueryTarget = {
     execution_project?: string;
 };
 
-export const bigqueryTargetJsonSchema: JSONSchemaType<BigqueryTarget> = {
+const bigqueryTargetJsonSchema: JSONSchemaType<BigqueryTarget> = {
     type: 'object',
     properties: {
         project: {

--- a/packages/cli/src/dbt/targets/Bigquery/serviceAccount.ts
+++ b/packages/cli/src/dbt/targets/Bigquery/serviceAccount.ts
@@ -18,7 +18,7 @@ export type BigqueryServiceAccountTarget = {
     timeout_seconds?: number;
     execution_project?: string;
 };
-export const bigqueryServiceAccountSchema: JSONSchemaType<BigqueryServiceAccountTarget> =
+const bigqueryServiceAccountSchema: JSONSchemaType<BigqueryServiceAccountTarget> =
     {
         type: 'object',
         properties: {
@@ -115,7 +115,7 @@ export type BigqueryServiceAccountJsonTarget = {
     timeout_seconds?: number;
     execution_project?: string;
 };
-export const bigqueryServiceAccountJsonSchema: JSONSchemaType<BigqueryServiceAccountJsonTarget> =
+const bigqueryServiceAccountJsonSchema: JSONSchemaType<BigqueryServiceAccountJsonTarget> =
     {
         type: 'object',
         properties: {

--- a/packages/cli/src/dbt/targets/athena.ts
+++ b/packages/cli/src/dbt/targets/athena.ts
@@ -26,7 +26,7 @@ export type AthenaTarget = {
     num_retries?: number;
 };
 
-export const athenaSchema: JSONSchemaType<AthenaTarget> = {
+const athenaSchema: JSONSchemaType<AthenaTarget> = {
     type: 'object',
     properties: {
         type: {

--- a/packages/cli/src/dbt/targets/clickhouse.ts
+++ b/packages/cli/src/dbt/targets/clickhouse.ts
@@ -27,7 +27,7 @@ export type ClickhouseTarget = {
     custom_settings?: Record<string, unknown>;
 };
 
-export const clickhouseSchema: JSONSchemaType<ClickhouseTarget> = {
+const clickhouseSchema: JSONSchemaType<ClickhouseTarget> = {
     type: 'object',
     properties: {
         type: {

--- a/packages/cli/src/dbt/targets/databricks.ts
+++ b/packages/cli/src/dbt/targets/databricks.ts
@@ -36,7 +36,7 @@ export type DatabricksTarget = {
     compute?: DatabricksComputeConfig;
 };
 
-export const databricksSchema: JSONSchemaType<DatabricksTarget> = {
+const databricksSchema: JSONSchemaType<DatabricksTarget> = {
     type: 'object',
     properties: {
         type: {

--- a/packages/cli/src/dbt/targets/postgres.ts
+++ b/packages/cli/src/dbt/targets/postgres.ts
@@ -32,7 +32,7 @@ export type PostgresTarget = {
     sslrootcert?: string;
 };
 
-export const postgresSchema: JSONSchemaType<PostgresTarget> = {
+const postgresSchema: JSONSchemaType<PostgresTarget> = {
     type: 'object',
     properties: {
         type: {

--- a/packages/cli/src/dbt/targets/redshift.ts
+++ b/packages/cli/src/dbt/targets/redshift.ts
@@ -35,7 +35,7 @@ export type RedshiftTarget = {
     autocreate?: boolean;
 };
 
-export const redshiftSchema: JSONSchemaType<RedshiftTarget> = {
+const redshiftSchema: JSONSchemaType<RedshiftTarget> = {
     type: 'object',
     properties: {
         type: {

--- a/packages/cli/src/dbt/targets/trino.ts
+++ b/packages/cli/src/dbt/targets/trino.ts
@@ -19,7 +19,7 @@ export type TrinoTarget = {
     http_scheme: string;
 };
 
-export const trinoSchema: JSONSchemaType<TrinoTarget> = {
+const trinoSchema: JSONSchemaType<TrinoTarget> = {
     type: 'object',
     properties: {
         type: {

--- a/packages/cli/src/handlers/apps/scaffolding.ts
+++ b/packages/cli/src/handlers/apps/scaffolding.ts
@@ -109,7 +109,7 @@ export const loadTemplateDependencies = (
 /**
  * Reads vendored template, excluding sandbox-only entries (skill.md, scripts/, src/).
  */
-export const loadVendoredTemplate = (): DataAppCodeFile[] => {
+const loadVendoredTemplate = (): DataAppCodeFile[] => {
     const { templateDir } = resolveVendorDirs();
     const SKIP = new Set(['skill.md', 'scripts', 'src']);
     return walkDir(templateDir, templateDir, SKIP);

--- a/packages/cli/src/handlers/contentAsCode/fileNames.ts
+++ b/packages/cli/src/handlers/contentAsCode/fileNames.ts
@@ -3,7 +3,7 @@ import { createHash } from 'crypto';
 import * as path from 'path';
 
 export const CODE_FILENAME_MAX_STEM_LENGTH = 200;
-export const CODE_FILENAME_HASH_LENGTH = 8;
+const CODE_FILENAME_HASH_LENGTH = 8;
 
 export const getStableCodeHash = (
     value: string,

--- a/packages/cli/src/handlers/dbt/compile.ts
+++ b/packages/cli/src/handlers/dbt/compile.ts
@@ -75,7 +75,7 @@ const optionsToArgs = (options: Partial<DbtCompileOptions>): string[] =>
         return acc;
     }, []);
 
-export const dbtCompile = async (options: DbtCompileOptions) => {
+const dbtCompile = async (options: DbtCompileOptions) => {
     try {
         const args = optionsToArgs(options);
         GlobalState.debug(`> Running: dbt compile ${args.join(' ')}`);

--- a/packages/cli/src/handlers/dbt/getDbtVersion.ts
+++ b/packages/cli/src/handlers/dbt/getDbtVersion.ts
@@ -12,7 +12,7 @@ import GlobalState from '../../globalState';
 import * as styles from '../../styles';
 
 const DBT_CORE_VERSION_REGEX = /installed:.*/;
-export const DBT_CLOUD_CLI_REGEX = /dbt Cloud CLI.*/;
+const DBT_CLOUD_CLI_REGEX = /dbt Cloud CLI.*/;
 const DBT_FUSION_VERSION_REGEX = /dbt-fusion.*/;
 
 const getDbtCLIVersion = async () => {

--- a/packages/cli/src/handlers/dbt/getWarehouseClient.ts
+++ b/packages/cli/src/handlers/dbt/getWarehouseClient.ts
@@ -71,7 +71,7 @@ type GetTableCatalogProps = {
     databaseName?: string;
 };
 
-export const getTableSchema = async ({
+const getTableSchema = async ({
     projectUuid,
     tableName,
     schemaName,

--- a/packages/cli/src/handlers/dbt/refresh.ts
+++ b/packages/cli/src/handlers/dbt/refresh.ts
@@ -43,7 +43,7 @@ function delay(ms: number) {
     });
 }
 
-export const getRunningStepsMessage = (steps: JobStep[]): string => {
+const getRunningStepsMessage = (steps: JobStep[]): string => {
     const runningStep = steps.find(
         (step) => step.stepStatus === JobStepStatusType.RUNNING,
     );
@@ -55,7 +55,7 @@ export const getRunningStepsMessage = (steps: JobStep[]): string => {
     }: ${runningStep?.stepLabel || ''}`;
 };
 
-export const getErrorStepsMessage = (steps: JobStep[]): string => {
+const getErrorStepsMessage = (steps: JobStep[]): string => {
     const errorStep = steps.find(
         (step) => step.stepStatus === JobStepStatusType.ERROR,
     );

--- a/packages/cli/src/handlers/deploy.ts
+++ b/packages/cli/src/handlers/deploy.ts
@@ -74,7 +74,7 @@ type DeployArgs = DeployHandlerOptions & {
     projectUuid: string;
 };
 
-export const logDeployWarnings = (
+const logDeployWarnings = (
     warningResults: ApiDeployExploresResults['warnings'] | undefined,
 ) => {
     if (

--- a/packages/cli/src/handlers/renameHandler.test.ts
+++ b/packages/cli/src/handlers/renameHandler.test.ts
@@ -1,4 +1,5 @@
 import { RenameType, SchedulerJobStatus } from '@lightdash/common';
+import { LightdashAnalytics } from '../analytics/analytics';
 import { getConfig } from '../config';
 import { checkLightdashVersion, lightdashApi } from './dbt/apiClient';
 import { getProject } from './dbt/refresh';
@@ -88,6 +89,12 @@ describe('renameHandler follow-up validation', () => {
         vi.restoreAllMocks();
     });
 
+    const trackedEvents = () =>
+        vi.mocked(LightdashAnalytics.track).mock.calls.map(([payload]) => ({
+            event: payload.event,
+            properties: payload.properties,
+        }));
+
     test('reports a failed validation job as a validation failure, not a rename failure', async () => {
         mockApi(VALIDATION_JOB_ID);
 
@@ -100,6 +107,21 @@ describe('renameHandler follow-up validation', () => {
         expect(output).not.toContain('unexpected error');
     });
 
+    test('counts a rename whose follow-up validation failed as completed', async () => {
+        mockApi(VALIDATION_JOB_ID);
+
+        await renameHandler({ ...baseOptions });
+
+        expect(trackedEvents()).toEqual([
+            {
+                event: 'rename.completed',
+                properties: expect.objectContaining({
+                    validationStatus: 'failed',
+                }),
+            },
+        ]);
+    });
+
     test('still reports a failed rename job as a rename failure', async () => {
         mockApi(RENAME_JOB_ID);
 
@@ -108,6 +130,24 @@ describe('renameHandler follow-up validation', () => {
         const output = errorOutput.join('\n');
         expect(output).toContain('Rename failed: job blew up');
         expect(output).not.toContain('Validation failed');
+        expect(trackedEvents()).toEqual([
+            { event: 'rename.error', properties: expect.anything() },
+        ]);
+    });
+
+    test('records a passing validation on the completed event', async () => {
+        mockApi(null);
+
+        await renameHandler({ ...baseOptions });
+
+        expect(trackedEvents()).toEqual([
+            {
+                event: 'rename.completed',
+                properties: expect.objectContaining({
+                    validationStatus: 'passed',
+                }),
+            },
+        ]);
     });
 
     test('does not run the validation job when --validate is not set', async () => {
@@ -123,5 +163,13 @@ describe('renameHandler follow-up validation', () => {
         const output = errorOutput.join('\n');
         expect(output).not.toContain('failed');
         expect(output).not.toContain('unexpected error');
+        expect(trackedEvents()).toEqual([
+            {
+                event: 'rename.completed',
+                properties: expect.objectContaining({
+                    validationStatus: 'skipped',
+                }),
+            },
+        ]);
     });
 });

--- a/packages/cli/src/handlers/renameHandler.test.ts
+++ b/packages/cli/src/handlers/renameHandler.test.ts
@@ -1,0 +1,127 @@
+import { RenameType, SchedulerJobStatus } from '@lightdash/common';
+import { getConfig } from '../config';
+import { checkLightdashVersion, lightdashApi } from './dbt/apiClient';
+import { getProject } from './dbt/refresh';
+import { renameHandler } from './renameHandler';
+
+vi.mock('../analytics/analytics');
+vi.mock('../config');
+vi.mock('./dbt/apiClient');
+vi.mock('./dbt/refresh');
+
+type RenameOptions = Parameters<typeof renameHandler>[0];
+
+const baseOptions: RenameOptions = {
+    verbose: false,
+    type: RenameType.FIELD,
+    project: 'test-project-uuid',
+    from: 'old_name',
+    to: 'new_name',
+    dryRun: false,
+    assumeYes: true,
+    list: false,
+    validate: true,
+};
+
+const emptyResults = {
+    charts: [],
+    dashboards: [],
+    alerts: [],
+    dashboardSchedulers: [],
+};
+
+const RENAME_JOB_ID = 'rename-job-id';
+const VALIDATION_JOB_ID = 'validation-job-id';
+
+describe('renameHandler follow-up validation', () => {
+    let errorOutput: string[];
+
+    const mockApi = (failingJobId: string | null) => {
+        vi.mocked(lightdashApi).mockImplementation(async ({ method, url }) => {
+            if (method === 'POST' && url.endsWith('/rename')) {
+                return { jobId: RENAME_JOB_ID };
+            }
+            if (method === 'POST' && url.endsWith('/validate')) {
+                return { jobId: VALIDATION_JOB_ID };
+            }
+            if (url.includes(`/schedulers/job/${failingJobId}/status`)) {
+                return {
+                    status: SchedulerJobStatus.ERROR,
+                    details: { error: 'job blew up' },
+                };
+            }
+            if (url.includes('/schedulers/job/')) {
+                return {
+                    status: SchedulerJobStatus.COMPLETED,
+                    details: { results: emptyResults },
+                };
+            }
+            if (url.includes('/validate?jobId=')) {
+                return [];
+            }
+            throw new Error(`Unexpected API call: ${method} ${url}`);
+        });
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(checkLightdashVersion).mockResolvedValue(undefined);
+        vi.mocked(getConfig).mockResolvedValue({
+            context: {
+                apiKey: 'test-key',
+                serverUrl: 'http://localhost',
+                project: 'test-project-uuid',
+            },
+        } as Awaited<ReturnType<typeof getConfig>>);
+        vi.mocked(getProject).mockResolvedValue({
+            name: 'test project',
+        } as Awaited<ReturnType<typeof getProject>>);
+
+        errorOutput = [];
+        vi.spyOn(console, 'error').mockImplementation((...args) => {
+            errorOutput.push(args.map(String).join(' '));
+        });
+        vi.spyOn(console, 'info').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    test('reports a failed validation job as a validation failure, not a rename failure', async () => {
+        mockApi(VALIDATION_JOB_ID);
+
+        await renameHandler({ ...baseOptions });
+
+        const output = errorOutput.join('\n');
+        expect(output).toContain('Rename completed');
+        expect(output).toContain('Validation failed: job blew up');
+        expect(output).not.toContain('Rename failed');
+        expect(output).not.toContain('unexpected error');
+    });
+
+    test('still reports a failed rename job as a rename failure', async () => {
+        mockApi(RENAME_JOB_ID);
+
+        await renameHandler({ ...baseOptions });
+
+        const output = errorOutput.join('\n');
+        expect(output).toContain('Rename failed: job blew up');
+        expect(output).not.toContain('Validation failed');
+    });
+
+    test('does not run the validation job when --validate is not set', async () => {
+        mockApi(null);
+
+        await renameHandler({ ...baseOptions, validate: false });
+
+        const validationCalls = vi
+            .mocked(lightdashApi)
+            .mock.calls.filter(([{ url }]) => url.endsWith('/validate'));
+        expect(validationCalls).toEqual([]);
+
+        const output = errorOutput.join('\n');
+        expect(output).not.toContain('failed');
+        expect(output).not.toContain('unexpected error');
+    });
+});

--- a/packages/cli/src/handlers/renameHandler.ts
+++ b/packages/cli/src/handlers/renameHandler.ts
@@ -5,7 +5,6 @@ import {
     LightdashError,
     RenameChange,
     RenameType,
-    SchedulerJobStatus,
 } from '@lightdash/common';
 import fs from 'fs';
 import inquirer from 'inquirer';
@@ -18,10 +17,10 @@ import * as styles from '../styles';
 import { checkLightdashVersion, lightdashApi } from './dbt/apiClient';
 import { getProject } from './dbt/refresh';
 import {
-    delay,
     getJobState,
     getValidation,
     requestValidation,
+    waitUntilFinished,
 } from './validate';
 
 type RenameHandlerOptions = {
@@ -38,19 +37,13 @@ type RenameHandlerOptions = {
 };
 
 const REFETCH_JOB_INTERVAL = 2000;
-const waitUntilFinished = async (jobUuid: string): Promise<string> => {
-    const job = await getJobState(jobUuid);
-    if (job.status === SchedulerJobStatus.COMPLETED) {
-        return job.status;
-    }
-    if (job.status === SchedulerJobStatus.ERROR) {
-        throw new Error(
-            `\nRename failed: ${job.details?.error || 'unknown error'}`,
-        );
-    }
 
-    return delay(REFETCH_JOB_INTERVAL).then(() => waitUntilFinished(jobUuid));
-};
+const waitUntilRenameFinished = (jobUuid: string): Promise<string> =>
+    waitUntilFinished({
+        jobUuid,
+        refetchIntervalMs: REFETCH_JOB_INTERVAL,
+        createError: (jobError) => new Error(`\nRename failed: ${jobError}`),
+    });
 
 const listResources = (
     resources: RenameChange[],
@@ -150,7 +143,7 @@ export const renameHandler = async (options: RenameHandlerOptions) => {
             body: JSON.stringify(options),
         });
         GlobalState.debug(`Rename job scheduled with id: ${jobResponse.jobId}`);
-        const status = await waitUntilFinished(jobResponse.jobId);
+        const status = await waitUntilRenameFinished(jobResponse.jobId);
         GlobalState.debug(`Rename job finished with status: ${status}`);
         const job = await getJobState(jobResponse.jobId);
 
@@ -226,7 +219,7 @@ export const renameHandler = async (options: RenameHandlerOptions) => {
 
             const { jobId } = validationJob;
 
-            await waitUntilFinished(jobId);
+            await waitUntilRenameFinished(jobId);
 
             const validation = await getValidation(projectUuid, jobId);
             console.info(validation);

--- a/packages/cli/src/handlers/renameHandler.ts
+++ b/packages/cli/src/handlers/renameHandler.ts
@@ -223,15 +223,31 @@ export const renameHandler = async (options: RenameHandlerOptions) => {
             );
         }
 
+        let validationStatus: 'skipped' | 'passed' | 'failed' = 'skipped';
+
         if (options.validate && !options.dryRun) {
-            const validationJob = await requestValidation(projectUuid, [], []);
+            try {
+                const validationJob = await requestValidation(
+                    projectUuid,
+                    [],
+                    [],
+                );
 
-            const { jobId } = validationJob;
+                const { jobId } = validationJob;
 
-            await waitUntilValidationFinished(jobId);
+                await waitUntilValidationFinished(jobId);
 
-            const validation = await getValidation(projectUuid, jobId);
-            console.info(validation);
+                const validation = await getValidation(projectUuid, jobId);
+                console.info(validation);
+                validationStatus = 'passed';
+            } catch (e: unknown) {
+                validationStatus = 'failed';
+                console.error(
+                    `Rename completed, but the follow-up validation failed: ${getErrorMessage(
+                        e,
+                    )}`,
+                );
+            }
         }
 
         await LightdashAnalytics.track({
@@ -244,6 +260,7 @@ export const renameHandler = async (options: RenameHandlerOptions) => {
                 chartsUpdated: results.charts.length,
                 dashboardsUpdated: results.dashboards.length,
                 durationMs: Date.now() - startTime,
+                validationStatus,
             },
         });
     } catch (e: unknown) {
@@ -266,10 +283,6 @@ export const renameHandler = async (options: RenameHandlerOptions) => {
                         '--model',
                     )} to specify a model to filter on`,
                 );
-        } else if (errorString.includes(`Validation failed`)) {
-            console.error(
-                `Rename completed, but the follow-up validation failed:${errorString}`,
-            );
         } else {
             console.error('Unable to rename, unexpected error:', e);
         }

--- a/packages/cli/src/handlers/renameHandler.ts
+++ b/packages/cli/src/handlers/renameHandler.ts
@@ -5,6 +5,7 @@ import {
     LightdashError,
     RenameChange,
     RenameType,
+    UnexpectedServerError,
 } from '@lightdash/common';
 import fs from 'fs';
 import inquirer from 'inquirer';
@@ -43,6 +44,14 @@ const waitUntilRenameFinished = (jobUuid: string): Promise<string> =>
         jobUuid,
         refetchIntervalMs: REFETCH_JOB_INTERVAL,
         createError: (jobError) => new Error(`\nRename failed: ${jobError}`),
+    });
+
+const waitUntilValidationFinished = (jobUuid: string): Promise<string> =>
+    waitUntilFinished({
+        jobUuid,
+        refetchIntervalMs: REFETCH_JOB_INTERVAL,
+        createError: (jobError) =>
+            new UnexpectedServerError(`\nValidation failed: ${jobError}`),
     });
 
 const listResources = (
@@ -219,7 +228,7 @@ export const renameHandler = async (options: RenameHandlerOptions) => {
 
             const { jobId } = validationJob;
 
-            await waitUntilRenameFinished(jobId);
+            await waitUntilValidationFinished(jobId);
 
             const validation = await getValidation(projectUuid, jobId);
             console.info(validation);
@@ -257,6 +266,10 @@ export const renameHandler = async (options: RenameHandlerOptions) => {
                         '--model',
                     )} to specify a model to filter on`,
                 );
+        } else if (errorString.includes(`Validation failed`)) {
+            console.error(
+                `Rename completed, but the follow-up validation failed:${errorString}`,
+            );
         } else {
             console.error('Unable to rename, unexpected error:', e);
         }

--- a/packages/cli/src/handlers/renameProject.ts
+++ b/packages/cli/src/handlers/renameProject.ts
@@ -9,7 +9,7 @@ type RenameProjectOptions = {
     verbose: boolean;
 };
 
-export const renameProjectCommand = async (name: string) => {
+const renameProjectCommand = async (name: string) => {
     const trimmedName = name.trim();
     if (trimmedName.length === 0) {
         throw new ParameterError('Project name cannot be empty');

--- a/packages/cli/src/handlers/setProject.ts
+++ b/packages/cli/src/handlers/setProject.ts
@@ -143,7 +143,7 @@ export const setProjectHandler = async (options: SetProjectOptions) => {
     }
 };
 
-export const unsetProjectCommand = async () => {
+const unsetProjectCommand = async () => {
     await unsetProject();
     console.error(`\n  Project unset.\n`);
 };

--- a/packages/cli/src/handlers/validate.ts
+++ b/packages/cli/src/handlers/validate.ts
@@ -56,7 +56,7 @@ export const getValidation = async (projectUuid: string, jobId: string) =>
         body: undefined,
     });
 
-export const getProjectSpaces = async (projectUuid: string) =>
+const getProjectSpaces = async (projectUuid: string) =>
     lightdashApi<ApiSpaceSummaryListResponse['results']>({
         method: 'GET',
         url: `/api/v1/projects/${projectUuid}/spaces`,
@@ -89,7 +89,7 @@ type ValidateHandlerOptions = CompileHandlerOptions & {
     excludeSpaces?: string[];
 };
 
-export const waitUntilFinished = async (jobUuid: string): Promise<string> => {
+const waitUntilFinished = async (jobUuid: string): Promise<string> => {
     const job = await getJobState(jobUuid);
     if (job.status === SchedulerJobStatus.COMPLETED) {
         return job.status;

--- a/packages/cli/src/handlers/validate.ts
+++ b/packages/cli/src/handlers/validate.ts
@@ -63,7 +63,7 @@ const getProjectSpaces = async (projectUuid: string) =>
         body: undefined,
     });
 
-export function delay(ms: number) {
+function delay(ms: number) {
     return new Promise((resolve) => {
         setTimeout(resolve, ms);
     });
@@ -89,18 +89,28 @@ type ValidateHandlerOptions = CompileHandlerOptions & {
     excludeSpaces?: string[];
 };
 
-const waitUntilFinished = async (jobUuid: string): Promise<string> => {
+type WaitUntilFinishedOptions = {
+    jobUuid: string;
+    refetchIntervalMs: number;
+    createError: (jobError: string) => Error;
+};
+
+export const waitUntilFinished = async ({
+    jobUuid,
+    refetchIntervalMs,
+    createError,
+}: WaitUntilFinishedOptions): Promise<string> => {
     const job = await getJobState(jobUuid);
     if (job.status === SchedulerJobStatus.COMPLETED) {
         return job.status;
     }
     if (job.status === SchedulerJobStatus.ERROR) {
-        throw new UnexpectedServerError(
-            `\nValidation failed: ${job.details?.error || 'unknown error'}`,
-        );
+        throw createError(job.details?.error || 'unknown error');
     }
 
-    return delay(REFETCH_JOB_INTERVAL).then(() => waitUntilFinished(jobUuid));
+    return delay(refetchIntervalMs).then(() =>
+        waitUntilFinished({ jobUuid, refetchIntervalMs, createError }),
+    );
 };
 
 export const validateHandler = async (
@@ -228,7 +238,12 @@ export const validateHandler = async (
             `  Waiting for validation to finish`,
         );
 
-        await waitUntilFinished(jobId);
+        await waitUntilFinished({
+            jobUuid: jobId,
+            refetchIntervalMs: REFETCH_JOB_INTERVAL,
+            createError: (jobError) =>
+                new UnexpectedServerError(`\nValidation failed: ${jobError}`),
+        });
 
         const allValidation = await getValidation(projectUuid, jobId);
 

--- a/packages/cli/src/terminal/contentAsCodeOutput.ts
+++ b/packages/cli/src/terminal/contentAsCodeOutput.ts
@@ -49,7 +49,7 @@ const getOperationLabel = (
     return tense === 'running' ? 'Uploading' : 'Uploaded';
 };
 
-export const formatDurationTag = (durationMs: number) =>
+const formatDurationTag = (durationMs: number) =>
     chalk.gray(getDurationLabel(durationMs));
 
 export const formatContentAsCodeAction = ({
@@ -135,7 +135,7 @@ export const formatContentAsCodeComplete = ({
     return [header, ...items.map(formatTreeItem), pathItem].join('\n');
 };
 
-export const canRenderContentAsCodeTree = (): boolean =>
+const canRenderContentAsCodeTree = (): boolean =>
     Boolean(
         process.stderr.isTTY &&
         process.env.CI !== 'true' &&
@@ -152,7 +152,7 @@ export const logContentAsCodeDiscovery = (message: string): void => {
     }
 };
 
-export const renderContentAsCodeComplete = (
+const renderContentAsCodeComplete = (
     props: ContentAsCodeOutputProps,
 ): boolean => {
     if (!canRenderContentAsCodeTree()) {


### PR DESCRIPTION
`ts-unused-exports` reported 60 unused exports in `packages/cli`. Hand-triaging the 28 value exports showed almost none of it was dead code — it was over-exporting. Removing the redundant keywords exposed a copied function; deduplicating that exposed a reporting bug; fixing the reporting exposed a bad analytics event. Each step is a separate commit.

## What changed

**1 deletion.** `analytics.ts` exported an `analytics` singleton (`new LightdashAnalytics()`) that nothing imported. Every consumer uses the class statically — 10+ handlers import `LightdashAnalytics`/`categorizeError` from that module and none import `analytics`. Deleted.

**27 `export` keywords dropped.** Each of these is used inside its own file and nowhere else, so the symbol stays exactly where it is and keeps every call site — only the module's public surface shrinks. Covers `dbtCompile`, `getTableSchema`, `DBT_CLOUD_CLI_REGEX`, `renameProjectCommand`, the ajv warehouse-target schemas, the `contentAsCodeOutput` helpers, and the `manifest.ts` loaders.

**1 dedupe.** `waitUntilFinished` existed twice: exported from `validate.ts` and copied privately into `renameHandler.ts`. The bodies were identical apart from the error thrown and the poll interval, so both are now parameters:

```ts
type WaitUntilFinishedOptions = {
    jobUuid: string;
    refetchIntervalMs: number;
    createError: (jobError: string) => Error;
};
```

`waitUntilFinished` therefore stays exported — it now has a real second consumer — and `delay`, which `renameHandler` only needed for its own copy, drops its `export` instead.

**1 reporting fix.** With both pollers side by side it became clear `renameHandler` was polling the *optional post-rename validation job* with the rename poller, so a validation failure was reported as `Rename failed: …` after a rename that had already succeeded. The validation job now gets its own error and the handler says what actually happened:

```
Rename completed, but the follow-up validation failed: …
```

**1 analytics fix.** The same failure also fired `rename.error` and suppressed `rename.completed`, so a rename that worked was counted as a failed rename — and `rename.error` couldn't answer "how often does rename actually fail?". The validation now has its own error boundary inside the handler, so the rename is tracked as completed and the validation outcome is reported explicitly:

```ts
validationStatus: 'skipped' | 'passed' | 'failed'
```

An explicit `'skipped'` rather than an absent property, so `--validate`-off runs stay distinguishable from validations that never reported.

## Verification

| check | result |
| --- | --- |
| `pnpm -F cli typecheck` | pass |
| `pnpm -F cli test` | 337 passed / 35 files |
| `pnpm -F cli run linter <touched>` | clean |
| `ts-unused-exports` value exports | 28 → 0 |
| `ts-unused-exports` total | 60 → 32 |

`renameHandler` had no tests; this adds five, covering both poller paths, the `--validate` off case, and the three `validationStatus` outcomes. Each new test was run against the code as it stood before its fix and fails there, so they pin the behaviour instead of describing it.

The 32 remaining unused exports are type-only and untouched here — `--allowUnusedTypes` is what the frontend's own `unused-exports` script runs with, so they may well be deliberate and deserve their own triage. Diffing the before/after reports confirms exactly 28 entries disappeared and **no new unused export appeared**.

## Note for whoever owns the rename dashboards

`rename.error` gets rarer and `rename.completed` more common, because runs that only failed their follow-up validation now land in the second bucket. That is the point of the change, but any existing "rename failure rate" chart will step at this release and should be read with `validationStatus` alongside it.

## Why the export changes are safe

`packages/cli/package.json` declares only `bin` — no `main`, no `types`, no `exports` map. `@lightdash/cli` ships as an executable, not a library, so nothing downstream can import these. There are also no `export *` barrels in `src/`, so no symbol is re-exported out of view of the analysis.

## Left alone

`dbt/refresh.ts` has a similar-looking poller that is deliberately untouched — it polls a different endpoint (`/api/v1/jobs/{uuid}` returning `Job`/`jobStatus`/`steps`, not the scheduler status API) and only resembles these two superficially.

A failed follow-up validation still exits 0, as it did before. Changing the exit code would break anyone scripting `lightdash rename --validate`, so it stays out of a fix about reporting.

## Note on the tooling

`ts-unused-exports` line numbers were wrong for `dbt/manifest.ts` — it reported 18/37/70 for symbols actually declared at 15/18/53. The edits were applied by matching the declaration text for the named symbol, not by line offset, and three mismatches were caught and re-resolved by hand. Worth knowing before anyone scripts against this tool's output.

Linear: SPK-714