### PR TITLE
feat(homepage-builder): let admins choose what the homepage opens on

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -503,6 +503,8 @@ import {
     HomepageAssignmentsTable,
     HomepageAssignmentsTableName,
     HomepagesTableName,
+    ProjectHomepageSettingsTable,
+    ProjectHomepageSettingsTableName,
     ProjectHomepagesTable,
 } from '../ee/database/entities/projectHomepages';
 import {
@@ -644,6 +646,7 @@ declare module 'knex/types/tables' {
         [AiAgentUserPreferencesTableName]: AiAgentUserPreferencesTable;
         [HomepagesTableName]: ProjectHomepagesTable;
         [HomepageAssignmentsTableName]: HomepageAssignmentsTable;
+        [ProjectHomepageSettingsTableName]: ProjectHomepageSettingsTable;
         [AnnouncementsTableName]: AnnouncementsTable;
         [AiAgentReasoningTableName]: AiAgentReasoningTable;
         [AiAgentToolCallTableName]: AiAgentToolCallTable;

--- a/packages/backend/src/ee/controllers/projectHomepageController.ts
+++ b/packages/backend/src/ee/controllers/projectHomepageController.ts
@@ -7,6 +7,7 @@ import {
     type ApiHomepageViewAsResponse,
     type ApiProjectHomepageOrNullResponse,
     type ApiProjectHomepageResponse,
+    type ApiProjectHomepageSettingsResponse,
     type ApiProjectHomepagesResponse,
     type ApiRecentlyViewedResponse,
     type ApiResolvedHomepageResponse,
@@ -17,6 +18,7 @@ import {
     type PublishProjectHomepageRequest,
     type UpdateHomepageGroupPrioritiesRequest,
     type UpdateProjectHomepageDraftRequest,
+    type UpdateProjectHomepageSettingsRequest,
     type UUID,
 } from '@lightdash/common';
 import {
@@ -185,6 +187,50 @@ export class ProjectHomepageController extends BaseController {
             results: await this.getHomepageService().getAssignments(
                 toSessionUser(req.account),
                 projectUuid,
+            ),
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/settings')
+    @OperationId('getProjectHomepageSettings')
+    async getSettings(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+    ): Promise<ApiProjectHomepageSettingsResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getHomepageService().getSettings(
+                toSessionUser(req.account),
+                projectUuid,
+            ),
+        };
+    }
+
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Patch('/settings')
+    @OperationId('updateProjectHomepageSettings')
+    async updateSettings(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Body() body: UpdateProjectHomepageSettingsRequest,
+    ): Promise<ApiProjectHomepageSettingsResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getHomepageService().updateSettings(
+                toSessionUser(req.account),
+                projectUuid,
+                body,
             ),
         };
     }

--- a/packages/backend/src/ee/database/entities/projectHomepages.ts
+++ b/packages/backend/src/ee/database/entities/projectHomepages.ts
@@ -41,6 +41,21 @@ export type ProjectHomepagesTable = Knex.CompositeTableType<
     DbProjectHomepageUpdate
 >;
 
+export const ProjectHomepageSettingsTableName = 'project_homepage_settings';
+
+export type DbProjectHomepageSettings = {
+    project_uuid: string;
+    opening: string | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type ProjectHomepageSettingsTable = Knex.CompositeTableType<
+    DbProjectHomepageSettings,
+    Pick<DbProjectHomepageSettings, 'project_uuid' | 'opening'>,
+    Pick<DbProjectHomepageSettings, 'opening' | 'updated_at'>
+>;
+
 export const HomepageAssignmentsTableName = 'homepage_assignments';
 
 export type DbHomepageAssignment = {

--- a/packages/backend/src/ee/database/migrations/20260729140000_create_project_homepage_settings.ts
+++ b/packages/backend/src/ee/database/migrations/20260729140000_create_project_homepage_settings.ts
@@ -1,0 +1,31 @@
+import { Knex } from 'knex';
+
+const PROJECT_HOMEPAGE_SETTINGS_TABLE = 'project_homepage_settings';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(PROJECT_HOMEPAGE_SETTINGS_TABLE, (table) => {
+        // One row per project: the settings *are* the project's, so the
+        // project uuid is the key rather than a surrogate.
+        table
+            .uuid('project_uuid')
+            .primary()
+            .references('project_uuid')
+            .inTable('projects')
+            .onDelete('CASCADE');
+        // 'ask-first' | 'content-first'. Nullable means the admin hasn't
+        // chosen, and the layout falls back to whether AI is available.
+        table.text('opening').nullable();
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(PROJECT_HOMEPAGE_SETTINGS_TABLE);
+}

--- a/packages/backend/src/ee/models/ProjectHomepageModel.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.ts
@@ -7,9 +7,11 @@ import {
     type HomepageAssignment,
     type HomepageAudience,
     type HomepageConfig,
+    type HomepageOpening,
     type HomepageRecentlyViewedItem,
     type ProjectAnnouncement,
     type ProjectHomepage,
+    type ProjectHomepageSettings,
     type ProjectMemberRole,
     type PublishedProjectHomepage,
     type ResolvedPublishedHomepage,
@@ -20,6 +22,7 @@ import {
     AnnouncementsTableName,
     HomepageAssignmentsTableName,
     HomepagesTableName,
+    ProjectHomepageSettingsTableName,
     type DbAnnouncement,
     type DbProjectHomepage,
 } from '../database/entities/projectHomepages';
@@ -331,6 +334,31 @@ export class ProjectHomepageModel {
             }
             return ProjectHomepageModel.mapDbHomepage(row);
         });
+    }
+
+    async getSettings(projectUuid: string): Promise<ProjectHomepageSettings> {
+        const row = await this.database(ProjectHomepageSettingsTableName)
+            .select('opening')
+            .where('project_uuid', projectUuid)
+            .first();
+        // An unrecognised stored value (a rolling deploy reading a value a
+        // newer version wrote) reads as "not chosen" rather than throwing.
+        const opening =
+            row?.opening === 'ask-first' || row?.opening === 'content-first'
+                ? (row.opening as HomepageOpening)
+                : null;
+        return { opening };
+    }
+
+    async setOpening(
+        projectUuid: string,
+        opening: HomepageOpening | null,
+    ): Promise<ProjectHomepageSettings> {
+        await this.database(ProjectHomepageSettingsTableName)
+            .insert({ project_uuid: projectUuid, opening })
+            .onConflict('project_uuid')
+            .merge({ opening, updated_at: new Date() });
+        return { opening };
     }
 
     async getAssignments(projectUuid: string): Promise<HomepageAssignment[]> {

--- a/packages/backend/src/ee/services/ProjectHomepageService.test.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.test.ts
@@ -138,6 +138,8 @@ const makeService = ({
             getPublishedDefault: vi.fn().mockResolvedValue(undefined),
             getRecentlyViewed: vi.fn().mockResolvedValue([]),
             getAssignments: vi.fn().mockResolvedValue([]),
+            getSettings: vi.fn().mockResolvedValue({ opening: null }),
+            setOpening: vi.fn().mockResolvedValue({ opening: null }),
             updateGroupPriorities: vi.fn().mockResolvedValue(undefined),
             resolvePublished: vi.fn().mockResolvedValue(undefined),
             list: vi.fn().mockResolvedValue([]),

--- a/packages/backend/src/ee/services/ProjectHomepageService.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.ts
@@ -21,11 +21,13 @@ import {
     type HomepageViewAsTarget,
     type ProjectAnnouncement,
     type ProjectHomepage,
+    type ProjectHomepageSettings,
     type ProjectMemberRole,
     type ResolvedHomepage,
     type SessionUser,
     type UpdateAnnouncementRequest,
     type UpdateProjectHomepageDraftRequest,
+    type UpdateProjectHomepageSettingsRequest,
 } from '@lightdash/common';
 import { type KnownBlock } from '@slack/web-api';
 import { createCanvas, loadImage } from 'canvas';
@@ -167,6 +169,8 @@ export type ProjectHomepageServiceArguments = {
         | 'getPublishedDefault'
         | 'getRecentlyViewed'
         | 'getAssignments'
+        | 'getSettings'
+        | 'setOpening'
         | 'updateGroupPriorities'
         | 'resolvePublished'
         | 'list'
@@ -389,6 +393,32 @@ export class ProjectHomepageService extends BaseService {
             default:
                 return assertUnreachable(target, 'Unknown view-as target type');
         }
+    }
+
+    async getSettings(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<ProjectHomepageSettings> {
+        await this.assertFlagEnabled(user);
+        this.assertCanView(user, projectUuid);
+        return this.projectHomepageModel.getSettings(projectUuid);
+    }
+
+    async updateSettings(
+        user: SessionUser,
+        projectUuid: string,
+        { opening }: UpdateProjectHomepageSettingsRequest,
+    ): Promise<ProjectHomepageSettings> {
+        await this.assertFlagEnabled(user);
+        this.assertCanManage(user, projectUuid);
+        if (
+            opening !== null &&
+            opening !== 'ask-first' &&
+            opening !== 'content-first'
+        ) {
+            throw new ParameterError(`Unknown homepage opening: ${opening}`);
+        }
+        return this.projectHomepageModel.setOpening(projectUuid, opening);
     }
 
     async getAssignments(

--- a/packages/common/src/ee/homepage/types.ts
+++ b/packages/common/src/ee/homepage/types.ts
@@ -154,6 +154,37 @@ export type HomepageBlock =
     | HomepageFavoritesBlock
     | HomepageRecentBlock;
 
+/** Which opening a project's homepage leads with. An admin's choice, not a
+ * consequence of whether AI is licensed — see resolveHomepageOpening. */
+export type HomepageOpening = 'ask-first' | 'content-first';
+
+export type ProjectHomepageSettings = {
+    /** null = not chosen; the layout falls back to AI availability. */
+    opening: HomepageOpening | null;
+};
+
+export type UpdateProjectHomepageSettingsRequest = {
+    opening: HomepageOpening | null;
+};
+
+export type ApiProjectHomepageSettingsResponse =
+    ApiSuccess<ProjectHomepageSettings>;
+
+/**
+ * The opening a viewer actually gets. An explicit admin choice always wins;
+ * with no choice stored, a project with a usable AI agent opens on the
+ * composer and one without opens on content. AI availability can only ever
+ * *downgrade* ask-first — a composer that can't answer anything is worse than
+ * no composer.
+ */
+export const resolveHomepageOpening = (
+    chosen: HomepageOpening | null,
+    canAskAi: boolean,
+): HomepageOpening => {
+    if (!canAskAi) return 'content-first';
+    return chosen ?? 'ask-first';
+};
+
 export type HomepageAudience =
     | { type: 'everyone' }
     | { type: 'groups'; groupUuids: string[] }

--- a/packages/common/src/ee/homepageOpening.test.ts
+++ b/packages/common/src/ee/homepageOpening.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { resolveHomepageOpening } from './homepage/types';
+
+describe('resolveHomepageOpening', () => {
+    it("uses the admin's choice when there is one", () => {
+        expect(resolveHomepageOpening('content-first', true)).toBe(
+            'content-first',
+        );
+        expect(resolveHomepageOpening('ask-first', true)).toBe('ask-first');
+    });
+
+    it('opens on the composer by default when AI is usable', () => {
+        expect(resolveHomepageOpening(null, true)).toBe('ask-first');
+    });
+
+    it('opens on content by default when AI is not usable', () => {
+        expect(resolveHomepageOpening(null, false)).toBe('content-first');
+    });
+
+    it('never opens on a composer that cannot answer, even if asked to', () => {
+        // A project can lose its agent after an admin chose ask-first.
+        expect(resolveHomepageOpening('ask-first', false)).toBe(
+            'content-first',
+        );
+    });
+});

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -80,6 +80,7 @@ import type {
     ApiPreviewTokenResponse,
     ApiProjectHomepageOrNullResponse,
     ApiProjectHomepageResponse,
+    ApiProjectHomepageSettingsResponse,
     ApiPromoteAppDiffResponse,
     ApiPromoteAppResponse,
     ApiResolvedHomepageResponse,
@@ -1338,6 +1339,7 @@ type ApiResults =
     | ApiOrganizationDesignFileResponse['results']
     | ApiProjectHomepageResponse['results']
     | ApiProjectHomepageOrNullResponse['results']
+    | ApiProjectHomepageSettingsResponse['results']
     | ApiResolvedHomepageResponse['results']
     | ApiAnnouncementsResponse['results']
     | ApiAnnouncementResponse['results']

--- a/packages/frontend/src/ee/features/homepageBuilder/AdminHomepageControls.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/AdminHomepageControls.tsx
@@ -5,11 +5,15 @@ import { useNavigate } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { Can } from '../../../providers/Ability';
 import classes from './adminHomepageControls.module.css';
+import { OpeningChoiceMenu } from './OpeningChoiceMenu';
 
 type Props = {
     projectUuid: string;
     organizationUuid: string | undefined;
     showNewHomepage?: boolean;
+    /** Day-0 only: there's no published layout yet, so the opening is the one
+     * thing an admin can change without entering the builder. */
+    showOpeningChoice?: boolean;
 };
 
 // Pinned top-right, just below the navbar, for anyone who can manage the
@@ -18,6 +22,7 @@ export const AdminHomepageControls: FC<Props> = ({
     projectUuid,
     organizationUuid,
     showNewHomepage = false,
+    showOpeningChoice = false,
 }) => {
     const navigate = useNavigate();
     return (
@@ -29,6 +34,9 @@ export const AdminHomepageControls: FC<Props> = ({
                     projectUuid,
                 })}
             >
+                {showOpeningChoice && (
+                    <OpeningChoiceMenu projectUuid={projectUuid} />
+                )}
                 {showNewHomepage && (
                     <button
                         type="button"

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.test.tsx
@@ -14,6 +14,10 @@ const { aiState, keySpaces, recentContents } = vi.hoisted(() => ({
     recentContents: { current: { contents: [{ uuid: 'recent-1' }] } },
 }));
 
+vi.mock('./hooks/useHomepageSettings', () => ({
+    useHomepageSettings: () => ({ data: { opening: null } }),
+}));
+
 vi.mock('./hooks/useKeySpaces', () => ({
     useKeySpaces: () => ({ spaces: keySpaces.current, isLoading: false }),
 }));

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.tsx
@@ -1,4 +1,4 @@
-import { type PinnedItems } from '@lightdash/common';
+import { resolveHomepageOpening, type PinnedItems } from '@lightdash/common';
 import { Box, Stack, Text } from '@mantine-8/core';
 import { IconClock, IconPin } from '@tabler/icons-react';
 import { type FC } from 'react';
@@ -16,6 +16,7 @@ import { getGreeting } from './greeting';
 import layout from './homepageLayout.module.css';
 import { useCollectionContent } from './hooks/useCollectionContent';
 import { useHomepageAiState } from './hooks/useHomepageAiState';
+import { useHomepageSettings } from './hooks/useHomepageSettings';
 import { useKeySpaces } from './hooks/useKeySpaces';
 import { useRecentContents } from './hooks/useRecentContents';
 
@@ -58,6 +59,10 @@ const MAX_KEY_SPACES = 4;
 export const DayOneHomepage: FC<Props> = ({ projectUuid, pinnedItems }) => {
     const { user } = useApp();
     const { canAskAi } = useHomepageAiState(projectUuid);
+    const { data: settings } = useHomepageSettings(projectUuid);
+    // The admin's choice decides the opening; AI availability can only
+    // downgrade ask-first, never force it.
+    const opening = resolveHomepageOpening(settings?.opening ?? null, canAskAi);
     const { spaces: keySpaces } = useKeySpaces(projectUuid, MAX_KEY_SPACES);
     const recent = useRecentContents(projectUuid);
     // Keep the header while loading so the section doesn't pop in under the
@@ -77,7 +82,7 @@ export const DayOneHomepage: FC<Props> = ({ projectUuid, pinnedItems }) => {
                 data-presentation="shared"
                 data-density="compact"
             >
-                {canAskAi ? (
+                {opening === 'ask-first' ? (
                     <div className={layout.hero}>
                         <AskAiHero
                             projectUuid={projectUuid}
@@ -101,8 +106,11 @@ export const DayOneHomepage: FC<Props> = ({ projectUuid, pinnedItems }) => {
                                 new.
                             </Text>
                         </Box>
+                        {/* Ask AI stays reachable as a quick action whenever
+                            the project has it — content-first changes what the
+                            page opens on, not what's available. */}
                         <QuickActionCards
-                            actions={getDefaultQuickActions(false)}
+                            actions={getDefaultQuickActions(canAskAi)}
                             projectUuid={projectUuid}
                         />
                     </Stack>

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageBuilderPage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageBuilderPage.tsx
@@ -1,5 +1,8 @@
 import { subject } from '@casl/ability';
-import { type ProjectHomepage } from '@lightdash/common';
+import {
+    resolveHomepageOpening,
+    type ProjectHomepage,
+} from '@lightdash/common';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useRef, useState, type FC } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router';
@@ -12,6 +15,7 @@ import useApp from '../../../providers/App/useApp';
 import { CreateHomepageModal } from './CreateHomepageModal';
 import { HomepageEditor } from './HomepageEditor';
 import { useHomepageAiState } from './hooks/useHomepageAiState';
+import { useHomepageSettings } from './hooks/useHomepageSettings';
 import { useKeySpaces } from './hooks/useKeySpaces';
 import {
     useCreateHomepageWithDraft,
@@ -48,6 +52,9 @@ export const HomepageBuilderPage: FC = () => {
         project?.pinnedListUuid,
     );
     const { spaces: keySpaces } = useKeySpaces(projectUuid, MAX_STARTER_SPACES);
+    const { data: settings } = useHomepageSettings(projectUuid, {
+        enabled: isFlagEnabled,
+    });
     const homepage = useHomepageForBuilder(projectUuid, {
         enabled: isFlagEnabled,
         homepageUuid: selectedHomepageUuid,
@@ -94,14 +101,18 @@ export const HomepageBuilderPage: FC = () => {
         createFirstHomepage.mutate(
             {
                 name: 'Homepage',
-                draftConfig: buildStarterHomepage(
+                draftConfig: buildStarterHomepage({
+                    opening: resolveHomepageOpening(
+                        settings?.opening ?? null,
+                        canAskAi,
+                    ),
                     canAskAi,
-                    (pinnedItems ?? []).map((item) => ({
+                    pinnedItems: (pinnedItems ?? []).map((item) => ({
                         contentType: item.type,
                         uuid: item.data.uuid,
                     })),
-                    keySpaces.map((space) => space.uuid),
-                ),
+                    keySpaceUuids: keySpaces.map((space) => space.uuid),
+                }),
             },
             { onSuccess: openHomepage },
         );
@@ -112,6 +123,7 @@ export const HomepageBuilderPage: FC = () => {
         canAskAi,
         pinnedItems,
         keySpaces,
+        settings?.opening,
     ]);
 
     if (isFlagLoading || isAiStateLoading) {

--- a/packages/frontend/src/ee/features/homepageBuilder/OpeningChoiceMenu.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/OpeningChoiceMenu.tsx
@@ -1,0 +1,108 @@
+import { type HomepageOpening } from '@lightdash/common';
+import { Menu, Text } from '@mantine-8/core';
+import { IconCheck, IconLayoutNavbarExpand } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import classes from './adminHomepageControls.module.css';
+import { useHomepageAiState } from './hooks/useHomepageAiState';
+import {
+    useHomepageSettings,
+    useUpdateHomepageOpening,
+} from './hooks/useHomepageSettings';
+
+const OPTIONS: {
+    value: HomepageOpening;
+    label: string;
+    description: string;
+    /** Which schematic row is the composer, top-down. */
+    composerRow: 0 | 1;
+}[] = [
+    {
+        value: 'ask-first',
+        label: 'Ask first',
+        description: 'Opens on the AI composer, with content below it.',
+        composerRow: 0,
+    },
+    {
+        value: 'content-first',
+        label: 'Content first',
+        description:
+            'Opens on a greeting and quick actions. Ask AI stays a click away.',
+        composerRow: 1,
+    },
+];
+
+/** A schematic of where the composer sits, so the choice reads at a glance
+ * rather than only as words. */
+const OpeningPreview: FC<{ composerRow: 0 | 1 }> = ({ composerRow }) => (
+    <div className={classes.previewFrame} aria-hidden="true">
+        {[0, 1].map((row) => (
+            <div
+                key={row}
+                className={
+                    row === composerRow
+                        ? classes.previewComposer
+                        : classes.previewContent
+                }
+            />
+        ))}
+    </div>
+);
+
+/**
+ * Lets an admin choose what the homepage opens on. Only rendered when the
+ * project actually has AI available — without it there's no choice to make,
+ * and offering one would imply a composer that can't answer anything.
+ */
+export const OpeningChoiceMenu: FC<{ projectUuid: string }> = ({
+    projectUuid,
+}) => {
+    const { canAskAi } = useHomepageAiState(projectUuid);
+    const { data: settings } = useHomepageSettings(projectUuid);
+    const { mutate: setOpening } = useUpdateHomepageOpening(projectUuid);
+    // No stored choice reads as ask-first here, which is what the viewer gets.
+    const current = settings?.opening ?? 'ask-first';
+
+    if (!canAskAi) return null;
+
+    return (
+        <Menu position="bottom-end" withinPortal>
+            <Menu.Target>
+                <button
+                    type="button"
+                    className={classes.tbBtn}
+                    aria-label="Change what the homepage opens on"
+                >
+                    <MantineIcon icon={IconLayoutNavbarExpand} size={15} />
+                    <span className={classes.tbBtnLabel} aria-hidden="true">
+                        Opening
+                    </span>
+                </button>
+            </Menu.Target>
+            <Menu.Dropdown>
+                <Menu.Label>What this homepage opens on</Menu.Label>
+                {OPTIONS.map((option) => (
+                    <Menu.Item
+                        key={option.value}
+                        onClick={() => setOpening(option.value)}
+                        leftSection={
+                            <OpeningPreview composerRow={option.composerRow} />
+                        }
+                        rightSection={
+                            option.value === current ? (
+                                <MantineIcon icon={IconCheck} size={14} />
+                            ) : null
+                        }
+                    >
+                        <Text size="sm" fw={500}>
+                            {option.label}
+                        </Text>
+                        <Text size="xs" c="dimmed" maw={230}>
+                            {option.description}
+                        </Text>
+                    </Menu.Item>
+                ))}
+            </Menu.Dropdown>
+        </Menu>
+    );
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/adminHomepageControls.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/adminHomepageControls.module.css
@@ -57,3 +57,28 @@
         transition: none;
     }
 }
+
+/* A two-row schematic of the opening: the filled row is the composer, so
+   "ask first" and "content first" are distinguishable without reading. */
+.previewFrame {
+    width: 26px;
+    height: 20px;
+    border-radius: 4px;
+    border: 1px solid var(--mantine-color-ldGray-3);
+    padding: 2px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.previewComposer {
+    flex: 1;
+    border-radius: 2px;
+    background: var(--mantine-color-ldGray-7);
+}
+
+.previewContent {
+    flex: 1;
+    border-radius: 2px;
+    background: var(--mantine-color-ldGray-2);
+}

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useHomepageSettings.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useHomepageSettings.ts
@@ -1,0 +1,60 @@
+import {
+    type ApiError,
+    type HomepageOpening,
+    type ProjectHomepageSettings,
+} from '@lightdash/common';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { lightdashApi } from '../../../../api';
+import useToaster from '../../../../hooks/toaster/useToaster';
+
+const HOMEPAGE_SETTINGS_QUERY_KEY = 'project_homepage_settings';
+
+const getSettings = async (projectUuid: string) =>
+    lightdashApi<ProjectHomepageSettings>({
+        url: `/projects/${projectUuid}/homepage/settings`,
+        method: 'GET',
+        body: undefined,
+    });
+
+const updateOpening = async (
+    projectUuid: string,
+    opening: HomepageOpening | null,
+) =>
+    lightdashApi<ProjectHomepageSettings>({
+        url: `/projects/${projectUuid}/homepage/settings`,
+        method: 'PATCH',
+        body: JSON.stringify({ opening }),
+    });
+
+export const useHomepageSettings = (
+    projectUuid: string | undefined,
+    options: { enabled?: boolean } = {},
+) =>
+    useQuery<ProjectHomepageSettings, ApiError>({
+        queryKey: [HOMEPAGE_SETTINGS_QUERY_KEY, projectUuid],
+        queryFn: () => getSettings(projectUuid!),
+        enabled: (options.enabled ?? true) && !!projectUuid,
+    });
+
+export const useUpdateHomepageOpening = (projectUuid: string) => {
+    const queryClient = useQueryClient();
+    const { showToastApiError } = useToaster();
+    return useMutation<
+        ProjectHomepageSettings,
+        ApiError,
+        HomepageOpening | null
+    >({
+        mutationFn: (opening) => updateOpening(projectUuid, opening),
+        onSuccess: (settings) => {
+            queryClient.setQueryData(
+                [HOMEPAGE_SETTINGS_QUERY_KEY, projectUuid],
+                settings,
+            );
+        },
+        onError: ({ error }) =>
+            showToastApiError({
+                title: 'Failed to change the homepage opening',
+                apiError: error,
+            }),
+    });
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/starterHomepage.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/starterHomepage.test.ts
@@ -1,19 +1,29 @@
 import { describe, expect, it } from 'vitest';
 import { buildStarterHomepage } from './starterHomepage';
 
-const types = (
-    canAskAi: boolean,
-    pins: { contentType: 'chart'; uuid: string }[] = [],
-) =>
-    buildStarterHomepage(canAskAi, pins).rows.flatMap((row) =>
-        row.blocks.map((block) => block.type),
-    );
+const types = ({
+    opening,
+    canAskAi = opening === 'ask-first',
+    pins = [],
+    spaces = [],
+}: {
+    opening: 'ask-first' | 'content-first';
+    canAskAi?: boolean;
+    pins?: { contentType: 'chart'; uuid: string }[];
+    spaces?: string[];
+}) =>
+    buildStarterHomepage({
+        opening,
+        canAskAi,
+        pinnedItems: pins,
+        keySpaceUuids: spaces,
+    }).rows.flatMap((row) => row.blocks.map((block) => block.type));
 
 describe('buildStarterHomepage', () => {
     // The first homepage must reproduce day-0 block for block, in order, so
     // publishing it doesn't change the page out from under viewers.
-    it('mirrors the non-AI day-0 page', () => {
-        expect(types(false)).toEqual([
+    it('mirrors the content-first day-0 page', () => {
+        expect(types({ opening: 'content-first' })).toEqual([
             'favorites',
             'greeting',
             'quick-actions',
@@ -21,23 +31,96 @@ describe('buildStarterHomepage', () => {
         ]);
     });
 
-    it('leads with the Ask AI hero when the project has an agent', () => {
-        expect(types(true)).toEqual(['favorites', 'ask-ai-hero']);
+    it('leads with the Ask AI hero when the opening is ask-first', () => {
+        expect(types({ opening: 'ask-first' })).toEqual([
+            'favorites',
+            'ask-ai-hero',
+        ]);
+    });
+
+    it('builds the content-first preset even when AI is available', () => {
+        expect(
+            types({ opening: 'content-first', canAskAi: true }),
+        ).not.toContain('ask-ai-hero');
+    });
+
+    it('keeps Ask AI as a quick action in the content-first preset', () => {
+        const config = buildStarterHomepage({
+            opening: 'content-first',
+            canAskAi: true,
+            pinnedItems: [],
+        });
+        const quickActions = config.rows
+            .flatMap((row) => row.blocks)
+            .find((block) => block.type === 'quick-actions');
+        expect(quickActions).toMatchObject({
+            config: { actions: expect.arrayContaining([{ type: 'ask-ai' }]) },
+        });
+    });
+
+    it('leaves Ask AI out of the quick actions when the project has no agent', () => {
+        const config = buildStarterHomepage({
+            opening: 'content-first',
+            canAskAi: false,
+            pinnedItems: [],
+        });
+        const quickActions = config.rows
+            .flatMap((row) => row.blocks)
+            .find((block) => block.type === 'quick-actions');
+        expect(quickActions).toMatchObject({
+            config: {
+                actions: expect.not.arrayContaining([{ type: 'ask-ai' }]),
+            },
+        });
     });
 
     it('carries the project pins across as a collection', () => {
         const pins = [{ contentType: 'chart' as const, uuid: 'chart-1' }];
-        const config = buildStarterHomepage(false, pins);
+        const config = buildStarterHomepage({
+            opening: 'content-first',
+            canAskAi: false,
+            pinnedItems: pins,
+        });
         const collection = config.rows
             .flatMap((row) => row.blocks)
-            .find((block) => block.type === 'collection');
+            .find(
+                (block) =>
+                    block.type === 'collection' &&
+                    block.config.title === 'Pinned',
+            );
 
         expect(collection).toMatchObject({
             config: { title: 'Pinned', items: pins },
         });
     });
 
+    it('carries the day-0 key spaces across as a collection', () => {
+        const config = buildStarterHomepage({
+            opening: 'ask-first',
+            canAskAi: true,
+            pinnedItems: [],
+            keySpaceUuids: ['space-1', 'space-2'],
+        });
+        const collection = config.rows
+            .flatMap((row) => row.blocks)
+            .find(
+                (block) =>
+                    block.type === 'collection' &&
+                    block.config.title === 'Start here',
+            );
+
+        expect(collection).toMatchObject({
+            config: {
+                title: 'Start here',
+                items: [
+                    { contentType: 'space', uuid: 'space-1' },
+                    { contentType: 'space', uuid: 'space-2' },
+                ],
+            },
+        });
+    });
+
     it('leaves out the pinned collection when nothing is pinned', () => {
-        expect(types(false)).not.toContain('collection');
+        expect(types({ opening: 'content-first' })).not.toContain('collection');
     });
 });

--- a/packages/frontend/src/ee/features/homepageBuilder/starterHomepage.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/starterHomepage.ts
@@ -2,6 +2,7 @@ import {
     type HomepageBlock,
     type HomepageCollectionItemRef,
     type HomepageConfig,
+    type HomepageOpening,
 } from '@lightdash/common';
 import { v4 as uuidv4 } from 'uuid';
 import { getDefaultQuickActions } from './blocks/quickActionDefaults';
@@ -12,11 +13,21 @@ import { getDefaultQuickActions } from './blocks/quickActionDefaults';
  * recently viewed, pinned). Publishing the first homepage should keep the page
  * people were already looking at, not drop them onto a different one.
  */
-export const buildStarterHomepage = (
-    canAskAi: boolean,
-    pinnedItems: HomepageCollectionItemRef[],
-    keySpaceUuids: string[] = [],
-): HomepageConfig => {
+export const buildStarterHomepage = ({
+    opening,
+    canAskAi,
+    pinnedItems,
+    keySpaceUuids = [],
+}: {
+    /** What the page opens on — the admin's choice, already resolved. */
+    opening: HomepageOpening;
+    /** Whether Ask AI is usable at all, which decides only whether it appears
+     * as a quick action in the content-first preset. */
+    canAskAi: boolean;
+    pinnedItems: HomepageCollectionItemRef[];
+    keySpaceUuids?: string[];
+}): HomepageConfig => {
+    const asksFirst = opening === 'ask-first';
     const row = (block: HomepageBlock) => ({ id: uuidv4(), blocks: [block] });
 
     const rows = [
@@ -25,7 +36,7 @@ export const buildStarterHomepage = (
             type: 'favorites',
             config: { title: 'My favorites' },
         }),
-        canAskAi
+        asksFirst
             ? row({
                   id: uuidv4(),
                   type: 'ask-ai-hero',
@@ -60,12 +71,12 @@ export const buildStarterHomepage = (
     }
 
     // Day-0 pairs the greeting with quick actions; the AI hero stands alone.
-    if (!canAskAi) {
+    if (!asksFirst) {
         rows.push(
             row({
                 id: uuidv4(),
                 type: 'quick-actions',
-                config: { actions: getDefaultQuickActions(false) },
+                config: { actions: getDefaultQuickActions(canAskAi) },
             }),
             row({
                 id: uuidv4(),

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -134,6 +134,7 @@ const Home: FC = () => {
                 <AdminHomepageControls
                     projectUuid={project.data.projectUuid}
                     organizationUuid={project.data.organizationUuid}
+                    showOpeningChoice
                 />
                 <FavoritesProvider projectUuid={project.data.projectUuid}>
                     <PinnedItemsProvider


### PR DESCRIPTION
Closes #26440

Stacked on #26450.

## What

Whether the homepage opened on the AI composer was decided by whether AI was *available*: `DayOneHomepage` branched on `canAskAi`. So an org with AI enabled had no way to open its homepage on anything else short of turning AI off entirely — the wrong trade. AI adoption inside a company is gradual: a data team can be using the agent daily while most business users have never opened it, and putting the composer in the first screen presents it as the company's primary action before it is one.

The opening is now an admin's layout decision, persisted per project.

| | Before | After |
|---|---|---|
| Who decides the opening | AI availability | the admin |
| What AI availability controls | the whole layout | only whether AI blocks are *offered* |
| Opening on content with AI enabled | impossible | supported, Ask AI still a quick action |

## How

- **`project_homepage_settings`** (EE, new): one nullable `opening` per project. Null means "not chosen", which is every existing project.
- **`resolveHomepageOpening(chosen, canAskAi)`** in common decides what a viewer gets. An explicit choice wins; with no choice, a project with a usable agent opens ask-first and one without opens content-first. AI availability can only ever **downgrade** ask-first — a composer that can't answer anything is worse than no composer, so a project that loses its agent falls back instead of rendering a dead composer.
- **An "Opening" menu** in the day-0 admin controls switches between the two, with a small schematic of where the composer sits in each so the choice reads without being read. It renders only when the project has AI: without it there is no choice to make, and offering one would imply a composer that can't answer.
- **Content-first keeps Ask AI as a quick action** whenever the project has it. The preset changes what the page opens on, not what's available.

`buildStarterHomepage` now takes the resolved opening (plus `canAskAi` for the quick actions), so the first draft an admin opens matches what viewers were already seeing. Its four positional arguments became an options object on the way.

The builder rail already gated AI blocks behind `requiresAi && canAskAi`, so orgs without AI never saw them offered — that acceptance criterion needed no change.

## Verified live

- `GET /homepage/settings` → `{ opening: null }`
- `PATCH { opening: 'content-first' }` → persists, and re-reads as `content-first`
- `PATCH { opening: 'nonsense' }` → **422 at the request boundary** (TSOA validates the union before the service is reached; the service also guards, for non-HTTP callers)
- An AI-enabled project set to content-first renders greeting + quick actions with **no composer**, and Ask AI is among the quick actions
- One click in the menu switches back to ask-first and the composer returns

## Regression analysis

- **Every existing project is unaffected.** `opening` starts null, and `resolveHomepageOpening(null, canAskAi)` reproduces exactly the old `canAskAi` branch. The table is empty until an admin makes a choice.
- **An unrecognised stored value reads as "not chosen"** rather than throwing — a rolling deploy where an older pod reads a value a newer one wrote degrades to the default instead of erroring.
- **The settings read is view-gated, the write manage-gated**, matching the rest of the homepage endpoints. The write also carries `unauthorisedInDemo`.
- **Migration**: table creation only, no data mutation. `project_uuid` is the primary key — a single-column natural key that is `NOT NULL` and immutable, which also enforces the one-row-per-project invariant a surrogate key would need a separate unique index for. The FK column is therefore indexed by the PK. No `@lightdash/common` imports, no bind parameters in DDL.
- **Generated API artefacts are deliberately not committed** (`routes.ts` / `swagger.json`), per the repo convention — they're regenerated in CI and by the release workflow.

## Tests

4 new `resolveHomepageOpening` tests in common (choice respected, both defaults, and the "never open on a composer that cannot answer" downgrade) and 5 new starter-homepage tests (content-first preset with AI available, Ask AI present/absent in quick actions, key spaces carried across). Backend homepage suites green (46 tests), frontend homepage-builder suite green (20 files / 203 tests), backend lint and typecheck clean.
