### PR TITLE
feat(onboarding): silence the invite toast and tighten the returnTo guard

### DIFF
--- a/packages/frontend/src/hooks/useInviteLink.tsx
+++ b/packages/frontend/src/hooks/useInviteLink.tsx
@@ -76,7 +76,9 @@ export const useActivateInviteLinkMutation = (
     );
 };
 
-export const useCreateInviteLinkMutation = () => {
+export const useCreateInviteLinkMutation = ({
+    showSuccessToast = true,
+}: { showSuccessToast?: boolean } = {}) => {
     const queryClient = useQueryClient();
     const { showToastApiError, showToastSuccess } = useToaster();
     return useMutation<
@@ -94,9 +96,11 @@ export const useCreateInviteLinkMutation = () => {
         onSuccess: async () => {
             await queryClient.invalidateQueries(['onboarding-status']);
             await queryClient.refetchQueries(['organization_users']);
-            showToastSuccess({
-                title: 'Created new invite link',
-            });
+            if (showSuccessToast) {
+                showToastSuccess({
+                    title: 'Created new invite link',
+                });
+            }
         },
     });
 };

--- a/packages/frontend/src/pages/OnboardingInviteExpert.tsx
+++ b/packages/frontend/src/pages/OnboardingInviteExpert.tsx
@@ -191,7 +191,7 @@ const OnboardingInviteExpert: FC = () => {
         data: inviteLink,
         mutateAsync,
         isLoading,
-    } = useCreateInviteLinkMutation();
+    } = useCreateInviteLinkMutation({ showSuccessToast: false });
     const { mutateAsync: updateUserAsync, isLoading: isUpdatingUser } =
         useUserUpdateMutation();
     const { track } = useTracking();

--- a/packages/frontend/src/pages/OnboardingInviteExpert.tsx
+++ b/packages/frontend/src/pages/OnboardingInviteExpert.tsx
@@ -202,7 +202,9 @@ const OnboardingInviteExpert: FC = () => {
     // Only accept app-local paths; anything else (e.g. "//host") would make
     // pushState throw.
     const returnTo =
-        rawReturnTo && /^\/(?!\/)/.test(rawReturnTo) ? rawReturnTo : undefined;
+        rawReturnTo && /^\/(?![/\\])/.test(rawReturnTo)
+            ? rawReturnTo
+            : undefined;
 
     const newOnboardingFlag = useServerFeatureFlag(FeatureFlags.NewOnboarding);
     const isNewOnboarding = newOnboardingFlag.data?.enabled ?? false;


### PR DESCRIPTION
## Summary

Follow-up to #26465 (two commits that landed on that branch after it merged):

- **No invite toast on the invite-expert page**: `useCreateInviteLinkMutation` gains a `showSuccessToast` option (default `true`, so the Users & Groups settings invite flows keep their toast); the onboarding page opts out since it navigates away immediately after the invite is sent.
- **Tighter `returnTo` guard**: the app-local path check on `location.state.returnTo` now also rejects backslash-prefixed values, so malformed paths degrade to the fallback target instead of throwing in the navigation handler.

## Testing

- `OnboardingInviteExpert.test.tsx` (11 tests) passing on top of latest main; frontend typecheck and lint clean.
- Toast removal verified in the browser on a local EE instance: both the playground path (straight to the homepage) and the non-playground path (closes back to the data-source step) complete without the "Created new invite link" toast, with invite emails still delivered.

Linear: SPK-726

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvTbhuZLhvaBspaAdFekcf