### PR TITLE
fix(deep-research): stop token budgets from aborting runs

### DIFF
--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.integration.test.ts
@@ -25,7 +25,6 @@ import {
 import { AiDeepResearchRunModel } from './AiDeepResearchRunModel';
 
 const budget: AiDeepResearchBudget = {
-    maxTokens: 10_000,
     maxToolCalls: 20,
     maxWarehouseQueries: 10,
     maxResultRows: 1_000,

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.test.ts
@@ -9,7 +9,6 @@ import { AI_DEEP_RESEARCH_REPORT_TOOL_NAME } from './AiDeepResearchAgent';
 import { AiDeepResearchExecutor } from './AiDeepResearchExecutor';
 
 const budget: AiDeepResearchBudget = {
-    maxTokens: 10_000,
     maxToolCalls: 20,
     maxWarehouseQueries: 10,
     maxResultRows: 1_000,
@@ -422,7 +421,11 @@ describe('AiDeepResearchExecutor', () => {
         });
     });
 
-    it('returns the saved report when the model token budget is exhausted', async () => {
+    it('continues after exceeding the legacy model token budget', async () => {
+        const legacyBudget = {
+            ...budget,
+            maxTokens: 1_000,
+        } as AiDeepResearchBudget;
         const generateAgentThreadResponse = vi.fn(
             async (
                 _user: SessionUser,
@@ -441,15 +444,12 @@ describe('AiDeepResearchExecutor', () => {
         await expect(
             executor.execute(
                 run({
-                    budget_snapshot: {
-                        ...budget,
-                        maxTokens: 1_000,
-                    },
+                    budget_snapshot: legacyBudget,
                 }),
                 { signal: new AbortController().signal },
             ),
         ).resolves.toEqual({
-            status: 'partially_completed',
+            status: 'completed',
             report,
             warehouseQueryUuids: [],
         });
@@ -520,13 +520,6 @@ describe('AiDeepResearchExecutor', () => {
     });
 
     it.each([
-        {
-            budgetName: 'maxTokens',
-            budget: { ...budget, maxTokens: 1 },
-            consumeBudget: async (options: AnyType, _attempt: number) => {
-                await options.execution.onStepUsage(1);
-            },
-        },
         {
             budgetName: 'maxToolCalls',
             budget: { ...budget, maxToolCalls: 1 },

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.ts
@@ -388,17 +388,6 @@ export class AiDeepResearchExecutor {
                     initialTokenUsage: tokens,
                     onStepUsage: (stepTokens) => {
                         tokens += stepTokens;
-                        if (tokens > run.budget_snapshot.maxTokens) {
-                            budgetExceeded = 'maxTokens';
-                            controller.abort(
-                                new Error(
-                                    'Deep Research exceeded its token budget',
-                                ),
-                            );
-                            throw new Error(
-                                'Deep Research exceeded its token budget',
-                            );
-                        }
                     },
                     onWarehouseQuery: () => {
                         warehouseQueries += 1;

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
@@ -17,7 +17,6 @@ import { Readable } from 'stream';
 import { AiDeepResearchService } from './AiDeepResearchService';
 
 const budget: AiDeepResearchBudget = {
-    maxTokens: 10_000,
     maxToolCalls: 20,
     maxWarehouseQueries: 10,
     maxResultRows: 1_000,
@@ -75,7 +74,6 @@ const effortBudgets = [
     {
         effort: 'low',
         budget: {
-            maxTokens: 500_000,
             maxToolCalls: 50,
             maxWarehouseQueries: 10,
             maxResultRows: 5_000,
@@ -84,7 +82,6 @@ const effortBudgets = [
     {
         effort: 'medium',
         budget: {
-            maxTokens: 1_000_000,
             maxToolCalls: 125,
             maxWarehouseQueries: 25,
             maxResultRows: 10_000,
@@ -93,7 +90,6 @@ const effortBudgets = [
     {
         effort: 'high',
         budget: {
-            maxTokens: 2_000_000,
             maxToolCalls: 250,
             maxWarehouseQueries: 50,
             maxResultRows: 25_000,
@@ -102,7 +98,6 @@ const effortBudgets = [
     {
         effort: 'xhigh',
         budget: {
-            maxTokens: 4_000_000,
             maxToolCalls: 500,
             maxWarehouseQueries: 100,
             maxResultRows: 50_000,
@@ -795,7 +790,7 @@ describe('AiDeepResearchService', () => {
             await expect(
                 service.createRun({
                     ...validCreateRunArgs(),
-                    budget: { ...budget, maxTokens: 0 },
+                    budget: { ...budget, maxToolCalls: 0 },
                 }),
             ).rejects.toBeInstanceOf(ParameterError);
             expect(model.create).not.toHaveBeenCalled();
@@ -809,7 +804,7 @@ describe('AiDeepResearchService', () => {
                     ...validCreateRunArgs(),
                     budget: {
                         ...budget,
-                        maxTokens: 4_000_000 + 1,
+                        maxToolCalls: 501,
                     },
                 }),
             ).rejects.toBeInstanceOf(ParameterError);
@@ -818,10 +813,11 @@ describe('AiDeepResearchService', () => {
     });
 
     describe('access and cancellation', () => {
-        it('omits legacy runtime limits from returned budget snapshots', async () => {
+        it('omits legacy limits from returned budget snapshots', async () => {
             const legacyBudget = {
                 ...budget,
                 maxRuntimeMs: 30 * 60 * 1_000,
+                maxTokens: 1_000_000,
             } as AiDeepResearchBudget;
             const { service } = buildService({
                 model: {

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
@@ -208,7 +208,6 @@ const toRun = (row: DbAiDeepResearchRun): AiDeepResearchRun => ({
     resultMarkdown: row.result_markdown,
     resultChartData: row.result_chart_data,
     budget: {
-        maxTokens: row.budget_snapshot.maxTokens,
         maxToolCalls: row.budget_snapshot.maxToolCalls,
         maxWarehouseQueries: row.budget_snapshot.maxWarehouseQueries,
         maxResultRows: row.budget_snapshot.maxResultRows,
@@ -308,25 +307,21 @@ export const AI_DEEP_RESEARCH_BUDGETS_BY_EFFORT: Record<
     AiDeepResearchBudget
 > = {
     low: {
-        maxTokens: 500_000,
         maxToolCalls: 50,
         maxWarehouseQueries: 10,
         maxResultRows: 5_000,
     },
     medium: {
-        maxTokens: 1_000_000,
         maxToolCalls: 125,
         maxWarehouseQueries: 25,
         maxResultRows: 10_000,
     },
     high: {
-        maxTokens: 2_000_000,
         maxToolCalls: 250,
         maxWarehouseQueries: 50,
         maxResultRows: 25_000,
     },
     xhigh: {
-        maxTokens: 4_000_000,
         maxToolCalls: 500,
         maxWarehouseQueries: 100,
         maxResultRows: 50_000,

--- a/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
@@ -5,10 +5,26 @@ import {
     buildForcedFirstStep,
     buildMessagesWithMemoryBlock,
     getAgentTools,
+    getDeepResearchBudgetInstruction,
     normalizeToolOutput,
     withEarlyToolProgress,
     type AgentMcpToolSetup,
 } from './agentV2';
+
+describe('getDeepResearchBudgetInstruction', () => {
+    it('advertises only enforceable Deep Research limits', () => {
+        const instruction = getDeepResearchBudgetInstruction({
+            maxToolCalls: 20,
+            maxWarehouseQueries: 10,
+            maxResultRows: 1_000,
+        });
+
+        expect(instruction).toContain('20 tool calls');
+        expect(instruction).toContain('10 warehouse queries');
+        expect(instruction).toContain('1000 rows per query result');
+        expect(instruction).not.toContain('token');
+    });
+});
 
 describe('buildForcedFirstStep', () => {
     it('forces the hinted report tool on only the opening step', () => {
@@ -361,7 +377,6 @@ describe('getAgentTools workstream tool gate', () => {
             mode: 'deep_research',
             maxSteps: 30,
             budget: {
-                maxTokens: 10_000,
                 maxToolCalls: 20,
                 maxWarehouseQueries: 10,
                 maxResultRows: 1_000,

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -3,6 +3,7 @@ import {
     AnyType,
     assertUnreachable,
     Explore,
+    type AiDeepResearchBudget,
     type AiDeepResearchExecutionContextSnapshot,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
@@ -1003,6 +1004,11 @@ export const buildMessagesWithMemoryBlock = ({
     ...messageHistory,
 ];
 
+export const getDeepResearchBudgetInstruction = (
+    budget: AiDeepResearchBudget,
+): string =>
+    `Run limits: at most ${budget.maxToolCalls} tool calls, ${budget.maxWarehouseQueries} warehouse queries, and ${budget.maxResultRows} rows per query result. Submit the best report available before a limit is exhausted.`;
+
 const getAgentMessages = (
     args: AiAgentArgs,
     availableExplores: Explore[],
@@ -1027,7 +1033,7 @@ const getAgentMessages = (
         args.projectContextEnabled && args.projectContext.length > 0;
     const deepResearchBudgetInstruction =
         args.execution.mode === 'deep_research'
-            ? `Run limits: at most ${args.execution.budget.maxToolCalls} tool calls, ${args.execution.budget.maxWarehouseQueries} warehouse queries, ${args.execution.budget.maxResultRows} rows per query result, and ${args.execution.budget.maxTokens} total model tokens. Submit the best report available before a limit is exhausted.`
+            ? getDeepResearchBudgetInstruction(args.execution.budget)
             : null;
     const instructions = [
         args.agentSettings.instruction,

--- a/packages/common/src/ee/aiDeepResearch/types.ts
+++ b/packages/common/src/ee/aiDeepResearch/types.ts
@@ -32,7 +32,6 @@ export const isAiDeepResearchRunTerminal = (
     );
 
 export type AiDeepResearchBudget = {
-    maxTokens: number;
     maxToolCalls: number;
     maxWarehouseQueries: number;
     maxResultRows: number;

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.test.tsx
@@ -55,7 +55,6 @@ const getRun = (status: 'running' | 'completed') => ({
               }
             : null,
     budget: {
-        maxTokens: 10_000,
         maxToolCalls: 25,
         maxWarehouseQueries: 25,
         maxResultRows: 10_000,


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9319/stop-token-budgets-from-aborting-deep-research

## Summary

Deep Research runs stop with a partial report when cumulative model usage crosses the effort tier's token threshold. Token usage remains observable, but it no longer terminates a run.

## Root cause

The executor combines usage accounting with enforcement. Each model step increases a cumulative token count, then aborts the run controller when that count exceeds the persisted `maxTokens`.

```ts
tokens += stepTokens;
if (tokens > run.budget_snapshot.maxTokens) {
    controller.abort();
}
```

Raising the thresholds in #25530 reduced how often this happened but retained the abort path.

## Fix

Remove `maxTokens` from current effort budgets, API responses, generated contracts, executor enforcement, and the agent's limit instruction. Keep cumulative usage accounting and all non-token limits unchanged.

- Legacy JSON snapshots containing `maxTokens` remain readable and no longer affect execution.
- New snapshots and API responses contain only tool-call, warehouse-query, and result-row limits.
- Token usage continues across forced-report recovery for cost and observability.

## Before

```text
600 + 500 tokens > legacy limit 1,000
                    │
                    └── abort → partially_completed
```

## After

```text
600 + 500 tokens → usage recorded → completed report
non-token limits  → unchanged      → partial result when exhausted
```

## Test plan

- [x] Focused backend suites — 81 tests pass, including the legacy-token regression, usage recovery, remaining budgets, API projection, and prompt contract.
- [x] Focused frontend hook suite — 4 tests pass.
- [x] Common, backend, and frontend typechecks pass.
- [x] Common, backend, and frontend lint pass with pre-existing warnings only.
- [x] Regenerated Swagger/routes omit `maxTokens`; `git diff --check` passes.
- [x] Verified legacy snapshots containing `maxTokens` load and return only current budget fields.

