### PR TITLE
chore: bump data-apps E2B sandbox to pnpm 11.17.0

### DIFF
--- a/sandboxes/data-apps/e2b.Dockerfile
+++ b/sandboxes/data-apps/e2b.Dockerfile
@@ -1,7 +1,7 @@
 FROM node:22
 
 # Global tooling
-RUN npm install -g pnpm@10.33.0
+RUN npm install -g pnpm@11.17.0
 RUN npm install -g @anthropic-ai/claude-code@2.1.220
 
 WORKDIR /app


### PR DESCRIPTION
## Summary
- Bump the E2B Dockerfile to install pnpm@11.17.0 in the data-apps sandbox image.

## Notes
- This PR is stacked on PROD-9334 and should be merged after it.
- An E2B template image rebuild should follow the dependency/tooling change.

Linear: PROD-9336