### PR TITLE
fix: replace dead .eslintrc.js COPY with oxlint config in Dockerfiles

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -196,7 +196,7 @@ COPY pnpm-workspace.yaml .
 COPY pnpm-lock.yaml .
 COPY turbo.json .
 COPY tsconfig.json .
-COPY .eslintrc.js .
+COPY .oxlintrc.base.json .
 COPY .pnpmfile.cjs .
 COPY packages/common/package.json ./packages/common/
 COPY packages/formula/package.json ./packages/formula/

--- a/dockerfile-prs
+++ b/dockerfile-prs
@@ -100,7 +100,7 @@ ENV TURBO_API=https://cache.depot.dev
 
 # Install development dependencies for all
 COPY tsconfig.json .
-COPY .eslintrc.js .
+COPY .oxlintrc.base.json .
 COPY .pnpmfile.cjs .
 
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json turbo.json ./


### PR DESCRIPTION
## Summary

My oxlint migration (#26250, "chore: remove the dead ESLint toolchain") deleted the root `.eslintrc.js`, but `dockerfile` and `dockerfile-prs` still `COPY .eslintrc.js .` during the deps-install layer — breaking `docker build` for both the production image and the PR preview image.

Fix: copy `.oxlintrc.base.json` (the new root oxlint config that replaced it) instead.

## Regression analysis

This file was only ever copied into the deps-install layer for caching parity with root config files (`tsconfig.json`, `turbo.json`, etc.) — it isn't referenced by any build/runtime step downstream, so swapping it for the oxlint equivalent is a drop-in fix with no behavior change beyond making the build succeed again.

test-all

## Test plan

- [ ] `docker build -f dockerfile .` succeeds
- [ ] `docker build -f dockerfile-prs .` succeeds
- [ ] Preview deploy + e2e CI (triggered via `test-all` above) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KjqYXSGSRE1A5ZEgzLFEff