### PR TITLE
feat: complete big number parity for sql charts

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1370,6 +1370,10 @@ export type CreateSqlChartVersionEvent = BaseTrack & {
         pieChart?: {
             groupByCount: number;
         };
+        bigNumber?: {
+            hasComparison: boolean;
+            aggregationTypes: string[];
+        };
     };
 };
 

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
@@ -9,6 +9,7 @@ import {
     isValidFrequency,
     isValidTimezone,
     isVizBarChartConfig,
+    isVizBigNumberConfig,
     isVizLineChartConfig,
     isVizPieChartConfig,
     NotFoundError,
@@ -94,7 +95,7 @@ export class SavedSqlService
         config: SqlChart['config'],
     ): Pick<
         CreateSqlChartVersionEvent['properties'],
-        'chartKind' | 'barChart' | 'lineChart' | 'pieChart'
+        'chartKind' | 'barChart' | 'lineChart' | 'pieChart' | 'bigNumber'
     > {
         return {
             chartKind: config.type,
@@ -123,6 +124,16 @@ export class SavedSqlService
             pieChart: isVizPieChartConfig(config)
                 ? {
                       groupByCount: config.fieldConfig?.x ? 1 : 0,
+                  }
+                : undefined,
+            bigNumber: isVizBigNumberConfig(config)
+                ? {
+                      hasComparison: !!config.display?.showComparison,
+                      aggregationTypes: uniq(
+                          (config.fieldConfig?.y ?? []).map(
+                              (y) => y.aggregation ?? VIZ_DEFAULT_AGGREGATION,
+                          ),
+                      ),
                   }
                 : undefined,
         };

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -9,6 +9,7 @@ import {
     expandSelectedTabs,
     EXPORT_TAB_PAGE_CLASS,
     ForbiddenError,
+    getChartType,
     getErrorMessage,
     HealthState,
     isDashboardChartTileType,
@@ -496,6 +497,9 @@ export class UnfurlService extends BaseService {
                     title: sqlChart.name,
                     description: sqlChart.description ?? undefined,
                     organizationUuid: sqlChart.organization.organizationUuid,
+                    // Drives the screenshot viewport; big numbers get a
+                    // shorter one so the value isn't lost in whitespace.
+                    chartType: getChartType(sqlChart.chartKind),
                     resourceUuid: sqlChart.savedSqlUuid,
                 };
             case LightdashPage.EXPLORE:

--- a/packages/e2e/cypress/e2e/app/sqlRunner.cy.ts
+++ b/packages/e2e/cypress/e2e/app/sqlRunner.cy.ts
@@ -181,6 +181,15 @@ describe('SQL Runner (new)', () => {
             'exist',
         );
 
+        // Verify that the big number is displayed
+        cy.get(
+            `button[data-testid="visualization-${ChartKind.BIG_NUMBER}"]`,
+        ).click();
+        cy.get(`div[data-testid="chart-view-${ChartKind.BIG_NUMBER}"]`).should(
+            'exist',
+        );
+        cy.get('[data-testid="big-number-value"]').should('be.visible');
+
         // Verify that the bar chart is displayed
         cy.get(
             `button[data-testid="visualization-${ChartKind.VERTICAL_BAR}"]`,
@@ -188,6 +197,45 @@ describe('SQL Runner (new)', () => {
         cy.get(
             `div[data-testid="chart-view-${ChartKind.VERTICAL_BAR}"]`,
         ).should('exist');
+    });
+
+    it('Should save a big number chart and render it in view mode', () => {
+        cy.get('.monaco-editor').should('be.visible');
+        cy.contains('jaffle').click().wait(500);
+        cy.contains(/^customers$/).click();
+        cy.contains('Run query').click();
+        cy.get('table thead th').eq(0).should('contain.text', 'customer_id');
+
+        cy.contains('label', 'Chart').click();
+        cy.get(
+            `button[data-testid="visualization-${ChartKind.BIG_NUMBER}"]`,
+        ).click();
+
+        // The label defaults to the value field and can be overridden
+        cy.contains('button', 'Display').click();
+        cy.get('input[placeholder="age"]').type('Average age');
+        cy.get(`div[data-testid="chart-view-${ChartKind.BIG_NUMBER}"]`).should(
+            'contain.text',
+            'Average age',
+        );
+
+        cy.contains('Save').click();
+        cy.get(
+            'input[placeholder="eg. How many weekly active users do we have?"]',
+        ).type('Customers big number SQL chart');
+        cy.findByText('Next').click();
+        cy.get('section[role="dialog"]')
+            .find('button')
+            .contains('Save')
+            .click();
+
+        // The saved chart renders on the view page, not an ECharts canvas
+        cy.contains('Customers big number SQL chart').should('be.visible');
+        cy.get(`div[data-testid="chart-view-${ChartKind.BIG_NUMBER}"]`).should(
+            'exist',
+        );
+        cy.get('[data-testid="big-number-value"]').should('be.visible');
+        cy.get('.echarts-for-react').should('not.exist');
     });
 
     it('Should save a chart', () => {

--- a/packages/frontend/src/components/common/BigNumber/BigNumberDisplay.test.tsx
+++ b/packages/frontend/src/components/common/BigNumber/BigNumberDisplay.test.tsx
@@ -1,0 +1,106 @@
+import { ComparisonDiffTypes } from '@lightdash/common';
+import { cleanup, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { BigNumberDisplay } from './BigNumberDisplay';
+
+const baseProps = {
+    value: '1,234',
+    label: 'Revenue',
+    showLabel: true,
+    comparison: undefined,
+    flipColors: false,
+};
+
+const pillClassesFor = (
+    direction: ComparisonDiffTypes,
+    flipColors: boolean,
+) => {
+    cleanup();
+    renderWithProviders(
+        <BigNumberDisplay
+            {...baseProps}
+            flipColors={flipColors}
+            comparison={{
+                formattedValue: '+20',
+                direction,
+                label: undefined,
+                tooltip: 'tooltip',
+            }}
+        />,
+    );
+    return screen.getByText('+20').parentElement?.className ?? '';
+};
+
+describe('BigNumberDisplay', () => {
+    it('renders the value and label', () => {
+        renderWithProviders(<BigNumberDisplay {...baseProps} />);
+
+        expect(screen.getByTestId('big-number-value')).toHaveTextContent(
+            '1,234',
+        );
+        expect(screen.getByText('Revenue')).toBeInTheDocument();
+    });
+
+    it('hides the label', () => {
+        renderWithProviders(
+            <BigNumberDisplay {...baseProps} showLabel={false} />,
+        );
+
+        expect(screen.queryByText('Revenue')).not.toBeInTheDocument();
+    });
+
+    it('applies a conditional formatting colour to the value', () => {
+        renderWithProviders(
+            <BigNumberDisplay
+                {...baseProps}
+                valueColor="light-dark(#ff0000, #ff8888)"
+            />,
+        );
+
+        expect(screen.getByTestId('big-number-value')).toHaveStyle({
+            '--big-number-color': 'light-dark(#ff0000, #ff8888)',
+        });
+    });
+
+    it('wraps the value when a renderer is supplied', () => {
+        renderWithProviders(
+            <BigNumberDisplay
+                {...baseProps}
+                renderValue={(value) => (
+                    <button type="button" data-testid="context-menu">
+                        {value}
+                    </button>
+                )}
+            />,
+        );
+
+        expect(screen.getByTestId('context-menu')).toContainElement(
+            screen.getByTestId('big-number-value'),
+        );
+    });
+
+    it('colours an increase green and a decrease red', () => {
+        expect(pillClassesFor(ComparisonDiffTypes.POSITIVE, false)).toContain(
+            'trendPillUp',
+        );
+        expect(pillClassesFor(ComparisonDiffTypes.NEGATIVE, false)).toContain(
+            'trendPillDown',
+        );
+    });
+
+    it('swaps the comparison colours when flipColors is on', () => {
+        expect(pillClassesFor(ComparisonDiffTypes.POSITIVE, true)).toContain(
+            'trendPillDown',
+        );
+        expect(pillClassesFor(ComparisonDiffTypes.NEGATIVE, true)).toContain(
+            'trendPillUp',
+        );
+    });
+
+    it('renders an unchanged comparison neutrally', () => {
+        expect(pillClassesFor(ComparisonDiffTypes.NONE, false)).toContain(
+            'trendPillNeutral',
+        );
+    });
+});


### PR DESCRIPTION
Part 5 of 6 adding a big value (big number) chart to the SQL Runner.

## What

The remaining parity work outside the chart itself.

- **Analytics.** `sql_chart_version.created` now carries a `bigNumber` property alongside `barChart` / `lineChart` / `pieChart`, recording whether a comparison is configured and which aggregations are used.
- **Screenshots.** The SQL-chart unfurl path never populated `chartType`, so a big number was captured with the wide default viewport and the value was lost in whitespace. It now passes the chart's type through, which routes it to the same short `bigNumberViewport` the explorer's big number already uses.
- **e2e.** `sqlRunner.cy.ts` covers the big number in the chart switcher, asserts it renders without an ECharts canvas, and round-trips a save into view mode with a custom label.
- **Unit tests.** `BigNumberDisplay` gets coverage for the comparison pill colours (including `flipColors`), the conditional-formatting colour hook and the `renderValue` wrapper the explorer's context menu depends on.

## Regression analysis

- **Analytics** is an added optional property; existing event consumers are unaffected.
- **The unfurl change** now sets `chartType` for every SQL chart, not just big numbers. `chartType` has exactly two consumers in `UnfurlService`: the initial viewport choice and the post-render resize skip, both of which only branch on `ChartType.BIG_NUMBER`. Every other SQL chart kind maps to a non-big-number `ChartType` and so keeps its current viewport and resize behaviour.

Relates: PROD-1096
Relates: #11194
