### PR TITLE
fix: validate additional dbt source environment variables

### DIFF
--- a/packages/backend/src/services/ProjectDbtSourcesService.test.ts
+++ b/packages/backend/src/services/ProjectDbtSourcesService.test.ts
@@ -157,6 +157,27 @@ describe('ProjectDbtSourcesService', () => {
     });
 
     describe('createProjectDbtSource', () => {
+        it('rejects unsafe dbt environment variables', async () => {
+            const service = getService();
+
+            await expect(
+                service.createProjectDbtSource(adminAccount, projectUuid, {
+                    name: 'unsafe-source',
+                    dbtConnection: {
+                        ...githubConnection,
+                        environment: [
+                            {
+                                key: 'GIT_SSH_COMMAND',
+                                value: 'echo unsafe',
+                            },
+                        ],
+                    } as never,
+                }),
+            ).rejects.toThrow(/GIT_SSH_COMMAND/);
+
+            expect(projectDbtSourcesModel.createSource).not.toHaveBeenCalled();
+        });
+
         it('rejects non-GitHub connection types', async () => {
             const service = getService();
 
@@ -212,6 +233,36 @@ describe('ProjectDbtSourcesService', () => {
     });
 
     describe('updateProjectDbtSource', () => {
+        it('rejects unsafe dbt environment variables', async () => {
+            projectDbtSourcesModel.getSource.mockResolvedValue({
+                projectDbtSourceUuid: sourceUuid,
+                projectUuid,
+                dbtConnection: githubConnection,
+            } as never);
+            const service = getService();
+
+            await expect(
+                service.updateProjectDbtSource(
+                    adminAccount,
+                    projectUuid,
+                    sourceUuid,
+                    {
+                        dbtConnection: {
+                            ...githubConnection,
+                            environment: [
+                                {
+                                    key: 'GIT_CONFIG_COUNT',
+                                    value: '1',
+                                },
+                            ],
+                        } as never,
+                    },
+                ),
+            ).rejects.toThrow(/GIT_CONFIG_COUNT/);
+
+            expect(projectDbtSourcesModel.updateSource).not.toHaveBeenCalled();
+        });
+
         it('rejects non-GitHub connection types on update, matching create', async () => {
             projectDbtSourcesModel.getSource.mockResolvedValue({
                 projectDbtSourceUuid: sourceUuid,

--- a/packages/backend/src/services/ProjectDbtSourcesService.ts
+++ b/packages/backend/src/services/ProjectDbtSourcesService.ts
@@ -5,6 +5,7 @@ import {
     DbtProjectConfig,
     DbtProjectType,
     ForbiddenError,
+    getDbtEnvironmentVariableKeyError,
     ParameterError,
     ProjectDbtSource,
     ProjectDbtSourceSummary,
@@ -106,6 +107,21 @@ export class ProjectDbtSourcesService extends BaseService {
         };
     }
 
+    private static validateDbtEnvironmentVariables(
+        dbtConnection: DbtProjectConfig,
+    ): void {
+        if (!('environment' in dbtConnection) || !dbtConnection.environment) {
+            return;
+        }
+
+        dbtConnection.environment.forEach(({ key }) => {
+            const error = getDbtEnvironmentVariableKeyError(key);
+            if (error) {
+                throw new ParameterError(error);
+            }
+        });
+    }
+
     private async checkProjectAccess(
         account: Account,
         projectUuid: string,
@@ -168,6 +184,9 @@ export class ProjectDbtSourcesService extends BaseService {
                 'Additional dbt sources currently support GitHub connections only',
             );
         }
+        ProjectDbtSourcesService.validateDbtEnvironmentVariables(
+            data.dbtConnection,
+        );
         const existing =
             await this.projectDbtSourcesModel.getSources(projectUuid);
         // Append after the highest existing precedence (primary is 0).
@@ -248,6 +267,11 @@ export class ProjectDbtSourcesService extends BaseService {
         ) {
             throw new ParameterError(
                 'Additional dbt sources currently support GitHub connections only',
+            );
+        }
+        if (data.dbtConnection) {
+            ProjectDbtSourcesService.validateDbtEnvironmentVariables(
+                data.dbtConnection,
             );
         }
         // The edit form receives the connection with secrets stripped; restore


### PR DESCRIPTION
## Summary

- validate environment-variable keys when creating additional dbt sources
- apply the same validation when updating an existing source
- reuse the existing dbt environment-variable validation for consistent project configuration behavior
- add focused service coverage for rejected keys

## Testing

- focused backend service tests
- backend lint and typecheck
- local API checks for accepted and rejected source configuration

Closes: PROD-8754