### PR TITLE
fix: strip assumeRoleExternalId from project credential responses

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
@@ -400,6 +400,32 @@ describe('ProjectModel', () => {
             expect(result.oauthClientId).toEqual('client-id');
             expect(result.oauthClientSecret).toEqual('client-secret');
         });
+
+        test('should merge assumeRoleExternalId when missing in the new config', async () => {
+            const completeAthenaCredentials: CreateAthenaCredentials = {
+                type: WarehouseTypes.ATHENA,
+                region: 'us-east-1',
+                database: 'AwsDataCatalog',
+                schema: 'default',
+                s3StagingDir: 's3://test-results/',
+                assumeRoleArn: 'arn:aws:iam::111:role/test-role',
+                assumeRoleExternalId: 'test-external-id',
+            };
+            const incompleteAthenaCredentials: CreateAthenaCredentials = {
+                ...completeAthenaCredentials,
+                assumeRoleExternalId: undefined,
+            };
+
+            const result = ProjectModel.mergeMissingWarehouseSecrets(
+                incompleteAthenaCredentials,
+                completeAthenaCredentials,
+            );
+
+            expect(result.assumeRoleArn).toEqual(
+                'arn:aws:iam::111:role/test-role',
+            );
+            expect(result.assumeRoleExternalId).toEqual('test-external-id');
+        });
     });
 
     describe('removing sensitive credentials from API', () => {
@@ -445,6 +471,37 @@ describe('ProjectModel', () => {
             expect(
                 (project.warehouseConnection as AnyType).sslrootcert,
             ).toBeUndefined();
+        });
+
+        test('should remove assumeRoleExternalId but keep assumeRoleArn', async () => {
+            const athenaProjectMock = {
+                ...projectMock,
+                warehouse_type: WarehouseTypes.ATHENA,
+                encrypted_credentials: Buffer.from(
+                    JSON.stringify({
+                        type: WarehouseTypes.ATHENA,
+                        region: 'us-east-1',
+                        database: 'AwsDataCatalog',
+                        schema: 'default',
+                        s3StagingDir: 's3://test-results/',
+                        assumeRoleArn: 'arn:aws:iam::111:role/test-role',
+                        assumeRoleExternalId: 'test-external-id',
+                    }),
+                ),
+            };
+            tracker.on
+                .select(queryMatcher(ProjectTableName, [projectUuid]))
+                .response([athenaProjectMock]);
+
+            const project = await model.get(projectUuid);
+
+            expect(project.warehouseConnection).toBeDefined();
+            expect(
+                (project.warehouseConnection as AnyType).assumeRoleExternalId,
+            ).toBeUndefined();
+            expect(
+                (project.warehouseConnection as AnyType).assumeRoleArn,
+            ).toEqual('arn:aws:iam::111:role/test-role');
         });
     });
 

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -88,6 +88,7 @@ export const sensitiveCredentialsFieldNames = [
     'accessKeyId',
     'secretAccessKey',
     'sessionToken',
+    'assumeRoleExternalId',
 ] as const;
 export type SensitiveCredentialsFieldNames =
     (typeof sensitiveCredentialsFieldNames)[number];
@@ -654,7 +655,6 @@ export const mergeWarehouseCredentials = <T extends CreateWarehouseCredentials>(
         ...sensitiveCredentialsFieldNames,
         'authenticationType',
         'assumeRoleArn',
-        'assumeRoleExternalId',
     ];
     const filteredBaseCredentials = Object.fromEntries(
         Object.entries(baseCredentials).filter(

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/AthenaForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/AthenaForm.tsx
@@ -214,10 +214,15 @@ const AthenaForm: FC<{
                             placeholder="arn:aws:iam::123456789012:role/my-athena-role"
                             disabled={disabled}
                         />
-                        <TextInput
+                        <PasswordInput
                             name="warehouse.assumeRoleExternalId"
                             label="Assume Role External ID"
                             description="Optional external ID for the assume role trust policy."
+                            placeholder={
+                                disabled || !requireSecrets
+                                    ? '**************'
+                                    : undefined
+                            }
                             {...form.getInputProps(
                                 'warehouse.assumeRoleExternalId',
                             )}


### PR DESCRIPTION
Adds `assumeRoleExternalId` to the sensitive warehouse credential fields so it is removed from project API responses and merged back from the saved config when omitted on update; the Athena connection form now masks the field.

Linear: SPK-598