### PR TITLE
fix(frontend): stop Mantine transitions leaking timers past test teardown

### DIFF
--- a/packages/frontend/src/providers/Mantine8Provider.tsx
+++ b/packages/frontend/src/providers/Mantine8Provider.tsx
@@ -14,6 +14,7 @@ type Props = {
     notificationsLimit?: number;
     cssVariablesSelector?: string;
     getRootElement?: () => HTMLElement | undefined;
+    env?: 'default' | 'test';
 };
 
 const Mantine8Provider: FC<React.PropsWithChildren<Props>> = ({
@@ -22,6 +23,7 @@ const Mantine8Provider: FC<React.PropsWithChildren<Props>> = ({
     forceColorScheme,
     cssVariablesSelector,
     getRootElement,
+    env,
 }) => {
     const { colorScheme } = useMantineColorScheme();
     const effectiveColorScheme = forceColorScheme || colorScheme;
@@ -43,6 +45,7 @@ const Mantine8Provider: FC<React.PropsWithChildren<Props>> = ({
             cssVariablesSelector={cssVariablesSelector}
             getRootElement={getRootElement}
             classNamesPrefix="mantine-8"
+            env={env}
         >
             <CodeHighlightProvider>{children}</CodeHighlightProvider>
         </MantineProviderBase>

--- a/packages/frontend/src/testing/testUtils.tsx
+++ b/packages/frontend/src/testing/testUtils.tsx
@@ -27,7 +27,7 @@ const getMockedProviders = (appMocks?: AppProviderMockProps['mocks']) => {
         return (
             <ReactQueryProvider>
                 <MantineProvider>
-                    <Mantine8Provider>
+                    <Mantine8Provider env="test">
                         <AppProviderMock mocks={appMocks}>
                             <TrackingProvider>{children}</TrackingProvider>
                         </AppProviderMock>


### PR DESCRIPTION
## What

Sets Mantine's `env="test"` on the Mantine v8 provider used by the frontend test utilities, and forwards the `env` prop through `Mantine8Provider` so that is possible.

## Why

`Build & Test` has been failing intermittently on PRs with **every test passing**:

```
 Test Files  213 passed (213)
      Tests  1681 passed (1681)
     Errors  1 error

⎯⎯⎯⎯⎯ Uncaught Exception ⎯⎯⎯⎯⎯
ReferenceError: window is not defined
 ❯ resolveUpdatePriority react-dom-client.development.js:1308:7
 ❯ dispatchSetState react-dom-client.development.js:9126:14
 ❯ Timeout._onTimeout @mantine/core/esm/components/Transition/use-transition.mjs:55:13

This error originated in "src/features/dashboardFilters/FilterRequirements/GuidedFilterSetupOverlay.test.tsx"
```

Vitest fails the run on an unhandled error even when no assertion failed, so the whole job goes red.

`useTransition` drives its status through a `requestAnimationFrame` chain that ends in `window.setTimeout(..., transitionDuration)`. Its unmount cleanup clears the handles it currently holds, but the timer is scheduled from inside the nested rAF callback, so a transition still in flight when the file's environment is torn down fires its callback into a dead jsdom, calls `setStatus`, and React dereferences `window`.

Mantine ships an escape hatch for exactly this: with `env="test"`, `Transition` renders its children directly and never schedules rAF or timers at all. That removes the failure at the source rather than papering over it in one test file — any component rendered through `renderWithProviders` is covered.

## Regression analysis

`env="test"` also disables portals, so modal/menu/dropdown content renders inline instead of under `document.body`. Tests that reach for portalled nodes via `document.querySelector` still find them, since the queries are document-scoped either way.

The full frontend suite passes with the change (213 files, 1669 tests locally), and `GuidedFilterSetupOverlay.test.tsx` passes both in isolation and in the full run. Nothing outside the test render path changes: `env` defaults to `undefined` for every application-side `Mantine8Provider`, so app behaviour and transitions are untouched.

The failure is load- and ordering-dependent and does not reproduce locally on either side of the change (4 clean baseline runs), so the evidence here is mechanical rather than statistical: with `env="test"` the timer in the stack trace is never scheduled.

One unrelated flake showed up in a single full-suite run while verifying (`AiAgentAdminMemoriesTable > filters by scope through the scope facet`, a `toHaveBeenLastCalledWith` assertion). It passes 6/6 in isolation with the change and is not portal- or transition-dependent; flagging it here as a known separate flake rather than claiming it fixed or caused.