### PR TITLE
feat(ai-memory): fan out consolidation into per-partition child jobs

### DIFF
--- a/packages/backend/src/ee/scheduler/SchedulerClient.test.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerClient.test.ts
@@ -76,3 +76,32 @@ describe('CommercialSchedulerClient.aiAgentMemoryDistill', () => {
         );
     });
 });
+
+describe('CommercialSchedulerClient.aiAgentMemoryConsolidatePartition', () => {
+    it('enqueues one keyed attempt per partition on the project queue', async () => {
+        const addJob = vi.fn().mockResolvedValue({ id: 'job-1' });
+        const client = Object.create(
+            CommercialSchedulerClient.prototype,
+        ) as CommercialSchedulerClient;
+        client.graphileUtils = Promise.resolve({ addJob } as AnyType);
+        const payload = {
+            organizationUuid: 'org-1',
+            projectUuid: 'project-1',
+            userUuid: 'system',
+            ownerUserUuid: 'owner-1',
+        };
+
+        await client.aiAgentMemoryConsolidatePartition(payload);
+
+        expect(addJob).toHaveBeenCalledWith(
+            EE_SCHEDULER_TASKS.CONSOLIDATE_AI_AGENT_MEMORY_PARTITION,
+            payload,
+            expect.objectContaining({
+                maxAttempts: 1,
+                jobKey: 'ai-agent-memory-consolidate:project-1:owner-1',
+                queueName: 'ai-agent-memory-consolidate:project-1',
+                priority: JobPriority.LOW,
+            }),
+        );
+    });
+});

