### PR TITLE
feat(data-apps): deliver app CSV/XLSX queries with partial-failure and limit-reached notices

### DIFF
--- a/packages/backend/src/clients/EmailClient/EmailClient.test.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.test.ts
@@ -1,4 +1,8 @@
-import { InviteLinkPurpose } from '@lightdash/common';
+import {
+    InviteLinkPurpose,
+    PartialFailureType,
+    SchedulerFormat,
+} from '@lightdash/common';
 import * as nodemailer from 'nodemailer';
 import type SMTPConnection from 'nodemailer/lib/smtp-connection';
 import EmailClient from './EmailClient';
@@ -137,6 +141,71 @@ describe('EmailClient', () => {
             const sentMessage = sentOptions.context?.message ?? '';
             expect(sentMessage).not.toContain('<script>');
             expect(sentMessage).toContain('<strong>world</strong>');
+        });
+
+        test('should render app delivery failures with a name the template can print', async () => {
+            const client = new EmailClient({
+                lightdashConfig: lightdashConfigWithBasicSMTP,
+            });
+
+            await client.sendDashboardCsvNotificationEmail(
+                'recipient@example.com',
+                'subject',
+                'title',
+                'description',
+                undefined,
+                'date',
+                'frequency',
+                [
+                    {
+                        path: 'https://example.com/file.csv',
+                        filename: 'file.csv',
+                        localPath: '',
+                        truncated: false,
+                    },
+                ],
+                'https://example.com/app',
+                'https://example.com/scheduler',
+                true,
+                7,
+                false,
+                SchedulerFormat.CSV,
+                [
+                    {
+                        type: PartialFailureType.APP_QUERY,
+                        stage: 'download',
+                        captureKey: 'v1:a',
+                        label: 'Revenue by month',
+                        error: 'storage unavailable',
+                    },
+                    {
+                        type: PartialFailureType.APP_CAPTURE_OVERFLOW,
+                        droppedCount: 3,
+                    },
+                ],
+            );
+
+            const sentContext = (
+                vi.mocked(client.transporter!.sendMail).mock
+                    .calls[0][0] as unknown as {
+                    context: {
+                        failures: { chartName?: string; error: string }[];
+                        failureCountPhrase: string;
+                    };
+                }
+            ).context;
+
+            expect(sentContext.failures).toEqual([
+                {
+                    chartName: 'Revenue by month',
+                    error: 'storage unavailable',
+                },
+                {
+                    chartName: undefined,
+                    error: '3 queries were dropped from capture (limit 50)',
+                },
+            ]);
+            expect(sentContext.failureCountPhrase).toBe('1 query and 1 issue');
         });
 
         test('should use the setup invitation template for setup invites', async () => {

--- a/packages/backend/src/clients/EmailClient/EmailClient.test.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.test.ts
@@ -183,6 +183,7 @@ describe('EmailClient', () => {
                         droppedCount: 3,
                     },
                 ],
+                [{ type: 'limit_reached', label: 'Sessions', rowCount: 5000 }],
             );
 
             const sentContext = (
@@ -191,6 +192,8 @@ describe('EmailClient', () => {
                     context: {
                         failures: { chartName?: string; error: string }[];
                         failureCountPhrase: string;
+                        notices: { label: string; rowCount: number }[];
+                        hasNotices: boolean;
                     };
                 }
             ).context;
@@ -206,6 +209,52 @@ describe('EmailClient', () => {
                 },
             ]);
             expect(sentContext.failureCountPhrase).toBe('1 query and 1 issue');
+            // Notices ride their own context key so the template can render them
+            // outside the failure block.
+            expect(sentContext.hasNotices).toBe(true);
+            expect(sentContext.notices).toEqual([
+                { type: 'limit_reached', label: 'Sessions', rowCount: 5000 },
+            ]);
+        });
+
+        test('should not flag notices when an app delivery had none', async () => {
+            const client = new EmailClient({
+                lightdashConfig: lightdashConfigWithBasicSMTP,
+            });
+
+            await client.sendDashboardCsvNotificationEmail(
+                'recipient@example.com',
+                'subject',
+                'title',
+                'description',
+                undefined,
+                'date',
+                'frequency',
+                [
+                    {
+                        path: 'https://example.com/file.csv',
+                        filename: 'file.csv',
+                        localPath: '',
+                        truncated: false,
+                    },
+                ],
+                'https://example.com/app',
+                'https://example.com/scheduler',
+                true,
+                7,
+                false,
+                SchedulerFormat.CSV,
+            );
+
+            const sentContext = (
+                vi.mocked(client.transporter!.sendMail).mock
+                    .calls[0][0] as unknown as {
+                    context: { hasNotices?: boolean; notices?: unknown };
+                }
+            ).context;
+
+            expect(sentContext.hasNotices).toBeUndefined();
+            expect(sentContext.notices).toBeUndefined();
         });
 
         test('should use the setup invitation template for setup invites', async () => {

--- a/packages/backend/src/clients/EmailClient/EmailClient.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.ts
@@ -14,6 +14,7 @@ import {
     SchedulerFormat,
     SessionUser,
     SmptError,
+    type DeliveryNotice,
     type PartialFailure,
 } from '@lightdash/common';
 import fs from 'fs';
@@ -864,6 +865,7 @@ export default class EmailClient {
         asAttachment?: boolean,
         format?: SchedulerFormat,
         failures?: PartialFailure[],
+        notices?: DeliveryNotice[],
         sender?: EmailSenderIdentity | null,
     ) {
         const csvUrls = attachments.filter(
@@ -921,6 +923,8 @@ export default class EmailClient {
                     ? buildFailureCountPhrase(failures)
                     : undefined,
                 hasFailures: failures && failures.length > 0,
+                notices,
+                hasNotices: notices && notices.length > 0,
                 allChartsFailed,
             },
             text: title,

--- a/packages/backend/src/clients/EmailClient/EmailClient.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.ts
@@ -28,6 +28,10 @@ import SMTPPool from 'nodemailer/lib/smtp-pool';
 import path from 'path';
 import { LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
+import {
+    buildFailureCountPhrase,
+    toEmailFailureFields,
+} from '../../utils/partialFailureUtils';
 
 const RETRYABLE_ERROR_CODES = ['ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND'];
 
@@ -912,7 +916,10 @@ export default class EmailClient {
                 includeLinks,
                 hasAttachments: emailAttachments && emailAttachments.length > 0,
                 attachmentCount: emailAttachments?.length || 0,
-                failures,
+                failures: failures?.map(toEmailFailureFields),
+                failureCountPhrase: failures
+                    ? buildFailureCountPhrase(failures)
+                    : undefined,
                 hasFailures: failures && failures.length > 0,
                 allChartsFailed,
             },

--- a/packages/backend/src/clients/EmailClient/templates/dashboardCsvNotification.html
+++ b/packages/backend/src/clients/EmailClient/templates/dashboardCsvNotification.html
@@ -1605,9 +1605,10 @@
                                                                                                                             line-height: 18px;
                                                                                                                         "
                                                                                                                     >
-                                                                                                                        <strong
+                                                                                                                        {{#if
+                                                                                                                        chartName}}<strong
                                                                                                                             >{{chartName}}:</strong
-                                                                                                                        >
+                                                                                                                        >{{/if}}
                                                                                                                         {{error}}
                                                                                                                     </li>
                                                                                                                     {{/failures}}
@@ -1662,8 +1663,7 @@
                                                                                                                 >
                                                                                                                     ⚠️
                                                                                                                     Warning:
-                                                                                                                    {{failures.length}}
-                                                                                                                    chart(s)
+                                                                                                                    {{failureCountPhrase}}
                                                                                                                     failed
                                                                                                                     to
                                                                                                                     export
@@ -1693,9 +1693,10 @@
                                                                                                                             line-height: 18px;
                                                                                                                         "
                                                                                                                     >
-                                                                                                                        <strong
+                                                                                                                        {{#if
+                                                                                                                        chartName}}<strong
                                                                                                                             >{{chartName}}:</strong
-                                                                                                                        >
+                                                                                                                        >{{/if}}
                                                                                                                         {{error}}
                                                                                                                     </li>
                                                                                                                     {{/failures}}

--- a/packages/backend/src/clients/EmailClient/templates/dashboardCsvNotification.html
+++ b/packages/backend/src/clients/EmailClient/templates/dashboardCsvNotification.html
@@ -1706,6 +1706,42 @@
                                                                                                     </tr>
                                                                                                     {{/if}}
                                                                                                     {{/if}}
+                                                                                                    {{#if hasNotices}}
+                                                                                                    <tr>
+                                                                                                        <td>
+                                                                                                            <div
+                                                                                                                style="
+                                                                                                                    padding: 16px;
+                                                                                                                    margin-top: 16px;
+                                                                                                                    background-color: #e7f3fe;
+                                                                                                                    border-left: 4px solid #2196f3;
+                                                                                                                    border-radius: 4px;
+                                                                                                                    font-family: BlinkMacSystemFont, Segoe UI,
+                                                                                                                        Helvetica Neue, Arial, sans-serif, 'Inter';
+                                                                                                                "
+                                                                                                            >
+                                                                                                                <ul
+                                                                                                                    style="
+                                                                                                                        margin: 0;
+                                                                                                                        padding-left: 20px;
+                                                                                                                        color: #0c5460;
+                                                                                                                        font-size: 12px;
+                                                                                                                        font-family: BlinkMacSystemFont, Segoe UI,
+                                                                                                                            Helvetica Neue, Arial, sans-serif, 'Inter';
+                                                                                                                        line-height: 18px;
+                                                                                                                    "
+                                                                                                                >
+                                                                                                                    {{#notices}}
+                                                                                                                    <li style="margin-bottom: 6px; line-height: 18px">
+                                                                                                                        {{label}} reached its query limit; additional rows
+                                                                                                                        may exist ({{rowCount}} rows delivered)
+                                                                                                                    </li>
+                                                                                                                    {{/notices}}
+                                                                                                                </ul>
+                                                                                                            </div>
+                                                                                                        </td>
+                                                                                                    </tr>
+                                                                                                    {{/if}}
                                                                                                 </table>
                                                                                             </td>
                                                                                         </tr>

--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -1,5 +1,6 @@
 import {
     DimensionType,
+    DownloadFileType,
     FieldReferenceError,
     FieldType,
     ForbiddenError,
@@ -7,7 +8,14 @@ import {
     GoogleSheetsTransientError,
     MetricType,
     NotEnoughResults,
+    PartialFailureType,
+    SchedulerFormat,
     ThresholdOperator,
+    type CapturedQuery,
+    type CreateSchedulerAndTargets,
+    type DeliveryCaptureManifest,
+    type NotificationPayloadBase,
+    type ScheduledDeliveryPayload,
     type UploadGsheetPayload,
 } from '@lightdash/common';
 import ExecutionContext from 'node-execution-context';
@@ -15,6 +23,7 @@ import type { ExecutionContextInfo } from '../logging/winston';
 import SchedulerTask, {
     buildItemMapFromColumns,
     buildSchedulerLogContext,
+    dedupeArtifactFilename,
     GSHEET_UPLOAD_MAX_ATTEMPTS,
     retryTransientGoogleSheetsWrite,
     setSchedulerJobLogContext,
@@ -596,6 +605,32 @@ describe('buildItemMapFromColumns', () => {
     });
 });
 
+describe('dedupeArtifactFilename', () => {
+    it('leaves the first occurrence untouched', () => {
+        const used = new Map<string, number>();
+        expect(dedupeArtifactFilename('csv-Q_A-2026.csv', used)).toBe(
+            'csv-Q_A-2026.csv',
+        );
+    });
+
+    it('suffixes repeats before the extension', () => {
+        const used = new Map<string, number>();
+        dedupeArtifactFilename('csv-Q_A-2026.csv', used);
+        expect(dedupeArtifactFilename('csv-Q_A-2026.csv', used)).toBe(
+            'csv-Q_A-2026 (2).csv',
+        );
+        expect(dedupeArtifactFilename('csv-Q_A-2026.csv', used)).toBe(
+            'csv-Q_A-2026 (3).csv',
+        );
+    });
+
+    it('appends the suffix at the end when there is no extension', () => {
+        const used = new Map<string, number>();
+        dedupeArtifactFilename('report', used);
+        expect(dedupeArtifactFilename('report', used)).toBe('report (2)');
+    });
+});
+
 describe('uploadGsheetFromQuery — rows branch', () => {
     // SchedulerTask has 20+ constructor dependencies. We create minimal mocks
     // for only the services touched by the rows branch.
@@ -701,5 +736,669 @@ describe('uploadGsheetFromQuery — rows branch', () => {
         expect(mockAppendToSheet).toHaveBeenCalledTimes(1);
         expect(mockAppendToSheet.mock.calls[0][2]).toEqual(payload.rows);
         expect(mockExecuteMetricQueryAndGetResults).not.toHaveBeenCalled();
+    });
+});
+
+type TaskDeps = ConstructorParameters<typeof SchedulerTask>[0];
+
+const makeTaskWithDeps = (overrides: Partial<TaskDeps> = {}) =>
+    new SchedulerTask({ ...({} as TaskDeps), ...overrides });
+
+const asDep = <K extends keyof TaskDeps>(value: unknown): TaskDeps[K] =>
+    value as TaskDeps[K];
+
+const APP_ROW = {
+    project_uuid: 'project-1',
+    organization_uuid: 'org-1',
+    name: 'Sales App',
+    description: 'Sales overview',
+};
+
+const readyItem = (
+    overrides: Partial<Extract<CapturedQuery, { status: 'ready' }>> = {},
+): CapturedQuery => ({
+    status: 'ready',
+    captureKey: 'v1:key-1',
+    label: 'Revenue by month',
+    exploreName: 'orders',
+    queryUuid: 'query-1',
+    order: 0,
+    rowCount: 42,
+    limitReached: false,
+    ...overrides,
+});
+
+const errorItem = (
+    overrides: Partial<Extract<CapturedQuery, { status: 'error' }>> = {},
+): CapturedQuery => ({
+    status: 'error',
+    captureKey: 'v1:key-err',
+    label: 'Broken query',
+    exploreName: null,
+    queryUuid: null,
+    order: 9,
+    error: 'Query timed out',
+    ...overrides,
+});
+
+const manifestOf = (
+    items: CapturedQuery[],
+    overflowCount = 0,
+): DeliveryCaptureManifest => ({ version: 1, items, overflowCount });
+
+const appScheduler = (
+    overrides: Partial<CreateSchedulerAndTargets> = {},
+): CreateSchedulerAndTargets =>
+    ({
+        name: 'App delivery',
+        createdBy: 'user-1',
+        format: SchedulerFormat.CSV,
+        cron: '0 9 * * *',
+        timezone: 'UTC',
+        savedChartUuid: null,
+        dashboardUuid: null,
+        savedSqlUuid: null,
+        appUuid: 'app-1',
+        appName: 'Sales App',
+        options: { formatted: true, limit: 'table' },
+        enabled: true,
+        includeLinks: true,
+        targets: [],
+        ...overrides,
+    }) as CreateSchedulerAndTargets;
+
+type PageData = NotificationPayloadBase['page'];
+
+const callGetNotificationPageData = (
+    task: SchedulerTask,
+    scheduler: CreateSchedulerAndTargets,
+    appCaptureManifest?: DeliveryCaptureManifest,
+    expirationSecondsOverride?: number,
+): Promise<PageData> =>
+    (
+        task as unknown as {
+            getNotificationPageData(
+                scheduler: CreateSchedulerAndTargets,
+                jobId: string,
+                isFinalAttempt: boolean,
+                expirationSecondsOverride?: number,
+                exportOptions?: undefined,
+                appCaptureManifest?: DeliveryCaptureManifest,
+            ): Promise<PageData>;
+        }
+    ).getNotificationPageData(
+        scheduler,
+        'job-1',
+        false,
+        expirationSecondsOverride,
+        undefined,
+        appCaptureManifest,
+    );
+
+describe('getNotificationPageData — app CSV/XLSX branch', () => {
+    const setup = ({
+        download,
+        fileStorageEnabled = false,
+    }: {
+        download?: (args: { queryUuid: string }) => Promise<{
+            fileUrl: string;
+            s3FileUrl?: string;
+        }>;
+        fileStorageEnabled?: boolean;
+    } = {}) => {
+        const downloadSyncQueryResults = vi.fn(
+            download ??
+                (async ({ queryUuid }: { queryUuid: string }) => ({
+                    fileUrl: `https://files.example.com/${queryUuid}`,
+                    s3FileUrl: `s3://bucket/${queryUuid}`,
+                })),
+        );
+        const findAppByUuid = vi.fn().mockResolvedValue(APP_ROW);
+        const trackAccount = vi.fn();
+        const task = makeTaskWithDeps({
+            lightdashConfig: asDep<'lightdashConfig'>({
+                siteUrl: 'https://lightdash.example.com',
+                headlessBrowser: {
+                    internalLightdashHost: 'http://lightdash-dev:3000',
+                },
+                query: {},
+            }),
+            schedulerService: asDep<'schedulerService'>({
+                appModel: { findAppByUuid },
+            }),
+            userService: asDep<'userService'>({
+                getAccountByUserUuid: vi.fn().mockResolvedValue({
+                    user: { id: 'user-id-1' },
+                    organization: { organizationUuid: 'org-1' },
+                }),
+            }),
+            analytics: asDep<'analytics'>({ trackAccount, track: vi.fn() }),
+            fileStorageClient: asDep<'fileStorageClient'>({
+                isEnabled: () => fileStorageEnabled,
+            }),
+            asyncQueryService: asDep<'asyncQueryService'>({
+                downloadSyncQueryResults,
+            }),
+            slackClient: asDep<'slackClient'>({ isEnabled: false }),
+        });
+        return { task, downloadSyncQueryResults, findAppByUuid, trackAccount };
+    };
+
+    it('downloads every ready query and names the files after the capture labels', async () => {
+        const { task, downloadSyncQueryResults } = setup();
+
+        const page = await callGetNotificationPageData(
+            task,
+            appScheduler(),
+            manifestOf([
+                readyItem({
+                    captureKey: 'v1:a',
+                    label: 'Revenue by month',
+                    queryUuid: 'query-a',
+                    order: 0,
+                }),
+                readyItem({
+                    captureKey: 'v1:b',
+                    label: 'Orders by status',
+                    queryUuid: 'query-b',
+                    order: 1,
+                }),
+                readyItem({
+                    captureKey: 'v1:c',
+                    label: 'Top customers',
+                    queryUuid: 'query-c',
+                    order: 2,
+                }),
+            ]),
+            604800,
+        );
+
+        expect(downloadSyncQueryResults).toHaveBeenCalledTimes(3);
+        expect(downloadSyncQueryResults.mock.calls[0][0]).toMatchObject({
+            projectUuid: 'project-1',
+            queryUuid: 'query-a',
+            type: DownloadFileType.CSV,
+            onlyRaw: false,
+            expirationSecondsOverride: 604800,
+        });
+        expect(page.csvUrls).toHaveLength(3);
+        expect(page.csvUrls?.map((file) => file.chartName)).toEqual([
+            'Revenue by month',
+            'Orders by status',
+            'Top customers',
+        ]);
+        page.csvUrls?.forEach((file) => {
+            expect(file.truncated).toBe(false);
+        });
+        expect(page.csvUrls?.[0].filename).toMatch(
+            /^csv-Revenue by month-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d{4}\.csv$/,
+        );
+        expect(page.csvUrls?.[0].path).toBe(
+            'https://files.example.com/query-a',
+        );
+        expect(page.csvUrls?.[0].localPath).toBe('s3://bucket/query-a');
+        expect(page.failures ?? []).toEqual([]);
+        expect(page.notices ?? []).toEqual([]);
+    });
+
+    it('passes onlyRaw when the scheduler asks for unformatted values', async () => {
+        const { task, downloadSyncQueryResults } = setup();
+
+        await callGetNotificationPageData(
+            task,
+            appScheduler({ options: { formatted: false, limit: 'table' } }),
+            manifestOf([readyItem()]),
+        );
+
+        expect(downloadSyncQueryResults.mock.calls[0][0]).toMatchObject({
+            onlyRaw: true,
+        });
+    });
+
+    it('requests XLSX downloads for an XLSX scheduler', async () => {
+        const { task, downloadSyncQueryResults } = setup();
+
+        const page = await callGetNotificationPageData(
+            task,
+            appScheduler({
+                format: SchedulerFormat.XLSX,
+                options: { formatted: true, limit: 'table' },
+            }),
+            manifestOf([readyItem({ label: 'Revenue' })]),
+        );
+
+        expect(downloadSyncQueryResults.mock.calls[0][0]).toMatchObject({
+            type: DownloadFileType.XLSX,
+        });
+        expect(page.csvUrls?.[0].filename).toMatch(
+            /^xlsx-Revenue-[\d-]+\.xlsx$/,
+        );
+    });
+
+    it('merges the files into a single workbook when the layout is workbook', async () => {
+        const { task } = setup({ fileStorageEnabled: true });
+        const createWorkbookDownloadUrl = vi.fn().mockResolvedValue({
+            url: 'https://files.example.com/workbook.xlsx',
+            numFileFailures: 0,
+        });
+        (task as unknown as Record<string, unknown>).createWorkbookDownloadUrl =
+            createWorkbookDownloadUrl;
+
+        const page = await callGetNotificationPageData(
+            task,
+            appScheduler({
+                format: SchedulerFormat.XLSX,
+                options: {
+                    formatted: true,
+                    limit: 'table',
+                    xlsxFileLayout: 'workbook',
+                },
+            }),
+            manifestOf([
+                readyItem({ label: 'Revenue', queryUuid: 'query-a' }),
+                readyItem({
+                    captureKey: 'v1:b',
+                    label: 'Orders',
+                    queryUuid: 'query-b',
+                    order: 1,
+                }),
+            ]),
+        );
+
+        expect(createWorkbookDownloadUrl).toHaveBeenCalledTimes(1);
+        expect(
+            createWorkbookDownloadUrl.mock.calls[0][0].files.map(
+                (file: { chartName?: string }) => file.chartName,
+            ),
+        ).toEqual(['Revenue', 'Orders']);
+        expect(createWorkbookDownloadUrl.mock.calls[0][0]).toMatchObject({
+            workbookNameBase: 'Sales App',
+        });
+        expect(page.csvUrls).toEqual([
+            {
+                filename: 'Sales App',
+                path: 'https://files.example.com/workbook.xlsx',
+                localPath: 'https://files.example.com/workbook.xlsx',
+                truncated: false,
+            },
+        ]);
+    });
+
+    it('delivers the ready queries and reports render-stage failures for the errored ones', async () => {
+        const { task, downloadSyncQueryResults } = setup();
+
+        const page = await callGetNotificationPageData(
+            task,
+            appScheduler(),
+            manifestOf([
+                readyItem({ label: 'Revenue', queryUuid: 'query-a' }),
+                errorItem({
+                    captureKey: 'v1:boom',
+                    label: 'Broken query',
+                    error: 'Query timed out',
+                }),
+            ]),
+        );
+
+        expect(downloadSyncQueryResults).toHaveBeenCalledTimes(1);
+        expect(page.csvUrls).toHaveLength(1);
+        expect(page.failures).toEqual([
+            {
+                type: PartialFailureType.APP_QUERY,
+                stage: 'render',
+                captureKey: 'v1:boom',
+                label: 'Broken query',
+                error: 'Query timed out',
+            },
+        ]);
+    });
+
+    it('reports a download-stage failure and still delivers the rest', async () => {
+        const { task } = setup({
+            download: async ({ queryUuid }) => {
+                if (queryUuid === 'query-b') {
+                    throw new Error('storage unavailable');
+                }
+                return { fileUrl: `https://files.example.com/${queryUuid}` };
+            },
+        });
+
+        const page = await callGetNotificationPageData(
+            task,
+            appScheduler(),
+            manifestOf([
+                readyItem({ label: 'Revenue', queryUuid: 'query-a' }),
+                readyItem({
+                    captureKey: 'v1:b',
+                    label: 'Orders',
+                    queryUuid: 'query-b',
+                    order: 1,
+                }),
+            ]),
+        );
+
+        expect(page.csvUrls).toHaveLength(1);
+        expect(page.csvUrls?.[0].chartName).toBe('Revenue');
+        expect(page.failures).toEqual([
+            {
+                type: PartialFailureType.APP_QUERY,
+                stage: 'download',
+                captureKey: 'v1:b',
+                label: 'Orders',
+                error: 'storage unavailable',
+            },
+        ]);
+    });
+
+    it('throws when every download fails', async () => {
+        const { task } = setup({
+            download: async () => {
+                throw new Error('storage unavailable');
+            },
+        });
+
+        await expect(
+            callGetNotificationPageData(
+                task,
+                appScheduler(),
+                manifestOf([
+                    readyItem({ queryUuid: 'query-a' }),
+                    readyItem({
+                        captureKey: 'v1:b',
+                        queryUuid: 'query-b',
+                        order: 1,
+                    }),
+                ]),
+            ),
+        ).rejects.toThrow(/all app delivery downloads failed/i);
+    });
+
+    it('reports dropped queries as a capture overflow failure', async () => {
+        const { task } = setup();
+
+        const page = await callGetNotificationPageData(
+            task,
+            appScheduler(),
+            manifestOf([readyItem()], 2),
+        );
+
+        expect(page.failures).toEqual([
+            {
+                type: PartialFailureType.APP_CAPTURE_OVERFLOW,
+                droppedCount: 2,
+            },
+        ]);
+    });
+
+    it('reports a limit-reached query as a notice, never as a failure', async () => {
+        const { task } = setup();
+
+        const page = await callGetNotificationPageData(
+            task,
+            appScheduler(),
+            manifestOf([
+                readyItem({ label: 'Revenue', rowCount: 500 }),
+                readyItem({
+                    captureKey: 'v1:b',
+                    label: 'Orders',
+                    queryUuid: 'query-b',
+                    order: 1,
+                    rowCount: 5000,
+                    limitReached: true,
+                }),
+            ]),
+        );
+
+        expect(page.notices).toEqual([
+            { type: 'limit_reached', label: 'Orders', rowCount: 5000 },
+        ]);
+        expect(page.failures ?? []).toEqual([]);
+        expect(page.csvUrls).toHaveLength(2);
+    });
+
+    it('throws when the render captured no successful queries', async () => {
+        const { task, downloadSyncQueryResults } = setup();
+
+        await expect(
+            callGetNotificationPageData(
+                task,
+                appScheduler(),
+                manifestOf([errorItem()]),
+            ),
+        ).rejects.toThrow(/captured no successful queries/i);
+        expect(downloadSyncQueryResults).not.toHaveBeenCalled();
+    });
+
+    it('throws when no capture manifest was provided', async () => {
+        const { task } = setup();
+
+        await expect(
+            callGetNotificationPageData(task, appScheduler()),
+        ).rejects.toThrow(/requires a capture manifest/i);
+    });
+
+    it('suffixes filenames that collide once sanitized', async () => {
+        const { task } = setup();
+
+        const page = await callGetNotificationPageData(
+            task,
+            appScheduler(),
+            manifestOf([
+                readyItem({ label: 'Q/A', queryUuid: 'query-a' }),
+                readyItem({
+                    captureKey: 'v1:b',
+                    label: 'Q:A',
+                    queryUuid: 'query-b',
+                    order: 1,
+                }),
+            ]),
+        );
+
+        const filenames = page.csvUrls?.map((file) => file.filename) ?? [];
+        expect(filenames[0]).toMatch(/^csv-Q_A-[\d-]+\.csv$/);
+        expect(filenames[1]).toMatch(/^csv-Q_A-[\d-]+ \(2\)\.csv$/);
+    });
+});
+
+describe('captureAppDeliveryQueries', () => {
+    const setup = () => {
+        const captureAppDeliveryManifest = vi
+            .fn()
+            .mockResolvedValue(manifestOf([readyItem()]));
+        const task = makeTaskWithDeps({
+            lightdashConfig: asDep<'lightdashConfig'>({
+                siteUrl: 'https://lightdash.example.com',
+                headlessBrowser: {
+                    internalLightdashHost: 'http://lightdash-dev:3000',
+                },
+            }),
+            schedulerService: asDep<'schedulerService'>({
+                appModel: {
+                    findAppByUuid: vi.fn().mockResolvedValue(APP_ROW),
+                },
+            }),
+            unfurlService: asDep<'unfurlService'>({
+                captureAppDeliveryManifest,
+            }),
+        });
+        return { task, captureAppDeliveryManifest };
+    };
+
+    const call = (task: SchedulerTask, scheduler: CreateSchedulerAndTargets) =>
+        (
+            task as unknown as {
+                captureAppDeliveryQueries(
+                    scheduler: CreateSchedulerAndTargets,
+                    jobId: string,
+                ): Promise<DeliveryCaptureManifest>;
+            }
+        ).captureAppDeliveryQueries(scheduler, 'job-9');
+
+    it('renders the minimal app page in delivery capture mode', async () => {
+        const { task, captureAppDeliveryManifest } = setup();
+
+        const manifest = await call(task, appScheduler());
+
+        expect(manifest.items).toHaveLength(1);
+        const args = captureAppDeliveryManifest.mock.calls[0][0];
+        expect(args.authUserUuid).toBe('user-1');
+        expect(args.contextId).toBe('job-9');
+        const url = new URL(args.url);
+        expect(url.origin).toBe('http://lightdash-dev:3000');
+        expect(url.pathname).toBe('/minimal/projects/project-1/apps/app-1');
+        expect(url.searchParams.get('captureMode')).toBe('delivery');
+        expect(url.searchParams.get('state')).toBeNull();
+    });
+
+    it('seeds the capture render with the scheduler app state', async () => {
+        const { task, captureAppDeliveryManifest } = setup();
+
+        await call(
+            task,
+            appScheduler({
+                appState: { tab: 'revenue' },
+            } as Partial<CreateSchedulerAndTargets>),
+        );
+
+        const url = new URL(captureAppDeliveryManifest.mock.calls[0][0].url);
+        expect(url.searchParams.get('state')).toBe('{"tab":"revenue"}');
+        expect(url.searchParams.get('captureMode')).toBe('delivery');
+    });
+});
+
+describe('handleScheduledDelivery — app delivery capture', () => {
+    const setup = () => {
+        const captureAppDeliveryManifest = vi
+            .fn()
+            .mockResolvedValue(manifestOf([readyItem()]));
+        const generateJobsForSchedulerTargets = vi.fn().mockResolvedValue([]);
+        const task = makeTaskWithDeps({
+            lightdashConfig: asDep<'lightdashConfig'>({
+                siteUrl: 'https://lightdash.example.com',
+                headlessBrowser: {
+                    internalLightdashHost: 'http://lightdash-dev:3000',
+                },
+                persistentDownloadUrls: { expirationSeconds: 3600 },
+            }),
+            schedulerService: asDep<'schedulerService'>({
+                logSchedulerJob: vi.fn().mockResolvedValue(undefined),
+                appModel: {
+                    findAppByUuid: vi.fn().mockResolvedValue(APP_ROW),
+                },
+            }),
+            organizationSettingsModel: asDep<'organizationSettingsModel'>({
+                get: vi.fn().mockResolvedValue({
+                    scheduledDeliveryExpirationSecondsEmail: 100,
+                    scheduledDeliveryExpirationSecondsSlack: 200,
+                    scheduledDeliveryExpirationSecondsMsTeams: null,
+                    scheduledDeliveryExpirationSecondsGoogleChat: null,
+                    scheduledDeliveryExpirationSeconds: null,
+                }),
+            }),
+            userService: asDep<'userService'>({
+                getSessionByUserUuid: vi.fn().mockResolvedValue({}),
+                getAccountByUserUuid: vi.fn().mockResolvedValue({
+                    user: { id: 'user-id-1' },
+                    organization: { organizationUuid: 'org-1' },
+                }),
+            }),
+            analytics: asDep<'analytics'>({ track: vi.fn() }),
+            schedulerClient: asDep<'schedulerClient'>({
+                generateJobsForSchedulerTargets,
+            }),
+            unfurlService: asDep<'unfurlService'>({
+                captureAppDeliveryManifest,
+            }),
+        });
+        const getNotificationPageData = vi.fn().mockResolvedValue({
+            url: 'https://lightdash.example.com/app',
+            details: { name: 'Sales App', description: undefined },
+            pageType: 'app',
+            organizationUuid: 'org-1',
+            csvUrls: [],
+        });
+        (task as unknown as Record<string, unknown>).getNotificationPageData =
+            getNotificationPageData;
+        return {
+            task,
+            captureAppDeliveryManifest,
+            getNotificationPageData,
+            generateJobsForSchedulerTargets,
+        };
+    };
+
+    const run = (task: SchedulerTask, scheduler: CreateSchedulerAndTargets) =>
+        (
+            task as unknown as {
+                handleScheduledDelivery(
+                    jobId: string,
+                    scheduledTime: Date,
+                    payload: ScheduledDeliveryPayload,
+                    isFinalAttempt: boolean,
+                ): Promise<void>;
+            }
+        ).handleScheduledDelivery(
+            'job-1',
+            new Date('2026-07-30T09:00:00Z'),
+            {
+                ...scheduler,
+                organizationUuid: 'org-1',
+                projectUuid: 'project-1',
+                userUuid: 'user-1',
+            } as unknown as ScheduledDeliveryPayload,
+            true,
+        );
+
+    it('captures the app render exactly once across two expiration groups', async () => {
+        const { task, captureAppDeliveryManifest, getNotificationPageData } =
+            setup();
+
+        await run(
+            task,
+            appScheduler({
+                targets: [{ recipient: 'a@b.com' }, { channel: 'C123' }],
+            }),
+        );
+
+        expect(getNotificationPageData).toHaveBeenCalledTimes(2);
+        expect(captureAppDeliveryManifest).toHaveBeenCalledTimes(1);
+        const manifests = getNotificationPageData.mock.calls.map(
+            (call) => call[5],
+        );
+        expect(manifests[0]).toBeDefined();
+        expect(manifests[0]).toBe(manifests[1]);
+    });
+
+    it('does not capture for an image-format app delivery', async () => {
+        const { task, captureAppDeliveryManifest, getNotificationPageData } =
+            setup();
+
+        await run(
+            task,
+            appScheduler({
+                format: SchedulerFormat.IMAGE,
+                options: {},
+                targets: [{ recipient: 'a@b.com' }],
+            }),
+        );
+
+        expect(captureAppDeliveryManifest).not.toHaveBeenCalled();
+        expect(getNotificationPageData.mock.calls[0][5]).toBeUndefined();
+    });
+
+    it('does not capture for a dashboard CSV delivery', async () => {
+        const { task, captureAppDeliveryManifest } = setup();
+
+        await run(
+            task,
+            appScheduler({
+                appUuid: null,
+                appName: null,
+                dashboardUuid: 'dashboard-1',
+                targets: [{ recipient: 'a@b.com' }],
+            }),
+        );
+
+        expect(captureAppDeliveryManifest).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -6,6 +6,7 @@ import {
     ForbiddenError,
     GoogleSheetsQuotaError,
     GoogleSheetsTransientError,
+    LightdashPage,
     MetricType,
     NotEnoughResults,
     PartialFailureType,
@@ -1156,6 +1157,45 @@ describe('getNotificationPageData — app CSV/XLSX branch', () => {
         expect(page.csvUrls).toHaveLength(2);
     });
 
+    it('drops the limit notice when that query never made it into a file', async () => {
+        const { task } = setup({
+            download: async ({ queryUuid }) => {
+                if (queryUuid === 'query-b') {
+                    throw new Error('storage unavailable');
+                }
+                return { fileUrl: `https://files.example.com/${queryUuid}` };
+            },
+        });
+
+        const page = await callGetNotificationPageData(
+            task,
+            appScheduler(),
+            manifestOf([
+                readyItem({ label: 'Revenue', queryUuid: 'query-a' }),
+                readyItem({
+                    captureKey: 'v1:b',
+                    label: 'Orders',
+                    queryUuid: 'query-b',
+                    order: 1,
+                    rowCount: 5000,
+                    limitReached: true,
+                }),
+            ]),
+        );
+
+        expect(page.csvUrls).toHaveLength(1);
+        expect(page.notices ?? []).toEqual([]);
+        expect(page.failures).toEqual([
+            {
+                type: PartialFailureType.APP_QUERY,
+                stage: 'download',
+                captureKey: 'v1:b',
+                label: 'Orders',
+                error: 'storage unavailable',
+            },
+        ]);
+    });
+
     it('throws when the render captured no successful queries', async () => {
         const { task, downloadSyncQueryResults } = setup();
 
@@ -1400,5 +1440,208 @@ describe('handleScheduledDelivery — app delivery capture', () => {
         );
 
         expect(captureAppDeliveryManifest).not.toHaveBeenCalled();
+    });
+});
+
+describe('app delivery target senders', () => {
+    const senderPage = (
+        overrides: Partial<PageData> = {},
+    ): PageData & { notices?: PageData['notices'] } => ({
+        url: 'https://lightdash.example.com/projects/project-1/apps/app-1/view',
+        details: { name: 'Sales App', description: 'Sales overview' },
+        pageType: LightdashPage.APP,
+        organizationUuid: 'org-1',
+        csvUrls: [
+            {
+                filename: 'csv-Revenue-2026-07-30.csv',
+                path: 'https://files.example.com/revenue.csv',
+                localPath: 'https://files.example.com/revenue.csv',
+                chartName: 'Revenue',
+                truncated: false,
+            },
+        ],
+        failures: [
+            {
+                type: PartialFailureType.APP_QUERY,
+                stage: 'download',
+                captureKey: 'v1:b',
+                label: 'Orders',
+                error: 'storage unavailable',
+            },
+        ],
+        notices: [{ type: 'limit_reached', label: 'Sessions', rowCount: 5000 }],
+        ...overrides,
+    });
+
+    const senderBaseDeps = (): Partial<TaskDeps> => ({
+        analytics: asDep<'analytics'>({ track: vi.fn() }),
+        schedulerService: asDep<'schedulerService'>({
+            logSchedulerJob: vi.fn().mockResolvedValue(undefined),
+            getSchedulerDefaultTimezone: vi.fn().mockResolvedValue('UTC'),
+        }),
+        organizationSettingsModel: asDep<'organizationSettingsModel'>({
+            get: vi.fn().mockResolvedValue({}),
+        }),
+        lightdashConfig: asDep<'lightdashConfig'>({
+            siteUrl: 'https://lightdash.example.com',
+            persistentDownloadUrls: { expirationSeconds: 604800 },
+        }),
+    });
+
+    const notificationOf = (
+        scheduler: CreateSchedulerAndTargets,
+        page: PageData,
+        target: Record<string, string>,
+    ) =>
+        ({
+            organizationUuid: 'org-1',
+            projectUuid: 'project-1',
+            userUuid: 'user-1',
+            scheduledTime: new Date('2026-07-30T09:00:00Z'),
+            jobGroup: 'job-1',
+            scheduler,
+            page,
+            ...target,
+        }) as unknown as never;
+
+    it('posts an app csv delivery to Slack with the files and the limit notice', async () => {
+        const postMessage = vi.fn().mockResolvedValue({ ts: '111' });
+        const task = makeTaskWithDeps({
+            ...senderBaseDeps(),
+            slackClient: asDep<'slackClient'>({ isEnabled: true, postMessage }),
+        });
+        const page = senderPage();
+
+        await (
+            task as unknown as {
+                sendSlackNotification(
+                    jobId: string,
+                    notification: never,
+                ): Promise<void>;
+            }
+        ).sendSlackNotification(
+            'job-1',
+            notificationOf(appScheduler(), page, { channel: 'C123' }),
+        );
+
+        expect(postMessage).toHaveBeenCalledTimes(1);
+        const blocks = JSON.stringify(postMessage.mock.calls[0][0].blocks);
+        expect(blocks).toContain('csv-Revenue-2026-07-30.csv');
+        expect(blocks).toContain(
+            'Sessions reached its query limit; additional rows may exist (5000 rows delivered)',
+        );
+        expect(blocks).toContain('Orders');
+    });
+
+    it('sends an app csv delivery by email with its failures and notices', async () => {
+        const sendDashboardCsvNotificationEmail = vi
+            .fn()
+            .mockResolvedValue(undefined);
+        const task = makeTaskWithDeps({
+            ...senderBaseDeps(),
+            emailClient: asDep<'emailClient'>({
+                sendDashboardCsvNotificationEmail,
+            }),
+            emailWhitelabelService: asDep<'emailWhitelabelService'>({
+                resolveSenderIdentity: vi.fn().mockResolvedValue(null),
+            }),
+        });
+        const page = senderPage();
+
+        await (
+            task as unknown as {
+                sendEmailNotification(
+                    jobId: string,
+                    notification: never,
+                ): Promise<void>;
+            }
+        ).sendEmailNotification(
+            'job-1',
+            notificationOf(appScheduler(), page, {
+                recipient: 'recipient@example.com',
+            }),
+        );
+
+        expect(sendDashboardCsvNotificationEmail).toHaveBeenCalledTimes(1);
+        const args = sendDashboardCsvNotificationEmail.mock.calls[0];
+        expect(args[0]).toBe('recipient@example.com');
+        expect(args[7]).toEqual(page.csvUrls);
+        expect(args[14]).toEqual(page.failures);
+        expect(args[15]).toEqual(page.notices);
+    });
+
+    it('posts an app xlsx delivery to the MS Teams webhook', async () => {
+        const postCsvsWithWebhook = vi.fn().mockResolvedValue(undefined);
+        const task = makeTaskWithDeps({
+            ...senderBaseDeps(),
+            lightdashConfig: asDep<'lightdashConfig'>({
+                siteUrl: 'https://lightdash.example.com',
+                persistentDownloadUrls: { expirationSeconds: 604800 },
+                microsoftTeams: { enabled: true },
+            }),
+            msTeamsClient: asDep<'msTeamsClient'>({ postCsvsWithWebhook }),
+        });
+        const page = senderPage();
+
+        await (
+            task as unknown as {
+                sendMsTeamsNotification(
+                    jobId: string,
+                    notification: never,
+                ): Promise<void>;
+            }
+        ).sendMsTeamsNotification(
+            'job-1',
+            notificationOf(
+                appScheduler({ format: SchedulerFormat.XLSX }),
+                page,
+                { webhook: 'https://webhook.example.com/teams' },
+            ),
+        );
+
+        expect(postCsvsWithWebhook).toHaveBeenCalledTimes(1);
+        expect(postCsvsWithWebhook.mock.calls[0][0]).toMatchObject({
+            webhookUrl: 'https://webhook.example.com/teams',
+            csvUrls: page.csvUrls,
+            failures: page.failures,
+        });
+    });
+
+    it('posts a dashboard xlsx delivery to the Google Chat webhook', async () => {
+        const postCsvsWithWebhook = vi.fn().mockResolvedValue(undefined);
+        const task = makeTaskWithDeps({
+            ...senderBaseDeps(),
+            googleChatClient: asDep<'googleChatClient'>({
+                postCsvsWithWebhook,
+            }),
+        });
+        const page = senderPage({ pageType: LightdashPage.DASHBOARD });
+
+        await (
+            task as unknown as {
+                sendGoogleChatNotification(
+                    jobId: string,
+                    notification: never,
+                ): Promise<void>;
+            }
+        ).sendGoogleChatNotification(
+            'job-1',
+            notificationOf(
+                appScheduler({
+                    format: SchedulerFormat.XLSX,
+                    appUuid: null,
+                    appName: null,
+                    dashboardUuid: 'dashboard-1',
+                }),
+                page,
+                { googleChatWebhook: 'https://webhook.example.com/chat' },
+            ),
+        );
+
+        expect(postCsvsWithWebhook).toHaveBeenCalledTimes(1);
+        expect(postCsvsWithWebhook.mock.calls[0][0]).toMatchObject({
+            webhookUrl: 'https://webhook.example.com/chat',
+            csvUrls: page.csvUrls,
+        });
     });
 });

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -1015,20 +1015,6 @@ export default class SchedulerTask {
                                 label: item.label,
                                 error: item.error,
                             }));
-                        const appNotices: DeliveryNotice[] = readyItems
-                            .filter(
-                                (item) =>
-                                    item.limitReached && item.rowCount !== null,
-                            )
-                            .map((item) => ({
-                                type: 'limit_reached',
-                                label: item.label,
-                                rowCount: item.rowCount ?? 0,
-                            }));
-                        if (appNotices.length > 0) {
-                            notices = appNotices;
-                        }
-
                         if (readyItems.length === 0) {
                             throw new Error(
                                 'App delivery render captured no successful queries',
@@ -1061,6 +1047,10 @@ export default class SchedulerTask {
                             NotificationPayloadBase['page']['csvUrls']
                         > = [];
                         const appDeliveryQueries: SchedulerDeliveryQuery[] = [];
+                        const deliveredItems: Extract<
+                            CapturedQuery,
+                            { status: 'ready' }
+                        >[] = [];
 
                         settled.forEach((result, index) => {
                             const item = readyItems[index];
@@ -1103,12 +1093,29 @@ export default class SchedulerTask {
                                 chartName: item.label,
                                 queryUuid: item.queryUuid,
                             });
+                            deliveredItems.push(item);
                         });
 
                         if (appCsvUrls.length === 0) {
                             throw new Error(
                                 'All app delivery downloads failed',
                             );
+                        }
+
+                        // Only for files that actually shipped — a notice about
+                        // an unattached file would just confuse recipients.
+                        const appNotices: DeliveryNotice[] = deliveredItems
+                            .filter(
+                                (item) =>
+                                    item.limitReached && item.rowCount !== null,
+                            )
+                            .map((item) => ({
+                                type: 'limit_reached',
+                                label: item.label,
+                                rowCount: item.rowCount ?? 0,
+                            }));
+                        if (appNotices.length > 0) {
+                            notices = appNotices;
                         }
 
                         const appFailures = [
@@ -2228,7 +2235,10 @@ export default class SchedulerTask {
                 throw new ParameterError(
                     'PDF-only format is not supported for MS Teams webhooks',
                 );
-            } else if (format === SchedulerFormat.CSV) {
+            } else if (
+                format === SchedulerFormat.CSV ||
+                format === SchedulerFormat.XLSX
+            ) {
                 if (savedChartUuid) {
                     if (csvUrl === undefined) {
                         throw new UnexpectedServerError('Missing CSV URL');
@@ -3320,6 +3330,7 @@ export default class SchedulerTask {
                 pdfFile,
                 pdfPageCount,
                 failures,
+                notices,
             } = notificationPageData;
 
             const imageBuffer =
@@ -3474,6 +3485,7 @@ export default class SchedulerTask {
                     csvOptions?.asAttachment,
                     format,
                     failures,
+                    notices,
                     senderIdentity,
                 );
             } else {
@@ -4667,9 +4679,8 @@ export default class SchedulerTask {
                 if (hasMsTeams) addToMap(msTeamsExpiration, 'msteams');
                 if (hasGoogleChat) addToMap(googleChatExpiration, 'googlechat');
 
-                // Captured once here: the fan-out below builds one page per
-                // distinct expiry, and each render would otherwise re-run the
-                // app's queries and hand recipients different data.
+                // Captured once: the fan-out builds a page per distinct expiry,
+                // and a second render would hand recipients different data.
                 const appCaptureManifest =
                     isAppCreateScheduler(scheduler) &&
                     (scheduler.format === SchedulerFormat.CSV ||
@@ -6785,7 +6796,10 @@ export default class SchedulerTask {
                 throw new ParameterError(
                     'PDF-only format is not supported for Google Chat webhooks',
                 );
-            } else if (format === SchedulerFormat.CSV) {
+            } else if (
+                format === SchedulerFormat.CSV ||
+                format === SchedulerFormat.XLSX
+            ) {
                 if (savedChartUuid) {
                     if (csvUrl === undefined) {
                         throw new UnexpectedServerError('Missing CSV URL');

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -115,6 +115,9 @@ import {
     WarehouseConnectionError,
     type Account as AccountType,
     type BatchDeliveryResult,
+    type CapturedQuery,
+    type DeliveryCaptureManifest,
+    type DeliveryNotice,
     type DeliveryResult,
     type DownloadAsyncQueryResultsPayload,
     type EmailBatchNotificationPayload,
@@ -135,6 +138,7 @@ import {
 import archiver from 'archiver';
 import fsSync from 'fs';
 import fs from 'fs/promises';
+import moment from 'moment';
 import { nanoid } from 'nanoid';
 import ExecutionContext from 'node-execution-context';
 import pLimit from 'p-limit';
@@ -374,6 +378,25 @@ export function buildItemMapFromColumns(columns: GsheetColumn[]): ItemsMap {
     return map;
 }
 
+// Different labels can sanitize to the same file name (e.g. "Q/A" and "Q:A"), so
+// duplicates get a " (n)" suffix before the extension.
+export function dedupeArtifactFilename(
+    filename: string,
+    used: Map<string, number>,
+): string {
+    const seen = used.get(filename);
+    if (seen === undefined) {
+        used.set(filename, 1);
+        return filename;
+    }
+    const next = seen + 1;
+    used.set(filename, next);
+    const dotIndex = filename.lastIndexOf('.');
+    return dotIndex === -1
+        ? `${filename} (${next})`
+        : `${filename.slice(0, dotIndex)} (${next})${filename.slice(dotIndex)}`;
+}
+
 export default class SchedulerTask {
     protected readonly lightdashConfig: LightdashConfig;
 
@@ -594,6 +617,41 @@ export default class SchedulerTask {
         throw new Error("Chart or dashboard can't be both undefined");
     }
 
+    // Renders the app once in delivery capture mode and returns the manifest of
+    // queries it ran. Must be called once per job, before the per-channel fan-out.
+    protected async captureAppDeliveryQueries(
+        scheduler: CreateSchedulerAndTargets,
+        jobId: string,
+    ): Promise<DeliveryCaptureManifest> {
+        if (!isAppCreateScheduler(scheduler)) {
+            throw new Error(
+                'Delivery capture is only available for app schedulers',
+            );
+        }
+        const { minimalUrl } = await this.getChartOrDashboard(
+            null,
+            null,
+            undefined,
+            QueryExecutionContext.SCHEDULED_DELIVERY,
+            null,
+            scheduler.appUuid,
+        );
+        const captureUrl = new URL(minimalUrl);
+        if (scheduler.appState) {
+            captureUrl.searchParams.set(
+                'state',
+                JSON.stringify(scheduler.appState),
+            );
+        }
+        captureUrl.searchParams.set('captureMode', 'delivery');
+
+        return this.unfurlService.captureAppDeliveryManifest({
+            url: captureUrl.href,
+            authUserUuid: scheduler.createdBy,
+            contextId: jobId,
+        });
+    }
+
     protected async getNotificationPageData(
         scheduler: CreateSchedulerAndTargets,
         jobId: string,
@@ -604,6 +662,9 @@ export default class SchedulerTask {
             dateZoomGranularity?: ExportContentPayload['dateZoomGranularity'];
             parameters?: ExportContentPayload['parameters'];
         },
+        // Captured once per job by captureAppDeliveryQueries — never rendered here,
+        // so the per-channel fan-out can't trigger a second app render.
+        appCaptureManifest?: DeliveryCaptureManifest,
     ): Promise<
         NotificationPayloadBase['page'] & {
             deliveryQueries?: SchedulerDeliveryQuery[];
@@ -625,6 +686,7 @@ export default class SchedulerTask {
         let pdfFile;
         let pdfPageCount: number | undefined;
         let failures: PartialFailure[] | undefined;
+        let notices: DeliveryNotice[] | undefined;
         let deliveryQueries: SchedulerDeliveryQuery[] | undefined;
 
         const schedulerUuid =
@@ -911,7 +973,187 @@ export default class SchedulerTask {
                 };
 
                 try {
-                    if (savedChartUuid) {
+                    if (appUuid) {
+                        if (!appCaptureManifest) {
+                            throw new Error(
+                                'App delivery requires a capture manifest from the delivery render',
+                            );
+                        }
+                        this.analytics.trackAccount(account, {
+                            event: 'download_results.started',
+                            userId: account.user.id,
+                            properties: baseAnalyticsProperties,
+                        });
+
+                        // Files (and workbook sheets) follow the order the app
+                        // declared the queries in.
+                        const capturedItems = [
+                            ...appCaptureManifest.items,
+                        ].sort((a, b) => a.order - b.order);
+                        const readyItems = capturedItems.filter(
+                            (
+                                item,
+                            ): item is Extract<
+                                CapturedQuery,
+                                { status: 'ready' }
+                            > => item.status === 'ready',
+                        );
+
+                        const renderFailures: PartialFailure[] = capturedItems
+                            .filter(
+                                (
+                                    item,
+                                ): item is Extract<
+                                    CapturedQuery,
+                                    { status: 'error' }
+                                > => item.status === 'error',
+                            )
+                            .map((item) => ({
+                                type: PartialFailureType.APP_QUERY,
+                                stage: 'render',
+                                captureKey: item.captureKey,
+                                label: item.label,
+                                error: item.error,
+                            }));
+                        const appNotices: DeliveryNotice[] = readyItems
+                            .filter(
+                                (item) =>
+                                    item.limitReached && item.rowCount !== null,
+                            )
+                            .map((item) => ({
+                                type: 'limit_reached',
+                                label: item.label,
+                                rowCount: item.rowCount ?? 0,
+                            }));
+                        if (appNotices.length > 0) {
+                            notices = appNotices;
+                        }
+
+                        if (readyItems.length === 0) {
+                            throw new Error(
+                                'App delivery render captured no successful queries',
+                            );
+                        }
+
+                        const settled = await Promise.allSettled(
+                            readyItems.map((item) =>
+                                this.asyncQueryService.downloadSyncQueryResults(
+                                    {
+                                        account,
+                                        projectUuid,
+                                        queryUuid: item.queryUuid,
+                                        type: downloadFileType,
+                                        onlyRaw:
+                                            csvOptions?.formatted === false,
+                                        expirationSecondsOverride,
+                                    },
+                                    SCHEDULER_POLLING_OPTIONS,
+                                ),
+                            ),
+                        );
+
+                        // One timestamp for the whole delivery, so labels that
+                        // sanitize to the same name collide and get deduped.
+                        const fileIdTime = moment();
+                        const usedFilenames = new Map<string, number>();
+                        const downloadFailures: PartialFailure[] = [];
+                        const appCsvUrls: NonNullable<
+                            NotificationPayloadBase['page']['csvUrls']
+                        > = [];
+                        const appDeliveryQueries: SchedulerDeliveryQuery[] = [];
+
+                        settled.forEach((result, index) => {
+                            const item = readyItems[index];
+                            if (result.status === 'rejected') {
+                                Logger.warn(
+                                    `Failed to download app delivery query "${item.label}" (${item.queryUuid}): ${result.reason}`,
+                                );
+                                downloadFailures.push({
+                                    type: PartialFailureType.APP_QUERY,
+                                    stage: 'download',
+                                    captureKey: item.captureKey,
+                                    label: item.label,
+                                    error: getErrorMessage(result.reason),
+                                });
+                                return;
+                            }
+                            appCsvUrls.push({
+                                filename: dedupeArtifactFilename(
+                                    downloadFileType === DownloadFileType.XLSX
+                                        ? ExcelService.generateFileId(
+                                              item.label,
+                                              false,
+                                              fileIdTime,
+                                          )
+                                        : CsvService.generateFileId(
+                                              item.label,
+                                              false,
+                                              fileIdTime,
+                                          ),
+                                    usedFilenames,
+                                ),
+                                path: result.value.fileUrl,
+                                localPath:
+                                    result.value.s3FileUrl ??
+                                    result.value.fileUrl,
+                                chartName: item.label,
+                                truncated: false,
+                            });
+                            appDeliveryQueries.push({
+                                chartName: item.label,
+                                queryUuid: item.queryUuid,
+                            });
+                        });
+
+                        if (appCsvUrls.length === 0) {
+                            throw new Error(
+                                'All app delivery downloads failed',
+                            );
+                        }
+
+                        const appFailures = [
+                            ...renderFailures,
+                            ...downloadFailures,
+                            ...(appCaptureManifest.overflowCount > 0
+                                ? [
+                                      {
+                                          type: PartialFailureType.APP_CAPTURE_OVERFLOW,
+                                          droppedCount:
+                                              appCaptureManifest.overflowCount,
+                                      } satisfies PartialFailure,
+                                  ]
+                                : []),
+                        ];
+                        if (appFailures.length > 0) {
+                            failures = appFailures;
+                        }
+                        csvUrls = appCsvUrls;
+                        deliveryQueries = appDeliveryQueries;
+
+                        if (
+                            format === SchedulerFormat.XLSX &&
+                            csvOptions?.xlsxFileLayout === 'workbook'
+                        ) {
+                            csvUrls = await this.buildWorkbookCsvUrls({
+                                files: csvUrls,
+                                workbookNameBase: details.name,
+                                organizationUuid,
+                                projectUuid,
+                                createdByUserUuid: userUuid,
+                                expirationSecondsOverride,
+                            });
+                        }
+
+                        this.analytics.trackAccount(account, {
+                            event: 'download_results.completed',
+                            userId: account.user.id,
+                            properties: {
+                                ...baseAnalyticsProperties,
+                                numCharts: csvUrls.length,
+                                numFailures: appFailures.length,
+                            },
+                        });
+                    } else if (savedChartUuid) {
                         this.analytics.trackAccount(account, {
                             event: 'download_results.started',
                             userId: account.user.id,
@@ -1341,24 +1583,14 @@ export default class SchedulerTask {
                             csvUrls.length > 0 &&
                             csvOptions?.xlsxFileLayout === 'workbook'
                         ) {
-                            const workbookResult =
-                                await this.createWorkbookDownloadUrl({
-                                    files: csvUrls,
-                                    workbookNameBase: details.name,
-                                    organizationUuid,
-                                    projectUuid,
-                                    createdByUserUuid: userUuid,
-                                    expirationSecondsOverride,
-                                });
-
-                            csvUrls = [
-                                {
-                                    filename: details.name,
-                                    path: workbookResult.url,
-                                    localPath: workbookResult.url,
-                                    truncated: false,
-                                },
-                            ];
+                            csvUrls = await this.buildWorkbookCsvUrls({
+                                files: csvUrls,
+                                workbookNameBase: details.name,
+                                organizationUuid,
+                                projectUuid,
+                                createdByUserUuid: userUuid,
+                                expirationSecondsOverride,
+                            });
                         }
 
                         this.analytics.trackAccount(account, {
@@ -1422,6 +1654,7 @@ export default class SchedulerTask {
             pdfFile,
             pdfPageCount,
             failures,
+            notices,
             deliveryQueries,
         };
     }
@@ -1497,6 +1730,7 @@ export default class SchedulerTask {
                 format,
                 savedChartUuid,
                 dashboardUuid,
+                appUuid,
                 name,
                 cron,
                 timezone,
@@ -1546,6 +1780,7 @@ export default class SchedulerTask {
                 pdfFile,
                 pdfPageCount,
                 failures,
+                notices,
             } = notificationPageData;
 
             const defaultSchedulerTimezone =
@@ -1732,7 +1967,7 @@ export default class SchedulerTask {
                                 ? csvUrl.path
                                 : undefined,
                     });
-                } else if (dashboardUuid) {
+                } else if (dashboardUuid || appUuid) {
                     if (csvUrls === undefined) {
                         throw new Error('Missing CSV URLS');
                     }
@@ -1740,6 +1975,7 @@ export default class SchedulerTask {
                         ...getBlocksArgs,
                         csvUrls,
                         failures,
+                        notices,
                     });
                 } else {
                     throw new Error('Not implemented');
@@ -1890,6 +2126,7 @@ export default class SchedulerTask {
                 format,
                 savedChartUuid,
                 dashboardUuid,
+                appUuid,
                 name,
                 cron,
                 timezone,
@@ -2001,7 +2238,7 @@ export default class SchedulerTask {
                         ...getBlocksArgs,
                         csvUrl,
                     });
-                } else if (dashboardUuid) {
+                } else if (dashboardUuid || appUuid) {
                     if (csvUrls === undefined) {
                         throw new UnexpectedServerError('Missing CSV URLS');
                     }
@@ -3036,6 +3273,7 @@ export default class SchedulerTask {
                 format,
                 savedChartUuid,
                 dashboardUuid,
+                appUuid,
                 name,
                 thresholds,
                 includeLinks,
@@ -3211,7 +3449,7 @@ export default class SchedulerTask {
                     format,
                     senderIdentity,
                 );
-            } else if (dashboardUuid) {
+            } else if (dashboardUuid || appUuid) {
                 if (csvUrls === undefined) {
                     throw new Error('Missing CSV URLS');
                 }
@@ -4429,6 +4667,16 @@ export default class SchedulerTask {
                 if (hasMsTeams) addToMap(msTeamsExpiration, 'msteams');
                 if (hasGoogleChat) addToMap(googleChatExpiration, 'googlechat');
 
+                // Captured once here: the fan-out below builds one page per
+                // distinct expiry, and each render would otherwise re-run the
+                // app's queries and hand recipients different data.
+                const appCaptureManifest =
+                    isAppCreateScheduler(scheduler) &&
+                    (scheduler.format === SchedulerFormat.CSV ||
+                        scheduler.format === SchedulerFormat.XLSX)
+                        ? await this.captureAppDeliveryQueries(scheduler, jobId)
+                        : undefined;
+
                 const pageByChannel = await Array.from(
                     expirationToChannels.entries(),
                 ).reduce(
@@ -4445,6 +4693,8 @@ export default class SchedulerTask {
                             jobId,
                             isFinalAttempt,
                             expiration,
+                            undefined,
+                            appCaptureManifest,
                         );
                         deliveryQueries ??= pageDeliveryQueries;
                         for (const channel of channels) {
@@ -5020,6 +5270,27 @@ export default class SchedulerTask {
             createdByUserUuid,
             source: 'scheduler',
         });
+    }
+
+    // Collapses per-query XLSX files into the single multi-sheet workbook the
+    // delivery attaches instead of them.
+    private async buildWorkbookCsvUrls(args: {
+        files: NonNullable<NotificationPayloadBase['page']['csvUrls']>;
+        workbookNameBase: string;
+        organizationUuid: string;
+        projectUuid: string;
+        createdByUserUuid: string;
+        expirationSecondsOverride?: number;
+    }): Promise<NonNullable<NotificationPayloadBase['page']['csvUrls']>> {
+        const workbookResult = await this.createWorkbookDownloadUrl(args);
+        return [
+            {
+                filename: args.workbookNameBase,
+                path: workbookResult.url,
+                localPath: workbookResult.url,
+                truncated: false,
+            },
+        ];
     }
 
     private async createWorkbookDownloadUrl({
@@ -6411,6 +6682,7 @@ export default class SchedulerTask {
                 format,
                 savedChartUuid,
                 dashboardUuid,
+                appUuid,
                 name,
                 cron,
                 timezone,
@@ -6523,7 +6795,7 @@ export default class SchedulerTask {
                         ...getBlocksArgs,
                         csvUrl,
                     });
-                } else if (dashboardUuid) {
+                } else if (dashboardUuid || appUuid) {
                     if (csvUrls === undefined) {
                         throw new UnexpectedServerError('Missing CSV URLS');
                     }

--- a/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
@@ -702,35 +702,42 @@ describe('SchedulerService', () => {
             },
         );
 
-        test('should reject a csv/xlsx format change on the generic update path', async () => {
-            const { appService } = buildAppService();
-            const appScheduler = {
+        // The generic PATCH /schedulers path is the only way to edit an app
+        // scheduler, so the format gate has to hold there too.
+        const buildAppUpdateService = () => {
+            const existingAppScheduler = {
                 ...chartSchedulerInPrivateSpace,
                 savedChartUuid: null,
                 appUuid,
                 appName: 'Sales App',
-                format: SchedulerFormat.CSV,
+                format: SchedulerFormat.IMAGE,
+                options: {},
+            };
+            const appUpdateSchedulerModel = {
+                getScheduler: vi.fn(async () => existingAppScheduler),
+                updateScheduler: vi.fn(async () => ({
+                    ...existingAppScheduler,
+                    targets: [],
+                })),
+                deleteScheduledLogs: vi.fn(async () => {}),
             };
             const appUpdateService = new SchedulerService({
                 lightdashConfig: lightdashConfigMock,
                 analytics: analyticsMock,
-                schedulerModel: {
-                    getScheduler: vi.fn(async () => appScheduler),
-                    updateScheduler: vi.fn(async () => ({
-                        ...appScheduler,
-                        targets: [],
-                    })),
-                    deleteScheduledLogs: vi.fn(async () => {}),
-                } as unknown as SchedulerModel,
+                schedulerModel:
+                    appUpdateSchedulerModel as unknown as SchedulerModel,
                 dashboardModel: {} as DashboardModel,
                 savedChartModel: {} as SavedChartModel,
                 savedSqlModel: {} as SavedSqlModel,
                 appModel: {
                     findAppByUuid: vi.fn(async () => appRow),
                 } as unknown as AppModel,
-                projectModel: {} as ProjectModel,
+                projectModel: {
+                    get: vi.fn(async () => ({ schedulerTimezone: 'UTC' })),
+                } as unknown as ProjectModel,
                 schedulerClient: {
                     deleteScheduledJobs: vi.fn(async () => {}),
+                    generateDailyJobsForScheduler: vi.fn(async () => {}),
                 } as unknown as SchedulerClient,
                 slackClient: {
                     joinChannels: vi.fn(async () => {}),
@@ -745,28 +752,83 @@ describe('SchedulerService', () => {
                 spacePermissionService:
                     spacePermissionService as unknown as SpacePermissionService,
             });
-            expect(appService).toBeDefined();
+            return { appUpdateService, appUpdateSchedulerModel };
+        };
+
+        const appUpdateActor = () =>
+            buildUser([
+                {
+                    subject: 'ScheduledDeliveries',
+                    action: ['manage'],
+                    conditions: { organizationUuid },
+                },
+            ]);
+
+        const appUpdatePayload = (format: SchedulerFormat, options: unknown) =>
+            ({
+                name: 'scheduler',
+                cron: '0 0 * * *',
+                timezone: 'UTC',
+                format,
+                options,
+                targets: [],
+            }) as unknown as UpdateSchedulerAndTargetsWithoutId;
+
+        test('should reject a PDF format change on the generic update path', async () => {
+            const { appUpdateService, appUpdateSchedulerModel } =
+                buildAppUpdateService();
 
             await expect(
                 appUpdateService.updateScheduler(
-                    buildUser([
-                        {
-                            subject: 'ScheduledDeliveries',
-                            action: ['manage'],
-                            conditions: { organizationUuid },
-                        },
-                    ]),
+                    appUpdateActor(),
                     'schedulerUuid',
-                    {
-                        name: 'scheduler',
-                        cron: '0 0 * * *',
-                        timezone: 'UTC',
-                        format: SchedulerFormat.PDF,
-                        options: {},
-                        targets: [],
-                    } as unknown as UpdateSchedulerAndTargetsWithoutId,
+                    appUpdatePayload(SchedulerFormat.PDF, {}),
                 ),
             ).rejects.toThrowError(ParameterError);
+
+            expect(
+                appUpdateSchedulerModel.updateScheduler,
+            ).not.toHaveBeenCalled();
+        });
+
+        test('should reject a csv limit change on the generic update path', async () => {
+            const { appUpdateService, appUpdateSchedulerModel } =
+                buildAppUpdateService();
+
+            await expect(
+                appUpdateService.updateScheduler(
+                    appUpdateActor(),
+                    'schedulerUuid',
+                    appUpdatePayload(SchedulerFormat.CSV, {
+                        formatted: true,
+                        limit: 'all',
+                    }),
+                ),
+            ).rejects.toThrowError(ParameterError);
+
+            expect(
+                appUpdateSchedulerModel.updateScheduler,
+            ).not.toHaveBeenCalled();
+        });
+
+        test('should allow an image app scheduler update on the generic update path', async () => {
+            const { appUpdateService, appUpdateSchedulerModel } =
+                buildAppUpdateService();
+
+            await appUpdateService.updateScheduler(
+                appUpdateActor(),
+                'schedulerUuid',
+                appUpdatePayload(SchedulerFormat.IMAGE, { withPdf: false }),
+            );
+
+            expect(
+                appUpdateSchedulerModel.updateScheduler,
+            ).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    schedulerUuid: 'schedulerUuid',
+                    format: SchedulerFormat.IMAGE,
+                }),
+            );
         });
     });
 });

--- a/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
@@ -563,4 +563,210 @@ describe('SchedulerService', () => {
             });
         });
     });
+
+    describe('createAppScheduler', () => {
+        const appUuid = 'appUuid';
+        const appRow = {
+            app_uuid: appUuid,
+            organization_uuid: organizationUuid,
+            project_uuid: projectUuid,
+            space_uuid: null,
+            created_by_user_uuid: 'userUuid',
+            name: 'Sales App',
+        };
+
+        const appActor = buildUser([
+            {
+                subject: 'DataApp',
+                action: ['view'],
+                conditions: { organizationUuid },
+            },
+            {
+                subject: 'ScheduledDeliveries',
+                action: ['create'],
+                conditions: { organizationUuid },
+            },
+        ]);
+
+        const buildAppService = () => {
+            const appSchedulerModel = {
+                createScheduler: vi.fn(async (scheduler) => ({
+                    ...scheduler,
+                    schedulerUuid: 'newSchedulerUuid',
+                })),
+            };
+            const appService = new SchedulerService({
+                lightdashConfig: lightdashConfigMock,
+                analytics: analyticsMock,
+                schedulerModel: appSchedulerModel as unknown as SchedulerModel,
+                dashboardModel: {} as DashboardModel,
+                savedChartModel: {} as SavedChartModel,
+                savedSqlModel: {} as SavedSqlModel,
+                appModel: {
+                    findAppByUuid: vi.fn(async () => appRow),
+                } as unknown as AppModel,
+                projectModel: {} as ProjectModel,
+                schedulerClient: {} as SchedulerClient,
+                slackClient: {
+                    joinChannels: vi.fn(async () => {}),
+                } as unknown as SlackClient,
+                emailClient: {} as EmailClient,
+                userModel: {} as UserModel,
+                googleDriveClient: {} as GoogleDriveClient,
+                userService: {} as UserService,
+                jobModel: {} as JobModel,
+                spacePermissionService:
+                    spacePermissionService as unknown as SpacePermissionService,
+            });
+            return { appService, appSchedulerModel };
+        };
+
+        const appSchedulerPayload = (
+            format: SchedulerFormat,
+            options: unknown,
+        ) =>
+            ({
+                name: 'App delivery',
+                cron: '0 9 * * *',
+                timezone: 'UTC',
+                format,
+                options,
+                enabled: true,
+                includeLinks: true,
+                targets: [],
+            }) as unknown as Parameters<
+                SchedulerService['createAppScheduler']
+            >[2];
+
+        test.each([
+            SchedulerFormat.IMAGE,
+            SchedulerFormat.CSV,
+            SchedulerFormat.XLSX,
+        ])('should accept %s deliveries', async (format) => {
+            const { appService, appSchedulerModel } = buildAppService();
+
+            await appService.createAppScheduler(
+                appActor,
+                appUuid,
+                appSchedulerPayload(
+                    format,
+                    format === SchedulerFormat.IMAGE
+                        ? {}
+                        : { formatted: true, limit: 'table' },
+                ),
+            );
+
+            expect(appSchedulerModel.createScheduler).toHaveBeenCalledWith(
+                expect.objectContaining({ format, appUuid }),
+            );
+        });
+
+        test.each([SchedulerFormat.GSHEETS, SchedulerFormat.PDF])(
+            'should reject %s deliveries',
+            async (format) => {
+                const { appService, appSchedulerModel } = buildAppService();
+
+                await expect(
+                    appService.createAppScheduler(
+                        appActor,
+                        appUuid,
+                        appSchedulerPayload(format, {}),
+                    ),
+                ).rejects.toThrowError(ParameterError);
+
+                expect(
+                    appSchedulerModel.createScheduler,
+                ).not.toHaveBeenCalled();
+            },
+        );
+
+        test.each(['all', 500])(
+            'should reject a csv limit of %s',
+            async (limit) => {
+                const { appService, appSchedulerModel } = buildAppService();
+
+                await expect(
+                    appService.createAppScheduler(
+                        appActor,
+                        appUuid,
+                        appSchedulerPayload(SchedulerFormat.CSV, {
+                            formatted: true,
+                            limit,
+                        }),
+                    ),
+                ).rejects.toThrowError(ParameterError);
+
+                expect(
+                    appSchedulerModel.createScheduler,
+                ).not.toHaveBeenCalled();
+            },
+        );
+
+        test('should reject a csv/xlsx format change on the generic update path', async () => {
+            const { appService } = buildAppService();
+            const appScheduler = {
+                ...chartSchedulerInPrivateSpace,
+                savedChartUuid: null,
+                appUuid,
+                appName: 'Sales App',
+                format: SchedulerFormat.CSV,
+            };
+            const appUpdateService = new SchedulerService({
+                lightdashConfig: lightdashConfigMock,
+                analytics: analyticsMock,
+                schedulerModel: {
+                    getScheduler: vi.fn(async () => appScheduler),
+                    updateScheduler: vi.fn(async () => ({
+                        ...appScheduler,
+                        targets: [],
+                    })),
+                    deleteScheduledLogs: vi.fn(async () => {}),
+                } as unknown as SchedulerModel,
+                dashboardModel: {} as DashboardModel,
+                savedChartModel: {} as SavedChartModel,
+                savedSqlModel: {} as SavedSqlModel,
+                appModel: {
+                    findAppByUuid: vi.fn(async () => appRow),
+                } as unknown as AppModel,
+                projectModel: {} as ProjectModel,
+                schedulerClient: {
+                    deleteScheduledJobs: vi.fn(async () => {}),
+                } as unknown as SchedulerClient,
+                slackClient: {
+                    joinChannels: vi.fn(async () => {}),
+                } as unknown as SlackClient,
+                emailClient: {
+                    canSendEmail: vi.fn(() => false),
+                } as unknown as EmailClient,
+                userModel: {} as UserModel,
+                googleDriveClient: {} as GoogleDriveClient,
+                userService: {} as UserService,
+                jobModel: {} as JobModel,
+                spacePermissionService:
+                    spacePermissionService as unknown as SpacePermissionService,
+            });
+            expect(appService).toBeDefined();
+
+            await expect(
+                appUpdateService.updateScheduler(
+                    buildUser([
+                        {
+                            subject: 'ScheduledDeliveries',
+                            action: ['manage'],
+                            conditions: { organizationUuid },
+                        },
+                    ]),
+                    'schedulerUuid',
+                    {
+                        name: 'scheduler',
+                        cron: '0 0 * * *',
+                        timezone: 'UTC',
+                        format: SchedulerFormat.PDF,
+                        options: {},
+                        targets: [],
+                    } as unknown as UpdateSchedulerAndTargetsWithoutId,
+                ),
+            ).rejects.toThrowError(ParameterError);
+        });
+    });
 });

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -17,6 +17,7 @@ import {
     isCreateSchedulerMsTeamsTarget,
     isCreateSchedulerSlackTarget,
     isDashboardScheduler,
+    isSchedulerCsvOptions,
     isSchedulerGsheetsOptions,
     isSqlChartScheduler,
     isUserWithOrg,
@@ -36,6 +37,7 @@ import {
     SchedulerCronUpdate,
     SchedulerFormat,
     SchedulerJobStatus,
+    SchedulerOptions,
     SchedulerResourceType,
     SchedulerRun,
     SchedulerRunLogsResponse,
@@ -559,6 +561,32 @@ export class SchedulerService extends BaseService {
         }
     }
 
+    // App deliveries render the app once and materialise whatever queries it ran,
+    // so each query brings its own limit and GSheets/PDF have no equivalent yet.
+    private static validateAppSchedulerDelivery(scheduler: {
+        format: SchedulerFormat;
+        options: SchedulerOptions;
+    }): void {
+        const allowedFormats = [
+            SchedulerFormat.IMAGE,
+            SchedulerFormat.CSV,
+            SchedulerFormat.XLSX,
+        ];
+        if (!allowedFormats.includes(scheduler.format)) {
+            throw new ParameterError(
+                'Data app schedulers support image, csv and xlsx deliveries',
+            );
+        }
+        if (
+            isSchedulerCsvOptions(scheduler.options) &&
+            scheduler.options.limit !== 'table'
+        ) {
+            throw new ParameterError(
+                "Data app deliveries always use each query's own limit",
+            );
+        }
+    }
+
     private async checkAppScheduledDeliveryAccess(
         user: SessionUser,
         appUuid: string,
@@ -629,11 +657,7 @@ export class SchedulerService extends BaseService {
     ): Promise<SchedulerAndTargets> {
         await this.checkAppScheduledDeliveryAccess(user, appUuid);
 
-        if (newScheduler.format !== SchedulerFormat.IMAGE) {
-            throw new ParameterError(
-                'Data app schedulers only support image deliveries',
-            );
-        }
+        SchedulerService.validateAppSchedulerDelivery(newScheduler);
         if (!isValidFrequency(newScheduler.cron)) {
             throw new ParameterError(
                 'Frequency not allowed, custom input is limited to hourly',
@@ -810,8 +834,13 @@ export class SchedulerService extends BaseService {
         }
 
         const {
+            scheduler: existingScheduler,
             resource: { organizationUuid, projectUuid },
         } = await this.checkUserCanUpdateSchedulerResource(user, schedulerUuid);
+
+        if (isAppScheduler(existingScheduler)) {
+            SchedulerService.validateAppSchedulerDelivery(updatedScheduler);
+        }
 
         if (updatedScheduler.format === SchedulerFormat.GSHEETS) {
             const auditedAbility = this.createAuditedAbility(user);

--- a/packages/backend/src/utils/partialFailureUtils.ts
+++ b/packages/backend/src/utils/partialFailureUtils.ts
@@ -1,4 +1,9 @@
-import { PartialFailureType, type PartialFailure } from '@lightdash/common';
+import {
+    assertUnreachable,
+    MAX_DELIVERY_QUERIES,
+    PartialFailureType,
+    type PartialFailure,
+} from '@lightdash/common';
 
 // Builds "2 charts and 1 query failed to export" from the failure kinds present,
 // falling back to a generic "issue(s)" bucket for non-content failure types.
@@ -30,4 +35,44 @@ export const buildFailureCountPhrase = (failures: PartialFailure[]): string => {
         parts.push(`${otherCount} issue${otherCount === 1 ? '' : 's'}`);
     }
     return parts.join(' and ');
+};
+
+// The email template prints `{{chartName}}: {{error}}`; only some failure kinds
+// carry those two fields, so flatten every variant into that shape here.
+export const toEmailFailureFields = (
+    failure: PartialFailure,
+): { chartName: string | undefined; error: string } => {
+    switch (failure.type) {
+        case PartialFailureType.DASHBOARD_CHART:
+        case PartialFailureType.DASHBOARD_SQL_CHART:
+            return { chartName: failure.chartName, error: failure.error };
+        case PartialFailureType.APP_QUERY:
+            return { chartName: failure.label, error: failure.error };
+        case PartialFailureType.APP_QUERY_MISSING:
+            return {
+                chartName: failure.label,
+                error: `did not run in this delivery${
+                    failure.identityChanged
+                        ? ' (query changed since it was selected)'
+                        : ''
+                }`,
+            };
+        case PartialFailureType.APP_CAPTURE_OVERFLOW:
+            return {
+                chartName: undefined,
+                error: `${failure.droppedCount} queries were dropped from capture (limit ${MAX_DELIVERY_QUERIES})`,
+            };
+        case PartialFailureType.AI_AUGMENTATION:
+            return {
+                chartName: undefined,
+                error: `AI summary could not be generated: ${failure.error}`,
+            };
+        case PartialFailureType.MISSING_TARGETS:
+            return {
+                chartName: undefined,
+                error: 'This delivery has no destinations, so it was disabled',
+            };
+        default:
+            return assertUnreachable(failure, 'Unknown partial failure type');
+    }
 };


### PR DESCRIPTION
### Description:

This PR adds CSV and XLSX delivery support for Data App schedulers, alongside a richer partial-failure and notice reporting system surfaced in email, Slack, MS Teams, and Google Chat notifications.

**App delivery capture pipeline**

A new `captureAppDeliveryQueries` method renders the app once in `delivery` capture mode before the per-channel fan-out begins. The resulting `DeliveryCaptureManifest` is passed into `getNotificationPageData` for every channel, ensuring all recipients receive data from the same render rather than triggering a second app execution.

**Per-query download and failure tracking**

Inside `getNotificationPageData`, ready queries from the manifest are downloaded in parallel via `downloadSyncQueryResults`. Queries that failed during render are recorded as `APP_QUERY / render` failures; queries whose download throws are recorded as `APP_QUERY / download` failures. If every download fails the job throws. Queries that hit their row limit but were successfully delivered are surfaced as `DeliveryNotice` entries rather than failures, so recipients know data may be incomplete without treating it as an error. If the capture dropped queries due to the `MAX_DELIVERY_QUERIES` cap, an `APP_CAPTURE_OVERFLOW` failure is appended.

**Filename deduplication**

A new `dedupeArtifactFilename` helper ensures that labels which sanitize to the same filename (e.g. `Q/A` and `Q:A`) receive a ` (2)`, ` (3)` … suffix before the extension rather than silently overwriting each other.

**Workbook layout**

When the scheduler requests `xlsxFileLayout: 'workbook'`, the individual per-query XLSX files are merged into a single multi-sheet workbook via the extracted `buildWorkbookCsvUrls` helper, which is now shared between the app and dashboard branches.

**Email template improvements**

- The failure warning line now reads `{{failureCountPhrase}} failed to export` (e.g. `1 query and 1 issue`) instead of the hard-coded `{{failures.length}} chart(s)`.
- Chart names in the failure list are now conditional (`{{#if chartName}}`), so failure types without a chart name (e.g. capture overflow) render cleanly.
- A new `{{#if hasNotices}}` block renders a blue info banner listing any `limit_reached` notices separately from the failure warning.

**`toEmailFailureFields` utility**

A new `toEmailFailureFields` function in `partialFailureUtils` maps every `PartialFailure` variant to the `{ chartName, error }` shape the email template expects, with exhaustiveness checked via `assertUnreachable`.

**Scheduler validation**

`createAppScheduler` and the generic `updateScheduler` path now both call `validateAppSchedulerDelivery`, which allows `IMAGE`, `CSV`, and `XLSX` formats and rejects `GSHEETS`, `PDF`, and any CSV limit other than `'table'`.

Relates: PROD-8374
Relates: #24475
