### PR TITLE
fix: sweep orphaned dev instance volumes in dev-ports gc and add a destroy verb

### DIFF
--- a/.claude/commands/docker-dev.md
+++ b/.claude/commands/docker-dev.md
@@ -1,4 +1,4 @@
-Manage Docker dev environment. Args: (none) = show status & help, `start` = auto-detect and setup, `stop` = stop this instance, `stop-all` = stop everything, `reset` = reset db from snapshot, `rebuild` = full db rebuild, `snapshot [name]` = save db snapshot, `list-snapshots` = list snapshots, `restore <name>` = restore named snapshot, `list-instances` = show all instances.
+Manage Docker dev environment. Args: (none) = show status & help, `start` = auto-detect and setup, `stop` = stop this instance, `destroy` = permanently remove this instance, `stop-all` = stop everything, `reset` = reset db from snapshot, `rebuild` = full db rebuild, `snapshot [name]` = save db snapshot, `list-snapshots` = list snapshots, `restore <name>` = restore named snapshot, `list-instances` = show all instances.
 
 **NEVER use `scripts/reset-db.sh`** — it requires a local `psql` client which is not available. Instead, use `docker exec` to run psql inside the container, then run migrate/seed via pnpm.
 
@@ -9,6 +9,7 @@ Manage Docker dev environment. Args: (none) = show status & help, `start` = auto
 - **`start <profiles>`**: Provision for named capabilities, comma-separated — e.g. `start ee` (turnkey EE: all AI + GitHub), `start github` (Core + dbt-over-GitHub, no AI), `start ee,slack`. Skips the menu. The AI tier is just **Core vs EE** — all AI features (agents, writeback, reviews classifier) are bundled into `ee`. See `scripts/dev-profiles.json`. `ee` requires `github` so writeback opens PRs out of the box; profiles run their GitHub/dbt-repo + classifier reconcile + verify automatically.
 - **`start ee`** (also `start --ee`, "start with ee enabled", "enterprise"): The EE profile — provisions an Enterprise Edition license (`LIGHTDASH_LICENSE_KEY`), runs the EE migration/seed pass, and **bundles all AI features** (Copilot/agents, AI writeback, reviews classifier) plus the GitHub integration so writeback is turnkey. See **Enterprise Edition (EE) Mode** below. Auto-enabled if `.env.development.local` already contains `LIGHTDASH_LICENSE_KEY`. EE instances bootstrap from a dedicated EE base snapshot (`ld-shared_postgres_base_ee`) so they skip the slow EE migrate pass.
 - **`stop`**: Stop this instance's PM2 processes and PostgreSQL. Shared services stay running. Releases port slot.
+- **`destroy`**: Permanently remove this instance's PM2 processes, PostgreSQL containers, volumes, and port slot. Use when removing a worktree.
 - **`stop-all`**: Stop ALL instances — all PM2 processes, all per-instance PostgreSQL containers, shared services, and release all port slots. Use when shutting down for the day.
 - **`reset`**: Restore database from this instance's volume snapshot (fast, ~3 seconds). Fails if no snapshot exists.
 - **`rebuild`**: Full database reset from scratch (drop schema, migrate, seed, dbt). Takes a new snapshot when done.
@@ -54,6 +55,7 @@ Then run the **State Detection** checks below and present the results as a statu
 Available commands:
   /docker-dev start          Auto-detect and start what's needed
   /docker-dev stop           Stop this instance (preserves data)
+  /docker-dev destroy        Permanently remove this instance
   /docker-dev stop-all       Stop ALL instances and shared services
   /docker-dev reset          Restore db from snapshot (~3s)
   /docker-dev rebuild        Full db rebuild from scratch
@@ -826,7 +828,7 @@ pm2 logs "${LD_INSTANCE_ID}-frontend" --raw 2>/dev/null | grep --line-buffered -
 **Launch both monitors in parallel** (two Monitor tool calls in a single message). They filter for actionable signals only — not raw log streams — so you won't be overwhelmed.
 
 If a monitor fires, investigate the error. Common responses:
-- **EADDRINUSE**: Port conflict — run `./scripts/dev-ports.sh gc` then restart the process
+- **EADDRINUSE**: Port conflict — run `./scripts/dev-ports.sh gc` (or `gc --dry-run` to preview; both sweep orphaned instance volumes) then restart the process
 - **Cannot find module**: Missing build — run `pnpm -F common build`
 - **ECONNREFUSED on 5432**: PostgreSQL container down — restart with `docker compose -p "$LD_COMPOSE_PROJECT" -f docker/docker-compose.dev.instance.yml up -d`
 - **TypeErrors/build failures**: Code issue — read the full log with `pm2 logs ${LD_INSTANCE_ID}-api --lines 50 --nostream`
@@ -918,6 +920,7 @@ Restart Claude Code to load the new `statusLine` command. If there's no command-
 ## `stop`: Stop This Instance
 
 Stop this instance's services. Shared services and other instances are not affected.
