### PR TITLE
fix: keep data-apps template pnpm settings effective under pnpm 11

### DIFF
--- a/sandboxes/data-apps/.npmrc
+++ b/sandboxes/data-apps/.npmrc
@@ -1,1 +1,2 @@
+# pnpm <=10 only. pnpm 11 reads this setting from pnpm-workspace.yaml.
 ignore-workspace-root-check=true

--- a/sandboxes/data-apps/pnpm-workspace.yaml
+++ b/sandboxes/data-apps/pnpm-workspace.yaml
@@ -1,1 +1,3 @@
 packages: []
+# pnpm 11 reads settings from here; the .npmrc copy remains for pnpm <=10.
+ignoreWorkspaceRootCheck: true

--- a/sandboxes/data-apps/template/.npmrc
+++ b/sandboxes/data-apps/template/.npmrc
@@ -1,3 +1,4 @@
+# pnpm <=10 only. pnpm 11 reads these settings from pnpm-workspace.yaml.
 shamefully-hoist=true
 ignore-workspace-root-check=true
 # The pinned SDK version is often <3 days old; exempt it from release-age policies

--- a/sandboxes/data-apps/template/pnpm-workspace.yaml
+++ b/sandboxes/data-apps/template/pnpm-workspace.yaml
@@ -1,1 +1,10 @@
 packages: []
+# pnpm 11 reads settings from here; the .npmrc copies remain for pnpm <=10.
+shamefullyHoist: true
+ignoreWorkspaceRootCheck: true
+# The pinned SDK version is often <3 days old; exempt it from release-age policies
+minimumReleaseAgeExclude:
+  - '@lightdash/query-sdk'
+# Downloaded apps may be authored by someone else — never run their
+# dependencies' lifecycle scripts locally (explicit `pnpm run` still works)
+ignoreScripts: true


### PR DESCRIPTION
## Summary
- Move pnpm 11-relevant template settings from .npmrc to pnpm-workspace.yaml so data-apps scaffolds keep ignore-scripts and hoist behavior consistent under pnpm 11.
- Add compatibility note in the template .npmrc indicating it is for pnpm <=10 only.
- Confirm  is already included in vendored template files copied during app scaffolding.

## Verification
- In sandboxes/data-apps/template, verified with:
  -  -> 
  - undefined -> 
  -  -> 
  - undefined -> 

Linear: PROD-9334
Part of pnpm 11 stack (PROD-8816).