### PR TITLE
feat(ai): expose Deep Research status and reports to chat

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -420,6 +420,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         models.getProjectContextModel<ProjectContextModel>(),
                     aiAgentDocumentModel:
                         models.getAiAgentDocumentModel<AiAgentDocumentModel>(),
+                    aiDeepResearchRunModel:
+                        models.getAiDeepResearchRunModel<AiDeepResearchRunModel>(),
                     featureFlagService: repository.getFeatureFlagService(),
                     previewDeploySetupService:
                         repository.getPreviewDeploySetupService<PreviewDeploySetupService>(),

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.test.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.test.ts
@@ -126,6 +126,95 @@ describe('AiDeepResearchRunModel', () => {
         expect(tracker.history.select).toHaveLength(0);
     });
 
+    it('loads thread status without selecting report content', async () => {
+        tracker.on.select(AiDeepResearchRunsTableName).responseOnce([]);
+
+        await model.findAgentContextByThreadScoped({
+            aiThreadUuid: 'thread-1',
+            organizationUuid: 'organization-1',
+            projectUuid: 'project-1',
+            createdByUserUuid: 'user-1',
+        });
+
+        const [query] = tracker.history.select;
+        expect(query.sql).toContain(
+            'coalesce(octet_length(result_markdown), 0) > 0 as has_report',
+        );
+        expect(query.sql).not.toContain('select "result_markdown"');
+        expect(query.bindings).toEqual([
+            'thread-1',
+            'organization-1',
+            'project-1',
+            'user-1',
+        ]);
+    });
+
+    it('lists report metadata without selecting report content', async () => {
+        tracker.on.select(AiDeepResearchRunsTableName).responseOnce([]);
+
+        await model.findReportSummariesByThreadScoped({
+            aiThreadUuid: 'thread-1',
+            organizationUuid: 'organization-1',
+            projectUuid: 'project-1',
+            createdByUserUuid: 'user-1',
+        });
+
+        const [query] = tracker.history.select;
+        expect(query.sql).toContain(
+            'octet_length(result_markdown) as content_size_bytes',
+        );
+        expect(query.sql).not.toContain('select "result_markdown"');
+        expect(query.sql).toContain('octet_length(result_markdown) > 0');
+        expect(query.bindings).toEqual([
+            'thread-1',
+            'organization-1',
+            'project-1',
+            'user-1',
+        ]);
+    });
+
+    it('loads report content only for one scoped run', async () => {
+        tracker.on.select(AiDeepResearchRunsTableName).responseOnce([]);
+
+        await model.findReportByUuidThreadScoped({
+            aiDeepResearchRunUuid: RUN_UUID,
+            aiThreadUuid: 'thread-1',
+            organizationUuid: 'organization-1',
+            projectUuid: 'project-1',
+            createdByUserUuid: 'user-1',
+        });
+
+        const [query] = tracker.history.select;
+        expect(query.sql).toContain(
+            'select "ai_deep_research_run_uuid", "prompt", "result_markdown"',
+        );
+        expect(query.sql).toContain('octet_length(result_markdown) > 0');
+        expect(query.bindings).toEqual([
+            RUN_UUID,
+            'thread-1',
+            'organization-1',
+            'project-1',
+            'user-1',
+            1,
+        ]);
+    });
+
+    it('loads only the latest progress event for each run', async () => {
+        tracker.on.select(AiDeepResearchEventsTableName).responseOnce([]);
+
+        await model.findLatestProgressByRunUuids(['run-1', 'run-2']);
+
+        const [query] = tracker.history.select;
+        expect(query.sql).toContain(
+            'distinct on ("ai_deep_research_run_uuid")',
+        );
+        expect(query.sql).toContain('"event_type" = $3');
+        expect(query.sql).toContain(
+            'order by "ai_deep_research_run_uuid" asc, "created_at" desc, "ai_deep_research_event_uuid" desc',
+        );
+        expect(query.bindings).toEqual(['run-1', 'run-2', 'progress']);
+    });
+
     it('does not overwrite a cancellation request with completion', async () => {
         tracker.on.update(AiDeepResearchRunsTableName).responseOnce([]);
 

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
@@ -36,6 +36,31 @@ type CreateAiDeepResearchRun = {
     executionContextSnapshot: AiDeepResearchExecutionContextSnapshot;
 };
 
+export type AiDeepResearchRunContextRow = Pick<
+    DbAiDeepResearchRun,
+    | 'ai_deep_research_run_uuid'
+    | 'prompt'
+    | 'status'
+    | 'created_at'
+    | 'started_at'
+    | 'completed_at'
+> & {
+    has_report: boolean;
+};
+
+export type AiDeepResearchReportSummaryRow = Pick<
+    DbAiDeepResearchRun,
+    | 'ai_deep_research_run_uuid'
+    | 'organization_uuid'
+    | 'project_uuid'
+    | 'created_by_user_uuid'
+    | 'prompt'
+    | 'created_at'
+    | 'updated_at'
+> & {
+    content_size_bytes: number;
+};
+
 type EventCursor = {
     createdAt: string;
     eventUuid: string;
@@ -190,6 +215,111 @@ export class AiDeepResearchRunModel {
             .where('project_uuid', args.projectUuid)
             .where('created_by_user_uuid', args.createdByUserUuid)
             .orderBy('created_at', 'asc');
+    }
+
+    async findAgentContextByThreadScoped(args: {
+        aiThreadUuid: string;
+        organizationUuid: string;
+        projectUuid: string;
+        createdByUserUuid: string;
+    }): Promise<AiDeepResearchRunContextRow[]> {
+        const rows = await this.database<AiDeepResearchRunsTable>(
+            AiDeepResearchRunsTableName,
+        )
+            .select(
+                'ai_deep_research_run_uuid',
+                'prompt',
+                'status',
+                'created_at',
+                'started_at',
+                'completed_at',
+                this.database.raw(
+                    'coalesce(octet_length(result_markdown), 0) > 0 as has_report',
+                ),
+            )
+            .where('ai_thread_uuid', args.aiThreadUuid)
+            .where('organization_uuid', args.organizationUuid)
+            .where('project_uuid', args.projectUuid)
+            .where('created_by_user_uuid', args.createdByUserUuid)
+            .orderBy('created_at', 'asc');
+
+        return rows as unknown as AiDeepResearchRunContextRow[];
+    }
+
+    async findReportSummariesByThreadScoped(args: {
+        aiThreadUuid: string;
+        organizationUuid: string;
+        projectUuid: string;
+        createdByUserUuid: string;
+    }): Promise<AiDeepResearchReportSummaryRow[]> {
+        const rows = await this.database<AiDeepResearchRunsTable>(
+            AiDeepResearchRunsTableName,
+        )
+            .select(
+                'ai_deep_research_run_uuid',
+                'organization_uuid',
+                'project_uuid',
+                'created_by_user_uuid',
+                'prompt',
+                'created_at',
+                'updated_at',
+                this.database.raw(
+                    'octet_length(result_markdown) as content_size_bytes',
+                ),
+            )
+            .where('ai_thread_uuid', args.aiThreadUuid)
+            .where('organization_uuid', args.organizationUuid)
+            .where('project_uuid', args.projectUuid)
+            .where('created_by_user_uuid', args.createdByUserUuid)
+            .whereRaw('octet_length(result_markdown) > 0')
+            .orderBy('created_at', 'asc');
+
+        return rows as unknown as AiDeepResearchReportSummaryRow[];
+    }
+
+    async findReportByUuidThreadScoped(args: {
+        aiDeepResearchRunUuid: string;
+        aiThreadUuid: string;
+        organizationUuid: string;
+        projectUuid: string;
+        createdByUserUuid: string;
+    }): Promise<
+        | Pick<
+              DbAiDeepResearchRun,
+              'ai_deep_research_run_uuid' | 'prompt' | 'result_markdown'
+          >
+        | undefined
+    > {
+        return this.database<AiDeepResearchRunsTable>(
+            AiDeepResearchRunsTableName,
+        )
+            .select('ai_deep_research_run_uuid', 'prompt', 'result_markdown')
+            .where('ai_deep_research_run_uuid', args.aiDeepResearchRunUuid)
+            .where('ai_thread_uuid', args.aiThreadUuid)
+            .where('organization_uuid', args.organizationUuid)
+            .where('project_uuid', args.projectUuid)
+            .where('created_by_user_uuid', args.createdByUserUuid)
+            .whereRaw('octet_length(result_markdown) > 0')
+            .first();
+    }
+
+    async findLatestProgressByRunUuids(
+        aiDeepResearchRunUuids: string[],
+    ): Promise<DbAiDeepResearchEvent[]> {
+        if (aiDeepResearchRunUuids.length === 0) {
+            return [];
+        }
+
+        return this.database<AiDeepResearchEventsTable>(
+            AiDeepResearchEventsTableName,
+        )
+            .distinctOn('ai_deep_research_run_uuid')
+            .select('*')
+            .whereIn('ai_deep_research_run_uuid', aiDeepResearchRunUuids)
+            .where('event_type', 'progress')
+            .orderBy('ai_deep_research_run_uuid', 'asc')
+            .orderBy('created_at', 'desc')
+            .orderBy('ai_deep_research_event_uuid', 'desc');
     }
 
     async deleteUnstartedFailedRun(

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -76,6 +76,7 @@ import {
     GITHUB_MCP_SERVER_URL,
     hasAiAgentAccessToSpace,
     InsufficientGitPermissionsError,
+    isAiDeepResearchRunTerminal,
     isAiSqlChartArtifactConfig,
     isAiWritebackRunInProgress,
     isGitProjectType,
@@ -112,6 +113,7 @@ import {
     type AiAgentModelConfig,
     type AiClonedThreadCreatedFrom,
     type AiDeepResearchBudget,
+    type AiDeepResearchEventPayloadMap,
     type AiDeepResearchExecutionContextSnapshot,
     type AiPromptContextInput,
     type AiWebAppThreadCreatedFrom,
@@ -217,7 +219,7 @@ import { ShareService } from '../../../services/ShareService/ShareService';
 import { SpaceService } from '../../../services/SpaceService/SpaceService';
 import { wrapSentryTransaction } from '../../../utils';
 import { validatePublicHttpUrl } from '../../../utils/ssrfProtection';
-import { type DbAiDeepResearchRun } from '../../database/entities/aiDeepResearch';
+import { type DbAiDeepResearchEvent } from '../../database/entities/aiDeepResearch';
 import { AiAgentDocumentModel } from '../../models/AiAgentDocumentModel';
 import { AiAgentMemoryModel } from '../../models/AiAgentMemoryModel';
 import {
@@ -231,7 +233,10 @@ import {
 } from '../../models/AiAgentModel';
 import { AiAgentReviewClassifierModel } from '../../models/AiAgentReviewClassifierModel';
 import { AiAgentReviewNotificationModel } from '../../models/AiAgentReviewNotificationModel';
-import { AiDeepResearchRunModel } from '../../models/AiDeepResearchRunModel';
+import {
+    AiDeepResearchRunModel,
+    type AiDeepResearchRunContextRow,
+} from '../../models/AiDeepResearchRunModel';
 import { CommercialSlackAuthenticationModel } from '../../models/CommercialSlackAuthenticationModel';
 import { ProjectContextModel } from '../../models/ProjectContextModel';
 import { CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
@@ -286,6 +291,7 @@ import { renderBlocks as renderSqlApprovalBlocks } from '../ai/tools/slackSqlAgg
 import {
     AiAgentArgs,
     AiAgentDependencies,
+    type AiAgentDeepResearchRunContext,
     type AiAgentExecutionConfig,
     type AiAgentMcpServer,
     type AiAgentRequestingUser,
@@ -431,7 +437,7 @@ type AiAgentServiceDependencies = {
     aiAgentDocumentModel: AiAgentDocumentModel;
     aiDeepResearchRunModel: Pick<
         AiDeepResearchRunModel,
-        'findByPromptUuidsScoped'
+        'findAgentContextByThreadScoped' | 'findLatestProgressByRunUuids'
     >;
     projectContextModel: ProjectContextModel;
     analytics: LightdashAnalytics;
@@ -653,7 +659,7 @@ export class AiAgentService extends BaseService {
 
     private readonly aiDeepResearchRunModel: Pick<
         AiDeepResearchRunModel,
-        'findByPromptUuidsScoped'
+        'findAgentContextByThreadScoped' | 'findLatestProgressByRunUuids'
     >;
 
     private readonly githubAppInstallationsModel: GithubAppInstallationsModel;
@@ -4673,26 +4679,8 @@ export class AiAgentService extends BaseService {
             },
         };
 
-        const promptUuidsToCompact = [
-            ...new Set(messagesToCompact.map((message) => message.uuid)),
-        ];
-        const deepResearchRuns =
-            await this.aiDeepResearchRunModel.findByPromptUuidsScoped({
-                promptUuids: promptUuidsToCompact,
-                organizationUuid: user.organizationUuid,
-                projectUuid: prompt.projectUuid,
-            });
-        const deepResearchReportsByPromptUuid = new Map(
-            deepResearchRuns.flatMap((run) =>
-                run.result_markdown
-                    ? [[run.prompt_uuid, run.result_markdown] as const]
-                    : [],
-            ),
-        );
-        const serializedInput = Compaction.serializeConversation(
-            messagesToCompact,
-            { deepResearchReportsByPromptUuid },
-        );
+        const serializedInput =
+            Compaction.serializeConversation(messagesToCompact);
 
         const summary = await generateCompactionSummary(compactionModel, {
             previousSummary: latestCompaction?.summary,
@@ -6758,6 +6746,8 @@ export class AiAgentService extends BaseService {
     // Rendered by Slack as "<agent name> <status>" under the user's message.
     private static readonly THINKING_STATUS = 'is thinking...';
 
+    private static readonly DEEP_RESEARCH_TERMINAL_CONTEXT_LIMIT = 5;
+
     private static readonly THINKING_LOADING_MESSAGES = [
         'Checking the project context...',
         'Finding the relevant metrics...',
@@ -6791,21 +6781,65 @@ Use them as a reference, but do all the due dilligence and follow the instructio
         } satisfies UserModelMessage;
     }
 
-    static createDeepResearchContextMessage(
-        run: Pick<DbAiDeepResearchRun, 'result_markdown'> | undefined,
-    ): AssistantModelMessage | null {
-        if (!run?.result_markdown) {
-            return null;
-        }
+    static createDeepResearchRunContext(
+        runs: AiDeepResearchRunContextRow[],
+        latestProgressEvents: DbAiDeepResearchEvent[],
+        now = new Date(),
+    ): AiAgentDeepResearchRunContext[] {
+        const contextRuns = AiAgentService.selectDeepResearchContextRuns(runs);
+        const progressByRunUuid = new Map(
+            latestProgressEvents.map((event) => [
+                event.ai_deep_research_run_uuid,
+                (event.payload as AiDeepResearchEventPayloadMap['progress'])
+                    .progress,
+            ]),
+        );
 
-        return {
-            role: 'assistant',
-            content: [
-                '<deep_research_report>',
-                run.result_markdown,
-                '</deep_research_report>',
-            ].join('\n'),
-        } satisfies AssistantModelMessage;
+        return contextRuns.map((run) => {
+            const progress = progressByRunUuid.get(
+                run.ai_deep_research_run_uuid,
+            );
+            const startedAt = run.started_at ?? run.created_at;
+            const endedAt = run.completed_at ?? now;
+
+            return {
+                uuid: run.ai_deep_research_run_uuid,
+                question: run.prompt,
+                status: run.status,
+                phase: progress?.phase ?? null,
+                activity: progress?.activity ?? null,
+                progressCurrent: progress?.current ?? null,
+                progressTotal: progress?.total ?? null,
+                startedAt: run.started_at?.toISOString() ?? null,
+                elapsedSeconds: Math.max(
+                    0,
+                    Math.floor(
+                        (endedAt.getTime() - startedAt.getTime()) / 1000,
+                    ),
+                ),
+                hasReport: run.has_report,
+            };
+        });
+    }
+
+    static selectDeepResearchContextRuns(
+        runs: AiDeepResearchRunContextRow[],
+    ): AiDeepResearchRunContextRow[] {
+        const activeRuns = runs.filter(
+            ({ status }) => !isAiDeepResearchRunTerminal(status),
+        );
+        const recentTerminalRuns = runs
+            .filter(({ status }) => isAiDeepResearchRunTerminal(status))
+            .slice(-AiAgentService.DEEP_RESEARCH_TERMINAL_CONTEXT_LIMIT);
+        const includedRunUuids = new Set(
+            [...activeRuns, ...recentTerminalRuns].map(
+                ({ ai_deep_research_run_uuid: uuid }) => uuid,
+            ),
+        );
+
+        return runs.filter(({ ai_deep_research_run_uuid: uuid }) =>
+            includedRunUuids.has(uuid),
+        );
     }
 
     static createPinnedContextMessage(
@@ -7181,17 +7215,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         const promptUuids = threadMessages.map(
             (message) => message.ai_prompt_uuid,
         );
-        const [contextMap, deepResearchRuns] = await Promise.all([
-            this.aiAgentModel.getContextForPromptUuids(promptUuids),
-            this.aiDeepResearchRunModel.findByPromptUuidsScoped({
-                promptUuids,
-                organizationUuid: options.organizationUuid,
-                projectUuid: options.projectUuid,
-            }),
-        ]);
-        const deepResearchRunsByPromptUuid = new Map(
-            deepResearchRuns.map((run) => [run.prompt_uuid, run]),
-        );
+        const contextMap =
+            await this.aiAgentModel.getContextForPromptUuids(promptUuids);
 
         const messagesWithToolCalls = await Promise.all(
             threadMessages.map(async (message, index) => {
@@ -7262,16 +7287,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         toolCallsAndResults,
                     );
 
-                const deepResearchContextMessage =
-                    AiAgentService.createDeepResearchContextMessage(
-                        deepResearchRunsByPromptUuid.get(
-                            message.ai_prompt_uuid,
-                        ),
-                    );
-
-                if (deepResearchContextMessage) {
-                    messages.push(deepResearchContextMessage);
-                } else if (
+                if (
                     message.response &&
                     !message.error_message &&
                     (!hasUnresolvedApproval || !isCurrentPrompt)
@@ -7789,6 +7805,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             userAttributeOverrides:
                 options?.runtimeOptions?.userAttributeOverrides,
             agentUuid: runtimeAgentSettings.uuid,
+            threadUuid: prompt.threadUuid,
             onWarehouseQuery: options?.onWarehouseQuery,
         });
 
@@ -8758,6 +8775,31 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 agentUuid: agentSettings.uuid,
                 projectUuid: prompt.projectUuid,
             });
+        const threadDeepResearchRuns =
+            responseExecution.mode === 'standard'
+                ? await this.aiDeepResearchRunModel.findAgentContextByThreadScoped(
+                      {
+                          aiThreadUuid: prompt.threadUuid,
+                          organizationUuid: prompt.organizationUuid,
+                          projectUuid: prompt.projectUuid,
+                          createdByUserUuid: user.userUuid,
+                      },
+                  )
+                : [];
+        const deepResearchContextRuns =
+            AiAgentService.selectDeepResearchContextRuns(
+                threadDeepResearchRuns,
+            );
+        const latestDeepResearchProgress =
+            await this.aiDeepResearchRunModel.findLatestProgressByRunUuids(
+                deepResearchContextRuns.map(
+                    ({ ai_deep_research_run_uuid: uuid }) => uuid,
+                ),
+            );
+        const deepResearchRuns = AiAgentService.createDeepResearchRunContext(
+            deepResearchContextRuns,
+            latestDeepResearchProgress,
+        );
         const mcpServers = await this.getAgentRuntimeMcpServers({
             user,
             projectUuid: prompt.projectUuid,
@@ -9003,6 +9045,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             agentSettings,
             requestingUser,
             knowledgeDocuments,
+            deepResearchRuns,
             projectContext,
             projectContextEnabled,
             aiAgentMemoryEnabled,

--- a/packages/backend/src/ee/services/AiAgentService/deepResearchContextMessage.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/deepResearchContextMessage.test.ts
@@ -9,101 +9,85 @@ vi.mock('../ai/AiAgentMcpRuntimeClient', () => ({
         }),
 }));
 
-describe('AiAgentService.createDeepResearchContextMessage', () => {
-    it('makes the report Markdown available as assistant context', () => {
-        const message = AiAgentService.createDeepResearchContextMessage({
-            result_markdown: '# Retention report\n\nRetention improved.',
-        });
+const createRun = (
+    status: 'queued' | 'running' | 'completed' | 'partially_completed',
+    overrides: Record<string, unknown> = {},
+) =>
+    ({
+        ai_deep_research_run_uuid: `${status}-run`,
+        prompt: `${status} question`,
+        status,
+        has_report: false,
+        created_at: new Date('2026-07-29T10:00:00.000Z'),
+        updated_at: new Date('2026-07-29T10:00:00.000Z'),
+        started_at:
+            status === 'queued' ? null : new Date('2026-07-29T10:01:00.000Z'),
+        completed_at:
+            status === 'completed' || status === 'partially_completed'
+                ? new Date('2026-07-29T10:05:00.000Z')
+                : null,
+        ...overrides,
+    }) as never;
 
-        expect(message).toEqual({
-            role: 'assistant',
-            content: expect.stringContaining(
-                '# Retention report\n\nRetention improved.',
-            ),
+describe('AiAgentService.createDeepResearchRunContext', () => {
+    it('includes current progress and report availability', () => {
+        const run = createRun('running', {
+            has_report: true,
         });
+        const context = AiAgentService.createDeepResearchRunContext(
+            [run],
+            [
+                {
+                    ai_deep_research_run_uuid: 'running-run',
+                    event_type: 'progress',
+                    payload: {
+                        progress: {
+                            phase: 'investigating',
+                            activity: 'warehouse_query',
+                            current: 2,
+                            total: 5,
+                        },
+                    },
+                } as never,
+            ],
+            new Date('2026-07-29T10:03:00.000Z'),
+        );
+
+        expect(context).toEqual([
+            expect.objectContaining({
+                uuid: 'running-run',
+                status: 'running',
+                phase: 'investigating',
+                activity: 'warehouse_query',
+                progressCurrent: 2,
+                progressTotal: 5,
+                elapsedSeconds: 120,
+                hasReport: true,
+            }),
+        ]);
     });
 
-    it('does not create context before a report is available', () => {
-        expect(
-            AiAgentService.createDeepResearchContextMessage({
-                result_markdown: null,
+    it('bounds terminal metadata to the five most recent runs', () => {
+        const runs = Array.from({ length: 7 }, (_, index) =>
+            createRun('completed', {
+                ai_deep_research_run_uuid: `run-${index}`,
             }),
-        ).toBeNull();
+        );
+
         expect(
-            AiAgentService.createDeepResearchContextMessage(undefined),
-        ).toBeNull();
+            AiAgentService.createDeepResearchRunContext(runs, []).map(
+                ({ uuid }) => uuid,
+            ),
+        ).toEqual(['run-2', 'run-3', 'run-4', 'run-5', 'run-6']);
     });
 });
 
 describe('AiAgentService deep research conversation history', () => {
-    it('replays a completed report for a follow-up prompt', async () => {
-        const aiDeepResearchRunModel = {
-            findByPromptUuidsScoped: vi.fn().mockResolvedValue([
-                {
-                    prompt_uuid: 'research-prompt',
-                    result_markdown: '# Retention report',
-                },
-            ]),
-        };
+    it('keeps the ordinary response without injecting report Markdown', async () => {
         const service = new AiAgentService({
             aiAgentModel: {
                 getContextForPromptUuids: vi.fn().mockResolvedValue(new Map()),
                 getToolCallsAndResultsForPrompt: vi.fn().mockResolvedValue([]),
-            },
-            aiDeepResearchRunModel,
-            lightdashConfig: {},
-        } as unknown as ConstructorParameters<typeof AiAgentService>[0]);
-
-        const history = await service.getChatHistoryFromThreadMessages(
-            [
-                {
-                    ai_prompt_uuid: 'research-prompt',
-                    prompt: 'Research retention',
-                    response: null,
-                    error_message: null,
-                    human_score: null,
-                    human_feedback: null,
-                },
-            ] as never,
-            {
-                organizationUuid: 'organization-1',
-                projectUuid: 'project-1',
-                agentUuid: 'agent-1',
-                retrieveRelevantArtifacts: false,
-                compaction: null,
-                currentPromptUuid: 'follow-up-prompt',
-            },
-        );
-
-        expect(
-            aiDeepResearchRunModel.findByPromptUuidsScoped,
-        ).toHaveBeenCalledWith({
-            promptUuids: ['research-prompt'],
-            organizationUuid: 'organization-1',
-            projectUuid: 'project-1',
-        });
-        expect(history).toEqual([
-            { role: 'user', content: 'Research retention' },
-            {
-                role: 'assistant',
-                content: expect.stringContaining('# Retention report'),
-            },
-        ]);
-    });
-
-    it('keeps the ordinary response when a research report is incomplete', async () => {
-        const service = new AiAgentService({
-            aiAgentModel: {
-                getContextForPromptUuids: vi.fn().mockResolvedValue(new Map()),
-                getToolCallsAndResultsForPrompt: vi.fn().mockResolvedValue([]),
-            },
-            aiDeepResearchRunModel: {
-                findByPromptUuidsScoped: vi.fn().mockResolvedValue([
-                    {
-                        prompt_uuid: 'research-prompt',
-                        result_markdown: null,
-                    },
-                ]),
             },
             lightdashConfig: {},
         } as unknown as ConstructorParameters<typeof AiAgentService>[0]);

--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
@@ -92,6 +92,8 @@ const makeService = ({
     aiAgentContentValidation = {},
     scheduleCompileProject = vi.fn().mockResolvedValue({ jobUuid: 'job-1' }),
     jobModel = { get: vi.fn() },
+    aiAgentDocumentModel = {},
+    aiDeepResearchRunModel = {},
 }: {
     explores?: Record<string, Explore>;
     userAttributes?: Record<string, string[]>;
@@ -107,6 +109,8 @@ const makeService = ({
     aiAgentContentValidation?: Record<string, unknown>;
     scheduleCompileProject?: import('vitest').Mock;
     jobModel?: Record<string, unknown>;
+    aiAgentDocumentModel?: Record<string, unknown>;
+    aiDeepResearchRunModel?: Record<string, unknown>;
 } = {}) =>
     new AiAgentToolsService({
         builtInSkills: {
@@ -167,7 +171,8 @@ const makeService = ({
         contentService: {},
         aiAgentContentValidation,
         projectContextModel: {},
-        aiAgentDocumentModel: {},
+        aiAgentDocumentModel,
+        aiDeepResearchRunModel,
         featureFlagService: {},
         previewDeploySetupService: {},
         shareService: {},
@@ -198,6 +203,111 @@ function makeRuntimeContext(
 }
 
 describe('AiAgentToolsService', () => {
+    describe('Deep Research knowledge documents', () => {
+        const run = {
+            ai_deep_research_run_uuid: 'run-uuid',
+            organization_uuid: organizationUuid,
+            project_uuid: projectUuid,
+            created_by_user_uuid: userUuid,
+            prompt: 'Why did revenue fall?',
+            result_markdown: '# Revenue report',
+            content_size_bytes: 16,
+            created_at: new Date('2026-07-29T10:00:00.000Z'),
+            updated_at: new Date('2026-07-29T10:05:00.000Z'),
+        };
+
+        it('lists report-bearing runs as virtual thread documents', async () => {
+            const service = makeService({
+                aiAgentDocumentModel: {
+                    findAllForAgent: vi.fn().mockResolvedValue([]),
+                },
+                aiDeepResearchRunModel: {
+                    findReportSummariesByThreadScoped: vi
+                        .fn()
+                        .mockResolvedValue([run]),
+                },
+            });
+            const runtime = service.createRuntime(
+                makeRuntimeContext({
+                    agentUuid: 'agent-uuid',
+                    threadUuid: 'thread-uuid',
+                }),
+            );
+
+            await expect(runtime.listKnowledgeDocuments()).resolves.toEqual([
+                expect.objectContaining({
+                    uuid: 'run-uuid',
+                    name: 'Why did revenue fall?',
+                    mimeType: 'text/markdown',
+                    alwaysIncludeInContext: false,
+                }),
+            ]);
+        });
+
+        it('reads report Markdown only from the current user and thread scope', async () => {
+            const findReportByUuidThreadScoped = vi.fn().mockResolvedValue(run);
+            const service = makeService({
+                aiAgentDocumentModel: {
+                    getContentForAgent: vi.fn().mockResolvedValue(undefined),
+                },
+                aiDeepResearchRunModel: {
+                    findReportByUuidThreadScoped,
+                },
+            });
+            const runtime = service.createRuntime(
+                makeRuntimeContext({
+                    agentUuid: 'agent-uuid',
+                    threadUuid: 'thread-uuid',
+                }),
+            );
+
+            await expect(
+                runtime.getKnowledgeDocumentContent({
+                    documentUuid: 'run-uuid',
+                }),
+            ).resolves.toEqual({
+                uuid: 'run-uuid',
+                name: 'Why did revenue fall?',
+                mimeType: 'text/markdown',
+                content: '# Revenue report',
+            });
+            expect(findReportByUuidThreadScoped).toHaveBeenCalledWith({
+                aiDeepResearchRunUuid: 'run-uuid',
+                aiThreadUuid: 'thread-uuid',
+                organizationUuid,
+                projectUuid,
+                createdByUserUuid: userUuid,
+            });
+        });
+
+        it('rejects runs without an accessible report', async () => {
+            const service = makeService({
+                aiAgentDocumentModel: {
+                    getContentForAgent: vi.fn().mockResolvedValue(undefined),
+                },
+                aiDeepResearchRunModel: {
+                    findReportByUuidThreadScoped: vi
+                        .fn()
+                        .mockResolvedValue(undefined),
+                },
+            });
+            const runtime = service.createRuntime(
+                makeRuntimeContext({
+                    agentUuid: 'agent-uuid',
+                    threadUuid: 'thread-uuid',
+                }),
+            );
+
+            await expect(
+                runtime.getKnowledgeDocumentContent({
+                    documentUuid: 'missing-run',
+                }),
+            ).rejects.toThrow(
+                'Knowledge document missing-run is not accessible to this agent.',
+            );
+        });
+    });
+
     it.each(['', 'tru', 'FALSE', 'unknown'])(
         'returns the boolean domain for query "%s"',
         async (query) => {

--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
@@ -33,6 +33,7 @@ import {
     TimeoutError,
     UserAttributeValueMap,
     WarehouseQueryError,
+    type AiAgentDocumentSummary,
     type ChartAsCode,
     type DashboardAsCode,
     type FieldValueSearchResult,
@@ -70,6 +71,7 @@ import {
 import type { UserService } from '../../../services/UserService';
 import { wrapSentryTransaction } from '../../../utils';
 import { AiAgentDocumentModel } from '../../models/AiAgentDocumentModel';
+import { AiDeepResearchRunModel } from '../../models/AiDeepResearchRunModel';
 import { ProjectContextModel } from '../../models/ProjectContextModel';
 import type { BuiltInSkills } from '../ai/skills/builtInSkills';
 import {
@@ -141,6 +143,7 @@ export type AiAgentToolsRuntimeContext = {
     spaceAccess: string[] | null;
     userAttributeOverrides?: UserAttributeValueMap;
     agentUuid?: string;
+    threadUuid?: string;
     onWarehouseQuery?: () => void | Promise<void>;
 };
 
@@ -259,6 +262,7 @@ type AiAgentToolsServiceDependencies = {
     aiAgentContentValidation: AiAgentContentValidation;
     projectContextModel: ProjectContextModel;
     aiAgentDocumentModel: AiAgentDocumentModel;
+    aiDeepResearchRunModel: AiDeepResearchRunModel;
     featureFlagService: FeatureFlagService;
     previewDeploySetupService: PreviewDeploySetupService;
     shareService: ShareService;
@@ -310,6 +314,8 @@ export class AiAgentToolsService extends BaseService {
     private readonly aiAgentContentValidation: AiAgentContentValidation;
 
     private readonly aiAgentDocumentModel: AiAgentDocumentModel;
+
+    private readonly aiDeepResearchRunModel: AiDeepResearchRunModel;
 
     private readonly featureFlagService: FeatureFlagService;
 
@@ -377,6 +383,7 @@ export class AiAgentToolsService extends BaseService {
         contentService,
         aiAgentContentValidation,
         aiAgentDocumentModel,
+        aiDeepResearchRunModel,
         featureFlagService,
         previewDeploySetupService,
         shareService,
@@ -405,6 +412,7 @@ export class AiAgentToolsService extends BaseService {
         this.contentService = contentService;
         this.aiAgentContentValidation = aiAgentContentValidation;
         this.aiAgentDocumentModel = aiAgentDocumentModel;
+        this.aiDeepResearchRunModel = aiDeepResearchRunModel;
         this.featureFlagService = featureFlagService;
         this.previewDeploySetupService = previewDeploySetupService;
         this.shareService = shareService;
@@ -2270,15 +2278,55 @@ export class AiAgentToolsService extends BaseService {
         return wrapSentryTransaction(
             `${AiAgentToolsService.transactionPrefix(context)}.listKnowledgeDocuments`,
             {},
-            () => {
+            async () => {
                 if (!context.agentUuid) {
-                    return Promise.resolve([]);
+                    return [];
                 }
-                return this.aiAgentDocumentModel.findAllForAgent({
-                    organizationUuid: context.organizationUuid,
-                    agentUuid: context.agentUuid,
-                    projectUuid: context.projectUuid,
-                });
+                const [documents, deepResearchRuns] = await Promise.all([
+                    this.aiAgentDocumentModel.findAllForAgent({
+                        organizationUuid: context.organizationUuid,
+                        agentUuid: context.agentUuid,
+                        projectUuid: context.projectUuid,
+                    }),
+                    context.threadUuid
+                        ? this.aiDeepResearchRunModel.findReportSummariesByThreadScoped(
+                              {
+                                  aiThreadUuid: context.threadUuid,
+                                  organizationUuid: context.organizationUuid,
+                                  projectUuid: context.projectUuid,
+                                  createdByUserUuid: context.user.userUuid,
+                              },
+                          )
+                        : [],
+                ]);
+                const deepResearchDocuments: AiAgentDocumentSummary[] =
+                    deepResearchRuns.map((run) => ({
+                        uuid: run.ai_deep_research_run_uuid,
+                        organizationUuid: run.organization_uuid,
+                        projectUuid: run.project_uuid,
+                        name: run.prompt,
+                        originalFilename: `${run.ai_deep_research_run_uuid}.md`,
+                        mimeType: 'text/markdown',
+                        contentSizeBytes: run.content_size_bytes,
+                        alwaysIncludeInContext: false,
+                        summary: {
+                            description:
+                                'Deep Research report from this conversation.',
+                            definedTerms: [],
+                            relatedExploreNames: [],
+                            useWhen: `Answering follow-up questions about: ${run.prompt}`,
+                            relevance: 'high',
+                            warning:
+                                'Read-only and available only in this conversation.',
+                        },
+                        agentAccess: [],
+                        createdByUserUuid: run.created_by_user_uuid,
+                        updatedByUserUuid: null,
+                        createdAt: run.created_at,
+                        updatedAt: run.updated_at,
+                    }));
+
+                return [...documents, ...deepResearchDocuments];
             },
         );
     }
@@ -2305,12 +2353,32 @@ export class AiAgentToolsService extends BaseService {
                         projectUuid: context.projectUuid,
                         documentUuid: args.documentUuid,
                     });
-                if (!content) {
-                    throw new NotFoundError(
-                        `Knowledge document ${args.documentUuid} is not accessible to this agent.`,
-                    );
+                if (content) {
+                    return content;
                 }
-                return content;
+                if (context.threadUuid) {
+                    const run =
+                        await this.aiDeepResearchRunModel.findReportByUuidThreadScoped(
+                            {
+                                aiDeepResearchRunUuid: args.documentUuid,
+                                aiThreadUuid: context.threadUuid,
+                                organizationUuid: context.organizationUuid,
+                                projectUuid: context.projectUuid,
+                                createdByUserUuid: context.user.userUuid,
+                            },
+                        );
+                    if (run?.result_markdown) {
+                        return {
+                            uuid: run.ai_deep_research_run_uuid,
+                            name: run.prompt,
+                            mimeType: 'text/markdown',
+                            content: run.result_markdown,
+                        };
+                    }
+                }
+                throw new NotFoundError(
+                    `Knowledge document ${args.documentUuid} is not accessible to this agent.`,
+                );
             },
         );
     }

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -1044,6 +1044,7 @@ const getAgentMessages = (
         availableExplores,
         availableSkills: args.availableSkills,
         knowledgeDocuments: args.knowledgeDocuments,
+        deepResearchRuns: args.deepResearchRuns,
         hasProjectContext,
         enableAiAgentMemory: args.aiAgentMemoryEnabled,
         enableDataAccess: args.enableDataAccess,

--- a/packages/backend/src/ee/services/ai/compaction.test.ts
+++ b/packages/backend/src/ee/services/ai/compaction.test.ts
@@ -101,8 +101,9 @@ describe('AI context compaction helpers', () => {
         expect(serialized).toContain('[truncated 500 chars]');
     });
 
-    it('includes deep research Markdown in the compaction input', () => {
-        const serialized = Compaction.serializeConversation(
+    it('does not include Deep Research report Markdown in compaction input', () => {
+        const reportSentinel = 'DEEP_RESEARCH_REPORT_SENTINEL';
+        const messages: Parameters<typeof Compaction.serializeConversation>[0] =
             [
                 {
                     role: 'assistant',
@@ -123,17 +124,25 @@ describe('AI context compaction helpers', () => {
                     modelConfig: null,
                     tokenUsage: null,
                 },
-            ],
-            {
-                deepResearchReportsByPromptUuid: new Map([
-                    ['research-prompt', '# Retention report'],
-                ]),
-            },
-        );
+            ];
+        const serializeWithLegacyReportOption =
+            Compaction.serializeConversation as unknown as (
+                input: typeof messages,
+                legacyOptions: {
+                    deepResearchReportsByPromptUuid: ReadonlyMap<
+                        string,
+                        string
+                    >;
+                },
+            ) => string;
 
-        expect(serialized).toContain(
-            '[Deep research report]: # Retention report',
-        );
+        const serialized = serializeWithLegacyReportOption(messages, {
+            deepResearchReportsByPromptUuid: new Map([
+                ['research-prompt', reportSentinel],
+            ]),
+        });
+
+        expect(serialized).not.toContain(reportSentinel);
     });
 
     it('serializes a same-named file and repository as distinct, unambiguous lines', () => {

--- a/packages/backend/src/ee/services/ai/compaction.ts
+++ b/packages/backend/src/ee/services/ai/compaction.ts
@@ -89,12 +89,7 @@ export class Compaction {
         return threadMessages.slice(compactedThroughIndex + 1);
     }
 
-    static serializeConversation(
-        messages: AiAgentMessage[],
-        options?: {
-            deepResearchReportsByPromptUuid?: ReadonlyMap<string, string>;
-        },
-    ): string {
+    static serializeConversation(messages: AiAgentMessage[]): string {
         const lines: string[] = [];
 
         for (const message of messages) {
@@ -106,12 +101,6 @@ export class Compaction {
             } else {
                 if (message.message) {
                     lines.push(`[Assistant]: ${message.message}`);
-                }
-
-                const deepResearchReport =
-                    options?.deepResearchReportsByPromptUuid?.get(message.uuid);
-                if (deepResearchReport) {
-                    lines.push(`[Deep research report]: ${deepResearchReport}`);
                 }
 
                 if (message.toolCalls.length > 0) {

--- a/packages/backend/src/ee/services/ai/prompts/systemV2.test.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2.test.ts
@@ -147,6 +147,38 @@ describe('getSystemPromptV2 knowledge documents', () => {
     });
 });
 
+describe('getSystemPromptV2 Deep Research context', () => {
+    test('includes bounded status metadata and on-demand report guidance', () => {
+        const content = promptText({
+            availableExplores: [],
+            deepResearchRuns: [
+                {
+                    uuid: 'run-1',
+                    question: 'Why did <revenue> fall?',
+                    status: 'running',
+                    phase: 'investigating',
+                    activity: 'warehouse_query',
+                    progressCurrent: 2,
+                    progressTotal: 5,
+                    startedAt: '2026-07-29T10:00:00.000Z',
+                    elapsedSeconds: 90,
+                    hasReport: false,
+                },
+            ],
+        });
+
+        expect(content).toContain('## Deep Research in this conversation');
+        expect(content).toContain('status="running"');
+        expect(content).toContain('phase="investigating"');
+        expect(content).toContain('progress_current="2"');
+        expect(content).toContain('progress_total="5"');
+        expect(content).toContain('elapsed_seconds="90"');
+        expect(content).toContain('Why did &lt;revenue&gt; fall?');
+        expect(content).toContain('getKnowledgeDocumentContent');
+        expect(content).toContain('implicitly start a duplicate run');
+    });
+});
+
 describe('getSystemPromptV2 requesting user', () => {
     test('renders identity and non-technical guidance for a viewer', () => {
         const content = promptText({

--- a/packages/backend/src/ee/services/ai/prompts/systemV2.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2.ts
@@ -7,7 +7,10 @@ import {
 import { SystemModelMessage } from 'ai';
 import moment from 'moment';
 import { AiAgentSkillReference } from '../skills/types';
-import { AiAgentRequestingUser } from '../types/aiAgent';
+import {
+    AiAgentDeepResearchRunContext,
+    AiAgentRequestingUser,
+} from '../types/aiAgent';
 import { xmlBuilder } from '../xmlBuilder';
 import { renderAvailableExplores } from './availableExplores';
 import { getAiWritebackSection } from './systemV2AiWriteback';
@@ -38,6 +41,7 @@ export const getSystemPromptV2 = (args: {
     availableExplores: Explore[];
     availableSkills?: AiAgentSkillReference[];
     knowledgeDocuments?: AiAgentDocumentContext[];
+    deepResearchRuns?: AiAgentDeepResearchRunContext[];
     hasProjectContext?: boolean;
     instructions?: string;
     agentName?: string;
@@ -150,6 +154,41 @@ export const getSystemPromptV2 = (args: {
         knowledgeDocuments.length === 0
             ? 'No knowledge documents have been curated for this agent.'
             : knowledgeDocuments.map(renderKnowledgeDocument).join('\n');
+
+    const deepResearchRuns = args.deepResearchRuns ?? [];
+    const deepResearchContent =
+        deepResearchRuns.length === 0
+            ? ''
+            : [
+                  '## Deep Research in this conversation',
+                  'This state is current for this user turn. Treat active progress separately from report findings. Never claim unfinished findings are available, implicitly start a duplicate run, or offer to cancel, restart, or modify a run.',
+                  'For questions about report findings, call `listKnowledgeDocuments`, identify the matching Deep Research report, then call `getKnowledgeDocumentContent`. If more than one report could match, ask which research question the user means.',
+                  xmlBuilder(
+                      'deep_research_runs',
+                      { count: deepResearchRuns.length },
+                      ...deepResearchRuns.map((run) =>
+                          xmlBuilder(
+                              'deep_research_run',
+                              {
+                                  uuid: run.uuid,
+                                  status: run.status,
+                                  phase: run.phase,
+                                  activity: run.activity,
+                                  progress_current: run.progressCurrent,
+                                  progress_total: run.progressTotal,
+                                  started_at: run.startedAt,
+                                  elapsed_seconds: run.elapsedSeconds,
+                                  report_available: run.hasReport,
+                              },
+                              xmlBuilder(
+                                  'question',
+                                  null,
+                                  escapeXmlText(run.question),
+                              ),
+                          ),
+                      ),
+                  ),
+              ].join('\n');
 
     const projectContextContent = args.hasProjectContext
         ? 'This project has curated business context (acronyms, definitions, rules). Call the `loadProjectContext` tool BEFORE findExplores/findFields/discoverFields — it can change which explore, field, or filter value you should use. Treat it as authoritative over your own assumptions.'
@@ -276,6 +315,7 @@ export const getSystemPromptV2 = (args: {
 
     const finalContent = [
         content,
+        deepResearchContent,
         grepFieldsSection,
         mcpConnectionsSection,
         skillsSection,

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -7,7 +7,10 @@ import {
     AiWritebackAttribution,
     ProjectContextEntry,
     WarehouseTypes,
+    type AiDeepResearchActivity,
     type AiDeepResearchExecutionContextSnapshot,
+    type AiDeepResearchPhase,
+    type AiDeepResearchRunStatus,
 } from '@lightdash/common';
 // eslint-disable-next-line import/extensions
 import { type OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
@@ -125,6 +128,19 @@ export type AiAgentExecutionConfig =
           ) => void | Promise<void>;
       };
 
+export type AiAgentDeepResearchRunContext = {
+    uuid: string;
+    question: string;
+    status: AiDeepResearchRunStatus;
+    phase: AiDeepResearchPhase | null;
+    activity: AiDeepResearchActivity | null;
+    progressCurrent: number | null;
+    progressTotal: number | null;
+    startedAt: string | null;
+    elapsedSeconds: number;
+    hasReport: boolean;
+};
+
 export type AiAgentArgs = AnyAiModel & {
     // Whether this turn runs on a Lightdash-managed or self-managed (BYO) key.
     // Stamped by the model builder and carried through for usage analytics.
@@ -132,6 +148,7 @@ export type AiAgentArgs = AnyAiModel & {
     agentSettings: AiAgent;
     requestingUser: AiAgentRequestingUser | null;
     knowledgeDocuments: AiAgentDocumentContext[];
+    deepResearchRuns: AiAgentDeepResearchRunContext[];
     projectContext: ProjectContextEntry[];
     // Whether the project_context feature is on for this turn (Control = off).
     projectContextEnabled: boolean;


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9328/give-the-chat-agent-awareness-of-deep-research-runs-and-reports

## Description:

Gives the regular chat agent current, bounded awareness of Deep Research runs in the same conversation. Report-bearing runs appear as read-only virtual knowledge documents scoped to the requesting user, project, and thread, so the agent fetches Markdown only when a follow-up needs it instead of replaying every report into history and compaction.

```text
Current chat turn
  ├─ run metadata ───────────────→ bounded system context
  └─ report UUID ─→ list docs ─→ get content ─→ report Markdown
```

## Test plan

- Run the five focused backend suites covering run metadata, virtual documents, history, compaction, and prompt guidance: 94 tests pass.
- Run backend typecheck, lint, format, and `git diff --check`.
- Restart the Paris backend and verify `/api/v1/health`.
- Verify read-only DB scoping returns the report for the exact thread, organization, project, and user, and returns nothing when each scope is changed.
