### PR TITLE
feat(data-apps): add a host color-scheme store to the query SDK

### DIFF
--- a/packages/common/src/ee/apps/sdkFeatures.ts
+++ b/packages/common/src/ee/apps/sdkFeatures.ts
@@ -87,6 +87,13 @@ export const SDK_FEATURES: SdkFeature[] = [
             "Let viewers adjust the visualization from the Lightdash config panel — toggles, dropdowns, numbers, text and colours — and take series colours from the chart's palette, without regenerating the app.",
         wiring: 'Declare configOptions (and colorPalette, if the viz colours series) in the viz schema, then read options[name] and colorPalette from useVizContext().',
     },
+    {
+        key: 'follow-host-theme',
+        label: 'Follow the host light/dark mode',
+        description:
+            "Render in whatever light or dark mode the viewer's Lightdash (or embed) is set to, instead of a fixed theme, and restyle live when they switch.",
+        wiring: 'Keep complete light tokens in :root and dark tokens in .dark, remove any fixed dark class from the app shell, and use useColorScheme() only for colours that cannot be expressed in CSS.',
+    },
 ];
 
 export const SDK_FEATURE_KEYS: string[] = SDK_FEATURES.map((f) => f.key);

--- a/packages/query-sdk/src/client.ts
+++ b/packages/query-sdk/src/client.ts
@@ -6,6 +6,7 @@
  */
 
 import { createApiTransport } from './apiTransport';
+import { applyColorSchemeSeed, mountColorScheme } from './colorScheme';
 import { mountInspector } from './inspector';
 import { mountLineage } from './lineage';
 import { createPostMessageTransport } from './postMessageTransport';
