### PR TITLE
fix: quote AI writeback project paths in shell commands

### DIFF
--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -144,6 +144,7 @@ import {
     parsePullNumber,
     parsePullRequestUrl,
     progressTextForStage,
+    quoteShellArgument,
     resolvePrMetadataValue,
     resolveSandboxDbtVersion,
     resolveSandboxTemplateRef,
@@ -3422,7 +3423,7 @@ export class AiWritebackService extends BaseService {
             const base =
                 projectSubPath === '.' ? CWD : `${CWD}/${projectSubPath}`;
             const found = await sandbox.commands.run(
-                `find ${base} -maxdepth 2 -name profiles.yml 2>/dev/null | head -1`,
+                `find ${quoteShellArgument(base)} -maxdepth 2 -name profiles.yml 2>/dev/null | head -1`,
                 { cwd: CWD },
             );
             const profilesPath = found.stdout.trim();
@@ -3904,7 +3905,7 @@ export class AiWritebackService extends BaseService {
         // resolve, and we're no worse off than before this ran.
         try {
             await sandbox.commands.run(
-                `env ${unsetFlags} PATH="${dbtBin}:$PATH" dbt deps --project-dir ${JSON.stringify(
+                `env ${unsetFlags} PATH="${dbtBin}:$PATH" dbt deps --project-dir ${quoteShellArgument(
                     `${CWD}/${turn.gitConnection.projectSubPath}`,
                 )}`,
             );
@@ -3917,9 +3918,11 @@ export class AiWritebackService extends BaseService {
             // `dbt_packages/` stays installed, so compile is unaffected.
             const lockfile = `${turn.gitConnection.projectSubPath}/package-lock.yml`;
             await sandbox.commands.run(
-                `git -C ${CWD} checkout -- ${JSON.stringify(
+                `git -C ${CWD} checkout -- ${quoteShellArgument(
                     lockfile,
-                )} 2>/dev/null || rm -f ${JSON.stringify(`${CWD}/${lockfile}`)}`,
+                )} 2>/dev/null || rm -f ${quoteShellArgument(
+                    `${CWD}/${lockfile}`,
+                )}`,
             );
         } catch (error) {
             this.logger.warn(

--- a/packages/backend/src/ee/services/AiWritebackService/providers/sandboxGit.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/providers/sandboxGit.ts
@@ -5,7 +5,7 @@ import type { SandboxHandle } from '../../SandboxRuntime';
 import { CWD } from '../constants';
 import { DeniedPathError, findDeniedCommitPaths } from '../deniedPaths';
 import type { GitCommitAuthor } from '../types';
-import { parseGitNameStatus } from '../utils';
+import { parseGitNameStatus, quoteShellArgument } from '../utils';
 
 // Default dbt package install directory, relative to the project dir. Overridable
 // in dbt_project.yml via `packages-install-path`; see resolveDbtProjectPaths.
@@ -139,10 +139,13 @@ export const resolveDbtProjectPaths = async (
     // inside the repo. Vendored hub packages are real dirs (`-L` fails) and are
     // skipped. All interpolated values are charset-validated above.
     const packageList = [...packageNames].join(' ');
+    const packagesDirectory = quoteShellArgument(
+        `${CWD}/${projectSubPath}/${installPath}/`,
+    );
     const script = [
         `cwd_real=$(readlink -f ${JSON.stringify(CWD)})`,
         `for p in ${packageList}; do`,
-        `  link="${CWD}/${projectSubPath}/${installPath}/$p"`,
+        `  link=${packagesDirectory}$p`,
         `  [ -L "$link" ] || continue`,
         `  real=$(readlink -f "$link" 2>/dev/null) || continue`,
         `  [ -n "$real" ] || continue`,

--- a/packages/backend/src/ee/services/AiWritebackService/scripts.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/scripts.test.ts
@@ -1,0 +1,40 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildGatherRepoContextScript } from './scripts';
+
+describe('buildGatherRepoContextScript', () => {
+    const temporaryDirectories: string[] = [];
+
+    afterEach(() => {
+        temporaryDirectories.forEach((directory) =>
+            rmSync(directory, { recursive: true, force: true }),
+        );
+        temporaryDirectories.length = 0;
+    });
+
+    it.each(['dbt/$(printf evaluated)', "dbt/team's models"])(
+        'treats the project subpath %s as a literal shell argument',
+        (projectSubPath) => {
+            const repository = mkdtempSync(join(tmpdir(), 'ai-writeback-'));
+            temporaryDirectories.push(repository);
+            const projectDirectory = join(repository, projectSubPath);
+            mkdirSync(projectDirectory, { recursive: true });
+            writeFileSync(join(projectDirectory, 'model.sql'), 'select 1');
+
+            const output = execFileSync(
+                'bash',
+                ['-c', buildGatherRepoContextScript(projectSubPath)],
+                {
+                    cwd: repository,
+                    encoding: 'utf8',
+                    env: { ...process.env, CDPATH: '' },
+                },
+            );
+
+            expect(output.trim()).toBe('./model.sql');
+        },
+    );
+});

--- a/packages/backend/src/ee/services/AiWritebackService/scripts.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/scripts.ts
@@ -1,3 +1,5 @@
+import { quoteShellArgument } from './utils';
+
 /**
  * Bash scripts that the host writes into the sandbox at runtime. Each export
  * is a function returning the rendered script body so call sites get
@@ -10,11 +12,18 @@
  * reads the listing as `<repo_context>` in its system prompt and `Read`s
  * individual files on demand.
  */
-export const buildGatherRepoContextScript = (projectSubPath: string): string =>
-    `
-cd ${JSON.stringify(projectSubPath)} || { echo "(could not enter ${projectSubPath})"; exit 0; }
+export const buildGatherRepoContextScript = (
+    projectSubPath: string,
+): string => {
+    const quotedPath = quoteShellArgument(projectSubPath);
+    const quotedError = quoteShellArgument(
+        `(could not enter ${projectSubPath})`,
+    );
+    return `
+cd ${quotedPath} || { echo ${quotedError}; exit 0; }
 
 find . \\( -name target -o -name dbt_packages -o -name logs -o -name .git \\) -prune -o \\
   -type f \\( -name "*.sql" -o -name "*.yml" -o -name "*.yaml" \\) -print \\
   | LC_ALL=C sort
 `;
+};

--- a/packages/backend/src/ee/services/AiWritebackService/utils.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/utils.ts
@@ -36,6 +36,11 @@ import type {
 
 const DEFAULT_GITLAB_HOST_DOMAIN = 'gitlab.com';
 
+export const quoteShellArgument = (value: string): string => {
+    const escaped = value.replace(/'/g, "'\"'\"'");
+    return `'${escaped}'`;
+};
+
 const splitOwnerRepo = (
     repository: string,
 ): { owner: string; repo: string } => {


### PR DESCRIPTION
## Summary

- quote configured repository subpaths wherever AI writeback builds shell commands
- reuse one shell-argument helper across repository preparation and cleanup
- cover complex literal subpaths without restricting supported path characters

## Testing

- `pnpm -F backend exec vitest run src/ee/services/AiWritebackService/scripts.test.ts src/ee/services/AiWritebackService/utils.test.ts src/ee/services/AiWritebackService/providers/sandboxGit.test.ts`
- `pnpm -F backend exec vitest run src/ee/services/AiWritebackService/AiWritebackService.test.ts`

Closes: PROD-8805