### PR TITLE
fix(dev): truly warm agent Okteto environments

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -36,7 +36,7 @@
           {
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/agent-okteto-dev.sh\" hook-stop",
-            "timeout": 600,
+            "timeout": 1800,
             "statusMessage": "Verifying the Lightdash Okteto development environment"
           }
         ]

--- a/.github/workflows/dev-warm-image.yml
+++ b/.github/workflows/dev-warm-image.yml
@@ -5,7 +5,8 @@ name: Dev Warm Image
 # pre-built package dists. okteto.dev.yaml points its dev container at this
 # image so a fresh namespace starts hot-reloading in minutes instead of
 # deriving that state on first `okteto up`. The DB-state twin of
-# preview-db-snapshot.yml.
+# preview-db-snapshot.yml. After publishing, unclaimed pool namespaces are
+# refreshed so their ready markers pin the new digest.
 
 on:
   schedule:
@@ -29,9 +30,9 @@ concurrency:
 
 jobs:
   build:
-    name: Build and push the dev-warm image
+    name: Build, push, and prepare the dev-warm image
     runs-on: depot-ubuntu-24.04-4
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
@@ -57,3 +58,10 @@ jobs:
           okteto build -f dockerfile-prs --target dev-warm \
             -t okteto.global/lightdash-dev-warm:latest .
           echo "Image build took $(( $(date +%s) - start ))s" | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Refresh unclaimed development environments
+        env:
+          LIGHTDASH_OKTETO_TOKEN: ${{ secrets.LIGHTDASH_OKTETO_TOKEN }}
+          OKTETO_CONTEXT: ${{ secrets.OKTETO_CONTEXT }}
+          OKTETO_FORCE_POOL_REFRESH: "true"
+        run: ./scripts/maintain-agent-okteto-pool.sh 3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,8 @@ replace it with a local Docker environment.
 
 If setup fails, do not make code changes. Follow the reported error and
 `docs/agent-okteto.md`, then resume the session after fixing the setup.
+The prompt guard reports whether setup is still running or the specific startup
+failure recorded by the SessionStart gate.
 
 After making and validating code changes, run
 `./scripts/agent-okteto-dev.sh wait` before the final response. Include the URL

--- a/docker/docker-compose.okteto-dev.yml
+++ b/docker/docker-compose.okteto-dev.yml
@@ -37,17 +37,10 @@ services:
             - '3000'
 
     lightdash-dev:
-        build:
-            # The dev image is toolchain-only (node, pnpm, dbt): source code
-            # arrives via okteto up file sync, so code changes never rebuild it
-            target: dev
-            context: ..
-            dockerfile: dockerfile-prs
+        image: ${DEV_WARM_IMAGE:-okteto.global/lightdash-dev-warm:latest}
         depends_on:
             - db-preview
             - headless-browser
-        # The base container idles; okteto up swaps it for the dev container
-        # which runs scripts/okteto-dev-up.sh
         command: ['sleep', 'infinity']
         ports:
             - '3000'

--- a/docs/agent-okteto.md
+++ b/docs/agent-okteto.md
@@ -117,6 +117,9 @@ application health are stable. Its `READY:` output is added to Claude's
 SessionStart context. `BASH_MAX_TIMEOUT_MS` does not control hook execution;
 the timeout is set directly on the hook.
 
+The internal startup deadline is 1700 seconds, leaving time for the hook to
+surface a clean failure before the 1800-second SessionStart timeout.
+
 `start` claims an unclaimed, healthy pooled namespace and runs `okteto up`
 against its existing deployment. If the pool is temporarily exhausted, it
 falls back to creating and deploying a session-specific namespace.
@@ -124,9 +127,10 @@ falls back to creating and deploying a session-specific namespace.
 SessionStart exit codes do not block Claude. The hook therefore returns
 structured `continue: false` output when setup fails. A fast
 `UserPromptSubmit` guard also rejects prompts unless the startup gate recorded
-readiness, covering hook cancellation or timeout. A `Stop` hook verifies
-synchronization and health again and requires the ready URL in Claude's final
-response.
+readiness, covering hook cancellation or timeout. It distinguishes an active
+startup from a failed startup and reports the recorded failure. A `Stop` hook
+verifies synchronization and health again and requires the ready URL in
+Claude's final response.
 
 All hooks return immediately without output when `LIGHTDASH_OKTETO_TOKEN` is
 unset.
