### PR TITLE
ci: bump pnpm/action-setup to v6.0.9

### DIFF
--- a/.github/workflows/_setup_node_pnpm_cypress/action.yml
+++ b/.github/workflows/_setup_node_pnpm_cypress/action.yml
@@ -14,7 +14,7 @@ runs:
               mode: firewall-free
 
         - name: Setup PNPM
-          uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+          uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         - name: Setup Node
           uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
           with:

--- a/.github/workflows/ai-agent-integration-tests.yml
+++ b/.github/workflows/ai-agent-integration-tests.yml
@@ -46,7 +46,7 @@ jobs:
               with:
                   mode: firewall-free
 
-            - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+            - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
             - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
               with:
                   node-version-file: '.nvmrc'
@@ -157,7 +157,7 @@ jobs:
 
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-            - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+            - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
             - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
               with:
                   node-version-file: '.nvmrc'

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -248,7 +248,7 @@ jobs:
         with:
           mode: firewall-free
 
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -127,7 +127,7 @@ jobs:
         uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall-free
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version-file: ".nvmrc"
@@ -171,7 +171,7 @@ jobs:
         uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall-free
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version-file: ".nvmrc"
@@ -229,7 +229,7 @@ jobs:
         uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall-free
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version-file: ".nvmrc"
@@ -496,7 +496,7 @@ jobs:
         uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall-free
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version-file: ".nvmrc"

--- a/.github/workflows/publish-e2b-template.yml
+++ b/.github/workflows/publish-e2b-template.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           mode: firewall-free
 
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:

--- a/.github/workflows/release-safety-pr.yml
+++ b/.github/workflows/release-safety-pr.yml
@@ -110,7 +110,7 @@ jobs:
         with:
           mode: firewall-free
 
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall-free
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version-file: '.nvmrc'
@@ -58,7 +58,7 @@ jobs:
         with:
           mode: firewall-free
 
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:


### PR DESCRIPTION
### Description:

Bumps every `pnpm/action-setup` pin (12 call sites across 7 workflow files) from `fc06bc12… # v5` (2026-03-13) to `0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9`.

The pinned v5 SHA predates the fix for a known failure of `pnpm publish` with GitHub OIDC trusted publishing on pnpm 11 (pnpm/pnpm#11513 — same workflow shape as our release job: `id-token: write`, publish without `--provenance`). The fix landed in pnpm/action-setup#249 (v6.0.6); v6.0.9 is the current release. The v6 line is the pnpm 11 support line and has no breaking changes for our usage — every call site omits the `version:` input and resolves pnpm from `packageManager`, which v6 still does, so this is dual-compatible with pnpm 10 and belongs below the switch PR in the stack: it must be in effect before the first post-switch release publishes.

Part of the pnpm 11 Graphite stack (see #26410 for the full stack table).

Verification watch item (shared with PROD-9340): the first post-switch release must publish all packages with provenance intact.

Closes: PROD-9343
