### PR TITLE
fix(ai): redirect getMetadata field misses to explores where the field is reachable

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/getMetadata.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/getMetadata.test.ts
@@ -223,6 +223,46 @@ describe('getMetadata explore field listing', () => {
         );
     });
 
+    it('redirects to explores where a missing field is actually reachable', async () => {
+        // The agent frequently pairs a real fieldId (surfaced by grepFields
+        // across the whole catalog) with the wrong explore. A bare "not found"
+        // is a dead end that sends it back to grep in a loop; the error must
+        // say where the field IS reachable.
+        const sales = makeExplore({});
+        const billing: Explore = {
+            ...sales,
+            name: 'billing',
+            label: 'Billing',
+            tables: {
+                orders: {
+                    ...sales.tables.orders,
+                    dimensions: {},
+                },
+            },
+        };
+
+        const tool = getGetMetadata({ availableExplores: [billing, sales] });
+        const result = (await tool.execute!(
+            {
+                requests: [
+                    {
+                        type: 'field',
+                        fields: [
+                            { exploreId: 'billing', fieldId: 'orders_status' },
+                        ],
+                    },
+                ],
+            },
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            {} as any,
+        )) as ExecuteResult;
+
+        expect(result.result).toContain(
+            'Field "orders_status" not found in explore "billing"',
+        );
+        expect(result.result).toContain('It IS available in: sales');
+    });
+
     it('truncates very wide base tables with a "+N more" marker', async () => {
         const explore = makeExplore({});
         for (let i = 0; i < 150; i += 1) {

--- a/packages/backend/src/ee/services/ai/tools/getMetadata.ts
+++ b/packages/backend/src/ee/services/ai/tools/getMetadata.ts
@@ -236,6 +236,48 @@ const buildFieldStructuredResult = (
     };
 };
 
+// A field that misses on the requested explore often exists on another explore
+// (grep surfaces fields across the whole catalog, so the agent may pair a real
+// fieldId with the wrong explore). Without a redirect the "not found" is a dead
+// end and the agent loops grep -> getMetadata -> not found indefinitely.
+const REACHABLE_EXPLORES_MAX = 5;
+
+const findExploresContainingField = (
+    explores: Explore[],
+    fieldId: string,
+    excludeExploreId: string,
+): string[] =>
+    explores
+        .filter(
+            (explore) =>
+                explore.name !== excludeExploreId &&
+                findField(explore, fieldId) !== null,
+        )
+        .map((explore) => explore.name);
+
+const buildFieldNotFoundError = (
+    availableExplores: Explore[],
+    exploreId: string,
+    fieldId: string,
+): string => {
+    const reachableFrom = findExploresContainingField(
+        availableExplores,
+        fieldId,
+        exploreId,
+    );
+    if (reachableFrom.length === 0) {
+        return `Field "${fieldId}" not found in explore "${exploreId}".`;
+    }
+    const shown = reachableFrom.slice(0, REACHABLE_EXPLORES_MAX);
+    const overflow =
+        reachableFrom.length > shown.length
+            ? ` (+${reachableFrom.length - shown.length} more)`
+            : '';
+    return `Field "${fieldId}" not found in explore "${exploreId}" — its table is not joined there. It IS available in: ${shown.join(
+        ', ',
+    )}${overflow}. Query it from one of those explores instead; it cannot be combined with "${exploreId}" fields in a single query.`;
+};
+
 export const executeGetMetadata = (
     { requests }: ToolGetMetadataArgs,
     { availableExplores }: Dependencies,
@@ -279,7 +321,11 @@ export const executeGetMetadata = (
                 } else {
                     const found = findField(explore, fieldId);
                     if (!found) {
-                        const error = `Field "${fieldId}" not found in explore "${exploreId}".`;
+                        const error = buildFieldNotFoundError(
+                            availableExplores,
+                            exploreId,
+                            fieldId,
+                        );
                         textBlocks.push(error);
                         fields.push({
                             exploreId,


### PR DESCRIPTION
## Summary

Fixes #26430.

`grepFields` deliberately searches the whole explore catalog, so it routinely surfaces fields from other explores' join trees. When the agent pairs that (real) fieldId with the wrong explore, `getMetadata` returned a bare dead-end — `Field "X" not found in explore "Y".` — giving the agent no way to tell a bad field name from a missing join. Observed result in production traces: the agent loops grep → getMetadata → not-found → grep until it exhausts its steps and fails without answering (one trace burned ~115k tokens on 12 discovery-only calls).

On a field miss, we now scan the other available explores (in-memory, no extra queries) and redirect:

```
Field "X" not found in explore "Y" — its table is not joined there. It IS available in: a, b. Query it from one of those explores instead; it cannot be combined with "Y" fields in a single query.
```

- Capped at 5 explore names with a `+N more` marker
- Falls back to the original message when the field exists nowhere (hidden fields stay unresolvable)

## Testing

- New unit test: field missing on requested explore but reachable on another → error names the reachable explore
- Existing tests unchanged and passing (11/11), including hidden-field not-found keeping the plain message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtdNpFTpFnuXSMrnwYoxNA