### PR TITLE
fix(homepage-builder): reduce space below a leading Ask AI block

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.tsx
@@ -57,8 +57,8 @@ export const DayOneHomepage: FC<Props> = ({ projectUuid, pinnedItems }) => {
             {/* Same favourites strip the published homepage puts above its
                 blocks — day-0 opens the same way */}
             <PersonalFavoritesBar projectUuid={projectUuid} />
-            {/* Body rows always follow, so the hero yields part of the
-                viewport and Recently viewed peeks above the fold */}
+            {/* Body rows always follow, so the hero sizes to its content and
+                Recently viewed stays close behind it */}
             <div className={layout.heroSection} data-presentation="shared">
                 {canAskAi ? (
                     <div className={layout.hero}>

--- a/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
@@ -42,16 +42,17 @@
     );
 }
 
-/* Fold-aware hero: when body rows follow, the hero yields part of the
- * viewport so the first row just peeks above the fold — the composer owns
- * the opening view and the body starts clearly below it. Solo heroes — and
- * day-0, which never stamps the attribute — keep the full-viewport treatment
- * above. The favBar variant is repeated so it can't win the specificity
- * contest. */
+/* When body rows follow, the hero sizes to its content instead of reserving a
+ * slice of the viewport: a leading composer that reserved 66vh centred itself
+ * in it, pushing the rest of the page below the fold behind a band of empty
+ * space. Solo heroes — and day-0, which never stamps the attribute — keep the
+ * full-viewport treatment above. The favBar variant is repeated so it can't
+ * win the specificity contest. */
 .heroSection[data-presentation='shared'],
 .page:has(.favBar) .heroSection[data-presentation='shared'] {
-    min-height: 66vh;
-    padding-bottom: 32px;
+    min-height: 0;
+    padding-top: 24px;
+    padding-bottom: 40px;
 }
 
 .favBar {

--- a/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
@@ -21,8 +21,8 @@ const HERO_COMPANION_TYPES: HomepageBlock['type'][] = ['quick-actions'];
 export type RowGap = 'none' | 'grouped' | 'section';
 
 // 'viewport' = the hero is the only content, centred in the full viewport
-// (day-0 feel). 'shared' = body rows follow, so the hero yields part of the
-// viewport and the first row peeks above the fold.
+// (day-0 feel). 'shared' = body rows follow, so the hero sizes to its content
+// instead of reserving viewport height that would push the body down.
 export type HeroPresentation = 'viewport' | 'shared';
 
 // 'intro' = a lone leading text block that opens the page and gets breathing
@@ -359,7 +359,7 @@ export const resolveHomepageLayout = (
     const smoothed = applyRowAlign(applyItemSpans(smoothWidthTiers(resolved)));
     const rows = hasLeadingHero ? smoothed : applyIntroRole(smoothed);
     // A hero keeps the whole viewport only when it's alone; with body rows it
-    // yields so the first row peeks above the fold.
+    // yields so the body isn't pushed down.
     const hero = hasLeadingHero
         ? {
               companions: visibleRows


### PR DESCRIPTION
When a homepage opened with the Ask AI block, the hero section reserved `min-height: 66vh` and centred the composer inside it — so on a published homepage the leftover space above and below pushed everything else down behind a band of emptiness.

The hero now sizes to its content when body rows follow (24px above, 40px below), instead of claiming a slice of the viewport. Solo heroes (Ask AI as the only content) keep the full-viewport centred treatment.

This also applies to the day-0 homepage, which uses the same hero shell and always has content below.
