### PR TITLE
fix: include column totals row in non-pivot Excel exports

### DIFF
--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -586,6 +586,7 @@ export class QueryController extends BaseController {
             exportPivotedData: body.exportPivotedData,
             attachmentDownloadName: body.attachmentDownloadName,
             conditionalFormattings: body.conditionalFormattings,
+            showColumnTotals: body.showColumnTotals,
         });
 
         return {
@@ -627,6 +628,7 @@ export class QueryController extends BaseController {
                 exportPivotedData: body.exportPivotedData,
                 attachmentDownloadName: body.attachmentDownloadName,
                 conditionalFormattings: body.conditionalFormattings,
+                showColumnTotals: body.showColumnTotals,
             });
 
         return {

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -42,6 +42,7 @@ import {
     getRequestMethod,
     getSchedulerResourceTypeAndId,
     getSchedulerUuid,
+    getShowColumnTotalsFromChartConfig,
     getSourceSchedulerUuid,
     GoogleSheetsQuotaError,
     GoogleSheetsTransientError,
@@ -961,6 +962,10 @@ export default class SchedulerTask {
                                         getConditionalFormattingsFromChartConfig(
                                             chart.chartConfig.config,
                                         ),
+                                    showColumnTotals:
+                                        getShowColumnTotalsFromChartConfig(
+                                            chart.chartConfig.config,
+                                        ),
                                     expirationSecondsOverride,
                                 },
                                 SCHEDULER_POLLING_OPTIONS,
@@ -1150,6 +1155,10 @@ export default class SchedulerTask {
                                             chart.tableConfig.columnOrder,
                                         conditionalFormattings:
                                             getConditionalFormattingsFromChartConfig(
+                                                chart.chartConfig.config,
+                                            ),
+                                        showColumnTotals:
+                                            getShowColumnTotalsFromChartConfig(
                                                 chart.chartConfig.config,
                                             ),
                                         expirationSecondsOverride,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1348,6 +1348,41 @@ export class AsyncQueryService extends ProjectService {
     }
 
     /**
+     * Column totals for an export, keyed by field id. For a pivoted source this
+     * is one total per rendered value column; for a plain table the
+     * `calculate-total` query collapses to a single grand-total row, which is
+     * exactly the footer the table chart shows. Returns undefined when the
+     * totals query fails so the export still succeeds without them.
+     */
+    private async getExportColumnTotals({
+        account,
+        projectUuid,
+        sourceQueryUuid,
+    }: {
+        account: Account;
+        projectUuid: string;
+        sourceQueryUuid: string;
+    }): Promise<Record<string, number> | undefined> {
+        try {
+            const { rows, fields } =
+                await this.executeCalculateTotalAndGetResults({
+                    account,
+                    projectUuid,
+                    queryUuid: sourceQueryUuid,
+                    kind: 'columnTotal',
+                });
+            return buildWarehouseColumnTotals(formatRows(rows, fields));
+        } catch (error) {
+            this.logger.warn('Failed to compute column totals for export', {
+                projectUuid,
+                sourceQueryUuid,
+                error: getErrorMessage(error),
+            });
+            return undefined;
+        }
+    }
+
+    /**
      * Pivot totals are exclusively warehouse-computed — the export renderer has
      * no client-side fallback, so without this they come out blank. Mirrors the
      * UI: re-run the source query collapsed across the pivot (`calculate-total`)
@@ -1377,27 +1412,11 @@ export class AsyncQueryService extends ProjectService {
         let warehouseGrandTotals: Record<string, number> | undefined;
 
         if (pivotConfig.columnTotals) {
-            try {
-                const { rows, fields } =
-                    await this.executeCalculateTotalAndGetResults({
-                        account,
-                        projectUuid,
-                        queryUuid: sourceQueryUuid,
-                        kind: 'columnTotal',
-                    });
-                warehouseColumnTotals = buildWarehouseColumnTotals(
-                    formatRows(rows, fields),
-                );
-            } catch (error) {
-                this.logger.warn(
-                    'Failed to compute column totals for pivot export',
-                    {
-                        projectUuid,
-                        sourceQueryUuid,
-                        error: getErrorMessage(error),
-                    },
-                );
-            }
+            warehouseColumnTotals = await this.getExportColumnTotals({
+                account,
+                projectUuid,
+                sourceQueryUuid,
+            });
         }
 
         const { indexColumn } = pivotDetails;
@@ -1477,6 +1496,7 @@ export class AsyncQueryService extends ProjectService {
         attachmentDownloadName,
         expirationSecondsOverride,
         conditionalFormattings,
+        showColumnTotals = false,
     }: DownloadAsyncQueryResultsArgs): Promise<DownloadAsyncQueryResultsInternal> {
         assertIsAccountWithOrg(account);
 
@@ -1771,6 +1791,13 @@ export class AsyncQueryService extends ProjectService {
                               hiddenFields,
                               attachmentDownloadName,
                               conditionalFormattings,
+                              columnTotals: showColumnTotals
+                                  ? await this.getExportColumnTotals({
+                                        account,
+                                        projectUuid,
+                                        sourceQueryUuid: queryUuid,
+                                    })
+                                  : undefined,
                           },
                           displayTimezone ?? undefined,
                       );

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -60,6 +60,7 @@ export type DownloadAsyncQueryResultsArgs = Omit<
     attachmentDownloadName?: string;
     expirationSecondsOverride?: number;
     conditionalFormattings?: ConditionalFormattingConfig[];
+    showColumnTotals?: boolean;
 };
 
 export type ScheduleDownloadAsyncQueryResultsArgs = Omit<

--- a/packages/backend/src/services/ExcelService/ExcelService.test.ts
+++ b/packages/backend/src/services/ExcelService/ExcelService.test.ts
@@ -2095,3 +2095,122 @@ describe('ExcelService conditional formatting in xlsx export (PROD-8199)', () =>
         });
     });
 });
+
+describe('ExcelService column totals row in xlsx export (PROD-9169)', () => {
+    const dimension = {
+        fieldType: FieldType.DIMENSION,
+        type: DimensionType.STRING,
+        name: 'status',
+        table: 'orders',
+        tableLabel: 'Orders',
+        label: 'Status',
+        sql: '',
+        hidden: false,
+    } as ItemsMap[string];
+    const metric = {
+        fieldType: FieldType.METRIC,
+        type: MetricType.SUM,
+        name: 'revenue',
+        table: 'orders',
+        tableLabel: 'Orders',
+        label: 'Revenue',
+        sql: '',
+        hidden: false,
+        compiledSql: '',
+        tablesReferences: [],
+    } as ItemsMap[string];
+    const dimensionId = getItemId(dimension);
+    const metricId = getItemId(metric);
+
+    const { streamJsonlToExcelFile } = ExcelService as unknown as {
+        streamJsonlToExcelFile: (
+            resultsStream: Readable,
+            tempFilePath: string,
+            headers: string[],
+            fields: ItemsMap,
+            onlyRaw: boolean,
+            sortedFieldIds: string[],
+            timezone?: string,
+            conditionalFormattings?: undefined,
+            minMaxMap?: undefined,
+            columnTotals?: Record<string, number>,
+        ) => Promise<{ truncated: boolean }>;
+    };
+
+    const writeAndReadBack = async ({
+        fields,
+        sortedFieldIds,
+        rows,
+        columnTotals,
+    }: {
+        fields: ItemsMap;
+        sortedFieldIds: string[];
+        rows: Record<string, unknown>[];
+        columnTotals?: Record<string, number>;
+    }) => {
+        const tempFilePath = path.join(
+            os.tmpdir(),
+            `excel-totals-test-${process.pid}-${sortedFieldIds.length}-${
+                columnTotals ? 'totals' : 'none'
+            }.xlsx`,
+        );
+        const jsonl = rows.map((row) => JSON.stringify(row)).join('\n');
+        await streamJsonlToExcelFile(
+            Readable.from([jsonl]),
+            tempFilePath,
+            sortedFieldIds.map((id) => id),
+            fields,
+            false,
+            sortedFieldIds,
+            undefined,
+            undefined,
+            undefined,
+            columnTotals,
+        );
+
+        const workbook = new (await import('exceljs')).Workbook();
+        await workbook.xlsx.readFile(tempFilePath);
+        const worksheet = workbook.getWorksheet('Sheet1');
+        fs.unlinkSync(tempFilePath);
+        return worksheet;
+    };
+
+    it('appends a labelled totals row after the data rows', async () => {
+        const worksheet = await writeAndReadBack({
+            fields: { [dimensionId]: dimension, [metricId]: metric },
+            sortedFieldIds: [dimensionId, metricId],
+            rows: [
+                { [dimensionId]: 'placed', [metricId]: 10 },
+                { [dimensionId]: 'shipped', [metricId]: 32.5 },
+            ],
+            columnTotals: { [metricId]: 42.5 },
+        });
+
+        // Row 1 is the header, rows 2-3 the data, row 4 the totals.
+        expect(worksheet!.rowCount).toBe(4);
+        const totalsRow = worksheet!.getRow(4);
+        expect(totalsRow.getCell(1).value).toBe('Total');
+        expect(totalsRow.getCell(2).value).toBe(42.5);
+    });
+
+    it('keeps a first-column total instead of overwriting it with the label', async () => {
+        const worksheet = await writeAndReadBack({
+            fields: { [metricId]: metric },
+            sortedFieldIds: [metricId],
+            rows: [{ [metricId]: 10 }],
+            columnTotals: { [metricId]: 10 },
+        });
+
+        expect(worksheet!.getRow(2).getCell(1).value).toBe(10);
+    });
+
+    it('does not append a row when there are no totals', async () => {
+        const worksheet = await writeAndReadBack({
+            fields: { [dimensionId]: dimension, [metricId]: metric },
+            sortedFieldIds: [dimensionId, metricId],
+            rows: [{ [dimensionId]: 'placed', [metricId]: 10 }],
+        });
+
+        expect(worksheet!.rowCount).toBe(2);
+    });
+});

--- a/packages/backend/src/services/ExcelService/ExcelService.ts
+++ b/packages/backend/src/services/ExcelService/ExcelService.ts
@@ -796,6 +796,7 @@ export class ExcelService {
         timezone?: string,
         conditionalFormattings?: ConditionalFormattingConfig[],
         minMaxMap?: ConditionalFormattingMinMaxMap,
+        columnTotals?: Record<string, number>,
     ): Promise<{ truncated: boolean }> {
         // Use the same approach as our working tests - direct filename instead of stream
         const workbook = new Excel.stream.xlsx.WorkbookWriter({
@@ -883,6 +884,22 @@ export class ExcelService {
             maxLines: ExcelService.EXCEL_ROW_LIMIT,
         });
 
+        if (columnTotals && Object.keys(columnTotals).length > 0) {
+            const totalsRow: Record<string, string | number> = {};
+            sortedFieldIds.forEach((fieldId, colIndex) => {
+                const total = columnTotals[fieldId];
+                if (total !== undefined) {
+                    totalsRow[`col_${colIndex}`] = total;
+                }
+            });
+            // Label the row like the table footer does, as long as the first
+            // column has no total of its own to show.
+            if (totalsRow.col_0 === undefined) {
+                totalsRow.col_0 = 'Total';
+            }
+            worksheet.addRow(totalsRow).commit();
+        }
+
         // Commit Excel to temp file
         worksheet.commit();
         await workbook.commit();
@@ -909,6 +926,8 @@ export class ExcelService {
             hiddenFields?: string[];
             attachmentDownloadName?: string;
             conditionalFormattings?: ConditionalFormattingConfig[];
+            // Warehouse-computed totals appended as a final row, keyed by field id
+            columnTotals?: Record<string, number>;
         } = {},
         timezone?: string,
     ): Promise<{ fileUrl: string; truncated: boolean; s3Key: string }> {
@@ -921,6 +940,7 @@ export class ExcelService {
             hiddenFields = [],
             attachmentDownloadName,
             conditionalFormattings,
+            columnTotals,
         } = options;
 
         const { resultsStorageClient, exportsStorageClient } = clients;
@@ -968,6 +988,7 @@ export class ExcelService {
                 timezone,
                 conditionalFormattings,
                 minMaxMap,
+                columnTotals,
             );
 
             // Generate filename with truncated flag

--- a/packages/common/src/types/api/paginatedQuery.ts
+++ b/packages/common/src/types/api/paginatedQuery.ts
@@ -134,6 +134,7 @@ export type DownloadAsyncQueryResultsRequestParams = {
     exportPivotedData?: boolean;
     attachmentDownloadName?: string;
     conditionalFormattings?: ConditionalFormattingConfig[];
+    showColumnTotals?: boolean;
 };
 
 export type ExecuteAsyncFieldValueSearchRequestParams =

--- a/packages/common/src/types/downloadFile.ts
+++ b/packages/common/src/types/downloadFile.ts
@@ -31,4 +31,7 @@ export type DownloadOptions = {
     exportPivotedData?: boolean;
     attachmentDownloadName?: string;
     conditionalFormattings?: ConditionalFormattingConfig[];
+    // Table chart "Show column total" — appends a warehouse-computed totals row
+    // to unpivoted exports. Pivoted exports carry it in `pivotConfig`.
+    showColumnTotals?: boolean;
 };

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -1112,6 +1112,13 @@ export const getConditionalFormattingsFromChartConfig = (
         ? config.conditionalFormattings
         : undefined;
 
+export const getShowColumnTotalsFromChartConfig = (
+    config: ChartConfig['config'] | undefined,
+): boolean | undefined =>
+    config && isTableChartConfig(config)
+        ? config.showColumnCalculation
+        : undefined;
+
 export const hashFieldReference = (reference: PivotReference) =>
     reference.pivotValues
         ? `${reference.field}.${reference.pivotValues

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -881,6 +881,7 @@ export type DownloadAsyncQueryResultsPayload = TraceTaskBase & {
     exportPivotedData?: boolean;
     attachmentDownloadName?: string;
     conditionalFormattings?: ConditionalFormattingConfig[];
+    showColumnTotals?: boolean;
     encodedJwt?: string;
 };
 

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -12,6 +12,7 @@ import {
     getItemId,
     getItemMap,
     getPivotConfig,
+    getShowColumnTotalsFromChartConfig,
     getTotalFilterRules,
     getVisibleFields,
     isCartesianChartConfig,
@@ -1852,6 +1853,9 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                     )}
                     hiddenFields={getHiddenTableFields(chart.chartConfig)}
                     pivotConfig={downloadPivotConfig}
+                    showColumnTotals={getShowColumnTotalsFromChartConfig(
+                        chart.chartConfig.config,
+                    )}
                 />
                 <ExportImageModal
                     echartRef={echartRef}
@@ -2145,6 +2149,9 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
                     )}
                     hiddenFields={getHiddenTableFields(chart.chartConfig)}
                     pivotConfig={downloadPivotConfig}
+                    showColumnTotals={getShowColumnTotalsFromChartConfig(
+                        chart.chartConfig.config,
+                    )}
                 />
             )}
             {canExportImages && (

--- a/packages/frontend/src/components/ExportResults/index.tsx
+++ b/packages/frontend/src/components/ExportResults/index.tsx
@@ -134,9 +134,10 @@ const ExportResults: FC<ExportResultsProps> = memo(
                             ? undefined
                             : conditionalFormattings,
                         // Pivoted exports get their totals from `pivotConfig`
-                        showColumnTotals: exportPivotedData
-                            ? undefined
-                            : showColumnTotals,
+                        showColumnTotals:
+                            exportPivotedData && pivotConfig
+                                ? undefined
+                                : showColumnTotals,
                     };
 
                     return scheduleDownloadQuery(

--- a/packages/frontend/src/components/ExportResults/index.tsx
+++ b/packages/frontend/src/components/ExportResults/index.tsx
@@ -64,6 +64,7 @@ export type ExportResultsProps = {
     chartName?: string;
     pivotConfig?: PivotConfig;
     conditionalFormattings?: ConditionalFormattingConfig[];
+    showColumnTotals?: boolean;
     hideLimitSelection?: boolean;
     forceShowLimitSelection?: boolean;
     renderDialogActions?: (renderProps: ExportCsvRenderProps) => ReactNode;
@@ -83,6 +84,7 @@ const ExportResults: FC<ExportResultsProps> = memo(
         chartName,
         pivotConfig,
         conditionalFormattings,
+        showColumnTotals,
         hideLimitSelection = false,
         forceShowLimitSelection = false,
         renderDialogActions,
@@ -131,6 +133,10 @@ const ExportResults: FC<ExportResultsProps> = memo(
                         conditionalFormattings: exportPivotedData
                             ? undefined
                             : conditionalFormattings,
+                        // Pivoted exports get their totals from `pivotConfig`
+                        showColumnTotals: exportPivotedData
+                            ? undefined
+                            : showColumnTotals,
                     };
 
                     return scheduleDownloadQuery(

--- a/packages/frontend/src/components/ExportSelector/index.tsx
+++ b/packages/frontend/src/components/ExportSelector/index.tsx
@@ -32,6 +32,7 @@ const ExportSelector: FC<
         chartName,
         pivotConfig,
         conditionalFormattings,
+        showColumnTotals,
     }) => {
         const health = useHealth();
         const hasGoogleDrive =
@@ -72,6 +73,7 @@ const ExportSelector: FC<
                         chartName={chartName}
                         pivotConfig={pivotConfig}
                         conditionalFormattings={conditionalFormattings}
+                        showColumnTotals={showColumnTotals}
                     />
                 </>
             );
@@ -105,6 +107,7 @@ const ExportSelector: FC<
                 chartName={chartName}
                 pivotConfig={pivotConfig}
                 conditionalFormattings={conditionalFormattings}
+                showColumnTotals={showColumnTotals}
             />
         );
     },

--- a/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
+++ b/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
@@ -163,6 +163,10 @@ const ChartDownloadMenu: React.FC<ChartDownloadMenuProps> = memo(
                                 visualizationConfig.chartConfig
                                     .conditionalFormattings
                             }
+                            showColumnTotals={
+                                visualizationConfig.chartConfig
+                                    .showColumnCalculation
+                            }
                             getGsheetLink={
                                 getGsheetLink === undefined
                                     ? undefined

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -125,6 +125,7 @@ export const scheduleDownloadQuery = async (
             exportPivotedData: options.exportPivotedData,
             attachmentDownloadName: options.attachmentDownloadName,
             conditionalFormattings: options.conditionalFormattings,
+            showColumnTotals: options.showColumnTotals,
         }),
         version: 'v2',
     });


### PR DESCRIPTION
Closes: lightdash/lightdash#26014

### Description:

Table charts with "Show column total" enabled exported to Excel without the totals row. Warehouse totals were only computed when a pivot config asked for them, and only the pivot renderer received them — the direct (unpivoted) XLSX path streamed data rows and never read `showColumnCalculation`.

This adds a `showColumnTotals` download option. When set, the direct XLSX path runs the same `calculate-total` (`kind: 'columnTotal'`) query the table footer uses — which collapses to a single grand-total row for an unpivoted source — and appends it as a final row, labelling the first column `Total` unless that column has a total of its own. A failed totals query logs and leaves the export intact, matching the pivot path.

The `columnTotal` computation that the pivot path already had is extracted into `getExportColumnTotals` and shared.

Wired up from the explore/chart export menu, the dashboard tile export modal, and scheduled chart + dashboard-chart deliveries. Pivoted exports keep getting their totals from `pivotConfig`, so the new flag is only sent for unpivoted exports.

Out of scope: CSV exports have the same gap on the non-pivot path.

### Verification

New unit tests in [`ExcelService.test.ts`](<https://github.com/lightdash/lightdash/blob/073e93cb2/packages/backend/src/services/ExcelService/ExcelService.test.ts>) write real `.xlsx` files through the private streaming writer and read them back, asserting the appended row, the label placement, and that no row is added when there are no totals. This sandbox had no running app or database, so the change has **not** been exercised against a live export — worth a manual check on a table chart with and without a pivot before merging.