### PR TITLE
fix: apply AI agent field tag filtering

### DIFF
--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
@@ -453,6 +453,37 @@ describe('AiAgentToolsService', () => {
         ]);
     });
 
+    it('filters explore fields by tags', async () => {
+        const service = makeService({
+            explores: {
+                orders: makeExplore({
+                    name: 'orders',
+                    dimensions: {
+                        visible_dimension: { tags: ['ai'] },
+                        hidden_dimension: { tags: ['internal'] },
+                    },
+                    metrics: {
+                        visible_metric: { tags: ['ai'] },
+                        hidden_metric: { tags: ['internal'] },
+                    },
+                }),
+            },
+        });
+
+        const [explore] = await service.getAvailableExplores({
+            user,
+            projectUuid,
+            availableTags: ['ai'],
+        });
+
+        expect(Object.keys(explore.tables.orders.dimensions)).toEqual([
+            'visible_dimension',
+        ]);
+        expect(Object.keys(explore.tables.orders.metrics)).toEqual([
+            'visible_metric',
+        ]);
+    });
+
     it('adds verified field usage for AI runtime searches but not MCP searches', async () => {
         const searchCatalog = vi.fn(async ({ catalogSearch }) => ({
             data:

--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
@@ -480,7 +480,7 @@ export class AiAgentToolsService extends BaseService {
                     .map((explore) =>
                         getFilteredExplore(explore, userAttributes),
                     )
-                    .filter((explore) =>
+                    .map((explore) =>
                         filterExploreByTags({
                             explore,
                             availableTags,


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9298/ai-agent-field-level-tag-filtering-not-applied-all-dimensions-visible
Closes: #26327

### Description
- apply the tag-filtered explore instead of discarding the transformed result
- cover dimension and metric filtering with a regression test

### Verification
- AiAgentToolsService tests: 35/35 passed
- dbt parse: passed
- Jaffle Shop access preview: Customers shows 13 dimensions and 3 metrics with the `ai` tag
- actual agent tool result: no exact matches for untagged Customers base fields