### PR TITLE
feat(apps): add org-wide data app activity page

### DIFF
--- a/packages/frontend/src/features/dataAppActivity/components/DataAppActivitySettingsPage.tsx
+++ b/packages/frontend/src/features/dataAppActivity/components/DataAppActivitySettingsPage.tsx
@@ -1,0 +1,12 @@
+import { type FC } from 'react';
+import { SettingsPage } from '../../../components/common/Settings/SettingsPage';
+import { DataAppActivityTable } from './DataAppActivityTable';
+
+export const DataAppActivitySettingsPage: FC = () => (
+    <SettingsPage
+        title="Activity"
+        description="See who generated which data app, when, and with which model."
+    >
+        <DataAppActivityTable />
+    </SettingsPage>
+);

--- a/packages/frontend/src/features/dataAppActivity/components/DataAppActivityTable.tsx
+++ b/packages/frontend/src/features/dataAppActivity/components/DataAppActivityTable.tsx
@@ -23,7 +23,6 @@ import {
     useEffect,
     useMemo,
     useRef,
-    useState,
     type FC,
     type UIEvent,
 } from 'react';
@@ -115,13 +114,6 @@ export const DataAppActivityTable: FC = () => {
     useEffect(() => {
         fetchMoreOnBottomReached(tableContainerRef.current);
     }, [fetchMoreOnBottomReached]);
-
-    // Mirrors the other admin tables: the table memoises on identity, so the
-    // rows are staged through state to force a re-render on new pages.
-    const [tableData, setTableData] = useState<DataAppActivityEvent[]>([]);
-    useEffect(() => {
-        setTableData(flatData);
-    }, [flatData]);
 
     const columns = useMemo<ContentTableColumnDef<DataAppActivityEvent>[]>(
         () => [
@@ -319,7 +311,7 @@ export const DataAppActivityTable: FC = () => {
 
     const table = useContentTable({
         columns,
-        data: tableData,
+        data: flatData,
         enableColumnResizing: true,
         enableRowNumbers: false,
         enableRowVirtualization: true,

--- a/packages/frontend/src/features/dataAppActivity/components/DataAppActivityTable.tsx
+++ b/packages/frontend/src/features/dataAppActivity/components/DataAppActivityTable.tsx
@@ -1,0 +1,392 @@
+import {
+    getAppDisplayName,
+    type DataAppActivityEvent,
+} from '@lightdash/common';
+import { Badge, Group, Text, Tooltip, useMantineTheme } from '@mantine-8/core';
+import {
+    IconAppWindow,
+    IconBox,
+    IconClock,
+    IconSparkles,
+    IconUser,
+} from '@tabler/icons-react';
+import dayjs from 'dayjs';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type FC,
+    type UIEvent,
+} from 'react';
+import {
+    ContentTable,
+    useContentTable,
+    type ContentTableColumnDef,
+} from '../../../components/common/ContentTable';
+import ErrorState from '../../../components/common/ErrorState';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { useIsTruncated } from '../../../hooks/useIsTruncated/index';
+import { useInfiniteDataAppActivity } from '../hooks/useDataAppActivity';
+import { useDataAppActivityFilters } from '../hooks/useDataAppActivityFilters';
+import { DataAppActivityTopToolbar } from './DataAppActivityTopToolbar';
+
+const STATUS_COLORS: Record<string, string> = {
+    ready: 'green',
+    error: 'red',
+};
+
+const PromptCell: FC<{ prompt: string }> = ({ prompt }) => {
+    const { ref, isTruncated } = useIsTruncated<HTMLDivElement>();
+    const text = prompt.trim();
+    if (text === '') {
+        return (
+            <Text fz="sm" fs="italic" c="ldGray.6">
+                No prompt
+            </Text>
+        );
+    }
+    return (
+        <Tooltip
+            withinPortal
+            label={text}
+            disabled={!isTruncated}
+            multiline
+            maw={400}
+        >
+            <Text ref={ref} fz="sm" c="ldGray.9" truncate>
+                {text}
+            </Text>
+        </Tooltip>
+    );
+};
+
+export const DataAppActivityTable: FC = () => {
+    const theme = useMantineTheme();
+    const filters = useDataAppActivityFilters();
+
+    const {
+        data,
+        error,
+        isError,
+        isInitialLoading,
+        isFetching,
+        hasNextPage,
+        fetchNextPage,
+    } = useInfiniteDataAppActivity(filters.apiFilters, {
+        keepPreviousData: true,
+    });
+
+    const flatData = useMemo(
+        () => data?.pages.flatMap((page) => page.data) ?? [],
+        [data],
+    );
+
+    const totalResults =
+        data?.pages[data.pages.length - 1]?.pagination?.totalResults ?? 0;
+
+    const tableContainerRef = useRef<HTMLDivElement>(null);
+
+    const fetchMoreOnBottomReached = useCallback(
+        (containerRefElement?: HTMLDivElement | null) => {
+            if (!containerRefElement) return;
+            const { scrollHeight, scrollTop, clientHeight } =
+                containerRefElement;
+            if (
+                scrollHeight - scrollTop - clientHeight < 200 &&
+                !isFetching &&
+                hasNextPage
+            ) {
+                void fetchNextPage();
+            }
+        },
+        [fetchNextPage, isFetching, hasNextPage],
+    );
+
+    useEffect(() => {
+        fetchMoreOnBottomReached(tableContainerRef.current);
+    }, [fetchMoreOnBottomReached]);
+
+    // Mirrors the other admin tables: the table memoises on identity, so the
+    // rows are staged through state to force a re-render on new pages.
+    const [tableData, setTableData] = useState<DataAppActivityEvent[]>([]);
+    useEffect(() => {
+        setTableData(flatData);
+    }, [flatData]);
+
+    const columns = useMemo<ContentTableColumnDef<DataAppActivityEvent>[]>(
+        () => [
+            {
+                id: 'createdAt',
+                accessorFn: (row) => row.createdAt,
+                header: 'When',
+                size: 140,
+                enableSorting: false,
+                Header: ({ column }) => (
+                    <Group gap="two">
+                        <MantineIcon icon={IconClock} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => (
+                    <Tooltip
+                        withinPortal
+                        label={dayjs(row.original.createdAt).format(
+                            'YYYY-MM-DD HH:mm:ss',
+                        )}
+                    >
+                        <Text fz="sm" c="ldGray.9" truncate>
+                            {dayjs(row.original.createdAt).format(
+                                'MMM D, HH:mm',
+                            )}
+                        </Text>
+                    </Tooltip>
+                ),
+            },
+            {
+                id: 'user',
+                accessorFn: (row) =>
+                    row.user
+                        ? `${row.user.firstName} ${row.user.lastName}`
+                        : 'Unknown user',
+                header: 'User',
+                size: 148,
+                enableSorting: false,
+                Header: ({ column }) => (
+                    <Group gap="two">
+                        <MantineIcon icon={IconUser} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) =>
+                    row.original.user ? (
+                        <Text fz="sm" c="ldGray.9" truncate>
+                            {`${row.original.user.firstName} ${row.original.user.lastName}`}
+                        </Text>
+                    ) : (
+                        <Text fz="sm" fs="italic" c="ldGray.6">
+                            Deleted user
+                        </Text>
+                    ),
+            },
+            {
+                id: 'app',
+                accessorFn: (row) => row.appName,
+                header: 'App',
+                size: 168,
+                enableSorting: false,
+                Header: ({ column }) => (
+                    <Group gap="two">
+                        <MantineIcon icon={IconAppWindow} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => (
+                    <Group gap="xs" wrap="nowrap">
+                        <Text fz="sm" c="ldGray.9" truncate>
+                            {getAppDisplayName(
+                                row.original.appName,
+                                row.original.appUuid,
+                            )}
+                        </Text>
+                        {row.original.appDeleted && (
+                            <Badge
+                                size="xs"
+                                variant="light"
+                                color="gray"
+                                flex="0 0 auto"
+                            >
+                                Deleted
+                            </Badge>
+                        )}
+                    </Group>
+                ),
+            },
+            {
+                id: 'project',
+                accessorFn: (row) => row.projectName,
+                header: 'Project',
+                size: 110,
+                enableSorting: false,
+                Header: ({ column }) => (
+                    <Group gap="two">
+                        <MantineIcon icon={IconBox} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => (
+                    <Text fz="sm" c="ldGray.9" truncate>
+                        {row.original.projectName}
+                    </Text>
+                ),
+            },
+            {
+                id: 'version',
+                accessorFn: (row) => row.version,
+                header: 'Type',
+                size: 122,
+                enableSorting: false,
+                Cell: ({ row }) => (
+                    <Group gap="xs" wrap="nowrap">
+                        <Text fz="sm" c="ldGray.9" truncate>
+                            {row.original.version === 1
+                                ? 'Created'
+                                : 'Iteration'}
+                        </Text>
+                        <Text
+                            fz="xs"
+                            c="ldGray.6"
+                            ff="monospace"
+                            flex="0 0 auto"
+                        >
+                            {`v${row.original.version}`}
+                        </Text>
+                    </Group>
+                ),
+            },
+            {
+                id: 'claudeModel',
+                accessorFn: (row) => row.claudeModel,
+                header: 'Model',
+                size: 100,
+                enableSorting: false,
+                Header: ({ column }) => (
+                    <Group gap="two">
+                        <MantineIcon icon={IconSparkles} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => (
+                    <Text fz="sm" c="ldGray.9">
+                        {row.original.claudeModel}
+                    </Text>
+                ),
+            },
+            {
+                id: 'status',
+                accessorFn: (row) => row.status,
+                header: 'Status',
+                size: 105,
+                enableSorting: false,
+                Cell: ({ row }) => (
+                    <Badge
+                        size="sm"
+                        variant="light"
+                        color={STATUS_COLORS[row.original.status] ?? 'blue'}
+                    >
+                        {row.original.status}
+                    </Badge>
+                ),
+            },
+            {
+                id: 'prompt',
+                accessorFn: (row) => row.prompt,
+                header: 'Prompt',
+                size: 187,
+                grow: true,
+                enableSorting: false,
+                Cell: ({ row }) => <PromptCell prompt={row.original.prompt} />,
+            },
+        ],
+        [],
+    );
+
+    const table = useContentTable({
+        columns,
+        data: tableData,
+        enableColumnResizing: true,
+        enableRowNumbers: false,
+        enableRowVirtualization: true,
+        enablePagination: false,
+        enableFilters: false,
+        enableFullScreenToggle: false,
+        enableDensityToggle: false,
+        enableColumnActions: false,
+        enableColumnFilters: false,
+        enableHiding: false,
+        enableSorting: false,
+        enableTopToolbar: true,
+        getRowId: (row) => `${row.appUuid}:${row.version}`,
+        state: {
+            showProgressBars: false,
+            showSkeletons: isInitialLoading,
+        },
+        rowVirtualizerProps: { estimateSize: () => 72, overscan: 40 },
+        // Row metrics copied from the sibling admin tables (agents, threads,
+        // memories) so the settings tables stay visually consistent.
+        mantineTableBodyCellProps: {
+            h: 72,
+            style: {
+                padding: `${theme.spacing.md} ${theme.spacing.xl}`,
+                borderRight: 'none',
+                borderLeft: 'none',
+                borderBottom: `1px solid ${theme.colors.ldGray[2]}`,
+                borderTop: 'none',
+            },
+        },
+        emptyState: {
+            entityName: 'generations',
+            emptyMessage: 'No data apps have been generated yet.',
+            filteredMessage: 'No generations match these filters.',
+            hasActiveFilters: filters.hasActiveFilters,
+            onClearFilters: filters.resetFilters,
+        },
+        mantinePaperProps: {
+            shadow: undefined,
+            sx: {
+                border: `1px solid ${theme.colors.ldGray[2]}`,
+                borderRadius: theme.spacing.sm,
+                boxShadow: theme.shadows.subtle,
+                display: 'flex',
+                flexDirection: 'column',
+            },
+        },
+        mantineTableContainerProps: {
+            ref: tableContainerRef,
+            sx: {
+                maxHeight: 'calc(100dvh - 350px)',
+                minHeight: '600px',
+                display: 'flex',
+                flexDirection: 'column',
+            },
+            onScroll: (event: UIEvent<HTMLDivElement>) =>
+                fetchMoreOnBottomReached(event.target as HTMLDivElement),
+        },
+        mantineTableProps: {
+            highlightOnHover: true,
+            withColumnBorders: Boolean(flatData.length),
+            sx: {
+                flexGrow: 1,
+                display: 'flex',
+                flexDirection: 'column',
+            },
+        },
+        renderTopToolbar: () => (
+            <DataAppActivityTopToolbar
+                selectedProjectUuids={filters.selectedProjectUuids}
+                selectedUserUuids={filters.selectedUserUuids}
+                selectedModels={filters.selectedModels}
+                selectedPeriod={filters.selectedPeriod}
+                setSelectedProjectUuids={filters.setSelectedProjectUuids}
+                setSelectedUserUuids={filters.setSelectedUserUuids}
+                setSelectedModels={filters.setSelectedModels}
+                setSelectedPeriod={filters.setSelectedPeriod}
+                hasActiveFilters={filters.hasActiveFilters}
+                resetFilters={filters.resetFilters}
+                totalResults={totalResults}
+                currentResultsCount={flatData.length}
+                isFetching={isFetching}
+                hasNextPage={Boolean(hasNextPage)}
+            />
+        ),
+    });
+
+    // Without this a failed request falls through to the table's empty state,
+    // which would claim the org has never generated an app.
+    if (isError) {
+        return <ErrorState error={error?.error} />;
+    }
+
+    return <ContentTable table={table} />;
+};

--- a/packages/frontend/src/features/dataAppActivity/components/DataAppActivityTable.tsx
+++ b/packages/frontend/src/features/dataAppActivity/components/DataAppActivityTable.tsx
@@ -10,13 +10,6 @@ import {
     Tooltip,
     useMantineTheme,
 } from '@mantine-8/core';
-import {
-    IconAppWindow,
-    IconBox,
-    IconClock,
-    IconSparkles,
-    IconUser,
-} from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import {
     useCallback,
@@ -33,7 +26,6 @@ import {
     type ContentTableColumnDef,
 } from '../../../components/common/ContentTable';
 import ErrorState from '../../../components/common/ErrorState';
-import MantineIcon from '../../../components/common/MantineIcon';
 import { useIsTruncated } from '../../../hooks/useIsTruncated/index';
 import { useInfiniteDataAppActivity } from '../hooks/useDataAppActivity';
 import { useDataAppActivityFilters } from '../hooks/useDataAppActivityFilters';
@@ -121,14 +113,8 @@ export const DataAppActivityTable: FC = () => {
                 id: 'createdAt',
                 accessorFn: (row) => row.createdAt,
                 header: 'When',
-                size: 140,
+                size: 132,
                 enableSorting: false,
-                Header: ({ column }) => (
-                    <Group gap="two">
-                        <MantineIcon icon={IconClock} color="ldGray.6" />
-                        {column.columnDef.header}
-                    </Group>
-                ),
                 Cell: ({ row }) => (
                     <Tooltip
                         withinPortal
@@ -151,14 +137,8 @@ export const DataAppActivityTable: FC = () => {
                         ? `${row.user.firstName} ${row.user.lastName}`
                         : 'Unknown user',
                 header: 'User',
-                size: 148,
+                size: 142,
                 enableSorting: false,
-                Header: ({ column }) => (
-                    <Group gap="two">
-                        <MantineIcon icon={IconUser} color="ldGray.6" />
-                        {column.columnDef.header}
-                    </Group>
-                ),
                 Cell: ({ row }) =>
                     row.original.user ? (
                         <Text fz="sm" c="ldGray.9" truncate>
@@ -173,15 +153,9 @@ export const DataAppActivityTable: FC = () => {
             {
                 id: 'app',
                 accessorFn: (row) => row.appName,
-                header: 'App',
-                size: 168,
+                header: 'Name',
+                size: 162,
                 enableSorting: false,
-                Header: ({ column }) => (
-                    <Group gap="two">
-                        <MantineIcon icon={IconAppWindow} color="ldGray.6" />
-                        {column.columnDef.header}
-                    </Group>
-                ),
                 Cell: ({ row }) => {
                     const displayName = getAppDisplayName(
                         row.original.appName,
@@ -224,14 +198,8 @@ export const DataAppActivityTable: FC = () => {
                 id: 'project',
                 accessorFn: (row) => row.projectName,
                 header: 'Project',
-                size: 110,
+                size: 105,
                 enableSorting: false,
-                Header: ({ column }) => (
-                    <Group gap="two">
-                        <MantineIcon icon={IconBox} color="ldGray.6" />
-                        {column.columnDef.header}
-                    </Group>
-                ),
                 Cell: ({ row }) => (
                     <Text fz="sm" c="ldGray.9" truncate>
                         {row.original.projectName}
@@ -268,12 +236,6 @@ export const DataAppActivityTable: FC = () => {
                 header: 'Model',
                 size: 100,
                 enableSorting: false,
-                Header: ({ column }) => (
-                    <Group gap="two">
-                        <MantineIcon icon={IconSparkles} color="ldGray.6" />
-                        {column.columnDef.header}
-                    </Group>
-                ),
                 Cell: ({ row }) => (
                     <Text fz="sm" c="ldGray.9">
                         {row.original.claudeModel}
@@ -284,7 +246,7 @@ export const DataAppActivityTable: FC = () => {
                 id: 'status',
                 accessorFn: (row) => row.status,
                 header: 'Status',
-                size: 105,
+                size: 130,
                 enableSorting: false,
                 Cell: ({ row }) => (
                     <Badge

--- a/packages/frontend/src/features/dataAppActivity/components/DataAppActivityTable.tsx
+++ b/packages/frontend/src/features/dataAppActivity/components/DataAppActivityTable.tsx
@@ -2,7 +2,14 @@ import {
     getAppDisplayName,
     type DataAppActivityEvent,
 } from '@lightdash/common';
-import { Badge, Group, Text, Tooltip, useMantineTheme } from '@mantine-8/core';
+import {
+    Anchor,
+    Badge,
+    Group,
+    Text,
+    Tooltip,
+    useMantineTheme,
+} from '@mantine-8/core';
 import {
     IconAppWindow,
     IconBox,
@@ -20,6 +27,7 @@ import {
     type FC,
     type UIEvent,
 } from 'react';
+import { Link } from 'react-router';
 import {
     ContentTable,
     useContentTable,
@@ -182,26 +190,43 @@ export const DataAppActivityTable: FC = () => {
                         {column.columnDef.header}
                     </Group>
                 ),
-                Cell: ({ row }) => (
-                    <Group gap="xs" wrap="nowrap">
-                        <Text fz="sm" c="ldGray.9" truncate>
-                            {getAppDisplayName(
-                                row.original.appName,
-                                row.original.appUuid,
+                Cell: ({ row }) => {
+                    const displayName = getAppDisplayName(
+                        row.original.appName,
+                        row.original.appUuid,
+                    );
+                    return (
+                        <Group gap="xs" wrap="nowrap">
+                            {row.original.appDeleted ? (
+                                // Deleted apps have nothing to open.
+                                <Text fz="sm" c="ldGray.9" truncate>
+                                    {displayName}
+                                </Text>
+                            ) : (
+                                <Anchor
+                                    component={Link}
+                                    to={`/projects/${row.original.projectUuid}/apps/${row.original.appUuid}`}
+                                    fz="sm"
+                                    c="inherit"
+                                    underline="hover"
+                                    truncate="end"
+                                >
+                                    {displayName}
+                                </Anchor>
                             )}
-                        </Text>
-                        {row.original.appDeleted && (
-                            <Badge
-                                size="xs"
-                                variant="light"
-                                color="gray"
-                                flex="0 0 auto"
-                            >
-                                Deleted
-                            </Badge>
-                        )}
-                    </Group>
-                ),
+                            {row.original.appDeleted && (
+                                <Badge
+                                    size="xs"
+                                    variant="light"
+                                    color="gray"
+                                    flex="0 0 auto"
+                                >
+                                    Deleted
+                                </Badge>
+                            )}
+                        </Group>
+                    );
+                },
             },
             {
                 id: 'project',

--- a/packages/frontend/src/features/dataAppActivity/components/DataAppActivityTopToolbar.tsx
+++ b/packages/frontend/src/features/dataAppActivity/components/DataAppActivityTopToolbar.tsx
@@ -1,0 +1,227 @@
+import { DATA_APP_CLAUDE_MODELS } from '@lightdash/common';
+import {
+    Box,
+    Button,
+    Divider,
+    Group,
+    SegmentedControl,
+    Text,
+    useMantineTheme,
+} from '@mantine-8/core';
+import {
+    IconBox,
+    IconSparkles,
+    IconTrash,
+    IconUser,
+} from '@tabler/icons-react';
+import { useMemo, useState, type FC } from 'react';
+import FilterFacet, {
+    type FilterFacetOption,
+} from '../../../components/common/FilterFacet';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { useOrganizationUsers } from '../../../hooks/useOrganizationUsers';
+import { useProjects } from '../../../hooks/useProjects';
+import {
+    DATA_APP_ACTIVITY_PERIODS,
+    type useDataAppActivityFilters,
+} from '../hooks/useDataAppActivityFilters';
+
+const PERIOD_LABELS: Record<
+    (typeof DATA_APP_ACTIVITY_PERIODS)[number],
+    string
+> = {
+    all: 'All time',
+    '7d': '7 days',
+    '30d': '30 days',
+    '90d': '90 days',
+};
+
+type DataAppActivityTopToolbarProps = Pick<
+    ReturnType<typeof useDataAppActivityFilters>,
+    | 'selectedProjectUuids'
+    | 'selectedUserUuids'
+    | 'selectedModels'
+    | 'selectedPeriod'
+    | 'setSelectedProjectUuids'
+    | 'setSelectedUserUuids'
+    | 'setSelectedModels'
+    | 'setSelectedPeriod'
+    | 'hasActiveFilters'
+    | 'resetFilters'
+> & {
+    totalResults: number;
+    currentResultsCount: number;
+    isFetching: boolean;
+    hasNextPage: boolean;
+};
+
+export const DataAppActivityTopToolbar: FC<DataAppActivityTopToolbarProps> = ({
+    selectedProjectUuids,
+    selectedUserUuids,
+    selectedModels,
+    selectedPeriod,
+    setSelectedProjectUuids,
+    setSelectedUserUuids,
+    setSelectedModels,
+    setSelectedPeriod,
+    hasActiveFilters,
+    resetFilters,
+    totalResults,
+    currentResultsCount,
+    isFetching,
+    hasNextPage,
+}) => {
+    const theme = useMantineTheme();
+    const [projectSearch, setProjectSearch] = useState('');
+    const [userSearch, setUserSearch] = useState('');
+
+    const { data: projects, isLoading: isLoadingProjects } = useProjects();
+    const { data: users, isLoading: isLoadingUsers } = useOrganizationUsers();
+
+    const projectOptions = useMemo<FilterFacetOption[]>(
+        () =>
+            projects?.map((project) => ({
+                value: project.projectUuid,
+                label: project.name,
+            })) ?? [],
+        [projects],
+    );
+
+    const userOptions = useMemo<FilterFacetOption[]>(
+        () =>
+            users?.map((user) => ({
+                value: user.userUuid,
+                label:
+                    `${user.firstName} ${user.lastName}`.trim() || user.email,
+            })) ?? [],
+        [users],
+    );
+
+    const modelOptions = useMemo<FilterFacetOption[]>(
+        () =>
+            DATA_APP_CLAUDE_MODELS.map((model) => ({
+                value: model,
+                label: model,
+            })),
+        [],
+    );
+
+    return (
+        <Box>
+            <Group
+                p={`${theme.spacing.lg} ${theme.spacing.xl}`}
+                justify="space-between"
+            >
+                <Group gap="xs">
+                    <FilterFacet
+                        label="Projects"
+                        icon={IconBox}
+                        selected={selectedProjectUuids}
+                        onChange={setSelectedProjectUuids}
+                        options={projectOptions}
+                        loading={isLoadingProjects}
+                        tooltipLabel="Filter activity by project"
+                        searchValue={projectSearch}
+                        onSearchChange={setProjectSearch}
+                    />
+                    <Divider
+                        orientation="vertical"
+                        w={1}
+                        h={20}
+                        style={{ alignSelf: 'center' }}
+                    />
+                    <FilterFacet
+                        label="Users"
+                        icon={IconUser}
+                        selected={selectedUserUuids}
+                        onChange={setSelectedUserUuids}
+                        options={userOptions}
+                        loading={isLoadingUsers}
+                        tooltipLabel="Filter activity by who generated it"
+                        searchValue={userSearch}
+                        onSearchChange={setUserSearch}
+                    />
+                    <Divider
+                        orientation="vertical"
+                        w={1}
+                        h={20}
+                        style={{ alignSelf: 'center' }}
+                    />
+                    <FilterFacet
+                        label="Models"
+                        icon={IconSparkles}
+                        selected={selectedModels}
+                        onChange={setSelectedModels}
+                        options={modelOptions}
+                        tooltipLabel="Filter activity by the model that built it"
+                    />
+                    <Divider
+                        orientation="vertical"
+                        w={1}
+                        h={20}
+                        style={{ alignSelf: 'center' }}
+                    />
+                    <SegmentedControl
+                        size="xs"
+                        radius="md"
+                        value={selectedPeriod}
+                        onChange={(value) =>
+                            setSelectedPeriod(
+                                value as (typeof DATA_APP_ACTIVITY_PERIODS)[number],
+                            )
+                        }
+                        data={DATA_APP_ACTIVITY_PERIODS.map((period) => ({
+                            label: PERIOD_LABELS[period],
+                            value: period,
+                        }))}
+                    />
+                    {hasActiveFilters && (
+                        <>
+                            <Divider
+                                orientation="vertical"
+                                w={1}
+                                h={20}
+                                style={{ alignSelf: 'center' }}
+                            />
+                            <Button
+                                variant="subtle"
+                                size="xs"
+                                leftSection={
+                                    <MantineIcon icon={IconTrash} size="sm" />
+                                }
+                                onClick={resetFilters}
+                            >
+                                Clear all filters
+                            </Button>
+                        </>
+                    )}
+                </Group>
+
+                <Box
+                    bg="ldGray.1"
+                    c="ldGray.9"
+                    style={{
+                        borderRadius: 6,
+                        padding: `${theme.spacing.sm} ${theme.spacing.xs}`,
+                        height: 32,
+                        display: 'flex',
+                        alignItems: 'center',
+                    }}
+                >
+                    <Text fz="sm" fw={500}>
+                        {isFetching
+                            ? 'Loading...'
+                            : hasNextPage
+                              ? `${currentResultsCount} of ${totalResults} generations`
+                              : `${totalResults} ${
+                                    totalResults === 1
+                                        ? 'generation'
+                                        : 'generations'
+                                }`}
+                    </Text>
+                </Box>
+            </Group>
+            <Divider color="ldGray.2" />
+        </Box>
+    );
+};

--- a/packages/frontend/src/features/dataAppActivity/hooks/useDataAppActivity.ts
+++ b/packages/frontend/src/features/dataAppActivity/hooks/useDataAppActivity.ts
@@ -1,0 +1,58 @@
+import {
+    type ApiDataAppActivityResponse,
+    type ApiError,
+    type DataAppActivityFilters,
+} from '@lightdash/common';
+import {
+    useInfiniteQuery,
+    type UseInfiniteQueryOptions,
+} from '@tanstack/react-query';
+import { lightdashApi } from '../../../api';
+
+type DataAppActivityResults = ApiDataAppActivityResponse['results'];
+
+const createQueryString = (params: Record<string, unknown>): string => {
+    const query = new URLSearchParams();
+    for (const [key, value] of Object.entries(params)) {
+        if (Array.isArray(value)) {
+            value.forEach((entry) => query.append(key, String(entry)));
+        } else if (value !== undefined) {
+            query.append(key, String(value));
+        }
+    }
+    return query.toString();
+};
+
+const getDataAppActivity = async (
+    args: DataAppActivityFilters & { page: number },
+) =>
+    lightdashApi<DataAppActivityResults>({
+        version: 'v1',
+        url: `/ee/org/apps/activity?${createQueryString(args)}`,
+        method: 'GET',
+        body: undefined,
+    });
+
+export const useInfiniteDataAppActivity = (
+    filters: DataAppActivityFilters,
+    infiniteQueryOpts: UseInfiniteQueryOptions<
+        DataAppActivityResults,
+        ApiError
+    > = {},
+) =>
+    useInfiniteQuery<DataAppActivityResults, ApiError>({
+        queryKey: ['data-app-activity', filters],
+        queryFn: ({ pageParam }) =>
+            getDataAppActivity({
+                ...filters,
+                page: (pageParam as number) ?? 1,
+            }),
+        getNextPageParam: (lastPage) => {
+            const { pagination } = lastPage;
+            if (!pagination) return undefined;
+            return pagination.page < pagination.totalPageCount
+                ? pagination.page + 1
+                : undefined;
+        },
+        ...infiniteQueryOpts,
+    });

--- a/packages/frontend/src/features/dataAppActivity/hooks/useDataAppActivityFilters.ts
+++ b/packages/frontend/src/features/dataAppActivity/hooks/useDataAppActivityFilters.ts
@@ -1,0 +1,180 @@
+import {
+    DATA_APP_CLAUDE_MODELS,
+    type DataAppActivityFilters,
+    type DataAppClaudeModel,
+} from '@lightdash/common';
+import { useCallback, useMemo } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+import { validate as isUuid } from 'uuid';
+import useSearchParams from '../../../hooks/useSearchParams';
+
+/**
+ * Relative windows rather than an absolute range: an admin asking "who has been
+ * building lately" wants a period, and it keeps the filter shareable as a URL
+ * without pinning it to the day it was copied.
+ */
+export const DATA_APP_ACTIVITY_PERIODS = ['all', '7d', '30d', '90d'] as const;
+export type DataAppActivityPeriod = (typeof DATA_APP_ACTIVITY_PERIODS)[number];
+
+const PERIOD_DAYS: Record<Exclude<DataAppActivityPeriod, 'all'>, number> = {
+    '7d': 7,
+    '30d': 30,
+    '90d': 90,
+};
+
+const DEFAULT_PERIOD: DataAppActivityPeriod = 'all';
+
+type DataAppActivityFiltersState = {
+    projectUuids: string[];
+    userUuids: string[];
+    models: DataAppClaudeModel[];
+    period: DataAppActivityPeriod;
+};
+
+const isPeriod = (value: string | null): value is DataAppActivityPeriod =>
+    value !== null &&
+    (DATA_APP_ACTIVITY_PERIODS as readonly string[]).includes(value);
+
+const isModel = (value: string): value is DataAppClaudeModel =>
+    (DATA_APP_CLAUDE_MODELS as readonly string[]).includes(value);
+
+/** Data app activity filters, persisted in the URL so a view is shareable. */
+export const useDataAppActivityFilters = () => {
+    const navigate = useNavigate();
+    const { pathname } = useLocation();
+
+    const projectsParam = useSearchParams<string>('projects');
+    const usersParam = useSearchParams<string>('users');
+    const modelsParam = useSearchParams<string>('models');
+    const periodParam = useSearchParams<string>('period');
+
+    // Values that can't match anything (hand-edited URLs) are dropped rather
+    // than sent on, so the filter UI never shows a selection it can't render.
+    const selectedProjectUuids = useMemo(
+        () => projectsParam?.split(',').filter(isUuid) ?? [],
+        [projectsParam],
+    );
+    const selectedUserUuids = useMemo(
+        () => usersParam?.split(',').filter(isUuid) ?? [],
+        [usersParam],
+    );
+    const selectedModels = useMemo(
+        () => modelsParam?.split(',').filter(isModel) ?? [],
+        [modelsParam],
+    );
+    const selectedPeriod: DataAppActivityPeriod = isPeriod(periodParam)
+        ? periodParam
+        : DEFAULT_PERIOD;
+
+    const updateUrl = useCallback(
+        (patch: Partial<DataAppActivityFiltersState>) => {
+            const next: DataAppActivityFiltersState = {
+                projectUuids: selectedProjectUuids,
+                userUuids: selectedUserUuids,
+                models: selectedModels,
+                period: selectedPeriod,
+                ...patch,
+            };
+            const searchParams = new URLSearchParams();
+            if (next.projectUuids.length > 0) {
+                searchParams.set('projects', next.projectUuids.join(','));
+            }
+            if (next.userUuids.length > 0) {
+                searchParams.set('users', next.userUuids.join(','));
+            }
+            if (next.models.length > 0) {
+                searchParams.set('models', next.models.join(','));
+            }
+            if (next.period !== DEFAULT_PERIOD) {
+                searchParams.set('period', next.period);
+            }
+            const search = searchParams.toString();
+            void navigate(
+                { pathname, search: search ? `?${search}` : '' },
+                { replace: true },
+            );
+        },
+        [
+            navigate,
+            pathname,
+            selectedProjectUuids,
+            selectedUserUuids,
+            selectedModels,
+            selectedPeriod,
+        ],
+    );
+
+    const setSelectedProjectUuids = useCallback(
+        (projectUuids: string[]) => updateUrl({ projectUuids }),
+        [updateUrl],
+    );
+    const setSelectedUserUuids = useCallback(
+        (userUuids: string[]) => updateUrl({ userUuids }),
+        [updateUrl],
+    );
+    const setSelectedModels = useCallback(
+        (models: string[]) => updateUrl({ models: models.filter(isModel) }),
+        [updateUrl],
+    );
+    const setSelectedPeriod = useCallback(
+        (period: DataAppActivityPeriod) => updateUrl({ period }),
+        [updateUrl],
+    );
+    const resetFilters = useCallback(
+        () =>
+            updateUrl({
+                projectUuids: [],
+                userUuids: [],
+                models: [],
+                period: DEFAULT_PERIOD,
+            }),
+        [updateUrl],
+    );
+
+    const hasActiveFilters =
+        selectedProjectUuids.length > 0 ||
+        selectedUserUuids.length > 0 ||
+        selectedModels.length > 0 ||
+        selectedPeriod !== DEFAULT_PERIOD;
+
+    // Memoised on the selections, not per render: this object is the react-query
+    // key, and a `dateFrom` that moved every render would refetch forever.
+    const apiFilters = useMemo<DataAppActivityFilters>(() => {
+        const dateFrom =
+            selectedPeriod === 'all'
+                ? undefined
+                : new Date(
+                      Date.now() -
+                          PERIOD_DAYS[selectedPeriod] * 24 * 60 * 60 * 1000,
+                  ).toISOString();
+        return {
+            ...(selectedProjectUuids.length > 0 && {
+                projectUuids: selectedProjectUuids,
+            }),
+            ...(selectedUserUuids.length > 0 && {
+                userUuids: selectedUserUuids,
+            }),
+            ...(selectedModels.length > 0 && { models: selectedModels }),
+            ...(dateFrom && { dateFrom }),
+        };
+    }, [
+        selectedProjectUuids,
+        selectedUserUuids,
+        selectedModels,
+        selectedPeriod,
+    ]);
+
+    return {
+        selectedProjectUuids,
+        selectedUserUuids,
+        selectedModels,
+        selectedPeriod,
+        setSelectedProjectUuids,
+        setSelectedUserUuids,
+        setSelectedModels,
+        setSelectedPeriod,
+        resetFilters,
+        hasActiveFilters,
+        apiFilters,
+    };
+};

--- a/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
@@ -300,6 +300,24 @@ export const useSettingsNavigation = (
                 });
             }
 
+            if (ability?.can('manage', 'Organization')) {
+                dataAppChildren.push({
+                    label: 'Activity',
+                    to: '/generalSettings/dataApps/activity',
+                    icon: IconReportAnalytics,
+                    keywords: [
+                        'usage',
+                        'audit',
+                        'log',
+                        'generations',
+                        'who built',
+                        'tokens',
+                    ],
+                    children: [],
+                    exact: true,
+                });
+            }
+
             if (dataAppChildren.length > 0) {
                 organizationItems.push({
                     label: 'Data apps',

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -85,6 +85,7 @@ import { CustomRoleDuplicate } from '../ee/pages/customRoles/CustomRoleDuplicate
 import { CustomRoleEdit } from '../ee/pages/customRoles/CustomRoleEdit';
 import { CustomRoles } from '../ee/pages/customRoles/CustomRoles';
 import Roadmap from '../ee/pages/Roadmap';
+import { DataAppActivitySettingsPage } from '../features/dataAppActivity/components/DataAppActivitySettingsPage';
 import DesignListPage from '../features/organizationDesigns/components/DesignListPage';
 import { filterSettingsNavigation } from '../hooks/settings/filterSettingsNavigation';
 import { useSettingsContext } from '../hooks/settings/useSettingsContext';
@@ -487,20 +488,40 @@ const Settings: FC = () => {
             });
         }
 
-        if (
-            dataAppsFlag?.enabled &&
-            user?.ability.can('view', 'OrganizationDesign')
-        ) {
-            allowedRoutes.push({
-                path: '/dataApps',
-                element: (
-                    <Navigate to="/generalSettings/dataApps/themes" replace />
-                ),
-            });
-            allowedRoutes.push({
-                path: '/dataApps/themes',
-                element: <DesignListPage />,
-            });
+        if (dataAppsFlag?.enabled) {
+            const canViewThemes =
+                user?.ability.can('view', 'OrganizationDesign') ?? false;
+            const canViewActivity =
+                user?.ability.can('manage', 'Organization') ?? false;
+
+            if (canViewThemes) {
+                allowedRoutes.push({
+                    path: '/dataApps/themes',
+                    element: <DesignListPage />,
+                });
+            }
+            if (canViewActivity) {
+                allowedRoutes.push({
+                    path: '/dataApps/activity',
+                    element: <DataAppActivitySettingsPage />,
+                });
+            }
+            // Land on whichever sub-page the user can actually reach.
+            if (canViewThemes || canViewActivity) {
+                allowedRoutes.push({
+                    path: '/dataApps',
+                    element: (
+                        <Navigate
+                            to={
+                                canViewThemes
+                                    ? '/generalSettings/dataApps/themes'
+                                    : '/generalSettings/dataApps/activity'
+                            }
+                            replace
+                        />
+                    ),
+                });
+            }
         }
 
         if (user?.ability.can('manage', 'Organization')) {
@@ -855,7 +876,14 @@ const Settings: FC = () => {
                 { path: '/generalSettings/ai/issues/:fingerprint' },
                 location.pathname,
             ) &&
-            !matchPath({ path: '/generalSettings/roadmap' }, location.pathname)
+            !matchPath(
+                { path: '/generalSettings/roadmap' },
+                location.pathname,
+            ) &&
+            !matchPath(
+                { path: '/generalSettings/dataApps/activity' },
+                location.pathname,
+            )
         );
     }, [location.pathname]);
 


### PR DESCRIPTION
Third slice of the org-level data-app activity log: the Activity page itself, consuming the API from #26407.

Lives at **Settings → Data apps → Activity**, org admins only. Shows who generated which app, when, with which model, and whether it succeeded — covering new apps, iterations and failed generations.

- Filterable by project, user, model and time window; the selection persists in the URL so a filtered view is shareable.
- App names link through to the app (deleted apps stay plain text — there's nothing to open).
- Infinite scroll, matching the other org-admin activity tables.
- Full width, and reuses the row metrics the sibling admin tables set, so it doesn't introduce a new table look.

The `/dataApps` index redirect now lands on whichever sub-page the user can reach, since Themes and Activity have different permissions.

## One bug worth noting

A failed request rendered as *"No data apps have been generated yet"* — an error showing up as an authoritative "nothing here", which is the wrong answer on an audit log. It now renders an error state.

## Verified against local dev data

23 real generations: Created/Iteration with version numbers, `sonnet`/`opus`, `ready`/`error`, and the one soft-deleted app flagged and unlinked. Filters checked end-to-end through the UI — `models=opus` → 1 row, `models=sonnet` → 22 (the default-model fallback, matching the API-level counts). App links resolve to the app's chat history.

Export and token/cost columns land in the GA slice.

Relates: PROD-9312
Relates: #26197