### PR TITLE
feat(apps): show a building visualization as a draft

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -106,6 +106,8 @@ export const ConfigTabs: FC = memo(() => {
         fieldMapping,
     );
 
+    const draft = build.draft;
+
     const settings = (
         <DataAppVizSettings
             projectUuid={projectUuid ?? ''}
@@ -114,6 +116,8 @@ export const ConfigTabs: FC = memo(() => {
             itemsMap={itemsMap ?? NO_COLUMNS}
             fields={fields}
             fieldMapping={effectiveMapping}
+            draft={draft ? { dataAppVizUuid: draft.appUuid, elapsed } : null}
+            onSelectDraft={() => setDataAppVizUuid('', {})}
             onSelect={(picked) =>
                 setDataAppVizUuid(
                     picked?.dataAppVizUuid ?? '',
@@ -163,6 +167,11 @@ export const ConfigTabs: FC = memo(() => {
                                     elapsed={elapsed}
                                 />
                             ) : undefined
+                        }
+                        onCancelBuild={
+                            build.draft !== null && !dataAppVizUuid
+                                ? build.discard
+                                : null
                         }
                         footer={
                             // Asking a saved visualization to change is not

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizSettings.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizSettings.tsx
@@ -8,7 +8,9 @@ import {
 } from '@lightdash/common';
 import { Stack, Text } from '@mantine-8/core';
 import { useMemo, type FC } from 'react';
-import DataAppVizLibraryPicker from '../../../features/apps/components/DataAppVizLibraryPicker';
+import DataAppVizLibraryPicker, {
+    type DataAppVizDraftOption,
+} from '../../../features/apps/components/DataAppVizLibraryPicker';
 import { poolKeyForSlot } from '../../../features/apps/utils/autoMapDataAppVizFields';
 import { getDataAppVizFieldItems } from '../../../features/apps/utils/getDataAppVizFieldItems';
 import FieldSelect from '../../common/FieldSelect';
@@ -24,7 +26,9 @@ type Props = {
     fields: DataAppVizField[];
     /** The saved binding, reconciled against the contract in force now. */
     fieldMapping: DataAppVizFieldMapping;
+    draft: DataAppVizDraftOption | null;
     onSelect: (dataAppViz: DataAppViz | null) => void;
+    onSelectDraft: () => void;
     onFieldChange: (fieldName: string, fieldId: string | null) => void;
 };
 
@@ -41,7 +45,9 @@ const DataAppVizSettings: FC<Props> = ({
     itemsMap,
     fields,
     fieldMapping,
+    draft,
     onSelect,
+    onSelectDraft,
     onFieldChange,
 }) => {
     const { dimensions, metrics } = useMemo(
@@ -49,6 +55,7 @@ const DataAppVizSettings: FC<Props> = ({
         [itemsMap],
     );
     const itemPools = { dimension: dimensions, metric: metrics };
+    const isOnDraft = draft !== null && !dataAppVizUuid;
     const fieldItems = (field: DataAppVizField): Item[] =>
         itemPools[poolKeyForSlot(field)];
     // Auto-binding cannot run without columns, and it only runs once, at pick
@@ -62,9 +69,15 @@ const DataAppVizSettings: FC<Props> = ({
                     <Config.Heading>Visualization</Config.Heading>
                     <DataAppVizLibraryPicker
                         projectUuid={projectUuid}
-                        selectedDataAppVizUuid={dataAppVizUuid || null}
+                        selectedDataAppVizUuid={
+                            isOnDraft
+                                ? draft.dataAppVizUuid
+                                : dataAppVizUuid || null
+                        }
                         selectedDataAppViz={dataAppViz}
                         disabled={!hasColumns}
+                        draft={draft}
+                        onSelectDraft={onSelectDraft}
                         onSelect={onSelect}
                     />
                     {!hasColumns && (

--- a/packages/frontend/src/features/apps/components/DataAppVizDock.test.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizDock.test.tsx
@@ -341,6 +341,33 @@ describe('DataAppVizDock', () => {
         ).not.toBeInTheDocument();
     });
 
+    it('keeps stopping a draft build reachable from its row', async () => {
+        const discard = vi.fn();
+        setVersions([]);
+        renderWithProviders(
+            <DataAppVizDock
+                projectUuid="project-1"
+                dataAppVizUuid="draft-app"
+                build={buildStub({
+                    isBuilding: true,
+                    pendingPrompt: 'a donut of orders by status',
+                    appUuid: 'draft-app',
+                    draft: {
+                        appUuid: 'draft-app',
+                        version: 1,
+                        startedAt: new Date(),
+                    },
+                    discard,
+                })}
+                elapsed="0:14"
+                onCancelBuild={discard}
+            />,
+        );
+
+        await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+        expect(discard).toHaveBeenCalled();
+    });
+
     it('closes back down to the bar', async () => {
         setVersions([version()]);
         render();

--- a/packages/frontend/src/features/apps/components/DataAppVizDock.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizDock.tsx
@@ -49,6 +49,7 @@ type Props = {
     /** Sits under the log wherever there is one. A resting dock has none, so
      *  it is one line and nothing else. */
     footer?: ReactNode;
+    onCancelBuild?: (() => void) | null;
 };
 
 /**
@@ -71,6 +72,7 @@ const DataAppVizDock: FC<Props> = ({
     elapsed,
     status,
     footer,
+    onCancelBuild = null,
 }) => {
     // Open on arrival when there is nothing selected: describing one is the
     // only thing to do here.
@@ -118,6 +120,7 @@ const DataAppVizDock: FC<Props> = ({
                         dataAppVizUuid={dataAppVizUuid}
                         build={build}
                         elapsed={elapsed}
+                        onCancelBuild={onCancelBuild}
                     />
                 )}
                 {footer && <Box className={classes.footer}>{footer}</Box>}
@@ -189,6 +192,7 @@ const DataAppVizDock: FC<Props> = ({
                         dataAppVizUuid={dataAppVizUuid}
                         build={build}
                         elapsed={elapsed}
+                        onCancelBuild={onCancelBuild}
                     />
                 </Box>
 

--- a/packages/frontend/src/features/apps/components/DataAppVizLibraryPicker.test.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizLibraryPicker.test.tsx
@@ -42,6 +42,10 @@ const setData = (data: DataAppViz[]) => {
 const render = (
     onSelect: (dataAppViz: DataAppViz | null) => void,
     selected: DataAppViz | null = null,
+    extra: {
+        draft?: { dataAppVizUuid: string; elapsed: string | null };
+        onSelectDraft?: () => void;
+    } = {},
 ) =>
     renderWithProviders(
         <DataAppVizLibraryPicker
@@ -49,9 +53,16 @@ const render = (
             selectedDataAppVizUuid={selected?.dataAppVizUuid ?? null}
             selectedDataAppViz={selected}
             disabled={false}
+            draft={extra.draft ?? null}
+            onSelectDraft={extra.onSelectDraft ?? vi.fn()}
             onSelect={onSelect}
         />,
     );
+
+const rightSectionPointerEvents = (container: HTMLElement) =>
+    container
+        .querySelector<HTMLElement>('.mantine-8-Input-wrapper')
+        ?.style.getPropertyValue('--input-right-section-pointer-events');
 
 // Options live in the Select dropdown, which only mounts once opened.
 const openDropdown = () =>
@@ -137,6 +148,49 @@ describe('DataAppVizLibraryPicker', () => {
         fireEvent.click(clearButton!);
 
         expect(onSelect).toHaveBeenCalledWith(null);
+    });
+
+    it('leaves the clear button clickable', () => {
+        const selected = makeDataAppViz({ dataAppVizUuid: 'a' });
+        setData([selected]);
+        const { container } = render(vi.fn(), selected);
+
+        expect(rightSectionPointerEvents(container)).not.toBe('none');
+    });
+
+    it('keeps the draft badge out of the way of pointer events', () => {
+        setData([]);
+        const { container } = render(vi.fn(), null, {
+            draft: { dataAppVizUuid: 'building-1', elapsed: '0:12' },
+        });
+
+        expect(rightSectionPointerEvents(container)).toBe('none');
+    });
+
+    it('lists a build in flight, which the server cannot return yet', () => {
+        setData([]);
+        render(vi.fn(), null, {
+            draft: { dataAppVizUuid: 'draft-1', elapsed: '0:12' },
+        });
+        openDropdown();
+
+        expect(screen.getByText('Untitled visualization')).toBeDefined();
+        expect(screen.getByText('building 0:12')).toBeDefined();
+    });
+
+    it('reports picking the draft separately: it is not a viz yet', () => {
+        setData([]);
+        const onSelect = vi.fn();
+        const onSelectDraft = vi.fn();
+        render(onSelect, null, {
+            draft: { dataAppVizUuid: 'draft-1', elapsed: null },
+            onSelectDraft,
+        });
+        openDropdown();
+        fireEvent.click(screen.getByText('Untitled visualization'));
+
+        expect(onSelectDraft).toHaveBeenCalledTimes(1);
+        expect(onSelect).not.toHaveBeenCalled();
     });
 
     it('shows an empty state when there are no bindable vizs', () => {

--- a/packages/frontend/src/features/apps/components/DataAppVizLibraryPicker.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizLibraryPicker.tsx
@@ -1,16 +1,32 @@
 import { getAppDisplayName, type DataAppViz } from '@lightdash/common';
-import { Box, Loader, Select, Text, type ComboboxItem } from '@mantine-8/core';
+import {
+    Badge,
+    Box,
+    Group,
+    Loader,
+    Select,
+    Text,
+    type ComboboxItem,
+} from '@mantine-8/core';
 import { useDebouncedValue } from '@mantine-8/hooks';
 import { IconPuzzle } from '@tabler/icons-react';
 import { useMemo, useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useDataAppVisualizations } from '../hooks/useDataAppVisualizations';
 
+/** A build in flight: a real app, but with nothing ready to render yet. */
+export type DataAppVizDraftOption = {
+    dataAppVizUuid: string;
+    elapsed: string | null;
+};
+
 type Props = {
     projectUuid: string;
     selectedDataAppVizUuid: string | null;
     selectedDataAppViz: DataAppViz | null;
     disabled: boolean;
+    draft: DataAppVizDraftOption | null;
+    onSelectDraft: () => void;
     /** Receives the whole viz so the caller can bind its contract straight
      *  away, without waiting on a fetch for the newly selected uuid, or null
      *  when the selection is cleared. */
@@ -19,7 +35,10 @@ type Props = {
 
 interface DataAppVizItem extends ComboboxItem {
     description: string;
+    isDraft: boolean;
 }
+
+const DRAFT_LABEL = 'Untitled visualization';
 
 const fieldSummary = (dataAppViz: DataAppViz): string => {
     const count = dataAppViz.schema?.fields.length ?? 0;
@@ -30,6 +49,7 @@ const toItem = (dataAppViz: DataAppViz): DataAppVizItem => ({
     value: dataAppViz.dataAppVizUuid,
     label: getAppDisplayName(dataAppViz.name, dataAppViz.dataAppVizUuid),
     description: dataAppViz.description || fieldSummary(dataAppViz),
+    isDraft: false,
 });
 
 // Library picker: a searchable Select of the project's saved data app vizs.
@@ -40,7 +60,9 @@ const DataAppVizLibraryPicker: FC<Props> = ({
     selectedDataAppVizUuid,
     selectedDataAppViz,
     disabled,
+    draft,
     onSelect,
+    onSelectDraft,
 }) => {
     const [search, setSearch] = useState('');
     const selectedLabel = selectedDataAppViz
@@ -59,6 +81,9 @@ const DataAppVizLibraryPicker: FC<Props> = ({
 
     const { data, isInitialLoading, isFetching, error } =
         useDataAppVisualizations(projectUuid, debouncedSearch);
+
+    const isOnDraft =
+        draft !== null && selectedDataAppVizUuid === draft.dataAppVizUuid;
 
     // Keep the fetched rows addressable by uuid so `onChange` can hand the
     // caller the whole viz (contract included), not just its uuid.
@@ -84,8 +109,26 @@ const DataAppVizLibraryPicker: FC<Props> = ({
         ) {
             items.unshift(toItem(selectedDataAppViz));
         }
+        if (draft) {
+            items.unshift({
+                value: draft.dataAppVizUuid,
+                label: DRAFT_LABEL,
+                description: draft.elapsed
+                    ? `building ${draft.elapsed}`
+                    : 'building',
+                isDraft: true,
+            });
+        }
         return items;
-    }, [data?.pages, selectedDataAppViz]);
+    }, [data?.pages, selectedDataAppViz, draft]);
+
+    const decoration = isOnDraft ? (
+        <Badge size="xs" variant="light" radius="sm">
+            Draft
+        </Badge>
+    ) : isFetching && !isInitialLoading ? (
+        <Loader size={14} />
+    ) : undefined;
 
     return (
         <Select
@@ -97,9 +140,13 @@ const DataAppVizLibraryPicker: FC<Props> = ({
             onSearchChange={setSearch}
             // Search is done server-side, so keep every returned option.
             filter={({ options }) => options}
-            onChange={(value) =>
-                onSelect(value ? (dataAppVizsByUuid.get(value) ?? null) : null)
-            }
+            onChange={(value) => {
+                if (value && value === draft?.dataAppVizUuid) {
+                    onSelectDraft();
+                    return;
+                }
+                onSelect(value ? (dataAppVizsByUuid.get(value) ?? null) : null);
+            }}
             allowDeselect={false}
             clearable
             placeholder="Select a visualization"
@@ -111,16 +158,21 @@ const DataAppVizLibraryPicker: FC<Props> = ({
                       : 'No data app visualizations yet'
             }
             leftSection={<MantineIcon icon={IconPuzzle} />}
-            rightSection={
-                isFetching && !isInitialLoading ? (
-                    <Loader size={14} />
-                ) : undefined
-            }
+            rightSectionWidth={isOnDraft ? 58 : undefined}
+            rightSectionPointerEvents={decoration ? 'none' : undefined}
+            rightSection={decoration}
             renderOption={({ option }) => {
                 const item = option as DataAppVizItem;
                 return (
                     <Box>
-                        <Text size="sm">{item.label}</Text>
+                        <Group gap="xs" wrap="nowrap">
+                            <Text size="sm">{item.label}</Text>
+                            {item.isDraft && (
+                                <Badge size="xs" variant="light" radius="sm">
+                                    Draft
+                                </Badge>
+                            )}
+                        </Group>
                         <Text size="xs" c="dimmed" lineClamp={2}>
                             {item.description}
                         </Text>

--- a/packages/frontend/src/features/apps/components/DataAppVizVersionLog.test.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizVersionLog.test.tsx
@@ -34,6 +34,8 @@ const setVersions = (
     );
 };
 
+const onCancelBuild = vi.fn();
+
 const render = (build: DataAppVizBuildState = buildStub()) =>
     renderWithProviders(
         <DataAppVizVersionLog
@@ -41,6 +43,7 @@ const render = (build: DataAppVizBuildState = buildStub()) =>
             dataAppVizUuid="viz-1"
             build={build}
             elapsed={build.isBuilding ? '0:14' : null}
+            onCancelBuild={onCancelBuild}
         />,
     );
 
@@ -236,6 +239,27 @@ describe('DataAppVizVersionLog', () => {
         expect(
             screen.queryByRole('button', { name: 'Restore' }),
         ).not.toBeInTheDocument();
+    });
+
+    it('stops only the build claimed by the local request', async () => {
+        setVersions([
+            version({ status: 'generating', statusUpdatedAt: null }),
+            version({
+                version: 2,
+                status: 'generating',
+                statusUpdatedAt: null,
+            }),
+        ]);
+        render(buildStub({ isBuilding: true, claimedVersion: 2 }));
+
+        const cancel = screen.getAllByRole('button', { name: 'Cancel' });
+        expect(cancel).toHaveLength(1);
+        expect(cancel[0]).toBeInTheDocument();
+        expect(screen.getByTestId('version-log-row-2')).toContainElement(
+            cancel[0],
+        );
+        await userEvent.click(cancel[0]);
+        expect(onCancelBuild).toHaveBeenCalled();
     });
 
     it('offers to re-send a request the server never accepted', async () => {

--- a/packages/frontend/src/features/apps/components/DataAppVizVersionLog.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizVersionLog.tsx
@@ -86,8 +86,9 @@ const LogRow: FC<{
     isCurrent: boolean;
     /** Ticking clock, when this row is the build in flight. */
     elapsed: string | null;
+    onCancel: (() => void) | null;
     onRestore: (version: number) => void;
-}> = ({ entry, isCurrent, elapsed, onRestore }) => {
+}> = ({ entry, isCurrent, elapsed, onCancel, onRestore }) => {
     // A version the poller has written but not yet finished — any of the seven
     // stages before it lands. Its own row reports the progress, so the build
     // never needs a second one.
@@ -118,6 +119,18 @@ const LogRow: FC<{
                 )}
             </Stack>
 
+            {isBuilding && onCancel && (
+                <Anchor
+                    component="button"
+                    type="button"
+                    size="xs"
+                    c="dimmed"
+                    className={classes.rowAction}
+                    onClick={onCancel}
+                >
+                    Cancel
+                </Anchor>
+            )}
             {isCurrent && (
                 <Text size="xs" c="dimmed" className={classes.rowAction}>
                     current
@@ -145,7 +158,8 @@ const LogRow: FC<{
 const LiveRow: FC<{
     build: DataAppVizBuildState;
     elapsed: string | null;
-}> = ({ build, elapsed }) => (
+    onCancel: (() => void) | null;
+}> = ({ build, elapsed, onCancel }) => (
     <Group className={classes.row} gap="xs" wrap="nowrap" align="flex-start">
         <Badge
             size="xs"
@@ -162,6 +176,19 @@ const LiveRow: FC<{
             </Text>
             <Building elapsed={elapsed} />
         </Stack>
+
+        {onCancel && (
+            <Anchor
+                component="button"
+                type="button"
+                size="xs"
+                c="dimmed"
+                className={classes.rowAction}
+                onClick={onCancel}
+            >
+                Cancel
+            </Anchor>
+        )}
     </Group>
 );
 
@@ -206,6 +233,7 @@ type Props = {
     build: DataAppVizBuildState;
     /** Ticking `0:12` while a build runs; null when nothing is running. */
     elapsed: string | null;
+    onCancelBuild: (() => void) | null;
 };
 
 /**
@@ -221,6 +249,7 @@ const DataAppVizVersionLog: FC<Props> = ({
     dataAppVizUuid,
     build,
     elapsed,
+    onCancelBuild,
 }) => {
     const {
         versions,
@@ -289,7 +318,11 @@ const DataAppVizVersionLog: FC<Props> = ({
         <>
             <Stack gap={0}>
                 {build.isBuilding && !isClaimedInHistory && (
-                    <LiveRow build={build} elapsed={elapsed} />
+                    <LiveRow
+                        build={build}
+                        elapsed={elapsed}
+                        onCancel={onCancelBuild}
+                    />
                 )}
 
                 {build.error && (
@@ -302,6 +335,11 @@ const DataAppVizVersionLog: FC<Props> = ({
                         entry={entry}
                         isCurrent={entry.version === latestReadyVersion}
                         elapsed={elapsed}
+                        onCancel={
+                            entry.version === build.claimedVersion
+                                ? onCancelBuild
+                                : null
+                        }
                         onRestore={setRestoreTarget}
                     />
                 ))}

--- a/packages/frontend/src/features/apps/hooks/useDataAppVizBuild.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useDataAppVizBuild.test.ts
@@ -3,14 +3,20 @@ import { act } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHookWithProviders } from '../../../testing/testUtils';
 import { useAppBuildPoller } from './useAppBuildPoller';
+import { useCancelAppVersion } from './useCancelAppVersion';
 import { useDataAppVizBuild } from './useDataAppVizBuild';
+import { useDeleteApp } from './useDeleteApp';
 import { useGenerateApp } from './useGenerateApp';
 
 vi.mock('./useGenerateApp', () => ({ useGenerateApp: vi.fn() }));
 vi.mock('./useAppBuildPoller', () => ({ useAppBuildPoller: vi.fn() }));
+vi.mock('./useCancelAppVersion', () => ({ useCancelAppVersion: vi.fn() }));
+vi.mock('./useDeleteApp', () => ({ useDeleteApp: vi.fn() }));
 
 const mockedGenerate = vi.mocked(useGenerateApp);
 const mockedPoller = vi.mocked(useAppBuildPoller);
+const mockedCancel = vi.mocked(useCancelAppVersion);
+const mockedDelete = vi.mocked(useDeleteApp);
 
 type GenerateHandlers = {
     onSuccess: (result: { appUuid: string; version: number }) => void;
@@ -55,14 +61,24 @@ const itemsMap = {
 
 describe('useDataAppVizBuild', () => {
     let generate: ReturnType<typeof vi.fn>;
+    let cancelVersion: ReturnType<typeof vi.fn>;
+    let deleteApp: ReturnType<typeof vi.fn>;
 
     beforeEach(() => {
         vi.clearAllMocks();
         generate = vi.fn();
+        cancelVersion = vi.fn();
+        deleteApp = vi.fn();
         mockedGenerate.mockReturnValue({
             mutate: generate,
             isLoading: false,
         } as unknown as ReturnType<typeof useGenerateApp>);
+        mockedCancel.mockReturnValue({
+            mutate: cancelVersion,
+        } as unknown as ReturnType<typeof useCancelAppVersion>);
+        mockedDelete.mockReturnValue({
+            mutate: deleteApp,
+        } as unknown as ReturnType<typeof useDeleteApp>);
     });
 
     const setup = (onCreated = vi.fn()) => {
@@ -162,5 +178,35 @@ describe('useDataAppVizBuild', () => {
         act(() => result.current.send({ description: 'actually a bar chart' }));
 
         expect(generate).toHaveBeenCalledTimes(1);
+    });
+
+    it('cancels a draft before deleting its app', () => {
+        const { result } = setup();
+
+        act(() => result.current.send({ description: 'a donut' }));
+        const generateHandlers = generate.mock
+            .lastCall?.[1] as GenerateHandlers;
+        act(() => generateHandlers.onSuccess({ appUuid: 'viz-1', version: 1 }));
+        act(() => result.current.discard?.());
+
+        expect(cancelVersion).toHaveBeenCalledWith(
+            {
+                projectUuid: 'project-1',
+                appUuid: 'viz-1',
+                version: 1,
+            },
+            expect.anything(),
+        );
+        expect(deleteApp).not.toHaveBeenCalled();
+
+        const cancelHandlers = cancelVersion.mock.lastCall?.[1] as {
+            onSettled: () => void;
+        };
+        act(() => cancelHandlers.onSettled());
+
+        expect(deleteApp).toHaveBeenCalledWith({
+            projectUuid: 'project-1',
+            appUuid: 'viz-1',
+        });
     });
 });

--- a/packages/frontend/src/features/apps/hooks/useDataAppVizBuild.ts
+++ b/packages/frontend/src/features/apps/hooks/useDataAppVizBuild.ts
@@ -8,6 +8,8 @@ import {
 import { useCallback, useState } from 'react';
 import { autoMapDataAppVizFields } from '../utils/autoMapDataAppVizFields';
 import { useAppBuildPoller } from './useAppBuildPoller';
+import { useCancelAppVersion } from './useCancelAppVersion';
+import { useDeleteApp } from './useDeleteApp';
 import { useGenerateApp } from './useGenerateApp';
 
 type Args = {
@@ -27,16 +29,14 @@ export type VizBuildRequest = {
     description: string;
 };
 
-/**
- * A build in flight, once the server has accepted it. It is a real app
- * already — the request creates it — but it has no ready version yet, so it is
- * not worth pointing a chart at.
- */
-type RunningBuild = {
+/** The app claimed by a build before it has a renderable version. */
+export type DataAppVizDraft = {
     appUuid: string;
     version: number;
     startedAt: Date;
 };
+
+type RunningBuild = DataAppVizDraft;
 
 export type DataAppVizBuildState = {
     /**
@@ -45,6 +45,7 @@ export type DataAppVizBuildState = {
      * chart still points at nothing.
      */
     appUuid: string | null;
+    draft: DataAppVizDraft | null;
     /** When the build in flight started, for the panel's clock. */
     startedAt: Date | null;
     /**
@@ -60,6 +61,8 @@ export type DataAppVizBuildState = {
     send: (request: VizBuildRequest) => void;
     /** Re-send the request that failed; null when there is nothing to retry. */
     retry: (() => void) | null;
+    /** Cancels the build and deletes its draft app. */
+    discard: (() => void) | null;
 };
 
 /**
@@ -86,6 +89,8 @@ export const useDataAppVizBuild = ({
         request: VizBuildRequest | null;
     } | null>(null);
     const { mutate: generateApp } = useGenerateApp();
+    const { mutate: cancelVersion } = useCancelAppVersion();
+    const { mutate: deleteApp } = useDeleteApp();
 
     const handleDone = useCallback(
         (version: ApiAppVersionSummary) => {
@@ -154,9 +159,11 @@ export const useDataAppVizBuild = ({
     );
 
     const failedRequest = failed?.request ?? null;
+    const draft = building;
 
     return {
         appUuid: building?.appUuid ?? null,
+        draft,
         startedAt: building?.startedAt ?? null,
         claimedVersion: building?.version ?? null,
         // A request is in flight from the moment it is sent until the build
@@ -167,5 +174,28 @@ export const useDataAppVizBuild = ({
         error: failed?.message ?? null,
         send,
         retry: failedRequest ? () => send(failedRequest) : null,
+        discard:
+            projectUuid && draft
+                ? () => {
+                      // Cancel before delete to avoid orphaned sandbox work.
+                      cancelVersion(
+                          {
+                              projectUuid,
+                              appUuid: draft.appUuid,
+                              version: draft.version,
+                          },
+                          {
+                              onSettled: () =>
+                                  deleteApp({
+                                      projectUuid,
+                                      appUuid: draft.appUuid,
+                                  }),
+                          },
+                      );
+                      setBuilding(null);
+                      setInFlight(null);
+                      setFailed(null);
+                  }
+                : null,
     };
 };

--- a/packages/frontend/src/features/apps/testing/dataAppVizBuildStub.ts
+++ b/packages/frontend/src/features/apps/testing/dataAppVizBuildStub.ts
@@ -6,6 +6,7 @@ export const buildStub = (
     overrides: Partial<DataAppVizBuildState> = {},
 ): DataAppVizBuildState => ({
     appUuid: null,
+    draft: null,
     startedAt: null,
     claimedVersion: null,
     isBuilding: false,
@@ -13,5 +14,6 @@ export const buildStub = (
     error: null,
     send: vi.fn(),
     retry: null,
+    discard: null,
     ...overrides,
 });


### PR DESCRIPTION
A build claims its app the moment it starts, but the server's list only offers visualizations that already have a ready version — so the panel puts the draft in front of that list while it runs.

**Cancel** lives on the row of the build it stops: it cancels the build first, then deletes the app it claimed. Navigating away does not cancel, because a build is a job, not a modal.

Relates: GLITCH-630
