### PR TITLE
feat: add a big number data model for sql charts

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -4414,11 +4414,6 @@ const models: TsoaRoute.Models = {
         enums: ['vertical_bar'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'ChartKind.LINE': {
-        dataType: 'refEnum',
-        enums: ['line'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     VizIndexType: {
         dataType: 'refEnum',
         enums: ['time', 'category'],
@@ -4625,7 +4620,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    VizCartesianChartConfig: {
+    VizBarChartConfig: {
         dataType: 'refAlias',
         type: {
             dataType: 'intersection',
@@ -4650,14 +4645,45 @@ const models: TsoaRoute.Models = {
                             ],
                             required: true,
                         },
-                        type: {
+                        type: { ref: 'ChartKind.VERTICAL_BAR', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ChartKind.LINE': {
+        dataType: 'refEnum',
+        enums: ['line'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    VizLineChartConfig: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'VizBaseConfig' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        display: {
                             dataType: 'union',
                             subSchemas: [
-                                { ref: 'ChartKind.VERTICAL_BAR' },
-                                { ref: 'ChartKind.LINE' },
+                                { ref: 'CartesianChartDisplay' },
+                                { dataType: 'undefined' },
                             ],
                             required: true,
                         },
+                        fieldConfig: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'PivotChartLayout' },
+                                { dataType: 'undefined' },
+                            ],
+                            required: true,
+                        },
+                        type: { ref: 'ChartKind.LINE', required: true },
                     },
                 },
             ],
@@ -4705,6 +4731,61 @@ const models: TsoaRoute.Models = {
                             required: true,
                         },
                         type: { ref: 'ChartKind.PIE', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ChartKind.BIG_NUMBER': {
+        dataType: 'refEnum',
+        enums: ['big_number'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    VizBigNumberDisplay: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                flipColors: { dataType: 'boolean' },
+                comparisonLabel: { dataType: 'string' },
+                comparisonFormat: { ref: 'ComparisonFormatTypes' },
+                showComparison: { dataType: 'boolean' },
+                style: { ref: 'CompactOrAlias' },
+                showLabel: { dataType: 'boolean' },
+                label: { dataType: 'string' },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    VizBigNumberConfig: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'VizBaseConfig' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        display: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'VizBigNumberDisplay' },
+                                { dataType: 'undefined' },
+                            ],
+                            required: true,
+                        },
+                        fieldConfig: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'PivotChartLayout' },
+                                { dataType: 'undefined' },
+                            ],
+                            required: true,
+                        },
+                        type: { ref: 'ChartKind.BIG_NUMBER', required: true },
                     },
                 },
             ],
@@ -4793,6 +4874,21 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AllVizChartConfig: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { ref: 'VizBarChartConfig' },
+                { ref: 'VizLineChartConfig' },
+                { ref: 'VizPieChartConfig' },
+                { ref: 'VizBigNumberConfig' },
+                { ref: 'VizTableConfig' },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_SqlChart.name-or-description-or-slug-or-sql-or-limit-or-config-or-chartKind_':
         {
             dataType: 'refAlias',
@@ -4810,21 +4906,7 @@ const models: TsoaRoute.Models = {
                     },
                     slug: { dataType: 'string', required: true },
                     limit: { dataType: 'double', required: true },
-                    config: {
-                        dataType: 'intersection',
-                        subSchemas: [
-                            { ref: 'VizBaseConfig' },
-                            {
-                                dataType: 'union',
-                                subSchemas: [
-                                    { ref: 'VizCartesianChartConfig' },
-                                    { ref: 'VizPieChartConfig' },
-                                    { ref: 'VizTableConfig' },
-                                ],
-                            },
-                        ],
-                        required: true,
-                    },
+                    config: { ref: 'AllVizChartConfig', required: true },
                     sql: { dataType: 'string', required: true },
                     chartKind: { ref: 'ChartKind', required: true },
                 },
@@ -14115,21 +14197,7 @@ const models: TsoaRoute.Models = {
                 },
                 createdAt: { dataType: 'datetime', required: true },
                 chartKind: { ref: 'ChartKind', required: true },
-                config: {
-                    dataType: 'intersection',
-                    subSchemas: [
-                        { ref: 'VizBaseConfig' },
-                        {
-                            dataType: 'union',
-                            subSchemas: [
-                                { ref: 'VizCartesianChartConfig' },
-                                { ref: 'VizPieChartConfig' },
-                                { ref: 'VizTableConfig' },
-                            ],
-                        },
-                    ],
-                    required: true,
-                },
+                config: { ref: 'AllVizChartConfig', required: true },
                 limit: { dataType: 'double', required: true },
                 sql: { dataType: 'string', required: true },
                 slug: { dataType: 'string', required: true },
