### PR TITLE
feat: add display and comparison options to sql big numbers

### DIFF
--- a/packages/frontend/src/components/DataViz/config/BigNumberComparisonConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/BigNumberComparisonConfig.tsx
@@ -1,0 +1,154 @@
+import { ComparisonFormatTypes, type VizColumn } from '@lightdash/common';
+import { SegmentedControl, Stack, Switch, TextInput } from '@mantine-8/core';
+import {
+    useAppDispatch as useVizDispatch,
+    useAppSelector as useVizSelector,
+} from '../../../features/sqlRunner/store/hooks';
+import { Config } from '../../VisualizationConfigs/common/Config';
+import { FieldReferenceSelect } from '../FieldReferenceSelect';
+import {
+    setComparisonAggregation,
+    setComparisonFormat,
+    setComparisonLabel,
+    setComparisonReference,
+    setFlipColors,
+    setShowComparison,
+} from '../store/bigNumberSlice';
+import { DataVizAggregationConfig } from './DataVizAggregationConfig';
+import { useBigNumberFieldOptions } from './useBigNumberFieldOptions';
+
+export const BigNumberComparisonConfig = ({
+    columns,
+}: {
+    columns: VizColumn[];
+}) => {
+    const dispatch = useVizDispatch();
+    const display = useVizSelector((state) => state.bigNumberConfig.display);
+    const valueField = useVizSelector(
+        (state) => state.bigNumberConfig.fieldConfig?.y[0],
+    );
+    const comparisonField = useVizSelector(
+        (state) => state.bigNumberConfig.fieldConfig?.y[1],
+    );
+    const { selectData, fieldTypeOf, aggregationOptionsFor } =
+        useBigNumberFieldOptions(columns);
+
+    const showComparison = display?.showComparison ?? false;
+
+    return (
+        <Stack gap="sm" mb="lg">
+            <Config.Section>
+                <Config.Group>
+                    <Config.Heading>Compare to a field</Config.Heading>
+                    <Switch
+                        size="xs"
+                        checked={showComparison}
+                        onChange={(event) =>
+                            dispatch(
+                                setShowComparison(event.currentTarget.checked),
+                            )
+                        }
+                    />
+                </Config.Group>
+            </Config.Section>
+
+            {showComparison && (
+                <>
+                    <Config.Section>
+                        <Config.Heading>Field</Config.Heading>
+
+                        <FieldReferenceSelect
+                            data={selectData.filter(
+                                (option) =>
+                                    option.value !== valueField?.reference,
+                            )}
+                            value={comparisonField?.reference}
+                            placeholder="Select a field to compare against"
+                            onChange={(value) =>
+                                dispatch(
+                                    setComparisonReference(value ?? undefined),
+                                )
+                            }
+                            fieldType={fieldTypeOf(comparisonField?.reference)}
+                        />
+
+                        <Config.Group>
+                            <Config.Label>Aggregation</Config.Label>
+
+                            <DataVizAggregationConfig
+                                options={aggregationOptionsFor(
+                                    comparisonField?.reference,
+                                )}
+                                aggregation={comparisonField?.aggregation}
+                                onChangeAggregation={(value) =>
+                                    dispatch(setComparisonAggregation(value))
+                                }
+                            />
+                        </Config.Group>
+                    </Config.Section>
+
+                    <Config.Section>
+                        <Config.Label>Format</Config.Label>
+                        <SegmentedControl
+                            size="xs"
+                            value={
+                                display?.comparisonFormat ??
+                                ComparisonFormatTypes.RAW
+                            }
+                            data={[
+                                {
+                                    value: ComparisonFormatTypes.RAW,
+                                    label: 'Raw value',
+                                },
+                                {
+                                    value: ComparisonFormatTypes.PERCENTAGE,
+                                    label: 'Percentage',
+                                },
+                            ]}
+                            onChange={(value) =>
+                                dispatch(
+                                    setComparisonFormat(
+                                        value as ComparisonFormatTypes,
+                                    ),
+                                )
+                            }
+                        />
+                    </Config.Section>
+
+                    <Config.Section>
+                        <Config.Group>
+                            <Config.Label>Flip positive color</Config.Label>
+                            <Switch
+                                size="xs"
+                                checked={display?.flipColors ?? false}
+                                onChange={(event) =>
+                                    dispatch(
+                                        setFlipColors(
+                                            event.currentTarget.checked,
+                                        ),
+                                    )
+                                }
+                            />
+                        </Config.Group>
+                    </Config.Section>
+
+                    <Config.Section>
+                        <Config.Label>Comparison label</Config.Label>
+                        <TextInput
+                            size="xs"
+                            placeholder="Add an optional label"
+                            value={display?.comparisonLabel ?? ''}
+                            onChange={(event) =>
+                                dispatch(
+                                    setComparisonLabel(
+                                        event.currentTarget.value || undefined,
+                                    ),
+                                )
+                            }
+                        />
+                    </Config.Section>
+                </>
+            )}
+        </Stack>
+    );
+};

