### PR TITLE
feat: enable coding agent onboarding for orgs provisioned via new onboarding

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -916,6 +916,10 @@ export type HomepageBuilderEnablement =
     | EnsureOrganizationOverrideOutcome
     | 'failed';
 
+export type CodingAgentOnboardingEnablement =
+    | EnsureOrganizationOverrideOutcome
+    | 'failed';
+
 type PlaygroundProjectProvisionedEvent = BaseTrack & {
     event: 'playground_project.provisioned';
     userId: string;
@@ -926,6 +930,7 @@ type PlaygroundProjectProvisionedEvent = BaseTrack & {
         onboardingFlow: OnboardingFlow;
         catalogIndexErrorType: string | null;
         homepageBuilderEnablement: HomepageBuilderEnablement;
+        codingAgentOnboardingEnablement: CodingAgentOnboardingEnablement;
     };
 };
 

--- a/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.test.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.test.ts
@@ -290,6 +290,7 @@ describe('provisionPlaygroundProject', () => {
                 onboardingFlow: 'new',
                 catalogIndexErrorType: null,
                 homepageBuilderEnablement: 'enabled',
+                codingAgentOnboardingEnablement: 'enabled',
             },
         });
         expect(mocks.validatePlaygroundDatabase).toHaveBeenCalledWith(
@@ -348,24 +349,33 @@ describe('provisionPlaygroundProject', () => {
                 onboardingFlow: 'new',
                 catalogIndexErrorType: 'Error',
                 homepageBuilderEnablement: 'enabled',
+                codingAgentOnboardingEnablement: 'enabled',
             },
         });
     });
 
