### PR TITLE
chore: provision Node 24.18 in agent-harness cloud-init

### DIFF
--- a/agent-harness/cloud/cloud-init.yml
+++ b/agent-harness/cloud/cloud-init.yml
@@ -4,7 +4,7 @@
 # =============================================================================
 #
 # Provisions a bare VPS (Hetzner, DigitalOcean, Vultr, etc.) with everything
-# needed to run the agent harness: Docker, Node.js 20.x, pnpm, PM2, dbt,
+# needed to run the agent harness: Docker, Node.js 24.x, pnpm, PM2, dbt,
 # just, and the Lightdash repo itself.
 #
 # Usage:
@@ -136,14 +136,14 @@ runcmd:
   - apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
   - systemctl enable --now docker
 
-  # -- Install fnm (Fast Node Manager) and Node.js 20.19 ----------------------
+  # -- Install fnm (Fast Node Manager) and Node.js 24.18 ---------------------
   - |
     su - lightdash -c '
       curl -fsSL https://fnm.vercel.app/install | bash -s -- --install-dir /home/lightdash/.local/share/fnm --skip-shell
       export PATH="/home/lightdash/.local/share/fnm:$PATH"
       eval "$(fnm env --shell bash)"
-      fnm install 20.19
-      fnm default 20.19
+      fnm install 24.18
+      fnm default 24.18
     '
 
   # -- Install pnpm 10.33.0 ---------------------------------------------------


### PR DESCRIPTION
This updates the agent-harness cloud-init provisioning script to use Node.js 24.18 instead of 20.19, including the top-level documentation and fnm install/default steps so new VPS agents are provisioned with the intended runtime version.
Linear: PROD-9333
This is part of the pnpm 11 upgrade stack (PROD-8816); the pnpm pin is intentionally left at 10.33.0 here until the pnpm 11 switch lands.