--- a/packages/frontend/src/components/DataViz/config/BigNumberConfiguration.tsx
+++ b/packages/frontend/src/components/DataViz/config/BigNumberConfiguration.tsx
@@ -1,92 +1,31 @@
-import { DimensionType, type VizColumn } from '@lightdash/common';
-import { Stack, Title } from '@mantine-8/core';
-import { useMemo } from 'react';
-import {
-    useAppDispatch as useVizDispatch,
-    useAppSelector as useVizSelector,
-} from '../../../features/sqlRunner/store/hooks';
-import { Config } from '../../VisualizationConfigs/common/Config';
-import { FieldReferenceSelect } from '../FieldReferenceSelect';
-import {
-    setValueAggregation,
-    setValueReference,
-} from '../store/bigNumberSlice';
-import { DataVizAggregationConfig } from './DataVizAggregationConfig';
+import { type VizColumn } from '@lightdash/common';
+import { Tabs } from '@mantine-8/core';
+import { BigNumberComparisonConfig } from './BigNumberComparisonConfig';
+import { BigNumberDataConfig } from './BigNumberDataConfig';
+import { BigNumberDisplayConfig } from './BigNumberDisplayConfig';
 
 export const BigNumberConfiguration = ({
     columns,
 }: {
     columns: VizColumn[];
-}) => {
-    const dispatch = useVizDispatch();
+}) => (
+    <Tabs defaultValue="data" keepMounted={false}>
+        <Tabs.List mb="md">
+            <Tabs.Tab value="data">Data</Tabs.Tab>
+            <Tabs.Tab value="display">Display</Tabs.Tab>
+            <Tabs.Tab value="comparison">Comparison</Tabs.Tab>
+        </Tabs.List>
 
-    const valueField = useVizSelector(
-        (state) => state.bigNumberConfig.fieldConfig?.y[0],
-    );
-    const metricFieldOptions = useVizSelector(
-        (state) => state.bigNumberConfig.options.metricFieldOptions,
-    );
-    const customMetricFieldOptions = useVizSelector(
-        (state) => state.bigNumberConfig.options.customMetricFieldOptions,
-    );
-    const errors = useVizSelector((state) => state.bigNumberConfig.errors);
+        <Tabs.Panel value="data">
+            <BigNumberDataConfig columns={columns} />
+        </Tabs.Panel>
 
-    const fieldOptions = useMemo(
-        () => [...metricFieldOptions, ...customMetricFieldOptions],
-        [metricFieldOptions, customMetricFieldOptions],
-    );
+        <Tabs.Panel value="display">
+            <BigNumberDisplayConfig />
+        </Tabs.Panel>
 
-    const errorMessage = errors?.metricFieldError?.references?.[0]
-        ? `Column "${errors.metricFieldError.references[0]}" not in SQL query`
-        : undefined;
-
-    return (
-        <Stack gap="sm" mb="lg">
-            <Title order={5} fz="sm" c="ldGray.9">
-                Data
-            </Title>
-
-            <Config.Section>
-                <Config.Heading>Value</Config.Heading>
-
-                <FieldReferenceSelect
-                    data={fieldOptions.map((option) => ({
-                        value: option.reference,
-                        label: option.reference,
-                    }))}
-                    disabled={fieldOptions.length === 0}
-                    value={valueField?.reference}
-                    error={errorMessage}
-                    placeholder="Select a value"
-                    onChange={(value) => {
-                        if (!value) return;
-                        dispatch(setValueReference(value));
-                    }}
-                    fieldType={
-                        columns?.find(
-                            (column) =>
-                                column.reference === valueField?.reference,
-                        )?.type ?? DimensionType.NUMBER
-                    }
-                />
-
-                <Config.Group>
-                    <Config.Label>Aggregation</Config.Label>
-
-                    <DataVizAggregationConfig
-                        options={
-                            customMetricFieldOptions.find(
-                                (option) =>
-                                    option.reference === valueField?.reference,
-                            )?.aggregationOptions
-                        }
-                        aggregation={valueField?.aggregation}
-                        onChangeAggregation={(value) =>
-                            dispatch(setValueAggregation(value))
-                        }
-                    />
-                </Config.Group>
-            </Config.Section>
-        </Stack>
-    );
-};
+        <Tabs.Panel value="comparison">
+            <BigNumberComparisonConfig columns={columns} />
+        </Tabs.Panel>
+    </Tabs>
+);

