### PR TITLE
fix: authorize project content with owning organization

### DIFF
--- a/packages/backend/src/ee/services/ProjectHomepageService.test.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.test.ts
@@ -78,12 +78,18 @@ const makeAdminUser = (): SessionUser => ({
         {
             action: 'view',
             subject: 'Project',
-            conditions: { projectUuid: PROJECT_UUID },
+            conditions: {
+                organizationUuid: ORGANIZATION_UUID,
+                projectUuid: PROJECT_UUID,
+            },
         },
         {
             action: 'manage',
             subject: 'ProjectHomepage',
-            conditions: { projectUuid: PROJECT_UUID },
+            conditions: {
+                organizationUuid: ORGANIZATION_UUID,
+                projectUuid: PROJECT_UUID,
+            },
         },
     ]),
 });
@@ -95,7 +101,10 @@ const makeViewerUser = (): SessionUser => ({
         {
             action: 'view',
             subject: 'Project',
-            conditions: { projectUuid: PROJECT_UUID },
+            conditions: {
+                organizationUuid: ORGANIZATION_UUID,
+                projectUuid: PROJECT_UUID,
+            },
         },
     ]),
 });
@@ -162,6 +171,9 @@ const makeService = ({
         },
         projectModel: {
             getProjectMemberAccess: vi.fn().mockResolvedValue(undefined),
+            getSummary: vi.fn().mockResolvedValue({
+                organizationUuid: ORGANIZATION_UUID,
+            }),
             ...projectModel,
         },
         fileStorageClient: {
@@ -212,6 +224,20 @@ describe('ProjectHomepageService', () => {
         ).resolves.toBeNull();
     });
 
+    it('getPublishedHomepage rejects a project owned by another organization', async () => {
+        const service = makeService({
+            projectModel: {
+                getSummary: vi.fn().mockResolvedValue({
+                    organizationUuid: 'another-organization-uuid',
+                }),
+            },
+        });
+
+        await expect(
+            service.getResolvedHomepage(makeAdminUser(), PROJECT_UUID),
+        ).rejects.toThrow(ForbiddenError);
+    });
+
     it('createHomepage throws ForbiddenError for a viewer', async () => {
         const service = makeService();
 
@@ -219,6 +245,20 @@ describe('ProjectHomepageService', () => {
             service.createHomepage(makeViewerUser(), PROJECT_UUID, {
                 name: 'Nope',
             }),
+        ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('listHomepages rejects a project owned by another organization', async () => {
+        const service = makeService({
+            projectModel: {
+                getSummary: vi.fn().mockResolvedValue({
+                    organizationUuid: 'another-organization-uuid',
+                }),
+            },
+        });
+
+        await expect(
+            service.listHomepages(makeAdminUser(), PROJECT_UUID),
         ).rejects.toThrow(ForbiddenError);
     });
 

--- a/packages/backend/src/ee/services/ProjectHomepageService.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.ts
@@ -184,7 +184,7 @@ export type ProjectHomepageServiceArguments = {
     >;
     featureFlagService: Pick<FeatureFlagService, 'get'>;
     groupsModel: Pick<GroupsModel, 'findUserGroups'>;
-    projectModel: Pick<ProjectModel, 'getProjectMemberAccess'>;
+    projectModel: Pick<ProjectModel, 'getProjectMemberAccess' | 'getSummary'>;
     fileStorageClient: FileStorageClient;
     persistentDownloadFileService: PersistentDownloadFileService;
     slackClient: Pick<SlackClient, 'postMessage'>;
@@ -237,16 +237,21 @@ export class ProjectHomepageService extends BaseService {
         }
     }
 
-    private assertCanView(user: SessionUser, projectUuid: string): void {
+    private async assertCanView(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<void> {
         if (!user.organizationUuid) {
             throw new ForbiddenError();
         }
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
         const ability = this.createAuditedAbility(user);
         if (
             ability.cannot(
                 'view',
                 subject('Project', {
-                    organizationUuid: user.organizationUuid,
+                    organizationUuid,
                     projectUuid,
                 }),
             )
@@ -255,16 +260,21 @@ export class ProjectHomepageService extends BaseService {
         }
     }
 
-    private assertCanManage(user: SessionUser, projectUuid: string): void {
+    private async assertCanManage(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<void> {
         if (!user.organizationUuid) {
             throw new ForbiddenError();
         }
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
         const ability = this.createAuditedAbility(user);
         if (
             ability.cannot(
                 'manage',
                 subject('ProjectHomepage', {
-                    organizationUuid: user.organizationUuid,
+                    organizationUuid,
                     projectUuid,
                 }),
             )
@@ -350,7 +360,7 @@ export class ProjectHomepageService extends BaseService {
         projectUuid: string,
     ): Promise<ResolvedHomepage | null> {
         await this.assertFlagEnabled(user);
-        this.assertCanView(user, projectUuid);
+        await this.assertCanView(user, projectUuid);
         const viewer = await this.getViewerContext(
             user.organizationUuid,
             projectUuid,
@@ -366,7 +376,7 @@ export class ProjectHomepageService extends BaseService {
         target: HomepageViewAsTarget,
     ): Promise<HomepageViewAsResult> {
         await this.assertFlagEnabled(user);
-        this.assertCanManage(user, projectUuid);
+        await this.assertCanManage(user, projectUuid);
         switch (target.type) {
             case 'user': {
                 const viewer = await this.getViewerContext(
@@ -396,7 +406,7 @@ export class ProjectHomepageService extends BaseService {
         projectUuid: string,
     ): Promise<HomepageAssignment[]> {
         await this.assertFlagEnabled(user);
-        this.assertCanManage(user, projectUuid);
+        await this.assertCanManage(user, projectUuid);
         return this.projectHomepageModel.getAssignments(projectUuid);
     }
 
@@ -406,7 +416,7 @@ export class ProjectHomepageService extends BaseService {
         groupUuids: string[],
     ): Promise<void> {
         await this.assertFlagEnabled(user);
-        this.assertCanManage(user, projectUuid);
+        await this.assertCanManage(user, projectUuid);
         await this.projectHomepageModel.updateGroupPriorities(
             projectUuid,
             groupUuids,
@@ -418,7 +428,7 @@ export class ProjectHomepageService extends BaseService {
         projectUuid: string,
     ): Promise<HomepageRecentlyViewedItem[]> {
         await this.assertFlagEnabled(user);
-        this.assertCanView(user, projectUuid);
+        await this.assertCanView(user, projectUuid);
         return this.projectHomepageModel.getRecentlyViewed(
             projectUuid,
             user.userUuid,
@@ -431,7 +441,7 @@ export class ProjectHomepageService extends BaseService {
         homepageUuid?: string,
     ): Promise<ProjectHomepage | null> {
         await this.assertFlagEnabled(user);
-        this.assertCanManage(user, projectUuid);
+        await this.assertCanManage(user, projectUuid);
         if (homepageUuid) {
             return this.getOwnedHomepage(projectUuid, homepageUuid);
         }
@@ -447,7 +457,7 @@ export class ProjectHomepageService extends BaseService {
         projectUuid: string,
     ): Promise<ProjectHomepage[]> {
         await this.assertFlagEnabled(user);
-        this.assertCanManage(user, projectUuid);
+        await this.assertCanManage(user, projectUuid);
         return this.projectHomepageModel.list(projectUuid);
     }
 
@@ -457,7 +467,7 @@ export class ProjectHomepageService extends BaseService {
         data: CreateProjectHomepageRequest,
     ): Promise<ProjectHomepage> {
         await this.assertFlagEnabled(user);
-        this.assertCanManage(user, projectUuid);
+        await this.assertCanManage(user, projectUuid);
         const draftConfig = data.duplicateFrom
             ? (await this.getOwnedHomepage(projectUuid, data.duplicateFrom))
                   .draftConfig
@@ -476,7 +486,7 @@ export class ProjectHomepageService extends BaseService {
         homepageUuid: string,
     ): Promise<void> {
         await this.assertFlagEnabled(user);
-        this.assertCanManage(user, projectUuid);
+        await this.assertCanManage(user, projectUuid);
         await this.getOwnedHomepage(projectUuid, homepageUuid);
         await this.projectHomepageModel.delete(homepageUuid);
     }
@@ -488,7 +498,7 @@ export class ProjectHomepageService extends BaseService {
         data: UpdateProjectHomepageDraftRequest,
     ): Promise<ProjectHomepage> {
         await this.assertFlagEnabled(user);
-        this.assertCanManage(user, projectUuid);
+        await this.assertCanManage(user, projectUuid);
         ProjectHomepageService.validateConfig(data.draftConfig);
         await this.getOwnedHomepage(projectUuid, homepageUuid);
         return this.projectHomepageModel.updateDraft(homepageUuid, {
@@ -504,7 +514,7 @@ export class ProjectHomepageService extends BaseService {
         homepageUuid: string,
     ): Promise<ProjectHomepage> {
         await this.assertFlagEnabled(user);
-        this.assertCanManage(user, projectUuid);
+        await this.assertCanManage(user, projectUuid);
         await this.getOwnedHomepage(projectUuid, homepageUuid);
         return this.projectHomepageModel.discardDraft(homepageUuid);
     }
@@ -516,7 +526,7 @@ export class ProjectHomepageService extends BaseService {
         audience: HomepageAudience,
     ): Promise<ProjectHomepage> {
         await this.assertFlagEnabled(user);
-        this.assertCanManage(user, projectUuid);
+        await this.assertCanManage(user, projectUuid);
         await this.getOwnedHomepage(projectUuid, homepageUuid);
         const published = await this.projectHomepageModel.publish(
             homepageUuid,
@@ -556,7 +566,7 @@ export class ProjectHomepageService extends BaseService {
         url: string,
     ): Promise<HomepageLinkMetadata> {
         await this.assertFlagEnabled(user);
-        this.assertCanManage(user, projectUuid);
+        await this.assertCanManage(user, projectUuid);
 
         const provider = classifyResourceUrl(url);
         try {
@@ -644,7 +654,7 @@ export class ProjectHomepageService extends BaseService {
         },
     ): Promise<AnnouncementsPage> {
         await this.assertFlagEnabled(user);
-        this.assertCanView(user, projectUuid);
+        await this.assertCanView(user, projectUuid);
         if (
             options.page < 1 ||
             options.pageSize < 1 ||
@@ -654,7 +664,7 @@ export class ProjectHomepageService extends BaseService {
         }
         // Drafts are only ever visible to someone who can manage the homepage.
         if (options.includeUnpublished) {
-            this.assertCanManage(user, projectUuid);
+            await this.assertCanManage(user, projectUuid);
         }
         return this.projectHomepageModel.listAnnouncements(
             projectUuid,
@@ -781,7 +791,7 @@ export class ProjectHomepageService extends BaseService {
         data: CreateAnnouncementRequest,
     ): Promise<ProjectAnnouncement> {
         await this.assertFlagEnabled(user);
-        this.assertCanManage(user, projectUuid);
+        await this.assertCanManage(user, projectUuid);
         ProjectHomepageService.validateAnnouncementTitle(data.title);
         ProjectHomepageService.validateAnnouncementBody(data.body);
         if (data.slackChannelId) {
@@ -808,7 +818,7 @@ export class ProjectHomepageService extends BaseService {
         update: UpdateAnnouncementRequest,
     ): Promise<ProjectAnnouncement> {
         await this.assertFlagEnabled(user);
-        this.assertCanManage(user, projectUuid);
+        await this.assertCanManage(user, projectUuid);
         const announcement = await this.getOwnedAnnouncement(
             projectUuid,
             announcementUuid,
@@ -874,7 +884,7 @@ export class ProjectHomepageService extends BaseService {
         announcementUuid: string,
     ): Promise<void> {
         await this.assertFlagEnabled(user);
-        this.assertCanManage(user, projectUuid);
+        await this.assertCanManage(user, projectUuid);
         const announcement = await this.getOwnedAnnouncement(
             projectUuid,
             announcementUuid,
@@ -956,7 +966,7 @@ export class ProjectHomepageService extends BaseService {
         contentLength: number,
     ): Promise<{ url: string }> {
         await this.assertFlagEnabled(user);
-        this.assertCanManage(user, projectUuid);
+        await this.assertCanManage(user, projectUuid);
         if (!user.organizationUuid) {
             throw new ForbiddenError();
         }

--- a/packages/backend/src/services/ContentService/ContentService.test.ts
+++ b/packages/backend/src/services/ContentService/ContentService.test.ts
@@ -2,6 +2,7 @@ import {
     ChartSourceType,
     ContentType,
     defineUserAbility,
+    ForbiddenError,
     KnexPaginatedData,
     OrganizationMemberRole,
     ProjectMemberRole,
@@ -44,6 +45,19 @@ const createUser = (): SessionUser =>
             ],
         ),
     }) as SessionUser;
+
+const createOrganizationAdminUser = (): SessionUser => ({
+    ...createUser(),
+    role: OrganizationMemberRole.ADMIN,
+    ability: defineUserAbility(
+        {
+            userUuid,
+            role: OrganizationMemberRole.ADMIN,
+            organizationUuid,
+        },
+        [],
+    ),
+});
 
 const createService = ({
     contentModel = {} as ContentModel,
@@ -305,5 +319,27 @@ describe('ContentService.find', () => {
             expect.any(Object),
             expect.objectContaining({ page: 1, pageSize: 50 }),
         );
+    });
+});
+
+describe('ContentService.findDeleted', () => {
+    it('rejects a project owned by another organization', async () => {
+        const findDeletedContents = vi.fn();
+        const deps = createService({
+            contentModel: {
+                findDeletedContents,
+            } as unknown as ContentModel,
+        });
+        deps.projectModel.getSummary.mockResolvedValue({
+            organizationUuid: 'another-organization-uuid',
+            name: 'Another project',
+        });
+
+        await expect(
+            deps.service.findDeleted(createOrganizationAdminUser(), {
+                projectUuids: [projectUuid],
+            }),
+        ).rejects.toThrow(ForbiddenError);
+        expect(findDeletedContents).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/services/ContentService/ContentService.ts
+++ b/packages/backend/src/services/ContentService/ContentService.ts
@@ -438,8 +438,7 @@ export class ContentService extends BaseService {
         filters: DeletedContentFilters,
         paginateArgs?: KnexPaginateArgs,
     ): Promise<KnexPaginatedData<DeletedContentWithDescendants[]>> {
-        const { organizationUuid } = user;
-        if (organizationUuid === undefined) {
+        if (user.organizationUuid === undefined) {
             throw new NotFoundError('Organization not found');
         }
 
@@ -448,7 +447,7 @@ export class ContentService extends BaseService {
             throw new NotFoundError('Project UUID is required');
         }
 
-        const { name: projectName } =
+        const { name: projectName, organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
         const auditedAbility = this.createAuditedAbility(user);
 


### PR DESCRIPTION
## Summary

- use each project’s owning organization when authorizing homepage operations
- apply the same project scoping to deleted-content listing
- add service coverage for organization-scoped access

## Testing

- focused backend service tests
- backend lint and typecheck
- local API checks for allowed and denied project access

Closes: PROD-9033