### PR TITLE
feat(onboarding): enable homepage builder for orgs provisioned via new onboarding

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -51,6 +51,7 @@ import { Request } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 import { LightdashConfig } from '../config/parseConfig';
 import { type ExternalConnectionEvent } from '../ee/analytics';
+import type { EnsureOrganizationOverrideOutcome } from '../models/FeatureFlagModel/FeatureFlagModel';
 import type { FeatureFlagCheckAggregateEntry } from '../models/FeatureFlagModel/flagCheckAggregator';
 import { type PersistentDownloadFileSource } from '../services/PersistentDownloadFileService/PersistentDownloadFileService';
 import { VERSION } from '../version';
@@ -911,6 +912,10 @@ type OnboardingHomepageFailedEvent = BaseTrack & {
     };
 };
 
+export type HomepageBuilderEnablement =
+    | EnsureOrganizationOverrideOutcome
+    | 'failed';
+
 type PlaygroundProjectProvisionedEvent = BaseTrack & {
     event: 'playground_project.provisioned';
     userId: string;
@@ -920,6 +925,7 @@ type PlaygroundProjectProvisionedEvent = BaseTrack & {
         trigger: 'invite_expert';
         onboardingFlow: OnboardingFlow;
         catalogIndexErrorType: string | null;
+        homepageBuilderEnablement: HomepageBuilderEnablement;
     };
 };
 

--- a/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.test.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.test.ts
@@ -1,5 +1,6 @@
 import { Ability } from '@casl/ability';
 import {
+    CommercialFeatureFlags,
     FeatureFlags,
     OrganizationMemberRole,
     ProjectType,
@@ -8,6 +9,7 @@ import {
     type SessionUser,
 } from '@lightdash/common';
 import path from 'path';
+import Logger from '../../../logging/logger';
 import {
     provisionPlaygroundProject,
     type ProvisionPlaygroundProjectArguments,
@@ -58,6 +60,9 @@ const buildArguments = () => {
         id: FeatureFlags.NewOnboarding,
         enabled: true,
     }));
+    const ensureOrganizationOverrideEnabled = vi.fn<
+        ProvisionPlaygroundProjectArguments['featureFlagService']['ensureOrganizationOverrideEnabled']
+    >(async () => 'enabled');
     const getAllByOrganizationUuid = vi.fn(
         async () => [] as OrganizationProject[],
     );
