### PR TITLE
chore(dev): automate agent Okteto environments

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,6 +15,15 @@
             "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/agent-okteto-dev.sh\" hook-env"
           }
         ]
+      },
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/agent-okteto-dev.sh\" hook-start"
+          }
+        ]
       }
     ]
   }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,5 +4,18 @@
       "Read(packages/formula-tests/**)",
       "Edit(packages/formula-tests/**)"
     ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact|fork",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/agent-okteto-dev.sh\" hook-env"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.github/workflows/agent-okteto-pool.yml
+++ b/.github/workflows/agent-okteto-pool.yml
@@ -1,0 +1,40 @@
+name: Agent Okteto Pool
+
+on:
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: agent-okteto-pool
+  cancel-in-progress: false
+
+jobs:
+  maintain:
+    name: Keep three development environments ready
+    runs-on: depot-ubuntu-24.04-4
+    timeout-minutes: 60
+    env:
+      LIGHTDASH_OKTETO_TOKEN: ${{ secrets.LIGHTDASH_OKTETO_TOKEN }}
+      OKTETO_CONTEXT: ${{ secrets.OKTETO_CONTEXT }}
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Okteto CLI
+        run: |
+          curl -sSfL -o okteto \
+            https://github.com/okteto/okteto/releases/download/3.21.0/okteto-Linux-x86_64
+          echo "f1fc644e2c2d2285a557577eafc6d4494410dce17b36bac6c3c269fc04c573ef  okteto" |
+            sha256sum --check
+          chmod +x okteto
+          sudo mv okteto /usr/local/bin/okteto
+
+      - name: Maintain ready environment pool
+        run: ./scripts/maintain-agent-okteto-pool.sh 3

--- a/.github/workflows/agent-okteto-pool.yml
+++ b/.github/workflows/agent-okteto-pool.yml
@@ -2,7 +2,7 @@ name: Agent Okteto Pool
 
 on:
   schedule:
-    - cron: "17 * * * *"
+    - cron: "*/30 * * * *"
   workflow_dispatch:
 
 permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,37 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Opt-in Agent Okteto Development Environment
+
+This workflow is enabled only when
+`LIGHTDASH_OKTETO_TOKEN` is set. If it is not set, skip this section and
+follow the normal development workflow.
+
+When it is set, immediately after receiving the user's first prompt:
+
+1. Tell the user that the development environment is starting.
+2. Start a background subagent that runs
+   `./scripts/agent-okteto-dev.sh start` with a 10-minute Bash timeout.
+3. Continue working on the user's prompt in the main agent while the environment
+   starts. Do not wait for the subagent before beginning the task.
+
+If startup fails, give the user the exact error plus
+`docs/agent-okteto.md`, but continue working on their request.
+
+This applies to any opted-in coding-agent session. Do not replace it with a
+local Docker environment.
+
+For an opted-in session, after making and validating code changes, collect the
+startup subagent's result and have a background subagent run
+`./scripts/agent-okteto-dev.sh wait` with a 10-minute Bash timeout. If the
+environment is ready, include the URL from its `READY:` line and the manual
+test login in the final response:
+`demo@lightdash.com` / `demo_password!`. If it is unavailable, report that
+without blocking delivery of the completed code changes.
+
+Leave the Okteto namespace and sync process running so the user can test the
+changes.
+
 ## Formula Package Development
 
 The `packages/formula/` package contains a Peggy-based parser that compiles Google Sheets-like formulas to SQL for each warehouse dialect (Postgres, BigQuery, Snowflake, DuckDB).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,27 +8,18 @@ This workflow is enabled only when
 `LIGHTDASH_OKTETO_TOKEN` is set. If it is not set, skip this section and
 follow the normal development workflow.
 
-When it is set, immediately after receiving the user's first prompt:
+When it is set, the Okteto development environment is started automatically by
+the `SessionStart` hook (`agent-okteto-dev.sh hook-start`) — you do NOT need to
+start it yourself. It provisions in the background while you work on the user's
+prompt. Do not replace it with a local Docker environment.
 
-1. Tell the user that the development environment is starting.
-2. Start a background subagent that runs
-   `./scripts/agent-okteto-dev.sh start` with a 10-minute Bash timeout.
-3. Continue working on the user's prompt in the main agent while the environment
-   starts. Do not wait for the subagent before beginning the task.
-
-If startup fails, give the user the exact error plus
-`docs/agent-okteto.md`, but continue working on their request.
-
-This applies to any opted-in coding-agent session. Do not replace it with a
-local Docker environment.
-
-For an opted-in session, after making and validating code changes, collect the
-startup subagent's result and have a background subagent run
-`./scripts/agent-okteto-dev.sh wait` with a 10-minute Bash timeout. If the
-environment is ready, include the URL from its `READY:` line and the manual
-test login in the final response:
-`demo@lightdash.com` / `demo_password!`. If it is unavailable, report that
-without blocking delivery of the completed code changes.
+For an opted-in session, after making and validating code changes, have a
+background subagent run `./scripts/agent-okteto-dev.sh wait` with a 10-minute
+Bash timeout. If the environment is ready, include the URL from its `READY:`
+line and the manual test login in the final response:
+`demo@lightdash.com` / `demo_password!`. If it is unavailable (for example the
+background start failed — check `docs/agent-okteto.md` and the logs it points
+to), report that without blocking delivery of the completed code changes.
 
 Leave the Okteto namespace and sync process running so the user can test the
 changes.

--- a/docs/agent-okteto.md
+++ b/docs/agent-okteto.md
@@ -171,13 +171,14 @@ LIGHTDASH_OKTETO_TOKEN=<shared automation token>
 OKTETO_CONTEXT=https://lightdash.okteto.dev
 ```
 
-The maintainer marks a namespace ready only after
-`/api/v1/health` succeeds. An agent claims it by atomically creating the
+The maintainer marks a namespace ready after its base pods and public ingress
+are available. An agent claims it by atomically creating the
 `lightdash-agent-claim` ConfigMap with its session hash. Kubernetes allows only
 one creation to succeed, preventing two simultaneous sessions from selecting
-the same namespace. Claimed namespaces are excluded when the workflow
-replenishes the pool. The same hash is available inside the development
-container as `LIGHTDASH_AGENT_SESSION_HASH`.
+the same namespace. After `okteto up`, the launcher waits for file
+synchronization and `/api/v1/health`. Claimed namespaces are excluded when the
+workflow replenishes the pool. The same hash is available inside the
+development container as `LIGHTDASH_AGENT_SESSION_HASH`.
 
 The workflow uses `scripts/maintain-agent-okteto-pool.sh`. Run it manually with
 the desired minimum pool size when testing administrator changes:
@@ -191,7 +192,7 @@ the desired minimum pool size when testing administrator changes:
 The agent's final response includes a URL like:
 
 ```text
-https://lightdash-agent-pool-<pool-id>.lightdash.okteto.dev
+https://<deployment>-agent-pool-<pool-id>.lightdash.okteto.dev
 ```
 
 Use these credentials:

--- a/docs/agent-okteto.md
+++ b/docs/agent-okteto.md
@@ -162,9 +162,9 @@ variable.
 
 ## Ready environment pool
 
-The `Agent Okteto Pool` GitHub Actions workflow runs hourly and can also be
-started manually. It keeps at least three unclaimed namespaces deployed and
-healthy. Pooled namespaces use short sequential names such as `dev-warm-1`.
+The `Agent Okteto Pool` GitHub Actions workflow runs every 30 minutes and can
+also be started manually. It keeps at least three unclaimed namespaces deployed
+and healthy. Pooled namespaces use short sequential names such as `dev-warm-1`.
 Configure these GitHub Actions secrets:
 
 ```text

--- a/docs/agent-okteto.md
+++ b/docs/agent-okteto.md
@@ -6,9 +6,9 @@ agent only starts it when the Lightdash-specific Okteto token variable is
 configured. Engineers without that variable continue using the normal
 development workflow.
 
-Each opted-in agent workspace receives its own namespace, so multiple tasks can
-run at the same time without overwriting one another. The namespace remains
-available after the agent finishes so you can test the result.
+Each opted-in session atomically claims a ready namespace from a shared pool, so
+multiple tasks can run without overwriting one another. The namespace remains
+claimed after the agent finishes so you can test the result.
 
 ## What you need
 
@@ -94,9 +94,9 @@ command -v tmux >/dev/null || {
 }
 ```
 
-Start a new Claude Code session after saving the environment. Claude creates
-the Okteto namespace in a background subagent while its main agent works on
-your task.
+Start a new Claude Code session after saving the environment. Claude claims a
+ready Okteto namespace and starts file synchronization in the background while
+its main agent works on your task.
 
 ### How the Claude hook works
 
@@ -105,18 +105,20 @@ cleared, compacted, and forked Claude sessions. Claude sends session metadata
 to the hook over standard input and provides `CLAUDE_ENV_FILE` for variables
 that should remain available to later shell commands.
 
-The hook calls `agent-okteto-dev.sh hook-env`. When
-`LIGHTDASH_OKTETO_TOKEN` is set, that command copies Claude's `session_id` into
-`LIGHTDASH_AGENT_SESSION_ID` through `CLAUDE_ENV_FILE`. It exits without doing
-anything when the token is absent.
+The first hook calls `agent-okteto-dev.sh hook-env`. When the token is set, it
+copies Claude's `session_id` into `LIGHTDASH_AGENT_SESSION_ID` through
+`CLAUDE_ENV_FILE`. The second hook calls `hook-start`, which launches `start`
+as a detached process and immediately returns. Both hooks do nothing when the
+token is absent.
 
-The hook never creates an Okteto environment. The background subagent described
-in `CLAUDE.md` runs the launcher's `start` command after the first prompt.
+`start` claims an unclaimed, healthy pooled namespace and runs `okteto up`
+against its existing deployment. If the pool is temporarily exhausted, it
+falls back to creating and deploying a session-specific namespace.
 
 ## Other coding agents
 
 Make the same `LIGHTDASH_OKTETO_TOKEN` variable available to the agent process
-and install Okteto, `kubectl`, and `tmux` in its environment. Agents use
+and install Okteto, `kubectl`, `jq`, and `tmux` in its environment. Agents use
 `LIGHTDASH_AGENT_SESSION_ID` when their platform provides one; otherwise the
 launcher derives a stable identity from the current workspace.
 
@@ -125,7 +127,7 @@ launcher derives a stable identity from the current workspace.
 Install the required tools on macOS:
 
 ```bash
