### PR TITLE
feat: rename content slugs from the CLI

### DIFF
--- a/packages/backend/src/controllers/ProjectCoderController.ts
+++ b/packages/backend/src/controllers/ProjectCoderController.ts
@@ -10,6 +10,7 @@ import {
     type ApiAlertAsCodeUpsertResponse,
     type ApiChartAsCodeListResponse,
     type ApiChartAsCodeUpsertResponse,
+    type ApiContentSlugUpdateResponse,
     type ApiDashboardAsCodeListResponse,
     type ApiDashboardAsCodeUpsertResponse,
     type ApiErrorPayload,
@@ -550,6 +551,42 @@ export class ProjectCoderController extends BaseController {
                     spaceNames: chart.spaceNames,
                 },
             ),
+        );
+    }
+
+    /**
+     * Rename a content slug and its references
+     * @summary Update a content slug
+     */
+    @Tags('Projects')
+    @Middlewares(CODE_WRITE_MIDDLEWARES)
+    @SuccessResponse('200', 'Success')
+    @Post('/code/slugs')
+    @OperationId('updateCodeContentSlug')
+    async updateContentSlug(
+        @Path() projectUuid: string,
+        @Body()
+        body: {
+            contentType: ContentAsCodeType;
+            oldSlug: string;
+            newSlug: string;
+            dryRun?: boolean;
+        },
+        @Request() req: express.Request,
+    ): Promise<ApiContentSlugUpdateResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return codeSuccess(
+            await this.services
+                .getCoderService()
+                .updateContentSlug(
+                    toSessionUser(req.account),
+                    projectUuid,
+                    body.contentType,
+                    body.oldSlug,
+                    body.newSlug,
+                    body.dryRun ?? false,
+                ),
         );
     }
 

