### PR TITLE
fix(dev): gate Claude on Okteto readiness

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,16 +12,32 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/agent-okteto-dev.sh\" hook-env"
+            "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/agent-okteto-dev.sh\" hook-start",
+            "timeout": 1800,
+            "statusMessage": "Preparing the Lightdash Okteto development environment"
           }
         ]
-      },
+      }
+    ],
+    "UserPromptSubmit": [
       {
-        "matcher": "startup|resume",
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/agent-okteto-dev.sh\" hook-start"
+            "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/agent-okteto-dev.sh\" hook-prompt",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/agent-okteto-dev.sh\" hook-stop",
+            "timeout": 600,
+            "statusMessage": "Verifying the Lightdash Okteto development environment"
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,17 +9,18 @@ This workflow is enabled only when
 follow the normal development workflow.
 
 When it is set, the Okteto development environment is started automatically by
-the `SessionStart` hook (`agent-okteto-dev.sh hook-start`) — you do NOT need to
-start it yourself. It provisions in the background while you work on the user's
-prompt. Do not replace it with a local Docker environment.
+the `SessionStart` hook (`agent-okteto-dev.sh hook-start`). The hook captures
+the session ID, starts synchronization, and waits for the environment to become
+healthy before the first prompt reaches Claude. Do not start it yourself or
+replace it with a local Docker environment.
 
-For an opted-in session, after making and validating code changes, have a
-background subagent run `./scripts/agent-okteto-dev.sh wait` with a 10-minute
-Bash timeout. If the environment is ready, include the URL from its `READY:`
-line and the manual test login in the final response:
-`demo@lightdash.com` / `demo_password!`. If it is unavailable (for example the
-background start failed — check `docs/agent-okteto.md` and the logs it points
-to), report that without blocking delivery of the completed code changes.
+If setup fails, do not make code changes. Follow the reported error and
+`docs/agent-okteto.md`, then resume the session after fixing the setup.
+
+After making and validating code changes, run
+`./scripts/agent-okteto-dev.sh wait` before the final response. Include the URL
+from its `READY:` line in the final response. The `Stop` hook verifies readiness
+again and prevents a final response that omits the URL.
 
 Leave the Okteto namespace and sync process running so the user can test the
 changes.

--- a/docs/agent-okteto.md
+++ b/docs/agent-okteto.md
@@ -44,7 +44,6 @@ Add these values:
 
 ```text
 LIGHTDASH_OKTETO_TOKEN=<shared automation token>
-BASH_MAX_TIMEOUT_MS=600000
 ```
 
 Changing environment variables only affects newly created sessions.
@@ -94,26 +93,39 @@ command -v tmux >/dev/null || {
 }
 ```
 
-Start a new Claude Code session after saving the environment. Claude claims a
-ready Okteto namespace and starts file synchronization in the background while
-its main agent works on your task.
+Start a new Claude Code session after saving the environment. Before processing
+the first prompt, Claude claims a ready Okteto namespace, starts file
+synchronization, waits for 100% synchronization, and waits for the Lightdash
+health endpoint.
 
 ### How the Claude hook works
 
 The `SessionStart` hook in `.claude/settings.json` runs on new, resumed,
-cleared, compacted, and forked Claude sessions. Claude sends session metadata
-to the hook over standard input and provides `CLAUDE_ENV_FILE` for variables
-that should remain available to later shell commands.
+cleared, compacted, and forked Claude sessions. It has an explicit 1800-second
+timeout for the cold fallback path. Claude sends session metadata to the hook
+over standard input and provides `CLAUDE_ENV_FILE` for variables that should
+remain available to later shell commands.
 
-The first hook calls `agent-okteto-dev.sh hook-env`. When the token is set, it
-copies Claude's `session_id` into `LIGHTDASH_AGENT_SESSION_ID` through
-`CLAUDE_ENV_FILE`. The second hook calls `hook-start`, which launches `start`
-as a detached process and immediately returns. Both hooks do nothing when the
-token is absent.
+One hook invocation copies Claude's `session_id` into
+`LIGHTDASH_AGENT_SESSION_ID` through `CLAUDE_ENV_FILE`, claims or reuses a
+namespace, starts `okteto up` in tmux, and waits until synchronization and
+application health are stable. Its `READY:` output is added to Claude's
+SessionStart context. `BASH_MAX_TIMEOUT_MS` does not control hook execution;
+the timeout is set directly on the hook.
 
 `start` claims an unclaimed, healthy pooled namespace and runs `okteto up`
 against its existing deployment. If the pool is temporarily exhausted, it
 falls back to creating and deploying a session-specific namespace.
+
+SessionStart exit codes do not block Claude. The hook therefore returns
+structured `continue: false` output when setup fails. A fast
+`UserPromptSubmit` guard also rejects prompts unless the startup gate recorded
+readiness, covering hook cancellation or timeout. A `Stop` hook verifies
+synchronization and health again and requires the ready URL in Claude's final
+response.
+
+All hooks return immediately without output when `LIGHTDASH_OKTETO_TOKEN` is
+unset.
 
 ## Other coding agents
 
@@ -136,7 +148,6 @@ in the terminal immediately before starting Claude:
 
 ```bash
 export LIGHTDASH_OKTETO_TOKEN='<shared automation token>'
-export BASH_MAX_TIMEOUT_MS=600000
 claude
 ```
 
@@ -193,7 +204,8 @@ the desired minimum pool size when testing administrator changes:
 
 ## Manual testing
 
-The agent's final response includes a URL like:
+The agent verifies synchronization and health again before its final response,
+which includes a URL like:
 
 ```text
 https://<deployment>-dev-warm-<number>.lightdash.okteto.dev
@@ -208,9 +220,8 @@ Email: demo@lightdash.com
 Password: demo_password!
 ```
 
-If startup fails, the agent reports the setup error and continues working on
-your request without a test environment. Expired tokens must be replaced in the
-agent environment or local secret manager before starting a new session.
+If startup fails, Claude stops before working on the request. Follow the setup
+error, replace expired tokens or fix missing tools, and then resume the session.
 
 Okteto recommends a separate namespace for each autonomous run to prevent
 parallel branches from colliding. See

--- a/docs/agent-okteto.md
+++ b/docs/agent-okteto.md
@@ -10,6 +10,10 @@ Each opted-in session atomically claims a ready namespace from a shared pool, so
 multiple tasks can run without overwriting one another. The namespace remains
 claimed after the agent finishes so you can test the result.
 
+The manifest uses the stable development environment name `lightdash` so pool
+provisioning and agent synchronization update the same Okteto environment
+record regardless of the checkout directory name.
+
 ## What you need
 
 Ask a Lightdash administrator for the shared coding-agent Okteto token. This is

--- a/okteto.dev.yaml
+++ b/okteto.dev.yaml
@@ -5,6 +5,8 @@
 #
 # Okteto derives the public endpoint from the deployment and namespace names.
 # The agent launcher discovers it from the ingress before starting sync.
+name: lightdash
+
 deploy:
     commands:
         - name: Configuring database...

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -5,8 +5,9 @@
 ### `agent-okteto-dev.sh <start|wait|url>`
 
 When `LIGHTDASH_OKTETO_TOKEN` is set, atomically claims a ready Okteto namespace
-for the session, keeps source changes synchronized through a detached `okteto
-up`, and reports the public test URL. See
+for the session, keeps source changes synchronized through `okteto up` in tmux,
+waits for synchronization and application health, and reports the public test
+URL. See
 `docs/agent-okteto.md` for setup.
 
 ### `maintain-agent-okteto-pool.sh [minimum_ready]`

--- a/scripts/agent-okteto-dev.sh
+++ b/scripts/agent-okteto-dev.sh
@@ -43,9 +43,8 @@ require_command() {
 }
 
 extract_session_id() {
-    local hook_input session_id
+    local hook_input="$1" session_id
 
-    hook_input="$(cat)"
     session_id="$(
         printf '%s\n' "$hook_input" |
             sed -nE 's/.*"session_id"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' |
@@ -58,50 +57,114 @@ extract_session_id() {
     printf '%s' "$session_id"
 }
 
-capture_session_env() {
-    local session_id
-
-    [ -n "${LIGHTDASH_OKTETO_TOKEN:-}" ] || return 0
-
-    [ -n "${CLAUDE_ENV_FILE:-}" ] ||
-        fail "CLAUDE_ENV_FILE is unavailable in the SessionStart hook."
-
-    session_id="$(extract_session_id)" ||
-        fail "Claude SessionStart input has no usable session_id."
-
-    printf 'export LIGHTDASH_AGENT_SESSION_ID=%s\n' "$session_id" >>"$CLAUDE_ENV_FILE"
-}
-
 hook_start() {
-    local session_id pidfile pid
+    local hook_input hook_output ready_line session_id
 
     [ -n "${LIGHTDASH_OKTETO_TOKEN:-}" ] || return 0
 
-    session_id="$(extract_session_id)" || return 0
-    [ -n "$session_id" ] || return 0
+    hook_input="$(cat)"
+    if [ -z "${CLAUDE_ENV_FILE:-}" ]; then
+        hook_setup_failed "CLAUDE_ENV_FILE is unavailable."
+        return
+    fi
+    if ! session_id="$(extract_session_id "$hook_input")"; then
+        hook_setup_failed "Claude SessionStart input has no usable session_id."
+        return
+    fi
 
     export LIGHTDASH_AGENT_SESSION_ID="$session_id"
-    load_session_config
-    mkdir -p "$RUN_DIR"
-
-    if tmux_session_exists; then
-        return 0
+    if ! printf 'export LIGHTDASH_AGENT_SESSION_ID=%s\n' \
+        "$session_id" >>"$CLAUDE_ENV_FILE"; then
+        hook_setup_failed "Could not persist the Claude session ID."
+        return
     fi
 
-    pidfile="$RUN_DIR/hook-start.pid"
-    if [ -f "$pidfile" ]; then
-        pid="$(cat "$pidfile" 2>/dev/null || true)"
-        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
-            return 0
-        fi
+    if ! hook_output="$(bash "$SCRIPT_DIR/agent-okteto-dev.sh" start 2>&1)"; then
+        printf '%s\n' "$hook_output" >&2
+        hook_setup_failed "Okteto startup failed."
+        return
     fi
 
-    nohup bash "$SCRIPT_DIR/agent-okteto-dev.sh" start \
-        </dev/null >>"$RUN_DIR/hook-start.log" 2>&1 &
-    printf '%s\n' "$!" >"$pidfile"
-    disown 2>/dev/null || true
+    ready_line="$(
+        printf '%s\n' "$hook_output" |
+            grep '^READY: https://' |
+            tail -n 1 ||
+            true
+    )"
+    if [ -z "$ready_line" ]; then
+        printf '%s\n' "$hook_output" >&2
+        hook_setup_failed "Okteto startup finished without a ready URL."
+        return
+    fi
 
-    echo "Okteto development environment starting in the background."
+    printf '%s\n' "$ready_line"
+}
+
+hook_setup_failed() {
+    local detail="$1"
+
+    printf '%s\n' "$detail" >&2
+    printf '%s\n' \
+        '{"continue":false,"stopReason":"Lightdash Okteto setup failed before Claude could start. Check the SessionStart hook error and docs/agent-okteto.md, fix the setup, then resume the session."}'
+}
+
+hook_prompt() {
+    local hook_input session_id
+
+    [ -n "${LIGHTDASH_OKTETO_TOKEN:-}" ] || return 0
+
+    hook_input="$(cat)"
+    session_id="$(extract_session_id "$hook_input")" || {
+        echo "Lightdash Okteto setup is not ready: no usable Claude session ID." >&2
+        exit 2
+    }
+
+    export LIGHTDASH_AGENT_SESSION_ID="$session_id"
+    if ! bash "$SCRIPT_DIR/agent-okteto-dev.sh" check-ready >/dev/null 2>&1; then
+        echo "Lightdash Okteto setup did not reach READY. Fix the SessionStart setup error, then resubmit the prompt." >&2
+        exit 2
+    fi
+}
+
+hook_stop() {
+    local hook_input hook_output last_message ready_line ready_url session_id
+
+    [ -n "${LIGHTDASH_OKTETO_TOKEN:-}" ] || return 0
+
+    hook_input="$(cat)"
+    session_id="$(extract_session_id "$hook_input")" || {
+        echo "Cannot verify Lightdash Okteto readiness: no usable Claude session ID." >&2
+        exit 2
+    }
+    export LIGHTDASH_AGENT_SESSION_ID="$session_id"
+
+    if ! hook_output="$(bash "$SCRIPT_DIR/agent-okteto-dev.sh" start 2>&1)"; then
+        printf '%s\n' "$hook_output" >&2
+        echo "The Lightdash Okteto environment must be ready before the final response." >&2
+        exit 2
+    fi
+
+    ready_line="$(
+        printf '%s\n' "$hook_output" |
+            grep '^READY: https://' |
+            tail -n 1 ||
+            true
+    )"
+    ready_url="${ready_line#READY: }"
+    last_message="$(
+        printf '%s\n' "$hook_input" |
+            jq -r '.last_assistant_message // empty'
+    )" || {
+        echo "Cannot inspect the final response. See $SETUP_DOC." >&2
+        exit 2
+    }
+
+    if [ -z "$ready_line" ] ||
+        ! printf '%s' "$last_message" | grep -Fq "$ready_url"; then
+        printf '%s\n' "$ready_line" >&2
+        echo "The final response must include the ready testing URL." >&2
+        exit 2
+    fi
 }
 
 agent_session_id() {
@@ -141,6 +204,7 @@ load_session_config() {
     LOG_FILE="$RUN_DIR/okteto-up.log"
     NAMESPACE_FILE="$RUN_DIR/namespace"
     URL_FILE="$RUN_DIR/url"
+    READY_FILE="$RUN_DIR/ready"
 
     saved_namespace=""
     if [ -f "$NAMESPACE_FILE" ]; then
@@ -386,6 +450,8 @@ wait_until_ready() {
         if sync_is_ready && app_is_healthy; then
             sleep 2
             if sync_is_ready && app_is_healthy; then
+                mkdir -p "$RUN_DIR"
+                printf 'READY: %s\n' "$PUBLIC_URL" >"$READY_FILE"
                 echo "READY: $PUBLIC_URL"
                 return
             fi
@@ -428,6 +494,7 @@ start_tmux_session() {
 }
 
 start_environment() {
+    rm -f "$READY_FILE"
     require_runtime
     prepare_runtime_dir
     authenticate
@@ -489,13 +556,16 @@ main() {
     local command_name="${1:-}"
 
     case "$command_name" in
-        hook-env)
-            capture_session_env
-            ;;
         hook-start)
             hook_start
             ;;
-        start | wait | url)
+        hook-prompt)
+            hook_prompt
+            ;;
+        hook-stop)
+            hook_stop
+            ;;
+        start | wait | url | check-ready)
             if [ -z "${LIGHTDASH_OKTETO_TOKEN:-}" ]; then
                 echo "SKIPPED: $TOKEN_ENV_VAR is not set."
                 return
@@ -506,6 +576,7 @@ main() {
                 start) start_environment ;;
                 wait) wait_for_environment ;;
                 url) echo "$PUBLIC_URL" ;;
+                check-ready) [ -s "$READY_FILE" ] ;;
             esac
             ;;
         -h | --help | help | "")


### PR DESCRIPTION
## Summary

- combine session ID persistence and Okteto startup into one synchronous SessionStart hook with a 30-minute timeout
- stop Claude cleanly on setup failures and add a prompt fail-safe for hook cancellation or timeout
- revalidate synchronization and application health at Stop, requiring the ready URL in the final response
- use the stable `lightdash` Okteto environment name for both pool deployment and agent synchronization
- update agent guidance and setup docs to describe blocking startup and explicit hook timeouts

## Testing

- `bash -n scripts/agent-okteto-dev.sh`
- `jq empty .claude/settings.json`
- `okteto validate -f okteto.dev.yaml`
- `git diff --check`
- mocked Bash 3.2 lifecycle coverage for token-absent no-ops, warm claim/reuse, cold fallback, startup failure, prompt gating, and Stop verification
- live cold fallback, resumed SessionStart, Stop verification, and explicit-name status check: `READY: https://canberra-dev-cold-a54dea51.lightdash.okteto.dev`

The namespace and tmux sync process are intentionally left running. A fresh dev warm image was manually built successfully from `main`: https://github.com/lightdash/lightdash/actions/runs/30505529175