### PR TITLE
chore(dev): pre-pull Okteto warm image on cluster nodes

### DIFF
--- a/.github/workflows/dev-warm-image.yml
+++ b/.github/workflows/dev-warm-image.yml
@@ -17,6 +17,7 @@ on:
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
       - "dockerfile-prs"
+      - "docker/okteto-dev-warm-prepull.yaml"
       - ".github/workflows/dev-warm-image.yml"
   workflow_dispatch:
 
@@ -31,7 +32,7 @@ jobs:
   build:
     name: Build and push the dev-warm image
     runs-on: depot-ubuntu-24.04-4
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
@@ -57,3 +58,21 @@ jobs:
           okteto build -f dockerfile-prs --target dev-warm \
             -t okteto.global/lightdash-dev-warm:latest .
           echo "Image build took $(( $(date +%s) - start ))s" | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Pre-pull image on cluster nodes
+        run: |
+          okteto namespace create db-snapshot || echo "namespace already exists, continuing"
+          okteto kubeconfig
+          kubectl apply -f docker/okteto-dev-warm-prepull.yaml
+          kubectl rollout restart daemonset/lightdash-dev-warm-prepull -n db-snapshot
+          if ! kubectl rollout status daemonset/lightdash-dev-warm-prepull \
+            -n db-snapshot --timeout=15m; then
+            kubectl get daemonset lightdash-dev-warm-prepull -n db-snapshot -o wide || true
+            kubectl get pods -n db-snapshot \
+              -l app.kubernetes.io/name=lightdash-dev-warm-prepull -o wide || true
+            kubectl describe daemonset lightdash-dev-warm-prepull -n db-snapshot || true
+            exit 1
+          fi
+          kubectl get pods -n db-snapshot \
+            -l app.kubernetes.io/name=lightdash-dev-warm-prepull \
+            -o custom-columns='NAME:.metadata.name,NODE:.spec.nodeName,IMAGE_ID:.status.containerStatuses[0].imageID'

--- a/docker/okteto-dev-warm-prepull.yaml
+++ b/docker/okteto-dev-warm-prepull.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: lightdash-dev-warm-prepull
+  namespace: db-snapshot
+  labels:
+    app.kubernetes.io/name: lightdash-dev-warm-prepull
+    app.kubernetes.io/part-of: lightdash-dev
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: lightdash-dev-warm-prepull
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 100%
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: lightdash-dev-warm-prepull
+        app.kubernetes.io/part-of: lightdash-dev
+    spec:
+      imagePullSecrets:
+        - name: okteto-regcred
+      containers:
+        - name: warm-image
+          image: registry.lightdash.okteto.dev/okteto/lightdash-dev-warm:latest
+          imagePullPolicy: Always
+          command:
+            - sleep
+            - infinity
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 20m
+              memory: 64Mi
+      terminationGracePeriodSeconds: 0


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates: SPK-565

### Description:
Adds a lightweight DaemonSet that keeps the nightly Okteto warm development image cached on ordinary cluster nodes and refreshes it after successful builds. The workflow waits for rollout completion and reports resolved image digests and diagnostics. YAML validation and Kubernetes dry runs pass, but live creation is currently blocked by Okteto's default DaemonSet admission policy, so this draft requires a platform-level exception or deployment path before merge.