### PR TITLE
feat(data-apps): surface app delivery partial failures in Slack, Teams, and Google Chat notifications

### DIFF
--- a/packages/backend/src/clients/GoogleChat/GoogleChatClient.test.ts
+++ b/packages/backend/src/clients/GoogleChat/GoogleChatClient.test.ts
@@ -1,0 +1,103 @@
+import { PartialFailureType, type PartialFailure } from '@lightdash/common';
+import { type AttachmentUrl } from '../EmailClient/EmailClient';
+import { GoogleChatClient } from './GoogleChatClient';
+
+describe('postCsvsWithWebhook app failure lines', () => {
+    const client = new GoogleChatClient();
+    const csvUrl: AttachmentUrl = {
+        filename: 'chart-0.csv',
+        path: 'https://s3.example.com/exports/chart-0.csv',
+        localPath: '/tmp/chart-0.csv',
+        truncated: false,
+    };
+    // App code authors these, and Google Chat interprets a subset of HTML in
+    // textParagraph.text — a raw label could otherwise inject a live link.
+    const HOSTILE_LABEL = '</b><a href="https://evil">x</a>';
+    const HOSTILE_ERROR = '<b>boom</b><img src="https://evil/pixel">';
+
+    /** Sends the card and returns the text of the failure widget only — the
+     *  download-links widget legitimately contains anchors. */
+    const failureWidgetText = async (
+        failures: PartialFailure[],
+        csvUrls: AttachmentUrl[],
+    ): Promise<string> => {
+        const fetchMock = vi
+            .spyOn(globalThis, 'fetch')
+            .mockResolvedValue({ ok: true, status: 200 } as Response);
+        try {
+            await client.postCsvsWithWebhook({
+                webhookUrl: 'https://chat.googleapis.com/v1/spaces/abc',
+                title: 'App delivery',
+                name: 'App delivery',
+                description: 'desc',
+                ctaUrl: 'https://app.lightdash.com/apps/abc',
+                csvUrls,
+                footer: 'footer',
+                failures,
+            });
+            const [, init] = fetchMock.mock.calls[0];
+            const payload = JSON.parse(init?.body as string);
+            const texts: string[] = payload.cardsV2[0].card.sections[0].widgets
+                .map(
+                    (widget: { textParagraph?: { text: string } }) =>
+                        widget.textParagraph?.text ?? '',
+                )
+                .filter((text: string) => text.includes('failed to export'));
+            expect(texts).toHaveLength(1);
+            return texts[0];
+        } finally {
+            fetchMock.mockRestore();
+        }
+    };
+
+    it.each([
+        ['the warning branch', [csvUrl]],
+        ['the all-failed branch', [] as AttachmentUrl[]],
+    ])(
+        'strips HTML from an APP_QUERY label and error in %s',
+        async (_name, csvUrls) => {
+            const text = await failureWidgetText(
+                [
+                    {
+                        type: PartialFailureType.APP_QUERY,
+                        stage: 'render',
+                        captureKey: 'v1:abc123',
+                        label: HOSTILE_LABEL,
+                        error: HOSTILE_ERROR,
+                    },
+                ],
+                csvUrls,
+            );
+
+            expect(text).not.toContain('<a href');
+            expect(text).not.toContain('<img');
+            // Only the static <b> wrapper the template adds survives.
+            expect(text).toContain('- <b>x:</b> boom');
+        },
+    );
+
+    it.each([
+        ['the warning branch', [csvUrl]],
+        ['the all-failed branch', [] as AttachmentUrl[]],
+    ])(
+        'strips HTML from an APP_QUERY_MISSING label in %s',
+        async (_name, csvUrls) => {
+            const text = await failureWidgetText(
+                [
+                    {
+                        type: PartialFailureType.APP_QUERY_MISSING,
+                        captureKey: 'v1:def456',
+                        label: HOSTILE_LABEL,
+                        identityChanged: true,
+                    },
+                ],
+                csvUrls,
+            );
+
+            expect(text).not.toContain('<a href');
+            expect(text).toContain(
+                '- <b>x:</b> did not run in this delivery (query changed since it was selected)',
+            );
+        },
+    );
+});

--- a/packages/backend/src/clients/GoogleChat/GoogleChatClient.ts
+++ b/packages/backend/src/clients/GoogleChat/GoogleChatClient.ts
@@ -11,33 +11,8 @@ import {
     type PartialFailure,
 } from '@lightdash/common';
 import Logger from '../../logging/logger';
+import { buildFailureCountPhrase } from '../../utils/partialFailureUtils';
 import { AttachmentUrl } from '../EmailClient/EmailClient';