@@ -36626,86 +36694,6 @@ const models: TsoaRoute.Models = {
                 },
                 status: { dataType: 'enum', enums: ['ok'], required: true },
             },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    VizBarChartConfig: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                { ref: 'VizBaseConfig' },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        display: {
-                            dataType: 'union',
-                            subSchemas: [
-                                { ref: 'CartesianChartDisplay' },
-                                { dataType: 'undefined' },
-                            ],
-                            required: true,
-                        },
-                        fieldConfig: {
-                            dataType: 'union',
-                            subSchemas: [
-                                { ref: 'PivotChartLayout' },
-                                { dataType: 'undefined' },
-                            ],
-                            required: true,
-                        },
-                        type: { ref: 'ChartKind.VERTICAL_BAR', required: true },
-                    },
-                },
-            ],
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    VizLineChartConfig: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                { ref: 'VizBaseConfig' },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        display: {
-                            dataType: 'union',
-                            subSchemas: [
-                                { ref: 'CartesianChartDisplay' },
-                                { dataType: 'undefined' },
-                            ],
-                            required: true,
-                        },
-                        fieldConfig: {
-                            dataType: 'union',
-                            subSchemas: [
-                                { ref: 'PivotChartLayout' },
-                                { dataType: 'undefined' },
-                            ],
-                            required: true,
-                        },
-                        type: { ref: 'ChartKind.LINE', required: true },
-                    },
-                },
-            ],
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    AllVizChartConfig: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'union',
-            subSchemas: [
-                { ref: 'VizBarChartConfig' },
-                { ref: 'VizLineChartConfig' },
-                { ref: 'VizPieChartConfig' },
-                { ref: 'VizTableConfig' },
-            ],
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -4661,10 +4661,6 @@
                 "enum": ["vertical_bar"],
                 "type": "string"
             },
-            "ChartKind.LINE": {
-                "enum": ["line"],
-                "type": "string"
-            },
             "VizIndexType": {
                 "enum": ["time", "category"],
                 "type": "string"
@@ -4878,7 +4874,7 @@
                 },
                 "type": "object"
             },
-            "VizCartesianChartConfig": {
+            "VizBarChartConfig": {
                 "allOf": [
                     {
                         "$ref": "#/components/schemas/VizBaseConfig"
@@ -4892,14 +4888,33 @@
                                 "$ref": "#/components/schemas/PivotChartLayout"
                             },
                             "type": {
-                                "anyOf": [
-                                    {
-                                        "$ref": "#/components/schemas/ChartKind.VERTICAL_BAR"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/ChartKind.LINE"
-                                    }
-                                ]
+                                "$ref": "#/components/schemas/ChartKind.VERTICAL_BAR"
+                            }
+                        },
+                        "required": ["type"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ChartKind.LINE": {
+                "enum": ["line"],
+                "type": "string"
+            },
+            "VizLineChartConfig": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/VizBaseConfig"
+                    },
+                    {
+                        "properties": {
+                            "display": {
+                                "$ref": "#/components/schemas/CartesianChartDisplay"
+                            },
+                            "fieldConfig": {
+                                "$ref": "#/components/schemas/PivotChartLayout"
+                            },
+                            "type": {
+                                "$ref": "#/components/schemas/ChartKind.LINE"
                             }
                         },
                         "required": ["type"],
@@ -4934,6 +4949,63 @@
                             },
                             "type": {
                                 "$ref": "#/components/schemas/ChartKind.PIE"
+                            }
+                        },
+                        "required": ["type"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ChartKind.BIG_NUMBER": {
+                "enum": ["big_number"],
+                "type": "string"
+            },
+            "VizBigNumberDisplay": {
+                "properties": {
+                    "flipColors": {
+                        "type": "boolean",
+                        "description": "Colours an increase red and a decrease green."
+                    },
+                    "comparisonLabel": {
+                        "type": "string"
+                    },
+                    "comparisonFormat": {
+                        "$ref": "#/components/schemas/ComparisonFormatTypes"
+                    },
+                    "showComparison": {
+                        "type": "boolean",
+                        "description": "Compares the value against the second selected field."
+                    },
+                    "style": {
+                        "$ref": "#/components/schemas/CompactOrAlias",
+                        "description": "Compact notation applied to the value (K/M/B/T)."
+                    },
+                    "showLabel": {
+                        "type": "boolean"
+                    },
+                    "label": {
+                        "type": "string",
+                        "description": "Custom label rendered under the value. Falls back to the field name."
+                    }
+                },
+                "type": "object"
+            },
+            "VizBigNumberConfig": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/VizBaseConfig"
+                    },
+                    {
+                        "properties": {
+                            "display": {
+                                "$ref": "#/components/schemas/VizBigNumberDisplay"
+                            },
+                            "fieldConfig": {
+                                "$ref": "#/components/schemas/PivotChartLayout",
+                                "description": "Big numbers aggregate every row, so `x` is always undefined and `y`\nholds the value field followed by the optional comparison field."
+                            },
+                            "type": {
+                                "$ref": "#/components/schemas/ChartKind.BIG_NUMBER"
                             }
                         },
                         "required": ["type"],
@@ -5023,6 +5095,25 @@
                     }
                 ]
             },
