### PR TITLE
fix(data-apps): drain in-flight query tracking when POSTs share a queryUuid

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1261,6 +1261,20 @@ type ShareSlack = BaseTrack & {
     };
 };
 
+// Incidence measure for the app screenshot ready-indicator wait in
+// UnfurlService: whether the indicator was detected before the timeout, and
+// how long the wait took.
+type AppReadyWaitEvent = BaseTrack & {
+    event: 'headless_browser.app_ready_wait';
+    anonymousId: string;
+    properties: {
+        ready: boolean;
+        waitMs: number;
+        context: string;
+        imageId: string;
+    };
+};
+
 type SavedChartView = BaseTrack & {
     event: 'saved_chart.view';
     userId?: string;
@@ -3187,6 +3201,7 @@ type TypedEvent =
     | ShareUrl
     | AiAgentThreadShareEvent
     | ShareSlack
+    | AppReadyWaitEvent
     | SavedChartView
     | DashboardView
     | PromoteContent

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -1717,6 +1717,7 @@ export class UnfurlService extends BaseService {
                         this.logger.info(
                             `Waiting for app screenshot ready indicator (timeout ${APP_READY_TIMEOUT_MS}ms) - unfurlId: ${imageId}`,
                         );
+                        const waitStart = Date.now();
                         try {
                             await page.waitForSelector(
                                 SCREENSHOT_SELECTORS.READY_INDICATOR,
@@ -1728,6 +1729,16 @@ export class UnfurlService extends BaseService {
                             this.logger.info(
                                 `App ready indicator found - waiting ${APP_ANIMATION_BUFFER_MS}ms for animations - unfurlId: ${imageId}`,
                             );
+                            this.analytics.track({
+                                event: 'headless_browser.app_ready_wait',
+                                anonymousId: LightdashAnalytics.anonymousId,
+                                properties: {
+                                    ready: true,
+                                    waitMs: Date.now() - waitStart,
+                                    context,
+                                    imageId,
+                                },
+                            });
                         } catch (waitError) {
                             // Fall through to the animation buffer so the
                             // screenshot still happens for apps that never
@@ -1735,6 +1746,16 @@ export class UnfurlService extends BaseService {
                             this.logger.warn(
                                 `App ready indicator not detected within ${APP_READY_TIMEOUT_MS}ms; proceeding with animation buffer only - unfurlId: ${imageId}`,
                             );
+                            this.analytics.track({
+                                event: 'headless_browser.app_ready_wait',
+                                anonymousId: LightdashAnalytics.anonymousId,
+                                properties: {
+                                    ready: false,
+                                    waitMs: Date.now() - waitStart,
+                                    context,
+                                    imageId,
+                                },
+                            });
                         }
                         // page.evaluate keeps CDP traffic flowing during the
                         // animation buffer so a remote Chromium doesn't drop

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
@@ -184,6 +184,92 @@ describe('useAppSdkBridge', () => {
         });
     });
 
+    it('drains both POST ids when two POSTs resolve to the same queryUuid', async () => {
+        // Regression: when the backend's results-cache dedupe returns the
+        // SAME queryUuid for two different metric-query POSTs (e.g. two
+        // components firing identical queries), the second POST's mapping
+        // write overwrote the first's, so the first POST's pending/running
+        // entry never reached a terminal status. MinimalApp's in-flight set
+        // never drained, isReady stayed false, and the screenshot indicator
+        // never mounted even though every fetch had completed.
+        const events: QueryEvent[] = [];
+        renderBridge((e) => events.push(e));
+
+        const POST_ID_B = '44444444-4444-4444-4444-444444444444';
+
+        // POST A resolves first.
+        mockFetchOk({
+            status: 'ok',
+            results: { queryUuid: QUERY_UUID, metricQuery: METRIC_QUERY },
+        });
+        postMetricQuery();
+        await vi.waitFor(() =>
+            expect(
+                events.some((e) => e.id === POST_ID && e.status === 'running'),
+            ).toBe(true),
+        );
+
+        // POST B — a second component's identical query — resolves to the
+        // SAME queryUuid (the backend's results-cache dedupe).
+        mockFetchOk({
+            status: 'ok',
+            results: { queryUuid: QUERY_UUID, metricQuery: METRIC_QUERY },
+        });
+        dispatchFetchMessage({
+            type: 'lightdash:sdk:fetch',
+            id: POST_ID_B,
+            method: 'POST',
+            path: POST_PATH,
+            body: { query: METRIC_QUERY },
+        });
+        await vi.waitFor(() =>
+            expect(
+                events.some(
+                    (e) => e.id === POST_ID_B && e.status === 'running',
+                ),
+            ).toBe(true),
+        );
+
+        // A single terminal GET poll for the shared queryUuid.
+        mockFetchOk({
+            status: 'ok',
+            results: {
+                queryUuid: QUERY_UUID,
+                status: 'ready',
+                totalResults: 10,
+                metadata: { performance: { initialQueryExecutionMs: 5 } },
+            },
+        });
+        pollQueryResult();
+
+        // Every id that ever entered pending/running must reach a terminal
+        // ready/error status. Wrapping the assertion itself in vi.waitFor
+        // lets it retry until either both ids drain (fixed) or it times out
+        // (bug: POST A's id is never emitted as terminal).
+        await vi.waitFor(
+            () => {
+                const terminalIds = new Set(
+                    events
+                        .filter(
+                            (e) => e.status === 'ready' || e.status === 'error',
+                        )
+                        .map((e) => e.id),
+                );
+                const initiatedIds = new Set(
+                    events
+                        .filter(
+                            (e) =>
+                                e.status === 'pending' ||
+                                e.status === 'running',
+                        )
+                        .map((e) => e.id),
+                );
+                initiatedIds.forEach((id) => expect(terminalIds).toContain(id));
+            },
+            { timeout: 500 },
+        );
+    });
+
     it('attaches the app UUID header to metric-query requests for warehouse attribution', async () => {
         renderBridge(() => undefined);
 

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -839,16 +839,8 @@ export function useAppSdkBridge({
                             metadata as Record<string, unknown> | undefined
                         )?.label as string | undefined;
 
-                        // Results-cache dedupe: a second POST (e.g. from a
-                        // different component firing an identical query) can
-                        // resolve to the SAME queryUuid as one already
-                        // in-flight. The map only holds one id per
-                        // queryUuid, so this write would silently displace
-                        // the first POST's id — its pending/running entry
-                        // would then never reach a terminal status, and
-                        // MinimalApp's in-flight set would never drain (see
-                        // the ref comment above). Close the displaced
-                        // lifecycle here instead.
+                        // Displaced by results-cache dedupe (see ref comment
+                        // above); `queryUuid: null` avoids masking the real terminal.
                         const displacedId = queryUuidToPostIdRef.current.get(
                             json.results.queryUuid,
                         );
@@ -857,7 +849,7 @@ export function useAppSdkBridge({
                                 ...TERMINAL_EVENT_DEFAULTS,
                                 id: displacedId,
                                 timestamp: Date.now(),
-                                queryUuid: json.results.queryUuid,
+                                queryUuid: null,
                                 status: 'ready',
                                 rowCount: null,
                                 durationMs: null,

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -73,6 +73,37 @@ export type QueryEvent = {
 };
 
 /**
+ * Shared null/empty field defaults for a terminal (ready/error) QueryEvent.
+ * A terminal event carries no query shape of its own — only the fields the
+ * emitter actually knows (id, queryUuid, status, rowCount/durationMs/error)
+ * vary between call sites.
+ */
+const TERMINAL_EVENT_DEFAULTS: Pick<
+    QueryEvent,
+    | 'label'
+    | 'exploreName'
+    | 'dimensions'
+    | 'metrics'
+    | 'filters'
+    | 'sorts'
+    | 'tableCalculations'
+    | 'additionalMetrics'
+    | 'limit'
+    | 'rawMetricQuery'
+> = {
+    label: null,
+    exploreName: '',
+    dimensions: [],
+    metrics: [],
+    filters: {},
+    sorts: [],
+    tableCalculations: [],
+    additionalMetrics: [],
+    limit: 0,
+    rawMetricQuery: null,
+};
+
+/**
  * A single external-connection fetch proxied through the bridge, reported for
  * the external-requests inspector tab. Single-shot lifecycle: one `pending`
  * event when the fetch starts, one terminal `ready`/`error` event when it
@@ -807,6 +838,32 @@ export function useAppSdkBridge({
                         const initLabel = (
                             metadata as Record<string, unknown> | undefined
                         )?.label as string | undefined;
+
+                        // Results-cache dedupe: a second POST (e.g. from a
+                        // different component firing an identical query) can
+                        // resolve to the SAME queryUuid as one already
+                        // in-flight. The map only holds one id per
+                        // queryUuid, so this write would silently displace
+                        // the first POST's id — its pending/running entry
+                        // would then never reach a terminal status, and
+                        // MinimalApp's in-flight set would never drain (see
+                        // the ref comment above). Close the displaced
+                        // lifecycle here instead.
+                        const displacedId = queryUuidToPostIdRef.current.get(
+                            json.results.queryUuid,
+                        );
+                        if (displacedId !== undefined && displacedId !== id) {
+                            onQueryEvent({
+                                ...TERMINAL_EVENT_DEFAULTS,
+                                id: displacedId,
+                                timestamp: Date.now(),
+                                queryUuid: json.results.queryUuid,
+                                status: 'ready',
+                                rowCount: null,
+                                durationMs: null,
+                                error: null,
+                            });
+                        }
                         queryUuidToPostIdRef.current.set(
                             json.results.queryUuid,
                             id,
@@ -858,17 +915,9 @@ export function useAppSdkBridge({
                                 result.queryUuid,
                             );
                             onQueryEvent({
+                                ...TERMINAL_EVENT_DEFAULTS,
                                 id: lifecycleId,
                                 timestamp: Date.now(),
-                                label: null,
-                                exploreName: '',
-                                dimensions: [],
-                                metrics: [],
-                                filters: {},
-                                sorts: [],
-                                tableCalculations: [],
-                                additionalMetrics: [],
-                                limit: 0,
                                 queryUuid: result.queryUuid,
                                 status: 'ready',
                                 // Use totalResults (full row count across all
@@ -880,7 +929,6 @@ export function useAppSdkBridge({
                                     result.metadata?.performance
                                         ?.initialQueryExecutionMs ?? null,
                                 error: null,
-                                rawMetricQuery: null,
                             });
                         } else if (
                             result?.status === 'error' ||
@@ -890,23 +938,14 @@ export function useAppSdkBridge({
                                 result.queryUuid,
                             );
                             onQueryEvent({
+                                ...TERMINAL_EVENT_DEFAULTS,
                                 id: lifecycleId,
                                 timestamp: Date.now(),
-                                label: null,
-                                exploreName: '',
-                                dimensions: [],
-                                metrics: [],
-                                filters: {},
-                                sorts: [],
-                                tableCalculations: [],
-                                additionalMetrics: [],
-                                limit: 0,
                                 queryUuid: result.queryUuid,
                                 status: 'error',
                                 rowCount: null,
                                 durationMs: null,
                                 error: result.error ?? 'Query failed',
-                                rawMetricQuery: null,
                             });
                         }
                     }

--- a/packages/frontend/src/features/apps/hooks/useTrackedAppQueries.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useTrackedAppQueries.test.ts
@@ -1,0 +1,109 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { QueryEvent } from './useAppSdkBridge';
+import { useTrackedAppQueries } from './useTrackedAppQueries';
+
+const QUERY_UUID = 'q-shared-uuid';
+const POST_ID_A = 'post-a';
+const POST_ID_B = 'post-b';
+
+function baseEvent(
+    overrides: Partial<QueryEvent> & Pick<QueryEvent, 'id' | 'status'>,
+): QueryEvent {
+    return {
+        timestamp: Date.now(),
+        label: null,
+        exploreName: '',
+        dimensions: [],
+        metrics: [],
+        filters: {},
+        sorts: [],
+        tableCalculations: [],
+        additionalMetrics: [],
+        limit: 0,
+        queryUuid: null,
+        rowCount: null,
+        durationMs: null,
+        error: null,
+        rawMetricQuery: null,
+        ...overrides,
+    };
+}
+
+describe('useTrackedAppQueries', () => {
+    it('drains a results-cache-dedupe displaced id without corrupting the shared queryUuid entry', () => {
+        // Same event sequence useAppSdkBridge emits when two POSTs (e.g. from
+        // two components) resolve to the same queryUuid: POST A goes
+        // pending -> running, POST B's own pending placeholder is added,
+        // the bridge closes A's displaced lifecycle (queryUuid: null), POST
+        // B's running event lands on the shared row, then the REAL GET-poll
+        // terminal arrives keyed to POST B's id.
+        const { result } = renderHook(() => useTrackedAppQueries());
+
+        act(() => {
+            result.current.handleQueryEvent(
+                baseEvent({ id: POST_ID_A, status: 'pending' }),
+            );
+        });
+        act(() => {
+            result.current.handleQueryEvent(
+                baseEvent({
+                    id: POST_ID_A,
+                    status: 'running',
+                    queryUuid: QUERY_UUID,
+                    exploreName: 'orders',
+                }),
+            );
+        });
+        act(() => {
+            result.current.handleQueryEvent(
+                baseEvent({ id: POST_ID_B, status: 'pending' }),
+            );
+        });
+        act(() => {
+            // Displaced-lifecycle close for A — queryUuid: null, as emitted
+            // by useAppSdkBridge's fix.
+            result.current.handleQueryEvent(
+                baseEvent({ id: POST_ID_A, status: 'ready', queryUuid: null }),
+            );
+        });
+        act(() => {
+            result.current.handleQueryEvent(
+                baseEvent({
+                    id: POST_ID_B,
+                    status: 'running',
+                    queryUuid: QUERY_UUID,
+                    exploreName: 'orders',
+                }),
+            );
+        });
+        act(() => {
+            // The REAL poll outcome, re-keyed to POST B's id (the survivor
+            // of the queryUuid -> id map overwrite) — a real error, so a
+            // fabricated 'ready' would be an obvious, testable corruption.
+            result.current.handleQueryEvent(
+                baseEvent({
+                    id: POST_ID_B,
+                    status: 'error',
+                    queryUuid: QUERY_UUID,
+                    error: 'Warehouse timeout',
+                }),
+            );
+        });
+
+        expect(result.current.queries.some((q) => q.status === 'pending')).toBe(
+            false,
+        );
+
+        const sharedEntry = result.current.queries.find(
+            (q) => q.queryUuid === QUERY_UUID,
+        );
+        expect(sharedEntry).toMatchObject({
+            status: 'error',
+            error: 'Warehouse timeout',
+        });
+
+        // No blank ghost rows left over from the displaced-close signal.
+        expect(result.current.queries).toHaveLength(1);
+    });
+});

--- a/packages/frontend/src/features/apps/hooks/useTrackedAppQueries.ts
+++ b/packages/frontend/src/features/apps/hooks/useTrackedAppQueries.ts
@@ -96,20 +96,35 @@ export const useTrackedAppQueries = (): UseTrackedAppQueriesResult => {
                     ) {
                         return prev;
                     }
-                    return prev.map((q) =>
-                        q.queryUuid === event.queryUuid
-                            ? {
-                                  ...q,
-                                  label: event.label ?? q.label,
-                                  status: event.status,
-                                  rowCount: event.rowCount ?? q.rowCount,
-                                  durationMs: event.durationMs ?? q.durationMs,
-                                  error: event.error ?? q.error,
-                                  rawMetricQuery:
-                                      event.rawMetricQuery ?? q.rawMetricQuery,
-                              }
-                            : q,
-                    );
+                    return prev
+                        .map((q) =>
+                            q.queryUuid === event.queryUuid
+                                ? {
+                                      ...q,
+                                      label: event.label ?? q.label,
+                                      status: event.status,
+                                      rowCount: event.rowCount ?? q.rowCount,
+                                      durationMs:
+                                          event.durationMs ?? q.durationMs,
+                                      error: event.error ?? q.error,
+                                      rawMetricQuery:
+                                          event.rawMetricQuery ??
+                                          q.rawMetricQuery,
+                                  }
+                                : q,
+                        )
+                        .filter(
+                            // Drop this event's own now-redundant `pending`
+                            // placeholder — results-cache dedupe means a
+                            // second POST can fold into an entry it didn't
+                            // create, stranding its own placeholder row.
+                            (q) =>
+                                !(
+                                    q.id === event.id &&
+                                    q.status === 'pending' &&
+                                    q.queryUuid !== event.queryUuid
+                                ),
+                        );
                 }
             }
             // If this is a POST initiation with queryUuid, check if we
@@ -127,6 +142,18 @@ export const useTrackedAppQueries = (): UseTrackedAppQueriesResult => {
                           }
                         : q,
                 );
+            }
+            const isTerminal =
+                event.status === 'ready' || event.status === 'error';
+            // A queryUuid-less terminal for an id we already track (e.g. a
+            // displaced-lifecycle close signal) carries no new info — drop
+            // it rather than append a blank ghost row.
+            if (
+                !event.queryUuid &&
+                isTerminal &&
+                prev.some((q) => q.id === event.id)
+            ) {
+                return prev;
             }
             return [...prev, event];
         });


### PR DESCRIPTION
## Summary

A data app running the same query from two components gets two metric-query POSTs that can resolve to the **same queryUuid**. The bridge's uuid→POST-id map kept only the last writer, so the first POST's `pending` event never received a terminal counterpart — `MinimalApp`'s in-flight set never drained and the screenshot ready indicator never mounted. Scheduled image deliveries for such apps silently fell back to the early 8s screenshot every run (repro: stock jaffle app — SDK announced, all fetches completed, indicator absent).

- On a displaced map entry, emit a synthetic terminal event closing the orphaned lifecycle id — with `queryUuid: null` so the queries-inspector merge logic can't mistake it for the real poll outcome; two narrow guards in `useTrackedAppQueries` drop the stale placeholder rows the duplicate-uuid scenario produced.
- Repro tests at both levels: bridge event-stream invariant (every initiated lifecycle id reaches a terminal) and consumer-level merge (no ghost pending row; the real poll outcome — including real errors — survives).
- Adds a `headless_browser.app_ready_wait` analytics event ({ready, waitMs}) on the app unfurl wait, to measure ready-indicator incidence in production.

## Testing

- `useAppSdkBridge.test.ts` 35/35 (new repro RED→GREEN), new `useTrackedAppQueries.test.ts` (RED verified via stash against pre-fix code)
- frontend + backend typecheck clean; backend `test:dev:nowatch` 1025/1025

Relates: PROD-8374