### PR TITLE
feat(data-apps): load sandbox skills by name instead of by file path

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/templates.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/templates.ts
@@ -34,13 +34,12 @@ Build a print-optimized report:
 // The viz build contract (the hook, the declaration, the option vocabulary, the
 // final pass) lives in the sandbox's `reusable-visualization` skill, so it sits alongside
 // the app-focused sandbox skill it overrides instead of competing with it from
-// the user prompt. This prompt only orients the request and loads that skill by
-// path — `Read(//app/**)` is allowlisted for every generation, so reading it
-// does not depend on the Skill tool being permitted.
+// the user prompt. This prompt only orients the request and names that skill —
+// naming it is enough for the agent to load it through the skill mechanism.
 const DATA_APP_VIZ_INSTRUCTIONS = `[Data app viz]
 You are building ONE reusable chart component. You do NOT fetch data or run queries: Lightdash runs the query, then gives you the result rows plus a mapping from your field names to the columns in those rows. The same component is reused across many different queries, so never hardcode column names — just render whatever data you are handed.
 
-Before you write any code, read \`/app/.claude/skills/reusable-visualization/SKILL.md\` with the Read tool — the \`reusable-visualization\` skill. It is the contract for this build: the \`useVizContext()\` hook you take your data and settings from, the fields and config options you declare as structured output, the exact option vocabulary, the palette rule, and the final pass you run before you finish. Where it and the sandbox skill disagree, it wins. Follow it as written.
+Before you write any code, use the \`reusable-visualization\` skill. It is the contract for this build: the \`useVizContext()\` hook you take your data and settings from, the fields and config options you declare as structured output, the exact option vocabulary, the palette rule, and the final pass you run before you finish. Where it and the sandbox skill disagree, it wins. Follow it as written.
 
 Build the chart type the user asked for; only if they did not name one, pick what best fits the fields (bars to compare categories, a line for a trend over time).
 

--- a/sandboxes/data-apps/template/skill.md
+++ b/sandboxes/data-apps/template/skill.md
@@ -2,7 +2,7 @@
 
 You are building a React data app that queries the Lightdash semantic layer. This file is your reference for the environment, SDK, and data model.
 
-**Building a single reusable chart rather than an app?** Read `.claude/skills/reusable-visualization/SKILL.md` before writing any code. A reusable visualization runs no query of its own — the host hands it rows, a field mapping, config option values and a colour palette — so the data and filter APIs below do not apply to it. That skill is the contract for those builds and overrides this guide wherever the two differ. Everything else here (environment, components, visual design) still applies.
+**Building a single reusable chart rather than an app?** Use the `reusable-visualization` skill before writing any code. A reusable visualization runs no query of its own — the host hands it rows, a field mapping, config option values and a colour palette — so the data and filter APIs below do not apply to it. That skill is the contract for those builds and overrides this guide wherever the two differ. Everything else here (environment, components, visual design) still applies.
 
 ## Iteration mindset
 
@@ -653,7 +653,7 @@ For any external HTTP API call, read `/app/references/external-apis.md` and use 
 
 ## Visual Design
 
-**Invoke the `frontend-design` skill before writing any UI code** (auto-loaded from `.claude/skills/frontend-design/`). It drives the aesthetic direction — pick a distinctive look for *this* app rather than defaulting to generic shadcn-on-dark-mode. This guide does not prescribe layout, typography, color, or composition; that's `frontend-design`'s job.
+**Use the `frontend-design` skill before writing any UI code.** It drives the aesthetic direction — pick a distinctive look for *this* app rather than defaulting to generic shadcn-on-dark-mode. This guide does not prescribe layout, typography, color, or composition; that's `frontend-design`'s job.
 
 Lightdash-specific constraints that apply on top of `frontend-design`'s direction:
 


### PR DESCRIPTION
Sandbox instructions pointed at skills by file path (`Read /app/.claude/skills/reusable-visualization/SKILL.md`) on the assumption that the `Skill` tool isn't available to the generation agent. It is. Every skill baked into the image is auto-discovered by the CLI, so naming a skill is enough — no path, no explicit "use the Skill tool".

The path form actively bypassed the skill mechanism: the viz template read the markdown as a plain file and never activated the skill.

## Changes

- `templates.ts` — `DATA_APP_VIZ_INSTRUCTIONS` names `reusable-visualization` instead of reading its `SKILL.md` path.
- `skill.md` — same for the viz pointer at the top; dropped the `(auto-loaded from .claude/skills/frontend-design/)` path hint from the Visual Design section.
- Updated the stale comment in `templates.ts` claiming the Skill tool may not be permitted.

Prompt text only. No behaviour change in code paths, no schema or API change.

## Measurement

Instrumented with the existing `DATA_APP_OTEL_*` support: the `claude` CLI in the sandbox exports OTLP to a local collector, so each build is one trace (`worker.task.appGeneratePipeline` → `DataApp.generate` → `claude_code.interaction` + a span per tool call and LLM request).

12 real generations through `POST /api/v1/ee/projects/{uuid}/apps`, 3 per template per arm, same prompts, same model (`sonnet`, effort `low`), sandbox image rebuilt for each arm so `skill.md` matched. Sole worker on the queue for both arms.

### Skill activation

| Template | Arm | Skill invoked | `SKILL.md` read by path | Built OK |
| --- | --- | --- | --- | --- |
| `data_app_viz` | before | **0 / 3** | 3 / 3 | 3 / 3 |
| `data_app_viz` | after | **3 / 3** | 0 / 3 | 3 / 3 |
| `dashboard` | before | 3 / 3 | 0 / 3 | 3 / 3 |
| `dashboard` | after | 3 / 3 | 0 / 3 | 3 / 3 |

The viz template is what this fixes. `dashboard` already invoked `frontend-design` properly — it's unchanged, and the run confirms removing the path hint doesn't regress it.

In the after arm `Skill` is the **first** tool call in 5 of 6 runs (the sixth read the catalog first).

Representative viz sequences:

```
before:  Read(SKILL.md) → Bash → Write → Edit → Edit → Write → Edit → StructuredOutput
after:   Skill → Glob → Read → Write → Edit → Edit → Write → StructuredOutput
```

### Cost and latency (median of 3)

| Template | Metric | Before | After |
| --- | --- | --- | --- |
| `data_app_viz` | wall clock | 41s | 37s |
| `data_app_viz` | output tokens | 3,779 | 3,114 |
| `dashboard` | wall clock | 92s | 87s |
| `dashboard` | output tokens | 9,762 | 8,561 |

Both directions favour the change, but n=3 — treat as "no regression", not as a speedup claim.

### Output quality

All 12 builds reached `ready`. Viz declarations were equivalent: 2 fields in every run; config options 5/5/7 before vs 4/5/4 after. The slightly lower option count in the after arm is within noise at this sample size but is the one number that didn't move in our favour — worth a second look if viz option richness matters.

## Rollout note

`skill.md` is baked into the sandbox image, so the wording change only reaches generations once the template is rebuilt — the release workflow already rebuilds when `sandboxes/data-apps/` changes.

## Follow-up (not in this PR)

`--allowedTools` in `AppGenerateService` doesn't list `Skill`; it works because Claude Code auto-approves it alongside `ToolSearch` and safe read-only `Bash`. The lockdown still holds (verified: `WebFetch`, writes outside `/app/src`, reads outside the allowlisted globs, `curl` and `npm install` are all denied). But now that the contract depends on `Skill`, adding it to `--allowedTools` explicitly would stop a future CLI change from silently regressing this.
