### PR TITLE
feat(apps): record data app generation token spend

### DIFF
--- a/packages/backend/src/database/entities/apps.ts
+++ b/packages/backend/src/database/entities/apps.ts
@@ -3,6 +3,7 @@ import {
     type AppVersionResources,
     type AppVersionStatus,
     type AppVersionStatusHistoryEntry,
+    type DataAppGenerationUsage,
     type DataAppTemplate,
     type DataAppVizSchema,
 } from '@lightdash/common';
@@ -94,6 +95,9 @@ export type DbAppVersion = {
     dependencies: AppVersionDependencies | null;
     // Declared schema for data-app-viz versions; null otherwise.
     viz_schema: DataAppVizSchema | null;
+    // Token/cost spend for this version's generation. Null when the version
+    // predates spend recording or never called the model.
+    generation_usage: DataAppGenerationUsage | null;
     created_at: Date;
     created_by_user_uuid: string;
 };
@@ -109,6 +113,7 @@ export type DbAppActivityRow = Pick<
     | 'prompt'
     | 'status'
     | 'resources'
+    | 'generation_usage'
     | 'created_at'
     | 'created_by_user_uuid'
 > & {
@@ -141,6 +146,7 @@ export type AppVersionsTable = Knex.CompositeTableType<
             | 'status_history'
             | 'status_updated_at'
             | 'viz_schema'
+            | 'generation_usage'
         >
     >
 >;

--- a/packages/backend/src/database/migrations/20260729122405_add_generation_usage_to_app_versions.ts
+++ b/packages/backend/src/database/migrations/20260729122405_add_generation_usage_to_app_versions.ts
@@ -1,0 +1,21 @@
+import { type Knex } from 'knex';
+
+const AppVersionsTableName = 'app_versions';
+
+/**
+ * Token/cost spend for the version's generation.
+ *
+ * Nullable with no default, so the ALTER is metadata-only: existing rows stay
+ * NULL, which reads as "not recorded" rather than "spent nothing".
+ */
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AppVersionsTableName, (table) => {
+        table.jsonb('generation_usage').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AppVersionsTableName, (table) => {
+        table.dropColumn('generation_usage');
+    });
+}

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -495,7 +495,7 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                             'Build timed out. Please try again.',
                         );
                         if (marked) {
-                            this.appGenerateService.trackTimeoutFailure(
+                            await this.appGenerateService.trackTimeoutFailure(
                                 payload,
                                 e,
                                 schedulerWaitMs,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -1695,12 +1695,12 @@ export class AppGenerateService extends BaseService {
         return Math.round(performance.now() - start);
     }
 
-    trackTimeoutFailure(
+    async trackTimeoutFailure(
         payload: AppGeneratePipelineJobPayload,
         error: unknown,
         schedulerWaitMs?: number,
-    ): void {
-        this.trackVersionFailed(payload, 'timeout', error, {}, null, 0, {
+    ): Promise<void> {
+        await this.trackVersionFailed(payload, 'timeout', error, {}, null, 0, {
             schedulerWaitMs,
         });
     }
@@ -1767,7 +1767,7 @@ export class AppGenerateService extends BaseService {
         }
     }
 
-    private trackVersionFailed(
+    private async trackVersionFailed(
         payload: AppGeneratePipelineJobPayload,
         failureStage:
             | 'sandbox'
@@ -1783,7 +1783,7 @@ export class AppGenerateService extends BaseService {
         overallStart: number | null,
         buildFixAttempts: number,
         telemetry: DataAppVersionFailureTelemetry = {},
-    ): void {
+    ): Promise<void> {
         const { generationUsage } = telemetry;
         const claudeModel =
             payload.claudeModel ?? DEFAULT_DATA_APP_CLAUDE_MODEL;
@@ -1804,9 +1804,7 @@ export class AppGenerateService extends BaseService {
                 telemetry.keyManagement ?? 'lightdash-managed',
                 generationUsage,
             );
-            // This path is synchronous (called from ~10 error sites), so the
-            // write is floated rather than awaited; it swallows its own errors.
-            void this.recordGenerationUsage(payload, generationUsage);
+            await this.recordGenerationUsage(payload, generationUsage);
         }
 
         this.analytics.track({
@@ -3884,9 +3882,17 @@ export class AppGenerateService extends BaseService {
                 userMessage,
             );
             if (marked) {
-                this.trackVersionFailed(payload, 'config', error, {}, null, 0, {
-                    schedulerWaitMs,
-                });
+                await this.trackVersionFailed(
+                    payload,
+                    'config',
+                    error,
+                    {},
+                    null,
+                    0,
+                    {
+                        schedulerWaitMs,
+                    },
+                );
             }
             return;
         }
@@ -3984,7 +3990,7 @@ export class AppGenerateService extends BaseService {
                     'Failed to set up build environment. Please try again.',
                 );
                 if (marked) {
-                    this.trackVersionFailed(
+                    await this.trackVersionFailed(
                         payload,
                         'sandbox',
                         error,
@@ -4010,7 +4016,7 @@ export class AppGenerateService extends BaseService {
                     'Failed to resume build environment. Please try again.',
                 );
                 if (marked) {
-                    this.trackVersionFailed(
+                    await this.trackVersionFailed(
                         payload,
                         'sandbox',
                         missingSandboxError,
@@ -4041,7 +4047,7 @@ export class AppGenerateService extends BaseService {
                     'Failed to resume build environment. Please try again.',
                 );
                 if (marked) {
-                    this.trackVersionFailed(
+                    await this.trackVersionFailed(
                         payload,
                         'sandbox',
                         error,
@@ -4240,7 +4246,7 @@ export class AppGenerateService extends BaseService {
                     message,
                 );
                 if (marked) {
-                    this.trackVersionFailed(
+                    await this.trackVersionFailed(
                         payload,
                         'config',
                         themeError,
@@ -4375,7 +4381,7 @@ export class AppGenerateService extends BaseService {
                     'Failed to load your data models. Please try again.',
                 );
                 if (marked) {
-                    this.trackVersionFailed(
+                    await this.trackVersionFailed(
                         payload,
                         'catalog',
                         error,
@@ -4479,7 +4485,7 @@ export class AppGenerateService extends BaseService {
                     userMessage,
                 );
                 if (marked) {
-                    this.trackVersionFailed(
+                    await this.trackVersionFailed(
                         payload,
                         'generating',
                         error,
@@ -4548,7 +4554,7 @@ export class AppGenerateService extends BaseService {
                             'Installing dependencies',
                         );
                         if (marked) {
-                            this.trackVersionFailed(
+                            await this.trackVersionFailed(
                                 payload,
                                 'building',
                                 installError,
@@ -4618,7 +4624,7 @@ export class AppGenerateService extends BaseService {
                         : "The generated code couldn't be compiled. Try again or simplify your request.",
                 );
                 if (marked) {
-                    this.trackVersionFailed(
+                    await this.trackVersionFailed(
                         payload,
                         'building',
                         error,
@@ -4669,7 +4675,7 @@ export class AppGenerateService extends BaseService {
                     'Failed to deploy your app. Please try again.',
                 );
                 if (marked) {
-                    this.trackVersionFailed(
+                    await this.trackVersionFailed(
                         payload,
                         'packaging',
                         error,
@@ -4716,7 +4722,7 @@ export class AppGenerateService extends BaseService {
                 'Something went wrong. Please try again.',
             );
             if (marked) {
-                this.trackVersionFailed(
+                await this.trackVersionFailed(
                     payload,
                     'db',
                     error,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -1745,6 +1745,28 @@ export class AppGenerateService extends BaseService {
         );
     }
 
+    /**
+     * Persist what the generation cost onto the version row, for the org-wide
+     * activity log. Bookkeeping only — a failure here must never take down a
+     * generation that otherwise succeeded, so it logs and moves on.
+     */
+    private async recordGenerationUsage(
+        payload: AppGeneratePipelineJobPayload,
+        usage: ClaudeGenerationUsage,
+    ): Promise<void> {
+        try {
+            await this.appModel.recordVersionGenerationUsage(
+                payload.appUuid,
+                payload.version,
+                usage,
+            );
+        } catch (error) {
+            this.logger.warn(
+                `App ${payload.appUuid}: failed to record generation usage for version ${payload.version}: ${getErrorMessage(error)}`,
+            );
+        }
+    }
+
     private trackVersionFailed(
         payload: AppGeneratePipelineJobPayload,
         failureStage:
@@ -1782,6 +1804,9 @@ export class AppGenerateService extends BaseService {
                 telemetry.keyManagement ?? 'lightdash-managed',
                 generationUsage,
             );
+            // This path is synchronous (called from ~10 error sites), so the
+            // write is floated rather than awaited; it swallows its own errors.
+            void this.recordGenerationUsage(payload, generationUsage);
         }
 
         this.analytics.track({
@@ -4730,6 +4755,7 @@ export class AppGenerateService extends BaseService {
             claudeKeyManagement,
             generationUsage,
         );
+        await this.recordGenerationUsage(payload, generationUsage);
 
         this.analytics.track({
             event: 'data_app.version.completed',
@@ -7665,6 +7691,7 @@ export class AppGenerateService extends BaseService {
                           firstName: row.created_by_user_first_name,
                           lastName: row.created_by_user_last_name,
                       },
+            usage: row.generation_usage,
         };
     }
 

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -9,6 +9,7 @@ import {
     type AppVersionResources,
     type AppVersionStatusHistoryEntryKind,
     type DataAppActivityFilters,
+    type DataAppGenerationUsage,
     type DataAppVizSchema,
     type KnexPaginateArgs,
     type KnexPaginatedData,
@@ -161,6 +162,53 @@ export class AppModel {
                 ]),
             ],
         ) as unknown as DbAppVersion['status_history'];
+    }
+
+    /**
+     * Record what the version's generation cost. Called once the pipeline
+     * reaches a terminal state, on both the success and failure paths — a
+     * generation that failed halfway still spent what it spent.
+     *
+     * Adds to any spend already recorded rather than replacing it. A version's
+     * pipeline can run more than once: when a job is retried the resumed
+     * `--continue` leg reports only its own usage, so overwriting would leave
+     * the row showing the tail of the work instead of all of it. Accumulating
+     * in SQL keeps it a single atomic statement, with no read-modify-write race
+     * between concurrent legs.
+     */
+    async recordVersionGenerationUsage(
+        appId: string,
+        version: number,
+        usage: DataAppGenerationUsage,
+    ): Promise<void> {
+        const sum = (field: keyof DataAppGenerationUsage) =>
+            `COALESCE((generation_usage->>'${field}')::numeric, 0) + ?`;
+        await this.database(AppVersionsTableName)
+            .where({ app_id: appId, version })
+            .update({
+                generation_usage: this.database.raw(
+                    `jsonb_build_object(
+                        'inputTokens', ${sum('inputTokens')},
+                        'outputTokens', ${sum('outputTokens')},
+                        'cacheReadInputTokens', ${sum('cacheReadInputTokens')},
+                        'cacheCreationInputTokens', ${sum(
+                            'cacheCreationInputTokens',
+                        )},
+                        'numTurns', ${sum('numTurns')},
+                        'durationApiMs', ${sum('durationApiMs')},
+                        'costUsd', ${sum('costUsd')}
+                    )`,
+                    [
+                        usage.inputTokens,
+                        usage.outputTokens,
+                        usage.cacheReadInputTokens,
+                        usage.cacheCreationInputTokens,
+                        usage.numTurns,
+                        usage.durationApiMs,
+                        usage.costUsd,
+                    ],
+                ) as unknown as DataAppGenerationUsage,
+            });
     }
 
     async updateVersionStatus(
@@ -1185,6 +1233,7 @@ export class AppModel {
                 `${AppVersionsTableName}.prompt`,
                 `${AppVersionsTableName}.status`,
                 `${AppVersionsTableName}.resources`,
+                `${AppVersionsTableName}.generation_usage`,
                 `${AppVersionsTableName}.created_at`,
                 `${AppVersionsTableName}.created_by_user_uuid`,
                 `${AppsTableName}.name as app_name`,

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -631,6 +631,26 @@ export type ApiMyAppsResponse = ApiSuccess<{
 }>;
 
 /**
+ * What one generation cost, aggregated across every `claude` CLI invocation in
+ * that version's pipeline — including build-fix retries.
+ *
+ * This is spend attributable to a generation, not all data-app AI spend: the
+ * short prompt-clarification and app-naming calls happen outside any version.
+ *
+ * `costUsd` is the CLI's own figure, computed from public list prices, so treat
+ * it as an estimate rather than an invoice.
+ */
+export type DataAppGenerationUsage = {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadInputTokens: number;
+    cacheCreationInputTokens: number;
+    numTurns: number;
+    durationApiMs: number;
+    costUsd: number;
+};
+
+/**
  * One data app generation event — a row of the org-wide activity log. Backed by
  * an `app_versions` row, so it covers both new apps and iterations, and both
  * successful and failed generations.
@@ -657,6 +677,9 @@ export type DataAppActivityEvent = {
         firstName: string;
         lastName: string;
     } | null;
+    // Null for versions generated before spend was recorded, and for those that
+    // never called the model at all — "not recorded", not "spent nothing".
+    usage: DataAppGenerationUsage | null;
 };
 
 export type DataAppActivityFilters = {

--- a/packages/frontend/src/features/dataAppActivity/components/DataAppActivityTable.tsx
+++ b/packages/frontend/src/features/dataAppActivity/components/DataAppActivityTable.tsx
@@ -1,11 +1,13 @@
 import {
     getAppDisplayName,
     type DataAppActivityEvent,
+    type DataAppGenerationUsage,
 } from '@lightdash/common';
 import {
     Anchor,
     Badge,
     Group,
+    Stack,
     Text,
     Tooltip,
     useMantineTheme,
@@ -34,6 +36,57 @@ import { DataAppActivityTopToolbar } from './DataAppActivityTopToolbar';
 const STATUS_COLORS: Record<string, string> = {
     ready: 'green',
     error: 'red',
+};
+
+const compactTokens = new Intl.NumberFormat(undefined, {
+    notation: 'compact',
+    maximumFractionDigits: 1,
+});
+const exactTokens = new Intl.NumberFormat();
+
+const formatCost = (costUsd: number) =>
+    `$${costUsd.toFixed(costUsd < 0.01 ? 4 : 2)}`;
+
+/**
+ * Blank rather than zero when nothing was recorded: versions that predate spend
+ * tracking, and those that never called the model, are unknown — not free.
+ */
+const NotRecorded: FC = () => (
+    <Text fz="sm" c="ldGray.5">
+        -
+    </Text>
+);
+
+const TokensCell: FC<{ usage: DataAppGenerationUsage | null }> = ({
+    usage,
+}) => {
+    if (!usage) return <NotRecorded />;
+    // Cached tokens dominate an agentic run — every turn re-sends the system
+    // prompt and conversation so far, served from Anthropic's cache. Leaving
+    // them out understated a generation by ~30x, so the total counts them and
+    // the tooltip shows them (read and write combined) to keep it reconcilable.
+    const cached = usage.cacheReadInputTokens + usage.cacheCreationInputTokens;
+    const total = usage.inputTokens + usage.outputTokens + cached;
+    return (
+        <Tooltip
+            withinPortal
+            label={
+                <Stack gap={2}>
+                    <Text fz="xs">{`Input: ${exactTokens.format(usage.inputTokens)}`}</Text>
+                    <Text fz="xs">{`Output: ${exactTokens.format(usage.outputTokens)}`}</Text>
+                    <Text fz="xs">{`Cached: ${exactTokens.format(cached)}`}</Text>
+                    <Text fz="xs">{`${usage.numTurns} turns`}</Text>
+                    <Text fz="xs">{`Estimated cost: ${formatCost(
+                        usage.costUsd,
+                    )}`}</Text>
+                </Stack>
+            }
+        >
+            <Text fz="sm" c="ldGray.9">
+                {compactTokens.format(total)}
+            </Text>
+        </Tooltip>
+    );
 };
 
 const PromptCell: FC<{ prompt: string }> = ({ prompt }) => {
@@ -113,7 +166,7 @@ export const DataAppActivityTable: FC = () => {
                 id: 'createdAt',
                 accessorFn: (row) => row.createdAt,
                 header: 'When',
-                size: 132,
+                size: 118,
                 enableSorting: false,
                 Cell: ({ row }) => (
                     <Tooltip
@@ -137,7 +190,7 @@ export const DataAppActivityTable: FC = () => {
                         ? `${row.user.firstName} ${row.user.lastName}`
                         : 'Unknown user',
                 header: 'User',
-                size: 142,
+                size: 138,
                 enableSorting: false,
                 Cell: ({ row }) =>
                     row.original.user ? (
@@ -154,7 +207,7 @@ export const DataAppActivityTable: FC = () => {
                 id: 'app',
                 accessorFn: (row) => row.appName,
                 header: 'Name',
-                size: 162,
+                size: 150,
                 enableSorting: false,
                 Cell: ({ row }) => {
                     const displayName = getAppDisplayName(
@@ -198,7 +251,7 @@ export const DataAppActivityTable: FC = () => {
                 id: 'project',
                 accessorFn: (row) => row.projectName,
                 header: 'Project',
-                size: 105,
+                size: 100,
                 enableSorting: false,
                 Cell: ({ row }) => (
                     <Text fz="sm" c="ldGray.9" truncate>
@@ -210,7 +263,7 @@ export const DataAppActivityTable: FC = () => {
                 id: 'version',
                 accessorFn: (row) => row.version,
                 header: 'Type',
-                size: 122,
+                size: 114,
                 enableSorting: false,
                 Cell: ({ row }) => (
                     <Group gap="xs" wrap="nowrap">
@@ -234,7 +287,7 @@ export const DataAppActivityTable: FC = () => {
                 id: 'claudeModel',
                 accessorFn: (row) => row.claudeModel,
                 header: 'Model',
-                size: 100,
+                size: 78,
                 enableSorting: false,
                 Cell: ({ row }) => (
                     <Text fz="sm" c="ldGray.9">
@@ -246,7 +299,7 @@ export const DataAppActivityTable: FC = () => {
                 id: 'status',
                 accessorFn: (row) => row.status,
                 header: 'Status',
-                size: 130,
+                size: 112,
                 enableSorting: false,
                 Cell: ({ row }) => (
                     <Badge
@@ -259,10 +312,20 @@ export const DataAppActivityTable: FC = () => {
                 ),
             },
             {
+                id: 'tokens',
+                accessorFn: (row) => row.usage?.inputTokens ?? null,
+                header: 'Tokens',
+                size: 80,
+                enableSorting: false,
+                mantineTableBodyCellProps: { ta: 'right' },
+                mantineTableHeadCellProps: { ta: 'right' },
+                Cell: ({ row }) => <TokensCell usage={row.original.usage} />,
+            },
+            {
                 id: 'prompt',
                 accessorFn: (row) => row.prompt,
                 header: 'Prompt',
-                size: 187,
+                size: 190,
                 grow: true,
                 enableSorting: false,
                 Cell: ({ row }) => <PromptCell prompt={row.original.prompt} />,
@@ -297,7 +360,7 @@ export const DataAppActivityTable: FC = () => {
         mantineTableBodyCellProps: {
             h: 72,
             style: {
-                padding: `${theme.spacing.md} ${theme.spacing.xl}`,
+                padding: theme.spacing.md,
                 borderRight: 'none',
                 borderLeft: 'none',
                 borderBottom: `1px solid ${theme.colors.ldGray[2]}`,


### PR DESCRIPTION
Final slice of the org-level data-app activity log: what each generation cost.

Adds `app_versions.generation_usage`, written when the pipeline reaches a terminal state on **both** the success and failure paths — a generation that failed halfway still spent what it spent. The column is nullable with no default, so the ALTER is metadata-only and existing rows read as "not recorded" rather than "spent nothing".

Surfaced as a **Tokens** column on the activity page, with input, output, cached, turns and estimated cost on hover.

## Two things worth reviewing closely

**The write accumulates rather than overwrites.** A version's pipeline can run more than once. On a retry the pipeline resumes with `claude --continue`, and that leg reports only its own usage — so a blind overwrite left the row showing the tail of the work instead of all of it. Caught this on a real generation: 436s of wall time and 34 build-narration entries recorded as `numTurns: 1, outputTokens: 216, durationApiMs: 4338`, because the resumed leg just replied "this looks like the same starter prompt came through again". Accumulating in SQL keeps it one atomic statement with no read-modify-write race between legs.

**Cached tokens count toward the total.** Every turn re-sends the system prompt and conversation so far, served from Anthropic's cache, so cache reads dominate an agentic run. A real 25-turn generation:

| bucket | tokens |
|---|---|
| input | 20 |
| output | 22,632 |
| cache creation | 94,713 |
| cache read | 672,401 |
| **total** | **789,766** |

Excluding cache would have displayed 22.7K — 2.9% of what was actually consumed — next to a `$0.90` estimate derived from the full figure. The tooltip shows input / output / cached so the three lines sum to the cell.

Cost is the Claude CLI's own `total_cost_usd`, computed from public list prices, hence "estimated" rather than billed spend.

## Verified against real generations

- A 25-turn app records 789.8K / $0.90, tooltip reconciles with the cell exactly
- A failed generation records its spend
- Accumulation exercised directly against the DB — two legs summed, including the NULL-first-write branch and the float `costUsd`

Relates: PROD-9313
Relates: PROD-9314
Relates: #26197