-    it('enables the homepage builder for the organization before creating the project', async () => {
+    it('enables the homepage builder and coding agent onboarding for the organization before creating the project', async () => {
         const mocks = buildArguments();
         await expect(provisionPlaygroundProject(mocks.args)).resolves.toEqual({
             projectUuid,
             created: true,
         });
-        expect(
-            mocks.ensureOrganizationOverrideEnabled,
-        ).toHaveBeenCalledExactlyOnceWith({
+        expect(mocks.ensureOrganizationOverrideEnabled).toHaveBeenCalledTimes(
+            2,
+        );
+        expect(mocks.ensureOrganizationOverrideEnabled).toHaveBeenCalledWith({
             user,
             featureFlagId: CommercialFeatureFlags.HomepageBuilder,
         });
+        expect(mocks.ensureOrganizationOverrideEnabled).toHaveBeenCalledWith({
+            user,
+            featureFlagId: FeatureFlags.CodingAgentOnboarding,
+        });
         expect(
-            mocks.ensureOrganizationOverrideEnabled.mock.invocationCallOrder[0],
+            Math.max(
+                ...mocks.ensureOrganizationOverrideEnabled.mock
+                    .invocationCallOrder,
+            ),
         ).toBeLessThan(
             vi.mocked(mocks.createWithoutCompile).mock.invocationCallOrder[0],
         );
@@ -373,8 +383,11 @@ describe('provisionPlaygroundProject', () => {
 
     it('reports when an explicit disabled override is preserved', async () => {
         const mocks = buildArguments();
-        mocks.ensureOrganizationOverrideEnabled.mockResolvedValue(
-            'kept_disabled',
+        mocks.ensureOrganizationOverrideEnabled.mockImplementation(
+            async ({ featureFlagId }) =>
+                featureFlagId === CommercialFeatureFlags.HomepageBuilder
+                    ? 'kept_disabled'
+                    : 'enabled',
         );
         await expect(provisionPlaygroundProject(mocks.args)).resolves.toEqual({
             projectUuid,
@@ -390,6 +403,34 @@ describe('provisionPlaygroundProject', () => {
                 onboardingFlow: 'new',
                 catalogIndexErrorType: null,
                 homepageBuilderEnablement: 'kept_disabled',
+                codingAgentOnboardingEnablement: 'enabled',
+            },
+        });
+    });
+
+    it('reports when an explicit disabled coding agent onboarding override is preserved', async () => {
+        const mocks = buildArguments();
+        mocks.ensureOrganizationOverrideEnabled.mockImplementation(
+            async ({ featureFlagId }) =>
+                featureFlagId === FeatureFlags.CodingAgentOnboarding
+                    ? 'kept_disabled'
+                    : 'enabled',
+        );
+        await expect(provisionPlaygroundProject(mocks.args)).resolves.toEqual({
+            projectUuid,
+            created: true,
+        });
+        expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
+            event: 'playground_project.provisioned',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+                trigger: 'invite_expert',
+                onboardingFlow: 'new',
+                catalogIndexErrorType: null,
+                homepageBuilderEnablement: 'enabled',
+                codingAgentOnboardingEnablement: 'kept_disabled',
             },
         });
     });
@@ -400,8 +441,15 @@ describe('provisionPlaygroundProject', () => {
             .mockImplementation(() => Logger);
         try {
             const mocks = buildArguments();
-            mocks.ensureOrganizationOverrideEnabled.mockRejectedValue(
-                new Error('Override write failed'),
+            mocks.ensureOrganizationOverrideEnabled.mockImplementation(
+                async ({ featureFlagId }) => {
+                    if (
+                        featureFlagId === CommercialFeatureFlags.HomepageBuilder
+                    ) {
+                        throw new Error('Override write failed');
+                    }
+                    return 'enabled';
+                },
             );
             await expect(
                 provisionPlaygroundProject(mocks.args),
@@ -419,6 +467,46 @@ describe('provisionPlaygroundProject', () => {
                     onboardingFlow: 'new',
                     catalogIndexErrorType: null,
                     homepageBuilderEnablement: 'failed',
+                    codingAgentOnboardingEnablement: 'enabled',
+                },
+            });
+            expect(errorSpy).toHaveBeenCalled();
+        } finally {
+            errorSpy.mockRestore();
+        }
+    });
+
+    it('still provisions when enabling coding agent onboarding fails', async () => {
+        const errorSpy = vi
+            .spyOn(Logger, 'error')
+            .mockImplementation(() => Logger);
+        try {
+            const mocks = buildArguments();
+            mocks.ensureOrganizationOverrideEnabled.mockImplementation(
+                async ({ featureFlagId }) => {
+                    if (featureFlagId === FeatureFlags.CodingAgentOnboarding) {
+                        throw new Error('Override write failed');
+                    }
+                    return 'enabled';
+                },
+            );
+            await expect(
+                provisionPlaygroundProject(mocks.args),
+            ).resolves.toEqual({
+                projectUuid,
+                created: true,
+            });
+            expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
+                event: 'playground_project.provisioned',
+                userId: user.userUuid,
+                properties: {
+                    organizationId: organizationUuid,
+                    projectId: projectUuid,
+                    trigger: 'invite_expert',
+                    onboardingFlow: 'new',
+                    catalogIndexErrorType: null,
+                    homepageBuilderEnablement: 'enabled',
+                    codingAgentOnboardingEnablement: 'failed',
                 },
             });
             expect(errorSpy).toHaveBeenCalled();

--- a/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.ts
@@ -20,6 +20,7 @@ import * as Sentry from '@sentry/node';
 import fs from 'fs/promises';
 import path from 'path';
 import {
+    type CodingAgentOnboardingEnablement,
     type HomepageBuilderEnablement,
     type LightdashAnalytics,
     type OnboardingFlow,
@@ -225,6 +226,28 @@ export const provisionPlaygroundProject = async ({
                     homepageBuilderEnablement = 'failed';
                 }
 
+                let codingAgentOnboardingEnablement: CodingAgentOnboardingEnablement;
+                try {
+                    codingAgentOnboardingEnablement =
+                        await featureFlagService.ensureOrganizationOverrideEnabled(
+                            {
+                                user,
+                                featureFlagId:
+                                    FeatureFlags.CodingAgentOnboarding,
+                            },
+                        );
+                } catch (error) {
+                    Sentry.captureException(error);
+                    Logger.error(
+                        `Failed to enable coding agent onboarding for organization ${organizationUuid}: ${
+                            error instanceof Error
+                                ? error.message
+                                : String(error)
+                        }`,
+                    );
+                    codingAgentOnboardingEnablement = 'failed';
+                }
+
                 const creation = await projectService.createWithoutCompile(
                     user,
                     {
@@ -294,6 +317,7 @@ export const provisionPlaygroundProject = async ({
                         onboardingFlow,
                         catalogIndexErrorType,
                         homepageBuilderEnablement,
+                        codingAgentOnboardingEnablement,
                     },
                 });
                 return { projectUuid, created: true };


### PR DESCRIPTION
Playground provisioning in the new onboarding flow now also enables the `coding-agent-onboarding` feature flag for the organization, using the same insert-only org-override mechanism already used for the homepage builder flag. A failed flag enablement never fails provisioning: the error is reported to Sentry and logged, and the outcome is recorded on the `playground_project.provisioned` analytics event, which now carries a `codingAgentOnboardingEnablement` property alongside the existing `homepageBuilderEnablement` one.

Linear: SPK-722

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AcAUrDLK7sdqeEWNDqrs9y