### PR TITLE
fix(dev): pass warm image through deploy environment

### DIFF
--- a/scripts/agent-okteto-dev.sh
+++ b/scripts/agent-okteto-dev.sh
@@ -619,7 +619,6 @@ start_environment() {
         if ! DEV_WARM_IMAGE="$ACTIVE_WARM_IMAGE" okteto deploy \
             -f "$OKTETO_MANIFEST" \
             -n "$OKTETO_NAMESPACE" \
-            --env "DEV_WARM_IMAGE=$ACTIVE_WARM_IMAGE" \
             --wait \
             --timeout 8m; then
             fail "Okteto deployment failed in $OKTETO_NAMESPACE."

--- a/scripts/maintain-agent-okteto-pool.sh
+++ b/scripts/maintain-agent-okteto-pool.sh
@@ -154,7 +154,6 @@ deploy_namespace() {
     DEV_WARM_IMAGE="$WARM_IMAGE" okteto deploy \
         -f "$OKTETO_MANIFEST" \
         -n "$namespace" \
-        --env "DEV_WARM_IMAGE=$WARM_IMAGE" \
         --wait \
         --timeout 20m
     if [ "$FORCE_REFRESH" = "true" ]; then


### PR DESCRIPTION
## Summary

- remove the unsupported `--env` flag from both `okteto deploy` invocations
- retain `DEV_WARM_IMAGE=... okteto deploy`, which makes the value available to manifest interpolation and nested deploy commands

## Context

The post-merge Dev Warm Image run failed during pool refresh with `Unknown flag: --env`. The flag is supported by `okteto up`, but not by `okteto deploy` in the pinned Okteto CLI.

## Testing

Not run, per request.