-brew install okteto tmux kubectl
+brew install okteto tmux kubectl jq
 ```
 
 Make `LIGHTDASH_OKTETO_TOKEN` available to the process that launches Claude
@@ -158,12 +160,38 @@ The launcher defaults to `https://lightdash.okteto.dev`. Administrators can
 override it for testing with the non-secret `OKTETO_CONTEXT` environment
 variable.
 
+## Ready environment pool
+
+The `Agent Okteto Pool` GitHub Actions workflow runs hourly and can also be
+started manually. It keeps at least three unclaimed namespaces deployed and
+healthy. Configure these GitHub Actions secrets:
+
+```text
+LIGHTDASH_OKTETO_TOKEN=<shared automation token>
+OKTETO_CONTEXT=https://lightdash.okteto.dev
+```
+
+The maintainer marks a namespace ready only after
+`/api/v1/health` succeeds. An agent claims it by atomically creating the
+`lightdash-agent-claim` ConfigMap with its session hash. Kubernetes allows only
+one creation to succeed, preventing two simultaneous sessions from selecting
+the same namespace. Claimed namespaces are excluded when the workflow
+replenishes the pool. The same hash is available inside the development
+container as `LIGHTDASH_AGENT_SESSION_HASH`.
+
+The workflow uses `scripts/maintain-agent-okteto-pool.sh`. Run it manually with
+the desired minimum pool size when testing administrator changes:
+
+```bash
+./scripts/maintain-agent-okteto-pool.sh 3
+```
+
 ## Manual testing
 
 The agent's final response includes a URL like:
 
 ```text
-https://lightdash-agent-<session-hash>.lightdash.okteto.dev
+https://lightdash-agent-pool-<pool-id>.lightdash.okteto.dev
 ```
 
 Use these credentials:

