### PR TITLE
fix(homepage-builder): data apps fall back to a neutral icon, not a coloured placeholder

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.test.tsx
@@ -9,8 +9,16 @@ vi.mock('../hooks/useHomepageLinkMetadata', () => ({
     fetchHomepageLinkMetadata: vi.fn(),
 }));
 
+const { thumbnailState } = vi.hoisted(() => ({
+    thumbnailState: {
+        current: { data: null } as {
+            data: { thumbnailUrl: string } | null;
+        },
+    },
+}));
+
 vi.mock('../../../../features/apps/hooks/useAppThumbnail', () => ({
-    useAppThumbnailUrl: vi.fn(() => ({ data: null })),
+    useAppThumbnailUrl: () => thumbnailState.current,
 }));
 
 const mockFetch = vi.mocked(fetchHomepageLinkMetadata);
@@ -84,6 +92,66 @@ describe('ResourcesBlockView', () => {
             'href',
             '/projects/p1/apps/abc-123/view',
         );
+    });
+
+    describe('data app thumbnails', () => {
+        const dataAppItem = {
+            url: '/projects/p1/napp-1',
+            kind: 'data-app' as const,
+            title: 'Orders KPI Snapshot',
+            description: 'Daily orders and revenue',
+            appUuid: 'app-1',
+        };
+
+        afterEach(() => {
+            thumbnailState.current = { data: null };
+        });
+
+        const withThumbnail = (thumbnailUrl: string | undefined) => {
+            thumbnailState.current = {
+                data: thumbnailUrl ? { thumbnailUrl } : null,
+            };
+        };
+
+        it('shows the screenshot when the app has one', () => {
+            withThumbnail('https://example.invalid/shot.png');
+            wrap(
+                <ResourcesBlockView
+                    itemSpan={null}
+                    projectUuid="p1"
+                    block={block({ layout: 'card', items: [dataAppItem] })}
+                />,
+            );
+            expect(screen.getByRole('img')).toHaveAttribute(
+                'src',
+                'https://example.invalid/shot.png',
+            );
+        });
+
+        it('falls back to an icon rather than an image when there is no screenshot', () => {
+            withThumbnail(undefined);
+            wrap(
+                <ResourcesBlockView
+                    itemSpan={null}
+                    projectUuid="p1"
+                    block={block({ layout: 'card', items: [dataAppItem] })}
+                />,
+            );
+            expect(screen.queryByRole('img')).not.toBeInTheDocument();
+            expect(screen.getByText('Orders KPI Snapshot')).toBeInTheDocument();
+        });
+
+        it('falls back to an icon in list layout too', () => {
+            withThumbnail(undefined);
+            wrap(
+                <ResourcesBlockView
+                    itemSpan={null}
+                    projectUuid="p1"
+                    block={block({ layout: 'list', items: [dataAppItem] })}
+                />,
+            );
+            expect(screen.queryByRole('img')).not.toBeInTheDocument();
+        });
     });
 
     it('renders nothing when there are no items', () => {

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
@@ -51,9 +51,12 @@ import {
 } from './resourceUrls';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
+// `thumbAccent` is the kind-tinted wash behind a bare favicon: it exists so an
+// external link's kind is legible when there's no image to show. Internal
+// content carries its own icon language and takes no tint — see DataAppCardMedia.
 const KIND_META: Record<
     HomepageResourceKind,
-    { icon: Icon; label: string; thumbAccent: string }
+    { icon: Icon; label: string; thumbAccent?: string }
 > = {
     video: {
         icon: IconVideo,
@@ -72,11 +75,7 @@ const KIND_META: Record<
         label: 'YouTube',
         thumbAccent: classes.resThumbYoutube,
     },
-    'data-app': {
-        icon: IconAppWindow,
-        label: 'Data app',
-        thumbAccent: classes.resThumbDataApp,
-    },
+    'data-app': { icon: IconAppWindow, label: 'Data app' },
 };
 
 // Data apps are added via the picker, not the kind dropdown, so they're
@@ -95,10 +94,12 @@ const isDefaultFavicon = (img: HTMLImageElement) => img.naturalWidth < 32;
 
 // --- Thumbnails -------------------------------------------------------------
 
-// Data app thumbnails are short-lived signed URLs, so they're fetched live
-// from `appUuid` at render time. Missing thumbnail (or no view access) →
-// falls back to the data app glyph on a polished accent background.
-const DataAppCardThumb: FC<{
+// The media slot for a data app card: its screenshot when there is one,
+// otherwise the neutral icon square native content uses (see ContentCard) —
+// never a full-size coloured placeholder. A fallback should be quieter than
+// the real thing, not louder. Kind stays legible in text on the card body.
+// Shared by the published card and the editor canvas so they can't drift.
+const DataAppCardMedia: FC<{
     item: HomepageResourceItem;
     projectUuid: string;
 }> = ({ item, projectUuid }) => {
@@ -108,24 +109,22 @@ const DataAppCardThumb: FC<{
         item.appUuid,
         !!item.appUuid,
     );
-    const thumbnailUrl = data?.thumbnailUrl;
-    if (thumbnailUrl && !failed) {
+    const thumbnailUrl = failed ? undefined : data?.thumbnailUrl;
+    if (!thumbnailUrl) {
         return (
-            <div className={classes.resThumb}>
-                <img
-                    src={thumbnailUrl}
-                    alt={item.title}
-                    loading="lazy"
-                    onError={() => setFailed(true)}
-                />
+            <div className={classes.mediaIcon}>
+                <IconSquare icon={IconAppWindow} />
             </div>
         );
     }
     return (
-        <div className={`${classes.resThumbTile} ${classes.resThumbDataApp}`}>
-            <div className={classes.resGlyphTile}>
-                <MantineIcon icon={IconAppWindow} size={22} />
-            </div>
+        <div className={classes.resThumb}>
+            <img
+                src={thumbnailUrl}
+                alt={item.title}
+                loading="lazy"
+                onError={() => setFailed(true)}
+            />
         </div>
     );
 };
@@ -153,13 +152,8 @@ const DataAppRowThumb: FC<{
             </div>
         );
     }
-    return (
-        <div
-            className={`${classes.rowThumb} ${classes.rowThumbFallback} ${classes.resThumbDataApp}`}
-        >
-            <MantineIcon icon={IconAppWindow} size={18} />
-        </div>
-    );
+    // Same neutral square a link with no favicon falls back to — no kind tint.
+    return <IconSquare icon={IconAppWindow} />;
 };
 
 const UrlCardThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => {
@@ -186,7 +180,11 @@ const UrlCardThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => {
 
     // No sharp photo → a quiet kind-tinted wash with the bare favicon on it.
     return (
-        <div className={`${classes.resThumbTile} ${meta.thumbAccent}`}>
+        <div
+            className={[classes.resThumbTile, meta.thumbAccent]
+                .filter(Boolean)
+                .join(' ')}
+        >
             {favicon && !faviconFailed ? (
                 <img
                     className={classes.resFavTile}
@@ -213,7 +211,7 @@ const CardThumb: FC<{ item: HomepageResourceItem; projectUuid: string }> = ({
     projectUuid,
 }) =>
     item.kind === 'data-app' ? (
-        <DataAppCardThumb item={item} projectUuid={projectUuid} />
+        <DataAppCardMedia item={item} projectUuid={projectUuid} />
     ) : (
         <UrlCardThumb item={item} />
     );

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -567,15 +567,6 @@ a .hoverCard:hover,
 
 /* Data apps use the brand orange, tinted into a quiet backdrop for the
  * icon fallback when an app has no thumbnail. */
-.resThumbDataApp {
-    background: linear-gradient(
-        135deg,
-        light-dark(#fff3e8, #362a1c),
-        light-dark(#f8e3cd, #2c2114)
-    );
-    color: light-dark(#c2410c, #fdba74);
-}
-
 /* External-link affordance: quiet corner mark, revealed on hover. */
 .resExternal {
     position: absolute;
@@ -589,6 +580,15 @@ a .hoverCard:hover,
 
 .mediaCard:hover .resExternal {
     opacity: 1;
+}
+
+.mediaIcon {
+    /* Stands in for the image band, so an icon-only card is exactly as tall as
+     * one with a screenshot and a mixed grid keeps a single baseline. */
+    flex: 1;
+    min-height: 56px;
+    display: grid;
+    place-items: center;
 }
 
 .mediaBody {


### PR DESCRIPTION
Closes #26437

Stacked on #26443.

## What

A data app resource with no screenshot rendered a full-size orange gradient tile with a browser-window glyph (`resThumbDataApp`). On a homepage that is mostly data apps that reads as a wall of orange — the placeholder was louder than the thing it stood for, and it pushed each app's name into the smaller share of its card.

The rule this settles, so it holds for the next content type we add:

> **Kind colour is for external links, where colour is the only type signal a bare favicon has. Internal Lightdash content carries its own icon language and takes no tint.**

So:

- Data app **with** a screenshot — unchanged. Still the best affordance there is, and it now stands out because it's the only colour in the row.
- Data app **without** one — the same neutral icon square native content uses (`ContentCard`), in both the `card` and `list` layouts. No coloured band, no tinted 34px row tile.
- Type stays legible in text via the existing `Data app` pill, so nothing is lost by dropping the colour.

Two tidy-ups that fall out of it: `thumbAccent` becomes optional on `KIND_META` rather than carrying a value nothing reads, and the `.resThumbDataApp` gradient is deleted.

## Regression analysis

- **The media slot is one shared component** (`DataAppCardMedia`) used by both the published card and the editor canvas, so the builder can't show something different from what viewers get. That was the failure mode of the previous shape, which had a separate `DataAppCardThumb` for published and the same dispatch for build.
- **Mixed blocks keep one baseline.** Verified with two apps that have screenshots and two that don't: all four cards measure exactly 200px, so the grid doesn't ladder. `.mediaIcon` stands in for the image band with the same `flex: 1` and `min-height` the band had, which is what holds the height.
- **The thumbnail-load-failure path lands on the same fallback** as "no thumbnail at all", rather than the old coloured tile — one visual outcome for both, so a broken signed URL doesn't look like a different state.
- **No stored config changes**, nothing to migrate. `thumbAccent` going optional is internal to the component; `HomepageResourceItem` is untouched.
- **`UrlCardThumb` guards the optional accent** with a `.filter(Boolean)` class join, so a kind without a tint can't emit `class="... undefined"`.

## Tests

3 new: screenshot shown when present, icon fallback (no `img` element) in card layout, icon fallback in list layout. The positive path is the one the dev environment can't show — no app here has a stored thumbnail — so it's covered by the test and by route-intercepting the thumbnail endpoint in the browser for the screenshots. Full homepage-builder suite green: 19 files / 190 tests.
