### PR TITLE
fix(apps): offer the visualization library to whoever can build a chart

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
@@ -1,6 +1,7 @@
 // Stub the e2b/ai SDKs so the tests never reach a real sandbox or model client.
 import {
     DATA_APP_VIZ_TEMPLATE,
+    ForbiddenError,
     getUserAbilityBuilder,
     NotFoundError,
     OrganizationMemberRole,
@@ -95,26 +96,14 @@ function buildService(appModel: unknown) {
 
 /**
  * A service whose ability is the real thing, so the rules under test are the
- * ones that ship. `getSpaceAccessContext` stands in for the space lookup: a
- * space the user can reach reports `inheritsFromOrgOrProject`.
+ * ones that ship.
  */
 function buildServiceWithRealAbility(
     appModel: unknown,
     role: OrganizationMemberRole,
     userUuid: string,
-    readableSpaceUuids: string[],
 ) {
     const service = buildService(appModel);
-    (
-        service as unknown as { spacePermissionService: unknown }
-    ).spacePermissionService = {
-        getSpaceAccessContext: (_userUuid: string, spaceUuid: string) =>
-            Promise.resolve(
-                readableSpaceUuids.includes(spaceUuid)
-                    ? { inheritsFromOrgOrProject: true }
-                    : {},
-            ),
-    };
     const { builder } = getUserAbilityBuilder({
         user: {
             role,
@@ -181,7 +170,7 @@ describe('AppGenerateService data app vizs', () => {
         });
     });
 
-    describe('who a listed visualization is offered to', () => {
+    describe('who the library is offered to', () => {
         const listPagination = {
             page: 1,
             pageSize: 25,
@@ -200,15 +189,13 @@ describe('AppGenerateService data app vizs', () => {
                 created_by_user_uuid: 'someone-else',
             }),
             makeDataAppVizRow({
-                app_id: 'in-a-space-i-can-see',
+                app_id: 'in-someone-elses-space',
                 space_uuid: 'space-1',
                 created_by_user_uuid: 'someone-else',
             }),
         ];
-        const listed = async (
-            role: OrganizationMemberRole,
-            readableSpaceUuids: string[] = ['space-1'],
-        ) => {
+        const wholeLibrary = rows.map((row) => row.app_id);
+        const listed = async (role: OrganizationMemberRole) => {
             const appModel = {
                 listDataAppVisualizations: vi.fn().mockResolvedValue({
                     data: rows,
@@ -219,7 +206,6 @@ describe('AppGenerateService data app vizs', () => {
                 appModel,
                 role,
                 'editor-1',
-                readableSpaceUuids,
             );
             const result = await service.listDataAppVisualizations(
                 user,
@@ -229,39 +215,21 @@ describe('AppGenerateService data app vizs', () => {
             return result.data.map((viz) => viz.dataAppVizUuid);
         };
 
-        it('offers an editor their own, and anything in a space they can see', async () => {
-            // Regression: this list was gated on a project-wide subject with no
-            // space context and no creator, which only an admin's unconditional
-            // `manage` could satisfy — so the picker came back empty for
-            // everyone else, including the author of the visualization.
-            expect(await listed(OrganizationMemberRole.EDITOR)).toEqual([
-                'mine-unfiled',
-                'in-a-space-i-can-see',
-            ]);
+        // The library follows the explore: whoever can build a chart is offered
+        // every renderer in the project, whether or not they authored it.
+        it.each([
+            OrganizationMemberRole.INTERACTIVE_VIEWER,
+            OrganizationMemberRole.EDITOR,
+            OrganizationMemberRole.DEVELOPER,
+            OrganizationMemberRole.ADMIN,
+        ])('offers the whole project library to a %s', async (role) => {
+            expect(await listed(role)).toEqual(wholeLibrary);
         });
 
-        it('offers an interactive viewer the same — they can use one without authoring it', async () => {
-            expect(
-                await listed(OrganizationMemberRole.INTERACTIVE_VIEWER),
-            ).toEqual(['mine-unfiled', 'in-a-space-i-can-see']);
-        });
-
-        it('withholds a visualization in a space the user cannot reach', async () => {
-            expect(await listed(OrganizationMemberRole.EDITOR, [])).toEqual([
-                'mine-unfiled',
-            ]);
-        });
-
-        it('offers a viewer nothing — they hold no view:DataApp at all', async () => {
-            expect(await listed(OrganizationMemberRole.VIEWER)).toEqual([]);
-        });
-
-        it('offers an admin every visualization in the project', async () => {
-            expect(await listed(OrganizationMemberRole.ADMIN, [])).toEqual([
-                'mine-unfiled',
-                'someone-elses-unfiled',
-                'in-a-space-i-can-see',
-            ]);
+        it('refuses a viewer, who has no explore to render one in', async () => {
+            await expect(listed(OrganizationMemberRole.VIEWER)).rejects.toThrow(
+                ForbiddenError,
+            );
         });
     });
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
@@ -1,7 +1,9 @@
 // Stub the e2b/ai SDKs so the tests never reach a real sandbox or model client.
 import {
     DATA_APP_VIZ_TEMPLATE,
+    getUserAbilityBuilder,
     NotFoundError,
+    OrganizationMemberRole,
     type DataAppVizSchema,
 } from '@lightdash/common';
 import { AppGenerateService } from './AppGenerateService';
@@ -91,6 +93,51 @@ function buildService(appModel: unknown) {
     return service;
 }
 
+/**
+ * A service whose ability is the real thing, so the rules under test are the
+ * ones that ship. `getSpaceAccessContext` stands in for the space lookup: a
+ * space the user can reach reports `inheritsFromOrgOrProject`.
+ */
+function buildServiceWithRealAbility(
+    appModel: unknown,
+    role: OrganizationMemberRole,
+    userUuid: string,
+    readableSpaceUuids: string[],
+) {
+    const service = buildService(appModel);
+    (
+        service as unknown as { spacePermissionService: unknown }
+    ).spacePermissionService = {
+        getSpaceAccessContext: (_userUuid: string, spaceUuid: string) =>
+            Promise.resolve(
+                readableSpaceUuids.includes(spaceUuid)
+                    ? { inheritsFromOrgOrProject: true }
+                    : {},
+            ),
+    };
+    const { builder } = getUserAbilityBuilder({
+        user: {
+            role,
+            organizationUuid: 'org-1',
+            userUuid,
+            roleUuid: undefined,
+        },
+        projectProfiles: [],
+        permissionsConfig: { pat: { enabled: false, allowedOrgRoles: [] } },
+    });
+    // Drop buildService's allow-everything stub so the real rules apply.
+    delete (service as unknown as { createAuditedAbility?: unknown })
+        .createAuditedAbility;
+    return {
+        service,
+        user: {
+            userUuid,
+            organizationUuid: 'org-1',
+            ability: builder.build(),
+        } as never,
+    };
+}
+
 describe('AppGenerateService data app vizs', () => {
     it('maps a page of rows to by-reference DataAppVizs (no code copied)', async () => {
         const pagination = {
@@ -131,6 +178,90 @@ describe('AppGenerateService data app vizs', () => {
                 },
             ],
             pagination,
+        });
+    });
+
+    describe('who a listed visualization is offered to', () => {
+        const listPagination = {
+            page: 1,
+            pageSize: 25,
+            totalPageCount: 1,
+            totalResults: 3,
+        };
+        const rows = [
+            makeDataAppVizRow({
+                app_id: 'mine-unfiled',
+                space_uuid: null,
+                created_by_user_uuid: 'editor-1',
+            }),
+            makeDataAppVizRow({
+                app_id: 'someone-elses-unfiled',
+                space_uuid: null,
+                created_by_user_uuid: 'someone-else',
+            }),
+            makeDataAppVizRow({
+                app_id: 'in-a-space-i-can-see',
+                space_uuid: 'space-1',
+                created_by_user_uuid: 'someone-else',
+            }),
+        ];
+        const listed = async (
+            role: OrganizationMemberRole,
+            readableSpaceUuids: string[] = ['space-1'],
+        ) => {
+            const appModel = {
+                listDataAppVisualizations: vi.fn().mockResolvedValue({
+                    data: rows,
+                    pagination: listPagination,
+                }),
+            };
+            const { service, user } = buildServiceWithRealAbility(
+                appModel,
+                role,
+                'editor-1',
+                readableSpaceUuids,
+            );
+            const result = await service.listDataAppVisualizations(
+                user,
+                'project-1',
+                { page: 1, pageSize: 25 },
+            );
+            return result.data.map((viz) => viz.dataAppVizUuid);
+        };
+
+        it('offers an editor their own, and anything in a space they can see', async () => {
+            // Regression: this list was gated on a project-wide subject with no
+            // space context and no creator, which only an admin's unconditional
+            // `manage` could satisfy — so the picker came back empty for
+            // everyone else, including the author of the visualization.
+            expect(await listed(OrganizationMemberRole.EDITOR)).toEqual([
+                'mine-unfiled',
+                'in-a-space-i-can-see',
+            ]);
+        });
+
+        it('offers an interactive viewer the same — they can use one without authoring it', async () => {
+            expect(
+                await listed(OrganizationMemberRole.INTERACTIVE_VIEWER),
+            ).toEqual(['mine-unfiled', 'in-a-space-i-can-see']);
+        });
+
+        it('withholds a visualization in a space the user cannot reach', async () => {
+            expect(await listed(OrganizationMemberRole.EDITOR, [])).toEqual([
+                'mine-unfiled',
+            ]);
+        });
+
+        it('offers a viewer nothing — they hold no view:DataApp at all', async () => {
+            expect(await listed(OrganizationMemberRole.VIEWER)).toEqual([]);
+        });
+
+        it('offers an admin every visualization in the project', async () => {
+            expect(await listed(OrganizationMemberRole.ADMIN, [])).toEqual([
+                'mine-unfiled',
+                'someone-elses-unfiled',
+                'in-a-space-i-can-see',
+            ]);
         });
     });
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -7574,22 +7574,35 @@ export class AppGenerateService extends BaseService {
         await this.assertDataAppsEnabled(user);
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
-        const auditedAbility = this.createAuditedAbility(user);
-        if (
-            auditedAbility.cannot(
-                'view',
-                subject('DataApp', { organizationUuid, projectUuid }),
-            )
-        ) {
-            throw new ForbiddenError('Insufficient permissions');
-        }
         const { data, pagination } =
             await this.appModel.listDataAppVisualizations(
                 projectUuid,
                 paginateArgs,
                 search,
             );
-        return { data: data.map(AppGenerateService.mapDataAppViz), pagination };
+        // Every row is checked the way a single fetch is. A project-wide
+        // subject carries neither a space context nor a creator, so it could
+        // satisfy none of the `view:DataApp` rules except an admin's
+        // unconditional `manage` — which made this list admin-only while
+        // handing admins rows they had no space access to.
+        const visible = await Promise.all(
+            data.map((app) =>
+                this.canViewApp(user, {
+                    organization_uuid: organizationUuid,
+                    project_uuid: app.project_uuid,
+                    space_uuid: app.space_uuid,
+                    created_by_user_uuid: app.created_by_user_uuid,
+                }),
+            ),
+        );
+        return {
+            data: data
+                .filter((_, index) => visible[index])
+                .map(AppGenerateService.mapDataAppViz),
+            // Counted before filtering: the page size is what the database
+            // returned, so a page can come back short while more pages remain.
+            pagination,
+        };
     }
 
     async getDataAppVisualization(

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -7574,35 +7574,24 @@ export class AppGenerateService extends BaseService {
         await this.assertDataAppsEnabled(user);
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
+        // The library is offered to whoever can build a chart in an explore:
+        // picking a renderer is part of configuring a chart, not app access.
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('Explore', { organizationUuid, projectUuid }),
+            )
+        ) {
+            throw new ForbiddenError('Insufficient permissions');
+        }
         const { data, pagination } =
             await this.appModel.listDataAppVisualizations(
                 projectUuid,
                 paginateArgs,
                 search,
             );
-        // Every row is checked the way a single fetch is. A project-wide
-        // subject carries neither a space context nor a creator, so it could
-        // satisfy none of the `view:DataApp` rules except an admin's
-        // unconditional `manage` — which made this list admin-only while
-        // handing admins rows they had no space access to.
-        const visible = await Promise.all(
-            data.map((app) =>
-                this.canViewApp(user, {
-                    organization_uuid: organizationUuid,
-                    project_uuid: app.project_uuid,
-                    space_uuid: app.space_uuid,
-                    created_by_user_uuid: app.created_by_user_uuid,
-                }),
-            ),
-        );
-        return {
-            data: data
-                .filter((_, index) => visible[index])
-                .map(AppGenerateService.mapDataAppViz),
-            // Counted before filtering: the page size is what the database
-            // returned, so a page can come back short while more pages remain.
-            pagination,
-        };
+        return { data: data.map(AppGenerateService.mapDataAppViz), pagination };
     }
 
     async getDataAppVisualization(


### PR DESCRIPTION
The library picker was gated on a project-wide `DataApp` subject, which carries no space context and no creator, so only an admin's unconditional `manage` could ever match it. Verified with real logins at every role: 403 for viewer, interactive viewer, editor and developer. In the panel that showed up as an empty picker and a chart stuck on "still generating".

Listing now follows the explore. Picking a renderer is part of configuring a chart, not app access, so the gate is `manage:Explore`, which interactive viewers and above hold. Nothing is filtered per row, so pagination counts stay exact.

Measured against a dev instance with five users, one per org role:

| role | before | after |
| --- | --- | --- |
| viewer | 403 | 403 |
| interactive viewer | 403 | 200, 46 rows |
| editor | 403 | 200, 46 rows |
| developer | 403 | 200, 46 rows |
| admin | 200, 46 rows | 200, 46 rows |

Reading one visualization is deliberately unchanged: `assertCanViewApp` still applies, so a non-admin can only open one that sits in a space they can reach, or one they authored. That leaves a gap this PR does not close. Of the 46 offered, an interactive viewer and a developer can open 2, an editor 3, an admin all 46, because the composer files new visualizations with no space and most of the library is therefore personal to its author. Closing it is a follow-up: either the read path follows the chart rule instead of the app rule, or new visualizations get filed into a shared space on creation.

Relates: GLITCH-630