+            "AllVizChartConfig": {
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/VizBarChartConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/VizLineChartConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/VizPieChartConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/VizBigNumberConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/VizTableConfig"
+                    }
+                ]
+            },
             "Pick_SqlChart.name-or-description-or-slug-or-sql-or-limit-or-config-or-chartKind_": {
                 "properties": {
                     "name": {
@@ -5040,24 +5131,7 @@
                         "format": "double"
                     },
                     "config": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/VizBaseConfig"
-                            },
-                            {
-                                "anyOf": [
-                                    {
-                                        "$ref": "#/components/schemas/VizCartesianChartConfig"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/VizPieChartConfig"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/VizTableConfig"
-                                    }
-                                ]
-                            }
-                        ]
+                        "$ref": "#/components/schemas/AllVizChartConfig"
                     },
                     "sql": {
                         "type": "string"
@@ -15389,24 +15463,7 @@
                         "$ref": "#/components/schemas/ChartKind"
                     },
                     "config": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/VizBaseConfig"
-                            },
-                            {
-                                "anyOf": [
-                                    {
-                                        "$ref": "#/components/schemas/VizCartesianChartConfig"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/VizPieChartConfig"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/VizTableConfig"
-                                    }
-                                ]
-                            }
-                        ]
+                        "$ref": "#/components/schemas/AllVizChartConfig"
                     },
                     "limit": {
                         "type": "number",
@@ -36710,66 +36767,6 @@
                 },
                 "required": ["results", "status"],
                 "type": "object"
