### PR TITLE
fix(release): version with pnpm pkg set and assert install completeness

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,13 +66,15 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
 
-      # pnpm 11 publishes natively via OIDC trusted publishing; npm is pinned only
-      # for the npm version prepare step in release.config.js.
-      - name: Pin npm for the versioning step
-        run: sfw npm install -g npm@12.0.1
-
       - name: Install dependencies
         run: sfw pnpm install --frozen-lockfile --prefer-offline --prod=false
+
+      # sfw exits 0 when its proxy crashes mid-install (runs 30491182209 and
+      # 30492147529 went green at ~2/3 installed). An offline relink is a
+      # precise completeness assertion: it is a no-op if and only if every
+      # lockfile package reached the store, and it fails loudly otherwise.
+      - name: Assert the install completed
+        run: pnpm install --frozen-lockfile --offline --prod=false
 
       # PROD-8359: install oasdiff so the release-safety marker generator can diff
       # the REST API (swagger.json) between the previous tag and HEAD for breaking

--- a/release.config.js
+++ b/release.config.js
@@ -30,29 +30,28 @@ module.exports = {
             },
         ],
 
+        // Metadata-only version bump for the release cohort: root plus the
+        // eight workspace manifests committed by the git plugin's assets list
+        // below. pkg set edits package.json files and nothing else — no
+        // dependency resolution, no node_modules reification (npm version
+        // reified and destroyed pnpm's layout, which is why a repair install
+        // used to live here). Other workspace members (formula, test apps,
+        // mcp-chart-app) keep their own unrelated versions on purpose.
         [
             '@semantic-release/exec',
             {
                 prepareCmd:
-                    'npm version ${nextRelease.version} --workspaces --include-workspace-root --allow-same-version --no-git-tag-version 2>&1 | grep -q -E "EUNSUPPORTEDPROTOCOL|Invalid comparator"',
+                    'pnpm pkg set version=${nextRelease.version} && pnpm --filter backend --filter @lightdash/cli --filter @lightdash/common --filter e2e --filter @lightdash/frontend --filter @lightdash/warehouses --filter @lightdash/query-sdk --filter @lightdash/sdk pkg set version=${nextRelease.version}',
             },
         ],
 
-        // npm version starts reifying node_modules toward npm's ideal tree
-        // (destroying parts of pnpm's symlink layout) before it hits the
-        // expected workspace:* error above. Reinstall from the unchanged
-        // lockfile to repair the tree; pnpm 11 used to do this implicitly via
-        // verifyDepsBeforeRun before it was pinned off in pnpm-workspace.yaml.
-        // Store-first with network fallback: strict --offline failed because
-        // the runner store lacks some lockfile tarballs even after the job's
-        // install step (run 30492147529, ERR_PNPM_NO_OFFLINE_TARBALL). No sfw
-        // wrapper: its crashed proxy masked a failed install with exit 0 (run
-        // 30491182209); plain pnpm re-fetches lockfile-pinned, integrity-
-        // checked packages with its own retries and honest exit codes.
+        // Unmatched pnpm filters exit 0, so a renamed package would silently
+        // stop being versioned. Assert every cohort manifest took the bump.
         [
             '@semantic-release/exec',
             {
-                prepareCmd: 'pnpm install --prefer-offline',
+                prepareCmd:
+                    'for f in package.json packages/backend/package.json packages/cli/package.json packages/common/package.json packages/e2e/package.json packages/frontend/package.json packages/warehouses/package.json packages/query-sdk/package.json packages/frontend/sdk/package.json; do grep -q "\\"version\\": \\"${nextRelease.version}\\"" "$f" || { echo "Version not bumped in $f"; exit 1; }; done',
             },
         ],
 


### PR DESCRIPTION
## What — the resting state after tonight's release-pipeline incident

Three changes that together remove the root causes rather than compensating for them:

1. **Version bump is now metadata-only.** The `npm version --workspaces … | grep -q EUNSUPPORTEDPROTOCOL` hack — which relied on npm *erroring* at `workspace:*` and destroyed pnpm's node_modules layout on the way to that error — is replaced by:
   ```
   pnpm pkg set version=${nextRelease.version} && pnpm --filter backend --filter @lightdash/cli … pkg set version=${nextRelease.version}
   ```
   `pkg set` edits package.json files and nothing else: no dependency resolution, no reification, no error contract.
2. **The repair install is deleted** (added in #26495/#26497 tonight) — with nothing damaging node_modules, there is nothing to repair. The `npm@12` pin step in the workflow goes with it (it existed solely for the versioning step; `npx tsx` in gen-release-safety uses node's bundled npm).
3. **Two loud assertions replace silent assumptions:**
   - After the bump: every cohort manifest is grepped for the new version — unmatched pnpm filters exit 0, so a renamed package would otherwise silently stop being versioned.
   - After the release job's `Install dependencies`: `pnpm install --frozen-lockfile --offline --prod=false` — a no-op **iff** every lockfile package reached the store. This closes the sfw exit-masking hole (runs 30491182209 / 30492147529 both went green at ~⅔ installed when sfw's proxy crashed).

## The cohort decision (flagged in review)

Recursive bumping would touch 16 workspace manifests, but the release commit's assets list carries only 9 — and the repo's committed reality is that only those 9 track the release version (`formula` is 0.0.1, test apps 0.0.0, mcp-chart-app 1.0.0, all deliberately unrelated; the old npm step bumped some of them only transiently in the runner). This PR **filters to the exact committed cohort**: root + backend, cli, common, e2e, frontend, warehouses, query-sdk, sdk. Nothing about what the repo carries changes.

## Verified locally (pnpm 11.17.0 / Node 24)

- Simulated both prepareCmds with a fake version: exactly the 9 cohort manifests change, indentation preserved, and a follow-up `pnpm install --offline` is a pure no-op — node_modules untouched by construction.
- Negative-tested the cohort assertion (reverted one file → loop fails naming it).
- `release.config.js` loads; workflow YAML parses.
- One knowing trade-off: `pkg set` normalizes dependency-key order, so the first release commits a one-time alphabetical sort of a few devDependencies blocks (backend, cli, warehouses) that were manually appended out of order. Cosmetic, one-time, and arguably a fix.

The real proof is the first release run after merge: expect the version step to take ~2s (vs npm's 6s + destruction + 50–150s repair), and the new install assertion to pass in seconds.

Context: #26493, #26495, #26496, #26497, and the incident retro. Two independent consultations (fresh-context reviews of the raw job logs) converged on exactly this shape.

Relates: PROD-8816

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtuAUhvZyGLHdct6SJiL2C