### PR TITLE
feat(deep-research): track lifecycle and report engagement

### DIFF
--- a/packages/backend/src/@types/rudder-sdk-node.d.ts
+++ b/packages/backend/src/@types/rudder-sdk-node.d.ts
@@ -25,6 +25,7 @@ declare module '@rudderstack/rudder-sdk-node' {
     export interface Track {
         userId?: string;
         anonymousId?: string;
+        messageId?: string;
         event: string;
         properties?: Record<string, AnyType>;
         context?: Record<string, AnyType>;

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -34,6 +34,10 @@ import {
     type AiAgentReviewItemWritebackBlockedReason,
     type AiAgentReviewItemWritebackStrategy,
     type AiAgentRootCause,
+    type AiDeepResearchEffort,
+    type AiDeepResearchEntryPoint,
+    type AiDeepResearchTerminalReason,
+    type AiDeepResearchTerminalStatus,
     type AiRouterDecisionConfidence,
     type AiRouterRouteNextAction,
     type AiWritebackFailureStage,
@@ -2062,6 +2066,46 @@ export type ManagedAgentEvent =
     | ManagedAgentRunCompletedEvent
     | ManagedAgentActionCreatedEvent;
 
+type AiDeepResearchRunDimensions = {
+    organizationId: string;
+    projectId: string;
+    runUuid: string;
+    threadId: string;
+    aiAgentId: string;
+    entryPoint: AiDeepResearchEntryPoint;
+    effort: AiDeepResearchEffort;
+    provider: string | null;
+    model: string | null;
+    keyManagement: 'lightdash-managed' | 'self-managed' | null;
+    selectedMcpServerCount: number;
+};
+
+export type AiDeepResearchRunStartedEvent = BaseTrack & {
+    event: 'ai_deep_research.run_started';
+    userId: string;
+    properties: AiDeepResearchRunDimensions;
+};
+
+export type AiDeepResearchRunCompletedEvent = BaseTrack & {
+    event: 'ai_deep_research.run_completed';
+    userId: string;
+    properties: AiDeepResearchRunDimensions & {
+        status: AiDeepResearchTerminalStatus;
+        terminalReason: AiDeepResearchTerminalReason | null;
+        durationMs: number;
+        totalTokens: number;
+        toolCallCount: number;
+        warehouseQueryCount: number;
+        mcpToolCallCount: number;
+        hasReport: boolean;
+        chartCount: number;
+    };
+};
+
+export type AiDeepResearchEvent =
+    | AiDeepResearchRunStartedEvent
+    | AiDeepResearchRunCompletedEvent;
+
 export const parseAnalyticsLimit = (
     limit: 'table' | 'all' | number | null | undefined,
 ) => {
@@ -3155,6 +3199,7 @@ type TypedEvent =
     | CreateSqlChartVersionEvent
     | CommentsEvent
     | ManagedAgentEvent
+    | AiDeepResearchEvent
     | VirtualViewEvent
     | GithubInstallEvent
     | GithubUserLinkEvent

--- a/packages/backend/src/ee/controllers/AiDeepResearchController.ts
+++ b/packages/backend/src/ee/controllers/AiDeepResearchController.ts
@@ -70,6 +70,7 @@ export class AiDeepResearchController extends BaseController {
                 aiThreadUuid: body.threadUuid,
                 promptUuid: body.promptUuid,
                 mcpServerUuids: body.mcpServerUuids,
+                entryPoint: body.entryPoint,
             }),
         };
     }

--- a/packages/backend/src/ee/database/entities/aiDeepResearch.ts
+++ b/packages/backend/src/ee/database/entities/aiDeepResearch.ts
@@ -1,10 +1,13 @@
 import {
     type AiDeepResearchBudget,
     type AiDeepResearchChartDataMap,
+    type AiDeepResearchEffort,
+    type AiDeepResearchEntryPoint,
     type AiDeepResearchEventPayload,
     type AiDeepResearchEventType,
     type AiDeepResearchExecutionContextSnapshot,
     type AiDeepResearchRunStatus,
+    type AiDeepResearchTerminalReason,
 } from '@lightdash/common';
 import { Knex } from 'knex';
 
@@ -22,6 +25,8 @@ export type DbAiDeepResearchRun = {
     prompt: string;
     status: AiDeepResearchRunStatus;
     selected_mcp_server_uuids: string[];
+    entry_point: AiDeepResearchEntryPoint;
+    effort: AiDeepResearchEffort;
     result_markdown: string | null;
     result_chart_data: AiDeepResearchChartDataMap | null;
     budget_snapshot: AiDeepResearchBudget;
@@ -47,6 +52,8 @@ export type AiDeepResearchRunsTable = Knex.CompositeTableType<
         | 'tool_call_id'
         | 'prompt'
         | 'selected_mcp_server_uuids'
+        | 'entry_point'
+        | 'effort'
         | 'budget_snapshot'
         | 'execution_context_snapshot'
     >,
@@ -83,4 +90,27 @@ export type AiDeepResearchEventsTable = Knex.CompositeTableType<
         'ai_deep_research_run_uuid' | 'event_type' | 'payload'
     > &
         Partial<Pick<DbAiDeepResearchEvent, 'created_at'>>
+>;
+
+export const AiDeepResearchAnalyticsOutboxTableName =
+    'ai_deep_research_analytics_outbox';
+
+export type AiDeepResearchAnalyticsEventType = 'run_started' | 'run_completed';
+
+export type DbAiDeepResearchAnalyticsOutbox = {
+    ai_deep_research_analytics_event_uuid: string;
+    ai_deep_research_run_uuid: string;
+    event_type: AiDeepResearchAnalyticsEventType;
+    terminal_reason: AiDeepResearchTerminalReason | null;
+    delivered_at: Date | null;
+    created_at: Date;
+};
+
+export type AiDeepResearchAnalyticsOutboxTable = Knex.CompositeTableType<
+    DbAiDeepResearchAnalyticsOutbox,
+    Pick<
+        DbAiDeepResearchAnalyticsOutbox,
+        'ai_deep_research_run_uuid' | 'event_type' | 'terminal_reason'
+    >,
+    Pick<DbAiDeepResearchAnalyticsOutbox, 'delivered_at'>
 >;

--- a/packages/backend/src/ee/database/migrations/20260729170000_add_ai_deep_research_analytics_dimensions.ts
+++ b/packages/backend/src/ee/database/migrations/20260729170000_add_ai_deep_research_analytics_dimensions.ts
@@ -1,0 +1,16 @@
+import { type Knex } from 'knex';
+
+const AiDeepResearchRunsTableName = 'ai_deep_research_runs';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AiDeepResearchRunsTableName, (table) => {
+        table.text('entry_point').notNullable().defaultTo('ask_ai');
+        table.text('effort').notNullable().defaultTo('medium');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AiDeepResearchRunsTableName, (table) => {
+        table.dropColumns('entry_point', 'effort');
+    });
+}

--- a/packages/backend/src/ee/database/migrations/20260729171000_add_ai_deep_research_analytics_outbox.ts
+++ b/packages/backend/src/ee/database/migrations/20260729171000_add_ai_deep_research_analytics_outbox.ts
@@ -1,0 +1,36 @@
+import { type Knex } from 'knex';
+
+const AiDeepResearchRunsTableName = 'ai_deep_research_runs';
+const AiDeepResearchAnalyticsOutboxTableName =
+    'ai_deep_research_analytics_outbox';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(
+        AiDeepResearchAnalyticsOutboxTableName,
+        (table) => {
+            table
+                .uuid('ai_deep_research_analytics_event_uuid')
+                .primary()
+                .defaultTo(knex.raw('uuid_generate_v4()'));
+            table
+                .uuid('ai_deep_research_run_uuid')
+                .notNullable()
+                .references('ai_deep_research_run_uuid')
+                .inTable(AiDeepResearchRunsTableName)
+                .onDelete('CASCADE');
+            table.text('event_type').notNullable();
+            table.text('terminal_reason').nullable();
+            table.timestamp('delivered_at', { useTz: false }).nullable();
+            table
+                .timestamp('created_at', { useTz: false })
+                .notNullable()
+                .defaultTo(knex.fn.now());
+            table.unique(['ai_deep_research_run_uuid', 'event_type']);
+            table.index(['delivered_at', 'created_at']);
+        },
+    );
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(AiDeepResearchAnalyticsOutboxTableName);
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -187,7 +187,12 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         models.getSlackAuthenticationModel(),
                     lightdashConfig: context.lightdashConfig,
                 }),
