### PR TITLE
ci: correct npm rationale in release workflow for pnpm 11 native publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
     concurrency: ${{ github.ref }}
     permissions:
       contents: read
-      id-token: write  # Required for OIDC authentication with npm
+      id-token: write  # Required for OIDC trusted publishing (pnpm publish is native since pnpm 11)
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
@@ -66,7 +66,9 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
 
-      - name: Upgrade npm for OIDC support
+      # pnpm 11 publishes natively via OIDC trusted publishing; npm is pinned only
+      # for the npm version prepare step in release.config.js.
+      - name: Pin npm for the versioning step
         run: sfw npm install -g npm@12.0.1
 
       - name: Install dependencies


### PR DESCRIPTION
Under pnpm 11 the release job publishes via pnpm's native OIDC trusted publishing, so the global npm upgrade no longer serves publishing; npm stays pinned solely for the npm version prepareCmd in release.config.js; this is a comment and step-name-only change with no runtime behavior change.

Must merge only after the pnpm 11 switch PR #26410 (stacked above it); verify the first post-merge release publishes all packages with provenance intact.
Closes: PROD-9340