### PR TITLE
feat(apps): dock a visualization's versions under the chart config

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -6178,6 +6178,11 @@ export class AppGenerateService extends BaseService {
             'ready',
             user.userUuid,
             source.resources ?? undefined,
+            source.dependencies ?? undefined,
+            // A data app viz is only listed while its latest ready version
+            // declares a schema, so dropping it here delists the viz and
+            // strips the contract from every chart bound to it.
+            source.viz_schema ?? undefined,
         );
         await this.appModel.updateStatusMessage(
             appUuid,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.vizSchemaCopy.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.vizSchemaCopy.test.ts
@@ -2,6 +2,7 @@
 // version's viz_schema — it exists only in the database (generation structured
 // output), so a copy that drops it produces a data app viz that never appears
 // in the viz picker.
+import { type AppVersionDependencies } from '@lightdash/common';
 import { AppGenerateService } from './AppGenerateService';
 
 vi.mock('e2b', () => ({
@@ -59,6 +60,11 @@ const sourceApp = {
     deleted_by_user_uuid: null,
 };
 
+const DEPENDENCIES: AppVersionDependencies = {
+    custom: [{ name: 'recharts', version: '2.12.0' }],
+    lockfileHash: 'a'.repeat(64),
+};
+
 const sourceVersion = {
     app_version_id: 'version-id',
     app_id: SOURCE_APP_UUID,
@@ -87,6 +93,7 @@ function buildService() {
             version: { version: 1 },
         }),
         createVersion: vi.fn().mockResolvedValue({ version: 7 }),
+        getVersion: vi.fn().mockResolvedValue(sourceVersion),
         setUpstreamAppUuid: vi.fn().mockResolvedValue(undefined),
         syncPromotedApp: vi.fn().mockResolvedValue(undefined),
         updateStatusMessage: vi.fn().mockResolvedValue(undefined),
@@ -319,6 +326,31 @@ describe('viz_schema propagation on app copy paths', () => {
         expect(externalConnectionModel.replaceAppLinks).toHaveBeenCalledWith(
             UPSTREAM_APP_UUID,
             [{ externalConnectionUuid: 'upstream-conn-1', alias: 'stripe' }],
+        );
+    });
+
+    it('restoreVersion carries the source viz_schema and dependencies onto the new version', async () => {
+        const { service, appModel } = buildService();
+        appModel.getVersion.mockResolvedValue({
+            ...sourceVersion,
+            dependencies: DEPENDENCIES,
+        });
+
+        await service.restoreVersion(
+            makeUser(),
+            PROJECT_UUID,
+            SOURCE_APP_UUID,
+            3,
+        );
+
+        expect(appModel.createVersion).toHaveBeenCalledWith(
+            SOURCE_APP_UUID,
+            { version: 7, prompt: 'Restore version 3' },
+            'ready',
+            USER_UUID,
+            undefined, // source has no resources
+            DEPENDENCIES,
+            VIZ_SCHEMA,
         );
     });
 

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.module.css
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.module.css
@@ -1,0 +1,6 @@
+/* The data app viz panel is a conversation, not a form: it fills the scroll
+   viewport so the composer sits at the bottom rather than under the last
+   message. Opt-in, so the other config panels keep hugging their content. */
+.fillHeight {
+    height: 100%;
+}

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
@@ -23,6 +23,7 @@ import { ConfigTabs as SankeyConfigTabs } from '../../VisualizationConfigs/Sanke
 import { ConfigTabs as TableConfigTabs } from '../../VisualizationConfigs/TableConfigPanel/TableConfigTabs';
 import { ConfigTabs as TreemapConfigTabs } from '../../VisualizationConfigs/TreemapConfig/TreemapConfigTabs';
 import VisualizationCardOptions from '../VisualizationCardOptions';
+import classes from './VisualizationConfig.module.css';
 
 // Lazy load CustomVisConfig as it includes the heavy Monaco editor
 const CustomVisConfigTabsLazy = lazy(() =>
@@ -104,7 +105,12 @@ const VisualizationConfig: FC<Props> = ({ chartType, onClose }) => {
             <ScrollArea
                 offsetScrollbars
                 scrollbars="y"
-                classNames={{ content: scrollAreaClasses.verticalContent }}
+                classNames={{
+                    content:
+                        chartType === ChartType.DATA_APP_VIZ
+                            ? `${scrollAreaClasses.verticalContent} ${classes.fillHeight}`
+                            : scrollAreaClasses.verticalContent,
+                }}
                 style={{ flex: 1 }}
                 type="hover"
                 scrollbarSize={8}

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.module.css
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.module.css
@@ -1,0 +1,20 @@
+/* One column: the settings, and the build session docked under them. The dock
+   takes what it needs; the settings keep the rest and scroll. */
+.panel {
+    display: flex;
+    flex-direction: column;
+    gap: var(--mantine-spacing-xs);
+    height: 100%;
+    min-height: 0;
+    /* The config sidebar is padded `16px 16px 0` — no bottom, because its
+       forms normally scroll. Filling the panel means we reach that edge. */
+    padding-bottom: var(--mantine-spacing-md);
+}
+
+/* Scrolls on its own, so the dock under it stays put — and so expanding the
+   dock squeezes the settings rather than pushing them off the panel. */
+.settings {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+}

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
@@ -1,10 +1,12 @@
 import {
     ChartType,
     CustomDimensionType,
+    defineUserAbility,
     DimensionType,
     FieldType,
     getItemId,
     MetricType,
+    OrganizationMemberRole,
     type CompiledDimension,
     type CompiledMetric,
     type CustomSqlDimension,
@@ -18,7 +20,9 @@ import {
 } from '@lightdash/common';
 import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type * as ReactRouter from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { defaultAbility } from '../../../providers/Ability/constants';
 import { renderWithProviders } from '../../../testing/testUtils';
 import { ConfigTabs } from './DataAppVizConfigTabs';
 
@@ -40,6 +44,14 @@ vi.mock('../../../features/apps/components/DataAppVizLibraryPicker', () => ({
 }));
 vi.mock('../../../features/apps/hooks/useDataAppVisualization', () => ({
     useDataAppVisualization: vi.fn(),
+}));
+vi.mock('../../../features/apps/components/DataAppVizDock', () => ({
+    default: () => <div data-testid="viz-dock" />,
+}));
+// The panel reads the project from the route, which this test does not mount.
+vi.mock('react-router', async (importOriginal) => ({
+    ...(await importOriginal<typeof ReactRouter>()),
+    useParams: () => ({ projectUuid: 'project-1' }),
 }));
 vi.mock('../../common/FieldSelect', () => ({
     default: ({ items }: { items: Item[] }) => {
@@ -125,13 +137,33 @@ const declaredOptions: DataAppVizConfigOption[] = [
 const mockSchema = (
     configOptions: DataAppVizConfigOption[],
     colorPalette: DataAppVizPaletteDeclaration | null = null,
+    viz: Partial<DataAppViz> = {},
 ) => {
     vi.mocked(useDataAppVisualization).mockReturnValue({
         data: {
             schema: { fields: declaredFields, configOptions, colorPalette },
+            ...viz,
         },
     } as unknown as ReturnType<typeof useDataAppVisualization>);
 };
+
+// The org and user the app-provider mock signs in as; an ability has to be
+// built for the same pair to match its conditions.
+const MOCK_ORGANIZATION_UUID = '172a2270-000f-42be-9c68-c4752c23ae51';
+const MOCK_USER_UUID = 'b264d83a-9000-426a-85ec-3f9c20f368ce';
+
+const signInAs = (role: OrganizationMemberRole) =>
+    defaultAbility.update(
+        defineUserAbility(
+            {
+                role,
+                organizationUuid: MOCK_ORGANIZATION_UUID,
+                userUuid: MOCK_USER_UUID,
+                roleUuid: undefined,
+            },
+            [],
+        ).rules,
+    );
 
 const queryColumns: ItemsMap = {
     orders_visible: makeDimension('visible', false),
@@ -167,8 +199,51 @@ describe('DataAppVizConfigTabs', () => {
         pickerProps.length = 0;
         setOption.mockClear();
         setDataAppVizUuid.mockClear();
+        defaultAbility.update([]);
         mockSchema([]);
         mockContext(queryColumns);
+    });
+
+    it('offers the dock over their own visualization', async () => {
+        signInAs(OrganizationMemberRole.EDITOR);
+        mockSchema([], null, {
+            spaceUuid: null,
+            createdByUserUuid: MOCK_USER_UUID,
+        });
+
+        renderWithProviders(<ConfigTabs />);
+
+        expect(await screen.findByTestId('viz-dock')).toBeInTheDocument();
+    });
+
+    // Ownership grants manage, so the role floor for revising a visualization
+    // is lower than the one for building a new one.
+    it('offers it to an interactive viewer over their own visualization', async () => {
+        signInAs(OrganizationMemberRole.INTERACTIVE_VIEWER);
+        mockSchema([], null, {
+            spaceUuid: null,
+            createdByUserUuid: MOCK_USER_UUID,
+        });
+
+        renderWithProviders(<ConfigTabs />);
+
+        expect(await screen.findByTestId('viz-dock')).toBeInTheDocument();
+    });
+
+    it("withholds it over someone else's visualization, which they cannot revise", async () => {
+        signInAs(OrganizationMemberRole.EDITOR);
+        mockSchema([], null, {
+            spaceUuid: null,
+            createdByUserUuid: 'someone-else',
+        });
+
+        renderWithProviders(<ConfigTabs />);
+
+        // The picker is theirs — choosing a renderer is configuring a chart.
+        expect(await screen.findByTestId('viz-picker')).toBeInTheDocument();
+        // `findBy` rather than `queryBy`: the gate reads false until the user
+        // query settles, so an immediate assertion passes on timing alone.
+        await expect(screen.findByTestId('viz-dock')).rejects.toThrow();
     });
 
     it('matches Explorer field visibility', () => {

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -1,28 +1,26 @@
-import {
-    getEffectiveOptionValues,
-    getItemId,
-    type DataAppVizField,
-    type Item,
-} from '@lightdash/common';
-import { Stack, Text } from '@mantine-8/core';
+import { getEffectiveOptionValues, type ItemsMap } from '@lightdash/common';
+import { Box } from '@mantine-8/core';
 import { MantineProvider, useMantineColorScheme } from '@mantine/core';
 import { memo, useMemo, type FC } from 'react';
 import { useParams } from 'react-router';
-import DataAppVizLibraryPicker from '../../../features/apps/components/DataAppVizLibraryPicker';
+import DataAppVizDock from '../../../features/apps/components/DataAppVizDock';
+import { useCanCreateDataApp } from '../../../features/apps/hooks/useCanCreateDataApp';
+import { useCanEditDataApp } from '../../../features/apps/hooks/useCanEditDataApp';
 import { useDataAppVisualization } from '../../../features/apps/hooks/useDataAppVisualization';
 import {
     autoMapDataAppVizFields,
-    poolKeyForSlot,
     reconcileDataAppVizFieldMapping,
 } from '../../../features/apps/utils/autoMapDataAppVizFields';
-import { getDataAppVizFieldItems } from '../../../features/apps/utils/getDataAppVizFieldItems';
-import FieldSelect from '../../common/FieldSelect';
 import { isDataAppVizVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
 import { ColorPaletteSection } from '../common/ColorPaletteSection';
-import { Config } from '../common/Config';
 import { getVizConfigThemeOverride } from '../mantineTheme';
+import classes from './DataAppVizConfigTabs.module.css';
 import DataAppVizOptionTabs from './DataAppVizOptionTabs';
+import DataAppVizSettings from './DataAppVizSettings';
+
+// Stable identity, so the field pools stay memoized before results land.
+const NO_COLUMNS: ItemsMap = {};
 
 export const ConfigTabs: FC = memo(() => {
     const { colorScheme } = useMantineColorScheme();
@@ -43,23 +41,23 @@ export const ConfigTabs: FC = memo(() => {
         dataAppVizUuid || undefined,
     );
 
-    const itemPools = useMemo(() => {
-        const { dimensions, metrics } = getDataAppVizFieldItems(itemsMap ?? {});
-        return { dimension: dimensions, metric: metrics };
-    }, [itemsMap]);
-    // Auto-binding cannot run without columns, and it only runs once, at pick
-    // time — so picking now would leave the slots empty for good.
-    const hasColumns =
-        itemPools.dimension.length > 0 || itemPools.metric.length > 0;
-
     const configOptions = useMemo(
         () => dataAppViz?.schema?.configOptions ?? [],
         [dataAppViz],
     );
     const colorPalette = dataAppViz?.schema?.colorPalette ?? null;
 
-    const fieldItems = (field: DataAppVizField): Item[] =>
-        itemPools[poolKeyForSlot(field)];
+    const canCreateApp = useCanCreateDataApp(projectUuid);
+    const canEditSelected = useCanEditDataApp(projectUuid, {
+        spaceUuid: dataAppViz?.spaceUuid ?? null,
+        createdByUserUuid: dataAppViz?.createdByUserUuid ?? null,
+    });
+    // The dock is authoring end to end — the version log's restores, the way
+    // into the builder — so it is offered on the same rules as the builder
+    // page: creating a new visualization, or managing the one selected.
+    // Without either, the panel is the picker and the settings. The create
+    // arm only becomes reachable once the dock renders with nothing selected.
+    const canAuthor = dataAppVizUuid ? canEditSelected : canCreateApp;
 
     if (!isDataAppViz) return null;
 
@@ -80,92 +78,59 @@ export const ConfigTabs: FC = memo(() => {
     // contract and columns in force now — the same value the renderer uses.
     const effectiveMapping = reconcileDataAppVizFieldMapping(
         fields,
-        itemsMap ?? {},
+        itemsMap ?? NO_COLUMNS,
         fieldMapping,
     );
 
-    const generalPanel = (
-        <Stack>
-            <Config>
-                <Config.Section>
-                    <Config.Heading>Data app visualization</Config.Heading>
-                    <DataAppVizLibraryPicker
-                        projectUuid={projectUuid ?? ''}
-                        selectedDataAppVizUuid={dataAppVizUuid || null}
-                        selectedDataAppViz={dataAppViz ?? null}
-                        disabled={!hasColumns}
-                        onSelect={(picked) =>
-                            setDataAppVizUuid(
-                                picked?.dataAppVizUuid ?? '',
-                                picked
-                                    ? autoMapDataAppVizFields(
-                                          picked.schema?.fields ?? [],
-                                          itemsMap ?? {},
-                                      )
-                                    : {},
-                            )
-                        }
-                    />
-                    {!hasColumns && (
-                        <Text c="dimmed" size="xs">
-                            Run your query to pick a visualization.
-                        </Text>
-                    )}
-                </Config.Section>
-            </Config>
-
-            {dataAppVizUuid && fields.length === 0 && (
-                <Text c="dimmed" size="sm">
-                    This visualization has no fields to map.
-                </Text>
-            )}
-
-            {fields.map((field) => {
-                const items = fieldItems(field);
-                const selectedId = effectiveMapping[field.name];
-                const selectedItem = selectedId
-                    ? items.find((i) => getItemId(i) === selectedId)
-                    : undefined;
-                return (
-                    <Config key={field.name}>
-                        <Config.Section>
-                            <Config.Heading>{field.label}</Config.Heading>
-                            <FieldSelect
-                                placeholder={`Select ${field.label.toLowerCase()}`}
-                                disabled={items.length === 0}
-                                item={selectedItem}
-                                items={items}
-                                onChange={(newField) =>
-                                    setField(
-                                        field.name,
-                                        newField ? getItemId(newField) : null,
-                                    )
-                                }
-                                clearable={!field.required}
-                                hasGrouping
-                            />
-                        </Config.Section>
-                    </Config>
-                );
-            })}
-        </Stack>
+    const settings = (
+        <DataAppVizSettings
+            projectUuid={projectUuid ?? ''}
+            dataAppVizUuid={dataAppVizUuid}
+            dataAppViz={dataAppViz ?? null}
+            itemsMap={itemsMap ?? NO_COLUMNS}
+            fields={fields}
+            fieldMapping={effectiveMapping}
+            onSelect={(picked) =>
+                setDataAppVizUuid(
+                    picked?.dataAppVizUuid ?? '',
+                    picked
+                        ? autoMapDataAppVizFields(
+                              picked.schema?.fields ?? [],
+                              itemsMap ?? NO_COLUMNS,
+                          )
+                        : {},
+                )
+            }
+            onFieldChange={setField}
+        />
     );
 
     return (
         <MantineProvider inherit theme={themeOverride}>
-            <DataAppVizOptionTabs
-                // Remount on a viz switch so no control keeps the previous
-                // viz's draft edit.
-                key={dataAppVizUuid}
-                generalContent={generalPanel}
-                configOptions={configOptions}
-                values={effectiveValues}
-                onChange={(name, value) =>
-                    setOption(dataAppVizUuid, name, value)
-                }
-                colorPalette={colorPalette}
-                paletteControl={<ColorPaletteSection />}
-            />
+            <Box className={classes.panel}>
+                <Box className={classes.settings}>
+                    <DataAppVizOptionTabs
+                        // Remount on a viz switch so no control keeps the
+                        // previous viz's draft edit.
+                        key={dataAppVizUuid}
+                        generalContent={settings}
+                        configOptions={configOptions}
+                        values={effectiveValues}
+                        onChange={(name, value) =>
+                            setOption(dataAppVizUuid, name, value)
+                        }
+                        colorPalette={colorPalette}
+                        paletteControl={<ColorPaletteSection />}
+                    />
+                </Box>
+
+                {dataAppVizUuid && canAuthor && (
+                    <DataAppVizDock
+                        projectUuid={projectUuid ?? ''}
+                        dataAppVizUuid={dataAppVizUuid}
+                    />
+                )}
+            </Box>
         </MantineProvider>
     );
 });

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizSettings.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizSettings.tsx
@@ -1,0 +1,115 @@
+import {
+    getItemId,
+    type DataAppViz,
+    type DataAppVizField,
+    type DataAppVizFieldMapping,
+    type Item,
+    type ItemsMap,
+} from '@lightdash/common';
+import { Stack, Text } from '@mantine-8/core';
+import { useMemo, type FC } from 'react';
+import DataAppVizLibraryPicker from '../../../features/apps/components/DataAppVizLibraryPicker';
+import { poolKeyForSlot } from '../../../features/apps/utils/autoMapDataAppVizFields';
+import { getDataAppVizFieldItems } from '../../../features/apps/utils/getDataAppVizFieldItems';
+import FieldSelect from '../../common/FieldSelect';
+import { Config } from '../common/Config';
+
+type Props = {
+    projectUuid: string;
+    /** The visualization the chart points at; empty when it points at none. */
+    dataAppVizUuid: string;
+    dataAppViz: DataAppViz | null;
+    itemsMap: ItemsMap;
+    /** The contract's declared slots. */
+    fields: DataAppVizField[];
+    /** The saved binding, reconciled against the contract in force now. */
+    fieldMapping: DataAppVizFieldMapping;
+    onSelect: (dataAppViz: DataAppViz | null) => void;
+    onFieldChange: (fieldName: string, fieldId: string | null) => void;
+};
+
+/**
+ * What the chart is pointing at, and what each of its slots is bound to.
+ *
+ * Changes here are free and instant — no build, no request.
+ */
+const DataAppVizSettings: FC<Props> = ({
+    projectUuid,
+    dataAppVizUuid,
+    dataAppViz,
+    itemsMap,
+    fields,
+    fieldMapping,
+    onSelect,
+    onFieldChange,
+}) => {
+    const { dimensions, metrics } = useMemo(
+        () => getDataAppVizFieldItems(itemsMap),
+        [itemsMap],
+    );
+    const itemPools = { dimension: dimensions, metric: metrics };
+    const fieldItems = (field: DataAppVizField): Item[] =>
+        itemPools[poolKeyForSlot(field)];
+    // Auto-binding cannot run without columns, and it only runs once, at pick
+    // time — so picking now would leave the slots empty for good.
+    const hasColumns = dimensions.length > 0 || metrics.length > 0;
+
+    return (
+        <Stack>
+            <Config>
+                <Config.Section>
+                    <Config.Heading>Visualization</Config.Heading>
+                    <DataAppVizLibraryPicker
+                        projectUuid={projectUuid}
+                        selectedDataAppVizUuid={dataAppVizUuid || null}
+                        selectedDataAppViz={dataAppViz}
+                        disabled={!hasColumns}
+                        onSelect={onSelect}
+                    />
+                    {!hasColumns && (
+                        <Text c="dimmed" size="xs">
+                            Run your query to pick a visualization.
+                        </Text>
+                    )}
+                </Config.Section>
+            </Config>
+
+            {dataAppVizUuid && fields.length === 0 && (
+                <Text c="dimmed" size="sm">
+                    This visualization has no fields to map.
+                </Text>
+            )}
+
+            {fields.map((field) => {
+                const items = fieldItems(field);
+                const selectedId = fieldMapping[field.name];
+                const selectedItem = selectedId
+                    ? items.find((i) => getItemId(i) === selectedId)
+                    : undefined;
+                return (
+                    <Config key={field.name}>
+                        <Config.Section>
+                            <Config.Heading>{field.label}</Config.Heading>
+                            <FieldSelect
+                                placeholder={`Select ${field.label.toLowerCase()}`}
+                                disabled={items.length === 0}
+                                item={selectedItem}
+                                items={items}
+                                onChange={(newField) =>
+                                    onFieldChange(
+                                        field.name,
+                                        newField ? getItemId(newField) : null,
+                                    )
+                                }
+                                clearable={!field.required}
+                                hasGrouping
+                            />
+                        </Config.Section>
+                    </Config>
+                );
+            })}
+        </Stack>
+    );
+};
+
+export default DataAppVizSettings;

--- a/packages/frontend/src/features/apps/components/DataAppVizDock.module.css
+++ b/packages/frontend/src/features/apps/components/DataAppVizDock.module.css
@@ -1,0 +1,78 @@
+/* Sits on the panel's bottom edge. Collapsed it takes one line; expanded it
+   takes only what its versions need, and scrolls past three of them. */
+.dock {
+    /* One log row: the prompt line, the receipt line, and the row's padding. */
+    --dock-log-row: 3rem;
+    position: relative;
+    flex: 0 0 auto;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    gap: var(--mantine-spacing-xs);
+    padding-top: var(--mantine-spacing-xs);
+    border-top: 1px solid var(--mantine-color-default-border);
+}
+
+.dockExpanded {
+    /* Grows with its versions rather than claiming the settings' room. */
+    flex: 0 1 auto;
+}
+
+.sheetHeader {
+    flex: 0 0 auto;
+}
+
+.log {
+    flex: 0 1 auto;
+    min-height: 0;
+    /* Three rows, then scroll — clipping the fourth mid-row is what says
+       there are more. */
+    max-height: calc(3 * var(--dock-log-row));
+    overflow-y: auto;
+}
+
+/* Whatever the caller docks under the log keeps its own height. */
+.footer {
+    flex: 0 0 auto;
+}
+
+.bar {
+    display: flex;
+    align-items: center;
+    gap: var(--mantine-spacing-xs);
+    min-height: 22px;
+}
+
+/* The whole status line opens the dock, so the target is the sentence rather
+   than the chevron alone. */
+.barTrigger {
+    flex: 1 1 auto;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+    padding: 0;
+    border: none;
+    background: none;
+    text-align: left;
+    cursor: pointer;
+}
+
+.toggle {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    padding: 0;
+    border: none;
+    border-radius: var(--mantine-radius-sm);
+    background: none;
+    color: var(--mantine-color-dimmed);
+    cursor: pointer;
+}
+
+.toggle:hover {
+    background-color: var(--mantine-color-default-hover);
+}

--- a/packages/frontend/src/features/apps/components/DataAppVizDock.test.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizDock.test.tsx
@@ -1,0 +1,226 @@
+import { type ApiAppVersionSummary } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { useGetApp } from '../hooks/useGetApp';
+import {
+    appVersion,
+    appVersionsPage,
+    appVersionsUnreadable,
+} from '../testing/appVersionHistory';
+import DataAppVizDock from './DataAppVizDock';
+
+vi.mock('../hooks/useGetApp', () => ({ useGetApp: vi.fn() }));
+vi.mock('../hooks/useRestoreAppVersion', () => ({
+    useRestoreAppVersion: () => ({
+        mutate: vi.fn(),
+        isLoading: false,
+        error: null,
+        reset: vi.fn(),
+    }),
+}));
+
+const mockedUseGetApp = vi.mocked(useGetApp);
+
+const version = appVersion;
+
+const setVersions = (
+    versions: ApiAppVersionSummary[],
+    latestReadyVersion?: number | null,
+) => {
+    mockedUseGetApp.mockReturnValue(
+        appVersionsPage(versions, latestReadyVersion),
+    );
+};
+
+const render = () =>
+    renderWithProviders(
+        <DataAppVizDock projectUuid="project-1" dataAppVizUuid="viz-1" />,
+    );
+
+describe('DataAppVizDock', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('rests as provenance: who first asked, and how current it is', () => {
+        setVersions([version(), version({ version: 2 })]);
+        render();
+
+        expect(screen.getByText(/Built by Katie Jones/)).toBeInTheDocument();
+        expect(screen.getByText('v2')).toBeInTheDocument();
+    });
+
+    // The badge names what the chart is rendering. Reading it off the newest
+    // version instead would claim a build that failed is on screen.
+    it('badges the last good build, not a newer one that failed', () => {
+        setVersions([version(), version({ version: 2, status: 'error' })]);
+        render();
+
+        expect(screen.getByText('v1')).toBeInTheDocument();
+        expect(screen.queryByText('v2')).not.toBeInTheDocument();
+    });
+
+    it('badges the last good build while a newer one is running', () => {
+        setVersions([version(), version({ version: 2, status: 'building' })]);
+        render();
+
+        expect(screen.getByText('v1')).toBeInTheDocument();
+        expect(screen.queryByText('v2')).not.toBeInTheDocument();
+    });
+
+    it('badges the rendered version even when it is older than the page', () => {
+        setVersions([version({ version: 9, status: 'error' })], 4);
+        render();
+
+        expect(screen.getByText('v4')).toBeInTheDocument();
+    });
+
+    it('shows no version badge before anything has built successfully', () => {
+        setVersions([version({ status: 'building' })]);
+        render();
+
+        expect(screen.queryByText(/^v\d+$/)).not.toBeInTheDocument();
+    });
+
+    it('does not claim origin when earlier versions are still unloaded', () => {
+        setVersions([version({ version: 7 })]);
+        render();
+
+        expect(
+            screen.getByText(/Last updated by Katie Jones/),
+        ).toBeInTheDocument();
+    });
+
+    it('reports the newest version once the history pages past the origin', () => {
+        setVersions([
+            version({
+                version: 7,
+                createdAt: new Date('2026-05-20T10:00:00Z'),
+                createdByUser: {
+                    userUuid: 'u2',
+                    firstName: 'Ada',
+                    lastName: 'Lovelace',
+                },
+            } as Partial<ApiAppVersionSummary>),
+            version({ version: 3 }),
+        ]);
+        render();
+
+        expect(
+            screen.getByText(/Last updated by Ada Lovelace/),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText(/Last updated by Katie Jones/),
+        ).not.toBeInTheDocument();
+    });
+
+    it('admits it when the history cannot be read', () => {
+        mockedUseGetApp.mockReturnValue(appVersionsUnreadable());
+        render();
+
+        expect(screen.getByText('Versions unavailable')).toBeInTheDocument();
+    });
+
+    // Nothing built yet is not the same as nothing readable, and the composer
+    // upstack replaces this bar with its own status line.
+    it('stays quiet when the history is simply empty', () => {
+        setVersions([]);
+        render();
+
+        expect(
+            screen.queryByText('Versions unavailable'),
+        ).not.toBeInTheDocument();
+    });
+
+    it('keeps the versions out of the way until they are asked for', () => {
+        setVersions([version()]);
+        render();
+
+        expect(screen.queryByText('Versions')).not.toBeInTheDocument();
+    });
+
+    it('opens from the status line, not just the chevron', async () => {
+        setVersions([version()]);
+        render();
+
+        await userEvent.click(screen.getByText(/Built by Katie Jones/));
+
+        expect(screen.getByText('Versions')).toBeInTheDocument();
+        expect(
+            screen.getByText('a donut of orders by status'),
+        ).toBeInTheDocument();
+    });
+
+    it('offers the full builder as the way out', async () => {
+        setVersions([version()]);
+        render();
+
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Show versions' }),
+        );
+
+        expect(
+            screen.getByRole('link', { name: /Open in builder/ }),
+        ).toHaveAttribute('href', '/projects/project-1/apps/viz-1');
+    });
+
+    // The dock is a shell: what else belongs against the panel's bottom edge
+    // is the caller's business, so these are slots rather than branches here.
+    it('takes over the resting line when the caller supplies a status', () => {
+        setVersions([version()]);
+        renderWithProviders(
+            <DataAppVizDock
+                projectUuid="project-1"
+                dataAppVizUuid="viz-1"
+                status={<span>Building v2</span>}
+            />,
+        );
+
+        expect(screen.getByText('Building v2')).toBeInTheDocument();
+        expect(
+            screen.queryByText(/Built by Katie Jones/),
+        ).not.toBeInTheDocument();
+    });
+
+    // Resting, the dock is one line of provenance. The footer belongs to the
+    // versions it sits under, so it comes and goes with them.
+    it('holds the footer back until the versions are open', async () => {
+        setVersions([version()]);
+        renderWithProviders(
+            <DataAppVizDock
+                projectUuid="project-1"
+                dataAppVizUuid="viz-1"
+                footer={<span>footer slot</span>}
+            />,
+        );
+
+        expect(screen.queryByText('footer slot')).not.toBeInTheDocument();
+
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Show versions' }),
+        );
+
+        expect(screen.getByText('footer slot')).toBeInTheDocument();
+
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Hide versions' }),
+        );
+
+        expect(screen.queryByText('footer slot')).not.toBeInTheDocument();
+    });
+
+    it('closes back down to the bar', async () => {
+        setVersions([version()]);
+        render();
+
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Show versions' }),
+        );
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Hide versions' }),
+        );
+
+        expect(screen.queryByText('Versions')).not.toBeInTheDocument();
+        expect(screen.getByText(/Built by Katie Jones/)).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/features/apps/components/DataAppVizDock.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizDock.tsx
@@ -1,0 +1,190 @@
+import { Badge, Box, Button, Group, Text, Tooltip } from '@mantine-8/core';
+import { useDisclosure } from '@mantine-8/hooks';
+import {
+    IconChevronDown,
+    IconChevronUp,
+    IconExternalLink,
+    IconPuzzle,
+} from '@tabler/icons-react';
+import { type FC, type ReactNode } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { useTimeAgo } from '../../../hooks/useTimeAgo';
+import { useAppVersionHistory } from '../hooks/useAppVersionHistory';
+import { getVersionAuthorName } from '../utils/versionsToChatMessages';
+import classes from './DataAppVizDock.module.css';
+import DataAppVizVersionLog from './DataAppVizVersionLog';
+
+const Provenance: FC<{
+    authorName: string | null;
+    at: Date;
+    /** False when older versions are still unloaded — then this is not the
+     *  origin, it is just the oldest we can see. */
+    isOrigin: boolean;
+}> = ({ authorName, at, isOrigin }) => {
+    const timeAgo = useTimeAgo(at);
+    const verb = isOrigin ? 'Built' : 'Last updated';
+    return (
+        <Text size="xs" c="dimmed" truncate="end">
+            {authorName
+                ? `${verb} by ${authorName} · ${timeAgo}`
+                : `${verb} ${timeAgo}`}
+        </Text>
+    );
+};
+
+type Props = {
+    projectUuid: string;
+    /**
+     * The visualization whose versions are on show, already resolved by the
+     * caller. The dock does not work out which one that is.
+     */
+    dataAppVizUuid: string;
+    /** Replaces the provenance line on the resting bar while it is present. */
+    status?: ReactNode;
+    /** Sits under the log wherever there is one. A resting dock has none, so
+     *  it is one line and nothing else. */
+    footer?: ReactNode;
+};
+
+/**
+ * The visualization's versions, docked to the bottom of the config panel.
+ *
+ * Resting it is a slim bar: where this visualization came from, and the way in.
+ * Expanded it is every version it has had, and the way out to the full builder.
+ * The settings above it never move.
+ *
+ * What the bar reports and what sits under the log are the caller's business,
+ * so the status line and the footer are slots rather than branches here.
+ */
+const DataAppVizDock: FC<Props> = ({
+    projectUuid,
+    dataAppVizUuid,
+    status,
+    footer,
+}) => {
+    const [isExpanded, { toggle }] = useDisclosure(false);
+    const { latest, oldest, hasOrigin, latestReadyVersion, isError } =
+        useAppVersionHistory(projectUuid, dataAppVizUuid);
+    // With the origin loaded the line reports where the visualization came
+    // from; without it the verb flips to "Last updated", which is the newest
+    // version rather than the oldest page we happen to hold.
+    const provenanceVersion = hasOrigin ? oldest : latest;
+    // The badge names what the chart is rendering, so it tracks the newest
+    // finished version. A build that failed or is still running has not
+    // replaced it.
+    const versionBadge = latestReadyVersion !== null && (
+        <Badge size="xs" variant="light" color="violet">
+            {`v${latestReadyVersion}`}
+        </Badge>
+    );
+
+    const toggleButton = (
+        <Tooltip
+            withArrow
+            label={isExpanded ? 'Hide versions' : 'Show versions'}
+        >
+            <button
+                type="button"
+                className={classes.toggle}
+                aria-expanded={isExpanded}
+                aria-label={isExpanded ? 'Hide versions' : 'Show versions'}
+                onClick={toggle}
+            >
+                <MantineIcon
+                    icon={isExpanded ? IconChevronDown : IconChevronUp}
+                    size={14}
+                />
+            </button>
+        </Tooltip>
+    );
+
+    if (isExpanded) {
+        return (
+            <Box className={`${classes.dock} ${classes.dockExpanded}`}>
+                <Group
+                    justify="space-between"
+                    wrap="nowrap"
+                    gap="xs"
+                    className={classes.sheetHeader}
+                >
+                    <Group gap={6} wrap="nowrap">
+                        <MantineIcon icon={IconPuzzle} size={13} />
+                        <Text size="xs" fw={600}>
+                            Versions
+                        </Text>
+                        {versionBadge}
+                    </Group>
+
+                    <Group gap={4} wrap="nowrap">
+                        <Button
+                            component="a"
+                            href={`/projects/${projectUuid}/apps/${dataAppVizUuid}`}
+                            target="_blank"
+                            rel="noreferrer"
+                            size="compact-xs"
+                            variant="default"
+                            rightSection={
+                                <MantineIcon
+                                    icon={IconExternalLink}
+                                    size={12}
+                                />
+                            }
+                        >
+                            Open in builder
+                        </Button>
+                        {toggleButton}
+                    </Group>
+                </Group>
+
+                <Box className={classes.log}>
+                    <DataAppVizVersionLog
+                        projectUuid={projectUuid}
+                        dataAppVizUuid={dataAppVizUuid}
+                    />
+                </Box>
+
+                {footer && <Box className={classes.footer}>{footer}</Box>}
+            </Box>
+        );
+    }
+
+    return (
+        <Box className={classes.dock}>
+            <Box className={classes.bar}>
+                <button
+                    type="button"
+                    className={classes.barTrigger}
+                    aria-expanded={false}
+                    onClick={toggle}
+                >
+                    <MantineIcon icon={IconPuzzle} size={13} />
+                    {status ?? (
+                        <>
+                            {versionBadge}
+                            {provenanceVersion ? (
+                                <Provenance
+                                    authorName={getVersionAuthorName(
+                                        provenanceVersion,
+                                    )}
+                                    at={new Date(provenanceVersion.createdAt)}
+                                    isOrigin={hasOrigin}
+                                />
+                            ) : (
+                                // Otherwise the bar is a lone icon that says
+                                // nothing about why it is empty.
+                                isError && (
+                                    <Text size="xs" c="dimmed" truncate="end">
+                                        Versions unavailable
+                                    </Text>
+                                )
+                            )}
+                        </>
+                    )}
+                </button>
+                {toggleButton}
+            </Box>
+        </Box>
+    );
+};
+
+export default DataAppVizDock;

--- a/packages/frontend/src/features/apps/components/DataAppVizVersionLog.module.css
+++ b/packages/frontend/src/features/apps/components/DataAppVizVersionLog.module.css
@@ -1,0 +1,26 @@
+/* One line per build. Rows are read down the version badges, so the badge
+   column is fixed and the prompt takes whatever is left. */
+.row {
+    padding: 6px var(--mantine-spacing-xs);
+    border-radius: var(--mantine-radius-sm);
+}
+
+.row:hover {
+    background-color: var(--mantine-color-default-hover);
+}
+
+.versionBadge {
+    flex: 0 0 auto;
+    margin-top: 1px;
+}
+
+/* Without an explicit min-width a flex child refuses to shrink below its
+   content, so a long prompt would push the action off the row. */
+.rowBody {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.rowAction {
+    flex: 0 0 auto;
+}

--- a/packages/frontend/src/features/apps/components/DataAppVizVersionLog.test.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizVersionLog.test.tsx
@@ -1,0 +1,176 @@
+import { type ApiAppVersionSummary } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { useGetApp } from '../hooks/useGetApp';
+import { useRestoreAppVersion } from '../hooks/useRestoreAppVersion';
+import {
+    appVersion,
+    appVersionsPage,
+    appVersionsUnreadable,
+} from '../testing/appVersionHistory';
+import DataAppVizVersionLog from './DataAppVizVersionLog';
+
+vi.mock('../hooks/useGetApp', () => ({ useGetApp: vi.fn() }));
+vi.mock('../hooks/useRestoreAppVersion', () => ({
+    useRestoreAppVersion: vi.fn(),
+}));
+
+const mockedUseGetApp = vi.mocked(useGetApp);
+const mockedUseRestore = vi.mocked(useRestoreAppVersion);
+const restoreMutate = vi.fn();
+
+const version = appVersion;
+
+const setVersions = (
+    versions: ApiAppVersionSummary[],
+    latestReadyVersion?: number | null,
+) => {
+    mockedUseGetApp.mockReturnValue(
+        appVersionsPage(versions, latestReadyVersion),
+    );
+};
+
+const render = () =>
+    renderWithProviders(
+        <DataAppVizVersionLog projectUuid="project-1" dataAppVizUuid="viz-1" />,
+    );
+
+describe('DataAppVizVersionLog', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockedUseRestore.mockReturnValue({
+            mutate: restoreMutate,
+            isLoading: false,
+            error: null,
+            reset: vi.fn(),
+        } as unknown as ReturnType<typeof useRestoreAppVersion>);
+    });
+
+    it('reads newest first, one line per build', () => {
+        setVersions([
+            version(),
+            version({ version: 2, prompt: 'make the bars horizontal' }),
+        ]);
+        render();
+
+        const rows = screen.getAllByTestId(/version-log-row-/);
+        expect(rows.map((row) => row.dataset.testid)).toEqual([
+            'version-log-row-2',
+            'version-log-row-1',
+        ]);
+        expect(
+            screen.getByText('make the bars horizontal'),
+        ).toBeInTheDocument();
+    });
+
+    it('receipts a finished build with its duration', () => {
+        setVersions([version()]);
+        render();
+
+        expect(screen.getByText(/Built in 52s/)).toBeInTheDocument();
+    });
+
+    it('states why a build failed instead of receipting it', () => {
+        setVersions([
+            version({ status: 'error', error: 'The sandbox ran out of time' }),
+        ]);
+        render();
+
+        expect(
+            screen.getByText(/The sandbox ran out of time/),
+        ).toBeInTheDocument();
+    });
+
+    it('marks the latest version as current and offers no restore for it', () => {
+        setVersions([version(), version({ version: 2 })]);
+        render();
+
+        expect(screen.getByText('current')).toBeInTheDocument();
+        expect(screen.getAllByRole('button', { name: 'Restore' })).toHaveLength(
+            1,
+        );
+    });
+
+    // "Current" is what the chart renders, which is the newest version that
+    // finished. Reading it off the top of the log instead would crown a build
+    // that failed and offer to restore the one already on screen.
+    it('leaves current on the last good build when the newest one failed', () => {
+        setVersions([version(), version({ version: 2, status: 'error' })]);
+        render();
+
+        expect(screen.getByTestId('version-log-row-1')).toHaveTextContent(
+            'current',
+        );
+        expect(screen.getByTestId('version-log-row-2')).not.toHaveTextContent(
+            'current',
+        );
+        // v1 is on screen, so restoring it would be a no-op that costs a build.
+        expect(
+            screen.queryByRole('button', { name: 'Restore' }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('leaves current on the last good build while a new one is running', () => {
+        setVersions([version(), version({ version: 2, status: 'building' })]);
+        render();
+
+        expect(screen.getByTestId('version-log-row-1')).toHaveTextContent(
+            'current',
+        );
+        expect(screen.getByTestId('version-log-row-2')).not.toHaveTextContent(
+            'current',
+        );
+    });
+
+    // The ready version can be older than the page window, and the server
+    // resolves it across all versions. Crowning a row we happen to hold would
+    // be a guess.
+    it('crowns no row when the rendered version is older than the page', () => {
+        setVersions(
+            [
+                version({ version: 9, status: 'error' }),
+                version({ version: 8, status: 'error' }),
+            ],
+            4,
+        );
+        render();
+
+        expect(screen.queryByText('current')).not.toBeInTheDocument();
+    });
+
+    it('does not offer to restore a build that failed', () => {
+        setVersions([version({ status: 'error' }), version({ version: 2 })]);
+        render();
+
+        expect(
+            screen.queryByRole('button', { name: 'Restore' }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('says so when the history cannot be read, rather than reading empty', () => {
+        mockedUseGetApp.mockReturnValue(appVersionsUnreadable());
+        render();
+
+        expect(
+            screen.getByText(/Could not load this visualization's versions/),
+        ).toBeInTheDocument();
+    });
+
+    it('restores only once the consequence is confirmed', async () => {
+        setVersions([version(), version({ version: 2 })]);
+        render();
+
+        await userEvent.click(screen.getByRole('button', { name: 'Restore' }));
+        expect(restoreMutate).not.toHaveBeenCalled();
+
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Restore version' }),
+        );
+        expect(restoreMutate).toHaveBeenCalledWith(
+            { projectUuid: 'project-1', appUuid: 'viz-1', version: 1 },
+            expect.anything(),
+        );
+    });
+});

--- a/packages/frontend/src/features/apps/components/DataAppVizVersionLog.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizVersionLog.tsx
@@ -1,0 +1,256 @@
+import { type ApiAppVersionSummary } from '@lightdash/common';
+import { Anchor, Badge, Group, Loader, Stack, Text } from '@mantine-8/core';
+import { IconAlertTriangle, IconCheck, IconRestore } from '@tabler/icons-react';
+import { useMemo, useState, type FC } from 'react';
+import Callout from '../../../components/common/Callout';
+import MantineIcon from '../../../components/common/MantineIcon';
+import MantineModal from '../../../components/common/MantineModal';
+import { useTimeAgo } from '../../../hooks/useTimeAgo';
+import { useAppVersionHistory } from '../hooks/useAppVersionHistory';
+import { useRestoreAppVersion } from '../hooks/useRestoreAppVersion';
+import { type ChatMessage } from '../utils/chatMessage';
+import { formatBuildDuration } from '../utils/formatBuildDuration';
+import { versionsToChatMessages } from '../utils/versionsToChatMessages';
+import classes from './DataAppVizVersionLog.module.css';
+
+/** One exchange: what was asked for, and what the build made of it. */
+type LogEntry = {
+    version: number;
+    status: ApiAppVersionSummary['status'];
+    request: ChatMessage;
+    /** Null while the version is still building — it has no outcome yet. */
+    receipt: ChatMessage | null;
+};
+
+const Receipt: FC<{ message: ChatMessage }> = ({ message }) => {
+    const timeAgo = useTimeAgo(message.timestamp);
+
+    if (message.status === 'error') {
+        return (
+            <Group gap={4} wrap="nowrap">
+                <MantineIcon icon={IconAlertTriangle} size={12} color="red.6" />
+                <Text size="xs" c="red.7" lineClamp={1}>
+                    {message.content}
+                </Text>
+            </Group>
+        );
+    }
+
+    const built =
+        message.durationMs === null
+            ? 'Built'
+            : `Built in ${formatBuildDuration(message.durationMs)}`;
+    return (
+        <Group gap={4} wrap="nowrap">
+            <MantineIcon icon={IconCheck} size={12} color="green.7" />
+            <Text size="xs" c="dimmed">
+                {`${built} · ${timeAgo}`}
+            </Text>
+        </Group>
+    );
+};
+
+const Prompt: FC<{ message: ChatMessage }> = ({ message }) =>
+    message.content ? (
+        <Text size="xs" lineClamp={1} title={message.content}>
+            {message.content}
+        </Text>
+    ) : (
+        <Text size="xs" c="dimmed" fs="italic">
+            Uploaded from source
+        </Text>
+    );
+
+const LogRow: FC<{
+    entry: LogEntry;
+    /** The version every chart using this visualization renders right now. */
+    isCurrent: boolean;
+    onRestore: (version: number) => void;
+}> = ({ entry, isCurrent, onRestore }) => {
+    return (
+        <Group
+            className={classes.row}
+            gap="xs"
+            wrap="nowrap"
+            align="flex-start"
+            data-testid={`version-log-row-${entry.version}`}
+        >
+            <Badge
+                size="xs"
+                variant="light"
+                color={isCurrent ? 'violet' : 'gray'}
+                className={classes.versionBadge}
+            >
+                {`v${entry.version}`}
+            </Badge>
+
+            <Stack gap={2} className={classes.rowBody}>
+                <Prompt message={entry.request} />
+                {entry.receipt && <Receipt message={entry.receipt} />}
+            </Stack>
+
+            {isCurrent && (
+                <Text size="xs" c="dimmed" className={classes.rowAction}>
+                    current
+                </Text>
+            )}
+            {!isCurrent && entry.status === 'ready' && (
+                <Anchor
+                    component="button"
+                    type="button"
+                    size="xs"
+                    className={classes.rowAction}
+                    onClick={() => onRestore(entry.version)}
+                >
+                    Restore
+                </Anchor>
+            )}
+        </Group>
+    );
+};
+
+type Props = {
+    projectUuid: string;
+    /** The visualization whose history this is. */
+    dataAppVizUuid: string;
+};
+
+/**
+ * Every build this visualization has had, newest first — one line each, so the
+ * whole session reads at a glance rather than as a scroll of bubbles.
+ *
+ * Restoring an older version puts its contents back on top of the timeline as a
+ * new version. The newest version that finished is what every chart using this
+ * visualization renders, so a restore reaches all of them.
+ */
+const DataAppVizVersionLog: FC<Props> = ({ projectUuid, dataAppVizUuid }) => {
+    const {
+        versions,
+        latestReadyVersion,
+        hasEarlier,
+        isLoading,
+        isError,
+        isFetchingEarlier,
+        fetchEarlier,
+    } = useAppVersionHistory(projectUuid, dataAppVizUuid);
+    // Which version the user is about to restore; null while nothing is asked.
+    const [restoreTarget, setRestoreTarget] = useState<number | null>(null);
+    const {
+        mutate: restoreVersion,
+        isLoading: isRestoring,
+        error: restoreError,
+        reset: resetRestore,
+    } = useRestoreAppVersion();
+
+    const entries = useMemo<LogEntry[]>(
+        () =>
+            [...versions]
+                .sort((a, b) => b.version - a.version)
+                .map((version) => {
+                    // Per version, so each row is exactly the pair the
+                    // generator's thread renders for it.
+                    const [request, receipt] = versionsToChatMessages([
+                        version,
+                    ]);
+                    return {
+                        version: version.version,
+                        status: version.status,
+                        request,
+                        receipt: receipt ?? null,
+                    };
+                }),
+        [versions],
+    );
+
+    if (isLoading) {
+        return (
+            <Group justify="center" p="md">
+                <Loader size="sm" />
+            </Group>
+        );
+    }
+
+    // Only when the failure left nothing to read — a page that fails partway
+    // should not throw away the versions already on screen.
+    if (isError && entries.length === 0) {
+        return (
+            <Text size="xs" c="dimmed" px="xs" py={6}>
+                Could not load this visualization's versions.
+            </Text>
+        );
+    }
+
+    return (
+        <>
+            <Stack gap={0}>
+                {entries.map((entry) => (
+                    <LogRow
+                        key={entry.version}
+                        entry={entry}
+                        isCurrent={entry.version === latestReadyVersion}
+                        onRestore={setRestoreTarget}
+                    />
+                ))}
+
+                {hasEarlier && (
+                    <Anchor
+                        component="button"
+                        type="button"
+                        size="xs"
+                        px="xs"
+                        py={6}
+                        disabled={isFetchingEarlier}
+                        onClick={fetchEarlier}
+                    >
+                        {isFetchingEarlier ? 'Loading…' : 'Load earlier builds'}
+                    </Anchor>
+                )}
+            </Stack>
+
+            {restoreTarget !== null && (
+                <MantineModal
+                    opened
+                    onClose={() => {
+                        if (isRestoring) return;
+                        setRestoreTarget(null);
+                        resetRestore();
+                    }}
+                    title={`Restore version ${restoreTarget}?`}
+                    icon={IconRestore}
+                    confirmLabel="Restore version"
+                    cancelDisabled={isRestoring}
+                    confirmLoading={isRestoring}
+                    onConfirm={() =>
+                        restoreVersion(
+                            {
+                                projectUuid,
+                                appUuid: dataAppVizUuid,
+                                version: restoreTarget,
+                            },
+                            { onSuccess: () => setRestoreTarget(null) },
+                        )
+                    }
+                >
+                    <Stack gap="sm">
+                        <Text fz="sm">
+                            This adds a new version on top that duplicates
+                            version {restoreTarget}. Every chart using this
+                            visualization follows the latest version, so they
+                            will all show it — and any chart bound to a field
+                            that version {restoreTarget} does not declare will
+                            lose that binding.
+                        </Text>
+                        {restoreError && (
+                            <Callout variant="danger">
+                                {restoreError.error?.message ??
+                                    'Failed to restore version.'}
+                            </Callout>
+                        )}
+                    </Stack>
+                </MantineModal>
+            )}
+        </>
+    );
+};
+
+export default DataAppVizVersionLog;

--- a/packages/frontend/src/features/apps/hooks/useAppVersionHistory.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppVersionHistory.ts
@@ -1,0 +1,98 @@
+import { type ApiAppVersionSummary } from '@lightdash/common';
+import { useMemo } from 'react';
+import { useGetApp } from './useGetApp';
+
+export type AppVersionHistory = {
+    /** Every version loaded so far, newest first. */
+    versions: ApiAppVersionSummary[];
+    /** The oldest loaded version; null before anything has loaded. */
+    oldest: ApiAppVersionSummary | null;
+    /**
+     * The newest loaded version whatever its status, so a build that failed or
+     * is still running is the one reported. This is "last updated", not what
+     * anything renders — for that, use `latestReadyVersion`.
+     */
+    latest: ApiAppVersionSummary | null;
+    /**
+     * The version every chart using this visualization renders: the newest one
+     * that finished, resolved server-side across ALL versions rather than the
+     * loaded page window. Null when nothing has ever built successfully.
+     */
+    latestReadyVersion: number | null;
+    /**
+     * True once version 1 is loaded. Versions are 1-indexed and contiguous, so
+     * holding it means `oldest` really is the origin rather than the oldest
+     * page we happened to fetch.
+     */
+    hasOrigin: boolean;
+    /** There are older versions the server has not been asked for yet. */
+    hasEarlier: boolean;
+    isLoading: boolean;
+    /** The history could not be read, so `versions` is empty by failure. */
+    isError: boolean;
+    isFetchingEarlier: boolean;
+    fetchEarlier: () => void;
+};
+
+/**
+ * A visualization's version history — the thread it carries.
+ *
+ * Every surface that reads it (the conversation, the panel's footer) shares
+ * one query key, so they page together and derive provenance the same way.
+ */
+export const useAppVersionHistory = (
+    projectUuid: string,
+    appUuid: string | null,
+): AppVersionHistory => {
+    const {
+        data,
+        isLoading,
+        isError,
+        hasNextPage,
+        fetchNextPage,
+        isFetchingNextPage,
+    } = useGetApp(projectUuid, appUuid ?? undefined);
+
+    const versions = useMemo(
+        () => data?.pages.flatMap((page) => page.versions) ?? [],
+        [data?.pages],
+    );
+
+    const oldest = useMemo(
+        () =>
+            versions.reduce<ApiAppVersionSummary | null>(
+                (found, v) =>
+                    found === null || v.version < found.version ? v : found,
+                null,
+            ),
+        [versions],
+    );
+
+    const latest = useMemo(
+        () =>
+            versions.reduce<ApiAppVersionSummary | null>(
+                (found, v) =>
+                    found === null || v.version > found.version ? v : found,
+                null,
+            ),
+        [versions],
+    );
+
+    const hasOrigin = versions.some((v) => v.version === 1);
+
+    return {
+        versions,
+        oldest,
+        latest,
+        // Taken from the server rather than scanned out of `versions`: the
+        // ready version can be older than the page window, and a limit=1 poll
+        // carries it correctly because it is resolved outside pagination.
+        latestReadyVersion: data?.pages?.[0]?.latestReadyVersion ?? null,
+        hasOrigin,
+        hasEarlier: hasNextPage === true && !hasOrigin,
+        isLoading: appUuid !== null && isLoading,
+        isError,
+        isFetchingEarlier: isFetchingNextPage,
+        fetchEarlier: () => void fetchNextPage(),
+    };
+};

--- a/packages/frontend/src/features/apps/hooks/useRestoreAppVersion.test.tsx
+++ b/packages/frontend/src/features/apps/hooks/useRestoreAppVersion.test.tsx
@@ -1,0 +1,53 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { type PropsWithChildren } from 'react';
+import { useRestoreAppVersion } from './useRestoreAppVersion';
+
+const lightdashApi = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../api', () => ({ lightdashApi }));
+
+const renderWithClient = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: PropsWithChildren) => (
+        <QueryClientProvider client={queryClient}>
+            {children}
+        </QueryClientProvider>
+    );
+
+    return {
+        queryClient,
+        ...renderHook(() => useRestoreAppVersion(), { wrapper }),
+    };
+};
+
+describe('useRestoreAppVersion', () => {
+    beforeEach(() => {
+        lightdashApi.mockReset();
+    });
+
+    it('invalidates the visualization contract as well as the timeline', async () => {
+        lightdashApi.mockResolvedValue({ appUuid: 'viz-1', version: 8 });
+        const { queryClient, result } = renderWithClient();
+        const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+
+        await result.current.mutateAsync({
+            projectUuid: 'project-1',
+            appUuid: 'viz-1',
+            version: 3,
+        });
+
+        await waitFor(() => {
+            expect(invalidateQueries).toHaveBeenCalledWith({
+                queryKey: ['app', 'project-1', 'viz-1'],
+            });
+            // A restored version declares its own fields, so a panel left open
+            // over the pre-restore contract would map onto stale slot names.
+            expect(invalidateQueries).toHaveBeenCalledWith({
+                queryKey: ['data-app-viz', 'project-1', 'viz-1'],
+            });
+        });
+    });
+});

--- a/packages/frontend/src/features/apps/hooks/useRestoreAppVersion.ts
+++ b/packages/frontend/src/features/apps/hooks/useRestoreAppVersion.ts
@@ -38,6 +38,16 @@ export const useRestoreAppVersion = () => {
             void queryClient.invalidateQueries({
                 queryKey: ['app', variables.projectUuid, variables.appUuid],
             });
+            // The restored version carries its own field schema, so any panel
+            // open over this visualization is now reconciling against a
+            // contract that is no longer the one being rendered.
+            void queryClient.invalidateQueries({
+                queryKey: [
+                    'data-app-viz',
+                    variables.projectUuid,
+                    variables.appUuid,
+                ],
+            });
         },
     });
 };

--- a/packages/frontend/src/features/apps/testing/appVersionHistory.ts
+++ b/packages/frontend/src/features/apps/testing/appVersionHistory.ts
@@ -1,0 +1,58 @@
+import { type ApiAppVersionSummary } from '@lightdash/common';
+import { type useGetApp } from '../hooks/useGetApp';
+
+type UseGetAppResult = ReturnType<typeof useGetApp>;
+
+/** A ready version, newest-first fixtures override what they care about. */
+export const appVersion = (
+    overrides: Partial<ApiAppVersionSummary> = {},
+): ApiAppVersionSummary =>
+    ({
+        version: 1,
+        prompt: 'a donut of orders by status',
+        status: 'ready',
+        createdAt: new Date('2026-05-15T10:00:00Z'),
+        statusUpdatedAt: new Date('2026-05-15T10:00:52Z'),
+        createdByUser: {
+            userUuid: 'u1',
+            firstName: 'Katie',
+            lastName: 'Jones',
+        },
+        resources: null,
+        ...overrides,
+    }) as ApiAppVersionSummary;
+
+const newestReady = (versions: ApiAppVersionSummary[]): number | null =>
+    versions
+        .filter((v) => v.status === 'ready')
+        .reduce<number | null>(
+            (max, v) => (max === null ? v.version : Math.max(max, v.version)),
+            null,
+        );
+
+/**
+ * What `useGetApp` returns for one loaded page.
+ *
+ * The server resolves `latestReadyVersion` outside pagination; by default it
+ * agrees with the newest ready version here. Pass it to pull the two apart.
+ */
+export const appVersionsPage = (
+    versions: ApiAppVersionSummary[],
+    latestReadyVersion: number | null = newestReady(versions),
+): UseGetAppResult =>
+    ({
+        data: {
+            pages: [{ versions, hasMore: false, latestReadyVersion }],
+            pageParams: [undefined],
+        },
+        isLoading: false,
+        isError: false,
+    }) as unknown as UseGetAppResult;
+
+/** What `useGetApp` returns when the history could not be read at all. */
+export const appVersionsUnreadable = (): UseGetAppResult =>
+    ({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+    }) as unknown as UseGetAppResult;

--- a/packages/frontend/src/features/apps/utils/chatMessage.test.ts
+++ b/packages/frontend/src/features/apps/utils/chatMessage.test.ts
@@ -1,23 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import { mergeChatMessages, type ChatMessage } from './chatMessage';
+import {
+    emptyChatMessage,
+    mergeChatMessages,
+    type ChatMessage,
+} from './chatMessage';
 
 const baseMessage: ChatMessage = {
+    ...emptyChatMessage(),
     role: 'user',
-    status: null,
-    content: '',
-    imagePreviewUrls: [],
-    imageResourceIds: [],
-    files: [],
-    charts: [],
-    externalConnections: [],
-    dashboardName: null,
-    clarifications: [],
-    version: null,
     timestamp: new Date('2026-05-15T10:00:00Z'),
     userName: 'Test User',
-    vizSchema: null,
-    reasoning: [],
-    activity: [],
 };
 
 describe('mergeChatMessages', () => {

--- a/packages/frontend/src/features/apps/utils/chatMessage.ts
+++ b/packages/frontend/src/features/apps/utils/chatMessage.ts
@@ -28,6 +28,11 @@ export type ChatMessage = {
      * renderers use to tell success from failure.
      */
     status: 'ready' | 'error' | null;
+    /**
+     * How long the build took, for the thread's "built in 52s" receipt. Null on
+     * user bubbles and on versions predating completion-time capture.
+     */
+    durationMs: number | null;
     content: string;
     imagePreviewUrls: string[];
     imageResourceIds: string[];
@@ -67,6 +72,7 @@ export const emptyChatMessage = (): Omit<
     'role' | 'timestamp'
 > => ({
     status: null,
+    durationMs: null,
     content: '',
     imagePreviewUrls: [],
     imageResourceIds: [],

--- a/packages/frontend/src/features/apps/utils/formatBuildDuration.test.ts
+++ b/packages/frontend/src/features/apps/utils/formatBuildDuration.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { formatBuildDuration } from './formatBuildDuration';
+
+describe('formatBuildDuration', () => {
+    it('renders sub-minute builds in seconds', () => {
+        expect(formatBuildDuration(52_000)).toBe('52s');
+    });
+
+    it('rounds to the nearest second', () => {
+        expect(formatBuildDuration(52_400)).toBe('52s');
+        expect(formatBuildDuration(52_600)).toBe('53s');
+    });
+
+    it('never claims a build took no time', () => {
+        expect(formatBuildDuration(0)).toBe('1s');
+        expect(formatBuildDuration(120)).toBe('1s');
+    });
+
+    it('switches to minutes at a minute', () => {
+        expect(formatBuildDuration(60_000)).toBe('1m');
+        expect(formatBuildDuration(72_000)).toBe('1m 12s');
+        expect(formatBuildDuration(605_000)).toBe('10m 5s');
+    });
+
+    it('omits a zero seconds remainder', () => {
+        expect(formatBuildDuration(180_000)).toBe('3m');
+    });
+});

--- a/packages/frontend/src/features/apps/utils/formatBuildDuration.ts
+++ b/packages/frontend/src/features/apps/utils/formatBuildDuration.ts
@@ -1,0 +1,12 @@
+/**
+ * Render a build duration the way the thread's receipt reads it: seconds up to
+ * a minute, then minutes and seconds. Sub-second builds round up to `1s` rather
+ * than claiming `0s`.
+ */
+export const formatBuildDuration = (durationMs: number): string => {
+    const totalSeconds = Math.max(1, Math.round(durationMs / 1000));
+    if (totalSeconds < 60) return `${totalSeconds}s`;
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return seconds === 0 ? `${minutes}m` : `${minutes}m ${seconds}s`;
+};

--- a/packages/frontend/src/features/apps/utils/versionsToChatMessages.test.ts
+++ b/packages/frontend/src/features/apps/utils/versionsToChatMessages.test.ts
@@ -181,6 +181,33 @@ describe('versionsToChatMessages', () => {
         expect(assistant.activity).toEqual(['Creating App.tsx']);
     });
 
+    // A viz-only version has no attachments, so the server serves the schema
+    // on an otherwise empty resources blob rather than omitting the blob.
+    it('carries the schema of a version that attached nothing else', () => {
+        const [user, assistant] = convert([
+            version({
+                resources: {
+                    images: [],
+                    charts: [],
+                    dashboardName: null,
+                    clarifications: [],
+                    vizSchema: {
+                        fields: [],
+                        configOptions: [],
+                        colorPalette: null,
+                    },
+                },
+            }),
+        ]);
+        expect(user.charts).toEqual([]);
+        expect(user.imageResourceIds).toEqual([]);
+        expect(assistant.vizSchema).toEqual({
+            fields: [],
+            configOptions: [],
+            colorPalette: null,
+        });
+    });
+
     it('handles a missing author', () => {
         const [user] = convert([version({ createdByUser: null })]);
         expect(user.userName).toBeNull();

--- a/packages/frontend/src/features/apps/utils/versionsToChatMessages.ts
+++ b/packages/frontend/src/features/apps/utils/versionsToChatMessages.ts
@@ -48,7 +48,10 @@ const NO_FALLBACKS: ChatMessageFallbacks = {
     dashboardName: new Map(),
 };
 
-const authorNameOf = (version: ApiAppVersionSummary): string | null => {
+/** Display name of whoever asked for a version; null when unknown. */
+export const getVersionAuthorName = (
+    version: ApiAppVersionSummary,
+): string | null => {
     if (!version.createdByUser) return null;
     return (
         [version.createdByUser.firstName, version.createdByUser.lastName]
@@ -121,6 +124,12 @@ export function versionsToChatMessages(
             v.version === 1
                 ? 'Your app is ready!'
                 : `Version ${v.version} is ready!`;
+        // Null rather than 0 when the version never recorded a transition:
+        // an unknown duration is not a zero-second build.
+        const durationMs = v.statusUpdatedAt
+            ? new Date(v.statusUpdatedAt).getTime() -
+              new Date(v.createdAt).getTime()
+            : null;
         const reasoning = versionNarrationTexts(v.statusHistory, 'thinking');
         const activity = versionNarrationTexts(v.statusHistory, 'tool');
 
@@ -137,7 +146,7 @@ export function versionsToChatMessages(
                 dashboardName,
                 clarifications,
                 timestamp: new Date(v.createdAt),
-                userName: authorNameOf(v),
+                userName: getVersionAuthorName(v),
             },
         ];
 
@@ -146,6 +155,7 @@ export function versionsToChatMessages(
                 ...emptyChatMessage(),
                 role: 'assistant',
                 status: 'ready',
+                durationMs,
                 content: isUploadedVersion
                     ? readyMessage
                     : (v.statusMessage ?? readyMessage),
@@ -160,6 +170,7 @@ export function versionsToChatMessages(
                 ...emptyChatMessage(),
                 role: 'assistant',
                 status: 'error',
+                durationMs,
                 content: getAppVersionFailureMessage(v),
                 // `version` stays null: a deps chip renders off it, and a
                 // failed build has no artifacts to describe.


### PR DESCRIPTION
The config panel fills its viewport: the settings scroll, and a dock sits on the bottom edge. Resting it is one line of provenance; expanded it is the visualization's versions, one line each, with `current` on the newest and **Restore** on the rest.

Restore adds a new version on top. The modal says so, because every chart using the visualization follows the latest one.

Rows call `versionsToChatMessages` one version at a time, so a row is exactly the request/receipt pair the generator's thread renders for it. The log caps at three rows, then scrolls.

Relates: GLITCH-630