-            },
-            "VizBarChartConfig": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/VizBaseConfig"
-                    },
-                    {
-                        "properties": {
-                            "display": {
-                                "$ref": "#/components/schemas/CartesianChartDisplay"
-                            },
-                            "fieldConfig": {
-                                "$ref": "#/components/schemas/PivotChartLayout"
-                            },
-                            "type": {
-                                "$ref": "#/components/schemas/ChartKind.VERTICAL_BAR"
-                            }
-                        },
-                        "required": ["type"],
-                        "type": "object"
-                    }
-                ]
-            },
-            "VizLineChartConfig": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/VizBaseConfig"
-                    },
-                    {
-                        "properties": {
-                            "display": {
-                                "$ref": "#/components/schemas/CartesianChartDisplay"
-                            },
-                            "fieldConfig": {
-                                "$ref": "#/components/schemas/PivotChartLayout"
-                            },
-                            "type": {
-                                "$ref": "#/components/schemas/ChartKind.LINE"
-                            }
-                        },
-                        "required": ["type"],
-                        "type": "object"
-                    }
-                ]
-            },
-            "AllVizChartConfig": {
-                "anyOf": [
-                    {
-                        "$ref": "#/components/schemas/VizBarChartConfig"
-                    },
-                    {
-                        "$ref": "#/components/schemas/VizLineChartConfig"
-                    },
-                    {
-                        "$ref": "#/components/schemas/VizPieChartConfig"
-                    },
-                    {
-                        "$ref": "#/components/schemas/VizTableConfig"
-                    }
-                ]
             },
             "CreateSqlChart": {
                 "properties": {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -369,6 +369,7 @@ export * from './utils/timeFrames';
 export * from './utils/resolveQueryTimezone';
 export * from './utils/virtualView';
 export * from './utils/warehouse';
+export * from './visualizations/BigNumberDataModel';
 export * from './visualizations/CartesianChartDataModel';
 export * from './visualizations/helpers/getCartesianAxisFormatterConfig';
 export * from './visualizations/helpers/seriesZOrder';

--- a/packages/common/src/visualizations/BigNumberDataModel.test.ts
+++ b/packages/common/src/visualizations/BigNumberDataModel.test.ts
@@ -1,0 +1,384 @@
+import { Compact, DimensionType } from '../types/field';
+import {
+    ChartKind,
+    ComparisonDiffTypes,
+    ComparisonFormatTypes,
+} from '../types/savedCharts';
+import { BigNumberDataModel } from './BigNumberDataModel';
+import {
+    VizAggregationOptions,
+    VizIndexType,
+    type PivotChartData,
+    type PivotChartLayout,
+} from './types';
+import { type IResultsRunner } from './types/IResultsRunner';
+
+const pivotResults = (row: Record<string, unknown>): PivotChartData => ({
+    queryUuid: 'query-uuid',
+    fileUrl: 'https://example.com/results.jsonl',
+    results: [row],
+    indexColumn: undefined,
+    valuesColumns: Object.keys(row).map((pivotColumnName) => ({
+        referenceField: pivotColumnName.replace(
+            /_(sum|count|avg|min|max)$/,
+            '',
+        ),
+        pivotColumnName,
+        aggregation: VizAggregationOptions.SUM,
+        pivotValues: [],
+    })),
+    columns: Object.keys(row).map((reference) => ({ reference })),
+    columnCount: Object.keys(row).length,
+});
+
+const buildRunner = (
+    overrides: Partial<IResultsRunner> = {},
+): IResultsRunner => ({
+    getColumnNames: () => ['revenue', 'target', 'region'],
+    getRows: () => [],
+    getPivotedVisualizationData: async () => pivotResults({ revenue_sum: 100 }),
+    getPivotQueryDimensions: () => [
+        {
+            reference: 'region',
+            axisType: VizIndexType.CATEGORY,
+            dimensionType: DimensionType.STRING,
+        },
+    ],
+    getPivotQueryMetrics: () => [
+        { reference: 'revenue', aggregation: VizAggregationOptions.SUM },
+        { reference: 'target', aggregation: VizAggregationOptions.SUM },
+    ],
+    getPivotQueryCustomMetrics: () => [],
+    ...overrides,
+});
+
+const layout = (references: string[]): PivotChartLayout => ({
+    x: undefined,
+    y: references.map((reference) => ({
+        reference,
+        aggregation: VizAggregationOptions.SUM,
+    })),
+    groupBy: [],
+});
+
+describe('BigNumberDataModel', () => {
+    describe('getDefaultLayout', () => {
+        it('selects the first metric and no index', () => {
+            const model = new BigNumberDataModel({
+                resultsRunner: buildRunner(),
+            });
+
+            expect(model.getDefaultLayout()).toEqual({
+                x: undefined,
+                y: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupBy: [],
+            });
+        });
+
+        it('falls back to a numeric dimension as a custom metric', () => {
+            const model = new BigNumberDataModel({
+                resultsRunner: buildRunner({
+                    getPivotQueryMetrics: () => [],
+                    getPivotQueryCustomMetrics: () => [
+                        {
+                            reference: 'region',
+                            axisType: VizIndexType.CATEGORY,
+                            dimensionType: DimensionType.STRING,
+                            aggregation: VizAggregationOptions.COUNT,
+                        },
+                        {
+                            reference: 'revenue',
+                            axisType: VizIndexType.CATEGORY,
+                            dimensionType: DimensionType.NUMBER,
+                            aggregation: VizAggregationOptions.SUM,
+                        },
+                    ],
+                }),
+            });
+
+            expect(model.getDefaultLayout()?.y).toEqual([
+                {
+                    reference: 'revenue',
+                    aggregation: VizAggregationOptions.SUM,
+                },
+            ]);
+        });
+
+        it('returns undefined when there is nothing to aggregate', () => {
+            const model = new BigNumberDataModel({
+                resultsRunner: buildRunner({
+                    getPivotQueryMetrics: () => [],
+                    getPivotQueryCustomMetrics: () => [],
+                }),
+            });
+
+            expect(model.getDefaultLayout()).toBeUndefined();
+        });
+    });
+
+    describe('mergeConfig', () => {
+        it('keeps a saved layout whose fields still exist', () => {
+            const model = new BigNumberDataModel({
+                resultsRunner: buildRunner(),
+            });
+            const saved = layout(['target']);
+
+            expect(
+                model.mergeConfig(ChartKind.BIG_NUMBER, {
+                    fieldConfig: saved,
+                    display: { label: 'Target' },
+                }),
+            ).toEqual({
+                metadata: { version: 1 },
+                type: ChartKind.BIG_NUMBER,
+                fieldConfig: saved,
+                display: { label: 'Target' },
+            });
+        });
+
+        it('falls back to the default layout when a saved field is gone', () => {
+            const model = new BigNumberDataModel({
+                resultsRunner: buildRunner(),
+            });
+
+            expect(
+                model.mergeConfig(ChartKind.BIG_NUMBER, {
+                    fieldConfig: layout(['deleted_column']),
+                    display: undefined,
+                }).fieldConfig,
+            ).toEqual(layout(['revenue']));
+        });
+    });
+
+    describe('getConfigErrors', () => {
+        it('reports fields that no longer exist', () => {
+            const model = new BigNumberDataModel({
+                resultsRunner: buildRunner(),
+            });
+
+            expect(model.getConfigErrors(layout(['deleted_column']))).toEqual({
+                metricFieldError: { references: ['deleted_column'] },
+            });
+        });
+
+        it('accepts fields that exist as custom metrics', () => {
+            const model = new BigNumberDataModel({
+                resultsRunner: buildRunner({
+                    getPivotQueryMetrics: () => [],
+                    getPivotQueryCustomMetrics: () => [
+                        {
+                            reference: 'revenue',
+                            axisType: VizIndexType.CATEGORY,
+                            dimensionType: DimensionType.NUMBER,
+                            aggregation: VizAggregationOptions.SUM,
+                        },
+                    ],
+                }),
+            });
+
+            expect(model.getConfigErrors(layout(['revenue']))).toBeUndefined();
+        });
+    });
+
+    describe('getPivotedChartData', () => {
+        it('queries values with an empty index so every row aggregates', async () => {
+            const getPivotedVisualizationData = vi
+                .fn()
+                .mockResolvedValue(pivotResults({ revenue_sum: 100 }));
+            const model = new BigNumberDataModel({
+                resultsRunner: buildRunner({ getPivotedVisualizationData }),
+                fieldConfig: layout(['revenue']),
+            });
+
+            await model.getPivotedChartData({
+                sql: 'SELECT 1',
+                limit: 500,
+                sortBy: [],
+                filters: [],
+            });
+
+            expect(getPivotedVisualizationData).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    dimensions: [],
+                    timeDimensions: [],
+                    metrics: [{ name: 'revenue' }],
+                    pivot: { index: [], on: [], values: ['revenue'] },
+                }),
+            );
+        });
+
+        it('turns a dimension into a custom metric', async () => {
+            const getPivotedVisualizationData = vi
+                .fn()
+                .mockResolvedValue(pivotResults({ region_count: 3 }));
+            const model = new BigNumberDataModel({
+                resultsRunner: buildRunner({ getPivotedVisualizationData }),
+                fieldConfig: {
+                    x: undefined,
+                    y: [
+                        {
+                            reference: 'region',
+                            aggregation: VizAggregationOptions.COUNT,
+                        },
+                    ],
+                    groupBy: [],
+                },
+            });
+
+            await model.getPivotedChartData({
+                sql: 'SELECT 1',
+                limit: 500,
+                sortBy: [],
+                filters: [],
+            });
+
+            expect(getPivotedVisualizationData).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    customMetrics: [
+                        {
+                            name: 'region_count',
+                            baseDimension: 'region',
+                            aggType: VizAggregationOptions.COUNT,
+                        },
+                    ],
+                    metrics: [{ name: 'region_count' }],
+                }),
+            );
+        });
+    });
+
+    describe('getSpec', () => {
+        const buildSpecModel = async (
+            row: Record<string, unknown>,
+            references: string[],
+        ) => {
+            const model = new BigNumberDataModel({
+                resultsRunner: buildRunner({
+                    getPivotedVisualizationData: async () => pivotResults(row),
+                }),
+                fieldConfig: layout(references),
+            });
+            await model.getPivotedChartData({
+                sql: 'SELECT 1',
+                limit: 500,
+                sortBy: [],
+                filters: [],
+            });
+            return model;
+        };
+
+        it('returns no spec before results arrive', () => {
+            const model = new BigNumberDataModel({
+                resultsRunner: buildRunner(),
+            });
+
+            expect(model.getSpec()).toBeUndefined();
+        });
+
+        it('formats the value and defaults the label to the field name', async () => {
+            const model = await buildSpecModel({ revenue_sum: 1234.5 }, [
+                'revenue',
+            ]);
+
+            expect(model.getSpec()).toMatchObject({
+                value: 1234.5,
+                formattedValue: '1,234.5',
+                label: 'revenue',
+                showLabel: true,
+                comparison: undefined,
+            });
+        });
+
+        it('applies the compact style and custom label', async () => {
+            const model = await buildSpecModel({ revenue_sum: 1_500_000 }, [
+                'revenue',
+            ]);
+
+            expect(
+                model.getSpec({ style: Compact.MILLIONS, label: 'Revenue' }),
+            ).toMatchObject({
+                formattedValue: '1.5M',
+                label: 'Revenue',
+            });
+        });
+
+        it('ignores the comparison field until the comparison is turned on', async () => {
+            const model = await buildSpecModel(
+                { revenue_sum: 120, target_sum: 100 },
+                ['revenue', 'target'],
+            );
+
+            expect(model.getSpec()?.comparison).toBeUndefined();
+        });
+
+        it('computes a raw comparison', async () => {
+            const model = await buildSpecModel(
+                { revenue_sum: 120, target_sum: 100 },
+                ['revenue', 'target'],
+            );
+
+            expect(model.getSpec({ showComparison: true })?.comparison).toEqual(
+                {
+                    value: 20,
+                    formattedValue: '+20',
+                    direction: ComparisonDiffTypes.POSITIVE,
+                    label: undefined,
+                    tooltip: '+20 compared to target',
+                },
+            );
+        });
+
+        it('computes a percentage comparison', async () => {
+            const model = await buildSpecModel(
+                { revenue_sum: 80, target_sum: 100 },
+                ['revenue', 'target'],
+            );
+
+            expect(
+                model.getSpec({
+                    showComparison: true,
+                    comparisonFormat: ComparisonFormatTypes.PERCENTAGE,
+                    comparisonLabel: 'vs target',
+                })?.comparison,
+            ).toMatchObject({
+                value: -0.2,
+                formattedValue: '-20%',
+                direction: ComparisonDiffTypes.NEGATIVE,
+                label: 'vs target',
+            });
+        });
+
+        it('marks an unchanged comparison', async () => {
+            const model = await buildSpecModel(
+                { revenue_sum: 100, target_sum: 100 },
+                ['revenue', 'target'],
+            );
+
+            expect(
+                model.getSpec({ showComparison: true })?.comparison,
+            ).toMatchObject({
+                direction: ComparisonDiffTypes.NONE,
+                formattedValue: '+0',
+            });
+        });
+
+        it('handles a missing comparison value', async () => {
+            const model = await buildSpecModel(
+                { revenue_sum: 100, target_sum: null },
+                ['revenue', 'target'],
+            );
+
+            expect(
+                model.getSpec({ showComparison: true })?.comparison,
+            ).toMatchObject({
+                direction: ComparisonDiffTypes.UNDEFINED,
+                formattedValue: 'n/a',
+            });
+        });
+    });
+});

