### PR TITLE
feat(charts): make series draw order legible in the Series panel

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/BasicSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/BasicSeriesConfiguration.tsx
@@ -18,6 +18,11 @@ import ColorSelector from '../../ColorSelector';
 import { Config } from '../../common/Config';
 import { EditableText } from '../../common/EditableText';
 import { GrabIcon } from '../../common/GrabIcon';
+import {
+    SeriesDepthControl,
+    type SeriesDrawOrderControl,
+} from './SeriesDrawOrder';
+import drawOrderStyles from './seriesDrawOrder.module.css';
 import SingleSeriesConfiguration from './SingleSeriesConfiguration';
 
 type BasicSeriesConfigurationProps = {
@@ -27,6 +32,7 @@ type BasicSeriesConfigurationProps = {
     item: Field | TableCalculation | CustomDimension;
     dragHandleProps?: DraggableProvidedDragHandleProps | null;
     isDragDisabled?: boolean;
+    drawOrder?: SeriesDrawOrderControl;
     showColorPickerIcon?: boolean;
 } & Pick<
     ReturnType<typeof useCartesianChartConfig>,
@@ -42,6 +48,7 @@ const BasicSeriesConfiguration: FC<BasicSeriesConfigurationProps> = ({
     updateSingleSeries,
     dragHandleProps,
     isDragDisabled,
+    drawOrder,
     showColorPickerIcon,
 }) => {
     const { colorPalette, getSeriesColor } = useVisualizationContext();
@@ -53,7 +60,11 @@ const BasicSeriesConfiguration: FC<BasicSeriesConfigurationProps> = ({
     return (
         <Config>
             <Config.Section>
-                <Group wrap="nowrap" gap="two">
+                <Group
+                    wrap="nowrap"
+                    gap="two"
+                    className={drawOrderStyles.seriesHeader}
+                >
                     <GrabIcon
                         dragHandleProps={dragHandleProps}
                         disabled={isDragDisabled}
@@ -83,6 +94,7 @@ const BasicSeriesConfiguration: FC<BasicSeriesConfigurationProps> = ({
                         <Box
                             style={{
                                 flexGrow: 1,
+                                minWidth: 0,
                             }}
                         >
                             <EditableText
@@ -101,6 +113,7 @@ const BasicSeriesConfiguration: FC<BasicSeriesConfigurationProps> = ({
                             />
                         </Box>
                     )}
+                    {drawOrder && <SeriesDepthControl control={drawOrder} />}
                 </Group>
                 <SingleSeriesConfiguration
                     layout={layout}

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
@@ -28,6 +28,11 @@ import { Config } from '../../common/Config';
 import { GrabIcon } from '../../common/GrabIcon';
 import compactStyles from '../../mantineTheme.module.css';
 import { ChartTypeSelect } from './ChartTypeSelect';
+import {
+    SeriesDepthControl,
+    type SeriesDrawOrderControl,
+} from './SeriesDrawOrder';
+import drawOrderStyles from './seriesDrawOrder.module.css';
 import SingleSeriesConfiguration from './SingleSeriesConfiguration';
 
 const VALUE_LABELS_OPTIONS = [
@@ -77,6 +82,7 @@ type GroupedSeriesConfigurationProps = {
     items: Array<Field | TableCalculation | CustomDimension>;
     dragHandleProps?: DraggableProvidedDragHandleProps | null;
     isDragDisabled?: boolean;
+    drawOrder?: SeriesDrawOrderControl;
     updateAllGroupedSeries: (fieldKey: string, series: Partial<Series>) => void;
     series: Series[];
 } & Pick<
@@ -94,6 +100,7 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
     updateAllGroupedSeries,
     dragHandleProps,
     isDragDisabled,
+    drawOrder,
     updateSeries,
     series,
 }) => {
@@ -153,7 +160,11 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
     return (
         <Config>
             <Config.Section>
-                <Group wrap="nowrap" gap="two">
+                <Group
+                    wrap="nowrap"
+                    gap="two"
+                    className={drawOrderStyles.seriesHeader}
+                >
                     <GrabIcon
                         dragHandleProps={dragHandleProps}
                         disabled={isDragDisabled}
@@ -163,6 +174,7 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
                     <Config.Heading>
                         {getItemLabelWithoutTableName(item)} (grouped)
                     </Config.Heading>
+                    {drawOrder && <SeriesDepthControl control={drawOrder} />}
                 </Group>
                 <Stack gap="xs" ml="md">
                     <Group wrap="nowrap" gap="xs" align="start">

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/SeriesDrawOrder.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/SeriesDrawOrder.tsx
@@ -1,0 +1,99 @@
+import {
+    ActionIcon,
+    Badge,
+    Button,
+    Group,
+    Text,
+    Tooltip,
+} from '@mantine-8/core';
+import {
+    IconArrowsUpDown,
+    IconStack2,
+    IconStackFront,
+} from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../common/MantineIcon';
+import styles from './seriesDrawOrder.module.css';
+
+export type SeriesDrawOrderControl = {
+    isFront: boolean;
+    onBringToFront: () => void;
+};
+
+type SeriesDrawOrderBarProps = {
+    canReorder: boolean;
+    onReverse: () => void;
+};
+
+export const SeriesDrawOrderBar: FC<SeriesDrawOrderBarProps> = ({
+    canReorder,
+    onReverse,
+}) => (
+    <Group className={styles.orderBar} px="xs" py="two" wrap="nowrap">
+        <MantineIcon icon={IconStack2} color="ldGray.6" />
+        <Text size="xs" c="dimmed">
+            Draw order{' '}
+            <Text span inherit fw={600} c="ldGray.9">
+                Back
+            </Text>
+            {' → '}
+            <Text span inherit fw={600} c="ldGray.9">
+                Front
+            </Text>
+        </Text>
+        {canReorder && (
+            <Tooltip
+                label="Flip the order of every series"
+                position="top"
+                openDelay={300}
+                withinPortal
+            >
+                <Button
+                    ml="auto"
+                    variant="subtle"
+                    color="gray"
+                    size="compact-xs"
+                    leftSection={<MantineIcon icon={IconArrowsUpDown} />}
+                    onClick={onReverse}
+                >
+                    Reverse
+                </Button>
+            </Tooltip>
+        )}
+    </Group>
+);
+
+type SeriesDepthControlProps = {
+    control: SeriesDrawOrderControl;
+};
+
+// Fixed-width slot so revealing the action on hover can't resize the series name field.
+export const SeriesDepthControl: FC<SeriesDepthControlProps> = ({
+    control,
+}) => (
+    <Group className={styles.depthSlot} justify="flex-end" wrap="nowrap">
+        {control.isFront ? (
+            <Badge size="xs" radius="sm" variant="light">
+                Front
+            </Badge>
+        ) : (
+            <Tooltip
+                label="Bring to front"
+                position="top"
+                openDelay={300}
+                withinPortal
+            >
+                <ActionIcon
+                    className={styles.frontAction}
+                    variant="subtle"
+                    color="gray"
+                    size="sm"
+                    aria-label="Bring to front"
+                    onClick={control.onBringToFront}
+                >
+                    <MantineIcon icon={IconStackFront} />
+                </ActionIcon>
+            </Tooltip>
+        )}
+    </Group>
+);

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/index.tsx
@@ -17,12 +17,13 @@ import {
     type TableCalculation,
 } from '@lightdash/common';
 import { Checkbox, Divider, Stack, Switch } from '@mantine-8/core';
-import { produce } from 'immer';
 import React, { Fragment, useCallback, useMemo, type FC } from 'react';
 import { createPortal } from 'react-dom';
 import {
     getSeriesGroupedByField,
     isPivotSeriesOrderDeterminedByQuery,
+    moveSeriesGroup,
+    type SeriesGroup,
 } from '../../../../hooks/cartesianChartConfig/utils';
 import { isCartesianVisualizationConfig } from '../../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../../LightdashVisualization/useVisualizationContext';
@@ -33,6 +34,7 @@ import BasicSeriesConfiguration from './BasicSeriesConfiguration';
 import { CustomColors } from './CustomColors';
 import GroupedSeriesConfiguration from './GroupedSeriesConfiguration';
 import InvalidSeriesConfiguration from './InvalidSeriesConfiguration';
+import { SeriesDrawOrderBar } from './SeriesDrawOrder';
 
 type DraggablePortalHandlerProps = {
     snapshot: DraggableStateSnapshot;
@@ -88,36 +90,59 @@ export const Series: FC<Props> = ({ items }) => {
         return getSeriesGroupedByField(dirtyEchartsConfig?.series ?? []);
     }, [isCartesianChart, visualizationConfig]);
 
+    const applyGroupOrder = useCallback(
+        (groups: SeriesGroup[]) => {
+            if (!chartConfig) return;
+            chartConfig.updateSeries(
+                groups.reduce<SeriesType[]>(
+                    (acc, seriesGroup) => [
+                        ...acc,
+                        ...seriesGroup.value.map((s) => ({
+                            ...s,
+                            color: getSeriesColor(s),
+                        })),
+                    ],
+                    [],
+                ),
+            );
+        },
+        [chartConfig, getSeriesColor],
+    );
+
     const onDragEnd = useCallback(
         (result: DropResult) => {
-            if (!chartConfig || !seriesGroupedByField) return;
-
-            const { updateSeries } = chartConfig;
-
+            if (!seriesGroupedByField) return;
             if (!result.destination) return;
             if (result.destination.index === result.source.index) return;
-            const sourceIndex = result.source.index;
-            const destinationIndex = result.destination.index;
-            const reorderedSeriesGroups = produce(
-                seriesGroupedByField,
-                (newState) => {
-                    const [removed] = newState.splice(sourceIndex, 1);
-                    newState.splice(destinationIndex, 0, removed);
-                },
+
+            applyGroupOrder(
+                moveSeriesGroup(
+                    seriesGroupedByField,
+                    result.source.index,
+                    result.destination.index,
+                ),
             );
-            const reorderedSeries = reorderedSeriesGroups.reduce<SeriesType[]>(
-                (acc, seriesGroup) => [
-                    ...acc,
-                    ...seriesGroup.value.map((s) => ({
-                        ...s,
-                        color: getSeriesColor(s),
-                    })),
-                ],
-                [],
-            );
-            updateSeries(reorderedSeries);
         },
-        [seriesGroupedByField, chartConfig, getSeriesColor],
+        [seriesGroupedByField, applyGroupOrder],
+    );
+
+    const onReverseOrder = useCallback(() => {
+        if (!seriesGroupedByField) return;
+        applyGroupOrder([...seriesGroupedByField].reverse());
+    }, [seriesGroupedByField, applyGroupOrder]);
+
+    const onBringToFront = useCallback(
+        (index: number) => {
+            if (!seriesGroupedByField) return;
+            applyGroupOrder(
+                moveSeriesGroup(
+                    seriesGroupedByField,
+                    index,
+                    seriesGroupedByField.length - 1,
+                ),
+            );
+        },
+        [seriesGroupedByField, applyGroupOrder],
     );
 
     if (!isCartesianChart) return null;
@@ -186,10 +211,19 @@ export const Series: FC<Props> = ({ items }) => {
     const customColorsEnabled =
         colorByCategory || conditionalFormattings.length > 0;
 
+    const hasMultipleSeries = (seriesGroupedByField?.length ?? 0) > 1;
+    const canReorder = hasMultipleSeries && !sortedByPivot;
+
     return (
         <Stack gap="md">
             <ColorPaletteSection />
             <Divider />
+            {hasMultipleSeries && (
+                <SeriesDrawOrderBar
+                    canReorder={canReorder}
+                    onReverse={onReverseOrder}
+                />
+            )}
             <DragDropContext onDragEnd={onDragEnd}>
                 <Droppable droppableId="results-table-sort-fields">
                     {(dropProps) => (
@@ -208,6 +242,16 @@ export const Series: FC<Props> = ({ items }) => {
 
                                 const hasDivider =
                                     seriesGroupedByField.length !== i + 1;
+
+                                const drawOrder = canReorder
+                                    ? {
+                                          isFront:
+                                              i ===
+                                              seriesGroupedByField.length - 1,
+                                          onBringToFront: () =>
+                                              onBringToFront(i),
+                                      }
+                                    : undefined;
 
                                 if (!field) {
                                     return (
@@ -268,6 +312,9 @@ export const Series: FC<Props> = ({ items }) => {
                                                             isDragDisabled={
                                                                 sortedByPivot
                                                             }
+                                                            drawOrder={
+                                                                drawOrder
+                                                            }
                                                             updateSeries={
                                                                 updateSeries
                                                             }
@@ -301,6 +348,9 @@ export const Series: FC<Props> = ({ items }) => {
                                                             }
                                                             isDragDisabled={
                                                                 sortedByPivot
+                                                            }
+                                                            drawOrder={
+                                                                drawOrder
                                                             }
                                                             showColorPickerIcon={
                                                                 colorByCategory

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/seriesDrawOrder.module.css
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/seriesDrawOrder.module.css
@@ -1,0 +1,27 @@
+.orderBar {
+    background-color: var(--mantine-color-ldGray-0);
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: var(--mantine-radius-sm);
+}
+
+.depthSlot {
+    flex: 0 0 auto;
+    min-width: 46px;
+    margin-left: auto;
+}
+
+.seriesHeader .frontAction {
+    opacity: 0;
+    transition: opacity 100ms ease;
+}
+
+.seriesHeader:hover .frontAction,
+.seriesHeader:focus-within .frontAction {
+    opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .seriesHeader .frontAction {
+        transition: none;
+    }
+}

--- a/packages/frontend/src/hooks/cartesianChartConfig/utils.test.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { moveSeriesGroup, type SeriesGroup } from './utils';
+
+const group = (name: string): SeriesGroup =>
+    ({ index: 0, value: [{ name }] }) as unknown as SeriesGroup;
+
+const names = (groups: SeriesGroup[]) => groups.map((g) => g.value[0].name);
+
+describe('moveSeriesGroup', () => {
+    const groups = [group('a'), group('b'), group('c')];
+
+    it('moves a group forward in the list', () => {
+        expect(names(moveSeriesGroup(groups, 0, 2))).toEqual(['b', 'c', 'a']);
+    });
+
+    it('moves a group backward in the list', () => {
+        expect(names(moveSeriesGroup(groups, 2, 0))).toEqual(['c', 'a', 'b']);
+    });
+
+    it('does not mutate the input', () => {
+        moveSeriesGroup(groups, 0, 2);
+        expect(names(groups)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('returns the same list when the group does not move', () => {
+        expect(moveSeriesGroup(groups, 1, 1)).toBe(groups);
+    });
+
+    it('returns the same list for an out-of-range source', () => {
+        expect(moveSeriesGroup(groups, 5, 0)).toBe(groups);
+    });
+});

--- a/packages/frontend/src/hooks/cartesianChartConfig/utils.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/utils.ts
@@ -315,6 +315,20 @@ export const getSeriesGroupedByField = (series: Series[]) => {
     return Object.values(seriesGroupMap).sort((a, b) => a.index - b.index);
 };
 
+export type SeriesGroup = ReturnType<typeof getSeriesGroupedByField>[number];
+
+export const moveSeriesGroup = (
+    groups: SeriesGroup[],
+    from: number,
+    to: number,
+): SeriesGroup[] => {
+    if (from === to || from < 0 || from >= groups.length) return groups;
+    const next = [...groups];
+    const [moved] = next.splice(from, 1);
+    next.splice(Math.min(Math.max(to, 0), next.length), 0, moved);
+    return next;
+};
+
 export const sortDimensions = (
     dimensionIds: string[],
     itemsMap: ItemsMap | undefined,


### PR DESCRIPTION
## Problem

#26134 made the Series list the source of truth for paint order — earlier in the list paints behind. The behaviour is right and matches the convention in Tableau (left measure draws behind right), Power BI, Excel/Sheets, and ECharts itself. But nothing in the Series panel says so.

The result is that a two-row list is pure ambiguity: you can't tell which series is in front without experimenting, and if the front series is an area fill swallowing the bars behind it, there's no visible way to fix it short of guessing that drag-and-drop is what you want.

## Change

Three additions to the Series tab, all of them list operations over the **existing** reorder path (`updateSeries`). No new ordering semantics, no new persisted state, nothing that changes how an existing chart renders:

- **Draw order bar** — `Draw order Back → Front`, stating the rule the list already follows.
- **Reverse** — flips the whole list. Equivalent to dragging every row into reverse order by hand; it reverses stack order along with paint order because those are the same array (see below).
- **Per-row depth control** — a `Front` badge on the series that paints on top, and a hover/focus-revealed *Bring to front* action on the others. This is the Tableau *Move marks to front* affordance.

All three are hidden when there's only one series, and the reorder actions are hidden when the list is pivot-sorted (`isPivotSeriesOrderDeterminedByQuery`), matching the existing drag-disabled rule.

## Regression analysis

**Paint order is unchanged for every existing chart.** The three controls are new entry points to `updateSeries` with a reordered array — exactly what drag-and-drop already did. No chart renders differently until a user clicks one of them.

**Reverse also reverses stacking, deliberately.** The series array drives both paint order and stacked-bar segment order; there is no separate stack-order field. Reversing only the paint order would require decoupling them, which is a much larger change and would desync "first = bottom of the stack" — a stronger convention than the z-order one. Reverse is therefore scoped as a bulk drag, not a new axis of control.

**Layout shift was the one real risk and is handled.** The depth control sits at the end of the row header, which also holds the editable series-name field. A hover-revealed text button would have cost the name field ~100px *and* resized it on every mouse-over. Instead the control lives in a fixed 46px slot holding either the badge or an icon button, so the name field width is constant — measured identical (272px) across both rows and hovered/unhovered. `minWidth: 0` was added to the name box so it shrinks rather than overflowing in a narrow sidebar.

**Keyboard access**: the action is revealed by `:focus-within` as well as `:hover`, and carries an `aria-label`, so it's reachable by tab.

## Verification

- Unit tests for `moveSeriesGroup` (ordering both directions, no input mutation, no-op and out-of-range cases).
- Manually verified against a live dev stack on a bar + area mixed chart — the exact case where the area fill hides the bars. Confirmed: Reverse swaps rows, legend, `Front` badge and paint order together; *Bring to front* moves a single series to the end of the array; name-field width does not move.
- `pnpm -F frontend typecheck` and `lint` clean.

## Follow-up not in this PR

Even with correct labelling, an opaque area series drawn in front of bars will keep reading as a bug. Reducing fill opacity for area series that sit in front of another series is probably a bigger usability win than the affordance itself — worth its own ticket.

Relates: PROD-9309
Relates: #26029

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdEF1ymBKV8zXuVqufbJwY
