### PR TITLE
chore(dead-code): remove two orphaned AI-agent validators

### DIFF
--- a/packages/backend/src/ee/services/ai/utils/validators.ts
+++ b/packages/backend/src/ee/services/ai/utils/validators.ts
@@ -750,58 +750,6 @@ ${customMetricFields
     }
 }
 
-/**
- * Validate that table names exist in the explore
- * @param explore - The explore containing table definitions
- * @param tableNames - Array of table names to validate
- */
-export function validateTableNames(explore: Explore, tableNames: string[]) {
-    const availableTableNames = Object.keys(explore.tables);
-    const errors: string[] = [];
-
-    tableNames.forEach((tableName) => {
-        if (!availableTableNames.includes(tableName)) {
-            errors.push(
-                `Error: Table "${tableName}" does not exist in the explore.`,
-            );
-        }
-    });
-
-    if (errors.length > 0) {
-        const errorMessage = `Invalid table names:
-
-${errors.join('\n\n')}
-
-Available tables:
-${availableTableNames.map((t) => `- ${t}`).join('\n')}`;
-
-        Logger.error(`[AiAgent][Validate Table Names] ${errorMessage}`);
-
-        throw new AiAgentValidatorError(errorMessage);
-    }
-}
-
-/**
- * Validate that an explore name exists in the list of available explores
- * @param availableExploreNames - Array of available explore names
- * @param exploreName - The explore name to validate
- */
-export function validateExploreNameExists(
-    availableExplores: Explore[],
-    exploreName: string,
-) {
-    if (availableExplores.some((e) => e.name === exploreName)) return;
-
-    const errorMessage = `Invalid explore name: "${exploreName}"
-
-Available explores:
-${availableExplores.map((e) => `- ${e.name}`).join('\n')}`;
-
-    Logger.error(`[AiAgent][Validate Explore Name Exists] ${errorMessage}`);
-
-    throw new AiAgentValidatorError(errorMessage);
-}
-
 // Numeric metric types that support most table calculations
 const NUMERIC_METRIC_TYPES: MetricType[] = [
     MetricType.NUMBER,


### PR DESCRIPTION
Removes two exported validators from `packages/backend/src/ee/services/ai/utils/validators.ts` that have no callers anywhere in the repo:

- `validateTableNames(explore, tableNames)`
- `validateExploreNameExists(availableExplores, exploreName)`

52 lines, deletion only — no imports are stranded.

## Why they're dead

**Static signal.** A sweep of every `export const|function|class|type|interface|enum` in `packages/backend/src`, counting word-boundary occurrences across `packages/` and `scripts/`, returned a total occurrence count of exactly **1** for both symbols — the definition line itself.

**Grep, repo-wide (every package, every file type):**

```
$ git grep -nw 'validateTableNames' -- .
packages/backend/src/ee/services/ai/utils/validators.ts:758:export function validateTableNames(explore: Explore, tableNames: string[]) {

$ git grep -nw 'validateExploreNameExists' -- .
packages/backend/src/ee/services/ai/utils/validators.ts:789:export function validateExploreNameExists(
```

Nothing but the definitions. This is a bare word-match over all file types rather than an import-graph walk, so it also rules out string/dynamic dispatch, registry maps, template literals and `[key]` access — no quoted or computed reference to either name exists.

**How each was orphaned** (`git log -S`):

| Symbol | Added | Last caller removed |
|---|---|---|
| `validateTableNames` | #17163, 2025-10-01 (propose-change tool) | #23828, 2026-06-03 — deleted `ee/services/ai/tools/proposeChange.ts`, its only call site, when changesets were replaced by AI writeback. That file no longer exists on main. |
| `validateExploreNameExists` | #17752, 2025-11-05 (findExplores tool) | #18180, 2025-11-19 — removed the call and its import when findExplores was rewritten around ranking/ambiguity checks. Dead ~8 months. |

**Not a public surface.** Both are backend-internal, not exported from `@lightdash/common`, not re-exported by any barrel, not referenced by a TSOA controller, and not reachable from any REST/MCP route. The module is imported by name in exactly three places (`AiAgentService.ts`, `tools/runMetricQuery.ts`, `tools/runQuery.ts`), none of which pull either symbol.

**Unmerged-branch sweep.** All 328 `origin/*` branches with commits in the last 60 days (dependabot/snyk/renovate excluded) were grepped for both symbols. The only hits outside the definition file are in `ee/services/ai/tools/proposeChange.ts` on 10 branches, all with merge-bases of 2026-06-02/06-03 — before #23828 deleted that file. No branch modified `proposeChange.ts` relative to its own merge-base, so no live branch adds or retains a call site; those hits are pre-deletion staleness that resolves on rebase.

## Verification

- `pnpm -F backend typecheck` — clean (whole package, not just the touched file).
- oxlint on the touched path — clean.
- Every import the deleted code used (`Explore`, `AiAgentValidatorError`, `Logger`) is used many times over by the file's remaining validators, so the diff is pure deletion.

## Residual risk

Low. The only realistic breakage path is a private/unpushed branch that re-adds a call — nothing in origin does. 13 live branches touch `validators.ts` for unrelated reasons and may hit a small rebase conflict in this region, but none reference either symbol.

Linear: SPK-727

Draft pending human review — raised as draft per the agent merge freeze; not to be marked ready or merged by an agent.