-
-// Builds "2 charts and 1 query failed to export" from the failure kinds present,
-// falling back to a generic "issue(s)" bucket for non-content failure types.
-const buildFailureCountPhrase = (failures: PartialFailure[]): string => {
-    const chartCount = failures.filter(
-        (f) =>
-            f.type === PartialFailureType.DASHBOARD_CHART ||
-            f.type === PartialFailureType.DASHBOARD_SQL_CHART,
-    ).length;
-    const queryCount = failures.filter(
-        (f) => f.type === PartialFailureType.APP_QUERY,
-    ).length;
-    const otherCount = failures.length - chartCount - queryCount;
-
-    const parts: string[] = [];
-    if (chartCount > 0) {
-        parts.push(`${chartCount} chart${chartCount === 1 ? '' : 's'}`);
-    }
-    if (queryCount > 0) {
-        parts.push(`${queryCount} quer${queryCount === 1 ? 'y' : 'ies'}`);
-    }
-    if (otherCount > 0) {
-        parts.push(`${otherCount} issue${otherCount === 1 ? '' : 's'}`);
-    }
-    return parts.join(' and ');
-};
 
 /* eslint-disable class-methods-use-this */
 export class GoogleChatClient {

--- a/packages/backend/src/clients/GoogleChat/GoogleChatClient.ts
+++ b/packages/backend/src/clients/GoogleChat/GoogleChatClient.ts
@@ -14,6 +14,11 @@ import Logger from '../../logging/logger';
 import { buildFailureCountPhrase } from '../../utils/partialFailureUtils';
 import { AttachmentUrl } from '../EmailClient/EmailClient';
 
+// Google Chat renders a subset of HTML in textParagraph.text, and app delivery
+// labels/errors are authored by app code, so strip markup before interpolating.
+const stripMarkup = (text: string): string =>
+    sanitizeHtml(text, { allowedTags: [], allowedAttributes: {} });
+
 /* eslint-disable class-methods-use-this */
 export class GoogleChatClient {
     private async sendWebhook(webhookUrl: string, payload: AnyType) {
@@ -282,11 +287,13 @@ export class GoogleChatClient {
                         case PartialFailureType.AI_AUGMENTATION:
                             return `- <b>AI summary could not be generated</b>`;
                         case PartialFailureType.APP_QUERY:
-                            return `- <b>${f.label}:</b> ${f.error}`;
+                            return `- <b>${stripMarkup(
+                                f.label,
+                            )}:</b> ${stripMarkup(f.error)}`;
                         case PartialFailureType.APP_QUERY_MISSING:
-                            return `- <b>${
-                                f.label
-                            }:</b> did not run in this delivery${
+                            return `- <b>${stripMarkup(
+                                f.label,
+                            )}:</b> did not run in this delivery${
                                 f.identityChanged
                                     ? ' (query changed since it was selected)'
                                     : ''
@@ -365,20 +372,11 @@ export class GoogleChatClient {
         contentName: string | null;
         contactSentence: string | null;
     }): Promise<void> {
-        // Google Chat renders a subset of HTML in textParagraph.text, so
-        // strip any markup from admin-supplied strings before interpolating
-        // into the template (which uses static <b> tags around contentName).
-        const safeContentName = contentName
-            ? sanitizeHtml(contentName, {
-                  allowedTags: [],
-                  allowedAttributes: {},
-              })
-            : null;
+        // The template wraps contentName in static <b> tags, so admin-supplied
+        // strings must not carry markup of their own.
+        const safeContentName = contentName ? stripMarkup(contentName) : null;
         const safeContactSentence = contactSentence
-            ? sanitizeHtml(contactSentence, {
-                  allowedTags: [],
-                  allowedAttributes: {},
-              })
+            ? stripMarkup(contactSentence)
             : null;
         const baseSentence = safeContentName
             ? `The scheduled delivery for <b>"${safeContentName}"</b> failed to run, and the delivery owner has been notified.`

--- a/packages/backend/src/clients/GoogleChat/GoogleChatClient.ts
+++ b/packages/backend/src/clients/GoogleChat/GoogleChatClient.ts
@@ -3,6 +3,7 @@ import {
     assertUnreachable,
     friendlyName,
     GoogleChatError,
+    MAX_DELIVERY_QUERIES,
     operatorActionValue,
     PartialFailureType,
     sanitizeHtml,
@@ -11,6 +12,32 @@ import {
 } from '@lightdash/common';
 import Logger from '../../logging/logger';
 import { AttachmentUrl } from '../EmailClient/EmailClient';
+
+// Builds "2 charts and 1 query failed to export" from the failure kinds present,
+// falling back to a generic "issue(s)" bucket for non-content failure types.
+const buildFailureCountPhrase = (failures: PartialFailure[]): string => {
+    const chartCount = failures.filter(
+        (f) =>
+            f.type === PartialFailureType.DASHBOARD_CHART ||
+            f.type === PartialFailureType.DASHBOARD_SQL_CHART,
+    ).length;
+    const queryCount = failures.filter(
+        (f) => f.type === PartialFailureType.APP_QUERY,
+    ).length;
+    const otherCount = failures.length - chartCount - queryCount;
+
+    const parts: string[] = [];
+    if (chartCount > 0) {
+        parts.push(`${chartCount} chart${chartCount === 1 ? '' : 's'}`);
+    }
+    if (queryCount > 0) {
+        parts.push(`${queryCount} quer${queryCount === 1 ? 'y' : 'ies'}`);
+    }
+    if (otherCount > 0) {
+        parts.push(`${otherCount} issue${otherCount === 1 ? '' : 's'}`);
+    }
+    return parts.join(' and ');
+};
 
 /* eslint-disable class-methods-use-this */
 export class GoogleChatClient {
@@ -279,6 +306,18 @@ export class GoogleChatClient {
                             return `- <b>No targets found for this scheduled delivery</b>`;
                         case PartialFailureType.AI_AUGMENTATION:
                             return `- <b>AI summary could not be generated</b>`;
+                        case PartialFailureType.APP_QUERY:
+                            return `- <b>${f.label}:</b> ${f.error}`;
+                        case PartialFailureType.APP_QUERY_MISSING:
+                            return `- <b>${
+                                f.label
+                            }:</b> did not run in this delivery${
+                                f.identityChanged
+                                    ? ' (query changed since it was selected)'
+                                    : ''
+                            }`;
+                        case PartialFailureType.APP_CAPTURE_OVERFLOW:
+                            return `- <b>${f.droppedCount} queries were dropped from capture (limit ${MAX_DELIVERY_QUERIES})</b>`;
                         default:
                             return assertUnreachable(
                                 f,
@@ -297,7 +336,9 @@ export class GoogleChatClient {
             } else {
                 widgets.push({
                     textParagraph: {
-                        text: `⚠️ <b>Warning:</b> ${failures.length} chart(s) failed to export\n${failureLines}`,
+                        text: `⚠️ <b>Warning:</b> ${buildFailureCountPhrase(
+                            failures,
+                        )} failed to export\n${failureLines}`,
                     },
                 });
             }

--- a/packages/backend/src/clients/MicrosoftTeams/MicrosoftTeamsClient.test.ts
+++ b/packages/backend/src/clients/MicrosoftTeams/MicrosoftTeamsClient.test.ts
@@ -1,4 +1,10 @@
-import { redactWebhookIdentity } from './MicrosoftTeamsClient';
+import { PartialFailureType, type PartialFailure } from '@lightdash/common';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { type AttachmentUrl } from '../EmailClient/EmailClient';
+import {
+    MicrosoftTeamsClient,
+    redactWebhookIdentity,
+} from './MicrosoftTeamsClient';
 
 describe('redactWebhookIdentity', () => {
     const teamsWebhookUrl =
@@ -59,5 +65,101 @@ describe('redactWebhookIdentity', () => {
     it('returns the literal "invalid-url" string for malformed input without throwing', () => {
         expect(() => redactWebhookIdentity('not-a-url')).not.toThrow();
         expect(redactWebhookIdentity('not-a-url')).toBe('invalid-url');
+    });
+});
+
+describe('postCsvsWithWebhook app failure lines', () => {
+    const client = new MicrosoftTeamsClient({
+        lightdashConfig: {
+            ...lightdashConfigMock,
+            microsoftTeams: { enabled: true },
+        },
+    });
+    const csvUrl: AttachmentUrl = {
+        filename: 'chart-0.csv',
+        path: 'https://s3.example.com/exports/chart-0.csv',
+        localPath: '/tmp/chart-0.csv',
+        truncated: false,
+    };
+    // App code authors these, and an Adaptive Card TextBlock renders a markdown
+    // subset — a raw label could otherwise inject a link or emphasis.
+    const HOSTILE_LABEL = '[x](https://evil) **bold** `code` _em_ ~s~';
+    const HOSTILE_ERROR =
+        '</b><a href="https://evil">click</a> [y](https://evil)';
+
+    const sendAndCollectText = async (
+        failures: PartialFailure[],
+        csvUrls: AttachmentUrl[],
+    ): Promise<string> => {
+        const fetchMock = vi
+            .spyOn(globalThis, 'fetch')
+            .mockResolvedValue({ ok: true, status: 200 } as Response);
+        try {
+            await client.postCsvsWithWebhook({
+                webhookUrl: 'https://outlook.office.com/webhook/abc',
+                title: 'App delivery',
+                name: 'App delivery',
+                description: 'desc',
+                ctaUrl: 'https://app.lightdash.com/apps/abc',
+                csvUrls,
+                footer: 'footer',
+                failures,
+            });
+            const [, init] = fetchMock.mock.calls[0];
+            return init?.body as string;
+        } finally {
+            fetchMock.mockRestore();
+        }
+    };
+
+    const expectNoLiveMarkup = (body: string) => {
+        const rendered = JSON.parse(body);
+        const text = JSON.stringify(rendered);
+        // Markdown link syntax and HTML tags must not survive unescaped.
+        expect(text).not.toContain('[x](https://evil)');
+        expect(text).not.toContain('[y](https://evil)');
+        expect(text).not.toContain('<a href');
+        expect(text).not.toContain('</b>');
+        // The escaped forms are still present, so nothing was silently dropped.
+        expect(text).toContain('evil');
+    };
+
+    it.each([
+        ['the warning switch', [csvUrl]],
+        ['the all-failed switch', [] as AttachmentUrl[]],
+    ])('escapes an APP_QUERY label and error in %s', async (_name, csvUrls) => {
+        const body = await sendAndCollectText(
+            [
+                {
+                    type: PartialFailureType.APP_QUERY,
+                    stage: 'render',
+                    captureKey: 'v1:abc123',
+                    label: HOSTILE_LABEL,
+                    error: HOSTILE_ERROR,
+                },
+            ],
+            csvUrls,
+        );
+        expectNoLiveMarkup(body);
+    });
+
+    it.each([
+        ['the warning switch', [csvUrl]],
+        ['the all-failed switch', [] as AttachmentUrl[]],
+    ])('escapes an APP_QUERY_MISSING label in %s', async (_name, csvUrls) => {
+        const body = await sendAndCollectText(
+            [
+                {
+                    type: PartialFailureType.APP_QUERY_MISSING,
+                    captureKey: 'v1:def456',
+                    label: HOSTILE_LABEL,
+                    identityChanged: true,
+                },
+            ],
+            csvUrls,
+        );
+        const text = JSON.stringify(JSON.parse(body));
+        expect(text).not.toContain('[x](https://evil)');
+        expect(text).toContain('query changed since it was selected');
     });
 });

--- a/packages/backend/src/clients/MicrosoftTeams/MicrosoftTeamsClient.ts
+++ b/packages/backend/src/clients/MicrosoftTeams/MicrosoftTeamsClient.ts
@@ -17,6 +17,15 @@ import Logger from '../../logging/logger';
 import { buildFailureCountPhrase } from '../../utils/partialFailureUtils';
 import { AttachmentUrl } from '../EmailClient/EmailClient';
 
+// Adaptive Card TextBlocks render a markdown subset (links, emphasis, code) and
+// ignore HTML, and app delivery labels/errors are authored by app code — strip
+// tags, then escape the metacharacters that could still form live markup.
+const stripMarkup = (text: string): string =>
+    sanitizeHtml(text, { allowedTags: [], allowedAttributes: {} }).replace(
+        /[\\`*_[\]~]/g,
+        (character) => `\\${character}`,
+    );
+
 export const redactWebhookIdentity = (webhookUrl: string) => {
     try {
         const parsed = new URL(webhookUrl);
@@ -399,16 +408,18 @@ export class MicrosoftTeamsClient {
                                     case PartialFailureType.APP_QUERY:
                                         return {
                                             type: 'TextBlock',
-                                            text: `- **${f.label}:** ${f.error}`,
+                                            text: `- **${stripMarkup(
+                                                f.label,
+                                            )}:** ${stripMarkup(f.error)}`,
                                             wrap: true,
                                             spacing: 'None',
                                         };
                                     case PartialFailureType.APP_QUERY_MISSING:
                                         return {
                                             type: 'TextBlock',
-                                            text: `- **${
-                                                f.label
-                                            }:** did not run in this delivery${
+                                            text: `- **${stripMarkup(
+                                                f.label,
+                                            )}:** did not run in this delivery${
                                                 f.identityChanged
                                                     ? ' (query changed since it was selected)'
                                                     : ''
@@ -476,16 +487,18 @@ export class MicrosoftTeamsClient {
                                 case PartialFailureType.APP_QUERY:
                                     return {
                                         type: 'TextBlock',
-                                        text: `- **${f.label}:** ${f.error}`,
+                                        text: `- **${stripMarkup(
+                                            f.label,
+                                        )}:** ${stripMarkup(f.error)}`,
                                         wrap: true,
                                         spacing: 'None',
                                     };
                                 case PartialFailureType.APP_QUERY_MISSING:
                                     return {
                                         type: 'TextBlock',
-                                        text: `- **${
-                                            f.label
-                                        }:** did not run in this delivery${
+                                        text: `- **${stripMarkup(
+                                            f.label,
+                                        )}:** did not run in this delivery${
                                             f.identityChanged
                                                 ? ' (query changed since it was selected)'
                                                 : ''

--- a/packages/backend/src/clients/MicrosoftTeams/MicrosoftTeamsClient.ts
+++ b/packages/backend/src/clients/MicrosoftTeams/MicrosoftTeamsClient.ts
@@ -2,6 +2,7 @@ import {
     AnyType,
     assertUnreachable,
     friendlyName,
+    MAX_DELIVERY_QUERIES,
     MissingConfigError,
     MsTeamsError,
     operatorActionValue,
@@ -14,6 +15,32 @@ import { createHash } from 'crypto';
 import { LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
 import { AttachmentUrl } from '../EmailClient/EmailClient';
+
+// Builds "2 charts and 1 query failed to export" from the failure kinds present,
+// falling back to a generic "issue(s)" bucket for non-content failure types.
+const buildFailureCountPhrase = (failures: PartialFailure[]): string => {
+    const chartCount = failures.filter(
+        (f) =>
+            f.type === PartialFailureType.DASHBOARD_CHART ||
+            f.type === PartialFailureType.DASHBOARD_SQL_CHART,
+    ).length;
+    const queryCount = failures.filter(
+        (f) => f.type === PartialFailureType.APP_QUERY,
+    ).length;
+    const otherCount = failures.length - chartCount - queryCount;
+
+    const parts: string[] = [];
+    if (chartCount > 0) {
+        parts.push(`${chartCount} chart${chartCount === 1 ? '' : 's'}`);
+    }
+    if (queryCount > 0) {
+        parts.push(`${queryCount} quer${queryCount === 1 ? 'y' : 'ies'}`);
+    }
+    if (otherCount > 0) {
+        parts.push(`${otherCount} issue${otherCount === 1 ? '' : 's'}`);
+    }
+    return parts.join(' and ');
+};
 
 export const redactWebhookIdentity = (webhookUrl: string) => {
     try {
@@ -394,6 +421,33 @@ export class MicrosoftTeamsClient {
                                             wrap: true,
                                             spacing: 'None',
                                         };
+                                    case PartialFailureType.APP_QUERY:
+                                        return {
+                                            type: 'TextBlock',
+                                            text: `- **${f.label}:** ${f.error}`,
+                                            wrap: true,
+                                            spacing: 'None',
+                                        };
+                                    case PartialFailureType.APP_QUERY_MISSING:
+                                        return {
+                                            type: 'TextBlock',
+                                            text: `- **${
+                                                f.label
+                                            }:** did not run in this delivery${
+                                                f.identityChanged
+                                                    ? ' (query changed since it was selected)'
+                                                    : ''
+                                            }`,
+                                            wrap: true,
+                                            spacing: 'None',
+                                        };
+                                    case PartialFailureType.APP_CAPTURE_OVERFLOW:
+                                        return {
+                                            type: 'TextBlock',
+                                            text: `- **${f.droppedCount} queries were dropped from capture (limit ${MAX_DELIVERY_QUERIES})**`,
+                                            wrap: true,
+                                            spacing: 'None',
+                                        };
                                     default:
                                         return assertUnreachable(
                                             f,
@@ -413,7 +467,9 @@ export class MicrosoftTeamsClient {
                     items: [
                         {
                             type: 'TextBlock',
-                            text: `⚠️ **Warning:** ${failures.length} chart(s) failed to export`,
+                            text: `⚠️ **Warning:** ${buildFailureCountPhrase(
+                                failures,
+                            )} failed to export`,
                             weight: 'Bolder',
                             color: 'Warning',
                             wrap: true,
@@ -439,6 +495,33 @@ export class MicrosoftTeamsClient {
                                     return {
                                         type: 'TextBlock',
                                         text: `- **AI summary could not be generated**`,
+                                        wrap: true,
+                                        spacing: 'None',
+                                    };
+                                case PartialFailureType.APP_QUERY:
+                                    return {
+                                        type: 'TextBlock',
+                                        text: `- **${f.label}:** ${f.error}`,
+                                        wrap: true,
+                                        spacing: 'None',
+                                    };
+                                case PartialFailureType.APP_QUERY_MISSING:
+                                    return {
+                                        type: 'TextBlock',
+                                        text: `- **${
+                                            f.label
+                                        }:** did not run in this delivery${
+                                            f.identityChanged
+                                                ? ' (query changed since it was selected)'
+                                                : ''
+                                        }`,
+                                        wrap: true,
+                                        spacing: 'None',
+                                    };
+                                case PartialFailureType.APP_CAPTURE_OVERFLOW:
+                                    return {
+                                        type: 'TextBlock',
+                                        text: `- **${f.droppedCount} queries were dropped from capture (limit ${MAX_DELIVERY_QUERIES})**`,
                                         wrap: true,
                                         spacing: 'None',
                                     };

--- a/packages/backend/src/clients/MicrosoftTeams/MicrosoftTeamsClient.ts
+++ b/packages/backend/src/clients/MicrosoftTeams/MicrosoftTeamsClient.ts
@@ -14,33 +14,8 @@ import {
 import { createHash } from 'crypto';
 import { LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
+import { buildFailureCountPhrase } from '../../utils/partialFailureUtils';
 import { AttachmentUrl } from '../EmailClient/EmailClient';
-
-// Builds "2 charts and 1 query failed to export" from the failure kinds present,
-// falling back to a generic "issue(s)" bucket for non-content failure types.
-const buildFailureCountPhrase = (failures: PartialFailure[]): string => {
-    const chartCount = failures.filter(
-        (f) =>
-            f.type === PartialFailureType.DASHBOARD_CHART ||
-            f.type === PartialFailureType.DASHBOARD_SQL_CHART,
-    ).length;
-    const queryCount = failures.filter(
-        (f) => f.type === PartialFailureType.APP_QUERY,
-    ).length;
-    const otherCount = failures.length - chartCount - queryCount;
-
-    const parts: string[] = [];
-    if (chartCount > 0) {
-        parts.push(`${chartCount} chart${chartCount === 1 ? '' : 's'}`);
-    }
-    if (queryCount > 0) {
-        parts.push(`${queryCount} quer${queryCount === 1 ? 'y' : 'ies'}`);
-    }
-    if (otherCount > 0) {
-        parts.push(`${otherCount} issue${otherCount === 1 ? '' : 's'}`);
-    }
-    return parts.join(' and ');
-};
 
 export const redactWebhookIdentity = (webhookUrl: string) => {
     try {

--- a/packages/backend/src/clients/Slack/SlackMessageBlocks.test.ts
+++ b/packages/backend/src/clients/Slack/SlackMessageBlocks.test.ts
@@ -1,4 +1,9 @@
-import { PartialFailureType, type PartialFailure } from '@lightdash/common';
+import {
+    MAX_DELIVERY_QUERIES,
+    PartialFailureType,
+    type DeliveryNotice,
+    type PartialFailure,
+} from '@lightdash/common';
 import { KnownBlock } from '@slack/bolt';
 import {
     getChartAndDashboardBlocks,
@@ -460,6 +465,237 @@ describe('SlackMessageBlocks', () => {
                 s.text?.text?.includes('Failing chart'),
             );
             expect(failureSection).toBeDefined();
+        });
+    });
+
+    describe('app delivery partial failures (PROD-8374)', () => {
+        const csvUrls = [
+            {
+                filename: 'chart-0.csv',
+                path: 'https://s3.example.com/exports/chart-0.csv',
+                localPath: '/tmp/chart-0.csv',
+                truncated: false,
+            },
+        ];
+
+        it('renders an APP_QUERY failure as "label: error" and pluralizes the headline as a query', () => {
+            const failures: PartialFailure[] = [
+                {
+                    type: PartialFailureType.APP_QUERY,
+                    stage: 'render',
+                    captureKey: 'v1:abc123',
+                    label: 'Revenue by region',
+                    error: 'Query timed out',
+                },
+            ];
+
+            const blocks = getDashboardCsvResultsBlocks({
+                title: 'App delivery',
+                name: 'App delivery',
+                description: 'desc',
+                ctaUrl: 'https://app.lightdash.com/apps/abc',
+                csvUrls,
+                failures,
+            });
+
+            const sections = findBlocks(blocks, 'section');
+            const text = sections.map((s) => s.text?.text ?? '').join('\n');
+            expect(text).toContain('Revenue by region: Query timed out');
+            expect(text).toContain('1 query failed to export');
+        });
+
+        it('renders an APP_QUERY_MISSING failure, appending the identity-changed note when set', () => {
+            const failures: PartialFailure[] = [
+                {
+                    type: PartialFailureType.APP_QUERY_MISSING,
+                    captureKey: 'v1:def456',
+                    label: 'Signups by week',
+                    identityChanged: true,
+                },
+            ];
+
+            const blocks = getDashboardCsvResultsBlocks({
+                title: 'App delivery',
+                name: 'App delivery',
+                description: 'desc',
+                ctaUrl: 'https://app.lightdash.com/apps/abc',
+                csvUrls,
+                failures,
+            });
+
+            const sections = findBlocks(blocks, 'section');
+            const text = sections.map((s) => s.text?.text ?? '').join('\n');
+            expect(text).toContain(
+                'Signups by week: did not run in this delivery (query changed since it was selected)',
+            );
+        });
+
+        it('omits the identity-changed note for APP_QUERY_MISSING when identityChanged is false', () => {
+            const failures: PartialFailure[] = [
+                {
+                    type: PartialFailureType.APP_QUERY_MISSING,
+                    captureKey: 'v1:def456',
+                    label: 'Signups by week',
+                    identityChanged: false,
+                },
+            ];
+
+            const blocks = getDashboardCsvResultsBlocks({
+                title: 'App delivery',
+                name: 'App delivery',
+                description: 'desc',
+                ctaUrl: 'https://app.lightdash.com/apps/abc',
+                csvUrls,
+                failures,
+            });
+
+            const sections = findBlocks(blocks, 'section');
+            const text = sections.map((s) => s.text?.text ?? '').join('\n');
+            expect(text).toContain(
+                'Signups by week: did not run in this delivery',
+            );
+            expect(text).not.toContain('query changed since it was selected');
+        });
+
+        it('renders an APP_CAPTURE_OVERFLOW failure with the dropped count and limit', () => {
+            const failures: PartialFailure[] = [
+                {
+                    type: PartialFailureType.APP_CAPTURE_OVERFLOW,
+                    droppedCount: 7,
+                },
+            ];
+
+            const blocks = getDashboardCsvResultsBlocks({
+                title: 'App delivery',
+                name: 'App delivery',
+                description: 'desc',
+                ctaUrl: 'https://app.lightdash.com/apps/abc',
+                csvUrls,
+                failures,
+            });
+
+            const sections = findBlocks(blocks, 'section');
+            const text = sections.map((s) => s.text?.text ?? '').join('\n');
+            expect(text).toContain(
+                `7 queries were dropped from capture (limit ${MAX_DELIVERY_QUERIES})`,
+            );
+        });
+
+        it('builds a per-kind headline when charts and queries fail together', () => {
+            const failures: PartialFailure[] = [
+                {
+                    type: PartialFailureType.DASHBOARD_CHART,
+                    chartName: 'Failing chart A',
+                    error: 'Query timed out',
+                    chartUuid: 'chart-uuid-a',
+                    tileUuid: 'tile-uuid-a',
+                },
+                {
+                    type: PartialFailureType.DASHBOARD_CHART,
+                    chartName: 'Failing chart B',
+                    error: 'Query timed out',
+                    chartUuid: 'chart-uuid-b',
+                    tileUuid: 'tile-uuid-b',
+                },
+                {
+                    type: PartialFailureType.APP_QUERY,
+                    stage: 'download',
+                    captureKey: 'v1:abc123',
+                    label: 'Revenue by region',
+                    error: 'Query timed out',
+                },
+            ];
+
+            const blocks = getDashboardCsvResultsBlocks({
+                title: 'Mixed delivery',
+                name: 'Mixed delivery',
+                description: 'desc',
+                ctaUrl: 'https://app.lightdash.com/apps/abc',
+                csvUrls,
+                failures,
+            });
+
+            const sections = findBlocks(blocks, 'section');
+            const text = sections.map((s) => s.text?.text ?? '').join('\n');
+            expect(text).toContain('2 charts and 1 query failed to export');
+        });
+
+        it('renders notices as a separate info section, not the failure block', () => {
+            const notices: DeliveryNotice[] = [
+                {
+                    type: 'limit_reached',
+                    label: 'Orders over time',
+                    rowCount: 5000,
+                },
+            ];
+
+            const blocks = getDashboardCsvResultsBlocks({
+                title: 'App delivery',
+                name: 'App delivery',
+                description: 'desc',
+                ctaUrl: 'https://app.lightdash.com/apps/abc',
+                csvUrls,
+                notices,
+            });
+
+            const sections = findBlocks(blocks, 'section');
+            const noticeSection = sections.find((s) =>
+                s.text?.text?.includes('Orders over time'),
+            );
+            expect(noticeSection).toBeDefined();
+            expect(noticeSection?.text?.text).toContain(
+                'Orders over time reached its query limit; additional rows may exist (5000 rows delivered)',
+            );
+            expect(noticeSection?.text?.text).toContain(':information_source:');
+
+            // Notices must never appear inside the failure block, and vice versa.
+            const failureSection = sections.find((s) =>
+                s.text?.text?.includes(':warning:'),
+            );
+            expect(failureSection).toBeUndefined();
+        });
+
+        it('keeps notices out of the failure block when both failures and notices are present', () => {
+            const failures: PartialFailure[] = [
+                {
+                    type: PartialFailureType.APP_QUERY,
+                    stage: 'render',
+                    captureKey: 'v1:abc123',
+                    label: 'Revenue by region',
+                    error: 'Query timed out',
+                },
+            ];
+            const notices: DeliveryNotice[] = [
+                {
+                    type: 'limit_reached',
+                    label: 'Orders over time',
+                    rowCount: 5000,
+                },
+            ];
+
+            const blocks = getDashboardCsvResultsBlocks({
+                title: 'App delivery',
+                name: 'App delivery',
+                description: 'desc',
+                ctaUrl: 'https://app.lightdash.com/apps/abc',
+                csvUrls,
+                failures,
+                notices,
+            });
+
+            const sections = findBlocks(blocks, 'section');
+            const failureSection = sections.find((s) =>
+                s.text?.text?.includes('Revenue by region'),
+            );
+            const noticeSection = sections.find((s) =>
+                s.text?.text?.includes('Orders over time'),
+            );
+            expect(failureSection?.text?.text).not.toContain(
+                'Orders over time',
+            );
+            expect(noticeSection?.text?.text).not.toContain(
+                'Revenue by region',
+            );
         });
     });
 });

--- a/packages/backend/src/clients/Slack/SlackMessageBlocks.test.ts
+++ b/packages/backend/src/clients/Slack/SlackMessageBlocks.test.ts
@@ -620,6 +620,38 @@ describe('SlackMessageBlocks', () => {
             expect(text).toContain('2 charts and 1 query failed to export');
         });
 
+        it('counts APP_QUERY_MISSING as a failing query in the headline', () => {
+            const failures: PartialFailure[] = [
+                {
+                    type: PartialFailureType.APP_QUERY,
+                    stage: 'render',
+                    captureKey: 'v1:abc123',
+                    label: 'Revenue by region',
+                    error: 'Query timed out',
+                },
+                {
+                    type: PartialFailureType.APP_QUERY_MISSING,
+                    captureKey: 'v1:def456',
+                    label: 'Signups by week',
+                    identityChanged: false,
+                },
+            ];
+
+            const blocks = getDashboardCsvResultsBlocks({
+                title: 'App delivery',
+                name: 'App delivery',
+                description: 'desc',
+                ctaUrl: 'https://app.lightdash.com/apps/abc',
+                csvUrls,
+                failures,
+            });
+
+            const sections = findBlocks(blocks, 'section');
+            const text = sections.map((s) => s.text?.text ?? '').join('\n');
+            expect(text).toContain('2 queries failed to export');
+            expect(text).not.toContain('issue');
+        });
+
         it('renders notices as a separate info section, not the failure block', () => {
             const notices: DeliveryNotice[] = [
                 {

--- a/packages/backend/src/clients/Slack/SlackMessageBlocks.ts
+++ b/packages/backend/src/clients/Slack/SlackMessageBlocks.ts
@@ -3,9 +3,11 @@ import {
     assertUnreachable,
     friendlyName,
     LightdashPage,
+    MAX_DELIVERY_QUERIES,
     operatorActionValue,
     PartialFailureType,
     ThresholdOptions,
+    type DeliveryNotice,
     type PartialFailure,
 } from '@lightdash/common';
 import {
@@ -465,6 +467,32 @@ export const getChartThresholdAlertBlocks = ({
             : undefined,
     ]);
 };
+// Builds "2 charts and 1 query failed to export" from the failure kinds present,
+// falling back to a generic "issue(s)" bucket for non-content failure types.
+const buildFailureCountPhrase = (failures: PartialFailure[]): string => {
+    const chartCount = failures.filter(
+        (f) =>
+            f.type === PartialFailureType.DASHBOARD_CHART ||
+            f.type === PartialFailureType.DASHBOARD_SQL_CHART,
+    ).length;
+    const queryCount = failures.filter(
+        (f) => f.type === PartialFailureType.APP_QUERY,
+    ).length;
+    const otherCount = failures.length - chartCount - queryCount;
+
+    const parts: string[] = [];
+    if (chartCount > 0) {
+        parts.push(`${chartCount} chart${chartCount === 1 ? '' : 's'}`);
+    }
+    if (queryCount > 0) {
+        parts.push(`${queryCount} quer${queryCount === 1 ? 'y' : 'ies'}`);
+    }
+    if (otherCount > 0) {
+        parts.push(`${otherCount} issue${otherCount === 1 ? '' : 's'}`);
+    }
+    return parts.join(' and ');
+};
+
 type GetDashboardCsvResultsBlocksArgs = {
     title: string;
     name: string;
@@ -474,6 +502,7 @@ type GetDashboardCsvResultsBlocksArgs = {
     csvUrls: AttachmentUrl[];
     footerMarkdown?: string;
     failures?: PartialFailure[];
+    notices?: DeliveryNotice[];
 };
 export const getDashboardCsvResultsBlocks = ({
     title,
@@ -484,6 +513,7 @@ export const getDashboardCsvResultsBlocks = ({
     footerMarkdown,
     ctaUrl,
     failures,
+    notices,
 }: GetDashboardCsvResultsBlocksArgs): KnownBlock[] => {
     const getFailureBlock = ():
         | { type: 'section'; text: { type: 'mrkdwn'; text: string } }
@@ -506,6 +536,20 @@ export const getDashboardCsvResultsBlocks = ({
                             return `\t• No targets found for this scheduled delivery`;
                         case PartialFailureType.AI_AUGMENTATION:
                             return `\t• AI summary could not be generated`;
+                        case PartialFailureType.APP_QUERY:
+                            return `\t• *${sanitizeText(
+                                f.label,
+                            )}:* ${sanitizeText(f.error)}`;
+                        case PartialFailureType.APP_QUERY_MISSING:
+                            return `\t• ${sanitizeText(
+                                f.label,
+                            )}: did not run in this delivery${
+                                f.identityChanged
+                                    ? ' (query changed since it was selected)'
+                                    : ''
+                            }`;
+                        case PartialFailureType.APP_CAPTURE_OVERFLOW:
+                            return `\t• ${f.droppedCount} queries were dropped from capture (limit ${MAX_DELIVERY_QUERIES})`;
                         default:
                             return assertUnreachable(
                                 f,
@@ -538,6 +582,20 @@ export const getDashboardCsvResultsBlocks = ({
                         return `\t• No targets found for this scheduled delivery`;
                     case PartialFailureType.AI_AUGMENTATION:
                         return `\t• AI summary could not be generated`;
+                    case PartialFailureType.APP_QUERY:
+                        return `\t• ${sanitizeText(
+                            f.label,
+                        )}: ${sanitizeText(f.error)}`;
+                    case PartialFailureType.APP_QUERY_MISSING:
+                        return `\t• ${sanitizeText(
+                            f.label,
+                        )}: did not run in this delivery${
+                            f.identityChanged
+                                ? ' (query changed since it was selected)'
+                                : ''
+                        }`;
+                    case PartialFailureType.APP_CAPTURE_OVERFLOW:
+                        return `\t• ${f.droppedCount} queries were dropped from capture (limit ${MAX_DELIVERY_QUERIES})`;
                     default:
                         return assertUnreachable(
                             f,
@@ -551,7 +609,37 @@ export const getDashboardCsvResultsBlocks = ({
             text: {
                 type: 'mrkdwn',
                 text: truncateText(
-                    `:warning: *Warning:* ${failures.length} chart(s) failed to export:\n${errorText}`,
+                    `:warning: *Warning:* ${buildFailureCountPhrase(
+                        failures,
+                    )} failed to export:\n${errorText}`,
+                    SLACK_LIMITS.SECTION_TEXT,
+                ),
+            },
+        };
+    };
+
+    const getNoticesBlock = ():
+        | { type: 'section'; text: { type: 'mrkdwn'; text: string } }
+        | undefined => {
+        if (!notices || notices.length === 0) {
+            return undefined;
+        }
+        const noticeText = notices
+            .map(
+                (n) =>
+                    `\t• ${sanitizeText(
+                        n.label,
+                    )} reached its query limit; additional rows may exist (${
+                        n.rowCount
+                    } rows delivered)`,
+            )
+            .join('\n');
+        return {
+            type: 'section',
+            text: {
+                type: 'mrkdwn',
+                text: truncateText(
+                    `:information_source: ${noticeText}`,
                     SLACK_LIMITS.SECTION_TEXT,
                 ),
             },
@@ -717,6 +805,7 @@ export const getDashboardCsvResultsBlocks = ({
         },
         ...csvSections,
         getFailureBlock(),
+        getNoticesBlock(),
         footerMarkdown?.trim()
             ? {
                   type: 'context',

--- a/packages/backend/src/clients/Slack/SlackMessageBlocks.ts
+++ b/packages/backend/src/clients/Slack/SlackMessageBlocks.ts
@@ -16,6 +16,7 @@ import {
     SectionBlock,
     SectionBlockAccessory,
 } from '@slack/bolt';
+import { buildFailureCountPhrase } from '../../utils/partialFailureUtils';
 import { AttachmentUrl } from '../EmailClient/EmailClient';
 
 // Slack Block Kit text and structural limits
@@ -467,32 +468,6 @@ export const getChartThresholdAlertBlocks = ({
             : undefined,
     ]);
 };
-// Builds "2 charts and 1 query failed to export" from the failure kinds present,
-// falling back to a generic "issue(s)" bucket for non-content failure types.
-const buildFailureCountPhrase = (failures: PartialFailure[]): string => {
-    const chartCount = failures.filter(
-        (f) =>
-            f.type === PartialFailureType.DASHBOARD_CHART ||
-            f.type === PartialFailureType.DASHBOARD_SQL_CHART,
-    ).length;
-    const queryCount = failures.filter(
-        (f) => f.type === PartialFailureType.APP_QUERY,
-    ).length;
-    const otherCount = failures.length - chartCount - queryCount;
-
-    const parts: string[] = [];
-    if (chartCount > 0) {
-        parts.push(`${chartCount} chart${chartCount === 1 ? '' : 's'}`);
-    }
-    if (queryCount > 0) {
-        parts.push(`${queryCount} quer${queryCount === 1 ? 'y' : 'ies'}`);
-    }
-    if (otherCount > 0) {
-        parts.push(`${otherCount} issue${otherCount === 1 ? '' : 's'}`);
-    }
-    return parts.join(' and ');
-};
-
 type GetDashboardCsvResultsBlocksArgs = {
     title: string;
     name: string;

--- a/packages/backend/src/utils/partialFailureUtils.ts
+++ b/packages/backend/src/utils/partialFailureUtils.ts
@@ -1,0 +1,29 @@
+import { PartialFailureType, type PartialFailure } from '@lightdash/common';
+
+// Builds "2 charts and 1 query failed to export" from the failure kinds present,
+// falling back to a generic "issue(s)" bucket for non-content failure types.
+// Shared across Slack/Google Chat/MS Teams — the surrounding markup differs per
+// medium, but this phrase is plain text in all three.
+export const buildFailureCountPhrase = (failures: PartialFailure[]): string => {
+    const chartCount = failures.filter(
+        (f) =>
+            f.type === PartialFailureType.DASHBOARD_CHART ||
+            f.type === PartialFailureType.DASHBOARD_SQL_CHART,
+    ).length;
+    const queryCount = failures.filter(
+        (f) => f.type === PartialFailureType.APP_QUERY,
+    ).length;
+    const otherCount = failures.length - chartCount - queryCount;
+
+    const parts: string[] = [];
+    if (chartCount > 0) {
+        parts.push(`${chartCount} chart${chartCount === 1 ? '' : 's'}`);
+    }
+    if (queryCount > 0) {
+        parts.push(`${queryCount} quer${queryCount === 1 ? 'y' : 'ies'}`);
+    }
+    if (otherCount > 0) {
+        parts.push(`${otherCount} issue${otherCount === 1 ? '' : 's'}`);
+    }
+    return parts.join(' and ');
+};

--- a/packages/backend/src/utils/partialFailureUtils.ts
+++ b/packages/backend/src/utils/partialFailureUtils.ts
@@ -10,8 +10,12 @@ export const buildFailureCountPhrase = (failures: PartialFailure[]): string => {
             f.type === PartialFailureType.DASHBOARD_CHART ||
             f.type === PartialFailureType.DASHBOARD_SQL_CHART,
     ).length;
+    // APP_QUERY_MISSING counts as a failing query here too, matching how
+    // RunDetailsModal tallies it.
     const queryCount = failures.filter(
-        (f) => f.type === PartialFailureType.APP_QUERY,
+        (f) =>
+            f.type === PartialFailureType.APP_QUERY ||
+            f.type === PartialFailureType.APP_QUERY_MISSING,
     ).length;
     const otherCount = failures.length - chartCount - queryCount;
 

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -655,6 +655,13 @@ export enum LightdashPage {
     APP = 'app',
 }
 
+// Info-only delivery notice — never a failure, must not affect run status.
+export type DeliveryNotice = {
+    type: 'limit_reached';
+    label: string;
+    rowCount: number;
+};
+
 export type NotificationPayloadBase = {
     schedulerUuid?: string;
     scheduledTime: Date;
@@ -688,6 +695,7 @@ export type NotificationPayloadBase = {
         };
         pdfPageCount?: number;
         failures?: PartialFailure[];
+        notices?: DeliveryNotice[];
     };
     scheduler: CreateSchedulerAndTargets;
 };

--- a/packages/common/src/types/schedulerLog.ts
+++ b/packages/common/src/types/schedulerLog.ts
@@ -28,6 +28,9 @@ export enum PartialFailureType {
     DASHBOARD_CHART = 'dashboard_chart',
     DASHBOARD_SQL_CHART = 'dashboard_sql_chart',
     AI_AUGMENTATION = 'ai_augmentation',
+    APP_QUERY = 'app_query',
+    APP_QUERY_MISSING = 'app_query_missing',
+    APP_CAPTURE_OVERFLOW = 'app_capture_overflow',
 }
 
 export type DashboardChartPartialFailure = {
@@ -57,12 +60,40 @@ export type AiAugmentationPartialFailure = {
     error: string;
 };
 
+// A captured app query failed while the delivery re-ran it (render or download stage).
+export type AppQueryPartialFailure = {
+    type: PartialFailureType.APP_QUERY;
+    stage: 'render' | 'download';
+    captureKey: string;
+    label: string;
+    error: string;
+};
+
+// A query declared in the delivery manifest wasn't found among the captured queries.
+export type AppQueryMissingPartialFailure = {
+    type: PartialFailureType.APP_QUERY_MISSING;
+    captureKey: string;
+    label: string;
+    /** True when a captured query matched this snapshot entry by
+     *  label+explore but not by captureKey (identity changed). */
+    identityChanged: boolean;
+};
+
+// Distinct captureKeys dropped once the app delivery hit MAX_DELIVERY_QUERIES.
+export type AppCaptureOverflowPartialFailure = {
+    type: PartialFailureType.APP_CAPTURE_OVERFLOW;
+    droppedCount: number;
+};
+
 // Union of all partial failure types
 export type PartialFailure =
     | DashboardChartPartialFailure
     | DashboardSqlChartPartialFailure
     | MissingTargetsPartialFailure
-    | AiAugmentationPartialFailure;
+    | AiAugmentationPartialFailure
+    | AppQueryPartialFailure
+    | AppQueryMissingPartialFailure
+    | AppCaptureOverflowPartialFailure;
 
 /**
  * Outcome of evaluating a threshold-alert scheduler against the latest query results.

--- a/packages/frontend/src/components/SchedulersView/RunDetailsModal.tsx
+++ b/packages/frontend/src/components/SchedulersView/RunDetailsModal.tsx
@@ -1,5 +1,6 @@
 import {
     assertUnreachable,
+    MAX_DELIVERY_QUERIES,
     PartialFailureType,
     SchedulerFormat,
     SchedulerJobStatus,
@@ -239,9 +240,88 @@ const PartialFailureText: FC<{
                     </Code>
                 </Stack>
             );
+        case PartialFailureType.APP_QUERY:
+            return (
+                <Stack
+                    gap={4}
+                    p="xs"
+                    style={{
+                        borderRadius: theme.radius.sm,
+                        backgroundColor: theme.colors.orange[0],
+                    }}
+                >
+                    <Text fz="xs" fw={500} c="orange.9">
+                        {failure.label}
+                    </Text>
+                    <Code
+                        c="orange.9"
+                        bg="transparent"
+                        style={{
+                            fontSize: '11px',
+                            padding: 0,
+                        }}
+                    >
+                        {failure.error}
+                    </Code>
+                </Stack>
+            );
+        case PartialFailureType.APP_QUERY_MISSING:
+            return (
+                <Stack
+                    gap={4}
+                    p="xs"
+                    style={{
+                        borderRadius: theme.radius.sm,
+                        backgroundColor: theme.colors.orange[0],
+                    }}
+                >
+                    <Text fz="xs" fw={500} c="orange.9">
+                        {failure.label}
+                    </Text>
+                    <Code
+                        c="orange.9"
+                        bg="transparent"
+                        style={{
+                            fontSize: '11px',
+                            padding: 0,
+                        }}
+                    >
+                        {`did not run in this delivery${
+                            failure.identityChanged
+                                ? ' (query changed since it was selected)'
+                                : ''
+                        }`}
+                    </Code>
+                </Stack>
+            );
+        case PartialFailureType.APP_CAPTURE_OVERFLOW:
+            return (
+                <Stack
+                    gap={4}
+                    p="xs"
+                    style={{
+                        borderRadius: theme.radius.sm,
+                        backgroundColor: theme.colors.orange[0],
+                    }}
+                >
+                    <Text fz="xs" fw={500} c="orange.9">
+                        {`${failure.droppedCount} queries were dropped from capture (limit ${MAX_DELIVERY_QUERIES})`}
+                    </Text>
+                </Stack>
+            );
         default:
             return assertUnreachable(failure, 'Unknown partial failure type');
     }
+};
+
+// Stable key for a partial failure row: tileUuid > captureKey > index fallback
+const getPartialFailureKey = (
+    failure: PartialFailure,
+    index: number,
+): string | number => {
+    if ('tileUuid' in failure) return failure.tileUuid;
+    if ('captureKey' in failure) return failure.captureKey;
+    return index;
 };
 
 // Unified component for job rows (success, failure, partial failure)
@@ -281,27 +361,63 @@ const JobRow: FC<{
         getLogStatusIconWithoutTooltip(job.finalStatus, theme)
     );
 
-    // Determine status message
-    const chartFailures = partialFailures.filter(
+    // Determine status message: charts/dashboard-sql-charts and app queries are
+    // both "content" failures (a delivery only ever produces one kind at a time)
+    const contentFailures = partialFailures.filter(
         (f) =>
             f.type === PartialFailureType.DASHBOARD_CHART ||
-            f.type === PartialFailureType.DASHBOARD_SQL_CHART,
+            f.type === PartialFailureType.DASHBOARD_SQL_CHART ||
+            f.type === PartialFailureType.APP_QUERY ||
+            f.type === PartialFailureType.APP_QUERY_MISSING,
     );
-    const hasMissingTargets = partialFailures.some(
+    const missingTargetsCount = partialFailures.filter(
         (f) => f.type === PartialFailureType.MISSING_TARGETS,
-    );
+    ).length;
+    const hasMissingTargets = missingTargetsCount > 0;
 
     const getPartialFailureMessage = (): string => {
+        const chartFailureCount = contentFailures.filter(
+            (f) =>
+                f.type === PartialFailureType.DASHBOARD_CHART ||
+                f.type === PartialFailureType.DASHBOARD_SQL_CHART,
+        ).length;
+        const queryFailureCount = contentFailures.filter(
+            (f) =>
+                f.type === PartialFailureType.APP_QUERY ||
+                f.type === PartialFailureType.APP_QUERY_MISSING,
+        ).length;
+        // Anything not counted above (AI_AUGMENTATION, APP_CAPTURE_OVERFLOW, …)
+        // falls back to a generic "issue(s)" bucket so this never goes empty.
+        const otherIssueCount =
+            partialFailures.length -
+            contentFailures.length -
+            missingTargetsCount;
+
         const parts: string[] = [];
-        if (chartFailures.length > 0) {
+        if (chartFailureCount > 0) {
             parts.push(
-                `${chartFailures.length} failing chart${
-                    chartFailures.length > 1 ? 's' : ''
-                }`,
+                `${chartFailureCount} failing ${pluralize(
+                    chartFailureCount,
+                    'chart',
+                )}`,
+            );
+        }
+        if (queryFailureCount > 0) {
+            parts.push(
+                `${queryFailureCount} failing ${pluralize(
+                    queryFailureCount,
+                    'query',
+                    'queries',
+                )}`,
             );
         }
         if (hasMissingTargets) {
             parts.push('missing recipients');
+        }
+        if (otherIssueCount > 0) {
+            parts.push(
+                `${otherIssueCount} ${pluralize(otherIssueCount, 'issue')}`,
+            );
         }
         return `Completed with ${parts.join(' and ')}`;
     };
@@ -394,12 +510,7 @@ const JobRow: FC<{
                     {partialFailures.map((failure, index) => {
                         return (
                             <PartialFailureText
-                                key={
-                                    // MISSING_TARGETS doesn't have a tileUuid, falling back to index (shouldn't use index, but since it should only be one, it's fine)
-                                    'tileUuid' in failure
-                                        ? failure.tileUuid
-                                        : index
-                                }
+                                key={getPartialFailureKey(failure, index)}
                                 failure={failure}
                                 theme={theme}
                             />


### PR DESCRIPTION
Closes: PROD-8374

### Description:

Adds three new partial failure types for app deliveries — `APP_QUERY`, `APP_QUERY_MISSING`, and `APP_CAPTURE_OVERFLOW` — and surfaces them in Slack, Google Chat, Microsoft Teams, and the scheduler run details modal.

**`APP_QUERY`** — a captured query failed during the render or download stage. Rendered as `label: error message`.

**`APP_QUERY_MISSING`** — a query declared in the delivery manifest was not found among the captured queries. When the query's identity changed since it was selected (matched by label/explore but not by capture key), an additional note is appended: `(query changed since it was selected)`.

**`APP_CAPTURE_OVERFLOW`** — one or more distinct capture keys were dropped because the delivery hit `MAX_DELIVERY_QUERIES`. Rendered as `N queries were dropped from capture (limit X)`.

The warning headline is now built by a shared `buildFailureCountPhrase` utility that produces per-kind counts (e.g. `2 charts and 1 query failed to export`) instead of a flat `N chart(s)` count, and falls back to a generic `issue(s)` bucket for non-content failure types.

A new `DeliveryNotice` type (`limit_reached`) is introduced for info-only signals that must not affect run status. Notices are rendered in a separate `:information_source:` block in Slack, kept entirely separate from the failure block.