### PR TITLE
feat: show Resume on the semantic layer step card

### DIFF
--- a/packages/backend/src/ee/controllers/OnboardingAgentController.ts
+++ b/packages/backend/src/ee/controllers/OnboardingAgentController.ts
@@ -1,5 +1,6 @@
 import {
     assertRegisteredAccount,
+    type ApiAgentOnboardingActiveRunResponse,
     type ApiAgentOnboardingFileResponse,
     type ApiAgentOnboardingRunResponse,
     type ApiErrorPayload,
@@ -55,6 +56,30 @@ export class OnboardingAgentController extends BaseController {
                 user: toSessionUser(req.account),
                 projectUuid,
             }),
+        };
+    }
+
+    /**
+     * Get the agent onboarding run that is currently queued or running for a
+     * project, if any.
+     * @summary Get active agent onboarding run
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/')
+    @OperationId('getActiveAgentOnboardingRun')
+    async getActiveRun(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+    ): Promise<ApiAgentOnboardingActiveRunResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getOnboardingAgentService().getActiveRun(
+                toSessionUser(req.account),
+                projectUuid,
+            ),
         };
     }
 

--- a/packages/backend/src/ee/services/OnboardingAgentService/OnboardingAgentService.ts
+++ b/packages/backend/src/ee/services/OnboardingAgentService/OnboardingAgentService.ts
@@ -240,6 +240,18 @@ export class OnboardingAgentService extends BaseService {
         return toRun(run);
     }
 
+    async getActiveRun(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<AgentOnboardingRun | null> {
+        await this.assertCanViewProject(user, projectUuid);
+        const run =
+            await this.agentOnboardingRunModel.findActiveRunForProject(
+                projectUuid,
+            );
+        return run ? toRun(run) : null;
+    }
+
     private async findOrganizationScopedRun(
         user: SessionUser,
         agentOnboardingRunUuid: string,

--- a/packages/common/src/ee/agentOnboarding/types.ts
+++ b/packages/common/src/ee/agentOnboarding/types.ts
@@ -91,6 +91,9 @@ export type AgentOnboardingRun = {
 
 export type ApiAgentOnboardingRunResponse = ApiSuccess<AgentOnboardingRun>;
 
+export type ApiAgentOnboardingActiveRunResponse =
+    ApiSuccess<AgentOnboardingRun | null>;
+
 export type ApiAgentOnboardingFileResponse =
     ApiSuccess<AgentOnboardingFileContent>;
 

--- a/packages/frontend/src/ee/features/agentOnboarding/hooks/useAgentOnboarding.ts
+++ b/packages/frontend/src/ee/features/agentOnboarding/hooks/useAgentOnboarding.ts
@@ -3,6 +3,7 @@ import {
     type AgentOnboardingFile,
     type AgentOnboardingFileContent,
     type AgentOnboardingRun,
+    type ApiAgentOnboardingActiveRunResponse,
     type ApiAgentOnboardingFileResponse,
     type ApiAgentOnboardingRunResponse,
     type ApiError,
@@ -33,6 +34,13 @@ const getAgentOnboardingRefetchInterval = (
 const getRun = async (projectUuid: string, runUuid: string) =>
     lightdashApi<ApiAgentOnboardingRunResponse['results']>({
         url: `/ee/projects/${projectUuid}/agent-onboarding/${runUuid}`,
+        method: 'GET',
+        body: undefined,
+    });
+
+const getActiveRun = async (projectUuid: string) =>
+    lightdashApi<ApiAgentOnboardingActiveRunResponse['results']>({
+        url: `/ee/projects/${projectUuid}/agent-onboarding`,
         method: 'GET',
         body: undefined,
     });
@@ -71,6 +79,19 @@ export const useAgentOnboardingRun = (
         enabled: !!projectUuid && !!runUuid && (options?.enabled ?? true),
         refetchInterval: getAgentOnboardingRefetchInterval,
         refetchIntervalInBackground: true,
+    });
+
+export const useActiveAgentOnboardingRun = (
+    projectUuid: string | undefined,
+    options?: Pick<
+        UseQueryOptions<AgentOnboardingRun | null, ApiError>,
+        'enabled'
+    >,
+) =>
+    useQuery<AgentOnboardingRun | null, ApiError>({
+        queryKey: ['agent-onboarding-active-run', projectUuid],
+        queryFn: () => getActiveRun(projectUuid!),
+        enabled: !!projectUuid && (options?.enabled ?? true),
     });
 
 export const useAgentOnboardingFile = (

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/RecommendedActionsChecklist.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/RecommendedActionsChecklist.tsx
@@ -180,7 +180,7 @@ const ActionRow: FC<{
                             })
                         }
                     >
-                        Set up
+                        {status.ctaLabel}
                     </Button>
                     {SKIPPABLE_ACTION_KEYS.includes(actionKey) && (
                         <Tooltip label="Skip this step" withinPortal>

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.test.tsx
@@ -12,6 +12,7 @@ import { useProject } from '../../../../hooks/useProject';
 import { useProjects } from '../../../../hooks/useProjects';
 import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../providers/App/useApp';
+import { useActiveAgentOnboardingRun } from '../../agentOnboarding/hooks/useAgentOnboarding';
 import { useRecommendedActions } from './useRecommendedActions';
 
 vi.mock(
@@ -26,6 +27,7 @@ vi.mock('../../../../hooks/useProject');
 vi.mock('../../../../hooks/useProjects');
 vi.mock('../../../../providers/App/useApp');
 vi.mock('../../../../hooks/useServerOrClientFeatureFlag');
+vi.mock('../../agentOnboarding/hooks/useAgentOnboarding');
 
 const organizationProject = (
     overrides: Partial<OrganizationProject>,
@@ -73,6 +75,9 @@ describe('useRecommendedActions', () => {
         vi.mocked(useServerFeatureFlag).mockReturnValue({
             data: undefined,
         } as ReturnType<typeof useServerFeatureFlag>);
+        vi.mocked(useActiveAgentOnboardingRun).mockReturnValue({
+            data: null,
+        } as ReturnType<typeof useActiveAgentOnboardingRun>);
         localStorage.clear();
     });
 
@@ -251,6 +256,35 @@ describe('useRecommendedActions', () => {
             expect(
                 result.current.statuses['add-semantic-layer'].url,
             ).toStrictEqual('/projects/project-uuid/onboarding/agent');
+            expect(
+                result.current.statuses['add-semantic-layer'].ctaLabel,
+            ).toStrictEqual('Set up');
+        });
+
+        it('resumes an in-flight agent run instead of restarting the flow', () => {
+            vi.mocked(useServerFeatureFlag).mockImplementation(
+                () =>
+                    ({
+                        data: { enabled: true },
+                    }) as ReturnType<typeof useServerFeatureFlag>,
+            );
+            vi.mocked(useActiveAgentOnboardingRun).mockReturnValue({
+                data: {
+                    agentOnboardingRunUuid: 'run-uuid',
+                    projectUuid: 'project-uuid',
+                },
+            } as ReturnType<typeof useActiveAgentOnboardingRun>);
+
+            const { result } = renderHook(() =>
+                useRecommendedActions('project-uuid'),
+            );
+
+            expect(
+                result.current.statuses['add-semantic-layer'].url,
+            ).toStrictEqual('/projects/project-uuid/onboarding/runs/run-uuid');
+            expect(
+                result.current.statuses['add-semantic-layer'].ctaLabel,
+            ).toStrictEqual('Resume');
         });
 
         it('keeps the settings link when coding-agent onboarding is disabled', () => {

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
@@ -20,10 +20,14 @@ import { useProjects } from '../../../../hooks/useProjects';
 import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../providers/App/useApp';
 import { isPlaygroundProvisioningSource } from '../../../../utils/playgroundProject';
+import { useActiveAgentOnboardingRun } from '../../agentOnboarding/hooks/useAgentOnboarding';
+import { getAgentOnboardingRunUrl } from '../../agentOnboarding/utils';
 import {
     RECOMMENDED_ACTION_KEYS,
     readSkippedActions,
 } from './recommendedActionDefaults';
+
+const DEFAULT_CTA_LABEL = 'Set up';
 
 export type ActionStatus = {
     isVisible: boolean;
@@ -32,6 +36,7 @@ export type ActionStatus = {
     /** Replaces the default icon once the action is complete */
     doneIcon: ReactNode | null;
     url: string;