--- a/packages/frontend/src/components/DataViz/config/BigNumberDataConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/BigNumberDataConfig.tsx
@@ -1,0 +1,61 @@
+import { type VizColumn } from '@lightdash/common';
+import { Stack } from '@mantine-8/core';
+import {
+    useAppDispatch as useVizDispatch,
+    useAppSelector as useVizSelector,
+} from '../../../features/sqlRunner/store/hooks';
+import { Config } from '../../VisualizationConfigs/common/Config';
+import { FieldReferenceSelect } from '../FieldReferenceSelect';
+import {
+    setValueAggregation,
+    setValueReference,
+} from '../store/bigNumberSlice';
+import { DataVizAggregationConfig } from './DataVizAggregationConfig';
+import { useBigNumberFieldOptions } from './useBigNumberFieldOptions';
+
+export const BigNumberDataConfig = ({ columns }: { columns: VizColumn[] }) => {
+    const dispatch = useVizDispatch();
+    const valueField = useVizSelector(
+        (state) => state.bigNumberConfig.fieldConfig?.y[0],
+    );
+    const errors = useVizSelector((state) => state.bigNumberConfig.errors);
+    const { fieldOptions, selectData, fieldTypeOf, aggregationOptionsFor } =
+        useBigNumberFieldOptions(columns);
+
+    const errorMessage = errors?.metricFieldError?.references?.[0]
+        ? `Column "${errors.metricFieldError.references[0]}" not in SQL query`
+        : undefined;
+
+    return (
+        <Stack gap="sm" mb="lg">
+            <Config.Section>
+                <Config.Heading>Value</Config.Heading>
+
+                <FieldReferenceSelect
+                    data={selectData}
+                    disabled={fieldOptions.length === 0}
+                    value={valueField?.reference}
+                    error={errorMessage}
+                    placeholder="Select a value"
+                    onChange={(value) => {
+                        if (!value) return;
+                        dispatch(setValueReference(value));
+                    }}
+                    fieldType={fieldTypeOf(valueField?.reference)}
+                />
+
+                <Config.Group>
+                    <Config.Label>Aggregation</Config.Label>
+
+                    <DataVizAggregationConfig
+                        options={aggregationOptionsFor(valueField?.reference)}
+                        aggregation={valueField?.aggregation}
+                        onChangeAggregation={(value) =>
+                            dispatch(setValueAggregation(value))
+                        }
+                    />
+                </Config.Group>
+            </Config.Section>
+        </Stack>
+    );
+};

