### PR TITLE
ci: record esbuild allowBuilds decision in E2B sandbox pnpm configs

### DIFF
--- a/sandboxes/agent-onboarding/pnpm-workspace.yaml
+++ b/sandboxes/agent-onboarding/pnpm-workspace.yaml
@@ -1,1 +1,6 @@
 packages: []
+# esbuild ships its platform binary via optionalDependencies; its install
+# script is a fallback we have never run (pnpm 10 ignored it with a warning).
+# pnpm 11 errors on unreviewed build scripts, so record the decision here.
+allowBuilds:
+  esbuild: false

--- a/sandboxes/ai-coding-agent/pnpm-workspace.yaml
+++ b/sandboxes/ai-coding-agent/pnpm-workspace.yaml
@@ -1,1 +1,6 @@
 packages: []
+# esbuild ships its platform binary via optionalDependencies; its install
+# script is a fallback we have never run (pnpm 10 ignored it with a warning).
+# pnpm 11 errors on unreviewed build scripts, so record the decision here.
+allowBuilds:
+  esbuild: false

--- a/sandboxes/ai-writeback/pnpm-workspace.yaml
+++ b/sandboxes/ai-writeback/pnpm-workspace.yaml
@@ -1,1 +1,6 @@
 packages: []
+# esbuild ships its platform binary via optionalDependencies; its install
+# script is a fallback we have never run (pnpm 10 ignored it with a warning).
+# pnpm 11 errors on unreviewed build scripts, so record the decision here.
+allowBuilds:
+  esbuild: false

--- a/sandboxes/data-apps/pnpm-workspace.yaml
+++ b/sandboxes/data-apps/pnpm-workspace.yaml
@@ -1,3 +1,8 @@
 packages: []
 # pnpm 11 reads settings from here; the .npmrc copy remains for pnpm <=10.
 ignoreWorkspaceRootCheck: true
+# esbuild ships its platform binary via optionalDependencies; its install
+# script is a fallback we have never run (pnpm 10 ignored it with a warning).
+# pnpm 11 errors on unreviewed build scripts, so record the decision here.
+allowBuilds:
+  esbuild: false


### PR DESCRIPTION
## What

Adds `allowBuilds: { esbuild: false }` to the four standalone E2B sandbox `pnpm-workspace.yaml` files (`agent-onboarding`, `ai-coding-agent`, `ai-writeback`, `data-apps`).

## Why

All eight `Publish * E2B template` jobs in the 1.37.0 post-release run failed at **Install sandbox deps**:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.18.20
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```

pnpm 11 turns unreviewed dependency build scripts into a hard install error where pnpm 10 only warned. The root workspace has an `allowBuilds` map, but the sandboxes are standalone pnpm projects (deliberately outside the root workspace) and were missed in the pnpm 11 migration.

`esbuild: false` (not `true`) because esbuild ships its platform binary via `optionalDependencies`; its install script is a fallback that has never run in these sandboxes — pnpm 10 ignored it on every previously successful template publish.

Failing run: https://github.com/lightdash/lightdash/actions/runs/30484055935

## Verification

Ran the exact CI command (`sfw pnpm install --frozen-lockfile --prefer-offline`) in all four sandbox directories under pnpm 11.17.0 / Node 24: all fail with `ERR_PNPM_IGNORED_BUILDS` before this change, all complete cleanly after it.

## Impact note

Release **1.37.0 has no E2B template tags** (the re-tag step was skipped in all eight jobs). Backends default sandbox template tags to their running `VERSION`, so a 1.37.0 deployment would not find its matching templates for AI writeback / coding agent / data apps / agent onboarding. The next release after this merges will publish templates again.

Relates: PROD-8816

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtuAUhvZyGLHdct6SJiL2C