### PR TITLE
fix: disable pnpm 11 verifyDepsBeforeRun so the production entrypoint boots

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -93,6 +93,14 @@ minimumReleaseAgeExclude:
   # Renovate security update: tar@7.5.21
   - tar@7.5.21
 
+# pnpm 11 defaults verifyDepsBeforeRun to `install`, which re-verifies (and
+# reinstalls) node_modules before running any package script. The production
+# image assembles node_modules across build stages, so the check can never pass
+# there — the entrypoint's `pnpm -F backend migrate-production` then triggers a
+# full install at container boot and the pod is killed before it finishes.
+# Restore the pnpm 10 behaviour: scripts run against node_modules as-is.
+verifyDepsBeforeRun: false
+
 # Dependency lifecycle scripts (preinstall/install/postinstall) are a supply-chain
 # attack/breakage vector — they also run on `npm install` for downstream consumers
 # of our published packages (e.g. @lightdash/cli). pnpm blocks them by default;


### PR DESCRIPTION
## What

Sets `verifyDepsBeforeRun: false` in `pnpm-workspace.yaml`, restoring the pnpm 10 behaviour for package-script runs.

## Why — production backend crash-loop on 1.38.0

pnpm 11 changed the default of [`verifyDepsBeforeRun` to `install`](https://github.com/pnpm/pnpm/releases/tag/v11.0.0). The production image's entrypoint (`docker/prod-entrypoint.sh`) runs `pnpm -F backend migrate-production` before starting the server — under pnpm 11 that now verifies `node_modules` against the lockfile first. The prod image assembles `node_modules` across multi-stage COPYs, so verification can never pass, and pnpm launches a **full reinstall at container boot** ("Scope: all 7 workspace projects", 350+ packages downloaded, `reused 0`). The pod is SIGTERMed (~21s, consistent with the 1Gi ephemeral-storage limit being exhausted) before migrations ever run — a crash-loop.

Observed live on the analytics instance after pinning to `1.38.0-commercial` (lightdash-cloud#2982): new backend ReplicaSet 0/1 with 6 restarts, previous-run logs show the runtime pnpm install; old 1.35.0 pods kept serving. Worker/scheduler pods override the entrypoint with a direct `node dist/scheduler.js` command, which is why only the backend loops.

Why PR CI never caught it: no PR workflow boots the production image — only `post-release.yml` builds it, and image *build* succeeds; the failure is at *runtime*.

## Verification

- `pnpm config get verifyDepsBeforeRun` → `false` with this change; package scripts run without triggering verification/install.
- The real proof is the next release's image booting on a customer instance — this is a `fix:` commit precisely so merging it cuts that release.

Relates: PROD-8816

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtuAUhvZyGLHdct6SJiL2C