### PR TITLE
fix(homepage-builder): make the Resources list layout scannable

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.test.tsx
@@ -154,6 +154,83 @@ describe('ResourcesBlockView', () => {
         });
     });
 
+    describe('list layout scan hierarchy', () => {
+        it('carries kind in the leading glyph, not a trailing pill', () => {
+            wrap(
+                <ResourcesBlockView
+                    itemSpan={null}
+                    projectUuid="p1"
+                    block={block({
+                        layout: 'list',
+                        items: [
+                            {
+                                url: 'https://example.com/handbook',
+                                kind: 'doc' as const,
+                                title: 'How we define revenue',
+                                description: 'Metric definitions',
+                            },
+                        ],
+                    })}
+                />,
+            );
+            expect(
+                screen.getByText('How we define revenue'),
+            ).toBeInTheDocument();
+            // The pill repeated what the glyph already says, from the far edge.
+            expect(screen.queryByText('Doc')).not.toBeInTheDocument();
+        });
+
+        it('does not put a hero image in the 34px leading slot', () => {
+            wrap(
+                <ResourcesBlockView
+                    itemSpan={null}
+                    projectUuid="p1"
+                    block={block({
+                        layout: 'list',
+                        items: [
+                            {
+                                url: 'https://www.youtube.com/watch?v=abc',
+                                kind: 'youtube' as const,
+                                title: 'Reading the funnel report',
+                                imageUrl: 'https://i.ytimg.com/vi/abc/hq.jpg',
+                            },
+                        ],
+                    })}
+                />,
+            );
+            // A 16:9 still cropped to 34px is a smudge; the favicon identifies
+            // the source instead.
+            const sources = screen
+                .queryAllByRole('img')
+                .map((img) => img.getAttribute('src'));
+            expect(sources).not.toContain('https://i.ytimg.com/vi/abc/hq.jpg');
+        });
+
+        it('still shows a hero image in the card layout', () => {
+            wrap(
+                <ResourcesBlockView
+                    itemSpan={null}
+                    projectUuid="p1"
+                    block={block({
+                        layout: 'card',
+                        items: [
+                            {
+                                url: 'https://www.youtube.com/watch?v=abc',
+                                kind: 'youtube' as const,
+                                title: 'Reading the funnel report',
+                                imageUrl: 'https://i.ytimg.com/vi/abc/hq.jpg',
+                            },
+                        ],
+                    })}
+                />,
+            );
+            expect(screen.getByRole('img')).toHaveAttribute(
+                'src',
+                'https://i.ytimg.com/vi/abc/hq.jpg',
+            );
+        });
+    });
+
     it('renders nothing when there are no items', () => {
         wrap(
             <ResourcesBlockView

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.test.tsx
@@ -180,7 +180,7 @@ describe('ResourcesBlockView', () => {
             expect(screen.queryByText('Doc')).not.toBeInTheDocument();
         });
 
-        it('does not put a hero image in the 34px leading slot', () => {
+        it('uses one monochrome glyph family — no hero images, no brand favicons', () => {
             wrap(
                 <ResourcesBlockView
                     itemSpan={null}
@@ -194,16 +194,19 @@ describe('ResourcesBlockView', () => {
                                 title: 'Reading the funnel report',
                                 imageUrl: 'https://i.ytimg.com/vi/abc/hq.jpg',
                             },
+                            {
+                                url: 'https://example.com/handbook',
+                                kind: 'doc' as const,
+                                title: 'How we define revenue',
+                            },
                         ],
                     })}
                 />,
             );
-            // A 16:9 still cropped to 34px is a smudge; the favicon identifies
-            // the source instead.
-            const sources = screen
-                .queryAllByRole('img')
-                .map((img) => img.getAttribute('src'));
-            expect(sources).not.toContain('https://i.ytimg.com/vi/abc/hq.jpg');
+            // A cropped 16:9 still is a smudge at 34px, and a saturated brand
+            // favicon is a hotspot in a row of grey glyphs. Every row gets the
+            // same neutral square instead.
+            expect(screen.queryAllByRole('img')).toHaveLength(0);
         });
 
         it('still shows a hero image in the card layout', () => {

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
@@ -216,22 +216,11 @@ const CardThumb: FC<{ item: HomepageResourceItem; projectUuid: string }> = ({
         <UrlCardThumb item={item} />
     );
 
+// No hero image in the leading slot: a 16:9 still cropped to 34px is a smudge,
+// not an identifier. The favicon says which site this is, and the kind glyph
+// says what it is — either is legible at this size, an image crop isn't.
 const UrlRowThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => {
-    const [imgFailed, setImgFailed] = useState(false);
     const [faviconFailed, setFaviconFailed] = useState(false);
-    const imageUrl = safeImageUrl(item.imageUrl);
-    if (imageUrl && item.kind !== 'claude' && !imgFailed) {
-        return (
-            <div className={classes.rowThumb}>
-                <img
-                    src={imageUrl}
-                    alt=""
-                    loading="lazy"
-                    onError={() => setImgFailed(true)}
-                />
-            </div>
-        );
-    }
     const favicon = faviconUrl(item.url);
     if (favicon && !faviconFailed) {
         return (
@@ -314,11 +303,16 @@ const ResourceCard: FC<{
     );
 };
 
+// The list layout exists for blocks with more items than a card grid can
+// carry — which is exactly when scanning matters. So: the name is the only
+// primary thing on the row, the description is one truncated supporting line,
+// and kind is carried once by the glyph on the left rather than twice (the
+// trailing pill used to repeat it from the far edge, where nothing else was).
+// The external-link arrow still marks what leaves Lightdash.
 const ResourceRow: FC<{ item: HomepageResourceItem; projectUuid: string }> = ({
     item,
     projectUuid,
 }) => {
-    const meta = kindMeta(item.kind);
     const dataApp = isDataApp(item);
     return (
         <a
@@ -330,11 +324,10 @@ const ResourceRow: FC<{ item: HomepageResourceItem; projectUuid: string }> = ({
             <RowThumb item={item} projectUuid={projectUuid} />
             <div className={classes.flexFill}>
                 <div className={classes.rowName}>{item.title}</div>
-                <div className={classes.rowMeta}>
+                <div className={classes.rowDesc}>
                     {item.description || (dataApp ? '' : hostnameOf(item.url))}
                 </div>
             </div>
-            <MiniPill>{meta.label}</MiniPill>
             {!dataApp && (
                 <MantineIcon
                     icon={IconExternalLink}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
@@ -216,31 +216,19 @@ const CardThumb: FC<{ item: HomepageResourceItem; projectUuid: string }> = ({
         <UrlCardThumb item={item} />
     );
 
-// No hero image in the leading slot: a 16:9 still cropped to 34px is a smudge,
-// not an identifier. The favicon says which site this is, and the kind glyph
-// says what it is — either is legible at this size, an image crop isn't.
-const UrlRowThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => {
-    const [faviconFailed, setFaviconFailed] = useState(false);
-    const favicon = faviconUrl(item.url);
-    if (favicon && !faviconFailed) {
-        return (
-            <div className={`${classes.rowThumb} ${classes.rowThumbFallback}`}>
-                <img
-                    className={classes.rowFavicon}
-                    src={favicon}
-                    alt=""
-                    loading="lazy"
-                    onError={() => setFaviconFailed(true)}
-                    onLoad={(e) => {
-                        if (isDefaultFavicon(e.currentTarget))
-                            setFaviconFailed(true);
-                    }}
-                />
-            </div>
-        );
-    }
-    return <IconSquare icon={kindMeta(item.kind).icon} />;
-};
+// One glyph family for the whole dense list: the monochrome kind icon in a
+// neutral square, every row identical in weight and colour.
+//
+// Not a hero image — a 16:9 still cropped to 34px is a smudge, not an
+// identifier. And not a favicon either: a saturated brand tile (YouTube's red
+// is the worst offender) is a hotspot in a row of grey glyphs, and it pulls the
+// eye to whichever item happens to be branded rather than to what matters.
+// Kind is what a scanner needs at this size; the hostname is still in the
+// supporting line for links without a description. The card layout keeps
+// favicons, where there's room for brand recognition to be worth its colour.
+const UrlRowThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => (
+    <IconSquare icon={kindMeta(item.kind).icon} />
+);
 
 const RowThumb: FC<{ item: HomepageResourceItem; projectUuid: string }> = ({
     item,

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -668,17 +668,6 @@ a .hoverCard:hover,
     display: block;
 }
 
-.rowThumbFallback {
-    display: grid;
-    place-items: center;
-}
-
-.rowFavicon {
-    width: 20px;
-    height: 20px;
-    object-fit: contain;
-}
-
 /* Skeletons while a pasted link resolves */
 .skeletonBlock,
 .skeletonLine {

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -241,13 +241,31 @@ a .hoverCard:hover,
 }
 
 .rowName {
-    font-size: 13.5px;
-    font-weight: 500;
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 1.35;
+    /* The name is the thing being scanned: never let it wrap and push the
+     * supporting line around. */
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .rowMeta {
     font-size: 12px;
     color: var(--mantine-color-ldGray-6);
+}
+
+/* The supporting line under a name in the list layout. One line, always: a
+ * wrapped sentence outweighs the name it is supporting and makes row heights
+ * ragged, so a list of ten stops being scannable. */
+.rowDesc {
+    font-size: 12px;
+    line-height: 1.35;
+    color: var(--mantine-color-ldGray-6);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .rowAside {


### PR DESCRIPTION
Closes #26438

Stacked on #26446.

## What

The `list` layout exists for blocks with more items than a card grid can carry — which is exactly when scanning matters most. It wasn't faster to scan than the card layout, so it had no reason to exist.

Three things were competing with the name:

| | Before | After |
|---|---|---|
| Name | 13.5px / 500 | **14px / 600**, never wraps |
| Description | 12px / 400, wrapped freely | 12px / 400, **one line + ellipsis** |
| Kind | leading glyph **and** a trailing pill | leading glyph only |

The pill sat at the far right repeating what the glyph already said, from an edge nothing else occupied. The external-link arrow still marks what leaves Lightdash, so internal vs external stays legible without it.

**One monochrome glyph family in the leading slot.** Two things were wrong there:

- A hero image cropped to 34px is a smudge, not an identifier — in the before screenshot a YouTube row renders as a grey blur where its glyph should be.
- A favicon puts a saturated brand tile in a row of neutral grey glyphs. YouTube's red is the worst offender: it reads as a hotspot and pulls the eye to whichever item happens to be branded rather than to whatever matters. In a dense list that's an eyesore, and it defeats the point of the layout.

So every row now gets the same monochrome kind icon in the same neutral square — same weight, same colour, one glyph per kind. Kind is what a scanner needs at 34px; the hostname is still in the supporting line for links without a description. The `card` layout keeps both hero images and favicons on the kind-tinted wash, where there's room for brand recognition to be worth its colour.

## Measurements (1440×900, five-item mixed block)

| | Before | After |
|---|---|---|
| Row heights | 59, 59, 59, 59, **74** — ragged | **57, 58, 58, 58, 58** |
| Description lines | 1–2, depending on text | always 1, truncating |
| Rows with a legible leading glyph | 4 of 5 | **5 of 5** |
| Distinct glyph treatments in one list | 3 (grey square, brand favicon, image crop) | **1** |

The 74px row is the point: one long description in a list makes that row 25% taller than its neighbours, and a list of ten stops reading as a list.

## Regression analysis

- **`.rowMeta` is untouched.** The description moved to a new `.rowDesc` class rather than restyling `.rowMeta`, because `.rowMeta` is shared with `ContentCard`'s kind/views line — adding `nowrap` + `overflow: hidden` there would have quietly changed collection and day-0 cards too. Nothing outside the Resources list picks up `.rowDesc`.
- **The card layout is unchanged** — verified by a test asserting a hero image still renders there. Only `UrlRowThumb` (list) dropped the image branch.
- **Dead CSS removed**: `.rowThumbFallback` and `.rowFavicon` had no remaining consumers once the list stopped rendering favicons; confirmed by grep before deleting.
- **`safeImageUrl` is still used** by `UrlCardThumb`, so the URL-safety check on stored `imageUrl` values hasn't been bypassed; the list simply no longer reaches for it.
- **No config or type changes**, nothing to migrate. `HomepageResourceItem` still carries `imageUrl`; the list just doesn't render it.
- **`MiniPill` is still used** by the builder's `KindControl`, so removing it from the row didn't orphan the component.

## Tests

3 new: kind is not repeated as a trailing pill in list layout, one monochrome glyph family in list layout (asserts zero `img` elements across a branded + unbranded pair), hero image still shown in card layout. Full homepage-builder suite green: 19 files / 193 tests.
