### PR TITLE
fix(onboarding): enable homepage builder flag when provisioning the onboarding homepage

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -882,6 +882,7 @@ type OnboardingHomepageProvisionedEvent = BaseTrack & {
         homepageUuid: string;
         onboardingFlow: OnboardingFlow;
         homepageBuilderEnablement: HomepageBuilderEnablement | null;
+        codingAgentOnboardingEnablement: CodingAgentOnboardingEnablement | null;
     };
 };
 
@@ -899,6 +900,7 @@ type OnboardingHomepageSkippedEvent = BaseTrack & {
         projectId: string;
         onboardingFlow: OnboardingFlow;
         homepageBuilderEnablement: HomepageBuilderEnablement | null;
+        codingAgentOnboardingEnablement: CodingAgentOnboardingEnablement | null;
         reason: OnboardingHomepageSkippedReason;
     };
 };
@@ -911,6 +913,7 @@ type OnboardingHomepageFailedEvent = BaseTrack & {
         projectId: string;
         onboardingFlow: OnboardingFlow;
         homepageBuilderEnablement: HomepageBuilderEnablement | null;
+        codingAgentOnboardingEnablement: CodingAgentOnboardingEnablement | null;
         errorType: string;
     };
 };
@@ -932,7 +935,6 @@ type PlaygroundProjectProvisionedEvent = BaseTrack & {
         trigger: 'invite_expert';
         onboardingFlow: OnboardingFlow;
         catalogIndexErrorType: string | null;
-        codingAgentOnboardingEnablement: CodingAgentOnboardingEnablement;
     };
 };
 

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -932,7 +932,6 @@ type PlaygroundProjectProvisionedEvent = BaseTrack & {
         trigger: 'invite_expert';
         onboardingFlow: OnboardingFlow;
         catalogIndexErrorType: string | null;
-        homepageBuilderEnablement: HomepageBuilderEnablement;
         codingAgentOnboardingEnablement: CodingAgentOnboardingEnablement;
     };
 };

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -881,6 +881,7 @@ type OnboardingHomepageProvisionedEvent = BaseTrack & {
         projectId: string;
         homepageUuid: string;
         onboardingFlow: OnboardingFlow;
+        homepageBuilderEnablement: HomepageBuilderEnablement | null;
     };
 };
 
@@ -897,6 +898,7 @@ type OnboardingHomepageSkippedEvent = BaseTrack & {
         organizationId: string;
         projectId: string;
         onboardingFlow: OnboardingFlow;
+        homepageBuilderEnablement: HomepageBuilderEnablement | null;
         reason: OnboardingHomepageSkippedReason;
     };
 };
@@ -908,6 +910,7 @@ type OnboardingHomepageFailedEvent = BaseTrack & {
         organizationId: string;
         projectId: string;
         onboardingFlow: OnboardingFlow;
+        homepageBuilderEnablement: HomepageBuilderEnablement | null;
         errorType: string;
     };
 };

--- a/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.test.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.test.ts
@@ -11,6 +11,7 @@ import {
     type ProjectHomepage,
     type SessionUser,
 } from '@lightdash/common';
+import Logger from '../../../logging/logger';
 import {
     provisionOnboardingHomepage,
     type ProvisionOnboardingHomepageArguments,
@@ -158,11 +159,16 @@ describe('provisionOnboardingHomepage', () => {
 
         await provisionOnboardingHomepage(mocks.args);
 
-        expect(
-            mocks.ensureOrganizationOverrideEnabled,
-        ).toHaveBeenCalledExactlyOnceWith({
+        expect(mocks.ensureOrganizationOverrideEnabled).toHaveBeenCalledTimes(
+            2,
+        );
+        expect(mocks.ensureOrganizationOverrideEnabled).toHaveBeenCalledWith({
             user,
             featureFlagId: CommercialFeatureFlags.HomepageBuilder,
+        });
+        expect(mocks.ensureOrganizationOverrideEnabled).toHaveBeenCalledWith({
+            user,
+            featureFlagId: FeatureFlags.CodingAgentOnboarding,
         });
         expect(mocks.listHomepages).not.toHaveBeenCalled();
         expect(mocks.createHomepage).not.toHaveBeenCalled();
@@ -175,6 +181,7 @@ describe('provisionOnboardingHomepage', () => {
                 projectId: PROJECT_UUID,
                 onboardingFlow: 'new',
                 homepageBuilderEnablement: 'kept_disabled',
+                codingAgentOnboardingEnablement: 'kept_disabled',
                 reason: 'homepage_builder_flag_disabled',
             },
         });
@@ -202,6 +209,7 @@ describe('provisionOnboardingHomepage', () => {
                 projectId: PROJECT_UUID,
                 onboardingFlow: 'new',
                 homepageBuilderEnablement: 'failed',
+                codingAgentOnboardingEnablement: 'failed',
                 reason: 'homepage_builder_flag_disabled',
             },
         });
@@ -229,6 +237,7 @@ describe('provisionOnboardingHomepage', () => {
                 projectId: PROJECT_UUID,
                 onboardingFlow: 'legacy',
                 homepageBuilderEnablement: null,
+                codingAgentOnboardingEnablement: null,
                 reason: 'new_onboarding_flag_disabled',
             },
         });
@@ -250,6 +259,7 @@ describe('provisionOnboardingHomepage', () => {
                 projectId: PROJECT_UUID,
                 onboardingFlow: 'new',
                 homepageBuilderEnablement: 'enabled',
+                codingAgentOnboardingEnablement: 'enabled',
                 reason: 'homepage_already_exists',
             },
         });
@@ -276,6 +286,7 @@ describe('provisionOnboardingHomepage', () => {
                 projectId: PROJECT_UUID,
                 onboardingFlow: 'new',
                 homepageBuilderEnablement: null,
+                codingAgentOnboardingEnablement: null,
                 reason: 'not_first_project',
             },
         });