@@ -187,14 +191,22 @@ LIGHTDASH_OKTETO_TOKEN=<shared automation token>
 OKTETO_CONTEXT=https://lightdash.okteto.dev
 ```
 
-The maintainer marks a namespace ready after its base pods and public ingress
+The maintainer runs the baked development image in the idle `lightdash-dev`
+pod, then records its immutable digest after the base pods and public ingress
 are available. An agent claims it by atomically creating the
 `lightdash-agent-claim` ConfigMap with its session hash. Kubernetes allows only
 one creation to succeed, preventing two simultaneous sessions from selecting
-the same namespace. After `okteto up`, the launcher waits for file
+the same namespace. The claim also records the prepared digest, and `okteto up`
+uses that exact image instead of resolving the mutable `latest` tag. After
+`okteto up`, the launcher waits for file
 synchronization and `/api/v1/health`. Claimed namespaces are excluded when the
 workflow replenishes the pool. The same hash is available inside the
 development container as `LIGHTDASH_AGENT_SESSION_HASH`.
+
+After `Dev Warm Image` publishes a new image, it refreshes unclaimed pool
+namespaces and records the new digest. It never restarts claimed namespaces.
+Both the image workflow and pool workflow support manual `workflow_dispatch`
+runs.
 
 If no warm namespace is available, the launcher creates an on-demand namespace
 named `dev-cold-<8-character-session-hash>`.

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -14,7 +14,9 @@ URL. See
 
 Repairs and replenishes the pool of unclaimed agent development environments.
 The `agent-okteto-pool.yml` workflow runs it every 30 minutes with a minimum of
-three.
+three. A ready namespace has the baked development image running in its idle
+Lightdash pod and records the resolved immutable digest. The image workflow
+refreshes unclaimed pool members after publishing a new digest.
 
 ## Okteto Preview Environment
 

--- a/scripts/agent-okteto-dev.sh
+++ b/scripts/agent-okteto-dev.sh
@@ -12,7 +12,7 @@ POOL_NAMESPACE_PREFIX="dev-warm-"
 COLD_NAMESPACE_PREFIX="dev-cold-"
 POOL_CLAIM_CONFIGMAP="lightdash-agent-claim"
 POOL_READY_CONFIGMAP="lightdash-agent-ready"
-READY_TIMEOUT_SECONDS="${OKTETO_READY_TIMEOUT_SECONDS:-300}"
+READY_TIMEOUT_SECONDS="${OKTETO_READY_TIMEOUT_SECONDS:-1700}"
 SYNC_START_TIMEOUT_SECONDS="${OKTETO_SYNC_START_TIMEOUT_SECONDS:-600}"
 POLL_INTERVAL_SECONDS="${OKTETO_POLL_INTERVAL_SECONDS:-5}"
 SETUP_DOC="docs/agent-okteto.md"
@@ -20,6 +20,9 @@ TOKEN_ENV_VAR="LIGHTDASH_OKTETO_TOKEN"
 KUBECTL_CONFIGURED=false
 
 fail() {
+    if [ -n "${STATE_FILE:-}" ]; then
+        write_setup_state "FAILED" "$*" || true
+    fi
     echo "ERROR: $*" >&2
     exit 1
 }
@@ -58,7 +61,7 @@ extract_session_id() {
 }
 
 hook_start() {
-    local hook_input hook_output ready_line session_id
+    local failure_detail hook_input hook_output ready_line session_id
 
     [ -n "${LIGHTDASH_OKTETO_TOKEN:-}" ] || return 0
 
@@ -80,8 +83,17 @@ hook_start() {
     fi
 
     if ! hook_output="$(bash "$SCRIPT_DIR/agent-okteto-dev.sh" start 2>&1)"; then
-        printf '%s\n' "$hook_output" >&2
-        hook_setup_failed "Okteto startup failed."
+        failure_detail="$(
+            printf '%s\n' "$hook_output" |
+                grep '^ERROR:' |
+                tail -n 1 |
+                sed 's/^ERROR:[[:space:]]*//' ||
+                true
+        )"
+        failure_detail="${failure_detail:-Okteto startup command exited unexpectedly. See the session setup log.}"
+        load_session_config
+        write_setup_state "FAILED" "$failure_detail"
+        hook_setup_failed "$failure_detail"
         return
     fi
 
@@ -109,7 +121,7 @@ hook_setup_failed() {
 }
 
 hook_prompt() {
-    local hook_input session_id
+    local hook_input session_id status_output
 
     [ -n "${LIGHTDASH_OKTETO_TOKEN:-}" ] || return 0
 
@@ -120,8 +132,10 @@ hook_prompt() {
     }
 
     export LIGHTDASH_AGENT_SESSION_ID="$session_id"
-    if ! bash "$SCRIPT_DIR/agent-okteto-dev.sh" check-ready >/dev/null 2>&1; then
-        echo "Lightdash Okteto setup did not reach READY. Fix the SessionStart setup error, then resubmit the prompt." >&2
+    if ! status_output="$(
+        bash "$SCRIPT_DIR/agent-okteto-dev.sh" setup-status 2>&1
+    )"; then
+        printf '%s\n' "$status_output" >&2
         exit 2
     fi
 }
@@ -205,6 +219,10 @@ load_session_config() {
     NAMESPACE_FILE="$RUN_DIR/namespace"
     URL_FILE="$RUN_DIR/url"
     READY_FILE="$RUN_DIR/ready"
+    STATE_FILE="$RUN_DIR/state"
+    FAILURE_FILE="$RUN_DIR/failure"
+    WARM_IMAGE_FILE="$RUN_DIR/warm-image"
+    ACTIVE_WARM_IMAGE="okteto.global/lightdash-dev-warm:latest"
 
     saved_namespace=""
     if [ -f "$NAMESPACE_FILE" ]; then
@@ -223,6 +241,11 @@ load_session_config() {
     if [[ "$saved_url" =~ ^https://[A-Za-z0-9.-]+$ ]]; then
         PUBLIC_URL="$saved_url"
     fi
+
+    if [ -f "$WARM_IMAGE_FILE" ]; then
+        set_active_warm_image "$(cat "$WARM_IMAGE_FILE" 2>/dev/null || true)" ||
+            true
+    fi
 }
 
 set_active_namespace() {
@@ -238,6 +261,28 @@ save_active_namespace() {
     mkdir -p "$RUN_DIR"
     printf '%s\n' "$OKTETO_NAMESPACE" >"$NAMESPACE_FILE"
     printf '%s\n' "$PUBLIC_URL" >"$URL_FILE"
+}
+
+set_active_warm_image() {
+    local image="$1"
+
+    [[ "$image" =~ ^okteto\.global/lightdash-dev-warm@sha256:[a-f0-9]{64}$ ]] ||
+        return 1
+    ACTIVE_WARM_IMAGE="$image"
+    mkdir -p "$RUN_DIR"
+    printf '%s\n' "$ACTIVE_WARM_IMAGE" >"$WARM_IMAGE_FILE"
+}
+
+write_setup_state() {
+    local state="$1" detail="${2:-}"
+
+    mkdir -p "$RUN_DIR"
+    printf '%s\n' "$state" >"$STATE_FILE"
+    if [ -n "$detail" ]; then
+        printf '%s\n' "$detail" >"$FAILURE_FILE"
+    else
+        rm -f "$FAILURE_FILE"
+    fi
 }
 
 require_client_runtime() {
@@ -340,10 +385,16 @@ pool_namespace_resources_are_ready() {
 }
 
 pool_namespace_is_ready() {
-    local namespace="$1"
+    local namespace="$1" running_image warm_image
 
-    kubectl -n "$namespace" get configmap "$POOL_READY_CONFIGMAP" \
-        >/dev/null 2>&1 &&
+    warm_image="$(
+        kubectl -n "$namespace" get configmap "$POOL_READY_CONFIGMAP" \
+            -o jsonpath='{.data.warm_image}' 2>/dev/null ||
+            true
+    )"
+    running_image="$(namespace_deployed_warm_image "$namespace" || true)"
+    [[ "$warm_image" =~ ^okteto\.global/lightdash-dev-warm@sha256:[a-f0-9]{64}$ ]] &&
+        [ "$warm_image" = "$running_image" ] &&
         pool_namespace_resources_are_ready "$namespace"
 }
 
@@ -354,17 +405,34 @@ claim_owner() {
         -o jsonpath='{.data.session_hash}' 2>/dev/null || true
 }
 
-use_claimed_namespace() {
+claim_warm_image() {
     local namespace="$1"
+
+    kubectl -n "$namespace" get configmap "$POOL_CLAIM_CONFIGMAP" \
+        -o jsonpath='{.data.warm_image}' 2>/dev/null || true
+}
+
+pool_warm_image() {
+    local namespace="$1"
+
+    kubectl -n "$namespace" get configmap "$POOL_READY_CONFIGMAP" \
+        -o jsonpath='{.data.warm_image}' 2>/dev/null || true
+}
+
+use_claimed_namespace() {
+    local namespace="$1" warm_image="${2:-}"
 
     set_active_namespace "$namespace"
     discover_public_url "$namespace" || return 1
+    if [ -n "$warm_image" ]; then
+        set_active_warm_image "$warm_image" || return 1
+    fi
     save_active_namespace
     echo "Using pre-provisioned Okteto namespace $OKTETO_NAMESPACE."
 }
 
 claim_pool_namespace() {
-    local namespace owner first_pool_namespace
+    local namespace owner first_pool_namespace warm_image
 
     first_pool_namespace="$(
         list_namespaces |
@@ -379,7 +447,8 @@ claim_pool_namespace() {
     while IFS= read -r namespace; do
         owner="$(claim_owner "$namespace")"
         if [ "$owner" = "$SESSION_HASH" ]; then
-            if use_claimed_namespace "$namespace"; then
+            warm_image="$(claim_warm_image "$namespace")"
+            if use_claimed_namespace "$namespace" "$warm_image"; then
                 return 0
             fi
         fi
@@ -388,14 +457,16 @@ claim_pool_namespace() {
     while IFS= read -r namespace; do
         [ -z "$(claim_owner "$namespace")" ] || continue
         pool_namespace_is_ready "$namespace" || continue
+        warm_image="$(pool_warm_image "$namespace")"
 
         if kubectl -n "$namespace" create configmap "$POOL_CLAIM_CONFIGMAP" \
             --from-literal="session_hash=$SESSION_HASH" \
             --from-literal="claimed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --from-literal="warm_image=$warm_image" \
             >/dev/null 2>&1; then
             kubectl -n "$namespace" delete configmap "$POOL_READY_CONFIGMAP" \
                 --ignore-not-found >/dev/null 2>&1 || true
-            if use_claimed_namespace "$namespace"; then
+            if use_claimed_namespace "$namespace" "$warm_image"; then
                 return 0
             fi
             return 1
@@ -428,6 +499,34 @@ app_is_healthy() {
         "$PUBLIC_URL/api/v1/health" >/dev/null 2>&1
 }
 
+namespace_deployed_warm_image() {
+    local namespace="$1" digest image_id
+
+    image_id="$(
+        kubectl -n "$namespace" get pods \
+            -l stack.okteto.com/service=lightdash-dev \
+            -o json 2>/dev/null |
+            jq -r '
+                [
+                    .items[].status.containerStatuses[]?
+                    | select(.name == "lightdash-dev")
+                    | .imageID
+                ][0] // empty
+            '
+    )"
+    digest="${image_id##*@}"
+    [[ "$digest" =~ ^sha256:[a-f0-9]{64}$ ]] || return 1
+    printf 'okteto.global/lightdash-dev-warm@%s' "$digest"
+}
+
+discover_deployed_warm_image() {
+    local warm_image
+
+    warm_image="$(namespace_deployed_warm_image "$OKTETO_NAMESPACE")" ||
+        return 1
+    set_active_warm_image "$warm_image"
+}
+
 show_log_tail() {
     if [ -s "$LOG_FILE" ]; then
         echo "Last Okteto output:" >&2
@@ -438,7 +537,7 @@ show_log_tail() {
 wait_until_ready() {
     local deadline last_report now
 
-    deadline=$((SECONDS + READY_TIMEOUT_SECONDS))
+    deadline="${START_DEADLINE:-$((SECONDS + READY_TIMEOUT_SECONDS))}"
     last_report=$((SECONDS - 30))
 
     while ((SECONDS < deadline)); do
@@ -452,6 +551,7 @@ wait_until_ready() {
             if sync_is_ready && app_is_healthy; then
                 mkdir -p "$RUN_DIR"
                 printf 'READY: %s\n' "$PUBLIC_URL" >"$READY_FILE"
+                write_setup_state "READY"
                 echo "READY: $PUBLIC_URL"
                 return
             fi
@@ -476,12 +576,14 @@ start_tmux_session() {
     : >"$LOG_FILE"
 
     printf -v up_command \
-        'exec okteto up %q -f %q -n %q --env %q --env %q' \
+        'DEV_WARM_IMAGE=%q exec okteto up %q -f %q -n %q --env %q --env %q --env %q' \
+        "$ACTIVE_WARM_IMAGE" \
         "$OKTETO_SERVICE" \
         "$OKTETO_MANIFEST" \
         "$OKTETO_NAMESPACE" \
         "LIGHTDASH_AGENT_SESSION_HASH=$SESSION_HASH" \
-        "SITE_URL=$PUBLIC_URL"
+        "SITE_URL=$PUBLIC_URL" \
+        "DEV_WARM_IMAGE=$ACTIVE_WARM_IMAGE"
     printf -v pipe_command 'cat >> %q' "$LOG_FILE"
 
     echo "Starting Okteto file synchronization..."
@@ -494,7 +596,9 @@ start_tmux_session() {
 }
 
 start_environment() {
+    START_DEADLINE=$((SECONDS + READY_TIMEOUT_SECONDS))
     rm -f "$READY_FILE"
+    write_setup_state "STARTING"
     require_runtime
     prepare_runtime_dir
     authenticate
@@ -512,14 +616,19 @@ start_environment() {
         save_active_namespace
         ensure_namespace
         echo "No ready pooled environment was available; deploying one now..."
-        okteto deploy \
+        if ! DEV_WARM_IMAGE="$ACTIVE_WARM_IMAGE" okteto deploy \
             -f "$OKTETO_MANIFEST" \
             -n "$OKTETO_NAMESPACE" \
+            --env "DEV_WARM_IMAGE=$ACTIVE_WARM_IMAGE" \
             --wait \
-            --timeout 8m
+            --timeout 8m; then
+            fail "Okteto deployment failed in $OKTETO_NAMESPACE."
+        fi
         configure_kubectl_access "$OKTETO_NAMESPACE"
         discover_public_url "$OKTETO_NAMESPACE" ||
             fail "No public ingress found in $OKTETO_NAMESPACE."
+        discover_deployed_warm_image ||
+            fail "Could not resolve the deployed warm image digest in $OKTETO_NAMESPACE."
         save_active_namespace
     fi
 
@@ -552,6 +661,29 @@ wait_for_environment() {
     wait_until_ready
 }
 
+setup_status() {
+    local detail state
+
+    state="$(cat "$STATE_FILE" 2>/dev/null || true)"
+    case "$state" in
+        READY)
+            [ -s "$READY_FILE" ] && return 0
+            echo "Lightdash Okteto setup lost its READY marker. Resume the session to verify it again." >&2
+            ;;
+        STARTING)
+            echo "Lightdash Okteto setup is still starting. Wait for the SessionStart hook to finish, then resubmit the prompt." >&2
+            ;;
+        FAILED)
+            detail="$(cat "$FAILURE_FILE" 2>/dev/null || true)"
+            echo "Lightdash Okteto setup failed: ${detail:-unknown setup error}. Resume the session after fixing it." >&2
+            ;;
+        *)
+            echo "Lightdash Okteto setup has not started. Resume the session to run the startup gate." >&2
+            ;;
+    esac
+    return 1
+}
+
 main() {
     local command_name="${1:-}"
 
@@ -565,7 +697,7 @@ main() {
         hook-stop)
             hook_stop
             ;;
-        start | wait | url | check-ready)
+        start | wait | url | check-ready | setup-status)
             if [ -z "${LIGHTDASH_OKTETO_TOKEN:-}" ]; then
                 echo "SKIPPED: $TOKEN_ENV_VAR is not set."
                 return
@@ -576,7 +708,8 @@ main() {
                 start) start_environment ;;
                 wait) wait_for_environment ;;
                 url) echo "$PUBLIC_URL" ;;
-                check-ready) [ -s "$READY_FILE" ] ;;
+                check-ready) setup_status >/dev/null 2>&1 ;;
+                setup-status) setup_status ;;
             esac
             ;;
         -h | --help | help | "")

--- a/scripts/maintain-agent-okteto-pool.sh
+++ b/scripts/maintain-agent-okteto-pool.sh
@@ -13,6 +13,8 @@ POOL_READY_CONFIGMAP="lightdash-agent-ready"
 TARGET_SIZE="${1:-${LIGHTDASH_AGENT_POOL_SIZE:-3}}"
 READY_TIMEOUT_SECONDS="${OKTETO_POOL_READY_TIMEOUT_SECONDS:-600}"
 POLL_INTERVAL_SECONDS="${OKTETO_POOL_POLL_INTERVAL_SECONDS:-10}"
+WARM_IMAGE="${DEV_WARM_IMAGE:-okteto.global/lightdash-dev-warm:latest}"
+FORCE_REFRESH="${OKTETO_FORCE_POOL_REFRESH:-false}"
 KUBECTL_CONFIGURED=false
 
 fail() {
@@ -59,10 +61,16 @@ namespace_is_claimed() {
 }
 
 namespace_is_ready() {
-    local namespace="$1"
+    local namespace="$1" prepared_image running_image
 
-    kubectl -n "$namespace" get configmap "$POOL_READY_CONFIGMAP" \
-        >/dev/null 2>&1 &&
+    prepared_image="$(
+        kubectl -n "$namespace" get configmap "$POOL_READY_CONFIGMAP" \
+            -o jsonpath='{.data.warm_image}' 2>/dev/null ||
+            true
+    )"
+    running_image="$(namespace_warm_image "$namespace" || true)"
+    [ -n "$prepared_image" ] &&
+        [ "$prepared_image" = "$running_image" ] &&
         namespace_resources_are_ready "$namespace"
 }
 
@@ -105,11 +113,35 @@ configure_kubectl_access() {
     KUBECTL_CONFIGURED=true
 }
 
+namespace_warm_image() {
+    local namespace="$1" digest image_id
+
+    image_id="$(
+        kubectl -n "$namespace" get pods \
+            -l stack.okteto.com/service=lightdash-dev \
+            -o json 2>/dev/null |
+            jq -r '
+                [
+                    .items[].status.containerStatuses[]?
+                    | select(.name == "lightdash-dev")
+                    | .imageID
+                ][0] // empty
+            '
+    )"
+    digest="${image_id##*@}"
+    [[ "$digest" =~ ^sha256:[a-f0-9]{64}$ ]] || return 1
+    printf 'okteto.global/lightdash-dev-warm@%s' "$digest"
+}
+
 mark_namespace_ready() {
-    local namespace="$1"
+    local namespace="$1" warm_image
+
+    warm_image="$(namespace_warm_image "$namespace")" ||
+        fail "Could not resolve the warm image digest in $namespace."
 
     kubectl -n "$namespace" create configmap "$POOL_READY_CONFIGMAP" \
         --from-literal="prepared_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        --from-literal="warm_image=$warm_image" \
         --dry-run=client -o yaml |
         kubectl -n "$namespace" apply -f - >/dev/null
 }
@@ -119,11 +151,17 @@ deploy_namespace() {
 
     kubectl -n "$namespace" delete configmap "$POOL_READY_CONFIGMAP" \
         --ignore-not-found >/dev/null 2>&1 || true
-    okteto deploy \
+    DEV_WARM_IMAGE="$WARM_IMAGE" okteto deploy \
         -f "$OKTETO_MANIFEST" \
         -n "$namespace" \
+        --env "DEV_WARM_IMAGE=$WARM_IMAGE" \
         --wait \
         --timeout 20m
+    if [ "$FORCE_REFRESH" = "true" ]; then
+        kubectl -n "$namespace" rollout restart deployment/lightdash-dev
+        kubectl -n "$namespace" rollout status deployment/lightdash-dev \
+            --timeout="${READY_TIMEOUT_SECONDS}s"
+    fi
     if ! wait_for_namespace_ready "$namespace"; then
         return 1
     fi
@@ -193,13 +231,8 @@ main() {
     while IFS= read -r namespace; do
         namespace_is_claimed "$namespace" && continue
 
-        if namespace_is_ready "$namespace"; then
-            available=$((available + 1))
-            continue
-        fi
-
-        if namespace_resources_are_ready "$namespace"; then
-            mark_namespace_ready "$namespace"
+        if [ "$FORCE_REFRESH" != "true" ] &&
+            namespace_is_ready "$namespace"; then
             available=$((available + 1))
             continue
         fi


### PR DESCRIPTION
## Summary

- run the baked development image in idle pool pods and pin its resolved digest through readiness and claim ConfigMaps
- refresh only unclaimed pool environments after warm-image builds, while preserving manual workflow dispatch
- expand the synchronous startup gate to a 1700-second overall deadline and persist STARTING/FAILED/READY state for actionable prompt errors

## Context

`dev-warm-2` and `dev-warm-3` had healthy infrastructure but did not have the baked development image prepared before `okteto up`. A fresh image activation consumed most of the previous 300-second readiness window, leaving both sessions without a connected sync process or healthy application.

## Testing

Not run, per request.