### PR TITLE
feat: support un-grouped aggregate pivot queries

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -2151,6 +2151,62 @@ SELECT * FROM group_by_query LIMIT 50`);
                 'dense_rank() over (order by g."event_type" asc) as "column_index"',
             );
         });
+
+        test('Should aggregate over every row when there are no index or groupBy columns', () => {
+            const pivotConfiguration = {
+                indexColumn: undefined,
+                valuesColumns: [
+                    {
+                        reference: 'event_id',
+                        aggregation: VizAggregationOptions.COUNT,
+                    },
+                ],
+                groupByColumns: undefined,
+                sortBy: undefined,
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+            const result = replaceWhitespace(builder.toSql());
+
+            expect(result).toContain(
+                'group_by_query AS (SELECT count("event_id") AS "event_id_count" FROM original_query)',
+            );
+            expect(result.toLowerCase()).not.toContain('group by');
+        });
+
+        test('Should aggregate multiple value columns into a single row', () => {
+            const pivotConfiguration = {
+                indexColumn: [],
+                valuesColumns: [
+                    {
+                        reference: 'event_id',
+                        aggregation: VizAggregationOptions.COUNT,
+                    },
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [],
+                sortBy: undefined,
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+            const result = replaceWhitespace(builder.toSql());
+
+            expect(result).toContain(
+                'group_by_query AS (SELECT count("event_id") AS "event_id_count", sum("revenue") AS "revenue_sum" FROM original_query)',
+            );
+            expect(result.toLowerCase()).not.toContain('group by');
+        });
     });
 
     describe('Warehouse type compatibility', () => {

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -499,13 +499,19 @@ export class PivotQueryBuilder {
                   })
                 : [];
 
+        const dedupedDimensions = Array.from(new Set(groupBySelectDimensions));
+
+        // With no dimensions at all the values collapse to a single aggregate
+        // row, so there is nothing to group by (big number charts).
+        const groupBy = dedupedDimensions.length
+            ? ` group by ${dedupedDimensions.join(', ')}`
+            : '';
+
         return `SELECT ${[
-            ...new Set(groupBySelectDimensions), // Remove duplicate columns
+            ...dedupedDimensions,
             ...groupBySelectMetrics,
             ...implicitMetricSelects,
-        ].join(', ')} FROM original_query group by ${Array.from(
-            new Set(groupBySelectDimensions),
-        ).join(', ')}`;
+        ].join(', ')} FROM original_query${groupBy}`;
     }
 
     /**

--- a/packages/frontend/src/features/queryRunner/sqlRunnerPivotQueries.ts
+++ b/packages/frontend/src/features/queryRunner/sqlRunnerPivotQueries.ts
@@ -29,7 +29,8 @@ const convertSqlRunnerQueryToSqlRunnerPivotQuery = (
     SqlRunnerPivotQueryBody,
     'indexColumn' | 'groupByColumns' | 'valuesColumns'
 > => {
-    const index = fields.find((field) => field.name === query.pivot?.index[0]);
+    const indexReference = query.pivot?.index[0];
+    const index = fields.find((field) => field.name === indexReference);
     const values = query.pivot?.values.map((value) => {
         const customMetric = query.customMetrics?.find(
             (metric) => metric.name === value,
@@ -56,11 +57,18 @@ const convertSqlRunnerQueryToSqlRunnerPivotQuery = (
         return f;
     });
 
-    if (index === undefined || values === undefined || values.length === 0) {
+    // An index is optional: charts that aggregate every row into a single
+    // value (big number) pivot on values alone.
+    if (indexReference !== undefined && index === undefined) {
+        throw new Error(
+            'Unexpected error: incorrect pivot configuration, invalid index',
+        );
+    }
+    if (values === undefined || values.length === 0) {
         throw new Error('Unexpected error: incorrect pivot configuration');
     }
     return {
-        indexColumn: {
+        indexColumn: index && {
             reference: index.name,
             type: getVizIndexTypeFromSqlRunnerFieldType(index.type),
         },
@@ -90,9 +98,7 @@ export const getPivotQueryFunctionForSqlQuery = ({
     parameters: ParametersValuesMap;
 }): RunPivotQuery => {
     return async (query: SqlRunnerQuery) => {
-        const index = query.pivot?.index[0];
-
-        if (index === undefined) {
+        if (!query.pivot?.values.length) {
             return {
                 queryUuid: undefined,
                 results: [],


### PR DESCRIPTION
Part 1 of 6 adding a big value (big number) chart to the SQL Runner.

## What

`PivotQueryBuilder.getGroupByQuerySQL` built the `group by` clause from the index + groupBy columns without checking that there were any. With neither, it emitted a trailing bare `group by` and the warehouse rejected the query:

```sql
SELECT count("event_id") AS "event_id_count" FROM original_query group by
```

The clause is now omitted when there are no dimensions, so a values-only pivot config collapses every row into a single aggregate row.

On the frontend, `getPivotQueryFunctionForSqlQuery` returned an empty result whenever no index column was set. That guard now keys off value columns instead: a pivot query runs as long as there is at least one thing to aggregate.

## Why

Big numbers aggregate the whole result set into one value, so they have values but no index. Reusing `PivotChartLayout` with `x: undefined` lets the rest of the pipeline — the backend's chart-config-to-pivot derivation, dashboard filters, downloads — work unchanged, but only once an empty index is legal.

## Regression analysis

Two behaviour changes, both narrow:

- **SQL generation** is byte-identical whenever there is at least one index or groupBy column, which is every chart type that exists today. Only the previously-broken no-dimension case changes. The existing `PivotQueryBuilder` suite (153 tests, including the metric-sort and Trino single-scan paths) passes unchanged, and two tests were added for the new case.
- **The frontend guard** was doing double duty: it also short-circuited a bar/line/pie chart whose X axis wasn't set yet. Those charts now issue one pivot query in that state instead of none. The query is a cheap single-row aggregate and the result is discarded — `ChartView` still renders "You're missing an X axis" as before — so this is a small amount of extra work in a transient config state, not a behaviour change the user sees.

Relates: PROD-1096
Relates: #11194
