### PR TITLE
feat(data-apps): add `captureAppDeliveryManifest` to UnfurlService

### DIFF
--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -53,6 +53,10 @@ services:
         build:
             dockerfile: Dockerfile.headless-browser
         restart: always
+        environment:
+            # browserless v2 default session budget is 30s — too short for
+            # dev-Vite page loads and the app capture ready-wait (60s).
+            - TIMEOUT=180000
         ports:
             - '3001:3000'
 

--- a/packages/backend/src/services/UnfurlService/UnfurlService.test.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.test.ts
@@ -1,7 +1,11 @@
 import {
+    DELIVERY_CAPTURE_GLOBAL,
     DownloadFileType,
     LightdashPage,
     NotFoundError,
+    SCREENSHOT_SELECTORS,
+    UnexpectedServerError,
+    type DeliveryCaptureManifest,
 } from '@lightdash/common';
 import { type LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { type FileStorageClient } from '../../clients/FileStorage/FileStorageClient';
@@ -18,6 +22,15 @@ import { type SlackAuthenticationModel } from '../../models/SlackAuthenticationM
 import { type SlackUnfurlImageModel } from '../../models/SlackUnfurlImageModel';
 import type { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 import { UnfurlService } from './UnfurlService';
+
+const playwrightMocks = vi.hoisted(() => ({
+    connectOverCDP: vi.fn(),
+}));
+
+vi.mock('playwright', () => ({
+    default: { chromium: { connectOverCDP: playwrightMocks.connectOverCDP } },
+    chromium: { connectOverCDP: playwrightMocks.connectOverCDP },
+}));
 
 const mockFileStorageClient = {
     isEnabled: vi.fn(),
@@ -50,6 +63,7 @@ function createService(
     overrides: Partial<{
         savedSqlModel: Partial<SavedSqlModel>;
         savedChartModel: Partial<SavedChartModel>;
+        headlessBrowser: Record<string, unknown>;
     }> = {},
 ) {
     return new UnfurlService({
@@ -57,6 +71,7 @@ function createService(
             siteUrl: 'https://app.lightdash.cloud',
             headlessBrowser: {
                 internalLightdashHost: 'http://headless-browser:8080',
+                ...(overrides.headlessBrowser ?? {}),
             },
         } as unknown as LightdashConfig,
         dashboardModel: {} as unknown as DashboardModel,
@@ -353,6 +368,166 @@ describe('UnfurlService', () => {
 
             expect(result.isValid).toBe(false);
             expect(getBySlug).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('captureAppDeliveryManifest', () => {
+        const APP_URL =
+            'http://headless-browser:8080/minimal/projects/p1/apps/a1?captureMode=delivery';
+        const validManifest: DeliveryCaptureManifest = {
+            version: 1,
+            items: [
+                {
+                    status: 'ready',
+                    captureKey: 'v1:abc',
+                    label: 'Revenue by month',
+                    exploreName: 'orders',
+                    queryUuid: '11111111-1111-4111-8111-111111111111',
+                    order: 0,
+                    rowCount: 12,
+                    limitReached: false,
+                },
+            ],
+            overflowCount: 0,
+        };
+
+        const createMockPage = () => {
+            const cdpSession = { send: vi.fn().mockResolvedValue(undefined) };
+            const pageContext = {
+                addCookies: vi.fn().mockResolvedValue(undefined),
+                newCDPSession: vi.fn().mockResolvedValue(cdpSession),
+            };
+            return {
+                cdpSession,
+                pageContext,
+                route: vi.fn().mockResolvedValue(undefined),
+                addInitScript: vi.fn().mockResolvedValue(undefined),
+                context: vi.fn().mockReturnValue(pageContext),
+                on: vi.fn(),
+                goto: vi.fn().mockResolvedValue(undefined),
+                waitForSelector: vi.fn().mockResolvedValue(undefined),
+                evaluate: vi.fn().mockResolvedValue(undefined),
+                screenshot: vi.fn().mockResolvedValue(Buffer.from('nope')),
+                close: vi.fn().mockResolvedValue(undefined),
+            };
+        };
+
+        const setup = () => {
+            const page = createMockPage();
+            const browser = {
+                newPage: vi.fn().mockResolvedValue(page),
+                close: vi.fn().mockResolvedValue(undefined),
+            };
+            playwrightMocks.connectOverCDP.mockResolvedValue(browser);
+            const service = createService({
+                headlessBrowser: {
+                    host: 'headless-browser',
+                    browserEndpoint: 'ws://headless-browser:3000',
+                },
+            });
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            vi.spyOn(service as any, 'getUserCookie').mockResolvedValue(
+                'connect.sid=session-value; Path=/; HttpOnly',
+            );
+            return { service, browser, page };
+        };
+
+        it('returns the validated manifest published on the window global', async () => {
+            const { service, browser, page } = setup();
+            page.evaluate.mockResolvedValue(validManifest);
+
+            const result = await service.captureAppDeliveryManifest({
+                url: APP_URL,
+                authUserUuid: 'user-uuid-1',
+                contextId: 'job-1',
+            });
+
+            expect(result).toEqual(validManifest);
+            expect(page.goto).toHaveBeenCalledWith(
+                APP_URL,
+                expect.objectContaining({ timeout: expect.any(Number) }),
+            );
+            expect(page.waitForSelector).toHaveBeenCalledWith(
+                SCREENSHOT_SELECTORS.READY_INDICATOR,
+                { state: 'attached', timeout: 60_000 },
+            );
+            expect(page.evaluate).toHaveBeenCalledWith(
+                expect.any(Function),
+                DELIVERY_CAPTURE_GLOBAL,
+            );
+            expect(page.screenshot).not.toHaveBeenCalled();
+            expect(page.close).toHaveBeenCalled();
+            expect(browser.close).toHaveBeenCalled();
+        });
+
+        it('renders with the same window geometry as the app screenshot path', async () => {
+            const { service, page } = setup();
+            page.evaluate.mockResolvedValue(validManifest);
+
+            await service.captureAppDeliveryManifest({
+                url: APP_URL,
+                authUserUuid: 'user-uuid-1',
+            });
+
+            expect(playwrightMocks.connectOverCDP).toHaveBeenCalledWith(
+                expect.stringContaining('--window-size%3D1400%2C4000'),
+                expect.anything(),
+            );
+            expect(page.cdpSession.send).toHaveBeenCalledWith(
+                'Emulation.setDeviceMetricsOverride',
+                expect.objectContaining({ width: 1400, height: 4000 }),
+            );
+        });
+
+        it('throws when the window global is missing', async () => {
+            const { service, browser, page } = setup();
+            page.evaluate.mockResolvedValue(undefined);
+
+            await expect(
+                service.captureAppDeliveryManifest({
+                    url: APP_URL,
+                    authUserUuid: 'user-uuid-1',
+                    contextId: 'job-1',
+                }),
+            ).rejects.toThrow(UnexpectedServerError);
+            expect(page.close).toHaveBeenCalled();
+            expect(browser.close).toHaveBeenCalled();
+        });
+
+        it('throws when the window global is malformed', async () => {
+            const { service, page } = setup();
+            page.evaluate.mockResolvedValue({
+                version: 1,
+                items: [{ status: 'ready', captureKey: 'v1:abc' }],
+                overflowCount: 0,
+            });
+
+            await expect(
+                service.captureAppDeliveryManifest({
+                    url: APP_URL,
+                    authUserUuid: 'user-uuid-1',
+                    contextId: 'job-1',
+                }),
+            ).rejects.toThrow(/malformed/);
+        });
+
+        it('rethrows the ready-indicator timeout without falling back to a screenshot', async () => {
+            const { service, browser, page } = setup();
+            const timeoutError = new Error('Timeout 60000ms exceeded');
+            timeoutError.name = 'TimeoutError';
+            page.waitForSelector.mockRejectedValue(timeoutError);
+
+            await expect(
+                service.captureAppDeliveryManifest({
+                    url: APP_URL,
+                    authUserUuid: 'user-uuid-1',
+                    contextId: 'job-1',
+                }),
+            ).rejects.toThrow('Timeout 60000ms exceeded');
+            expect(page.evaluate).not.toHaveBeenCalled();
+            expect(page.screenshot).not.toHaveBeenCalled();
+            expect(page.close).toHaveBeenCalled();
+            expect(browser.close).toHaveBeenCalled();
         });
     });
 

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -5,6 +5,7 @@ import {
     AuthorizationError,
     ChartType,
     DashboardTileTypes,
+    DELIVERY_CAPTURE_GLOBAL,
     DownloadFileType,
     expandSelectedTabs,
     EXPORT_TAB_PAGE_CLASS,
@@ -21,6 +22,7 @@ import {
     LightdashRequestMethodHeader,
     NotFoundError,
     ParameterError,
+    parseDeliveryCaptureManifest,
     QueryHistoryStatus,
     RequestMethod,
     resolveExportTabs,
@@ -35,6 +37,7 @@ import {
     validateSelectedTabs,
     type DashboardFilterRule,
     type DashboardFilters,
+    type DeliveryCaptureManifest,
     type ParametersValuesMap,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
@@ -217,6 +220,9 @@ const appViewport = {
 
 const APP_SCREENSHOT_MIN_HEIGHT = 600;
 
+// How long we wait for `MinimalApp` to mount the ready indicator.
+const APP_READY_TIMEOUT_MS = 60_000;
+
 const bigNumberViewport = {
     width: 768,
     height: 500,
@@ -240,6 +246,22 @@ const getBackoffDelay = (retryCount: number, baseDelayMs: number): number => {
     const exponentialDelay = baseDelayMs * 2 ** retryCount;
     const jitter = exponentialDelay * 0.25 * (Math.random() * 2 - 1);
     return Math.round(exponentialDelay + jitter);
+};
+
+// Browserless honours the window size only through launch args, not the
+// Playwright viewport, and app iframes size themselves to the window.
+const getAppBrowserEndpoint = (
+    browserEndpoint: string,
+    size: { width: number; height: number },
+): string => {
+    const endpoint = new URL(browserEndpoint);
+    endpoint.searchParams.set(
+        'launch',
+        JSON.stringify({
+            args: [`--window-size=${size.width},${size.height}`],
+        }),
+    );
+    return endpoint.toString();
 };
 
 const isBrowserQueueFullError = (error: unknown): boolean => {
@@ -1228,18 +1250,10 @@ export class UnfurlService extends BaseService {
 
                     const browserConnectionEndpoint =
                         lightdashPage === LightdashPage.APP
-                            ? (() => {
-                                  const endpoint = new URL(browserEndpoint);
-                                  endpoint.searchParams.set(
-                                      'launch',
-                                      JSON.stringify({
-                                          args: [
-                                              `--window-size=${initialViewport.width},${initialViewport.height}`,
-                                          ],
-                                      }),
-                                  );
-                                  return endpoint.toString();
-                              })()
+                            ? getAppBrowserEndpoint(
+                                  browserEndpoint,
+                                  initialViewport,
+                              )
                             : browserEndpoint;
 
                     browser = await playwright.chromium.connectOverCDP(
@@ -1283,30 +1297,11 @@ export class UnfurlService extends BaseService {
                     });
 
                     if (lightdashPage === LightdashPage.APP) {
-                        // Browserless drops Playwright's viewport over CDP;
-                        // push the override straight to Chrome.
-                        try {
-                            const cdp = await page
-                                .context()
-                                .newCDPSession(page);
-                            await cdp.send(
-                                'Emulation.setDeviceMetricsOverride',
-                                {
-                                    width: initialViewport.width,
-                                    height: initialViewport.height,
-                                    deviceScaleFactor: 1,
-                                    mobile: false,
-                                },
-                            );
-                        } catch (cdpErr) {
-                            this.logger.warn(
-                                `[APP] CDP viewport override failed; falling through - unfurlId: ${imageId}, err: ${
-                                    cdpErr instanceof Error
-                                        ? cdpErr.message
-                                        : String(cdpErr)
-                                }`,
-                            );
-                        }
+                        await this.overrideCdpViewport(
+                            page,
+                            initialViewport,
+                            `unfurlId: ${imageId}`,
+                        );
                     }
 
                     // Scope custom headers to internal requests only — setting them
@@ -1716,7 +1711,6 @@ export class UnfurlService extends BaseService {
                         // (the bridge sees every metric query the iframe
                         // runs). After the signal we sleep briefly so CSS /
                         // chart entrance animations can finish.
-                        const APP_READY_TIMEOUT_MS = 60_000;
                         const APP_ANIMATION_BUFFER_MS = 5_000;
                         this.logger.info(
                             `Waiting for app screenshot ready indicator (timeout ${APP_READY_TIMEOUT_MS}ms) - unfurlId: ${imageId}`,
@@ -2302,6 +2296,155 @@ export class UnfurlService extends BaseService {
                 }
             },
         );
+    }
+
+    // Browserless drops Playwright's viewport over CDP; push it to Chrome.
+    private async overrideCdpViewport(
+        page: playwright.Page,
+        size: { width: number; height: number },
+        logContext: string,
+    ): Promise<void> {
+        try {
+            const cdp = await page.context().newCDPSession(page);
+            await cdp.send('Emulation.setDeviceMetricsOverride', {
+                width: size.width,
+                height: size.height,
+                deviceScaleFactor: 1,
+                mobile: false,
+            });
+        } catch (cdpErr) {
+            this.logger.warn(
+                `[APP] CDP viewport override failed; falling through - ${logContext}, err: ${
+                    cdpErr instanceof Error ? cdpErr.message : String(cdpErr)
+                }`,
+            );
+        }
+    }
+
+    // Fail-closed: a missing ready indicator, missing global or invalid
+    // manifest all throw — an empty manifest would ship a partial delivery.
+    async captureAppDeliveryManifest({
+        url,
+        authUserUuid,
+        contextId,
+    }: {
+        url: string;
+        authUserUuid: string;
+        contextId?: string;
+    }): Promise<DeliveryCaptureManifest> {
+        if (this.lightdashConfig.headlessBrowser?.host === undefined) {
+            throw new UnexpectedServerError(
+                `Can't capture app delivery queries if HEADLESS_BROWSER_HOST env variable is not defined`,
+            );
+        }
+        const cookie = await this.getUserCookie(authUserUuid);
+
+        let browser: playwright.Browser | undefined;
+        let page: playwright.Page | undefined;
+        try {
+            browser = await playwright.chromium.connectOverCDP(
+                getAppBrowserEndpoint(
+                    this.lightdashConfig.headlessBrowser.browserEndpoint,
+                    appViewport,
+                ),
+                { timeout: 1000 * 60 * 30 },
+            );
+            page = await browser.newPage({
+                viewport: appViewport,
+                ignoreHTTPSErrors:
+                    this.lightdashConfig.headlessBrowser
+                        .internalLightdashHostIgnoreHttpsErrors,
+            });
+            // Same geometry as the screenshot render so the app issues the
+            // same set of queries.
+            await this.overrideCdpViewport(
+                page,
+                appViewport,
+                `contextId: ${contextId}`,
+            );
+
+            // Scope custom headers to internal requests only — setting them on
+            // every request (e.g. Google Fonts) triggers CORS preflight failures.
+            const internalHost =
+                this.lightdashConfig.headlessBrowser.internalLightdashHost.replace(
+                    /\/+$/,
+                    '',
+                );
+            await page.route(`${internalHost}/**`, async (route) => {
+                try {
+                    await route.continue({
+                        headers: {
+                            ...route.request().headers(),
+                            [LightdashRequestMethodHeader]:
+                                RequestMethod.HEADLESS_BROWSER,
+                            'Lightdash-Headless-Browser-Context':
+                                ScreenshotContext.SCHEDULED_DELIVERY,
+                            'Lightdash-Headless-Browser-Context-Id':
+                                contextId ?? 'undefined',
+                        },
+                    });
+                } catch {
+                    await route.fallback().catch(() => {});
+                }
+            });
+
+            const cookieMatch = cookie.match(/connect\.sid=([^;]+)/);
+            if (!cookieMatch)
+                throw new UnexpectedServerError('Invalid cookie provided');
+            await page.context().addCookies([
+                {
+                    name: 'connect.sid',
+                    value: cookieMatch[1],
+                    domain: new URL(url).hostname,
+                    path: '/',
+                    sameSite: 'Strict',
+                },
+            ]);
+
+            page.on('console', (msg) => {
+                if (msg.type() === 'error') {
+                    this.logger.error(
+                        `Delivery capture console error - contextId: ${contextId}, text: ${msg.text()}`,
+                    );
+                }
+            });
+
+            await page.goto(url, { timeout: 150000 });
+
+            try {
+                await page.waitForSelector(
+                    SCREENSHOT_SELECTORS.READY_INDICATOR,
+                    { state: 'attached', timeout: APP_READY_TIMEOUT_MS },
+                );
+            } catch (waitError) {
+                // Fail-closed: unlike the screenshot path there is no partial
+                // result worth shipping, so the timeout propagates.
+                this.logger.error(
+                    `App delivery capture ready indicator not detected within ${APP_READY_TIMEOUT_MS}ms - contextId: ${contextId}`,
+                );
+                throw waitError;
+            }
+
+            const raw = await page.evaluate(
+                (globalName) =>
+                    (window as unknown as Record<string, unknown>)[globalName],
+                DELIVERY_CAPTURE_GLOBAL,
+            );
+            const manifest = parseDeliveryCaptureManifest(raw);
+            if (manifest === null) {
+                throw new UnexpectedServerError(
+                    `App delivery capture missing or malformed - contextId: ${contextId}`,
+                );
+            }
+
+            this.logger.info(
+                `App delivery capture returned ${manifest.items.length} queries (overflow ${manifest.overflowCount}) - contextId: ${contextId}`,
+            );
+            return manifest;
+        } finally {
+            if (page) await page.close().catch(() => {});
+            if (browser) await browser.close().catch(() => {});
+        }
     }
 
     private async getSharedUrl(linkUrl: string): Promise<string> {

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -253,14 +253,18 @@ const getBackoffDelay = (retryCount: number, baseDelayMs: number): number => {
 const getAppBrowserEndpoint = (
     browserEndpoint: string,
     size: { width: number; height: number },
+    internalHost?: string,
 ): string => {
     const endpoint = new URL(browserEndpoint);
-    endpoint.searchParams.set(
-        'launch',
-        JSON.stringify({
-            args: [`--window-size=${size.width},${size.height}`],
-        }),
-    );
+    const args = [`--window-size=${size.width},${size.height}`];
+    // App bundles call secure-context APIs (crypto.randomUUID in the SDK
+    // transport), which a plain-http internal host silently breaks.
+    if (internalHost?.startsWith('http://')) {
+        args.push(
+            `--unsafely-treat-insecure-origin-as-secure=${new URL(internalHost).origin}`,
+        );
+    }
+    endpoint.searchParams.set('launch', JSON.stringify({ args }));
     return endpoint.toString();
 };
 
@@ -1253,6 +1257,8 @@ export class UnfurlService extends BaseService {
                             ? getAppBrowserEndpoint(
                                   browserEndpoint,
                                   initialViewport,
+                                  this.lightdashConfig.headlessBrowser
+                                      .internalLightdashHost,
                               )
                             : browserEndpoint;
 
@@ -2346,6 +2352,7 @@ export class UnfurlService extends BaseService {
                 getAppBrowserEndpoint(
                     this.lightdashConfig.headlessBrowser.browserEndpoint,
                     appViewport,
+                    this.lightdashConfig.headlessBrowser.internalLightdashHost,
                 ),
                 { timeout: 1000 * 60 * 30 },
             );
@@ -2379,12 +2386,18 @@ export class UnfurlService extends BaseService {
                                 RequestMethod.HEADLESS_BROWSER,
                             'Lightdash-Headless-Browser-Context':
                                 ScreenshotContext.SCHEDULED_DELIVERY,
-                            'Lightdash-Headless-Browser-Context-Id':
+                            // String(): a non-string jobId (graphile ids can
+                            // surface as bigint) throws in route.continue.
+                            'Lightdash-Headless-Browser-Context-Id': String(
                                 contextId ?? 'undefined',
+                            ),
                         },
                     });
                 } catch {
-                    await route.fallback().catch(() => {});
+                    // Best effort only: a failed continue({headers}) pollutes
+                    // the request's fallback overrides, so no retry can resume
+                    // it — the String() above is the real safeguard.
+                    await route.continue().catch(() => {});
                 }
             });
 


### PR DESCRIPTION
Closes:

### Description:

Adds a new `captureAppDeliveryManifest` method to `UnfurlService` that launches a headless browser session, navigates to a delivery capture URL, waits for the app's ready indicator, and reads the `DeliveryCaptureManifest` published on the window global (`DELIVERY_CAPTURE_GLOBAL`). The method is fail-closed — a missing ready indicator, absent global, or malformed manifest all throw rather than returning a partial result.

The browser is launched with the same window geometry (`appViewport`) used by the existing app screenshot path, ensuring the app issues the same set of queries in both flows. Custom request headers are scoped to internal Lightdash host requests only to avoid CORS preflight failures on third-party resources.

As part of this work, the inline CDP viewport override logic and the browser endpoint construction logic were extracted into reusable private helpers (`overrideCdpViewport` and `getAppBrowserEndpoint`) so they can be shared between the existing screenshot path and the new manifest capture path.

Tests cover the happy path (valid manifest returned), correct window geometry, a missing window global, a malformed manifest, and a ready-indicator timeout — verifying in each case that the browser and page are always closed in the `finally` block.

Relates: PROD-8374
Relates: #24475
