### PR TITLE
fix: bind Postgres catalog filter values

### DIFF
--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
@@ -141,6 +141,34 @@ describe('PostgresWarehouseClient', () => {
         const warehouse = new PostgresWarehouseClient(credentials);
         expect(await warehouse.getCatalog([])).toEqual({});
     });
+
+    it('binds catalog filter values as query parameters', async () => {
+        const warehouse = new PostgresWarehouseClient(credentials);
+        const database =
+            "missing') OR (SELECT CAST(current_database() AS integer)=0) OR ('x'='x";
+        const runQuery = vi
+            .spyOn(warehouse, 'runQuery')
+            .mockResolvedValueOnce({
+                rows: [{ version: 'PostgreSQL 15.4' }],
+                fields: {},
+            })
+            .mockResolvedValueOnce({ rows: [], fields: {} });
+
+        await warehouse.getCatalog([
+            { database, schema: 'public', table: 'orders' },
+        ]);
+
+        const catalogQuery = runQuery.mock.calls[1][0];
+        expect(catalogQuery).toContain('table_catalog IN ($1)');
+        expect(catalogQuery).toContain('table_schema IN ($2)');
+        expect(catalogQuery).toContain('table_name IN ($3)');
+        expect(catalogQuery).not.toContain(database);
+        expect(runQuery.mock.calls[1][3]).toEqual([
+            database,
+            'public',
+            'orders',
+        ]);
+    });
 });
 
 describe('PostgresWarehouseClient statement timeout', () => {

--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
@@ -226,6 +226,13 @@ export class PostgresSqlBuilder extends WarehouseBaseSqlBuilder {
     }
 }
 
+type CatalogQueryFilters = {
+    databaseFilters: string[];
+    schemaFilters: string[];
+    tableFilters: string[];
+    values: string[] | undefined;
+};
+
 export class PostgresClient<
     T extends CreatePostgresLikeCredentials,
 > extends WarehouseBaseClient<T> {
@@ -234,6 +241,19 @@ export class PostgresClient<
     constructor(credentials: T, config: pg.PoolConfig) {
         super(credentials, new PostgresSqlBuilder(credentials.startOfWeek));
         this.config = config;
+    }
+
+    protected getCatalogQueryFilters(
+        databases: Set<string>,
+        schemas: Set<string>,
+        tables: Set<string>,
+    ): CatalogQueryFilters {
+        return {
+            databaseFilters: [...databases].map((value) => `'${value}'`),
+            schemaFilters: [...schemas].map((value) => `'${value}'`),
+            tableFilters: [...tables].map((value) => `'${value}'`),
+            values: undefined,
+        };
     }
 
     private getSQLWithMetadata(sql: string, tags?: Record<string, string>) {
@@ -529,9 +549,9 @@ export class PostgresClient<
             tables: Set<string>;
         }>(
             (acc, { database, schema, table }) => ({
-                databases: acc.databases.add(`'${database}'`),
-                schemas: acc.schemas.add(`'${schema}'`),
-                tables: acc.tables.add(`'${table}'`),
+                databases: acc.databases.add(database),
+                schemas: acc.schemas.add(schema),
+                tables: acc.tables.add(table),
             }),
             {
                 databases: new Set(),
@@ -539,7 +559,13 @@ export class PostgresClient<
                 tables: new Set(),
             },
         );
-        if (databases.size <= 0 || schemas.size <= 0 || tables.size <= 0) {
+        const { databaseFilters, schemaFilters, tableFilters, values } =
+            this.getCatalogQueryFilters(databases, schemas, tables);
+        if (
+            databaseFilters.length <= 0 ||
+            schemaFilters.length <= 0 ||
+            tableFilters.length <= 0
+        ) {
             return {};
         }
 
@@ -559,9 +585,9 @@ export class PostgresClient<
                    column_name,
                    data_type
             FROM information_schema.columns
-            WHERE table_catalog IN (${Array.from(databases)})
-              AND table_schema IN (${Array.from(schemas)})
-              AND table_name IN (${Array.from(tables)})
+            WHERE table_catalog IN (${databaseFilters})
+              AND table_schema IN (${schemaFilters})
+              AND table_name IN (${tableFilters})
             ${
                 supportsMatviews
                     ? `
@@ -578,15 +604,18 @@ export class PostgresClient<
             JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
             JOIN pg_catalog.pg_matviews mv ON n.nspname = mv.schemaname AND c.relname = mv.matviewname
             WHERE c.relkind = 'm'
-            AND current_database() IN (${Array.from(databases)})
-            AND n.nspname IN (${Array.from(schemas)})
-            AND c.relname IN (${Array.from(tables)})
+            AND current_database() IN (${databaseFilters})
+            AND n.nspname IN (${schemaFilters})
+            AND c.relname IN (${tableFilters})
             AND a.attnum > 0
             AND NOT a.attisdropped`
                     : ''
             }`;
 
-        const { rows } = await this.runQuery(query);
+        const { rows } =
+            values === undefined
+                ? await this.runQuery(query)
+                : await this.runQuery(query, {}, undefined, values);
         const catalog = rows.reduce(
             (
                 acc,
@@ -785,6 +814,25 @@ const getSSLConfigFromMode = ({
 };
 
 export class PostgresWarehouseClient extends PostgresClient<CreatePostgresCredentials> {
+    protected getCatalogQueryFilters(
+        databases: Set<string>,
+        schemas: Set<string>,
+        tables: Set<string>,
+    ): CatalogQueryFilters {
+        const values = [...databases, ...schemas, ...tables];
+
+        return {
+            databaseFilters: [...databases].map((_, index) => `$${index + 1}`),
+            schemaFilters: [...schemas].map(
+                (_, index) => `$${databases.size + index + 1}`,
+            ),
+            tableFilters: [...tables].map(
+                (_, index) => `$${databases.size + schemas.size + index + 1}`,
+            ),
+            values,
+        };
+    }
+
     constructor(credentials: CreatePostgresCredentials) {
         const ssl = getSSLConfigFromMode(credentials);
         super(credentials, {

--- a/packages/warehouses/src/warehouseClients/RedshiftWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/RedshiftWarehouseClient.test.ts
@@ -1,0 +1,34 @@
+import { RedshiftAuthenticationType, WarehouseTypes } from '@lightdash/common';
+import { RedshiftWarehouseClient } from './RedshiftWarehouseClient';
+
+describe('RedshiftWarehouseClient', () => {
+    it('keeps catalog filters in the Redshift query', async () => {
+        const warehouse = new RedshiftWarehouseClient({
+            type: WarehouseTypes.REDSHIFT,
+            host: 'localhost',
+            user: 'analytics',
+            password: 'password',
+            port: 5439,
+            dbname: 'warehouse',
+            schema: 'public',
+            authenticationType: RedshiftAuthenticationType.PASSWORD,
+        });
+        const runQuery = vi
+            .spyOn(warehouse, 'runQuery')
+            .mockResolvedValueOnce({
+                rows: [{ version: 'PostgreSQL 8.0.2' }],
+                fields: {},
+            })
+            .mockResolvedValueOnce({ rows: [], fields: {} });
+
+        await warehouse.getCatalog([
+            { database: 'warehouse', schema: 'public', table: 'orders' },
+        ]);
+
+        const catalogQuery = runQuery.mock.calls[1][0];
+        expect(catalogQuery).toContain("table_catalog IN ('warehouse')");
+        expect(catalogQuery).toContain("table_schema IN ('public')");
+        expect(catalogQuery).toContain("table_name IN ('orders')");
+        expect(runQuery.mock.calls[1][3]).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Summary

- bind PostgreSQL catalog database, schema, and table filters as query values
- isolate parameter binding to the concrete PostgreSQL client
- keep Redshift on its existing catalog query path because bound-filter compatibility has not been validated against a live Redshift instance
- add focused regression coverage for both PostgreSQL and Redshift behavior

## Impact

This changes catalog metadata loading during project compilation and refresh, including dbt sync/deploy flows. It can affect discovery of new tables or columns and refreshed metadata for existing models. It does not change chart, dashboard, download, delivery, or export query execution.

## Testing

- `pnpm -F @lightdash/warehouses exec vitest run --config vitest.config.ts src/warehouseClients/PostgresWarehouseClient.test.ts src/warehouseClients/RedshiftWarehouseClient.test.ts` (12 tests passed)
- `pnpm -F @lightdash/warehouses typecheck`
- verified catalog lookup and complex filter handling through the real `pg` driver against a local PostgreSQL 18 instance
- Redshift behavior is regression-tested with the existing client call path; no live Redshift endpoint was available for compatibility validation

Closes: PROD-9306