### PR TITLE
fix(frontend): make onboarding tour card pop in light and dark mode

### DIFF
--- a/packages/frontend/src/components/common/GuidedTour/GuidedTour.module.css
+++ b/packages/frontend/src/components/common/GuidedTour/GuidedTour.module.css
@@ -32,10 +32,7 @@
     border-radius: var(--mantine-radius-md);
     box-shadow:
         0 0 0 2px var(--mantine-color-indigo-4),
-        0 0 0 6px light-dark(
-                rgba(76, 87, 217, 0.25),
-                rgba(129, 140, 248, 0.22)
-            ),
+        0 0 0 6px light-dark(rgba(76, 87, 217, 0.25), rgba(129, 140, 248, 0.22)),
         0 0 0 9999px light-dark(rgba(17, 24, 39, 0.62), rgba(0, 0, 0, 0.75));
     pointer-events: none;
     transition:

--- a/packages/frontend/src/components/common/GuidedTour/GuidedTour.module.css
+++ b/packages/frontend/src/components/common/GuidedTour/GuidedTour.module.css
@@ -18,10 +18,11 @@
 .dim {
     position: absolute;
     inset: 0;
-    background: light-dark(rgba(17, 24, 39, 0.55), rgba(0, 0, 0, 0.7));
+    background: light-dark(rgba(17, 24, 39, 0.62), rgba(0, 0, 0, 0.75));
 }
 
-/* the cutout: its huge box-shadow darkens the rest of the screen */
+/* the cutout: its huge box-shadow darkens the rest of the screen, and a ring
+   marks the showcased feature so it reads as highlighted, not just un-dimmed */
 .spotlight {
     position: fixed;
     top: var(--tour-top);
@@ -29,8 +30,13 @@
     width: var(--tour-width);
     height: var(--tour-height);
     border-radius: var(--mantine-radius-md);
-    box-shadow: 0 0 0 9999px
-        light-dark(rgba(17, 24, 39, 0.55), rgba(0, 0, 0, 0.7));
+    box-shadow:
+        0 0 0 2px var(--mantine-color-indigo-4),
+        0 0 0 6px light-dark(
+                rgba(76, 87, 217, 0.25),
+                rgba(129, 140, 248, 0.22)
+            ),
+        0 0 0 9999px light-dark(rgba(17, 24, 39, 0.62), rgba(0, 0, 0, 0.75));
     pointer-events: none;
     transition:
         top 0.2s ease,
@@ -43,8 +49,8 @@
     position: fixed;
     top: var(--tour-card-top);
     left: var(--tour-card-left);
-    width: 340px;
-    max-width: calc(100vw - 32px);
+    width: var(--tour-card-width);
+    max-width: calc(100vw - 24px);
     pointer-events: auto;
     z-index: 1101;
 }
@@ -54,10 +60,84 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    width: 420px;
-    max-width: calc(100vw - 32px);
+    width: 460px;
+    max-width: calc(100vw - 24px);
     pointer-events: auto;
     z-index: 1101;
