### PR TITLE
chore(docker): run knex directly in the production entrypoint

### DIFF
--- a/docker/prod-entrypoint.sh
+++ b/docker/prod-entrypoint.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 set -e
 
-# Migrate db
-pnpm -F backend migrate-production
+# Migrate db, invoking knex directly: production boot must not depend on
+# package-manager runtime semantics (pnpm 11's verifyDepsBeforeRun default
+# turned `pnpm -F backend migrate-production` into a full reinstall at boot)
+cd /usr/app/packages/backend
+./node_modules/.bin/knex migrate:latest --knexfile dist/knexfile.js
 
 # Run prod
 exec "$@"


### PR DESCRIPTION
## What

`docker/prod-entrypoint.sh` now runs `./node_modules/.bin/knex migrate:latest --knexfile dist/knexfile.js` directly instead of `pnpm -F backend migrate-production`. Covers both images that use the entrypoint (`dockerfile` and `dockerfile-prs`).

## Why

Production container boot should not depend on package-manager runtime semantics. pnpm 11's `verifyDepsBeforeRun: install` default turned the entrypoint's script invocation into a full dependency reinstall at boot — the multi-stage-assembled `node_modules` can never pass verification — crash-looping the backend on the first 1.38.0 rollout (see #26493 for the incident and the config-level workaround, which stays in place as defence for every other script path).

With this change the prod runtime never invokes pnpm: migrations run via the knex binary, the server via `node dist/index.js` (unchanged CMD). The exact command was verified live on the analytics instance — the deployment ran with precisely this knex+node pair as its container command and booted/migrated cleanly on the 1.38.0 image.

## Verification

- `bash -n` clean; the knex invocation is byte-identical to what `migrate-production` resolves to (`knex migrate:latest --knexfile dist/knexfile.js` from `packages/backend`).
- Runtime-verified on the real 1.38.0-commercial image in production (analytics) as described above.
- The `migrate-production` package script is kept — nothing else in the repo invokes it at runtime, but it remains the documented manual path.

Relates: PROD-9346

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtuAUhvZyGLHdct6SJiL2C