### PR TITLE
fix(release): repair install falls back to the network when the store is short

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -43,15 +43,16 @@ module.exports = {
         // expected workspace:* error above. Reinstall from the unchanged
         // lockfile to repair the tree; pnpm 11 used to do this implicitly via
         // verifyDepsBeforeRun before it was pinned off in pnpm-workspace.yaml.
-        // --offline: the job's install step already populated the store, so
-        // the relink must not touch the network — a registry flake here left
-        // a half-restored tree, and sfw's crashed proxy masked the failure
-        // with exit 0 (run 30491182209). Offline means no fetches to firewall
-        // and a hard failure if the store is somehow incomplete.
+        // Store-first with network fallback: strict --offline failed because
+        // the runner store lacks some lockfile tarballs even after the job's
+        // install step (run 30492147529, ERR_PNPM_NO_OFFLINE_TARBALL). No sfw
+        // wrapper: its crashed proxy masked a failed install with exit 0 (run
+        // 30491182209); plain pnpm re-fetches lockfile-pinned, integrity-
+        // checked packages with its own retries and honest exit codes.
         [
             '@semantic-release/exec',
             {
-                prepareCmd: 'pnpm install --offline',
+                prepareCmd: 'pnpm install --prefer-offline',
             },
         ],
 


### PR DESCRIPTION
## What

Third and final shape of the post-`npm version` repair install in `release.config.js`: `pnpm install --prefer-offline` (no sfw wrapper).

## The three attempts, for the record

| Attempt | Command | Outcome |
|---|---|---|
| #26495 | `sfw pnpm install --prefer-offline` | Registry flake mid-relink; **sfw's crashed proxy masked the failure with exit 0** → died downstream at generate-api ([run 30491182209](https://github.com/lightdash/lightdash/actions/runs/30491182209)) |
| #26496 | `pnpm install --offline` | Failed **loudly at the right step** (by design): `ERR_PNPM_NO_OFFLINE_TARBALL @tsoa/runtime` — the runner store demonstrably lacks some lockfile tarballs even immediately after the job's own `Install dependencies` ([run 30492147529](https://github.com/lightdash/lightdash/actions/runs/30492147529)) |
| this | `pnpm install --prefer-offline` | Store-first for everything cached; pnpm's own retry logic and **honest exit codes** for the remainder — no proxy layer that can die and mask |

## Security note

Unchanged from #26495/#26496: this step re-installs the exact lockfile-pinned, integrity-hashed set the job already installed minutes earlier; `strictDepBuilds`/`allowBuilds` enforced. The fetching `Install dependencies` steps remain sfw-wrapped per policy; this repair step drops the wrapper specifically because sfw's proxy-crash exit-masking (run 30491182209) is worse than the marginal value of re-firewalling packages it already vetted in the same job.

If a plain network flake hits this step now, semantic-release fails cleanly at the install with pnpm's real error — retryable, never a half-tree.

Relates: PROD-8816

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtuAUhvZyGLHdct6SJiL2C