### PR TITLE
fix(homepage-builder): size the hero to its content so curated rows stay above the fold

### DIFF
--- a/packages/common/src/ee/homepage/types.ts
+++ b/packages/common/src/ee/homepage/types.ts
@@ -7,6 +7,11 @@ export type HomepageMarkdownBlock = {
     config: { content: string };
 };
 
+/** How much of the opening view the hero claims. `full` centres it in the
+ * viewport; `compact` gives it only the height of its own content. Absent in
+ * stored configs means "let the layout decide" — see resolveHeroDensity. */
+export type HomepageHeroDensity = 'full' | 'compact';
+
 export type HomepageAskAiHeroBlock = {
     id: string;
     type: 'ask-ai-hero';
@@ -15,6 +20,7 @@ export type HomepageAskAiHeroBlock = {
         /** Replaces the prompt suggestions with the setup checklist.
          * Optional for configs persisted before this field existed. */
         showRecommendedActions?: boolean;
+        density?: HomepageHeroDensity;
     };
 };
 
@@ -24,7 +30,7 @@ export type HomepageAskAiHeroBlock = {
 export type HomepageGreetingBlock = {
     id: string;
     type: 'greeting';
-    config: { subtitle: string };
+    config: { subtitle: string; density?: HomepageHeroDensity };
 };
 
 export type HomepageCollectionItemRef = {

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.module.css
@@ -4,26 +4,29 @@
     font-size: var(--mantine-font-size-md) !important;
 }
 
-/* One chip-line of height reserved up front (pill: 12px text + 10px padding +
-   2px border = 30px) so late-arriving chips don't shove the composer. */
+/* One chip-line of height reserved up front (pill: 12px text + 8px padding =
+   26px) so late-arriving chips don't shove the composer. */
 .pillRow {
-    margin-top: 12px;
-    min-height: 30px;
+    margin-top: 10px;
+    min-height: 26px;
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
-    gap: 6px;
+    gap: 4px;
 }
 
+/* Quiet by default: no card, no border, no fill — these are a hint at what the
+   composer can do, not two more buttons competing with it. The affordance
+   arrives on hover, where it's actually needed. */
 .pill {
     font-size: 12px;
-    font-weight: 500;
-    padding: 5px 11px;
+    font-weight: 400;
+    padding: 4px 10px;
     border-radius: 999px;
     cursor: pointer;
-    background: light-dark(#fff, var(--mantine-color-dark-6));
-    border: 1px solid var(--mantine-color-ldGray-2);
-    color: var(--mantine-color-ldGray-7);
+    background: transparent;
+    border: 1px solid transparent;
+    color: var(--mantine-color-ldGray-6);
     display: inline-flex;
     align-items: center;
     gap: 6px;
@@ -34,18 +37,6 @@
 
 .pill:nth-child(2) {
     animation-delay: 40ms;
-}
-.pill:nth-child(3) {
-    animation-delay: 80ms;
-}
-.pill:nth-child(4) {
-    animation-delay: 120ms;
-}
-.pill:nth-child(5) {
-    animation-delay: 160ms;
-}
-.pill:nth-child(6) {
-    animation-delay: 200ms;
 }
 
 @keyframes pillIn {
@@ -60,9 +51,15 @@
 }
 
 .pill:hover {
+    background: light-dark(#fff, var(--mantine-color-dark-6));
+    border-color: var(--mantine-color-ldGray-2);
+    color: var(--mantine-color-ldGray-9);
+}
+
+.pill:focus-visible {
+    background: light-dark(#fff, var(--mantine-color-dark-6));
     border-color: var(--mantine-color-ldGray-4);
     color: var(--mantine-color-ldGray-9);
-    box-shadow: var(--mantine-shadow-subtle);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.test.tsx
@@ -1,9 +1,9 @@
 import { MantineProvider } from '@mantine-8/core';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { act, render } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { type ComponentProps } from 'react';
 import type * as ReactRouter from 'react-router';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AgentChatInput } from '../aiCopilot/components/ChatElements/AgentChatInput';
 import { DayOneAskInput } from './DayOneAskInput';
 
@@ -82,11 +82,19 @@ vi.mock(
     }),
 );
 
+const { suggestionsState } = vi.hoisted(() => ({
+    suggestionsState: {
+        current: { data: undefined, isLoading: false } as {
+            data:
+                | { chips: { kind: 'prompt'; label: string; tool: string }[] }
+                | undefined;
+            isLoading: boolean;
+        },
+    },
+}));
+
 vi.mock('../aiCopilot/hooks/useAgentSuggestions', () => ({
-    useAgentSuggestions: () => ({
-        data: undefined,
-        isLoading: false,
-    }),
+    useAgentSuggestions: () => suggestionsState.current,
 }));
 
 vi.mock('../aiCopilot/hooks/useAiAgentPermission', () => ({
@@ -157,6 +165,57 @@ const renderInput = (routerEnabled = false) => {
         </MantineProvider>,
     );
 };
+
+const renderWithSuggestions = (labels: string[]) => {
+    suggestionsState.current = {
+        data: {
+            chips: labels.map((label) => ({
+                kind: 'prompt' as const,
+                label,
+                tool: 'generateQuery',
+            })),
+        },
+        isLoading: false,
+    };
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    queryClient.setQueryData(['ai-router'], { enabled: false });
+    return render(
+        <MantineProvider>
+            <QueryClientProvider client={queryClient}>
+                <DayOneAskInput projectUuid="project-1" />
+            </QueryClientProvider>
+        </MantineProvider>,
+    );
+};
+
+describe('DayOneAskInput suggestion chips', () => {
+    afterEach(() => {
+        suggestionsState.current = { data: undefined, isLoading: false };
+    });
+
+    it('shows at most two chips on the homepage, however many are generated', () => {
+        renderWithSuggestions([
+            'First suggestion',
+            'Second suggestion',
+            'Third suggestion',
+            'Fourth suggestion',
+            'Fifth suggestion',
+        ]);
+
+        expect(screen.getAllByRole('button')).toHaveLength(2);
+        expect(screen.getByText('First suggestion')).toBeInTheDocument();
+        expect(screen.getByText('Second suggestion')).toBeInTheDocument();
+        expect(screen.queryByText('Third suggestion')).not.toBeInTheDocument();
+    });
+
+    it('shows a single chip without padding the row', () => {
+        renderWithSuggestions(['Only suggestion']);
+
+        expect(screen.getAllByRole('button')).toHaveLength(1);
+    });
+});
 
 describe('DayOneAskInput', () => {
     beforeEach(() => {

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.tsx
@@ -73,6 +73,13 @@ const useAiRouterEnabledFromCache = (): boolean | undefined => {
     return enabled;
 };
 
+// Two chips, not the full generated set. On the homepage the composer is the
+// opening view and the chips are a hint at what it can do — five of them read
+// as a menu to work through, and they cost more vertical space than the
+// composer itself, pushing curated content under the fold. The thread page
+// still shows the full set, where there's nothing below to protect.
+const HOMEPAGE_SUGGESTION_LIMIT = 2;
+
 // The chips come from an LLM generation, so on a cold view they land a second
 // or two after the composer. The row reserves one chip-line of height while
 // loading so their arrival never shoves the greeting/composer up; the chips
@@ -285,7 +292,12 @@ const DayOneAskInputInner: FC<Props> = ({
         submitPrompt(chip.label, [chip.tool]);
     };
 
-    const chips = suggestionsQuery.data?.chips ?? [];
+    // Sliced at the source so the impression/click analytics count what the
+    // viewer actually saw.
+    const chips = (suggestionsQuery.data?.chips ?? []).slice(
+        0,
+        HOMEPAGE_SUGGESTION_LIMIT,
+    );
     const impressionFiredRef = useRef(false);
     useEffect(() => {
         if (impressionFiredRef.current) return;

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.tsx
@@ -80,15 +80,11 @@ export const DayOneHomepage: FC<Props> = ({ projectUuid, pinnedItems }) => {
                         <Box ta="center">
                             <Text
                                 component="h1"
-                                fz={23}
-                                fw={600}
-                                lts="-0.02em"
-                                lh={1.2}
-                                m={0}
+                                className={layout.heroGreeting}
                             >
                                 {getGreeting(user.data?.firstName)}
                             </Text>
-                            <Text c="dimmed" fz={15} mt={8}>
+                            <Text className={layout.heroGreetingSub}>
                                 Pick up where you left off, or start something
                                 new.
                             </Text>

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.tsx
@@ -57,9 +57,14 @@ export const DayOneHomepage: FC<Props> = ({ projectUuid, pinnedItems }) => {
             {/* Same favourites strip the published homepage puts above its
                 blocks — day-0 opens the same way */}
             <PersonalFavoritesBar projectUuid={projectUuid} />
-            {/* Body rows always follow, so the hero yields part of the
-                viewport and Recently viewed peeks above the fold */}
-            <div className={layout.heroSection} data-presentation="shared">
+            {/* Body rows always follow — Recently viewed and Pinned are the
+                point of day-0 — so the hero stays compact and they're on
+                screen. Same shell for both the AI and non-AI openings. */}
+            <div
+                className={layout.heroSection}
+                data-presentation="shared"
+                data-density="compact"
+            >
                 {canAskAi ? (
                     <div className={layout.hero}>
                         <AskAiHero

--- a/packages/frontend/src/ee/features/homepageBuilder/NoProjectHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/NoProjectHomepage.tsx
@@ -57,15 +57,7 @@ const NoProjectHomepage: FC = () => {
                 <HomepageStars />
                 <Box className={`${layout.hero} ${layout.heroStageContent}`}>
                     <Stack gap={16} align="center" w="100%">
-                        <Text
-                            component="h1"
-                            fz={23}
-                            fw={600}
-                            lts="-0.02em"
-                            lh={1.2}
-                            ta="center"
-                            m={0}
-                        >
+                        <Text component="h1" className={layout.heroGreeting}>
                             {getGreeting(user.data?.firstName)}.
                         </Text>
                         {isCopilotEnabled ? (

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
@@ -117,6 +117,7 @@ export const PublishedHomepage: FC<Props> = ({
                 <div
                     className={layout.heroSection}
                     data-presentation={hero.presentation}
+                    data-density={hero.density}
                 >
                     {hero.companions.length > 0 && (
                         <div className={layout.heroCompanions}>

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.tsx
@@ -5,6 +5,7 @@ import useApp from '../../../../providers/App/useApp';
 import { useAiAgentButtonVisibility } from '../../aiCopilot/hooks/useAiAgentsButtonVisibility';
 import { DayOneAskInput } from '../DayOneAskInput';
 import { getGreeting } from '../greeting';
+import layout from '../homepageLayout.module.css';
 import { RecommendedActionsChecklist } from './RecommendedActionsChecklist';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 import { useRecommendedActions } from './useRecommendedActions';
@@ -32,15 +33,7 @@ export const AskAiHero: FC<{
     return (
         <Stack gap={16} align="center" w="100%">
             {showGreeting && (
-                <Text
-                    component="h1"
-                    fz={23}
-                    fw={600}
-                    lts="-0.02em"
-                    lh={1.2}
-                    ta="center"
-                    m={0}
-                >
+                <Text component="h1" className={layout.heroGreeting}>
                     {getGreeting(user.data?.firstName)}. What do you want to
                     know?
                 </Text>

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.tsx
@@ -1,4 +1,5 @@
-import { Box, Stack, Switch, Text } from '@mantine-8/core';
+import { type HomepageHeroDensity } from '@lightdash/common';
+import { Box, SegmentedControl, Stack, Switch, Text } from '@mantine-8/core';
 import { type FC } from 'react';
 import useApp from '../../../../providers/App/useApp';
 import { useAiAgentButtonVisibility } from '../../aiCopilot/hooks/useAiAgentsButtonVisibility';
@@ -57,6 +58,39 @@ export const AskAiHero: FC<{
     );
 };
 
+// Shared by both hero-capable blocks. 'auto' clears the stored choice and
+// lets the layout decide (compact when content follows, full when alone) —
+// the right default for most pages, so it stays the first option.
+export const HeroDensityControl: FC<{
+    value: HomepageHeroDensity | undefined;
+    onChange: (density: HomepageHeroDensity | undefined) => void;
+}> = ({ value, onChange }) => (
+    <Stack gap={4}>
+        <Text size="xs" fw={500}>
+            Opening size
+        </Text>
+        <SegmentedControl
+            size="xs"
+            value={value ?? 'auto'}
+            onChange={(next) =>
+                onChange(
+                    next === 'auto' ? undefined : (next as HomepageHeroDensity),
+                )
+            }
+            data={[
+                { value: 'auto', label: 'Auto' },
+                { value: 'compact', label: 'Compact' },
+                { value: 'full', label: 'Full screen' },
+            ]}
+        />
+        <Text size="xs" c="dimmed">
+            {value === 'full'
+                ? 'Fills the opening view — content below starts under the fold.'
+                : 'Sized to its own content, so what you add below stays visible.'}
+        </Text>
+    </Stack>
+);
+
 export const AskAiHeroBlockView: FC<BlockComponentProps> = ({
     block,
     projectUuid,
@@ -103,6 +137,12 @@ export const AskAiHeroBlockBuild: FC<BuildComponentProps> = ({
                             showGreeting: e.currentTarget.checked,
                         },
                     })
+                }
+            />
+            <HeroDensityControl
+                value={block.config.density}
+                onChange={(density) =>
+                    onChange({ ...block, config: { ...block.config, density } })
                 }
             />
         </Stack>

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/GreetingBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/GreetingBlock.tsx
@@ -2,6 +2,7 @@ import { Box, Stack, Text, TextInput } from '@mantine-8/core';
 import { type FC } from 'react';
 import useApp from '../../../../providers/App/useApp';
 import { getGreeting } from '../greeting';
+import layout from '../homepageLayout.module.css';
 import { HeroDensityControl } from './AskAiHeroBlock';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
@@ -11,13 +12,11 @@ const Greeting: FC<{ subtitle: string }> = ({ subtitle }) => {
     const { user } = useApp();
     return (
         <Box ta="center">
-            <Text component="h1" fz={23} fw={600} lts="-0.02em" lh={1.2} m={0}>
+            <Text component="h1" className={layout.heroGreeting}>
                 {getGreeting(user.data?.firstName)}
             </Text>
             {subtitle.trim() ? (
-                <Text c="dimmed" fz={15} mt={8}>
-                    {subtitle}
-                </Text>
+                <Text className={layout.heroGreetingSub}>{subtitle}</Text>
             ) : null}
         </Box>
     );

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/GreetingBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/GreetingBlock.tsx
@@ -2,6 +2,7 @@ import { Box, Stack, Text, TextInput } from '@mantine-8/core';
 import { type FC } from 'react';
 import useApp from '../../../../providers/App/useApp';
 import { getGreeting } from '../greeting';
+import { HeroDensityControl } from './AskAiHeroBlock';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
 // Same type scale as the day-0 opening, so a greeting-led homepage and day-0
@@ -43,8 +44,17 @@ export const GreetingBlockBuild: FC<BuildComponentProps> = ({
                 onChange={(e) =>
                     onChange({
                         ...block,
-                        config: { subtitle: e.currentTarget.value },
+                        config: {
+                            ...block.config,
+                            subtitle: e.currentTarget.value,
+                        },
                     })
+                }
+            />
+            <HeroDensityControl
+                value={block.config.density}
+                onChange={(density) =>
+                    onChange({ ...block, config: { ...block.config, density } })
                 }
             />
         </Stack>

--- a/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
@@ -26,32 +26,45 @@
 }
 
 .heroSection {
-    min-height: calc(100vh - var(--navbar-height) - 72px);
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
 }
 
+/* `full` density: the hero is the opening view and owns the fold. Alone on the
+ * page it takes the whole viewport; sharing the page it yields a third so the
+ * first body row peeks above the fold. */
+.heroSection[data-density='full'] {
+    min-height: calc(100vh - var(--navbar-height) - 72px);
+}
+
 /* When the fav-bar is actually rendered above the hero, subtract its footprint
  * so the hero stays centred in the remaining viewport. The bar hides itself
  * when empty, so this only kicks in when there's really a bar. */
-.page:has(.favBar) .heroSection {
+.page:has(.favBar) .heroSection[data-density='full'] {
     min-height: calc(
         100vh - var(--navbar-height) - 72px - var(--homepage-favbar-height)
     );
 }
 
-/* Fold-aware hero: when body rows follow, the hero yields part of the
- * viewport so the first row just peeks above the fold — the composer owns
- * the opening view and the body starts clearly below it. Solo heroes — and
- * day-0, which never stamps the attribute — keep the full-viewport treatment
- * above. The favBar variant is repeated so it can't win the specificity
- * contest. */
-.heroSection[data-presentation='shared'],
-.page:has(.favBar) .heroSection[data-presentation='shared'] {
+/* The favBar variant is repeated so it can't win the specificity contest. */
+.heroSection[data-density='full'][data-presentation='shared'],
+.page:has(.favBar)
+    .heroSection[data-density='full'][data-presentation='shared'] {
     min-height: 66vh;
     padding-bottom: 32px;
+}
+
+/* `compact` density — the default whenever body rows follow. The hero is
+ * exactly as tall as the greeting + composer + chips inside it, plus the
+ * page's section rhythm below, so what the admin curated is on screen instead
+ * of under the fold. No reserved viewport share, no vertical centring: with
+ * content below, "centred in dead space" is the bug, not the feature. */
+.heroSection[data-density='compact'] {
+    justify-content: flex-start;
+    padding-top: 32px;
+    padding-bottom: 56px;
 }
 
 .favBar {

--- a/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
@@ -30,25 +30,24 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-}
-
-/* `full` density: the hero is the opening view and owns the fold. Alone on the
- * page it takes the whole viewport; sharing the page it yields a third so the
- * first body row peeks above the fold. */
-.heroSection[data-density='full'] {
+    /* Full-viewport opening by default: a surface that doesn't declare a
+     * density (the no-project page) keeps the treatment it always had, and
+     * `compact` below opts out explicitly. */
     min-height: calc(100vh - var(--navbar-height) - 72px);
 }
 
 /* When the fav-bar is actually rendered above the hero, subtract its footprint
  * so the hero stays centred in the remaining viewport. The bar hides itself
  * when empty, so this only kicks in when there's really a bar. */
-.page:has(.favBar) .heroSection[data-density='full'] {
+.page:has(.favBar) .heroSection {
     min-height: calc(
         100vh - var(--navbar-height) - 72px - var(--homepage-favbar-height)
     );
 }
 
-/* The favBar variant is repeated so it can't win the specificity contest. */
+/* `full` density sharing the page with body rows: the hero yields a third of
+ * the viewport so the first row peeks above the fold. The favBar variant is
+ * repeated so it can't win the specificity contest. */
 .heroSection[data-density='full'][data-presentation='shared'],
 .page:has(.favBar)
     .heroSection[data-density='full'][data-presentation='shared'] {
@@ -60,11 +59,41 @@
  * exactly as tall as the greeting + composer + chips inside it, plus the
  * page's section rhythm below, so what the admin curated is on screen instead
  * of under the fold. No reserved viewport share, no vertical centring: with
- * content below, "centred in dead space" is the bug, not the feature. */
-.heroSection[data-density='compact'] {
+ * content below, "centred in dead space" is the bug, not the feature.
+ * Repeated with the favBar ancestor so it beats the rule above. */
+.heroSection[data-density='compact'],
+.page:has(.favBar) .heroSection[data-density='compact'] {
+    min-height: 0;
     justify-content: flex-start;
     padding-top: 32px;
     padding-bottom: 56px;
+}
+
+/* With no favourites bar above it the greeting is the first thing on the page,
+ * and sitting it 32px under the navbar reads as cramped rather than as an
+ * opening. The bar removes itself when empty (see FavoritesBlock), so :has is
+ * a reliable signal for "nothing above the hero". */
+.page:not(:has(.favBar)) .heroSection[data-density='compact'] {
+    padding-top: 64px;
+}
+
+/* The day-part greeting, shared by every surface that opens with one — the AI
+ * hero, the standalone greeting block, day-0's non-AI opening and the
+ * no-project page — so they can't drift apart at four different sizes. */
+.heroGreeting {
+    font-size: 28px;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+    line-height: 1.2;
+    margin: 0;
+    text-align: center;
+}
+
+.heroGreetingSub {
+    font-size: 15px;
+    margin-top: 8px;
+    color: var(--mantine-color-dimmed);
+    text-align: center;
 }
 
 .favBar {

--- a/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.test.ts
@@ -115,6 +115,122 @@ const makeConfig = (rows: HomepageBlock[][]): HomepageConfig => ({
     rows: rows.map((blocks, i) => ({ id: `row-${i}`, blocks })),
 });
 
+const heroWithDensity = (
+    id: string,
+    density: 'full' | 'compact' | undefined,
+): HomepageBlock => ({
+    id,
+    type: 'ask-ai-hero',
+    config: { showGreeting: true, density },
+});
+
+describe('hero density', () => {
+    it('defaults to compact when body rows follow, so they stay above the fold', () => {
+        const config = makeConfig([
+            [heroWithDensity('a', undefined)],
+            [block('b', 'collection')],
+        ]);
+        const { hero } = resolveHomepageLayout(config);
+        expect(hero?.presentation).toBe('shared');
+        expect(hero?.density).toBe('compact');
+    });
+
+    it('defaults to full when the hero is the whole page', () => {
+        const config = makeConfig([[heroWithDensity('a', undefined)]]);
+        const { hero } = resolveHomepageLayout(config);
+        expect(hero?.presentation).toBe('viewport');
+        expect(hero?.density).toBe('full');
+    });
+
+    it('honours an explicit full density even with body rows', () => {
+        const config = makeConfig([
+            [heroWithDensity('a', 'full')],
+            [block('b', 'collection')],
+        ]);
+        expect(resolveHomepageLayout(config).hero?.density).toBe('full');
+    });
+
+    it('honours an explicit compact density on a solo hero', () => {
+        const config = makeConfig([[heroWithDensity('a', 'compact')]]);
+        expect(resolveHomepageLayout(config).hero?.density).toBe('compact');
+    });
+
+    it('treats a row that only becomes empty at resolve time as no body row', () => {
+        const config = makeConfig([
+            [heroWithDensity('a', undefined)],
+            [emptyBlock('b', 'collection')],
+        ]);
+        const { hero, rows } = resolveHomepageLayout(config);
+        expect(rows).toHaveLength(0);
+        expect(hero?.density).toBe('full');
+    });
+
+    it('resolves density for a greeting hero too', () => {
+        const config = makeConfig([
+            [block('g', 'greeting')],
+            [block('c', 'collection')],
+        ]);
+        const { hero } = resolveHomepageLayout(config);
+        expect(hero?.row.columns[0].block.type).toBe('greeting');
+        expect(hero?.density).toBe('compact');
+    });
+});
+
+describe('greeting de-duplication', () => {
+    it('drops a greeting block that follows a greeting-bearing hero', () => {
+        const config = makeConfig([
+            [block('a', 'ask-ai-hero')],
+            [block('g', 'greeting')],
+            [block('c', 'collection')],
+        ]);
+        const { hero, rows } = resolveHomepageLayout(config);
+        expect(hero?.row.columns[0].block.id).toBe('a');
+        expect(rows.map((r) => r.columns[0].block.id)).toEqual(['c']);
+    });
+
+    it("turns off a later hero's built-in greeting when a greeting block leads", () => {
+        const config = makeConfig([
+            [block('g', 'greeting')],
+            [block('a', 'ask-ai-hero')],
+        ]);
+        const { hero, rows } = resolveHomepageLayout(config);
+        expect(hero?.row.columns[0].block.id).toBe('g');
+        const laterHero = rows[0].columns[0].block;
+        expect(laterHero.type).toBe('ask-ai-hero');
+        expect(
+            laterHero.type === 'ask-ai-hero' && laterHero.config.showGreeting,
+        ).toBe(false);
+    });
+
+    it('leaves a hero with showGreeting off untouched as the greeting claimant', () => {
+        const config = makeConfig([
+            [
+                {
+                    id: 'a',
+                    type: 'ask-ai-hero',
+                    config: { showGreeting: false },
+                } satisfies HomepageBlock,
+            ],
+            [block('g', 'greeting')],
+        ]);
+        const { hero, rows } = resolveHomepageLayout(config);
+        expect(hero?.row.columns[0].block.id).toBe('a');
+        expect(rows.map((r) => r.columns[0].block.id)).toEqual(['g']);
+    });
+
+    it('keeps every block on the build surface so nothing becomes un-editable', () => {
+        const config = makeConfig([
+            [block('a', 'ask-ai-hero')],
+            [block('g', 'greeting')],
+        ]);
+        const { rows } = resolveHomepageLayout(config, { surface: 'build' });
+        expect(rows.flatMap((r) => r.columns.map((c) => c.block.id))).toEqual([
+            'a',
+            'g',
+        ]);
+    });
+});
+
 describe('resolveHomepageLayout', () => {
     it('pulls a single leading ask-ai-hero into the hero slot', () => {
         const config = makeConfig([

--- a/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
@@ -2,6 +2,7 @@ import {
     assertUnreachable,
     type HomepageBlock,
     type HomepageConfig,
+    type HomepageHeroDensity,
 } from '@lightdash/common';
 import { type BlockWidthTier, traitFor } from './blockLayout';
 
@@ -21,8 +22,7 @@ const HERO_COMPANION_TYPES: HomepageBlock['type'][] = ['quick-actions'];
 export type RowGap = 'none' | 'grouped' | 'section';
 
 // 'viewport' = the hero is the only content, centred in the full viewport
-// (day-0 feel). 'shared' = body rows follow, so the hero yields part of the
-// viewport and the first row peeks above the fold.
+// (day-0 feel). 'shared' = body rows follow, so the hero shares the page.
 export type HeroPresentation = 'viewport' | 'shared';
 
 // 'intro' = a lone leading text block that opens the page and gets breathing
@@ -67,12 +67,13 @@ export type ResolvedRow = {
 };
 
 export type ResolvedLayout = {
-    // The leading hero composition, rendered vertically-centred above
-    // everything: optional chrome rows (quick-actions) + the composer row.
+    // The leading hero composition, rendered above everything: optional chrome
+    // rows (quick-actions) + the composer row.
     hero: {
         companions: ResolvedRow[];
         row: ResolvedRow;
         presentation: HeroPresentation;
+        density: HomepageHeroDensity;
     } | null;
     // Every other row, in order, with gaps derived from adjacency.
     rows: ResolvedRow[];
@@ -80,6 +81,60 @@ export type ResolvedLayout = {
 
 const isLeadingHero = (blocks: HomepageBlock[]): boolean =>
     blocks.length === 1 && LEADING_HERO_TYPES.includes(blocks[0].type);
+
+// The hero's vertical budget. An explicit choice always wins; otherwise a hero
+// with content below it stays compact so that content is actually visible, and
+// a hero that *is* the page keeps the full-viewport opening.
+const resolveHeroDensity = (
+    block: HomepageBlock,
+    hasBodyRows: boolean,
+): HomepageHeroDensity => {
+    const configured =
+        block.type === 'ask-ai-hero' || block.type === 'greeting'
+            ? block.config.density
+            : undefined;
+    if (configured) return configured;
+    return hasBodyRows ? 'compact' : 'full';
+};
+
+// One day-part greeting per page. The AI hero carries its own; a standalone
+// greeting block carries one too, so a page with both greets twice and pays
+// for the vertical space twice. First in reading order keeps it: a later hero
+// drops its built-in greeting, a later greeting block drops out entirely
+// (a greeting block with no greeting left has nothing to render).
+const dedupeGreetings = (
+    rows: HomepageConfig['rows'],
+): HomepageConfig['rows'] => {
+    let claimed = false;
+    return rows
+        .map((row) => ({
+            ...row,
+            blocks: row.blocks.flatMap((block): HomepageBlock[] => {
+                if (block.type === 'greeting') {
+                    if (claimed) return [];
+                    claimed = true;
+                    return [block];
+                }
+                if (block.type === 'ask-ai-hero' && block.config.showGreeting) {
+                    if (claimed) {
+                        return [
+                            {
+                                ...block,
+                                config: {
+                                    ...block.config,
+                                    showGreeting: false,
+                                },
+                            },
+                        ];
+                    }
+                    claimed = true;
+                    return [block];
+                }
+                return [block];
+            }),
+        }))
+        .filter((row) => row.blocks.length > 0);
+};
 
 // Blocks whose config makes them provably render nothing (their Views return
 // null). Config is persisted data that crosses code versions in both
@@ -340,7 +395,11 @@ export const resolveHomepageLayout = (
     opts: { surface: LayoutSurface } = { surface: 'view' },
 ): ResolvedLayout => {
     const isBuild = opts.surface === 'build';
-    const visibleRows = isBuild ? config.rows : toVisibleRows(config.rows);
+    // Build keeps every row/block 1:1 so nothing becomes un-editable — the
+    // greeting de-dup is a render-time concern.
+    const visibleRows = isBuild
+        ? config.rows
+        : dedupeGreetings(toVisibleRows(config.rows));
     // Leading chrome rows join the hero rather than demoting it: the composer
     // is still "leading" with a quick-actions strip above it.
     const composerIdx = visibleRows.findIndex(
@@ -359,7 +418,7 @@ export const resolveHomepageLayout = (
     const smoothed = applyRowAlign(applyItemSpans(smoothWidthTiers(resolved)));
     const rows = hasLeadingHero ? smoothed : applyIntroRole(smoothed);
     // A hero keeps the whole viewport only when it's alone; with body rows it
-    // yields so the first row peeks above the fold.
+    // sizes to its own content so the first row is visible without scrolling.
     const hero = hasLeadingHero
         ? {
               companions: visibleRows
@@ -368,6 +427,10 @@ export const resolveHomepageLayout = (
               row: resolveRow(composerRow, true, isBuild),
               presentation:
                   rows.length > 0 ? ('shared' as const) : ('viewport' as const),
+              density: resolveHeroDensity(
+                  composerRow.blocks[0],
+                  rows.length > 0,
+              ),
           }
         : null;
     return { hero, rows };


### PR DESCRIPTION
Closes #26436

## What

The homepage hero reserved a fixed share of the viewport whether or not it needed it. `min-height: 66vh` plus 32px padding applied the moment body rows followed, and that floor was independent of what the hero actually contained — greeting, quick-actions strip, composer and suggestion chips all stacked *inside* a height that never grew. A homepage with curated content below the hero opened on the composer and nothing else.

Density is now an explicit property of the opening instead of a side effect of position:

| Density | Behaviour | Default when |
|---|---|---|
| `compact` | Hero is as tall as its own content, plus the page's section rhythm below it | Body rows follow the hero |
| `full` | Reserved-viewport opening (today's behaviour) | The hero *is* the whole page |
| `auto` (builder only) | Stores nothing, lets the layout decide | — |

Day-0 opts into `compact` for **both** openings — the AI composer and the greeting + quick actions variant — since Recently viewed and Pinned are the entire point of that page. One `data-density` attribute on the shared hero shell covers both branches.

Also de-duplicates the day-part greeting: the AI hero carries its own via `showGreeting`, and the standalone `greeting` block carries one too, so a page with both greeted twice and paid for the vertical space twice. First in reading order keeps it — a later hero drops its built-in greeting, a later greeting block drops out of the layout entirely.

## Measurements (1440×900)

| Surface | Hero height | First body row |
|---|---|---|
| Day-0, AI agent present | 594px → **391px** | y=802 → **y=598** |
| Day-0, no AI agent | 594px → **~170px** (content is ~110px) | two skeleton rows at the very bottom → Recently viewed *and* Pinned fully on screen |
| Published: AI hero + collection + recently viewed | 594px → **423px** | curated row was a cut-off header → complete row, with Recently viewed below it |

Verified in the browser at 1440×900 across all three surfaces plus the double-greeting case. Before/after screenshots are in the PR thread.

## Suggestion chips: two, and quieter

The chips are the other half of the hero's vertical budget — five of them measured ~190px of a 391px hero, so nearly half the opening view was suggestion pills and the fold guarantee above couldn't really hold.

- **Capped at two**, sliced at the source so impression/click analytics count what the viewer actually saw rather than what was generated.
- **Quiet styling**: no card, no border, no fill, lighter weight, dimmed text. They read as a hint at what the composer can do, not as two more buttons competing with it. The card treatment and affordance return on `:hover` and `:focus-visible`.

Scoped to the homepage by construction: `DayOneAskInput` is only used by the homepage surfaces (`AskAiHero`, `NoProjectHomepage`). The agent thread page renders its own suggestions and keeps the full generated set, where there is nothing below the composer to protect.

Cumulative effect at 1440x900:

| Measure | Original | + compact hero | + two quiet chips |
|---|---|---|---|
| Hero height | 594px | 391px | **319px** |
| First body row | y=802 (cut off) | y=598 | **y=527** |
| Above the fold | hero only | 4 recent rows + Pinned header | **4 recent rows + Pinned + first card** |

## Greeting presence and opening space

Two adjustments now that the hero is sized to its content:

- The day-part greeting goes **23px → 28px**. It's the first line on the page and was competing with body copy rather than opening the page.
- With **no favourites bar** above it, the hero's top padding goes **32px → 64px**. The bar removes itself when a viewer has no favourites, and in that case the greeting sat cramped under the navbar instead of reading as an opening. With a bar present it stays 32px. Verified both ways in the browser (`:has(.favBar)` toggling correctly).

The greeting was styled inline in **four** places at the same four values — the AI hero, the standalone greeting block, day-0's non-AI opening, and the no-project page. It's now one `.heroGreeting` class, so they can't drift apart at four different sizes.

## Regression analysis

- **Fixed a regression inside this branch.** The first commit keyed `min-height` on `[data-density='full']`, which silently dropped the full-viewport treatment on the no-project page — that surface renders `.heroSection` without declaring a density. The base class now carries the full-viewport min-height and `compact` opts out with `min-height: 0`, so any surface that doesn't declare a density keeps the behaviour it always had.
- **Stored configs are untouched.** `density` is optional on `HomepageAskAiHeroBlock` / `HomepageGreetingBlock`. Absent means "let the layout decide", which is what every existing config gets.
- **The one intentional behaviour change** is that existing published homepages with a hero *and* body rows move from 66vh to content-height. That is the bug being fixed, and an admin who wants the old opening can pick `Full screen`. Solo-hero homepages are byte-for-byte unchanged (still `viewport` presentation, still `full` density).
- **The `:has(.favBar)` specificity pair is preserved** for the `full` path, so the fav-bar subtraction still wins where it did before.
- **The greeting de-dup is render-time only.** `resolveHomepageLayout` applies it on the `view` surface; the `build` surface still maps every row and block 1:1, so no block becomes un-editable or silently disappears from the builder. Covered by a test.
- **Density is resolved from post-visibility rows**, so a body row that is config-empty (e.g. a collection with no items) does not force the hero compact — the hero correctly keeps the full-viewport opening when everything below it renders nothing. Covered by a test.

## Tests

13 new tests: 11 resolver (density defaulting both directions, explicit overrides, config-empty body rows, greeting hero density, four greeting de-dup cases including the build surface) and 2 composer (chip cap with five generated, single chip). Full homepage-builder suite green: 19 files / 187 tests.
