### PR TITLE
feat: show a clear not-set-up state when the org roadmap is unavailable

### DIFF
--- a/packages/backend/src/ee/services/RoadmapService/RoadmapService.test.ts
+++ b/packages/backend/src/ee/services/RoadmapService/RoadmapService.test.ts
@@ -154,9 +154,18 @@ describe('RoadmapService', () => {
         expect(fetchMock).not.toHaveBeenCalled();
     });
 
-    it('maps roadmap service errors to a stable server error', async () => {
+    it('maps a roadmap service auth denial to Forbidden (org not bound)', async () => {
         const account = buildAccount(viewRoadmapAbility(sessionOrgUuid));
         fetchMock.mockResolvedValue(new Response('denied', { status: 403 }));
+
+        await expect(buildService().getRoadmap(account)).rejects.toThrow(
+            ForbiddenError,
+        );
+    });
+
+    it('maps other roadmap service errors to a stable server error', async () => {
+        const account = buildAccount(viewRoadmapAbility(sessionOrgUuid));
+        fetchMock.mockResolvedValue(new Response('boom', { status: 500 }));
 
         await expect(buildService().getRoadmap(account)).rejects.toThrow(
             UnexpectedServerError,

--- a/packages/backend/src/ee/services/RoadmapService/RoadmapService.ts
+++ b/packages/backend/src/ee/services/RoadmapService/RoadmapService.ts
@@ -119,6 +119,17 @@ export class RoadmapService extends BaseService {
             );
         }
 
+        // 401/403 means the instance license is not bound to this org in the
+        // roadmap service — a provisioning state, not a transient failure.
+        if (response.status === 401 || response.status === 403) {
+            this.logger.warn('Roadmap service denied the request', {
+                statusCode: response.status,
+            });
+            throw new ForbiddenError(
+                'The organization roadmap is not available',
+            );
+        }
+
         if (!response.ok) {
             this.logger.warn('Roadmap service returned an error', {
                 statusCode: response.status,

--- a/packages/frontend/src/ee/pages/Roadmap.tsx
+++ b/packages/frontend/src/ee/pages/Roadmap.tsx
@@ -487,12 +487,31 @@ const RoadmapState: FC<{
     items: RoadmapItem[];
     isLoading: boolean;
     isError: boolean;
+    isUnavailable: boolean;
     hasActiveFilters: boolean;
     onRetry: () => void;
     children: ReactNode;
-}> = ({ items, isLoading, isError, hasActiveFilters, onRetry, children }) => {
+}> = ({
+    items,
+    isLoading,
+    isError,
+    isUnavailable,
+    hasActiveFilters,
+    onRetry,
+    children,
+}) => {
     if (isLoading) {
         return <EmptyStateLoader title="Loading your roadmap" />;
+    }
+
+    if (isUnavailable) {
+        return (
+            <SuboptimalState
+                icon={IconRoad}
+                title="Your roadmap isn't set up yet"
+                description="Your organization's roadmap hasn't been enabled. Reach out to your Lightdash contact to get it switched on."
+            />
+        );
     }
 
     if (isError) {
@@ -533,6 +552,7 @@ type RoadmapContentProps = {
     items: RoadmapItem[];
     isLoading: boolean;
     isError: boolean;
+    isUnavailable: boolean;
     hasActiveFilters?: boolean;
     onRetry: () => void;
 };
@@ -548,6 +568,7 @@ const RoadmapKanban: FC<RoadmapKanbanProps> = ({
     visibleStatuses,
     isLoading,
     isError,
+    isUnavailable,
     hasActiveFilters = false,
     onRetry,
 }) => {
@@ -575,6 +596,7 @@ const RoadmapKanban: FC<RoadmapKanbanProps> = ({
             items={items}
             isLoading={isLoading}
             isError={isError}
+            isUnavailable={isUnavailable}
             hasActiveFilters={hasActiveFilters}
             onRetry={onRetry}
         >
@@ -618,6 +640,7 @@ const RoadmapTable: FC<RoadmapTableProps> = ({
     pagination,
     isLoading,
     isError,
+    isUnavailable,
     hasActiveFilters = false,
     onRetry,
     onPageChange,
@@ -762,6 +785,7 @@ const RoadmapTable: FC<RoadmapTableProps> = ({
             items={items}
             isLoading={isLoading}
             isError={isError}
+            isUnavailable={isUnavailable}
             hasActiveFilters={hasActiveFilters}
             onRetry={onRetry}
         >
@@ -848,6 +872,7 @@ const Roadmap: FC = () => {
         },
     ]);
     const roadmapQuery = useAllOrgRoadmap();
+    const isRoadmapUnavailable = roadmapQuery.error?.error?.statusCode === 403;
     const allItems = roadmapQuery.data?.data ?? EMPTY_ROADMAP_ITEMS;
     const boardItems = useMemo(
         () =>
@@ -969,6 +994,7 @@ const Roadmap: FC = () => {
                         visibleStatuses={statuses}
                         isLoading={roadmapQuery.isInitialLoading}
                         isError={roadmapQuery.isError}
+                        isUnavailable={isRoadmapUnavailable}
                         hasActiveFilters={hasActiveFilters}
                         onRetry={() => void roadmapQuery.refetch()}
                     />
@@ -983,6 +1009,7 @@ const Roadmap: FC = () => {
                         }}
                         isLoading={roadmapQuery.isInitialLoading}
                         isError={roadmapQuery.isError}
+                        isUnavailable={isRoadmapUnavailable}
                         hasActiveFilters={hasActiveFilters}
                         onRetry={() => void roadmapQuery.refetch()}
                         onPageChange={setPage}


### PR DESCRIPTION
## Summary

An org whose instance license is not bound to it in the central roadmap service currently sees "Could not load your roadmap / Try again" — a transient-looking error for a state that retrying can never fix (observed on a real instance). This distinguishes the two cases:

- **Backend**: `RoadmapService` now maps upstream 401/403 (license not bound to the org — a provisioning state) to `ForbiddenError('The organization roadmap is not available')` instead of a generic 500. Other upstream failures still map to `UnexpectedServerError`.
- **Frontend**: the Roadmap page distinguishes a 403 from transient errors and renders a calm "Your roadmap isn't set up yet" empty state with guidance to contact Lightdash — no retry button. Transient errors keep the existing "Try again" state.

## Testing

- Unit: upstream 403 → `ForbiddenError`, upstream 500 → `UnexpectedServerError` (RoadmapService.test.ts, 7 passing).
- Live: registered a fresh org on a local EE instance (unbound in the central service) — API returns 403 with the stable message, page shows the new state; a bound org still loads its roadmap (verified against the production roadmap service, recording available).

Closes: CS-19

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AudGgVyb7S2cjVN9DnyjHZ