### PR TITLE
fix(onboarding): stop organization setup wizard restarting after completion

### DIFF
--- a/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.test.tsx
+++ b/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.test.tsx
@@ -2,12 +2,46 @@ import { LightdashMode } from '@lightdash/common';
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
-import { MemoryRouter, Route, Routes } from 'react-router';
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { BASE_API_URL } from '../../api';
+import { useUserCompleteMutation } from '../../hooks/user/useUserCompleteMutation';
 import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
+import useApp from '../../providers/App/useApp';
 import { renderWithProviders } from '../../testing/testUtils';
 import UserCompletionModal from './UserCompletionModal';
+
+const CompleteSetupHarness = () => {
+    const navigate = useNavigate();
+    const { mutate } = useUserCompleteMutation();
+    return (
+        <button
+            type="button"
+            onClick={() => {
+                mutate({
+                    organizationName: 'test organization',
+                    jobTitle: 'Software Engineer',
+                    howDidYouHearAboutUs: '',
+                    enableEmailDomainAccess: false,
+                    isMarketingOptedIn: true,
+                    isTrackingAnonymized: false,
+                });
+                void navigate('/');
+            }}
+        >
+            Complete setup
+        </button>
+    );
+};
+
+const SetupStateProbe = () => {
+    const { user } = useApp();
+    return (
+        <div>
+            {user.data?.isSetupComplete ? 'setup complete' : 'setup incomplete'}
+        </div>
+    );
+};
 
 vi.mock('../../hooks/useServerOrClientFeatureFlag', () => ({
     useServerFeatureFlag: vi.fn(),
@@ -397,6 +431,71 @@ describe('UserCompletionModal', () => {
             await screen.findByText('Organization setup page'),
         ).toBeInTheDocument();
         expect(screen.queryByText('Nearly there...')).not.toBeInTheDocument();
+    });
+
+    it('does not bounce back to organization setup while user setup is completing', async () => {
+        mockFeatureFlag(true);
+        const user = userEvent.setup();
+
+        const scope = nock(BASE_API_URL)
+            .patch('/api/v1/user/me/complete')
+            .delay(100)
+            .reply(200, {
+                status: 'ok',
+                results: {
+                    isSetupComplete: true,
+                    organizationName: 'test organization',
+                },
+            });
+
+        renderWithProviders(
+            <MemoryRouter initialEntries={['/organization-setup']}>
+                <Routes>
+                    <Route
+                        path="/organization-setup"
+                        element={
+                            <>
+                                <CompleteSetupHarness />
+                                <div>Organization setup page</div>
+                            </>
+                        }
+                    />
+                    <Route
+                        path="/"
+                        element={
+                            <>
+                                <UserCompletionModal />
+                                <SetupStateProbe />
+                                <div>Home page</div>
+                            </>
+                        }
+                    />
+                </Routes>
+            </MemoryRouter>,
+            {
+                user: {
+                    isSetupComplete: false,
+                    organizationName: '',
+                },
+            },
+        );
+
+        await user.click(
+            await screen.findByRole('button', { name: 'Complete setup' }),
+        );
+
+        expect(await screen.findByText('Home page')).toBeInTheDocument();
+        expect(await screen.findByText('setup incomplete')).toBeInTheDocument();
+        expect(
+            screen.queryByText('Organization setup page'),
+        ).not.toBeInTheDocument();
+
+        expect(await screen.findByText('setup complete')).toBeInTheDocument();
+        await waitFor(() => expect(scope.isDone()).toBe(true));
+        expect(screen.getByText('Home page')).toBeInTheDocument();
+        expect(
+            screen.queryByText('Organization setup page'),
+        ).not.toBeInTheDocument();
     });
 
     it('still redirects to organization setup when telemetry is disabled', async () => {

--- a/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.tsx
+++ b/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.tsx
@@ -9,6 +9,7 @@ import {
 import { Button, Checkbox, Select, Stack, TextInput } from '@mantine-8/core';
 import { useForm } from '@mantine/form';
 import { IconConfetti } from '@tabler/icons-react';
+import { useIsMutating } from '@tanstack/react-query';
 import { zodResolver } from 'mantine-form-zod-resolver';
 import { useEffect, useMemo, type FC } from 'react';
 import { Navigate, useLocation } from 'react-router';
@@ -196,6 +197,8 @@ const UserCompletionModalWithUser = () => {
     const { user, health } = useApp();
     const location = useLocation();
     const orgSetupPageFlag = useServerFeatureFlag(FeatureFlags.NewOnboarding);
+    const isCompletingUser =
+        useIsMutating({ mutationKey: ['user_complete'] }) > 0;
 
     if (orgSetupPageFlag.isLoading) {
         return null;
@@ -203,7 +206,10 @@ const UserCompletionModalWithUser = () => {
 
     if (orgSetupPageFlag.data?.enabled) {
         const shouldSetup =
-            user.data && !user.data.isSetupComplete && health.isSuccess;
+            user.data &&
+            !user.data.isSetupComplete &&
+            health.isSuccess &&
+            !isCompletingUser;
         // Keyed by pathname so the redirect re-fires if a competing route
         // redirect (e.g. AppRoute's needsProject -> /createProject) wins the
         // same render commit.

--- a/packages/frontend/src/hooks/user/useUserCompleteMutation.test.tsx
+++ b/packages/frontend/src/hooks/user/useUserCompleteMutation.test.tsx
@@ -1,0 +1,72 @@
+import { Ability } from '@casl/ability';
+import { useQueryClient } from '@tanstack/react-query';
+import { waitFor } from '@testing-library/react';
+import nock from 'nock';
+import { describe, expect, it, vi } from 'vitest';
+import { BASE_API_URL } from '../../api';
+import { renderHookWithProviders } from '../../testing/testUtils';
+import { type UserWithAbility } from './useUser';
+import { useUserCompleteMutation } from './useUserCompleteMutation';
+
+describe('useUserCompleteMutation', () => {
+    it('writes the completed user into the user cache and keeps client-side fields', async () => {
+        const { result } = renderHookWithProviders(
+            () => ({
+                mutation: useUserCompleteMutation(),
+                queryClient: useQueryClient(),
+            }),
+            {
+                user: {
+                    isSetupComplete: false,
+                    organizationName: '',
+                },
+            },
+        );
+
+        await waitFor(() =>
+            expect(
+                result.current.queryClient.getQueryData<UserWithAbility>([
+                    'user',
+                ])?.isSetupComplete,
+            ).toBe(false),
+        );
+
+        const invalidateSpy = vi.spyOn(
+            result.current.queryClient,
+            'invalidateQueries',
+        );
+
+        const scope = nock(BASE_API_URL)
+            .patch('/api/v1/user/me/complete')
+            .reply(200, {
+                status: 'ok',
+                results: {
+                    isSetupComplete: true,
+                    organizationName: 'New organization',
+                },
+            });
+
+        result.current.mutation.mutate({
+            organizationName: 'New organization',
+            jobTitle: 'Software Engineer',
+            howDidYouHearAboutUs: '',
+            enableEmailDomainAccess: false,
+            isMarketingOptedIn: true,
+            isTrackingAnonymized: false,
+        });
+
+        await waitFor(() =>
+            expect(result.current.mutation.isSuccess).toBe(true),
+        );
+        expect(scope.isDone()).toBe(true);
+
+        const cachedUser =
+            result.current.queryClient.getQueryData<UserWithAbility>(['user']);
+        expect(cachedUser?.isSetupComplete).toBe(true);
+        expect(cachedUser?.organizationName).toBe('New organization');
+        expect(cachedUser?.ability).toBeInstanceOf(Ability);
+        expect(cachedUser?.impersonation).toBeNull();
+        expect(invalidateSpy).toHaveBeenCalledWith(['organization']);
+        expect(invalidateSpy).not.toHaveBeenCalledWith(['user']);
+    });
+});

--- a/packages/frontend/src/hooks/user/useUserCompleteMutation.ts
+++ b/packages/frontend/src/hooks/user/useUserCompleteMutation.ts
@@ -5,6 +5,7 @@ import {
 } from '@lightdash/common';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { lightdashApi } from '../../api';
+import { type UserWithAbility } from './useUser';
 
 const completeUserQuery = async (data: CompleteUserArgs) =>
     lightdashApi<LightdashUser>({
@@ -25,8 +26,14 @@ export const useUserCompleteMutation = (
         completeUserQuery,
         {
             mutationKey: ['user_complete'],
-            onSuccess: async () => {
-                await queryClient.invalidateQueries(['user']);
+            onSuccess: async (completedUser) => {
+                queryClient.setQueryData<UserWithAbility>(
+                    ['user'],
+                    (currentUser) =>
+                        currentUser
+                            ? { ...currentUser, ...completedUser }
+                            : currentUser,
+                );
                 await queryClient.invalidateQueries(['organization']);
                 options?.onSuccess?.();
             },

--- a/packages/frontend/src/pages/OrganizationSetup.test.tsx
+++ b/packages/frontend/src/pages/OrganizationSetup.test.tsx
@@ -13,19 +13,34 @@ vi.mock('../hooks/useServerOrClientFeatureFlag', () => ({
     useServerFeatureFlag: vi.fn(),
 }));
 
-const renderSetupPage = (mocks?: Parameters<typeof renderWithProviders>[1]) =>
+const renderSetupPage = (
+    mocks?: Parameters<typeof renderWithProviders>[1],
+    initialEntry = '/organization-setup',
+) =>
     renderWithProviders(
-        <MemoryRouter initialEntries={['/organization-setup']}>
+        <MemoryRouter initialEntries={[initialEntry]}>
             <Routes>
                 <Route
                     path="/organization-setup"
                     element={<OrganizationSetup />}
+                />
+                <Route
+                    path="/onboarding/data-source"
+                    element={<div>Data source page</div>}
                 />
                 <Route path="/" element={<div>Home page</div>} />
             </Routes>
         </MemoryRouter>,
         mocks,
     );
+
+const mockOrgApi = (name: string, { optional = false } = {}) => {
+    const interceptor = nock(BASE_API_URL).get('/api/v1/org');
+    if (optional) {
+        interceptor.optionally();
+    }
+    return interceptor.reply(200, { status: 'ok', results: { name } });
+};
 
 const selectRole = async (user: ReturnType<typeof userEvent.setup>) => {
     const roleSelect = await screen.findByPlaceholderText('Select your role');
@@ -45,6 +60,7 @@ describe('OrganizationSetup', () => {
     it('submits an empty referral answer when a user joining an existing organization skips it', async () => {
         const user = userEvent.setup();
 
+        mockOrgApi('test organization');
         renderSetupPage({
             user: {
                 isSetupComplete: false,
@@ -95,6 +111,7 @@ describe('OrganizationSetup', () => {
     it('submits the trimmed referral answer when a user creating an organization answers it', async () => {
         const user = userEvent.setup();
 
+        mockOrgApi('');
         renderSetupPage({
             user: {
                 isSetupComplete: false,
@@ -142,5 +159,73 @@ describe('OrganizationSetup', () => {
 
         await waitFor(() => expect(scope.isDone()).toBe(true));
         await waitFor(() => expect(brandScope.isDone()).toBe(true));
+    });
+
+    it('skips the workspace step when the organization is already named', async () => {
+        const user = userEvent.setup();
+
+        mockOrgApi('test organization');
+        renderSetupPage({
+            user: {
+                isSetupComplete: false,
+                organizationName: '',
+                email: 'demo@lightdash.com',
+            },
+            health: {
+                mode: LightdashMode.DEFAULT,
+            },
+        });
+
+        expect(
+            await screen.findByText('Tell us about you'),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByPlaceholderText('Acme Analytics'),
+        ).not.toBeInTheDocument();
+
+        await selectRole(user);
+
+        const scope = nock(BASE_API_URL)
+            .patch('/api/v1/user/me/complete', {
+                jobTitle: 'Software Engineer',
+                howDidYouHearAboutUs: '',
+                enableEmailDomainAccess: false,
+                isMarketingOptedIn: true,
+                isTrackingAnonymized: false,
+            })
+            .reply(200);
+
+        await user.click(await screen.findByRole('button', { name: 'Finish' }));
+
+        await waitFor(() => expect(scope.isDone()).toBe(true));
+    });
+
+    it('redirects to the redirect target when setup is already complete', async () => {
+        mockOrgApi('test organization', { optional: true });
+        renderSetupPage(
+            {
+                user: {
+                    isSetupComplete: true,
+                },
+            },
+            '/organization-setup?redirect=%2Fonboarding%2Fdata-source',
+        );
+
+        expect(await screen.findByText('Data source page')).toBeInTheDocument();
+        expect(screen.queryByText('Home page')).not.toBeInTheDocument();
+    });
+
+    it('falls back to home when the redirect target is the setup page itself', async () => {
+        mockOrgApi('test organization', { optional: true });
+        renderSetupPage(
+            {
+                user: {
+                    isSetupComplete: true,
+                },
+            },
+            '/organization-setup?redirect=%2Forganization-setup',
+        );
+
+        expect(await screen.findByText('Home page')).toBeInTheDocument();
     });
 });

--- a/packages/frontend/src/pages/OrganizationSetup.tsx
+++ b/packages/frontend/src/pages/OrganizationSetup.tsx
@@ -28,6 +28,7 @@ import AboutFooter from '../components/AboutFooter';
 import { DocumentTitle } from '../components/common/DocumentTitle';
 import PageSpinner from '../components/PageSpinner';
 import { jobTitles } from '../components/UserCompletionModal/jobTitles';
+import { useOrganization } from '../hooks/organization/useOrganization';
 import {
     useDetectOrganizationBrand,
     useSaveOrganizationBrand,
@@ -115,15 +116,18 @@ type OrganizationSetupFormValues = {
 type OrganizationSetupContentProps = {
     user: UserWithAbility;
     health: HealthState;
+    organizationHasName: boolean;
     completeMutation: ReturnType<typeof useUserCompleteMutation>;
 };
 
 const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
     user,
     health,
+    organizationHasName,
     completeMutation,
 }) => {
-    const canEnterOrganizationName = user.organizationName === '';
+    const canEnterOrganizationName =
+        user.organizationName === '' && !organizationHasName;
     const emailDomain = user.email ? getEmailDomain(user.email) : '';
     const isCompanyDomain =
         !!user.email && !validateOrganizationEmailDomains([emailDomain]);
@@ -245,7 +249,7 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
             properties: { step: 'about_you' },
         });
 
-        if (user.organizationName) {
+        if (!canEnterOrganizationName) {
             // Joining an existing org: no org name to set, and the brand
             // belongs to the org (which a joiner — often a viewer — has no
             // rights to change), so don't attempt to save it.
@@ -533,10 +537,14 @@ const OrganizationSetup: FC = () => {
     const redirectTo =
         redirectParam &&
         redirectParam.startsWith('/') &&
-        !redirectParam.startsWith('//')
+        !redirectParam.startsWith('//') &&
+        !redirectParam.startsWith('/organization-setup')
             ? redirectParam
             : '/';
     const orgSetupPageFlag = useServerFeatureFlag(FeatureFlags.NewOnboarding);
+    const organization = useOrganization({
+        enabled: !!user.data?.organizationUuid,
+    });
     const completeMutation = useUserCompleteMutation({
         onSuccess: () => void navigate(redirectTo),
     });
@@ -564,11 +572,15 @@ const OrganizationSetup: FC = () => {
     }
 
     if (user.data.isSetupComplete && !isCompletingSetup) {
-        return <Navigate to="/" />;
+        return <Navigate to={redirectTo} />;
     }
 
     if (!orgSetupPageFlag.data?.enabled) {
         return <Navigate to="/" />;
+    }
+
+    if (organization.isInitialLoading) {
+        return <PageSpinner />;
     }
 
     return (
@@ -576,6 +588,7 @@ const OrganizationSetup: FC = () => {
             key={user.data.userUuid}
             user={user.data}
             health={health.data}
+            organizationHasName={!!organization.data?.name}
             completeMutation={completeMutation}
         />
     );


### PR DESCRIPTION
## Summary

With the new-onboarding flow enabled, completing the organization setup wizard could bounce the user back to `/organization-setup` and restart the wizard, because the setup-completion state was read from a stale cache during navigation.

## Changes

- `useUserCompleteMutation` now writes the updated user returned by the API directly into the user query cache (merging so client-side fields like the CASL ability are preserved) instead of awaiting an invalidation that can resolve without refetching when the query is unmounted. The organization invalidation is kept.
- The organization-setup redirect guard no longer fires while a `user_complete` mutation is pending or settling.
- `OrganizationSetup` honors the `redirect` query param when setup is already complete (with a guard against redirecting to itself), and skips the workspace-name step when the organization is already named, using the organization query as the fresh signal.
- Unit tests covering the cache write, the in-flight guard, redirect handling, and the skipped workspace step.

Linear: SPK-720
Closes: SPK-720

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6Fe8gq6uF9Wu3Btq2Aan8