--- a/packages/frontend/src/components/DataViz/config/BigNumberDisplayConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/BigNumberDisplayConfig.tsx
@@ -1,0 +1,81 @@
+import { type Compact } from '@lightdash/common';
+import { ActionIcon, Select, Stack, TextInput, Tooltip } from '@mantine-8/core';
+import { IconEye, IconEyeOff } from '@tabler/icons-react';
+import {
+    useAppDispatch as useVizDispatch,
+    useAppSelector as useVizSelector,
+} from '../../../features/sqlRunner/store/hooks';
+import MantineIcon from '../../common/MantineIcon';
+import { StyleOptions } from '../../VisualizationConfigs/BigNumberConfig/common';
+import { Config } from '../../VisualizationConfigs/common/Config';
+import { setLabel, setShowLabel, setStyle } from '../store/bigNumberSlice';
+
+/** `StyleOptions` uses an empty string for "no compact notation". */
+const NO_COMPACT_STYLE = '';
+
+export const BigNumberDisplayConfig = () => {
+    const dispatch = useVizDispatch();
+    const display = useVizSelector((state) => state.bigNumberConfig.display);
+    const valueField = useVizSelector(
+        (state) => state.bigNumberConfig.fieldConfig?.y[0],
+    );
+
+    const showLabel = display?.showLabel ?? true;
+
+    return (
+        <Stack gap="sm" mb="lg">
+            <Config.Section>
+                <Config.Group>
+                    <Config.Heading>Label</Config.Heading>
+                    <Tooltip
+                        label={showLabel ? 'Hide label' : 'Show label'}
+                        withinPortal
+                    >
+                        <ActionIcon
+                            variant="subtle"
+                            color="ldGray.6"
+                            onClick={() => dispatch(setShowLabel(!showLabel))}
+                        >
+                            <MantineIcon
+                                icon={showLabel ? IconEye : IconEyeOff}
+                            />
+                        </ActionIcon>
+                    </Tooltip>
+                </Config.Group>
+
+                <TextInput
+                    size="xs"
+                    disabled={!showLabel}
+                    placeholder={valueField?.reference ?? 'Label'}
+                    value={display?.label ?? ''}
+                    onChange={(event) =>
+                        dispatch(
+                            setLabel(event.currentTarget.value || undefined),
+                        )
+                    }
+                />
+            </Config.Section>
+
+            <Config.Section>
+                <Config.Group>
+                    <Config.Label>Format</Config.Label>
+                    <Select
+                        size="xs"
+                        data={StyleOptions}
+                        value={display?.style ?? NO_COMPACT_STYLE}
+                        allowDeselect={false}
+                        onChange={(value) =>
+                            dispatch(
+                                setStyle(
+                                    !value || value === NO_COMPACT_STYLE
+                                        ? undefined
+                                        : (value as Compact),
+                                ),
+                            )
+                        }
+                    />
+                </Config.Group>
+            </Config.Section>
+        </Stack>
+    );
+};

--- a/packages/frontend/src/components/DataViz/config/useBigNumberFieldOptions.ts
+++ b/packages/frontend/src/components/DataViz/config/useBigNumberFieldOptions.ts
@@ -1,0 +1,41 @@
+import { DimensionType, type VizColumn } from '@lightdash/common';
+import { useMemo } from 'react';
+import { useAppSelector as useVizSelector } from '../../../features/sqlRunner/store/hooks';
+
+/**
+ * The value and comparison pickers offer the same fields and share the way a
+ * field's type and aggregation options are resolved.
+ */
+export const useBigNumberFieldOptions = (columns: VizColumn[]) => {
+    const metricFieldOptions = useVizSelector(
+        (state) => state.bigNumberConfig.options.metricFieldOptions,
+    );
+    const customMetricFieldOptions = useVizSelector(
+        (state) => state.bigNumberConfig.options.customMetricFieldOptions,
+    );
+
+    const fieldOptions = useMemo(
+        () => [...metricFieldOptions, ...customMetricFieldOptions],
+        [metricFieldOptions, customMetricFieldOptions],
+    );
+
+    const selectData = useMemo(
+        () =>
+            fieldOptions.map((option) => ({
+                value: option.reference,
+                label: option.reference,
+            })),
+        [fieldOptions],
+    );
+
+    const fieldTypeOf = (reference: string | undefined) =>
+        columns?.find((column) => column.reference === reference)?.type ??
+        DimensionType.NUMBER;
+
+    const aggregationOptionsFor = (reference: string | undefined) =>
+        customMetricFieldOptions.find(
+            (option) => option.reference === reference,
+        )?.aggregationOptions;
+
+    return { fieldOptions, selectData, fieldTypeOf, aggregationOptionsFor };
+};

--- a/packages/frontend/src/components/DataViz/store/bigNumberSlice.test.ts
+++ b/packages/frontend/src/components/DataViz/store/bigNumberSlice.test.ts
@@ -1,5 +1,7 @@
 import {
     ChartKind,
+    Compact,
+    ComparisonFormatTypes,
     VizAggregationOptions,
     type VizBigNumberConfig,
 } from '@lightdash/common';
@@ -11,6 +13,15 @@ import {
 } from './actions/commonChartActions';
 import {
     bigNumberConfigSlice,
+    setComparisonAggregation,
+    setComparisonFormat,
+    setComparisonLabel,
+    setComparisonReference,
+    setFlipColors,
+    setLabel,
+    setShowComparison,
+    setShowLabel,
+    setStyle,
     setValueAggregation,
     setValueReference,
 } from './bigNumberSlice';
