### PR TITLE
feat(data-apps): push the host color scheme into app iframes

### DIFF
--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -987,6 +987,21 @@ export const APP_SDK_DATA_APP_VIZ_CONTEXT_MESSAGE =
 export const APP_SDK_VIZ_CONTEXT_REQUEST_MESSAGE =
     'lightdash:sdk:viz-context-request';
 
+// The light/dark mode an app iframe renders in: the host's resolved Mantine
+// scheme, or the embed's `?theme=`.
+export type AppColorScheme = 'light' | 'dark';
+
+// postMessage type the host uses to tell a running app which color scheme to
+// render in. Also seeded into the iframe URL hash as `theme=` so the SDK can
+// apply the right scheme before the app's first render.
+export const APP_SDK_COLOR_SCHEME_MESSAGE = 'lightdash:sdk:theme';
+
+// Posted by the app's SDK once its theme listener is live, so the host replies
+// with the current scheme instead of the app depending on having been listening
+// when the load-time push went out.
+export const APP_SDK_COLOR_SCHEME_REQUEST_MESSAGE =
+    'lightdash:sdk:theme-request';
+
 // Host-owned render context pushed into a data app viz: field name → bound query
 // field id, the host-fetched result rows the renderer reads, the effective
 // config option values (stored value ?? declared default), and the palette

--- a/packages/frontend/src/features/apps/AppIframePreview.test.tsx
+++ b/packages/frontend/src/features/apps/AppIframePreview.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react';
+import { type FC } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import MantineProvider from '../../providers/MantineProvider';
+import AppIframePreview from './AppIframePreview';
+
+vi.mock('./hooks/useAppSdkBridge', () => ({
+    useAppSdkBridge: () => ({
+        handleIframeLoad: vi.fn(),
+        enableInspector: vi.fn(),
+        disableInspector: vi.fn(),
+        enableLineage: vi.fn(),
+        disableLineage: vi.fn(),
+        highlightLineage: vi.fn(),
+    }),
+}));
+
+vi.mock('./hooks/useIframeScreenshot', () => ({
+    useIframeScreenshot: () => ({ captureScreenshot: vi.fn() }),
+}));
+
+const SRC =
+    'https://preview.example/api/apps/a/versions/1/t/tok/#transport=postMessage&projectUuid=p';
+
+type HarnessProps = {
+    hostColorScheme: 'light' | 'dark';
+    forceColorScheme?: 'light' | 'dark';
+};
+
+const Harness: FC<HarnessProps> = ({ hostColorScheme, forceColorScheme }) => (
+    <MantineProvider forceColorScheme={hostColorScheme}>
+        <AppIframePreview
+            src={SRC}
+            expectedPreviewOrigin="https://preview.example"
+            projectUuid="p"
+            appUuid="a"
+            identityKey="a:1"
+            forceColorScheme={forceColorScheme}
+        />
+    </MantineProvider>
+);
+
+const iframeSrc = (): string =>
+    screen.getByTitle('App preview').getAttribute('src') ?? '';
+
+const iframeTheme = (): string | null =>
+    new URLSearchParams(iframeSrc().split('#')[1]).get('theme');
+
+describe('AppIframePreview', () => {
+    it('seeds the iframe URL with the host color scheme', () => {
+        render(<Harness hostColorScheme="dark" />);
+        expect(iframeTheme()).toEqual('dark');
+        expect(iframeSrc()).toContain('transport=postMessage');
+    });
+
+    it('keeps the iframe URL stable when the host toggles theme (a reload would drop app state)', () => {
+        const { rerender } = render(<Harness hostColorScheme="dark" />);
+        const before = iframeSrc();
+        // The toggle reaches the running app over the SDK bridge; re-latching
+        // the URL here would reload the iframe and lose its state.
+        rerender(<Harness hostColorScheme="light" />);
+        expect(iframeSrc()).toEqual(before);
+    });
+
+    it('lets an explicit override win over the host scheme (scheduled renders)', () => {
+        render(<Harness hostColorScheme="dark" forceColorScheme="light" />);
+        expect(iframeTheme()).toEqual('light');
+    });
+});

