### PR TITLE
fix: refresh feature flags when org context changes

### DIFF
--- a/packages/frontend/src/components/ProjectConnection/CreateProjectconnection.tsx
+++ b/packages/frontend/src/components/ProjectConnection/CreateProjectconnection.tsx
@@ -12,6 +12,7 @@ import confetti from 'canvas-confetti';
 import { useEffect, useMemo, useRef, useState, type FC } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { getProject, useCreateMutation } from '../../hooks/useProject';
+import { refetchFeatureFlags } from '../../hooks/useServerOrClientFeatureFlag';
 import useActiveJob from '../../providers/ActiveJob/useActiveJob';
 import useApp from '../../providers/App/useApp';
 import useTracking from '../../providers/Tracking/useTracking';
@@ -172,9 +173,10 @@ const CreateProjectConnection: FC<CreateProjectConnectionProps> = ({
 
         // Warm the caches the home reads before we land there, so it doesn't
         // flash the stale "connect your warehouse" checklist (the projects/org
-        // lists still show no warehouse) or a cold project spinner. The button
-        // stays busy meanwhile, so it reads as one smooth step. Navigate even
-        // if priming fails.
+        // lists still show no warehouse), the pre-homepage-builder home (the
+        // org's onboarding flags are only enabled once this first project
+        // exists) or a cold project spinner. The button stays busy meanwhile,
+        // so it reads as one smooth step. Navigate even if priming fails.
         void (async () => {
             try {
                 await Promise.all([
@@ -186,6 +188,7 @@ const CreateProjectConnection: FC<CreateProjectConnectionProps> = ({
                         queryKey: ['organization'],
                         type: 'all',
                     }),
+                    refetchFeatureFlags(queryClient),
                     queryClient.prefetchQuery({
                         queryKey: ['project', projectUuid],
                         queryFn: () => getProject(projectUuid),

--- a/packages/frontend/src/hooks/organization/useOrganizationCreateMutation.ts
+++ b/packages/frontend/src/hooks/organization/useOrganizationCreateMutation.ts
@@ -1,6 +1,7 @@
 import { type ApiError, type CreateOrganization } from '@lightdash/common';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { lightdashApi } from '../../api';
+import { refetchFeatureFlags } from '../useServerOrClientFeatureFlag';
 
 const createOrgQuery = async (data: CreateOrganization) =>
     lightdashApi<null>({
@@ -14,7 +15,11 @@ export const useOrganizationCreateMutation = () => {
     return useMutation<null, ApiError, CreateOrganization>(createOrgQuery, {
         mutationKey: ['organization_create'],
         onSuccess: async () => {
-            await queryClient.invalidateQueries(['user']);
+            await Promise.all([
+                queryClient.invalidateQueries(['user']),
+                queryClient.invalidateQueries(['organization']),
+                refetchFeatureFlags(queryClient),
+            ]);
         },
     });
 };

--- a/packages/frontend/src/hooks/useEnsurePlaygroundProject.ts
+++ b/packages/frontend/src/hooks/useEnsurePlaygroundProject.ts
@@ -4,6 +4,7 @@ import {
 } from '@lightdash/common';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { lightdashApi } from '../api';
+import { refetchFeatureFlags } from './useServerOrClientFeatureFlag';
 
 const ensurePlaygroundProjectQuery = async () =>
     lightdashApi<EnsurePlaygroundProjectResults>({
@@ -21,6 +22,9 @@ export const useEnsurePlaygroundProject = () => {
             onSuccess: async () => {
                 await queryClient.invalidateQueries(['organization']);
                 await queryClient.invalidateQueries(['projects']);
+                // Provisioning the first project enables the org's onboarding
+                // flags server-side.
+                await refetchFeatureFlags(queryClient);
             },
         },
     );

--- a/packages/frontend/src/hooks/useServerOrClientFeatureFlag.test.tsx
+++ b/packages/frontend/src/hooks/useServerOrClientFeatureFlag.test.tsx
@@ -1,0 +1,66 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { PropsWithChildren } from 'react';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import {
+    refetchFeatureFlags,
+    useServerFeatureFlag,
+} from './useServerOrClientFeatureFlag';
+
+vi.mock('../api', () => ({
+    lightdashApi: vi.fn(),
+}));
+
+import { lightdashApi } from '../api';
+
+const mockApi = lightdashApi as unknown as Mock;
+
+const createQueryClient = () =>
+    new QueryClient({
+        defaultOptions: {
+            queries: { retry: false, staleTime: 30000 },
+            mutations: { retry: false },
+        },
+    });
+
+const createWrapper = (queryClient: QueryClient) =>
+    function Wrapper({ children }: PropsWithChildren) {
+        return (
+            <QueryClientProvider client={queryClient}>
+                {children}
+            </QueryClientProvider>
+        );
+    };
+
+describe('refetchFeatureFlags', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    // Flags resolve per org on the server, so a value cached before the org (or
+    // its first project) existed is wrong for the rest of the session. Because
+    // the query sets refetchOnMount: false, invalidating is not enough — the
+    // next page to mount would still read the stale value.
+    it('refreshes flags cached by an unmounted consumer', async () => {
+        const queryClient = createQueryClient();
+        const wrapper = createWrapper(queryClient);
+
+        mockApi.mockResolvedValueOnce({ id: 'a-flag', enabled: false });
+        const first = renderHook(() => useServerFeatureFlag('a-flag'), {
+            wrapper,
+        });
+        await waitFor(() => expect(first.result.current.isSuccess).toBe(true));
+        first.unmount();
+
+        mockApi.mockResolvedValueOnce({ id: 'a-flag', enabled: true });
+        await refetchFeatureFlags(queryClient);
+
+        const second = renderHook(() => useServerFeatureFlag('a-flag'), {
+            wrapper,
+        });
+        await waitFor(() =>
+            expect(second.result.current.data?.enabled).toBe(true),
+        );
+        expect(mockApi).toHaveBeenCalledTimes(2);
+    });
+});

--- a/packages/frontend/src/hooks/useServerOrClientFeatureFlag.ts
+++ b/packages/frontend/src/hooks/useServerOrClientFeatureFlag.ts
@@ -1,6 +1,21 @@
 import { type ApiError, type FeatureFlag } from '@lightdash/common';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, type QueryClient } from '@tanstack/react-query';
 import { lightdashApi } from '../api';
+
+export const FEATURE_FLAG_QUERY_KEY = 'feature-flag';
+
+/**
+ * Flags resolve per user/organization on the server, so anything that changes
+ * that context (creating or joining an org, creating the first project — which
+ * enables org overrides) has to refresh them. This refetches rather than
+ * invalidates because `refetchOnMount: false` means a stale cached flag would
+ * otherwise be served to the next page that mounts.
+ */
+export const refetchFeatureFlags = (queryClient: QueryClient) =>
+    queryClient.refetchQueries({
+        queryKey: [FEATURE_FLAG_QUERY_KEY],
+        type: 'all',
+    });
 
 /**
  * Get a feature flag value from the backend, which resolves through the
@@ -12,7 +27,7 @@ export const useServerFeatureFlag = (
     options?: { retry?: number | boolean },
 ) => {
     return useQuery<FeatureFlag, ApiError>(
-        ['feature-flag', featureFlagId],
+        [FEATURE_FLAG_QUERY_KEY, featureFlagId],
         () => {
             return lightdashApi<FeatureFlag>({
                 url: `/feature-flag/${featureFlagId}`,

--- a/packages/frontend/src/hooks/useServerOrClientFeatureFlag.ts
+++ b/packages/frontend/src/hooks/useServerOrClientFeatureFlag.ts
@@ -2,7 +2,7 @@ import { type ApiError, type FeatureFlag } from '@lightdash/common';
 import { useQuery, type QueryClient } from '@tanstack/react-query';
 import { lightdashApi } from '../api';
 
-export const FEATURE_FLAG_QUERY_KEY = 'feature-flag';
+const FEATURE_FLAG_QUERY_KEY = 'feature-flag';
 
 /**
  * Flags resolve per user/organization on the server, so anything that changes

--- a/packages/frontend/src/hooks/user/useJoinOrganizationMutation.ts
+++ b/packages/frontend/src/hooks/user/useJoinOrganizationMutation.ts
@@ -1,6 +1,7 @@
 import { type ApiError } from '@lightdash/common';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { lightdashApi } from '../../api';
+import { refetchFeatureFlags } from '../useServerOrClientFeatureFlag';
 
 const joinOrgQuery = async (orgUuid: string) =>
     lightdashApi<null>({
@@ -14,7 +15,11 @@ export const useJoinOrganizationMutation = () => {
     return useMutation<null, ApiError, string>(joinOrgQuery, {
         mutationKey: ['organization_create'],
         onSuccess: async () => {
-            await queryClient.invalidateQueries(['user']);
+            await Promise.all([
+                queryClient.invalidateQueries(['user']),
+                queryClient.invalidateQueries(['organization']),
+                refetchFeatureFlags(queryClient),
+            ]);
         },
     });
 };


### PR DESCRIPTION
### Description:

Feature flags resolve per organization on the server, but the frontend caches them under `['feature-flag', id]` with `refetchOnMount: false` and nothing ever refreshes them.

In the new onboarding flow this means the `homepage-builder` (and `coding-agent-onboarding`) flags get cached as **disabled** — `AppRoute`/`NoProjectHomepage` fetch them before the org has a project — while the org overrides that enable them are only written server-side when the first project is created (`provisionOnboardingHomepage`). `Home.tsx` then reads the stale `false`, skips the resolved-homepage query entirely and renders the old pre-homepage-builder home for the rest of the session, until a full reload drops the cache.

Refresh the flag cache at the points where server-side resolution changes:
- creating / joining an org (these also now invalidate `['organization']`, which was missing)
- first project provisioned — added to the existing cache-warming block in `CreateProjectconnection` (warehouse connect) and to `useEnsurePlaygroundProject` (sample-data path)

`refetchQueries` rather than `invalidateQueries`: with `refetchOnMount: false`, an invalidated flag with no active observer is still served to the next page that mounts. The added test covers exactly that.
