### PR TITLE
feat(data-apps): wire delivery capture accumulator into useAppSdkBridge

### DIFF
--- a/packages/frontend/src/features/apps/deliveryCapture/deliveryCaptureAccumulator.test.ts
+++ b/packages/frontend/src/features/apps/deliveryCapture/deliveryCaptureAccumulator.test.ts
@@ -481,7 +481,28 @@ describe('deliveryCaptureAccumulator', () => {
         expect(manifest.overflowCount).toBe(0);
     });
 
-    it('pending entries that never reach a terminal status are excluded from the manifest', async () => {
+    it('an initiated-but-never-responded entry surfaces as an error item with queryUuid null (partial capture must never look complete)', async () => {
+        const acc = createDeliveryCaptureAccumulator();
+        acc.onInitiation({
+            requestId: 'r1',
+            method: 'POST',
+            path: METRIC_PATH,
+            body: { query: baseMetricQuery() },
+            label: null,
+        });
+        // No onPostResponse/onTerminal — the POST never resolved.
+
+        const manifest = await acc.getManifest();
+        expect(manifest.items).toHaveLength(1);
+        expect(manifest.items[0]).toMatchObject({
+            status: 'error',
+            queryUuid: null,
+            error: 'Query did not settle before capture completed',
+        });
+        expect(parseDeliveryCaptureManifest(manifest)).not.toBeNull();
+    });
+
+    it('a responded-but-never-polled-terminal entry surfaces as an error item carrying the uuid', async () => {
         const acc = createDeliveryCaptureAccumulator();
         acc.onInitiation({
             requestId: 'r1',
@@ -491,9 +512,15 @@ describe('deliveryCaptureAccumulator', () => {
             label: null,
         });
         acc.onPostResponse('r1', { queryUuid: 'u1' });
-        // No onTerminal call — query never settles.
+        // No onTerminal call — the poll never reached ready/error.
 
         const manifest = await acc.getManifest();
-        expect(manifest.items).toHaveLength(0);
+        expect(manifest.items).toHaveLength(1);
+        expect(manifest.items[0]).toMatchObject({
+            status: 'error',
+            queryUuid: 'u1',
+            error: 'Query did not settle before capture completed',
+        });
+        expect(parseDeliveryCaptureManifest(manifest)).not.toBeNull();
     });
 });

--- a/packages/frontend/src/features/apps/deliveryCapture/deliveryCaptureAccumulator.test.ts
+++ b/packages/frontend/src/features/apps/deliveryCapture/deliveryCaptureAccumulator.test.ts
@@ -163,6 +163,47 @@ describe('deliveryCaptureAccumulator', () => {
         expect(manifest.items[0].queryUuid).toBe('u2');
     });
 
+    it('array order changes the captureKey — arrays must not be sorted like object keys', async () => {
+        // Only top-level object keys are permuted above; this proves a
+        // multi-element array (e.g. a filter group) keeps its order in the
+        // hash input, so reordering it produces a genuinely different key.
+        const filterOne = { id: 'f1', value: 'a' };
+        const filterTwo = { id: 'f2', value: 'b' };
+        const acc = createDeliveryCaptureAccumulator();
+        acc.onInitiation({
+            requestId: 'r1',
+            method: 'POST',
+            path: METRIC_PATH,
+            body: {
+                query: baseMetricQuery({
+                    filters: { dimensions: { and: [filterOne, filterTwo] } },
+                }),
+            },
+            label: null,
+        });
+        acc.onInitiation({
+            requestId: 'r2',
+            method: 'POST',
+            path: METRIC_PATH,
+            body: {
+                query: baseMetricQuery({
+                    filters: { dimensions: { and: [filterTwo, filterOne] } },
+                }),
+            },
+            label: null,
+        });
+        completeReady(acc, 'r1', 'u1', 1);
+        completeReady(acc, 'r2', 'u2', 2);
+
+        const manifest = await acc.getManifest();
+        // Must NOT collapse to one item — array order is part of the query's
+        // identity (a reordered filter group is a semantically different query).
+        expect(manifest.items).toHaveLength(2);
+        expect(manifest.items[0].captureKey).not.toBe(
+            manifest.items[1].captureKey,
+        );
+    });
+
     it('a body with invalidateCache: true hashes identically to one without', async () => {
         const acc = createDeliveryCaptureAccumulator();
         acc.onInitiation({

--- a/packages/frontend/src/features/apps/deliveryCapture/deliveryCaptureAccumulator.test.ts
+++ b/packages/frontend/src/features/apps/deliveryCapture/deliveryCaptureAccumulator.test.ts
@@ -256,18 +256,11 @@ describe('deliveryCaptureAccumulator', () => {
         expect(manifest.items[0].queryUuid).toBe('u2');
     });
 
-    it('order is assigned synchronously in onInitiation, independent of hash resolution order', async () => {
-        // Mock digest so the SECOND initiation's hash resolves before the FIRST's,
-        // and confirm capture order still reflects call order, not resolution order.
-        const resolvers: Array<(value: ArrayBuffer) => void> = [];
-        const digestSpy = vi
-            .spyOn(globalThis.crypto.subtle, 'digest')
-            .mockImplementation(
-                () =>
-                    new Promise<ArrayBuffer>((resolve) => {
-                        resolvers.push(resolve);
-                    }),
-            );
+    it('captureKey and order are assigned synchronously in onInitiation, without crypto.subtle', async () => {
+        // crypto.subtle is undefined outside secure contexts, and the headless
+        // browser loads the minimal app over plain HTTP — hashing must be
+        // synchronous and pure JS, with no digest work left to await.
+        const digestSpy = vi.spyOn(globalThis.crypto.subtle, 'digest');
 
         const acc = createDeliveryCaptureAccumulator();
         acc.onInitiation({
@@ -285,26 +278,33 @@ describe('deliveryCaptureAccumulator', () => {
             label: null,
         });
 
-        expect(resolvers).toHaveLength(2);
-        // Resolve out of call order: second's digest settles first.
-        const fakeDigest = (byte: number) => {
-            const buf = new Uint8Array(32).fill(byte);
-            return buf.buffer;
-        };
-        resolvers[1](fakeDigest(2));
-        resolvers[0](fakeDigest(1));
-
         acc.onPostResponse('first', { queryUuid: 'u-first' });
         acc.onPostResponse('second', { queryUuid: 'u-second' });
         acc.onTerminal('u-first', { status: 'ready', rowCount: 1 });
         acc.onTerminal('u-second', { status: 'ready', rowCount: 2 });
 
-        const manifest = await acc.getManifest();
+        // getManifest() awaits nothing, so its continuation is queued ahead of
+        // a microtask scheduled right after it.
+        const settleOrder: string[] = [];
+        const manifestPromise = acc.getManifest().then((manifest) => {
+            settleOrder.push('manifest');
+            return manifest;
+        });
+        void Promise.resolve().then(() => settleOrder.push('microtask'));
+
+        const manifest = await manifestPromise;
+        expect(settleOrder).toEqual(['manifest', 'microtask']);
+        expect(digestSpy).not.toHaveBeenCalled();
+
         expect(manifest.items).toHaveLength(2);
         const first = manifest.items.find((i) => i.queryUuid === 'u-first');
         const second = manifest.items.find((i) => i.queryUuid === 'u-second');
         expect(first?.order).toBe(0);
         expect(second?.order).toBe(1);
+        const keyPattern = new RegExp(`^${CAPTURE_KEY_VERSION}:[0-9a-f]{64}$`);
+        expect(first?.captureKey).toMatch(keyPattern);
+        expect(second?.captureKey).toMatch(keyPattern);
+        expect(first?.captureKey).not.toBe(second?.captureKey);
 
         digestSpy.mockRestore();
     });

--- a/packages/frontend/src/features/apps/deliveryCapture/deliveryCaptureAccumulator.test.ts
+++ b/packages/frontend/src/features/apps/deliveryCapture/deliveryCaptureAccumulator.test.ts
@@ -1,0 +1,499 @@
+import {
+    CAPTURE_KEY_VERSION,
+    MAX_CAPTURE_LABEL_CHARS,
+    MAX_DELIVERY_QUERIES,
+    parseDeliveryCaptureManifest,
+} from '@lightdash/common';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+    createDeliveryCaptureAccumulator,
+    type DeliveryCaptureAccumulator,
+} from './deliveryCaptureAccumulator';
+
+const METRIC_PATH = '/api/v2/projects/proj/query/metric-query';
+const CHART_PATH = '/api/v2/projects/proj/query/chart';
+
+const baseMetricQuery = (overrides: Record<string, unknown> = {}) => ({
+    exploreName: 'orders',
+    dimensions: [],
+    metrics: [],
+    filters: {},
+    sorts: [],
+    limit: 500,
+    ...overrides,
+});
+
+/** Drives an entry through onPostResponse + onTerminal(ready) in one call. */
+function completeReady(
+    acc: DeliveryCaptureAccumulator,
+    requestId: string,
+    queryUuid: string,
+    rowCount: number | null,
+    metricQuery?: { exploreName?: string; limit?: number },
+) {
+    acc.onPostResponse(requestId, { queryUuid, metricQuery });
+    acc.onTerminal(queryUuid, { status: 'ready', rowCount });
+}
+
+describe('deliveryCaptureAccumulator', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('metric-query happy path produces a ready item with rowCount', async () => {
+        const acc = createDeliveryCaptureAccumulator();
+        acc.onInitiation({
+            requestId: 'r1',
+            method: 'POST',
+            path: METRIC_PATH,
+            body: { query: baseMetricQuery({ limit: 100 }) },
+            label: null,
+        });
+        completeReady(acc, 'r1', 'u1', 42);
+
+        const manifest = await acc.getManifest();
+        expect(manifest.items).toHaveLength(1);
+        expect(manifest.items[0]).toMatchObject({
+            status: 'ready',
+            exploreName: 'orders',
+            queryUuid: 'u1',
+            rowCount: 42,
+            label: 'orders',
+            order: 0,
+        });
+        expect(parseDeliveryCaptureManifest(manifest)).not.toBeNull();
+    });
+
+    it('captureKey is v1:<sha256 hex> over method+path+stripped-body', async () => {
+        const acc = createDeliveryCaptureAccumulator();
+        acc.onInitiation({
+            requestId: 'r1',
+            method: 'post',
+            path: METRIC_PATH,
+            body: { query: baseMetricQuery() },
+            label: null,
+        });
+        completeReady(acc, 'r1', 'u1', 1);
+
+        const manifest = await acc.getManifest();
+        expect(manifest.items[0].captureKey).toMatch(
+            new RegExp(`^${CAPTURE_KEY_VERSION}:[0-9a-f]{64}$`),
+        );
+    });
+
+    it('chart-query gets exploreName/limit only after onPostResponse', async () => {
+        const acc = createDeliveryCaptureAccumulator();
+        acc.onInitiation({
+            requestId: 'r1',
+            method: 'POST',
+            path: CHART_PATH,
+            body: { chartUuid: 'chart-1' },
+            label: null,
+        });
+        completeReady(acc, 'r1', 'u1', 7, {
+            exploreName: 'customers',
+            limit: 50,
+        });
+
+        const manifest = await acc.getManifest();
+        expect(manifest.items[0]).toMatchObject({
+            exploreName: 'customers',
+            label: 'customers',
+            limitReached: false,
+        });
+    });
+
+    it('two identical payloads collapse to one item with the later requestId', async () => {
+        const acc = createDeliveryCaptureAccumulator();
+        const body = { query: baseMetricQuery() };
+        acc.onInitiation({
+            requestId: 'r1',
+            method: 'POST',
+            path: METRIC_PATH,
+            body,
+            label: null,
+        });
+        acc.onInitiation({
+            requestId: 'r2',
+            method: 'POST',
+            path: METRIC_PATH,
+            body,
+            label: null,
+        });
+        completeReady(acc, 'r2', 'u2', 5);
+
+        const manifest = await acc.getManifest();
+        expect(manifest.items).toHaveLength(1);
+        expect(manifest.items[0].queryUuid).toBe('u2');
+    });
+
+    it('field-order-permuted bodies hash identically (collapse to one item)', async () => {
+        const acc = createDeliveryCaptureAccumulator();
+        acc.onInitiation({
+            requestId: 'r1',
+            method: 'POST',
+            path: METRIC_PATH,
+            body: {
+                query: {
+                    exploreName: 'orders',
+                    dimensions: ['a'],
+                    metrics: ['b'],
+                },
+            },
+            label: null,
+        });
+        acc.onInitiation({
+            requestId: 'r2',
+            method: 'POST',
+            path: METRIC_PATH,
+            body: {
+                query: {
+                    metrics: ['b'],
+                    dimensions: ['a'],
+                    exploreName: 'orders',
+                },
+            },
+            label: null,
+        });
+        completeReady(acc, 'r1', 'u1', 1);
+        completeReady(acc, 'r2', 'u2', 2);
+
+        const manifest = await acc.getManifest();
+        expect(manifest.items).toHaveLength(1);
+        expect(manifest.items[0].queryUuid).toBe('u2');
+    });
+
+    it('a body with invalidateCache: true hashes identically to one without', async () => {
+        const acc = createDeliveryCaptureAccumulator();
+        acc.onInitiation({
+            requestId: 'r1',
+            method: 'POST',
+            path: METRIC_PATH,
+            body: { query: baseMetricQuery() },
+            label: null,
+        });
+        acc.onInitiation({
+            requestId: 'r2',
+            method: 'POST',
+            path: METRIC_PATH,
+            body: { query: baseMetricQuery(), invalidateCache: true },
+            label: null,
+        });
+        completeReady(acc, 'r1', 'u1', 1);
+        completeReady(acc, 'r2', 'u2', 2);
+
+        const manifest = await acc.getManifest();
+        expect(manifest.items).toHaveLength(1);
+        expect(manifest.items[0].queryUuid).toBe('u2');
+    });
+
+    it('a body with context/dashboardFilters stamped hashes identically to one without', async () => {
+        const acc = createDeliveryCaptureAccumulator();
+        acc.onInitiation({
+            requestId: 'r1',
+            method: 'POST',
+            path: METRIC_PATH,
+            body: { query: baseMetricQuery() },
+            label: null,
+        });
+        acc.onInitiation({
+            requestId: 'r2',
+            method: 'POST',
+            path: METRIC_PATH,
+            body: {
+                query: baseMetricQuery(),
+                context: 'scheduledDelivery',
+                dashboardFilters: { dimensions: [], metrics: [] },
+            },
+            label: null,
+        });
+        completeReady(acc, 'r1', 'u1', 1);
+        completeReady(acc, 'r2', 'u2', 2);
+
+        const manifest = await acc.getManifest();
+        expect(manifest.items).toHaveLength(1);
+        expect(manifest.items[0].queryUuid).toBe('u2');
+    });
+
+    it('order is assigned synchronously in onInitiation, independent of hash resolution order', async () => {
+        // Mock digest so the SECOND initiation's hash resolves before the FIRST's,
+        // and confirm capture order still reflects call order, not resolution order.
+        const resolvers: Array<(value: ArrayBuffer) => void> = [];
+        const digestSpy = vi
+            .spyOn(globalThis.crypto.subtle, 'digest')
+            .mockImplementation(
+                () =>
+                    new Promise<ArrayBuffer>((resolve) => {
+                        resolvers.push(resolve);
+                    }),
+            );
+
+        const acc = createDeliveryCaptureAccumulator();
+        acc.onInitiation({
+            requestId: 'first',
+            method: 'POST',
+            path: METRIC_PATH,
+            body: { query: baseMetricQuery({ dimensions: ['x'] }) },
+            label: null,
+        });
+        acc.onInitiation({
+            requestId: 'second',
+            method: 'POST',
+            path: METRIC_PATH,
+            body: { query: baseMetricQuery({ dimensions: ['y'] }) },
+            label: null,
+        });
+
+        expect(resolvers).toHaveLength(2);
+        // Resolve out of call order: second's digest settles first.
+        const fakeDigest = (byte: number) => {
+            const buf = new Uint8Array(32).fill(byte);
+            return buf.buffer;
+        };
+        resolvers[1](fakeDigest(2));
+        resolvers[0](fakeDigest(1));
+
+        acc.onPostResponse('first', { queryUuid: 'u-first' });
+        acc.onPostResponse('second', { queryUuid: 'u-second' });
+        acc.onTerminal('u-first', { status: 'ready', rowCount: 1 });
+        acc.onTerminal('u-second', { status: 'ready', rowCount: 2 });
+
+        const manifest = await acc.getManifest();
+        expect(manifest.items).toHaveLength(2);
+        const first = manifest.items.find((i) => i.queryUuid === 'u-first');
+        const second = manifest.items.find((i) => i.queryUuid === 'u-second');
+        expect(first?.order).toBe(0);
+        expect(second?.order).toBe(1);
+
+        digestSpy.mockRestore();
+    });
+
+    it('same captureKey re-initiated keeps original order; a response for the superseded requestId is ignored', async () => {
+        const acc = createDeliveryCaptureAccumulator();
+        const body = { query: baseMetricQuery() };
+        acc.onInitiation({
+            requestId: 'A',
+            method: 'POST',
+            path: METRIC_PATH,
+            body,
+            label: null,
+        });
+        acc.onInitiation({
+            requestId: 'B',
+            method: 'POST',
+            path: METRIC_PATH,
+            body,
+            label: null,
+        });
+
+        // Superseded requestId's late response must not resurrect/affect the entry.
+        acc.onPostResponse('A', { queryUuid: 'u-A' });
+        acc.onTerminal('u-A', { status: 'ready', rowCount: 999 });
+
+        completeReady(acc, 'B', 'u-B', 10);
+
+        const manifest = await acc.getManifest();
+        expect(manifest.items).toHaveLength(1);
+        expect(manifest.items[0]).toMatchObject({
+            queryUuid: 'u-B',
+            rowCount: 10,
+            order: 0,
+        });
+    });
+
+    it('distinct captureKeys with the same label get (2), (3) suffixes in capture order', async () => {
+        const acc = createDeliveryCaptureAccumulator();
+        ['a', 'b', 'c'].forEach((dim, i) => {
+            acc.onInitiation({
+                requestId: `r${i}`,
+                method: 'POST',
+                path: METRIC_PATH,
+                body: { query: baseMetricQuery({ dimensions: [dim] }) },
+                label: 'My Query',
+            });
+        });
+        completeReady(acc, 'r0', 'u0', 1);
+        completeReady(acc, 'r1', 'u1', 2);
+        completeReady(acc, 'r2', 'u2', 3);
+
+        const manifest = await acc.getManifest();
+        expect(manifest.items.map((i) => i.label)).toEqual([
+            'My Query',
+            'My Query (2)',
+            'My Query (3)',
+        ]);
+    });
+
+    it('label resolution: metadata.label wins over exploreName and the Query N fallback', async () => {
+        const acc = createDeliveryCaptureAccumulator();
+        acc.onInitiation({
+            requestId: 'r1',
+            method: 'POST',
+            path: METRIC_PATH,
+            body: { query: baseMetricQuery() },
+            label: 'Custom label',
+        });
+        completeReady(acc, 'r1', 'u1', 1);
+
+        const manifest = await acc.getManifest();
+        expect(manifest.items[0].label).toBe('Custom label');
+    });
+
+    it('label resolution falls back to `Query ${order + 1}` when there is no label or exploreName', async () => {
+        const acc = createDeliveryCaptureAccumulator();
+        acc.onInitiation({
+            requestId: 'r1',
+            method: 'POST',
+            path: CHART_PATH,
+            body: { chartUuid: 'chart-1' },
+            label: null,
+        });
+        completeReady(acc, 'r1', 'u1', 1, {});
+
+        const manifest = await acc.getManifest();
+        expect(manifest.items[0].label).toBe('Query 1');
+    });
+
+    it('truncates labels to MAX_CAPTURE_LABEL_CHARS', async () => {
+        const acc = createDeliveryCaptureAccumulator();
+        const longLabel = 'x'.repeat(MAX_CAPTURE_LABEL_CHARS + 50);
+        acc.onInitiation({
+            requestId: 'r1',
+            method: 'POST',
+            path: METRIC_PATH,
+            body: { query: baseMetricQuery() },
+            label: longLabel,
+        });
+        completeReady(acc, 'r1', 'u1', 1);
+
+        const manifest = await acc.getManifest();
+        expect(manifest.items[0].label.length).toBeLessThanOrEqual(
+            MAX_CAPTURE_LABEL_CHARS,
+        );
+        expect(parseDeliveryCaptureManifest(manifest)).not.toBeNull();
+    });
+
+    it('limitReached is true when rowCount >= limit, computed in onTerminal', async () => {
+        const acc = createDeliveryCaptureAccumulator();
+        acc.onInitiation({
+            requestId: 'r1',
+            method: 'POST',
+            path: METRIC_PATH,
+            body: { query: baseMetricQuery({ limit: 10 }) },
+            label: null,
+        });
+        completeReady(acc, 'r1', 'u1', 10);
+
+        const manifest = await acc.getManifest();
+        expect(manifest.items[0]).toMatchObject({
+            status: 'ready',
+            limitReached: true,
+        });
+    });
+
+    it('limitReached is false when rowCount < limit', async () => {
+        const acc = createDeliveryCaptureAccumulator();
+        acc.onInitiation({
+            requestId: 'r1',
+            method: 'POST',
+            path: METRIC_PATH,
+            body: { query: baseMetricQuery({ limit: 10 }) },
+            label: null,
+        });
+        completeReady(acc, 'r1', 'u1', 3);
+
+        const manifest = await acc.getManifest();
+        expect(manifest.items[0]).toMatchObject({ limitReached: false });
+    });
+
+    it('limitReached is false when rowCount is null', async () => {
+        const acc = createDeliveryCaptureAccumulator();
+        acc.onInitiation({
+            requestId: 'r1',
+            method: 'POST',
+            path: METRIC_PATH,
+            body: { query: baseMetricQuery({ limit: 10 }) },
+            label: null,
+        });
+        completeReady(acc, 'r1', 'u1', null);
+
+        const manifest = await acc.getManifest();
+        expect(manifest.items[0]).toMatchObject({ limitReached: false });
+    });
+
+    it('onPostFailure before a uuid is assigned produces an error item with queryUuid: null', async () => {
+        const acc = createDeliveryCaptureAccumulator();
+        acc.onInitiation({
+            requestId: 'r1',
+            method: 'POST',
+            path: METRIC_PATH,
+            body: { query: baseMetricQuery() },
+            label: null,
+        });
+        acc.onPostFailure('r1', 'Warehouse timeout');
+
+        const manifest = await acc.getManifest();
+        expect(manifest.items).toHaveLength(1);
+        expect(manifest.items[0]).toMatchObject({
+            status: 'error',
+            queryUuid: null,
+            error: 'Warehouse timeout',
+        });
+        expect(parseDeliveryCaptureManifest(manifest)).not.toBeNull();
+    });
+
+    it('drops initiations beyond MAX_DELIVERY_QUERIES distinct keys and counts them in overflowCount', async () => {
+        const acc = createDeliveryCaptureAccumulator();
+        const total = MAX_DELIVERY_QUERIES + 3;
+        for (let i = 0; i < total; i += 1) {
+            acc.onInitiation({
+                requestId: `r${i}`,
+                method: 'POST',
+                path: METRIC_PATH,
+                body: { query: baseMetricQuery({ dimensions: [`d${i}`] }) },
+                label: null,
+            });
+        }
+
+        const manifest = await acc.getManifest();
+        expect(manifest.overflowCount).toBe(3);
+    });
+
+    it('reset() clears all state so a late onPostResponse/onTerminal for a pre-reset id is dropped', async () => {
+        const acc = createDeliveryCaptureAccumulator();
+        acc.onInitiation({
+            requestId: 'r1',
+            method: 'POST',
+            path: METRIC_PATH,
+            body: { query: baseMetricQuery() },
+            label: null,
+        });
+
+        acc.reset();
+
+        // Late signals referencing pre-reset ids must find nothing.
+        acc.onPostResponse('r1', { queryUuid: 'u1' });
+        acc.onTerminal('u1', { status: 'ready', rowCount: 1 });
+        acc.onPostFailure('r1', 'too late');
+
+        const manifest = await acc.getManifest();
+        expect(manifest.items).toHaveLength(0);
+        expect(manifest.overflowCount).toBe(0);
+    });
+
+    it('pending entries that never reach a terminal status are excluded from the manifest', async () => {
+        const acc = createDeliveryCaptureAccumulator();
+        acc.onInitiation({
+            requestId: 'r1',
+            method: 'POST',
+            path: METRIC_PATH,
+            body: { query: baseMetricQuery() },
+            label: null,
+        });
+        acc.onPostResponse('r1', { queryUuid: 'u1' });
+        // No onTerminal call — query never settles.
+
+        const manifest = await acc.getManifest();
+        expect(manifest.items).toHaveLength(0);
+    });
+});

--- a/packages/frontend/src/features/apps/deliveryCapture/deliveryCaptureAccumulator.ts
+++ b/packages/frontend/src/features/apps/deliveryCapture/deliveryCaptureAccumulator.ts
@@ -6,6 +6,7 @@ import {
     type DeliveryCaptureManifest,
 } from '@lightdash/common';
 import isPlainObject from 'lodash/isPlainObject';
+import { sha256Hex } from './sha256';
 import { stableStringify, stripCaptureBodyFields } from './stableStringify';
 
 export type DeliveryCaptureAccumulator = {
@@ -31,7 +32,7 @@ export type DeliveryCaptureAccumulator = {
             | { status: 'ready'; rowCount: number | null }
             | { status: 'error'; error: string },
     ): void;
-    /** Awaits in-flight sha256 work, applies display-label suffixes, caps.
+    /** Applies display-label suffixes and caps.
      *  A partial capture must never look complete: entries still `pending`
      *  when this resolves are surfaced as `error` items, not dropped. */
     getManifest(): Promise<DeliveryCaptureManifest>;
@@ -46,20 +47,11 @@ type CaptureEntry = {
     exploreName: string | null;
     limit: number | undefined;
     status: 'pending' | 'ready' | 'error';
-    /** Filled in once the async digest resolves; null briefly after creation. */
-    captureKey: string | null;
+    captureKey: string;
     queryUuid: string | null;
     rowCount: number | null;
     limitReached: boolean;
     error: string | null;
-};
-
-const sha256Hex = async (input: string): Promise<string> => {
-    const bytes = new TextEncoder().encode(input);
-    const digest = await crypto.subtle.digest('SHA-256', bytes);
-    return Array.from(new Uint8Array(digest))
-        .map((byte) => byte.toString(16).padStart(2, '0'))
-        .join('');
 };
 
 /** Metric-query bodies carry `query.exploreName`/`query.limit` synchronously
@@ -96,13 +88,12 @@ const applyDisplaySuffix = (base: string, occurrence: number): string => {
 
 export const createDeliveryCaptureAccumulator =
     (): DeliveryCaptureAccumulator => {
-        // Keyed by the pre-hash stableStringify input (synchronous) — lets
-        // onInitiation dedupe/replace-in-place without waiting on the digest.
+        // Keyed by the pre-hash stableStringify input — cheaper to compare than
+        // the digest, and lets onInitiation dedupe/replace-in-place.
         let entriesByRawKey = new Map<string, CaptureEntry>();
         let requestIdToEntry = new Map<string, CaptureEntry>();
         let uuidToEntry = new Map<string, CaptureEntry>();
         let droppedKeys = new Set<string>();
-        let pendingHashWork = new Set<Promise<void>>();
         let nextOrder = 0;
 
         const onInitiation: DeliveryCaptureAccumulator['onInitiation'] = ({
@@ -131,7 +122,7 @@ export const createDeliveryCaptureAccumulator =
                     exploreName: null,
                     limit: undefined,
                     status: 'pending',
-                    captureKey: null,
+                    captureKey: `${CAPTURE_KEY_VERSION}:${sha256Hex(rawKey)}`,
                     queryUuid: null,
                     rowCount: null,
                     limitReached: false,
@@ -139,15 +130,6 @@ export const createDeliveryCaptureAccumulator =
                 };
                 nextOrder += 1;
                 entriesByRawKey.set(rawKey, entry);
-
-                // Same rawKey always hashes to the same value, so writing
-                // captureKey here is race-free regardless of resolution order.
-                const settledEntry = entry;
-                const work = sha256Hex(rawKey).then((hex) => {
-                    settledEntry.captureKey = `${CAPTURE_KEY_VERSION}:${hex}`;
-                });
-                pendingHashWork.add(work);
-                void work.finally(() => pendingHashWork.delete(work));
             }
 
             // Replace in place: keep `order`/`captureKey`, reset per-execution
@@ -229,8 +211,6 @@ export const createDeliveryCaptureAccumulator =
 
         const getManifest: DeliveryCaptureAccumulator['getManifest'] =
             async () => {
-                await Promise.all(pendingHashWork);
-
                 const ordered = [...entriesByRawKey.values()].sort(
                     (a, b) => a.order - b.order,
                 );
@@ -243,7 +223,7 @@ export const createDeliveryCaptureAccumulator =
                         (labelOccurrences.get(baseLabel) ?? 0) + 1;
                     labelOccurrences.set(baseLabel, occurrence);
                     const label = applyDisplaySuffix(baseLabel, occurrence);
-                    const captureKey = entry.captureKey ?? '';
+                    const { captureKey } = entry;
 
                     if (entry.status === 'ready') {
                         items.push({
@@ -286,7 +266,6 @@ export const createDeliveryCaptureAccumulator =
             requestIdToEntry = new Map();
             uuidToEntry = new Map();
             droppedKeys = new Set();
-            pendingHashWork = new Set();
             // So a post-reset capture's first unlabeled query reads "Query 1"
             // again, not a number carried over from the previous capture.
             nextOrder = 0;

--- a/packages/frontend/src/features/apps/deliveryCapture/deliveryCaptureAccumulator.ts
+++ b/packages/frontend/src/features/apps/deliveryCapture/deliveryCaptureAccumulator.ts
@@ -96,9 +96,8 @@ const applyDisplaySuffix = (base: string, occurrence: number): string => {
 
 export const createDeliveryCaptureAccumulator =
     (): DeliveryCaptureAccumulator => {
-        // Keyed by the pre-hash stableStringify input, which is available
-        // synchronously — this is what lets onInitiation dedupe/replace-in-place
-        // without ever waiting on the async digest.
+        // Keyed by the pre-hash stableStringify input (synchronous) — lets
+        // onInitiation dedupe/replace-in-place without waiting on the digest.
         let entriesByRawKey = new Map<string, CaptureEntry>();
         let requestIdToEntry = new Map<string, CaptureEntry>();
         let uuidToEntry = new Map<string, CaptureEntry>();
@@ -141,9 +140,8 @@ export const createDeliveryCaptureAccumulator =
                 nextOrder += 1;
                 entriesByRawKey.set(rawKey, entry);
 
-                // Every initiation of the same rawKey hashes to the same
-                // value, so writing captureKey here is race-free regardless
-                // of resolution order across re-initiations.
+                // Same rawKey always hashes to the same value, so writing
+                // captureKey here is race-free regardless of resolution order.
                 const settledEntry = entry;
                 const work = sha256Hex(rawKey).then((hex) => {
                     settledEntry.captureKey = `${CAPTURE_KEY_VERSION}:${hex}`;
@@ -259,9 +257,8 @@ export const createDeliveryCaptureAccumulator =
                             limitReached: entry.limitReached,
                         });
                     } else {
-                        // 'error' status, or 'pending' (never reached a
-                        // terminal state) — either way a visible failure
-                        // rather than a silently missing file downstream.
+                        // 'error', or 'pending' (never reached a terminal
+                        // state) — a visible failure, not a silent gap.
                         items.push({
                             status: 'error',
                             captureKey,
@@ -290,6 +287,9 @@ export const createDeliveryCaptureAccumulator =
             uuidToEntry = new Map();
             droppedKeys = new Set();
             pendingHashWork = new Set();
+            // So a post-reset capture's first unlabeled query reads "Query 1"
+            // again, not a number carried over from the previous capture.
+            nextOrder = 0;
         };
 
         return {

--- a/packages/frontend/src/features/apps/deliveryCapture/deliveryCaptureAccumulator.ts
+++ b/packages/frontend/src/features/apps/deliveryCapture/deliveryCaptureAccumulator.ts
@@ -1,0 +1,296 @@
+import {
+    CAPTURE_KEY_VERSION,
+    MAX_CAPTURE_LABEL_CHARS,
+    MAX_DELIVERY_QUERIES,
+    type CapturedQuery,
+    type DeliveryCaptureManifest,
+} from '@lightdash/common';
+import isPlainObject from 'lodash/isPlainObject';
+import { stableStringify, stripCaptureBodyFields } from './stableStringify';
+
+export type DeliveryCaptureAccumulator = {
+    onInitiation(init: {
+        requestId: string;
+        method: string;
+        path: string;
+        body: unknown;
+        label: string | null;
+    }): void;
+    /** POST response arrived. results null/undefined = ok-without-uuid. */
+    onPostResponse(
+        requestId: string,
+        results: {
+            queryUuid?: string;
+            metricQuery?: { exploreName?: string; limit?: number };
+        } | null,
+    ): void;
+    onPostFailure(requestId: string, error: string): void;
+    onTerminal(
+        queryUuid: string,
+        outcome:
+            | { status: 'ready'; rowCount: number | null }
+            | { status: 'error'; error: string },
+    ): void;
+    /** Awaits in-flight sha256 work, applies display-label suffixes, caps. */
+    getManifest(): Promise<DeliveryCaptureManifest>;
+    reset(): void;
+};
+
+type CaptureEntry = {
+    order: number;
+    /** Current owning requestId — "last initiated wins" on key collisions. */
+    requestId: string;
+    rawLabel: string | null;
+    exploreName: string | null;
+    limit: number | undefined;
+    status: 'pending' | 'ready' | 'error';
+    /** Filled in once the async digest resolves; null briefly after creation. */
+    captureKey: string | null;
+    queryUuid: string | null;
+    rowCount: number | null;
+    limitReached: boolean;
+    error: string | null;
+};
+
+const sha256Hex = async (input: string): Promise<string> => {
+    const bytes = new TextEncoder().encode(input);
+    const digest = await crypto.subtle.digest('SHA-256', bytes);
+    return Array.from(new Uint8Array(digest))
+        .map((byte) => byte.toString(16).padStart(2, '0'))
+        .join('');
+};
+
+/** Metric-query bodies carry `query.exploreName`/`query.limit` synchronously
+ *  at initiation; chart bodies only carry `chartUuid` until onPostResponse. */
+const extractMetricQuery = (body: unknown): Record<string, unknown> | null => {
+    if (!isPlainObject(body)) return null;
+    const { query } = body as Record<string, unknown>;
+    return isPlainObject(query) ? (query as Record<string, unknown>) : null;
+};
+
+const truncateLabel = (label: string): string =>
+    label.length > MAX_CAPTURE_LABEL_CHARS
+        ? label.slice(0, MAX_CAPTURE_LABEL_CHARS)
+        : label;
+
+const resolveBaseLabel = (entry: CaptureEntry): string =>
+    truncateLabel(
+        entry.rawLabel ?? entry.exploreName ?? `Query ${entry.order + 1}`,
+    );
+
+/** Appends a display-only " (n)" suffix for the nth occurrence of a label,
+ *  re-truncating so the final label still respects the cap. */
+const applyDisplaySuffix = (base: string, occurrence: number): string => {
+    if (occurrence <= 1) return base;
+    const suffix = ` (${occurrence})`;
+    const maxBaseLength = Math.max(0, MAX_CAPTURE_LABEL_CHARS - suffix.length);
+    const trimmedBase =
+        base.length > maxBaseLength ? base.slice(0, maxBaseLength) : base;
+    return `${trimmedBase}${suffix}`;
+};
+
+export const createDeliveryCaptureAccumulator =
+    (): DeliveryCaptureAccumulator => {
+        // Keyed by the pre-hash stableStringify input, which is available
+        // synchronously — this is what lets onInitiation dedupe/replace-in-place
+        // without ever waiting on the async digest.
+        let entriesByRawKey = new Map<string, CaptureEntry>();
+        let requestIdToEntry = new Map<string, CaptureEntry>();
+        let uuidToEntry = new Map<string, CaptureEntry>();
+        let droppedKeys = new Set<string>();
+        let pendingHashWork = new Set<Promise<void>>();
+        let nextOrder = 0;
+
+        const onInitiation: DeliveryCaptureAccumulator['onInitiation'] = ({
+            requestId,
+            method,
+            path,
+            body,
+            label,
+        }) => {
+            const rawKey = stableStringify({
+                method: method.toUpperCase(),
+                path,
+                body: stripCaptureBodyFields(body),
+            });
+
+            let entry = entriesByRawKey.get(rawKey);
+            if (!entry) {
+                if (entriesByRawKey.size >= MAX_DELIVERY_QUERIES) {
+                    droppedKeys.add(rawKey);
+                    return;
+                }
+                entry = {
+                    order: nextOrder,
+                    requestId,
+                    rawLabel: null,
+                    exploreName: null,
+                    limit: undefined,
+                    status: 'pending',
+                    captureKey: null,
+                    queryUuid: null,
+                    rowCount: null,
+                    limitReached: false,
+                    error: null,
+                };
+                nextOrder += 1;
+                entriesByRawKey.set(rawKey, entry);
+
+                // Every initiation of the same rawKey hashes to the same
+                // value, so writing captureKey here is race-free regardless
+                // of resolution order across re-initiations.
+                const settledEntry = entry;
+                const work = sha256Hex(rawKey).then((hex) => {
+                    settledEntry.captureKey = `${CAPTURE_KEY_VERSION}:${hex}`;
+                });
+                pendingHashWork.add(work);
+                void work.finally(() => pendingHashWork.delete(work));
+            }
+
+            // Replace in place: keep `order`/`captureKey`, reset per-execution
+            // state, and hand ownership to this (newest) requestId.
+            entry.requestId = requestId;
+            entry.rawLabel = label;
+            entry.status = 'pending';
+            entry.queryUuid = null;
+            entry.rowCount = null;
+            entry.limitReached = false;
+            entry.error = null;
+
+            const query = extractMetricQuery(body);
+            entry.exploreName =
+                typeof query?.exploreName === 'string'
+                    ? query.exploreName
+                    : null;
+            entry.limit =
+                typeof query?.limit === 'number' ? query.limit : undefined;
+
+            requestIdToEntry.set(requestId, entry);
+        };
+
+        const onPostResponse: DeliveryCaptureAccumulator['onPostResponse'] = (
+            requestId,
+            results,
+        ) => {
+            const entry = requestIdToEntry.get(requestId);
+            if (!entry || entry.requestId !== requestId) return;
+
+            const queryUuid = results?.queryUuid;
+            if (typeof queryUuid === 'string') {
+                entry.queryUuid = queryUuid;
+                uuidToEntry.set(queryUuid, entry);
+            }
+            if (
+                entry.exploreName === null &&
+                typeof results?.metricQuery?.exploreName === 'string'
+            ) {
+                entry.exploreName = results.metricQuery.exploreName;
+            }
+            if (
+                entry.limit === undefined &&
+                typeof results?.metricQuery?.limit === 'number'
+            ) {
+                entry.limit = results.metricQuery.limit;
+            }
+        };
+
+        const onPostFailure: DeliveryCaptureAccumulator['onPostFailure'] = (
+            requestId,
+            error,
+        ) => {
+            const entry = requestIdToEntry.get(requestId);
+            if (!entry || entry.requestId !== requestId) return;
+            entry.status = 'error';
+            entry.queryUuid = null;
+            entry.error = error;
+        };
+
+        const onTerminal: DeliveryCaptureAccumulator['onTerminal'] = (
+            queryUuid,
+            outcome,
+        ) => {
+            const entry = uuidToEntry.get(queryUuid);
+            if (!entry || entry.queryUuid !== queryUuid) return;
+            if (outcome.status === 'ready') {
+                entry.status = 'ready';
+                entry.rowCount = outcome.rowCount;
+                entry.limitReached =
+                    outcome.rowCount !== null &&
+                    entry.limit !== undefined &&
+                    outcome.rowCount >= entry.limit;
+            } else {
+                entry.status = 'error';
+                entry.error = outcome.error;
+            }
+        };
+
+        const getManifest: DeliveryCaptureAccumulator['getManifest'] =
+            async () => {
+                await Promise.all(pendingHashWork);
+
+                const ordered = [...entriesByRawKey.values()].sort(
+                    (a, b) => a.order - b.order,
+                );
+                const labelOccurrences = new Map<string, number>();
+                const items: CapturedQuery[] = [];
+
+                ordered.forEach((entry) => {
+                    // Never reached ready/error — the manifest type has no
+                    // "pending" variant, so it's excluded rather than guessed at.
+                    if (entry.status === 'pending') return;
+
+                    const baseLabel = resolveBaseLabel(entry);
+                    const occurrence =
+                        (labelOccurrences.get(baseLabel) ?? 0) + 1;
+                    labelOccurrences.set(baseLabel, occurrence);
+                    const label = applyDisplaySuffix(baseLabel, occurrence);
+                    const captureKey = entry.captureKey ?? '';
+
+                    if (entry.status === 'ready') {
+                        items.push({
+                            status: 'ready',
+                            captureKey,
+                            label,
+                            exploreName: entry.exploreName,
+                            queryUuid: entry.queryUuid ?? '',
+                            order: entry.order,
+                            rowCount: entry.rowCount,
+                            limitReached: entry.limitReached,
+                        });
+                    } else {
+                        items.push({
+                            status: 'error',
+                            captureKey,
+                            label,
+                            exploreName: entry.exploreName,
+                            queryUuid: entry.queryUuid,
+                            order: entry.order,
+                            error: entry.error ?? 'Unknown error',
+                        });
+                    }
+                });
+
+                return {
+                    version: 1,
+                    items,
+                    overflowCount: droppedKeys.size,
+                };
+            };
+
+        const reset: DeliveryCaptureAccumulator['reset'] = () => {
+            entriesByRawKey = new Map();
+            requestIdToEntry = new Map();
+            uuidToEntry = new Map();
+            droppedKeys = new Set();
+            pendingHashWork = new Set();
+        };
+
+        return {
+            onInitiation,
+            onPostResponse,
+            onPostFailure,
+            onTerminal,
+            getManifest,
+            reset,
+        };
+    };

--- a/packages/frontend/src/features/apps/deliveryCapture/deliveryCaptureAccumulator.ts
+++ b/packages/frontend/src/features/apps/deliveryCapture/deliveryCaptureAccumulator.ts
@@ -31,7 +31,9 @@ export type DeliveryCaptureAccumulator = {
             | { status: 'ready'; rowCount: number | null }
             | { status: 'error'; error: string },
     ): void;
-    /** Awaits in-flight sha256 work, applies display-label suffixes, caps. */
+    /** Awaits in-flight sha256 work, applies display-label suffixes, caps.
+     *  A partial capture must never look complete: entries still `pending`
+     *  when this resolves are surfaced as `error` items, not dropped. */
     getManifest(): Promise<DeliveryCaptureManifest>;
     reset(): void;
 };
@@ -77,6 +79,9 @@ const resolveBaseLabel = (entry: CaptureEntry): string =>
     truncateLabel(
         entry.rawLabel ?? entry.exploreName ?? `Query ${entry.order + 1}`,
     );
+
+/** Error message for entries still `pending` when getManifest() resolves. */
+const NOT_SETTLED_ERROR = 'Query did not settle before capture completed';
 
 /** Appends a display-only " (n)" suffix for the nth occurrence of a label,
  *  re-truncating so the final label still respects the cap. */
@@ -235,10 +240,6 @@ export const createDeliveryCaptureAccumulator =
                 const items: CapturedQuery[] = [];
 
                 ordered.forEach((entry) => {
-                    // Never reached ready/error — the manifest type has no
-                    // "pending" variant, so it's excluded rather than guessed at.
-                    if (entry.status === 'pending') return;
-
                     const baseLabel = resolveBaseLabel(entry);
                     const occurrence =
                         (labelOccurrences.get(baseLabel) ?? 0) + 1;
@@ -258,6 +259,9 @@ export const createDeliveryCaptureAccumulator =
                             limitReached: entry.limitReached,
                         });
                     } else {
+                        // 'error' status, or 'pending' (never reached a
+                        // terminal state) — either way a visible failure
+                        // rather than a silently missing file downstream.
                         items.push({
                             status: 'error',
                             captureKey,
@@ -265,7 +269,10 @@ export const createDeliveryCaptureAccumulator =
                             exploreName: entry.exploreName,
                             queryUuid: entry.queryUuid,
                             order: entry.order,
-                            error: entry.error ?? 'Unknown error',
+                            error:
+                                entry.status === 'pending'
+                                    ? NOT_SETTLED_ERROR
+                                    : (entry.error ?? 'Unknown error'),
                         });
                     }
                 });

--- a/packages/frontend/src/features/apps/deliveryCapture/sha256.test.ts
+++ b/packages/frontend/src/features/apps/deliveryCapture/sha256.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { sha256Hex } from './sha256';
+
+describe('sha256Hex', () => {
+    // Digests from the NIST test vectors / `shasum -a 256`. The lengths cover
+    // both sides of the 55/56-byte padding boundary and multi-block input.
+    const vectors: Array<[name: string, input: string, digest: string]> = [
+        [
+            'empty string',
+            '',
+            'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+        ],
+        [
+            'abc',
+            'abc',
+            'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad',
+        ],
+        [
+            '56-byte NIST vector',
+            'abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq',
+            '248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1',
+        ],
+        [
+            '55 bytes (largest single-block payload)',
+            'a'.repeat(55),
+            '9f4390f8d30c2dd92ec9f095b65e2b9ae9b0a925a5258e241c9f1e910f734318',
+        ],
+        [
+            '56 bytes (padding spills into a second block)',
+            'a'.repeat(56),
+            'b35439a4ac6f0948b6d6f9e3c6af0f5f590ce20f1bde7090ef7970686ec6738a',
+        ],
+        [
+            '64 bytes (exactly one block)',
+            'a'.repeat(64),
+            'ffe054fe7ae0cb6dc65c3af9b61d5209f439851db43d0ba5997337df154668eb',
+        ],
+        [
+            '1000 bytes (many blocks)',
+            'a'.repeat(1000),
+            '41edece42d63e8d9bf515a9ba6932e1c20cbc9f5a5d134645adb5db1b9737ea3',
+        ],
+        [
+            'non-ASCII input is hashed as UTF-8',
+            'héllo 🌍 — ünïcødé',
+            '15894bb8345dd73761c2610b45ec6215f2049d93d310df8720077ddd40fd62f3',
+        ],
+    ];
+
+    it.each(vectors)(
+        'matches the known digest for %s',
+        (_name, input, digest) => {
+            expect(sha256Hex(input)).toBe(digest);
+        },
+    );
+
+    it('is deterministic and collision-free for near-identical inputs', () => {
+        expect(sha256Hex('query-a')).toBe(sha256Hex('query-a'));
+        expect(sha256Hex('query-a')).not.toBe(sha256Hex('query-b'));
+    });
+
+    it('does not use crypto.subtle', () => {
+        const { subtle } = globalThis.crypto;
+        Object.defineProperty(globalThis.crypto, 'subtle', {
+            value: undefined,
+            configurable: true,
+        });
+        try {
+            expect(sha256Hex('abc')).toBe(
+                'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad',
+            );
+        } finally {
+            Object.defineProperty(globalThis.crypto, 'subtle', {
+                value: subtle,
+                configurable: true,
+            });
+        }
+    });
+});

--- a/packages/frontend/src/features/apps/deliveryCapture/sha256.ts
+++ b/packages/frontend/src/features/apps/deliveryCapture/sha256.ts
@@ -1,0 +1,99 @@
+// Synchronous, dependency-free SHA-256. `crypto.subtle` is only defined in
+// secure contexts, and the headless browser loads the minimal app over plain
+// HTTP internal hosts, so delivery capture cannot rely on it.
+
+const K = new Uint32Array([
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+    0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+    0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+    0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+    0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+    0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+]);
+
+const INITIAL_STATE = [
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c,
+    0x1f83d9ab, 0x5be0cd19,
+];
+
+const rotr = (value: number, bits: number): number =>
+    (value >>> bits) | (value << (32 - bits));
+
+/** SHA-256 of the UTF-8 encoding of `input`, as lowercase hex. */
+export const sha256Hex = (input: string): string => {
+    const bytes = new TextEncoder().encode(input);
+    // Message + 0x80 marker + 8-byte length, rounded up to whole 64-byte blocks.
+    const blockCount = Math.ceil((bytes.length + 9) / 64);
+    const padded = new Uint8Array(blockCount * 64);
+    padded.set(bytes);
+    padded[bytes.length] = 0x80;
+
+    const view = new DataView(padded.buffer);
+    const bitLength = bytes.length * 8;
+    view.setUint32(padded.length - 8, Math.floor(bitLength / 2 ** 32));
+    view.setUint32(padded.length - 4, bitLength >>> 0);
+
+    const state = new Uint32Array(INITIAL_STATE);
+    const w = new Uint32Array(64);
+
+    for (let block = 0; block < blockCount; block += 1) {
+        const offset = block * 64;
+        for (let i = 0; i < 16; i += 1) {
+            w[i] = view.getUint32(offset + i * 4);
+        }
+        for (let i = 16; i < 64; i += 1) {
+            const s0 =
+                rotr(w[i - 15], 7) ^ rotr(w[i - 15], 18) ^ (w[i - 15] >>> 3);
+            const s1 =
+                rotr(w[i - 2], 17) ^ rotr(w[i - 2], 19) ^ (w[i - 2] >>> 10);
+            w[i] = w[i - 16] + s0 + w[i - 7] + s1;
+        }
+
+        let a = state[0];
+        let b = state[1];
+        let c = state[2];
+        let d = state[3];
+        let e = state[4];
+        let f = state[5];
+        let g = state[6];
+        let h = state[7];
+
+        for (let i = 0; i < 64; i += 1) {
+            const s1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+            const ch = (e & f) ^ (~e & g);
+            const temp1 = (h + s1 + ch + K[i] + w[i]) >>> 0;
+            const s0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+            const maj = (a & b) ^ (a & c) ^ (b & c);
+            const temp2 = (s0 + maj) >>> 0;
+
+            h = g;
+            g = f;
+            f = e;
+            e = (d + temp1) >>> 0;
+            d = c;
+            c = b;
+            b = a;
+            a = (temp1 + temp2) >>> 0;
+        }
+
+        state[0] += a;
+        state[1] += b;
+        state[2] += c;
+        state[3] += d;
+        state[4] += e;
+        state[5] += f;
+        state[6] += g;
+        state[7] += h;
+    }
+
+    let hex = '';
+    for (let i = 0; i < 8; i += 1) {
+        hex += state[i].toString(16).padStart(8, '0');
+    }
+    return hex;
+};

--- a/packages/frontend/src/features/apps/deliveryCapture/stableStringify.ts
+++ b/packages/frontend/src/features/apps/deliveryCapture/stableStringify.ts
@@ -1,0 +1,39 @@
+import isPlainObject from 'lodash/isPlainObject';
+
+/** Deterministic JSON stringify: object keys sorted recursively so
+ *  field-order-permuted payloads hash identically. Mirrors JSON.stringify's
+ *  handling of `undefined` (dropped from objects, nulled in arrays). */
+export const stableStringify = (value: unknown): string => {
+    if (value === undefined) return 'null';
+    if (value === null || typeof value !== 'object') {
+        return JSON.stringify(value);
+    }
+    if (Array.isArray(value)) {
+        return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+    }
+    const record = value as Record<string, unknown>;
+    const entries = Object.keys(record)
+        .sort()
+        .filter((key) => record[key] !== undefined)
+        .map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`);
+    return `{${entries.join(',')}}`;
+};
+
+/** Fields the delivery-capture hash must ignore: they vary per render
+ *  context/attribution rather than identifying a distinct query. */
+const STRIPPED_TOP_LEVEL_BODY_FIELDS = [
+    'invalidateCache',
+    'context',
+    'dashboardFilters',
+] as const;
+
+/** Strips top-level capture-irrelevant fields from a query POST body before
+ *  it feeds the captureKey hash. Non-object bodies pass through unchanged. */
+export const stripCaptureBodyFields = (body: unknown): unknown => {
+    if (!isPlainObject(body)) return body;
+    const rest = { ...(body as Record<string, unknown>) };
+    STRIPPED_TOP_LEVEL_BODY_FIELDS.forEach((field) => {
+        delete rest[field];
+    });
+    return rest;
+};

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
@@ -1323,7 +1323,13 @@ describe('delivery capture accumulator integration', () => {
         pollQueryResult();
         await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
 
-        const manifest = await deliveryCapture.getManifest();
+        // fetch having been called doesn't mean the bridge has read the body
+        // yet, so wait on the accumulator rather than on the fetch count.
+        const manifest = await vi.waitFor(async () => {
+            const current = await deliveryCapture.getManifest();
+            expect(current.items[0]?.status).toBe('ready');
+            return current;
+        });
         expect(manifest.items).toHaveLength(1);
         expect(manifest.items[0]).toMatchObject({
             status: 'ready',
@@ -1404,7 +1410,11 @@ describe('delivery capture accumulator integration', () => {
         });
         await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
 
-        const manifest = await deliveryCapture.getManifest();
+        const manifest = await vi.waitFor(async () => {
+            const current = await deliveryCapture.getManifest();
+            expect(current.items[0]?.status).toBe('ready');
+            return current;
+        });
         expect(manifest.items).toHaveLength(1);
         expect(manifest.items[0]).toMatchObject({
             status: 'ready',

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
@@ -3,6 +3,7 @@ import {
     APP_SDK_VIZ_CONTEXT_REQUEST_MESSAGE,
     FilterOperator,
     LightdashAppUuidHeader,
+    QueryExecutionContext,
     type DashboardFilters,
     type DataAppVizContext,
 } from '@lightdash/common';
@@ -17,6 +18,7 @@ import {
     vi,
     type Mock,
 } from 'vitest';
+import { createDeliveryCaptureAccumulator } from '../deliveryCapture/deliveryCaptureAccumulator';
 import {
     useAppSdkBridge,
     type ExternalRequestEvent,
@@ -1267,5 +1269,191 @@ describe('data-app-viz-context push', () => {
             }),
             '*',
         );
+    });
+});
+
+describe('delivery capture accumulator integration', () => {
+    beforeEach(() => {
+        vi.stubGlobal('fetch', vi.fn());
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.clearAllMocks();
+    });
+
+    it('records a metric POST + ready poll as one ready manifest item whose captureKey ignores stamped fields', async () => {
+        const deliveryCapture = createDeliveryCaptureAccumulator();
+        const dashboardFilters: DashboardFilters = {
+            dimensions: [],
+            metrics: [],
+            tableCalculations: [],
+        };
+        const iframeRef = {
+            current: { contentWindow: window } as unknown as HTMLIFrameElement,
+        } as RefObject<HTMLIFrameElement | null>;
+        renderHook(() =>
+            useAppSdkBridge({
+                iframeRef,
+                expectedPreviewOrigin: window.location.origin,
+                projectUuid: PROJECT_UUID,
+                appUuid: APP_UUID,
+                dashboardFilters,
+                invalidateCache: true,
+                deliveryCapture,
+            }),
+        );
+
+        mockFetchOk({
+            status: 'ok',
+            results: { queryUuid: QUERY_UUID, metricQuery: METRIC_QUERY },
+        });
+        postMetricQuery();
+        await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+
+        mockFetchOk({
+            status: 'ok',
+            results: {
+                queryUuid: QUERY_UUID,
+                status: 'ready',
+                totalResults: 42,
+                metadata: { performance: { initialQueryExecutionMs: 5 } },
+            },
+        });
+        pollQueryResult();
+        await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+
+        const manifest = await deliveryCapture.getManifest();
+        expect(manifest.items).toHaveLength(1);
+        expect(manifest.items[0]).toMatchObject({
+            status: 'ready',
+            exploreName: 'orders',
+            rowCount: 42,
+        });
+
+        // dashboardFilters/invalidateCache are stamped onto the outgoing fetch
+        // body but must never reach the captureKey hash — onInitiation is
+        // given the pre-stamp body. A reference accumulator fed the same
+        // unstamped body must hash to the identical captureKey.
+        const reference = createDeliveryCaptureAccumulator();
+        reference.onInitiation({
+            requestId: 'reference',
+            method: 'POST',
+            path: POST_PATH,
+            body: { query: METRIC_QUERY },
+            label: null,
+        });
+        reference.onPostResponse('reference', { queryUuid: 'reference-uuid' });
+        reference.onTerminal('reference-uuid', {
+            status: 'ready',
+            rowCount: 1,
+        });
+        const referenceManifest = await reference.getManifest();
+        expect(manifest.items[0].captureKey).toBe(
+            referenceManifest.items[0].captureKey,
+        );
+    });
+
+    it('records a /query/chart POST, resolving exploreName/limit only from the response', async () => {
+        const deliveryCapture = createDeliveryCaptureAccumulator();
+        const iframeRef = {
+            current: { contentWindow: window } as unknown as HTMLIFrameElement,
+        } as RefObject<HTMLIFrameElement | null>;
+        renderHook(() =>
+            useAppSdkBridge({
+                iframeRef,
+                expectedPreviewOrigin: window.location.origin,
+                projectUuid: PROJECT_UUID,
+                appUuid: APP_UUID,
+                deliveryCapture,
+            }),
+        );
+
+        const chartPath = `/api/v2/projects/${PROJECT_UUID}/query/chart`;
+        const chartQueryUuid = 'chart-query-uuid';
+        mockFetchOk({
+            status: 'ok',
+            results: {
+                queryUuid: chartQueryUuid,
+                metricQuery: { exploreName: 'customers', limit: 50 },
+            },
+        });
+        dispatchFetchMessage({
+            type: 'lightdash:sdk:fetch',
+            id: 'chart-post-id',
+            method: 'POST',
+            path: chartPath,
+            body: { chartUuid: 'chart-uuid' },
+        });
+        await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+
+        mockFetchOk({
+            status: 'ok',
+            results: {
+                queryUuid: chartQueryUuid,
+                status: 'ready',
+                totalResults: 12,
+                metadata: { performance: { initialQueryExecutionMs: 3 } },
+            },
+        });
+        dispatchFetchMessage({
+            type: 'lightdash:sdk:fetch',
+            id: 'chart-get-id',
+            method: 'GET',
+            path: `/api/v2/projects/${PROJECT_UUID}/query/${chartQueryUuid}`,
+        });
+        await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+
+        const manifest = await deliveryCapture.getManifest();
+        expect(manifest.items).toHaveLength(1);
+        expect(manifest.items[0]).toMatchObject({
+            status: 'ready',
+            exploreName: 'customers',
+            rowCount: 12,
+        });
+    });
+
+    it('stamps queryContextOverride onto the body alongside the existing invalidateCache stamp', async () => {
+        const iframeRef = {
+            current: { contentWindow: window } as unknown as HTMLIFrameElement,
+        } as RefObject<HTMLIFrameElement | null>;
+        renderHook(() =>
+            useAppSdkBridge({
+                iframeRef,
+                expectedPreviewOrigin: window.location.origin,
+                projectUuid: PROJECT_UUID,
+                appUuid: APP_UUID,
+                invalidateCache: true,
+                queryContextOverride: QueryExecutionContext.SCHEDULED_DELIVERY,
+            }),
+        );
+
+        mockFetchOk({
+            status: 'ok',
+            results: { queryUuid: QUERY_UUID, metricQuery: METRIC_QUERY },
+        });
+        postMetricQuery();
+
+        await vi.waitFor(() => expect(fetch).toHaveBeenCalled());
+        const [, init] = vi.mocked(fetch).mock.calls[0];
+        const sentBody = JSON.parse(String(init?.body));
+        expect(sentBody.invalidateCache).toBe(true);
+        expect(sentBody.context).toBe(QueryExecutionContext.SCHEDULED_DELIVERY);
+    });
+
+    it('does not call deliveryCapture methods when no accumulator is provided', async () => {
+        renderBridge(() => undefined);
+
+        mockFetchOk({
+            status: 'ok',
+            results: { queryUuid: QUERY_UUID, metricQuery: METRIC_QUERY },
+        });
+        postMetricQuery();
+
+        await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+        const [, init] = vi.mocked(fetch).mock.calls[0];
+        const sentBody = JSON.parse(String(init?.body));
+        // No deliveryCapture/queryContextOverride passed — body is untouched.
+        expect(sentBody).toEqual({ query: METRIC_QUERY });
     });
 });

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -670,9 +670,8 @@ export function useAppSdkBridge({
                 return;
             }
 
-            // Record the capture-key-relevant, pre-stamp body — dashboard
-            // filters/invalidateCache/context are per-render decoration, not
-            // part of the query's identity (stableStringify strips them too).
+            // Record the pre-stamp body — dashboard filters/invalidateCache/
+            // context are per-render decoration, not part of the query's identity.
             if (
                 isMetricQueryPost(method, path) ||
                 isChartQueryPost(method, path)

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -5,8 +5,9 @@ import {
     isAllowedAppSdkRoute,
     JWT_HEADER_NAME,
     LightdashAppUuidHeader,
-    type DataAppVizContext,
     type DashboardFilters,
+    type DataAppVizContext,
+    type QueryExecutionContext,
 } from '@lightdash/common';
 import { useCallback, useEffect, useRef, type RefObject } from 'react';
 import { lightdashApi } from '../../../api';
@@ -16,6 +17,7 @@ import {
     triggerGdriveLogin,
 } from '../../../hooks/gdrive/useGdrive';
 import useApp from '../../../providers/App/useApp';
+import type { DeliveryCaptureAccumulator } from '../deliveryCapture/deliveryCaptureAccumulator';
 import {
     handleGsheetExport,
     type GsheetExportColumn,
@@ -248,6 +250,12 @@ export type UseAppSdkBridgeParams = {
     // When set, `lightdash:sdk:url-state-change` messages from the iframe SDK
     // are validated and forwarded. Left undefined, they're ignored.
     onUrlStateChange?: (state: Record<string, unknown>) => void;
+    /** When set, every metric/chart query POST is recorded into this accumulator
+     *  (initiation, response, terminal) — the delivery/preview capture source. */
+    deliveryCapture?: DeliveryCaptureAccumulator;
+    /** When set, stamped as `context` onto metric/chart POST bodies (delivery
+     *  renders send SCHEDULED_DELIVERY for honest attribution). */
+    queryContextOverride?: QueryExecutionContext;
 };
 
 export function useAppSdkBridge({
@@ -268,6 +276,8 @@ export function useAppSdkBridge({
     dataAppVizContext,
     onUrlStateChange,
     onSdkManifest,
+    deliveryCapture,
+    queryContextOverride,
 }: UseAppSdkBridgeParams) {
     // Embed mode adapts the bridge's outgoing fetches in two ways:
     //   - Attaches the embed JWT header in lieu of session cookies
@@ -660,13 +670,31 @@ export function useAppSdkBridge({
                 return;
             }
 
-            // Stamp dashboard filters and the cache-invalidation flag onto
-            // outgoing query bodies. The backend drops filters whose fields
-            // aren't in the query's/chart's explore, so it's safe to send the
-            // full set on every call. Both `dashboardFilters` and
-            // `invalidateCache` apply to inline metric queries AND linked
-            // (/query/chart) charts, so a dashboard filter or refresh reaches
-            // linked charts too. App attribution rides on the
+            // Record the capture-key-relevant, pre-stamp body — dashboard
+            // filters/invalidateCache/context are per-render decoration, not
+            // part of the query's identity (stableStringify strips them too).
+            if (
+                isMetricQueryPost(method, path) ||
+                isChartQueryPost(method, path)
+            ) {
+                deliveryCapture?.onInitiation({
+                    requestId: id,
+                    method,
+                    path,
+                    body,
+                    label:
+                        ((metadata as Record<string, unknown> | undefined)
+                            ?.label as string | undefined) ?? null,
+                });
+            }
+
+            // Stamp dashboard filters, the cache-invalidation flag, and a
+            // query-context override onto outgoing query bodies. The backend
+            // drops filters whose fields aren't in the query's/chart's
+            // explore, so it's safe to send the full set on every call. All
+            // three apply to inline metric queries AND linked (/query/chart)
+            // charts, so a dashboard filter, refresh, or delivery-capture
+            // context reaches linked charts too. App attribution rides on the
             // LightdashAppUuidHeader instead (see the fetch below).
             const stampFilters =
                 (isMetricQueryPost(method, path) ||
@@ -676,12 +704,19 @@ export function useAppSdkBridge({
                 (isMetricQueryPost(method, path) ||
                     isChartQueryPost(method, path)) &&
                 !!invalidateCache;
+            const stampContext =
+                (isMetricQueryPost(method, path) ||
+                    isChartQueryPost(method, path)) &&
+                !!queryContextOverride;
             const effectiveBody =
-                stampFilters || stampInvalidate
+                stampFilters || stampInvalidate || stampContext
                     ? {
                           ...(body as Record<string, unknown> | undefined),
                           ...(stampFilters ? { dashboardFilters } : {}),
                           ...(stampInvalidate ? { invalidateCache } : {}),
+                          ...(stampContext
+                              ? { context: queryContextOverride }
+                              : {}),
                       }
                     : body;
 
@@ -739,11 +774,12 @@ export function useAppSdkBridge({
             // for the POST.
             const emitPostFailure = (errorMessage: string) => {
                 if (
-                    (!isMetricQueryPost(method, path) &&
-                        !isChartQueryPost(method, path)) ||
-                    !onQueryEvent
+                    !isMetricQueryPost(method, path) &&
+                    !isChartQueryPost(method, path)
                 )
                     return;
+                deliveryCapture?.onPostFailure(id, errorMessage);
+                if (!onQueryEvent) return;
                 onQueryEvent({
                     id,
                     timestamp: Date.now(),
@@ -790,6 +826,16 @@ export function useAppSdkBridge({
                 const json = await res.json();
 
                 if (json.status === 'ok') {
+                    if (
+                        isMetricQueryPost(method, path) ||
+                        isChartQueryPost(method, path)
+                    ) {
+                        deliveryCapture?.onPostResponse(
+                            id,
+                            json.results ?? null,
+                        );
+                    }
+
                     // Track metric query initiation response (has queryUuid)
                     if (
                         (isMetricQueryPost(method, path) ||
@@ -851,7 +897,7 @@ export function useAppSdkBridge({
                     }
 
                     // Track query result polling responses
-                    if (isQueryResultGet(method, path) && onQueryEvent) {
+                    if (isQueryResultGet(method, path)) {
                         const result = json.results;
                         // Re-key terminal events to the POST id so consumers
                         // see a single stable id across the pending →
@@ -868,7 +914,11 @@ export function useAppSdkBridge({
                             queryUuidToPostIdRef.current.delete(
                                 result.queryUuid,
                             );
-                            onQueryEvent({
+                            deliveryCapture?.onTerminal(result.queryUuid, {
+                                status: 'ready',
+                                rowCount: result.totalResults ?? null,
+                            });
+                            onQueryEvent?.({
                                 ...TERMINAL_EVENT_DEFAULTS,
                                 id: lifecycleId,
                                 timestamp: Date.now(),
@@ -891,7 +941,11 @@ export function useAppSdkBridge({
                             queryUuidToPostIdRef.current.delete(
                                 result.queryUuid,
                             );
-                            onQueryEvent({
+                            deliveryCapture?.onTerminal(result.queryUuid, {
+                                status: 'error',
+                                error: result.error ?? 'Query failed',
+                            });
+                            onQueryEvent?.({
                                 ...TERMINAL_EVENT_DEFAULTS,
                                 id: lifecycleId,
                                 timestamp: Date.now(),
@@ -940,6 +994,8 @@ export function useAppSdkBridge({
             onSdkManifest,
             health.data,
             user.data,
+            deliveryCapture,
+            queryContextOverride,
         ],
     );
 


### PR DESCRIPTION
Closes:

### Description:

Introduces a `DeliveryCaptureAccumulator` that tracks the full lifecycle of metric and chart query requests made through the app SDK bridge — from initiation through POST response to terminal poll result — and assembles them into a `DeliveryCaptureManifest`.

Key behaviours:

- **Deduplication via `captureKey`**: Each query is identified by a SHA-256 hash of its method, path, and body (with object keys sorted recursively for field-order stability, and array order preserved). Fields that are per-render decoration (`invalidateCache`, `context`, `dashboardFilters`) are stripped before hashing so they don't produce spurious distinct keys.
- **Last-write-wins on collision**: If the same logical query is initiated more than once, the later request takes ownership while preserving the original insertion order.
- **Overflow protection**: Initiations beyond `MAX_DELIVERY_QUERIES` distinct keys are counted in `overflowCount` rather than silently dropped from the manifest.
- **Unsettled entries surface as errors**: Any entry still `pending` when `getManifest()` is called (POST never responded, or poll never reached a terminal state) is emitted as an `error` item rather than omitted, so a partial capture can never appear complete.
- **Label resolution**: Uses the caller-supplied label, falling back to `exploreName`, then `Query N`. Duplicate labels across distinct keys receive `(2)`, `(3)` suffixes, and all labels are truncated to `MAX_CAPTURE_LABEL_CHARS`.
- **`queryContextOverride`**: A new `useAppSdkBridge` parameter that stamps a `context` field (e.g. `SCHEDULED_DELIVERY`) onto outgoing metric/chart POST bodies alongside the existing `invalidateCache` and `dashboardFilters` stamps.
- **`deliveryCapture` integration in `useAppSdkBridge`**: The accumulator's `onInitiation`, `onPostResponse`, `onPostFailure`, and `onTerminal` hooks are wired into the existing fetch interception logic. The pre-stamp body is passed to `onInitiation` so delivery-specific fields never influence the capture key.

Relates: PROD-8374
Relates: #24475

## Why sha256 is vendored (99 lines) rather than a dependency

The accumulator originally used `crypto.subtle`, which is secure-context-only — undefined on plain-http internal hosts (docker previews, okteto, self-hosted `INTERNAL_LIGHTDASH_HOST=http://…`), where it silently broke every capture. The replacement had to be synchronous JS. No browser-usable hash dep exists in the workspace (`hasha` is Node-only), and we chose vendoring over adding one because: (1) crypto-adjacent micro-packages are the most typosquatted category on npm and this repo runs a strict supply-chain posture (sfw, strictDepBuilds); (2) this is an identity/dedupe hash, not a security primitive — audit pedigree buys nothing; (3) SHA-256 is spec-frozen (FIPS 180-4), so there are no upstream fixes to miss. Verified against NIST vectors twice, including an independent re-implementation check in review. If we later prefer `@noble/hashes`, the swap is one import.