--- a/docs/agent-okteto.md
+++ b/docs/agent-okteto.md
@@ -1,0 +1,182 @@
+# Coding agent development environments
+
+Claude Code and other coding agents can use Okteto to create a complete
+Lightdash development environment for a session. The workflow is opt-in: an
+agent only starts it when the Lightdash-specific Okteto token variable is
+configured. Engineers without that variable continue using the normal
+development workflow.
+
+Each opted-in agent workspace receives its own namespace, so multiple tasks can
+run at the same time without overwriting one another. The namespace remains
+available after the agent finishes so you can test the result.
+
+## What you need
+
+Ask a Lightdash administrator for the shared coding-agent Okteto token. This is
+the only secret you need:
+
+```text
+LIGHTDASH_OKTETO_TOKEN=<shared automation token>
+```
+
+The token must belong to a dedicated, least-privileged Okteto account that can
+create namespaces. It should have an expiration date and be rotated regularly.
+Never commit it, paste it into a prompt, or add it to this repository's
+`.claude/settings.json`.
+
+The launcher gives each session an isolated Okteto and Kubernetes configuration
+under the system temporary directory. It does not add the token to repository
+files or logs and does not replace your normal local Okteto context.
+
+Claude cloud environments do not provide a dedicated secrets store. Values
+added to an environment are readable by anyone who can use that environment.
+Only distribute this token to trusted Lightdash users and keep its Okteto
+permissions narrow. See the
+[Claude Code cloud environment documentation](https://code.claude.com/docs/en/cloud-environments).
+
+## Claude Code on the web
+
+Create or edit the Claude cloud environment you use for Lightdash.
+
+### Environment variables
+
+Add these values:
+
+```text
+LIGHTDASH_OKTETO_TOKEN=<shared automation token>
+BASH_MAX_TIMEOUT_MS=600000
+```
+
+Changing environment variables only affects newly created sessions.
+
+### Network access
+
+Use custom network access, keep the default trusted domains enabled, and allow:
+
+```text
+downloads.okteto.com
+dl.k8s.io
+lightdash.okteto.dev
+*.lightdash.okteto.dev
+```
+
+### Setup script
+
+Use this setup script to install the versions expected by the Lightdash Okteto
+environment:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+OKTETO_VERSION=3.21.0
+OKTETO_SHA256=f1fc644e2c2d2285a557577eafc6d4494410dce17b36bac6c3c269fc04c573ef
+KUBECTL_VERSION=v1.35.0
+
+curl -sSfL \
+  "https://downloads.okteto.com/cli/stable/${OKTETO_VERSION}/okteto-Linux-x86_64" \
+  -o /tmp/okteto
+echo "${OKTETO_SHA256}  /tmp/okteto" | sha256sum --check
+install -m 0755 /tmp/okteto /usr/local/bin/okteto
+
+curl -sSfL \
+  "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+  -o /tmp/kubectl
+curl -sSfL \
+  "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256" \
+  -o /tmp/kubectl.sha256
+echo "$(cat /tmp/kubectl.sha256)  /tmp/kubectl" | sha256sum --check
+install -m 0755 /tmp/kubectl /usr/local/bin/kubectl
+
+command -v tmux >/dev/null || {
+  apt-get update
+  apt-get install -y tmux
+}
+```
+
+Start a new Claude Code session after saving the environment. Claude creates
+the Okteto namespace in a background subagent while its main agent works on
+your task.
+
+### How the Claude hook works
+
+The `SessionStart` hook in `.claude/settings.json` runs on new, resumed,
+cleared, compacted, and forked Claude sessions. Claude sends session metadata
+to the hook over standard input and provides `CLAUDE_ENV_FILE` for variables
+that should remain available to later shell commands.
+
+The hook calls `agent-okteto-dev.sh hook-env`. When
+`LIGHTDASH_OKTETO_TOKEN` is set, that command copies Claude's `session_id` into
+`LIGHTDASH_AGENT_SESSION_ID` through `CLAUDE_ENV_FILE`. It exits without doing
+anything when the token is absent.
+
+The hook never creates an Okteto environment. The background subagent described
+in `CLAUDE.md` runs the launcher's `start` command after the first prompt.
+
+## Other coding agents
+
+Make the same `LIGHTDASH_OKTETO_TOKEN` variable available to the agent process
+and install Okteto, `kubectl`, and `tmux` in its environment. Agents use
+`LIGHTDASH_AGENT_SESSION_ID` when their platform provides one; otherwise the
+launcher derives a stable identity from the current workspace.
+
+## Local Claude Code
+
+Install the required tools on macOS:
+
+```bash
+brew install okteto tmux kubectl
+```
+
+Make `LIGHTDASH_OKTETO_TOKEN` available to the process that launches Claude
+Code. For example, retrieve it from your team's password manager and export it
+in the terminal immediately before starting Claude:
+
+```bash
+export LIGHTDASH_OKTETO_TOKEN='<shared automation token>'
+export BASH_MAX_TIMEOUT_MS=600000
+claude
+```
+
+Do not put the token in a repository file. If your shell configuration is
+shared or backed up, use your password manager's CLI or another local secret
+manager rather than saving the token there.
+
+## What Okteto administrators configure
+
+End users do not need the Lightdash application secrets. Okteto administrators
+must configure these variables for the cluster:
+
+- `LIGHTDASH_LICENSE_KEY`
+- `S3_ACCESS_KEY`
+- `S3_SECRET_KEY`
+- `S3_ENDPOINT`
+- `S3_REGION`
+- `S3_BUCKET`
+
+The launcher defaults to `https://lightdash.okteto.dev`. Administrators can
+override it for testing with the non-secret `OKTETO_CONTEXT` environment
+variable.
+
+## Manual testing
+
+The agent's final response includes a URL like:
+
+```text
+https://lightdash-agent-<session-hash>.lightdash.okteto.dev
+```
+
+Use these credentials:
+
+```text
+Email: demo@lightdash.com
+Password: demo_password!
+```
+
+If startup fails, the agent reports the setup error and continues working on
+your request without a test environment. Expired tokens must be replaced in the
+agent environment or local secret manager before starting a new session.
+
+Okteto recommends a separate namespace for each autonomous run to prevent
+parallel branches from colliding. See
+[Okteto's autonomous workflow guidance](https://www.okteto.com/docs/agentic/autonomous-workflows/).

--- a/docs/agent-okteto.md
+++ b/docs/agent-okteto.md
@@ -164,7 +164,8 @@ variable.
 
 The `Agent Okteto Pool` GitHub Actions workflow runs hourly and can also be
 started manually. It keeps at least three unclaimed namespaces deployed and
-healthy. Configure these GitHub Actions secrets:
+healthy. Pooled namespaces use short sequential names such as `dev-warm-1`.
+Configure these GitHub Actions secrets:
 
 ```text
 LIGHTDASH_OKTETO_TOKEN=<shared automation token>
@@ -180,6 +181,9 @@ synchronization and `/api/v1/health`. Claimed namespaces are excluded when the
 workflow replenishes the pool. The same hash is available inside the
 development container as `LIGHTDASH_AGENT_SESSION_HASH`.
 
+If no warm namespace is available, the launcher creates an on-demand namespace
+named `dev-cold-<8-character-session-hash>`.
+
 The workflow uses `scripts/maintain-agent-okteto-pool.sh`. Run it manually with
 the desired minimum pool size when testing administrator changes:
 
@@ -192,8 +196,10 @@ the desired minimum pool size when testing administrator changes:
 The agent's final response includes a URL like:
 
 ```text
-https://<deployment>-agent-pool-<pool-id>.lightdash.okteto.dev
+https://<deployment>-dev-warm-<number>.lightdash.okteto.dev
 ```
+
+An on-demand fallback URL contains `dev-cold-<session-hash>` instead.
 
 Use these credentials:
 

--- a/okteto.dev.yaml
+++ b/okteto.dev.yaml
@@ -3,9 +3,8 @@
 #   okteto deploy -f okteto.dev.yaml --wait   # create/update the environment
 #   okteto up -f okteto.dev.yaml              # sync code + start dev servers
 #
-# The public endpoint is https://lightdash-<namespace>.lightdash.okteto.dev
-# (named after the dev environment, "lightdash") and serves the Vite dev
-# server, so synced changes hot-reload in the browser.
+# Okteto derives the public endpoint from the deployment and namespace names.
+# The agent launcher discovers it from the ingress before starting sync.
 deploy:
     commands:
         - name: Configuring database...
@@ -43,6 +42,8 @@ deploy:
                 echo "Reusing existing database volume (or starting blank if no snapshot is ready)"
               fi
 
+              # The agent launcher overrides this with the discovered ingress
+              # URL when it runs okteto up.
               echo "SITE_URL=https://lightdash-${OKTETO_NAMESPACE}.${OKTETO_DOMAIN}" >> "$OKTETO_ENV"
         - name: Deploying compose...
           command: |

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -1,5 +1,14 @@
 # Scripts
 
+## Claude Code Okteto Environment
+
+### `agent-okteto-dev.sh <start|wait|url>`
+
+When `LIGHTDASH_OKTETO_TOKEN` is set, creates one Okteto namespace per
+Claude Code session, keeps source changes synchronized through a detached
+`okteto up`, and reports the public test URL. See
+`docs/agent-okteto.md` for setup.
+
 ## Okteto Preview Environment
 
 ### `preview-db-snapshot.sh <suffix>`

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -4,10 +4,15 @@
 
 ### `agent-okteto-dev.sh <start|wait|url>`
 
-When `LIGHTDASH_OKTETO_TOKEN` is set, creates one Okteto namespace per
-Claude Code session, keeps source changes synchronized through a detached
-`okteto up`, and reports the public test URL. See
+When `LIGHTDASH_OKTETO_TOKEN` is set, atomically claims a ready Okteto namespace
+for the session, keeps source changes synchronized through a detached `okteto
+up`, and reports the public test URL. See
 `docs/agent-okteto.md` for setup.
+
+### `maintain-agent-okteto-pool.sh [minimum_ready]`
+
+Repairs and replenishes the pool of unclaimed agent development environments.
+The hourly `agent-okteto-pool.yml` workflow runs it with a minimum of three.
 
 ## Okteto Preview Environment
 

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -12,7 +12,8 @@ up`, and reports the public test URL. See
 ### `maintain-agent-okteto-pool.sh [minimum_ready]`
 
 Repairs and replenishes the pool of unclaimed agent development environments.
-The hourly `agent-okteto-pool.yml` workflow runs it with a minimum of three.
+The `agent-okteto-pool.yml` workflow runs it every 30 minutes with a minimum of
+three.
 
 ## Okteto Preview Environment
 

--- a/scripts/agent-okteto-dev.sh
+++ b/scripts/agent-okteto-dev.sh
@@ -8,6 +8,9 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 OKTETO_CONTEXT_URL="${OKTETO_CONTEXT:-https://lightdash.okteto.dev}"
 OKTETO_MANIFEST="$REPO_ROOT/okteto.dev.yaml"
 OKTETO_SERVICE="lightdash-dev"
+POOL_NAMESPACE_PREFIX="agent-pool-"
+POOL_CLAIM_CONFIGMAP="lightdash-agent-claim"
+POOL_READY_CONFIGMAP="lightdash-agent-ready"
 READY_TIMEOUT_SECONDS="${OKTETO_READY_TIMEOUT_SECONDS:-300}"
 SYNC_START_TIMEOUT_SECONDS="${OKTETO_SYNC_START_TIMEOUT_SECONDS:-600}"
 POLL_INTERVAL_SECONDS="${OKTETO_POLL_INTERVAL_SECONDS:-5}"
@@ -25,7 +28,7 @@ Usage: ./scripts/agent-okteto-dev.sh <start|wait|url>
 
 Requires LIGHTDASH_OKTETO_TOKEN. Commands safely skip when it is unset.
 
-  start  Create or reuse this Claude session's Okteto environment.
+  start  Claim or create this agent session's Okteto environment.
   wait   Wait for file synchronization and application health.
   url    Print the public URL for this Claude session.
 EOF
@@ -37,9 +40,6 @@ require_command() {
         fail "Missing required command '$command_name'. See $SETUP_DOC."
 }
 
-# Reads the SessionStart hook JSON on stdin and prints a validated session_id.
-# Returns non-zero (without exiting) when it is missing or malformed so callers
-# can decide whether that is fatal.
 extract_session_id() {
     local hook_input session_id
 
@@ -70,11 +70,6 @@ capture_session_env() {
     printf 'export LIGHTDASH_AGENT_SESSION_ID=%s\n' "$session_id" >>"$CLAUDE_ENV_FILE"
 }
 
-# Launches `start` as a detached background process so the SessionStart hook
-# returns immediately and never blocks session startup. Best-effort: any problem
-# skips the auto-start rather than breaking the session. The captured session_id
-# is exported so the background start computes the same namespace hash as the
-# model's later `wait`/`url` calls.
 hook_start() {
     local session_id pidfile pid
 
@@ -87,13 +82,10 @@ hook_start() {
     load_session_config
     mkdir -p "$RUN_DIR"
 
-    # Environment already syncing (e.g. on resume) — nothing to launch.
     if tmux_session_exists; then
         return 0
     fi
 
-    # Dedupe near-simultaneous hook fires: skip if a prior background start is
-    # still alive. A stale pidfile fails the liveness check and we proceed.
     pidfile="$RUN_DIR/hook-start.pid"
     if [ -f "$pidfile" ]; then
         pid="$(cat "$pidfile" 2>/dev/null || true)"
@@ -137,29 +129,53 @@ hash_value() {
 }
 
 load_session_config() {
-    local id context_host
+    local id saved_namespace
 
     id="$(agent_session_id)"
     SESSION_HASH="$(hash_value "$id")"
     SESSION_HASH="${SESSION_HASH:0:16}"
-    OKTETO_NAMESPACE="agent-$SESSION_HASH"
     TMUX_SESSION="ld-okteto-$SESSION_HASH"
+    RUN_DIR="${TMPDIR:-/tmp}/lightdash-agent-okteto/$SESSION_HASH"
+    LOG_FILE="$RUN_DIR/okteto-up.log"
+    NAMESPACE_FILE="$RUN_DIR/namespace"
 
+    saved_namespace=""
+    if [ -f "$NAMESPACE_FILE" ]; then
+        saved_namespace="$(cat "$NAMESPACE_FILE" 2>/dev/null || true)"
+    fi
+    if [[ "$saved_namespace" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]]; then
+        set_active_namespace "$saved_namespace"
+    else
+        set_active_namespace "agent-$SESSION_HASH"
+    fi
+}
+
+set_active_namespace() {
+    local namespace="$1" context_host
+
+    OKTETO_NAMESPACE="$namespace"
     context_host="${OKTETO_CONTEXT_URL#*://}"
     context_host="${context_host%%/*}"
     PUBLIC_URL="https://lightdash-${OKTETO_NAMESPACE}.${context_host}"
-
-    RUN_DIR="${TMPDIR:-/tmp}/lightdash-agent-okteto/$SESSION_HASH"
-    LOG_FILE="$RUN_DIR/okteto-up.log"
 }
 
-require_runtime() {
+save_active_namespace() {
+    mkdir -p "$RUN_DIR"
+    printf '%s\n' "$OKTETO_NAMESPACE" >"$NAMESPACE_FILE"
+}
+
+require_client_runtime() {
     [ -n "${LIGHTDASH_OKTETO_TOKEN:-}" ] ||
         fail "$TOKEN_ENV_VAR is not set. See $SETUP_DOC."
 
     require_command curl
+    require_command jq
     require_command kubectl
     require_command okteto
+}
+
+require_runtime() {
+    require_client_runtime
     require_command tmux
 }
 
@@ -178,14 +194,29 @@ authenticate() {
     fi
 }
 
-namespace_exists() {
-    local namespaces
+list_namespaces() {
+    okteto namespace list -o json |
+        awk '
+            found || /^[[:space:]]*\[/ || /^[[:space:]]*\{/ {
+                found = 1
+                print
+            }
+        ' |
+        jq -r '
+            if type == "array" then .
+            elif (.items | type) == "array" then .items
+            elif (.namespaces | type) == "array" then .namespaces
+            else []
+            end
+            | .[]
+            | if type == "string" then . else (.namespace // .name // empty) end
+        '
+}
 
-    namespaces="$(okteto namespace list -o json)" ||
-        fail "Unable to list Okteto namespaces."
-    printf '%s' "$namespaces" |
-        tr -d '[:space:]' |
-        grep -Fq "\"namespace\":\"$OKTETO_NAMESPACE\""
+namespace_exists() {
+    local namespace="${1:-$OKTETO_NAMESPACE}"
+
+    list_namespaces | grep -Fxq "$namespace"
 }
 
 ensure_namespace() {
@@ -196,6 +227,73 @@ ensure_namespace() {
 
     echo "Creating Okteto namespace $OKTETO_NAMESPACE..."
     okteto namespace create "$OKTETO_NAMESPACE" --use=false
+}
+
+pool_namespace_is_healthy() {
+    local namespace="$1" context_host
+
+    context_host="${OKTETO_CONTEXT_URL#*://}"
+    context_host="${context_host%%/*}"
+    curl --fail --silent --show-error --max-time 10 \
+        "https://lightdash-${namespace}.${context_host}/api/v1/health" \
+        >/dev/null 2>&1
+}
+
+pool_namespace_is_ready() {
+    local namespace="$1"
+
+    kubectl -n "$namespace" get configmap "$POOL_READY_CONFIGMAP" \
+        >/dev/null 2>&1 &&
+        pool_namespace_is_healthy "$namespace"
+}
+
+claim_owner() {
+    local namespace="$1"
+
+    kubectl -n "$namespace" get configmap "$POOL_CLAIM_CONFIGMAP" \
+        -o jsonpath='{.data.session_hash}' 2>/dev/null || true
+}
+
+use_claimed_namespace() {
+    local namespace="$1"
+
+    set_active_namespace "$namespace"
+    save_active_namespace
+    echo "Using pre-provisioned Okteto namespace $OKTETO_NAMESPACE."
+}
+
+claim_pool_namespace() {
+    local namespace owner
+    local -a pool_namespaces=()
+
+    while IFS= read -r namespace; do
+        pool_namespaces+=("$namespace")
+    done < <(list_namespaces | grep "^${POOL_NAMESPACE_PREFIX}" | sort)
+
+    for namespace in "${pool_namespaces[@]}"; do
+        owner="$(claim_owner "$namespace")"
+        if [ "$owner" = "$SESSION_HASH" ]; then
+            use_claimed_namespace "$namespace"
+            return 0
+        fi
+    done
+
+    for namespace in "${pool_namespaces[@]}"; do
+        [ -z "$(claim_owner "$namespace")" ] || continue
+        pool_namespace_is_ready "$namespace" || continue
+
+        if kubectl -n "$namespace" create configmap "$POOL_CLAIM_CONFIGMAP" \
+            --from-literal="session_hash=$SESSION_HASH" \
+            --from-literal="claimed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            >/dev/null 2>&1; then
+            kubectl -n "$namespace" delete configmap "$POOL_READY_CONFIGMAP" \
+                --ignore-not-found >/dev/null 2>&1 || true
+            use_claimed_namespace "$namespace"
+            return 0
+        fi
+    done
+
+    return 1
 }
 
 tmux_session_exists() {
@@ -267,10 +365,11 @@ start_tmux_session() {
     : >"$LOG_FILE"
 
     printf -v up_command \
-        'exec okteto up %q -f %q -n %q' \
+        'exec okteto up %q -f %q -n %q --env %q' \
         "$OKTETO_SERVICE" \
         "$OKTETO_MANIFEST" \
-        "$OKTETO_NAMESPACE"
+        "$OKTETO_NAMESPACE" \
+        "LIGHTDASH_AGENT_SESSION_HASH=$SESSION_HASH"
     printf -v pipe_command 'cat >> %q' "$LOG_FILE"
 
     echo "Starting Okteto file synchronization..."
@@ -286,7 +385,6 @@ start_environment() {
     require_runtime
     prepare_runtime_dir
     authenticate
-    ensure_namespace
 
     if tmux_session_exists; then
         echo "Reusing the active Okteto sync process."
@@ -294,12 +392,19 @@ start_environment() {
         return
     fi
 
-    echo "Deploying the Lightdash development environment..."
-    okteto deploy \
-        -f "$OKTETO_MANIFEST" \
-        -n "$OKTETO_NAMESPACE" \
-        --wait \
-        --timeout 8m
+    if claim_pool_namespace; then
+        echo "Claimed a ready environment from the shared pool."
+    else
+        set_active_namespace "agent-$SESSION_HASH"
+        save_active_namespace
+        ensure_namespace
+        echo "No ready pooled environment was available; deploying one now..."
+        okteto deploy \
+            -f "$OKTETO_MANIFEST" \
+            -n "$OKTETO_NAMESPACE" \
+            --wait \
+            --timeout 8m
+    fi
 
     start_tmux_session
     wait_until_ready
@@ -312,9 +417,6 @@ wait_for_environment() {
     prepare_runtime_dir
     authenticate
 
-    # The SessionStart hook starts the environment in the background, so the
-    # sync session may not exist yet if `okteto deploy` is still running. Wait
-    # for it to appear before waiting for readiness.
     deadline=$((SECONDS + SYNC_START_TIMEOUT_SECONDS))
     while ! tmux_session_exists; do
         if ((SECONDS >= deadline)); then
@@ -324,6 +426,9 @@ wait_for_environment() {
         sleep "$POLL_INTERVAL_SECONDS"
     done
 
+    if [ -f "$NAMESPACE_FILE" ]; then
+        set_active_namespace "$(cat "$NAMESPACE_FILE")"
+    fi
     wait_until_ready
 }
 

--- a/scripts/agent-okteto-dev.sh
+++ b/scripts/agent-okteto-dev.sh
@@ -8,7 +8,8 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 OKTETO_CONTEXT_URL="${OKTETO_CONTEXT:-https://lightdash.okteto.dev}"
 OKTETO_MANIFEST="$REPO_ROOT/okteto.dev.yaml"
 OKTETO_SERVICE="lightdash-dev"
-POOL_NAMESPACE_PREFIX="agent-pool-"
+POOL_NAMESPACE_PREFIX="dev-warm-"
+COLD_NAMESPACE_PREFIX="dev-cold-"
 POOL_CLAIM_CONFIGMAP="lightdash-agent-claim"
 POOL_READY_CONFIGMAP="lightdash-agent-ready"
 READY_TIMEOUT_SECONDS="${OKTETO_READY_TIMEOUT_SECONDS:-300}"
@@ -148,7 +149,7 @@ load_session_config() {
     if [[ "$saved_namespace" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]]; then
         set_active_namespace "$saved_namespace"
     else
-        set_active_namespace "agent-$SESSION_HASH"
+        set_active_namespace "${COLD_NAMESPACE_PREFIX}${SESSION_HASH:0:8}"
     fi
 
     saved_url=""
@@ -440,7 +441,7 @@ start_environment() {
     if claim_pool_namespace; then
         echo "Claimed a ready environment from the shared pool."
     else
-        set_active_namespace "agent-$SESSION_HASH"
+        set_active_namespace "${COLD_NAMESPACE_PREFIX}${SESSION_HASH:0:8}"
         save_active_namespace
         ensure_namespace
         echo "No ready pooled environment was available; deploying one now..."

--- a/scripts/agent-okteto-dev.sh
+++ b/scripts/agent-okteto-dev.sh
@@ -9,6 +9,7 @@ OKTETO_CONTEXT_URL="${OKTETO_CONTEXT:-https://lightdash.okteto.dev}"
 OKTETO_MANIFEST="$REPO_ROOT/okteto.dev.yaml"
 OKTETO_SERVICE="lightdash-dev"
 READY_TIMEOUT_SECONDS="${OKTETO_READY_TIMEOUT_SECONDS:-300}"
+SYNC_START_TIMEOUT_SECONDS="${OKTETO_SYNC_START_TIMEOUT_SECONDS:-600}"
 POLL_INTERVAL_SECONDS="${OKTETO_POLL_INTERVAL_SECONDS:-5}"
 SETUP_DOC="docs/agent-okteto.md"
 TOKEN_ENV_VAR="LIGHTDASH_OKTETO_TOKEN"
@@ -36,13 +37,11 @@ require_command() {
         fail "Missing required command '$command_name'. See $SETUP_DOC."
 }
 
-capture_session_env() {
+# Reads the SessionStart hook JSON on stdin and prints a validated session_id.
+# Returns non-zero (without exiting) when it is missing or malformed so callers
+# can decide whether that is fatal.
+extract_session_id() {
     local hook_input session_id
-
-    [ -n "${LIGHTDASH_OKTETO_TOKEN:-}" ] || return 0
-
-    [ -n "${CLAUDE_ENV_FILE:-}" ] ||
-        fail "CLAUDE_ENV_FILE is unavailable in the SessionStart hook."
 
     hook_input="$(cat)"
     session_id="$(
@@ -51,11 +50,64 @@ capture_session_env() {
             head -n 1
     )"
 
-    [ -n "$session_id" ] || fail "Claude SessionStart input has no session_id."
-    [[ "$session_id" =~ ^[A-Za-z0-9._:-]+$ ]] ||
-        fail "Claude session_id contains unsupported characters."
+    [ -n "$session_id" ] || return 1
+    [[ "$session_id" =~ ^[A-Za-z0-9._:-]+$ ]] || return 1
+
+    printf '%s' "$session_id"
+}
+
+capture_session_env() {
+    local session_id
+
+    [ -n "${LIGHTDASH_OKTETO_TOKEN:-}" ] || return 0
+
+    [ -n "${CLAUDE_ENV_FILE:-}" ] ||
+        fail "CLAUDE_ENV_FILE is unavailable in the SessionStart hook."
+
+    session_id="$(extract_session_id)" ||
+        fail "Claude SessionStart input has no usable session_id."
 
     printf 'export LIGHTDASH_AGENT_SESSION_ID=%s\n' "$session_id" >>"$CLAUDE_ENV_FILE"
+}
+
+# Launches `start` as a detached background process so the SessionStart hook
+# returns immediately and never blocks session startup. Best-effort: any problem
+# skips the auto-start rather than breaking the session. The captured session_id
+# is exported so the background start computes the same namespace hash as the
+# model's later `wait`/`url` calls.
+hook_start() {
+    local session_id pidfile pid
+
+    [ -n "${LIGHTDASH_OKTETO_TOKEN:-}" ] || return 0
+
+    session_id="$(extract_session_id)" || return 0
+    [ -n "$session_id" ] || return 0
+
+    export LIGHTDASH_AGENT_SESSION_ID="$session_id"
+    load_session_config
+    mkdir -p "$RUN_DIR"
+
+    # Environment already syncing (e.g. on resume) — nothing to launch.
+    if tmux_session_exists; then
+        return 0
+    fi
+
+    # Dedupe near-simultaneous hook fires: skip if a prior background start is
+    # still alive. A stale pidfile fails the liveness check and we proceed.
+    pidfile="$RUN_DIR/hook-start.pid"
+    if [ -f "$pidfile" ]; then
+        pid="$(cat "$pidfile" 2>/dev/null || true)"
+        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+            return 0
+        fi
+    fi
+
+    nohup bash "$SCRIPT_DIR/agent-okteto-dev.sh" start \
+        </dev/null >>"$RUN_DIR/hook-start.log" 2>&1 &
+    printf '%s\n' "$!" >"$pidfile"
+    disown 2>/dev/null || true
+
+    echo "Okteto development environment starting in the background."
 }
 
 agent_session_id() {
@@ -254,12 +306,23 @@ start_environment() {
 }
 
 wait_for_environment() {
+    local deadline
+
     require_runtime
     prepare_runtime_dir
     authenticate
 
-    tmux_session_exists ||
-        fail "No active Okteto sync process. Run './scripts/agent-okteto-dev.sh start'."
+    # The SessionStart hook starts the environment in the background, so the
+    # sync session may not exist yet if `okteto deploy` is still running. Wait
+    # for it to appear before waiting for readiness.
+    deadline=$((SECONDS + SYNC_START_TIMEOUT_SECONDS))
+    while ! tmux_session_exists; do
+        if ((SECONDS >= deadline)); then
+            fail "No active Okteto sync process after ${SYNC_START_TIMEOUT_SECONDS}s. See logs in $RUN_DIR and $SETUP_DOC."
+        fi
+        echo "Waiting for the Okteto deployment to start syncing..."
+        sleep "$POLL_INTERVAL_SECONDS"
+    done
 
     wait_until_ready
 }
@@ -270,6 +333,9 @@ main() {
     case "$command_name" in
         hook-env)
             capture_session_env
+            ;;
+        hook-start)
+            hook_start
             ;;
         start | wait | url)
             if [ -z "${LIGHTDASH_OKTETO_TOKEN:-}" ]; then

--- a/scripts/agent-okteto-dev.sh
+++ b/scripts/agent-okteto-dev.sh
@@ -16,6 +16,7 @@ SYNC_START_TIMEOUT_SECONDS="${OKTETO_SYNC_START_TIMEOUT_SECONDS:-600}"
 POLL_INTERVAL_SECONDS="${OKTETO_POLL_INTERVAL_SECONDS:-5}"
 SETUP_DOC="docs/agent-okteto.md"
 TOKEN_ENV_VAR="LIGHTDASH_OKTETO_TOKEN"
+KUBECTL_CONFIGURED=false
 
 fail() {
     echo "ERROR: $*" >&2
@@ -129,7 +130,7 @@ hash_value() {
 }
 
 load_session_config() {
-    local id saved_namespace
+    local id saved_namespace saved_url
 
     id="$(agent_session_id)"
     SESSION_HASH="$(hash_value "$id")"
@@ -138,6 +139,7 @@ load_session_config() {
     RUN_DIR="${TMPDIR:-/tmp}/lightdash-agent-okteto/$SESSION_HASH"
     LOG_FILE="$RUN_DIR/okteto-up.log"
     NAMESPACE_FILE="$RUN_DIR/namespace"
+    URL_FILE="$RUN_DIR/url"
 
     saved_namespace=""
     if [ -f "$NAMESPACE_FILE" ]; then
@@ -147,6 +149,14 @@ load_session_config() {
         set_active_namespace "$saved_namespace"
     else
         set_active_namespace "agent-$SESSION_HASH"
+    fi
+
+    saved_url=""
+    if [ -f "$URL_FILE" ]; then
+        saved_url="$(cat "$URL_FILE" 2>/dev/null || true)"
+    fi
+    if [[ "$saved_url" =~ ^https://[A-Za-z0-9.-]+$ ]]; then
+        PUBLIC_URL="$saved_url"
     fi
 }
 
@@ -162,6 +172,7 @@ set_active_namespace() {
 save_active_namespace() {
     mkdir -p "$RUN_DIR"
     printf '%s\n' "$OKTETO_NAMESPACE" >"$NAMESPACE_FILE"
+    printf '%s\n' "$PUBLIC_URL" >"$URL_FILE"
 }
 
 require_client_runtime() {
@@ -229,14 +240,38 @@ ensure_namespace() {
     okteto namespace create "$OKTETO_NAMESPACE" --use=false
 }
 
-pool_namespace_is_healthy() {
-    local namespace="$1" context_host
+configure_kubectl_access() {
+    local namespace="$1"
 
-    context_host="${OKTETO_CONTEXT_URL#*://}"
-    context_host="${context_host%%/*}"
-    curl --fail --silent --show-error --max-time 10 \
-        "https://lightdash-${namespace}.${context_host}/api/v1/health" \
-        >/dev/null 2>&1
+    [ "$KUBECTL_CONFIGURED" = false ] || return 0
+    okteto namespace use "$namespace" >/dev/null
+    okteto kubeconfig >/dev/null
+    KUBECTL_CONFIGURED=true
+}
+
+discover_public_url() {
+    local namespace="$1" host
+
+    host="$(
+        kubectl -n "$namespace" get ingress -o json 2>/dev/null |
+            jq -r '.items[0].spec.rules[0].host // empty'
+    )"
+    [ -n "$host" ] || return 1
+    PUBLIC_URL="https://$host"
+}
+
+pool_namespace_resources_are_ready() {
+    local namespace="$1" pod_status
+
+    pod_status="$(
+        kubectl -n "$namespace" get pods -o json 2>/dev/null |
+            jq -r '
+                if (.items | length) == 0 then "false"
+                else ([.items[].status.containerStatuses[]?.ready] | all)
+                end
+            '
+    )"
+    [ "$pod_status" = "true" ] && discover_public_url "$namespace"
 }
 
 pool_namespace_is_ready() {
@@ -244,7 +279,7 @@ pool_namespace_is_ready() {
 
     kubectl -n "$namespace" get configmap "$POOL_READY_CONFIGMAP" \
         >/dev/null 2>&1 &&
-        pool_namespace_is_healthy "$namespace"
+        pool_namespace_resources_are_ready "$namespace"
 }
 
 claim_owner() {
@@ -258,18 +293,30 @@ use_claimed_namespace() {
     local namespace="$1"
 
     set_active_namespace "$namespace"
+    discover_public_url "$namespace" || return 1
     save_active_namespace
     echo "Using pre-provisioned Okteto namespace $OKTETO_NAMESPACE."
 }
 
 claim_pool_namespace() {
-    local namespace owner
+    local namespace owner first_pool_namespace
+
+    first_pool_namespace="$(
+        list_namespaces |
+            grep "^${POOL_NAMESPACE_PREFIX}" |
+            sort |
+            head -n 1 ||
+            true
+    )"
+    [ -n "$first_pool_namespace" ] || return 1
+    configure_kubectl_access "$first_pool_namespace"
 
     while IFS= read -r namespace; do
         owner="$(claim_owner "$namespace")"
         if [ "$owner" = "$SESSION_HASH" ]; then
-            use_claimed_namespace "$namespace"
-            return 0
+            if use_claimed_namespace "$namespace"; then
+                return 0
+            fi
         fi
     done < <(list_namespaces | grep "^${POOL_NAMESPACE_PREFIX}" | sort)
 
@@ -283,8 +330,10 @@ claim_pool_namespace() {
             >/dev/null 2>&1; then
             kubectl -n "$namespace" delete configmap "$POOL_READY_CONFIGMAP" \
                 --ignore-not-found >/dev/null 2>&1 || true
-            use_claimed_namespace "$namespace"
-            return 0
+            if use_claimed_namespace "$namespace"; then
+                return 0
+            fi
+            return 1
         fi
     done < <(list_namespaces | grep "^${POOL_NAMESPACE_PREFIX}" | sort)
 
@@ -360,11 +409,12 @@ start_tmux_session() {
     : >"$LOG_FILE"
 
     printf -v up_command \
-        'exec okteto up %q -f %q -n %q --env %q' \
+        'exec okteto up %q -f %q -n %q --env %q --env %q' \
         "$OKTETO_SERVICE" \
         "$OKTETO_MANIFEST" \
         "$OKTETO_NAMESPACE" \
-        "LIGHTDASH_AGENT_SESSION_HASH=$SESSION_HASH"
+        "LIGHTDASH_AGENT_SESSION_HASH=$SESSION_HASH" \
+        "SITE_URL=$PUBLIC_URL"
     printf -v pipe_command 'cat >> %q' "$LOG_FILE"
 
     echo "Starting Okteto file synchronization..."
@@ -399,6 +449,10 @@ start_environment() {
             -n "$OKTETO_NAMESPACE" \
             --wait \
             --timeout 8m
+        configure_kubectl_access "$OKTETO_NAMESPACE"
+        discover_public_url "$OKTETO_NAMESPACE" ||
+            fail "No public ingress found in $OKTETO_NAMESPACE."
+        save_active_namespace
     fi
 
     start_tmux_session
@@ -423,6 +477,9 @@ wait_for_environment() {
 
     if [ -f "$NAMESPACE_FILE" ]; then
         set_active_namespace "$(cat "$NAMESPACE_FILE")"
+    fi
+    if [ -f "$URL_FILE" ]; then
+        PUBLIC_URL="$(cat "$URL_FILE")"
     fi
     wait_until_ready
 }

--- a/scripts/agent-okteto-dev.sh
+++ b/scripts/agent-okteto-dev.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+umask 077
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+OKTETO_CONTEXT_URL="${OKTETO_CONTEXT:-https://lightdash.okteto.dev}"
+OKTETO_MANIFEST="$REPO_ROOT/okteto.dev.yaml"
+OKTETO_SERVICE="lightdash-dev"
+READY_TIMEOUT_SECONDS="${OKTETO_READY_TIMEOUT_SECONDS:-300}"
+POLL_INTERVAL_SECONDS="${OKTETO_POLL_INTERVAL_SECONDS:-5}"
+SETUP_DOC="docs/agent-okteto.md"
+TOKEN_ENV_VAR="LIGHTDASH_OKTETO_TOKEN"
+
+fail() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+usage() {
+    cat <<'EOF'
+Usage: ./scripts/agent-okteto-dev.sh <start|wait|url>
+
+Requires LIGHTDASH_OKTETO_TOKEN. Commands safely skip when it is unset.
+
+  start  Create or reuse this Claude session's Okteto environment.
+  wait   Wait for file synchronization and application health.
+  url    Print the public URL for this Claude session.
+EOF
+}
+
+require_command() {
+    local command_name="$1"
+    command -v "$command_name" >/dev/null 2>&1 ||
+        fail "Missing required command '$command_name'. See $SETUP_DOC."
+}
+
+capture_session_env() {
+    local hook_input session_id
+
+    [ -n "${LIGHTDASH_OKTETO_TOKEN:-}" ] || return 0
+
+    [ -n "${CLAUDE_ENV_FILE:-}" ] ||
+        fail "CLAUDE_ENV_FILE is unavailable in the SessionStart hook."
+
+    hook_input="$(cat)"
+    session_id="$(
+        printf '%s\n' "$hook_input" |
+            sed -nE 's/.*"session_id"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' |
+            head -n 1
+    )"
+
+    [ -n "$session_id" ] || fail "Claude SessionStart input has no session_id."
+    [[ "$session_id" =~ ^[A-Za-z0-9._:-]+$ ]] ||
+        fail "Claude session_id contains unsupported characters."
+
+    printf 'export LIGHTDASH_AGENT_SESSION_ID=%s\n' "$session_id" >>"$CLAUDE_ENV_FILE"
+}
+
+agent_session_id() {
+    local workspace_root
+
+    if [ -n "${LIGHTDASH_AGENT_SESSION_ID:-}" ]; then
+        printf '%s' "$LIGHTDASH_AGENT_SESSION_ID"
+    elif [ -n "${CLAUDE_CODE_REMOTE_SESSION_ID:-}" ]; then
+        printf '%s' "$CLAUDE_CODE_REMOTE_SESSION_ID"
+    else
+        workspace_root="$(git -C "$REPO_ROOT" rev-parse --show-toplevel 2>/dev/null)" ||
+            fail "Agent session and workspace identity are unavailable."
+        printf 'workspace:%s' "$workspace_root"
+    fi
+}
+
+hash_value() {
+    local value="$1"
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        printf '%s' "$value" | sha256sum | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        printf '%s' "$value" | shasum -a 256 | awk '{print $1}'
+    else
+        fail "Missing sha256sum or shasum. See $SETUP_DOC."
+    fi
+}
+
+load_session_config() {
+    local id context_host
+
+    id="$(agent_session_id)"
+    SESSION_HASH="$(hash_value "$id")"
+    SESSION_HASH="${SESSION_HASH:0:16}"
+    OKTETO_NAMESPACE="agent-$SESSION_HASH"
+    TMUX_SESSION="ld-okteto-$SESSION_HASH"
+
+    context_host="${OKTETO_CONTEXT_URL#*://}"
+    context_host="${context_host%%/*}"
+    PUBLIC_URL="https://lightdash-${OKTETO_NAMESPACE}.${context_host}"
+
+    RUN_DIR="${TMPDIR:-/tmp}/lightdash-agent-okteto/$SESSION_HASH"
+    LOG_FILE="$RUN_DIR/okteto-up.log"
+}
+
+require_runtime() {
+    [ -n "${LIGHTDASH_OKTETO_TOKEN:-}" ] ||
+        fail "$TOKEN_ENV_VAR is not set. See $SETUP_DOC."
+
+    require_command curl
+    require_command kubectl
+    require_command okteto
+    require_command tmux
+}
+
+prepare_runtime_dir() {
+    mkdir -p "$RUN_DIR/okteto-home"
+    export OKTETO_HOME="$RUN_DIR/okteto-home"
+    export KUBECONFIG="$RUN_DIR/kubeconfig"
+}
+
+authenticate() {
+    echo "Authenticating with Okteto..."
+    if ! okteto context use \
+        "$OKTETO_CONTEXT_URL" \
+        --token "$LIGHTDASH_OKTETO_TOKEN" >/dev/null; then
+        fail "Okteto authentication failed. Check $TOKEN_ENV_VAR and see $SETUP_DOC."
+    fi
+}
+
+namespace_exists() {
+    local namespaces
+
+    namespaces="$(okteto namespace list -o json)" ||
+        fail "Unable to list Okteto namespaces."
+    printf '%s' "$namespaces" |
+        tr -d '[:space:]' |
+        grep -Fq "\"namespace\":\"$OKTETO_NAMESPACE\""
+}
+
+ensure_namespace() {
+    if namespace_exists; then
+        echo "Reusing Okteto namespace $OKTETO_NAMESPACE."
+        return
+    fi
+
+    echo "Creating Okteto namespace $OKTETO_NAMESPACE..."
+    okteto namespace create "$OKTETO_NAMESPACE" --use=false
+}
+
+tmux_session_exists() {
+    tmux has-session -t "$TMUX_SESSION" 2>/dev/null
+}
+
+sync_is_ready() {
+    local status_output
+
+    status_output="$(
+        okteto status "$OKTETO_SERVICE" \
+            -f "$OKTETO_MANIFEST" \
+            -n "$OKTETO_NAMESPACE" 2>&1
+    )" || return 1
+
+    printf '%s' "$status_output" |
+        grep -Eq 'Synchronization status:[[:space:]]*100([.]0+)?%'
+}
+
+app_is_healthy() {
+    curl --fail --silent --show-error \
+        --max-time 10 \
+        "$PUBLIC_URL/api/v1/health" >/dev/null 2>&1
+}
+
+show_log_tail() {
+    if [ -s "$LOG_FILE" ]; then
+        echo "Last Okteto output:" >&2
+        tail -n 80 "$LOG_FILE" >&2
+    fi
+}
+
+wait_until_ready() {
+    local deadline last_report now
+
+    deadline=$((SECONDS + READY_TIMEOUT_SECONDS))
+    last_report=$((SECONDS - 30))
+
+    while ((SECONDS < deadline)); do
+        if ! tmux_session_exists; then
+            show_log_tail
+            fail "Okteto file synchronization stopped. See $LOG_FILE."
+        fi
+
+        if sync_is_ready && app_is_healthy; then
+            sleep 2
+            if sync_is_ready && app_is_healthy; then
+                echo "READY: $PUBLIC_URL"
+                return
+            fi
+        fi
+
+        now=$SECONDS
+        if ((now - last_report >= 30)); then
+            echo "Waiting for file synchronization and application health..."
+            last_report=$now
+        fi
+        sleep "$POLL_INTERVAL_SECONDS"
+    done
+
+    show_log_tail
+    fail "Timed out waiting for $PUBLIC_URL. See $LOG_FILE."
+}
+
+start_tmux_session() {
+    local up_command pipe_command
+
+    mkdir -p "$RUN_DIR"
+    : >"$LOG_FILE"
+
+    printf -v up_command \
+        'exec okteto up %q -f %q -n %q' \
+        "$OKTETO_SERVICE" \
+        "$OKTETO_MANIFEST" \
+        "$OKTETO_NAMESPACE"
+    printf -v pipe_command 'cat >> %q' "$LOG_FILE"
+
+    echo "Starting Okteto file synchronization..."
+    tmux new-session \
+        -d \
+        -s "$TMUX_SESSION" \
+        -c "$REPO_ROOT" \
+        "$up_command"
+    tmux pipe-pane -o -t "$TMUX_SESSION" "$pipe_command"
+}
+
+start_environment() {
+    require_runtime
+    prepare_runtime_dir
+    authenticate
+    ensure_namespace
+
+    if tmux_session_exists; then
+        echo "Reusing the active Okteto sync process."
+        wait_until_ready
+        return
+    fi
+
+    echo "Deploying the Lightdash development environment..."
+    okteto deploy \
+        -f "$OKTETO_MANIFEST" \
+        -n "$OKTETO_NAMESPACE" \
+        --wait \
+        --timeout 8m
+
+    start_tmux_session
+    wait_until_ready
+}
+
+wait_for_environment() {
+    require_runtime
+    prepare_runtime_dir
+    authenticate
+
+    tmux_session_exists ||
+        fail "No active Okteto sync process. Run './scripts/agent-okteto-dev.sh start'."
+
+    wait_until_ready
+}
+
+main() {
+    local command_name="${1:-}"
+
+    case "$command_name" in
+        hook-env)
+            capture_session_env
+            ;;
+        start | wait | url)
+            if [ -z "${LIGHTDASH_OKTETO_TOKEN:-}" ]; then
+                echo "SKIPPED: $TOKEN_ENV_VAR is not set."
+                return
+            fi
+
+            load_session_config
+            case "$command_name" in
+                start) start_environment ;;
+                wait) wait_for_environment ;;
+                url) echo "$PUBLIC_URL" ;;
+            esac
+            ;;
+        -h | --help | help | "")
+            usage
+            ;;
+        *)
+            usage >&2
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"

--- a/scripts/agent-okteto-dev.sh
+++ b/scripts/agent-okteto-dev.sh
@@ -264,21 +264,16 @@ use_claimed_namespace() {
 
 claim_pool_namespace() {
     local namespace owner
-    local -a pool_namespaces=()
 
     while IFS= read -r namespace; do
-        pool_namespaces+=("$namespace")
-    done < <(list_namespaces | grep "^${POOL_NAMESPACE_PREFIX}" | sort)
-
-    for namespace in "${pool_namespaces[@]}"; do
         owner="$(claim_owner "$namespace")"
         if [ "$owner" = "$SESSION_HASH" ]; then
             use_claimed_namespace "$namespace"
             return 0
         fi
-    done
+    done < <(list_namespaces | grep "^${POOL_NAMESPACE_PREFIX}" | sort)
 
-    for namespace in "${pool_namespaces[@]}"; do
+    while IFS= read -r namespace; do
         [ -z "$(claim_owner "$namespace")" ] || continue
         pool_namespace_is_ready "$namespace" || continue
 
@@ -291,7 +286,7 @@ claim_pool_namespace() {
             use_claimed_namespace "$namespace"
             return 0
         fi
-    done
+    done < <(list_namespaces | grep "^${POOL_NAMESPACE_PREFIX}" | sort)
 
     return 1
 }

--- a/scripts/maintain-agent-okteto-pool.sh
+++ b/scripts/maintain-agent-okteto-pool.sh
@@ -7,7 +7,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 OKTETO_CONTEXT_URL="${OKTETO_CONTEXT:-https://lightdash.okteto.dev}"
 OKTETO_MANIFEST="$REPO_ROOT/okteto.dev.yaml"
-POOL_NAMESPACE_PREFIX="agent-pool-"
+POOL_NAMESPACE_PREFIX="dev-warm-"
 POOL_CLAIM_CONFIGMAP="lightdash-agent-claim"
 POOL_READY_CONFIGMAP="lightdash-agent-ready"
 TARGET_SIZE="${1:-${LIGHTDASH_AGENT_POOL_SIZE:-3}}"
@@ -135,19 +135,34 @@ create_pool_namespace() {
     local namespace="$1"
 
     echo "Creating pooled namespace $namespace..."
-    okteto namespace create "$namespace" --use=false
+    if ! okteto namespace create "$namespace" --use=false; then
+        echo "Namespace $namespace was created concurrently; trying another."
+        return 1
+    fi
     configure_kubectl_access "$namespace"
     deploy_namespace "$namespace"
     return 0
 }
 
+next_pool_index() {
+    local highest
+
+    highest="$(
+        list_namespaces |
+            sed -nE "s/^${POOL_NAMESPACE_PREFIX}([0-9]+)$/\\1/p" |
+            sort -n |
+            tail -n 1
+    )"
+    printf '%s' "$(( ${highest:-0} + 1 ))"
+}
+
 main() {
-    local available=0 attempts=0 created=0 namespace run_key max_attempts
-    local first_pool_namespace
+    local available=0 attempts=0 created=0 namespace max_attempts
+    local first_pool_namespace next_index
 
     [[ "$TARGET_SIZE" =~ ^[1-9][0-9]*$ ]] ||
         fail "Pool size must be a positive integer."
-    max_attempts="$TARGET_SIZE"
+    max_attempts=$((TARGET_SIZE + 3))
 
     for command_name in jq kubectl okteto; do
         require_command "$command_name"
@@ -195,12 +210,12 @@ main() {
         fi
     done < <(list_namespaces | grep "^${POOL_NAMESPACE_PREFIX}" | sort)
 
-    run_key="${GITHUB_RUN_ID:-$(date -u +%Y%m%d%H%M%S)-$$}-${GITHUB_RUN_ATTEMPT:-1}"
-    run_key="$(printf '%s' "$run_key" | tr -cd 'a-zA-Z0-9-' | tr 'A-Z' 'a-z')"
+    next_index="$(next_pool_index)"
 
     while ((available < TARGET_SIZE && attempts < max_attempts)); do
         attempts=$((attempts + 1))
-        namespace="${POOL_NAMESPACE_PREFIX}${run_key}-${attempts}"
+        namespace="${POOL_NAMESPACE_PREFIX}${next_index}"
+        next_index=$((next_index + 1))
 
         if create_pool_namespace "$namespace" &&
             namespace_is_ready "$namespace"; then

--- a/scripts/maintain-agent-okteto-pool.sh
+++ b/scripts/maintain-agent-okteto-pool.sh
@@ -11,6 +11,9 @@ POOL_NAMESPACE_PREFIX="agent-pool-"
 POOL_CLAIM_CONFIGMAP="lightdash-agent-claim"
 POOL_READY_CONFIGMAP="lightdash-agent-ready"
 TARGET_SIZE="${1:-${LIGHTDASH_AGENT_POOL_SIZE:-3}}"
+READY_TIMEOUT_SECONDS="${OKTETO_POOL_READY_TIMEOUT_SECONDS:-600}"
+POLL_INTERVAL_SECONDS="${OKTETO_POOL_POLL_INTERVAL_SECONDS:-10}"
+KUBECTL_CONFIGURED=false
 
 fail() {
     echo "ERROR: $*" >&2
@@ -41,11 +44,14 @@ list_namespaces() {
 }
 
 namespace_url() {
-    local namespace="$1" context_host
+    local namespace="$1" host
 
-    context_host="${OKTETO_CONTEXT_URL#*://}"
-    context_host="${context_host%%/*}"
-    printf 'https://lightdash-%s.%s' "$namespace" "$context_host"
+    host="$(
+        kubectl -n "$namespace" get ingress -o json 2>/dev/null |
+            jq -r '.items[0].spec.rules[0].host // empty'
+    )"
+    [ -n "$host" ] || return 1
+    printf 'https://%s' "$host"
 }
 
 namespace_is_claimed() {
@@ -57,8 +63,46 @@ namespace_is_ready() {
 
     kubectl -n "$namespace" get configmap "$POOL_READY_CONFIGMAP" \
         >/dev/null 2>&1 &&
-        curl --fail --silent --show-error --max-time 10 \
-            "$(namespace_url "$namespace")/api/v1/health" >/dev/null 2>&1
+        namespace_resources_are_ready "$namespace"
+}
+
+namespace_resources_are_ready() {
+    local namespace="$1" pod_status
+
+    pod_status="$(
+        kubectl -n "$namespace" get pods -o json 2>/dev/null |
+            jq -r '
+                if (.items | length) == 0 then "false"
+                else ([.items[].status.containerStatuses[]?.ready] | all)
+                end
+            '
+    )"
+    [ "$pod_status" = "true" ] && namespace_url "$namespace" >/dev/null
+}
+
+wait_for_namespace_ready() {
+    local namespace="$1" deadline
+
+    deadline=$((SECONDS + READY_TIMEOUT_SECONDS))
+    while ((SECONDS < deadline)); do
+        if namespace_resources_are_ready "$namespace"; then
+            return 0
+        fi
+        echo "Waiting for $namespace pods and ingress..."
+        sleep "$POLL_INTERVAL_SECONDS"
+    done
+
+    echo "ERROR: Timed out waiting for $namespace pods and ingress." >&2
+    return 1
+}
+
+configure_kubectl_access() {
+    local namespace="$1"
+
+    [ "$KUBECTL_CONFIGURED" = false ] || return 0
+    okteto namespace use "$namespace" >/dev/null
+    okteto kubeconfig >/dev/null
+    KUBECTL_CONFIGURED=true
 }
 
 mark_namespace_ready() {
@@ -80,6 +124,9 @@ deploy_namespace() {
         -n "$namespace" \
         --wait \
         --timeout 20m
+    if ! wait_for_namespace_ready "$namespace"; then
+        return 1
+    fi
     namespace_is_claimed "$namespace" || mark_namespace_ready "$namespace"
     return 0
 }
@@ -89,18 +136,20 @@ create_pool_namespace() {
 
     echo "Creating pooled namespace $namespace..."
     okteto namespace create "$namespace" --use=false
+    configure_kubectl_access "$namespace"
     deploy_namespace "$namespace"
     return 0
 }
 
 main() {
     local available=0 attempts=0 created=0 namespace run_key max_attempts
+    local first_pool_namespace
 
     [[ "$TARGET_SIZE" =~ ^[1-9][0-9]*$ ]] ||
         fail "Pool size must be a positive integer."
-    max_attempts=$((TARGET_SIZE + 6))
+    max_attempts="$TARGET_SIZE"
 
-    for command_name in curl jq kubectl okteto; do
+    for command_name in jq kubectl okteto; do
         require_command "$command_name"
     done
     [ -n "${LIGHTDASH_OKTETO_TOKEN:-}" ] ||
@@ -115,10 +164,27 @@ main() {
     okteto context use "$OKTETO_CONTEXT_URL" \
         --token "$LIGHTDASH_OKTETO_TOKEN" >/dev/null
 
+    first_pool_namespace="$(
+        list_namespaces |
+            grep "^${POOL_NAMESPACE_PREFIX}" |
+            sort |
+            head -n 1 ||
+            true
+    )"
+    if [ -n "$first_pool_namespace" ]; then
+        configure_kubectl_access "$first_pool_namespace"
+    fi
+
     while IFS= read -r namespace; do
         namespace_is_claimed "$namespace" && continue
 
         if namespace_is_ready "$namespace"; then
+            available=$((available + 1))
+            continue
+        fi
+
+        if namespace_resources_are_ready "$namespace"; then
+            mark_namespace_ready "$namespace"
             available=$((available + 1))
             continue
         fi

--- a/scripts/maintain-agent-okteto-pool.sh
+++ b/scripts/maintain-agent-okteto-pool.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+umask 077
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+OKTETO_CONTEXT_URL="${OKTETO_CONTEXT:-https://lightdash.okteto.dev}"
+OKTETO_MANIFEST="$REPO_ROOT/okteto.dev.yaml"
+POOL_NAMESPACE_PREFIX="agent-pool-"
+POOL_CLAIM_CONFIGMAP="lightdash-agent-claim"
+POOL_READY_CONFIGMAP="lightdash-agent-ready"
+TARGET_SIZE="${1:-${LIGHTDASH_AGENT_POOL_SIZE:-3}}"
+
+fail() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || fail "Missing required command '$1'."
+}
+
+list_namespaces() {
+    okteto namespace list -o json |
+        awk '
+            found || /^[[:space:]]*\[/ || /^[[:space:]]*\{/ {
+                found = 1
+                print
+            }
+        ' |
+        jq -r '
+            if type == "array" then .
+            elif (.items | type) == "array" then .items
+            elif (.namespaces | type) == "array" then .namespaces
+            else []
+            end
+            | .[]
+            | if type == "string" then . else (.namespace // .name // empty) end
+        '
+}
+
+namespace_url() {
+    local namespace="$1" context_host
+
+    context_host="${OKTETO_CONTEXT_URL#*://}"
+    context_host="${context_host%%/*}"
+    printf 'https://lightdash-%s.%s' "$namespace" "$context_host"
+}
+
+namespace_is_claimed() {
+    kubectl -n "$1" get configmap "$POOL_CLAIM_CONFIGMAP" >/dev/null 2>&1
+}
+
+namespace_is_ready() {
+    local namespace="$1"
+
+    kubectl -n "$namespace" get configmap "$POOL_READY_CONFIGMAP" \
+        >/dev/null 2>&1 &&
+        curl --fail --silent --show-error --max-time 10 \
+            "$(namespace_url "$namespace")/api/v1/health" >/dev/null 2>&1
+}
+
+mark_namespace_ready() {
+    local namespace="$1"
+
+    kubectl -n "$namespace" create configmap "$POOL_READY_CONFIGMAP" \
+        --from-literal="prepared_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        --dry-run=client -o yaml |
+        kubectl -n "$namespace" apply -f - >/dev/null
+}
+
+deploy_namespace() {
+    local namespace="$1"
+
+    kubectl -n "$namespace" delete configmap "$POOL_READY_CONFIGMAP" \
+        --ignore-not-found >/dev/null 2>&1 || true
+    okteto deploy \
+        -f "$OKTETO_MANIFEST" \
+        -n "$namespace" \
+        --wait \
+        --timeout 20m
+    namespace_is_claimed "$namespace" || mark_namespace_ready "$namespace"
+}
+
+create_pool_namespace() {
+    local namespace="$1"
+
+    echo "Creating pooled namespace $namespace..."
+    okteto namespace create "$namespace" --use=false
+    deploy_namespace "$namespace"
+}
+
+main() {
+    local available=0 attempts=0 created=0 namespace run_key max_attempts
+    local -a pool_namespaces=()
+
+    [[ "$TARGET_SIZE" =~ ^[1-9][0-9]*$ ]] ||
+        fail "Pool size must be a positive integer."
+    max_attempts=$((TARGET_SIZE + 6))
+
+    for command_name in curl jq kubectl okteto; do
+        require_command "$command_name"
+    done
+    [ -n "${LIGHTDASH_OKTETO_TOKEN:-}" ] ||
+        fail "LIGHTDASH_OKTETO_TOKEN is not set."
+
+    RUNTIME_DIR="$(mktemp -d "${TMPDIR:-/tmp}/lightdash-okteto-pool.XXXXXX")"
+    trap 'rm -rf "$RUNTIME_DIR"' EXIT
+    export OKTETO_HOME="$RUNTIME_DIR/okteto-home"
+    export KUBECONFIG="$RUNTIME_DIR/kubeconfig"
+    mkdir -p "$OKTETO_HOME"
+
+    okteto context use "$OKTETO_CONTEXT_URL" \
+        --token "$LIGHTDASH_OKTETO_TOKEN" >/dev/null
+
+    while IFS= read -r namespace; do
+        pool_namespaces+=("$namespace")
+    done < <(list_namespaces | grep "^${POOL_NAMESPACE_PREFIX}" | sort)
+
+    for namespace in "${pool_namespaces[@]}"; do
+        namespace_is_claimed "$namespace" && continue
+
+        if namespace_is_ready "$namespace"; then
+            available=$((available + 1))
+            continue
+        fi
+
+        echo "Repairing pooled namespace $namespace..."
+        if deploy_namespace "$namespace" && namespace_is_ready "$namespace"; then
+            available=$((available + 1))
+        fi
+    done
+
+    run_key="${GITHUB_RUN_ID:-$(date -u +%Y%m%d%H%M%S)-$$}-${GITHUB_RUN_ATTEMPT:-1}"
+    run_key="$(printf '%s' "$run_key" | tr -cd 'a-zA-Z0-9-' | tr 'A-Z' 'a-z')"
+
+    while ((available < TARGET_SIZE && attempts < max_attempts)); do
+        attempts=$((attempts + 1))
+        namespace="${POOL_NAMESPACE_PREFIX}${run_key}-${attempts}"
+
+        if create_pool_namespace "$namespace" &&
+            namespace_is_ready "$namespace"; then
+            available=$((available + 1))
+            created=$((created + 1))
+        fi
+    done
+
+    ((available >= TARGET_SIZE)) ||
+        fail "Only $available of $TARGET_SIZE pooled environments are ready."
+
+    echo "READY: $available unclaimed Okteto environments ($created created)."
+}
+
+main "$@"

--- a/scripts/maintain-agent-okteto-pool.sh
+++ b/scripts/maintain-agent-okteto-pool.sh
@@ -81,6 +81,7 @@ deploy_namespace() {
         --wait \
         --timeout 20m
     namespace_is_claimed "$namespace" || mark_namespace_ready "$namespace"
+    return 0
 }
 
 create_pool_namespace() {
@@ -89,11 +90,11 @@ create_pool_namespace() {
     echo "Creating pooled namespace $namespace..."
     okteto namespace create "$namespace" --use=false
     deploy_namespace "$namespace"
+    return 0
 }
 
 main() {
     local available=0 attempts=0 created=0 namespace run_key max_attempts
-    local -a pool_namespaces=()
 
     [[ "$TARGET_SIZE" =~ ^[1-9][0-9]*$ ]] ||
         fail "Pool size must be a positive integer."
@@ -115,10 +116,6 @@ main() {
         --token "$LIGHTDASH_OKTETO_TOKEN" >/dev/null
 
     while IFS= read -r namespace; do
-        pool_namespaces+=("$namespace")
-    done < <(list_namespaces | grep "^${POOL_NAMESPACE_PREFIX}" | sort)
-
-    for namespace in "${pool_namespaces[@]}"; do
         namespace_is_claimed "$namespace" && continue
 
         if namespace_is_ready "$namespace"; then
@@ -130,7 +127,7 @@ main() {
         if deploy_namespace "$namespace" && namespace_is_ready "$namespace"; then
             available=$((available + 1))
         fi
-    done
+    done < <(list_namespaces | grep "^${POOL_NAMESPACE_PREFIX}" | sort)
 
     run_key="${GITHUB_RUN_ID:-$(date -u +%Y%m%d%H%M%S)-$$}-${GITHUB_RUN_ATTEMPT:-1}"
     run_key="$(printf '%s' "$run_key" | tr -cd 'a-zA-Z0-9-' | tr 'A-Z' 'a-z')"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: SPK-565

### Description:
Adds an opt-in Okteto launcher gated by `LIGHTDASH_OKTETO_TOKEN` that automatically claims a deployment-ready namespace and starts detached file synchronization.
Adds an hourly GitHub Actions workflow that keeps at least three unclaimed Lightdash environments with ready pods and public ingress.
Uses an atomic Kubernetes ConfigMap claim keyed by the session hash to prevent concurrent agents from selecting the same namespace, then verifies synchronization and application health after `okteto up`.
Documents cloud and local setup, pool administration, credential security, and manual testing.

<!-- Even better add a screenshot / gif / loom -->