### PR TITLE
feat(homepage-builder): give collections a live source instead of only a frozen list

### DIFF
--- a/packages/common/src/ee/homepage/types.ts
+++ b/packages/common/src/ee/homepage/types.ts
@@ -38,11 +38,63 @@ export type HomepageCollectionItemRef = {
     uuid: string;
 };
 
+/**
+ * Where a collection block's items come from.
+ *
+ * `manual` reads the block's own `items`. Every other source is a live rule
+ * resolved per viewer at render time — which is the point: a snapshot of
+ * "most viewed" is stale the week after it's taken, and a frozen copy of the
+ * pin list stops tracking pins the moment it's published.
+ *
+ * `favorites` and `recently-viewed` are per-viewer; the rest are project-wide.
+ */
+export type HomepageCollectionSource =
+    | 'manual'
+    | 'most-viewed'
+    | 'recently-updated'
+    | 'pinned'
+    | 'favorites'
+    | 'recently-viewed';
+
+/** Sources whose content differs for every viewer, so an admin previewing as
+ * someone else must not see the target's data. */
+export const PERSONAL_COLLECTION_SOURCES: HomepageCollectionSource[] = [
+    'favorites',
+    'recently-viewed',
+];
+
+export const isPersonalCollectionSource = (
+    source: HomepageCollectionSource,
+): boolean => PERSONAL_COLLECTION_SOURCES.includes(source);
+
+export const DEFAULT_COLLECTION_LIMIT = 6;
+export const MAX_COLLECTION_LIMIT = 24;
+
 export type HomepageCollectionBlock = {
     id: string;
     type: 'collection';
-    config: { title: string; items: HomepageCollectionItemRef[] };
+    config: {
+        title: string;
+        /** The hand-picked items. Read only when `source` is `manual`, which
+         * is what an absent `source` means — every config stored before
+         * sources existed is a manual collection. */
+        items: HomepageCollectionItemRef[];
+        source?: HomepageCollectionSource;
+        /** Applies to every source, including manual. */
+        verifiedOnly?: boolean;
+        /** How many items to show. Absent means DEFAULT_COLLECTION_LIMIT. */
+        limit?: number;
+    };
 };
+
+export const collectionSourceOf = (
+    config: HomepageCollectionBlock['config'],
+): HomepageCollectionSource => config.source ?? 'manual';
+
+export const collectionLimitOf = (
+    config: HomepageCollectionBlock['config'],
+): number =>
+    Math.min(config.limit ?? DEFAULT_COLLECTION_LIMIT, MAX_COLLECTION_LIMIT);
 
 export type HomepageResourceKind =
     | 'video'

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
@@ -9,10 +9,12 @@ import { TIER_CLASS } from './blockLayout';
 import { getBlockDefinition } from './blocks/registry';
 import { type BlockPresentation } from './blocks/types';
 import layout from './homepageLayout.module.css';
+import { useRuntimeEmptyBlocks } from './hooks/useRuntimeEmptyBlocks';
 import {
     resolveHomepageLayout,
     type ResolvedRow,
 } from './resolveHomepageLayout';
+import { RuntimeEmptyBlocksProvider } from './RuntimeEmptyBlocks';
 
 const PERSONAL_BLOCK_TYPES: HomepageBlock['type'][] = ['favorites', 'recent'];
 
