### PR TITLE
feat(data-apps): publish delivery-capture manifest before screenshot indicator in MinimalApp

### DIFF
--- a/packages/frontend/src/features/apps/AppIframePreview.tsx
+++ b/packages/frontend/src/features/apps/AppIframePreview.tsx
@@ -1,6 +1,7 @@
 import {
     type DataAppVizContext,
     type DashboardFilters,
+    type QueryExecutionContext,
 } from '@lightdash/common';
 import {
     forwardRef,
@@ -10,6 +11,7 @@ import {
     useMemo,
     useRef,
 } from 'react';
+import { type DeliveryCaptureAccumulator } from './deliveryCapture/deliveryCaptureAccumulator';
 import {
     useAppSdkBridge,
     type ElementSelectedEvent,
@@ -88,6 +90,12 @@ type Props = {
      *  Set by `DashboardDataAppTile` after a dashboard refresh, mirroring what
      *  chart tiles send; left undefined elsewhere. */
     invalidateCache?: boolean;
+    /** Accumulates a delivery-capture manifest from the bridge's query
+     *  lifecycle events. Set by `MinimalApp` in capture modes only. */
+    deliveryCapture?: DeliveryCaptureAccumulator;
+    /** Overrides the query-execution-context stamped onto every metric
+     *  query the iframe runs, e.g. scheduled-delivery capture. */
+    queryContextOverride?: QueryExecutionContext;
     /** Fired on every iframe `onload` (including the initial about:blank).
      *  Used by `MinimalApp` to gate the screenshot readiness signal. */
     onIframeLoad?: () => void;
@@ -147,6 +155,8 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
             onLineageCancelled,
             dashboardFilters,
             invalidateCache,
+            deliveryCapture,
+            queryContextOverride,
             onIframeLoad,
             capabilities,
             dataAppVizContext,
@@ -197,6 +207,8 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
             onScreenshotAvailable: handleScreenshotAnnounce,
             dashboardFilters,
             invalidateCache,
+            deliveryCapture,
+            queryContextOverride,
             capabilities,
             onLineageAvailable: handleLineageAnnounce,
             onLineageSelected,

--- a/packages/frontend/src/features/apps/deliveryCapture/deliveryCaptureAccumulator.test.ts
+++ b/packages/frontend/src/features/apps/deliveryCapture/deliveryCaptureAccumulator.test.ts
@@ -564,4 +564,63 @@ describe('deliveryCaptureAccumulator', () => {
         });
         expect(parseDeliveryCaptureManifest(manifest)).not.toBeNull();
     });
+
+    describe('subscribe', () => {
+        it('reports the pending count on subscribe and across the entry lifecycle', () => {
+            const acc = createDeliveryCaptureAccumulator();
+            const counts: number[] = [];
+            const unsubscribe = acc.subscribe((count) => counts.push(count));
+            expect(counts).toEqual([0]);
+
+            acc.onInitiation({
+                requestId: 'r1',
+                method: 'POST',
+                path: CHART_PATH,
+                body: { chartUuid: 'c1' },
+                label: null,
+            });
+            // onPostResponse doesn't settle the entry — no notification.
+            acc.onPostResponse('r1', { queryUuid: 'u1' });
+            expect(counts).toEqual([0, 1]);
+
+            acc.onTerminal('u1', { status: 'ready', rowCount: 1 });
+            expect(counts).toEqual([0, 1, 0]);
+
+            unsubscribe();
+            acc.onInitiation({
+                requestId: 'r2',
+                method: 'POST',
+                path: METRIC_PATH,
+                body: { query: baseMetricQuery() },
+                label: null,
+            });
+            expect(counts).toEqual([0, 1, 0]);
+        });
+
+        it('a post failure and a reset both drain the pending count', () => {
+            const acc = createDeliveryCaptureAccumulator();
+            const counts: number[] = [];
+            acc.subscribe((count) => counts.push(count));
+
+            acc.onInitiation({
+                requestId: 'r1',
+                method: 'POST',
+                path: METRIC_PATH,
+                body: { query: baseMetricQuery() },
+                label: null,
+            });
+            acc.onPostFailure('r1', 'boom');
+            expect(counts).toEqual([0, 1, 0]);
+
+            acc.onInitiation({
+                requestId: 'r2',
+                method: 'POST',
+                path: CHART_PATH,
+                body: { chartUuid: 'c1' },
+                label: null,
+            });
+            acc.reset();
+            expect(counts).toEqual([0, 1, 0, 1, 0]);
+        });
+    });
 });

