### PR TITLE
fix(analytics): honour anonymized tracking preference in user.deleted events

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.test.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.test.ts
@@ -1,3 +1,4 @@
+import Analytics from '@rudderstack/rudder-sdk-node';
 import { lightdashConfigMock } from '../config/lightdashConfig.mock';
 import type { FeatureFlagCheckAggregateEntry } from '../models/FeatureFlagModel/flagCheckAggregator';
 import { LightdashAnalytics } from './LightdashAnalytics';
@@ -54,6 +55,93 @@ describe('LightdashAnalytics', () => {
                 ...entries[1],
                 processType: 'scheduler',
             },
+        });
+    });
+
+    describe('user.deleted anonymization', () => {
+        const analytics = new LightdashAnalytics({
+            lightdashConfig: {
+                ...lightdashConfigMock,
+                rudder: {
+                    writeKey: 'test-write-key',
+                    dataPlaneUrl: 'http://localhost',
+                },
+            },
+            writeKey: 'test-write-key',
+            dataPlaneUrl: 'http://localhost',
+            options: { enable: false },
+        });
+
+        const deletedUserProperties = {
+            context: 'delete_self',
+            firstName: 'Jane',
+            lastName: 'Doe',
+            email: 'jane.doe@example.com',
+            organizationId: 'org-uuid',
+            deletedUserId: 'deleted-user-uuid',
+        };
+
+        let superTrackSpy: ReturnType<typeof vi.spyOn>;
+
+        beforeEach(() => {
+            superTrackSpy = vi
+                .spyOn(Analytics.prototype, 'track')
+                .mockImplementation(() => {});
+        });
+
+        afterEach(() => {
+            superTrackSpy.mockRestore();
+        });
+
+        it('strips PII when the deleted user opted into anonymized tracking', () => {
+            analytics.track({
+                event: 'user.deleted',
+                userId: 'actor-uuid',
+                properties: {
+                    ...deletedUserProperties,
+                    isTrackingAnonymized: true,
+                },
+            });
+
+            expect(superTrackSpy).toHaveBeenCalledTimes(1);
+            expect(superTrackSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    event: 'lightdash_server.user.deleted',
+                    properties: {
+                        context: 'delete_self',
+                        organizationId: 'org-uuid',
+                        deletedUserId: 'deleted-user-uuid',
+                        is_tracking_anonymized: true,
+                    },
+                }),
+            );
+        });
+
+        it('keeps PII when the deleted user did not opt into anonymized tracking', () => {
+            analytics.track({
+                event: 'user.deleted',
+                userId: 'actor-uuid',
+                properties: {
+                    ...deletedUserProperties,
+                    isTrackingAnonymized: false,
+                },
+            });
+
+            expect(superTrackSpy).toHaveBeenCalledTimes(1);
+            expect(superTrackSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    event: 'lightdash_server.user.deleted',
+                    properties: {
+                        context: 'delete_self',
+                        organizationId: 'org-uuid',
+                        deletedUserId: 'deleted-user-uuid',
+                        is_tracking_anonymized: false,
+                        firstName: 'Jane',
+                        lastName: 'Doe',
+                        email: 'jane.doe@example.com',
+                    },
+                }),
+            );
         });
     });
 });

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -161,8 +161,13 @@ export type DeleteUserEvent = BaseTrack & {
         email: string | undefined;
         organizationId: string | undefined;
         deletedUserId: string;
+        isTrackingAnonymized: boolean;
     };
 };
+
+function isUserDeletedEvent(event: BaseTrack): event is DeleteUserEvent {
+    return event.event === 'user.deleted';
+}
 
 export type UpdateUserEvent = BaseTrack & {
     event: 'user.updated';
@@ -3327,6 +3332,29 @@ export class LightdashAnalytics extends Analytics {
                         ? undefined
                         : payload.properties.email,
                 },
+            });
+            return;
+        }
+        if (isUserDeletedEvent(payload)) {
+            const basicEventProperties = {
+                context: payload.properties.context,
+                organizationId: payload.properties.organizationId,
+                deletedUserId: payload.properties.deletedUserId,
+                is_tracking_anonymized: payload.properties.isTrackingAnonymized,
+            };
+
+            super.track({
+                ...payload,
+                event: `${this.lightdashContext.app.name}.${payload.event}`,
+                context: { ...this.lightdashContext },
+                properties: payload.properties.isTrackingAnonymized
+                    ? basicEventProperties
+                    : {
+                          ...basicEventProperties,
+                          firstName: payload.properties.firstName,
+                          lastName: payload.properties.lastName,
+                          email: payload.properties.email,
+                      },
             });
             return;
         }