--- a/packages/frontend/src/features/apps/AppIframePreview.tsx
+++ b/packages/frontend/src/features/apps/AppIframePreview.tsx
@@ -1,8 +1,10 @@
 import {
+    type AppColorScheme,
     type DataAppVizContext,
     type DashboardFilters,
     type QueryExecutionContext,
 } from '@lightdash/common';
+import { useMantineColorScheme } from '@mantine/core';
 import {
     forwardRef,
     useCallback,
@@ -21,6 +23,7 @@ import {
 } from './hooks/useAppSdkBridge';
 import { useAppUrlStateSync } from './hooks/useAppUrlStateSync';
 import { useIframeScreenshot } from './hooks/useIframeScreenshot';
+import { withColorSchemeParam } from './utils/appIframeUrl';
 
 export type AppIframePreviewHandle = {
     captureScreenshot: () => Promise<File>;
@@ -110,6 +113,10 @@ type Props = {
     // param. Leave unset where the page URL isn't the app's share surface
     // (dashboard tiles, screenshots).
     urlStateSync?: boolean;
+    /** Pins the scheme the app renders in, ignoring the host's own. Set by
+     *  `MinimalApp` so scheduled screenshots don't depend on whichever theme
+     *  the rendering browser happens to have stored. */
+    forceColorScheme?: AppColorScheme;
 };
 
 /**
@@ -162,20 +169,35 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
             dataAppVizContext,
             urlStateSync,
             onSdkManifest,
+            forceColorScheme,
         },
         ref,
     ) => {
         const iframeRef = useRef<HTMLIFrameElement>(null);
+        // Mantine v6 resolves to an exact light/dark (embed routes force it
+        // from `?theme=`), so this is the scheme the surrounding page renders in.
+        const { colorScheme: hostColorScheme } = useMantineColorScheme();
+        const colorScheme: AppColorScheme = forceColorScheme ?? hostColorScheme;
         const { applySeed, handleUrlStateChange } = useAppUrlStateSync({
             appUuid,
             enabled: urlStateSync === true,
         });
-        // Memoized on `src`: the seed is re-latched exactly when the iframe
+        // Latest scheme in a ref so the seed helper stays identity-stable: a
+        // theme toggle must restyle the running app over the bridge, never
+        // change the iframe URL (which would reload it and lose app state).
+        const colorSchemeRef = useRef(colorScheme);
+        colorSchemeRef.current = colorScheme;
+        const applyColorSchemeSeed = useCallback(
+            (baseUrl: string) =>
+                withColorSchemeParam(baseUrl, colorSchemeRef.current),
+            [],
+        );
+        // Memoized on `src`: the seeds are re-latched exactly when the iframe
         // would reload anyway (refresh counter, version bump, token refetch),
         // never on state changes alone — that would reload per filter click.
         const effectiveSrc = useMemo(
-            () => (urlStateSync ? applySeed(src) : src),
-            [urlStateSync, applySeed, src],
+            () => applyColorSchemeSeed(urlStateSync ? applySeed(src) : src),
+            [urlStateSync, applySeed, applyColorSchemeSeed, src],
         );
         // Memoized so the bridge's message listener doesn't re-attach on every
         // parent render — AppGenerate re-renders on every keystroke (editor's
@@ -216,6 +238,7 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
             dataAppVizContext,
             onUrlStateChange: urlStateSync ? handleUrlStateChange : undefined,
             onSdkManifest,
+            colorScheme,
         });
         const { captureScreenshot } = useIframeScreenshot(iframeRef);
 

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
@@ -1,9 +1,12 @@
 import {
+    APP_SDK_COLOR_SCHEME_MESSAGE,
+    APP_SDK_COLOR_SCHEME_REQUEST_MESSAGE,
     APP_SDK_DATA_APP_VIZ_CONTEXT_MESSAGE,
     APP_SDK_VIZ_CONTEXT_REQUEST_MESSAGE,
     FilterOperator,
     LightdashAppUuidHeader,
     QueryExecutionContext,
+    type AppColorScheme,
     type DashboardFilters,
     type DataAppVizContext,
 } from '@lightdash/common';
@@ -119,6 +122,7 @@ function renderBridge(onQueryEvent: (event: QueryEvent) => void) {
     } as RefObject<HTMLIFrameElement | null>;
     renderHook(() =>
         useAppSdkBridge({
+            colorScheme: 'light',
             iframeRef,
             expectedPreviewOrigin: window.location.origin,
             projectUuid: PROJECT_UUID,
@@ -542,6 +546,7 @@ describe('lineage message routing', () => {
         } as RefObject<HTMLIFrameElement | null>;
         renderHook(() =>
             useAppSdkBridge({
+                colorScheme: 'light',
                 iframeRef,
                 expectedPreviewOrigin: window.location.origin,
                 projectUuid: PROJECT_UUID,
@@ -565,6 +570,7 @@ describe('lineage message routing', () => {
         } as RefObject<HTMLIFrameElement | null>;
         renderHook(() =>
             useAppSdkBridge({
+                colorScheme: 'light',
                 iframeRef,
                 expectedPreviewOrigin: window.location.origin,
                 projectUuid: PROJECT_UUID,
@@ -588,6 +594,7 @@ describe('lineage message routing', () => {
         } as RefObject<HTMLIFrameElement | null>;
         renderHook(() =>
             useAppSdkBridge({
+                colorScheme: 'light',
                 iframeRef,
                 expectedPreviewOrigin: window.location.origin,
                 projectUuid: PROJECT_UUID,
@@ -610,6 +617,7 @@ describe('lineage message routing', () => {
         } as RefObject<HTMLIFrameElement | null>;
         renderHook(() =>
             useAppSdkBridge({
+                colorScheme: 'light',
                 iframeRef,
                 expectedPreviewOrigin: window.location.origin,
                 projectUuid: PROJECT_UUID,
@@ -647,6 +655,7 @@ describe('url-state-change routing', () => {
         } as RefObject<HTMLIFrameElement | null>;
         renderHook(() =>
             useAppSdkBridge({
+                colorScheme: 'light',
                 iframeRef,
                 expectedPreviewOrigin: window.location.origin,
                 projectUuid: PROJECT_UUID,
@@ -771,6 +780,7 @@ describe('chart-query routing', () => {
         } as RefObject<HTMLIFrameElement | null>;
         renderHook(() =>
             useAppSdkBridge({
+                colorScheme: 'light',
                 iframeRef,
                 expectedPreviewOrigin: window.location.origin,
                 projectUuid: PROJECT_UUID,
@@ -863,6 +873,7 @@ describe('external-fetch branch', () => {
         } as RefObject<HTMLIFrameElement | null>;
         renderHook(() =>
             useAppSdkBridge({
+                colorScheme: 'light',
                 iframeRef,
                 expectedPreviewOrigin: window.location.origin,
                 projectUuid: PROJECT_UUID,
@@ -1139,6 +1150,7 @@ describe('data-app-viz-context push', () => {
         } as RefObject<HTMLIFrameElement | null>;
         return renderHook(() =>
             useAppSdkBridge({
+                colorScheme: 'light',
                 iframeRef,
                 expectedPreviewOrigin: window.location.origin,
                 projectUuid: PROJECT_UUID,
@@ -1171,6 +1183,7 @@ describe('data-app-viz-context push', () => {
         const { rerender } = renderHook(
             ({ ctx }: { ctx: DataAppVizContext }) =>
                 useAppSdkBridge({
+                    colorScheme: 'light',
                     iframeRef,
                     expectedPreviewOrigin: window.location.origin,
                     projectUuid: PROJECT_UUID,
@@ -1205,6 +1218,7 @@ describe('data-app-viz-context push', () => {
         const { rerender } = renderHook(
             ({ ctx }: { ctx: DataAppVizContext }) =>
                 useAppSdkBridge({
+                    colorScheme: 'light',
                     iframeRef,
                     expectedPreviewOrigin: window.location.origin,
                     projectUuid: PROJECT_UUID,
@@ -1301,6 +1315,7 @@ describe('delivery capture accumulator integration', () => {
                 dashboardFilters,
                 invalidateCache: true,
                 deliveryCapture,
+                colorScheme: 'light',
             }),
         );
 
@@ -1372,6 +1387,7 @@ describe('delivery capture accumulator integration', () => {
                 projectUuid: PROJECT_UUID,
                 appUuid: APP_UUID,
                 deliveryCapture,
+                colorScheme: 'light',
             }),
         );
 
@@ -1435,6 +1451,7 @@ describe('delivery capture accumulator integration', () => {
                 appUuid: APP_UUID,
                 invalidateCache: true,
                 queryContextOverride: QueryExecutionContext.SCHEDULED_DELIVERY,
+                colorScheme: 'light',
             }),
         );
 
@@ -1465,5 +1482,100 @@ describe('delivery capture accumulator integration', () => {
         const sentBody = JSON.parse(String(init?.body));
         // No deliveryCapture/queryContextOverride passed — body is untouched.
         expect(sentBody).toEqual({ query: METRIC_QUERY });
+    });
+});
+
+describe('color scheme push', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    const iframeRef = {
+        current: { contentWindow: window } as unknown as HTMLIFrameElement,
+    } as RefObject<HTMLIFrameElement | null>;
+
+    const renderWithColorScheme = (colorScheme: AppColorScheme) =>
+        renderHook(
+            ({ scheme }: { scheme: AppColorScheme }) =>
+                useAppSdkBridge({
+                    iframeRef,
+                    expectedPreviewOrigin: window.location.origin,
+                    projectUuid: PROJECT_UUID,
+                    appUuid: APP_UUID,
+                    colorScheme: scheme,
+                }),
+            { initialProps: { scheme: colorScheme } },
+        );
+
+    it('pushes the host scheme to the iframe on mount', () => {
+        const postSpy = vi.spyOn(window, 'postMessage');
+        renderWithColorScheme('dark');
+        expect(postSpy).toHaveBeenCalledWith(
+            { type: APP_SDK_COLOR_SCHEME_MESSAGE, colorScheme: 'dark' },
+            '*',
+        );
+    });
+
+    it('re-pushes when the host toggles theme', () => {
+        const postSpy = vi.spyOn(window, 'postMessage');
+        const { rerender } = renderWithColorScheme('light');
+        postSpy.mockClear();
+        rerender({ scheme: 'dark' });
+        expect(postSpy).toHaveBeenCalledWith(
+            { type: APP_SDK_COLOR_SCHEME_MESSAGE, colorScheme: 'dark' },
+            '*',
+        );
+    });
+
+    it('re-sends the scheme on iframe load, after the ready signal', () => {
+        const postSpy = vi.spyOn(window, 'postMessage');
+        const { result } = renderWithColorScheme('dark');
+        postSpy.mockClear();
+        result.current.handleIframeLoad();
+        expect(postSpy.mock.calls.map(([message]) => message)).toEqual([
+            { type: 'lightdash:sdk:ready' },
+            { type: APP_SDK_COLOR_SCHEME_MESSAGE, colorScheme: 'dark' },
+        ]);
+    });
+
+    // The recovery path: an app whose SDK mounted after the load-time push (its
+    // `createClient()` isn't at module scope) asks, and gets an answer. Without
+    // this the app would keep the seed forever and silently ignore toggles.
+    it('answers a theme request from an app that missed the load-time push', async () => {
+        const postSpy = vi.spyOn(window, 'postMessage');
+        renderWithColorScheme('dark');
+        postSpy.mockClear();
+
+        window.dispatchEvent(
+            new MessageEvent('message', {
+                data: { type: APP_SDK_COLOR_SCHEME_REQUEST_MESSAGE },
+                source: window,
+                origin: window.location.origin,
+            }),
+        );
+        await vi.waitFor(() =>
+            expect(postSpy).toHaveBeenCalledWith(
+                { type: APP_SDK_COLOR_SCHEME_MESSAGE, colorScheme: 'dark' },
+                '*',
+            ),
+        );
+    });
+
+    it('ignores a theme request from a window that is not the iframe', async () => {
+        const postSpy = vi.spyOn(window, 'postMessage');
+        renderWithColorScheme('dark');
+        postSpy.mockClear();
+
+        window.dispatchEvent(
+            new MessageEvent('message', {
+                data: { type: APP_SDK_COLOR_SCHEME_REQUEST_MESSAGE },
+                source: null,
+                origin: window.location.origin,
+            }),
+        );
+        await new Promise((resolve) => {
+            setTimeout(resolve, 0);
+        });
+        expect(postSpy).not.toHaveBeenCalled();
     });
 });

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -1,10 +1,13 @@
 import {
+    APP_SDK_COLOR_SCHEME_MESSAGE,
+    APP_SDK_COLOR_SCHEME_REQUEST_MESSAGE,
     APP_SDK_DATA_APP_VIZ_CONTEXT_MESSAGE,
     APP_SDK_VIZ_CONTEXT_REQUEST_MESSAGE,
     extractAppSdkRouteProjectUuid,
     isAllowedAppSdkRoute,
     JWT_HEADER_NAME,
     LightdashAppUuidHeader,
+    type AppColorScheme,
     type DashboardFilters,
     type DataAppVizContext,
     type QueryExecutionContext,
@@ -256,6 +259,13 @@ export type UseAppSdkBridgeParams = {
     /** When set, stamped as `context` onto metric/chart POST bodies (delivery
      *  renders send SCHEDULED_DELIVERY for honest attribution). */
     queryContextOverride?: QueryExecutionContext;
+    /**
+     * The light/dark mode the app should render in — the host's resolved
+     * scheme. Pushed on load and on every change so a host theme toggle
+     * restyles the app without reloading the iframe. Bundles built before the
+     * SDK understood the message ignore it.
+     */
+    colorScheme: AppColorScheme;
 };
 
 export function useAppSdkBridge({
@@ -278,6 +288,7 @@ export function useAppSdkBridge({
     onSdkManifest,
     deliveryCapture,
     queryContextOverride,
+    colorScheme,
 }: UseAppSdkBridgeParams) {
     // Embed mode adapts the bridge's outgoing fetches in two ways:
     //   - Attaches the embed JWT header in lieu of session cookies
@@ -315,6 +326,16 @@ export function useAppSdkBridge({
             '*',
         );
     }, [iframeRef, dataAppVizContext]);
+
+    // Tell the iframe which scheme to render in. Wildcard target for the same
+    // reason as every other outbound message: the sandboxed iframe has an
+    // opaque origin, and the payload is a single non-sensitive enum.
+    const pushColorScheme = useCallback(() => {
+        iframeRef.current?.contentWindow?.postMessage(
+            { type: APP_SDK_COLOR_SCHEME_MESSAGE, colorScheme },
+            '*',
+        );
+    }, [iframeRef, colorScheme]);
 
     const handleMessage = useCallback(
         async (event: MessageEvent) => {
@@ -372,6 +393,13 @@ export function useAppSdkBridge({
             // isn't a data app viz).
             if (data?.type === APP_SDK_VIZ_CONTEXT_REQUEST_MESSAGE) {
                 pushDataAppVizContext();
+                return;
+            }
+
+            // Same handshake for the color scheme: the SDK asks as soon as its
+            // listener is live, so it can't miss the load-time push.
+            if (data?.type === APP_SDK_COLOR_SCHEME_REQUEST_MESSAGE) {
+                pushColorScheme();
                 return;
             }
 
@@ -989,6 +1017,7 @@ export function useAppSdkBridge({
             onLineageSelected,
             onExternalRequestEvent,
             pushDataAppVizContext,
+            pushColorScheme,
             onUrlStateChange,
             onSdkManifest,
             health.data,
@@ -1003,6 +1032,13 @@ export function useAppSdkBridge({
         return () => window.removeEventListener('message', handleMessage);
     }, [handleMessage]);
 
+    // Re-push on every host theme change so an already-loaded app restyles in
+    // place. The initial value also rides in the iframe URL hash, which the SDK
+    // applies as the app boots — this message would arrive too late for that.
+    useEffect(() => {
+        pushColorScheme();
+    }, [pushColorScheme]);
+
     const handleIframeLoad = useCallback(() => {
         // `*` because the load event fires once for the initial about:blank
         // (which inherits the parent's origin) and again after the iframe
@@ -1013,7 +1049,8 @@ export function useAppSdkBridge({
             { type: 'lightdash:sdk:ready' },
             '*',
         );
-    }, [iframeRef]);
+        pushColorScheme();
+    }, [iframeRef, pushColorScheme]);
 
     // Re-push the render context whenever the host's field mapping or rows
     // change, so an already-loaded iframe re-renders live. The initial delivery

--- a/packages/frontend/src/features/apps/utils/appIframeUrl.test.ts
+++ b/packages/frontend/src/features/apps/utils/appIframeUrl.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { withColorSchemeParam } from './appIframeUrl';
+
+const BASE =
+    'https://preview.example/api/apps/a/versions/1/t/tok/?r=0#transport=postMessage&projectUuid=p';
+
+describe('withColorSchemeParam', () => {
+    it('adds the scheme to the hash without disturbing the rest of the URL', () => {
+        const url = new URL(withColorSchemeParam(BASE, 'dark'));
+        expect(url.pathname).toEqual('/api/apps/a/versions/1/t/tok/');
+        expect(url.search).toEqual('?r=0');
+        const hash = new URLSearchParams(url.hash.replace(/^#/, ''));
+        expect(hash.get('transport')).toEqual('postMessage');
+        expect(hash.get('projectUuid')).toEqual('p');
+        expect(hash.get('theme')).toEqual('dark');
+    });
+
+    it('preserves an encoded url-state seed', () => {
+        const state = JSON.stringify({ period: 'last_month', q: 'a b&c' });
+        const seeded = `${BASE}&state=${encodeURIComponent(state)}`;
+        const hash = new URLSearchParams(
+            withColorSchemeParam(seeded, 'dark').split('#')[1],
+        );
+        expect(hash.get('state')).toEqual(state);
+        expect(hash.get('theme')).toEqual('dark');
+    });
+
+    it('replaces an existing scheme rather than appending a second one', () => {
+        const result = withColorSchemeParam(
+            withColorSchemeParam(BASE, 'dark'),
+            'light',
+        );
+        const hash = new URLSearchParams(result.split('#')[1]);
+        expect(hash.getAll('theme')).toEqual(['light']);
+    });
+
+    it('adds a hash to a URL that has none', () => {
+        expect(
+            withColorSchemeParam('https://preview.example/app/', 'dark'),
+        ).toEqual('https://preview.example/app/#theme=dark');
+    });
+});

--- a/packages/frontend/src/features/apps/utils/appIframeUrl.ts
+++ b/packages/frontend/src/features/apps/utils/appIframeUrl.ts
@@ -1,0 +1,23 @@
+import { type AppColorScheme } from '@lightdash/common';
+
+// Matches COLOR_SCHEME_PARAM in packages/query-sdk/src/colorScheme.ts.
+const COLOR_SCHEME_PARAM = 'theme';
+
+/**
+ * Seed an app preview URL's hash with the host's resolved color scheme, so the
+ * SDK can apply it as the app boots rather than waiting for the first bridge
+ * message. The hash is used (not the query string) because it isn't sent to the
+ * preview server and so never varies the cached response.
+ */
+export const withColorSchemeParam = (
+    url: string,
+    colorScheme: AppColorScheme,
+): string => {
+    const hashIndex = url.indexOf('#');
+    const base = hashIndex === -1 ? url : url.slice(0, hashIndex);
+    const params = new URLSearchParams(
+        hashIndex === -1 ? '' : url.slice(hashIndex + 1),
+    );
+    params.set(COLOR_SCHEME_PARAM, colorScheme);
+    return `${base}#${params.toString()}`;
+};

--- a/packages/frontend/src/pages/MinimalApp.tsx
+++ b/packages/frontend/src/pages/MinimalApp.tsx
@@ -272,6 +272,9 @@ export default function MinimalApp() {
                 // Seeds the app from ?state= so scheduled deliveries with a
                 // saved app state screenshot that view, not the default one.
                 urlStateSync
+                // Scheduled renders must not depend on the headless browser's
+                // stored theme preference.
+                forceColorScheme="light"
             />
             {indicatorReady && (
                 <ScreenshotReadyIndicator


### PR DESCRIPTION
Host side. Stacked on #26453.

Every app iframe surface goes through `AppIframePreview`, so this is one component deep.

The resolved scheme is seeded into the iframe hash as `theme=light|dark`, and `useAppSdkBridge` posts `lightdash:sdk:theme` on load and on every change. The bridge also answers #26453's `theme-request`, in the same switch that answers `viz-context-request`.

The seed is re-latched only when `src` changes for other reasons (refresh, new version, token refetch). If a theme toggle re-latched it, the iframe would reload and the running app would lose its state, so the toggle goes over the bridge instead. There's a test that fails if that breaks.

`MinimalApp` pins `forceColorScheme="light"` so scheduled screenshots don't depend on the rendering browser's stored theme. Embeds need no change, since `?theme=` already forces the host's Mantine scheme.

Relates: GLITCH-591