--- a/packages/frontend/src/features/apps/deliveryCapture/deliveryCaptureAccumulator.ts
+++ b/packages/frontend/src/features/apps/deliveryCapture/deliveryCaptureAccumulator.ts
@@ -36,6 +36,9 @@ export type DeliveryCaptureAccumulator = {
      *  A partial capture must never look complete: entries still `pending`
      *  when this resolves are surfaced as `error` items, not dropped. */
     getManifest(): Promise<DeliveryCaptureManifest>;
+    /** Readiness source for capture renders: fires with the current `pending`
+     *  entry count immediately and on every change. Returns an unsubscribe. */
+    subscribe(listener: (pendingCount: number) => void): () => void;
     reset(): void;
 };
 
@@ -95,6 +98,17 @@ export const createDeliveryCaptureAccumulator =
         let uuidToEntry = new Map<string, CaptureEntry>();
         let droppedKeys = new Set<string>();
         let nextOrder = 0;
+        const pendingListeners = new Set<(pendingCount: number) => void>();
+        let lastPendingCount = 0;
+
+        const notifyPendingCount = () => {
+            const pendingCount = [...entriesByRawKey.values()].filter(
+                (entry) => entry.status === 'pending',
+            ).length;
+            if (pendingCount === lastPendingCount) return;
+            lastPendingCount = pendingCount;
+            pendingListeners.forEach((listener) => listener(pendingCount));
+        };
 
         const onInitiation: DeliveryCaptureAccumulator['onInitiation'] = ({
             requestId,
@@ -151,6 +165,7 @@ export const createDeliveryCaptureAccumulator =
                 typeof query?.limit === 'number' ? query.limit : undefined;
 
             requestIdToEntry.set(requestId, entry);
+            notifyPendingCount();
         };
 
         const onPostResponse: DeliveryCaptureAccumulator['onPostResponse'] = (
@@ -188,6 +203,7 @@ export const createDeliveryCaptureAccumulator =
             entry.status = 'error';
             entry.queryUuid = null;
             entry.error = error;
+            notifyPendingCount();
         };
 
         const onTerminal: DeliveryCaptureAccumulator['onTerminal'] = (
@@ -207,6 +223,17 @@ export const createDeliveryCaptureAccumulator =
                 entry.status = 'error';
                 entry.error = outcome.error;
             }
+            notifyPendingCount();
+        };
+
+        const subscribe: DeliveryCaptureAccumulator['subscribe'] = (
+            listener,
+        ) => {
+            pendingListeners.add(listener);
+            listener(lastPendingCount);
+            return () => {
+                pendingListeners.delete(listener);
+            };
         };
 
         const getManifest: DeliveryCaptureAccumulator['getManifest'] =
@@ -269,6 +296,8 @@ export const createDeliveryCaptureAccumulator =
             // So a post-reset capture's first unlabeled query reads "Query 1"
             // again, not a number carried over from the previous capture.
             nextOrder = 0;
+            // Listeners survive a reset — the subscriber outlives the capture.
+            notifyPendingCount();
         };
 
         return {
@@ -277,6 +306,7 @@ export const createDeliveryCaptureAccumulator =
             onPostFailure,
             onTerminal,
             getManifest,
+            subscribe,
             reset,
         };
     };

