### PR TITLE
fix(release): reinstall after npm version damages the pnpm module tree

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -38,6 +38,18 @@ module.exports = {
             },
         ],
 
+        // npm version starts reifying node_modules toward npm's ideal tree
+        // (destroying parts of pnpm's symlink layout) before it hits the
+        // expected workspace:* error above. Reinstall from the unchanged
+        // lockfile to repair the tree; pnpm 11 used to do this implicitly via
+        // verifyDepsBeforeRun before it was pinned off in pnpm-workspace.yaml.
+        [
+            '@semantic-release/exec',
+            {
+                prepareCmd: 'sfw pnpm install --prefer-offline',
+            },
+        ],
+
         [
             '@semantic-release/exec',
             {


### PR DESCRIPTION
## What

Adds one prepare step to `release.config.js`, between the `npm version` hack and `pnpm generate-api:backend`:

```
sfw pnpm install --prefer-offline
```

## Why — the 1.38.1 release failure

[Run 30490081168](https://github.com/lightdash/lightdash/actions/runs/30490081168) failed at `generate-api` with `TS2688: Cannot find type definition file for 'node' / 'vitest/globals'` plus pnpm's *"Local package.json exists, but node_modules missing"* — minutes after the job's own `Install dependencies` completed normally.

Mechanism: the `npm version ${version} --workspaces …` prepare step intentionally relies on npm erroring at `workspace:*` (the `grep -q EUNSUPPORTEDPROTOCOL` contract). But before npm hits that error it begins **reifying node_modules toward npm's ideal tree** — and npm considers pnpm's entire symlink layout wrong, so it starts tearing it up, then dies mid-surgery. How far it gets varies with npm cache state.

Every pnpm 11 release until now (1.36.0–1.38.0) was silently repaired: `verifyDepsBeforeRun=install` triggered a full reinstall on the next `pnpm run` — visible in those release logs as an unexplained ~50s install (canvas/lz4 build scripts firing) right after `npm version`. #26493 pinned that setting off (correctly — it crash-looped production, see the PR), which exposed the damage.

This change makes the repair explicit and deliberate instead of implicit and accidental.

## Security note

No new supply-chain surface: the install re-runs against the **same lockfile** the job installed from minutes earlier (`npm version` only edits `package.json` version fields — pnpm resolution is unchanged), wrapped in `sfw` per repo policy, with `strictDepBuilds`/`allowBuilds` still enforced. `--prefer-offline` serves it mostly from the job's pnpm store.

## Verification

- `release.config.js` loads (`require` OK, 10 plugins, new exec step in position).
- The repair command is behaviourally identical to the implicit `verifyDepsBeforeRun` install that made 1.36.0–1.38.0 release runs green.
- Real proof is the next release run on main after merge.

Longer-term: replacing the `npm version`+grep hack with something that doesn't half-reify (e.g. `--no-workspaces-update`, or a script that edits versions directly) would remove the damage at source — left out of this PR deliberately since it changes a load-bearing error contract.

Relates: PROD-8816

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtuAUhvZyGLHdct6SJiL2C