### PR TITLE
feat(onboarding): remove the invite link screen after inviting an expert

### DIFF
--- a/packages/frontend/src/pages/OnboardingInviteExpert.test.tsx
+++ b/packages/frontend/src/pages/OnboardingInviteExpert.test.tsx
@@ -253,17 +253,12 @@ describe('OnboardingInviteExpert', () => {
         });
     });
 
-    it('explains an unavailable instance and keeps the invite as a fallback', async () => {
+    it('explains an unavailable instance and stays on the page', async () => {
         mocks.ensurePlayground.mockRejectedValue(
             apiError('NotFoundError', 'Playground projects are not available'),
         );
-        const { rerenderPage } = renderPage();
+        renderPage();
         await submitInvite();
-        mocks.inviteLink = {
-            email: 'expert@example.com',
-            inviteUrl: 'https://lightdash.test/invite/abc',
-        };
-        rerenderPage();
 
         expect(
             await screen.findByText(/couldn't set up a sample project/i),
@@ -271,7 +266,6 @@ describe('OnboardingInviteExpert', () => {
         expect(
             screen.getByText(/aren't available on this instance/i),
         ).toBeInTheDocument();
-        expect(screen.getByText('Invite ready')).toBeInTheDocument();
         expect(currentPath).toBe('/onboarding/invite-expert');
         expect(
             screen.queryByRole('button', { name: /try again/i }),
@@ -294,13 +288,8 @@ describe('OnboardingInviteExpert', () => {
         mocks.ensurePlayground.mockRejectedValue(
             apiError('UnexpectedServerError', 'boom'),
         );
-        const { rerenderPage } = renderPage();
+        renderPage();
         await submitInvite();
-        mocks.inviteLink = {
-            email: 'expert@example.com',
-            inviteUrl: 'https://lightdash.test/invite/abc',
-        };
-        rerenderPage();
 
         expect(
             await screen.findByText(/something went wrong while preparing/i),
@@ -323,7 +312,7 @@ describe('OnboardingInviteExpert', () => {
         });
     });
 
-    it('skips provisioning when the organization already has a project', async () => {
+    it('skips provisioning and leaves the page when the organization already has a project', async () => {
         mocks.needsProject = false;
         renderPage();
         await submitInvite();
@@ -332,12 +321,14 @@ describe('OnboardingInviteExpert', () => {
             expect(mocks.createInvite).toHaveBeenCalled();
         });
         expect(mocks.ensurePlayground).not.toHaveBeenCalled();
-        expect(currentPath).toBe('/onboarding/invite-expert');
+        await waitFor(() => {
+            expect(currentPath).toBe('/onboarding/data-source');
+        });
     });
 
-    it('skips provisioning when the instance has no playground projects', async () => {
+    it('skips provisioning and leaves the page when the instance has no playground projects', async () => {
         mocks.hasPlaygroundProjects = false;
-        const { rerenderPage } = renderPage();
+        renderPage();
         await submitInvite();
 
         await waitFor(() => {
@@ -345,18 +336,9 @@ describe('OnboardingInviteExpert', () => {
         });
         expect(mocks.ensurePlayground).not.toHaveBeenCalled();
         expect(screen.queryByText(/Preparing your playground/)).toBeNull();
-
-        mocks.inviteLink = {
-            email: 'expert@example.com',
-            inviteUrl: 'https://lightdash.test/invite/abc',
-        };
-        rerenderPage();
-
-        expect(await screen.findByText('Invite ready')).toBeInTheDocument();
-        expect(
-            screen.queryByText(/couldn't set up a sample project/i),
-        ).toBeNull();
-        expect(currentPath).toBe('/onboarding/invite-expert');
+        await waitFor(() => {
+            expect(currentPath).toBe('/onboarding/data-source');
+        });
     });
 
     it('Cancel returns to the page the CTA linked from', async () => {

--- a/packages/frontend/src/pages/OnboardingInviteExpert.tsx
+++ b/packages/frontend/src/pages/OnboardingInviteExpert.tsx
@@ -6,11 +6,9 @@ import {
     OrganizationMemberRole,
 } from '@lightdash/common';
 import {
-    ActionIcon,
     Alert,
     Box,
     Button,
-    CopyButton,
     Group,
     Loader,
     Paper,
@@ -18,18 +16,22 @@ import {
     Text,
     TextInput,
     Title,
-    Tooltip,
 } from '@mantine-8/core';
-import { useForm, zodResolver } from '@mantine/form';
+import { useForm, zodResolver, type UseFormReturnType } from '@mantine/form';
 import { captureException } from '@sentry/react';
 import {
     IconArrowLeft,
-    IconCheck,
-    IconCopy,
     IconInfoCircle,
     IconUserPlus,
 } from '@tabler/icons-react';
-import { useCallback, useEffect, useRef, useState, type FC } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useEffectEvent,
+    useRef,
+    useState,
+    type FC,
+} from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { z } from 'zod';
 import AboutFooter from '../components/AboutFooter';
@@ -58,6 +60,108 @@ type SetupInviteFormValues = {
     lastName: string;
     email: string;
 };
+
+const PreparingPlaygroundCard: FC = () => (
+    <Group gap="md" wrap="nowrap">
+        <Loader size="sm" />
+        <Stack gap={2}>
+            <Text size="sm" fw={500}>
+                Preparing your playground…
+            </Text>
+            <Text size="sm" c="dimmed">
+                Explore sample data while your expert connects your warehouse.
+            </Text>
+        </Stack>
+    </Group>
+);
+
+const PlaygroundFailureCard: FC<{
+    failure: PlaygroundSetupFailure;
+    onRetry: () => void;
+    onClose: () => void;
+}> = ({ failure, onRetry, onClose }) => (
+    <Stack gap="md">
+        <Callout variant="warning" title="We couldn't set up a sample project">
+            <Text size="sm">{PLAYGROUND_SETUP_FAILURE_MESSAGES[failure]}</Text>
+        </Callout>
+        <Group justify="flex-end" gap="xs">
+            {isRetryablePlaygroundSetupFailure(failure) && (
+                <Button variant="default" onClick={onRetry}>
+                    Try again
+                </Button>
+            )}
+            <Button onClick={onClose}>Done</Button>
+        </Group>
+    </Stack>
+);
+
+const InviteExpertForm: FC<{
+    form: UseFormReturnType<SetupInviteFormValues>;
+    needsName: boolean;
+    isSubmitting: boolean;
+    onSubmit: (values: SetupInviteFormValues) => Promise<void>;
+    onCancel: () => void;
+}> = ({ form, needsName, isSubmitting, onSubmit, onCancel }) => (
+    <form
+        id="setup_invite"
+        name="setup_invite"
+        onSubmit={form.onSubmit((values) => onSubmit(values))}
+    >
+        <Stack gap="sm">
+            {needsName && (
+                <>
+                    <Group grow gap="sm">
+                        <TextInput
+                            name="firstName"
+                            label="Your first name"
+                            required
+                            disabled={isSubmitting}
+                            {...form.getInputProps('firstName')}
+                        />
+                        <TextInput
+                            name="lastName"
+                            label="Your last name"
+                            required
+                            disabled={isSubmitting}
+                            {...form.getInputProps('lastName')}
+                        />
+                    </Group>
+                    <Text size="sm" c="dimmed">
+                        We'll include your name in the invite so they know who's
+                        asking.
+                    </Text>
+                </>
+            )}
+            <TextInput
+                name="email"
+                label="Their email address"
+                placeholder="example@company.com"
+                required
+                disabled={isSubmitting}
+                {...form.getInputProps('email')}
+            />
+            <Text size="sm" c="dimmed">
+                We'll ask them to connect your data warehouse.
+            </Text>
+            <Group justify="flex-end" mt="sm">
+                <Button
+                    variant="default"
+                    onClick={onCancel}
+                    disabled={isSubmitting}
+                >
+                    Cancel
+                </Button>
+                <Button
+                    loading={isSubmitting}
+                    type="submit"
+                    form="setup_invite"
+                >
+                    Send invite
+                </Button>
+            </Group>
+        </Stack>
+    </form>
+);
 
 const OnboardingInviteExpert: FC = () => {
     const { health, user } = useApp();
@@ -148,6 +252,8 @@ const OnboardingInviteExpert: FC = () => {
         title.focus({ preventScroll: true });
     }, [isBooting]);
 
+    const closeOnEscape = useEffectEvent(handleClose);
+
     useEffect(() => {
         if (isBooting) return undefined;
         const onKeyDown = (event: KeyboardEvent) => {
@@ -161,11 +267,11 @@ const OnboardingInviteExpert: FC = () => {
             ) {
                 return;
             }
-            handleClose();
+            closeOnEscape();
         };
         window.addEventListener('keydown', onKeyDown);
         return () => window.removeEventListener('keydown', onKeyDown);
-    }, [handleClose, isBooting]);
+    }, [isBooting]);
 
     const preparePlayground = async () => {
         try {
@@ -214,10 +320,15 @@ const OnboardingInviteExpert: FC = () => {
 
         if (canOfferPlayground) {
             await preparePlayground();
+        } else {
+            handleClose();
         }
     };
 
     const isSubmitting = isLoading || isUpdatingUser;
+
+    const isEnteringPlayground =
+        canOfferPlayground && !playgroundFailure && inviteLink !== undefined;
 
     if (isBooting) {
         return <PageSpinner />;
@@ -308,184 +419,25 @@ const OnboardingInviteExpert: FC = () => {
                     radius="md"
                     className={classes.card}
                 >
-                    {isPreparingPlayground ? (
-                        <Group gap="md" wrap="nowrap">
-                            <Loader size="sm" />
-                            <Stack gap={2}>
-                                <Text size="sm" fw={500}>
-                                    Preparing your playground…
-                                </Text>
-                                <Text size="sm" c="dimmed">
-                                    Explore sample data while your expert
-                                    connects your warehouse.
-                                </Text>
-                            </Stack>
-                        </Group>
-                    ) : inviteLink ? (
-                        <Stack gap="md">
-                            {playgroundFailure && (
-                                <Callout
-                                    variant="warning"
-                                    title="We couldn't set up a sample project"
-                                >
-                                    <Text size="sm">
-                                        {
-                                            PLAYGROUND_SETUP_FAILURE_MESSAGES[
-                                                playgroundFailure
-                                            ]
-                                        }
-                                    </Text>
-                                </Callout>
-                            )}
-                            <Alert
-                                icon={<IconCheck />}
-                                color="green"
-                                title="Invite ready"
-                            >
-                                <Stack gap="sm">
-                                    <Text size="sm">
-                                        {health.data?.hasEmailClient ? (
-                                            <>
-                                                Invite sent to{' '}
-                                                <b>{inviteLink.email}</b> —
-                                                we'll take them straight to
-                                                warehouse setup.
-                                            </>
-                                        ) : (
-                                            <>
-                                                Share this link with{' '}
-                                                <b>{inviteLink.email}</b> to
-                                                take them straight to warehouse
-                                                setup.
-                                            </>
-                                        )}
-                                    </Text>
-                                    <TextInput
-                                        readOnly
-                                        className="sentry-block ph-no-capture"
-                                        value={inviteLink.inviteUrl}
-                                        rightSection={
-                                            <CopyButton
-                                                value={inviteLink.inviteUrl}
-                                            >
-                                                {({ copied, copy }) => (
-                                                    <Tooltip
-                                                        label={
-                                                            copied
-                                                                ? 'Copied'
-                                                                : 'Copy'
-                                                        }
-                                                        withArrow
-                                                        position="right"
-                                                    >
-                                                        <ActionIcon
-                                                            color={
-                                                                copied
-                                                                    ? 'teal'
-                                                                    : 'gray'
-                                                            }
-                                                            onClick={copy}
-                                                        >
-                                                            <MantineIcon
-                                                                icon={
-                                                                    copied
-                                                                        ? IconCheck
-                                                                        : IconCopy
-                                                                }
-                                                            />
-                                                        </ActionIcon>
-                                                    </Tooltip>
-                                                )}
-                                            </CopyButton>
-                                        }
-                                    />
-                                </Stack>
-                            </Alert>
-                            <Group justify="flex-end" gap="xs">
-                                {playgroundFailure &&
-                                    isRetryablePlaygroundSetupFailure(
-                                        playgroundFailure,
-                                    ) && (
-                                        <Button
-                                            variant="default"
-                                            onClick={() => {
-                                                setPlaygroundFailure(null);
-                                                void preparePlayground();
-                                            }}
-                                        >
-                                            Try again
-                                        </Button>
-                                    )}
-                                <Button onClick={handleClose}>Done</Button>
-                            </Group>
-                        </Stack>
+                    {isPreparingPlayground || isEnteringPlayground ? (
+                        <PreparingPlaygroundCard />
+                    ) : playgroundFailure ? (
+                        <PlaygroundFailureCard
+                            failure={playgroundFailure}
+                            onRetry={() => {
+                                setPlaygroundFailure(null);
+                                void preparePlayground();
+                            }}
+                            onClose={handleClose}
+                        />
                     ) : (
-                        <form
-                            id="setup_invite"
-                            name="setup_invite"
-                            onSubmit={form.onSubmit((values) =>
-                                handleSubmit(values),
-                            )}
-                        >
-                            <Stack gap="sm">
-                                {needsName && (
-                                    <>
-                                        <Group grow gap="sm">
-                                            <TextInput
-                                                name="firstName"
-                                                label="Your first name"
-                                                required
-                                                disabled={isSubmitting}
-                                                {...form.getInputProps(
-                                                    'firstName',
-                                                )}
-                                            />
-                                            <TextInput
-                                                name="lastName"
-                                                label="Your last name"
-                                                required
-                                                disabled={isSubmitting}
-                                                {...form.getInputProps(
-                                                    'lastName',
-                                                )}
-                                            />
-                                        </Group>
-                                        <Text size="sm" c="dimmed">
-                                            We'll include your name in the
-                                            invite so they know who's asking.
-                                        </Text>
-                                    </>
-                                )}
-                                <TextInput
-                                    name="email"
-                                    label="Their email address"
-                                    placeholder="example@company.com"
-                                    required
-                                    disabled={isSubmitting}
-                                    {...form.getInputProps('email')}
-                                />
-                                <Text size="sm" c="dimmed">
-                                    We'll ask them to connect your data
-                                    warehouse.
-                                </Text>
-                                <Group justify="flex-end" mt="sm">
-                                    <Button
-                                        variant="default"
-                                        onClick={handleClose}
-                                        disabled={isSubmitting}
-                                    >
-                                        Cancel
-                                    </Button>
-                                    <Button
-                                        loading={isSubmitting}
-                                        type="submit"
-                                        form="setup_invite"
-                                    >
-                                        Send invite
-                                    </Button>
-                                </Group>
-                            </Stack>
-                        </form>
+                        <InviteExpertForm
+                            form={form}
+                            needsName={needsName}
+                            isSubmitting={isSubmitting}
+                            onSubmit={handleSubmit}
+                            onCancel={handleClose}
+                        />
                     )}
                 </Paper>
 


### PR DESCRIPTION
## Summary

In the new onboarding flow, submitting the invite-expert form created the invite link, briefly flashed the "Invite ready" panel (with the manual copy-link input), and then navigated straight to the playground homepage — the panel was never actually usable. This removes the invite-link screen entirely:

- **Playground path**: after the invite is sent, the "Preparing your playground…" state now holds until navigation — no flash of the link panel.
- **Non-playground paths** (org already has a project, instance without playground projects, old `/createProject` flow): the page closes back to where the user came from after the invite is sent. The existing "Created new invite link" toast still confirms the send.
- **Playground failure**: unchanged behaviour — warning callout with retry (when retryable) and Done.

Also cleans up the page now the panel is gone: the three card states (preparing / failure / form) are extracted into small components, unused imports removed, and the Escape-key listener no longer re-subscribes on every `handleClose` identity change (`useEffectEvent`, first use in the codebase — React 19.2).

Follow-up in #26474: silence the invite toast on this page and tighten the `returnTo` guard.

## Testing

- `OnboardingInviteExpert.test.tsx` updated to the new behaviour (11 tests passing): failure states stay on the page without the link panel, non-playground submits navigate back to the data-source step.
- Verified end-to-end on a local EE instance (new-onboarding flag on, fresh org): send invite → "Preparing your playground…" → lands directly on the playground homepage with no invite-link screen; a second invite from the same org (non-playground path) closes back to the data-source step. Invite emails confirmed delivered in both cases.
- Frontend typecheck and lint clean.

Linear: SPK-726

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvTbhuZLhvaBspaAdFekcf