### PR TITLE
feat: add 'Weekdays' frequency preset to scheduled deliveries

### DIFF
--- a/packages/backend/src/utils/cronUtils.test.ts
+++ b/packages/backend/src/utils/cronUtils.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { getAdjustedCronByOffset } from './cronUtils';
+
+describe('getAdjustedCronByOffset', () => {
+    it('adjusts the time without changing the days', () => {
+        expect(getAdjustedCronByOffset('0 9 * * 1-5', 120)).toEqual(
+            '0 11 * * 1-5',
+        );
+    });
+
+    it('shifts every day of the week when the hour overflows into the next day', () => {
+        expect(getAdjustedCronByOffset('0 23 * * 1-5', 120)).toEqual(
+            '0 1 * * 2-6',
+        );
+    });
+
+    it('shifts every day of the week when the hour overflows into the previous day', () => {
+        expect(getAdjustedCronByOffset('0 0 * * 1-5', -120)).toEqual(
+            '0 22 * * 0-4',
+        );
+    });
+
+    it('adjusts a single day of the week', () => {
+        expect(getAdjustedCronByOffset('0 23 * * 1', 120)).toEqual('0 1 * * 2');
+    });
+});

--- a/packages/backend/src/utils/cronUtils.ts
+++ b/packages/backend/src/utils/cronUtils.ts
@@ -71,12 +71,11 @@ export function getAdjustedCronByOffset(
         fields.hour[0] = offsetHour.hour;
     }
 