--- a/packages/backend/src/ee/services/ScimService/ScimService.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.ts
@@ -1114,6 +1114,10 @@ export class ScimService extends BaseService {
                 );
             }
 
+            const userToDelete = await this.userModel.getUserDetailsByUuid(
+                dbUser.userUuid,
+            );
+
             await this.userModel.delete(dbUser.userUuid);
 
             this.logger.info('SCIM: Successfully deleted user', {
@@ -1133,6 +1137,7 @@ export class ScimService extends BaseService {
                     email: dbUser.email,
                     organizationId: dbUser.organizationUuid,
                     deletedUserId: dbUser.userUuid,
+                    isTrackingAnonymized: userToDelete.isTrackingAnonymized,
                 },
             });
             return undefined;

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -395,6 +395,23 @@ export class UserModel {
         return results.length > 0;
     }
 
+    async getIsTrackingAnonymizedByUserUuids(
+        userUuids: string[],
+    ): Promise<Record<string, boolean>> {
+        if (userUuids.length === 0) {
+            return {};
+        }
+        const users = await this.database(UserTableName)
+            .whereIn('user_uuid', userUuids)
+            .select<Pick<DbUser, 'user_uuid' | 'is_tracking_anonymized'>[]>(
+                'user_uuid',
+                'is_tracking_anonymized',
+            );
+        return Object.fromEntries(
+            users.map((user) => [user.user_uuid, user.is_tracking_anonymized]),
+        );
+    }
+
     async getUserDetailsByUuid(userUuid: string): Promise<LightdashUser> {
         const [user] = await userDetailsQueryBuilder(this.database)
             .where('user_uuid', userUuid)

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -485,6 +485,9 @@ export class OrganizationService extends BaseService {
 
         const userUuids = orgUsers.map((orgUser) => orgUser.userUuid);
 
+        const isTrackingAnonymizedByUserUuid =
+            await this.userModel.getIsTrackingAnonymizedByUserUuids(userUuids);
+
         await this.organizationModel.deleteOrgAndUsers(
             organizationUuid,
             userUuids,
@@ -501,6 +504,9 @@ export class OrganizationService extends BaseService {
                     email: orgUser.email,
                     organizationId: organizationUuid,
                     deletedUserId: orgUser.userUuid,
+                    isTrackingAnonymized:
+                        isTrackingAnonymizedByUserUuid[orgUser.userUuid] ??
+                        false,
                 },
             });
         });

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -610,6 +610,7 @@ export class UserService extends BaseService {
                 email: userToDelete.email,
                 organizationId: userToDelete.organizationUuid,
                 deletedUserId: userToDelete.userUuid,
+                isTrackingAnonymized: userToDelete.isTrackingAnonymized,
             },
         });
     }


### PR DESCRIPTION
## What changed

`user.updated` and `user.verified` analytics events already honour the user's anonymized-tracking preference by omitting identifying properties, but `user.deleted` events forwarded `firstName`/`lastName`/`email` unconditionally.

This PR brings `user.deleted` in line with the existing pattern:

- Added `isTrackingAnonymized` (the deleted user's own preference) as a required property on `DeleteUserEvent`, so every call site must supply it.
- Added an `isUserDeletedEvent` guard in `LightdashAnalytics.track()` that emits only `context`, `organizationId`, `deletedUserId` and `is_tracking_anonymized` when the deleted user opted into anonymized tracking, mirroring the `isUserUpdatedEvent` handling. Events for users who did not opt in are unchanged apart from the new `is_tracking_anonymized` property.
- Passed the preference through from all three deletion paths: self/admin user deletion (`UserService`), whole-organization deletion (`OrganizationService`, via a new bulk `UserModel.getIsTrackingAnonymizedByUserUuids` lookup captured before the rows are removed), and SCIM deprovisioning (`ScimService`).
- Added unit tests covering both the anonymized and non-anonymized `user.deleted` payloads.

## Behaviour change

For deleted users who opted into anonymized tracking, `user.deleted` analytics events no longer carry `firstName`/`lastName`/`email`. They remain present for users who did not opt in.

Linear: SPK-725

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsCoJEGNd8RjrBCSN6oVaG