### PR TITLE
feat: add conditional formatting to sql big numbers

### DIFF
--- a/packages/common/src/visualizations/BigNumberDataModel.test.ts
+++ b/packages/common/src/visualizations/BigNumberDataModel.test.ts
@@ -1,4 +1,5 @@
 import { Compact, DimensionType } from '../types/field';
+import { FilterOperator } from '../types/filter';
 import {
     ChartKind,
     ComparisonDiffTypes,
@@ -365,6 +366,67 @@ describe('BigNumberDataModel', () => {
                 direction: ComparisonDiffTypes.NONE,
                 formattedValue: '+0',
             });
+        });
+
+        it('colours the value with the first matching rule', async () => {
+            const model = await buildSpecModel({ revenue_sum: 120 }, [
+                'revenue',
+            ]);
+
+            expect(
+                model.getSpec({
+                    conditionalFormatting: [
+                        {
+                            operator: FilterOperator.GREATER_THAN,
+                            value: 500,
+                            color: '#ff0000',
+                        },
+                        {
+                            operator: FilterOperator.GREATER_THAN,
+                            value: 100,
+                            color: '#00ff00',
+                            darkColor: '#88ff88',
+                        },
+                        {
+                            operator: FilterOperator.GREATER_THAN,
+                            value: 0,
+                            color: '#0000ff',
+                        },
+                    ],
+                })?.valueColor,
+            ).toBe('light-dark(#00ff00, #88ff88)');
+        });
+
+        it('reuses the light colour when no dark colour is set', async () => {
+            const model = await buildSpecModel({ revenue_sum: 5 }, ['revenue']);
+
+            expect(
+                model.getSpec({
+                    conditionalFormatting: [
+                        {
+                            operator: FilterOperator.LESS_THAN_OR_EQUAL,
+                            value: 5,
+                            color: '#ff0000',
+                        },
+                    ],
+                })?.valueColor,
+            ).toBe('light-dark(#ff0000, #ff0000)');
+        });
+
+        it('leaves the value uncoloured when no rule matches', async () => {
+            const model = await buildSpecModel({ revenue_sum: 5 }, ['revenue']);
+
+            expect(
+                model.getSpec({
+                    conditionalFormatting: [
+                        {
+                            operator: FilterOperator.GREATER_THAN,
+                            value: 10,
+                            color: '#ff0000',
+                        },
+                    ],
+                })?.valueColor,
+            ).toBeUndefined();
         });
 
         it('handles a missing comparison value', async () => {

--- a/packages/common/src/visualizations/BigNumberDataModel.ts
+++ b/packages/common/src/visualizations/BigNumberDataModel.ts
@@ -3,6 +3,7 @@ import {
     DimensionType,
     type CompactOrAlias,
 } from '../types/field';
+import { FilterOperator } from '../types/filter';
 import { type RawResultRow } from '../types/results';
 import {
     ComparisonDiffTypes,
@@ -10,6 +11,7 @@ import {
     type ChartKind,
 } from '../types/savedCharts';
 import { type SqlRunnerQuery } from '../types/sqlRunner';
+import assertUnreachable from '../utils/assertUnreachable';
 import {
     applyCustomFormat,
     getCustomFormatFromLegacy,
@@ -17,6 +19,7 @@ import {
 import {
     type PivotChartData,
     type PivotChartLayout,
+    type VizBigNumberConditionalRule,
     type VizBigNumberDisplay,
     type VizConfigErrors,
 } from './types';
@@ -39,6 +42,8 @@ export type BigNumberSpec = {
     label: string;
     showLabel: boolean;
     flipColors: boolean;
+    /** CSS colour from the first matching conditional formatting rule. */
+    valueColor: string | undefined;
     comparison: BigNumberComparisonSpec | undefined;
 };
 
@@ -77,6 +82,45 @@ const formatValue = (value: unknown, style: CompactOrAlias | undefined) => {
         Number(value),
         getCustomFormatFromLegacy({ compact: style }),
     );
+};
+
+const matchesRule = (
+    value: number,
+    rule: VizBigNumberConditionalRule,
+): boolean => {
+    switch (rule.operator) {
+        case FilterOperator.EQUALS:
+            return value === rule.value;
+        case FilterOperator.NOT_EQUALS:
+            return value !== rule.value;
+        case FilterOperator.LESS_THAN:
+            return value < rule.value;
+        case FilterOperator.LESS_THAN_OR_EQUAL:
+            return value <= rule.value;
+        case FilterOperator.GREATER_THAN:
+            return value > rule.value;
+        case FilterOperator.GREATER_THAN_OR_EQUAL:
+            return value >= rule.value;
+        default:
+            return assertUnreachable(
+                rule.operator,
+                `Unsupported big number conditional operator`,
+            );
+    }
+};
+
+export const getBigNumberValueColor = (
+    value: unknown,
+    rules: VizBigNumberConditionalRule[] | undefined,
+): string | undefined => {
+    if (!rules?.length || !isNumeric(value)) {
+        return undefined;
+    }
+    const match = rules.find((rule) => matchesRule(Number(value), rule));
+    if (!match) {
+        return undefined;
+    }
+    return `light-dark(${match.color}, ${match.darkColor ?? match.color})`;
 };
 
 const getComparisonDirection = (delta: number): ComparisonDiffTypes => {
@@ -348,6 +392,10 @@ export class BigNumberDataModel {
                 '',
             showLabel: display?.showLabel ?? true,
             flipColors: display?.flipColors ?? false,
+            valueColor: getBigNumberValueColor(
+                value,
+                display?.conditionalFormatting,
+            ),
             comparison: showComparison
                 ? BigNumberDataModel.buildComparison(
                       value,

--- a/packages/common/src/visualizations/types/index.ts
+++ b/packages/common/src/visualizations/types/index.ts
@@ -4,6 +4,7 @@ import {
     TableCalculationType,
     type CompactOrAlias,
 } from '../../types/field';
+import { type FilterOperator } from '../../types/filter';
 import { type PivotSortAnchor } from '../../types/metricQuery';
 import { type PivotConfiguration } from '../../types/pivot';
 import { type RawResultRow } from '../../types/results';
@@ -123,6 +124,23 @@ export type VizPieChartDisplay = {
     isDonut?: boolean;
 };
 
+/** Operators a big number threshold can be expressed with. */
+export type VizBigNumberConditionalOperator =
+    | FilterOperator.EQUALS
+    | FilterOperator.NOT_EQUALS
+    | FilterOperator.LESS_THAN
+    | FilterOperator.LESS_THAN_OR_EQUAL
+    | FilterOperator.GREATER_THAN
+    | FilterOperator.GREATER_THAN_OR_EQUAL;
+
+export type VizBigNumberConditionalRule = {
+    operator: VizBigNumberConditionalOperator;
+    value: number;
+    /** Applied in the light colour scheme, and in dark when darkColor is unset. */
+    color: string;
+    darkColor?: string;
+};
+
 export type VizBigNumberDisplay = {
     /** Custom label rendered under the value. Falls back to the field name. */
     label?: string;
@@ -135,6 +153,8 @@ export type VizBigNumberDisplay = {
     comparisonLabel?: string;
     /** Colours an increase red and a decrease green. */
     flipColors?: boolean;
+    /** Colours the value; the first matching rule wins. */
+    conditionalFormatting?: VizBigNumberConditionalRule[];
 };
 
 export type VizTableDisplay = {

--- a/packages/frontend/src/components/DataViz/VisualizationConfigPanel.tsx
+++ b/packages/frontend/src/components/DataViz/VisualizationConfigPanel.tsx
@@ -1,6 +1,8 @@
 import { ChartKind, type VizColumn } from '@lightdash/common';
 import { MantineProvider, useMantineColorScheme } from '@mantine/core';
 import { useMemo, type FC } from 'react';
+import { useAppSelector as useVizSelector } from '../../features/sqlRunner/store/hooks';
+import { useOrganization } from '../../hooks/organization/useOrganization';
 import { Config } from '../VisualizationConfigs/common/Config';
 import { getVizConfigThemeOverride } from '../VisualizationConfigs/mantineTheme';
 import { BigNumberConfiguration } from './config/BigNumberConfiguration';
@@ -15,6 +17,14 @@ export const VisualizationConfigPanel: FC<{
     columns: VizColumn[];
 }> = ({ selectedChartType, setSelectedChartType, columns }) => {
     const { colorScheme } = useMantineColorScheme();
+    const { data: organization } = useOrganization();
+    const savedSqlChart = useVizSelector(
+        (state) => state.sqlRunner.savedSqlChart,
+    );
+    const chartColors =
+        savedSqlChart?.resolvedColorPalette.colors ??
+        organization?.chartColors ??
+        [];
     const themeOverride = useMemo(
         () => getVizConfigThemeOverride(colorScheme),
         [colorScheme],
@@ -50,7 +60,10 @@ export const VisualizationConfigPanel: FC<{
                 <PieChartConfiguration columns={columns} />
             )}
             {selectedChartType === ChartKind.BIG_NUMBER && (
-                <BigNumberConfiguration columns={columns} />
+                <BigNumberConfiguration
+                    columns={columns}
+                    colors={chartColors}
+                />
             )}
         </MantineProvider>
     );

--- a/packages/frontend/src/components/DataViz/config/BigNumberConditionalFormatting.tsx
+++ b/packages/frontend/src/components/DataViz/config/BigNumberConditionalFormatting.tsx
@@ -1,0 +1,146 @@
+import {
+    FilterOperator,
+    type VizBigNumberConditionalOperator,
+    type VizBigNumberConditionalRule,
+} from '@lightdash/common';
+import { ActionIcon, Box, Button, Group, Select, Stack } from '@mantine-8/core';
+import { IconPlus, IconTrash } from '@tabler/icons-react';
+import {
+    useAppDispatch as useVizDispatch,
+    useAppSelector as useVizSelector,
+} from '../../../features/sqlRunner/store/hooks';
+import MantineIcon from '../../common/MantineIcon';
+import { NumberInput } from '../../common/NumberInput';
+import ColorSelector from '../../VisualizationConfigs/ColorSelector';
+import { Config } from '../../VisualizationConfigs/common/Config';
+import {
+    addConditionalFormattingRule,
+    removeConditionalFormattingRule,
+    updateConditionalFormattingRule,
+} from '../store/bigNumberSlice';
+
+const OPERATOR_OPTIONS: {
+    value: VizBigNumberConditionalOperator;
+    label: string;
+}[] = [
+    { value: FilterOperator.GREATER_THAN, label: 'is greater than' },
+    {
+        value: FilterOperator.GREATER_THAN_OR_EQUAL,
+        label: 'is greater than or equal to',
+    },
+    { value: FilterOperator.LESS_THAN, label: 'is less than' },
+    {
+        value: FilterOperator.LESS_THAN_OR_EQUAL,
+        label: 'is less than or equal to',
+    },
+    { value: FilterOperator.EQUALS, label: 'is equal to' },
+    { value: FilterOperator.NOT_EQUALS, label: 'is not equal to' },
+];
+
+const DEFAULT_RULE: VizBigNumberConditionalRule = {
+    operator: FilterOperator.GREATER_THAN,
+    value: 0,
+    color: '#00A47E',
+};
+
+export const BigNumberConditionalFormatting = ({
+    colors,
+}: {
+    colors: string[];
+}) => {
+    const dispatch = useVizDispatch();
+    const rules = useVizSelector(
+        (state) => state.bigNumberConfig.display?.conditionalFormatting ?? [],
+    );
+
+    return (
+        <Stack gap="sm" mb="lg">
+            <Config.Section>
+                <Config.Heading>Rules</Config.Heading>
+                <Config.Label>
+                    The value takes the colour of the first rule it matches.
+                </Config.Label>
+
+                {rules.map((rule, index) => (
+                    // Rules are an ordered list with no stable id; the index is
+                    // the identity here.
+                    // eslint-disable-next-line react/no-array-index-key
+                    <Group key={index} gap="xs" wrap="nowrap" align="flex-end">
+                        <Box>
+                            <ColorSelector
+                                color={rule.color}
+                                swatches={colors}
+                                onColorChange={(color) =>
+                                    dispatch(
+                                        updateConditionalFormattingRule({
+                                            index,
+                                            rule: { ...rule, color },
+                                        }),
+                                    )
+                                }
+                            />
+                        </Box>
+
+                        <Select
+                            size="xs"
+                            flex={1}
+                            data={OPERATOR_OPTIONS}
+                            value={rule.operator}
+                            allowDeselect={false}
+                            onChange={(operator) => {
+                                if (!operator) return;
+                                dispatch(
+                                    updateConditionalFormattingRule({
+                                        index,
+                                        rule: {
+                                            ...rule,
+                                            operator:
+                                                operator as VizBigNumberConditionalOperator,
+                                        },
+                                    }),
+                                );
+                            }}
+                        />
+
+                        <NumberInput
+                            size="xs"
+                            w={90}
+                            decimalScale="unlimited"
+                            value={rule.value}
+                            onNumberChange={(value: number | undefined) =>
+                                dispatch(
+                                    updateConditionalFormattingRule({
+                                        index,
+                                        rule: { ...rule, value: value ?? 0 },
+                                    }),
+                                )
+                            }
+                        />
+
+                        <ActionIcon
+                            variant="subtle"
+                            color="ldGray.6"
+                            aria-label="Remove rule"
+                            onClick={() =>
+                                dispatch(removeConditionalFormattingRule(index))
+                            }
+                        >
+                            <MantineIcon icon={IconTrash} />
+                        </ActionIcon>
+                    </Group>
+                ))}
+
+                <Button
+                    size="xs"
+                    variant="subtle"
+                    leftSection={<MantineIcon icon={IconPlus} />}
+                    onClick={() =>
+                        dispatch(addConditionalFormattingRule(DEFAULT_RULE))
+                    }
+                >
+                    Add rule
+                </Button>
+            </Config.Section>
+        </Stack>
+    );
+};

--- a/packages/frontend/src/components/DataViz/config/BigNumberConfiguration.tsx
+++ b/packages/frontend/src/components/DataViz/config/BigNumberConfiguration.tsx
@@ -1,19 +1,23 @@
 import { type VizColumn } from '@lightdash/common';
 import { Tabs } from '@mantine-8/core';
 import { BigNumberComparisonConfig } from './BigNumberComparisonConfig';
+import { BigNumberConditionalFormatting } from './BigNumberConditionalFormatting';
 import { BigNumberDataConfig } from './BigNumberDataConfig';
 import { BigNumberDisplayConfig } from './BigNumberDisplayConfig';
 
 export const BigNumberConfiguration = ({
     columns,
+    colors,
 }: {
     columns: VizColumn[];
+    colors: string[];
 }) => (
     <Tabs defaultValue="data" keepMounted={false}>
         <Tabs.List mb="md">
             <Tabs.Tab value="data">Data</Tabs.Tab>
             <Tabs.Tab value="display">Display</Tabs.Tab>
             <Tabs.Tab value="comparison">Comparison</Tabs.Tab>
+            <Tabs.Tab value="formatting">Formatting</Tabs.Tab>
         </Tabs.List>
 
         <Tabs.Panel value="data">
@@ -26,6 +30,10 @@ export const BigNumberConfiguration = ({
 
         <Tabs.Panel value="comparison">
             <BigNumberComparisonConfig columns={columns} />
+        </Tabs.Panel>
+
+        <Tabs.Panel value="formatting">
+            <BigNumberConditionalFormatting colors={colors} />
         </Tabs.Panel>
     </Tabs>
 );

--- a/packages/frontend/src/components/DataViz/store/bigNumberSlice.test.ts
+++ b/packages/frontend/src/components/DataViz/store/bigNumberSlice.test.ts
@@ -2,7 +2,9 @@ import {
     ChartKind,
     Compact,
     ComparisonFormatTypes,
+    FilterOperator,
     VizAggregationOptions,
+    type VizBigNumberConditionalRule,
     type VizBigNumberConfig,
 } from '@lightdash/common';
 import { describe, expect, it } from 'vitest';
@@ -12,7 +14,9 @@ import {
     setChartOptionsAndConfig,
 } from './actions/commonChartActions';
 import {
+    addConditionalFormattingRule,
     bigNumberConfigSlice,
+    removeConditionalFormattingRule,
     setComparisonAggregation,
     setComparisonFormat,
     setComparisonLabel,
@@ -24,6 +28,7 @@ import {
     setStyle,
     setValueAggregation,
     setValueReference,
+    updateConditionalFormattingRule,
 } from './bigNumberSlice';
 
 const { reducer } = bigNumberConfigSlice;
@@ -207,6 +212,59 @@ describe('bigNumberConfigSlice', () => {
                     setComparisonAggregation(VizAggregationOptions.MIN),
                 ).fieldConfig?.y[1].aggregation,
             ).toBe(VizAggregationOptions.MIN);
+        });
+    });
+
+    describe('conditional formatting', () => {
+        const rule: VizBigNumberConditionalRule = {
+            operator: FilterOperator.GREATER_THAN,
+            value: 100,
+            color: '#00ff00',
+        };
+
+        it('adds, updates and removes rules in order', () => {
+            let state = reducer(undefined, addConditionalFormattingRule(rule));
+            state = reducer(
+                state,
+                addConditionalFormattingRule({ ...rule, value: 200 }),
+            );
+
+            expect(state.display?.conditionalFormatting).toHaveLength(2);
+
+            state = reducer(
+                state,
+                updateConditionalFormattingRule({
+                    index: 0,
+                    rule: { ...rule, color: '#ff0000' },
+                }),
+            );
+
+            expect(state.display?.conditionalFormatting?.[0].color).toBe(
+                '#ff0000',
+            );
+
+            state = reducer(state, removeConditionalFormattingRule(0));
+
+            expect(state.display?.conditionalFormatting).toEqual([
+                { ...rule, value: 200 },
+            ]);
+        });
+
+        it('ignores an update for a rule that is gone', () => {
+            const withRule = reducer(
+                undefined,
+                addConditionalFormattingRule(rule),
+            );
+
+            expect(
+                reducer(
+                    withRule,
+                    updateConditionalFormattingRule({
+                        index: 5,
+                        rule: { ...rule, color: '#ff0000' },
+                    }),
+                ).display?.conditionalFormatting,
+            ).toEqual([rule]);
         });
     });
 

--- a/packages/frontend/src/components/DataViz/store/bigNumberSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/bigNumberSlice.ts
@@ -5,6 +5,7 @@ import {
     type CompactOrAlias,
     type ComparisonFormatTypes,
     type VizAggregationOptions,
+    type VizBigNumberConditionalRule,
     type VizBigNumberConfig,
     type VizBigNumberOptions,
     type VizConfigErrors,
@@ -166,6 +167,41 @@ export const bigNumberConfigSlice = createSlice({
         setFlipColors: (state, action: PayloadAction<boolean>) => {
             state.display = { ...state.display, flipColors: action.payload };
         },
+        addConditionalFormattingRule: (
+            state,
+            action: PayloadAction<VizBigNumberConditionalRule>,
+        ) => {
+            state.display = {
+                ...state.display,
+                conditionalFormatting: [
+                    ...(state.display?.conditionalFormatting ?? []),
+                    action.payload,
+                ],
+            };
+        },
+        updateConditionalFormattingRule: (
+            state,
+            action: PayloadAction<{
+                index: number;
+                rule: VizBigNumberConditionalRule;
+            }>,
+        ) => {
+            const rules = [...(state.display?.conditionalFormatting ?? [])];
+            if (!rules[action.payload.index]) return;
+            rules[action.payload.index] = action.payload.rule;
+            state.display = { ...state.display, conditionalFormatting: rules };
+        },
+        removeConditionalFormattingRule: (
+            state,
+            action: PayloadAction<number>,
+        ) => {
+            state.display = {
+                ...state.display,
+                conditionalFormatting: (
+                    state.display?.conditionalFormatting ?? []
+                ).filter((_, index) => index !== action.payload),
+            };
+        },
     },
     extraReducers: (builder) => {
         builder.addCase(prepareAndFetchChartData.pending, (state) => {
@@ -219,4 +255,7 @@ export const {
     setComparisonFormat,
     setComparisonLabel,
     setFlipColors,
+    addConditionalFormattingRule,
+    updateConditionalFormattingRule,
+    removeConditionalFormattingRule,
 } = bigNumberConfigSlice.actions;

--- a/packages/frontend/src/components/DataViz/visualizations/BigNumberView.test.tsx
+++ b/packages/frontend/src/components/DataViz/visualizations/BigNumberView.test.tsx
@@ -10,6 +10,7 @@ const spec: BigNumberSpec = {
     label: 'Revenue',
     showLabel: true,
     flipColors: false,
+    valueColor: undefined,
     comparison: undefined,
 };
 

--- a/packages/frontend/src/components/DataViz/visualizations/BigNumberView.tsx
+++ b/packages/frontend/src/components/DataViz/visualizations/BigNumberView.tsx
@@ -62,6 +62,7 @@ const BigNumberView: FC<Props> = memo(
                         label={spec.label}
                         showLabel={spec.showLabel}
                         flipColors={spec.flipColors}
+                        valueColor={spec.valueColor}
                         comparison={spec.comparison}
                     />
                 )}


### PR DESCRIPTION
Part 6 of 6 adding a big value (big number) chart to the SQL Runner.

## What

Colours the big number when its value crosses a threshold, matching what the explorer's big number offers.

Rules are an ordered list of comparison + value + colour. The first match wins, and its colour is emitted as `light-dark(light, dark)` so it follows the viewer's colour scheme — the same mechanism the explorer uses.

## Deviation from the explorer

The explorer's conditional formatting is built on `ConditionalFormattingConfig`, whose rules target a `FilterableItem`. SQL Runner result columns are not Items, and faking one to reuse that machinery would mean duck-typing a field object. This instead uses a small numeric-threshold shape of its own, `VizBigNumberConditionalRule`, while keeping the operator vocabulary as `FilterOperator` so the two remain directly comparable if they're ever unified.

Six operators are offered: greater than, greater than or equal, less than, less than or equal, equal, not equal.

## Regression analysis

Additive and opt-in. With no rules configured — every existing chart — `getBigNumberValueColor` returns `undefined` and the value keeps its default colour. Non-numeric values never match a rule. The evaluation is exhaustive over the operator union via `assertUnreachable`, so a future operator can't silently fall through.

Closes: PROD-1096
Closes: #11194
