### PR TITLE
fix: use application secret for Slack OAuth state

### DIFF
--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -238,6 +238,19 @@ test('Should include secret in output', () => {
     expect(parseConfig().lightdashSecret).toEqual('so very secret');
 });
 
+test('Should use the Lightdash secret as the Slack state secret fallback', () => {
+    process.env.LIGHTDASH_SECRET = 'instance-specific-secret';
+    expect(parseConfig().slack?.stateSecret).toEqual(
+        'instance-specific-secret',
+    );
+});
+
+test('Should prefer an explicit Slack state secret', () => {
+    process.env.LIGHTDASH_SECRET = 'instance-specific-secret';
+    process.env.SLACK_STATE_SECRET = 'slack-specific-secret';
+    expect(parseConfig().slack?.stateSecret).toEqual('slack-specific-secret');
+});
+
 test('Should parse bedrock inference profile prefix from env', () => {
     process.env.BEDROCK_API_KEY = 'test-bedrock-key';
     process.env.BEDROCK_REGION = 'ap-northeast-1';

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -2851,7 +2851,7 @@ export const parseConfig = (): LightdashConfig => {
             signingSecret: process.env.SLACK_SIGNING_SECRET,
             clientId: process.env.SLACK_CLIENT_ID,
             clientSecret: process.env.SLACK_CLIENT_SECRET,
-            stateSecret: process.env.SLACK_STATE_SECRET || 'slack-state-secret',
+            stateSecret: process.env.SLACK_STATE_SECRET || lightdashSecret,
             appToken: process.env.SLACK_APP_TOKEN,
             port: parseInt(process.env.SLACK_PORT || '4351', 10),
             socketMode: process.env.SLACK_SOCKET_MODE === 'true',


### PR DESCRIPTION
## Summary

- use the required application secret as the default Slack OAuth state signing secret
- preserve the dedicated Slack state secret override
- cover both configuration paths

## Testing

- backend config parser tests
- Slack OAuth state validation behavior

Closes: PROD-8811