### PR TITLE
feat(data-apps): add delivery capture manifest type and fail-closed parser

### DIFF
--- a/packages/common/src/ee/apps/deliveryCapture.test.ts
+++ b/packages/common/src/ee/apps/deliveryCapture.test.ts
@@ -1,0 +1,228 @@
+import {
+    MAX_CAPTURE_LABEL_CHARS,
+    MAX_DELIVERY_QUERIES,
+    parseDeliveryCaptureManifest,
+    type CapturedQuery,
+    type DeliveryCaptureManifest,
+} from './deliveryCapture';
+
+const readyItem: CapturedQuery = {
+    status: 'ready',
+    captureKey: 'v1:abc123',
+    label: 'Revenue by month',
+    exploreName: 'orders',
+    queryUuid: 'query-uuid-1',
+    order: 0,
+    rowCount: 42,
+    limitReached: false,
+};
+
+const errorItem: CapturedQuery = {
+    status: 'error',
+    captureKey: 'v1:def456',
+    label: 'Broken query',
+    exploreName: null,
+    queryUuid: null,
+    order: 1,
+    error: 'Query failed',
+};
+
+const validManifest: DeliveryCaptureManifest = {
+    version: 1,
+    items: [readyItem, errorItem],
+    overflowCount: 0,
+};
+
+describe('parseDeliveryCaptureManifest', () => {
+    it('round-trips a valid manifest', () => {
+        expect(parseDeliveryCaptureManifest(validManifest)).toEqual(
+            validManifest,
+        );
+    });
+
+    it('accepts an empty items array with overflowCount 0 (zero-queries is a job-level decision, not a shape error)', () => {
+        const manifest: DeliveryCaptureManifest = {
+            version: 1,
+            items: [],
+            overflowCount: 0,
+        };
+        expect(parseDeliveryCaptureManifest(manifest)).toEqual(manifest);
+    });
+
+    it('rejects non-object values', () => {
+        expect(parseDeliveryCaptureManifest(null)).toBeNull();
+        expect(parseDeliveryCaptureManifest(undefined)).toBeNull();
+        expect(parseDeliveryCaptureManifest('manifest')).toBeNull();
+        expect(parseDeliveryCaptureManifest(42)).toBeNull();
+        expect(parseDeliveryCaptureManifest([])).toBeNull();
+    });
+
+    it('rejects version !== 1', () => {
+        expect(
+            parseDeliveryCaptureManifest({ ...validManifest, version: 2 }),
+        ).toBeNull();
+        expect(
+            parseDeliveryCaptureManifest({ ...validManifest, version: '1' }),
+        ).toBeNull();
+        expect(
+            parseDeliveryCaptureManifest({
+                items: [],
+                overflowCount: 0,
+            }),
+        ).toBeNull();
+    });
+
+    it('rejects items that is not an array', () => {
+        expect(
+            parseDeliveryCaptureManifest({ ...validManifest, items: {} }),
+        ).toBeNull();
+        expect(
+            parseDeliveryCaptureManifest({
+                ...validManifest,
+                items: 'nope',
+            }),
+        ).toBeNull();
+    });
+
+    it('rejects more than MAX_DELIVERY_QUERIES items', () => {
+        const items = Array.from(
+            { length: MAX_DELIVERY_QUERIES + 1 },
+            (_, i) => ({
+                ...readyItem,
+                captureKey: `v1:${i}`,
+                order: i,
+            }),
+        );
+        expect(
+            parseDeliveryCaptureManifest({ ...validManifest, items }),
+        ).toBeNull();
+    });
+
+    it('accepts exactly MAX_DELIVERY_QUERIES items', () => {
+        const items = Array.from({ length: MAX_DELIVERY_QUERIES }, (_, i) => ({
+            ...readyItem,
+            captureKey: `v1:${i}`,
+            order: i,
+        }));
+        expect(
+            parseDeliveryCaptureManifest({ ...validManifest, items }),
+        ).not.toBeNull();
+    });
+
+    it('rejects an item with an unknown status', () => {
+        expect(
+            parseDeliveryCaptureManifest({
+                ...validManifest,
+                items: [{ ...readyItem, status: 'pending' }],
+            }),
+        ).toBeNull();
+    });
+
+    it('rejects a ready item with a non-string queryUuid', () => {
+        expect(
+            parseDeliveryCaptureManifest({
+                ...validManifest,
+                items: [{ ...readyItem, queryUuid: null }],
+            }),
+        ).toBeNull();
+        expect(
+            parseDeliveryCaptureManifest({
+                ...validManifest,
+                items: [{ ...readyItem, queryUuid: 123 }],
+            }),
+        ).toBeNull();
+    });
+
+    it('rejects an error item with a non-null, non-string queryUuid', () => {
+        expect(
+            parseDeliveryCaptureManifest({
+                ...validManifest,
+                items: [{ ...errorItem, queryUuid: 123 }],
+            }),
+        ).toBeNull();
+    });
+
+    it('accepts an error item with a string queryUuid', () => {
+        expect(
+            parseDeliveryCaptureManifest({
+                ...validManifest,
+                items: [{ ...errorItem, queryUuid: 'query-uuid-2' }],
+            }),
+        ).not.toBeNull();
+    });
+
+    it('rejects an item missing captureKey', () => {
+        const { captureKey, ...rest } = readyItem;
+        expect(
+            parseDeliveryCaptureManifest({
+                ...validManifest,
+                items: [rest],
+            }),
+        ).toBeNull();
+    });
+
+    it('rejects an item missing label', () => {
+        const { label, ...rest } = readyItem;
+        expect(
+            parseDeliveryCaptureManifest({
+                ...validManifest,
+                items: [rest],
+            }),
+        ).toBeNull();
+    });
+
+    it('rejects a non-number order', () => {
+        expect(
+            parseDeliveryCaptureManifest({
+                ...validManifest,
+                items: [{ ...readyItem, order: '0' }],
+            }),
+        ).toBeNull();
+    });
+
+    it('rejects a non-number overflowCount', () => {
+        expect(
+            parseDeliveryCaptureManifest({
+                ...validManifest,
+                overflowCount: '0',
+            }),
+        ).toBeNull();
+    });
+
+    it('rejects a negative overflowCount', () => {
+        expect(
+            parseDeliveryCaptureManifest({
+                ...validManifest,
+                overflowCount: -1,
+            }),
+        ).toBeNull();
+    });
+
+    it('rejects a label longer than MAX_CAPTURE_LABEL_CHARS', () => {
+        expect(
+            parseDeliveryCaptureManifest({
+                ...validManifest,
+                items: [
+                    {
+                        ...readyItem,
+                        label: 'x'.repeat(MAX_CAPTURE_LABEL_CHARS + 1),
+                    },
+                ],
+            }),
+        ).toBeNull();
+    });
+
+    it('accepts a label exactly MAX_CAPTURE_LABEL_CHARS long', () => {
+        expect(
+            parseDeliveryCaptureManifest({
+                ...validManifest,
+                items: [
+                    {
+                        ...readyItem,
+                        label: 'x'.repeat(MAX_CAPTURE_LABEL_CHARS),
+                    },
+                ],
+            }),
+        ).not.toBeNull();
+    });
+});

