### PR TITLE
fix(ai): reveal the deep research control on input focus

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.deepResearch.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.deepResearch.test.tsx
@@ -260,6 +260,45 @@ describe('AgentChatInput Deep research mode', () => {
         expect(control.parentElement?.firstElementChild).toBe(control);
     });
 
+    it('reveals the control with the agent selector once the composer is clicked', async () => {
+        const user = userEvent.setup();
+        const agent = {
+            uuid: 'agent-1',
+            name: 'Data agent',
+            imageUrl: null,
+            adminOnly: false,
+        };
+        renderWithProviders(
+            <Provider store={store}>
+                <MemoryRouter>
+                    <AgentChatInput
+                        onSubmit={vi.fn()}
+                        onStartDeepResearch={vi.fn()}
+                        projectUuid="project-1"
+                        agentUuid="agent-1"
+                        agents={[agent]}
+                        selectedAgent={agent}
+                        revealControlsOnFocus
+                        showSuggestions={false}
+                    />
+                </MemoryRouter>
+            </Provider>,
+        );
+
+        const control = screen.getByRole('button', {
+            name: 'Deep research',
+        });
+        const reveal = control.closest<HTMLElement>('[data-visible]');
+        expect(reveal).toHaveAttribute('data-visible', 'false');
+        expect(reveal?.textContent).toContain('Data agent');
+
+        const composer = control.closest<HTMLElement>('[data-variant="card"]');
+        expect(composer).not.toBeNull();
+        await user.click(composer!);
+
+        expect(reveal).toHaveAttribute('data-visible', 'true');
+    });
+
     it('places the control first in the inline composer right actions', () => {
         renderWithProviders(
             <Provider store={store}>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
@@ -28,7 +28,7 @@
     display: none;
 }
 
-.agentSelectorReveal {
+.controlsReveal {
     transition:
         opacity 160ms ease,
         transform 160ms ease;
@@ -41,7 +41,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-    .agentSelectorReveal {
+    .controlsReveal {
         transition: none;
     }
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -109,8 +109,9 @@ interface AgentChatInputProps {
     clearOnSubmit?: boolean;
     showSuggestions?: boolean;
     contentMentionPriorityItems?: ContentMentionSuggestionItem[];
-    // Reveals the agent selector on first focus instead of showing it always.
-    revealAgentSelectorOnFocus?: boolean;
+    // Reveals the deep research and agent controls on first focus instead of
+    // showing them always.
+    revealControlsOnFocus?: boolean;
     // Shrinks padding/min-heights for a more compact composer.
     dense?: boolean;
 }
@@ -156,17 +157,17 @@ export const AgentChatInput = ({
     clearOnSubmit = true,
     showSuggestions = true,
     contentMentionPriorityItems = [],
-    revealAgentSelectorOnFocus = false,
+    revealControlsOnFocus = false,
     dense = false,
 }: AgentChatInputProps) => {
     const user = useUser(true);
     const [value, setValueState] = useState(defaultValue ?? '');
     const [hasClickedInput, setHasClickedInput] = useState(
-        !revealAgentSelectorOnFocus,
+        !revealControlsOnFocus,
     );
     const handleInputCardMouseDown = useCallback(() => {
-        if (revealAgentSelectorOnFocus) setHasClickedInput(true);
-    }, [revealAgentSelectorOnFocus]);
+        if (revealControlsOnFocus) setHasClickedInput(true);
+    }, [revealControlsOnFocus]);
     const [composerMode, setComposerMode] = useState<AgentComposerMode>('ask');
     const [deepResearchDepth, setDeepResearchDepth] =
         useState<DeepResearchDepth>('standard');
@@ -769,19 +770,23 @@ export const AgentChatInput = ({
                 }
                 toolbarRight={
                     <Group gap="xs" align="center" wrap="nowrap">
-                        {deepResearchControl}
-
-                        {showAgentSelector && (
+                        {(deepResearchControl || showAgentSelector) && (
                             <Box
-                                className={styles.agentSelectorReveal}
+                                className={styles.controlsReveal}
                                 data-visible={hasClickedInput}
                             >
-                                <AgentSelector
-                                    projectUuid={projectUuid!}
-                                    agents={agents!}
-                                    selectedAgent={selectedAgent!}
-                                    compact
-                                />
+                                <Group gap="xs" align="center" wrap="nowrap">
+                                    {deepResearchControl}
+
+                                    {showAgentSelector && (
+                                        <AgentSelector
+                                            projectUuid={projectUuid!}
+                                            agents={agents!}
+                                            selectedAgent={selectedAgent!}
+                                            compact
+                                        />
+                                    )}
+                                </Group>
                             </Box>
                         )}
 

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.tsx
@@ -366,7 +366,7 @@ const DayOneAskInputInner: FC<Props> = ({
                 loading={isCreatingThread}
                 showSuggestions={false}
                 fullWidth
-                revealAgentSelectorOnFocus
+                revealControlsOnFocus
                 dense
                 disabled={!projectUuid || !canCreateThread}
                 disabledReason={


### PR DESCRIPTION
The Ask AI composer showed the "Deep research" control before the input was focused, while the agent chip deliberately stayed hidden until first click. Both are input-scoped controls, so they should reveal together.

Moves the deep research control into the same reveal wrapper as the agent selector in the card composer, so `revealControlsOnFocus` (previously `revealAgentSelectorOnFocus`, renamed since it now gates both) hides both until the composer is clicked. Only the homepage builder's Ask AI input opts in; every other surface still shows both immediately. The wrapper is opacity-only, so nothing shifts on reveal.

Covered by a new test in `AgentChatInput.deepResearch.test.tsx` asserting the control starts hidden and reveals with the agent chip on click. Not verified in the browser — no dev server available in this sandbox.
