### PR TITLE
ci: read pnpm overrides from pnpm-workspace.yaml in exact-version guard and key post-release cache on packageManager

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -256,6 +256,12 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
 
+      - name: Read packageManager
+        id: package-manager
+        run: |
+          version=$(node -p 'JSON.parse(require("fs").readFileSync("package.json","utf8")).packageManager.split("+")[0]')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Cache node_modules
         id: cache-node-modules
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
@@ -263,7 +269,7 @@ jobs:
           path: |
             node_modules
             packages/*/node_modules
-          key: ${{ runner.os }}-node-modules-cli-binaries-v2-${{ hashFiles('pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-node-modules-cli-binaries-v2-${{ steps.package-manager.outputs.version }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -38,6 +38,12 @@ jobs:
             .execSync('find . -name package.json -not -path \"*/node_modules/*\"', { encoding: 'utf8' })
             .trim().split('\n');
 
+          const workspaceFile = 'pnpm-workspace.yaml';
+          const workspaceContent = fs.existsSync(workspaceFile) ? fs.readFileSync(workspaceFile, 'utf8') : '';
+          const workspaceLines = workspaceContent.split('\n');
+          const workspaceIssues = [];
+          let inOverrides = false;
+
           const issues = [];
           for (const f of files) {
             const pkg = JSON.parse(fs.readFileSync(f, 'utf8'));
@@ -58,6 +64,31 @@ jobs:
               }
             }
           }
+          if (workspaceContent) {
+            for (const line of workspaceLines) {
+              if (!inOverrides && /^overrides:\s*$/.test(line)) {
+                inOverrides = true;
+                continue;
+              }
+              if (inOverrides) {
+                if (/^\S/.test(line)) {
+                  break;
+                }
+
+                const match = line.match(/^\\s{2}(?:'([^']+)'|\"([^\"]+)\"|([^:\\s]+))\\s*:\\s*(?:'([^']*)'|\"([^\"]*)\"|([^\\s#]+))/);
+                if (!match) {
+                  continue;
+                }
+
+                const key = match[1] || match[2] || match[3];
+                const ver = match[4] || match[5] || match[6];
+                if (/^[\^~><=]/.test(ver) || /\\|\\|/.test(ver)) {
+                  workspaceIssues.push('pnpm-workspace.yaml [pnpm-workspace overrides] ' + key + ': ' + ver);
+                }
+              }
+            }
+          }
+          issues.push(...workspaceIssues);
 
           if (issues.length > 0) {
             console.error('ERROR: Found range specifiers in dependencies. All deps must use exact versions.');
@@ -66,7 +97,7 @@ jobs:
             issues.forEach(i => console.error('  ' + i));
             console.error('');
             console.error('Fix: use exact versions (e.g. \"1.2.3\" not \"^1.2.3\"). The .npmrc save-exact=true');
-            console.error('setting ensures pnpm add uses exact versions by default.');
+            console.error('covers the npm CLI, and savePrefix set to empty string in pnpm-workspace.yaml covers pnpm.');
             process.exit(1);
           }
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -74,14 +74,17 @@ jobs:
                 if (/^\S/.test(line)) {
                   break;
                 }
+                if (/^\\s*#/.test(line)) {
+                  continue;
+                }
 
-                const match = line.match(/^\\s{2}(?:'([^']+)'|\"([^\"]+)\"|([^:\\s]+))\\s*:\\s*(?:'([^']*)'|\"([^\"]*)\"|([^\\s#]+))/);
+                const match = line.match(/^\\s{2}(?:'([^']+)'|\"([^\"]+)\"|([^:\\s]+))\\s*:\\s*(?:'([^']*)'|\"([^\"]*)\"|([^#]+?))\\s*(?:#.*)?$/);
                 if (!match) {
                   continue;
                 }
 
                 const key = match[1] || match[2] || match[3];
-                const ver = match[4] || match[5] || match[6];
+                const ver = (match[4] || match[5] || match[6]).trim();
                 if (/^[\^~><=]/.test(ver) || /\\|\\|/.test(ver)) {
                   workspaceIssues.push('pnpm-workspace.yaml [pnpm-workspace overrides] ' + key + ': ' + ver);
                 }


### PR DESCRIPTION
## What
- Update PR dependency exact-version CI guard to also validate `pnpm-workspace.yaml` overrides entries and flag ranges in a separate `[pnpm-workspace overrides]` issue bucket.
- Add a `Read packageManager` step to `post-release.yml` and include the package manager version in the macOS CLI dependencies cache key.
- Update remediation guidance to clarify that `.npmrc save-exact=true` applies to npm CLI, while `savePrefix` in `pnpm-workspace.yaml` governs pnpm behavior.

## Why
- This catches non-exact override specs that previously could bypass package.json checks and improves cache segmentation for pnpm release environments.

Linear: PROD-9335

- Part of the pnpm 11 stack (PROD-8816); this behavior is safe under pnpm 10 today.