+}
+
+/* The card must not read as regular UI: accent ring, deep elevation and a
+   coachmark caret pointing back at the spotlight. */
+.paper {
+    position: relative;
+    background: light-dark(
+        var(--mantine-color-body),
+        var(--mantine-color-dark-6)
+    );
+    box-shadow:
+        0 0 0 1px
+            light-dark(
+                var(--mantine-color-indigo-2),
+                var(--mantine-color-indigo-8)
+            ),
+        0 18px 45px light-dark(rgba(17, 24, 39, 0.22), rgba(0, 0, 0, 0.6));
+    animation: ldTourCardIn 160ms ease-out;
+}
+
+/* accent bar along the top edge */
+.paper::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: var(--mantine-color-indigo-5);
+    border-top-left-radius: var(--mantine-radius-md);
+    border-top-right-radius: var(--mantine-radius-md);
+}
+
+@keyframes ldTourCardIn {
+    from {
+        opacity: 0;
+        transform: translateY(-4px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.caret {
+    position: absolute;
+    left: var(--tour-caret-left);
+    width: 0;
+    height: 0;
+    margin-left: -8px;
+    border-left: 8px solid transparent;
+    border-right: 8px solid transparent;
+}
+
+.caretTop {
+    top: -8px;
+    border-bottom: 8px solid var(--mantine-color-indigo-5);
+}
+
+.caretBottom {
+    bottom: -8px;
+    border-top: 8px solid
+        light-dark(var(--mantine-color-body), var(--mantine-color-dark-6));
+}
+
+.eyebrow {
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: light-dark(
+        var(--mantine-color-indigo-6),
+        var(--mantine-color-indigo-3)
+    );
 }
 
 .dots {
@@ -70,9 +150,18 @@
     width: 6px;
     height: 6px;
     border-radius: 50%;
-    background: var(--mantine-color-ldGray-3);
+    background: light-dark(
+        var(--mantine-color-ldGray-3),
+        var(--mantine-color-dark-3)
+    );
 }
 
+/* light-dark() on both rules keeps them at the same specificity, so this one
+   still wins over .dot in either scheme. */
 .dotActive {
-    background: var(--mantine-color-ldGray-7);
+    background: light-dark(
+        var(--mantine-color-indigo-5),
+        var(--mantine-color-indigo-4)
+    );
+    transform: scale(1.15);
 }

--- a/packages/frontend/src/components/common/GuidedTour/GuidedTour.tsx
+++ b/packages/frontend/src/components/common/GuidedTour/GuidedTour.tsx
@@ -25,6 +25,13 @@ type GuidedTourProps = {
 };
 
 const SPOTLIGHT_PADDING = 6;
+const VIEWPORT_MARGIN = 12;
+/** Space between the spotlight and the card, enough to fit the caret. */
+const CARD_GAP = 14;
+const CARD_MIN_WIDTH = 340;
+const CARD_MAX_WIDTH = 480;
+/** Used until the card has been measured. */
+const CARD_FALLBACK_HEIGHT = 220;
 
 /** Track a target element's viewport rect while the tour is open. */
 const useTargetRect = (
@@ -67,25 +74,70 @@ const useTargetRect = (
     return rect;
 };
 
-/** Position the card below the target, flipping above when it would overflow. */
-const cardPosition = (rect: DOMRect): { top: number; left: number } => {
-    const margin = 12;
-    const cardWidth = 340;
-    const estHeight = 200;
-    const below = rect.bottom + margin;
-    const top =
-        below + estHeight > window.innerHeight
-            ? Math.max(margin, rect.top - estHeight - margin)
-            : below;
-    const left = Math.min(
-        Math.max(margin, rect.left),
-        window.innerWidth - cardWidth - margin,
+/** Keep the rendered card's height so it can be flipped without guessing. */
+const useCardHeight = (): [number, (el: HTMLDivElement | null) => void] => {
+    const [height, setHeight] = useState(CARD_FALLBACK_HEIGHT);
+    const [el, setEl] = useState<HTMLDivElement | null>(null);
+
+    useEffect(() => {
+        if (!el) return;
+        const observer = new ResizeObserver(() => {
+            setHeight(el.getBoundingClientRect().height);
+        });
+        observer.observe(el);
+        return () => observer.disconnect();
+    }, [el]);
+
+    return [height, setEl];
+};
+
+type CardLayout = {
+    top: number;
+    left: number;
+    width: number;
+    placement: 'below' | 'above';
+    /** Caret offset from the card's left edge, aimed at the target's centre. */
+    caretLeft: number;
+};
+
+/**
+ * Sit the card under the target, spanning as much of the target's width as it
+ * can so a wide banner doesn't get a lone card tucked in its corner. Flips
+ * above only when the card genuinely doesn't fit below.
+ */
+const cardLayout = (rect: DOMRect, cardHeight: number): CardLayout => {
+    const available = window.innerWidth - VIEWPORT_MARGIN * 2;
+    const width = Math.min(
+        Math.max(CARD_MIN_WIDTH, rect.width),
+        CARD_MAX_WIDTH,
+        available,
     );
-    return { top, left };
+    const fitsBelow =
+        rect.bottom + CARD_GAP + cardHeight + VIEWPORT_MARGIN <=
+        window.innerHeight;
+    const fitsAbove = rect.top - CARD_GAP - cardHeight >= VIEWPORT_MARGIN;
+    const placement = fitsBelow || !fitsAbove ? 'below' : 'above';
+    const top =
+        placement === 'below'
+            ? rect.bottom + CARD_GAP
+            : rect.top - CARD_GAP - cardHeight;
+    const targetCentre = rect.left + rect.width / 2;
+    const left = Math.min(
+        Math.max(VIEWPORT_MARGIN, targetCentre - width / 2),
+        window.innerWidth - width - VIEWPORT_MARGIN,
+    );
+    return {
+        top,
+        left,
+        width,
+        placement,
+        caretLeft: Math.min(Math.max(20, targetCentre - left), width - 20),
+    };
 };
 
 export const GuidedTour: FC<GuidedTourProps> = ({ steps, opened, onClose }) => {
     const [stepIndex, setStepIndex] = useState(0);
+    const [cardHeight, cardRef] = useCardHeight();
 
     const step = steps[stepIndex];
     // Each step resolves its own target when reached (rows may load late), so a
@@ -97,6 +149,7 @@ export const GuidedTour: FC<GuidedTourProps> = ({ steps, opened, onClose }) => {
 
     const isFirst = stepIndex === 0;
     const isLast = stepIndex === steps.length - 1;
+    const layout = rect ? cardLayout(rect, cardHeight) : null;
 
     const handleClose = () => {
         setStepIndex(0);
@@ -107,10 +160,30 @@ export const GuidedTour: FC<GuidedTourProps> = ({ steps, opened, onClose }) => {
     const handleBack = () => setStepIndex((i) => Math.max(0, i - 1));
 
     const cardBody = (
-        <Paper withBorder shadow="lg" radius="md" p="md">
+        <Paper
+            ref={cardRef}
+            radius="md"
+            p="md"
+            withBorder={false}
+            className={styles.paper}
+        >
+            {layout && (
+                <Box
+                    className={clsx(
+                        styles.caret,
+                        layout.placement === 'below'
+                            ? styles.caretTop
+                            : styles.caretBottom,
+                    )}
+                    __vars={{ '--tour-caret-left': `${layout.caretLeft}px` }}
+                />
+            )}
             <Stack gap="sm">
-                <Stack gap={4}>
-                    <Text fw={600} fz="sm">
+                <Stack gap={6}>
+                    <Text className={styles.eyebrow}>
+                        Step {stepIndex + 1} of {steps.length}
+                    </Text>
+                    <Text fw={600} fz="md" lh={1.3}>
                         {step.title}
                     </Text>
                     <Box fz="sm" c="dimmed">
@@ -121,7 +194,7 @@ export const GuidedTour: FC<GuidedTourProps> = ({ steps, opened, onClose }) => {
                     <Button
                         variant="subtle"
                         color="gray"
-                        size="compact-xs"
+                        size="compact-sm"
                         onClick={handleClose}
                     >
                         Skip
@@ -141,13 +214,13 @@ export const GuidedTour: FC<GuidedTourProps> = ({ steps, opened, onClose }) => {
                         {!isFirst && (
                             <Button
                                 variant="default"
-                                size="compact-xs"
+                                size="compact-sm"
                                 onClick={handleBack}
                             >
                                 Back
                             </Button>
                         )}
-                        <Button size="compact-xs" onClick={handleNext}>
+                        <Button size="compact-sm" onClick={handleNext}>
                             {isLast ? 'Got it' : 'Next'}
                         </Button>
                     </Group>
@@ -177,12 +250,13 @@ export const GuidedTour: FC<GuidedTourProps> = ({ steps, opened, onClose }) => {
                 ) : (
                     <Box className={styles.dim} />
                 )}
-                {rect ? (
+                {layout ? (
                     <Box
                         className={styles.card}
                         __vars={{
-                            '--tour-card-top': `${cardPosition(rect).top}px`,
-                            '--tour-card-left': `${cardPosition(rect).left}px`,
+                            '--tour-card-top': `${layout.top}px`,
+                            '--tour-card-left': `${layout.left}px`,
+                            '--tour-card-width': `${layout.width}px`,
                         }}
                     >
                         {cardBody}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.module.css
@@ -36,16 +36,21 @@
     text-align: left;
     cursor: pointer;
 }
-/* Onboarding sample cards: muted, and their action stays visible (no hover)
-   so the tour spotlight always lands on something. */
-.cardExample {
-    opacity: 0.85;
-}
+/* Onboarding sample cards: inert, and their action stays visible (no hover)
+   so the tour spotlight always lands on something. The "Example" badge marks
+   them — don't dim the card, the tour spotlights it. */
 .cardExample .cardBody {
     cursor: default;
 }
-.cardExample .startAction {
+/* The sample card's action is disabled, but Mantine's disabled colours (grey
+   text on grey) clashed with the filled background this class forces, which read
+   as broken in dark mode. Keep it looking like the real button. */
+.cardExample .startAction,
+.cardExample .startAction:disabled {
     opacity: 1;
+    background: var(--mantine-color-indigo-filled);
+    color: var(--mantine-color-white);
+    border-color: transparent;
 }
 .cardFooter {
     display: flex;


### PR DESCRIPTION
The first-run tour on Ask AI Issues/reviews was easy to mistake for regular UI — same border/shadow language as every other panel, and a narrow 340px card tucked under the left edge of a full-width banner. The example card's "Start fix" button also forced a filled indigo background over Mantine's disabled colours, which left dark grey text on indigo in dark mode.

**Changes**

- `GuidedTour` card gets an indigo accent bar, accent ring, deeper elevation, a caret pointing back at the spotlight, and a "Step n of m" label.
- The card now spans the target's width (up to 480px) centred beneath it, so a wide banner no longer gets a lone card in its corner. Its height is measured rather than guessed, so it only flips above the target when it genuinely doesn't fit below.
- Spotlight gets a ring so the showcased feature reads as highlighted, not just un-dimmed.
- Example "Start fix" button keeps the real button's filled look while disabled, and example cards are no longer blanket-dimmed (the "Example" badge already marks them, and the tour spotlights them).

Note: `light-dark()` compiles to `[data-mantine-color-scheme=…] .cls` rules, which outrank a plain `.cls` — `.dotActive` needs `light-dark()` too or the base `.dot` colour wins in dark mode.

**Verified** in Storybook with a throwaway story reproducing the Issues header + example card, in both schemes:

| Light | Dark |
|---|---|
| <img src="https://uploads.linear.app/63b56e5e-f571-4fec-a07d-c4fe22d5eef5/b3669a94-22f4-45b3-bce5-ae9840198860/297fa569-a69d-4865-aa41-6817e5dd2351?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzYzYjU2ZTVlLWY1NzEtNGZlYy1hMDdkLWM0ZmUyMmQ1ZWVmNS9iMzY2OWE5NC0yMmY0LTQ1YjMtYmNlNS1hZTk4NDAxOTg4NjAvMjk3ZmE1NjktYTY5ZC00ODY1LWFhNDEtNjgxN2U1ZGQyMzUxIiwiaWF0IjoxNzg1NDAxNTM2LCJleHAiOjE4MTY5NzIwOTZ9.lDxp06MstrvecaFA7z9rzB26rWZj8mL6-_tRsil9z5g" width="450" /> | <img src="https://uploads.linear.app/63b56e5e-f571-4fec-a07d-c4fe22d5eef5/c385b25b-aa88-4735-8e6e-da0de035f4ea/90782a79-9223-4cf7-9e09-2d812d533ae6?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzYzYjU2ZTVlLWY1NzEtNGZlYy1hMDdkLWM0ZmUyMmQ1ZWVmNS9jMzg1YjI1Yi1hYTg4LTQ3MzUtOGU2ZS1kYTBkZTAzNWY0ZWEvOTA3ODJhNzktOTIyMy00Y2Y3LTllMDktMmQ4MTJkNTMzYWU2IiwiaWF0IjoxNzg1NDAxNTM4LCJleHAiOjE4MTY5NzIwOTh9.AG4lB3CY314RaXb7KzsioZqQpzxiffS659c9Rb5alI0" width="450" /> |

Existing `GuidedTour` tests pass unchanged.
