### PR TITLE
fix(ai): polish deep research control (follow-up to #26418)

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchMcpSelector.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchMcpSelector.tsx
@@ -92,7 +92,7 @@ export const DeepResearchMcpSelector = ({
             })}
         </Stack>
     ) : (
-        <Text size="xs" c="dimmed">
+        <Text className={styles.emptyState} size="xs" c="dimmed">
             No MCP sources available.
         </Text>
     );

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.module.css
@@ -1,0 +1,37 @@
+.control {
+    flex: 0 0 rem(146px);
+    width: rem(146px);
+    min-width: rem(146px);
+    max-width: rem(146px);
+}
+
+.controlInner {
+    width: 100%;
+}
+
+.activeSegment.activeSegment {
+    background-color: var(--mantine-color-blue-light);
+
+    &:hover {
+        background-color: color-mix(
+            in srgb,
+            var(--mantine-color-blue-filled) 18%,
+            transparent
+        );
+    }
+}
+
+.activeMain.activeMain {
+    flex: 0 0 calc(100% - rem(24px));
+    width: calc(100% - rem(24px));
+    padding-left: var(--mantine-spacing-xs);
+    padding-right: rem(6px);
+    border-radius: var(--mantine-radius-xl) 0 0 var(--mantine-radius-xl);
+}
+
+.exitSegment.exitSegment {
+    flex: 0 0 rem(24px);
+    width: rem(24px);
+    min-width: rem(24px);
+    border-radius: 0 var(--mantine-radius-xl) var(--mantine-radius-xl) 0;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.test.tsx
@@ -56,7 +56,9 @@ describe('DeepResearchModeControl', () => {
         });
         await user.click(modeButton);
 
-        expect(modeButton).toHaveAttribute('aria-pressed', 'true');
+        expect(
+            screen.getByRole('button', { name: 'Deep research' }),
+        ).toHaveAttribute('aria-expanded', 'true');
         expect(await screen.findByRole('dialog')).toBeInTheDocument();
         expect(
             screen.getByRole('region', { name: 'Deep research settings' }),
@@ -66,8 +68,11 @@ describe('DeepResearchModeControl', () => {
         ).not.toBeInTheDocument();
         expect(screen.queryByText('Mode')).not.toBeInTheDocument();
         expect(
-            screen.getByRole('button', { name: 'Disable' }),
+            screen.getByRole('button', { name: 'Exit deep research' }),
         ).toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: 'Disable' }),
+        ).not.toBeInTheDocument();
         expect(screen.getByText('Depth')).toBeInTheDocument();
         expect(screen.getByText('MCP')).toBeInTheDocument();
         expect(
@@ -91,12 +96,41 @@ describe('DeepResearchModeControl', () => {
         expect(mediumDepth).toBeChecked();
         expect(mediumDepth).toHaveFocus();
 
-        await user.click(screen.getByRole('button', { name: 'Disable' }));
-        expect(modeButton).toHaveAttribute('aria-pressed', 'false');
+        await user.click(screen.getByRole('button', { name: 'Deep research' }));
         await waitFor(() => {
             expect(
                 screen.queryByRole('region', {
                     name: 'Deep research settings',
+                }),
+            ).not.toBeInTheDocument();
+        });
+
+        expect(
+            screen.getByRole('button', { name: 'Deep research' }),
+        ).toHaveAttribute('aria-expanded', 'false');
+
+        await user.click(screen.getByRole('button', { name: 'Deep research' }));
+        expect(
+            await screen.findByRole('region', {
+                name: 'Deep research settings',
+            }),
+        ).toBeInTheDocument();
+
+        await user.click(
+            screen.getByRole('button', { name: 'Exit deep research' }),
+        );
+        expect(
+            screen.getByRole('button', { name: 'Deep research' }),
+        ).toHaveAttribute('aria-pressed', 'false');
+        await waitFor(() => {
+            expect(
+                screen.queryByRole('region', {
+                    name: 'Deep research settings',
+                }),
+            ).not.toBeInTheDocument();
+            expect(
+                screen.queryByRole('button', {
+                    name: 'Exit deep research',
                 }),
             ).not.toBeInTheDocument();
         });

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.tsx
@@ -1,14 +1,8 @@
-import {
-    Box,
-    Button,
-    Divider,
-    Group,
-    Popover,
-    ScrollArea,
-} from '@mantine-8/core';
-import { IconChevronDown, IconTelescope } from '@tabler/icons-react';
+import { ActionIcon, Box, Button, Popover, ScrollArea } from '@mantine-8/core';
+import { IconChevronDown, IconTelescope, IconX } from '@tabler/icons-react';
 import { useState, type ReactNode } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
+import styles from './DeepResearchModeControl.module.css';
 
 export type AgentComposerMode = 'ask' | 'deep_research';
 
@@ -26,14 +20,16 @@ export const DeepResearchModeControl = ({
     const isDeepResearch = mode === 'deep_research';
     const [isOpen, setIsOpen] = useState(false);
 
-    const handleTargetClick = () => {
-        if (!isDeepResearch) {
-            onModeChange('deep_research');
-        }
+    const handleEnable = () => {
+        onModeChange('deep_research');
+        setIsOpen(true);
+    };
+
+    const handleConfigure = () => {
         setIsOpen((current) => !current);
     };
 
-    const handleDisable = () => {
+    const handleExit = () => {
         onModeChange('ask');
         setIsOpen(false);
     };
@@ -49,52 +45,79 @@ export const DeepResearchModeControl = ({
             withinPortal
             hideDetached={false}
         >
-            <Popover.Target>
-                <Button
-                    px="xs"
-                    size="xs"
-                    radius="xl"
-                    variant={isDeepResearch ? 'light' : 'subtle'}
-                    color={isDeepResearch ? 'blue' : 'gray'}
-                    leftSection={
-                        <MantineIcon
-                            icon={IconTelescope}
-                            size={14}
-                            stroke={1.8}
-                        />
-                    }
-                    rightSection={
-                        <MantineIcon
-                            icon={IconChevronDown}
-                            size={14}
-                            color={isDeepResearch ? 'blue.6' : 'ldGray.6'}
-                        />
-                    }
-                    onClick={handleTargetClick}
-                    aria-label="Deep research"
-                    aria-pressed={isDeepResearch}
-                >
-                    Deep research
-                </Button>
-            </Popover.Target>
+            <Box className={styles.control}>
+                {isDeepResearch ? (
+                    <Button.Group className={styles.controlInner}>
+                        <Popover.Target>
+                            <Button
+                                size="xs"
+                                variant="light"
+                                color="blue"
+                                className={`${styles.activeSegment} ${styles.activeMain}`}
+                                leftSection={
+                                    <MantineIcon
+                                        icon={IconTelescope}
+                                        size={14}
+                                        stroke={1.8}
+                                    />
+                                }
+                                onClick={handleConfigure}
+                                aria-label="Deep research"
+                                aria-expanded={isOpen}
+                                aria-haspopup="dialog"
+                            >
+                                Deep research
+                            </Button>
+                        </Popover.Target>
+                        <ActionIcon
+                            size={30}
+                            variant="light"
+                            color="blue"
+                            className={`${styles.activeSegment} ${styles.exitSegment}`}
+                            onClick={handleExit}
+                            aria-label="Exit deep research"
+                        >
+                            <MantineIcon icon={IconX} size={12} />
+                        </ActionIcon>
+                    </Button.Group>
+                ) : (
+                    <Popover.Target>
+                        <Button
+                            pl="xs"
+                            pr={6}
+                            size="xs"
+                            radius="xl"
+                            variant="subtle"
+                            color="gray"
+                            className={styles.controlInner}
+                            leftSection={
+                                <MantineIcon
+                                    icon={IconTelescope}
+                                    size={14}
+                                    stroke={1.8}
+                                />
+                            }
+                            rightSection={
+                                <MantineIcon
+                                    icon={IconChevronDown}
+                                    size={14}
+                                    color="ldGray.6"
+                                />
+                            }
+                            onClick={handleEnable}
+                            aria-label="Deep research"
+                            aria-pressed={false}
+                        >
+                            Deep research
+                        </Button>
+                    </Popover.Target>
+                )}
+            </Box>
 
             <Popover.Dropdown p={0}>
                 <ScrollArea.Autosize mah={420} type="auto">
                     {settings}
                 </ScrollArea.Autosize>
-                <Divider mx="sm" />
-                <Box p="sm">
-                    <Group justify="flex-end">
-                        <Button
-                            size="compact-xs"
-                            variant="subtle"
-                            color="gray"
-                            onClick={handleDisable}
-                        >
-                            Disable
-                        </Button>
-                    </Group>
-                </Box>
             </Popover.Dropdown>
         </Popover>
     );

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.module.css
@@ -24,6 +24,10 @@
     }
 }
 
+.emptyState {
+    padding-inline: var(--mantine-spacing-xs);
+}
+
 @media (max-width: 48em) {
     .root {
         max-width: calc(100vw - rem(32px));

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
@@ -80,64 +80,76 @@ export const DeepResearchPreflight = ({
             role="region"
             aria-label="Deep research settings"
         >
-            <Stack gap="xs">
-                <Text size="xs" fw={600} c="dimmed">
-                    Depth
-                </Text>
-                <Stack gap={2} role="radiogroup" aria-label="Research depth">
-                    {DEEP_RESEARCH_DEPTHS.map((option, optionIndex) => {
-                        const optionConfig = DEEP_RESEARCH_DEPTH_CONFIG[option];
-                        const isSelected = option === depth;
-                        return (
-                            <UnstyledButton
-                                key={option}
-                                className={styles.listOption}
-                                onClick={() => onDepthChange(option)}
-                                onKeyDown={(event) =>
-                                    handleDepthKeyDown(event, optionIndex)
-                                }
-                                role="radio"
-                                aria-checked={isSelected}
-                                tabIndex={isSelected ? 0 : -1}
-                            >
-                                <Group justify="space-between" wrap="nowrap">
-                                    <Stack gap={0}>
-                                        <Text size="sm" fw={500}>
-                                            {optionConfig.label}
-                                        </Text>
-                                        <Text size="xs" c="dimmed">
-                                            Up to{' '}
-                                            {optionConfig.warehouseQueries}{' '}
-                                            queries
-                                        </Text>
-                                    </Stack>
-                                    {isSelected && (
-                                        <MantineIcon
-                                            icon={IconCheck}
-                                            size="sm"
-                                            color="ldGray.7"
-                                        />
-                                    )}
-                                </Group>
-                            </UnstyledButton>
-                        );
-                    })}
+            <Stack gap="md">
+                <Stack gap="xs">
+                    <Text size="xs" fw={600} c="dimmed">
+                        Depth
+                    </Text>
+                    <Stack
+                        gap={2}
+                        role="radiogroup"
+                        aria-label="Research depth"
+                    >
+                        {DEEP_RESEARCH_DEPTHS.map((option, optionIndex) => {
+                            const optionConfig =
+                                DEEP_RESEARCH_DEPTH_CONFIG[option];
+                            const isSelected = option === depth;
+                            return (
+                                <UnstyledButton
+                                    key={option}
+                                    className={styles.listOption}
+                                    onClick={() => onDepthChange(option)}
+                                    onKeyDown={(event) =>
+                                        handleDepthKeyDown(event, optionIndex)
+                                    }
+                                    role="radio"
+                                    aria-checked={isSelected}
+                                    tabIndex={isSelected ? 0 : -1}
+                                >
+                                    <Group
+                                        justify="space-between"
+                                        wrap="nowrap"
+                                    >
+                                        <Stack gap={0}>
+                                            <Text size="sm" fw={500}>
+                                                {optionConfig.label}
+                                            </Text>
+                                            <Text size="xs" c="dimmed">
+                                                Up to{' '}
+                                                {optionConfig.warehouseQueries}{' '}
+                                                queries
+                                            </Text>
+                                        </Stack>
+                                        {isSelected && (
+                                            <MantineIcon
+                                                icon={IconCheck}
+                                                size="sm"
+                                                color="ldGray.7"
+                                            />
+                                        )}
+                                    </Group>
+                                </UnstyledButton>
+                            );
+                        })}
+                    </Stack>
                 </Stack>
 
-                <Divider my={4} />
+                <Divider />
 
-                <Text size="xs" fw={600} c="dimmed">
-                    MCP
-                </Text>
-                <DeepResearchMcpSelector
-                    mcpServers={mcpServers}
-                    selectedMcpServerUuids={selectedMcpServerUuids}
-                    onSelectedMcpServerUuidsChange={
-                        onSelectedMcpServerUuidsChange
-                    }
-                    isLoading={isLoadingMcpServers}
-                    error={mcpServerError}
-                />
+                <Stack gap="xs">
+                    <Text size="xs" fw={600} c="dimmed">
+                        MCP
+                    </Text>
+                    <DeepResearchMcpSelector
+                        mcpServers={mcpServers}
+                        selectedMcpServerUuids={selectedMcpServerUuids}
+                        onSelectedMcpServerUuidsChange={
+                            onSelectedMcpServerUuidsChange
+                        }
+                        isLoading={isLoadingMcpServers}
+                        error={mcpServerError}
+                    />
+                </Stack>
             </Stack>
         </Box>
     );


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9316/move-deep-research-into-the-ask-ai-and-homepage-composers

> Follow-up to #26418, which moved deep research into the Ask AI and homepage composers.

## Summary

Polishes the deep research composer control so enabling and disabling the mode does not move the surrounding composer UI, while keeping configuration one click away.

### Composer control

- Shows one button with a caret while deep research is inactive.
- Splits the active pill into a configuration button and an independent exit button.
- Keeps both states at a fixed 146px footprint: 122px for configuration and 24px for exit.
- Gives each active segment an independent hover state and preserves the outer pill radius.

### Settings popover

- Removes the redundant Disable footer; the pill's cross exits deep research.
- Uses matching vertical spacing for the Depth and MCP sections.
- Aligns the empty MCP message with the depth-option content inset.

## Interaction states

```text
Inactive  [ 🔭  Deep research  ⌄ ]  146px
Active    [ 🔭  Deep research | × ]  122px + 24px = 146px
                    opens settings   exits mode
```

## Regression analysis

- **Ask AI and homepage composers** — both continue to use the shared control and retain their existing submission behavior.
- **Mode state** — clicking the label only toggles configuration while active; clicking the cross returns to Ask mode and closes the popover.
- **MCP selection** — server availability and selected UUID handling are unchanged; this PR only adjusts layout.
- No backend or API surface is touched.

## Test plan

- [x] Focused `DeepResearchModeControl` tests cover enable, configure, keyboard depth selection, exit, and popover closure.
- [x] Frontend TypeScript typecheck.
- [x] Frontend lint and formatter through the pre-commit checks.
- [x] `git diff --check`.
- [ ] Manually verify the final fixed-width state in the browser; the CLI browser connection was unavailable after the last layout adjustment.