--- a/packages/backend/src/models/SavedChartModel.slugUpdate.test.ts
+++ b/packages/backend/src/models/SavedChartModel.slugUpdate.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from 'vitest';
+import { getChartSlugRenamePlan } from './SavedChartModel';
+
+const chart = ({
+    uuid,
+    name,
+    slug,
+    deleted = false,
+}: {
+    uuid: string;
+    name: string;
+    slug: string;
+    deleted?: boolean;
+}) => ({
+    saved_query_uuid: uuid,
+    name,
+    slug,
+    deleted_at: deleted ? new Date('2026-01-01') : null,
+});
+
+describe('getChartSlugRenamePlan', () => {
+    test('renames an arbitrary active chart slug', () => {
+        expect(
+            getChartSlugRenamePlan(
+                [
+                    chart({
+                        uuid: 'chart-uuid',
+                        name: 'My chart',
+                        slug: 'my-old-chart-name',
+                    }),
+                ],
+                'my-old-chart-name',
+                'my-amazing-chart',
+            ),
+        ).toEqual([
+            {
+                contentUuid: 'chart-uuid',
+                name: 'My chart',
+                oldSlug: 'my-old-chart-name',
+                newSlug: 'my-amazing-chart',
+            },
+        ]);
+    });
+
+    test('rejects a slug used by an active or deleted chart', () => {
+        const charts = [
+            chart({ uuid: 'source', name: 'Source', slug: 'source' }),
+            chart({
+                uuid: 'deleted',
+                name: 'Deleted',
+                slug: 'reserved',
+                deleted: true,
+            }),
+        ];
+
+        expect(() =>
+            getChartSlugRenamePlan(charts, 'source', 'reserved'),
+        ).toThrow('Chart slug "reserved" is already in use');
+    });
+
+    test('rejects a missing or deleted source chart', () => {
+        expect(() =>
+            getChartSlugRenamePlan(
+                [
+                    chart({
+                        uuid: 'deleted',
+                        name: 'Deleted',
+                        slug: 'old',
+                        deleted: true,
+                    }),
+                ],
+                'old',
+                'new',
+            ),
+        ).toThrow('Active chart with slug "old" was not found');
+    });
+
+    test.each([
+        'Uppercase',
+        'two--hyphens',
+        '-leading',
+        'trailing-',
+        'a'.repeat(256),
+    ])('rejects invalid target slug %s', (newSlug) => {
+        expect(() =>
+            getChartSlugRenamePlan(
+                [chart({ uuid: 'source', name: 'Source', slug: 'source' })],
+                'source',
+                newSlug,
+            ),
+        ).toThrow('Invalid chart slug');
+    });
+
+    test('rejects a no-op rename', () => {
+        expect(() =>
+            getChartSlugRenamePlan(
+                [chart({ uuid: 'source', name: 'Source', slug: 'source' })],
+                'source',
+                'source',
+            ),
+        ).toThrow('Chart already has the slug "source"');
+    });
+});

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -50,6 +50,7 @@ import {
     UpdatedByUser,
     UpdateMultipleSavedChart,
     UpdateSavedChart,
+    type ContentSlugRename,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import { Knex } from 'knex';
@@ -129,6 +130,50 @@ type DbSavedChartDetails = {
     dashboard_uuid: string | null;
     timezone: TimezoneSetting;
     color_palette_uuid: string | null;
+};
+
+type ChartSlugRenameCandidate = Pick<
+    DbSavedChart,
+    'saved_query_uuid' | 'name' | 'slug' | 'deleted_at'
+>;
+
+export const getChartSlugRenamePlan = (
+    charts: ChartSlugRenameCandidate[],
+    oldSlug: string,
+    newSlug: string,
+): ContentSlugRename[] => {
+    if (oldSlug === newSlug) {
+        throw new ParameterError(`Chart already has the slug "${oldSlug}"`);
+    }
+    if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(newSlug) || newSlug.length > 255) {
+        throw new ParameterError(
+            `Invalid chart slug "${newSlug}". Slugs must contain only lowercase letters, numbers, and single hyphens, up to 255 characters`,
+        );
+    }
+
+    const activeChartsBySlug = new Map(
+        charts
+            .filter((chart) => chart.deleted_at === null)
+            .map((chart) => [chart.slug, chart]),
+    );
+    const chart = activeChartsBySlug.get(oldSlug);
+    if (chart === undefined) {
+        throw new NotFoundError(
+            `Active chart with slug "${oldSlug}" was not found`,
+        );
+    }
+    if (charts.some((candidate) => candidate.slug === newSlug)) {
+        throw new ConflictError(`Chart slug "${newSlug}" is already in use`);
+    }
+
+    return [
+        {
+            contentUuid: chart.saved_query_uuid,
+            name: chart.name,
+            oldSlug,
+            newSlug,
+        },
+    ];
 };
 
 const getSavedChartPivotConfig = (
@@ -824,6 +869,44 @@ export class SavedChartModel {
             data,
         );
         return this.get(newSavedChartUuid);
+    }
+
+    async updateChartSlug(
+        projectUuid: string,
+        oldSlug: string,
+        newSlug: string,
+        dryRun: boolean,
+    ): Promise<ContentSlugRename[]> {
+        return this.database.transaction(async (trx) => {
+            await acquireProjectSlugLock(trx, projectUuid, 'update-chart-slug');
+
+            const charts = await trx(SavedChartsTableName)
+                .select<
+                    Array<
+                        Pick<
+                            DbSavedChart,
+                            'saved_query_uuid' | 'name' | 'slug' | 'deleted_at'
+                        >
+                    >
+                >(['saved_query_uuid', 'name', 'slug', 'deleted_at'])
+                .where('project_uuid', projectUuid)
+                .orderBy('slug', 'asc')
+                .forUpdate();
+
+            const changes = getChartSlugRenamePlan(charts, oldSlug, newSlug);
+
+            if (!dryRun && changes.length > 0) {
+                for (const change of changes) {
+                    // eslint-disable-next-line no-await-in-loop
+                    await trx(SavedChartsTableName)
+                        .update({ slug: change.newSlug })
+                        .where('project_uuid', projectUuid)
+                        .where('saved_query_uuid', change.contentUuid);
+                }
+            }
+
+            return changes;
+        });
     }
 
     async createVersion(

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -58,6 +58,7 @@ import {
     isSlackTarget,
     NotFoundError,
     NotificationFrequency,
+    NotSupportedError,
     OrganizationMemberRole,
     ParameterError,
     Project,
@@ -2860,6 +2861,64 @@ export class CoderService extends BaseService {
         );
 
         return promotionChanges;
+    }
+
+    async updateContentSlug(
+        user: SessionUser,
+        projectUuid: string,
+        contentType: ContentAsCodeType,
+        oldSlug: string,
+        newSlug: string,
+        dryRun: boolean,
+    ) {
+        if (contentType !== ContentAsCodeType.CHART) {
+            throw new NotSupportedError(
+                `Slug updates for content type "${contentType}" are not supported yet`,
+            );
+        }
+        const project = await this.projectModel.get(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
+        const { canUploadAnyContent } =
+            CoderService.checkContentAsCodeWriteAccess({
+                auditedAbility,
+                project,
+                slug: oldSlug,
+            });
+
+        const preview = await this.savedChartModel.updateChartSlug(
+            projectUuid,
+            oldSlug,
+            newSlug,
+            true,
+        );
+        if (!canUploadAnyContent && preview.length > 0) {
+            const charts = await this.savedChartModel.find({
+                projectUuid,
+                slugs: preview.map((change) => change.oldSlug),
+                excludeChartsSavedInDashboard: false,
+                includeOrphanChartsWithinDashboard: true,
+            });
+            const spaceUuids = charts.map((chart) => chart.spaceUuid);
+            await this.assertSpaceContentAccess({
+                userUuid: user.userUuid,
+                auditedAbility,
+                action: 'update',
+                subjectType: 'SavedChart',
+                spaceUuids,
+                errorMessage: `You don't have access to update chart "${oldSlug}"`,
+            });
+        }
+
+        return {
+            changes: dryRun
+                ? preview
+                : await this.savedChartModel.updateChartSlug(
+                      projectUuid,
+                      oldSlug,
+                      newSlug,
+                      false,
+                  ),
+        };
     }
 
     async upsertSqlChart(

--- a/packages/cli/src/handlers/slugUpdate.test.ts
+++ b/packages/cli/src/handlers/slugUpdate.test.ts
@@ -1,0 +1,423 @@
+import { ContentAsCodeType, LightdashError } from '@lightdash/common';
+import { promises as fs } from 'fs';
+import { tmpdir } from 'os';
+import * as path from 'path';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { parse } from 'yaml';
+import * as apiClient from './dbt/apiClient';
+import {
+    applyLocalChartSlugUpdates,
+    planLocalChartSlugUpdates,
+    requestSlugUpdate,
+} from './slugUpdate';
+
+const temporaryDirectories: string[] = [];
+
+const createTemporaryContent = async (): Promise<string> => {
+    const root = await fs.mkdtemp(path.join(tmpdir(), 'slug-update-'));
+    temporaryDirectories.push(root);
+    await Promise.all(
+        ['charts', 'dashboards', 'alerts'].map((folder) =>
+            fs.mkdir(path.join(root, folder), { recursive: true }),
+        ),
+    );
+    return root;
+};
+
+afterEach(async () => {
+    vi.restoreAllMocks();
+    await Promise.all(
+        temporaryDirectories
+            .splice(0)
+            .map((directory) =>
+                fs.rm(directory, { recursive: true, force: true }),
+            ),
+    );
+});
+
+describe('local chart slug updates', () => {
+    test('updates chart files, dashboard and scheduled references, filenames, and metadata', async () => {
+        const root = await createTemporaryContent();
+        const chartFile = path.join(root, 'charts', 'copy-of-orders.yml');
+        const languageMapFile = path.join(
+            root,
+            'charts',
+            'copy-of-orders.language.map.yml',
+        );
+        const dashboardFile = path.join(root, 'dashboards', 'overview.yml');
+        const alertFile = path.join(root, 'alerts', 'orders-alert.yml');
+        await Promise.all([
+            fs.writeFile(
+                chartFile,
+                'contentType: chart\nslug: copy-of-orders\nname: Orders\nmetricQuery: {}\n',
+            ),
+            fs.writeFile(languageMapFile, 'name: Orders\n'),
+            fs.writeFile(
+                dashboardFile,
+                'contentType: dashboard\nslug: overview\ntiles:\n  - type: saved_chart\n    properties:\n      chartSlug: copy-of-orders\n',
+            ),
+            fs.writeFile(
+                alertFile,
+                'contentType: alert\nslug: orders-alert\nresource:\n  type: chart\n  slug: copy-of-orders\n',
+            ),
+            fs.writeFile(
+                path.join(root, '.lightdash-metadata.json'),
+                JSON.stringify({
+                    version: 1,
+                    charts: {
+                        'copy-of-orders': '2026-07-30T10:00:00.000Z',
+                    },
+                    dashboards: {},
+                }),
+            ),
+        ]);
+
+        const plan = await planLocalChartSlugUpdates(root, [
+            {
+                contentUuid: 'chart-uuid',
+                name: 'Orders',
+                oldSlug: 'copy-of-orders',
+                newSlug: 'orders',
+            },
+        ]);
+        expect(plan.referencesUpdated).toBe(3);
+        expect(plan.fileMoves).toHaveLength(2);
+
+        await applyLocalChartSlugUpdates(plan);
+
+        await expect(fs.access(chartFile)).rejects.toThrow();
+        await expect(fs.access(languageMapFile)).rejects.toThrow();
+        expect(
+            parse(
+                await fs.readFile(
+                    path.join(root, 'charts', 'orders.yml'),
+                    'utf8',
+                ),
+            ).slug,
+        ).toBe('orders');
+        expect(
+            parse(await fs.readFile(dashboardFile, 'utf8')).tiles[0].properties
+                .chartSlug,
+        ).toBe('orders');
+        expect(parse(await fs.readFile(alertFile, 'utf8')).resource.slug).toBe(
+            'orders',
+        );
+        const metadata = JSON.parse(
+            await fs.readFile(
+                path.join(root, '.lightdash-metadata.json'),
+                'utf8',
+            ),
+        );
+        expect(metadata.charts).toEqual({
+            orders: '2026-07-30T10:00:00.000Z',
+        });
+    });
+
+    test('rejects a local filename collision before changing files', async () => {
+        const root = await createTemporaryContent();
+        await Promise.all([
+            fs.writeFile(
+                path.join(root, 'charts', 'copy-of-orders.yml'),
+                'contentType: chart\nslug: copy-of-orders\nname: Orders\nmetricQuery: {}\n',
+            ),
+            fs.writeFile(
+                path.join(root, 'charts', 'orders.yml'),
+                'contentType: chart\nslug: another-chart\nname: Another chart\nmetricQuery: {}\n',
+            ),
+        ]);
+
+        await expect(
+            planLocalChartSlugUpdates(root, [
+                {
+                    contentUuid: 'chart-uuid',
+                    name: 'Orders',
+                    oldSlug: 'copy-of-orders',
+                    newSlug: 'orders',
+                },
+            ]),
+        ).rejects.toThrow('already exists');
+    });
+
+    test('supports legacy yaml files without changing SQL chart or unrelated content', async () => {
+        const root = await createTemporaryContent();
+        const chartFile = path.join(root, 'charts', 'copy-of-orders.yaml');
+        const dashboardFile = path.join(root, 'dashboards', 'overview.yaml');
+        const unrelatedFile = path.join(root, 'dashboards', 'unrelated.yml');
+        const unrelatedSource =
+            '# This file must remain byte-identical\ncontentType: dashboard\nslug: unrelated\ntiles: []\n';
+        await Promise.all([
+            fs.writeFile(
+                chartFile,
+                '# Keep this chart comment\ncontentType: chart\nslug: copy-of-orders\nname: Orders\nmetricQuery: {}\n',
+            ),
+            fs.writeFile(
+                dashboardFile,
+                [
+                    '# Legacy dashboard with a tab UUID',
+                    'contentType: dashboard',
+                    'slug: overview',
+                    'tiles:',
+                    '  - type: saved_chart',
+                    '    tabUuid: legacy-tab',
+                    '    properties:',
+                    '      chartSlug: copy-of-orders',
+                    '  - type: sql_chart',
+                    '    properties:',
+                    '      chartSlug: copy-of-orders',
+                    '  - type: saved_chart',
+                    '    properties:',
+                    '      chartSlug: null',
+                    '',
+                ].join('\n'),
+            ),
+            fs.writeFile(unrelatedFile, unrelatedSource),
+        ]);
+
+        const plan = await planLocalChartSlugUpdates(root, [
+            {
+                contentUuid: 'chart-uuid',
+                name: 'Orders',
+                oldSlug: 'copy-of-orders',
+                newSlug: 'orders',
+            },
+        ]);
+        await applyLocalChartSlugUpdates(plan);
+
+        const renamedChartFile = path.join(root, 'charts', 'orders.yaml');
+        const dashboardSource = await fs.readFile(dashboardFile, 'utf8');
+        const dashboard = parse(dashboardSource);
+        expect(await fs.readFile(renamedChartFile, 'utf8')).toContain(
+            '# Keep this chart comment',
+        );
+        expect(dashboardSource).toContain('# Legacy dashboard with a tab UUID');
+        expect(dashboard.tiles[0]).toMatchObject({
+            tabUuid: 'legacy-tab',
+            properties: { chartSlug: 'orders' },
+        });
+        expect(dashboard.tiles[1].properties.chartSlug).toBe('copy-of-orders');
+        expect(dashboard.tiles[2].properties.chartSlug).toBeNull();
+        expect(await fs.readFile(unrelatedFile, 'utf8')).toBe(unrelatedSource);
+    });
+
+    test('preserves metadata values through chained slug renames', async () => {
+        const root = await createTemporaryContent();
+        await Promise.all([
+            fs.writeFile(
+                path.join(root, 'charts', 'copy-of-a.yml'),
+                'contentType: chart\nslug: copy-of-a\nname: A\nmetricQuery: {}\n',
+            ),
+            fs.writeFile(
+                path.join(root, 'charts', 'copy-of-b.yml'),
+                'contentType: chart\nslug: copy-of-b\nname: B\nmetricQuery: {}\n',
+            ),
+            fs.writeFile(
+                path.join(root, '.lightdash-metadata.json'),
+                JSON.stringify({
+                    version: 1,
+                    charts: {
+                        'copy-of-a': 'timestamp-a',
+                        'copy-of-b': 'timestamp-b',
+                    },
+                    dashboards: { overview: 'dashboard-timestamp' },
+                }),
+            ),
+        ]);
+
+        const plan = await planLocalChartSlugUpdates(root, [
+            {
+                contentUuid: 'a',
+                name: 'A',
+                oldSlug: 'copy-of-a',
+                newSlug: 'copy-of-b',
+            },
+            {
+                contentUuid: 'b',
+                name: 'B',
+                oldSlug: 'copy-of-b',
+                newSlug: 'b',
+            },
+        ]);
+        await applyLocalChartSlugUpdates(plan);
+
+        expect(
+            parse(
+                await fs.readFile(
+                    path.join(root, 'charts', 'copy-of-b.yml'),
+                    'utf8',
+                ),
+            ).name,
+        ).toBe('A');
+        expect(
+            parse(await fs.readFile(path.join(root, 'charts', 'b.yml'), 'utf8'))
+                .name,
+        ).toBe('B');
+        const metadata = JSON.parse(
+            await fs.readFile(
+                path.join(root, '.lightdash-metadata.json'),
+                'utf8',
+            ),
+        );
+        expect(metadata).toEqual({
+            version: 1,
+            charts: {
+                'copy-of-b': 'timestamp-a',
+                b: 'timestamp-b',
+            },
+            dashboards: { overview: 'dashboard-timestamp' },
+        });
+    });
+
+    test('is idempotent after files have already been updated', async () => {
+        const root = await createTemporaryContent();
+        await fs.writeFile(
+            path.join(root, 'charts', 'copy-of-orders.yml'),
+            'contentType: chart\nslug: copy-of-orders\nname: Orders\nmetricQuery: {}\n',
+        );
+        const changes = [
+            {
+                contentUuid: 'chart-uuid',
+                name: 'Orders',
+                oldSlug: 'copy-of-orders',
+                newSlug: 'orders',
+            },
+        ];
+
+        await applyLocalChartSlugUpdates(
+            await planLocalChartSlugUpdates(root, changes),
+        );
+        const firstResult = await fs.readFile(
+            path.join(root, 'charts', 'orders.yml'),
+            'utf8',
+        );
+        const secondPlan = await planLocalChartSlugUpdates(root, changes);
+        expect(secondPlan).toMatchObject({
+            fileUpdates: [],
+            fileMoves: [],
+            metadata: undefined,
+            referencesUpdated: 0,
+        });
+        await applyLocalChartSlugUpdates(secondPlan);
+        expect(
+            await fs.readFile(path.join(root, 'charts', 'orders.yml'), 'utf8'),
+        ).toBe(firstResult);
+    });
+
+    test('restores every file and removes staging files when a move fails', async () => {
+        const root = await createTemporaryContent();
+        const chartFile = path.join(root, 'charts', 'copy-of-orders.yml');
+        const dashboardFile = path.join(root, 'dashboards', 'overview.yml');
+        const chartSource =
+            'contentType: chart\nslug: copy-of-orders\nname: Orders\nmetricQuery: {}\n';
+        const dashboardSource =
+            'contentType: dashboard\nslug: overview\ntiles:\n  - type: saved_chart\n    properties:\n      chartSlug: copy-of-orders\n';
+        await Promise.all([
+            fs.writeFile(chartFile, chartSource),
+            fs.writeFile(dashboardFile, dashboardSource),
+        ]);
+        const plan = await planLocalChartSlugUpdates(root, [
+            {
+                contentUuid: 'chart-uuid',
+                name: 'Orders',
+                oldSlug: 'copy-of-orders',
+                newSlug: 'orders',
+            },
+        ]);
+        vi.spyOn(fs, 'rename').mockImplementationOnce(async () => {
+            throw new Error('simulated move failure');
+        });
+
+        await expect(applyLocalChartSlugUpdates(plan)).rejects.toThrow(
+            'simulated move failure',
+        );
+        expect(await fs.readFile(chartFile, 'utf8')).toBe(chartSource);
+        expect(await fs.readFile(dashboardFile, 'utf8')).toBe(dashboardSource);
+        await expect(
+            fs.access(path.join(root, 'charts', 'orders.yml')),
+        ).rejects.toThrow();
+        expect(
+            (await fs.readdir(path.join(root, 'charts'))).some((file) =>
+                file.includes('.slug-update-'),
+            ),
+        ).toBe(false);
+    });
+});
+
+describe('content slug update API', () => {
+    test('sends the generic content type and explicit slug mapping', async () => {
+        const changes = [
+            {
+                contentUuid: 'chart-uuid',
+                name: 'My chart',
+                oldSlug: 'my-old-chart-name',
+                newSlug: 'my-amazing-chart',
+            },
+        ];
+        const api = vi
+            .spyOn(apiClient, 'lightdashApi')
+            .mockResolvedValue({ changes });
+
+        await expect(
+            requestSlugUpdate(
+                'project-uuid',
+                ContentAsCodeType.CHART,
+                'my-old-chart-name',
+                'my-amazing-chart',
+                true,
+            ),
+        ).resolves.toEqual(changes);
+        expect(api).toHaveBeenCalledWith({
+            method: 'POST',
+            url: '/api/v1/projects/project-uuid/code/slugs',
+            body: JSON.stringify({
+                contentType: ContentAsCodeType.CHART,
+                oldSlug: 'my-old-chart-name',
+                newSlug: 'my-amazing-chart',
+                dryRun: true,
+            }),
+        });
+    });
+
+    test('explains when the connected server does not support slug-update', async () => {
+        vi.spyOn(apiClient, 'lightdashApi').mockRejectedValue(
+            new LightdashError({
+                message: 'API endpoint not found',
+                name: 'NotFoundError',
+                statusCode: 404,
+                data: {},
+            }),
+        );
+
+        await expect(
+            requestSlugUpdate(
+                'project-uuid',
+                ContentAsCodeType.CHART,
+                'old-slug',
+                'new-slug',
+                true,
+            ),
+        ).rejects.toThrow(
+            'This Lightdash server does not support slug-update yet',
+        );
+    });
+
+    test('preserves other API not-found errors', async () => {
+        vi.spyOn(apiClient, 'lightdashApi').mockRejectedValue(
+            new LightdashError({
+                message: 'Project not found',
+                name: 'NotFoundError',
+                statusCode: 404,
+                data: {},
+            }),
+        );
+
+        await expect(
+            requestSlugUpdate(
+                'project-uuid',
+                ContentAsCodeType.CHART,
+                'old-slug',
+                'new-slug',
+                true,
+            ),
+        ).rejects.toThrow('Project not found');
+    });
+});

--- a/packages/cli/src/handlers/slugUpdate.ts
+++ b/packages/cli/src/handlers/slugUpdate.ts
@@ -1,0 +1,433 @@
+import {
+    AuthorizationError,
+    ContentAsCodeType,
+    LightdashError,
+    ParameterError,
+    type ApiContentSlugUpdateResponse,
+    type ContentSlugRename,
+} from '@lightdash/common';
+import { promises as fs } from 'fs';
+import inquirer from 'inquirer';
+import * as path from 'path';
+import { parseDocument } from 'yaml';
+import { getConfig } from '../config';
+import GlobalState from '../globalState';
+import * as styles from '../styles';
+import { getDownloadFolder } from './contentAsCodePaths';
+import { checkLightdashVersion, lightdashApi } from './dbt/apiClient';
+import { METADATA_FILENAME, readMetadataFile } from './metadataFile';
+import { logSelectedProject, selectProject } from './selectProject';
+
+type SlugUpdateOptions = {
+    verbose: boolean;
+    project?: string;
+    path?: string;
+    type: string;
+    from: string;
+    to: string;
+    dryRun: boolean;
+    assumeYes: boolean;
+};
+
+type LocalSlugUpdatePlan = {
+    fileUpdates: Array<{ filePath: string; content: string }>;
+    fileMoves: Array<{ source: string; target: string }>;
+    metadata:
+        | {
+              root: string;
+              charts: Record<string, string>;
+          }
+        | undefined;
+    referencesUpdated: number;
+};
+
+const getYamlFiles = async (root: string): Promise<string[]> => {
+    try {
+        const entries = await fs.readdir(root, {
+            recursive: true,
+            withFileTypes: true,
+        });
+        return entries
+            .filter(
+                (entry) =>
+                    entry.isFile() &&
+                    (entry.name.endsWith('.yml') ||
+                        entry.name.endsWith('.yaml')) &&
+                    !entry.name.endsWith('.language.map.yml') &&
+                    !entry.name.endsWith('.language.map.yaml'),
+            )
+            .map((entry) => path.join(entry.parentPath ?? root, entry.name));
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            return [];
+        }
+        throw error;
+    }
+};
+
+const assertMovesAreSafe = async (
+    moves: LocalSlugUpdatePlan['fileMoves'],
+): Promise<void> => {
+    const sources = new Set(moves.map(({ source }) => source));
+    const targets = new Set<string>();
+    for (const { target } of moves) {
+        if (targets.has(target)) {
+            throw new ParameterError(
+                `Multiple content files would be renamed to "${target}"`,
+            );
+        }
+        targets.add(target);
+        try {
+            // eslint-disable-next-line no-await-in-loop
+            await fs.access(target);
+            if (!sources.has(target)) {
+                throw new ParameterError(
+                    `Cannot rename content file because "${target}" already exists`,
+                );
+            }
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+                throw error;
+            }
+        }
+    }
+};
+
+export const planLocalChartSlugUpdates = async (
+    customPath: string | undefined,
+    changes: ContentSlugRename[],
+): Promise<LocalSlugUpdatePlan> => {
+    const root = getDownloadFolder(customPath);
+    const changesByOldSlug = new Map(
+        changes.map((change) => [change.oldSlug, change]),
+    );
+    const fileUpdates: LocalSlugUpdatePlan['fileUpdates'] = [];
+    const fileMoves: LocalSlugUpdatePlan['fileMoves'] = [];
+    let referencesUpdated = 0;
+
+    const yamlFiles = await getYamlFiles(root);
+    for (const filePath of yamlFiles) {
+        // eslint-disable-next-line no-await-in-loop
+        const source = await fs.readFile(filePath, 'utf8');
+        const document = parseDocument(source);
+        if (document.errors.length > 0) {
+            throw new ParameterError(
+                `Could not parse "${filePath}": ${document.errors
+                    .map(({ message }) => message)
+                    .join('; ')}`,
+            );
+        }
+
+        let changed = false;
+        const parsed = document.toJS() as {
+            slug?: unknown;
+            contentType?: unknown;
+            metricQuery?: unknown;
+            tiles?: Array<{
+                type?: unknown;
+                properties?: { chartSlug?: unknown };
+            }>;
+            resource?: { type?: unknown; slug?: unknown };
+        };
+        const { slug, contentType } = parsed;
+        const isChart =
+            contentType === 'chart' || parsed.metricQuery !== undefined;
+        if (isChart && typeof slug === 'string') {
+            const rename = changesByOldSlug.get(slug);
+            if (rename) {
+                document.set('slug', rename.newSlug);
+                referencesUpdated += 1;
+                changed = true;
+
+                const extension = path.extname(filePath);
+                const oldFileName = `${rename.oldSlug}${extension}`;
+                if (path.basename(filePath) === oldFileName) {
+                    fileMoves.push({
+                        source: filePath,
+                        target: path.join(
+                            path.dirname(filePath),
+                            `${rename.newSlug}${extension}`,
+                        ),
+                    });
+                    for (const languageMapExtension of ['.yml', '.yaml']) {
+                        const oldLanguageMap = path.join(
+                            path.dirname(filePath),
+                            `${rename.oldSlug}.language.map${languageMapExtension}`,
+                        );
+                        try {
+                            // eslint-disable-next-line no-await-in-loop
+                            await fs.access(oldLanguageMap);
+                            fileMoves.push({
+                                source: oldLanguageMap,
+                                target: path.join(
+                                    path.dirname(filePath),
+                                    `${rename.newSlug}.language.map${languageMapExtension}`,
+                                ),
+                            });
+                        } catch (error) {
+                            if (
+                                (error as NodeJS.ErrnoException).code !==
+                                'ENOENT'
+                            ) {
+                                throw error;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        const { tiles } = parsed;
+        if (Array.isArray(tiles)) {
+            for (const [index, tile] of tiles.entries()) {
+                const oldSlug = tile.properties?.chartSlug;
+                if (
+                    tile.type === 'saved_chart' &&
+                    typeof oldSlug === 'string'
+                ) {
+                    const rename = changesByOldSlug.get(oldSlug);
+                    if (rename) {
+                        document.setIn(
+                            ['tiles', index, 'properties', 'chartSlug'],
+                            rename.newSlug,
+                        );
+                        referencesUpdated += 1;
+                        changed = true;
+                    }
+                }
+            }
+        }
+
+        if (parsed.resource?.type === 'chart') {
+            const oldSlug = parsed.resource.slug;
+            if (typeof oldSlug === 'string') {
+                const rename = changesByOldSlug.get(oldSlug);
+                if (rename) {
+                    document.setIn(['resource', 'slug'], rename.newSlug);
+                    referencesUpdated += 1;
+                    changed = true;
+                }
+            }
+        }
+
+        if (changed) {
+            fileUpdates.push({ filePath, content: document.toString() });
+        }
+    }
+
+    const metadata = await readMetadataFile(root);
+    let metadataChanged = false;
+    const updatedChartMetadata = { ...metadata.charts };
+    changes.forEach(({ oldSlug }) => {
+        if (oldSlug in metadata.charts) {
+            delete updatedChartMetadata[oldSlug];
+            metadataChanged = true;
+        }
+    });
+    changes.forEach(({ oldSlug, newSlug }) => {
+        if (oldSlug in metadata.charts) {
+            updatedChartMetadata[newSlug] = metadata.charts[oldSlug];
+        }
+    });
+
+    await assertMovesAreSafe(fileMoves);
+    return {
+        fileUpdates,
+        fileMoves,
+        metadata: metadataChanged
+            ? { root, charts: updatedChartMetadata }
+            : undefined,
+        referencesUpdated,
+    };
+};
+
+export const applyLocalChartSlugUpdates = async (
+    plan: LocalSlugUpdatePlan,
+): Promise<void> => {
+    const metadataPath = plan.metadata
+        ? path.join(plan.metadata.root, METADATA_FILENAME)
+        : undefined;
+    const affectedPaths = new Set([
+        ...plan.fileUpdates.map(({ filePath }) => filePath),
+        ...plan.fileMoves.flatMap(({ source, target }) => [source, target]),
+        ...(metadataPath ? [metadataPath] : []),
+    ]);
+    const snapshots = new Map<string, Buffer | undefined>();
+    for (const filePath of affectedPaths) {
+        try {
+            // eslint-disable-next-line no-await-in-loop
+            snapshots.set(filePath, await fs.readFile(filePath));
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+                throw error;
+            }
+            snapshots.set(filePath, undefined);
+        }
+    }
+
+    const stagedMoves: Array<{ temporary: string; target: string }> = [];
+    try {
+        await Promise.all(
+            plan.fileUpdates.map(({ filePath, content }) =>
+                fs.writeFile(filePath, content),
+            ),
+        );
+
+        for (const [index, move] of plan.fileMoves.entries()) {
+            const temporary = `${move.source}.slug-update-${process.pid}-${index}`;
+            // eslint-disable-next-line no-await-in-loop
+            await fs.rename(move.source, temporary);
+            stagedMoves.push({ temporary, target: move.target });
+        }
+        for (const move of stagedMoves) {
+            // eslint-disable-next-line no-await-in-loop
+            await fs.rename(move.temporary, move.target);
+        }
+
+        if (plan.metadata && metadataPath) {
+            const existing = await readMetadataFile(plan.metadata.root);
+            await fs.writeFile(
+                metadataPath,
+                JSON.stringify(
+                    {
+                        ...existing,
+                        charts: plan.metadata.charts,
+                    },
+                    null,
+                    2,
+                ),
+            );
+        }
+    } catch (error) {
+        await Promise.all(
+            stagedMoves.map(({ temporary }) =>
+                fs.rm(temporary, { force: true }),
+            ),
+        );
+        await Promise.all(
+            [...snapshots].map(([filePath, content]) =>
+                content === undefined
+                    ? fs.rm(filePath, { force: true })
+                    : fs.writeFile(filePath, content),
+            ),
+        );
+        throw error;
+    }
+};
+
+export const requestSlugUpdate = async (
+    projectUuid: string,
+    contentType: ContentAsCodeType,
+    oldSlug: string,
+    newSlug: string,
+    dryRun: boolean,
+): Promise<ContentSlugRename[]> => {
+    try {
+        return (
+            await lightdashApi<ApiContentSlugUpdateResponse['results']>({
+                method: 'POST',
+                url: `/api/v1/projects/${projectUuid}/code/slugs`,
+                body: JSON.stringify({
+                    contentType,
+                    oldSlug,
+                    newSlug,
+                    dryRun,
+                }),
+            })
+        ).changes;
+    } catch (error) {
+        if (
+            error instanceof LightdashError &&
+            error.statusCode === 404 &&
+            error.message === 'API endpoint not found'
+        ) {
+            throw new ParameterError(
+                'This Lightdash server does not support slug-update yet. Upgrade the server to a version that includes the content slug update endpoint, or restart the local API from the same branch as this CLI.',
+            );
+        }
+        throw error;
+    }
+};
+
+export const slugUpdateHandler = async (
+    options: SlugUpdateOptions,
+): Promise<void> => {
+    GlobalState.setVerbose(options.verbose);
+    await checkLightdashVersion();
+    if (options.type !== ContentAsCodeType.CHART) {
+        throw new ParameterError(
+            `Content type "${options.type}" is not supported yet. Currently supported: chart`,
+        );
+    }
+    const config = await getConfig();
+    if (!config.context?.apiKey || !config.context.serverUrl) {
+        throw new AuthorizationError(
+            `Not logged in. Run 'lightdash login --help'`,
+        );
+    }
+
+    const selection = await selectProject(config, options.project);
+    if (!selection) {
+        throw new ParameterError(
+            'No project selected. Run lightdash config set-project',
+        );
+    }
+    logSelectedProject(selection, config, 'Updating chart slugs in');
+
+    const contentType = ContentAsCodeType.CHART;
+    const preview = await requestSlugUpdate(
+        selection.projectUuid,
+        contentType,
+        options.from,
+        options.to,
+        true,
+    );
+
+    const localPreview = await planLocalChartSlugUpdates(options.path, preview);
+    preview.forEach(({ oldSlug, newSlug }) =>
+        console.info(`${oldSlug} -> ${newSlug}`),
+    );
+    console.info(
+        `\n${localPreview.referencesUpdated} local slug value(s), ${localPreview.fileMoves.length} file rename(s)`,
+    );
+
+    if (options.dryRun) {
+        console.info(
+            styles.warning(
+                'Dry run only: Lightdash and local files were not changed.',
+            ),
+        );
+        return;
+    }
+
+    if (!options.assumeYes) {
+        const { confirmed } = await inquirer.prompt<{ confirmed: boolean }>([
+            {
+                type: 'confirm',
+                name: 'confirmed',
+                message:
+                    'Rename this chart slug in Lightdash and update local content-as-code files?',
+                default: false,
+            },
+        ]);
+        if (!confirmed) {
+            console.info('Aborting slug update.');
+            return;
+        }
+    }
+
+    const applied = await requestSlugUpdate(
+        selection.projectUuid,
+        contentType,
+        options.from,
+        options.to,
+        false,
+    );
+    const localPlan = await planLocalChartSlugUpdates(options.path, applied);
+    await applyLocalChartSlugUpdates(localPlan);
+    console.info(
+        styles.success(
+            `Updated ${applied.length} chart slug(s) and ${localPlan.referencesUpdated} local slug value(s).`,
+        ),
+    );
+};

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -45,6 +45,7 @@ import { renameProjectHandler } from './handlers/renameProject';
 import { runChartHandler } from './handlers/runChart';
 import { setProjectHandler, unsetProjectHandler } from './handlers/setProject';
 import { setWarehouseHandler } from './handlers/setWarehouse';
+import { slugUpdateHandler } from './handlers/slugUpdate';
 import { sqlHandler } from './handlers/sql';
 import { validateHandler } from './handlers/validate';
 import { warehouseCatalogHandler } from './handlers/warehouseCatalog';
@@ -1417,6 +1418,35 @@ program
     .option('--list', 'List all charts and dashboards that are renamed', false)
 
     .action(renameHandler);
+
+program
+    .command('slug-update')
+    .description('Rename a content slug and update its local references')
+    .option('--verbose', undefined, false)
+    .option(
+        '-p, --project <project uuid>',
+        'specify a project UUID',
+        parseProjectArgument,
+        undefined,
+    )
+    .option(
+        '--path <path>',
+        'specify the local content-as-code path to update',
+        undefined,
+    )
+    .requiredOption(
+        '-t, --type <type>',
+        'content type to rename (currently: chart)',
+    )
+    .requiredOption('--from <slug>', 'current content slug')
+    .requiredOption('--to <slug>', 'new content slug')
+    .option(
+        '--dry-run',
+        'show slug and file changes without applying them',
+        false,
+    )
+    .option('-y, --assume-yes', 'apply without confirmation', false)
+    .action(slugUpdateHandler);
 
 program
     .command('generate-exposures')

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -134,6 +134,7 @@ import {
     type ApiAlertAsCodeUpsertResponse,
     type ApiChartAsCodeListResponse,
     type ApiChartAsCodeUpsertResponse,
+    type ApiContentSlugUpdateResponse,
     type ApiDashboardAsCodeListResponse,
     type ApiGoogleSheetsSyncAsCodeListResponse,
     type ApiGoogleSheetsSyncAsCodeUpsertResponse,
@@ -1230,6 +1231,7 @@ type ApiResults =
     | ApiSpaceAsCodeListResponse['results']
     | ApiSpaceAsCodeUpsertResponse['results']
     | ApiChartAsCodeUpsertResponse['results']
+    | ApiContentSlugUpdateResponse['results']
     | ApiGetMetricsTree['results']
     | ApiGetMetricsTreeResponse['results']
     | ApiGetMetricsTreesResponse['results']

--- a/packages/common/src/types/contentAsCode/index.ts
+++ b/packages/common/src/types/contentAsCode/index.ts
@@ -4,5 +4,6 @@ export * from './core';
 export * from './dashboards';
 export * from './parsers';
 export * from './scheduledContent';
+export * from './slugs';
 export * from './spaces';
 export * from './virtualViews';

--- a/packages/common/src/types/contentAsCode/slugs.ts
+++ b/packages/common/src/types/contentAsCode/slugs.ts
@@ -1,0 +1,13 @@
+export type ContentSlugRename = {
+    contentUuid: string;
+    name: string;
+    oldSlug: string;
+    newSlug: string;
+};
+
+export type ApiContentSlugUpdateResponse = {
+    status: 'ok';
+    results: {
+        changes: ContentSlugRename[];
+    };
+};


### PR DESCRIPTION
## Summary

- add a generic project-scoped `POST /code/slugs` API contract with explicit content type, old slug, new slug, and dry-run inputs
- implement transactional saved-chart slug renames; other content types return a clear not-supported error for now
- add `lightdash slug-update --type chart --from <old> --to <new>` with preview, confirmation, and non-interactive modes
- update chart YAML, saved-chart dashboard references, scheduled-content chart resources, language-map filenames, and `.lightdash-metadata.json`
- support `.yml` and `.yaml`, collision/format validation, and rollback of local writes on filesystem failure

## Validation

- performed a real arbitrary chart rename and rename-back against local Lightdash
- each rename updated 15 local slug values and renamed 1 chart file
- re-uploaded after both directions; each upload reported 1 chart updated and 0 created, proving no duplicate was introduced
- verified collision rejection against an existing chart slug and a clear unsupported-type error for dashboard
- parsed all 457 YAML files after the round trip with no errors, temporary slug text, or staging files
- ran focused backend slug validation tests (9 passing)
- ran focused CLI API/filesystem/reference/rollback tests (9 passing)
- ran common, CLI, and backend TypeScript builds/typechecks
- ran targeted backend/CLI lint, formatting, generated API, and diff checks

## Compatibility and security

- the command is explicit-only; there is no copy-specific discovery or automatic naming behavior
- the API contract is content-generic, while this initial implementation intentionally supports only `chart`
- occupied slugs include soft-deleted charts, preventing accidental reuse
- saved SQL chart tiles are not rewritten when they share a slug with a saved chart
- existing comments and unrelated YAML remain untouched; local apply restores files and metadata on failure
- content-as-code and per-space chart update permissions are checked before mutation
- server updates are project-scoped and transactional; no migration or feature flag is required

Closes: SPK-736
Relates: #14578