### PR TITLE
fix(frontend): open the guided setup operator menu instantly

### DIFF
--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/OperatorPicker.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/OperatorPicker.tsx
@@ -50,6 +50,7 @@ const OperatorPicker: FC<Props> = ({
             withinPortal
             position="bottom-start"
             shadow="md"
+            transitionProps={{ duration: 0 }}
             onOpen={onOpen}
             onClose={onClose}
         >


### PR DESCRIPTION
## Problem

`Build & Test` fails intermittently on unrelated PRs with every frontend test passing:

```
Test Files  211 passed (211)
     Tests  1668 passed (1668)
    Errors  1 error

ReferenceError: window is not defined
 ❯ resolveUpdatePriority   react-dom-client.development.js:1308
 ❯ dispatchSetState        react-dom-client.development.js:9126
 ❯ Timeout._onTimeout      @mantine/core/.../Transition/use-transition.mjs:55
This error originated in "src/features/dashboardFilters/FilterRequirements/GuidedFilterSetupOverlay.test.tsx"
```

`GuidedFilterSetupOverlay.test.tsx` opens the operator menu three times. Each open/close schedules a 150ms Mantine transition timer. Normally unmount clears them, but on a loaded runner one can still be pending when vitest tears down that file's jsdom, and its `setStatus` then runs with no `window` — an unhandled error that fails the job even though no test failed.

## Fix

Give the operator menu `transitionProps={{ duration: 0 }}`. Mantine's `useTransition` takes a fully synchronous path at duration 0 (no rAF, no timeout), so nothing can survive teardown. The overlay's modal already opens with `duration: 0`, so the dropdown now matches it.

`OperatorPicker` is only used by `GuidedFilterSetup`, so the only behaviour change is that dropdown losing its 150ms fade.

## Verification

Instrumented `window.setTimeout` in a copy of the test file to record scheduled timers:

- before: 3 timers from `use-transition` (150ms each)
- after: 0

Tests: `src/features/dashboardFilters/FilterRequirements` 52 passed; full frontend suite shows no new failures against a main baseline.

Note: the crash itself only reproduces under CI load, so this is verified by the timers no longer existing rather than by a red-to-green run.
