### PR TITLE
chore: pin Node 24.18 and corepack in Gitpod image

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,5 +1,8 @@
 FROM gitpod/workspace-full
 
+# Pin Node + corepack so the repo packageManager field drives the pnpm version
+RUN bash -c '. /home/gitpod/.nvm/nvm.sh && nvm install 24.18 && nvm alias default 24.18 && npm i -g corepack@latest && corepack enable'
+
 # Installing multiple versions of dbt
 # dbt 1.4 is the default
 RUN python3 -m venv /home/gitpod/dbt1.4


### PR DESCRIPTION
The Gitpod image floated on gitpod/workspace-full with no Node/corepack guarantee; this pins Node 24.18 (repo standard, .nvmrc) and enables corepack so the packageManager pin in package.json selects the pnpm version, keeping this dual-compatible with pnpm 10 and 11 as we transition to pnpm 11.
Closes: PROD-9339
Part of the pnpm 11 stack; will be restacked onto the pnpm 11 Graphite stack by the orchestrator.
