### PR TITLE
fix(backend): enforce custom SQL permissions on the query run path

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -4,6 +4,8 @@ import {
     AnyType,
     ChartType,
     CreateWarehouseCredentials,
+    CustomDimensionType,
+    CustomSqlQueryForbiddenError,
     DimensionType,
     DownloadFileType,
     ExecuteAsyncQueryRequestParams,
@@ -22,6 +24,7 @@ import {
     VizIndexType,
     WarehouseClient,
     WarehouseTypes,
+    type CustomSqlDimension,
     type Explore,
     type ItemsMap,
     type MetricQuery,
@@ -1548,6 +1551,106 @@ describe('AsyncQueryService', () => {
                 }),
                 expect.any(Object),
             );
+        });
+
+        describe('custom SQL authorization', () => {
+            const viewerAccount = {
+                ...sessionAccount,
+                user: {
+                    ...sessionAccount.user,
+                    ability: new Ability<PossibleAbilities>([
+                        { subject: 'Project', action: ['view'] },
+                        { subject: 'Explore', action: ['view', 'manage'] },
+                    ]),
+                },
+            } as unknown as Account;
+
+            const customSqlDimension: CustomSqlDimension = {
+                id: 'custom_sql_dim',
+                name: 'Custom SQL dimension',
+                type: CustomDimensionType.SQL,
+                table: validExplore.baseTable,
+                sql: '1',
+                dimensionType: DimensionType.NUMBER,
+            };
+
+            test('rejects custom SQL dimensions when the account lacks manage:CustomFields', async () => {
+                const service = getMockedAsyncQueryService(lightdashConfigMock);
+
+                await expect(
+                    service.executeAsyncMetricQuery({
+                        account: viewerAccount,
+                        projectUuid,
+                        metricQuery: {
+                            ...metricQueryMock,
+                            tableCalculations: [],
+                            customDimensions: [customSqlDimension],
+                        },
+                        context: QueryExecutionContext.EXPLORE,
+                    }),
+                ).rejects.toThrow(CustomSqlQueryForbiddenError);
+            });
+
+            test('rejects SQL table calculations when the account lacks manage:CustomSqlTableCalculations', async () => {
+                const service = getMockedAsyncQueryService(lightdashConfigMock);
+
+                await expect(
+                    service.executeAsyncMetricQuery({
+                        account: viewerAccount,
+                        projectUuid,
+                        metricQuery: metricQueryMock,
+                        context: QueryExecutionContext.EXPLORE,
+                    }),
+                ).rejects.toThrow(CustomSqlQueryForbiddenError);
+            });
+
+            test('allows custom SQL dimensions when the account can manage custom fields', async () => {
+                const service = getMockedAsyncQueryService(lightdashConfigMock);
+                service.getExploreWithUserAccessControls = vi
+                    .fn()
+                    .mockResolvedValue({
+                        explore: validExplore,
+                        userAccessControls: {
+                            userAttributes: {},
+                            intrinsicUserAttributes: {},
+                        },
+                    });
+                (service as AnyType).getWarehouseCredentials = vi
+                    .fn()
+                    .mockResolvedValue(warehouseClientMock.credentials);
+                service.combineParameters = vi
+                    .fn()
+                    .mockResolvedValue(undefined);
+                (service as AnyType).prepareMetricQueryAsyncQueryArgs = vi
+                    .fn()
+                    .mockResolvedValue(
+                        createQueryComposerMock({
+                            userAccessControls: {
+                                userAttributes: {},
+                                intrinsicUserAttributes: {},
+                            },
+                            availableParameterDefinitions: {},
+                        }),
+                    );
+                service['executeAsyncQuery'] = vi.fn().mockResolvedValue({
+                    queryUuid: 'queryUuid',
+                    cacheMetadata: { cacheHit: false },
+                });
+
+                await expect(
+                    service.executeAsyncMetricQuery({
+                        account: sessionAccount,
+                        projectUuid,
+                        metricQuery: {
+                            ...metricQueryMock,
+                            customDimensions: [customSqlDimension],
+                        },
+                        context: QueryExecutionContext.EXPLORE,
+                    }),
+                ).resolves.toEqual(
+                    expect.objectContaining({ queryUuid: 'queryUuid' }),
+                );
+            });
         });
 
         test('attaches required pre-aggregate routing metadata for direct pre-aggregate explores', async () => {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -17,7 +17,6 @@ import {
     CalculateTotalFromQuery,
     CompiledDimension,
     CreateWarehouseCredentials,
-    CustomSqlQueryForbiddenError,
     DashboardFilters,
     DashboardPreAggregateAudit,
     DEFAULT_RESULTS_PAGE_SIZE,
@@ -147,6 +146,7 @@ import type { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { traceSpan } from '../../tracing/tracing';
 import { wrapSentryTransaction } from '../../utils';
 import { metricQueryWithLimit as applyMetricQueryLimit } from '../../utils/csvLimitUtils';
+import { assertCanRunCustomSqlInMetricQuery } from '../../utils/customSqlPermissions';
 import {
     processFieldsForExport,
     streamJsonlData,
@@ -4377,6 +4377,13 @@ export class AsyncQueryService extends ProjectService {
         if (isForbidden) {
             throw new ForbiddenError();
         }
+
+        assertCanRunCustomSqlInMetricQuery({
+            ability: auditedAbility,
+            metricQuery: inputMetricQuery,
+            organizationUuid,
+            projectUuid,
+        });
 
         return this.runAsyncMetricQueryWithoutPermissionCheck(
             args,

--- a/packages/backend/src/services/GdriveService/GdriveService.ts
+++ b/packages/backend/src/services/GdriveService/GdriveService.ts
@@ -1,10 +1,8 @@
 import { subject } from '@casl/ability';
 import {
     Account,
-    CustomSqlQueryForbiddenError,
     ForbiddenError,
     GoogleNotConnectedError,
-    isCustomSqlDimension,
     NotFoundError,
     OpenIdIdentityIssuerType,
     ParameterError,

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -61,6 +61,8 @@ export const user: SessionUser = {
         { subject: 'Job', action: ['view'] },
         { subject: 'SqlRunner', action: ['manage'] },
         { subject: 'Explore', action: ['manage'] },
+        { subject: 'CustomFields', action: ['manage'] },
+        { subject: 'CustomSqlTableCalculations', action: ['manage'] },
     ]),
     isActive: true,
     abilityRules: [],

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -44,7 +44,6 @@ import {
     CreateWarehouseCredentials,
     currentUtcWallClock,
     CustomFormatType,
-    CustomSqlQueryForbiddenError,
     DashboardAvailableFilters,
     DashboardBasicDetails,
     DashboardFilters,
@@ -276,6 +275,7 @@ import { CachedWarehouse, ProjectAdapter } from '../../types';
 import { runWorkerThread, wrapSentryTransaction } from '../../utils';
 import { buildCacheHash, getCacheUserUuid } from '../../utils/cacheUtils';
 import { metricQueryWithLimit as applyMetricQueryLimit } from '../../utils/csvLimitUtils';
+import { assertCanRunCustomSqlInMetricQuery } from '../../utils/customSqlPermissions';
 import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
 import { PivotQueryBuilder } from '../../utils/QueryBuilder/PivotQueryBuilder';
 import { QueryComposer } from '../../utils/QueryBuilder/QueryComposer';
@@ -4869,6 +4869,13 @@ export class ProjectService extends BaseService {
             throw new ForbiddenError();
         }
 
+        assertCanRunCustomSqlInMetricQuery({
+            ability: auditedAbility,
+            metricQuery,
+            organizationUuid,
+            projectUuid,
+        });
+
         const queryTags: RunQueryTags = {
             ...this.getUserQueryTags(account),
             organization_uuid: organizationUuid,
@@ -5185,6 +5192,13 @@ export class ProjectService extends BaseService {
         ) {
             throw new ForbiddenError();
         }
+
+        assertCanRunCustomSqlInMetricQuery({
+            ability: auditedAbility,
+            metricQuery,
+            organizationUuid,
+            projectUuid,
+        });
 
         const queryTags: RunQueryTags = {
             ...this.getUserQueryTags(account),

--- a/packages/backend/src/utils/customSqlPermissions.ts
+++ b/packages/backend/src/utils/customSqlPermissions.ts
@@ -1,0 +1,57 @@
+import { subject } from '@casl/ability';
+import type { Ability } from '@casl/ability';
+import {
+    CustomSqlQueryForbiddenError,
+    isCustomSqlDimension,
+    isSqlTableCalculation,
+    type MetricQuery,
+} from '@lightdash/common';
+import type { CaslAuditWrapper } from '../logging/caslAuditWrapper';
+
+/**
+ * Custom SQL dimensions and SQL table calculations inject raw SQL into the
+ * compiled query, so running a client-supplied metric query that contains them
+ * requires the same abilities that gate saving them.
+ */
+export const assertCanRunCustomSqlInMetricQuery = ({
+    ability,
+    metricQuery,
+    organizationUuid,
+    projectUuid,
+}: {
+    ability: CaslAuditWrapper<Ability>;
+    metricQuery: Pick<MetricQuery, 'customDimensions' | 'tableCalculations'>;
+    organizationUuid: string;
+    projectUuid: string;
+}) => {
+    const hasCustomSqlDimension = (metricQuery.customDimensions ?? []).some(
+        isCustomSqlDimension,
+    );
+    if (
+        hasCustomSqlDimension &&
+        ability.cannot(
+            'manage',
+            subject('CustomFields', { organizationUuid, projectUuid }),
+        )
+    ) {
+        throw new CustomSqlQueryForbiddenError();
+    }
+
+    const hasSqlTableCalculation = (metricQuery.tableCalculations ?? []).some(
+        isSqlTableCalculation,
+    );
+    if (
+        hasSqlTableCalculation &&
+        ability.cannot(
+            'manage',
+            subject('CustomSqlTableCalculations', {
+                organizationUuid,
+                projectUuid,
+            }),
+        )
+    ) {
+        throw new CustomSqlQueryForbiddenError(
+            'User cannot run queries with SQL table calculations',
+        );
+    }
+};


### PR DESCRIPTION
Closes: #12045 (partially — see below)

### Description:

`manage:CustomFields` / `manage:CustomSqlTableCalculations` were only enforced when *saving* a chart (and in the frontend). Nothing checked them at query execution time, so any user who could view an explore could POST a `metricQuery` containing arbitrary custom SQL dimensions or SQL table calculations and have that SQL compiled and run against the warehouse — bypassing the developer-only restriction and potentially row-level security. Reachable directly via the API, no UI needed.

This wires up `CustomSqlQueryForbiddenError`, which existed but was never thrown anywhere.

New shared helper [`assertCanRunCustomSqlInMetricQuery`](https://github.com/lightdash/lightdash/blob/e7b25be47/packages/backend/src/utils/customSqlPermissions.ts) is called on the three paths that take a client-supplied `metricQuery`:

- `AsyncQueryService.executeAsyncMetricQuery` (v2 `POST /query/metric-query`)
- `ProjectService.runExploreQuery` and `runUnderlyingDataQuery` (deprecated v1 endpoints)

Saved chart, dashboard chart and the v2 underlying-data paths build the `metricQuery` server-side (underlying-data re-derives custom dimensions from the stored query), so viewers can still run and drill into saved charts that contain custom SQL — only ad-hoc client-supplied SQL is gated.

Note the gsheet export path also routes through `executeAsyncMetricQuery`, so it's covered too — that's where the unused `CustomSqlQueryForbiddenError` import in `GdriveService` came from; the now-dead imports are removed.

The `#12045` feature request (letting interactive viewers run custom dimensions from a saved chart) is *not* implemented here — this only makes the backend match the intended restriction it assumed was already in place.

Tests: three cases in `AsyncQueryService.test.ts` covering rejection for custom SQL dimensions, rejection for SQL table calculations, and the allowed developer case. The shared `user` mock gains the two abilities an admin actually has.
