### PR TITLE
feat(homepage-builder): lead day-0 with the project's key spaces

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.test.tsx
@@ -4,8 +4,26 @@ import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { DayOneHomepage } from './DayOneHomepage';
 
-const { aiState } = vi.hoisted(() => ({
+const { aiState, keySpaces, recentContents } = vi.hoisted(() => ({
     aiState: { current: { canAskAi: true } },
+    keySpaces: {
+        current: [
+            { uuid: 'space-1', name: 'Finance', itemCount: 12, isPinned: true },
+        ],
+    },
+    recentContents: { current: { contents: [{ uuid: 'recent-1' }] } },
+}));
+
+vi.mock('./hooks/useKeySpaces', () => ({
+    useKeySpaces: () => ({ spaces: keySpaces.current, isLoading: false }),
+}));
+
+vi.mock('./hooks/useRecentContents', () => ({
+    useRecentContents: () => ({
+        recents: [],
+        contents: recentContents.current.contents,
+        isLoading: false,
+    }),
 }));
 
 vi.mock('./hooks/useHomepageAiState', () => ({

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.tsx
@@ -7,6 +7,7 @@ import { AskAiHero } from './blocks/AskAiHeroBlock';
 import { BlockHeader } from './blocks/BlockShell';
 import { ContentCard } from './blocks/ContentCard';
 import { PersonalFavoritesBar } from './blocks/FavoritesBlock';
+import { KeySpaces } from './blocks/KeySpaces';
 import { getDefaultQuickActions } from './blocks/quickActionDefaults';
 import { QuickActionCards } from './blocks/QuickActionsBlock';
 import { RecentList } from './blocks/RecentBlock';
@@ -15,6 +16,8 @@ import { getGreeting } from './greeting';
 import layout from './homepageLayout.module.css';
 import { useCollectionContent } from './hooks/useCollectionContent';
 import { useHomepageAiState } from './hooks/useHomepageAiState';
+import { useKeySpaces } from './hooks/useKeySpaces';
+import { useRecentContents } from './hooks/useRecentContents';
 
 type Props = {
     projectUuid: string;
@@ -48,9 +51,18 @@ const PinnedCollection: FC<{
     );
 };
 
+// Four fits one grid row at the page's 3-column span, which is the point: a
+// starting set, not a directory.
+const MAX_KEY_SPACES = 4;
+
 export const DayOneHomepage: FC<Props> = ({ projectUuid, pinnedItems }) => {
     const { user } = useApp();
     const { canAskAi } = useHomepageAiState(projectUuid);
+    const { spaces: keySpaces } = useKeySpaces(projectUuid, MAX_KEY_SPACES);
+    const recent = useRecentContents(projectUuid);
+    // Keep the header while loading so the section doesn't pop in under the
+    // fold once it resolves.
+    const hasRecentlyViewed = recent.isLoading || recent.contents.length > 0;
 
     return (
         <div className={layout.page}>
@@ -99,10 +111,25 @@ export const DayOneHomepage: FC<Props> = ({ projectUuid, pinnedItems }) => {
 
             <div className={classes.secondary}>
                 <Stack gap="xl">
-                    <Box>
-                        <BlockHeader icon={IconClock} title="Recently viewed" />
-                        <RecentList projectUuid={projectUuid} />
-                    </Box>
+                    {/* Spaces lead the body: they're the one section that has
+                        content in any real project. Recently viewed is empty
+                        for a first-time viewer and Pinned is empty until
+                        someone curates, so neither can be the thing a new
+                        viewer is sent to first. */}
+                    <KeySpaces
+                        spaces={keySpaces}
+                        projectUuid={projectUuid}
+                        title="Start here"
+                    />
+                    {hasRecentlyViewed && (
+                        <Box>
+                            <BlockHeader
+                                icon={IconClock}
+                                title="Recently viewed"
+                            />
+                            <RecentList projectUuid={projectUuid} />
+                        </Box>
+                    )}
                     <PinnedCollection
                         projectUuid={projectUuid}
                         pinnedItems={pinnedItems}

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageBuilderPage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageBuilderPage.tsx
@@ -12,6 +12,7 @@ import useApp from '../../../providers/App/useApp';
 import { CreateHomepageModal } from './CreateHomepageModal';
 import { HomepageEditor } from './HomepageEditor';
 import { useHomepageAiState } from './hooks/useHomepageAiState';
+import { useKeySpaces } from './hooks/useKeySpaces';
 import {
     useCreateHomepageWithDraft,
     useHomepageBuilderFlag,
@@ -94,6 +95,7 @@ export const HomepageBuilderPage: FC = () => {
                         contentType: item.type,
                         uuid: item.data.uuid,
                     })),
+                    keySpaces.map((space) => space.uuid),
                 ),
             },
             { onSuccess: openHomepage },
@@ -104,6 +106,7 @@ export const HomepageBuilderPage: FC = () => {
         openHomepage,
         canAskAi,
         pinnedItems,
+        keySpaces,
     ]);
 
     if (isFlagLoading || isAiStateLoading) {

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageBuilderPage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageBuilderPage.tsx
@@ -21,6 +21,9 @@ import {
 } from './hooks/useProjectHomepage';
 import { buildStarterHomepage } from './starterHomepage';
 
+// Matches day-0's cap so the first draft is the page people were looking at.
+const MAX_STARTER_SPACES = 4;
+
 // ts-unused-exports:disable-next-line
 export const HomepageBuilderPage: FC = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
@@ -37,12 +40,14 @@ export const HomepageBuilderPage: FC = () => {
         useHomepageBuilderFlag();
     const { canAskAi, isLoading: isAiStateLoading } =
         useHomepageAiState(projectUuid);
-    // The starter homepage mirrors day-0, which shows the project's pins
+    // The starter homepage mirrors day-0: the project's pins and the same key
+    // spaces day-0 leads its body with.
     const { data: project } = useProject(projectUuid);
     const { data: pinnedItems } = usePinnedItems(
         projectUuid,
         project?.pinnedListUuid,
     );
+    const { spaces: keySpaces } = useKeySpaces(projectUuid, MAX_STARTER_SPACES);
     const homepage = useHomepageForBuilder(projectUuid, {
         enabled: isFlagEnabled,
         homepageUuid: selectedHomepageUuid,

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/KeySpaces.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/KeySpaces.tsx
@@ -1,0 +1,52 @@
+import { Box, Text } from '@mantine-8/core';
+import { IconFolder, IconFolders } from '@tabler/icons-react';
+import { type FC } from 'react';
+import { Link } from 'react-router';
+import { type KeySpace } from '../hooks/rankKeySpaces';
+import { BlockHeader, IconSquare } from './BlockShell';
+import classes from './blockStyles.module.css';
+import { PageGrid, PageGridItem } from './PageGrid';
+
+const itemLabel = (count: number) => `${count} item${count === 1 ? '' : 's'}`;
+
+const KeySpaceCard: FC<{ space: KeySpace; projectUuid: string }> = ({
+    space,
+    projectUuid,
+}) => (
+    <Link
+        to={`/projects/${projectUuid}/spaces/${space.uuid}`}
+        className={`${classes.hoverCard} ${classes.clickable} ${classes.plainLink} ${classes.contentTile}`}
+    >
+        <IconSquare icon={IconFolder} />
+        <Box className={classes.tileBody}>
+            <Text size="sm" fw={600} truncate>
+                {space.name}
+            </Text>
+            <Text size="xs" c="dimmed">
+                {itemLabel(space.itemCount)}
+            </Text>
+        </Box>
+    </Link>
+);
+
+/** The spaces a viewer should start from. Renders nothing when the project has
+ * none with content — an empty header is worse than no section. */
+export const KeySpaces: FC<{
+    spaces: KeySpace[];
+    projectUuid: string;
+    title?: string;
+}> = ({ spaces, projectUuid, title = 'Spaces' }) => {
+    if (spaces.length === 0) return null;
+    return (
+        <Box>
+            <BlockHeader icon={IconFolders} title={title} />
+            <PageGrid itemSpan={3}>
+                {spaces.map((space) => (
+                    <PageGridItem key={space.uuid}>
+                        <KeySpaceCard space={space} projectUuid={projectUuid} />
+                    </PageGridItem>
+                ))}
+            </PageGrid>
+        </Box>
+    );
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/RecentBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/RecentBlock.tsx
@@ -1,40 +1,18 @@
-import {
-    ContentType,
-    type ApiError,
-    type HomepageRecentlyViewedItem,
-    type SummaryContent,
-} from '@lightdash/common';
+import { ContentType, type SummaryContent } from '@lightdash/common';
 import { Skeleton, Stack } from '@mantine-8/core';
 import {
     IconChartBar,
     IconClock,
     IconLayoutDashboard,
 } from '@tabler/icons-react';
-import { useQuery } from '@tanstack/react-query';
 import { type FC } from 'react';
 import { Link } from 'react-router';
-import { lightdashApi } from '../../../../api';
 import TruncatedText from '../../../../components/common/TruncatedText';
 import { useTimeAgo } from '../../../../hooks/useTimeAgo';
-import { useCollectionContent } from '../hooks/useCollectionContent';
+import { useRecentContents } from '../hooks/useRecentContents';
 import { BlockHeader } from './BlockShell';
 import classes from './blockStyles.module.css';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
-
-const getRecentlyViewed = async (projectUuid: string) =>
-    lightdashApi<HomepageRecentlyViewedItem[]>({
-        url: `/projects/${projectUuid}/homepage/recently-viewed`,
-        method: 'GET',
-        body: undefined,
-    });
-
-const MAX_RECENT_ITEMS = 4;
-
-const useRecentlyViewed = (projectUuid: string) =>
-    useQuery<HomepageRecentlyViewedItem[], ApiError>({
-        queryKey: ['homepage_recently_viewed', projectUuid],
-        queryFn: () => getRecentlyViewed(projectUuid),
-    });
 
 const contentUrl = (projectUuid: string, content: SummaryContent): string =>
     content.contentType === ContentType.DASHBOARD
@@ -78,14 +56,9 @@ const RecentRow: FC<{
 };
 
 export const RecentList: FC<{ projectUuid: string }> = ({ projectUuid }) => {
-    const { data: recents, isInitialLoading } = useRecentlyViewed(projectUuid);
-    const uuids = (recents ?? [])
-        .slice(0, MAX_RECENT_ITEMS)
-        .map((item) => item.uuid);
-    const { data: contents, isInitialLoading: isResolving } =
-        useCollectionContent(projectUuid, uuids);
+    const { recents, contents, isLoading } = useRecentContents(projectUuid);
 
-    if (isInitialLoading || isResolving) {
+    if (isLoading) {
         return (
             <Stack gap="xs">
                 {[0, 1, 2].map((i) => (
@@ -94,7 +67,7 @@ export const RecentList: FC<{ projectUuid: string }> = ({ projectUuid }) => {
             </Stack>
         );
     }
-    if (!contents || contents.length === 0) {
+    if (contents.length === 0) {
         return (
             <div className={classes.dashedEmpty}>
                 Charts and dashboards you open will show up here.
@@ -102,7 +75,7 @@ export const RecentList: FC<{ projectUuid: string }> = ({ projectUuid }) => {
         );
     }
     const viewedAtByUuid = new Map(
-        (recents ?? []).map((item) => [item.uuid, item.viewedAt]),
+        recents.map((item) => [item.uuid, item.viewedAt]),
     );
     return (
         <div className={classes.listCard}>

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/rankKeySpaces.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/rankKeySpaces.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { rankKeySpaces, type RankableSpace } from './rankKeySpaces';
+
+const space = (overrides: Partial<RankableSpace> = {}): RankableSpace => ({
+    uuid: 'u',
+    name: 'Space',
+    dashboardCount: 1,
+    chartCount: 0,
+    appCount: 0,
+    isPinned: false,
+    ...overrides,
+});
+
+describe('rankKeySpaces', () => {
+    it('puts pinned spaces first — an admin pinning one has already answered', () => {
+        const ranked = rankKeySpaces(
+            [
+                space({ uuid: 'big', name: 'Big', chartCount: 50 }),
+                space({ uuid: 'pinned', name: 'Pinned', isPinned: true }),
+            ],
+            new Map([['big', 900]]),
+            4,
+        );
+        expect(ranked.map((s) => s.uuid)).toEqual(['pinned', 'big']);
+    });
+
+    it('ranks unpinned spaces by the views of the content inside them', () => {
+        const ranked = rankKeySpaces(
+            [
+                space({ uuid: 'quiet', name: 'Quiet', chartCount: 40 }),
+                space({ uuid: 'busy', name: 'Busy', chartCount: 2 }),
+            ],
+            new Map([
+                ['busy', 500],
+                ['quiet', 3],
+            ]),
+            4,
+        );
+        expect(ranked.map((s) => s.uuid)).toEqual(['busy', 'quiet']);
+    });
+
+    it('falls back to item count when nothing has been viewed yet', () => {
+        const ranked = rankKeySpaces(
+            [
+                space({ uuid: 'small', name: 'Small', chartCount: 1 }),
+                space({ uuid: 'large', name: 'Large', chartCount: 9 }),
+            ],
+            new Map(),
+            4,
+        );
+        expect(ranked.map((s) => s.uuid)).toEqual(['large', 'small']);
+    });
+
+    it('never sends someone to an empty space', () => {
+        const ranked = rankKeySpaces(
+            [
+                space({
+                    uuid: 'empty',
+                    dashboardCount: 0,
+                    chartCount: 0,
+                    appCount: 0,
+                }),
+                space({ uuid: 'has-content', chartCount: 1 }),
+            ],
+            new Map(),
+            4,
+        );
+        expect(ranked.map((s) => s.uuid)).toEqual(['has-content']);
+    });
+
+    it('counts apps towards a space being worth showing', () => {
+        const ranked = rankKeySpaces(
+            [
+                space({
+                    uuid: 'apps-only',
+                    dashboardCount: 0,
+                    chartCount: 0,
+                    appCount: 3,
+                }),
+            ],
+            new Map(),
+            4,
+        );
+        expect(ranked).toHaveLength(1);
+        expect(ranked[0].itemCount).toBe(3);
+    });
+
+    it('caps at the limit, breaking ties by name for a stable order', () => {
+        const ranked = rankKeySpaces(
+            [
+                space({ uuid: 'c', name: 'Charlie' }),
+                space({ uuid: 'a', name: 'Alpha' }),
+                space({ uuid: 'b', name: 'Bravo' }),
+            ],
+            new Map(),
+            2,
+        );
+        expect(ranked.map((s) => s.name)).toEqual(['Alpha', 'Bravo']);
+    });
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/rankKeySpaces.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/rankKeySpaces.ts
@@ -1,0 +1,58 @@
+export type RankableSpace = {
+    uuid: string;
+    name: string;
+    dashboardCount: number;
+    chartCount: number;
+    appCount: number;
+    isPinned: boolean;
+};
+
+export type KeySpace = {
+    uuid: string;
+    name: string;
+    itemCount: number;
+    isPinned: boolean;
+};
+
+/**
+ * Which spaces to put in front of someone who has just landed on the project.
+ *
+ * Ranked by, in order:
+ *
+ * 1. **Pinned.** An admin pinning a space has already answered the question.
+ * 2. **Views of the content inside it.** Spaces carry no view count of their
+ *    own (the content API selects `0 as views` for them), so usage is derived
+ *    from where the project's most-viewed charts and dashboards actually live.
+ * 3. **How much it holds.** A tiebreak for projects with no view history yet,
+ *    so day-0 still leads with the spaces where the work is.
+ * 4. **Name**, so the order is stable rather than incidental.
+ */
+export const rankKeySpaces = (
+    spaces: RankableSpace[],
+    viewsBySpaceUuid: Map<string, number>,
+    limit: number,
+): KeySpace[] =>
+    spaces
+        .map((space) => ({
+            uuid: space.uuid,
+            name: space.name,
+            itemCount: space.dashboardCount + space.chartCount + space.appCount,
+            isPinned: space.isPinned,
+            views: viewsBySpaceUuid.get(space.uuid) ?? 0,
+        }))
+        // An empty space is never the place to send someone first.
+        .filter((space) => space.itemCount > 0)
+        .sort(
+            (a, b) =>
+                Number(b.isPinned) - Number(a.isPinned) ||
+                b.views - a.views ||
+                b.itemCount - a.itemCount ||
+                a.name.localeCompare(b.name),
+        )
+        .slice(0, limit)
+        .map(({ uuid, name, itemCount, isPinned }) => ({
+            uuid,
+            name,
+            itemCount,
+            isPinned,
+        }));

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useKeySpaces.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useKeySpaces.ts
@@ -1,0 +1,70 @@
+import {
+    ContentType,
+    type SpaceContent,
+    type SummaryContent,
+} from '@lightdash/common';
+import { useMemo } from 'react';
+import { useInfiniteContent } from '../../../../hooks/useContent';
+import { useMostPopularAndRecentlyUpdated } from '../../../../hooks/useProject';
+import { rankKeySpaces, type KeySpace } from './rankKeySpaces';
+
+// Enough to rank meaningfully without paging: a project with more spaces than
+// this has plenty of signal in the first page either way.
+const SPACE_SCAN_SIZE = 100;
+
+const isSpace = (content: SummaryContent): content is SpaceContent =>
+    content.contentType === ContentType.SPACE;
+
+/**
+ * The spaces day-0 leads with. Ranking rules live in `rankKeySpaces`.
+ *
+ * Both queries already run on the project home page, so this adds no requests
+ * of its own — the space list is the same one the content API serves to browse,
+ * and most-popular is already fetched for the legacy panel.
+ */
+export const useKeySpaces = (
+    projectUuid: string | undefined,
+    limit: number,
+) => {
+    const spacesQuery = useInfiniteContent(
+        {
+            projectUuids: projectUuid ? [projectUuid] : [],
+            contentTypes: [ContentType.SPACE],
+            pageSize: SPACE_SCAN_SIZE,
+        },
+        { enabled: !!projectUuid },
+    );
+    const popularQuery = useMostPopularAndRecentlyUpdated(projectUuid);
+
+    const spaces = useMemo<KeySpace[]>(() => {
+        const all = (spacesQuery.data?.pages ?? [])
+            .flatMap((page) => page.data)
+            .filter(isSpace);
+        if (all.length === 0) return [];
+
+        // Views of the most-viewed content, summed onto the space holding it.
+        const viewsBySpace = new Map<string, number>();
+        (popularQuery.data?.mostPopular ?? []).forEach((item) => {
+            const views = 'views' in item ? (item.views ?? 0) : 0;
+            viewsBySpace.set(
+                item.spaceUuid,
+                (viewsBySpace.get(item.spaceUuid) ?? 0) + views,
+            );
+        });
+
+        return rankKeySpaces(
+            all.map((space) => ({
+                uuid: space.uuid,
+                name: space.name,
+                dashboardCount: space.dashboardCount,
+                chartCount: space.chartCount,
+                appCount: space.appCount,
+                isPinned: space.pinnedList !== null,
+            })),
+            viewsBySpace,
+            limit,
+        );
+    }, [spacesQuery.data?.pages, popularQuery.data?.mostPopular, limit]);
+
+    return { spaces, isLoading: spacesQuery.isInitialLoading };
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useRecentContents.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useRecentContents.ts
@@ -1,0 +1,39 @@
+import {
+    type ApiError,
+    type HomepageRecentlyViewedItem,
+} from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../../../../api';
+import { useCollectionContent } from './useCollectionContent';
+
+const getRecentlyViewed = async (projectUuid: string) =>
+    lightdashApi<HomepageRecentlyViewedItem[]>({
+        url: `/projects/${projectUuid}/homepage/recently-viewed`,
+        method: 'GET',
+        body: undefined,
+    });
+
+const MAX_RECENT_ITEMS = 4;
+
+const useRecentlyViewed = (projectUuid: string) =>
+    useQuery<HomepageRecentlyViewedItem[], ApiError>({
+        queryKey: ['homepage_recently_viewed', projectUuid],
+        queryFn: () => getRecentlyViewed(projectUuid),
+    });
+
+/** The viewer's recently-viewed content, resolved to real items. Exposed as a
+ * hook so a surface that owns the section header (day-0) can decide whether to
+ * render one at all — both callers share the same queries. */
+export const useRecentContents = (projectUuid: string) => {
+    const { data: recents, isInitialLoading } = useRecentlyViewed(projectUuid);
+    const uuids = (recents ?? [])
+        .slice(0, MAX_RECENT_ITEMS)
+        .map((item) => item.uuid);
+    const { data: contents, isInitialLoading: isResolving } =
+        useCollectionContent(projectUuid, uuids);
+    return {
+        recents: recents ?? [],
+        contents: contents ?? [],
+        isLoading: isInitialLoading || isResolving,
+    };
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/starterHomepage.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/starterHomepage.ts
@@ -8,13 +8,14 @@ import { getDefaultQuickActions } from './blocks/quickActionDefaults';
 
 /**
  * The layout a brand-new homepage starts from — a block-for-block copy of what
- * day-0 already renders, in the same order (favorites, hero, recently viewed,
- * pinned). Publishing the first homepage should keep the page people were
- * already looking at, not drop them onto a different one.
+ * day-0 already renders, in the same order (favorites, hero, key spaces,
+ * recently viewed, pinned). Publishing the first homepage should keep the page
+ * people were already looking at, not drop them onto a different one.
  */
 export const buildStarterHomepage = (
     canAskAi: boolean,
     pinnedItems: HomepageCollectionItemRef[],
+    keySpaceUuids: string[] = [],
 ): HomepageConfig => {
     const row = (block: HomepageBlock) => ({ id: uuidv4(), blocks: [block] });
 
@@ -39,6 +40,24 @@ export const buildStarterHomepage = (
                   },
               }),
     ];
+
+    // The same spaces day-0 leads its body with, so the first draft opens on
+    // the page people were already looking at.
+    if (keySpaceUuids.length > 0) {
+        rows.push(
+            row({
+                id: uuidv4(),
+                type: 'collection',
+                config: {
+                    title: 'Start here',
+                    items: keySpaceUuids.map((uuid) => ({
+                        contentType: 'space' as const,
+                        uuid,
+                    })),
+                },
+            }),
+        );
+    }
 
     // Day-0 pairs the greeting with quick actions; the AI hero stands alone.
     if (!canAskAi) {


### PR DESCRIPTION
Closes #26439

Stacked on #26448.

## What

Day-0 — what everyone sees the moment the new homepage is enabled, before any admin has built anything — showed a personal favourites strip, the hero, **Recently viewed** and **Pinned**. Both body sections are per-user history or an existing pin list. So a project where nobody has pinned much, and whose users navigated to two or three known spaces, lost its main navigation surface the moment the flag went on: Recently viewed is empty for anyone who hasn't been active, and there was no route to "the folder my team works out of" other than the nav.

Day-0 now leads its body with the spaces a viewer should start from, for **both** openings (AI composer and greeting + quick actions).

## Ranking

A pure `rankKeySpaces(spaces, viewsBySpaceUuid, limit)`:

1. **Pinned first** — an admin pinning a space has already answered the question.
2. **Then views of the content inside it.** Spaces carry no view count of their own: `SpaceContentConfiguration` selects `0 as views`, so a `sortBy: views` on spaces would be a no-op. Usage is instead derived from where the project's most-viewed charts and dashboards actually live.
3. **Then how much the space holds**, so a project with no view history still leads with where the work is.
4. **Then name**, so the order is stable rather than incidental.

Empty spaces are filtered out — never send someone to an empty folder. Apps count towards a space being worth showing, not just charts and dashboards.

## Empty sections no longer render headers

Recently viewed used to render its header plus a dashed empty state for every first-time viewer. Now the section is absent when there's nothing in it, so a viewer with no history in a project with no pins gets hero + spaces, which reads as complete rather than as three quarters empty. Verified by intercepting both endpoints: only "Start here" renders, and the page fits in 900px with no scroll.

`buildStarterHomepage` takes the same spaces, so the first draft an admin opens contains what day-0 was already showing.

## Regression analysis

- **No new requests.** The space list is the content API's own (`contentTypes: [space]`), and most-popular is already fetched unconditionally by the project home page for the legacy panel — so both queries are already in flight or cached. Nothing hits the warehouse.
- **Access filtering is the server's.** Spaces come back already filtered to what the viewer can see; the hook does no client-side permission logic and can't widen visibility.
- **`useRecentContents` moved to `hooks/`** rather than being exported from `RecentBlock.tsx`, because the fast-refresh lint rule bans non-component exports from component files. Both callers share the same two queries, so exposing it doesn't double-fetch.
- **The published `recent` block is unchanged** — it keeps its header and dashed empty state, which is right there: an admin placed that block deliberately, and the empty state tells the viewer what will fill it. Only day-0's own section hides itself.
- **The root-space scope is intentional.** The content API returns top-level spaces with descendant counts, so a nested space doesn't compete with its parent for a slot — which matches what "folders" means to the people this is for.
- **`PinnedCollection` already returned null when empty**; that behaviour is untouched.

## Tests

6 new ranking tests (pinned wins over a bigger space, views beat size, size as fallback, empty spaces excluded, apps counted, cap + stable tie-break) plus mocks added to the day-0 render tests. Full homepage-builder suite green: 20 files / 199 tests. Frontend typecheck clean for the feature.