--- a/packages/common/src/visualizations/BigNumberDataModel.ts
+++ b/packages/common/src/visualizations/BigNumberDataModel.ts
@@ -1,0 +1,361 @@
+import {
+    CustomFormatType,
+    DimensionType,
+    type CompactOrAlias,
+} from '../types/field';
+import { type RawResultRow } from '../types/results';
+import {
+    ComparisonDiffTypes,
+    ComparisonFormatTypes,
+    type ChartKind,
+} from '../types/savedCharts';
+import { type SqlRunnerQuery } from '../types/sqlRunner';
+import {
+    applyCustomFormat,
+    getCustomFormatFromLegacy,
+} from '../utils/formatting';
+import {
+    type PivotChartData,
+    type PivotChartLayout,
+    type VizBigNumberDisplay,
+    type VizConfigErrors,
+} from './types';
+import { type IResultsRunner } from './types/IResultsRunner';
+
+const NOT_APPLICABLE = 'n/a';
+
+export type BigNumberComparisonSpec = {
+    /** Raw delta, or the fractional change when the format is percentage. */
+    value: number | undefined;
+    formattedValue: string;
+    direction: ComparisonDiffTypes;
+    label: string | undefined;
+    tooltip: string;
+};
+
+export type BigNumberSpec = {
+    value: unknown;
+    formattedValue: string;
+    label: string;
+    showLabel: boolean;
+    flipColors: boolean;
+    comparison: BigNumberComparisonSpec | undefined;
+};
+
+/** Nothing selected yet: no value means no query and an empty spec. */
+const defaultFieldConfig: PivotChartLayout = {
+    x: undefined,
+    y: [],
+    groupBy: [],
+};
+
+export const calculateComparisonValue = (
+    value: number,
+    comparisonValue: number,
+    format: ComparisonFormatTypes | undefined,
+): number => {
+    const rawValue = value - comparisonValue;
+    return format === ComparisonFormatTypes.PERCENTAGE
+        ? rawValue / Math.abs(comparisonValue)
+        : rawValue;
+};
+
+const isNumeric = (value: unknown): value is number | string =>
+    value !== null &&
+    value !== undefined &&
+    value !== '' &&
+    !Number.isNaN(Number(value));
+
+const formatValue = (value: unknown, style: CompactOrAlias | undefined) => {
+    if (value === null || value === undefined) {
+        return NOT_APPLICABLE;
+    }
+    if (!isNumeric(value)) {
+        return String(value);
+    }
+    return applyCustomFormat(
+        Number(value),
+        getCustomFormatFromLegacy({ compact: style }),
+    );
+};
+
+const getComparisonDirection = (delta: number): ComparisonDiffTypes => {
+    if (delta > 0) return ComparisonDiffTypes.POSITIVE;
+    if (delta < 0) return ComparisonDiffTypes.NEGATIVE;
+    return ComparisonDiffTypes.NONE;
+};
+
+/**
+ * Renders a single aggregated value from a SQL query. Unlike the other SQL
+ * chart models there is no index — every row collapses into one aggregate per
+ * selected field — so `fieldConfig.y[0]` is the value and `fieldConfig.y[1]`
+ * is the optional comparison field.
+ */
+export class BigNumberDataModel {
+    private readonly resultsRunner: IResultsRunner;
+
+    private readonly fieldConfig: PivotChartLayout;
+
+    private pivotedChartData: PivotChartData | undefined;
+
+    constructor(args: {
+        resultsRunner: IResultsRunner;
+        fieldConfig?: PivotChartLayout;
+    }) {
+        this.resultsRunner = args.resultsRunner;
+        this.fieldConfig = args.fieldConfig ?? defaultFieldConfig;
+    }
+
+    getResultOptions() {
+        return {
+            metricFieldOptions: this.resultsRunner.getPivotQueryMetrics(),
+            customMetricFieldOptions:
+                this.resultsRunner.getPivotQueryCustomMetrics(),
+        };
+    }
+
+    getDefaultLayout(): PivotChartLayout | undefined {
+        const { metricFieldOptions, customMetricFieldOptions } =
+            this.getResultOptions();
+
+        const numericCustomMetrics = customMetricFieldOptions.filter(
+            (field) => field.dimensionType === DimensionType.NUMBER,
+        );
+
+        const valueField =
+            metricFieldOptions[0] ??
+            numericCustomMetrics[0] ??
+            customMetricFieldOptions[0];
+
+        if (valueField === undefined) {
+            return undefined;
+        }
+
+        return {
+            x: undefined,
+            y: [
+                {
+                    reference: valueField.reference,
+                    aggregation: valueField.aggregation,
+                },
+            ],
+            groupBy: [],
+        };
+    }
+
+    mergeConfig(
+        chartKind: ChartKind.BIG_NUMBER,
+        currentVizConfig?: {
+            fieldConfig: PivotChartLayout | undefined;
+            display: VizBigNumberDisplay | undefined;
+        },
+    ) {
+        const newDefaultLayout = this.getDefaultLayout();
+
+        const currentFields = currentVizConfig?.fieldConfig?.y ?? [];
+        const currentLayoutIsStillValid =
+            currentFields.length > 0 &&
+            this.getUnknownReferences(currentFields).length === 0;
+
+        return {
+            metadata: { version: 1 },
+            type: chartKind,
+            fieldConfig: currentLayoutIsStillValid
+                ? currentVizConfig?.fieldConfig
+                : (newDefaultLayout ?? currentVizConfig?.fieldConfig),
+            display: currentVizConfig?.display ?? {},
+        };
+    }
+
+    /**
+     * References in `y` that the current results can't provide, either as a
+     * pre-aggregated metric or as a custom metric over a dimension.
+     */
+    private getUnknownReferences(fields: PivotChartLayout['y']): string[] {
+        const { metricFieldOptions, customMetricFieldOptions } =
+            this.getResultOptions();
+        const knownReferences = new Set(
+            [...metricFieldOptions, ...customMetricFieldOptions].map(
+                (option) => option.reference,
+            ),
+        );
+
+        return fields
+            .map((field) => field.reference)
+            .filter((reference) => !knownReferences.has(reference));
+    }
+
+    getConfigErrors(config?: PivotChartLayout): VizConfigErrors | undefined {
+        if (!config) {
+            return undefined;
+        }
+
+        const unknownReferences = this.getUnknownReferences(config.y ?? []);
+
+        return unknownReferences.length > 0
+            ? { metricFieldError: { references: unknownReferences } }
+            : undefined;
+    }
+
+    async getPivotedChartData({
+        sortBy,
+        filters,
+        limit,
+        sql,
+    }: Pick<SqlRunnerQuery, 'sortBy' | 'filters' | 'limit' | 'sql'>): Promise<
+        PivotChartData | undefined
+    > {
+        const allDimensionNames = new Set(
+            this.resultsRunner
+                .getPivotQueryDimensions()
+                .map((d) => d.reference),
+        );
+
+        const { customMetrics, metrics } = (this.fieldConfig.y ?? []).reduce<{
+            customMetrics: Required<SqlRunnerQuery>['customMetrics'];
+            metrics: SqlRunnerQuery['metrics'];
+        }>(
+            (acc, field) => {
+                if (allDimensionNames.has(field.reference)) {
+                    const name = `${field.reference}_${field.aggregation}`;
+                    acc.customMetrics.push({
+                        name,
+                        baseDimension: field.reference,
+                        aggType: field.aggregation,
+                    });
+                    acc.metrics.push({ name });
+                } else {
+                    acc.metrics.push({ name: field.reference });
+                }
+                return acc;
+            },
+            { customMetrics: [], metrics: [] },
+        );
+
+        const query: SqlRunnerQuery = {
+            sql,
+            limit,
+            filters,
+            sortBy,
+            metrics,
+            dimensions: [],
+            timeDimensions: [],
+            pivot: {
+                index: [],
+                on: [],
+                values: metrics.map((metric) => metric.name),
+            },
+            customMetrics,
+        };
+
+        this.pivotedChartData =
+            await this.resultsRunner.getPivotedVisualizationData(query);
+
+        return this.pivotedChartData;
+    }
+
+    getPivotedTableData():
+        | { columns: string[]; rows: RawResultRow[] }
+        | undefined {
+        const transformedData = this.pivotedChartData;
+        if (!transformedData) {
+            return undefined;
+        }
+        return {
+            columns: Object.keys(transformedData.results[0] ?? {}),
+            rows: transformedData.results,
+        };
+    }
+
+    getDataDownloadUrl(): string | undefined {
+        return this.pivotedChartData?.fileUrl;
+    }
+
+    /**
+     * Compares the value against the second selected field. Returns undefined
+     * when there is nothing to compare against.
+     */
+    private static buildComparison(
+        value: unknown,
+        comparisonValue: unknown,
+        comparisonField: string,
+        display: VizBigNumberDisplay,
+    ): BigNumberComparisonSpec {
+        if (!isNumeric(value) || !isNumeric(comparisonValue)) {
+            return {
+                value: undefined,
+                formattedValue: NOT_APPLICABLE,
+                direction:
+                    comparisonValue === undefined || comparisonValue === null
+                        ? ComparisonDiffTypes.UNDEFINED
+                        : ComparisonDiffTypes.NAN,
+                label: display.comparisonLabel,
+                tooltip: 'Comparison field has no comparable value',
+            };
+        }
+
+        const format = display.comparisonFormat ?? ComparisonFormatTypes.RAW;
+        const delta = calculateComparisonValue(
+            Number(value),
+            Number(comparisonValue),
+            format,
+        );
+        const direction = getComparisonDirection(delta);
+        // Only a decrease carries its own sign.
+        const prefix = direction === ComparisonDiffTypes.NEGATIVE ? '' : '+';
+        const formattedValue =
+            format === ComparisonFormatTypes.PERCENTAGE
+                ? `${prefix}${applyCustomFormat(delta, {
+                      round: 0,
+                      type: CustomFormatType.PERCENT,
+                  })}`
+                : `${prefix}${formatValue(delta, display.style)}`;
+
+        return {
+            value: delta,
+            formattedValue,
+            direction,
+            label: display.comparisonLabel,
+            tooltip:
+                direction === ComparisonDiffTypes.NONE
+                    ? `No change compared to ${comparisonField}`
+                    : `${formattedValue} compared to ${comparisonField}`,
+        };
+    }
+
+    getSpec(display?: VizBigNumberDisplay): BigNumberSpec | undefined {
+        const transformedData = this.pivotedChartData;
+
+        if (!transformedData) {
+            return undefined;
+        }
+
+        const [valueColumn, comparisonColumn] = transformedData.valuesColumns;
+        const row = transformedData.results[0];
+        const value =
+            valueColumn && row ? row[valueColumn.pivotColumnName] : undefined;
+
+        const showComparison =
+            !!display?.showComparison && !!comparisonColumn && !!row;
+
+        return {
+            value,
+            formattedValue: formatValue(value, display?.style),
+            label:
+                display?.label ||
+                this.fieldConfig.y?.[0]?.reference ||
+                valueColumn?.referenceField ||
+                '',
+            showLabel: display?.showLabel ?? true,
+            flipColors: display?.flipColors ?? false,
+            comparison: showComparison
+                ? BigNumberDataModel.buildComparison(
+                      value,
+                      row[comparisonColumn.pivotColumnName],
+                      comparisonColumn.referenceField,
+                      display,
+                  )
+                : undefined,
+        };
+    }
+}