@@ -313,6 +324,7 @@ describe('provisionOnboardingHomepage', () => {
                 projectId: PROJECT_UUID,
                 onboardingFlow: 'new',
                 homepageBuilderEnablement: 'enabled',
+                codingAgentOnboardingEnablement: 'enabled',
                 errorType: 'Error',
             },
         });
@@ -334,6 +346,7 @@ describe('provisionOnboardingHomepage', () => {
                 projectId: PROJECT_UUID,
                 onboardingFlow: 'new',
                 homepageBuilderEnablement: 'enabled',
+                codingAgentOnboardingEnablement: 'enabled',
                 errorType: 'Error',
             },
         });
@@ -348,11 +361,16 @@ describe('provisionOnboardingHomepage', () => {
             user,
             featureFlagId: FeatureFlags.NewOnboarding,
         });
-        expect(
-            mocks.ensureOrganizationOverrideEnabled,
-        ).toHaveBeenCalledExactlyOnceWith({
+        expect(mocks.ensureOrganizationOverrideEnabled).toHaveBeenCalledTimes(
+            2,
+        );
+        expect(mocks.ensureOrganizationOverrideEnabled).toHaveBeenCalledWith({
             user,
             featureFlagId: CommercialFeatureFlags.HomepageBuilder,
+        });
+        expect(mocks.ensureOrganizationOverrideEnabled).toHaveBeenCalledWith({
+            user,
+            featureFlagId: FeatureFlags.CodingAgentOnboarding,
         });
         expect(mocks.getFeatureFlag).toHaveBeenCalledWith({
             user,
@@ -380,6 +398,7 @@ describe('provisionOnboardingHomepage', () => {
                 homepageUuid: HOMEPAGE_UUID,
                 onboardingFlow: 'new',
                 homepageBuilderEnablement: 'enabled',
+                codingAgentOnboardingEnablement: 'enabled',
             },
         });
     });
@@ -403,6 +422,71 @@ describe('provisionOnboardingHomepage', () => {
                 homepageUuid: HOMEPAGE_UUID,
                 onboardingFlow: 'new',
                 homepageBuilderEnablement: 'already_enabled',
+                codingAgentOnboardingEnablement: 'already_enabled',
+            },
+        });
+    });
+
+    it('provisions when coding agent onboarding enablement fails', async () => {
+        const errorSpy = vi
+            .spyOn(Logger, 'error')
+            .mockImplementation(() => Logger);
+        try {
+            const mocks = buildArguments();
+            mocks.ensureOrganizationOverrideEnabled.mockImplementation(
+                async ({ featureFlagId }) => {
+                    if (featureFlagId === FeatureFlags.CodingAgentOnboarding) {
+                        throw new Error('Enable failed');
+                    }
+                    return 'enabled';
+                },
+            );
+
+            await provisionOnboardingHomepage(mocks.args);
+
+            expect(mocks.createHomepage).toHaveBeenCalled();
+            expect(mocks.publishHomepage).toHaveBeenCalled();
+            expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
+                event: 'onboarding_homepage.provisioned',
+                userId: USER_UUID,
+                properties: {
+                    organizationId: ORGANIZATION_UUID,
+                    projectId: PROJECT_UUID,
+                    homepageUuid: HOMEPAGE_UUID,
+                    onboardingFlow: 'new',
+                    homepageBuilderEnablement: 'enabled',
+                    codingAgentOnboardingEnablement: 'failed',
+                },
+            });
+            expect(errorSpy).toHaveBeenCalled();
+        } finally {
+            errorSpy.mockRestore();
+        }
+    });
+
+    it('provisions when coding agent onboarding remains disabled', async () => {
+        const mocks = buildArguments();
+        mocks.ensureOrganizationOverrideEnabled.mockImplementation(
+            async ({ featureFlagId }) =>
+                featureFlagId === FeatureFlags.CodingAgentOnboarding
+                    ? 'kept_disabled'
+                    : 'enabled',
+        );
+
+        await provisionOnboardingHomepage(mocks.args);
+
+        expect(mocks.createHomepage).toHaveBeenCalled();
+        expect(mocks.publishHomepage).toHaveBeenCalled();
+        expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
+            event: 'onboarding_homepage.provisioned',
+            userId: USER_UUID,
+            properties: {
+                organizationId: ORGANIZATION_UUID,
+                projectId: PROJECT_UUID,
+                homepageUuid: HOMEPAGE_UUID,
+                onboardingFlow: 'new',
+                homepageBuilderEnablement: 'enabled',
+                codingAgentOnboardingEnablement: 'kept_disabled',
             },
         });
     });