@@ -108,6 +109,7 @@ export function createClient(): LightdashClient {
             const projectUuid = params.get('projectUuid') ?? '';
             mountInspector(window.parent);
             mountLineage(window.parent);
+            mountColorScheme(window.parent);
             return new LightdashClient(
                 { apiKey: '', baseUrl: '', projectUuid },
                 createPostMessageTransport({ targetWindow: window.parent, projectUuid }),
@@ -115,7 +117,9 @@ export function createClient(): LightdashClient {
         }
     }
 
-    // 2. Env vars → API transport
+    // 2. Env vars → API transport. No host to follow, but honour a `?theme=`
+    // seed so an author running the app top-level can see both modes.
+    applyColorSchemeSeed();
     const config = configFromEnv();
     if (!config) {
         throw new Error(

--- a/packages/query-sdk/src/colorScheme.test.ts
+++ b/packages/query-sdk/src/colorScheme.test.ts
@@ -1,0 +1,278 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    applyColorScheme,
+    applyColorSchemeSeed,
+    createColorSchemeStore,
+    HOST_COLOR_SCHEME_MESSAGE,
+    HOST_COLOR_SCHEME_REQUEST_MESSAGE,
+    mountColorScheme,
+    parseColorSchemeSeed,
+    resetColorSchemeState,
+} from './colorScheme';
+
+describe('parseColorSchemeSeed', () => {
+    it('reads the seed from the iframe hash', () => {
+        expect(
+            parseColorSchemeSeed({
+                hash: '#transport=postMessage&projectUuid=abc&theme=dark',
+                search: '',
+            }),
+        ).toEqual('dark');
+    });
+
+    it('falls back to the search param when the hash has none (local dev)', () => {
+        expect(
+            parseColorSchemeSeed({ hash: '', search: '?theme=dark' }),
+        ).toEqual('dark');
+    });
+
+    it('prefers the hash over the search param', () => {
+        expect(
+            parseColorSchemeSeed({
+                hash: '#theme=light',
+                search: '?theme=dark',
+            }),
+        ).toEqual('light');
+    });
+
+    it('returns null when absent or not a known scheme', () => {
+        expect(parseColorSchemeSeed({ hash: '', search: '' })).toBeNull();
+        expect(
+            parseColorSchemeSeed({ hash: '#theme=sepia', search: '' }),
+        ).toBeNull();
+        expect(
+            parseColorSchemeSeed({ hash: '#theme=', search: '' }),
+        ).toBeNull();
+    });
+});
+
+describe('applyColorScheme', () => {
+    afterEach(() => {
+        document.documentElement.classList.remove('dark');
+        document.documentElement.style.colorScheme = '';
+    });
+
+    it('stamps the dark class and the CSS color-scheme onto <html>', () => {
+        applyColorScheme('dark');
+        expect(document.documentElement.classList.contains('dark')).toBe(true);
+        expect(document.documentElement.style.colorScheme).toEqual('dark');
+    });
+
+    it('clears the dark class when going back to light', () => {
+        applyColorScheme('dark');
+        applyColorScheme('light');
+        expect(document.documentElement.classList.contains('dark')).toBe(false);
+        expect(document.documentElement.style.colorScheme).toEqual('light');
+    });
+});
+
+describe('createColorSchemeStore', () => {
+    it('starts on the seed it was given, with no dependency on read order', () => {
+        expect(createColorSchemeStore({ seed: 'dark' }).getScheme()).toEqual(
+            'dark',
+        );
+    });
+
+    it('notifies subscribers only when the value changes', () => {
+        const store = createColorSchemeStore({ seed: 'light', apply: vi.fn() });
+        const listener = vi.fn();
+        store.subscribe(listener);
+
+        store.setScheme('dark');
+        store.setScheme('dark');
+        expect(listener).toHaveBeenCalledTimes(1);
+
+        store.setScheme('light');
+        expect(listener).toHaveBeenCalledTimes(2);
+    });
+
+    it('re-applies even when the value is unchanged, so a clobbered <html> is repaired', () => {
+        const apply = vi.fn();
+        const store = createColorSchemeStore({ seed: 'light', apply });
+        store.setScheme('dark');
+        store.setScheme('dark');
+        expect(apply).toHaveBeenCalledTimes(2);
+        expect(apply).toHaveBeenLastCalledWith('dark');
+    });
+
+    it('stops notifying after unsubscribe', () => {
+        const store = createColorSchemeStore({ seed: 'light', apply: vi.fn() });
+        const listener = vi.fn();
+        store.subscribe(listener)();
+        store.setScheme('dark');
+        expect(listener).not.toHaveBeenCalled();
+    });
+});
+
+describe('mountColorScheme', () => {
+    let cleanup: () => void = () => {};
+
+    const setHash = (hash: string) => {
+        window.location.hash = hash;
+    };
+
+    const postToApp = (
+        source: MessageEventSource | null,
+        data: unknown,
+    ): void => {
+        window.dispatchEvent(new MessageEvent('message', { data, source }));
+    };
+
+    const requestCount = (spy: { mock: { calls: unknown[][] } }) =>
+        spy.mock.calls.filter(
+            (call) =>
+                (call[0] as { type?: string })?.type ===
+                HOST_COLOR_SCHEME_REQUEST_MESSAGE,
+        ).length;
+
+    beforeEach(() => {
+        setHash('');
+        document.documentElement.classList.remove('dark');
+        document.documentElement.style.colorScheme = '';
+        resetColorSchemeState();
+    });
+
+    afterEach(() => {
+        cleanup();
+        resetColorSchemeState();
+        vi.restoreAllMocks();
+    });
+
+    it('applies the hash seed on mount', () => {
+        setHash('#transport=postMessage&theme=dark');
+        cleanup = mountColorScheme(window as unknown as Window);
+        expect(document.documentElement.classList.contains('dark')).toBe(true);
+    });
+
+    // The handshake: without it the app depends on createClient() having run
+    // before the host's iframe-load push, which app-owned main.jsx can break.
+    it('asks the host for the current scheme once its listener is live', () => {
+        const postSpy = vi.spyOn(window, 'postMessage');
+        cleanup = mountColorScheme(window as unknown as Window);
+        expect(postSpy).toHaveBeenCalledWith(
+            { type: HOST_COLOR_SCHEME_REQUEST_MESSAGE },
+            '*',
+        );
+    });
+
+    it('re-asks when the host announces it is ready, in case the first ask was too early', () => {
+        const parent = window as unknown as Window;
+        const postSpy = vi.spyOn(window, 'postMessage');
+        cleanup = mountColorScheme(parent);
+        expect(requestCount(postSpy)).toEqual(1);
+
+        postToApp(parent as unknown as MessageEventSource, {
+            type: 'lightdash:sdk:ready',
+        });
+        expect(requestCount(postSpy)).toEqual(2);
+    });
+
+    it('does not re-ask on a ready message from another window', () => {
+        const postSpy = vi.spyOn(window, 'postMessage');
+        cleanup = mountColorScheme(window as unknown as Window);
+        postToApp(null, { type: 'lightdash:sdk:ready' });
+        expect(requestCount(postSpy)).toEqual(1);
+    });
+
+    it('applies a scheme pushed by the host after load', () => {
+        const parent = window as unknown as Window;
+        cleanup = mountColorScheme(parent);
+        postToApp(parent as unknown as MessageEventSource, {
+            type: HOST_COLOR_SCHEME_MESSAGE,
+            colorScheme: 'dark',
+        });
+        expect(document.documentElement.classList.contains('dark')).toBe(true);
+
+        postToApp(parent as unknown as MessageEventSource, {
+            type: HOST_COLOR_SCHEME_MESSAGE,
+            colorScheme: 'light',
+        });
+        expect(document.documentElement.classList.contains('dark')).toBe(false);
+    });
+
+    it('repairs <html> when the host re-sends the scheme the app is already on', () => {
+        const parent = window as unknown as Window;
+        cleanup = mountColorScheme(parent);
+        postToApp(parent as unknown as MessageEventSource, {
+            type: HOST_COLOR_SCHEME_MESSAGE,
+            colorScheme: 'dark',
+        });
+        // Something else stripped the class (app code, a hot reload, a library).
+        document.documentElement.classList.remove('dark');
+        postToApp(parent as unknown as MessageEventSource, {
+            type: HOST_COLOR_SCHEME_MESSAGE,
+            colorScheme: 'dark',
+        });
+        expect(document.documentElement.classList.contains('dark')).toBe(true);
+    });
+
+    it('ignores malformed payloads', () => {
+        const parent = window as unknown as MessageEventSource;
+        cleanup = mountColorScheme(parent as unknown as Window);
+        postToApp(parent, { type: HOST_COLOR_SCHEME_MESSAGE });
+        postToApp(parent, {
+            type: HOST_COLOR_SCHEME_MESSAGE,
+            colorScheme: 'sepia',
+        });
+        expect(document.documentElement.classList.contains('dark')).toBe(false);
+    });
+
+    it('ignores messages from windows other than the host', () => {
+        cleanup = mountColorScheme(window as unknown as Window);
+        postToApp(null, {
+            type: HOST_COLOR_SCHEME_MESSAGE,
+            colorScheme: 'dark',
+        });
+        expect(document.documentElement.classList.contains('dark')).toBe(false);
+    });
+
+    it('does not stack listeners when mounted repeatedly', () => {
+        const parent = window as unknown as Window;
+        const addSpy = vi.spyOn(window, 'addEventListener');
+        const removeSpy = vi.spyOn(window, 'removeEventListener');
+        mountColorScheme(parent);
+        cleanup = mountColorScheme(parent);
+        const messageListeners = (spy: typeof addSpy) =>
+            spy.mock.calls.filter(([type]) => type === 'message').length;
+        // Second mount tore the first listener down before registering its own.
+        expect(messageListeners(addSpy)).toEqual(2);
+        expect(messageListeners(removeSpy)).toEqual(1);
+    });
+
+    it('stops applying after cleanup', () => {
+        const parent = window as unknown as Window;
+        const stop = mountColorScheme(parent);
+        stop();
+        postToApp(parent as unknown as MessageEventSource, {
+            type: HOST_COLOR_SCHEME_MESSAGE,
+            colorScheme: 'dark',
+        });
+        expect(document.documentElement.classList.contains('dark')).toBe(false);
+    });
+});
+
+// Top-level dev (API transport): no host, but `?theme=` must still render the
+// app dark, or an author can't check the both-modes contract skill.md asks for.
+describe('applyColorSchemeSeed', () => {
+    beforeEach(() => {
+        window.location.hash = '';
+        document.documentElement.classList.remove('dark');
+        resetColorSchemeState();
+    });
+
+    afterEach(() => {
+        window.location.hash = '';
+        resetColorSchemeState();
+    });
+
+    it('applies the seed without registering a host listener', () => {
+        window.location.hash = '#theme=dark';
+        const addSpy = vi.spyOn(window, 'addEventListener');
+        applyColorSchemeSeed();
+        expect(document.documentElement.classList.contains('dark')).toBe(true);
+        expect(
+            addSpy.mock.calls.filter(([type]) => type === 'message'),
+        ).toHaveLength(0);
+        addSpy.mockRestore();
+    });
+});

--- a/packages/query-sdk/src/colorScheme.ts
+++ b/packages/query-sdk/src/colorScheme.ts
@@ -1,0 +1,232 @@
+/**
+ * Host color scheme — the iframe-side half of "data apps follow the host's
+ * light/dark mode". The Lightdash host owns the resolved scheme (its own theme
+ * toggle, or an embed's `?theme=`) and it reaches the app two ways, each doing
+ * a job the other can't:
+ *
+ *   - a `theme=` seed in the iframe URL hash, read **synchronously** by
+ *     `mountColorScheme()` from `createClient()`. That runs before React
+ *     renders, so the app's first rendered frame is already in the right
+ *     scheme. Only the seed can do this: a message reply lands a tick later,
+ *     by which point React may already have committed the wrong mode.
+ *   - `lightdash:sdk:theme` messages, which keep the app in step with every
+ *     later host toggle without reloading the iframe.
+ *
+ * Delivery is a handshake, like `vizContext`: `mountColorScheme()` posts
+ * `lightdash:sdk:theme-request` once its listener is live, and re-posts it
+ * whenever the host announces `lightdash:sdk:ready` (the same belt-and-braces
+ * `manifest` uses). Whichever side mounts first, the app ends up on the host's
+ * scheme. Without it the app would depend on `createClient()` having run before
+ * the host's iframe `load` push, which the template happens to guarantee but
+ * app-owned `main.jsx` can silently break.
+ *
+ * Applying means toggling `.dark` on `<html>` (Tailwind's `darkMode: ['class']`
+ * hook, and the only scope Radix portals inherit) plus the CSS `color-scheme`
+ * property, so form controls and scrollbars follow too.
+ *
+ * Seed and message both cross a trust boundary — the hash is user-editable and
+ * the message is postMessage — so both are validated, and messages are only
+ * accepted from the window the client was created against.
+ */
+
+import { useSyncExternalStore } from 'react';
+
+export type HostColorScheme = 'light' | 'dark';
+
+/** Host → iframe, in reply to a request and on every host theme change. */
+export type HostColorSchemeMessage = {
+    type: 'lightdash:sdk:theme';
+    colorScheme: HostColorScheme;
+};
+
+/** Iframe → host, once this module's listener is live. */
+export type HostColorSchemeRequestMessage = {
+    type: 'lightdash:sdk:theme-request';
+};
+
+export const HOST_COLOR_SCHEME_MESSAGE = 'lightdash:sdk:theme';
+export const HOST_COLOR_SCHEME_REQUEST_MESSAGE = 'lightdash:sdk:theme-request';
+
+const SDK_READY_MESSAGE = 'lightdash:sdk:ready';
+
+// Mirrored by the host in packages/frontend/src/features/apps/utils/appIframeUrl.ts
+const COLOR_SCHEME_PARAM = 'theme';
+
+const DARK_CLASS = 'dark';
+
+const isHostColorScheme = (value: unknown): value is HostColorScheme =>
+    value === 'light' || value === 'dark';
+
+/**
+ * Read the scheme seed. The iframe hash is where the host forwards it; the
+ * search param is the top-level (local dev) fallback. Null when absent or not
+ * one of the two valid values.
+ */
+export function parseColorSchemeSeed(location: {
+    hash: string;
+    search: string;
+}): HostColorScheme | null {
+    const raw =
+        new URLSearchParams(location.hash.replace(/^#/, '')).get(
+            COLOR_SCHEME_PARAM,
+        ) ?? new URLSearchParams(location.search).get(COLOR_SCHEME_PARAM);
+    return isHostColorScheme(raw) ? raw : null;
+}
+
+/** Stamp the scheme onto `<html>`. Idempotent. */
+export function applyColorScheme(scheme: HostColorScheme): void {
+    if (typeof document === 'undefined') return;
+    const root = document.documentElement;
+    root.classList.toggle(DARK_CLASS, scheme === 'dark');
+    root.style.colorScheme = scheme;
+}
+
+export type ColorSchemeStore = {
+    getScheme: () => HostColorScheme;
+    /**
+     * Stamp `<html>` and publish. Always re-applies (the DOM may have been
+     * clobbered since), but only notifies when the value actually changed.
+     */
+    setScheme: (scheme: HostColorScheme) => void;
+    subscribe: (listener: () => void) => () => void;
+};
+
+/**
+ * Minimal external store: synchronous reads for useSyncExternalStore. The seed
+ * is resolved by the caller and passed in, so the value never depends on when
+ * it was first read. Exported for tests — app code uses `useColorScheme`.
+ */
+export function createColorSchemeStore(options: {
+    seed: HostColorScheme;
+    apply?: (scheme: HostColorScheme) => void;
+}): ColorSchemeStore {
+    const apply = options.apply ?? applyColorScheme;
+    let scheme = options.seed;
+    const listeners = new Set<() => void>();
+
+    return {
+        getScheme: () => scheme,
+        setScheme: (next) => {
+            const changed = next !== scheme;
+            scheme = next;
+            apply(next);
+            if (changed) listeners.forEach((listener) => listener());
+        },
+        subscribe: (listener) => {
+            listeners.add(listener);
+            return () => {
+                listeners.delete(listener);
+            };
+        },
+    };
+}
+
+/**
+ * Initial value: the URL seed, else whatever is already on `<html>` — an app
+ * that pins its own scheme in `:root`/`index.html` keeps reporting that one
+ * until the host says otherwise.
+ */
+function readSeed(): HostColorScheme {
+    if (typeof window === 'undefined') return 'light';
+    const seed = parseColorSchemeSeed(window.location);
+    if (seed) return seed;
+    return document.documentElement.classList.contains(DARK_CLASS)
+        ? 'dark'
+        : 'light';
+}
+
+// Lazily created so tests (and SSR) never touch window at import time.
+let sharedStore: ColorSchemeStore | null = null;
+function getSharedStore(): ColorSchemeStore {
+    if (sharedStore === null) {
+        sharedStore = createColorSchemeStore({ seed: readSeed() });
+    }
+    return sharedStore;
+}
+
+let activeCleanup: (() => void) | null = null;
+
+/**
+ * Apply the URL seed and nothing else. Used by `createClient()` on the API
+ * transport (top-level local dev), where there is no host to talk to but
+ * `?theme=dark` should still render the app dark — otherwise an author can
+ * never see the dark half of the contract `skill.md` asks them to satisfy.
+ */
+export function applyColorSchemeSeed(): void {
+    applyColorScheme(getSharedStore().getScheme());
+}
+
+/**
+ * Follow the host's scheme: apply the seed, listen for `lightdash:sdk:theme`
+ * from `targetWindow`, and ask the host to send the current value now. Called
+ * by `createClient()` when the postMessage transport is detected. One listener
+ * per bundle — re-mounting replaces the previous listener rather than stacking.
+ */
+export function mountColorScheme(targetWindow: Window): () => void {
+    if (typeof window === 'undefined') return () => {};
+
+    const store = getSharedStore();
+    applyColorScheme(store.getScheme());
+
+    const request: HostColorSchemeRequestMessage = {
+        type: HOST_COLOR_SCHEME_REQUEST_MESSAGE,
+    };
+    // Wildcard for the same reason as every other outbound bridge message: the
+    // sandboxed iframe has an opaque origin and can't derive the parent's.
+    const post = () => targetWindow.postMessage(request, '*');
+
+    const handler = (event: MessageEvent) => {
+        if (event.source !== targetWindow) return;
+        const data = event.data as
+            | Partial<HostColorSchemeMessage>
+            | { type?: unknown }
+            | undefined;
+        // Re-ask on `sdk:ready`: if the host mounted its bridge after our first
+        // request, that request went nowhere and this is the recovery.
+        if (data?.type === SDK_READY_MESSAGE) {
+            post();
+            return;
+        }
+        if (data?.type !== HOST_COLOR_SCHEME_MESSAGE) return;
+        const { colorScheme } = data as Partial<HostColorSchemeMessage>;
+        if (!isHostColorScheme(colorScheme)) return;
+        store.setScheme(colorScheme);
+    };
+
+    activeCleanup?.();
+    window.addEventListener('message', handler);
+    const cleanup = () => {
+        window.removeEventListener('message', handler);
+        if (activeCleanup === cleanup) activeCleanup = null;
+    };
+    activeCleanup = cleanup;
+    post();
+    return cleanup;
+}
+
+/**
+ * The scheme the app is currently rendering in. CSS should follow the `.dark`
+ * class through the theme tokens; reach for this hook only where a value can't
+ * be expressed in CSS — a charting library's theme object, an image swap.
+ *
+ *   const colorScheme = useColorScheme();
+ *   <ResponsiveContainer theme={colorScheme === 'dark' ? darkTheme : lightTheme} />
+ */
+export function useColorScheme(): HostColorScheme {
+    const store = getSharedStore();
+    return useSyncExternalStore(
+        store.subscribe,
+        store.getScheme,
+        () => 'light',
+    );
+}
+
+/**
+ * Test-only seam: drops the listener and the shared store so the next mount
+ * re-reads the seed. The store itself is covered directly through
+ * `createColorSchemeStore`; this exists so the mount tests can vary the URL.
+ */
+export function resetColorSchemeState(): void {
+    activeCleanup?.();
+    sharedStore = null;
+}

--- a/packages/query-sdk/src/features.ts
+++ b/packages/query-sdk/src/features.ts
@@ -87,6 +87,13 @@ export const SDK_FEATURES: SdkFeature[] = [
             "Let viewers adjust the visualization from the Lightdash config panel — toggles, dropdowns, numbers, text and colours — and take series colours from the chart's palette, without regenerating the app.",
         wiring: 'Declare configOptions (and colorPalette, if the viz colours series) in the viz schema, then read options[name] and colorPalette from useVizContext().',
     },
+    {
+        key: 'follow-host-theme',
+        label: 'Follow the host light/dark mode',
+        description:
+            "Render in whatever light or dark mode the viewer's Lightdash (or embed) is set to, instead of a fixed theme, and restyle live when they switch.",
+        wiring: 'Keep complete light tokens in :root and dark tokens in .dark, remove any fixed dark class from the app shell, and use useColorScheme() only for colours that cannot be expressed in CSS.',
+    },
 ];
 
 export const SDK_FEATURE_KEYS: string[] = SDK_FEATURES.map((f) => f.key);

--- a/packages/query-sdk/src/index.ts
+++ b/packages/query-sdk/src/index.ts
@@ -108,6 +108,14 @@ export type {
     VizContextRequestMessage,
 } from './vizContext';
 
+// Host light/dark mode (seeded from the iframe URL, updated by the host)
+export { useColorScheme } from './colorScheme';
+export type {
+    HostColorScheme,
+    HostColorSchemeMessage,
+    HostColorSchemeRequestMessage,
+} from './colorScheme';
+
 // Shareable URL state (seeded from and written back to the host page URL)
 export { useUrlState } from './urlState';
 export type { SdkUrlStateChangeMessage, UrlStateMap } from './urlState';


### PR DESCRIPTION
Data apps commit to one theme when they're built, so a dark-mode viewer opening a light app gets a bright rectangle in their dark page.

First of three: the iframe-side primitive, not wired to anything yet.

`colorScheme.ts` receives the host's scheme two ways. The `theme=` hash seed is read synchronously from `createClient()`, before React renders, so the app's first rendered frame is right. `lightdash:sdk:theme` messages keep it in step after that.

Delivery is a handshake like `vizContext`: the SDK posts `lightdash:sdk:theme-request` once its listener is live, and re-posts on `sdk:ready`. Without it the app depends on `createClient()` having run before the host's load-time push, which the template guarantees but app-owned `main.jsx` can silently break.

Also registers `follow-host-theme` in the capability registry and its common mirror.

Relates: GLITCH-591