--- a/packages/common/src/ee/apps/deliveryCapture.test.ts
+++ b/packages/common/src/ee/apps/deliveryCapture.test.ts
@@ -198,6 +198,67 @@ describe('parseDeliveryCaptureManifest', () => {
         ).toBeNull();
     });
 
+    // typeof NaN === 'number' and typeof Infinity === 'number', so a bare
+    // typeof check lets these through a boundary meant to be fail-closed.
+    it('rejects NaN, Infinity and -Infinity for order', () => {
+        for (const bad of [NaN, Infinity, -Infinity]) {
+            expect(
+                parseDeliveryCaptureManifest({
+                    ...validManifest,
+                    items: [{ ...readyItem, order: bad }],
+                }),
+            ).toBeNull();
+        }
+    });
+
+    it('rejects NaN, Infinity and -Infinity for rowCount', () => {
+        for (const bad of [NaN, Infinity, -Infinity]) {
+            expect(
+                parseDeliveryCaptureManifest({
+                    ...validManifest,
+                    items: [{ ...readyItem, rowCount: bad }],
+                }),
+            ).toBeNull();
+        }
+    });
+
+    it('rejects NaN, Infinity and -Infinity for overflowCount', () => {
+        for (const bad of [NaN, Infinity, -Infinity]) {
+            expect(
+                parseDeliveryCaptureManifest({
+                    ...validManifest,
+                    overflowCount: bad,
+                }),
+            ).toBeNull();
+        }
+    });
+
+    it('rejects items array elements that are not plain objects', () => {
+        for (const bad of [null, 'x', 42, ['nested']]) {
+            expect(
+                parseDeliveryCaptureManifest({
+                    ...validManifest,
+                    items: [bad],
+                }),
+            ).toBeNull();
+        }
+    });
+
+    it('is unaffected by a `__proto__`-shaped payload and does not pollute Object.prototype', () => {
+        // JSON.parse creates a literal own property named "__proto__" (unlike
+        // an object literal, where that key sets the prototype instead) — the
+        // realistic shape an untrusted page.evaluate() payload could take.
+        const malicious = JSON.parse(
+            '{"version":1,"items":[],"overflowCount":0,"__proto__":{"polluted":true}}',
+        ) as unknown;
+        expect(parseDeliveryCaptureManifest(malicious)).toEqual({
+            version: 1,
+            items: [],
+            overflowCount: 0,
+        });
+        expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+
     it('rejects a label longer than MAX_CAPTURE_LABEL_CHARS', () => {
         expect(
             parseDeliveryCaptureManifest({

--- a/packages/common/src/ee/apps/deliveryCapture.ts
+++ b/packages/common/src/ee/apps/deliveryCapture.ts
@@ -42,8 +42,13 @@ export type DeliveryCaptureManifest = {
 const isNullableString = (value: unknown): value is string | null =>
     value === null || typeof value === 'string';
 
-const isNullableNumber = (value: unknown): value is number | null =>
-    value === null || typeof value === 'number';
+/** Rejects NaN/Infinity/-Infinity as well as non-numbers — every numeric
+ *  field here crosses an untrusted page.evaluate() boundary. */
+const isFiniteNumber = (value: unknown): value is number =>
+    typeof value === 'number' && Number.isFinite(value);
+
+const isNullableFiniteNumber = (value: unknown): value is number | null =>
+    value === null || isFiniteNumber(value);
 
 const parseCapturedQuery = (value: unknown): CapturedQuery | null => {
     if (!isPlainObject(value)) return null;
@@ -56,12 +61,12 @@ const parseCapturedQuery = (value: unknown): CapturedQuery | null => {
         return null;
     }
     if (!isNullableString(exploreName)) return null;
-    if (typeof order !== 'number') return null;
+    if (!isFiniteNumber(order)) return null;
 
     if (status === 'ready') {
         const { queryUuid, rowCount, limitReached } = candidate;
         if (typeof queryUuid !== 'string') return null;
-        if (!isNullableNumber(rowCount)) return null;
+        if (!isNullableFiniteNumber(rowCount)) return null;
         if (typeof limitReached !== 'boolean') return null;
         return {
             status: 'ready',
@@ -108,12 +113,8 @@ export const parseDeliveryCaptureManifest = (
     if (candidate.version !== 1) return null;
     if (!Array.isArray(candidate.items)) return null;
     if (candidate.items.length > MAX_DELIVERY_QUERIES) return null;
-    if (
-        typeof candidate.overflowCount !== 'number' ||
-        candidate.overflowCount < 0
-    ) {
-        return null;
-    }
+    const { overflowCount } = candidate;
+    if (!isFiniteNumber(overflowCount) || overflowCount < 0) return null;
 
     const items: CapturedQuery[] = [];
     for (const item of candidate.items) {
@@ -125,6 +126,6 @@ export const parseDeliveryCaptureManifest = (
     return {
         version: 1,
         items,
-        overflowCount: candidate.overflowCount,
+        overflowCount,
     };
 };

--- a/packages/common/src/ee/apps/deliveryCapture.ts
+++ b/packages/common/src/ee/apps/deliveryCapture.ts
@@ -1,0 +1,130 @@
+import isPlainObject from 'lodash/isPlainObject';
+
+/** Cap on distinct captured queries per delivery; overflow beyond this is dropped and counted. */
+export const MAX_DELIVERY_QUERIES = 50;
+
+/** Bumped whenever the captureKey hash inputs change, to invalidate stale keys across a deploy. */
+export const CAPTURE_KEY_VERSION = 'v1';
+
+/** Labels are display-only; capped at capture time. */
+export const MAX_CAPTURE_LABEL_CHARS = 200;
+
+/** Window global MinimalApp publishes and UnfurlService reads. */
+export const DELIVERY_CAPTURE_GLOBAL = '__lightdashAppDeliveryCapture';
+
+export type CapturedQuery =
+    | {
+          status: 'ready';
+          captureKey: string;
+          label: string;
+          exploreName: string | null;
+          queryUuid: string;
+          order: number;
+          rowCount: number | null;
+          limitReached: boolean;
+      }
+    | {
+          status: 'error';
+          captureKey: string;
+          label: string;
+          exploreName: string | null;
+          queryUuid: string | null;
+          order: number;
+          error: string;
+      };
+
+export type DeliveryCaptureManifest = {
+    version: 1;
+    items: CapturedQuery[];
+    overflowCount: number;
+};
+
+const isNullableString = (value: unknown): value is string | null =>
+    value === null || typeof value === 'string';
+
+const isNullableNumber = (value: unknown): value is number | null =>
+    value === null || typeof value === 'number';
+
+const parseCapturedQuery = (value: unknown): CapturedQuery | null => {
+    if (!isPlainObject(value)) return null;
+    const candidate = value as Record<string, unknown>;
+
+    const { status, captureKey, label, exploreName, order } = candidate;
+
+    if (typeof captureKey !== 'string') return null;
+    if (typeof label !== 'string' || label.length > MAX_CAPTURE_LABEL_CHARS) {
+        return null;
+    }
+    if (!isNullableString(exploreName)) return null;
+    if (typeof order !== 'number') return null;
+
+    if (status === 'ready') {
+        const { queryUuid, rowCount, limitReached } = candidate;
+        if (typeof queryUuid !== 'string') return null;
+        if (!isNullableNumber(rowCount)) return null;
+        if (typeof limitReached !== 'boolean') return null;
+        return {
+            status: 'ready',
+            captureKey,
+            label,
+            exploreName,
+            queryUuid,
+            order,
+            rowCount,
+            limitReached,
+        };
+    }
+
+    if (status === 'error') {
+        const { queryUuid, error } = candidate;
+        if (!isNullableString(queryUuid)) return null;
+        if (typeof error !== 'string') return null;
+        return {
+            status: 'error',
+            captureKey,
+            label,
+            exploreName,
+            queryUuid,
+            order,
+            error,
+        };
+    }
+
+    return null;
+};
+
+/**
+ * Fail-closed validator for the manifest MinimalApp publishes on
+ * `DELIVERY_CAPTURE_GLOBAL` and UnfurlService reads via page.evaluate. Any
+ * structural mismatch returns `null` — callers must treat that as a hard
+ * failure, not an empty manifest.
+ */
+export const parseDeliveryCaptureManifest = (
+    value: unknown,
+): DeliveryCaptureManifest | null => {
+    if (!isPlainObject(value)) return null;
+    const candidate = value as Record<string, unknown>;
+
+    if (candidate.version !== 1) return null;
+    if (!Array.isArray(candidate.items)) return null;
+    if (candidate.items.length > MAX_DELIVERY_QUERIES) return null;
+    if (
+        typeof candidate.overflowCount !== 'number' ||
+        candidate.overflowCount < 0
+    ) {
+        return null;
+    }
+
+    const items: CapturedQuery[] = [];
+    for (const item of candidate.items) {
+        const parsed = parseCapturedQuery(item);
+        if (!parsed) return null;
+        items.push(parsed);
+    }
+
+    return {
+        version: 1,
+        items,
+        overflowCount: candidate.overflowCount,
+    };
+};

--- a/packages/common/src/ee/index.ts
+++ b/packages/common/src/ee/index.ts
@@ -9,6 +9,7 @@ export * from './mcp/tasks';
 export * from './externalConnections/coder';
 export * from './externalConnections/types';
 export * from './AiRouter';
+export * from './apps/deliveryCapture';
 export * from './apps/sdkFeatures';
 export * from './apps/types';
 export * from './apps/code';


### PR DESCRIPTION
Closes:

### Description:

Introduces the `DeliveryCaptureManifest` type and its associated parsing logic, which defines the contract between `MinimalApp` (which publishes capture data to a browser global) and `UnfurlService` (which reads it via `page.evaluate`).

The manifest tracks up to `MAX_DELIVERY_QUERIES` (50) captured queries per delivery, each with a `ready` or `error` status, along with an `overflowCount` for any queries dropped beyond that limit. A `captureKey` versioned with `CAPTURE_KEY_VERSION` allows stale keys to be invalidated across deploys.

`parseDeliveryCaptureManifest` is a fail-closed validator — any structural mismatch, unknown status, invalid numeric field (including `NaN`, `Infinity`, and `-Infinity`), or prototype-polluting payload returns `null` rather than a partial result. Labels are capped at `MAX_CAPTURE_LABEL_CHARS` (200) characters at capture time.

Full test coverage is included, verifying round-trip fidelity, boundary conditions on item counts and label lengths, rejection of malformed fields, and protection against `__proto__`-shaped payloads.

Relates: PROD-8374
Relates: #24475