--- a/packages/common/src/visualizations/types/index.ts
+++ b/packages/common/src/visualizations/types/index.ts
@@ -1,10 +1,15 @@
 import { type AnyType } from '../../types/any';
-import { DimensionType, TableCalculationType } from '../../types/field';
+import {
+    DimensionType,
+    TableCalculationType,
+    type CompactOrAlias,
+} from '../../types/field';
 import { type PivotSortAnchor } from '../../types/metricQuery';
 import { type PivotConfiguration } from '../../types/pivot';
 import { type RawResultRow } from '../../types/results';
 import {
     ChartKind,
+    type ComparisonFormatTypes,
     type PivotReference,
     type Series,
 } from '../../types/savedCharts';
@@ -118,6 +123,20 @@ export type VizPieChartDisplay = {
     isDonut?: boolean;
 };
 
+export type VizBigNumberDisplay = {
+    /** Custom label rendered under the value. Falls back to the field name. */
+    label?: string;
+    showLabel?: boolean;
+    /** Compact notation applied to the value (K/M/B/T). */
+    style?: CompactOrAlias;
+    /** Compares the value against the second selected field. */
+    showComparison?: boolean;
+    comparisonFormat?: ComparisonFormatTypes;
+    comparisonLabel?: string;
+    /** Colours an increase red and a decrease green. */
+    flipColors?: boolean;
+};
+
 export type VizTableDisplay = {
     // TODO: split table display config out of table config
     // On vis column config, visible, label and frozen, at least seem like display options
@@ -201,6 +220,11 @@ export type VizPieChartOptions = {
     customMetricFieldOptions: VizCustomMetricLayoutOptions[];
 };
 
+export type VizBigNumberOptions = {
+    metricFieldOptions: VizValuesLayoutOptions[];
+    customMetricFieldOptions: VizCustomMetricLayoutOptions[];
+};
+
 export type VizColumnConfig = {
     visible: boolean;
     reference: string;
@@ -258,6 +282,16 @@ export type VizPieChartConfig = VizBaseConfig & {
     display: VizPieChartDisplay | undefined;
 };
 
+export type VizBigNumberConfig = VizBaseConfig & {
+    type: ChartKind.BIG_NUMBER;
+    /**
+     * Big numbers aggregate every row, so `x` is always undefined and `y`
+     * holds the value field followed by the optional comparison field.
+     */
+    fieldConfig: PivotChartLayout | undefined;
+    display: VizBigNumberDisplay | undefined;
+};
+
 export type VizTableConfig = VizBaseConfig & {
     type: ChartKind.TABLE;
     columns: VizTableColumnsConfig['columns'];
@@ -292,6 +326,11 @@ export const isVizPieChartConfig = (
 export const isVizTableConfig = (
     value: VizBaseConfig | undefined,
 ): value is VizTableConfig => !!value && value.type === ChartKind.TABLE;
+
+export const isVizBigNumberConfig = (
+    value: VizBaseConfig | undefined,
+): value is VizBigNumberConfig =>
+    !!value && value.type === ChartKind.BIG_NUMBER;
 
 export type VizConfigErrors = {
     indexFieldError?: {


### PR DESCRIPTION
Part 2 of 6 adding a big value (big number) chart to the SQL Runner.

## What

Adds the SQL-chart side of the big number visualization to `@lightdash/common`:

- `VizBigNumberConfig`, `VizBigNumberDisplay`, `VizBigNumberOptions` and the `isVizBigNumberConfig` guard.
- `BigNumberDataModel`, alongside the existing cartesian/pie/table models.

The model has no index — every result row aggregates into a single value — so `fieldConfig.y[0]` is the displayed value and `fieldConfig.y[1]` is the optional comparison field. Keeping the shape as `PivotChartLayout` means `AsyncQueryService.prepareSqlChartAsyncQueryArgs` derives the pivot configuration from a saved big number chart with no changes.

`getSpec()` returns a plain `BigNumberSpec` (value, formatted value, label, comparison) rather than an ECharts option, because the big number is rendered in React.

## Notes for reviewers

The config is deliberately **not** part of `AllVizChartConfig` yet — that union change lands in part 3 together with every render site that has to handle it, so no intermediate commit leaves an unhandled chart kind.

17 unit tests cover default layout selection, config merging when a saved field disappears, error reporting, the shape of the emitted pivot query, and value/comparison formatting.

Relates: PROD-1096
Relates: #11194