--- a/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.test.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.test.ts
@@ -76,6 +76,10 @@ const buildArguments = () => {
         vi.fn<
             ProvisionOnboardingHomepageArguments['featureFlagService']['get']
         >();
+    const ensureOrganizationOverrideEnabled =
+        vi.fn<
+            ProvisionOnboardingHomepageArguments['featureFlagService']['ensureOrganizationOverrideEnabled']
+        >();
     const getAllByOrganizationUuid =
         vi.fn<
             ProvisionOnboardingHomepageArguments['projectModel']['getAllByOrganizationUuid']
@@ -95,7 +99,10 @@ const buildArguments = () => {
     const track =
         vi.fn<ProvisionOnboardingHomepageArguments['analytics']['track']>();
 
-    const featureFlagService = { get: getFeatureFlag };
+    const featureFlagService = {
+        get: getFeatureFlag,
+        ensureOrganizationOverrideEnabled,
+    };
     const projectModel = { getAllByOrganizationUuid };
     const projectHomepageModel = {
         list: listHomepages,
@@ -108,6 +115,7 @@ const buildArguments = () => {
         id: featureFlagId,
         enabled: true,
     }));
+    vi.mocked(ensureOrganizationOverrideEnabled).mockResolvedValue('enabled');
     vi.mocked(getAllByOrganizationUuid).mockResolvedValue([
         makeProject(PROJECT_UUID),
     ]);
@@ -126,6 +134,9 @@ const buildArguments = () => {
             analytics,
         } satisfies ProvisionOnboardingHomepageArguments,
         getFeatureFlag: vi.mocked(getFeatureFlag),
+        ensureOrganizationOverrideEnabled: vi.mocked(
+            ensureOrganizationOverrideEnabled,
+        ),
         getAllByOrganizationUuid: vi.mocked(getAllByOrganizationUuid),
         listHomepages: vi.mocked(listHomepages),
         createHomepage: vi.mocked(createHomepage),
@@ -135,8 +146,11 @@ const buildArguments = () => {
 };
 
 describe('provisionOnboardingHomepage', () => {
-    it('skips provisioning when the homepage builder flag is disabled', async () => {
+    it('skips provisioning when the organization kept the homepage builder flag disabled', async () => {
         const mocks = buildArguments();
+        mocks.ensureOrganizationOverrideEnabled.mockResolvedValue(
+            'kept_disabled',
+        );
         mocks.getFeatureFlag.mockImplementation(async ({ featureFlagId }) => ({
             id: featureFlagId,
             enabled: featureFlagId !== CommercialFeatureFlags.HomepageBuilder,
@@ -144,7 +158,12 @@ describe('provisionOnboardingHomepage', () => {
 
         await provisionOnboardingHomepage(mocks.args);
 
-        expect(mocks.getAllByOrganizationUuid).not.toHaveBeenCalled();
+        expect(
+            mocks.ensureOrganizationOverrideEnabled,
+        ).toHaveBeenCalledExactlyOnceWith({
+            user,
+            featureFlagId: CommercialFeatureFlags.HomepageBuilder,
+        });
         expect(mocks.listHomepages).not.toHaveBeenCalled();
         expect(mocks.createHomepage).not.toHaveBeenCalled();
         expect(mocks.publishHomepage).not.toHaveBeenCalled();
@@ -155,6 +174,34 @@ describe('provisionOnboardingHomepage', () => {
                 organizationId: ORGANIZATION_UUID,
                 projectId: PROJECT_UUID,
                 onboardingFlow: 'new',
+                homepageBuilderEnablement: 'kept_disabled',
+                reason: 'homepage_builder_flag_disabled',
+            },
+        });
+    });
+
+    it('skips provisioning when enabling the homepage builder flag fails and the flag stays disabled', async () => {
+        const mocks = buildArguments();
+        mocks.ensureOrganizationOverrideEnabled.mockRejectedValue(
+            new Error('Enable failed'),
+        );
+        mocks.getFeatureFlag.mockImplementation(async ({ featureFlagId }) => ({
+            id: featureFlagId,
+            enabled: featureFlagId !== CommercialFeatureFlags.HomepageBuilder,
+        }));
+
+        await provisionOnboardingHomepage(mocks.args);
+
+        expect(mocks.createHomepage).not.toHaveBeenCalled();
+        expect(mocks.publishHomepage).not.toHaveBeenCalled();
+        expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
+            event: 'onboarding_homepage.skipped',
+            userId: USER_UUID,
+            properties: {
+                organizationId: ORGANIZATION_UUID,
+                projectId: PROJECT_UUID,
+                onboardingFlow: 'new',
+                homepageBuilderEnablement: 'failed',
                 reason: 'homepage_builder_flag_disabled',
             },
         });
@@ -170,6 +217,7 @@ describe('provisionOnboardingHomepage', () => {
         await provisionOnboardingHomepage(mocks.args);
 
         expect(mocks.getAllByOrganizationUuid).not.toHaveBeenCalled();
+        expect(mocks.ensureOrganizationOverrideEnabled).not.toHaveBeenCalled();
         expect(mocks.listHomepages).not.toHaveBeenCalled();
         expect(mocks.createHomepage).not.toHaveBeenCalled();
         expect(mocks.publishHomepage).not.toHaveBeenCalled();
@@ -180,6 +228,7 @@ describe('provisionOnboardingHomepage', () => {
                 organizationId: ORGANIZATION_UUID,
                 projectId: PROJECT_UUID,
                 onboardingFlow: 'legacy',
+                homepageBuilderEnablement: null,
                 reason: 'new_onboarding_flag_disabled',
             },
         });
@@ -200,6 +249,7 @@ describe('provisionOnboardingHomepage', () => {
                 organizationId: ORGANIZATION_UUID,
                 projectId: PROJECT_UUID,
                 onboardingFlow: 'new',
+                homepageBuilderEnablement: 'enabled',
                 reason: 'homepage_already_exists',
             },
         });
@@ -214,6 +264,7 @@ describe('provisionOnboardingHomepage', () => {
 
         await provisionOnboardingHomepage(mocks.args);
 
+        expect(mocks.ensureOrganizationOverrideEnabled).not.toHaveBeenCalled();
         expect(mocks.listHomepages).not.toHaveBeenCalled();
         expect(mocks.createHomepage).not.toHaveBeenCalled();
         expect(mocks.publishHomepage).not.toHaveBeenCalled();
@@ -224,6 +275,7 @@ describe('provisionOnboardingHomepage', () => {
                 organizationId: ORGANIZATION_UUID,
                 projectId: PROJECT_UUID,
                 onboardingFlow: 'new',
+                homepageBuilderEnablement: null,
                 reason: 'not_first_project',
             },
         });
@@ -238,6 +290,7 @@ describe('provisionOnboardingHomepage', () => {
         });
 
         expect(mocks.getFeatureFlag).not.toHaveBeenCalled();
+        expect(mocks.ensureOrganizationOverrideEnabled).not.toHaveBeenCalled();
         expect(mocks.track).not.toHaveBeenCalled();
     });
 
@@ -259,6 +312,7 @@ describe('provisionOnboardingHomepage', () => {
                 organizationId: ORGANIZATION_UUID,
                 projectId: PROJECT_UUID,
                 onboardingFlow: 'new',
+                homepageBuilderEnablement: 'enabled',
                 errorType: 'Error',
             },
         });
@@ -279,12 +333,13 @@ describe('provisionOnboardingHomepage', () => {
                 organizationId: ORGANIZATION_UUID,
                 projectId: PROJECT_UUID,
                 onboardingFlow: 'new',
+                homepageBuilderEnablement: 'enabled',
                 errorType: 'Error',
             },
         });
     });
 
-    it('creates and publishes the onboarding homepage for the first project', async () => {
+    it('enables the homepage builder flag and provisions the homepage for the first project', async () => {
         const mocks = buildArguments();
 
         await provisionOnboardingHomepage(mocks.args);
@@ -292,6 +347,12 @@ describe('provisionOnboardingHomepage', () => {
         expect(mocks.getFeatureFlag).toHaveBeenCalledWith({
             user,
             featureFlagId: FeatureFlags.NewOnboarding,
+        });
+        expect(
+            mocks.ensureOrganizationOverrideEnabled,
+        ).toHaveBeenCalledExactlyOnceWith({
+            user,
+            featureFlagId: CommercialFeatureFlags.HomepageBuilder,
         });
         expect(mocks.getFeatureFlag).toHaveBeenCalledWith({
             user,
@@ -318,6 +379,30 @@ describe('provisionOnboardingHomepage', () => {
                 projectId: PROJECT_UUID,
                 homepageUuid: HOMEPAGE_UUID,
                 onboardingFlow: 'new',
+                homepageBuilderEnablement: 'enabled',
+            },
+        });
+    });
+
+    it('provisions when the flag was already enabled for the organization', async () => {
+        const mocks = buildArguments();
+        mocks.ensureOrganizationOverrideEnabled.mockResolvedValue(
+            'already_enabled',
+        );
+
+        await provisionOnboardingHomepage(mocks.args);
+
+        expect(mocks.createHomepage).toHaveBeenCalled();
+        expect(mocks.publishHomepage).toHaveBeenCalled();
+        expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
+            event: 'onboarding_homepage.provisioned',
+            userId: USER_UUID,
+            properties: {
+                organizationId: ORGANIZATION_UUID,
+                projectId: PROJECT_UUID,
+                homepageUuid: HOMEPAGE_UUID,
+                onboardingFlow: 'new',
+                homepageBuilderEnablement: 'already_enabled',
             },
         });
     });

--- a/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.ts
@@ -7,6 +7,7 @@ import {
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import {
+    type CodingAgentOnboardingEnablement,
     type HomepageBuilderEnablement,
     type LightdashAnalytics,
     type OnboardingFlow,
@@ -55,6 +56,8 @@ export const provisionOnboardingHomepage = async ({
         ? 'new'
         : 'legacy';
     let homepageBuilderEnablement: HomepageBuilderEnablement | null = null;
+    let codingAgentOnboardingEnablement: CodingAgentOnboardingEnablement | null =
+        null;
     const trackSkipped = (reason: OnboardingHomepageSkippedReason) => {
         analytics.track({
             event: 'onboarding_homepage.skipped',
@@ -64,6 +67,7 @@ export const provisionOnboardingHomepage = async ({
                 projectId: projectUuid,
                 onboardingFlow,
                 homepageBuilderEnablement,
+                codingAgentOnboardingEnablement,
                 reason,
             },
         });
@@ -100,6 +104,22 @@ export const provisionOnboardingHomepage = async ({
             homepageBuilderEnablement = 'failed';
         }
 
+        try {
+            codingAgentOnboardingEnablement =
+                await featureFlagService.ensureOrganizationOverrideEnabled({
+                    user,
+                    featureFlagId: FeatureFlags.CodingAgentOnboarding,
+                });
+        } catch (error) {
+            Sentry.captureException(error);
+            Logger.error(
+                `Failed to enable coding agent onboarding for organization ${organizationUuid}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            codingAgentOnboardingEnablement = 'failed';
+        }
+
         const homepageBuilderFlag = await featureFlagService.get({
             user,
             featureFlagId: CommercialFeatureFlags.HomepageBuilder,
@@ -133,6 +153,7 @@ export const provisionOnboardingHomepage = async ({
                 homepageUuid: homepage.homepageUuid,
                 onboardingFlow,
                 homepageBuilderEnablement,
+                codingAgentOnboardingEnablement,
             },
         });
     } catch (error) {
@@ -144,6 +165,7 @@ export const provisionOnboardingHomepage = async ({
                 projectId: projectUuid,
                 onboardingFlow,
                 homepageBuilderEnablement,
+                codingAgentOnboardingEnablement,
                 errorType: error instanceof Error ? error.name : 'Unknown',
             },
         });

--- a/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.ts
@@ -5,11 +5,14 @@ import {
     ProjectType,
     type SessionUser,
 } from '@lightdash/common';
+import * as Sentry from '@sentry/node';
 import {
+    type HomepageBuilderEnablement,
     type LightdashAnalytics,
     type OnboardingFlow,
     type OnboardingHomepageSkippedReason,
 } from '../../../analytics/LightdashAnalytics';
+import Logger from '../../../logging/logger';
 import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { type FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
 import { type ProjectHomepageModel } from '../../models/ProjectHomepageModel';
@@ -18,7 +21,10 @@ export type ProvisionOnboardingHomepageArguments = {
     user: SessionUser;
     projectUuid: string;
     projectType: ProjectType;
-    featureFlagService: Pick<FeatureFlagService, 'get'>;
+    featureFlagService: Pick<
+        FeatureFlagService,
+        'get' | 'ensureOrganizationOverrideEnabled'
+    >;
     projectModel: Pick<ProjectModel, 'getAllByOrganizationUuid'>;
     projectHomepageModel: Pick<
         ProjectHomepageModel,
@@ -41,19 +47,14 @@ export const provisionOnboardingHomepage = async ({
         return;
     }
 
-    const [orgSetupPageFlag, homepageBuilderFlag] = await Promise.all([
-        featureFlagService.get({
-            user,
-            featureFlagId: FeatureFlags.NewOnboarding,
-        }),
-        featureFlagService.get({
-            user,
-            featureFlagId: CommercialFeatureFlags.HomepageBuilder,
-        }),
-    ]);
+    const orgSetupPageFlag = await featureFlagService.get({
+        user,
+        featureFlagId: FeatureFlags.NewOnboarding,
+    });
     const onboardingFlow: OnboardingFlow = orgSetupPageFlag.enabled
         ? 'new'
         : 'legacy';
+    let homepageBuilderEnablement: HomepageBuilderEnablement | null = null;
     const trackSkipped = (reason: OnboardingHomepageSkippedReason) => {
         analytics.track({
             event: 'onboarding_homepage.skipped',
@@ -62,16 +63,13 @@ export const provisionOnboardingHomepage = async ({
                 organizationId: organizationUuid,
                 projectId: projectUuid,
                 onboardingFlow,
+                homepageBuilderEnablement,
                 reason,
             },
         });
     };
     if (!orgSetupPageFlag.enabled) {
         trackSkipped('new_onboarding_flag_disabled');
-        return;
-    }
-    if (!homepageBuilderFlag.enabled) {
-        trackSkipped('homepage_builder_flag_disabled');
         return;
     }
 
@@ -83,6 +81,31 @@ export const provisionOnboardingHomepage = async ({
             organizationProjects[0].projectUuid !== projectUuid
         ) {
             trackSkipped('not_first_project');
+            return;
+        }
+
+        try {
+            homepageBuilderEnablement =
+                await featureFlagService.ensureOrganizationOverrideEnabled({
+                    user,
+                    featureFlagId: CommercialFeatureFlags.HomepageBuilder,
+                });
+        } catch (error) {
+            Sentry.captureException(error);
+            Logger.error(
+                `Failed to enable homepage builder for organization ${organizationUuid}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            homepageBuilderEnablement = 'failed';
+        }
+
+        const homepageBuilderFlag = await featureFlagService.get({
+            user,
+            featureFlagId: CommercialFeatureFlags.HomepageBuilder,
+        });
+        if (!homepageBuilderFlag.enabled) {
+            trackSkipped('homepage_builder_flag_disabled');
             return;
         }
 
@@ -109,6 +132,7 @@ export const provisionOnboardingHomepage = async ({
                 projectId: projectUuid,
                 homepageUuid: homepage.homepageUuid,
                 onboardingFlow,
+                homepageBuilderEnablement,
             },
         });
     } catch (error) {
@@ -119,6 +143,7 @@ export const provisionOnboardingHomepage = async ({
                 organizationId: organizationUuid,
                 projectId: projectUuid,
                 onboardingFlow,
+                homepageBuilderEnablement,
                 errorType: error instanceof Error ? error.name : 'Unknown',
             },
         });

--- a/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.test.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.test.ts
@@ -8,7 +8,6 @@ import {
     type SessionUser,
 } from '@lightdash/common';
 import path from 'path';
-import Logger from '../../../logging/logger';
 import {
     provisionPlaygroundProject,
     type ProvisionPlaygroundProjectArguments,
@@ -59,9 +58,6 @@ const buildArguments = () => {
         id: FeatureFlags.NewOnboarding,
         enabled: true,
     }));
-    const ensureOrganizationOverrideEnabled = vi.fn<
-        ProvisionPlaygroundProjectArguments['featureFlagService']['ensureOrganizationOverrideEnabled']
-    >(async () => 'enabled');
     const getAllByOrganizationUuid = vi.fn(
         async () => [] as OrganizationProject[],
     );
@@ -98,7 +94,7 @@ const buildArguments = () => {
     return {
         args: {
             user,
-            featureFlagService: { get, ensureOrganizationOverrideEnabled },
+            featureFlagService: { get },
             projectModel: {
                 getAllByOrganizationUuid,
                 delete: deleteProject,
@@ -116,7 +112,6 @@ const buildArguments = () => {
             validatePlaygroundDatabase,
         } satisfies ProvisionPlaygroundProjectArguments,
         get,
-        ensureOrganizationOverrideEnabled,
         getAllByOrganizationUuid,
         deleteProject,
         saveExploresToCache,
@@ -286,7 +281,6 @@ describe('provisionPlaygroundProject', () => {
                 trigger: 'invite_expert',
                 onboardingFlow: 'new',
                 catalogIndexErrorType: null,
-                codingAgentOnboardingEnablement: 'enabled',
             },
         });
         expect(mocks.validatePlaygroundDatabase).toHaveBeenCalledWith(
@@ -344,93 +338,8 @@ describe('provisionPlaygroundProject', () => {
                 trigger: 'invite_expert',
                 onboardingFlow: 'new',
                 catalogIndexErrorType: 'Error',
-                codingAgentOnboardingEnablement: 'enabled',
             },
         });
-    });
-
-    it('enables coding agent onboarding for the organization before creating the project', async () => {
-        const mocks = buildArguments();
-        await expect(provisionPlaygroundProject(mocks.args)).resolves.toEqual({
-            projectUuid,
-            created: true,
-        });
-        expect(mocks.ensureOrganizationOverrideEnabled).toHaveBeenCalledTimes(
-            1,
-        );
-        expect(mocks.ensureOrganizationOverrideEnabled).toHaveBeenCalledWith({
-            user,
-            featureFlagId: FeatureFlags.CodingAgentOnboarding,
-        });
-        expect(
-            mocks.ensureOrganizationOverrideEnabled.mock.invocationCallOrder[0],
-        ).toBeLessThan(
-            vi.mocked(mocks.createWithoutCompile).mock.invocationCallOrder[0],
-        );
-    });
-
-    it('reports when an explicit disabled coding agent onboarding override is preserved', async () => {
-        const mocks = buildArguments();
-        mocks.ensureOrganizationOverrideEnabled.mockImplementation(
-            async ({ featureFlagId }) =>
-                featureFlagId === FeatureFlags.CodingAgentOnboarding
-                    ? 'kept_disabled'
-                    : 'enabled',
-        );
-        await expect(provisionPlaygroundProject(mocks.args)).resolves.toEqual({
-            projectUuid,
-            created: true,
-        });
-        expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
-            event: 'playground_project.provisioned',
-            userId: user.userUuid,
-            properties: {
-                organizationId: organizationUuid,
-                projectId: projectUuid,
-                trigger: 'invite_expert',
-                onboardingFlow: 'new',
-                catalogIndexErrorType: null,
-                codingAgentOnboardingEnablement: 'kept_disabled',
-            },
-        });
-    });
-
-    it('still provisions when enabling coding agent onboarding fails', async () => {
-        const errorSpy = vi
-            .spyOn(Logger, 'error')
-            .mockImplementation(() => Logger);
-        try {
-            const mocks = buildArguments();
-            mocks.ensureOrganizationOverrideEnabled.mockImplementation(
-                async ({ featureFlagId }) => {
-                    if (featureFlagId === FeatureFlags.CodingAgentOnboarding) {
-                        throw new Error('Override write failed');
-                    }
-                    return 'enabled';
-                },
-            );
-            await expect(
-                provisionPlaygroundProject(mocks.args),
-            ).resolves.toEqual({
-                projectUuid,
-                created: true,
-            });
-            expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
-                event: 'playground_project.provisioned',
-                userId: user.userUuid,
-                properties: {
-                    organizationId: organizationUuid,
-                    projectId: projectUuid,
-                    trigger: 'invite_expert',
-                    onboardingFlow: 'new',
-                    catalogIndexErrorType: null,
-                    codingAgentOnboardingEnablement: 'failed',
-                },
-            });
-            expect(errorSpy).toHaveBeenCalled();
-        } finally {
-            errorSpy.mockRestore();
-        }
     });
 
     it('does not create a project when bundle validation fails', async () => {

--- a/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.test.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.test.ts
@@ -1,6 +1,5 @@
 import { Ability } from '@casl/ability';
 import {
-    CommercialFeatureFlags,
     FeatureFlags,
     OrganizationMemberRole,
     ProjectType,
@@ -179,7 +178,6 @@ describe('provisionPlaygroundProject', () => {
                 reason: 'playground_already_exists',
             },
         });
-        expect(mocks.ensureOrganizationOverrideEnabled).not.toHaveBeenCalled();
     });
 
     it('returns an existing real project without creating a playground', async () => {
@@ -201,7 +199,6 @@ describe('provisionPlaygroundProject', () => {
                 reason: 'organization_has_project',
             },
         });
-        expect(mocks.ensureOrganizationOverrideEnabled).not.toHaveBeenCalled();
     });
 
     it('does not disclose an existing project the user cannot view', async () => {
@@ -289,7 +286,6 @@ describe('provisionPlaygroundProject', () => {
                 trigger: 'invite_expert',
                 onboardingFlow: 'new',
                 catalogIndexErrorType: null,
-                homepageBuilderEnablement: 'enabled',
                 codingAgentOnboardingEnablement: 'enabled',
             },
         });
@@ -348,64 +344,29 @@ describe('provisionPlaygroundProject', () => {
                 trigger: 'invite_expert',
                 onboardingFlow: 'new',
                 catalogIndexErrorType: 'Error',
-                homepageBuilderEnablement: 'enabled',
                 codingAgentOnboardingEnablement: 'enabled',
             },
         });
     });
 
-    it('enables the homepage builder and coding agent onboarding for the organization before creating the project', async () => {
+    it('enables coding agent onboarding for the organization before creating the project', async () => {
         const mocks = buildArguments();
         await expect(provisionPlaygroundProject(mocks.args)).resolves.toEqual({
             projectUuid,
             created: true,
         });
         expect(mocks.ensureOrganizationOverrideEnabled).toHaveBeenCalledTimes(
-            2,
+            1,
         );
-        expect(mocks.ensureOrganizationOverrideEnabled).toHaveBeenCalledWith({
-            user,
-            featureFlagId: CommercialFeatureFlags.HomepageBuilder,
-        });
         expect(mocks.ensureOrganizationOverrideEnabled).toHaveBeenCalledWith({
             user,
             featureFlagId: FeatureFlags.CodingAgentOnboarding,
         });
         expect(
-            Math.max(
-                ...mocks.ensureOrganizationOverrideEnabled.mock
-                    .invocationCallOrder,
-            ),
+            mocks.ensureOrganizationOverrideEnabled.mock.invocationCallOrder[0],
         ).toBeLessThan(
             vi.mocked(mocks.createWithoutCompile).mock.invocationCallOrder[0],
         );
-    });
-
-    it('reports when an explicit disabled override is preserved', async () => {
-        const mocks = buildArguments();
-        mocks.ensureOrganizationOverrideEnabled.mockImplementation(
-            async ({ featureFlagId }) =>
-                featureFlagId === CommercialFeatureFlags.HomepageBuilder
-                    ? 'kept_disabled'
-                    : 'enabled',
-        );
-        await expect(provisionPlaygroundProject(mocks.args)).resolves.toEqual({
-            projectUuid,
-            created: true,
-        });
-        expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
-            event: 'playground_project.provisioned',
-            userId: user.userUuid,
-            properties: {
-                organizationId: organizationUuid,
-                projectId: projectUuid,
-                trigger: 'invite_expert',
-                onboardingFlow: 'new',
-                catalogIndexErrorType: null,
-                homepageBuilderEnablement: 'kept_disabled',
-                codingAgentOnboardingEnablement: 'enabled',
-            },
-        });
     });
 
     it('reports when an explicit disabled coding agent onboarding override is preserved', async () => {
@@ -429,51 +390,9 @@ describe('provisionPlaygroundProject', () => {
                 trigger: 'invite_expert',
                 onboardingFlow: 'new',
                 catalogIndexErrorType: null,
-                homepageBuilderEnablement: 'enabled',
                 codingAgentOnboardingEnablement: 'kept_disabled',
             },
         });
-    });
-
-    it('still provisions when enabling the homepage builder fails', async () => {
-        const errorSpy = vi
-            .spyOn(Logger, 'error')
-            .mockImplementation(() => Logger);
-        try {
-            const mocks = buildArguments();
-            mocks.ensureOrganizationOverrideEnabled.mockImplementation(
-                async ({ featureFlagId }) => {
-                    if (
-                        featureFlagId === CommercialFeatureFlags.HomepageBuilder
-                    ) {
-                        throw new Error('Override write failed');
-                    }
-                    return 'enabled';
-                },
-            );
-            await expect(
-                provisionPlaygroundProject(mocks.args),
-            ).resolves.toEqual({
-                projectUuid,
-                created: true,
-            });
-            expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
-                event: 'playground_project.provisioned',
-                userId: user.userUuid,
-                properties: {
-                    organizationId: organizationUuid,
-                    projectId: projectUuid,
-                    trigger: 'invite_expert',
-                    onboardingFlow: 'new',
-                    catalogIndexErrorType: null,
-                    homepageBuilderEnablement: 'failed',
-                    codingAgentOnboardingEnablement: 'enabled',
-                },
-            });
-            expect(errorSpy).toHaveBeenCalled();
-        } finally {
-            errorSpy.mockRestore();
-        }
     });
 
     it('still provisions when enabling coding agent onboarding fails', async () => {
@@ -505,7 +424,6 @@ describe('provisionPlaygroundProject', () => {
                     trigger: 'invite_expert',
                     onboardingFlow: 'new',
                     catalogIndexErrorType: null,
-                    homepageBuilderEnablement: 'enabled',
                     codingAgentOnboardingEnablement: 'failed',
                 },
             });

--- a/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.ts
@@ -19,7 +19,6 @@ import * as Sentry from '@sentry/node';
 import fs from 'fs/promises';
 import path from 'path';
 import {
-    type CodingAgentOnboardingEnablement,
     type LightdashAnalytics,
     type OnboardingFlow,
     type PlaygroundProjectSkippedReason,
@@ -33,10 +32,7 @@ import { type ProjectService } from '../../../services/ProjectService/ProjectSer
 
 export type ProvisionPlaygroundProjectArguments = {
     user: SessionUser;
-    featureFlagService: Pick<
-        FeatureFlagService,
-        'get' | 'ensureOrganizationOverrideEnabled'
-    >;
+    featureFlagService: Pick<FeatureFlagService, 'get'>;
     projectModel: Pick<
         ProjectModel,
         'getAllByOrganizationUuid' | 'delete' | 'saveExploresToCache'
@@ -200,28 +196,6 @@ export const provisionPlaygroundProject = async ({
                     validatePlaygroundDatabase,
                 );
 
-                let codingAgentOnboardingEnablement: CodingAgentOnboardingEnablement;
-                try {
-                    codingAgentOnboardingEnablement =
-                        await featureFlagService.ensureOrganizationOverrideEnabled(
-                            {
-                                user,
-                                featureFlagId:
-                                    FeatureFlags.CodingAgentOnboarding,
-                            },
-                        );
-                } catch (error) {
-                    Sentry.captureException(error);
-                    Logger.error(
-                        `Failed to enable coding agent onboarding for organization ${organizationUuid}: ${
-                            error instanceof Error
-                                ? error.message
-                                : String(error)
-                        }`,
-                    );
-                    codingAgentOnboardingEnablement = 'failed';
-                }
-
                 const creation = await projectService.createWithoutCompile(
                     user,
                     {
@@ -290,7 +264,6 @@ export const provisionPlaygroundProject = async ({
                         trigger: 'invite_expert',
                         onboardingFlow,
                         catalogIndexErrorType,
-                        codingAgentOnboardingEnablement,
                     },
                 });
                 return { projectUuid, created: true };

--- a/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.ts
@@ -1,5 +1,4 @@
 import {
-    CommercialFeatureFlags,
     DbtProjectType,
     DefaultSupportedDbtVersion,
     DuckdbConnectionType,
@@ -21,7 +20,6 @@ import fs from 'fs/promises';
 import path from 'path';
 import {
     type CodingAgentOnboardingEnablement,
-    type HomepageBuilderEnablement,
     type LightdashAnalytics,
     type OnboardingFlow,
     type PlaygroundProjectSkippedReason,
@@ -202,30 +200,6 @@ export const provisionPlaygroundProject = async ({
                     validatePlaygroundDatabase,
                 );
 
-                // Before project creation so the onProjectCreated hook sees
-                // the flag when provisioning the onboarding homepage.
-                let homepageBuilderEnablement: HomepageBuilderEnablement;
-                try {
-                    homepageBuilderEnablement =
-                        await featureFlagService.ensureOrganizationOverrideEnabled(
-                            {
-                                user,
-                                featureFlagId:
-                                    CommercialFeatureFlags.HomepageBuilder,
-                            },
-                        );
-                } catch (error) {
-                    Sentry.captureException(error);
-                    Logger.error(
-                        `Failed to enable homepage builder for organization ${organizationUuid}: ${
-                            error instanceof Error
-                                ? error.message
-                                : String(error)
-                        }`,
-                    );
-                    homepageBuilderEnablement = 'failed';
-                }
-
                 let codingAgentOnboardingEnablement: CodingAgentOnboardingEnablement;
                 try {
                     codingAgentOnboardingEnablement =
@@ -316,7 +290,6 @@ export const provisionPlaygroundProject = async ({
                         trigger: 'invite_expert',
                         onboardingFlow,
                         catalogIndexErrorType,
-                        homepageBuilderEnablement,
                         codingAgentOnboardingEnablement,
                     },
                 });


### PR DESCRIPTION
## What changed

`provisionOnboardingHomepage` now enables the organization's `homepage-builder` override itself — via `FeatureFlagService.ensureOrganizationOverrideEnabled` (introduced in #26428) — before checking the flag, instead of requiring the override to already exist. Details:

- The enablement runs only when the new-onboarding flag is enabled **and** the project is the organization's first default project (the first-project check moved ahead of the flag enablement/check so the override is only written for fresh organizations).
- Enablement is insert-only: an organization with an explicit `enabled=false` override keeps it (`kept_disabled`) and provisioning still skips.
- After the enablement attempt, the flag is re-resolved through the normal `FeatureFlagService.get` path, so instance-level env kill switches, explicit org disables, and user overrides all still win. Enablement failures are logged to Sentry and degrade to the skip path rather than failing project creation.
- `onboarding_homepage.provisioned` / `.skipped` / `.failed` events gain a `homepageBuilderEnablement` property (mirroring the existing playground event property): `enabled` / `already_enabled` / `kept_disabled` / `failed`, or `null` when enablement was not attempted.

- The playground provisioning path's own pre-creation enablement call (added in #26428) is now redundant — `provisionOnboardingHomepage` performs the enablement for every first-project path — so it is removed here along with its `homepageBuilderEnablement` property on the `playground_project.provisioned` event (the property lives on the `onboarding_homepage.*` events instead) and its dedicated tests.

- The coding-agent-onboarding enablement (#26444) moves into the same shared provisioning step: `provisionOnboardingHomepage` now also ensures `FeatureFlags.CodingAgentOnboarding` for the org (independent try/catch; its outcome never blocks homepage provisioning), covering every first-project path instead of only playground provisioning. The playground path's own block is removed, its `codingAgentOnboardingEnablement` event property moves from `playground_project.provisioned` to the `onboarding_homepage.*` events, and tests move accordingly.

Homepage rendering and builder access remain gated on the same flag — this change only ensures organizations going through the new onboarding flow have it enabled unless explicitly disabled.

## Why

Verified from source:
- `CommercialFeatureFlagModel.getHomepageBuilderFlag` resolves `homepage-builder` as default-off with per-org DB overrides only, so a brand-new organization has it disabled at first-project creation.
- Before this change, `provisionOnboardingHomepage` only read the flag, so it skipped with `homepage_builder_flag_disabled` for such organizations.
- #26428 (SPK-715) added the override enablement, but only on the playground provisioning path (`provisionPlaygroundProject`, reachable solely from the invite-expert onboarding page). An organization whose first project is created by connecting a warehouse directly never gets the override, so the default "Getting started" homepage is still skipped on that path.
- `ProjectHomepageService` gates all homepage reads/writes on the same flag, so provisioning without enabling the flag would leave the homepage inaccessible — which is why this enables the flag rather than decoupling provisioning from it.

Inferred (not runtime-verified): the originally reported production repro predates the deploy of #26428, so part of the observed behaviour is expected to be fixed by that PR alone once deployed; the direct warehouse-connection path above is the gap that remains after it.

## Testing

- Unit tests updated and extended: enablement outcomes (`enabled`, `already_enabled`, `kept_disabled`, `failed`), skip ordering, and analytics payloads (`pnpm -F backend test` on the provisioning test files — 23 passed).
- `pnpm -F backend typecheck` and lint on touched files pass.

- Verified end-to-end on a local EE instance: fresh signup through the new-onboarding warehouse-connect flow (with `homepage-builder` absent from any env allowlist) auto-created the org override, created and published the "Getting started" homepage in the same transaction window as project creation, and `GET /projects/:uuid/homepage` returns the resolved homepage.

Linear: SPK-721
Relates: SPK-715

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQg6TsLJEeGYKJxnYLXyhm