@@ -94,7 +99,7 @@ const buildArguments = () => {
     return {
         args: {
             user,
-            featureFlagService: { get },
+            featureFlagService: { get, ensureOrganizationOverrideEnabled },
             projectModel: {
                 getAllByOrganizationUuid,
                 delete: deleteProject,
@@ -112,6 +117,7 @@ const buildArguments = () => {
             validatePlaygroundDatabase,
         } satisfies ProvisionPlaygroundProjectArguments,
         get,
+        ensureOrganizationOverrideEnabled,
         getAllByOrganizationUuid,
         deleteProject,
         saveExploresToCache,
@@ -173,6 +179,7 @@ describe('provisionPlaygroundProject', () => {
                 reason: 'playground_already_exists',
             },
         });
+        expect(mocks.ensureOrganizationOverrideEnabled).not.toHaveBeenCalled();
     });
 
     it('returns an existing real project without creating a playground', async () => {
@@ -194,6 +201,7 @@ describe('provisionPlaygroundProject', () => {
                 reason: 'organization_has_project',
             },
         });
+        expect(mocks.ensureOrganizationOverrideEnabled).not.toHaveBeenCalled();
     });
 
     it('does not disclose an existing project the user cannot view', async () => {
@@ -281,6 +289,7 @@ describe('provisionPlaygroundProject', () => {
                 trigger: 'invite_expert',
                 onboardingFlow: 'new',
                 catalogIndexErrorType: null,
+                homepageBuilderEnablement: 'enabled',
             },
         });
         expect(mocks.validatePlaygroundDatabase).toHaveBeenCalledWith(
@@ -338,8 +347,84 @@ describe('provisionPlaygroundProject', () => {
                 trigger: 'invite_expert',
                 onboardingFlow: 'new',
                 catalogIndexErrorType: 'Error',
+                homepageBuilderEnablement: 'enabled',
             },
         });
+    });
+
+    it('enables the homepage builder for the organization before creating the project', async () => {
+        const mocks = buildArguments();
+        await expect(provisionPlaygroundProject(mocks.args)).resolves.toEqual({
+            projectUuid,
+            created: true,
+        });
+        expect(
+            mocks.ensureOrganizationOverrideEnabled,
+        ).toHaveBeenCalledExactlyOnceWith({
+            featureFlagId: CommercialFeatureFlags.HomepageBuilder,
+            organizationUuid,
+        });
+        expect(
+            mocks.ensureOrganizationOverrideEnabled.mock.invocationCallOrder[0],
+        ).toBeLessThan(
+            vi.mocked(mocks.createWithoutCompile).mock.invocationCallOrder[0],
+        );
+    });
+
+    it('reports when an explicit disabled override is preserved', async () => {
+        const mocks = buildArguments();
+        mocks.ensureOrganizationOverrideEnabled.mockResolvedValue(
+            'kept_disabled',
+        );
+        await expect(provisionPlaygroundProject(mocks.args)).resolves.toEqual({
+            projectUuid,
+            created: true,
+        });
+        expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
+            event: 'playground_project.provisioned',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+                trigger: 'invite_expert',
+                onboardingFlow: 'new',
+                catalogIndexErrorType: null,
+                homepageBuilderEnablement: 'kept_disabled',
+            },
+        });
+    });
+
+    it('still provisions when enabling the homepage builder fails', async () => {
+        const errorSpy = vi
+            .spyOn(Logger, 'error')
+            .mockImplementation(() => Logger);
+        try {
+            const mocks = buildArguments();
+            mocks.ensureOrganizationOverrideEnabled.mockRejectedValue(
+                new Error('Override write failed'),
+            );
+            await expect(
+                provisionPlaygroundProject(mocks.args),
+            ).resolves.toEqual({
+                projectUuid,
+                created: true,
+            });
+            expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
+                event: 'playground_project.provisioned',
+                userId: user.userUuid,
+                properties: {
+                    organizationId: organizationUuid,
+                    projectId: projectUuid,
+                    trigger: 'invite_expert',
+                    onboardingFlow: 'new',
+                    catalogIndexErrorType: null,
+                    homepageBuilderEnablement: 'failed',
+                },
+            });
+            expect(errorSpy).toHaveBeenCalled();
+        } finally {
+            errorSpy.mockRestore();
+        }
     });
 
     it('does not create a project when bundle validation fails', async () => {

--- a/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.test.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.test.ts
@@ -361,8 +361,8 @@ describe('provisionPlaygroundProject', () => {
         expect(
             mocks.ensureOrganizationOverrideEnabled,
         ).toHaveBeenCalledExactlyOnceWith({
+            user,
             featureFlagId: CommercialFeatureFlags.HomepageBuilder,
-            organizationUuid,
         });
         expect(
             mocks.ensureOrganizationOverrideEnabled.mock.invocationCallOrder[0],

--- a/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.ts
@@ -1,4 +1,5 @@
 import {
+    CommercialFeatureFlags,
     DbtProjectType,
     DefaultSupportedDbtVersion,
     DuckdbConnectionType,
@@ -19,6 +20,7 @@ import * as Sentry from '@sentry/node';
 import fs from 'fs/promises';
 import path from 'path';
 import {
+    type HomepageBuilderEnablement,
     type LightdashAnalytics,
     type OnboardingFlow,
     type PlaygroundProjectSkippedReason,
@@ -32,7 +34,10 @@ import { type ProjectService } from '../../../services/ProjectService/ProjectSer
 
 export type ProvisionPlaygroundProjectArguments = {
     user: SessionUser;
-    featureFlagService: Pick<FeatureFlagService, 'get'>;
+    featureFlagService: Pick<
+        FeatureFlagService,
+        'get' | 'ensureOrganizationOverrideEnabled'
+    >;
     projectModel: Pick<
         ProjectModel,
         'getAllByOrganizationUuid' | 'delete' | 'saveExploresToCache'
@@ -196,6 +201,30 @@ export const provisionPlaygroundProject = async ({
                     validatePlaygroundDatabase,
                 );
 
+                // Before project creation so the onProjectCreated hook sees
+                // the flag when provisioning the onboarding homepage.
+                let homepageBuilderEnablement: HomepageBuilderEnablement;
+                try {
+                    homepageBuilderEnablement =
+                        await featureFlagService.ensureOrganizationOverrideEnabled(
+                            {
+                                featureFlagId:
+                                    CommercialFeatureFlags.HomepageBuilder,
+                                organizationUuid,
+                            },
+                        );
+                } catch (error) {
+                    Sentry.captureException(error);
+                    Logger.error(
+                        `Failed to enable homepage builder for organization ${organizationUuid}: ${
+                            error instanceof Error
+                                ? error.message
+                                : String(error)
+                        }`,
+                    );
+                    homepageBuilderEnablement = 'failed';
+                }
+
                 const creation = await projectService.createWithoutCompile(
                     user,
                     {
@@ -264,6 +293,7 @@ export const provisionPlaygroundProject = async ({
                         trigger: 'invite_expert',
                         onboardingFlow,
                         catalogIndexErrorType,
+                        homepageBuilderEnablement,
                     },
                 });
                 return { projectUuid, created: true };

--- a/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.ts
@@ -208,9 +208,9 @@ export const provisionPlaygroundProject = async ({
                     homepageBuilderEnablement =
                         await featureFlagService.ensureOrganizationOverrideEnabled(
                             {
+                                user,
                                 featureFlagId:
                                     CommercialFeatureFlags.HomepageBuilder,
-                                organizationUuid,
                             },
                         );
                 } catch (error) {

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
@@ -95,6 +95,57 @@ const buildFakeDatabase = (rows: FakeRows): Knex => {
     return ((table: string) => makeBuilder(table)) as unknown as Knex;
 };
 
+// Fake Knex for the override-write path: serves org-override reads from a
+// queue (first read = existence check, second = post-conflict re-read) and
+// records inserts. `overrideInsertConflicts` simulates a concurrent insert by
+// making the override insert return no rows.
+const buildFakeWriteDatabase = ({
+    overrideReadResults = [],
+    overrideInsertConflicts = false,
+}: {
+    overrideReadResults?: (Partial<DbFeatureFlagOverride> | undefined)[];
+    overrideInsertConflicts?: boolean;
+}) => {
+    const flagInserts: Record<string, unknown>[] = [];
+    const overrideInserts: Record<string, unknown>[] = [];
+    let readIndex = 0;
+    const makeBuilder = (table: string) => {
+        const builder = {
+            where: () => builder,
+            whereNull: () => builder,
+            first: () => {
+                if (table === FeatureFlagOverridesTableName) {
+                    const result = overrideReadResults[readIndex];
+                    readIndex += 1;
+                    return Promise.resolve(result);
+                }
+                return Promise.resolve(undefined);
+            },
+            insert: (values: Record<string, unknown>) => {
+                if (table === FeatureFlagsTableName) {
+                    flagInserts.push(values);
+                } else {
+                    overrideInserts.push(values);
+                }
+                return builder;
+            },
+            onConflict: () => builder,
+            ignore: () => builder,
+            returning: () =>
+                Promise.resolve(
+                    overrideInsertConflicts
+                        ? []
+                        : [{ feature_flag_override_id: 1 }],
+                ),
+        };
+        return builder;
+    };
+    const database = Object.assign((table: string) => makeBuilder(table), {
+        raw: (sql: string) => sql,
+    }) as unknown as Knex;
+    return { database, flagInserts, overrideInserts };
+};
+
 describe('FeatureFlagModel', () => {
     describe('check telemetry', () => {
         beforeEach(() => {
@@ -446,6 +497,68 @@ describe('FeatureFlagModel', () => {
             });
 
             expect(result.enabled).toBe(true);
+        });
+    });
+
+    describe('ensureOrganizationOverrideEnabled', () => {
+        const FLAG_ID = 'homepage-builder';
+        const ORG_UUID = 'org-uuid';
+
+        it('inserts an enabled override and the flag row when none exist', async () => {
+            const fake = buildFakeWriteDatabase({
+                overrideReadResults: [undefined],
+            });
+            const model = buildModel({}, fake.database);
+
+            await expect(
+                model.ensureOrganizationOverrideEnabled(FLAG_ID, ORG_UUID),
+            ).resolves.toBe('enabled');
+            expect(fake.flagInserts).toEqual([{ flag_id: FLAG_ID }]);
+            expect(fake.overrideInserts).toEqual([
+                {
+                    flag_id: FLAG_ID,
+                    organization_uuid: ORG_UUID,
+                    enabled: true,
+                },
+            ]);
+        });
+
+        it('leaves an existing enabled override untouched', async () => {
+            const fake = buildFakeWriteDatabase({
+                overrideReadResults: [{ enabled: true }],
+            });
+            const model = buildModel({}, fake.database);
+
+            await expect(
+                model.ensureOrganizationOverrideEnabled(FLAG_ID, ORG_UUID),
+            ).resolves.toBe('already_enabled');
+            expect(fake.flagInserts).toEqual([]);
+            expect(fake.overrideInserts).toEqual([]);
+        });
+
+        it('never flips an explicit disabled override back on', async () => {
+            const fake = buildFakeWriteDatabase({
+                overrideReadResults: [{ enabled: false }],
+            });
+            const model = buildModel({}, fake.database);
+
+            await expect(
+                model.ensureOrganizationOverrideEnabled(FLAG_ID, ORG_UUID),
+            ).resolves.toBe('kept_disabled');
+            expect(fake.flagInserts).toEqual([]);
+            expect(fake.overrideInserts).toEqual([]);
+        });
+
+        it('re-reads the override when a concurrent insert wins', async () => {
+            const fake = buildFakeWriteDatabase({
+                overrideReadResults: [undefined, { enabled: false }],
+                overrideInsertConflicts: true,
+            });
+            const model = buildModel({}, fake.database);
+
+            await expect(
+                model.ensureOrganizationOverrideEnabled(FLAG_ID, ORG_UUID),
+            ).resolves.toBe('kept_disabled');
         });
     });
 

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -16,6 +16,11 @@ export type FeatureFlagLogicArgs = {
     featureFlagId: string;
 };
 
+export type EnsureOrganizationOverrideOutcome =
+    | 'enabled'
+    | 'already_enabled'
+    | 'kept_disabled';
+
 type FeatureFlagQueryOptions = { trx?: Knex };
 
 export class FeatureFlagModel {
@@ -135,6 +140,51 @@ export class FeatureFlagModel {
     ): Promise<FeatureFlag> {
         const dbResult = await this.tryGetFromDatabase(args, options);
         return dbResult ?? { id: args.featureFlagId, enabled: fallback };
+    }
+
+    // Insert-only enablement: an existing override row (including an explicit
+    // enabled=false) is never modified.
+    public async ensureOrganizationOverrideEnabled(
+        featureFlagId: string,
+        organizationUuid: string,
+    ): Promise<EnsureOrganizationOverrideOutcome> {
+        const getOrganizationOverride = () =>
+            this.database(FeatureFlagOverridesTableName)
+                .where('flag_id', featureFlagId)
+                .where('organization_uuid', organizationUuid)
+                .whereNull('user_uuid')
+                .first();
+
+        const existing = await getOrganizationOverride();
+        if (existing) {
+            return existing.enabled ? 'already_enabled' : 'kept_disabled';
+        }
+
+        await this.database(FeatureFlagsTableName)
+            .insert({ flag_id: featureFlagId })
+            .onConflict('flag_id')
+            .ignore();
+
+        const inserted = await this.database(FeatureFlagOverridesTableName)
+            .insert({
+                flag_id: featureFlagId,
+                organization_uuid: organizationUuid,
+                enabled: true,
+            })
+            .onConflict(
+                this.database.raw(
+                    '(flag_id, organization_uuid) WHERE organization_uuid IS NOT NULL AND user_uuid IS NULL',
+                ),
+            )
+            .ignore()
+            .returning('feature_flag_override_id');
+        if (inserted.length > 0) {
+            return 'enabled';
+        }
+        const concurrent = await getOrganizationOverride();
+        return concurrent?.enabled === false
+            ? 'kept_disabled'
+            : 'already_enabled';
     }
 
     protected async tryGetFromDatabase(

--- a/packages/backend/src/services/FeatureFlag/FeatureFlagService.test.ts
+++ b/packages/backend/src/services/FeatureFlag/FeatureFlagService.test.ts
@@ -1,0 +1,114 @@
+import { Ability } from '@casl/ability';
+import {
+    OrganizationMemberRole,
+    type PossibleAbilities,
+    type SessionUser,
+} from '@lightdash/common';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { type FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
+import { FeatureFlagService } from './FeatureFlagService';
+
+const organizationUuid = '00000000-0000-0000-0000-000000000001';
+const now = new Date('2026-07-29T00:00:00Z');
+
+const buildUser = (ability: Ability<PossibleAbilities>): SessionUser =>
+    ({
+        userUuid: '00000000-0000-0000-0000-000000000002',
+        organizationUuid,
+        organizationName: 'Organization',
+        organizationCreatedAt: now,
+        email: 'admin@example.com',
+        firstName: 'Admin',
+        lastName: 'User',
+        userId: 1,
+        role: OrganizationMemberRole.ADMIN,
+        ability,
+        abilityRules: [],
+        isTrackingAnonymized: false,
+        isMarketingOptedIn: false,
+        avatarUrl: null,
+        avatarGradient: null,
+        isSetupComplete: true,
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+        timezone: null,
+    }) as unknown as SessionUser;
+
+const buildService = () => {
+    const ensureOrganizationOverrideEnabled = vi.fn(async () => 'enabled');
+    const featureFlagModel = {
+        ensureOrganizationOverrideEnabled,
+    } as unknown as FeatureFlagModel;
+    const service = new FeatureFlagService({
+        lightdashConfig: lightdashConfigMock,
+        featureFlagModel,
+    });
+    return { service, ensureOrganizationOverrideEnabled };
+};
+
+describe('FeatureFlagService', () => {
+    describe('ensureOrganizationOverrideEnabled', () => {
+        it('delegates to the model for an organization admin', async () => {
+            const { service, ensureOrganizationOverrideEnabled } =
+                buildService();
+            const user = buildUser(
+                new Ability<PossibleAbilities>([
+                    { action: 'manage', subject: 'Organization' },
+                ]),
+            );
+
+            await expect(
+                service.ensureOrganizationOverrideEnabled({
+                    user,
+                    featureFlagId: 'homepage-builder',
+                }),
+            ).resolves.toBe('enabled');
+            expect(
+                ensureOrganizationOverrideEnabled,
+            ).toHaveBeenCalledExactlyOnceWith(
+                'homepage-builder',
+                organizationUuid,
+            );
+        });
+
+        it('rejects a user without manage permission on the organization', async () => {
+            const { service, ensureOrganizationOverrideEnabled } =
+                buildService();
+            const user = buildUser(
+                new Ability<PossibleAbilities>([
+                    { action: 'view', subject: 'Project' },
+                ]),
+            );
+
+            expect(() =>
+                service.ensureOrganizationOverrideEnabled({
+                    user,
+                    featureFlagId: 'homepage-builder',
+                }),
+            ).toThrow("You don't have access to this resource or action");
+            expect(ensureOrganizationOverrideEnabled).not.toHaveBeenCalled();
+        });
+
+        it('rejects a user without an organization', async () => {
+            const { service, ensureOrganizationOverrideEnabled } =
+                buildService();
+            const user = {
+                ...buildUser(
+                    new Ability<PossibleAbilities>([
+                        { action: 'manage', subject: 'Organization' },
+                    ]),
+                ),
+                organizationUuid: undefined,
+            } as unknown as SessionUser;
+
+            expect(() =>
+                service.ensureOrganizationOverrideEnabled({
+                    user,
+                    featureFlagId: 'homepage-builder',
+                }),
+            ).toThrow('User is not part of an organization');
+            expect(ensureOrganizationOverrideEnabled).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/backend/src/services/FeatureFlag/FeatureFlagService.ts
+++ b/packages/backend/src/services/FeatureFlag/FeatureFlagService.ts
@@ -1,4 +1,9 @@
-import { LightdashUser } from '@lightdash/common';
+import { subject } from '@casl/ability';
+import {
+    ForbiddenError,
+    LightdashUser,
+    type SessionUser,
+} from '@lightdash/common';
 import { LightdashConfig } from '../../config/parseConfig';
 import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import { BaseService } from '../BaseService';
@@ -30,12 +35,24 @@ export class FeatureFlagService extends BaseService {
     }
 
     ensureOrganizationOverrideEnabled({
+        user,
         featureFlagId,
-        organizationUuid,
     }: {
+        user: SessionUser;
         featureFlagId: string;
-        organizationUuid: string;
     }) {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('User is not part of an organization');
+        }
+        if (
+            this.createAuditedAbility(user).cannot(
+                'manage',
+                subject('Organization', { organizationUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
         return this.featureFlagModel.ensureOrganizationOverrideEnabled(
             featureFlagId,
             organizationUuid,

--- a/packages/backend/src/services/FeatureFlag/FeatureFlagService.ts
+++ b/packages/backend/src/services/FeatureFlag/FeatureFlagService.ts
@@ -28,4 +28,17 @@ export class FeatureFlagService extends BaseService {
     }) {
         return this.featureFlagModel.get({ user, featureFlagId });
     }
+
+    ensureOrganizationOverrideEnabled({
+        featureFlagId,
+        organizationUuid,
+    }: {
+        featureFlagId: string;
+        organizationUuid: string;
+    }) {
+        return this.featureFlagModel.ensureOrganizationOverrideEnabled(
+            featureFlagId,
+            organizationUuid,
+        );
+    }
 }


### PR DESCRIPTION
Linear: SPK-715

## Problem

Organizations created through the new onboarding flow auto-provision a playground project and a default AI agent, so they satisfy the new homepage's gating — except for the `homepage-builder` commercial feature flag, which is default-off and resolved only from per-org DB override rows. A brand-new org has no override row, so `provisionOnboardingHomepage` (which requires both `new-onboarding` and `homepage-builder`) always skips with `homepage_builder_flag_disabled`, and new signups are structurally excluded from the day-0 homepage.

## Change

When the new onboarding flow provisions the playground project, also enable `homepage-builder` for the organization by writing an org-scoped `feature_flag_overrides` row (`enabled=true`).

- New `FeatureFlagModel.ensureOrganizationOverrideEnabled(flagId, organizationUuid)`: insert-only enablement. It upserts the parent `feature_flags` row (`onConflict ignore`, so an existing row's `default_enabled` is never touched — required because override rows are invisible without a parent flag row) and inserts the org override only when none exists. An existing override — including an explicit `enabled=false` — is never modified. Returns `enabled | already_enabled | kept_disabled`; a conflict-ignored insert re-reads the row to report the concurrent winner's state.
- `FeatureFlagService.ensureOrganizationOverrideEnabled`: derives the target organization from the session user and requires `manage` permission on the organization (audited ability) before delegating to the model.
- `provisionPlaygroundProject` calls it right before `projectService.createWithoutCompile`. Ordering matters: project creation synchronously runs the `onProjectCreated` hook → `provisionOnboardingHomepage`, which re-reads the flag from the DB — the override must be committed first. The write goes through a separate pooled connection, so it is visible despite the advisory-lock transaction wrapping the provisioning callback. A failed enablement is logged and reported to Sentry but does not fail playground provisioning.
- Only the fresh-creation path writes the override — the skip paths (playground already exists, org already has projects, previously removed) don't touch flags, so existing orgs are unaffected.

## Analytics

`playground_project.provisioned` gains a `homepageBuilderEnablement` property (`enabled | already_enabled | kept_disabled | failed`). Rollout questions join on `organizationId`: enablement outcomes here vs. `onboarding_homepage.provisioned` / `onboarding_homepage.skipped` for whether the homepage actually materialized, and homepage view/usage events downstream.

## Tests

- `FeatureFlagModel.test.ts`: new suite for `ensureOrganizationOverrideEnabled` — inserts flag row + override when absent, leaves an existing enabled override untouched, never flips an explicit disabled override back on, and re-reads after a simulated concurrent insert.
- `provisionPlaygroundProject.test.ts`: enablement is called with the right flag/org **before** `createWithoutCompile` (asserted via mock invocation order), skip paths never call it, `kept_disabled` propagates to the event property, and an enablement failure still provisions the playground with `homepageBuilderEnablement: 'failed'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Tp1ChvSQRmcmFXFWt5wTU

