### PR TITLE
chore(deps): move pnpm config from package.json to pnpm-workspace.yaml

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
+# npm CLI only. pnpm reads savePrefix from pnpm-workspace.yaml.
 save-exact=true
 # npm CLI 11.10+ supply-chain cooldown: refuse to install package versions
 # published less than 3 days ago. Older npm versions silently ignore this.

--- a/package.json
+++ b/package.json
@@ -11,42 +11,6 @@
         "packages/*",
         "packages/frontend/sdk"
     ],
-    "pnpm": {
-        "overrides": {
-            "react-is": "19.2.0",
-            "@types/react": "19.2.2",
-            "@types/react-dom": "19.2.2",
-            "linkifyjs": "4.3.2",
-            "axios": "1.16.0",
-            "form-data@2.5.3": "2.5.5",
-            "form-data@3.0.1": "3.0.5",
-            "form-data@4.0.0": "4.0.6",
-            "form-data@4.0.2": "4.0.6",
-            "validator": "13.15.23",
-            "node-forge": "1.4.0",
-            "glob@>=10.2.0 <10.5.0": "10.5.0",
-            "jws": "4.0.1",
-            "qs": "6.15.2",
-            "hono": "4.12.27",
-            "tar": "7.5.21",
-            "eslint": "8.57.1",
-            "canvas": "3.2.1",
-            "ssh2": "1.17.0",
-            "cpu-features": "0.0.10",
-            "nan": "2.27.0",
-            "express-rate-limit": "8.3.0",
-            "@hapi/content": "6.0.1",
-            "undici": "6.27.0",
-            "handlebars": "4.7.9",
-            "basic-ftp": "5.3.1",
-            "vite@>=7.0.0 <7.3.2": "7.3.5",
-            "systeminformation": "5.31.6",
-            "path-to-regexp@0.1.12": "0.1.13",
-            "ajv@<6.14.0": "6.15.0",
-            "ajv@>=8.0.0 <8.18.0": "8.18.0",
-            "postcss@<8.5.10": "8.5.10"
-        }
-    },
     "dependencies": {
         "tslib": "2.8.1"
     },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,43 @@ packages:
   - 'packages/frontend/sdk'
   - 'packages/backend/src/ee/services/McpService/mcp-chart-app'
 
+# Exact versions on pnpm add. The npm CLI equivalent (save-exact) stays in .npmrc.
+savePrefix: ''
+
+overrides:
+  react-is: 19.2.0
+  '@types/react': 19.2.2
+  '@types/react-dom': 19.2.2
+  linkifyjs: 4.3.2
+  axios: 1.16.0
+  'form-data@2.5.3': 2.5.5
+  'form-data@3.0.1': 3.0.5
+  'form-data@4.0.0': 4.0.6
+  'form-data@4.0.2': 4.0.6
+  validator: 13.15.23
+  node-forge: 1.4.0
+  'glob@>=10.2.0 <10.5.0': 10.5.0
+  jws: 4.0.1
+  qs: 6.15.2
+  hono: 4.12.27
+  tar: 7.5.21
+  eslint: 8.57.1
+  canvas: 3.2.1
+  ssh2: 1.17.0
+  cpu-features: 0.0.10
+  nan: 2.27.0
+  express-rate-limit: 8.3.0
+  '@hapi/content': 6.0.1
+  undici: 6.27.0
+  handlebars: 4.7.9
+  basic-ftp: 5.3.1
+  'vite@>=7.0.0 <7.3.2': 7.3.5
+  systeminformation: 5.31.6
+  'path-to-regexp@0.1.12': 0.1.13
+  'ajv@<6.14.0': 6.15.0
+  'ajv@>=8.0.0 <8.18.0': 8.18.0
+  'postcss@<8.5.10': 8.5.10
+
 minimumReleaseAge: 4320 # 3 days — supply chain protection (matches .npmrc min-release-age)
 minimumReleaseAgeExclude:
   # Renovate security update: hono@4.12.18 || 4.12.21 || 4.12.25 || 4.12.27


### PR DESCRIPTION
## What

Moves all pnpm configuration from the root `package.json#pnpm` block into `pnpm-workspace.yaml`, including the 32 dependency overrides. It also adds pnpm’s `savePrefix` setting and clarifies that `.npmrc`'s `save-exact` applies only to npm.

## Why

pnpm 10 already reads these settings from `pnpm-workspace.yaml`, so this is behavior-neutral. It prepares the pnpm 11 switch, which stops reading `package.json#pnpm`.

## Verification

| Check | Result |
| --- | --- |
| `pnpm --version` | `10.33.0` |
| Override comparison against `origin/main:package.json` | 32 entries; zero missing, changed, or extra |
| `pnpm install --frozen-lockfile` | Passed |
| Lockfile after frozen install | `git diff --stat pnpm-lock.yaml` empty |
| `pnpm install --lockfile-only` | Passed |
| Lockfile after lockfile-only resolution | `git diff pnpm-lock.yaml` empty |

Linear: PROD-8816

This is the base of the pnpm 11 stack; PR #26410 will be rebased on top.