--- a/packages/backend/src/ee/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerClient.ts
@@ -2,6 +2,7 @@ import {
     AgentOnboardingPipelineJobPayload,
     AiAgentEditDbtProjectPipelineJobPayload,
     AiAgentEvalRunJobPayload,
+    AiAgentMemoryConsolidatePartitionJobPayload,
     AiAgentMemoryDistillJobPayload,
     AiAgentReviewClassifierJobPayload,
     AiAgentReviewRemediationCompileJobPayload,
@@ -51,6 +52,24 @@ export class CommercialSchedulerClient extends SchedulerClient {
                 maxAttempts: 1,
                 jobKey: `ai-agent-memory-distill:${payload.threadUuid}`,
                 queueName: `ai-agent-memory-distill:${payload.projectUuid}`,
+                priority: JobPriority.LOW,
+            },
+        );
+        return { jobId };
+    }
+
+    async aiAgentMemoryConsolidatePartition(
+        payload: AiAgentMemoryConsolidatePartitionJobPayload,
+    ) {
+        const graphileClient = await this.graphileUtils;
+        const { id: jobId } = await graphileClient.addJob(
+            EE_SCHEDULER_TASKS.CONSOLIDATE_AI_AGENT_MEMORY_PARTITION,
+            payload,
+            {
+                runAt: new Date(),
+                maxAttempts: 1,
+                jobKey: `ai-agent-memory-consolidate:${payload.projectUuid}:${payload.ownerUserUuid}`,
+                queueName: `ai-agent-memory-consolidate:${payload.projectUuid}`,
                 priority: JobPriority.LOW,
             },
         );

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -41,6 +41,8 @@ const AI_AGENT_REVIEW_WRITEBACK_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 const AI_AGENT_MEMORY_LLM_TIMEOUT_MS = 4 * 60 * 1000; // 4 minutes
 const AI_AGENT_MEMORY_DISTILL_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 const AI_AGENT_MEMORY_SWEEP_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+// Two curator attempts at the per-call ceiling, plus reads and the apply.
+const AI_AGENT_MEMORY_CONSOLIDATE_LLM_TIMEOUT_MS = 25 * 60 * 1000; // 25 minutes
 const AI_AGENT_MEMORY_CONSOLIDATE_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 const APP_GENERATE_TIMEOUT_MS = 60 * 60 * 1000; // 60 minutes
 const AI_WRITEBACK_TIMEOUT_MS = 30 * 60 * 1000;
@@ -712,16 +714,40 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                 payload,
                 helpers,
             ) => {
+                await tryJobOrTimeout(
+                    SchedulerClient.processJob(
+                        EE_SCHEDULER_TASKS.CONSOLIDATE_AI_AGENT_MEMORIES,
+                        helpers.job.id,
+                        helpers.job.run_at,
+                        payload,
+                        async () => {
+                            await this.aiAgentMemoryService.sweepConsolidationPartitions();
+                        },
+                    ),
+                    helpers.job,
+                    AI_AGENT_MEMORY_SWEEP_TIMEOUT_MS,
+                );
+            },
+            [EE_SCHEDULER_TASKS.CONSOLIDATE_AI_AGENT_MEMORY_PARTITION]: async (
+                payload,
+                helpers,
+            ) => {
                 const controller = new AbortController();
+                const abortSignal = AbortSignal.any([
+                    controller.signal,
+                    AbortSignal.timeout(
+                        AI_AGENT_MEMORY_CONSOLIDATE_LLM_TIMEOUT_MS,
+                    ),
+                ]);
                 const consolidatePromise = SchedulerClient.processJob(
-                    EE_SCHEDULER_TASKS.CONSOLIDATE_AI_AGENT_MEMORIES,
+                    EE_SCHEDULER_TASKS.CONSOLIDATE_AI_AGENT_MEMORY_PARTITION,
                     helpers.job.id,
                     helpers.job.run_at,
                     payload,
                     async () => {
-                        await this.aiAgentMemoryService.consolidate(
-                            new Date(),
-                            controller.signal,
+                        await this.aiAgentMemoryService.consolidateScheduledPartition(
+                            payload,
+                            abortSignal,
                         );
                     },
                 );

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryConsolidation.integration.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryConsolidation.integration.test.ts
@@ -201,7 +201,16 @@ describe('AI agent memory consolidation integration', () => {
         return rows.map((row) => row.slug);
     };
 
-    const buildService = (consolidateCall: AiAgentMemoryConsolidateCall) =>
+    /** Observes sweep enqueues without inserting real graphile jobs. */
+    const stubSchedulerClient = () => ({
+        aiAgentMemoryDistill: vi.fn(async () => ({})),
+        aiAgentMemoryConsolidatePartition: vi.fn(async () => ({})),
+    });
+
+    const buildService = (
+        consolidateCall: AiAgentMemoryConsolidateCall,
+        schedulerClientOverride?: ReturnType<typeof stubSchedulerClient>,
+    ) =>
         new AiAgentMemoryService({
             analytics,
             aiAgentMemoryModel: model,
@@ -209,9 +218,17 @@ describe('AI agent memory consolidation integration', () => {
             groupsModel: getTestContext().app.getModels().getGroupsModel(),
             projectModel: getTestContext().app.getModels().getProjectModel(),
             featureFlagService,
-            schedulerClient,
+            schedulerClient: schedulerClientOverride ?? schedulerClient,
             consolidateCall,
         });
+
+    /** The payload the sweep enqueues for one seeded partition. */
+    const partitionPayload = (ownerUserUuid: string) => ({
+        organizationUuid: SEED_ORG_1.organization_uuid,
+        projectUuid: SEED_PROJECT.project_uuid,
+        userUuid: 'system',
+        ownerUserUuid,
+    });
 
     const cannedCall = (operations: AiAgentMemoryConsolidationOperation[]) =>
         vi.fn().mockResolvedValue({ operations });
@@ -256,7 +273,9 @@ describe('AI agent memory consolidation integration', () => {
             ]),
         );
 
-        await service.consolidate();
+        await service.consolidateScheduledPartition(
+            partitionPayload(ownerUuid),
+        );
 
         const loser = await memoryBySlug(slugs[0]!);
         expect(loser).toMatchObject({
@@ -321,7 +340,9 @@ describe('AI agent memory consolidation integration', () => {
             ]),
         );
 
-        await service.consolidate();
+        await service.consolidateScheduledPartition(
+            partitionPayload(ownerUuid),
+        );
 
         const [run] = await runsForOwner(ownerUuid);
         expect(run).toMatchObject({
@@ -370,7 +391,9 @@ describe('AI agent memory consolidation integration', () => {
             ]),
         );
 
-        await service.consolidate();
+        await service.consolidateScheduledPartition(
+            partitionPayload(ownerUuid),
+        );
 
         const [run] = await runsForOwner(ownerUuid);
         expect(run).toMatchObject({ applied_count: 0, rejected_count: 2 });
@@ -420,7 +443,9 @@ describe('AI agent memory consolidation integration', () => {
             };
         });
 
-        await service.consolidate();
+        await service.consolidateScheduledPartition(
+            partitionPayload(ownerUuid),
+        );
 
         const [run] = await runsForOwner(ownerUuid);
         expect(run).toMatchObject({
@@ -478,7 +503,9 @@ describe('AI agent memory consolidation integration', () => {
                 ]),
             );
 
-            await service.consolidate();
+            await service.consolidateScheduledPartition(
+                partitionPayload(ownerUuid),
+            );
         } finally {
             await database.raw(
                 `DROP TRIGGER IF EXISTS consolidation_test_trip ON ${AiAgentMemoryTableName}`,
@@ -561,10 +588,14 @@ describe('AI agent memory consolidation integration', () => {
             prefix: 'skip',
         });
         const first = cannedCall([]);
-        await buildService(first).consolidate();
+        await buildService(first).consolidateScheduledPartition(
+            partitionPayload(ownerUuid),
+        );
 
         const second = cannedCall([]);
-        await buildService(second).consolidate();
+        await buildService(second).consolidateScheduledPartition(
+            partitionPayload(ownerUuid),
+        );
 
         expect(first).toHaveBeenCalledOnce();
         expect(second).not.toHaveBeenCalled();
@@ -578,10 +609,14 @@ describe('AI agent memory consolidation integration', () => {
             prefix: 'failskip',
         });
         const failing = vi.fn().mockRejectedValue(new Error('model exploded'));
-        await buildService(failing).consolidate();
+        await buildService(failing).consolidateScheduledPartition(
+            partitionPayload(ownerUuid),
+        );
 
         const afterFailure = cannedCall([]);
-        await buildService(afterFailure).consolidate();
+        await buildService(afterFailure).consolidateScheduledPartition(
+            partitionPayload(ownerUuid),
+        );
         expect(afterFailure).not.toHaveBeenCalled();
 
         await seedPartition({
@@ -590,7 +625,9 @@ describe('AI agent memory consolidation integration', () => {
             prefix: 'failskip-new',
         });
         const afterChange = cannedCall([]);
-        await buildService(afterChange).consolidate();
+        await buildService(afterChange).consolidateScheduledPartition(
+            partitionPayload(ownerUuid),
+        );
 
         expect(afterChange).toHaveBeenCalledOnce();
         const runs = await runsForOwner(ownerUuid);
@@ -604,12 +641,44 @@ describe('AI agent memory consolidation integration', () => {
             count: FLOOR - 1,
             prefix: 'floor',
         });
+        const enqueue = stubSchedulerClient();
         const call = cannedCall([]);
+        const service = buildService(call, enqueue);
 
-        await buildService(call).consolidate();
+        // The sweep never enqueues a below-floor partition...
+        await service.sweepConsolidationPartitions();
+        expect(
+            enqueue.aiAgentMemoryConsolidatePartition,
+        ).not.toHaveBeenCalledWith(partitionPayload(otherOwnerUuid));
+
+        // ...and a stale job for one is a quiet skip on the recheck.
+        await expect(
+            service.consolidateScheduledPartition(
+                partitionPayload(otherOwnerUuid),
+            ),
+        ).resolves.toBe('skipped');
 
         expect(call).not.toHaveBeenCalled();
         expect(await runsForOwner(otherOwnerUuid)).toHaveLength(0);
+    });
+
+    it('sweep enqueues one keyed job per eligible partition', async () => {
+        await seedPartition({
+            userUuid: ownerUuid,
+            count: FLOOR,
+            prefix: 'sweep',
+        });
+        const enqueue = stubSchedulerClient();
+
+        const enqueued = await buildService(
+            cannedCall([]),
+            enqueue,
+        ).sweepConsolidationPartitions();
+
+        expect(enqueued).toBeGreaterThanOrEqual(1);
+        expect(enqueue.aiAgentMemoryConsolidatePartition).toHaveBeenCalledWith(
+            partitionPayload(ownerUuid),
+        );
     });
 
     it('never selects an owner-null row and never lets an operation cross owners', async () => {
@@ -642,7 +711,9 @@ describe('AI agent memory consolidation integration', () => {
             },
         ]);
 
-        await buildService(call).consolidate();
+        await buildService(call).consolidateScheduledPartition(
+            partitionPayload(ownerUuid),
+        );
 
         const [{ input }] = call.mock.calls[0] as [
             { input: Array<{ id: string }> },
@@ -688,7 +759,9 @@ describe('AI agent memory consolidation integration', () => {
             });
         const call = cannedCall([]);
 
-        await buildService(call).consolidate();
+        await buildService(call).consolidateScheduledPartition(
+            partitionPayload(ownerUuid),
+        );
 
         const [{ input }] = call.mock.calls[0] as [
             {
@@ -719,9 +792,20 @@ describe('AI agent memory consolidation integration', () => {
             prefix: 'flagoff',
         });
         await setFeatureFlag(FeatureFlags.AiAgentMemory, false);
+        const enqueue = stubSchedulerClient();
         const call = cannedCall([]);
+        const service = buildService(call, enqueue);
 
-        await buildService(call).consolidate();
+        // The sweep filters the organization out...
+        await service.sweepConsolidationPartitions();
+        expect(
+            enqueue.aiAgentMemoryConsolidatePartition,
+        ).not.toHaveBeenCalledWith(partitionPayload(ownerUuid));
+
+        // ...and a job enqueued before the flag flipped skips on the recheck.
+        await expect(
+            service.consolidateScheduledPartition(partitionPayload(ownerUuid)),
+        ).resolves.toBe('skipped');
 
         expect(call).not.toHaveBeenCalled();
         expect(await runsForOwner(ownerUuid)).toHaveLength(0);
@@ -772,7 +856,7 @@ describe('AI agent memory consolidation integration', () => {
                     reason: 'Its explore no longer resolves.',
                 },
             ]),
-        ).consolidate();
+        ).consolidateScheduledPartition(partitionPayload(ownerUuid));
 
         const afterOwner = await renderFor(ownerUuid);
         expect(afterOwner.slugs).not.toContain(slugs[0]);

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.consolidateLlm.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.consolidateLlm.test.ts
@@ -51,26 +51,18 @@ const build = () => {
     const service = new AiAgentMemoryService({
         analytics: { track: vi.fn() } as AnyType,
         aiAgentMemoryModel: {
-            findConsolidationCandidates: vi.fn().mockResolvedValue([
-                {
-                    organizationUuid: 'org-enabled',
-                    projectUuid: 'project-enabled',
-                    ownerUserUuid: 'owner-1',
-                    activeCount: 30,
-                },
-            ]),
-            findActiveForProject: vi.fn().mockResolvedValue([
-                {
-                    ai_agent_memory_uuid: 'memory-1',
-                    slug: 'net-revenue-ab12cd34',
+            findActiveForProject: vi.fn().mockResolvedValue(
+                Array.from({ length: 30 }, (_, index) => ({
+                    ai_agent_memory_uuid: `memory-${index}`,
+                    slug: `net-revenue-${index}`,
                     title: 'Net revenue convention',
                     raw_memory: 'Use net revenue.',
                     terms: [],
                     objects: [],
                     scope: 'user',
                     generated_at: new Date('2026-07-20T10:00:00Z'),
-                },
-            ]),
+                })),
+            ),
             findLatestConsolidationRun: vi.fn().mockResolvedValue(undefined),
             recordConsolidationRun,
             applyConsolidation,
@@ -89,7 +81,10 @@ const build = () => {
                 enabled: true,
             })),
         } as AnyType,
-        schedulerClient: { aiAgentMemoryDistill: vi.fn() },
+        schedulerClient: {
+            aiAgentMemoryDistill: vi.fn(),
+            aiAgentMemoryConsolidatePartition: vi.fn(),
+        },
         orgAiCopilotConfigResolver: {
             getCopilotConfig: vi
                 .fn()
@@ -98,6 +93,13 @@ const build = () => {
         distillCall: vi.fn(),
     });
     return { service, recordConsolidationRun, applyConsolidation };
+};
+
+const payload = {
+    organizationUuid: 'org-enabled',
+    projectUuid: 'project-enabled',
+    userUuid: 'system',
+    ownerUserUuid: 'owner-1',
 };
 
 describe('AiAgentMemoryService consolidateWithLlm retry', () => {
@@ -111,7 +113,9 @@ describe('AiAgentMemoryService consolidateWithLlm retry', () => {
             .mockRejectedValueOnce(schemaFailure())
             .mockResolvedValueOnce({ object: { operations: [] } } as AnyType);
 
-        await expect(service.consolidate()).resolves.toBe(1);
+        await expect(
+            service.consolidateScheduledPartition(payload),
+        ).resolves.toBe('consolidated');
 
         expect(generateObjectMock).toHaveBeenCalledTimes(2);
         expect(applyConsolidation).toHaveBeenCalledOnce();
@@ -122,7 +126,9 @@ describe('AiAgentMemoryService consolidateWithLlm retry', () => {
         const { service, recordConsolidationRun, applyConsolidation } = build();
         generateObjectMock.mockRejectedValue(schemaFailure());
 
-        await expect(service.consolidate()).resolves.toBe(0);
+        await expect(
+            service.consolidateScheduledPartition(payload),
+        ).resolves.toBe('failed');
 
         expect(generateObjectMock).toHaveBeenCalledTimes(2);
         expect(applyConsolidation).not.toHaveBeenCalled();
@@ -137,7 +143,9 @@ describe('AiAgentMemoryService consolidateWithLlm retry', () => {
             .mockRejectedValueOnce(retryableApiFailure())
             .mockResolvedValueOnce({ object: { operations: [] } } as AnyType);
 
-        await expect(service.consolidate()).resolves.toBe(1);
+        await expect(
+            service.consolidateScheduledPartition(payload),
+        ).resolves.toBe('consolidated');
 
         expect(generateObjectMock).toHaveBeenCalledTimes(2);
         expect(generateObjectMock).toHaveBeenNthCalledWith(
@@ -156,7 +164,9 @@ describe('AiAgentMemoryService consolidateWithLlm retry', () => {
         const { service, recordConsolidationRun } = build();
         generateObjectMock.mockRejectedValue(new Error('provider down'));
 
-        await expect(service.consolidate()).resolves.toBe(0);
+        await expect(
+            service.consolidateScheduledPartition(payload),
+        ).resolves.toBe('failed');
 
         expect(generateObjectMock).toHaveBeenCalledOnce();
         expect(recordConsolidationRun).toHaveBeenCalledExactlyOnceWith(

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
@@ -174,6 +174,7 @@ describe('AiAgentMemoryService', () => {
         });
         const findExploresFromCache = vi.fn().mockResolvedValue({});
         const aiAgentMemoryDistill = vi.fn();
+        const aiAgentMemoryConsolidatePartition = vi.fn();
         const getAgent = vi.fn().mockResolvedValue({
             uuid: 'agent-1',
             name: 'Agent',
@@ -222,7 +223,10 @@ describe('AiAgentMemoryService', () => {
                 findExploresFromCache,
             } as AnyType,
             featureFlagService: { get: getFlag } as AnyType,
-            schedulerClient: { aiAgentMemoryDistill },
+            schedulerClient: {
+                aiAgentMemoryDistill,
+                aiAgentMemoryConsolidatePartition,
+            },
             distillCall,
             consolidateCall,
         });
@@ -245,6 +249,7 @@ describe('AiAgentMemoryService', () => {
             applyConsolidation,
             findExploresFromCache,
             aiAgentMemoryDistill,
+            aiAgentMemoryConsolidatePartition,
             getAgent,
             findThreadOwnership,
             distillCall,
@@ -934,6 +939,13 @@ describe('AiAgentMemoryService', () => {
         activeCount: 30,
     };
 
+    const partitionPayload = {
+        organizationUuid: 'org-enabled',
+        projectUuid: 'project-enabled',
+        userUuid: 'system',
+        ownerUserUuid: 'owner-1',
+    };
+
     const activeMemory = (
         overrides: Record<string, unknown> = {},
     ): Record<string, unknown> => ({
@@ -950,6 +962,18 @@ describe('AiAgentMemoryService', () => {
         ...overrides,
     });
 
+    /** A partition at the row floor, so the child's recheck lets it through. */
+    const activeMemories = (
+        overrides: Record<string, unknown> = {},
+    ): Record<string, unknown>[] =>
+        Array.from({ length: 30 }, (_, index) =>
+            activeMemory({
+                ai_agent_memory_uuid: `uuid-${index}`,
+                slug: `net-revenue-${index}`,
+                ...overrides,
+            }),
+        );
+
     // An empty catalog is treated as an unreadable one, so a partition that is
     // meant to be consolidated needs a catalog with something in it.
     const buildConsolidation = (options?: { enabledOrganization: string }) => {
@@ -957,29 +981,73 @@ describe('AiAgentMemoryService', () => {
         context.findExploresFromCache.mockResolvedValue({
             orders: { name: 'orders', tables: {}, joinedTables: [] },
         });
+        context.findActiveForProject.mockResolvedValue(activeMemories());
         return context;
     };
 
     it('asks only for partitions at or above the row floor', async () => {
-        const { service, findConsolidationCandidates } = build();
-
-        await expect(service.consolidate()).resolves.toBe(0);
-
-        expect(findConsolidationCandidates).toHaveBeenCalledExactlyOnceWith(30);
-    });
-
-    it('does nothing for an organization whose flag is off', async () => {
         const {
             service,
             findConsolidationCandidates,
+            aiAgentMemoryConsolidatePartition,
+        } = build();
+
+        await expect(service.sweepConsolidationPartitions()).resolves.toBe(0);
+
+        expect(findConsolidationCandidates).toHaveBeenCalledExactlyOnceWith(30);
+        expect(aiAgentMemoryConsolidatePartition).not.toHaveBeenCalled();
+    });
+
+    it('enqueues one partition job per eligible partition', async () => {
+        const {
+            service,
+            findConsolidationCandidates,
+            aiAgentMemoryConsolidatePartition,
+        } = build();
+        findConsolidationCandidates.mockResolvedValue([
+            consolidationCandidate,
+            { ...consolidationCandidate, ownerUserUuid: 'owner-2' },
+        ]);
+
+        await expect(service.sweepConsolidationPartitions()).resolves.toBe(2);
+
+        expect(aiAgentMemoryConsolidatePartition).toHaveBeenCalledTimes(2);
+        expect(aiAgentMemoryConsolidatePartition).toHaveBeenCalledWith(
+            partitionPayload,
+        );
+        expect(aiAgentMemoryConsolidatePartition).toHaveBeenCalledWith({
+            ...partitionPayload,
+            ownerUserUuid: 'owner-2',
+        });
+    });
+
+    it('enqueues nothing for an organization whose flag is off', async () => {
+        const {
+            service,
+            findConsolidationCandidates,
+            aiAgentMemoryConsolidatePartition,
+            findActiveForProject,
+        } = build({ enabledOrganization: 'none' });
+        findConsolidationCandidates.mockResolvedValue([consolidationCandidate]);
+
+        await expect(service.sweepConsolidationPartitions()).resolves.toBe(0);
+
+        expect(aiAgentMemoryConsolidatePartition).not.toHaveBeenCalled();
+        expect(findActiveForProject).not.toHaveBeenCalled();
+    });
+
+    it('skips the partition job quietly when the flag turned off after the sweep', async () => {
+        const {
+            service,
             findActiveForProject,
             consolidateCall,
             applyConsolidation,
             recordConsolidationRun,
-        } = build({ enabledOrganization: 'none' });
-        findConsolidationCandidates.mockResolvedValue([consolidationCandidate]);
+        } = buildConsolidation({ enabledOrganization: 'none' });
 
-        await expect(service.consolidate()).resolves.toBe(0);
+        await expect(
+            service.consolidateScheduledPartition(partitionPayload),
+        ).resolves.toBe('skipped');
 
         expect(findActiveForProject).not.toHaveBeenCalled();
         expect(consolidateCall).not.toHaveBeenCalled();
@@ -987,39 +1055,37 @@ describe('AiAgentMemoryService', () => {
         expect(recordConsolidationRun).not.toHaveBeenCalled();
     });
 
-    it('fetches the catalog once per project across its partitions', async () => {
+    it('skips a partition that fell below the row floor before the job ran', async () => {
         const {
             service,
-            findConsolidationCandidates,
             findActiveForProject,
-            findExploresFromCache,
+            findLatestConsolidationRun,
+            consolidateCall,
+            recordConsolidationRun,
         } = buildConsolidation();
-        findConsolidationCandidates.mockResolvedValue([
-            consolidationCandidate,
-            { ...consolidationCandidate, ownerUserUuid: 'owner-2' },
-        ]);
         findActiveForProject.mockResolvedValue([activeMemory()]);
 
-        await expect(service.consolidate()).resolves.toBe(2);
+        await expect(
+            service.consolidateScheduledPartition(partitionPayload),
+        ).resolves.toBe('skipped');
 
-        expect(findExploresFromCache).toHaveBeenCalledExactlyOnceWith(
-            'project-enabled',
-            'name',
-        );
+        expect(findLatestConsolidationRun).not.toHaveBeenCalled();
+        expect(consolidateCall).not.toHaveBeenCalled();
+        expect(recordConsolidationRun).not.toHaveBeenCalled();
     });
 
     it('skips a project whose catalog cannot be read', async () => {
         const {
             service,
-            findConsolidationCandidates,
             findExploresFromCache,
             consolidateCall,
             recordConsolidationRun,
-        } = build();
-        findConsolidationCandidates.mockResolvedValue([consolidationCandidate]);
+        } = buildConsolidation();
         findExploresFromCache.mockRejectedValue(new Error('catalog gone'));
 
-        await expect(service.consolidate()).resolves.toBe(0);
+        await expect(
+            service.consolidateScheduledPartition(partitionPayload),
+        ).resolves.toBe('skipped');
 
         // Every object would read as unresolved, which is exactly the evidence
         // the retire licence rests on.
@@ -1030,15 +1096,15 @@ describe('AiAgentMemoryService', () => {
     it('skips a project whose catalog is empty', async () => {
         const {
             service,
-            findConsolidationCandidates,
             findActiveForProject,
             consolidateCall,
             recordConsolidationRun,
         } = build();
-        findConsolidationCandidates.mockResolvedValue([consolidationCandidate]);
-        findActiveForProject.mockResolvedValue([activeMemory()]);
+        findActiveForProject.mockResolvedValue(activeMemories());
 
-        await expect(service.consolidate()).resolves.toBe(0);
+        await expect(
+            service.consolidateScheduledPartition(partitionPayload),
+        ).resolves.toBe('skipped');
 
         expect(consolidateCall).not.toHaveBeenCalled();
         expect(recordConsolidationRun).not.toHaveBeenCalled();
@@ -1047,38 +1113,27 @@ describe('AiAgentMemoryService', () => {
     it('skips a partition in which nothing resolves at all', async () => {
         const {
             service,
-            findConsolidationCandidates,
             findActiveForProject,
             consolidateCall,
             recordConsolidationRun,
         } = buildConsolidation();
-        findConsolidationCandidates.mockResolvedValue([consolidationCandidate]);
-        findActiveForProject.mockResolvedValue([
-            activeMemory({
+        findActiveForProject.mockResolvedValue(
+            activeMemories({
                 objects: [{ type: 'explore', name: 'no_such_explore' }],
             }),
-        ]);
+        );
 
-        await expect(service.consolidate()).resolves.toBe(0);
+        await expect(
+            service.consolidateScheduledPartition(partitionPayload),
+        ).resolves.toBe('skipped');
 
         expect(consolidateCall).not.toHaveBeenCalled();
         expect(recordConsolidationRun).not.toHaveBeenCalled();
     });
 
-    it('records no run for the partitions a job abort never reached', async () => {
-        const {
-            service,
-            findConsolidationCandidates,
-            findActiveForProject,
-            consolidateCall,
-            recordConsolidationRun,
-        } = buildConsolidation();
-        findConsolidationCandidates.mockResolvedValue([
-            consolidationCandidate,
-            { ...consolidationCandidate, ownerUserUuid: 'owner-2' },
-            { ...consolidationCandidate, ownerUserUuid: 'owner-3' },
-        ]);
-        findActiveForProject.mockResolvedValue([activeMemory()]);
+    it('records no run for a partition the job was aborted out of', async () => {
+        const { service, consolidateCall, recordConsolidationRun } =
+            buildConsolidation();
         const controller = new AbortController();
         consolidateCall.mockImplementation(async () => {
             controller.abort(new Error('Job timed out'));
@@ -1086,26 +1141,37 @@ describe('AiAgentMemoryService', () => {
         });
 
         await expect(
-            service.consolidate(new Date(), controller.signal),
-        ).resolves.toBe(0);
+            service.consolidateScheduledPartition(
+                partitionPayload,
+                controller.signal,
+            ),
+        ).resolves.toBe('aborted');
 
-        // A partition that was never attempted must not be stamped with a hash
-        // that would suppress it until its corpus changes.
+        // A partition that never really attempted anything must not be stamped
+        // with a hash that would suppress it until its corpus changes.
         expect(consolidateCall).toHaveBeenCalledOnce();
+        expect(recordConsolidationRun).not.toHaveBeenCalled();
+    });
+
+    it('returns failed without a run row when a read throws before the attempt', async () => {
+        const { service, findActiveForProject, recordConsolidationRun } =
+            buildConsolidation();
+        findActiveForProject.mockRejectedValue(new Error('database gone'));
+
+        await expect(
+            service.consolidateScheduledPartition(partitionPayload),
+        ).resolves.toBe('failed');
+
         expect(recordConsolidationRun).not.toHaveBeenCalled();
     });
 
     it('keeps the rejection audit on a run that fails during apply', async () => {
         const {
             service,
-            findConsolidationCandidates,
-            findActiveForProject,
             consolidateCall,
             applyConsolidation,
             recordConsolidationRun,
         } = buildConsolidation();
-        findConsolidationCandidates.mockResolvedValue([consolidationCandidate]);
-        findActiveForProject.mockResolvedValue([activeMemory()]);
         consolidateCall.mockResolvedValue({
             operations: [
                 {
@@ -1115,14 +1181,16 @@ describe('AiAgentMemoryService', () => {
                 },
                 {
                     type: 'retire',
-                    slug: 'net-revenue-ab12cd34',
+                    slug: 'net-revenue-0',
                     reason: 'Its explore no longer resolves.',
                 },
             ],
         });
         applyConsolidation.mockRejectedValue(new Error('database exploded'));
 
-        await expect(service.consolidate()).resolves.toBe(0);
+        await expect(
+            service.consolidateScheduledPartition(partitionPayload),
+        ).resolves.toBe('failed');
 
         expect(recordConsolidationRun).toHaveBeenCalledExactlyOnceWith(
             expect.objectContaining({
@@ -1141,56 +1209,45 @@ describe('AiAgentMemoryService', () => {
     });
 
     it('skips a partition whose corpus has not changed since the last run', async () => {
-        const {
-            service,
-            findConsolidationCandidates,
-            findActiveForProject,
-            findLatestConsolidationRun,
-            consolidateCall,
-            applyConsolidation,
-        } = buildConsolidation();
-        findConsolidationCandidates.mockResolvedValue([consolidationCandidate]);
-        findActiveForProject.mockResolvedValue([activeMemory()]);
+        const { service, findLatestConsolidationRun, applyConsolidation } =
+            buildConsolidation();
 
-        await expect(service.consolidate()).resolves.toBe(1);
+        await expect(
+            service.consolidateScheduledPartition(partitionPayload),
+        ).resolves.toBe('consolidated');
         const { inputHash } = applyConsolidation.mock.calls[0][0].run;
+        expect(findLatestConsolidationRun).toHaveBeenCalledWith({
+            projectUuid: 'project-enabled',
+            ownerUserUuid: 'owner-1',
+        });
 
         const second = buildConsolidation();
-        second.findConsolidationCandidates.mockResolvedValue([
-            consolidationCandidate,
-        ]);
-        second.findActiveForProject.mockResolvedValue([activeMemory()]);
         second.findLatestConsolidationRun.mockResolvedValue({
             input_hash: inputHash,
             status: 'failed',
         });
 
-        await expect(second.service.consolidate()).resolves.toBe(0);
+        await expect(
+            second.service.consolidateScheduledPartition(partitionPayload),
+        ).resolves.toBe('skipped');
         expect(second.consolidateCall).not.toHaveBeenCalled();
         expect(second.applyConsolidation).not.toHaveBeenCalled();
         // The catalog is read only for a partition that will be attempted.
         expect(second.findExploresFromCache).not.toHaveBeenCalled();
-        expect(findLatestConsolidationRun).toHaveBeenCalledWith({
-            projectUuid: 'project-enabled',
-            ownerUserUuid: 'owner-1',
-        });
-        expect(consolidateCall).toHaveBeenCalledOnce();
     });
 
     it('records a failed run carrying the input hash when the call throws', async () => {
         const {
             service,
-            findConsolidationCandidates,
-            findActiveForProject,
             consolidateCall,
             applyConsolidation,
             recordConsolidationRun,
         } = buildConsolidation();
-        findConsolidationCandidates.mockResolvedValue([consolidationCandidate]);
-        findActiveForProject.mockResolvedValue([activeMemory()]);
         consolidateCall.mockRejectedValue(new Error('model exploded'));
 
-        await expect(service.consolidate()).resolves.toBe(0);
+        await expect(
+            service.consolidateScheduledPartition(partitionPayload),
+        ).resolves.toBe('failed');
 
         expect(applyConsolidation).not.toHaveBeenCalled();
         expect(recordConsolidationRun).toHaveBeenCalledExactlyOnceWith(
@@ -1205,16 +1262,9 @@ describe('AiAgentMemoryService', () => {
     });
 
     it('never shows the curator a thread summary or a database uuid', async () => {
-        const {
-            service,
-            findConsolidationCandidates,
-            findActiveForProject,
-            consolidateCall,
-        } = buildConsolidation();
-        findConsolidationCandidates.mockResolvedValue([consolidationCandidate]);
-        findActiveForProject.mockResolvedValue([activeMemory()]);
+        const { service, consolidateCall } = buildConsolidation();
 
-        await service.consolidate();
+        await service.consolidateScheduledPartition(partitionPayload);
 
         const [{ input, partition }] = consolidateCall.mock.calls[0];
         expect(partition).toEqual({
@@ -1223,7 +1273,7 @@ describe('AiAgentMemoryService', () => {
             ownerUserUuid: 'owner-1',
         });
         expect(JSON.stringify(input)).not.toContain('Summary the curator');
-        expect(JSON.stringify(input)).not.toContain('memory-1');
+        expect(JSON.stringify(input)).not.toContain('uuid-');
     });
 
     it('returns not found without reading rows when the flag is off', async () => {

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
@@ -8,6 +8,7 @@ import {
     ParameterError,
     ProjectType,
     type AiAgentMemory,
+    type AiAgentMemoryConsolidatePartitionJobPayload,
     type AiAgentMemoryConsolidationInputEntry,
     type AiAgentMemoryConsolidationRejection,
     type AiAgentMemoryDistillJobPayload,
@@ -111,6 +112,9 @@ export type AiAgentMemoryConsolidateOutcome =
 type MemorySchedulerClient = {
     aiAgentMemoryDistill: (
         payload: AiAgentMemoryDistillJobPayload,
+    ) => Promise<unknown>;
+    aiAgentMemoryConsolidatePartition: (
+        payload: AiAgentMemoryConsolidatePartitionJobPayload,
     ) => Promise<unknown>;
 };
 
@@ -227,6 +231,28 @@ export class AiAgentMemoryService extends BaseService {
             }),
         ]);
         return copilot.enabled && memory.enabled;
+    }
+
+    private async filterByEnabledOrganizations<
+        T extends { organizationUuid: string },
+    >(candidates: T[]): Promise<T[]> {
+        const organizationUuids = [
+            ...new Set(candidates.map((row) => row.organizationUuid)),
+        ];
+        const enabledByOrganization = new Map(
+            await Promise.all(
+                organizationUuids.map(
+                    async (organizationUuid) =>
+                        [
+                            organizationUuid,
+                            await this.isEnabled(organizationUuid),
+                        ] as const,
+                ),
+            ),
+        );
+        return candidates.filter((candidate) =>
+            enabledByOrganization.get(candidate.organizationUuid),
+        );
     }
 
     private async getUnresolvedObjects(
@@ -453,23 +479,7 @@ export class AiAgentMemoryService extends BaseService {
                     now.getTime() - AI_AGENT_MEMORY_ACTIVITY_FLOOR_MS,
                 ),
             });
-        const organizationUuids = [
-            ...new Set(candidates.map((row) => row.organizationUuid)),
-        ];
-        const enabledByOrganization = new Map(
-            await Promise.all(
-                organizationUuids.map(
-                    async (organizationUuid) =>
-                        [
-                            organizationUuid,
-                            await this.isEnabled(organizationUuid),
-                        ] as const,
-                ),
-            ),
-        );
-        const due = candidates.filter((candidate) =>
-            enabledByOrganization.get(candidate.organizationUuid),
-        );
+        const due = await this.filterByEnabledOrganizations(candidates);
 
         await Promise.all(
             due.map((candidate) =>
@@ -487,85 +497,102 @@ export class AiAgentMemoryService extends BaseService {
     }
 
     /**
-     * Daily pass over every eligible `(project, owner)` partition. The flag is
-     * checked per organization here, so a flag-off organization costs nothing
-     * beyond the eligibility query.
+     * Daily sweep over every eligible `(project, owner)` partition: one child
+     * job per partition, mirroring the distill queue. The flag is checked per
+     * organization here, so a flag-off organization costs nothing beyond the
+     * eligibility query.
      */
-    async consolidate(
-        now = new Date(),
-        abortSignal?: AbortSignal,
-    ): Promise<number> {
+    async sweepConsolidationPartitions(): Promise<number> {
         const candidates =
             await this.aiAgentMemoryModel.findConsolidationCandidates(
                 AI_AGENT_MEMORY_CONSOLIDATION_MIN_ACTIVE_ROWS,
             );
-        const organizationUuids = [
-            ...new Set(candidates.map((row) => row.organizationUuid)),
-        ];
-        const enabledByOrganization = new Map(
-            await Promise.all(
-                organizationUuids.map(
-                    async (organizationUuid) =>
-                        [
-                            organizationUuid,
-                            await this.isEnabled(organizationUuid),
-                        ] as const,
-                ),
+        const due = await this.filterByEnabledOrganizations(candidates);
+
+        await Promise.all(
+            due.map((candidate) =>
+                this.schedulerClient.aiAgentMemoryConsolidatePartition({
+                    organizationUuid: candidate.organizationUuid,
+                    projectUuid: candidate.projectUuid,
+                    userUuid: 'system',
+                    ownerUserUuid: candidate.ownerUserUuid,
+                }),
             ),
         );
-        const due = candidates.filter((candidate) =>
-            enabledByOrganization.get(candidate.organizationUuid),
-        );
+        return due.length;
+    }
 
-        // One catalog fetch per project, shared by that project's partitions
-        // but loaded only when one of them survives the input-hash skip check:
-        // the common all-skipped day must not read a single cached_explores blob.
-        const catalogByProject = new Map<
-            string,
-            Promise<Record<string, Explore | ExploreError> | null>
-        >();
-        const loadCatalog = (projectUuid: string) => {
-            const cached = catalogByProject.get(projectUuid);
-            if (cached) return cached;
-            const promise = this.loadConsolidationCatalog(projectUuid);
-            catalogByProject.set(projectUuid, promise);
-            return promise;
+    /**
+     * One enqueued partition. Everything the sweep decided on is rechecked
+     * cheaply here — flag, partition existence, row floor, input hash — because
+     * any of it can go stale between sweep and run; a stale premise is a quiet
+     * skip, never a failure.
+     */
+    async consolidateScheduledPartition(
+        payload: AiAgentMemoryConsolidatePartitionJobPayload,
+        abortSignal?: AbortSignal,
+    ): Promise<AiAgentMemoryConsolidateOutcome> {
+        const partition: AiAgentMemoryConsolidationPartition = {
+            organizationUuid: payload.organizationUuid,
+            projectUuid: payload.projectUuid,
+            ownerUserUuid: payload.ownerUserUuid,
         };
-
-        let consolidated = 0;
-        for (const candidate of due) {
-            // A job timeout must not cascade into the partitions it never
-            // reached: they would each record a failed run carrying their
-            // current hash and never be attempted again.
-            if (abortSignal?.aborted) break;
-
-            try {
-                // eslint-disable-next-line no-await-in-loop
-                const outcome = await this.consolidatePartition({
-                    partition: {
-                        organizationUuid: candidate.organizationUuid,
-                        projectUuid: candidate.projectUuid,
-                        ownerUserUuid: candidate.ownerUserUuid,
-                    },
-                    loadCatalog: () => loadCatalog(candidate.projectUuid),
-                    now,
-                    abortSignal,
-                });
-                if (outcome === 'aborted') break;
-                if (outcome === 'consolidated') consolidated += 1;
-            } catch (error) {
-                // Every other failure here is per-partition; a read that
-                // throws outside the attempt must not cost the whole pass.
-                this.logger.warn(
-                    'Dropping AI agent memory consolidation partition',
-                    {
-                        projectUuid: candidate.projectUuid,
-                        error: getErrorMessage(error),
-                    },
-                );
+        try {
+            if (!(await this.isEnabled(partition.organizationUuid))) {
+                return 'skipped';
             }
+
+            const memories = await this.aiAgentMemoryModel.findActiveForProject(
+                {
+                    projectUuid: partition.projectUuid,
+                    userUuid: partition.ownerUserUuid,
+                    limit: AI_AGENT_MEMORY_CONSOLIDATION_INPUT_LIMIT,
+                },
+            );
+            if (
+                memories.length < AI_AGENT_MEMORY_CONSOLIDATION_MIN_ACTIVE_ROWS
+            ) {
+                return 'skipped';
+            }
+
+            // Same corpus state as the last attempt, whatever that attempt's
+            // status: a partition that reliably trips the pass cannot burn a
+            // call every day forever.
+            const inputHash = computeConsolidationInputHash(memories);
+            const latestRun =
+                await this.aiAgentMemoryModel.findLatestConsolidationRun({
+                    projectUuid: partition.projectUuid,
+                    ownerUserUuid: partition.ownerUserUuid,
+                });
+            if (latestRun?.input_hash === inputHash) return 'skipped';
+
+            // Read only for a partition that will be attempted: the common
+            // all-skipped day must not read a single cached_explores blob.
+            const explores = await this.loadConsolidationCatalog(
+                partition.projectUuid,
+            );
+            if (explores === null) return 'skipped';
+
+            return await this.consolidatePartition({
+                partition,
+                memories,
+                inputHash,
+                explores,
+                now: new Date(),
+                abortSignal,
+            });
+        } catch (error) {
+            // A read that throws before the attempt records no run row, so the
+            // partition is retried on the next sweep.
+            this.logger.warn(
+                'Dropping AI agent memory consolidation partition',
+                {
+                    projectUuid: partition.projectUuid,
+                    error: getErrorMessage(error),
+                },
+            );
+            return 'failed';
         }
-        return consolidated;
     }
 
     /**
@@ -600,33 +627,13 @@ export class AiAgentMemoryService extends BaseService {
 
     private async consolidatePartition(args: {
         partition: AiAgentMemoryConsolidationPartition;
-        loadCatalog: () => Promise<Record<
-            string,
-            Explore | ExploreError
-        > | null>;
+        memories: DbAiAgentMemory[];
+        inputHash: string;
+        explores: Record<string, Explore | ExploreError>;
         now: Date;
         abortSignal?: AbortSignal;
     }): Promise<AiAgentMemoryConsolidateOutcome> {
-        const { partition } = args;
-        const memories = await this.aiAgentMemoryModel.findActiveForProject({
-            projectUuid: partition.projectUuid,
-            userUuid: partition.ownerUserUuid,
-            limit: AI_AGENT_MEMORY_CONSOLIDATION_INPUT_LIMIT,
-        });
-        const inputHash = computeConsolidationInputHash(memories);
-
-        // Same corpus state as the last attempt, whatever that attempt's
-        // status: a partition that reliably trips the pass cannot burn a call
-        // every day forever.
-        const latestRun =
-            await this.aiAgentMemoryModel.findLatestConsolidationRun({
-                projectUuid: partition.projectUuid,
-                ownerUserUuid: partition.ownerUserUuid,
-            });
-        if (latestRun?.input_hash === inputHash) return 'skipped';
-
-        const explores = await args.loadCatalog();
-        if (explores === null) return 'skipped';
+        const { partition, memories, inputHash, explores } = args;
 
         const input = buildConsolidationInput({
             memories,

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -265,6 +265,11 @@ const getTagsForTask: {
         'ai_agent_memory.thread_uuid': payload.threadUuid,
     }),
     [SCHEDULER_TASKS.CONSOLIDATE_AI_AGENT_MEMORIES]: () => ({}),
+    [SCHEDULER_TASKS.CONSOLIDATE_AI_AGENT_MEMORY_PARTITION]: (payload) => ({
+        'organization.uuid': payload.organizationUuid,
+        'project.uuid': payload.projectUuid,
+        'ai_agent_memory.owner_user_uuid': payload.ownerUserUuid,
+    }),
     [SCHEDULER_TASKS.CLEAN_MCP_TOOL_CALLS]: () => ({}),
     [SCHEDULER_TASKS.AI_WRITEBACK_PIPELINE]: (payload) => ({
         'organization.uuid': payload.organizationUuid,

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -124,6 +124,10 @@ export type AiAgentMemoryDistillJobPayload = TraceTaskBase & {
     sweptUpdatedAt: string;
 };
 
+export type AiAgentMemoryConsolidatePartitionJobPayload = TraceTaskBase & {
+    ownerUserUuid: UUID;
+};
+
 export const EE_SCHEDULER_TASKS = {
     SLACK_AI_PROMPT: 'slackAiPrompt',
     AI_AGENT_EVAL_RESULT: 'aiAgentEvalResult',
@@ -147,6 +151,7 @@ export const EE_SCHEDULER_TASKS = {
     SWEEP_AI_AGENT_MEMORY_THREADS: 'sweepAiAgentMemoryThreads',
     AI_AGENT_MEMORY_DISTILL: 'aiAgentMemoryDistill',
     CONSOLIDATE_AI_AGENT_MEMORIES: 'consolidateAiAgentMemories',
+    CONSOLIDATE_AI_AGENT_MEMORY_PARTITION: 'consolidateAiAgentMemoryPartition',
     CLEAN_MCP_TOOL_CALLS: 'cleanMcpToolCalls',
 } as const;
 
@@ -253,6 +258,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.SWEEP_AI_AGENT_MEMORY_THREADS]: TraceTaskBase;
     [SCHEDULER_TASKS.AI_AGENT_MEMORY_DISTILL]: AiAgentMemoryDistillJobPayload;
     [SCHEDULER_TASKS.CONSOLIDATE_AI_AGENT_MEMORIES]: TraceTaskBase;
+    [SCHEDULER_TASKS.CONSOLIDATE_AI_AGENT_MEMORY_PARTITION]: AiAgentMemoryConsolidatePartitionJobPayload;
     [SCHEDULER_TASKS.CLEAN_MCP_TOOL_CALLS]: TraceTaskBase;
     [SCHEDULER_TASKS.AI_WRITEBACK_PIPELINE]: AiWritebackPipelineJobPayload;
     [SCHEDULER_TASKS.AI_DEEP_RESEARCH]: AiDeepResearchPipelineJobPayload;
@@ -279,6 +285,7 @@ export interface EETaskPayloadMap {
     [EE_SCHEDULER_TASKS.SWEEP_AI_AGENT_MEMORY_THREADS]: TraceTaskBase;
     [EE_SCHEDULER_TASKS.AI_AGENT_MEMORY_DISTILL]: AiAgentMemoryDistillJobPayload;
     [EE_SCHEDULER_TASKS.CONSOLIDATE_AI_AGENT_MEMORIES]: TraceTaskBase;
+    [EE_SCHEDULER_TASKS.CONSOLIDATE_AI_AGENT_MEMORY_PARTITION]: AiAgentMemoryConsolidatePartitionJobPayload;
     [EE_SCHEDULER_TASKS.CLEAN_MCP_TOOL_CALLS]: TraceTaskBase;
     [EE_SCHEDULER_TASKS.AI_WRITEBACK_PIPELINE]: AiWritebackPipelineJobPayload;
     [EE_SCHEDULER_TASKS.AI_DEEP_RESEARCH]: AiDeepResearchPipelineJobPayload;


### PR DESCRIPTION
Re-architects the daily consolidation cron from a monolithic in-task loop into a sweep + per-partition fan-out, mirroring the distill queue shape.

- The existing `consolidateAiAgentMemories` cron becomes a **sweep**: finds eligible `(project, owner)` partitions, filters by the org flag, enqueues one `consolidateAiAgentMemoryPartition` job per partition, returns the enqueued count. Keeping the old task identifier as the sweep makes rolling deploys safe: the cron's jobKey means one worker runs it as either the old full pass or the new sweep, never both.
- The **partition job** is enqueued with `jobKey: ai-agent-memory-consolidate:{projectUuid}:{ownerUserUuid}` (pending work dedupes per partition), `queueName: ai-agent-memory-consolidate:{projectUuid}` (serialized per project, projects run concurrently), `maxAttempts: 1`, low priority — byte-for-byte the distill enqueue shape. Each partition gets its own job visibility, timeout, and failure reporting.
- The child **rechecks everything cheap** before the LLM call: org flag, partition existence, row floor, input hash. A sweep→run race that invalidates any of these records a quiet skip, not a failure.
- The whole-pass timeout and its abort-must-not-cascade handling disappear; the per-partition handler mirrors the distill task (inner LLM abort inside the job timeout).
- Accepted cost: the per-project catalog cache becomes per-job — each partition job loads `cached_explores` itself, but only after surviving the input-hash check, so the common all-skipped day still reads nothing.

Follow-up to #26292, which merged the monolithic version of the pass.

Relates: ZAP-678

🤖 Generated with [Claude Code](https://claude.com/claude-code)
