### PR TITLE
fix(ai): never finish a prompt with empty response and no error message

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -1382,9 +1382,10 @@ export const generateAgentResponse = async ({
         );
 
         // Invariant: a finished prompt must persist either a response or an
-        // error message. Empty text under the step cap would otherwise be
-        // stored as a blank response with no explanation for the user.
-        if (!result.text) {
+        // error message. Empty (or whitespace-only) text under the step cap
+        // would otherwise be stored as a blank response with no explanation
+        // for the user.
+        if (!result.text.trim()) {
             if (result.steps.length >= args.execution.maxSteps) {
                 throw new AiAgentStepCapReachedError(result.steps.length);
             }
@@ -1787,8 +1788,9 @@ export const streamAgentResponse = async ({
                 // the client's post-stream refetch then reads persisted content.
                 // Invariant: a finished prompt must persist either a response
                 // or an error message — a blank response with no error renders
-                // as an empty chat bubble with no explanation.
-                if (!completeResponse) {
+                // as an empty chat bubble with no explanation. trim() matters:
+                // steps with empty text still join into "\n" strings.
+                if (!completeResponse.trim()) {
                     const emptyResponseError = stepCapReached
                         ? new AiAgentStepCapReachedError(steps.length)
                         : new AiAgentEmptyResponseError(

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -80,6 +80,7 @@ import type {
 } from '../types/aiAgent';
 import { AgentContext } from '../utils/AgentContext';
 import {
+    AiAgentEmptyResponseError,
     AiAgentStepCapReachedError,
     getUserFacingErrorMessage,
 } from '../utils/errorMessages';
@@ -1380,8 +1381,17 @@ export const generateAgentResponse = async ({
             `Generation complete. Result text length: ${result.text.length}, finishReason: ${result.finishReason}`,
         );
 
-        if (result.steps.length >= args.execution.maxSteps && !result.text) {
-            throw new AiAgentStepCapReachedError(result.steps.length);
+        // Invariant: a finished prompt must persist either a response or an
+        // error message. Empty text under the step cap would otherwise be
+        // stored as a blank response with no explanation for the user.
+        if (!result.text) {
+            if (result.steps.length >= args.execution.maxSteps) {
+                throw new AiAgentStepCapReachedError(result.steps.length);
+            }
+            throw new AiAgentEmptyResponseError(
+                result.finishReason,
+                result.steps.length,
+            );
         }
 
         if (args.execution.mode !== 'deep_research') {
@@ -1775,12 +1785,34 @@ export const streamAgentResponse = async ({
                 // The AI SDK holds the stream open until onFinish resolves, so
                 // the HTTP stream only closes once the response is persisted —
                 // the client's post-stream refetch then reads persisted content.
-                if (stepCapReached && !completeResponse) {
+                // Invariant: a finished prompt must persist either a response
+                // or an error message — a blank response with no error renders
+                // as an empty chat bubble with no explanation.
+                if (!completeResponse) {
+                    const emptyResponseError = stepCapReached
+                        ? new AiAgentStepCapReachedError(steps.length)
+                        : new AiAgentEmptyResponseError(
+                              finishReason,
+                              steps.length,
+                          );
+                    if (!stepCapReached) {
+                        // Under-cap empty finishes are unexpected — capture so
+                        // the underlying trigger stays observable in Sentry.
+                        Logger.error(
+                            `[AiAgent][Stream Agent Response] Stream finished with empty response under the step cap. finishReason: ${finishReason}, steps: ${steps.length}`,
+                        );
+                        Sentry.captureException(emptyResponseError, {
+                            tags: {
+                                errorType: 'AiAgentEmptyResponseError',
+                                'ai.model': modelName,
+                                'ai.finishReason': finishReason,
+                            },
+                        });
+                    }
                     await persistPrompt({
                         promptUuid: args.promptUuid,
-                        errorMessage: getUserFacingErrorMessage(
-                            new AiAgentStepCapReachedError(steps.length),
-                        ),
+                        errorMessage:
+                            getUserFacingErrorMessage(emptyResponseError),
                         tokenUsage: {
                             totalTokens: usage.totalTokens ?? 0,
                         },

--- a/packages/backend/src/ee/services/ai/utils/errorMessages.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/errorMessages.test.ts
@@ -1,5 +1,9 @@
 import { McpAuthorizationRequiredError } from '../AiAgentMcpRuntimeClient';
-import { getUserFacingErrorMessage } from './errorMessages';
+import {
+    AiAgentEmptyResponseError,
+    EMPTY_RESPONSE_MESSAGE,
+    getUserFacingErrorMessage,
+} from './errorMessages';
 
 const CONTEXT_LIMIT_MESSAGE =
     "This request exceeded the AI model's context limit, usually because the conversation or tool results became too large. Please start a new thread or break the request into smaller steps.";
@@ -11,6 +15,17 @@ const TIMEOUT_MESSAGE =
     'This request took too long to process. Try breaking it into smaller questions or start a new thread.';
 
 describe('getUserFacingErrorMessage', () => {
+    describe('empty response invariant', () => {
+        it('maps AiAgentEmptyResponseError to the user-facing empty-response message', () => {
+            const error = new AiAgentEmptyResponseError('stop', 3);
+            expect(getUserFacingErrorMessage(error)).toBe(
+                EMPTY_RESPONSE_MESSAGE,
+            );
+            expect(error.finishReason).toBe('stop');
+            expect(error.stepsCount).toBe(3);
+        });
+    });
+
     describe('context/token limit errors', () => {
         it.each([
             // OpenAI error code

--- a/packages/backend/src/ee/services/ai/utils/errorMessages.ts
+++ b/packages/backend/src/ee/services/ai/utils/errorMessages.ts
@@ -13,6 +13,26 @@ export class AiAgentStepCapReachedError extends Error {
     }
 }
 
+export const EMPTY_RESPONSE_MESSAGE =
+    'The agent finished without writing a response. Please try again — if it keeps happening, rephrase the question or start a new thread.';
+
+// A finished prompt must always carry either a response or an error message.
+// This error backs that invariant: the model stopped (under the step cap)
+// without producing any text, which would otherwise persist as a blank chat
+// bubble with no explanation.
+export class AiAgentEmptyResponseError extends Error {
+    readonly finishReason: string;
+
+    readonly stepsCount: number;
+
+    constructor(finishReason: string, stepsCount: number) {
+        super(EMPTY_RESPONSE_MESSAGE);
+        this.name = 'AiAgentEmptyResponseError';
+        this.finishReason = finishReason;
+        this.stepsCount = stepsCount;
+    }
+}
+
 /**
  * Converts technical error messages into user-friendly messages for AI agent errors.
  *
@@ -26,6 +46,10 @@ export const getUserFacingErrorMessage = (
 ): string => {
     if (error instanceof AiAgentStepCapReachedError) {
         return STEP_CAP_REACHED_MESSAGE;
+    }
+
+    if (error instanceof AiAgentEmptyResponseError) {
+        return EMPTY_RESPONSE_MESSAGE;
     }
 
     if (error instanceof McpAuthorizationRequiredError) {


### PR DESCRIPTION
## Summary

Fixes #26431.

Both agent completion paths could persist a **blank response with no error message** when the model finished with empty text while under the step cap. The user saw an empty chat bubble with no explanation. In a 30-day production window for one org this happened ~18 times (vs 2 correctly-surfaced step-cap errors).

- `generateAgentResponse` only threw `AiAgentStepCapReachedError` when `steps >= maxSteps && !text` — under the cap, an empty `result.text` was persisted as the response.
- `streamAgentResponse`'s `onFinish` guarded the error write with `stepCapReached && !completeResponse` — under-cap empty finishes persisted `response: ''`.

## Changes

- New `AiAgentEmptyResponseError` (carries `finishReason` + `stepsCount`) with a user-facing message: *"The agent finished without writing a response. Please try again — if it keeps happening, rephrase the question or start a new thread."*
- Invariant enforced in both paths: an empty finish always persists a user-facing error — the step-cap message at the cap, the empty-response message under it.
- Under-cap empty finishes are logged and captured in Sentry tagged with `finishReason`, so the underlying triggers (guardrail stops, discovery-loop giveups, zero-tool-call aborts) become observable instead of silent.

## Testing

- New unit test mapping `AiAgentEmptyResponseError` to the user-facing message
- Existing errorMessages + agentV2 suites pass (38/38)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtdNpFTpFnuXSMrnwYoxNA