### PR TITLE
fix(docker-dev): delete instance PM2 processes one name at a time

### DIFF
--- a/.claude/commands/docker-dev.md
+++ b/.claude/commands/docker-dev.md
@@ -779,7 +779,12 @@ fi
 If PM2 shows `MISMATCH`, delete this instance's processes first:
 
 ```bash
-pm2 delete "${LD_INSTANCE_ID}-api" "${LD_INSTANCE_ID}-scheduler" "${LD_INSTANCE_ID}-frontend" "${LD_INSTANCE_ID}-common-watch" "${LD_INSTANCE_ID}-formula-watch" "${LD_INSTANCE_ID}-warehouses-watch" "${LD_INSTANCE_ID}-sdk-test" "${LD_INSTANCE_ID}-spotlight" 2>/dev/null || true
+# One name per call — `pm2 delete a b c` aborts at the first name it cannot
+# find (e.g. sdk-test on an instance that never ran SDK test mode), leaving
+# every later name running.
+for suffix in api scheduler frontend common-watch formula-watch warehouses-watch sdk-test spotlight; do
+  pm2 delete "${LD_INSTANCE_ID}-${suffix}" 2>/dev/null || true
+done
 ```
 
 Then start:
@@ -915,7 +920,12 @@ Restart Claude Code to load the new `statusLine` command. If there's no command-
 Stop this instance's services. Shared services and other instances are not affected.
 
 ```bash
-pm2 delete "${LD_INSTANCE_ID}-api" "${LD_INSTANCE_ID}-scheduler" "${LD_INSTANCE_ID}-frontend" "${LD_INSTANCE_ID}-common-watch" "${LD_INSTANCE_ID}-formula-watch" "${LD_INSTANCE_ID}-warehouses-watch" "${LD_INSTANCE_ID}-sdk-test" "${LD_INSTANCE_ID}-spotlight" 2>/dev/null || true
+# One name per call — `pm2 delete a b c` aborts at the first name it cannot
+# find (e.g. sdk-test on an instance that never ran SDK test mode), leaving
+# every later name running.
+for suffix in api scheduler frontend common-watch formula-watch warehouses-watch sdk-test spotlight; do
+  pm2 delete "${LD_INSTANCE_ID}-${suffix}" 2>/dev/null || true
+done
 
 docker compose -p "$LD_COMPOSE_PROJECT" -f docker/docker-compose.dev.instance.yml down
 
@@ -933,7 +943,10 @@ Stop ALL instances, shared services, and release all port slots.
 for f in ~/.lightdash/dev-instances/*.json; do
   [ -f "$f" ] || continue
   INST_ID=$(python3 -c "import json; print(json.load(open('$f'))['instanceId'])")
-  pm2 delete "${INST_ID}-api" "${INST_ID}-scheduler" "${INST_ID}-frontend" "${INST_ID}-common-watch" "${INST_ID}-formula-watch" "${INST_ID}-warehouses-watch" "${INST_ID}-sdk-test" "${INST_ID}-spotlight" 2>/dev/null || true
+  # One name per call — see the note under `stop`.
+  for suffix in api scheduler frontend common-watch formula-watch warehouses-watch sdk-test spotlight; do
+    pm2 delete "${INST_ID}-${suffix}" 2>/dev/null || true
+  done
 done
 
 for f in ~/.lightdash/dev-instances/*.json; do

--- a/scripts/dev-fast-start.sh
+++ b/scripts/dev-fast-start.sh
@@ -51,6 +51,14 @@ instance_pm2_names() {
     done
 }
 
+# One name per call: `pm2 delete a b c` aborts at the first name it cannot
+# find, silently leaving every later one running.
+delete_instance_pm2() {
+    for name in $(instance_pm2_names); do
+        pm2 delete "$name" >/dev/null 2>&1 || true
+    done
+}
+
 dotenv_args() {
     if [ "$EE_MODE" = true ]; then
         echo "-e .env.development.local -e .env.development"
@@ -561,15 +569,13 @@ if mine:
 " 2>/dev/null || true)"
 if [ -n "$RUNNING_CWD" ] && [ "$RUNNING_CWD" != "$(pwd)" ]; then
     echo "Instance PM2 was running from $RUNNING_CWD — switching to this worktree"
-    # shellcheck disable=SC2046
-    pm2 delete $(instance_pm2_names) >/dev/null 2>&1 || true
+    delete_instance_pm2
 elif [ "${ENV_PORTS_CHANGED:-0}" = 1 ]; then
     # Ports were reconciled but procs may already be online with the stale env.
     # PM2 caches env at spawn time, so delete+start is required (restart --update-env
     # only inherits the current shell, not the .env file).
     echo "Env ports changed — recycling PM2 so the new env is picked up"
-    # shellcheck disable=SC2046
-    pm2 delete $(instance_pm2_names) >/dev/null 2>&1 || true
+    delete_instance_pm2
 fi
 if [ "$SDK_TEST_MODE" = true ]; then
     export LD_ENABLE_SDK_TEST=true


### PR DESCRIPTION
`pm2 delete a b c` stops at the first name it cannot find. Every name *after* the missing one is silently skipped, and the trailing `2>/dev/null || true` hides the error.

Both dev-env stop paths pass all eight instance process names in a single call, with `sdk-test` second-to-last and `spotlight` last. `sdk-test` only exists when SDK test mode ran, so on an ordinary instance it is missing — and **`spotlight` is never deleted**.

That is the origin of the leaked `<instance>-spotlight` processes that squat a port slot and crash-loop the next owner of that slot. One was found today with **7,480 restarts**, having survived a by-the-book `stop-all`.

## Reproduction

Seven of the eight instance processes running, `sdk-test` absent — exactly a normal instance:

```
before: t-api t-common-watch t-formula-watch t-frontend t-scheduler t-spotlight t-warehouses-watch

$ pm2 delete $(instance_pm2_names)      # current code
after:  t-spotlight                      ← leaked

$ delete_instance_pm2                    # this PR
after:  (none)
```

Isolated to the mechanism alone:

```
$ pm2 delete t-alpha t-MISSING t-omega
[PM2] [t-alpha](0) ✓
[PM2][ERROR] Process or Namespace t-MISSING not found
$ # t-omega still running
```

## The change

One `pm2 delete` per name, so each is independent of the others.

- `scripts/dev-fast-start.sh` — new `delete_instance_pm2` helper replaces both `pm2 delete $(instance_pm2_names)` call sites (the switching-worktree and env-changed recycle paths). Also drops the two now-unnecessary `# shellcheck disable=SC2046` pragmas, which existed only to allow the unquoted word-splitting this removes.
- `.claude/commands/docker-dev.md` — the `stop` and `stop-all` blocks become loops.

`instance_pm2_names` is kept as the single list of suffixes so the names stay defined in one place.

## Verification

`bash -n` clean on the script; all three edited runbook bash blocks extracted and `bash -n` clean. The before/after above is a real PM2 run against the fixed helper sourced verbatim out of the edited script, not a transcription of it.

Dev-env tooling only — no runtime or product code in the diff.

Linear: SPK-724