-    if (fields.dayOfWeek.length === 1) {
-        // Adjust day of the week based on hour overflow which crossed full day thresholds
-        fields.dayOfWeek[0] = getOffsetWeekDay(
-            fields.dayOfWeek[0],
-            dayOverflow,
-        );
+    if (fields.dayOfWeek.length < 7) {
+        // Adjust days of the week based on hour overflow which crossed full day thresholds
+        fields.dayOfWeek = fields.dayOfWeek
+            .map((dayOfWeek) => getOffsetWeekDay(dayOfWeek, dayOverflow))
+            .sort((a, b) => a - b);
     }
 
     return arrayToString([

--- a/packages/frontend/src/components/CronInput/FrequencySelect.tsx
+++ b/packages/frontend/src/components/CronInput/FrequencySelect.tsx
@@ -18,6 +18,10 @@ const FrequencyItems: Array<FrequencyItem> = [
         label: 'Daily',
     },
     {
+        value: Frequency.WEEKDAYS,
+        label: 'Weekdays',
+    },
+    {
         value: Frequency.WEEKLY,
         label: 'Weekly',
     },
@@ -43,7 +47,7 @@ const FrequencySelect: FC<{
             value={value}
             disabled={disabled}
             onChange={onChange}
-            w={110}
+            w={120}
         />
     );
 };

--- a/packages/frontend/src/components/CronInput/WeekdaysInputs.tsx
+++ b/packages/frontend/src/components/CronInput/WeekdaysInputs.tsx
@@ -1,0 +1,26 @@
+import { Group, Input } from '@mantine-8/core';
+import React, { type FC } from 'react';
+import { getWeekdaysCronExpression } from './cronInputUtils';
+import TimePicker from './TimePicker';
+
+const WeekdaysInputs: FC<{
+    disabled?: boolean;
+    cronExpression: string;
+    onChange: (value: string) => void;
+}> = ({ disabled, cronExpression, onChange }) => {
+    const handleChange = (newTime: { hours: number; minutes: number }) => {
+        onChange(getWeekdaysCronExpression(newTime.minutes, newTime.hours));
+    };
+
+    return (
+        <Group gap="sm">
+            <Input.Label>Monday to Friday at</Input.Label>
+            <TimePicker
+                disabled={disabled}
+                cronExpression={cronExpression}
+                onChange={handleChange}
+            />
+        </Group>
+    );
+};
+export default WeekdaysInputs;

--- a/packages/frontend/src/components/CronInput/cronInputUtils.test.ts
+++ b/packages/frontend/src/components/CronInput/cronInputUtils.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import {
+    Frequency,
+    getFrequencyCronExpression,
+    getWeekdaysCronExpression,
+    mapCronExpressionToFrequency,
+} from './cronInputUtils';
+
+describe('cronInputUtils', () => {
+    describe('mapCronExpressionToFrequency', () => {
+        it('maps monday to friday expressions to weekdays', () => {
+            expect(mapCronExpressionToFrequency('0 9 * * 1-5')).toEqual(
+                Frequency.WEEKDAYS,
+            );
+            expect(mapCronExpressionToFrequency('30 7 * * 1,2,3,4,5')).toEqual(
+                Frequency.WEEKDAYS,
+            );
+        });
+
+        it('keeps existing presets unchanged', () => {
+            expect(mapCronExpressionToFrequency('0 * * * *')).toEqual(
+                Frequency.HOURLY,
+            );
+            expect(mapCronExpressionToFrequency('0 9 * * *')).toEqual(
+                Frequency.DAILY,
+            );
+            expect(mapCronExpressionToFrequency('0 9 * * 1')).toEqual(
+                Frequency.WEEKLY,
+            );
+            expect(mapCronExpressionToFrequency('0 9 1 * *')).toEqual(
+                Frequency.MONTHLY,
+            );
+            expect(mapCronExpressionToFrequency('0 9 * * 2-6')).toEqual(
+                Frequency.CUSTOM,
+            );
+        });
+    });
+
+    describe('getWeekdaysCronExpression', () => {
+        it('builds a monday to friday expression', () => {
+            expect(getWeekdaysCronExpression(30, 9)).toEqual('30 9 * * 1-5');
+        });
+    });
+
+    describe('getFrequencyCronExpression', () => {
+        it('keeps the time when switching to weekdays', () => {
+            expect(
+                getFrequencyCronExpression(Frequency.WEEKDAYS, '15 8 * * *'),
+            ).toEqual('15 8 * * 1-5');
+        });
+    });
+});

--- a/packages/frontend/src/components/CronInput/cronInputUtils.ts
+++ b/packages/frontend/src/components/CronInput/cronInputUtils.ts
@@ -3,6 +3,7 @@ import { stringToArray } from 'cron-converter';
 export enum Frequency {
     HOURLY = 'HOURLY',
     DAILY = 'DAILY',
+    WEEKDAYS = 'WEEKDAYS',
     WEEKLY = 'WEEKLY',
     MONTHLY = 'MONTHLY',
     CUSTOM = 'CUSTOM',
@@ -12,6 +13,10 @@ const hasAllHours = (count: number) => count === 24;
 const hasAllDays = (count: number) => count === 31;
 const hasAllMonths = (count: number) => count === 12;
 const hasAllWeekDays = (count: number) => count === 7;
+const WEEK_DAYS_MONDAY_TO_FRIDAY = [1, 2, 3, 4, 5];
+const isMondayToFriday = (weekDays: number[]) =>
+    weekDays.length === WEEK_DAYS_MONDAY_TO_FRIDAY.length &&
+    WEEK_DAYS_MONDAY_TO_FRIDAY.every((day) => weekDays.includes(day));
 
 export const mapCronExpressionToFrequency = (value: string): Frequency => {
     try {
@@ -37,6 +42,14 @@ export const mapCronExpressionToFrequency = (value: string): Frequency => {
             hasAllWeekDays(weekDaysCount)
         ) {
             return Frequency.DAILY;
+        } else if (
+            minutesCount === 1 &&
+            hoursCount === 1 &&
+            hasAllDays(daysCount) &&
+            hasAllMonths(monthsCount) &&
+            isMondayToFriday(arr[4])
+        ) {
+            return Frequency.WEEKDAYS;
         } else if (
             minutesCount === 1 &&
             hoursCount === 1 &&
@@ -100,6 +113,13 @@ export const getDailyCronExpression = (
     return [minutes, hours, '*', '*', '*'].join(' ');
 };
 
+export const getWeekdaysCronExpression = (
+    minutes: number,
+    hours: number,
+): string => {
+    return [minutes, hours, '*', '*', '1-5'].join(' ');
+};
+
 export const getWeeklyCronExpression = (
     minutes: number,
     hours: number,
@@ -130,6 +150,10 @@ export const getFrequencyCronExpression = (
         }
         case Frequency.DAILY: {
             newCronExpression = getDailyCronExpression(minutes, hours);
+            break;
+        }
+        case Frequency.WEEKDAYS: {
+            newCronExpression = getWeekdaysCronExpression(minutes, hours);
             break;
         }
         case Frequency.WEEKLY: {

--- a/packages/frontend/src/components/CronInput/index.tsx
+++ b/packages/frontend/src/components/CronInput/index.tsx
@@ -16,6 +16,7 @@ import DailyInputs from './DailyInputs';
 import FrequencySelect from './FrequencySelect';
 import HourlyInputs from './HourlyInputs';
 import MonthlyInputs from './MonthlyInputs';
+import WeekdaysInputs from './WeekdaysInputs';
 import WeeklyInputs from './WeeklyInputs';
 
 type CronInternalInputsProps = {
@@ -62,6 +63,9 @@ export const CronInternalInputs: FC<
             )}
             {frequency === Frequency.DAILY && (
                 <DailyInputs cronExpression={value} onChange={onChange} />
+            )}
+            {frequency === Frequency.WEEKDAYS && (
+                <WeekdaysInputs cronExpression={value} onChange={onChange} />
             )}
             {frequency === Frequency.WEEKLY && (
                 <WeeklyInputs cronExpression={value} onChange={onChange} />

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerList.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerList.tsx
@@ -83,6 +83,7 @@ dayjs.extend(relativeTime);
 const FREQUENCY_LABEL: Record<Frequency, string> = {
     [Frequency.HOURLY]: 'Hourly',
     [Frequency.DAILY]: 'Daily',
+    [Frequency.WEEKDAYS]: 'Weekdays',
     [Frequency.WEEKLY]: 'Weekly',
     [Frequency.MONTHLY]: 'Monthly',
     [Frequency.CUSTOM]: 'Custom',


### PR DESCRIPTION
Closes: lightdash/lightdash#26514

### Description:

Adds a **Weekdays** (Monday–Friday) option to the frequency dropdown used by scheduled deliveries and threshold alerts, so users don't have to hand-write `0 9 * * 1-5` under "Custom".

Selecting it renders a time picker ("Monday to Friday at HH:mm") and produces a `m h * * 1-5` cron, which flows through the existing cron plumbing unchanged — validation, the Next runs preview, and the human-readable frequency labels all already handle it. Existing `1-5` crons are now detected as this preset instead of "Custom".

One backend fix came along: `getAdjustedCronByOffset` only shifted the day-of-week when it held a single value, so a weekdays cron whose hour overflowed into another day during a project timezone change kept the wrong days. It now shifts every value in the set.