@@ -132,5 +143,101 @@ describe('bigNumberConfigSlice', () => {
         expect(
             reducer(withConfig, resetChartState()).fieldConfig,
         ).toBeUndefined();
+    });
+
+    describe('comparison field', () => {
+        const withOptions = () =>
+            reducer(undefined, setChartOptionsAndConfig(optionsAndConfig));
+
+        it('adds the comparison field after the value field', () => {
+            const state = reducer(
+                withOptions(),
+                setComparisonReference('target'),
+            );
+
+            expect(state.fieldConfig?.y).toEqual([
+                {
+                    reference: 'revenue',
+                    aggregation: VizAggregationOptions.SUM,
+                },
+                { reference: 'target', aggregation: VizAggregationOptions.MAX },
+            ]);
+        });
+
+        it('clears the comparison field', () => {
+            const withComparison = reducer(
+                withOptions(),
+                setComparisonReference('target'),
+            );
+
+            expect(
+                reducer(withComparison, setComparisonReference(undefined))
+                    .fieldConfig?.y,
+            ).toHaveLength(1);
+        });
+
+        it('drops the comparison field when the comparison is switched off', () => {
+            const withComparison = reducer(
+                reducer(withOptions(), setShowComparison(true)),
+                setComparisonReference('target'),
+            );
+
+            const state = reducer(withComparison, setShowComparison(false));
+
+            expect(state.display?.showComparison).toBe(false);
+            expect(state.fieldConfig?.y).toHaveLength(1);
+        });
+
+        it('keeps the value field when the comparison is switched on', () => {
+            const state = reducer(withOptions(), setShowComparison(true));
+
+            expect(state.display?.showComparison).toBe(true);
+            expect(state.fieldConfig?.y).toHaveLength(1);
+        });
+
+        it('overrides the comparison aggregation', () => {
+            const withComparison = reducer(
+                withOptions(),
+                setComparisonReference('target'),
+            );
+
+            expect(
+                reducer(
+                    withComparison,
+                    setComparisonAggregation(VizAggregationOptions.MIN),
+                ).fieldConfig?.y[1].aggregation,
+            ).toBe(VizAggregationOptions.MIN);
+        });
+    });
+
+    describe('display options', () => {
+        it('updates each display option without touching the others', () => {
+            let state = reducer(undefined, setLabel('Total revenue'));
+            state = reducer(state, setShowLabel(false));
+            state = reducer(state, setStyle(Compact.MILLIONS));
+            state = reducer(
+                state,
+                setComparisonFormat(ComparisonFormatTypes.PERCENTAGE),
+            );
+            state = reducer(state, setComparisonLabel('vs target'));
+            state = reducer(state, setFlipColors(true));
+
+            expect(state.display).toEqual({
+                label: 'Total revenue',
+                showLabel: false,
+                style: Compact.MILLIONS,
+                comparisonFormat: ComparisonFormatTypes.PERCENTAGE,
+                comparisonLabel: 'vs target',
+                flipColors: true,
+            });
+        });
+
+        it('clears the label back to the default', () => {
+            const withLabel = reducer(undefined, setLabel('Total revenue'));
+
+            expect(
+                reducer(withLabel, setLabel(undefined)).display?.label,
+            ).toBeUndefined();
+        });
     });
 });