--- a/packages/frontend/src/pages/MinimalApp.captureMode.test.tsx
+++ b/packages/frontend/src/pages/MinimalApp.captureMode.test.tsx
@@ -1,0 +1,162 @@
+import {
+    DELIVERY_CAPTURE_GLOBAL,
+    QueryExecutionContext,
+    SCREENSHOT_READY_INDICATOR_ID,
+} from '@lightdash/common';
+import type * as MantineHooks from '@mantine-8/hooks';
+import { act, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../testing/testUtils';
+
+type IframePreviewProps = {
+    onScreenshotAvailabilityChange?: (available: boolean) => void;
+    deliveryCapture?: unknown;
+    invalidateCache?: boolean;
+    queryContextOverride?: string;
+};
+
+const mocks = vi.hoisted(() => ({
+    iframePreview: vi.fn((_props: IframePreviewProps) => null),
+    searchParams: new URLSearchParams(),
+}));
+
+vi.mock('react-router', () => ({
+    Navigate: () => null,
+    useParams: () => ({ projectUuid: 'project-uuid', appUuid: 'app-uuid' }),
+    useSearchParams: () => [mocks.searchParams, vi.fn()],
+}));
+
+vi.mock('../features/apps/AppIframePreview', () => ({
+    default: mocks.iframePreview,
+}));
+
+vi.mock('../features/apps/hooks/useAppPreviewToken', () => ({
+    useAppPreviewToken: () => ({
+        data: 'preview-token',
+        isLoading: false,
+        error: undefined,
+    }),
+}));
+
+vi.mock('../features/apps/hooks/useGetApp', () => ({
+    useGetApp: () => ({
+        data: { pages: [{ latestReadyVersion: 1 }] },
+        isLoading: false,
+        error: undefined,
+    }),
+}));
+
+vi.mock('../features/apps/previewOrigin', () => ({
+    usePreviewOrigin: () => 'https://preview.example.com',
+}));
+
+vi.mock('../hooks/useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: () => ({
+        isLoading: false,
+        data: { enabled: true },
+    }),
+}));
+
+// Bypasses the 1.5s app-quiet debounce so `isReady` tracks the underlying
+// signal synchronously — the debounce itself isn't what these tests cover.
+vi.mock('@mantine-8/hooks', async (importOriginal) => {
+    const actual = await importOriginal<typeof MantineHooks>();
+    return { ...actual, useDebouncedValue: (value: unknown) => [value] };
+});
+
+// eslint-disable-next-line import/first
+import MinimalApp from './MinimalApp';
+
+const latestIframeProps = (): IframePreviewProps => {
+    const { calls } = mocks.iframePreview.mock;
+    return calls[calls.length - 1][0];
+};
+
+/** Simulates the SDK announcing screenshot-availability with zero in-flight
+ *  queries — the underlying signal `isReady` is debounced from (mocked
+ *  above to be synchronous). */
+const markSdkReady = () => {
+    act(() => {
+        latestIframeProps().onScreenshotAvailabilityChange?.(true);
+    });
+};
+
+const readyIndicatorSelector = `#${SCREENSHOT_READY_INDICATOR_ID}`;
+
+describe('MinimalApp capture modes', () => {
+    beforeEach(() => {
+        mocks.iframePreview.mockClear();
+        mocks.searchParams = new URLSearchParams();
+        delete (window as unknown as Record<string, unknown>)[
+            DELIVERY_CAPTURE_GLOBAL
+        ];
+    });
+
+    it('stamps invalidateCache + scheduledDelivery context in delivery mode', () => {
+        mocks.searchParams.set('captureMode', 'delivery');
+        renderWithProviders(<MinimalApp />);
+
+        expect(latestIframeProps()).toEqual(
+            expect.objectContaining({
+                invalidateCache: true,
+                queryContextOverride: QueryExecutionContext.SCHEDULED_DELIVERY,
+                deliveryCapture: expect.anything(),
+            }),
+        );
+    });
+
+    it('passes the accumulator without stamps in preview mode', () => {
+        mocks.searchParams.set('captureMode', 'preview');
+        renderWithProviders(<MinimalApp />);
+
+        expect(latestIframeProps()).toEqual(
+            expect.objectContaining({
+                invalidateCache: undefined,
+                queryContextOverride: undefined,
+                deliveryCapture: expect.anything(),
+            }),
+        );
+    });
+
+    it('never publishes the manifest global outside capture modes', async () => {
+        renderWithProviders(<MinimalApp />);
+
+        markSdkReady();
+
+        // Give any (unexpected) publish microtask a chance to run.
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(
+            (window as unknown as Record<string, unknown>)[
+                DELIVERY_CAPTURE_GLOBAL
+            ],
+        ).toBeUndefined();
+    });
+
+    it('mounts the indicator only after the manifest global is published', async () => {
+        mocks.searchParams.set('captureMode', 'preview');
+        const { container } = renderWithProviders(<MinimalApp />);
+
+        markSdkReady();
+        // The publish is async (getManifest awaits pending hashing) — right
+        // after the ready signal flips, the indicator must not be mounted yet.
+        expect(container.querySelector(readyIndicatorSelector)).toBeNull();
+        expect(
+            (window as unknown as Record<string, unknown>)[
+                DELIVERY_CAPTURE_GLOBAL
+            ],
+        ).toBeUndefined();
+
+        await waitFor(() => {
+            expect(
+                (window as unknown as Record<string, unknown>)[
+                    DELIVERY_CAPTURE_GLOBAL
+                ],
+            ).toBeDefined();
+        });
+
+        expect(container.querySelector(readyIndicatorSelector)).not.toBeNull();
+    });
+});