+For permanent worktree removal, use `destroy` instead.
 
 ```bash
 # One name per call — `pm2 delete a b c` aborts at the first name it cannot
@@ -930,6 +933,23 @@ done
 docker compose -p "$LD_COMPOSE_PROJECT" -f docker/docker-compose.dev.instance.yml down
 
 ./scripts/dev-ports.sh release
+```
+
+---
+
+## `destroy`: Permanently Remove This Instance
+
+Permanently remove this instance's services, PostgreSQL volumes, and port slot. Shared services and other instances are not affected.
+
+```bash
+# One name per call — see the note under `stop`.
+for suffix in api scheduler frontend common-watch formula-watch warehouses-watch sdk-test spotlight; do
+  pm2 delete "${LD_INSTANCE_ID}-${suffix}" 2>/dev/null || true
+done
+
+docker compose -p "$LD_COMPOSE_PROJECT" -f docker/docker-compose.dev.instance.yml down -v
+
+./scripts/dev-ports.sh release --instance-id "$LD_INSTANCE_ID"
 ```
 
 ---
@@ -1125,6 +1145,8 @@ docker compose -p ld-shared -f docker/docker-compose.dev.shared.yml --env-file .
 ```
 
 ### Port Conflicts
+
+`gc` also sweeps orphaned per-instance PostgreSQL data and snapshot volumes; use `gc --dry-run` to preview its changes.
 
 ```bash
 ./scripts/dev-ports.sh list

--- a/scripts/dev-ports.sh
+++ b/scripts/dev-ports.sh
@@ -16,7 +16,7 @@
 #   dev-ports.sh show [--instance-id NAME]    Print current port assignments
 #   dev-ports.sh list                          List all active instances
 #   dev-ports.sh env [--instance-id NAME]     Output sourceable env var exports
-#   dev-ports.sh gc                            Release instances with missing worktree paths
+#   dev-ports.sh gc [--dry-run]                Release stale instances and orphaned volumes
 
 set -euo pipefail
 
@@ -48,12 +48,17 @@ parse_args() {
     SUBCOMMAND="${1:-}"
     shift || true
     INSTANCE_ID=""
+    DRY_RUN=false
 
     while [ $# -gt 0 ]; do
         case "$1" in
             --instance-id)
                 INSTANCE_ID="${2:-}"
                 shift 2
+                ;;
+            --dry-run)
+                DRY_RUN=true
+                shift
                 ;;
             *)
                 shift
@@ -369,10 +374,86 @@ print(f\"export EMAIL_SMTP_PORT={s['mailpitSmtp']}\")
 "
 }
 