+    ctaLabel: string;
 };
 
 const useActionStatuses = (
@@ -59,6 +64,14 @@ const useActionStatuses = (
         newOnboardingFlag.data?.enabled === true &&
         codingAgentOnboardingFlag.data?.enabled === true;
 
+    // An agent run left mid-flight is resumable, so the step points at the run
+    // instead of restarting the flow
+    const activeAgentRunQuery = useActiveAgentOnboardingRun(
+        projectUuid ?? undefined,
+        { enabled: hasAgentSemanticLayerEntry },
+    );
+    const activeAgentRun = activeAgentRunQuery.data ?? null;
+
     const hasGithub = !!health.data?.hasGithub;
     const hasGitlab = !!health.data?.hasGitlab;
     const gitlabQuery = useGitlabRepositories({
@@ -76,6 +89,7 @@ const useActionStatuses = (
         projectsQuery.isInitialLoading ||
         (hasGithub && githubConfigQuery.isInitialLoading) ||
         (hasGitlab && gitlabQuery.isInitialLoading) ||
+        activeAgentRunQuery.isInitialLoading ||
         (!!health.data?.hasSlack && slackQuery.isInitialLoading);
 
     const dbtConnection = project?.dbtConnection;
@@ -113,6 +127,7 @@ const useActionStatuses = (
                     ? getWarehouseIcon(warehouseType, 'sm')
                     : null,
                 url: '/onboarding/data-source',
+                ctaLabel: DEFAULT_CTA_LABEL,
             },
             'add-semantic-layer': {
                 isVisible: !!projectUuid,
@@ -121,9 +136,15 @@ const useActionStatuses = (
                     ? DbtProjectTypeLabels[dbtConnection.type]
                     : null,
                 doneIcon: null,
-                url: hasAgentSemanticLayerEntry
-                    ? `/projects/${projectUuid}/onboarding/agent`
-                    : `/generalSettings/projectManagement/${projectUuid}/settings`,
+                url: activeAgentRun
+                    ? getAgentOnboardingRunUrl(
+                          activeAgentRun.agentOnboardingRunUuid,
+                          activeAgentRun.projectUuid,
+                      )
+                    : hasAgentSemanticLayerEntry
+                      ? `/projects/${projectUuid}/onboarding/agent`
+                      : `/generalSettings/projectManagement/${projectUuid}/settings`,
+                ctaLabel: activeAgentRun ? 'Resume' : DEFAULT_CTA_LABEL,
             },
             'connect-source-control': {
                 isVisible: hasGithub || hasGitlab,
@@ -135,6 +156,7 @@ const useActionStatuses = (
                       : null,
                 doneIcon: null,
                 url: '/generalSettings/integrations',
+                ctaLabel: DEFAULT_CTA_LABEL,
             },
             'connect-slack': {
                 isVisible: !!health.data?.hasSlack,
@@ -142,6 +164,7 @@ const useActionStatuses = (
                 annotation: slack?.slackTeamName ?? 'Connected',
                 doneIcon: null,
                 url: '/generalSettings/integrations',
+                ctaLabel: DEFAULT_CTA_LABEL,
             },
         },
     };


### PR DESCRIPTION
### Description:

Once agentic semantic layer generation has been started, the homepage "Add a semantic layer" step card still said "Set up" and sent you back to the start of the flow. It now says "Resume" and links to the in-flight run.

There was no way for the client to know a run was in progress, so this adds `GET /api/v1/ee/projects/{projectUuid}/agent-onboarding` returning the project's queued/running run (or `null`), backed by the existing `findActiveRunForProject`. The checklist's `ActionStatus` gains a `ctaLabel` so the button label is per-step rather than hardcoded.

Not verified in a running app — this sandbox has no local stack. Covered by unit tests on `useRecommendedActions`.
