### PR TITLE
fix(ai): keep deep research cards in conversation order

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.test.tsx
@@ -1,0 +1,183 @@
+import {
+    type AiAgentMessageAssistant,
+    type AiAgentMessageUser,
+    type AiAgentThread,
+} from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+import { AgentChatDisplay } from './AgentChatDisplay';
+
+const { deepResearchRegistrationsMock } = vi.hoisted(() => ({
+    deepResearchRegistrationsMock: vi.fn(),
+}));
+
+vi.mock('../../hooks/useProjectAiMcpServers', () => ({
+    useAgentAiMcpServers: () => ({ data: [] }),
+}));
+
+vi.mock('../../hooks/useDeepResearch', () => ({
+    useDeepResearchThreadRunRegistrations: deepResearchRegistrationsMock,
+}));
+
+vi.mock('../DeepResearch/DeepResearchThreadRuns', () => ({
+    DeepResearchThreadRuns: ({
+        registrations,
+    }: {
+        registrations: Array<{ promptUuid: string }>;
+    }) =>
+        registrations.length > 0 ? (
+            <div data-testid="conversation-item">Deep research card</div>
+        ) : null,
+}));
+
+vi.mock('./AgentChatUserBubble', () => ({
+    UserBubble: ({ message }: { message: { message: string } }) => (
+        <div data-testid="conversation-item">{message.message}</div>
+    ),
+}));
+
+vi.mock('./AgentChatAssistantBubble', () => ({
+    AssistantBubble: ({ message }: { message: { message: string } }) => (
+        <div data-testid="conversation-item">{message.message}</div>
+    ),
+}));
+
+const deepResearchUserMessage: AiAgentMessageUser = {
+    role: 'user',
+    uuid: 'deep-research-prompt',
+    threadUuid: 'thread-1',
+    message: 'Find anomalies',
+    createdAt: '2026-07-29T09:00:00.000Z',
+    user: { uuid: 'user-1', name: 'Demo User' },
+    context: [],
+    steers: [],
+    hidden: false,
+};
+
+const getAssistantMessage = (
+    uuid: string,
+    message: string | null,
+    createdAt: string,
+): AiAgentMessageAssistant => ({
+    role: 'assistant',
+    status: 'idle',
+    uuid,
+    threadUuid: 'thread-1',
+    message,
+    errorMessage: null,
+    interrupted: false,
+    createdAt,
+    humanScore: null,
+    humanFeedback: null,
+    toolCalls: [],
+    toolResults: [],
+    reasoning: [],
+    savedQueryUuid: null,
+    artifacts: null,
+    referencedArtifacts: null,
+    modelConfig: null,
+    tokenUsage: null,
+});
+
+const followUpUserMessage: AiAgentMessageUser = {
+    ...deepResearchUserMessage,
+    uuid: 'follow-up-prompt',
+    message: 'What is inside the report?',
+    createdAt: '2026-07-29T09:01:00.000Z',
+};
+
+const thread: AiAgentThread = {
+    uuid: 'thread-1',
+    agentUuid: 'agent-1',
+    createdAt: '2026-07-29T09:00:00.000Z',
+    createdFrom: 'web_app',
+    title: 'Deep research chronology',
+    titleGeneratedAt: null,
+    firstMessage: {
+        uuid: 'deep-research-prompt',
+        message: 'Find anomalies',
+    },
+    user: {
+        uuid: 'user-1',
+        name: 'Demo User',
+    },
+    compactions: [],
+    messages: [
+        deepResearchUserMessage,
+        getAssistantMessage(
+            'deep-research-prompt',
+            null,
+            '2026-07-29T09:00:01.000Z',
+        ),
+        followUpUserMessage,
+        getAssistantMessage(
+            'follow-up-prompt',
+            'The report covers anomalies.',
+            '2026-07-29T09:01:01.000Z',
+        ),
+    ],
+};
+
+describe('AgentChatDisplay', () => {
+    beforeEach(() => {
+        deepResearchRegistrationsMock.mockReturnValue([
+            { promptUuid: 'deep-research-prompt' },
+        ]);
+    });
+
+    it('renders a deep research card after its initiating message', () => {
+        renderWithProviders(
+            <AgentChatDisplay
+                thread={thread}
+                projectUuid="project-1"
+                agentUuid="agent-1"
+            />,
+        );
+
+        expect(
+            screen
+                .getAllByTestId('conversation-item')
+                .map((element) => element.textContent),
+        ).toEqual([
+            'Find anomalies',
+            'Deep research card',
+            'What is inside the report?',
+            'The report covers anomalies.',
+        ]);
+    });
+
+    it('keeps an unanchored optimistic run visible at the thread tail', () => {
+        deepResearchRegistrationsMock.mockReturnValue([
+            { promptUuid: 'pending-prompt' },
+        ]);
+
+        renderWithProviders(
+            <AgentChatDisplay
+                thread={{
+                    ...thread,
+                    messages: [
+                        followUpUserMessage,
+                        getAssistantMessage(
+                            'follow-up-prompt',
+                            'The report covers anomalies.',
+                            '2026-07-29T09:01:01.000Z',
+                        ),
+                    ],
+                }}
+                projectUuid="project-1"
+                agentUuid="agent-1"
+            />,
+        );
+
+        expect(
+            screen
+                .getAllByTestId('conversation-item')
+                .map((element) => element.textContent),
+        ).toEqual([
+            'What is inside the report?',
+            'The report covers anomalies.',
+            'Deep research card',
+        ]);
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
@@ -18,7 +18,7 @@ import {
     type PropsWithChildren,
 } from 'react';
 import ErrorBoundary from '../../../../../features/errorBoundary/ErrorBoundary';
-import { useDeepResearchThreadRuns } from '../../hooks/useDeepResearch';
+import { useDeepResearchThreadRunRegistrations } from '../../hooks/useDeepResearch';
 import { useAgentAiMcpServers } from '../../hooks/useProjectAiMcpServers';
 import { AddToEvalModal } from '../Admin/AddToEvalModal';
 import { DeepResearchThreadRuns } from '../DeepResearch/DeepResearchThreadRuns';
@@ -114,18 +114,31 @@ export const AgentChatDisplay: FC<PropsWithChildren<Props>> = ({
     // Deep research prompts never receive a chat response — the run card is
     // the response — so their assistant bubbles must not render (they would
     // show as failed generations).
-    const deepResearchRuns = useDeepResearchThreadRuns(
+    const deepResearchRegistrations = useDeepResearchThreadRunRegistrations({
         projectUuid,
-        thread.uuid,
+        threadUuid: thread.uuid,
+    });
+    const deepResearchRegistrationsByPromptUuid = useMemo(
+        () =>
+            deepResearchRegistrations.reduce(
+                (registrationsByPromptUuid, registration) => {
+                    const promptRegistrations =
+                        registrationsByPromptUuid.get(
+                            registration.promptUuid,
+                        ) ?? [];
+                    registrationsByPromptUuid.set(registration.promptUuid, [
+                        ...promptRegistrations,
+                        registration,
+                    ]);
+                    return registrationsByPromptUuid;
+                },
+                new Map<string, typeof deepResearchRegistrations>(),
+            ),
+        [deepResearchRegistrations],
     );
     const deepResearchPromptUuids = useMemo(
-        () =>
-            new Set(
-                (deepResearchRuns.data ?? []).flatMap((run) =>
-                    run.promptUuid ? [run.promptUuid] : [],
-                ),
-            ),
-        [deepResearchRuns.data],
+        () => new Set(deepResearchRegistrationsByPromptUuid.keys()),
+        [deepResearchRegistrationsByPromptUuid],
     );
     const compactionsByTriggeringPromptUuid = new Map(
         thread.compactions.map((compaction) => [
@@ -133,6 +146,26 @@ export const AgentChatDisplay: FC<PropsWithChildren<Props>> = ({
             compaction,
         ]),
     );
+    // Hidden turns are answered by the agent but are not part of the visible
+    // conversation. Deep research assistant rows are replaced by run cards.
+    const visibleMessages = thread.messages.filter(
+        (message) =>
+            !(
+                (message.role === 'user' && message.hidden) ||
+                (message.role === 'assistant' &&
+                    deepResearchPromptUuids.has(message.uuid))
+            ),
+    );
+    const visibleUserPromptUuids = new Set(
+        visibleMessages.flatMap((message) =>
+            message.role === 'user' ? [message.uuid] : [],
+        ),
+    );
+    const unanchoredDeepResearchRegistrations =
+        deepResearchRegistrations.filter(
+            (registration) =>
+                !visibleUserPromptUuids.has(registration.promptUuid),
+        );
 
     return (
         <Flex
@@ -153,90 +186,83 @@ export const AgentChatDisplay: FC<PropsWithChildren<Props>> = ({
                     style={{ flexGrow: 1 }}
                 >
                     <Stack flex={1} style={{ flexGrow: 1 }}>
-                        {thread.messages
-                            // Hidden turns (e.g. the post-merge migration prompt)
-                            // are received and answered by the agent but never
-                            // rendered as a user bubble.
-                            .filter(
-                                (message) =>
-                                    !(
-                                        message.role === 'user' &&
-                                        message.hidden
-                                    ) &&
-                                    !(
-                                        message.role === 'assistant' &&
-                                        deepResearchPromptUuids.has(
-                                            message.uuid,
-                                        )
-                                    ),
-                            )
-                            .map((message, i, xs) => (
-                                <Fragment
-                                    key={`${message.role}-${message.uuid}`}
-                                >
-                                    {message.role === 'user' &&
-                                        compactionsByTriggeringPromptUuid.has(
-                                            message.uuid,
-                                        ) && <CompactionDivider />}
+                        {visibleMessages.map((message, i, xs) => (
+                            <Fragment key={`${message.role}-${message.uuid}`}>
+                                {message.role === 'user' &&
+                                    compactionsByTriggeringPromptUuid.has(
+                                        message.uuid,
+                                    ) && <CompactionDivider />}
 
-                                    {ChatElementsUtils.shouldRenderDivider(
-                                        message,
-                                        i,
-                                        xs,
-                                    ) && (
-                                        <Divider
-                                            label={
-                                                message.createdAt
-                                                    ? ChatElementsUtils.getDividerLabel(
-                                                          message.createdAt,
-                                                      )
-                                                    : undefined
-                                            }
-                                            labelPosition="center"
-                                            my="sm"
-                                        />
-                                    )}
+                                {ChatElementsUtils.shouldRenderDivider(
+                                    message,
+                                    i,
+                                    xs,
+                                ) && (
+                                    <Divider
+                                        label={
+                                            message.createdAt
+                                                ? ChatElementsUtils.getDividerLabel(
+                                                      message.createdAt,
+                                                  )
+                                                : undefined
+                                        }
+                                        labelPosition="center"
+                                        my="sm"
+                                    />
+                                )}
 
-                                    {message.role === 'user' ? (
-                                        <UserBubble
-                                            message={message}
-                                            projectUuid={projectUuid}
-                                        />
-                                    ) : (
-                                        <ErrorBoundary>
-                                            {projectUuid && agentUuid && (
-                                                <AssistantBubble
-                                                    message={message}
-                                                    isLastMessage={
-                                                        i === xs.length - 1
-                                                    }
-                                                    debug={debug}
-                                                    projectUuid={projectUuid}
-                                                    agentUuid={agentUuid}
-                                                    onAddToEvals={
-                                                        setAddToEvalsPromptUuid
-                                                    }
-                                                    showAddToEvalsButton={
-                                                        showAddToEvalsButton
-                                                    }
-                                                    mcpServers={mcpServers}
-                                                    renderArtifactsInline={
-                                                        renderArtifactsInline
-                                                    }
-                                                    onDashboardLinkClick={
-                                                        onDashboardLinkClick
-                                                    }
-                                                />
-                                            )}
-                                        </ErrorBoundary>
-                                    )}
-                                </Fragment>
-                            ))}
+                                {message.role === 'user' ? (
+                                    <UserBubble
+                                        message={message}
+                                        projectUuid={projectUuid}
+                                    />
+                                ) : (
+                                    <ErrorBoundary>
+                                        {projectUuid && agentUuid && (
+                                            <AssistantBubble
+                                                message={message}
+                                                isLastMessage={
+                                                    i === xs.length - 1
+                                                }
+                                                debug={debug}
+                                                projectUuid={projectUuid}
+                                                agentUuid={agentUuid}
+                                                onAddToEvals={
+                                                    setAddToEvalsPromptUuid
+                                                }
+                                                showAddToEvalsButton={
+                                                    showAddToEvalsButton
+                                                }
+                                                mcpServers={mcpServers}
+                                                renderArtifactsInline={
+                                                    renderArtifactsInline
+                                                }
+                                                onDashboardLinkClick={
+                                                    onDashboardLinkClick
+                                                }
+                                            />
+                                        )}
+                                    </ErrorBoundary>
+                                )}
 
-                        {projectUuid && (
+                                {message.role === 'user' && (
+                                    <DeepResearchThreadRuns
+                                        registrations={
+                                            deepResearchRegistrationsByPromptUuid.get(
+                                                message.uuid,
+                                            ) ?? []
+                                        }
+                                        canRetry={canRetryDeepResearch}
+                                    />
+                                )}
+                            </Fragment>
+                        ))}
+
+                        {unanchoredDeepResearchRegistrations.length > 0 && (
                             <DeepResearchThreadRuns
-                                projectUuid={projectUuid}
-                                threadUuid={thread.uuid}
+                                registrations={
+                                    unanchoredDeepResearchRegistrations
+                                }
                                 canRetry={canRetryDeepResearch}
                             />
                         )}

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchThreadRuns.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchThreadRuns.test.tsx
@@ -6,22 +6,9 @@ import { deepResearchRunFixture } from '../../deepResearch/fixtures';
 import { type DeepResearchRunRegistration } from '../../deepResearch/types';
 import { DeepResearchThreadRuns } from './DeepResearchThreadRuns';
 
-const {
-    continueDeepResearchMock,
-    localRegistrationsMock,
-    useDeepResearchRunMock,
-} = vi.hoisted(() => ({
+const { continueDeepResearchMock, useDeepResearchRunMock } = vi.hoisted(() => ({
     continueDeepResearchMock: vi.fn(),
-    localRegistrationsMock: vi.fn(),
     useDeepResearchRunMock: vi.fn(),
-}));
-
-vi.mock('../../../../../hooks/user/useUser', () => ({
-    default: () => ({ data: { userUuid: 'user-1' } }),
-}));
-
-vi.mock('../../deepResearch/deepResearchRegistry', () => ({
-    useDeepResearchRunsForThread: localRegistrationsMock,
 }));
 
 vi.mock('../../hooks/useDeepResearch', () => ({
@@ -30,7 +17,6 @@ vi.mock('../../hooks/useDeepResearch', () => ({
         isLoading: false,
     }),
     useDeepResearchRun: useDeepResearchRunMock,
-    useDeepResearchThreadRuns: () => ({ data: [] }),
 }));
 
 vi.mock('./DeepResearchRunCard', () => ({
@@ -53,7 +39,6 @@ describe('DeepResearchThreadRuns', () => {
     };
 
     beforeEach(() => {
-        localRegistrationsMock.mockReturnValue([registration]);
         continueDeepResearchMock.mockReset();
         useDeepResearchRunMock.mockReset();
     });
@@ -61,8 +46,7 @@ describe('DeepResearchThreadRuns', () => {
     const renderThreadRuns = (canRetry = false) =>
         renderWithProviders(
             <DeepResearchThreadRuns
-                projectUuid="project-1"
-                threadUuid="thread-1"
+                registrations={[registration]}
                 canRetry={canRetry}
             />,
         );
@@ -121,11 +105,13 @@ describe('DeepResearchThreadRuns', () => {
 
     it('does not retry a failed start while the thread is busy', async () => {
         const user = userEvent.setup();
-        localRegistrationsMock.mockReturnValue([
-            { ...registration, state: 'start_failed' },
-        ]);
 
-        renderThreadRuns(false);
+        renderWithProviders(
+            <DeepResearchThreadRuns
+                registrations={[{ ...registration, state: 'start_failed' }]}
+                canRetry={false}
+            />,
+        );
 
         const retryButton = screen.getByRole('button', { name: 'Try again' });
         expect(retryButton).toBeDisabled();
@@ -135,11 +121,13 @@ describe('DeepResearchThreadRuns', () => {
 
     it('retries a failed start with its original prompt while idle', async () => {
         const user = userEvent.setup();
-        localRegistrationsMock.mockReturnValue([
-            { ...registration, state: 'start_failed' },
-        ]);
 
-        renderThreadRuns(true);
+        renderWithProviders(
+            <DeepResearchThreadRuns
+                registrations={[{ ...registration, state: 'start_failed' }]}
+                canRetry
+            />,
+        );
         await user.click(screen.getByRole('button', { name: 'Try again' }));
 
         expect(continueDeepResearchMock).toHaveBeenCalledWith({

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchThreadRuns.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchThreadRuns.tsx
@@ -1,13 +1,8 @@
 import { Alert, Button, Paper, Skeleton, Stack, Text } from '@mantine-8/core';
-import { useMemo } from 'react';
-import useUser from '../../../../../hooks/user/useUser';
-import { useDeepResearchRunsForThread } from '../../deepResearch/deepResearchRegistry';
-import { toDeepResearchRegistration } from '../../deepResearch/runProgress';
 import { type DeepResearchRunRegistration } from '../../deepResearch/types';
 import {
     useContinueDeepResearchMutation,
     useDeepResearchRun,
-    useDeepResearchThreadRuns,
 } from '../../hooks/useDeepResearch';
 import { DeepResearchRunCard } from './DeepResearchRunCard';
 
@@ -112,43 +107,12 @@ const DeepResearchThreadRun = ({
 };
 
 export const DeepResearchThreadRuns = ({
-    projectUuid,
-    threadUuid,
+    registrations,
     canRetry = false,
 }: {
-    projectUuid: string;
-    threadUuid: string;
+    registrations: DeepResearchRunRegistration[];
     canRetry?: boolean;
 }) => {
-    const user = useUser(true);
-    const userUuid = user.data?.userUuid;
-    // Server is the source of truth; the local registry only contributes
-    // optimistic entries (starting / start_failed / just-started runs the
-    // list has not caught up with yet).
-    const serverRuns = useDeepResearchThreadRuns(projectUuid, threadUuid);
-    const localRegistrations = useDeepResearchRunsForThread(
-        projectUuid,
-        threadUuid,
-        userUuid,
-    );
-    const registrations = useMemo(() => {
-        const fromServer = (serverRuns.data ?? []).map((run) =>
-            toDeepResearchRegistration(run, {
-                threadUuid,
-                userUuid: userUuid ?? '',
-            }),
-        );
-        const serverRunUuids = new Set(
-            fromServer.map((registration) => registration.runUuid),
-        );
-        return [
-            ...fromServer,
-            ...localRegistrations.filter(
-                (registration) => !serverRunUuids.has(registration.runUuid),
-            ),
-        ];
-    }, [serverRuns.data, localRegistrations, threadUuid, userUuid]);
-
     if (!registrations.length) {
         return null;
     }

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.ts
@@ -11,6 +11,7 @@ import {
     type ApiError,
 } from '@lightdash/common';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMemo } from 'react';
 import { lightdashApi } from '../../../../api';
 import useToaster from '../../../../hooks/toaster/useToaster';
 import useUser from '../../../../hooks/user/useUser';
@@ -19,11 +20,13 @@ import {
     replaceDeepResearchRun,
     restoreDeepResearchComposerPrompt,
     updateDeepResearchRun,
+    useDeepResearchRunsForThread,
 } from '../deepResearch/deepResearchRegistry';
 import {
     adaptDeepResearchRun,
     DEEP_RESEARCH_DEPTH_CONFIG,
     isDeepResearchRunTerminal,
+    toDeepResearchRegistration,
 } from '../deepResearch/runProgress';
 import {
     type DeepResearchRunRegistration,
@@ -240,7 +243,7 @@ export const useStartDeepResearchForThreadMutation = (projectUuid: string) =>
         ({ agentUuid, threadUuid }) => ({ agentUuid, threadUuid }),
     );
 
-export const useDeepResearchThreadRuns = (
+const useDeepResearchThreadRuns = (
     projectUuid: string | undefined,
     threadUuid: string,
 ) =>
@@ -249,6 +252,41 @@ export const useDeepResearchThreadRuns = (
         queryFn: () => listDeepResearchRuns(projectUuid ?? '', threadUuid),
         enabled: !!projectUuid,
     });
+
+export const useDeepResearchThreadRunRegistrations = ({
+    projectUuid,
+    threadUuid,
+}: {
+    projectUuid: string | undefined;
+    threadUuid: string;
+}) => {
+    const user = useUser(true);
+    const userUuid = user.data?.userUuid;
+    const serverRuns = useDeepResearchThreadRuns(projectUuid, threadUuid);
+    const localRegistrations = useDeepResearchRunsForThread(
+        projectUuid ?? '',
+        threadUuid,
+        userUuid,
+    );
+
+    return useMemo(() => {
+        const fromServer = (serverRuns.data ?? []).map((run) =>
+            toDeepResearchRegistration(run, {
+                threadUuid,
+                userUuid: userUuid ?? '',
+            }),
+        );
+        const serverRunUuids = new Set(
+            fromServer.map((registration) => registration.runUuid),
+        );
+        return [
+            ...fromServer,
+            ...localRegistrations.filter(
+                (registration) => !serverRunUuids.has(registration.runUuid),
+            ),
+        ];
+    }, [serverRuns.data, localRegistrations, threadUuid, userUuid]);
+};
 
 export const useDeepResearchRun = (
     registration: DeepResearchRunRegistration,


### PR DESCRIPTION
Closes: PROD-9292

## Summary

PR 2 of 2 for the deep-research card fixes. Each card now renders immediately after the user message that started its run and stays in that chronological position as the run updates.

Stacks on [#26416](https://github.com/lightdash/lightdash/pull/26416), which renders the card’s executive answer through the shared AI Markdown pipeline.

## Changes

**Frontend**

- Merge durable and optimistic run registrations once per thread, then group them by their initiating `promptUuid`.
- Render each group immediately after its matching visible user message instead of after the complete conversation.
- Keep an unanchored optimistic registration at the tail until its user message arrives, then move it to the stable prompt position without duplicating it.
- Preserve the existing empty-assistant suppression, run polling, refresh fallback, and retry behavior.

## Conversation order

```text
Before: prompt A → prompt B → reply B → card A
After:  prompt A → card A → prompt B → reply B

Optimistic: card A at tail → prompt A arrives → card A anchors after prompt A
```

## Test plan

- [x] `pnpm -F frontend test src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.test.tsx src/ee/features/aiCopilot/components/DeepResearch/DeepResearchThreadRuns.test.tsx src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.test.tsx` — 18 tests pass.
- [x] `pnpm -F frontend test` — 1,667 tests pass.
- [x] `pnpm -F frontend typecheck`
- [x] `pnpm -F frontend lint` — 0 errors.
- [x] `pnpm -F frontend unused-exports`
- [x] Restacked both branches onto latest `main` and reran the full verification gates.