-            aiDeepResearchService: ({ models, clients, repository }) => {
+            aiDeepResearchService: ({
+                context,
+                models,
+                clients,
+                repository,
+            }) => {
                 const aiDeepResearchRunModel =
                     models.getAiDeepResearchRunModel<AiDeepResearchRunModel>();
                 const executor = new AiDeepResearchExecutor({
@@ -199,6 +204,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 });
 
                 return new AiDeepResearchService({
+                    analytics: context.lightdashAnalytics,
                     aiDeepResearchRunModel,
                     aiAgentModel: models.getAiAgentModel<AiAgentModel>(),
                     aiAgentService:

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.integration.test.ts
@@ -18,6 +18,7 @@ import {
     type AiAgentTable,
 } from '../database/entities/aiAgent';
 import {
+    AiDeepResearchAnalyticsOutboxTableName,
     AiDeepResearchEventsTableName,
     AiDeepResearchRunsTableName,
     type DbAiDeepResearchRun,
@@ -162,7 +163,12 @@ describe('AiDeepResearchRunModel integration', () => {
         runUuids.clear();
     });
 
-    const createRun = async (): Promise<DbAiDeepResearchRun> => {
+    const createRun = async (
+        dimensions: {
+            entryPoint?: 'homepage' | 'ask_ai';
+            effort?: 'low' | 'medium' | 'high' | 'xhigh';
+        } = {},
+    ): Promise<DbAiDeepResearchRun> => {
         const run = await model.create({
             organizationUuid: SEED_ORG_1.organization_uuid,
             projectUuid: SEED_PROJECT.project_uuid,
@@ -173,6 +179,8 @@ describe('AiDeepResearchRunModel integration', () => {
             toolCallId: null,
             prompt: `Integration race ${crypto.randomUUID()}`,
             selectedMcpServerUuids: [],
+            entryPoint: dimensions.entryPoint ?? 'ask_ai',
+            effort: dimensions.effort ?? 'medium',
             budget,
             executionContextSnapshot: {
                 ...executionContextSnapshot,
@@ -185,6 +193,12 @@ describe('AiDeepResearchRunModel integration', () => {
         runUuids.add(run.ai_deep_research_run_uuid);
         return run;
     };
+
+    const getAnalyticsOutbox = async (runUuid: string) =>
+        database(AiDeepResearchAnalyticsOutboxTableName)
+            .select('event_type', 'terminal_reason')
+            .where('ai_deep_research_run_uuid', runUuid)
+            .orderBy('created_at', 'asc');
 
     const getEventSequence = async (runUuid: string): Promise<string[]> => {
         const events = await database(AiDeepResearchEventsTableName)
@@ -215,6 +229,37 @@ describe('AiDeepResearchRunModel integration', () => {
             'status_changed:queued',
             'status_changed:running',
         ]);
+    });
+
+    it('round-trips persisted analytics dimensions', async () => {
+        const run = await createRun({
+            entryPoint: 'homepage',
+            effort: 'high',
+        });
+
+        expect(run).toMatchObject({
+            entry_point: 'homepage',
+            effort: 'high',
+        });
+        expect(
+            await model.findByUuid(run.ai_deep_research_run_uuid),
+        ).toMatchObject({
+            entry_point: 'homepage',
+            effort: 'high',
+        });
+    });
+
+    it('records one accepted-run outbox event across retries', async () => {
+        const run = await createRun();
+
+        await Promise.all([
+            model.recordRunAccepted(run.ai_deep_research_run_uuid),
+            model.recordRunAccepted(run.ai_deep_research_run_uuid),
+        ]);
+
+        expect(await getAnalyticsOutbox(run.ai_deep_research_run_uuid)).toEqual(
+            [{ event_type: 'run_started', terminal_reason: null }],
+        );
     });
 
     it('does not replay the cursor event when Postgres stores microseconds', async () => {
@@ -290,6 +335,17 @@ describe('AiDeepResearchRunModel integration', () => {
             run.ai_deep_research_run_uuid,
         );
         expect(['completed', 'cancelled']).toContain(terminalRun?.status);
+        expect(await getAnalyticsOutbox(run.ai_deep_research_run_uuid)).toEqual(
+            [
+                {
+                    event_type: 'run_completed',
+                    terminal_reason:
+                        terminalRun?.status === 'completed'
+                            ? null
+                            : 'user_cancellation',
+                },
+            ],
+        );
         expect(await getEventSequence(run.ai_deep_research_run_uuid)).toEqual(
             terminalRun?.status === 'completed'
                 ? [
@@ -325,5 +381,13 @@ describe('AiDeepResearchRunModel integration', () => {
             'status_changed:running',
             'status_changed:failed',
         ]);
+        expect(await getAnalyticsOutbox(run.ai_deep_research_run_uuid)).toEqual(
+            [
+                {
+                    event_type: 'run_completed',
+                    terminal_reason: 'internal_error',
+                },
+            ],
+        );
     });
 });

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
@@ -1,19 +1,26 @@
 import {
     type AiDeepResearchBudget,
     type AiDeepResearchChartDataMap,
+    type AiDeepResearchEffort,
+    type AiDeepResearchEntryPoint,
     type AiDeepResearchEventPayload,
     type AiDeepResearchEventPayloadMap,
     type AiDeepResearchEventType,
     type AiDeepResearchExecutionContextSnapshot,
     type AiDeepResearchProgress,
     type AiDeepResearchRunStatus,
+    type AiDeepResearchTerminalReason,
 } from '@lightdash/common';
 import { Knex } from 'knex';
 import {
+    AiDeepResearchAnalyticsOutboxTableName,
     AiDeepResearchEventsTable,
     AiDeepResearchEventsTableName,
     AiDeepResearchRunsTable,
     AiDeepResearchRunsTableName,
+    type AiDeepResearchAnalyticsEventType,
+    type AiDeepResearchAnalyticsOutboxTable,
+    type DbAiDeepResearchAnalyticsOutbox,
     type DbAiDeepResearchEvent,
     type DbAiDeepResearchRun,
 } from '../database/entities/aiDeepResearch';
@@ -32,6 +39,8 @@ type CreateAiDeepResearchRun = {
     toolCallId: string | null;
     prompt: string;
     selectedMcpServerUuids: string[];
+    entryPoint: AiDeepResearchEntryPoint;
+    effort: AiDeepResearchEffort;
     budget: AiDeepResearchBudget;
     executionContextSnapshot: AiDeepResearchExecutionContextSnapshot;
 };
@@ -70,6 +79,24 @@ export class AiDeepResearchRunModel {
         });
     }
 
+    private static async insertAnalyticsEvent(
+        database: Queryable,
+        aiDeepResearchRunUuid: string,
+        eventType: AiDeepResearchAnalyticsEventType,
+        terminalReason: AiDeepResearchTerminalReason | null = null,
+    ): Promise<void> {
+        await database<AiDeepResearchAnalyticsOutboxTable>(
+            AiDeepResearchAnalyticsOutboxTableName,
+        )
+            .insert({
+                ai_deep_research_run_uuid: aiDeepResearchRunUuid,
+                event_type: eventType,
+                terminal_reason: terminalReason,
+            })
+            .onConflict(['ai_deep_research_run_uuid', 'event_type'])
+            .ignore();
+    }
+
     async create(data: CreateAiDeepResearchRun): Promise<DbAiDeepResearchRun> {
         return this.database.transaction(async (transaction) => {
             const [run] = await transaction<AiDeepResearchRunsTable>(
@@ -87,6 +114,8 @@ export class AiDeepResearchRunModel {
                     selected_mcp_server_uuids: JSON.stringify(
                         data.selectedMcpServerUuids,
                     ) as unknown as string[],
+                    entry_point: data.entryPoint,
+                    effort: data.effort,
                     budget_snapshot: data.budget,
                     execution_context_snapshot: data.executionContextSnapshot,
                 })
@@ -99,6 +128,24 @@ export class AiDeepResearchRunModel {
                 { status: 'queued' },
             );
             return run;
+        });
+    }
+
+    async recordRunAccepted(aiDeepResearchRunUuid: string): Promise<void> {
+        await this.database.transaction(async (transaction) => {
+            const run = await transaction<AiDeepResearchRunsTable>(
+                AiDeepResearchRunsTableName,
+            )
+                .where('ai_deep_research_run_uuid', aiDeepResearchRunUuid)
+                .first();
+            if (!run) {
+                return;
+            }
+            await AiDeepResearchRunModel.insertAnalyticsEvent(
+                transaction,
+                aiDeepResearchRunUuid,
+                'run_started',
+            );
         });
     }
 
@@ -253,6 +300,7 @@ export class AiDeepResearchRunModel {
         status: 'completed' | 'partially_completed',
         resultMarkdown: string,
         resultChartData: AiDeepResearchChartDataMap,
+        terminalReason: AiDeepResearchTerminalReason | null,
     ): Promise<boolean> {
         return this.database.transaction(async (transaction) => {
             const [run] = await transaction<AiDeepResearchRunsTable>(
@@ -283,6 +331,12 @@ export class AiDeepResearchRunModel {
                 'status_changed',
                 { status },
             );
+            await AiDeepResearchRunModel.insertAnalyticsEvent(
+                transaction,
+                aiDeepResearchRunUuid,
+                'run_completed',
+                terminalReason,
+            );
             return true;
         });
     }
@@ -297,6 +351,7 @@ export class AiDeepResearchRunModel {
             'completed',
             resultMarkdown,
             resultChartData,
+            null,
         );
     }
 
@@ -304,18 +359,21 @@ export class AiDeepResearchRunModel {
         aiDeepResearchRunUuid: string,
         resultMarkdown: string,
         resultChartData: AiDeepResearchChartDataMap,
+        terminalReason: AiDeepResearchTerminalReason,
     ): Promise<boolean> {
         return this.markWithReport(
             aiDeepResearchRunUuid,
             'partially_completed',
             resultMarkdown,
             resultChartData,
+            terminalReason,
         );
     }
 
     async markFailed(
         aiDeepResearchRunUuid: string,
         errorMessage: string,
+        terminalReason: AiDeepResearchTerminalReason,
     ): Promise<boolean> {
         return this.database.transaction(async (transaction) => {
             const [run] = await transaction<AiDeepResearchRunsTable>(
@@ -341,11 +399,20 @@ export class AiDeepResearchRunModel {
                 'status_changed',
                 { status: 'failed' },
             );
+            await AiDeepResearchRunModel.insertAnalyticsEvent(
+                transaction,
+                aiDeepResearchRunUuid,
+                'run_completed',
+                terminalReason,
+            );
             return true;
         });
     }
 
-    async markCancelled(aiDeepResearchRunUuid: string): Promise<boolean> {
+    async markCancelled(
+        aiDeepResearchRunUuid: string,
+        terminalReason: AiDeepResearchTerminalReason = 'user_cancellation',
+    ): Promise<boolean> {
         return this.database.transaction(async (transaction) => {
             const [run] = await transaction<AiDeepResearchRunsTable>(
                 AiDeepResearchRunsTableName,
@@ -369,6 +436,12 @@ export class AiDeepResearchRunModel {
                 aiDeepResearchRunUuid,
                 'status_changed',
                 { status: 'cancelled' },
+            );
+            await AiDeepResearchRunModel.insertAnalyticsEvent(
+                transaction,
+                aiDeepResearchRunUuid,
+                'run_completed',
+                terminalReason,
             );
             return true;
         });
@@ -405,6 +478,12 @@ export class AiDeepResearchRunModel {
                     aiDeepResearchRunUuid,
                     'status_changed',
                     { status: 'cancelled' },
+                );
+                await AiDeepResearchRunModel.insertAnalyticsEvent(
+                    transaction,
+                    aiDeepResearchRunUuid,
+                    'run_completed',
+                    'user_cancellation',
                 );
                 return queuedRun;
             }
@@ -531,7 +610,53 @@ export class AiDeepResearchRunModel {
                     ),
                 ),
             );
+            await Promise.all(
+                runs.map((run) =>
+                    AiDeepResearchRunModel.insertAnalyticsEvent(
+                        transaction,
+                        run.ai_deep_research_run_uuid,
+                        'run_completed',
+                        'internal_error',
+                    ),
+                ),
+            );
             return runs;
         });
+    }
+
+    async listPendingAnalyticsEvents(args?: {
+        aiDeepResearchRunUuid?: string;
+        limit?: number;
+    }): Promise<DbAiDeepResearchAnalyticsOutbox[]> {
+        const query = this.database<AiDeepResearchAnalyticsOutboxTable>(
+            AiDeepResearchAnalyticsOutboxTableName,
+        )
+            .whereNull('delivered_at')
+            .orderBy('created_at', 'asc')
+            .limit(args?.limit ?? 100);
+
+        return args?.aiDeepResearchRunUuid
+            ? query.where(
+                  'ai_deep_research_run_uuid',
+                  args.aiDeepResearchRunUuid,
+              )
+            : query;
+    }
+
+    async markAnalyticsEventDelivered(
+        aiDeepResearchAnalyticsEventUuid: string,
+    ): Promise<boolean> {
+        const updated = await this.database<AiDeepResearchAnalyticsOutboxTable>(
+            AiDeepResearchAnalyticsOutboxTableName,
+        )
+            .where(
+                'ai_deep_research_analytics_event_uuid',
+                aiDeepResearchAnalyticsEventUuid,
+            )
+            .whereNull('delivered_at')
+            .update({
+                delivered_at: this.database.fn.now() as unknown as Date,
+            });
+        return updated > 0;
     }
 }

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.test.ts
@@ -91,6 +91,8 @@ const run = (
     prompt: 'Investigate revenue',
     status: 'running',
     selected_mcp_server_uuids: ['mcp-1'],
+    entry_point: 'ask_ai',
+    effort: 'medium',
     result_markdown: null,
     result_chart_data: null,
     budget_snapshot: budget,
@@ -211,6 +213,7 @@ describe('AiDeepResearchExecutor', () => {
             status: 'failed',
             errorMessage:
                 'Deep Research cannot run because its creator is inactive',
+            terminalReason: 'permission_revoked',
         });
         expect(generateAgentThreadResponse).not.toHaveBeenCalled();
     });
@@ -293,6 +296,7 @@ describe('AiDeepResearchExecutor', () => {
             status: 'completed',
             report,
             warehouseQueryUuids: [queryUuid],
+            terminalReason: null,
         });
         expect(generateAgentThreadResponse).toHaveBeenCalledTimes(1);
         expect(
@@ -351,6 +355,7 @@ describe('AiDeepResearchExecutor', () => {
         ).toHaveBeenCalledTimes(1);
         expect(result).toMatchObject({
             status: 'partially_completed',
+            terminalReason: 'tool_limit',
             warehouseQueryUuids: [],
             report: {
                 charts: [],
@@ -392,6 +397,7 @@ describe('AiDeepResearchExecutor', () => {
 
         expect(result).toMatchObject({
             status: 'partially_completed',
+            terminalReason: 'query_limit',
             warehouseQueryUuids: [],
         });
         expect(
@@ -418,6 +424,7 @@ describe('AiDeepResearchExecutor', () => {
             status: 'completed',
             report,
             warehouseQueryUuids: [],
+            terminalReason: null,
         });
     });
 
@@ -452,6 +459,7 @@ describe('AiDeepResearchExecutor', () => {
             status: 'completed',
             report,
             warehouseQueryUuids: [],
+            terminalReason: null,
         });
     });
 
@@ -470,6 +478,7 @@ describe('AiDeepResearchExecutor', () => {
             status: 'partially_completed',
             report,
             warehouseQueryUuids: [],
+            terminalReason: 'provider_error',
         });
     });
 
@@ -504,6 +513,7 @@ describe('AiDeepResearchExecutor', () => {
             status: 'completed',
             report,
             warehouseQueryUuids: [],
+            terminalReason: null,
         });
         expect(generateAgentThreadResponse).toHaveBeenCalledTimes(2);
         expect(generateAgentThreadResponse).toHaveBeenNthCalledWith(
@@ -575,7 +585,10 @@ describe('AiDeepResearchExecutor', () => {
 
         await expect(
             executor.execute(run(), { signal: controller.signal }),
-        ).resolves.toEqual({ status: 'cancelled' });
+        ).resolves.toEqual({
+            status: 'cancelled',
+            terminalReason: 'internal_error',
+        });
         expect(generateAgentThreadResponse).toHaveBeenCalledTimes(1);
     });
 
@@ -591,6 +604,7 @@ describe('AiDeepResearchExecutor', () => {
         ).resolves.toEqual({
             status: 'failed',
             errorMessage: 'Deep Research finished without submitting a report',
+            terminalReason: 'provider_error',
         });
         expect(generateAgentThreadResponse).toHaveBeenCalledTimes(2);
     });
@@ -603,7 +617,10 @@ describe('AiDeepResearchExecutor', () => {
 
         await expect(
             executor.execute(run(), { signal: controller.signal }),
-        ).resolves.toEqual({ status: 'cancelled' });
+        ).resolves.toEqual({
+            status: 'cancelled',
+            terminalReason: 'internal_error',
+        });
         expect(generateAgentThreadResponse).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.ts
@@ -21,20 +21,14 @@ import type {
     AiDeepResearchExecutor as AiDeepResearchExecutorFn,
     AiDeepResearchExecutorResult,
 } from './AiDeepResearchService';
+import {
+    isDeepResearchWarehouseMcpTool,
+    isDeepResearchWarehouseTool,
+} from './toolClassification';
 
 const CANCELLATION_POLL_INTERVAL_MS = 1_000;
 const HEARTBEAT_INTERVAL_MS = 15_000;
 const ACCESS_RECHECK_INTERVAL_MS = 15_000;
-const WAREHOUSE_TOOL_NAMES = new Set([
-    'generateVisualization',
-    'runContentQuery',
-    'runSavedChart',
-    'runSql',
-    'searchFieldValues',
-]);
-const WAREHOUSE_MCP_TOOL_RE =
-    /__(?:run_metric_query|run_sql|search_field_values)(?:_\d+)?$/;
-
 type ToolProvenance = {
     toolCall: AiAgentToolCall;
     toolResult: AiAgentToolResult | null;
@@ -55,12 +49,6 @@ type Dependencies = {
     >;
     userService: Pick<UserService, 'getSessionByUserUuidAndOrg'>;
 };
-
-const isWarehouseTool = (toolName: string): boolean =>
-    WAREHOUSE_TOOL_NAMES.has(toolName) || WAREHOUSE_MCP_TOOL_RE.test(toolName);
-
-const isWarehouseMcpTool = (toolName: string): boolean =>
-    WAREHOUSE_MCP_TOOL_RE.test(toolName);
 
 const parseJson = (value: string): unknown => {
     try {
@@ -89,7 +77,7 @@ const findStringValues = (value: unknown, key: string): string[] => {
 const getQueryUuids = (provenance: ToolProvenance[]): string[] => [
     ...new Set(
         provenance.flatMap(({ toolResult }) =>
-            toolResult && isWarehouseTool(toolResult.toolName)
+            toolResult && isDeepResearchWarehouseTool(toolResult.toolName)
                 ? findStringValues(parseJson(toolResult.result), 'queryUuid')
                 : [],
         ),
@@ -137,7 +125,7 @@ const getActivity = (toolName: string): AiDeepResearchActivity => {
     if (toolName === AI_DEEP_RESEARCH_REPORT_TOOL_NAME) {
         return 'reporting';
     }
-    if (isWarehouseTool(toolName)) {
+    if (isDeepResearchWarehouseTool(toolName)) {
         return 'warehouse_query';
     }
     return 'lightdash_metadata';
@@ -261,7 +249,12 @@ export class AiDeepResearchExecutor {
         { signal },
     ): Promise<AiDeepResearchExecutorResult> => {
         if (signal.aborted || run.cancellation_requested_at) {
-            return { status: 'cancelled' };
+            return {
+                status: 'cancelled',
+                terminalReason: run.cancellation_requested_at
+                    ? 'user_cancellation'
+                    : 'internal_error',
+            };
         }
 
         const user: SessionUser =
@@ -274,6 +267,7 @@ export class AiDeepResearchExecutor {
                 status: 'failed',
                 errorMessage:
                     'Deep Research cannot run because its creator is inactive',
+                terminalReason: 'permission_revoked',
             };
         }
         try {
@@ -290,6 +284,7 @@ export class AiDeepResearchExecutor {
             return {
                 status: 'failed',
                 errorMessage: getErrorMessage(error),
+                terminalReason: 'permission_revoked',
             };
         }
         const controller = new AbortController();
@@ -326,7 +321,7 @@ export class AiDeepResearchExecutor {
             if (!isReport) {
                 toolCalls += 1;
                 toolCallOrdinal = toolCalls;
-                if (isWarehouseMcpTool(toolName)) {
+                if (isDeepResearchWarehouseMcpTool(toolName)) {
                     warehouseQueries += 1;
                     warehouseQueryOrdinal = warehouseQueries;
                 }
@@ -437,12 +432,18 @@ export class AiDeepResearchExecutor {
         }
 
         if (cancelledByUser || signal.aborted) {
-            return { status: 'cancelled' };
+            return {
+                status: 'cancelled',
+                terminalReason: cancelledByUser
+                    ? 'user_cancellation'
+                    : 'internal_error',
+            };
         }
         if (authorizationRevokedReason) {
             return {
                 status: 'failed',
                 errorMessage: authorizationRevokedReason,
+                terminalReason: 'permission_revoked',
             };
         }
 
@@ -460,6 +461,10 @@ export class AiDeepResearchExecutor {
                         `The ${budgetExceeded} budget was exhausted.`,
                     ),
                 warehouseQueryUuids: queryUuids,
+                terminalReason:
+                    budgetExceeded === 'maxToolCalls'
+                        ? 'tool_limit'
+                        : 'query_limit',
             };
         }
         if (executionError) {
@@ -468,11 +473,13 @@ export class AiDeepResearchExecutor {
                     status: 'partially_completed',
                     report,
                     warehouseQueryUuids: queryUuids,
+                    terminalReason: 'provider_error',
                 };
             }
             return {
                 status: 'failed',
                 errorMessage: getErrorMessage(executionError),
+                terminalReason: 'provider_error',
             };
         }
         if (!report) {
@@ -480,6 +487,7 @@ export class AiDeepResearchExecutor {
                 status: 'failed',
                 errorMessage:
                     'Deep Research finished without submitting a report',
+                terminalReason: 'provider_error',
             };
         }
 
@@ -487,6 +495,7 @@ export class AiDeepResearchExecutor {
             status: 'completed',
             report,
             warehouseQueryUuids: queryUuids,
+            terminalReason: null,
         };
     };
 }

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
@@ -1,5 +1,6 @@
 import { Ability, AbilityBuilder } from '@casl/ability';
 import {
+    AI_DEEP_RESEARCH_REPORT_TOOL_NAME,
     AiResultType,
     AnyType,
     FeatureFlags,
@@ -184,6 +185,8 @@ const runRow = (overrides: Record<string, unknown> = {}) => ({
     prompt: 'Investigate revenue',
     status: 'queued',
     selected_mcp_server_uuids: ['mcp-1'],
+    entry_point: 'ask_ai',
+    effort: 'medium',
     result_markdown: null,
     result_chart_data: null,
     budget_snapshot: budget,
@@ -236,6 +239,9 @@ const buildService = (
         findByThreadScoped: vi.fn().mockResolvedValue([]),
         markStaleRunsAsFailed: vi.fn().mockResolvedValue([]),
         deleteUnstartedFailedRun: vi.fn().mockResolvedValue(true),
+        recordRunAccepted: vi.fn().mockResolvedValue(undefined),
+        listPendingAnalyticsEvents: vi.fn().mockResolvedValue([]),
+        markAnalyticsEventDelivered: vi.fn().mockResolvedValue(true),
         ...overrides.model,
     };
     const aiAgentModel = {
@@ -298,8 +304,13 @@ const buildService = (
             status: 'completed',
             report,
             warehouseQueryUuids: [],
+            terminalReason: null,
         });
+    const analytics = {
+        track: vi.fn(),
+    };
     const service = new AiDeepResearchService({
+        analytics: analytics as AnyType,
         aiDeepResearchRunModel: model as AnyType,
         aiAgentModel: aiAgentModel as AnyType,
         aiAgentService: aiAgentService as AnyType,
@@ -323,6 +334,7 @@ const buildService = (
         queryHistoryModel,
         resultsFileStorageClient,
         executor,
+        analytics,
     };
 };
 
@@ -334,6 +346,7 @@ const validCreateRunArgs = () => ({
     aiThreadUuid: 'thread-1',
     promptUuid: 'prompt-1',
     mcpServerUuids: ['mcp-1'],
+    entryPoint: 'ask_ai' as const,
 });
 
 describe('AiDeepResearchService', () => {
@@ -383,6 +396,8 @@ describe('AiDeepResearchService', () => {
                 toolCallId: null,
                 prompt: 'Investigate revenue',
                 selectedMcpServerUuids: ['mcp-1', 'mcp-2'],
+                entryPoint: 'ask_ai',
+                effort: 'medium',
                 budget,
                 executionContextSnapshot,
             });
@@ -397,6 +412,45 @@ describe('AiDeepResearchService', () => {
                 featureFlagId: FeatureFlags.AiDeepResearch,
             });
             expect(run.status).toBe('queued');
+        });
+
+        it('emits one accepted-run event with persisted dimensions', async () => {
+            const { service, analytics } = buildService({
+                model: {
+                    listPendingAnalyticsEvents: vi.fn().mockResolvedValue([
+                        {
+                            ai_deep_research_analytics_event_uuid:
+                                'analytics-start-1',
+                            ai_deep_research_run_uuid: 'run-1',
+                            event_type: 'run_started',
+                            terminal_reason: null,
+                            delivered_at: null,
+                            created_at: new Date(),
+                        },
+                    ]),
+                },
+            });
+
+            await service.createRun(validCreateRunArgs());
+
+            expect(analytics.track).toHaveBeenCalledExactlyOnceWith({
+                messageId: 'analytics-start-1',
+                event: 'ai_deep_research.run_started',
+                userId: 'user-1',
+                properties: {
+                    organizationId: 'org-1',
+                    projectId: 'project-1',
+                    runUuid: 'run-1',
+                    threadId: 'thread-1',
+                    aiAgentId: 'agent-1',
+                    entryPoint: 'ask_ai',
+                    effort: 'medium',
+                    provider: null,
+                    model: null,
+                    keyManagement: null,
+                    selectedMcpServerCount: 1,
+                },
+            });
         });
 
         it('uses the server-owned default budget when none is provided', async () => {
@@ -763,7 +817,7 @@ describe('AiDeepResearchService', () => {
 
         it('marks the durable run failed when enqueueing fails', async () => {
             const error = new Error('queue unavailable');
-            const { service, model } = buildService({
+            const { service, model, analytics } = buildService({
                 schedulerClient: {
                     aiDeepResearch: vi.fn().mockRejectedValue(error),
                 },
@@ -778,10 +832,12 @@ describe('AiDeepResearchService', () => {
             expect(model.markFailed).toHaveBeenCalledWith(
                 'run-1',
                 'Deep Research could not finish. Please try again.',
+                'internal_error',
             );
             expect(model.deleteUnstartedFailedRun).toHaveBeenCalledWith(
                 'run-1',
             );
+            expect(analytics.track).not.toHaveBeenCalled();
         });
 
         it('rejects invalid budget snapshots before persistence', async () => {
@@ -1042,6 +1098,240 @@ describe('AiDeepResearchService', () => {
                 reportMarkdown,
                 {},
             );
+        });
+
+        it('emits one terminal rollup from persisted usage and provenance', async () => {
+            const { service, analytics } = buildService({
+                model: {
+                    findByUuid: vi.fn().mockResolvedValue(
+                        runRow({
+                            status: 'completed',
+                            started_at: new Date('2026-07-13T12:00:01.000Z'),
+                            completed_at: new Date('2026-07-13T12:00:06.000Z'),
+                            result_markdown: reportMarkdown,
+                        }),
+                    ),
+                    listPendingAnalyticsEvents: vi
+                        .fn()
+                        .mockResolvedValueOnce([])
+                        .mockResolvedValueOnce([
+                            {
+                                ai_deep_research_analytics_event_uuid:
+                                    'analytics-complete-1',
+                                ai_deep_research_run_uuid: 'run-1',
+                                event_type: 'run_completed',
+                                terminal_reason: null,
+                                delivered_at: null,
+                                created_at: new Date(),
+                            },
+                        ]),
+                },
+                aiAgentModel: {
+                    findWebAppPrompt: vi.fn().mockResolvedValue({
+                        promptUuid: 'prompt-1',
+                        tokenUsage: { totalTokens: 321 },
+                    }),
+                    getToolCallsAndResultsForPrompt: vi.fn().mockResolvedValue([
+                        {
+                            toolCall: {
+                                toolName: 'runSql',
+                                toolType: 'mcp',
+                            },
+                            toolResult: null,
+                        },
+                        {
+                            toolCall: {
+                                toolName: 'searchContent',
+                                toolType: 'built_in',
+                            },
+                            toolResult: null,
+                        },
+                        {
+                            toolCall: {
+                                toolName: AI_DEEP_RESEARCH_REPORT_TOOL_NAME,
+                                toolType: 'built_in',
+                            },
+                            toolResult: null,
+                        },
+                    ]),
+                },
+            });
+
+            await service.executeRun({ aiDeepResearchRunUuid: 'run-1' });
+
+            expect(analytics.track).toHaveBeenCalledExactlyOnceWith({
+                messageId: 'analytics-complete-1',
+                event: 'ai_deep_research.run_completed',
+                userId: 'user-1',
+                properties: expect.objectContaining({
+                    status: 'completed',
+                    terminalReason: null,
+                    totalTokens: 321,
+                    toolCallCount: 2,
+                    warehouseQueryCount: 1,
+                    mcpToolCallCount: 1,
+                    hasReport: true,
+                    chartCount: 0,
+                    durationMs: 5_000,
+                }),
+            });
+            expect(
+                JSON.stringify(analytics.track.mock.calls[0][0]),
+            ).not.toContain(reportMarkdown);
+            expect(
+                analytics.track.mock.calls[0][0].properties,
+            ).not.toHaveProperty('errorMessage');
+        });
+
+        it.each([
+            {
+                status: 'partially_completed' as const,
+                terminalReason: 'tool_limit' as const,
+                executorResult: {
+                    status: 'partially_completed' as const,
+                    report,
+                    warehouseQueryUuids: [],
+                    terminalReason: 'tool_limit' as const,
+                },
+            },
+            {
+                status: 'failed' as const,
+                terminalReason: 'provider_error' as const,
+                executorResult: {
+                    status: 'failed' as const,
+                    errorMessage: 'provider unavailable',
+                    terminalReason: 'provider_error' as const,
+                },
+            },
+            {
+                status: 'cancelled' as const,
+                terminalReason: 'user_cancellation' as const,
+                executorResult: {
+                    status: 'cancelled' as const,
+                    terminalReason: 'user_cancellation' as const,
+                },
+            },
+        ])(
+            'emits one $status terminal event with its stable reason',
+            async ({ status, terminalReason, executorResult }) => {
+                const { service, analytics } = buildService({
+                    executor: vi.fn().mockResolvedValue(executorResult),
+                    model: {
+                        findByUuid: vi.fn().mockResolvedValue(
+                            runRow({
+                                status,
+                                started_at: new Date(
+                                    '2026-07-13T12:00:01.000Z',
+                                ),
+                                completed_at: new Date(
+                                    '2026-07-13T12:00:06.000Z',
+                                ),
+                                result_markdown:
+                                    status === 'partially_completed'
+                                        ? reportMarkdown
+                                        : null,
+                            }),
+                        ),
+                        listPendingAnalyticsEvents: vi
+                            .fn()
+                            .mockResolvedValueOnce([])
+                            .mockResolvedValueOnce([
+                                {
+                                    ai_deep_research_analytics_event_uuid: `analytics-${status}`,
+                                    ai_deep_research_run_uuid: 'run-1',
+                                    event_type: 'run_completed',
+                                    terminal_reason: terminalReason,
+                                    delivered_at: null,
+                                    created_at: new Date(),
+                                },
+                            ]),
+                    },
+                });
+
+                await service.executeRun({
+                    aiDeepResearchRunUuid: 'run-1',
+                });
+
+                expect(analytics.track).toHaveBeenCalledExactlyOnceWith(
+                    expect.objectContaining({
+                        messageId: `analytics-${status}`,
+                        event: 'ai_deep_research.run_completed',
+                        properties: expect.objectContaining({
+                            status,
+                            terminalReason,
+                            durationMs: 5_000,
+                        }),
+                    }),
+                );
+            },
+        );
+
+        it('does not emit a terminal event when the transition loses a race', async () => {
+            const { service, analytics } = buildService({
+                model: {
+                    markCompleted: vi.fn().mockResolvedValue(false),
+                    findByUuid: vi
+                        .fn()
+                        .mockResolvedValue(runRow({ status: 'completed' })),
+                    listPendingAnalyticsEvents: vi.fn().mockResolvedValue([]),
+                },
+            });
+
+            await service.executeRun({ aiDeepResearchRunUuid: 'run-1' });
+
+            expect(analytics.track).not.toHaveBeenCalled();
+        });
+
+        it('retries an undelivered terminal outbox event with the same message id', async () => {
+            const analyticsEvent = {
+                ai_deep_research_analytics_event_uuid: 'analytics-retry-1',
+                ai_deep_research_run_uuid: 'run-1',
+                event_type: 'run_completed' as const,
+                terminal_reason: null,
+                delivered_at: null,
+                created_at: new Date(),
+            };
+            const getToolCallsAndResultsForPrompt = vi
+                .fn()
+                .mockRejectedValueOnce(new Error('temporary read failure'))
+                .mockResolvedValueOnce([]);
+            const claimQueuedRun = vi
+                .fn()
+                .mockResolvedValueOnce(runRow({ status: 'running' }))
+                .mockResolvedValueOnce(undefined);
+            const { service, analytics, model } = buildService({
+                model: {
+                    claimQueuedRun,
+                    findByUuid: vi.fn().mockResolvedValue(
+                        runRow({
+                            status: 'completed',
+                            completed_at: new Date('2026-07-13T12:00:06.000Z'),
+                            result_markdown: reportMarkdown,
+                        }),
+                    ),
+                    listPendingAnalyticsEvents: vi
+                        .fn()
+                        .mockResolvedValueOnce([])
+                        .mockResolvedValueOnce([analyticsEvent])
+                        .mockResolvedValueOnce([analyticsEvent]),
+                },
+                aiAgentModel: {
+                    getToolCallsAndResultsForPrompt,
+                },
+            });
+
+            await service.executeRun({ aiDeepResearchRunUuid: 'run-1' });
+            await service.executeRun({ aiDeepResearchRunUuid: 'run-1' });
+
+            expect(analytics.track).toHaveBeenCalledExactlyOnceWith(
+                expect.objectContaining({
+                    messageId: 'analytics-retry-1',
+                    event: 'ai_deep_research.run_completed',
+                }),
+            );
+            expect(
+                model.markAnalyticsEventDelivered,
+            ).toHaveBeenCalledExactlyOnceWith('analytics-retry-1');
         });
 
         it('snapshots chart evidence returned by this research run', async () => {
@@ -1322,6 +1612,7 @@ describe('AiDeepResearchService', () => {
             expect(model.markFailed).toHaveBeenCalledWith(
                 'run-1',
                 'Deep Research could not finish. Please try again.',
+                'internal_error',
             );
         });
 

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    AI_DEEP_RESEARCH_REPORT_TOOL_NAME,
     AiResultType,
     buildInlineChartFields,
     buildInlineChartMetricQuery,
@@ -24,6 +25,7 @@ import {
     type AiDeepResearchChartSnapshot,
     type AiDeepResearchChartSnapshotValue,
     type AiDeepResearchEffort,
+    type AiDeepResearchEntryPoint,
     type AiDeepResearchEvent,
     type AiDeepResearchEventPayloadMap,
     type AiDeepResearchEventsPage,
@@ -32,12 +34,15 @@ import {
     type AiDeepResearchJobPayload,
     type AiDeepResearchProgress,
     type AiDeepResearchRun,
+    type AiDeepResearchTerminalReason,
+    type AiDeepResearchTerminalStatus,
     type AiDeepResearchWarehouseChart,
     type ApiAiAgentThreadMessageVizQuery,
     type SessionUser,
 } from '@lightdash/common';
 import { createInterface } from 'readline';
 import { validate as isValidUuid } from 'uuid';
+import { type LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
 import { type S3ResultsFileStorageClient } from '../../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
 import { type FeatureFlagModel } from '../../../models/FeatureFlagModel/FeatureFlagModel';
 import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
@@ -45,6 +50,7 @@ import { type QueryHistoryModel } from '../../../models/QueryHistoryModel/QueryH
 import { type AsyncQueryService } from '../../../services/AsyncQueryService/AsyncQueryService';
 import { BaseService } from '../../../services/BaseService';
 import {
+    type DbAiDeepResearchAnalyticsOutbox,
     type DbAiDeepResearchEvent,
     type DbAiDeepResearchRun,
 } from '../../database/entities/aiDeepResearch';
@@ -55,6 +61,7 @@ import {
 } from '../../models/AiDeepResearchRunModel';
 import { type CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
 import { type AiAgentService } from '../AiAgentService/AiAgentService';
+import { isDeepResearchWarehouseTool } from './toolClassification';
 
 const MAX_EVENT_PAGE_SIZE = 100;
 const DEFAULT_EVENT_PAGE_SIZE = 50;
@@ -67,7 +74,6 @@ const OMITTED_CHARTS_CAVEAT =
     'Some proposed charts were omitted because their query evidence could not be verified.';
 const OMITTED_CHART_REF_REPLACEMENT =
     '*(chart omitted: its query evidence could not be verified)*';
-
 const isChartConfigCompatible = (
     chart: AiDeepResearchWarehouseChart,
     metricQuery: {
@@ -153,14 +159,23 @@ export type AiDeepResearchExecutorResult =
           status: 'completed';
           report: AiDeepResearchSubmittedReport;
           warehouseQueryUuids: string[];
+          terminalReason: null;
       }
     | {
           status: 'partially_completed';
           report: AiDeepResearchSubmittedReport;
           warehouseQueryUuids: string[];
+          terminalReason: AiDeepResearchTerminalReason;
       }
-    | { status: 'failed'; errorMessage: string }
-    | { status: 'cancelled' };
+    | {
+          status: 'failed';
+          errorMessage: string;
+          terminalReason: AiDeepResearchTerminalReason;
+      }
+    | {
+          status: 'cancelled';
+          terminalReason: AiDeepResearchTerminalReason;
+      };
 
 export type AiDeepResearchExecutor = (
     run: DbAiDeepResearchRun,
@@ -168,6 +183,7 @@ export type AiDeepResearchExecutor = (
 ) => Promise<AiDeepResearchExecutorResult>;
 
 type Dependencies = {
+    analytics: LightdashAnalytics;
     aiDeepResearchRunModel: AiDeepResearchRunModel;
     aiAgentModel: Pick<
         AiAgentModel,
@@ -203,6 +219,8 @@ const toRun = (row: DbAiDeepResearchRun): AiDeepResearchRun => ({
     aiThreadUuid: row.ai_thread_uuid,
     promptUuid: row.prompt_uuid,
     mcpServerUuids: row.selected_mcp_server_uuids,
+    entryPoint: row.entry_point,
+    effort: row.effort,
     prompt: row.prompt,
     status: row.status,
     resultMarkdown: row.result_markdown,
@@ -359,6 +377,8 @@ const assertValidBudget = (budget: AiDeepResearchBudget): void => {
 };
 
 export class AiDeepResearchService extends BaseService {
+    private readonly analytics: LightdashAnalytics;
+
     private readonly aiDeepResearchRunModel: AiDeepResearchRunModel;
 
     private readonly aiAgentModel: Dependencies['aiAgentModel'];
@@ -389,6 +409,7 @@ export class AiDeepResearchService extends BaseService {
     private readonly executor: AiDeepResearchExecutor | undefined;
 
     constructor({
+        analytics,
         aiDeepResearchRunModel,
         aiAgentModel,
         aiAgentService,
@@ -401,6 +422,7 @@ export class AiDeepResearchService extends BaseService {
         executor,
     }: Dependencies) {
         super();
+        this.analytics = analytics;
         this.aiDeepResearchRunModel = aiDeepResearchRunModel;
         this.aiAgentModel = aiAgentModel;
         this.aiAgentService = aiAgentService;
@@ -411,6 +433,126 @@ export class AiDeepResearchService extends BaseService {
         this.queryHistoryModel = queryHistoryModel;
         this.resultsFileStorageClient = resultsFileStorageClient;
         this.executor = executor;
+    }
+
+    private getAnalyticsDimensions(run: DbAiDeepResearchRun) {
+        return {
+            organizationId: run.organization_uuid,
+            projectId: run.project_uuid,
+            runUuid: run.ai_deep_research_run_uuid,
+            threadId: run.ai_thread_uuid,
+            aiAgentId: run.agent_uuid,
+            entryPoint: run.entry_point,
+            effort: run.effort,
+            provider: run.execution_context_snapshot.model.provider,
+            model: run.execution_context_snapshot.model.modelName,
+            keyManagement: run.execution_context_snapshot.model.keyManagement,
+            selectedMcpServerCount: run.selected_mcp_server_uuids.length,
+        };
+    }
+
+    private trackRunStarted(
+        run: DbAiDeepResearchRun,
+        event: DbAiDeepResearchAnalyticsOutbox,
+    ): void {
+        this.analytics.track({
+            messageId: event.ai_deep_research_analytics_event_uuid,
+            event: 'ai_deep_research.run_started',
+            userId: run.created_by_user_uuid,
+            properties: this.getAnalyticsDimensions(run),
+        });
+    }
+
+    private async trackRunCompleted(args: {
+        run: DbAiDeepResearchRun;
+        event: DbAiDeepResearchAnalyticsOutbox;
+    }): Promise<boolean> {
+        if (!isAiDeepResearchRunTerminal(args.run.status)) {
+            return false;
+        }
+        const [prompt, provenance] = await Promise.all([
+            this.aiAgentModel.findWebAppPrompt(args.run.prompt_uuid),
+            this.aiAgentModel.getToolCallsAndResultsForPrompt(
+                args.run.prompt_uuid,
+            ),
+        ]);
+        const toolCalls = provenance.filter(
+            ({ toolCall }) =>
+                toolCall.toolName !== AI_DEEP_RESEARCH_REPORT_TOOL_NAME,
+        );
+        const promptWithTokenUsage = prompt as
+            | (typeof prompt & {
+                  tokenUsage?: { totalTokens: number } | null;
+              })
+            | undefined;
+
+        this.analytics.track({
+            messageId: args.event.ai_deep_research_analytics_event_uuid,
+            event: 'ai_deep_research.run_completed',
+            userId: args.run.created_by_user_uuid,
+            properties: {
+                ...this.getAnalyticsDimensions(args.run),
+                status: args.run.status,
+                terminalReason: args.event.terminal_reason,
+                durationMs: Math.max(
+                    0,
+                    (args.run.completed_at ?? args.run.updated_at).getTime() -
+                        (args.run.started_at ?? args.run.created_at).getTime(),
+                ),
+                totalTokens: promptWithTokenUsage?.tokenUsage?.totalTokens ?? 0,
+                toolCallCount: toolCalls.length,
+                warehouseQueryCount: toolCalls.filter(({ toolCall }) =>
+                    isDeepResearchWarehouseTool(toolCall.toolName),
+                ).length,
+                mcpToolCallCount: toolCalls.filter(
+                    ({ toolCall }) => toolCall.toolType === 'mcp',
+                ).length,
+                hasReport: args.run.result_markdown !== null,
+                chartCount: args.run.result_chart_data
+                    ? Object.keys(args.run.result_chart_data).length
+                    : 0,
+            },
+        });
+        return true;
+    }
+
+    private async dispatchPendingLifecycleAnalytics(
+        aiDeepResearchRunUuid?: string,
+    ): Promise<void> {
+        const events =
+            await this.aiDeepResearchRunModel.listPendingAnalyticsEvents({
+                aiDeepResearchRunUuid,
+            });
+        await Promise.all(
+            events.map(async (event) => {
+                try {
+                    const run = await this.aiDeepResearchRunModel.findByUuid(
+                        event.ai_deep_research_run_uuid,
+                    );
+                    if (!run) {
+                        return;
+                    }
+                    let delivered = true;
+                    if (event.event_type === 'run_started') {
+                        this.trackRunStarted(run, event);
+                    } else {
+                        delivered = await this.trackRunCompleted({
+                            run,
+                            event,
+                        });
+                    }
+                    if (delivered) {
+                        await this.aiDeepResearchRunModel.markAnalyticsEventDelivered(
+                            event.ai_deep_research_analytics_event_uuid,
+                        );
+                    }
+                } catch (error) {
+                    this.logger.warn(
+                        `Could not deliver ${event.event_type} analytics for Deep Research run ${event.ai_deep_research_run_uuid}: ${getErrorMessage(error)}`,
+                    );
+                }
+            }),
+        );
     }
 
     private async assertCanCreateRun(
@@ -480,6 +622,9 @@ export class AiDeepResearchService extends BaseService {
             projectUuid: run.project_uuid,
             userUuid: run.created_by_user_uuid,
         });
+        await this.aiDeepResearchRunModel.recordRunAccepted(
+            run.ai_deep_research_run_uuid,
+        );
     }
 
     async createRun(args: {
@@ -492,6 +637,7 @@ export class AiDeepResearchService extends BaseService {
         aiThreadUuid: string;
         promptUuid: string;
         mcpServerUuids: string[];
+        entryPoint: AiDeepResearchEntryPoint;
         toolCallId?: string;
     }): Promise<AiDeepResearchRun> {
         if (!isUserWithOrg(args.user)) {
@@ -505,11 +651,9 @@ export class AiDeepResearchService extends BaseService {
         if (args.prompt.trim().length === 0) {
             throw new ParameterError('Deep Research prompt is required');
         }
+        const effort = args.effort ?? AI_DEEP_RESEARCH_DEFAULT_EFFORT;
         const budget =
-            args.budget ??
-            AI_DEEP_RESEARCH_BUDGETS_BY_EFFORT[
-                args.effort ?? AI_DEEP_RESEARCH_DEFAULT_EFFORT
-            ];
+            args.budget ?? AI_DEEP_RESEARCH_BUDGETS_BY_EFFORT[effort];
         assertValidBudget(budget);
 
         await this.assertCanCreateRun(args.user, args.projectUuid);
@@ -563,6 +707,9 @@ export class AiDeepResearchService extends BaseService {
             if (existingRun.status === 'queued') {
                 await this.enqueueRun(existingRun);
             }
+            await this.dispatchPendingLifecycleAnalytics(
+                existingRun.ai_deep_research_run_uuid,
+            );
             return toRun(existingRun);
         }
 
@@ -604,6 +751,8 @@ export class AiDeepResearchService extends BaseService {
                 toolCallId: args.toolCallId ?? null,
                 prompt: prompt.prompt.trim(),
                 selectedMcpServerUuids: mcpServerUuids,
+                entryPoint: args.entryPoint,
+                effort,
                 budget,
                 executionContextSnapshot,
             });
@@ -620,6 +769,9 @@ export class AiDeepResearchService extends BaseService {
                 if (concurrentRun.status === 'queued') {
                     await this.enqueueRun(concurrentRun);
                 }
+                await this.dispatchPendingLifecycleAnalytics(
+                    concurrentRun.ai_deep_research_run_uuid,
+                );
                 return toRun(concurrentRun);
             }
             throw error;
@@ -634,6 +786,7 @@ export class AiDeepResearchService extends BaseService {
             await this.aiDeepResearchRunModel.markFailed(
                 run.ai_deep_research_run_uuid,
                 FAILED_RUN_ERROR_MESSAGE,
+                'internal_error',
             );
             await this.aiDeepResearchRunModel.deleteUnstartedFailedRun(
                 run.ai_deep_research_run_uuid,
@@ -641,6 +794,9 @@ export class AiDeepResearchService extends BaseService {
             throw error;
         }
 
+        await this.dispatchPendingLifecycleAnalytics(
+            run.ai_deep_research_run_uuid,
+        );
         return toRun(run);
     }
 
@@ -805,6 +961,7 @@ export class AiDeepResearchService extends BaseService {
                 `Deep Research run ${aiDeepResearchRunUuid} not found`,
             );
         }
+        await this.dispatchPendingLifecycleAnalytics(aiDeepResearchRunUuid);
         return {
             ...toRun({
                 ...run,
@@ -819,20 +976,33 @@ export class AiDeepResearchService extends BaseService {
         payload: AiDeepResearchJobPayload,
         signal: AbortSignal = new AbortController().signal,
     ): Promise<void> {
+        await this.aiDeepResearchRunModel.recordRunAccepted(
+            payload.aiDeepResearchRunUuid,
+        );
         const run = await this.aiDeepResearchRunModel.claimQueuedRun(
             payload.aiDeepResearchRunUuid,
         );
         if (!run) {
+            await this.dispatchPendingLifecycleAnalytics(
+                payload.aiDeepResearchRunUuid,
+            );
             this.logger.info(
                 `Deep Research run ${payload.aiDeepResearchRunUuid} was already claimed or is terminal`,
             );
             return;
         }
+        await this.dispatchPendingLifecycleAnalytics(
+            payload.aiDeepResearchRunUuid,
+        );
 
         if (!this.executor) {
             await this.aiDeepResearchRunModel.markFailed(
                 payload.aiDeepResearchRunUuid,
                 'Deep Research executor is not configured',
+                'internal_error',
+            );
+            await this.dispatchPendingLifecycleAnalytics(
+                payload.aiDeepResearchRunUuid,
             );
             throw new Error('Deep Research executor is not configured');
         }
@@ -855,6 +1025,10 @@ export class AiDeepResearchService extends BaseService {
                     await this.markCancelledAfterCompletedExecution(
                         payload.aiDeepResearchRunUuid,
                     );
+                } else {
+                    await this.dispatchPendingLifecycleAnalytics(
+                        payload.aiDeepResearchRunUuid,
+                    );
                 }
                 return;
             }
@@ -869,9 +1043,14 @@ export class AiDeepResearchService extends BaseService {
                         payload.aiDeepResearchRunUuid,
                         report.markdown,
                         report.chartData,
+                        result.terminalReason,
                     );
                 if (!completed) {
                     await this.markCancelledAfterCompletedExecution(
+                        payload.aiDeepResearchRunUuid,
+                    );
+                } else {
+                    await this.dispatchPendingLifecycleAnalytics(
                         payload.aiDeepResearchRunUuid,
                     );
                 }
@@ -884,17 +1063,30 @@ export class AiDeepResearchService extends BaseService {
                 await this.aiDeepResearchRunModel.markFailed(
                     payload.aiDeepResearchRunUuid,
                     FAILED_RUN_ERROR_MESSAGE,
+                    result.terminalReason,
+                );
+                await this.dispatchPendingLifecycleAnalytics(
+                    payload.aiDeepResearchRunUuid,
                 );
                 return;
             }
 
             const cancelled = await this.aiDeepResearchRunModel.markCancelled(
                 payload.aiDeepResearchRunUuid,
+                result.terminalReason,
             );
-            if (!cancelled) {
+            if (cancelled) {
+                await this.dispatchPendingLifecycleAnalytics(
+                    payload.aiDeepResearchRunUuid,
+                );
+            } else {
                 await this.aiDeepResearchRunModel.markFailed(
                     payload.aiDeepResearchRunUuid,
                     'Deep Research stopped without a cancellation request',
+                    'internal_error',
+                );
+                await this.dispatchPendingLifecycleAnalytics(
+                    payload.aiDeepResearchRunUuid,
                 );
             }
         } catch (error) {
@@ -904,6 +1096,10 @@ export class AiDeepResearchService extends BaseService {
             await this.aiDeepResearchRunModel.markFailed(
                 payload.aiDeepResearchRunUuid,
                 FAILED_RUN_ERROR_MESSAGE,
+                'internal_error',
+            );
+            await this.dispatchPendingLifecycleAnalytics(
+                payload.aiDeepResearchRunUuid,
             );
             throw error;
         }
@@ -1084,9 +1280,14 @@ export class AiDeepResearchService extends BaseService {
             !isAiDeepResearchRunTerminal(run.status) &&
             run.cancellation_requested_at
         ) {
-            await this.aiDeepResearchRunModel.markCancelled(
+            const cancelled = await this.aiDeepResearchRunModel.markCancelled(
                 aiDeepResearchRunUuid,
             );
+            if (cancelled) {
+                await this.dispatchPendingLifecycleAnalytics(
+                    aiDeepResearchRunUuid,
+                );
+            }
         }
     }
 
@@ -1114,6 +1315,7 @@ export class AiDeepResearchService extends BaseService {
                 `Swept ${runs.length} stale Deep Research run(s) after ${STALE_RUN_THRESHOLD_MINUTES} minutes`,
             );
         }
+        await this.dispatchPendingLifecycleAnalytics();
         return runs.length;
     }
 }

--- a/packages/backend/src/ee/services/AiDeepResearchService/toolClassification.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/toolClassification.ts
@@ -1,0 +1,16 @@
+const WAREHOUSE_TOOL_NAMES = new Set([
+    'generateVisualization',
+    'runContentQuery',
+    'runSavedChart',
+    'runSql',
+    'searchFieldValues',
+]);
+
+const WAREHOUSE_MCP_TOOL_RE =
+    /__(?:run_metric_query|run_sql|search_field_values)(?:_\d+)?$/;
+
+export const isDeepResearchWarehouseTool = (toolName: string): boolean =>
+    WAREHOUSE_TOOL_NAMES.has(toolName) || WAREHOUSE_MCP_TOOL_RE.test(toolName);
+
+export const isDeepResearchWarehouseMcpTool = (toolName: string): boolean =>
+    WAREHOUSE_MCP_TOOL_RE.test(toolName);

--- a/packages/common/src/ee/aiDeepResearch/types.ts
+++ b/packages/common/src/ee/aiDeepResearch/types.ts
@@ -24,6 +24,23 @@ export const AI_DEEP_RESEARCH_TERMINAL_STATUSES = [
 export type AiDeepResearchTerminalStatus =
     (typeof AI_DEEP_RESEARCH_TERMINAL_STATUSES)[number];
 
+export const AI_DEEP_RESEARCH_ENTRY_POINTS = ['homepage', 'ask_ai'] as const;
+
+export type AiDeepResearchEntryPoint =
+    (typeof AI_DEEP_RESEARCH_ENTRY_POINTS)[number];
+
+export const AI_DEEP_RESEARCH_TERMINAL_REASONS = [
+    'user_cancellation',
+    'permission_revoked',
+    'tool_limit',
+    'query_limit',
+    'provider_error',
+    'internal_error',
+] as const;
+
+export type AiDeepResearchTerminalReason =
+    (typeof AI_DEEP_RESEARCH_TERMINAL_REASONS)[number];
+
 export const isAiDeepResearchRunTerminal = (
     status: AiDeepResearchRunStatus,
 ): status is AiDeepResearchTerminalStatus =>
@@ -115,6 +132,8 @@ export type AiDeepResearchRequestBody = {
     promptUuid: string;
     /** Agent-attached MCP servers enabled for this run. */
     mcpServerUuids: string[];
+    /** Product surface that accepted the run. */
+    entryPoint: AiDeepResearchEntryPoint;
 };
 
 export const AI_DEEP_RESEARCH_CONFIDENCE_LEVELS = [
@@ -265,6 +284,8 @@ export type AiDeepResearchRun = {
     aiThreadUuid: string;
     promptUuid: string;
     mcpServerUuids: string[];
+    entryPoint: AiDeepResearchEntryPoint;
+    effort: AiDeepResearchEffort;
     prompt: string;
     status: AiDeepResearchRunStatus;
     /** The report narrative with compact <chart> references. */

--- a/packages/common/src/schemas/json/mcp-tools-1.0.json
+++ b/packages/common/src/schemas/json/mcp-tools-1.0.json
@@ -265,7 +265,7 @@
                         "type": "string"
                     },
                     "resourceUuidOrSlug": {
-                        "description": "UUID (preferred) or slug of the saved chart or dashboard to deliver. Use the uuid from createContent/findContent results — slugs are not guaranteed unique.",
+                        "description": "UUID (preferred) or project-scoped slug of the saved chart or dashboard to deliver. Use the uuid from createContent/findContent results as the canonical identity.",
                         "type": "string"
                     },
                     "targets": {

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.test.tsx
@@ -6,17 +6,20 @@ import { deepResearchRunFixture } from '../../deepResearch/fixtures';
 import { DeepResearchRunCard } from './DeepResearchRunCard';
 
 const cancelRun = vi.fn();
+const trackReportEngagement = vi.fn();
 
 vi.mock('../../hooks/useDeepResearch', () => ({
     useCancelDeepResearchMutation: () => ({
         mutate: cancelRun,
         isLoading: false,
     }),
+    useTrackDeepResearchReportEngagement: () => trackReportEngagement,
 }));
 
 describe('DeepResearchRunCard', () => {
     beforeEach(() => {
         cancelRun.mockClear();
+        trackReportEngagement.mockClear();
     });
 
     afterEach(() => {
@@ -155,6 +158,30 @@ describe('DeepResearchRunCard', () => {
         expect(
             screen.getByRole('button', { name: 'Open full report' }),
         ).toBeInTheDocument();
+    });
+
+    it('tracks explicitly opening the full report', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(
+            <DeepResearchRunCard
+                run={deepResearchRunFixture}
+                projectUuid="project-1"
+            />,
+        );
+
+        await user.click(
+            screen.getByRole('button', { name: 'Open full report' }),
+        );
+
+        expect(trackReportEngagement).toHaveBeenCalledWith('opened', {
+            aiDeepResearchRunUuid: deepResearchRunFixture.uuid,
+            projectUuid: deepResearchRunFixture.projectUuid,
+            agentUuid: deepResearchRunFixture.agentUuid,
+            aiThreadUuid: deepResearchRunFixture.threadUuid,
+            status: deepResearchRunFixture.status,
+            completedAt: deepResearchRunFixture.completedAt,
+            updatedAt: deepResearchRunFixture.updatedAt,
+        });
     });
 
     it('renders the executive answer as Markdown', () => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
@@ -37,7 +37,10 @@ import {
     isDeepResearchRunTerminal,
 } from '../../deepResearch/runProgress';
 import { type DeepResearchRunView } from '../../deepResearch/types';
-import { useCancelDeepResearchMutation } from '../../hooks/useDeepResearch';
+import {
+    useCancelDeepResearchMutation,
+    useTrackDeepResearchReportEngagement,
+} from '../../hooks/useDeepResearch';
 import { DeepResearchReport } from './DeepResearchReport';
 import styles from './DeepResearchRunCard.module.css';
 
@@ -133,6 +136,7 @@ export const DeepResearchRunCard = ({
     const cancelMutation = useCancelDeepResearchMutation(projectUuid, run.uuid);
     const [isActivityOpen, setIsActivityOpen] = useState(false);
     const [isReportOpen, setIsReportOpen] = useState(false);
+    const trackReportEngagement = useTrackDeepResearchReportEngagement();
     const [announcedStatus, setAnnouncedStatus] = useState(run.status);
 
     useEffect(() => {
@@ -345,7 +349,25 @@ export const DeepResearchRunCard = ({
                                 variant="light"
                                 size="xs"
                                 w="fit-content"
-                                onClick={() => setIsReportOpen(true)}
+                                onClick={() => {
+                                    if (
+                                        run.status === 'completed' ||
+                                        run.status === 'partially_completed' ||
+                                        run.status === 'failed' ||
+                                        run.status === 'cancelled'
+                                    ) {
+                                        trackReportEngagement('opened', {
+                                            aiDeepResearchRunUuid: run.uuid,
+                                            projectUuid: run.projectUuid,
+                                            agentUuid: run.agentUuid,
+                                            aiThreadUuid: run.threadUuid,
+                                            status: run.status,
+                                            completedAt: run.completedAt,
+                                            updatedAt: run.updatedAt,
+                                        });
+                                    }
+                                    setIsReportOpen(true);
+                                }}
                             >
                                 Open full report
                             </Button>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
@@ -33,6 +33,7 @@ import { useDashboardPageContextCuration } from '../../hooks/useDashboardPageCon
 import {
     useStartDeepResearchForThreadMutation,
     useStartDeepResearchMutation,
+    useTrackDeepResearchFollowUp,
 } from '../../hooks/useDeepResearch';
 import { usePendingThreadRefetch } from '../../hooks/usePendingThreadRefetch';
 import { usePinnedContext } from '../../hooks/usePinnedContext';
@@ -480,6 +481,10 @@ const ExistingThreadPanel: FC<{
         agentUuid: agent.uuid,
         threadUuid: threadId,
     });
+    const trackDeepResearchFollowUp = useTrackDeepResearchFollowUp({
+        projectUuid,
+        threadUuid: threadId,
+    });
 
     const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
     const sqlMode = useAiAgentStoreSelector(selectThreadSqlMode(threadId));
@@ -535,6 +540,7 @@ const ExistingThreadPanel: FC<{
             toolHints,
         }).then(() => {
             recordSubmittedContext(curatedContext.context);
+            trackDeepResearchFollowUp();
         });
     };
 

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/fixtures.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/fixtures.ts
@@ -123,6 +123,7 @@ const deepResearchChartDataFixture: AiDeepResearchChartDataMap = {
 export const deepResearchRunFixture: DeepResearchRunView = {
     uuid: 'run-quarterly-retention',
     projectUuid: 'project-1',
+    agentUuid: 'agent-1',
     threadUuid: 'thread-quarterly-retention',
     question:
         'Why did enterprise retention fall in Q2 despite higher product adoption?',
@@ -131,6 +132,7 @@ export const deepResearchRunFixture: DeepResearchRunView = {
     phase: 'Writing the report',
     startedAt: '2026-07-15T09:00:00.000Z',
     completedAt: '2026-07-15T09:18:00.000Z',
+    updatedAt: '2026-07-15T09:18:00.000Z',
     elapsedMs: 1_080_000,
     sourceCount: 4,
     queryCount: 7,

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/runProgress.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/runProgress.ts
@@ -179,6 +179,7 @@ export const adaptDeepResearchRun = ({
     return {
         uuid: run.aiDeepResearchRunUuid,
         projectUuid: run.projectUuid,
+        agentUuid: run.agentUuid,
         threadUuid: registration.threadUuid,
         question: registration.question,
         depth: registration.depth,
@@ -189,6 +190,7 @@ export const adaptDeepResearchRun = ({
         ),
         startedAt: run.startedAt,
         completedAt: run.completedAt,
+        updatedAt: run.updatedAt,
         elapsedMs: Math.max(0, endTime - startTime),
         sourceCount: null,
         queryCount,

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/types.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/types.ts
@@ -28,6 +28,7 @@ export type DeepResearchSource = {
 export type DeepResearchRunView = {
     uuid: string;
     projectUuid: string;
+    agentUuid: string;
     threadUuid: string;
     question: string;
     depth: DeepResearchDepth;
@@ -35,6 +36,7 @@ export type DeepResearchRunView = {
     phase: string | null;
     startedAt: string | null;
     completedAt: string | null;
+    updatedAt: string;
     elapsedMs: number;
     sourceCount: number | null;
     queryCount: number;

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.test.tsx
@@ -7,10 +7,24 @@ import { type DeepResearchRunRegistration } from '../deepResearch/types';
 import {
     useDeepResearchRun,
     useStartDeepResearchMutation,
+    useTrackDeepResearchFollowUp,
+    useTrackDeepResearchReportEngagement,
 } from './useDeepResearch';
 
 const lightdashApiMock = vi.fn();
 const showToastApiErrorMock = vi.fn();
+const trackMock = vi.fn();
+const appUser = {
+    current: {
+        userUuid: 'user-1',
+        organizationUuid: 'org-1',
+    } as
+        | {
+              userUuid: string;
+              organizationUuid: string;
+          }
+        | undefined,
+};
 
 vi.mock('../../../../api', () => ({
     lightdashApi: (args: unknown) => lightdashApiMock(args),
@@ -22,6 +36,18 @@ vi.mock('../../../../hooks/toaster/useToaster', () => ({
 
 vi.mock('../../../../hooks/user/useUser', () => ({
     default: () => ({ data: { userUuid: 'user-1' } }),
+}));
+
+vi.mock('../../../../providers/App/useApp', () => ({
+    default: () => ({
+        user: {
+            data: appUser.current,
+        },
+    }),
+}));
+
+vi.mock('../../../../providers/Tracking/useTracking', () => ({
+    default: () => ({ track: trackMock }),
 }));
 
 const registration: DeepResearchRunRegistration = {
@@ -41,6 +67,13 @@ const registration: DeepResearchRunRegistration = {
 const getRun = (status: 'running' | 'completed') => ({
     aiDeepResearchRunUuid: 'run-1',
     projectUuid: 'project-1',
+    agentUuid: 'agent-1',
+    aiThreadUuid: 'thread-1',
+    promptUuid: 'prompt-1',
+    mcpServerUuids: ['mcp-1'],
+    entryPoint: 'ask_ai',
+    effort: 'medium',
+    prompt: 'Why did enterprise retention fall in Q2?',
     status,
     result:
         status === 'completed'
@@ -122,6 +155,11 @@ describe('useStartDeepResearchMutation', () => {
             prompt: 'Why did retention fall?',
         });
         expect(showToastApiErrorMock).toHaveBeenCalledOnce();
+        expect(lightdashApiMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                body: expect.stringContaining('"entryPoint":"ask_ai"'),
+            }),
+        );
         expect(
             JSON.parse(
                 window.localStorage.getItem(
@@ -135,6 +173,104 @@ describe('useStartDeepResearchMutation', () => {
             }),
         ]);
         unsubscribe();
+    });
+});
+
+describe('useTrackDeepResearchFollowUp', () => {
+    afterEach(() => {
+        lightdashApiMock.mockReset();
+        trackMock.mockReset();
+    });
+
+    it('attributes a follow-up to the most recent terminal run', async () => {
+        lightdashApiMock.mockResolvedValue([
+            {
+                ...getRun('completed'),
+                aiDeepResearchRunUuid: 'older-run',
+                completedAt: '2026-07-15T09:04:00.000Z',
+            },
+            getRun('completed'),
+        ]);
+        const { result } = renderHook(
+            () =>
+                useTrackDeepResearchFollowUp({
+                    projectUuid: 'project-1',
+                    threadUuid: 'thread-1',
+                }),
+            { wrapper: getWrapper() },
+        );
+
+        await waitFor(() => expect(lightdashApiMock).toHaveBeenCalledOnce());
+        act(() => result.current());
+
+        expect(trackMock).toHaveBeenCalledWith({
+            name: 'ai_deep_research.report_engaged',
+            properties: expect.objectContaining({
+                action: 'follow_up',
+                runUuid: 'run-1',
+                threadId: 'thread-1',
+                aiAgentId: 'agent-1',
+                runStatus: 'completed',
+            }),
+        });
+    });
+});
+
+describe('useTrackDeepResearchReportEngagement', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-07-15T09:05:05.000Z'));
+        appUser.current = {
+            userUuid: 'user-1',
+            organizationUuid: 'org-1',
+        };
+        trackMock.mockReset();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        appUser.current = {
+            userUuid: 'user-1',
+            organizationUuid: 'org-1',
+        };
+    });
+
+    it('tracks the full terminal-run payload with persisted completion time', () => {
+        const { result } = renderHook(
+            () => useTrackDeepResearchReportEngagement(),
+            { wrapper: getWrapper() },
+        );
+
+        act(() => result.current('opened', getRun('completed')));
+
+        expect(trackMock).toHaveBeenCalledExactlyOnceWith({
+            name: 'ai_deep_research.report_engaged',
+            properties: {
+                action: 'opened',
+                organizationId: 'org-1',
+                projectId: 'project-1',
+                userId: 'user-1',
+                runUuid: 'run-1',
+                threadId: 'thread-1',
+                aiAgentId: 'agent-1',
+                runStatus: 'completed',
+                timeSinceCompletedMs: 5_000,
+            },
+        });
+    });
+
+    it('suppresses engagement for nonterminal runs or missing user context', () => {
+        const { result, rerender } = renderHook(
+            () => useTrackDeepResearchReportEngagement(),
+            { wrapper: getWrapper() },
+        );
+
+        act(() => result.current('opened', getRun('running')));
+        appUser.current = undefined;
+        rerender();
+        act(() => result.current('opened', getRun('completed')));
+
+        expect(trackMock).not.toHaveBeenCalled();
     });
 });
 

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.ts
@@ -1,5 +1,6 @@
 import {
     type AnyType,
+    type AiDeepResearchEntryPoint,
     type AiDeepResearchEventsPage,
     type AiDeepResearchRequestBody,
     type AiDeepResearchRun,
@@ -9,12 +10,16 @@ import {
     type ApiAiAgentThreadMessageVizQuery,
     type ApiAiAgentThreadMessageVizQueryResponse,
     type ApiError,
+    isAiDeepResearchRunTerminal,
 } from '@lightdash/common';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { lightdashApi } from '../../../../api';
 import useToaster from '../../../../hooks/toaster/useToaster';
 import useUser from '../../../../hooks/user/useUser';
+import useApp from '../../../../providers/App/useApp';
+import useTracking from '../../../../providers/Tracking/useTracking';
+import { EventName } from '../../../../types/Events';
 import {
     registerDeepResearchRun,
     replaceDeepResearchRun,
@@ -139,6 +144,7 @@ const useStartDeepResearchMutationBase = <
 >(
     projectUuid: string,
     getIds: (variables: Variables) => StartMutationIds,
+    entryPoint: AiDeepResearchEntryPoint,
 ) => {
     const queryClient = useQueryClient();
     const { showToastApiError } = useToaster();
@@ -177,6 +183,7 @@ const useStartDeepResearchMutationBase = <
                 threadUuid,
                 promptUuid: variables.promptUuid,
                 mcpServerUuids: variables.mcpServerUuids,
+                entryPoint,
             });
         },
         onSuccess: (run, variables, context) => {
@@ -224,23 +231,30 @@ export const useStartDeepResearchMutation = ({
     projectUuid,
     agentUuid,
     threadUuid,
+    entryPoint = 'ask_ai',
 }: {
     projectUuid: string;
     agentUuid: string;
     threadUuid: string;
+    entryPoint?: AiDeepResearchEntryPoint;
 }) =>
     useStartDeepResearchMutationBase<StartMutationVariables>(
         projectUuid,
         () => ({ agentUuid, threadUuid }),
+        entryPoint,
     );
 
 type StartForThreadMutationVariables = StartMutationVariables &
     StartMutationIds;
 
-export const useStartDeepResearchForThreadMutation = (projectUuid: string) =>
+export const useStartDeepResearchForThreadMutation = (
+    projectUuid: string,
+    entryPoint: AiDeepResearchEntryPoint = 'ask_ai',
+) =>
     useStartDeepResearchMutationBase<StartForThreadMutationVariables>(
         projectUuid,
         ({ agentUuid, threadUuid }) => ({ agentUuid, threadUuid }),
+        entryPoint,
     );
 
 const useDeepResearchThreadRuns = (
@@ -252,6 +266,83 @@ const useDeepResearchThreadRuns = (
         queryFn: () => listDeepResearchRuns(projectUuid ?? '', threadUuid),
         enabled: !!projectUuid,
     });
+
+type DeepResearchEngagementRun = Pick<
+    AiDeepResearchRun,
+    | 'aiDeepResearchRunUuid'
+    | 'projectUuid'
+    | 'agentUuid'
+    | 'aiThreadUuid'
+    | 'status'
+    | 'completedAt'
+    | 'updatedAt'
+>;
+
+export const useTrackDeepResearchReportEngagement = () => {
+    const { user } = useApp();
+    const { track } = useTracking();
+
+    return useCallback(
+        (
+            action: 'opened' | 'copied' | 'shared' | 'follow_up',
+            run: DeepResearchEngagementRun,
+        ) => {
+            const userId = user?.data?.userUuid;
+            const organizationId = user?.data?.organizationUuid;
+            if (
+                !userId ||
+                !organizationId ||
+                !isAiDeepResearchRunTerminal(run.status)
+            ) {
+                return;
+            }
+
+            const completedAt = run.completedAt ?? run.updatedAt;
+            track({
+                name: EventName.AI_DEEP_RESEARCH_REPORT_ENGAGED,
+                properties: {
+                    action,
+                    organizationId,
+                    projectId: run.projectUuid,
+                    userId,
+                    runUuid: run.aiDeepResearchRunUuid,
+                    threadId: run.aiThreadUuid,
+                    aiAgentId: run.agentUuid,
+                    runStatus: run.status,
+                    timeSinceCompletedMs: Math.max(
+                        0,
+                        Date.now() - new Date(completedAt).getTime(),
+                    ),
+                },
+            });
+        },
+        [track, user?.data?.organizationUuid, user?.data?.userUuid],
+    );
+};
+
+export const useTrackDeepResearchFollowUp = ({
+    projectUuid,
+    threadUuid,
+}: {
+    projectUuid: string;
+    threadUuid: string;
+}) => {
+    const runsQuery = useDeepResearchThreadRuns(projectUuid, threadUuid);
+    const trackEngagement = useTrackDeepResearchReportEngagement();
+
+    return useCallback(() => {
+        const latestTerminalRun = runsQuery.data
+            ?.filter((run) => isAiDeepResearchRunTerminal(run.status))
+            .toSorted(
+                (left, right) =>
+                    new Date(right.completedAt ?? right.updatedAt).getTime() -
+                    new Date(left.completedAt ?? left.updatedAt).getTime(),
+            )[0];
+        if (latestTerminalRun) {
+            trackEngagement('follow_up', latestTerminalRun);
+        }
+    }, [runsQuery.data, trackEngagement]);
+};
 
 export const useDeepResearchThreadRunRegistrations = ({
     projectUuid,

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.test.tsx
@@ -16,6 +16,7 @@ const {
     agents,
     createAgentThread,
     deepResearchEnabled,
+    deepResearchHookArgs,
     navigate,
     startDeepResearch,
 } = vi.hoisted(() => ({
@@ -32,6 +33,11 @@ const {
     },
     createAgentThread: vi.fn(),
     deepResearchEnabled: { current: true },
+    deepResearchHookArgs: {
+        current: undefined as
+            | [projectUuid: string, entryPoint: string]
+            | undefined,
+    },
     navigate: vi.fn(),
     startDeepResearch: vi.fn(),
 }));
@@ -92,9 +98,15 @@ vi.mock('../aiCopilot/hooks/useAiAgentSqlModeAvailable', () => ({
 }));
 
 vi.mock('../aiCopilot/hooks/useDeepResearch', () => ({
-    useStartDeepResearchForThreadMutation: () => ({
-        mutateAsync: startDeepResearch,
-    }),
+    useStartDeepResearchForThreadMutation: (
+        projectUuid: string,
+        entryPoint: string,
+    ) => {
+        deepResearchHookArgs.current = [projectUuid, entryPoint];
+        return {
+            mutateAsync: startDeepResearch,
+        };
+    },
 }));
 
 vi.mock('../aiCopilot/hooks/useProjectAiAgents', () => ({
@@ -156,6 +168,7 @@ describe('DayOneAskInput', () => {
             firstMessage: { uuid: 'prompt-1' },
         });
         deepResearchEnabled.current = true;
+        deepResearchHookArgs.current = undefined;
         startDeepResearch.mockReset();
         startDeepResearch.mockResolvedValue(undefined);
     });
@@ -164,6 +177,7 @@ describe('DayOneAskInput', () => {
         renderInput();
 
         expect(agentChatInputProps.current?.agentUuid).toBe('agent-1');
+        expect(deepResearchHookArgs.current).toEqual(['project-1', 'homepage']);
         expect(agentChatInputProps.current?.onStartDeepResearch).toBeDefined();
 
         await act(async () => {

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.tsx
@@ -148,7 +148,7 @@ const DayOneAskInputInner: FC<Props> = ({
     const { mutateAsync: createAgentThread, isLoading: isCreatingThread } =
         useCreateAgentThreadMutation(projectUuid ?? '');
     const { mutateAsync: startDeepResearch } =
-        useStartDeepResearchForThreadMutation(projectUuid ?? '');
+        useStartDeepResearchForThreadMutation(projectUuid ?? '', 'homepage');
     const deepResearchFlag = useServerFeatureFlag(FeatureFlags.AiDeepResearch);
 
     const showAutoOption = (agents?.length ?? 0) > 1 && routerEnabled === true;

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -26,7 +26,10 @@ import {
 import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentPermission';
 import { useAiAgentSqlModeAvailable } from '../../features/aiCopilot/hooks/useAiAgentSqlModeAvailable';
 import { useAiAgentThreadArtifact } from '../../features/aiCopilot/hooks/useAiAgentThreadArtifact';
-import { useStartDeepResearchMutation } from '../../features/aiCopilot/hooks/useDeepResearch';
+import {
+    useStartDeepResearchMutation,
+    useTrackDeepResearchFollowUp,
+} from '../../features/aiCopilot/hooks/useDeepResearch';
 import { useModelOptions } from '../../features/aiCopilot/hooks/useModelOptions';
 import { usePendingThreadRefetch } from '../../features/aiCopilot/hooks/usePendingThreadRefetch';
 import { usePinnedContext } from '../../features/aiCopilot/hooks/usePinnedContext';
@@ -176,6 +179,10 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
         agentUuid: agentUuid!,
         threadUuid: threadUuid!,
     });
+    const trackDeepResearchFollowUp = useTrackDeepResearchFollowUp({
+        projectUuid: projectUuid!,
+        threadUuid: threadUuid!,
+    });
     const sqlMode = useAiAgentStoreSelector(
         selectThreadSqlMode(threadUuid ?? ''),
     );
@@ -288,7 +295,7 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
             ),
             enableSqlMode: sqlModeAvailable && sqlMode,
             toolHints,
-        });
+        }).then(trackDeepResearchFollowUp);
     };
     const handleStartDeepResearch = async ({
         question,

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -1,4 +1,5 @@
 import {
+    type AiDeepResearchTerminalStatus,
     type CustomFormatType,
     type HomepageRecommendedActionKey,
     type SearchItemType,
@@ -520,6 +521,21 @@ type AiAgentChatMinimizedEvent = {
     };
 };
 
+type AiDeepResearchReportEngagedEvent = {
+    name: EventName.AI_DEEP_RESEARCH_REPORT_ENGAGED;
+    properties: {
+        action: 'opened' | 'copied' | 'shared' | 'follow_up';
+        organizationId: string;
+        projectId: string;
+        userId: string;
+        runUuid: string;
+        threadId: string;
+        aiAgentId: string;
+        runStatus: AiDeepResearchTerminalStatus;
+        timeSinceCompletedMs: number;
+    };
+};
+
 type AiAgentSuggestionImpressionEvent = {
     name: EventName.AI_AGENT_SUGGESTION_IMPRESSION;
     properties: {
@@ -802,6 +818,7 @@ export type EventData =
     | AiAgentChartExploredEvent
     | AiAgentAskClickedEvent
     | AiAgentChatMinimizedEvent
+    | AiDeepResearchReportEngagedEvent
     | AiAgentSuggestionImpressionEvent
     | AiAgentSuggestionClickEvent
     | ThemeToggledEvent

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -186,6 +186,7 @@ export enum EventName {
     AI_AGENT_CHAT_MINIMIZED = 'ai_agent_chat.minimized',
     AI_AGENT_SUGGESTION_IMPRESSION = 'ai_agent.suggestion_impression',
     AI_AGENT_SUGGESTION_CLICK = 'ai_agent.suggestion_click',
+    AI_DEEP_RESEARCH_REPORT_ENGAGED = 'ai_deep_research.report_engaged',
 
     // Theme
     THEME_TOGGLED = 'theme.toggled',


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9320/track-adoption-outcomes-and-engagement

## Summary

Adds durable Deep Research lifecycle analytics and frontend report-engagement tracking so adoption, terminal outcomes, and follow-up behavior can be measured without sending research content or raw errors.

Lifecycle events use a transactional outbox and stable message IDs, which preserves one logical start and terminal event across worker retries, process failures, cancellation races, and temporary provenance-read failures.

## How it works

```text
request → enqueue → accepted outbox row ─┐
                                        ├→ retryable dispatcher → analytics
worker  → terminal DB transition ───────┘
              └→ terminal outbox row
```

### Backend

- Persists `entryPoint` and `effort`, then reloads final provider/model/key-management dimensions from the resolved execution-context snapshot.
- Inserts unique `(run_uuid, event_type)` outbox rows after successful enqueue and inside terminal state transactions.
- Uses the outbox UUID as the analytics `messageId`; successful delivery marks the row complete, while failed aggregation/delivery remains pending for retry.
- Builds terminal duration, token usage, tool/MCP/warehouse counts, report presence, and chart counts from persisted state and provenance.
- Maps terminal outcomes to bounded reasons and excludes prompts, reports, raw errors, tool/MCP names, source URLs, arguments, and results.

### Frontend

- Sends `homepage` for homepage starts and defaults existing Ask AI surfaces to `ask_ai`.
- Tracks explicit full-report opens and successful follow-up messages against the most recent terminal run.
- Suppresses engagement for nonterminal runs or missing authenticated user/organization context.

## Regression analysis

| Group | Effect |
|---|---|
| Deep Research users | Lifecycle and supported report interactions emit typed analytics events. |
| Retried or concurrently cancelled runs | Unique outbox keys and stable message IDs preserve one logical event per lifecycle phase. |
| Existing runs | Migration defaults hydrate `entry_point = ask_ai` and `effort = medium`. |
| Analytics-disabled deployments | Run creation/execution remains independent of RudderStack configuration. |
| Service accounts and impersonated users | Existing Deep Research creation restrictions remain unchanged. |

## Migration

```bash
pnpm -F backend migrate
```

Adds non-null `entry_point` and `effort` columns to `ai_deep_research_runs`, plus `ai_deep_research_analytics_outbox` with a cascading run foreign key, unique run/event constraint, and pending-delivery index.

## Test plan

- [x] Common, backend, and frontend typechecks
- [x] Common, backend, and frontend lint
- [x] Deep Research backend service/executor tests — 71 passing
- [x] Deep Research Postgres model integration tests — 7 passing
- [x] Deep Research frontend hook/card/homepage tests — 23 passing
- [x] Berlin API/scheduler restart and `/api/v1/health` — HTTP 200, healthy
- [x] Applied schema inspection — columns, defaults, outbox PK/FK/unique/index verified

## Example payloads

`ai_deep_research.run_started`:

```json
{
  "runUuid": "run-123",
  "threadId": "thread-123",
  "aiAgentId": "agent-123",
  "entryPoint": "homepage",
  "effort": "high",
  "provider": "anthropic",
  "model": "model-name",
  "keyManagement": "lightdash-managed",
  "selectedMcpServerCount": 1
}
```

`ai_deep_research.run_completed` adds:

```json
{
  "status": "partially_completed",
  "terminalReason": "query_limit",
  "durationMs": 42000,
  "totalTokens": 12000,
  "toolCallCount": 8,
  "warehouseQueryCount": 3,
  "mcpToolCallCount": 2,
  "hasReport": true,
  "chartCount": 1
}
```

`ai_deep_research.report_engaged`:

```json
{
  "action": "follow_up",
  "runStatus": "completed",
  "timeSinceCompletedMs": 5000
}
```
