### PR TITLE
fix: scope data app bridge queries to their project

### DIFF
--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
@@ -359,6 +359,20 @@ describe('useAppSdkBridge', () => {
         );
     });
 
+    it('blocks SDK queries targeting a different project', () => {
+        renderBridge(() => undefined);
+
+        dispatchFetchMessage({
+            type: 'lightdash:sdk:fetch',
+            id: POST_ID,
+            method: 'POST',
+            path: '/api/v2/projects/another-project/query/metric-query',
+            body: { query: METRIC_QUERY },
+        });
+
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
     it('allows SDK download scheduling and job polling through the bridge', async () => {
         renderBridge(() => undefined);
 

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -139,7 +139,16 @@ const ALLOWED_ROUTES: Array<{ method: string; pattern: RegExp }> = [
     { method: 'GET', pattern: /^\/api\/v1\/user$/ },
 ];
 
-function isAllowedRoute(method: string, path: string): boolean {
+function isAllowedRoute(
+    method: string,
+    path: string,
+    projectUuid: string,
+): boolean {
+    const projectPath = path.match(/^\/api\/v2\/projects\/([^/]+)\//);
+    if (projectPath && projectPath[1] !== projectUuid) {
+        return false;
+    }
+
     return ALLOWED_ROUTES.some(
         (route) =>
             route.method === method.toUpperCase() && route.pattern.test(path),
@@ -653,7 +662,7 @@ export function useAppSdkBridge({
                 );
             };
 
-            if (!isAllowedRoute(method, path)) {
+            if (!isAllowedRoute(method, path, projectUuid)) {
                 respond({ error: `Blocked: ${method} ${path}` });
                 return;
             }


### PR DESCRIPTION
## Summary

- scope project-specific Data App SDK requests to the current app project
- preserve global SDK routes for user info and download polling
- add focused regression coverage for mismatched project routes

## Testing

- `pnpm -F frontend exec vitest run src/features/apps/hooks/useAppSdkBridge.test.ts`
- `pnpm exec oxfmt --check packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts`

Closes: PROD-8807