+get_env_instance_id() {
+    local env_file="$1/.env.development.local"
+    [ -f "$env_file" ] || return 0
+
+    sed -n -E 's/^LD_INSTANCE_ID=(.*)$/\1/p' "$env_file" | head -n 1 | sed -E "s/^['\"](.*)['\"]$/\1/"
+}
+
+add_live_instance() {
+    local instance_id="$1"
+    local live_instance_id
+    for live_instance_id in "${LIVE_INSTANCE_IDS[@]}"; do
+        [ "$live_instance_id" = "$instance_id" ] && return
+    done
+    LIVE_INSTANCE_IDS+=("$instance_id")
+}
+
+is_stale_instance() {
+    local instance_id="$1"
+    local stale_instance_id
+    for stale_instance_id in "${STALE_INSTANCE_IDS[@]}"; do
+        [ "$stale_instance_id" = "$instance_id" ] && return 0
+    done
+    return 1
+}
+
+collect_live_instances() {
+    LIVE_INSTANCE_IDS=()
+    CHECKOUT_COUNT=0
+
+    local registry_file
+    for registry_file in "$REGISTRY_DIR"/*.json; do
+        [ -f "$registry_file" ] || continue
+        local registered_instance_id
+        registered_instance_id=$(python3 -c "import json; print(json.load(open('$registry_file'))['instanceId'])" 2>/dev/null) || return 1
+        [ -n "$registered_instance_id" ] || continue
+        is_stale_instance "$registered_instance_id" || add_live_instance "$registered_instance_id"
+    done
+
+    local script_dir
+    script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+    local repo_root
+    repo_root=$(git -C "$script_dir/.." rev-parse --show-toplevel 2>/dev/null || true)
+    [ -n "$repo_root" ] || return 1
+
+    local checkout_instance_id
+    CHECKOUT_COUNT=$((CHECKOUT_COUNT + 1))
+    checkout_instance_id=$(get_env_instance_id "$repo_root") || return 1
+    [ -n "$checkout_instance_id" ] && add_live_instance "$checkout_instance_id"
+
+    local worktree_list
+    worktree_list=$(git -C "$repo_root" worktree list --porcelain) || return 1
+
+    local line
+    while IFS= read -r line; do
+        case "$line" in
+            "worktree "*)
+                CHECKOUT_COUNT=$((CHECKOUT_COUNT + 1))
+                checkout_instance_id=$(get_env_instance_id "${line#worktree }") || return 1
+                [ -n "$checkout_instance_id" ] && add_live_instance "$checkout_instance_id"
+                ;;
+        esac
+    done <<< "$worktree_list"
+
+    return 0
+}
+
+is_live_instance() {
+    local instance_id="$1"
+    local live_instance_id
+    for live_instance_id in "${LIVE_INSTANCE_IDS[@]}"; do
+        [ "$live_instance_id" = "$instance_id" ] && return 0
+    done
+    return 1
+}
+
 cmd_gc() {
     mkdir -p "$REGISTRY_DIR"
 
     local cleaned=0
+    STALE_INSTANCE_IDS=()
     for f in "$REGISTRY_DIR"/*.json; do
         [ -f "$f" ] || continue
 
@@ -382,16 +463,70 @@ cmd_gc() {
         instance_id=$(python3 -c "import json; print(json.load(open('$f'))['instanceId'])" 2>/dev/null || true)
 
         if [ -n "$worktree_path" ] && [ ! -d "$worktree_path" ]; then
-            echo "Releasing stale instance '$instance_id' (worktree $worktree_path no longer exists)"
-            rm "$f"
+            STALE_INSTANCE_IDS+=("$instance_id")
+            if [ "$DRY_RUN" = true ]; then
+                echo "Would release stale instance '$instance_id' (worktree $worktree_path no longer exists)"
+            else
+                echo "Releasing stale instance '$instance_id' (worktree $worktree_path no longer exists)"
+                rm "$f"
+            fi
             cleaned=$((cleaned + 1))
         fi
     done
 
     if [ "$cleaned" -eq 0 ]; then
         echo "No stale instances found"
+    elif [ "$DRY_RUN" = true ]; then
+        echo "Would clean up $cleaned stale instance(s)"
     else
         echo "Cleaned up $cleaned stale instance(s)"
+    fi
+
+    if ! command -v docker >/dev/null 2>&1; then
+        echo "Docker unavailable; skipping orphaned volume sweep"
+        return
+    fi
+
+    local volumes
+    if ! volumes=$(docker volume ls -q 2>/dev/null); then
+        echo "Docker unavailable; skipping orphaned volume sweep"
+        return
+    fi
+
+    if ! collect_live_instances; then
+        echo "WARNING: Could not complete live instance scan; skipping orphaned volume sweep"
+        return
+    fi
+
+    if [ "$CHECKOUT_COUNT" -gt 0 ] && [ "${#LIVE_INSTANCE_IDS[@]}" -eq 0 ]; then
+        echo "WARNING: Live instance scan found no instances for existing checkouts; skipping orphaned volume sweep"
+        return
+    fi
+
+    local volumes_cleaned=0
+    local volume
+    for volume in $volumes; do
+        [[ "$volume" == ld-shared_* ]] && continue
+        if [[ "$volume" =~ ^ld-(.*)_postgres_data(_snapshot)?$ ]]; then
+            local instance_id="${BASH_REMATCH[1]}"
+            if ! is_live_instance "$instance_id"; then
+                if [ "$DRY_RUN" = true ]; then
+                    echo "Would remove orphaned volume '$volume'"
+                    volumes_cleaned=$((volumes_cleaned + 1))
+                else
+                    if docker volume rm "$volume" >/dev/null; then
+                        echo "Removed orphaned volume '$volume'"
+                        volumes_cleaned=$((volumes_cleaned + 1))
+                    else
+                        echo "Could not remove orphaned volume '$volume' (it may be in use)"
+                    fi
+                fi
+            fi
+        fi
+    done
+
+    if [ "$volumes_cleaned" -eq 0 ]; then
+        echo "No orphaned instance volumes found"
     fi
 }
 


### PR DESCRIPTION
### Description:

The multi-instance dev workflow had no end-of-life path for an instance's docker volumes: teardown runs `docker compose down` without `-v`, so every removed worktree strands its `ld-<instance>_postgres_data` + `_postgres_data_snapshot` volumes. On one dev box this accumulated 60 stale volumes (~15GB) and contributed to filling the disk.

Two changes:

- `scripts/dev-ports.sh gc` now also sweeps orphaned instance volumes. A volume is only removed when its instance matches no port-registry entry AND no existing checkout's `LD_INSTANCE_ID` (repo root + all git worktrees); `ld-shared_*` (the base snapshots) is always excluded. The sweep is fail-safe — it aborts with a warning if the liveness scan errors or resolves zero live instances while checkouts exist — and `gc --dry-run` previews both slot releases and volume removals without acting.
- `/docker-dev` gains a `destroy` verb for permanent instance removal (worktree cleanup): per-name `pm2 delete`, `compose down -v`, port-slot release. `stop` stays volume-preserving for instances that will restart.

Linear: SPK-738