### PR TITLE
fix(navbar): attach the user credentials switcher to the project switcher

### DIFF
--- a/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
+++ b/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
@@ -95,9 +95,10 @@ export const MainNavBarContent: FC<Props> = ({
                         )}
 
                     <ProjectSwitcher />
+
+                    <UserCredentialsSwitcher />
                 </Button.Group>
 
-                <UserCredentialsSwitcher />
                 <UserMenu />
             </Group>
         </>

--- a/packages/frontend/src/components/NavBar/UserCredentialsSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/UserCredentialsSwitcher.tsx
@@ -186,7 +186,10 @@ const UserCredentialsSwitcher = () => {
                         variant="default"
                         size="xs"
                     >
-                        <MantineIcon icon={IconDatabaseCog} />
+                        <MantineIcon
+                            icon={IconDatabaseCog}
+                            color="light-dark(var(--mantine-color-blue-6), var(--mantine-color-blue-4))"
+                        />
                     </Button>
                 </Menu.Target>
 

--- a/packages/frontend/src/components/NavBar/UserCredentialsSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/UserCredentialsSwitcher.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, getDefaultZIndex, Menu, Text } from '@mantine-8/core';
+import { Button, getDefaultZIndex, Menu, Text } from '@mantine-8/core';
 import { IconCheck, IconDatabaseCog, IconPlus } from '@tabler/icons-react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useMemo, useState } from 'react';
@@ -181,12 +181,13 @@ const UserCredentialsSwitcher = () => {
                 portalProps={{ target: '#navbar-header' }}
             >
                 <Menu.Target>
-                    <ActionIcon size="sm" pos="relative">
-                        <MantineIcon
-                            data-testid="tile-icon-more"
-                            icon={IconDatabaseCog}
-                        />
-                    </ActionIcon>
+                    <Button
+                        aria-label="Warehouse credentials"
+                        variant="default"
+                        size="xs"
+                    >
+                        <MantineIcon icon={IconDatabaseCog} />
+                    </Button>
                 </Menu.Target>
 
                 <Menu.Dropdown>


### PR DESCRIPTION
## Summary

The navbar user-credentials switcher (the database icon) only renders when the active project has "Require users to provide their own credentials" enabled — it is a project-scoped control, but it floated on its own between the navbar button group and the user menu, visually belonging to neither.

This moves it inside the `Button.Group`, immediately after the project switcher, and swaps its `ActionIcon` target for the same `Button variant="default" size="xs"` markup its siblings use, so it renders attached with consistent styling and gains an `aria-label`.


The icon is also tinted blue to give the control an active accent: `blue.6` in light mode, `blue.4` in dark mode (via a `light-dark()` value passed through `MantineIcon`).

No behavioural changes — same menu, same conditional rendering (group simply ends at the project switcher when the flag is off).

## Testing

- Verified in the live dev app against a BigQuery project with `requireUserCredentials` enabled: icon renders attached after the project switcher, menu opens and switches credentials as before.
- `pnpm -F frontend typecheck` and oxlint on the changed files pass.

Relates: PROD-9317
Relates: #26408

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AaFq2pb3w4SHfBEqdXzHKx