--- a/packages/frontend/src/pages/MinimalApp.captureMode.test.tsx
+++ b/packages/frontend/src/pages/MinimalApp.captureMode.test.tsx
@@ -6,6 +6,7 @@ import {
 import type * as MantineHooks from '@mantine-8/hooks';
 import { act, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as DeliveryCaptureAccumulatorModule from '../features/apps/deliveryCapture/deliveryCaptureAccumulator';
 import { renderWithProviders } from '../testing/testUtils';
 
 type IframePreviewProps = {
@@ -19,6 +20,7 @@ type IframePreviewProps = {
 const mocks = vi.hoisted(() => ({
     iframePreview: vi.fn((_props: IframePreviewProps) => null),
     searchParams: new URLSearchParams(),
+    manifestError: null as Error | null,
 }));
 
 vi.mock('react-router', () => ({
@@ -58,6 +60,28 @@ vi.mock('../hooks/useServerOrClientFeatureFlag', () => ({
     }),
 }));
 
+// Real accumulator, with an opt-in rejecting getManifest for the failure path.
+vi.mock(
+    '../features/apps/deliveryCapture/deliveryCaptureAccumulator',
+    async (importOriginal) => {
+        const actual =
+            await importOriginal<typeof DeliveryCaptureAccumulatorModule>();
+        return {
+            ...actual,
+            createDeliveryCaptureAccumulator: () => {
+                const accumulator = actual.createDeliveryCaptureAccumulator();
+                return {
+                    ...accumulator,
+                    getManifest: () =>
+                        mocks.manifestError
+                            ? Promise.reject(mocks.manifestError)
+                            : accumulator.getManifest(),
+                };
+            },
+        };
+    },
+);
+
 // Bypasses the 1.5s app-quiet debounce so `isReady` tracks the underlying
 // signal synchronously — the debounce itself isn't what these tests cover.
 vi.mock('@mantine-8/hooks', async (importOriginal) => {
@@ -91,6 +115,7 @@ describe('MinimalApp capture modes', () => {
     beforeEach(() => {
         mocks.iframePreview.mockClear();
         mocks.searchParams = new URLSearchParams();
+        mocks.manifestError = null;
         delete (window as unknown as Record<string, unknown>)[
             DELIVERY_CAPTURE_GLOBAL
         ];
@@ -150,8 +175,8 @@ describe('MinimalApp capture modes', () => {
         const { container } = renderWithProviders(<MinimalApp />);
 
         markSdkReady();
-        // The publish is async (getManifest awaits pending hashing) — right
-        // after the ready signal flips, the indicator must not be mounted yet.
+        // The publish resolves a microtask later, so right after the ready
+        // signal flips the indicator must not be mounted yet.
         expect(container.querySelector(readyIndicatorSelector)).toBeNull();
         expect(readGlobal()).toBeUndefined();
 
@@ -160,6 +185,30 @@ describe('MinimalApp capture modes', () => {
         });
 
         expect(container.querySelector(readyIndicatorSelector)).not.toBeNull();
+    });
+
+    it('logs a console error when the manifest publish rejects', async () => {
+        // UnfurlService forwards console errors, so a rejection has to leave a
+        // diagnosable line rather than silently burning the render timeout.
+        mocks.manifestError = new Error('manifest boom');
+        mocks.searchParams.set('captureMode', 'preview');
+        const consoleError = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
+        const { container } = renderWithProviders(<MinimalApp />);
+
+        markSdkReady();
+
+        await waitFor(() => {
+            expect(consoleError).toHaveBeenCalledWith(
+                '[delivery-capture] manifest publish failed',
+                mocks.manifestError,
+            );
+        });
+        expect(readGlobal()).toBeUndefined();
+        expect(container.querySelector(readyIndicatorSelector)).toBeNull();
+
+        consoleError.mockRestore();
     });
 
     it('clears the stale manifest and republishes after an iframe reload', async () => {

--- a/packages/frontend/src/pages/MinimalApp.captureMode.test.tsx
+++ b/packages/frontend/src/pages/MinimalApp.captureMode.test.tsx
@@ -10,6 +10,7 @@ import { renderWithProviders } from '../testing/testUtils';
 
 type IframePreviewProps = {
     onScreenshotAvailabilityChange?: (available: boolean) => void;
+    onIframeLoad?: () => void;
     deliveryCapture?: unknown;
     invalidateCache?: boolean;
     queryContextOverride?: string;
@@ -83,6 +84,9 @@ const markSdkReady = () => {
 
 const readyIndicatorSelector = `#${SCREENSHOT_READY_INDICATOR_ID}`;
 
+const readGlobal = () =>
+    (window as unknown as Record<string, unknown>)[DELIVERY_CAPTURE_GLOBAL];
+
 describe('MinimalApp capture modes', () => {
     beforeEach(() => {
         mocks.iframePreview.mockClear();
@@ -128,11 +132,17 @@ describe('MinimalApp capture modes', () => {
             await Promise.resolve();
         });
 
-        expect(
-            (window as unknown as Record<string, unknown>)[
-                DELIVERY_CAPTURE_GLOBAL
-            ],
-        ).toBeUndefined();
+        expect(readGlobal()).toBeUndefined();
+    });
+
+    it('mounts the indicator once ready when no capture mode is set', () => {
+        const { container } = renderWithProviders(<MinimalApp />);
+
+        expect(container.querySelector(readyIndicatorSelector)).toBeNull();
+
+        markSdkReady();
+
+        expect(container.querySelector(readyIndicatorSelector)).not.toBeNull();
     });
 
     it('mounts the indicator only after the manifest global is published', async () => {
@@ -143,20 +153,41 @@ describe('MinimalApp capture modes', () => {
         // The publish is async (getManifest awaits pending hashing) — right
         // after the ready signal flips, the indicator must not be mounted yet.
         expect(container.querySelector(readyIndicatorSelector)).toBeNull();
-        expect(
-            (window as unknown as Record<string, unknown>)[
-                DELIVERY_CAPTURE_GLOBAL
-            ],
-        ).toBeUndefined();
+        expect(readGlobal()).toBeUndefined();
 
         await waitFor(() => {
-            expect(
-                (window as unknown as Record<string, unknown>)[
-                    DELIVERY_CAPTURE_GLOBAL
-                ],
-            ).toBeDefined();
+            expect(readGlobal()).toBeDefined();
         });
 
+        expect(container.querySelector(readyIndicatorSelector)).not.toBeNull();
+    });
+
+    it('clears the stale manifest and republishes after an iframe reload', async () => {
+        mocks.searchParams.set('captureMode', 'preview');
+        const { container } = renderWithProviders(<MinimalApp />);
+
+        markSdkReady();
+        await waitFor(() => {
+            expect(readGlobal()).toBeDefined();
+        });
+        expect(container.querySelector(readyIndicatorSelector)).not.toBeNull();
+        const firstManifest = readGlobal();
+
+        // Simulate a mid-render republish: the iframe reloads a new app
+        // version, which resets SDK availability before it re-announces.
+        act(() => {
+            latestIframeProps().onIframeLoad?.();
+            latestIframeProps().onScreenshotAvailabilityChange?.(false);
+        });
+
+        expect(readGlobal()).toBeUndefined();
+        expect(container.querySelector(readyIndicatorSelector)).toBeNull();
+
+        markSdkReady();
+        await waitFor(() => {
+            expect(readGlobal()).toBeDefined();
+        });
+        expect(readGlobal()).not.toBe(firstManifest);
         expect(container.querySelector(readyIndicatorSelector)).not.toBeNull();
     });
 });

--- a/packages/frontend/src/pages/MinimalApp.captureMode.test.tsx
+++ b/packages/frontend/src/pages/MinimalApp.captureMode.test.tsx
@@ -7,12 +7,15 @@ import type * as MantineHooks from '@mantine-8/hooks';
 import { act, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type * as DeliveryCaptureAccumulatorModule from '../features/apps/deliveryCapture/deliveryCaptureAccumulator';
+import type { DeliveryCaptureAccumulator } from '../features/apps/deliveryCapture/deliveryCaptureAccumulator';
+import type { QueryEvent } from '../features/apps/hooks/useAppSdkBridge';
 import { renderWithProviders } from '../testing/testUtils';
 
 type IframePreviewProps = {
     onScreenshotAvailabilityChange?: (available: boolean) => void;
     onIframeLoad?: () => void;
-    deliveryCapture?: unknown;
+    onQueryEvent?: (event: QueryEvent) => void;
+    deliveryCapture?: DeliveryCaptureAccumulator;
     invalidateCache?: boolean;
     queryContextOverride?: string;
 };
@@ -110,6 +113,43 @@ const readyIndicatorSelector = `#${SCREENSHOT_READY_INDICATOR_ID}`;
 
 const readGlobal = () =>
     (window as unknown as Record<string, unknown>)[DELIVERY_CAPTURE_GLOBAL];
+
+const CHART_PATH = '/api/v2/projects/project-uuid/query/chart';
+const METRIC_PATH = '/api/v2/projects/project-uuid/query/metric-query';
+
+const latestCapture = (): DeliveryCaptureAccumulator => {
+    const capture = latestIframeProps().deliveryCapture;
+    if (!capture) throw new Error('no accumulator passed to the iframe');
+    return capture;
+};
+
+const queryEvent = (
+    overrides: Partial<QueryEvent> & Pick<QueryEvent, 'id' | 'status'>,
+): QueryEvent => ({
+    timestamp: Date.now(),
+    label: null,
+    exploreName: 'orders',
+    dimensions: [],
+    metrics: [],
+    filters: {},
+    sorts: [],
+    tableCalculations: [],
+    additionalMetrics: [],
+    limit: 500,
+    queryUuid: null,
+    rowCount: null,
+    durationMs: null,
+    error: null,
+    rawMetricQuery: null,
+    ...overrides,
+});
+
+/** Lets any queued publish microtask run before asserting it did NOT happen. */
+const flushMicrotasks = async () => {
+    await act(async () => {
+        await Promise.resolve();
+    });
+};
 
 describe('MinimalApp capture modes', () => {
     beforeEach(() => {
@@ -209,6 +249,110 @@ describe('MinimalApp capture modes', () => {
         expect(container.querySelector(readyIndicatorSelector)).toBeNull();
 
         consoleError.mockRestore();
+    });
+
+    // A /query/chart POST emits no `pending` QueryEvent — the accumulator
+    // entry is the only in-flight signal until the POST resolves, so readiness
+    // has to consume it or an app of only saved charts publishes a manifest
+    // full of "did not settle" errors.
+    it('withholds the manifest while a chart-query POST is pending in the accumulator', async () => {
+        mocks.searchParams.set('captureMode', 'delivery');
+        const { container } = renderWithProviders(<MinimalApp />);
+
+        act(() => {
+            latestCapture().onInitiation({
+                requestId: 'chart-req',
+                method: 'POST',
+                path: CHART_PATH,
+                body: { chartUuid: 'chart-1' },
+                label: 'Revenue',
+            });
+        });
+        markSdkReady();
+        await flushMicrotasks();
+
+        expect(readGlobal()).toBeUndefined();
+        expect(container.querySelector(readyIndicatorSelector)).toBeNull();
+
+        act(() => {
+            latestCapture().onPostResponse('chart-req', {
+                queryUuid: 'chart-uuid',
+                metricQuery: { exploreName: 'orders', limit: 500 },
+            });
+            latestCapture().onTerminal('chart-uuid', {
+                status: 'ready',
+                rowCount: 12,
+            });
+        });
+
+        await waitFor(() => {
+            expect(readGlobal()).toBeDefined();
+        });
+        expect(readGlobal()).toMatchObject({
+            items: [
+                {
+                    status: 'ready',
+                    label: 'Revenue',
+                    queryUuid: 'chart-uuid',
+                    rowCount: 12,
+                },
+            ],
+        });
+        expect(container.querySelector(readyIndicatorSelector)).not.toBeNull();
+    });
+
+    // Unchanged behaviour: the QueryEvent in-flight set still gates on its own,
+    // so a settled accumulator entry can't publish ahead of a live metric query.
+    it('still gates on the QueryEvent in-flight set for metric queries', async () => {
+        mocks.searchParams.set('captureMode', 'delivery');
+        const { container } = renderWithProviders(<MinimalApp />);
+
+        act(() => {
+            latestCapture().onInitiation({
+                requestId: 'metric-req',
+                method: 'POST',
+                path: METRIC_PATH,
+                body: { query: { exploreName: 'orders', limit: 500 } },
+                label: null,
+            });
+            latestIframeProps().onQueryEvent?.(
+                queryEvent({ id: 'metric-req', status: 'pending' }),
+            );
+        });
+        markSdkReady();
+        await flushMicrotasks();
+
+        expect(readGlobal()).toBeUndefined();
+
+        act(() => {
+            latestCapture().onPostResponse('metric-req', {
+                queryUuid: 'metric-uuid',
+            });
+            latestCapture().onTerminal('metric-uuid', {
+                status: 'ready',
+                rowCount: 3,
+            });
+        });
+        await flushMicrotasks();
+
+        expect(readGlobal()).toBeUndefined();
+        expect(container.querySelector(readyIndicatorSelector)).toBeNull();
+
+        act(() => {
+            latestIframeProps().onQueryEvent?.(
+                queryEvent({
+                    id: 'metric-req',
+                    status: 'ready',
+                    queryUuid: 'metric-uuid',
+                    rowCount: 3,
+                }),
+            );
+        });
+
+        await waitFor(() => {
+            expect(readGlobal()).toBeDefined();
+        });
+        expect(container.querySelector(readyIndicatorSelector)).not.toBeNull();
     });
 
     it('clears the stale manifest and republishes after an iframe reload', async () => {

--- a/packages/frontend/src/pages/MinimalApp.tsx
+++ b/packages/frontend/src/pages/MinimalApp.tsx
@@ -145,13 +145,20 @@ export default function MinimalApp() {
         if (!isReady || !captureMode || !deliveryCapture || manifestPublished)
             return;
         let cancelled = false;
-        void deliveryCapture.getManifest().then((manifest) => {
-            if (cancelled) return;
-            (window as unknown as Record<string, unknown>)[
-                DELIVERY_CAPTURE_GLOBAL
-            ] = manifest;
-            setManifestPublished(true);
-        });
+        void deliveryCapture
+            .getManifest()
+            .then((manifest) => {
+                if (cancelled) return;
+                (window as unknown as Record<string, unknown>)[
+                    DELIVERY_CAPTURE_GLOBAL
+                ] = manifest;
+                setManifestPublished(true);
+            })
+            // A rejection here would otherwise leave the indicator unmounted
+            // until the render times out, with nothing in the logs.
+            .catch((e) =>
+                console.error('[delivery-capture] manifest publish failed', e),
+            );
         return () => {
             cancelled = true;
         };

--- a/packages/frontend/src/pages/MinimalApp.tsx
+++ b/packages/frontend/src/pages/MinimalApp.tsx
@@ -88,7 +88,13 @@ export default function MinimalApp() {
 
     const handleIframeLoad = useCallback(() => {
         setIframeLoaded(true);
-        deliveryCapture?.reset();
+        if (deliveryCapture) {
+            deliveryCapture.reset();
+            setManifestPublished(false);
+            delete (window as unknown as Record<string, unknown>)[
+                DELIVERY_CAPTURE_GLOBAL
+            ];
+        }
     }, [deliveryCapture]);
 
     const handleScreenshotAvailable = useCallback((available: boolean) => {

--- a/packages/frontend/src/pages/MinimalApp.tsx
+++ b/packages/frontend/src/pages/MinimalApp.tsx
@@ -1,13 +1,18 @@
-import { FeatureFlags } from '@lightdash/common';
+import {
+    DELIVERY_CAPTURE_GLOBAL,
+    FeatureFlags,
+    QueryExecutionContext,
+} from '@lightdash/common';
 import { Box, Loader, Stack, Text } from '@mantine-8/core';
 import { useDebouncedValue } from '@mantine-8/hooks';
 import { IconAppsOff } from '@tabler/icons-react';
-import { useCallback, useEffect, useState } from 'react';
-import { Navigate, useParams } from 'react-router';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Navigate, useParams, useSearchParams } from 'react-router';
 import ScreenshotReadyIndicator from '../components/common/ScreenshotReadyIndicator';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import ForbiddenPanel from '../components/ForbiddenPanel';
 import AppIframePreview from '../features/apps/AppIframePreview';
+import { createDeliveryCaptureAccumulator } from '../features/apps/deliveryCapture/deliveryCaptureAccumulator';
 import { useAppPreviewToken } from '../features/apps/hooks/useAppPreviewToken';
 import { type QueryEvent } from '../features/apps/hooks/useAppSdkBridge';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
@@ -46,6 +51,17 @@ export default function MinimalApp() {
         projectUuid: string;
         appUuid: string;
     }>();
+    const [searchParams] = useSearchParams();
+    const captureModeParam = searchParams.get('captureMode');
+    const captureMode: 'delivery' | 'preview' | null =
+        captureModeParam === 'delivery' || captureModeParam === 'preview'
+            ? captureModeParam
+            : null;
+    const deliveryCapture = useMemo(
+        () => (captureMode ? createDeliveryCaptureAccumulator() : undefined),
+        [captureMode],
+    );
+    const [manifestPublished, setManifestPublished] = useState(false);
 
     const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
 
@@ -72,7 +88,8 @@ export default function MinimalApp() {
 
     const handleIframeLoad = useCallback(() => {
         setIframeLoaded(true);
-    }, []);
+        deliveryCapture?.reset();
+    }, [deliveryCapture]);
 
     const handleScreenshotAvailable = useCallback((available: boolean) => {
         setSdkAlive(available);
@@ -115,6 +132,25 @@ export default function MinimalApp() {
         (sdkAlive || sdkAliveFallback) && activeQueryIds.size === 0,
         APP_QUIET_DEBOUNCE_MS,
     );
+
+    // Publishes the captured manifest to the window global exactly once per
+    // settle, before the indicator (which UnfurlService waits on) can mount.
+    useEffect(() => {
+        if (!isReady || !captureMode || !deliveryCapture || manifestPublished)
+            return;
+        let cancelled = false;
+        void deliveryCapture.getManifest().then((manifest) => {
+            if (cancelled) return;
+            (window as unknown as Record<string, unknown>)[
+                DELIVERY_CAPTURE_GLOBAL
+            ] = manifest;
+            setManifestPublished(true);
+        });
+        return () => {
+            cancelled = true;
+        };
+    }, [isReady, captureMode, deliveryCapture, manifestPublished]);
+    const indicatorReady = captureMode ? isReady && manifestPublished : isReady;
 
     if (dataAppsFlag.isLoading) return null;
     if (!dataAppsFlag.data?.enabled) {
@@ -197,11 +233,18 @@ export default function MinimalApp() {
                 onIframeLoad={handleIframeLoad}
                 onQueryEvent={handleQueryEvent}
                 onScreenshotAvailabilityChange={handleScreenshotAvailable}
+                deliveryCapture={deliveryCapture}
+                invalidateCache={captureMode === 'delivery' ? true : undefined}
+                queryContextOverride={
+                    captureMode === 'delivery'
+                        ? QueryExecutionContext.SCHEDULED_DELIVERY
+                        : undefined
+                }
                 // Seeds the app from ?state= so scheduled deliveries with a
                 // saved app state screenshot that view, not the default one.
                 urlStateSync
             />
-            {isReady && (
+            {indicatorReady && (
                 <ScreenshotReadyIndicator
                     tilesTotal={1}
                     tilesReady={1}

--- a/packages/frontend/src/pages/MinimalApp.tsx
+++ b/packages/frontend/src/pages/MinimalApp.tsx
@@ -2,6 +2,7 @@ import {
     DELIVERY_CAPTURE_GLOBAL,
     FeatureFlags,
     QueryExecutionContext,
+    type DeliveryCaptureManifest,
 } from '@lightdash/common';
 import { Box, Loader, Stack, Text } from '@mantine-8/core';
 import { useDebouncedValue } from '@mantine-8/hooks';
@@ -61,7 +62,10 @@ export default function MinimalApp() {
         () => (captureMode ? createDeliveryCaptureAccumulator() : undefined),
         [captureMode],
     );
-    const [manifestPublished, setManifestPublished] = useState(false);
+    // The published manifest doubles as the "already published" flag.
+    const [manifest, setManifest] = useState<DeliveryCaptureManifest | null>(
+        null,
+    );
 
     const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
 
@@ -85,12 +89,13 @@ export default function MinimalApp() {
     const [activeQueryIds, setActiveQueryIds] = useState<Set<string>>(
         () => new Set(),
     );
+    const [pendingCaptureCount, setPendingCaptureCount] = useState(0);
 
     const handleIframeLoad = useCallback(() => {
         setIframeLoaded(true);
         if (deliveryCapture) {
             deliveryCapture.reset();
-            setManifestPublished(false);
+            setManifest(null);
             delete (window as unknown as Record<string, unknown>)[
                 DELIVERY_CAPTURE_GLOBAL
             ];
@@ -128,6 +133,14 @@ export default function MinimalApp() {
         return () => clearTimeout(timer);
     }, [iframeLoaded]);
 
+    // In capture modes the accumulator — not the QueryEvent projection — is
+    // the delivery contract: a `/query/chart` POST is in-flight there before
+    // any QueryEvent exists for it, so readiness must consume it too.
+    useEffect(() => {
+        if (!deliveryCapture) return;
+        return deliveryCapture.subscribe(setPendingCaptureCount);
+    }, [deliveryCapture]);
+
     // Debounced ready signal: only true once the SDK has announced (or the
     // fallback timer has elapsed) AND in-flight query count has been zero
     // for APP_QUIET_DEBOUNCE_MS. Gating on the SDK announce — not the
@@ -135,24 +148,27 @@ export default function MinimalApp() {
     // between iframe HTML load and the SDK bundle bootstrapping, which
     // was the root cause of blank/mid-animation screenshots.
     const [isReady] = useDebouncedValue(
-        (sdkAlive || sdkAliveFallback) && activeQueryIds.size === 0,
+        (sdkAlive || sdkAliveFallback) &&
+            activeQueryIds.size === 0 &&
+            // Always 0 outside capture modes (no accumulator, no subscription).
+            pendingCaptureCount === 0,
         APP_QUIET_DEBOUNCE_MS,
     );
 
     // Publishes the captured manifest to the window global exactly once per
     // settle, before the indicator (which UnfurlService waits on) can mount.
     useEffect(() => {
-        if (!isReady || !captureMode || !deliveryCapture || manifestPublished)
+        if (!isReady || !captureMode || !deliveryCapture || manifest !== null)
             return;
         let cancelled = false;
         void deliveryCapture
             .getManifest()
-            .then((manifest) => {
+            .then((captured) => {
                 if (cancelled) return;
                 (window as unknown as Record<string, unknown>)[
                     DELIVERY_CAPTURE_GLOBAL
-                ] = manifest;
-                setManifestPublished(true);
+                ] = captured;
+                setManifest(captured);
             })
             // A rejection here would otherwise leave the indicator unmounted
             // until the render times out, with nothing in the logs.
@@ -162,8 +178,8 @@ export default function MinimalApp() {
         return () => {
             cancelled = true;
         };
-    }, [isReady, captureMode, deliveryCapture, manifestPublished]);
-    const indicatorReady = captureMode ? isReady && manifestPublished : isReady;
+    }, [isReady, captureMode, deliveryCapture, manifest]);
+    const indicatorReady = captureMode ? isReady && manifest !== null : isReady;
 
     if (dataAppsFlag.isLoading) return null;
     if (!dataAppsFlag.data?.enabled) {


### PR DESCRIPTION
Closes:

### Description:

Adds capture mode support to `MinimalApp` for scheduled delivery and preview screenshots.

A `captureMode` query parameter (`delivery` or `preview`) now controls how the app behaves when rendering for capture:

- In `delivery` mode, `invalidateCache` is set and the query execution context is stamped as `SCHEDULED_DELIVERY`, ensuring fresh data is fetched with the correct context.
- In `preview` mode, the accumulator is attached without those overrides.
- In both capture modes, a `DeliveryCaptureAccumulator` is created and passed to `AppIframePreview` to collect a delivery manifest from the bridge's query lifecycle events.

The `ScreenshotReadyIndicator` is now gated on both the SDK readiness signal and the manifest being published to `window[DELIVERY_CAPTURE_GLOBAL]`. This ensures the UnfurlService only proceeds once the manifest is available. When the iframe reloads (e.g. a new app version), the accumulator is reset, the global is cleared, and the indicator is unmounted until the manifest is republished.

Tests cover the key behaviors: correct prop stamping per capture mode, manifest publication gating the indicator, no global published outside capture modes, and correct reset/republish on iframe reload.

Relates: PROD-8374
Relates: #24475
