### PR TITLE
fix(release): repair install must run offline from the populated store

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -43,10 +43,15 @@ module.exports = {
         // expected workspace:* error above. Reinstall from the unchanged
         // lockfile to repair the tree; pnpm 11 used to do this implicitly via
         // verifyDepsBeforeRun before it was pinned off in pnpm-workspace.yaml.
+        // --offline: the job's install step already populated the store, so
+        // the relink must not touch the network — a registry flake here left
+        // a half-restored tree, and sfw's crashed proxy masked the failure
+        // with exit 0 (run 30491182209). Offline means no fetches to firewall
+        // and a hard failure if the store is somehow incomplete.
         [
             '@semantic-release/exec',
             {
-                prepareCmd: 'sfw pnpm install --prefer-offline',
+                prepareCmd: 'pnpm install --offline',
             },
         ],
 


### PR DESCRIPTION
## What

Changes the post-`npm version` repair install in `release.config.js` from `sfw pnpm install --prefer-offline` to `pnpm install --offline`.

## Why — the second 1.38.1 failure ([run 30491182209](https://github.com/lightdash/lightdash/actions/runs/30491182209))

The repair step from #26495 worked as designed — it began relinking all 3216 packages after `npm version`'s node_modules destruction — but a registry/egress flake hit mid-relink (waves of `GET … error (23)` retries, then `Socket Firewall encountered an unexpected error: connect ETIMEDOUT 104.16.0.34:443`). Two failures compounded:

1. The install was left half-complete.
2. **sfw's crashed proxy masked the failure with exit 0** — semantic-release logged `Completed step "prepare"` and marched into `generate-api`, which failed with the same missing-`@types` signature as before.

## Why `--offline` is the right shape

By the time this step runs, the job's own `Install dependencies` step has fully populated the pnpm store on the runner — the repair is purely a **relink**, and `--prefer-offline` was still fetching (attestations/metadata) only because a network path existed. `--offline`:
- needs zero network → the flake surface disappears entirely;
- fails **hard and loud** if the store were ever incomplete (no more silent half-trees);
- makes `sfw` moot for this step — with no fetches there is nothing to firewall, and removing it also removes the exit-code-masking failure mode. (Install steps that do fetch remain sfw-wrapped per policy.)

Verified locally: config loads, `pnpm install --offline` relinks cleanly from a populated store in 3.5s.

## Separate follow-up worth tracking

sfw swallowing a failed underlying install (exit 0 after its own proxy crash) affects every sfw-wrapped CI install, not just this step — worth an upstream report to SocketDev.

Status pages were clean during the incident (no npm/GitHub outage) — this was runner-egress or proxy-local flake, which is exactly why the step shouldn't depend on the network at all.

Relates: PROD-8816

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtuAUhvZyGLHdct6SJiL2C