### PR TITLE
feat(onboarding): add clickable Data Apps and BI-as-code media cards to the homepage stars rotation

### DIFF
--- a/packages/frontend/CLAUDE.md
+++ b/packages/frontend/CLAUDE.md
@@ -1,9 +1,10 @@
 ## 🎨 Frontend Style Guide
 
 **CRITICAL**: Before working on any frontend component, read
-the [Frontend Style Guide](STYLE_GUIDE.md). Key points:
+the [Frontend Style Guide](../../.cursor/rules/frontend.mdc). Key points:
 
 -   **Use Mantine v8 only** - Migrate any Mantine v6 components you encounter
+-   **Prefer Mantine components over raw HTML elements** - `Box` instead of `<div>`, `Text` instead of `<p>`/`<span>` for copy, `Group`/`Stack` for flex layouts. This applies even when mirroring existing code that uses raw elements - older files predate the rule and are not a licence to copy the pattern
 -   **Styling hierarchy**:
     1. Inline-style component props (≤3 simple layout props like `mt`, `p`, `w`)
     2. CSS modules (default choice when more than 3 inline-style props are needed or when component props aren't available)

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.module.css
@@ -74,6 +74,90 @@
     overflow: hidden;
 }
 
+/* The sky takes no pointer events; media cards opt back in so they are the
+   only stars that can be clicked. */
+.mediaCard {
+    display: flex;
+    flex-direction: column;
+    color: inherit;
+    text-decoration: none;
+    pointer-events: auto;
+    cursor: pointer;
+}
+
+.mediaCard:hover {
+    box-shadow: var(--mantine-shadow-md);
+}
+
+/* A hovered star is always a media card — nothing else takes the pointer. */
+.star:hover {
+    opacity: 1;
+}
+
+.mediaThumb,
+.mediaWash {
+    /* Proportional to the tier width so the card keeps the height envelope
+       the slot separation is measured against. */
+    height: calc(var(--star-width) * 0.28);
+    min-height: 46px;
+    overflow: hidden;
+}
+
+.mediaThumb {
+    background: var(--mantine-color-ldGray-1);
+}
+
+.mediaThumb img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.mediaWash {
+    display: grid;
+    place-items: center;
+    background: linear-gradient(
+        135deg,
+        light-dark(#eaedf8, #252a3b),
+        light-dark(#dfe3f2, #1e2231)
+    );
+    color: light-dark(#5a68a8, #9ba8dd);
+}
+
+.mediaFavicon {
+    width: 22px;
+    height: 22px;
+    border-radius: 6px;
+    object-fit: contain;
+}
+
+.mediaBody {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 8px 10px 10px;
+}
+
+.mediaTitle {
+    font-size: 12.5px;
+    font-weight: 600;
+    line-height: 1.3;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.mediaSubtitle {
+    font-size: 11.5px;
+    line-height: 1.35;
+    color: var(--mantine-color-ldGray-6);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 /* Presentational copy of the homepage-builder's quick-action chip. */
 .chip {
     display: inline-flex;

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.test.tsx
@@ -1,9 +1,16 @@
 import { MantineProvider } from '@mantine-8/core';
 import { act, fireEvent, render } from '@testing-library/react';
+import { EventName } from '../../../types/Events';
 import HomepageStars from './HomepageStars';
 
-// Nothing is mocked: the cards are purpose-built presentational markup, so
-// the focusability assertions below run against the real DOM.
+const { track } = vi.hoisted(() => ({ track: vi.fn() }));
+
+vi.mock('../../../providers/Tracking/useTracking', () => ({
+    default: () => ({ track, data: { rudder: true } }),
+}));
+
+// Only tracking is mocked: the cards are purpose-built presentational markup,
+// so the focusability assertions below run against the real DOM.
 // Answers min-width/min-height queries against a pretend viewport, so the
 // tier the component picks is the one a real browser would pick.
 const stubMatchMedia = ({
@@ -38,19 +45,29 @@ const renderStars = () =>
         </MantineProvider>,
     );
 
+const SKY_SELECTOR = '[data-testid="homepage-stars-sky"]';
+
+const VIDEO_HREF = 'https://www.youtube.com/watch?v=BwvgHQyhI1o';
+
+// Every draw returns the top of its range, so the last free def is always the
+// one picked — and the media cards sit last in the catalogue.
+const forceMediaCards = () => vi.spyOn(Math, 'random').mockReturnValue(0.99);
+
 describe('HomepageStars', () => {
     beforeEach(() => {
         vi.useFakeTimers();
         stubMatchMedia();
+        track.mockClear();
     });
 
     afterEach(() => {
         vi.useRealTimers();
+        vi.restoreAllMocks();
     });
 
     it('spawns stars over time and caps how many are visible at once', () => {
         const { container } = renderStars();
-        const sky = container.querySelector('[inert]');
+        const sky = container.querySelector(SKY_SELECTOR);
         expect(sky).not.toBeNull();
         expect(sky!.childElementCount).toBe(0);
 
@@ -73,7 +90,7 @@ describe('HomepageStars', () => {
 
     it('never shows two stars with the same identity', () => {
         const { container } = renderStars();
-        const sky = container.querySelector('[inert]')!;
+        const sky = container.querySelector(SKY_SELECTOR)!;
 
         for (let i = 0; i < 40; i++) {
             act(() => {
@@ -89,7 +106,7 @@ describe('HomepageStars', () => {
 
     it('never leaves one side empty while stars are visible', () => {
         const { container } = renderStars();
-        const sky = container.querySelector('[inert]')!;
+        const sky = container.querySelector(SKY_SELECTOR)!;
 
         for (let i = 0; i < 40; i++) {
             act(() => {
@@ -109,7 +126,7 @@ describe('HomepageStars', () => {
 
     it('keeps stars on a side a full card apart', () => {
         const { container } = renderStars();
-        const sky = container.querySelector('[inert]')!;
+        const sky = container.querySelector(SKY_SELECTOR)!;
 
         for (let i = 0; i < 40; i++) {
             act(() => {
@@ -136,7 +153,7 @@ describe('HomepageStars', () => {
 
     it('expires stars even when animationend never fires', () => {
         const { container } = renderStars();
-        const sky = container.querySelector('[inert]')!;
+        const sky = container.querySelector(SKY_SELECTOR)!;
 
         act(() => {
             vi.advanceTimersByTime(3000);
@@ -154,7 +171,7 @@ describe('HomepageStars', () => {
 
     it('settles a star out of its entry animation, then removes it once it leaves', () => {
         const { container } = renderStars();
-        const sky = container.querySelector('[inert]')!;
+        const sky = container.querySelector(SKY_SELECTOR)!;
 
         act(() => {
             vi.advanceTimersByTime(600);
@@ -188,21 +205,71 @@ describe('HomepageStars', () => {
         expect(star.isConnected).toBe(false);
     });
 
-    it('contains no focusable elements and is inert + aria-hidden', () => {
+    it('hides decorative stars from assistive tech and keeps them unfocusable', () => {
         const { container } = renderStars();
-        const sky = container.querySelector('[inert]')!;
-        expect(sky).toHaveAttribute('aria-hidden');
+        const sky = container.querySelector(SKY_SELECTOR)!;
+        expect(sky).not.toHaveAttribute('inert');
+        expect(sky).not.toHaveAttribute('aria-hidden');
 
         act(() => {
             vi.advanceTimersByTime(30000);
         });
-        expect(sky.childElementCount).toBeGreaterThan(0);
-        expect(sky.querySelectorAll('a, button')).toHaveLength(0);
+        const decorative = sky.querySelectorAll('[aria-hidden="true"]');
+        expect(decorative.length).toBeGreaterThan(0);
+        decorative.forEach((star) => {
+            expect(star.querySelectorAll('a, button, [tabindex]')).toHaveLength(
+                0,
+            );
+        });
+    });
+
+    it('shows media cards in the rotation as new-tab links', () => {
+        forceMediaCards();
+        const { container } = renderStars();
+        const sky = container.querySelector(SKY_SELECTOR)!;
+
+        act(() => {
+            vi.advanceTimersByTime(1000);
+        });
+        const links = [...sky.querySelectorAll('a')];
+        expect(links.map((link) => link.getAttribute('href'))).toContain(
+            VIDEO_HREF,
+        );
+        links.forEach((link) => {
+            expect(link).toHaveAttribute('target', '_blank');
+            expect(link).toHaveAttribute(
+                'rel',
+                expect.stringContaining('noreferrer'),
+            );
+            // Named by the card title, not by an aria-hidden wrapper.
+            expect(link.closest('[aria-hidden="true"]')).toBeNull();
+        });
+        expect(
+            sky.querySelector(`a[href="${VIDEO_HREF}"]`)?.textContent,
+        ).toContain(
+            'What can you build with Lightdash Data Apps? 3 real examples',
+        );
+    });
+
+    it('tracks a click on a media card', () => {
+        forceMediaCards();
+        const { container } = renderStars();
+
+        act(() => {
+            vi.advanceTimersByTime(1000);
+        });
+        const link = container.querySelector(`a[href="${VIDEO_HREF}"]`)!;
+        fireEvent.click(link);
+
+        expect(track).toHaveBeenCalledWith({
+            name: EventName.HOMEPAGE_STARS_MEDIA_CARD_CLICKED,
+            properties: { cardKey: 'data-apps-video', href: VIDEO_HREF },
+        });
     });
 
     it('keeps one timer per star no matter how long the page stays open', () => {
         const { container, unmount } = renderStars();
-        const sky = container.querySelector('[inert]')!;
+        const sky = container.querySelector(SKY_SELECTOR)!;
 
         act(() => {
             vi.advanceTimersByTime(120000);
@@ -219,7 +286,7 @@ describe('HomepageStars', () => {
     it('still shows stars on a smaller viewport, at a narrower width', () => {
         stubMatchMedia({ width: 1280, height: 820 });
         const { container } = renderStars();
-        const sky = container.querySelector('[inert]')!;
+        const sky = container.querySelector(SKY_SELECTOR)!;
 
         act(() => {
             vi.advanceTimersByTime(3000);
@@ -239,7 +306,7 @@ describe('HomepageStars', () => {
         act(() => {
             vi.advanceTimersByTime(10000);
         });
-        expect(container.querySelector('[inert]')).toBeNull();
+        expect(container.querySelector(SKY_SELECTOR)).toBeNull();
     });
 
     it('renders nothing and schedules no stars under prefers-reduced-motion', () => {
@@ -249,6 +316,6 @@ describe('HomepageStars', () => {
         act(() => {
             vi.advanceTimersByTime(10000);
         });
-        expect(container.querySelector('[inert]')).toBeNull();
+        expect(container.querySelector(SKY_SELECTOR)).toBeNull();
     });
 });

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.tsx
@@ -8,6 +8,7 @@ import {
     IconChartPie,
     IconFolder,
     IconLayoutDashboard,
+    IconLink,
     IconSparkles,
     IconTable,
     type Icon,
@@ -22,6 +23,9 @@ import {
     type ReactElement,
 } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
+import useTracking from '../../../providers/Tracking/useTracking';
+import { EventName } from '../../../types/Events';
+import { faviconUrl } from './blocks/resourceUrls';
 import classes from './HomepageStars.module.css';
 
 const randomBetween = (min: number, max: number) =>
@@ -204,6 +208,87 @@ const StaticChips: FC<{ types: ChipKey[] }> = ({ types }) => (
     </Group>
 );
 
+// The only real content in the sky: these link out, so they are the one kind
+// of star that takes clicks and reports them.
+type MediaCard = {
+    key: string;
+    title: string;
+    subtitle: string;
+    href: string;
+    thumbnailUrl: string | null;
+};
+
+const MEDIA_CARDS: MediaCard[] = [
+    {
+        key: 'data-apps-video',
+        title: 'What can you build with Lightdash Data Apps? 3 real examples',
+        subtitle: 'Oliver shows us how we can build data apps!',
+        href: 'https://www.youtube.com/watch?v=BwvgHQyhI1o',
+        thumbnailUrl: 'https://i.ytimg.com/vi/BwvgHQyhI1o/hqdefault.jpg',
+    },
+    {
+        key: 'bi-as-code',
+        title: 'BI-as-code',
+        subtitle: 'Building content with code',
+        href: 'https://www.lightdash.com/bi-as-code',
+        thumbnailUrl: null,
+    },
+];
+
+const MediaStarCard: FC<{ card: MediaCard }> = ({ card }) => {
+    const { track } = useTracking();
+    const [thumbnailFailed, setThumbnailFailed] = useState(false);
+    const [faviconFailed, setFaviconFailed] = useState(false);
+    const favicon = faviconUrl(card.href);
+    const thumbnail = thumbnailFailed ? null : card.thumbnailUrl;
+
+    return (
+        <a
+            href={card.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={`${classes.card} ${classes.mediaCard}`}
+            onClick={() =>
+                track({
+                    name: EventName.HOMEPAGE_STARS_MEDIA_CARD_CLICKED,
+                    properties: { cardKey: card.key, href: card.href },
+                })
+            }
+        >
+            {thumbnail ? (
+                <div className={classes.mediaThumb}>
+                    <img
+                        src={thumbnail}
+                        alt=""
+                        loading="lazy"
+                        draggable={false}
+                        onError={() => setThumbnailFailed(true)}
+                    />
+                </div>
+            ) : (
+                <div className={classes.mediaWash}>
+                    {favicon && !faviconFailed ? (
+                        <img
+                            className={classes.mediaFavicon}
+                            src={favicon}
+                            alt=""
+                            loading="lazy"
+                            draggable={false}
+                            onError={() => setFaviconFailed(true)}
+                        />
+                    ) : (
+                        <MantineIcon icon={IconLink} size={20} />
+                    )}
+                </div>
+            )}
+            <div className={classes.mediaBody}>
+                <div className={classes.mediaTitle}>{card.title}</div>
+                <div className={classes.mediaSubtitle}>{card.subtitle}</div>
+            </div>
+        </a>
+    );
+};
+
 const StarCard: FC<{
     icon: Icon;
     tint: string;
@@ -308,12 +393,18 @@ const buildSparklineValues = (): number[] => {
 
 // Catalog of distinct star identities. A def only spawns while no visible
 // star uses it, so the sky never shows duplicate cards, KPIs, or chips.
-type StarDef = { key: string; render: (seed: StarSeed) => ReactElement };
+// Only interactive defs are exposed to the accessibility tree and to clicks.
+type StarDef = {
+    key: string;
+    interactive: boolean;
+    render: (seed: StarSeed) => ReactElement;
+};
 
 const STAR_DEFS: StarDef[] = [
     ...MOCK_CHARTS.map(
         (chart): StarDef => ({
             key: `chart-${chart.name}`,
+            interactive: false,
             render: (seed) => (
                 <StarCard
                     icon={chart.icon}
@@ -327,6 +418,7 @@ const STAR_DEFS: StarDef[] = [
     ...MOCK_DASHBOARD_NAMES.map(
         (name): StarDef => ({
             key: `dashboard-${name}`,
+            interactive: false,
             render: (seed) => (
                 <StarCard
                     icon={IconLayoutDashboard}
@@ -340,6 +432,7 @@ const STAR_DEFS: StarDef[] = [
     ...MOCK_KPIS.map(
         (kpi): StarDef => ({
             key: `kpi-${kpi.label}`,
+            interactive: false,
             render: (seed) => (
                 <Box className={classes.card} p="sm">
                     <Text size="xs" c="dimmed" lineClamp={1}>
@@ -360,7 +453,15 @@ const STAR_DEFS: StarDef[] = [
     ...MOCK_CHIP_SETS.map(
         (types, index): StarDef => ({
             key: `chips-${index}`,
+            interactive: false,
             render: () => <StaticChips types={types} />,
+        }),
+    ),
+    ...MEDIA_CARDS.map(
+        (card): StarDef => ({
+            key: `media-${card.key}`,
+            interactive: true,
+            render: () => <MediaStarCard card={card} />,
         }),
     ),
 ];
@@ -687,31 +788,38 @@ const HomepageStars: FC = () => {
     if (disabled) return null;
 
     return (
-        <Box className={classes.sky} inert aria-hidden>
-            {stars.map((star) => (
-                <Box
-                    key={star.id}
-                    className={`${classes.star} ${star.className} ${phaseClass(
-                        star.phase,
-                    )}`}
-                    style={star.style}
-                    data-side={star.slot.side}
-                    data-star-def={star.defKey}
-                    data-star-phase={star.phase}
-                    onAnimationEnd={(event) => {
-                        if (event.target !== event.currentTarget) return;
-                        if (star.phase === 'leaving') {
-                            removeStar(star.id);
-                        } else if (star.phase === 'entering') {
-                            // Drop the animation so the settled card is
-                            // painted, not resampled from a compositor layer.
-                            settleStar(star.id);
-                        }
-                    }}
-                >
-                    {STAR_DEF_MAP.get(star.defKey)?.render(star.seed) ?? null}
-                </Box>
-            ))}
+        <Box className={classes.sky} data-testid="homepage-stars-sky">
+            {stars.map((star) => {
+                const def = STAR_DEF_MAP.get(star.defKey);
+                return (
+                    <Box
+                        key={star.id}
+                        className={`${classes.star} ${
+                            star.className
+                        } ${phaseClass(star.phase)}`}
+                        style={star.style}
+                        // Decoration stays out of the accessibility tree; only
+                        // media cards are announced, via their link text.
+                        aria-hidden={def?.interactive ? undefined : true}
+                        data-side={star.slot.side}
+                        data-star-def={star.defKey}
+                        data-star-phase={star.phase}
+                        onAnimationEnd={(event) => {
+                            if (event.target !== event.currentTarget) return;
+                            if (star.phase === 'leaving') {
+                                removeStar(star.id);
+                            } else if (star.phase === 'entering') {
+                                // Drop the animation so the settled card is
+                                // painted, not resampled from a compositor
+                                // layer.
+                                settleStar(star.id);
+                            }
+                        }}
+                    >
+                        {def?.render(star.seed) ?? null}
+                    </Box>
+                );
+            })}
         </Box>
     );
 };

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.tsx
@@ -256,7 +256,7 @@ const MediaStarCard: FC<{ card: MediaCard }> = ({ card }) => {
             }
         >
             {thumbnail ? (
-                <div className={classes.mediaThumb}>
+                <Box className={classes.mediaThumb}>
                     <img
                         src={thumbnail}
                         alt=""
@@ -264,9 +264,9 @@ const MediaStarCard: FC<{ card: MediaCard }> = ({ card }) => {
                         draggable={false}
                         onError={() => setThumbnailFailed(true)}
                     />
-                </div>
+                </Box>
             ) : (
-                <div className={classes.mediaWash}>
+                <Box className={classes.mediaWash}>
                     {favicon && !faviconFailed ? (
                         <img
                             className={classes.mediaFavicon}
@@ -279,12 +279,12 @@ const MediaStarCard: FC<{ card: MediaCard }> = ({ card }) => {
                     ) : (
                         <MantineIcon icon={IconLink} size={20} />
                     )}
-                </div>
+                </Box>
             )}
-            <div className={classes.mediaBody}>
-                <div className={classes.mediaTitle}>{card.title}</div>
-                <div className={classes.mediaSubtitle}>{card.subtitle}</div>
-            </div>
+            <Box className={classes.mediaBody}>
+                <Text className={classes.mediaTitle}>{card.title}</Text>
+                <Text className={classes.mediaSubtitle}>{card.subtitle}</Text>
+            </Box>
         </a>
     );
 };

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -749,6 +749,14 @@ type HomepageRecommendedActionRestoredEvent = {
     };
 };
 
+type HomepageStarsMediaCardClickedEvent = {
+    name: EventName.HOMEPAGE_STARS_MEDIA_CARD_CLICKED;
+    properties: {
+        cardKey: string;
+        href: string;
+    };
+};
+
 type CreateProjectColumnsDefinedButtonClickedEvent = {
     name: EventName.CREATE_PROJECT_COLUMNS_DEFINED_BUTTON_CLICKED;
     properties: {
@@ -776,6 +784,7 @@ export type EventData =
     | HomepageAskSubmittedEvent
     | HomepageRecommendedActionImpressionEvent
     | HomepageRecommendedActionRestoredEvent
+    | HomepageStarsMediaCardClickedEvent
     | CreateProjectColumnsDefinedButtonClickedEvent
     | HomepageQuickActionClickedEvent
     | HomepageRecommendedActionClickedEvent

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -210,6 +210,7 @@ export enum EventName {
     HOMEPAGE_ASK_SUBMITTED = 'homepage_ask.submitted',
     HOMEPAGE_RECOMMENDED_ACTION_IMPRESSION = 'homepage_recommended_action.impression',
     HOMEPAGE_RECOMMENDED_ACTION_RESTORED = 'homepage_recommended_action.restored',
+    HOMEPAGE_STARS_MEDIA_CARD_CLICKED = 'homepage_stars_media_card.clicked',
     AGENT_SETUP_PROMPT_COPIED = 'agent_setup_prompt.copied',
     CREATE_PROJECT_COLUMNS_DEFINED_BUTTON_CLICKED = 'create_project_columns_defined_button.click',
 }


### PR DESCRIPTION
## Summary

The no-warehouse `/get-started` homepage renders **HomepageStars** — ambient decorative cards that fade in and out around the hero. This PR adds two real media cards to that rotation:

1. **What can you build with Lightdash Data Apps? 3 real examples** — YouTube video card with thumbnail
2. **BI-as-code** — link to the BI-as-code guide, favicon-on-wash treatment

Unlike the decorative stars, these are clickable anchors that open in a new tab (`target="_blank" rel="noopener noreferrer"`), styled to match the media-card language of the homepage builder's resources block (reuses `faviconUrl`).

## Design change: interactivity

The sky container previously carried `inert` + `aria-hidden` with a test asserting nothing was focusable. Since two cards are now real links:

- the sky container drops `inert`/`aria-hidden` but keeps `pointer-events: none`
- decorative stars are individually `aria-hidden` and remain unfocusable
- only media cards opt back into pointer events; a hover opacity lift compensates for the small-tier fade
- animation contract untouched (enter/leave keyframes, `LEAVE_MS` sync, `MAX_STARS` cap, slot separation, reduced-motion and small-viewport gates)

## Analytics

New `homepage_stars_media_card.clicked` event with explicit `{ cardKey, href }` properties fires on click. Rendering stays untracked so the decoration never pollutes homepage analytics.

## Testing

- `HomepageStars.test.tsx`: replaced the inert assertion with decorative-stars-are-hidden + unfocusable; added media cards appear in rotation as new-tab links with exact hrefs, and click fires the tracking event with the right properties; all existing behavioural tests (cap, no duplicates, side balance, expiry, reduced-motion, tiers) still pass
- 19/19 tests pass across `HomepageStars.test.tsx` + `NoProjectHomepage.test.tsx`; frontend typecheck clean; lint clean on touched paths

Linear: SPK-734

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018coVBm6wgGF34DkWavpnkY