--- a/packages/frontend/src/components/DataViz/store/bigNumberSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/bigNumberSlice.ts
@@ -2,6 +2,8 @@ import {
     ChartKind,
     isVizBigNumberConfig,
     VIZ_DEFAULT_AGGREGATION,
+    type CompactOrAlias,
+    type ComparisonFormatTypes,
     type VizAggregationOptions,
     type VizBigNumberConfig,
     type VizBigNumberOptions,
@@ -53,6 +55,7 @@ const initialState: BigNumberState = {
 
 /** The value is always y[0]; the optional comparison field is always y[1]. */
 const VALUE_INDEX = 0;
+const COMPARISON_INDEX = 1;
 
 const defaultAggregationFor = (
     state: BigNumberState,
@@ -90,6 +93,78 @@ export const bigNumberConfigSlice = createSlice({
             const value = state.fieldConfig?.y[VALUE_INDEX];
             if (!value) return;
             value.aggregation = action.payload;
+        },
+        setComparisonReference: (
+            state,
+            action: PayloadAction<string | undefined>,
+        ) => {
+            if (!state.fieldConfig) return;
+            if (action.payload === undefined) {
+                state.fieldConfig.y = state.fieldConfig.y.slice(
+                    0,
+                    COMPARISON_INDEX,
+                );
+                return;
+            }
+            state.fieldConfig.y[COMPARISON_INDEX] = {
+                reference: action.payload,
+                aggregation: defaultAggregationFor(state, action.payload),
+            };
+        },
+        setComparisonAggregation: (
+            state,
+            action: PayloadAction<VizAggregationOptions>,
+        ) => {
+            const comparison = state.fieldConfig?.y[COMPARISON_INDEX];
+            if (!comparison) return;
+            comparison.aggregation = action.payload;
+        },
+        setLabel: (state, action: PayloadAction<string | undefined>) => {
+            state.display = { ...state.display, label: action.payload };
+        },
+        setShowLabel: (state, action: PayloadAction<boolean>) => {
+            state.display = { ...state.display, showLabel: action.payload };
+        },
+        setStyle: (
+            state,
+            action: PayloadAction<CompactOrAlias | undefined>,
+        ) => {
+            state.display = { ...state.display, style: action.payload };
+        },
+        setShowComparison: (state, action: PayloadAction<boolean>) => {
+            state.display = {
+                ...state.display,
+                showComparison: action.payload,
+            };
+            // Turning the comparison off drops the field so the query stops
+            // aggregating a column nothing reads.
+            if (!action.payload && state.fieldConfig) {
+                state.fieldConfig.y = state.fieldConfig.y.slice(
+                    0,
+                    COMPARISON_INDEX,
+                );
+            }
+        },
+        setComparisonFormat: (
+            state,
+            action: PayloadAction<ComparisonFormatTypes>,
+        ) => {
+            state.display = {
+                ...state.display,
+                comparisonFormat: action.payload,
+            };
+        },
+        setComparisonLabel: (
+            state,
+            action: PayloadAction<string | undefined>,
+        ) => {
+            state.display = {
+                ...state.display,
+                comparisonLabel: action.payload,
+            };
+        },
+        setFlipColors: (state, action: PayloadAction<boolean>) => {
+            state.display = { ...state.display, flipColors: action.payload };
         },
     },
     extraReducers: (builder) => {
@@ -132,5 +207,16 @@ export const bigNumberConfigSlice = createSlice({
     },
 });
 
-export const { setValueReference, setValueAggregation } =
-    bigNumberConfigSlice.actions;
+export const {
+    setValueReference,
+    setValueAggregation,
+    setComparisonReference,
+    setComparisonAggregation,
+    setLabel,
+    setShowLabel,
+    setStyle,
+    setShowComparison,
+    setComparisonFormat,
+    setComparisonLabel,
+    setFlipColors,
+} = bigNumberConfigSlice.actions;


### PR DESCRIPTION
Part 4 of 6 adding a big value (big number) chart to the SQL Runner.

## What

Splits the big number config panel into **Data / Display / Comparison** tabs and adds the options the explorer's big number already has:

**Display**
- Custom label with a show/hide toggle (defaults to the value field's name).
- Compact notation — None / Auto / K / M / B / T — reusing the explorer's `StyleOptions` so the two lists can't drift.

**Comparison**
- Compare the value against a second aggregated field.
- Raw delta or percentage change.
- Optional comparison label.
- Flip positive colour.

## Deviation from the explorer

The explorer's big number compares row 1 against row 2 of the results ("previous row"). A SQL Runner big number aggregates every row into one value, so there is no previous row to compare against — the comparison is against a second field instead. Everything else in the comparison UI mirrors the explorer.

## Regression analysis

Additive: the new options all live under `display`, which was `{}` before this change, and every one falls back to the previous behaviour when unset (`showLabel` defaults true, `showComparison` false, no compact style).

One deliberate side effect: turning the comparison switch off also drops the comparison field from `fieldConfig.y`, so the pivot query stops asking the warehouse to aggregate a column nothing reads. Turning it back on requires re-picking the field. The alternative — keeping a hidden field in the query — costs a warehouse aggregate on every refresh of every such chart.

Display-only changes do not re-run the query; they flow through the existing `selectCompleteConfigByKind` re-render path, same as cartesian display options. Field changes do re-run it, via the existing chart-config listener.

Relates: PROD-1096
Relates: #11194