@@ -65,32 +67,48 @@ const RowRenderer: FC<{
     row: ResolvedRow;
     projectUuid: string;
     personalPlaceholders: boolean;
-}> = ({ row, projectUuid, personalPlaceholders }) => (
-    <Box
-        className={`${layout.row} ${TIER_CLASS[row.widthTier]}`}
-        data-gap={row.gap}
-        data-role={row.role}
-        data-align={row.align}
-        data-fit={row.fit}
-    >
-        {row.columns.map((column) => (
-            <Box
-                key={column.block.id}
-                className={layout.col}
-                data-weight={column.weight}
-                data-hug-units={column.hugUnits ?? undefined}
-            >
-                <BlockRenderer
-                    block={column.block}
-                    projectUuid={projectUuid}
-                    personalPlaceholders={personalPlaceholders}
-                    itemSpan={column.itemSpan}
-                    standalone={row.columns.length === 1}
-                />
-            </Box>
-        ))}
-    </Box>
-);
+}> = ({ row, projectUuid, personalPlaceholders }) => {
+    const { emptyBlockIds } = useRuntimeEmptyBlocks();
+    // A row whose every block resolved to nothing takes no space and no gap —
+    // the same guarantee the resolver gives config-empty blocks, applied to
+    // blocks that can only know at runtime.
+    //
+    // Hidden, NOT unmounted: unmounting removes the block that reported the
+    // emptiness, its cleanup clears the flag, the row comes back, the block
+    // remounts and reports empty again — an infinite loop. `display: none`
+    // takes it out of flow (so no gap either) while leaving the reporter
+    // mounted and the state stable.
+    const isRuntimeEmpty =
+        row.columns.length > 0 &&
+        row.columns.every((column) => emptyBlockIds.has(column.block.id));
+    return (
+        <Box
+            className={`${layout.row} ${TIER_CLASS[row.widthTier]}`}
+            data-gap={row.gap}
+            data-role={row.role}
+            data-align={row.align}
+            data-fit={row.fit}
+            data-runtime-empty={isRuntimeEmpty || undefined}
+        >
+            {row.columns.map((column) => (
+                <Box
+                    key={column.block.id}
+                    className={layout.col}
+                    data-weight={column.weight}
+                    data-hug-units={column.hugUnits ?? undefined}
+                >
+                    <BlockRenderer
+                        block={column.block}
+                        projectUuid={projectUuid}
+                        personalPlaceholders={personalPlaceholders}
+                        itemSpan={column.itemSpan}
+                        standalone={row.columns.length === 1}
+                    />
+                </Box>
+            ))}
+        </Box>
+    );
+};
 
 type Props = {
     config: HomepageConfig;
@@ -111,50 +129,54 @@ export const PublishedHomepage: FC<Props> = ({
     const { hero, rows } = resolveHomepageLayout(migrateHomepageConfig(config));
 
     return (
-        <div className={layout.page}>
-            {topBar}
-            {hero && (
-                <div
-                    className={layout.heroSection}
-                    data-presentation={hero.presentation}
-                    data-density={hero.density}
-                >
-                    {hero.companions.length > 0 && (
-                        <div className={layout.heroCompanions}>
-                            {hero.companions.map((row) => (
-                                <RowRenderer
-                                    key={row.id}
-                                    row={row}
-                                    projectUuid={projectUuid}
-                                    personalPlaceholders={personalPlaceholders}
-                                />
-                            ))}
+        <RuntimeEmptyBlocksProvider>
+            <div className={layout.page}>
+                {topBar}
+                {hero && (
+                    <div
+                        className={layout.heroSection}
+                        data-presentation={hero.presentation}
+                        data-density={hero.density}
+                    >
+                        {hero.companions.length > 0 && (
+                            <div className={layout.heroCompanions}>
+                                {hero.companions.map((row) => (
+                                    <RowRenderer
+                                        key={row.id}
+                                        row={row}
+                                        projectUuid={projectUuid}
+                                        personalPlaceholders={
+                                            personalPlaceholders
+                                        }
+                                    />
+                                ))}
+                            </div>
+                        )}
+                        <div className={layout.hero}>
+                            <BlockRenderer
+                                block={hero.row.columns[0].block}
+                                projectUuid={projectUuid}
+                                personalPlaceholders={personalPlaceholders}
+                                presentation="hero"
+                                itemSpan={hero.row.columns[0].itemSpan}
+                                standalone={hero.row.columns.length === 1}
+                            />
                         </div>
-                    )}
-                    <div className={layout.hero}>
-                        <BlockRenderer
-                            block={hero.row.columns[0].block}
-                            projectUuid={projectUuid}
-                            personalPlaceholders={personalPlaceholders}
-                            presentation="hero"
-                            itemSpan={hero.row.columns[0].itemSpan}
-                            standalone={hero.row.columns.length === 1}
-                        />
                     </div>
-                </div>
-            )}
-            {rows.length > 0 && (
-                <div className={layout.secondary}>
-                    {rows.map((row) => (
-                        <RowRenderer
-                            key={row.id}
-                            row={row}
-                            projectUuid={projectUuid}
-                            personalPlaceholders={personalPlaceholders}
-                        />
-                    ))}
-                </div>
-            )}
-        </div>
+                )}
+                {rows.length > 0 && (
+                    <div className={layout.secondary}>
+                        {rows.map((row) => (
+                            <RowRenderer
+                                key={row.id}
+                                row={row}
+                                projectUuid={projectUuid}
+                                personalPlaceholders={personalPlaceholders}
+                            />
+                        ))}
+                    </div>
+                )}
+            </div>
+        </RuntimeEmptyBlocksProvider>
     );
 };

--- a/packages/frontend/src/ee/features/homepageBuilder/RuntimeEmptyBlocks.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/RuntimeEmptyBlocks.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from '@testing-library/react';
+import { type FC } from 'react';
+import { describe, expect, it } from 'vitest';
+import {
+    useReportRuntimeEmpty,
+    useRuntimeEmptyBlocks,
+} from './hooks/useRuntimeEmptyBlocks';
+import { RuntimeEmptyBlocksProvider } from './RuntimeEmptyBlocks';
+
+const Block: FC<{ id: string; isEmpty: boolean; isLoading?: boolean }> = ({
+    id,
+    isEmpty,
+    isLoading = false,
+}) => {
+    useReportRuntimeEmpty(id, isEmpty, isLoading);
+    return <div data-testid={`block-${id}`} />;
+};
+
+// Mirrors RowRenderer: an all-empty row is *hidden*, never unmounted. If it
+// unmounted, the block reporting the emptiness would unmount with it, its
+// cleanup would clear the flag, the row would return, and the pair would
+// oscillate forever.
+const Row: FC<{ blockIds: string[] }> = ({ blockIds }) => {
+    const { emptyBlockIds } = useRuntimeEmptyBlocks();
+    const isEmpty = blockIds.every((id) => emptyBlockIds.has(id));
+    return <div data-testid="row" data-runtime-empty={isEmpty || undefined} />;
+};
+
+const rowIsHidden = () =>
+    screen.getByTestId('row').hasAttribute('data-runtime-empty');
+
+describe('runtime empty blocks', () => {
+    it('collapses a row once every block in it resolves to nothing', async () => {
+        render(
+            <RuntimeEmptyBlocksProvider>
+                <Row blockIds={['a']} />
+                <Block id="a" isEmpty />
+            </RuntimeEmptyBlocksProvider>,
+        );
+        expect(await screen.findByTestId('block-a')).toBeInTheDocument();
+        expect(rowIsHidden()).toBe(true);
+    });
+
+    it('keeps a row whose blocks have content', () => {
+        render(
+            <RuntimeEmptyBlocksProvider>
+                <Row blockIds={['a']} />
+                <Block id="a" isEmpty={false} />
+            </RuntimeEmptyBlocksProvider>,
+        );
+        expect(rowIsHidden()).toBe(false);
+    });
+
+    it('keeps a row while a block is still loading, so it cannot flash', () => {
+        render(
+            <RuntimeEmptyBlocksProvider>
+                <Row blockIds={['a']} />
+                <Block id="a" isEmpty isLoading />
+            </RuntimeEmptyBlocksProvider>,
+        );
+        expect(rowIsHidden()).toBe(false);
+    });
+
+    it('keeps a row when only some of its blocks are empty', () => {
+        render(
+            <RuntimeEmptyBlocksProvider>
+                <Row blockIds={['a', 'b']} />
+                <Block id="a" isEmpty />
+                <Block id="b" isEmpty={false} />
+            </RuntimeEmptyBlocksProvider>,
+        );
+        expect(rowIsHidden()).toBe(false);
+    });
+
+    it('forgets a block that unmounts, so it stops holding a row empty', () => {
+        const { rerender } = render(
+            <RuntimeEmptyBlocksProvider>
+                <Row blockIds={['a']} />
+                <Block id="a" isEmpty />
+            </RuntimeEmptyBlocksProvider>,
+        );
+        expect(rowIsHidden()).toBe(true);
+
+        rerender(
+            <RuntimeEmptyBlocksProvider>
+                <Row blockIds={['a']} />
+            </RuntimeEmptyBlocksProvider>,
+        );
+        expect(rowIsHidden()).toBe(false);
+    });
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/RuntimeEmptyBlocks.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/RuntimeEmptyBlocks.tsx
@@ -1,0 +1,39 @@
+import {
+    useCallback,
+    useMemo,
+    useState,
+    type FC,
+    type PropsWithChildren,
+} from 'react';
+import { EmptyBlocksContext } from './hooks/useRuntimeEmptyBlocks';
+
+/** Holds which blocks resolved to nothing, so rows containing only those can
+ * collapse. See useReportRuntimeEmpty for why this can't be config-derived. */
+export const RuntimeEmptyBlocksProvider: FC<PropsWithChildren> = ({
+    children,
+}) => {
+    const [emptyBlockIds, setEmptyBlockIds] = useState<ReadonlySet<string>>(
+        () => new Set(),
+    );
+
+    const reportEmpty = useCallback((blockId: string, isEmpty: boolean) => {
+        setEmptyBlockIds((current) => {
+            if (current.has(blockId) === isEmpty) return current;
+            const next = new Set(current);
+            if (isEmpty) next.add(blockId);
+            else next.delete(blockId);
+            return next;
+        });
+    }, []);
+
+    const value = useMemo(
+        () => ({ emptyBlockIds, reportEmpty }),
+        [emptyBlockIds, reportEmpty],
+    );
+
+    return (
+        <EmptyBlocksContext.Provider value={value}>
+            {children}
+        </EmptyBlocksContext.Provider>
+    );
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
@@ -14,10 +14,16 @@ import {
 import { CSS } from '@dnd-kit/utilities';
 import {
     assertUnreachable,
+    collectionLimitOf,
+    collectionSourceOf,
     ContentType,
     contentToResourceViewItem,
+    isPersonalCollectionSource,
+    MAX_COLLECTION_LIMIT,
     ResourceViewItemType,
+    type HomepageCollectionBlock,
     type HomepageCollectionItemRef,
+    type HomepageCollectionSource,
     type SummaryContent,
 } from '@lightdash/common';
 import {
@@ -27,6 +33,7 @@ import {
     Divider,
     Group,
     SegmentedControl,
+    Select,
     Skeleton,
     Stack,
     Text,
@@ -42,6 +49,7 @@ import {
 import { useMemo, useRef, useState, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import MantineModal from '../../../../components/common/MantineModal';
+import { NumberInput } from '../../../../components/common/NumberInput';
 import { ResourceIcon } from '../../../../components/common/ResourceIcon';
 import SpaceSelector from '../../../../components/common/SpaceSelector/SpaceSelector';
 import { useFavoriteMutation } from '../../../../hooks/favorites/useFavoriteMutation';
@@ -53,6 +61,8 @@ import { useSpaceSummaries } from '../../../../hooks/useSpaces';
 import { reorderCollectionItems } from '../configOps';
 import layoutClasses from '../homepageLayout.module.css';
 import { useCollectionContent } from '../hooks/useCollectionContent';
+import { useCollectionSourceContent } from '../hooks/useCollectionSourceContent';
+import { useReportRuntimeEmpty } from '../hooks/useRuntimeEmptyBlocks';
 import { BlockHeader } from './BlockShell';
 import classes from './blockStyles.module.css';
 import { ContentCard } from './ContentCard';
@@ -459,41 +469,47 @@ const CollectionPickerModal: FC<{
     );
 };
 
+const EMPTY_CONFIG: HomepageCollectionBlock['config'] = {
+    title: '',
+    items: [],
+};
+
 export const CollectionBlockView: FC<BlockComponentProps> = ({
     itemSpan,
     block,
     projectUuid,
 }) => {
-    const uuids =
-        block.type === 'collection'
-            ? block.config.items.map((item) => item.uuid)
-            : [];
-    const { data: contents, isInitialLoading } = useCollectionContent(
+    const config = block.type === 'collection' ? block.config : EMPTY_CONFIG;
+    const { items: contents, isLoading } = useCollectionSourceContent(
         projectUuid,
-        uuids,
+        config,
     );
     const { data: favorites } = useFavorites(projectUuid);
     const { mutate: toggleFavorite } = useFavoriteMutation(projectUuid);
-    if (block.type !== 'collection' || block.config.items.length === 0) {
-        return null;
-    }
+    // Emptiness of a dynamic source is only knowable once its data lands, so
+    // the page is told rather than inferring it from config.
+    useReportRuntimeEmpty(block.id, contents.length === 0, isLoading);
+    if (block.type !== 'collection') return null;
+    // Nothing to show, and nothing on the way: render no header at all. The
+    // page drops the row on the next commit.
+    if (!isLoading && contents.length === 0) return null;
     const favoriteUuids = new Set(
         (favorites ?? []).map((item) => item.data.uuid),
     );
     return (
         <Stack gap={0}>
             <BlockHeader icon={IconLayoutGrid} title={block.config.title} />
-            {isInitialLoading ? (
+            {isLoading ? (
                 <PageGrid itemSpan={itemSpan ?? null} elastic>
-                    {uuids.slice(0, 3).map((uuid) => (
-                        <PageGridItem key={uuid}>
+                    {[0, 1, 2].map((i) => (
+                        <PageGridItem key={i}>
                             <Skeleton h={108} radius="md" />
                         </PageGridItem>
                     ))}
                 </PageGrid>
             ) : (
                 <PageGrid itemSpan={itemSpan ?? null} elastic>
-                    {(contents ?? []).map((content) => {
+                    {contents.map((content) => {
                         const favoriteType = toFavoriteType(content);
                         return (
                             <PageGridItem key={content.uuid}>
@@ -564,6 +580,152 @@ const SortableTile: FC<{
     );
 };
 
+const SOURCE_OPTIONS: {
+    value: HomepageCollectionSource;
+    label: string;
+    hint: string;
+}[] = [
+    {
+        value: 'manual',
+        label: 'Hand-picked',
+        hint: 'Exactly the items you choose.',
+    },
+    {
+        value: 'most-viewed',
+        label: 'Most viewed',
+        hint: 'What people in this project actually open.',
+    },
+    {
+        value: 'pinned',
+        label: 'Pinned',
+        hint: "Follows the project's pin list — new pins appear here.",
+    },
+    {
+        value: 'favorites',
+        label: 'Favourites',
+        hint: "Each viewer's own favourites.",
+    },
+    {
+        value: 'recently-viewed',
+        label: 'Recently viewed',
+        hint: "Each viewer's own history.",
+    },
+    {
+        value: 'recently-updated',
+        label: 'Recently updated',
+        hint: 'Recently changed content. Surfaces churn, not importance.',
+    },
+];
+
+const CollectionSourceControls: FC<{
+    config: HomepageCollectionBlock['config'];
+    onChange: (config: HomepageCollectionBlock['config']) => void;
+}> = ({ config, onChange }) => {
+    const source = collectionSourceOf(config);
+    const hint = SOURCE_OPTIONS.find((o) => o.value === source)?.hint;
+    return (
+        <Stack gap={6}>
+            <Select
+                size="xs"
+                label="Items"
+                data={SOURCE_OPTIONS.map(({ value, label }) => ({
+                    value,
+                    label,
+                }))}
+                value={source}
+                allowDeselect={false}
+                onChange={(next) =>
+                    next &&
+                    onChange({
+                        ...config,
+                        source: next as HomepageCollectionSource,
+                    })
+                }
+            />
+            {hint && (
+                <Text size="xs" c="dimmed">
+                    {hint}
+                </Text>
+            )}
+            <Group gap="sm" align="flex-end">
+                <NumberInput
+                    size="xs"
+                    label="Show at most"
+                    w={120}
+                    min={1}
+                    max={MAX_COLLECTION_LIMIT}
+                    value={collectionLimitOf(config)}
+                    onNumberChange={(limit) => onChange({ ...config, limit })}
+                />
+                <Checkbox
+                    size="xs"
+                    label="Verified only"
+                    checked={config.verifiedOnly === true}
+                    onChange={(e) =>
+                        onChange({
+                            ...config,
+                            verifiedOnly: e.currentTarget.checked,
+                        })
+                    }
+                />
+            </Group>
+        </Stack>
+    );
+};
+
+// The editor shows what the rule resolves to *for the editing admin*, which is
+// the honest preview for project-wide sources. Per-viewer sources say so
+// instead of implying everyone sees the admin's favourites.
+const DynamicSourcePreview: FC<{
+    projectUuid: string;
+    config: HomepageCollectionBlock['config'];
+    itemSpan: number | null;
+}> = ({ projectUuid, config, itemSpan }) => {
+    const { items, isLoading } = useCollectionSourceContent(
+        projectUuid,
+        config,
+    );
+    const isPersonal = isPersonalCollectionSource(collectionSourceOf(config));
+    if (isLoading) {
+        return (
+            <PageGrid itemSpan={itemSpan} elastic>
+                {[0, 1, 2].map((i) => (
+                    <PageGridItem key={i}>
+                        <Skeleton h={108} radius="md" />
+                    </PageGridItem>
+                ))}
+            </PageGrid>
+        );
+    }
+    return (
+        <Stack gap={6}>
+            {items.length === 0 ? (
+                <div className={classes.dashedEmpty}>
+                    Nothing matches this rule yet. The block won't render until
+                    it does.
+                </div>
+            ) : (
+                <PageGrid itemSpan={itemSpan} elastic>
+                    {items.map((content) => (
+                        <PageGridItem key={content.uuid}>
+                            <ContentCard
+                                content={content}
+                                projectUuid={projectUuid}
+                                variant="tile"
+                            />
+                        </PageGridItem>
+                    ))}
+                </PageGrid>
+            )}
+            <div className={classes.buildHint}>
+                {isPersonal
+                    ? 'Showing your own items as a sample — every viewer sees their own.'
+                    : 'Updates on its own as the project changes.'}
+            </div>
+        </Stack>
+    );
+};
+
 export const CollectionBlockBuild: FC<BuildComponentProps> = ({
     itemSpan,
     block,
@@ -585,6 +747,7 @@ export const CollectionBlockBuild: FC<BuildComponentProps> = ({
         project?.pinnedListUuid,
     );
     if (block.type !== 'collection') return null;
+    const source = collectionSourceOf(block.config);
 
     const importablePins = (pinnedItems ?? []).map(
         (item): HomepageCollectionItemRef => ({
@@ -610,81 +773,96 @@ export const CollectionBlockBuild: FC<BuildComponentProps> = ({
                     })
                 }
             />
-            <DndContext
-                sensors={sensors}
-                collisionDetection={closestCenter}
-                onDragEnd={(event: DragEndEvent) => {
-                    const { active, over } = event;
-                    if (!over || active.id === over.id) return;
-                    onChange({
-                        ...block,
-                        config: {
-                            ...block.config,
-                            items: reorderCollectionItems(
-                                block.config.items,
-                                String(active.id),
-                                String(over.id),
-                            ),
-                        },
-                    });
-                }}
-            >
-                <SortableContext
-                    items={(contents ?? []).map((content) => content.uuid)}
-                    strategy={rectSortingStrategy}
-                >
-                    <PageGrid itemSpan={itemSpan ?? null} elastic>
-                        {(contents ?? []).map((content) => (
-                            <SortableTile
-                                key={content.uuid}
-                                content={content}
-                                projectUuid={projectUuid}
-                                onRemove={() =>
-                                    onChange({
-                                        ...block,
-                                        config: {
-                                            ...block.config,
-                                            items: block.config.items.filter(
-                                                (item) =>
-                                                    item.uuid !== content.uuid,
-                                            ),
-                                        },
-                                    })
-                                }
-                            />
-                        ))}
-                        <PageGridItem>
-                            <button
-                                type="button"
-                                className={classes.addContentTile}
-                                onClick={() => setIsPickerOpen(true)}
-                            >
-                                <MantineIcon icon={IconPlus} size={14} />
-                                Add content
-                            </button>
-                        </PageGridItem>
-                    </PageGrid>
-                </SortableContext>
-            </DndContext>
-            {block.config.items.length === 0 && importablePins.length > 0 && (
-                <Button
-                    variant="subtle"
-                    size="xs"
-                    w="fit-content"
-                    leftSection={<MantineIcon icon={IconPin} />}
-                    onClick={() =>
+            <CollectionSourceControls
+                config={block.config}
+                onChange={(config) => onChange({ ...block, config })}
+            />
+            {source !== 'manual' ? (
+                <DynamicSourcePreview
+                    projectUuid={projectUuid}
+                    config={block.config}
+                    itemSpan={itemSpan ?? null}
+                />
+            ) : (
+                <DndContext
+                    sensors={sensors}
+                    collisionDetection={closestCenter}
+                    onDragEnd={(event: DragEndEvent) => {
+                        const { active, over } = event;
+                        if (!over || active.id === over.id) return;
                         onChange({
                             ...block,
                             config: {
                                 ...block.config,
-                                items: importablePins,
+                                items: reorderCollectionItems(
+                                    block.config.items,
+                                    String(active.id),
+                                    String(over.id),
+                                ),
                             },
-                        })
-                    }
+                        });
+                    }}
                 >
-                    Import pinned items
-                </Button>
+                    <SortableContext
+                        items={(contents ?? []).map((content) => content.uuid)}
+                        strategy={rectSortingStrategy}
+                    >
+                        <PageGrid itemSpan={itemSpan ?? null} elastic>
+                            {(contents ?? []).map((content) => (
+                                <SortableTile
+                                    key={content.uuid}
+                                    content={content}
+                                    projectUuid={projectUuid}
+                                    onRemove={() =>
+                                        onChange({
+                                            ...block,
+                                            config: {
+                                                ...block.config,
+                                                items: block.config.items.filter(
+                                                    (item) =>
+                                                        item.uuid !==
+                                                        content.uuid,
+                                                ),
+                                            },
+                                        })
+                                    }
+                                />
+                            ))}
+                            <PageGridItem>
+                                <button
+                                    type="button"
+                                    className={classes.addContentTile}
+                                    onClick={() => setIsPickerOpen(true)}
+                                >
+                                    <MantineIcon icon={IconPlus} size={14} />
+                                    Add content
+                                </button>
+                            </PageGridItem>
+                        </PageGrid>
+                    </SortableContext>
+                </DndContext>
             )}
+            {source === 'manual' &&
+                block.config.items.length === 0 &&
+                importablePins.length > 0 && (
+                    <Button
+                        variant="subtle"
+                        size="xs"
+                        w="fit-content"
+                        leftSection={<MantineIcon icon={IconPin} />}
+                        onClick={() =>
+                            onChange({
+                                ...block,
+                                config: {
+                                    ...block.config,
+                                    items: importablePins,
+                                },
+                            })
+                        }
+                    >
+                        Import pinned items
+                    </Button>
+                )}
             <CollectionPickerModal
                 opened={isPickerOpen}
                 onClose={() => setIsPickerOpen(false)}

--- a/packages/frontend/src/ee/features/homepageBuilder/collectionSources.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/collectionSources.test.ts
@@ -1,0 +1,111 @@
+import {
+    collectionLimitOf,
+    collectionSourceOf,
+    DEFAULT_COLLECTION_LIMIT,
+    isPersonalCollectionSource,
+    MAX_COLLECTION_LIMIT,
+    type HomepageBlock,
+    type HomepageConfig,
+} from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { resolveHomepageLayout } from './resolveHomepageLayout';
+
+const collection = (
+    config: Partial<HomepageBlock & { type: 'collection' }>['config'] = {
+        title: 't',
+        items: [],
+    },
+): HomepageBlock => ({ id: 'c1', type: 'collection', config });
+
+const configWith = (blocks: HomepageBlock[]): HomepageConfig => ({
+    version: 1,
+    rows: [{ id: 'row-0', blocks }],
+});
+
+describe('collection source helpers', () => {
+    it('treats a config with no source as hand-picked', () => {
+        // Every collection stored before sources existed.
+        expect(collectionSourceOf({ title: 't', items: [] })).toBe('manual');
+    });
+
+    it('defaults the limit and caps it', () => {
+        expect(collectionLimitOf({ title: 't', items: [] })).toBe(
+            DEFAULT_COLLECTION_LIMIT,
+        );
+        expect(collectionLimitOf({ title: 't', items: [], limit: 3 })).toBe(3);
+        expect(collectionLimitOf({ title: 't', items: [], limit: 500 })).toBe(
+            MAX_COLLECTION_LIMIT,
+        );
+    });
+
+    it('knows which sources differ per viewer', () => {
+        expect(isPersonalCollectionSource('favorites')).toBe(true);
+        expect(isPersonalCollectionSource('recently-viewed')).toBe(true);
+        expect(isPersonalCollectionSource('most-viewed')).toBe(false);
+        expect(isPersonalCollectionSource('pinned')).toBe(false);
+        expect(isPersonalCollectionSource('manual')).toBe(false);
+    });
+});
+
+describe('layout resolution for dynamic collections', () => {
+    it('drops a hand-picked collection with no items, as before', () => {
+        const { rows } = resolveHomepageLayout(
+            configWith([collection({ title: 't', items: [] })]),
+        );
+        expect(rows).toHaveLength(0);
+    });
+
+    it('keeps a dynamic collection with no config items — its content is a runtime fact', () => {
+        const { rows } = resolveHomepageLayout(
+            configWith([
+                collection({ title: 't', items: [], source: 'most-viewed' }),
+            ]),
+        );
+        expect(rows).toHaveLength(1);
+    });
+
+    it('sizes a dynamic collection by the limit it will fill up to', () => {
+        // A 6-item limit reads as a wide block (weight 2), same as 6 hand-picked
+        // items would; a 2-item limit stays narrow.
+        const wide = resolveHomepageLayout(
+            configWith([
+                collection({ title: 't', items: [], source: 'pinned' }),
+                {
+                    id: 'q',
+                    type: 'quick-actions',
+                    config: { actions: [{ type: 'ask-ai' }] },
+                },
+            ]),
+        );
+        expect(wide.rows[0].columns[0].weight).toBe(2);
+
+        const narrow = resolveHomepageLayout(
+            configWith([
+                collection({
+                    title: 't',
+                    items: [],
+                    source: 'pinned',
+                    limit: 2,
+                }),
+                {
+                    id: 'q',
+                    type: 'quick-actions',
+                    config: { actions: [{ type: 'ask-ai' }] },
+                },
+            ]),
+        );
+        expect(narrow.rows[0].columns[0].weight).toBe(1);
+    });
+
+    it('still tolerates a config from another code version with no items field', () => {
+        const foreign = configWith([
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+            {
+                id: 'c1',
+                type: 'collection',
+                config: { title: 't' },
+            } as HomepageBlock,
+        ]);
+        expect(() => resolveHomepageLayout(foreign)).not.toThrow();
+    });
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
@@ -139,6 +139,13 @@
     margin-inline: auto;
 }
 
+/* A row whose blocks all resolved to nothing. Out of flow entirely, so it
+ * contributes no height and no margin — see RowRenderer for why this is a
+ * style rather than an unmount. */
+.row[data-runtime-empty] {
+    display: none;
+}
+
 .row[data-align='start'] {
     margin-inline: 0 auto;
 }

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useCollectionSourceContent.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useCollectionSourceContent.ts
@@ -1,0 +1,117 @@
+import {
+    collectionLimitOf,
+    collectionSourceOf,
+    type HomepageCollectionBlock,
+    type SummaryContent,
+} from '@lightdash/common';
+import { useMemo } from 'react';
+import { useFavorites } from '../../../../hooks/favorites/useFavorites';
+import { usePinnedItems } from '../../../../hooks/pinning/usePinnedItems';
+import {
+    useMostPopularAndRecentlyUpdated,
+    useProject,
+} from '../../../../hooks/useProject';
+import { useCollectionContent } from './useCollectionContent';
+import { useRecentContents } from './useRecentContents';
+
+type Config = HomepageCollectionBlock['config'];
+
+const isVerified = (content: SummaryContent) =>
+    'verification' in content && !!content.verification;
+
+/**
+ * Resolves a collection block's items for the current viewer.
+ *
+ * Every branch goes through an endpoint that already exists, and every query
+ * is access-filtered server-side — this hook never widens what a viewer can
+ * see. Only the branch matching the block's source is enabled, so a manual
+ * collection costs exactly what it did before sources existed.
+ */
+export const useCollectionSourceContent = (
+    projectUuid: string,
+    config: Config,
+) => {
+    const source = collectionSourceOf(config);
+    const limit = collectionLimitOf(config);
+
+    const manualUuids = useMemo(
+        () =>
+            source === 'manual'
+                ? (config.items ?? []).map((item) => item.uuid)
+                : [],
+        [source, config.items],
+    );
+    const manual = useCollectionContent(projectUuid, manualUuids);
+
+    const popular = useMostPopularAndRecentlyUpdated(
+        source === 'most-viewed' || source === 'recently-updated'
+            ? projectUuid
+            : undefined,
+    );
+
+    const { data: project } = useProject(
+        source === 'pinned' ? projectUuid : undefined,
+    );
+    const pinned = usePinnedItems(
+        source === 'pinned' ? projectUuid : undefined,
+        source === 'pinned' ? project?.pinnedListUuid : undefined,
+    );
+
+    const favorites = useFavorites(
+        source === 'favorites' ? projectUuid : undefined,
+    );
+    const recent = useRecentContents(
+        source === 'recently-viewed' ? projectUuid : undefined,
+    );
+
+    // The uuid-driven sources resolve to real content through one shared
+    // endpoint, so their cards carry the same metadata manual ones do.
+    const derivedUuids = useMemo(() => {
+        switch (source) {
+            case 'most-viewed':
+                return (popular.data?.mostPopular ?? []).map(
+                    (item) => item.uuid,
+                );
+            case 'recently-updated':
+                return (popular.data?.recentlyUpdated ?? []).map(
+                    (item) => item.uuid,
+                );
+            case 'pinned':
+                return (pinned.data ?? []).map((item) => item.data.uuid);
+            case 'favorites':
+                // Favourites are ResourceViewItems: the uuid is on `data`.
+                return (favorites.data ?? []).map((item) => item.data.uuid);
+            case 'manual':
+            case 'recently-viewed':
+                return [];
+            default:
+                return [];
+        }
+    }, [source, popular.data, pinned.data, favorites.data]);
+
+    const derived = useCollectionContent(projectUuid, derivedUuids);
+
+    const resolved = useMemo<SummaryContent[]>(() => {
+        if (source === 'manual') return manual.data ?? [];
+        if (source === 'recently-viewed') return recent.contents;
+        return derived.data ?? [];
+    }, [source, manual.data, recent.contents, derived.data]);
+
+    const items = useMemo(() => {
+        const filtered = config.verifiedOnly
+            ? resolved.filter(isVerified)
+            : resolved;
+        return filtered.slice(0, limit);
+    }, [resolved, config.verifiedOnly, limit]);
+
+    const isLoading =
+        source === 'manual'
+            ? manual.isInitialLoading
+            : (source === 'recently-viewed' && recent.isLoading) ||
+              popular.isInitialLoading ||
+              pinned.isInitialLoading ||
+              favorites.isInitialLoading ||
+              derived.isInitialLoading;
+
+    return { items, isLoading, source };
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useRecentContents.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useRecentContents.ts
@@ -15,22 +15,23 @@ const getRecentlyViewed = async (projectUuid: string) =>
 
 const MAX_RECENT_ITEMS = 4;
 
-const useRecentlyViewed = (projectUuid: string) =>
+const useRecentlyViewed = (projectUuid: string | undefined) =>
     useQuery<HomepageRecentlyViewedItem[], ApiError>({
         queryKey: ['homepage_recently_viewed', projectUuid],
-        queryFn: () => getRecentlyViewed(projectUuid),
+        queryFn: () => getRecentlyViewed(projectUuid!),
+        enabled: !!projectUuid,
     });
 
 /** The viewer's recently-viewed content, resolved to real items. Exposed as a
  * hook so a surface that owns the section header (day-0) can decide whether to
  * render one at all — both callers share the same queries. */
-export const useRecentContents = (projectUuid: string) => {
+export const useRecentContents = (projectUuid: string | undefined) => {
     const { data: recents, isInitialLoading } = useRecentlyViewed(projectUuid);
     const uuids = (recents ?? [])
         .slice(0, MAX_RECENT_ITEMS)
         .map((item) => item.uuid);
     const { data: contents, isInitialLoading: isResolving } =
-        useCollectionContent(projectUuid, uuids);
+        useCollectionContent(projectUuid ?? '', uuids);
     return {
         recents: recents ?? [],
         contents: contents ?? [],

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useRuntimeEmptyBlocks.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useRuntimeEmptyBlocks.ts
@@ -1,0 +1,48 @@
+import { createContext, useContext, useEffect } from 'react';
+
+export type EmptyBlocksContextValue = {
+    /** Blocks that have resolved their data and found nothing to show. */
+    emptyBlockIds: ReadonlySet<string>;
+    reportEmpty: (blockId: string, isEmpty: boolean) => void;
+};
+
+export const EmptyBlocksContext = createContext<EmptyBlocksContextValue>({
+    emptyBlockIds: new Set(),
+    reportEmpty: () => {},
+});
+
+export const useRuntimeEmptyBlocks = () => useContext(EmptyBlocksContext);
+
+/**
+ * Reports this block's resolved emptiness up to the page.
+ *
+ * `resolveHomepageLayout` guarantees that a block which paints nothing doesn't
+ * hold a row, a gap or a column — but it decides that from config, and a
+ * dynamic collection ("most viewed" in a project with no view history) can't
+ * be judged that way. Emptiness becomes a runtime fact, so blocks report it
+ * and the page drops the rows that turn out to be empty.
+ *
+ * This is a genuine child-to-parent synchronisation — the page can't run the
+ * block's hooks itself — so it belongs in an effect rather than in render;
+ * setting a provider's state mid-render throws. The block renders nothing
+ * while loading and nothing when empty, so the row collapsing one commit later
+ * is invisible: there's never a frame with an empty header on screen.
+ */
+export const useReportRuntimeEmpty = (
+    blockId: string,
+    isEmpty: boolean,
+    isLoading: boolean,
+) => {
+    const { reportEmpty } = useRuntimeEmptyBlocks();
+    useEffect(() => {
+        if (isLoading) return;
+        reportEmpty(blockId, isEmpty);
+    }, [blockId, isEmpty, isLoading, reportEmpty]);
+
+    useEffect(
+        // A block that unmounts (an admin removing it, or a route change) must
+        // not leave its id behind marking a row empty forever.
+        () => () => reportEmpty(blockId, false),
+        [blockId, reportEmpty],
+    );
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
@@ -1,6 +1,9 @@
 import {
     assertUnreachable,
+    collectionLimitOf,
+    collectionSourceOf,
     type HomepageBlock,
+    type HomepageCollectionBlock,
     type HomepageConfig,
     type HomepageHeroDensity,
 } from '@lightdash/common';
@@ -143,7 +146,14 @@ const dedupeGreetings = (
 // must not demote the hero, leave a phantom row gap, or hold a ghost column.
 const isConfigEmptyBlock = (block: HomepageBlock): boolean => {
     switch (block.type) {
+        // A collection with a dynamic source has no items in config — what it
+        // will show is only knowable once its data lands, so it reports
+        // emptiness at runtime instead (see RuntimeEmptyBlocks).
         case 'collection':
+            return (
+                collectionSourceOf(block.config) === 'manual' &&
+                (block.config.items?.length ?? 0) === 0
+            );
         case 'resources':
         case 'metrics':
             return (block.config.items?.length ?? 0) === 0;
@@ -176,9 +186,18 @@ const toVisibleRows = (rows: HomepageConfig['rows']): HomepageConfig['rows'] =>
 // column with its centred 3-col grid. With only 1-2 items the extra width is
 // just empty margin around a centred card, and it starves whatever it shares
 // the row with — so weight follows actual item count, not just block type.
+// A dynamic source has no config item count to read, so it's sized by the
+// limit it will fill up to.
+const collectionItemCount = (
+    config: HomepageCollectionBlock['config'],
+): number =>
+    collectionSourceOf(config) === 'manual'
+        ? (config.items?.length ?? 0)
+        : collectionLimitOf(config);
+
 const columnWeightFor = (block: HomepageBlock): number => {
     if (block.type === 'collection') {
-        return (block.config.items?.length ?? 0) >= 3 ? 2 : 1;
+        return collectionItemCount(block.config) >= 3 ? 2 : 1;
     }
     return traitFor(block.type).columnWeight;
 };
@@ -193,7 +212,7 @@ const hugUnitsFor = (block: HomepageBlock): ResolvedColumn['hugUnits'] => {
         case 'metrics':
             return clampUnits(block.config.items?.length ?? 0, 4);
         case 'collection':
-            return clampUnits(block.config.items?.length ?? 0, 3);
+            return clampUnits(collectionItemCount(block.config), 3);
         // Resources render as a self-sizing list/media grid — natural width.
         case 'resources':
         case 'announcements':
@@ -212,8 +231,9 @@ const hugUnitsFor = (block: HomepageBlock): ResolvedColumn['hugUnits'] => {
 // How many items a block actually has, for blocks laid out on the page grid.
 const gridItemCountFor = (block: HomepageBlock): number => {
     switch (block.type) {
-        case 'metrics':
         case 'collection':
+            return collectionItemCount(block.config);
+        case 'metrics':
         case 'resources':
             return block.config.items?.length ?? 0;
         default:

--- a/packages/frontend/src/ee/features/homepageBuilder/starterHomepage.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/starterHomepage.test.ts
@@ -25,15 +25,16 @@ describe('buildStarterHomepage', () => {
         expect(types(true)).toEqual(['favorites', 'ask-ai-hero']);
     });
 
-    it('carries the project pins across as a collection', () => {
+    it('tracks the live pin list rather than copying it', () => {
         const pins = [{ contentType: 'chart' as const, uuid: 'chart-1' }];
         const config = buildStarterHomepage(false, pins);
         const collection = config.rows
             .flatMap((row) => row.blocks)
             .find((block) => block.type === 'collection');
 
+        // A frozen copy would stop following pins after publish.
         expect(collection).toMatchObject({
-            config: { title: 'Pinned', items: pins },
+            config: { title: 'Pinned', source: 'pinned', items: [] },
         });
     });
 

--- a/packages/frontend/src/ee/features/homepageBuilder/starterHomepage.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/starterHomepage.ts
@@ -80,7 +80,14 @@ export const buildStarterHomepage = (
             row({
                 id: uuidv4(),
                 type: 'collection',
-                config: { title: 'Pinned', items: pinnedItems },
+                config: {
+                    title: 'Pinned',
+                    // The live pin list, not a copy of it: a frozen snapshot
+                    // stops tracking pins the moment it's published, and
+                    // everyone reasonably expects this block to follow them.
+                    source: 'pinned',
+                    items: [],
+                },
             }),
         );
     }


### PR DESCRIPTION
Closes #26441

Stacked on #26461. Last of the six.

## What

A collection block could only hold a hand-picked list — the one thing the interesting collections can't be. A snapshot of "most viewed" is stale the week after it's taken, and there was a real bug hiding in the same shape: `buildStarterHomepage` baked the project's pinned items in as **static refs**, so a published "Pinned" block stopped following the pin list the moment it shipped. Anything pinned afterwards never appeared; anything unpinned stayed.

Collections now carry a `source`:

| Source | Scope | Notes |
|---|---|---|
| `manual` (default, and every existing config) | — | the block's own `items` |
| `most-viewed` | project | what people actually open |
| `pinned` | project | follows the live pin list |
| `recently-updated` | project | available, deliberately not a default — surfaces churn, not importance |
| `favorites` | **per viewer** | |
| `recently-viewed` | **per viewer** | |

Plus `verifiedOnly`, which applies to **every** source including manual, and `limit` (default 6, hard cap 24).

**One block with a source, not six block types.** A dynamic collection has the same width tier, item span, hug units and column weight as a manual one, so `blockLayoutTraits` and the resolver's per-type branches are untouched — six types would have meant six identical entries in each. `isPersonalCollectionSource` marks the two per-viewer sources, which is exactly what the view-as placeholder logic needs to know.

The starter homepage's Pinned block now uses the `pinned` source, so the frozen-pins bug is fixed at its origin.

## The hard part: emptiness became a runtime fact

`resolveHomepageLayout` guarantees a block that paints nothing doesn't hold a row, a gap or a column — but it judges that from config, and "most viewed" in a project with no view history can't be judged that way. Blocks now report resolved emptiness up to the page, which drops those rows.

**Two traps, both hit and fixed:**

1. **Rows are hidden, not unmounted.** Unmounting removes the block that reported the emptiness → its cleanup clears the flag → the row returns → the block remounts and reports empty again. That's an infinite render loop, and it's exactly what happened: the browser threw `Maximum update depth exceeded` until I switched to `display: none`. Out of flow also means no phantom gap, which was the other requirement.
2. **Blocks report only after their data resolves.** While loading they're treated as present, so a row can't flash in and out.

An existing `tolerates configs from other code versions` test caught the other real defect: reading `config.items.length` on a config written by a version that had no `items` field throws. Reads stay defensive (`config.items?.length ?? 0`) — that contract matters during rolling deploys.

## Verified live

A homepage with four dynamic collections, in a project with **no** verified content:

| Row | Result |
|---|---|
| `most-viewed` | 4 cards, ordered 150 / 129 / 128 / 97 views — ranking passes through |
| `pinned` | 4 cards from the live pin list |
| `most-viewed` + `verifiedOnly` | **`display: none`, height 0px** — nothing verified, so the row is gone |
| `favorites` | 4 cards |

Populated rows measure 93px, the empty one 0px, and the console is clean — **zero errors**, which is how I know the loop is really gone rather than just slower.

## Regression analysis

- **Every existing collection is unchanged.** `source` absent means `manual`, which reads `items` exactly as before. No migration, no config rewrite.
- **`verifiedOnly` and `limit` are both optional** with the old behaviour as their default (no filter; 6 is above the typical hand-picked count, and manual lists were already bounded by what an admin picked — a longer stored list is now capped, which is the one visible change and is what the option is for).
- **No new endpoints and no warehouse queries.** Each source reuses an existing hook (`useMostPopularAndRecentlyUpdated`, `usePinnedItems`, `useFavorites`, `useRecentContents`) and resolves uuids through the one shared access-filtered content endpoint, so dynamic cards carry the same metadata manual ones do.
- **Only the matching branch is enabled.** Every other query is passed `undefined` for the project and disables itself, so a manual collection issues exactly the requests it always did.
- **Access filtering stays server-side.** The hook never widens visibility; a viewer who can't see an item simply doesn't get it back.
- **Ordering is preserved**: `useCollectionContent` returns items in the order of the uuids it was given, so most-viewed stays view-ranked rather than being re-sorted by the resolver.
- **The builder shows a live preview** of what a rule resolves to, and says explicitly when a source is per-viewer ("Showing your own items as a sample — every viewer sees their own") rather than implying everyone sees the admin's favourites.

## Not done here

The issue lists batching dynamic-source requests. Each source currently uses its own existing hook, and React Query dedupes across blocks, so N collections with the same source cost one request rather than N. A single batched endpoint would only pay off with several *different* sources on one page; worth doing when that shows up, and not worth a new endpoint before it does.

## Tests

12 new: 7 on the source helpers and layout resolution (absent source reads as manual, limit default + cap, per-viewer classification, hand-picked-empty still dropped at config time, dynamic kept for runtime, dynamic sized by its limit, foreign-config tolerance) and 5 on the runtime-emptiness contract (row hides when all blocks empty, stays for content, stays while loading, stays when only some are empty, and forgets an unmounted block). Frontend homepage-builder suite: 22 files / 215 tests green. Common: 117 files / 3161 tests green. Lint and typecheck clean.
