### PR TITLE
fix(ai): render Markdown in deep research summaries

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.module.css
@@ -10,6 +10,14 @@
     );
 }
 
+.answerPreview {
+    display: -webkit-box;
+    padding-left: 0;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 5;
+}
+
 .liveRegion {
     position: absolute;
     width: 1px;

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.test.tsx
@@ -157,6 +157,53 @@ describe('DeepResearchRunCard', () => {
         ).toBeInTheDocument();
     });
 
+    it('renders the executive answer as Markdown', () => {
+        renderWithProviders(
+            <DeepResearchRunCard
+                run={{
+                    ...deepResearchRunFixture,
+                    status: 'completed',
+                    resultMarkdown: `# Executive summary
+
+This has **important context**, a [source](https://example.com), and \`inline code\`.
+
+- First finding
+- Second finding
+
+## Findings
+
+The full report continues here.`,
+                }}
+                projectUuid="project-1"
+            />,
+        );
+
+        expect(
+            screen.getByRole('heading', { name: 'Executive summary' }),
+        ).toBeInTheDocument();
+        expect(
+            screen
+                .getByText('important context')
+                .closest('[data-streamdown="strong"]'),
+        ).not.toBeNull();
+        expect(screen.getByText('source')).toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: 'source' }),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole('link', { name: 'source' }),
+        ).not.toBeInTheDocument();
+        expect(
+            screen
+                .getByText('inline code')
+                .closest('[data-streamdown="inline-code"]'),
+        ).not.toBeNull();
+        expect(screen.getByRole('list')).toBeInTheDocument();
+        expect(
+            screen.queryByText('The full report continues here.'),
+        ).not.toBeInTheDocument();
+    });
+
     it('offers reconnection and continue-without-source recovery', async () => {
         const user = userEvent.setup();
         const onReconnect = vi.fn();

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
@@ -21,7 +21,15 @@ import {
     IconPlugConnected,
     IconTelescope,
 } from '@tabler/icons-react';
-import { useEffect, useState } from 'react';
+import {
+    useEffect,
+    useState,
+    type AnchorHTMLAttributes,
+    type FC,
+    type ReactNode,
+} from 'react';
+import { type StreamdownProps } from 'streamdown';
+import { AiMarkdown } from '../../../../../components/common/AiMarkdown';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import {
     DEEP_RESEARCH_DEPTH_CONFIG,
@@ -32,6 +40,16 @@ import { type DeepResearchRunView } from '../../deepResearch/types';
 import { useCancelDeepResearchMutation } from '../../hooks/useDeepResearch';
 import { DeepResearchReport } from './DeepResearchReport';
 import styles from './DeepResearchRunCard.module.css';
+
+const PreviewLink: FC<AnchorHTMLAttributes<HTMLAnchorElement>> = ({
+    children,
+}) => <span>{children as ReactNode}</span>;
+
+const PREVIEW_MARKDOWN_COMPONENTS: StreamdownProps['components'] = {
+    a: PreviewLink as unknown as NonNullable<
+        StreamdownProps['components']
+    >['a'],
+};
 
 const STATUS_CONFIG: Record<
     DeepResearchRunView['status'],
@@ -313,13 +331,16 @@ export const DeepResearchRunCard = ({
                                     Executive answer
                                 </Text>
                             </Group>
-                            <Text size="sm" lineClamp={5}>
-                                {run.resultMarkdown
-                                    ? getDeepResearchReportPreview(
-                                          run.resultMarkdown,
-                                      )
-                                    : null}
-                            </Text>
+                            {run.resultMarkdown && (
+                                <AiMarkdown
+                                    className={styles.answerPreview}
+                                    components={PREVIEW_MARKDOWN_COMPONENTS}
+                                >
+                                    {getDeepResearchReportPreview(
+                                        run.resultMarkdown,
+                                    )}
+                                </AiMarkdown>
+                            )}
                             <Button
                                 variant="light"
                                 size="xs"

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/runProgress.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/runProgress.ts
@@ -146,14 +146,9 @@ export const toDeepResearchRegistration = (
     state: 'started',
 });
 
-/** Plain-text intro of the report markdown, for compact previews. */
+/** Intro of the report markdown, before the detailed report sections. */
 export const getDeepResearchReportPreview = (markdown: string): string =>
-    markdown
-        .split(/^## /m)[0]
-        .replace(/^(`{3,}|~{3,})[\s\S]*?(\1|$)/gm, ' ')
-        .replace(/<[^>]+>/g, ' ')
-        .replace(/\s+/g, ' ')
-        .trim();
+    markdown.split(/^## /m)[0].trim();
 
 export const adaptDeepResearchRun = ({
     run,


### PR DESCRIPTION
Closes: PROD-9293

## Summary

Completed deep-research cards now render executive answers with the same shared Markdown renderer as regular AI responses. The change is limited to the compact card preview.

## Root cause

The preview helper collapsed the report introduction into plain text before Mantine `Text` rendered it, so block structure disappeared and Markdown markers remained visible.

```ts
.replace(/\s+/g, ' ')
```

The full report already used `AiMarkdown`, but the card bypassed that shared render boundary.

## Fix

- Preserve Markdown in the executive introduction while still excluding detailed `##` report sections.
- Render the card preview through shared `AiMarkdown` and retain the existing five-line clamp.
- Keep preview links non-interactive so clamped content cannot create hidden keyboard stops; “Open full report” remains the card action.
- Add regression coverage for headings, emphasis, linked text, inline code, lists, and report-section exclusion.

## Before

- Heading: `# Executive summary`
- Emphasis: `**important context**`
- List: `- First finding`

Markdown syntax appeared as literal card text.

## After

- Heading: semantic heading
- Emphasis: styled strong text
- List: semantic list

The executive answer uses the regular AI Markdown pipeline.

## Test plan

- [x] `pnpm -F frontend test src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.test.tsx` — 11 tests pass.
- [x] `pnpm -F frontend test` — 1,665 tests pass.
- [x] `pnpm -F frontend typecheck`
- [x] `pnpm -F frontend lint` — 0 errors.
- [x] `git diff --check`
