### PR TITLE
chore(dev): pass warm image as an Okteto deploy variable

### DIFF
--- a/scripts/agent-okteto-dev.sh
+++ b/scripts/agent-okteto-dev.sh
@@ -616,9 +616,10 @@ start_environment() {
         save_active_namespace
         ensure_namespace
         echo "No ready pooled environment was available; deploying one now..."
-        if ! DEV_WARM_IMAGE="$ACTIVE_WARM_IMAGE" okteto deploy \
+        if ! okteto deploy \
             -f "$OKTETO_MANIFEST" \
             -n "$OKTETO_NAMESPACE" \
+            --var "DEV_WARM_IMAGE=$ACTIVE_WARM_IMAGE" \
             --wait \
             --timeout 8m; then
             fail "Okteto deployment failed in $OKTETO_NAMESPACE."

--- a/scripts/maintain-agent-okteto-pool.sh
+++ b/scripts/maintain-agent-okteto-pool.sh
@@ -151,9 +151,10 @@ deploy_namespace() {
 
     kubectl -n "$namespace" delete configmap "$POOL_READY_CONFIGMAP" \
         --ignore-not-found >/dev/null 2>&1 || true
-    DEV_WARM_IMAGE="$WARM_IMAGE" okteto deploy \
+    okteto deploy \
         -f "$OKTETO_MANIFEST" \
         -n "$namespace" \
+        --var "DEV_WARM_IMAGE=$WARM_IMAGE" \
         --wait \
         --timeout 20m
     if [ "$FORCE_REFRESH" = "true" ]; then


### PR DESCRIPTION
## Summary

- pass `DEV_WARM_IMAGE` with the supported `okteto deploy --var` flag in both deploy paths
- make manifest interpolation and nested deploy-command propagation explicit

## Verification

Deployed the real manifest to `dev-warm-9` with `--var DEV_WARM_IMAGE=...`. The nested Compose deployment completed successfully and the idle Lightdash pod became ready using warm-image digest `sha256:340c22f79651c15c9c7fc8ca131cc9316c0d877d6a14a7e3887a524f1acf4539`.