### PR TITLE
fix: restore invite step when adding a non-member to a project

### DIFF
--- a/packages/backend/src/controllers/OrganizationRolesController.ts
+++ b/packages/backend/src/controllers/OrganizationRolesController.ts
@@ -5,6 +5,7 @@ import {
     ApiRoleAssignmentResponse,
     ApiRoleWithScopesResponse,
     CreateRole,
+    type UUID,
 } from '@lightdash/common';
 import {
     Body,
@@ -61,7 +62,7 @@ export class OrganizationRolesController extends BaseController {
     @OperationId('GetOrganizationRoles')
     async getOrganizationRoles(
         @Request() req: express.Request,
-        @Path() orgUuid: string,
+        @Path() orgUuid: UUID,
         @Query() load?: string,
         @Query() roleTypeFilter?: string,
     ): Promise<ApiGetRolesResponse | ApiRoleWithScopesResponse> {
@@ -90,7 +91,7 @@ export class OrganizationRolesController extends BaseController {
     @OperationId('GetOrganizationRoleAssignments')
     async getOrganizationRoleAssignments(
         @Request() req: express.Request,
-        @Path() orgUuid: string,
+        @Path() orgUuid: UUID,
     ): Promise<ApiRoleAssignmentListResponse> {
         const assignments =
             await this.getRolesService().getOrganizationRoleAssignments(
@@ -115,8 +116,8 @@ export class OrganizationRolesController extends BaseController {
     @OperationId('GetCustomRoleByUuid')
     async getCustomRoleByUuid(
         @Request() req: express.Request,
-        @Path() orgUuid: string,
-        @Path() roleUuid: string,
+        @Path() orgUuid: UUID,
+        @Path() roleUuid: UUID,
     ): Promise<ApiRoleWithScopesResponse> {
         const role = await this.getRolesService().getRoleByUuid(
             req.account!,
@@ -144,8 +145,8 @@ export class OrganizationRolesController extends BaseController {
     @OperationId('UpsertOrganizationUserRoleAssignment')
     async upsertOrganizationUserRoleAssignment(
         @Request() req: express.Request,
-        @Path() orgUuid: string,
-        @Path() userId: string,
+        @Path() orgUuid: UUID,
+        @Path() userId: UUID,
         @Body() body: { roleId: string },
     ): Promise<ApiRoleAssignmentResponse> {
         const assignment =
@@ -177,7 +178,7 @@ export class OrganizationRolesController extends BaseController {
     @OperationId('DuplicateRole')
     async duplicateRole(
         @Request() req: express.Request,
-        @Path() orgUuid: string,
+        @Path() orgUuid: UUID,
         @Path() roleId: string,
         @Body() body: CreateRole,
     ): Promise<ApiRoleWithScopesResponse> {

--- a/packages/backend/src/controllers/ProjectRolesController.ts
+++ b/packages/backend/src/controllers/ProjectRolesController.ts
@@ -7,6 +7,7 @@ import {
     CreateUserRoleAssignmentRequest,
     UpdateRoleAssignmentRequest,
     UpsertUserRoleAssignmentRequest,
+    type UUID,
 } from '@lightdash/common';
 import {
     Body,
@@ -99,7 +100,7 @@ export class ProjectRolesController extends BaseController {
     async upsertProjectUserRoleAssignment(
         @Request() req: express.Request,
         @Path() projectId: string,
-        @Path() userId: string,
+        @Path() userId: UUID,
         @Body() body: UpsertUserRoleAssignmentRequest,
     ): Promise<ApiRoleAssignmentResponse> {
         const assignment =
@@ -132,7 +133,7 @@ export class ProjectRolesController extends BaseController {
     async upsertProjectGroupRoleAssignment(
         @Request() req: express.Request,
         @Path() projectId: string,
-        @Path() groupId: string,
+        @Path() groupId: UUID,
         @Body() body: UpsertUserRoleAssignmentRequest,
     ): Promise<ApiRoleAssignmentResponse> {
         const assignment =
@@ -165,7 +166,7 @@ export class ProjectRolesController extends BaseController {
     async updateProjectGroupRoleAssignment(
         @Request() req: express.Request,
         @Path() projectId: string,
-        @Path() groupId: string,
+        @Path() groupId: UUID,
         @Body() body: UpdateRoleAssignmentRequest,
     ): Promise<ApiRoleAssignmentResponse> {
         const assignment =
@@ -199,7 +200,7 @@ export class ProjectRolesController extends BaseController {
     async deleteProjectUserRoleAssignment(
         @Request() req: express.Request,
         @Path() projectId: string,
-        @Path() userId: string,
+        @Path() userId: UUID,
     ): Promise<ApiUnassignRoleFromUserResponse> {
         await this.getRolesService().deleteProjectRoleAssignment(
             req.account!,
@@ -230,7 +231,7 @@ export class ProjectRolesController extends BaseController {
     async deleteProjectGroupRoleAssignment(
         @Request() req: express.Request,
         @Path() projectId: string,
-        @Path() groupId: string,
+        @Path() groupId: UUID,
     ): Promise<ApiUnassignRoleFromUserResponse> {
         await this.getRolesService().deleteProjectRoleAssignment(
             req.account!,

--- a/packages/frontend/src/components/ProjectAccess/CreateProjectAccessModal.test.tsx
+++ b/packages/frontend/src/components/ProjectAccess/CreateProjectAccessModal.test.tsx
@@ -1,0 +1,115 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../testing/testUtils';
+import CreateProjectAccessModal from './CreateProjectAccessModal';
+
+const EXISTING_MEMBER = {
+    userUuid: 'c1f0f0a1-1111-4111-8111-111111111111',
+    email: 'member@lightdash.com',
+};
+const INVITED_USER_UUID = 'd2f0f0a1-2222-4222-8222-222222222222';
+
+const { upsertMock, inviteMock } = vi.hoisted(() => ({
+    upsertMock: vi.fn(),
+    inviteMock: vi.fn(),
+}));
+
+const ORG_USERS = [
+    { userUuid: EXISTING_MEMBER.userUuid, email: EXISTING_MEMBER.email },
+];
+
+vi.mock('../../hooks/useOrganizationUsers', () => ({
+    useOrganizationUsers: () => ({ data: ORG_USERS }),
+}));
+
+vi.mock('../../hooks/useProjectRoles', () => ({
+    useUpsertProjectUserRoleAssignmentMutation: () => ({
+        mutateAsync: upsertMock,
+        isLoading: false,
+    }),
+}));
+
+vi.mock('../../hooks/useInviteLink', () => ({
+    useCreateInviteLinkMutation: () => ({
+        mutateAsync: inviteMock,
+        isLoading: false,
+        reset: vi.fn(),
+    }),
+}));
+
+const ROLES = [{ value: 'viewer', label: 'Viewer', group: 'System role' }];
+
+const renderModal = () =>
+    renderWithProviders(
+        <CreateProjectAccessModal
+            projectUuid="e3f0f0a1-3333-4333-8333-333333333333"
+            roles={ROLES}
+            onClose={vi.fn()}
+        />,
+    );
+
+const submit = async (user: ReturnType<typeof userEvent.setup>) => {
+    await user.click(screen.getByRole('button', { name: 'Give access' }));
+};
+
+describe('CreateProjectAccessModal', () => {
+    beforeEach(() => {
+        upsertMock.mockReset().mockResolvedValue(undefined);
+        inviteMock
+            .mockReset()
+            .mockResolvedValue({ userUuid: INVITED_USER_UUID });
+    });
+
+    it('assigns the role directly when an existing member is selected', async () => {
+        const user = userEvent.setup();
+        renderModal();
+
+        const emailInput = screen.getByRole('textbox', {
+            name: 'Enter user email address',
+        });
+        await user.click(emailInput);
+        await user.click(await screen.findByText(EXISTING_MEMBER.email));
+
+        await submit(user);
+
+        await waitFor(() =>
+            expect(upsertMock).toHaveBeenCalledWith({
+                userId: EXISTING_MEMBER.userUuid,
+                roleId: 'viewer',
+                sendEmail: true,
+            }),
+        );
+        expect(inviteMock).not.toHaveBeenCalled();
+    });
+
+    it('invites a non-member first and assigns the role to the created user', async () => {
+        const user = userEvent.setup();
+        renderModal();
+
+        const emailInput = screen.getByRole('textbox', {
+            name: 'Enter user email address',
+        });
+        await user.click(emailInput);
+        await user.type(emailInput, 'newcomer@example.com');
+        await user.click(
+            await screen.findByText(/Select to invite them\./, {
+                exact: false,
+            }),
+        );
+
+        await submit(user);
+
+        await waitFor(() =>
+            expect(inviteMock).toHaveBeenCalledWith({
+                email: 'newcomer@example.com',
+                role: 'member',
+            }),
+        );
+        expect(upsertMock).toHaveBeenCalledWith({
+            userId: INVITED_USER_UUID,
+            roleId: 'viewer',
+            sendEmail: false,
+        });
+    });
+});

--- a/packages/frontend/src/components/ProjectAccess/CreateProjectAccessModal.tsx
+++ b/packages/frontend/src/components/ProjectAccess/CreateProjectAccessModal.tsx
@@ -1,9 +1,14 @@
 import { subject } from '@casl/ability';
-import { validateEmail, type InviteLink } from '@lightdash/common';
+import {
+    OrganizationMemberRole,
+    validateEmail,
+    type InviteLink,
+} from '@lightdash/common';
 import { Button, Group, Select } from '@mantine-8/core';
 import { useForm } from '@mantine/form';
 import { IconUserPlus } from '@tabler/icons-react';
-import { useEffect, useState, type FC } from 'react';
+import { useMemo, useState, type FC } from 'react';
+import { useCreateInviteLinkMutation } from '../../hooks/useInviteLink';
 import { useOrganizationUsers } from '../../hooks/useOrganizationUsers';
 import { useUpsertProjectUserRoleAssignmentMutation } from '../../hooks/useProjectRoles';
 import useApp from '../../providers/App/useApp';
@@ -36,6 +41,12 @@ const CreateProjectAccessModal: FC<Props> = ({
     const { mutateAsync: upsertMutation, isLoading } =
         useUpsertProjectUserRoleAssignmentMutation(projectUuid);
 
+    const {
+        mutateAsync: inviteMutation,
+        isLoading: isInvitationLoading,
+        reset: resetInvitation,
+    } = useCreateInviteLinkMutation({ showSuccessToast: false });
+
     const { data: organizationUsers } = useOrganizationUsers();
 
     const form = useForm<{ userId: string; roleId: string }>({
@@ -46,20 +57,16 @@ const CreateProjectAccessModal: FC<Props> = ({
     });
 
     const [inviteLink, setInviteLink] = useState<InviteLink | undefined>();
-    const [emailOptions, setEmailOptions] = useState<
-        { value: string; label: string }[]
-    >([]);
     const [emailSearch, setEmailSearch] = useState('');
 
-    useEffect(() => {
-        if (organizationUsers) {
-            const userData = organizationUsers.map((us) => ({
+    const emailOptions = useMemo(
+        () =>
+            (organizationUsers ?? []).map((us) => ({
                 value: us.userUuid,
                 label: us.email,
-            }));
-            setEmailOptions(userData);
-        }
-    }, [organizationUsers]);
+            })),
+        [organizationUsers],
+    );
 
     const handleSubmit = async (formData: {
         userId: string;
@@ -70,11 +77,33 @@ const CreateProjectAccessModal: FC<Props> = ({
         });
         setInviteLink(undefined);
 
-        await upsertMutation({
-            ...formData,
-            sendEmail: true,
-        });
+        // Existing members are selected by uuid; a new member is selected by email
+        const isExistingMember = emailOptions.some(
+            ({ value }) => value === formData.userId,
+        );
+
+        if (isExistingMember) {
+            await upsertMutation({
+                userId: formData.userId,
+                roleId: formData.roleId,
+                sendEmail: true,
+            });
+        } else {
+            const invite = await inviteMutation({
+                email: formData.userId,
+                role: OrganizationMemberRole.MEMBER,
+            });
+            await upsertMutation({
+                userId: invite.userUuid,
+                roleId: formData.roleId,
+                sendEmail: false,
+            });
+            setInviteLink(invite);
+            resetInvitation();
+        }
+
         form.reset();
+        setEmailSearch('');
     };
 
     const userCanInviteUsersToOrganization = user.data?.ability.can(
@@ -100,6 +129,8 @@ const CreateProjectAccessModal: FC<Props> = ({
           ]
         : emailOptions;
 
+    const isSubmitting = isLoading || isInvitationLoading;
+
     const formId = 'add-user-to-project';
 
     return (
@@ -113,8 +144,8 @@ const CreateProjectAccessModal: FC<Props> = ({
                 <Button
                     type="submit"
                     form={formId}
-                    disabled={isLoading}
-                    loading={isLoading}
+                    disabled={isSubmitting}
+                    loading={isSubmitting}
                 >
                     Give access
                 </Button>
@@ -148,7 +179,7 @@ const CreateProjectAccessModal: FC<Props> = ({
                             }
                             searchable
                             required
-                            disabled={isLoading}
+                            disabled={isSubmitting}
                             searchValue={emailSearch}
                             onSearchChange={setEmailSearch}
                             data={userOptions}
@@ -172,7 +203,7 @@ const CreateProjectAccessModal: FC<Props> = ({
                         <Select
                             allowDeselect={false}
                             data={groupComboboxItems(roles)}
-                            disabled={isLoading}
+                            disabled={isSubmitting}
                             required
                             radius="md"
                             placeholder="Select role"


### PR DESCRIPTION
## Problem

In **Project settings → Project access → Add user access**, typing an email that isn't an existing org member offers *"This user is not a member of your organization. Select to invite them."* Selecting it and clicking **Give access** always failed with:

> Failed to update user project role assignment — Something went wrong.

No invite was created and no access was granted. Reported by a customer on 1.38.2; reproducible on every instance.

## Root cause

The create-option puts the raw **email** into the form's `userId`, and submit sent it as a user UUID:

```
POST /api/v2/projects/{projectUuid}/roles/assignments/user/<email>
```

`RolesService.upsertProjectUserRoleAssignment` → `userModel.getUserDetailsByUuid(email)` → `.where('user_uuid', '<email>')`. `user_uuid` is a `uuid` column, so Postgres raises `22P02 invalid input syntax for type uuid` before the `NotFoundError` guard is reached. The unmapped driver error becomes a 500 `UnexpectedServerError`, which the UI renders as the generic "Something went wrong."

Verified against `main` on the sibling org endpoint (unchanged code path at the time):

```
POST /api/v2/orgs/{orgUuid}/roles/assignments/user/new.person@example.com
→ 500 {"name":"UnexpectedServerError","message":"Something went wrong."}
```

## Regression analysis

`CreateProjectAccessModal` originally ran two steps for a non-member: create an org invite link, then grant project access to the newly created user. When the modal was migrated from the email-based `POST /projects/{uuid}/access` endpoint to the uuid-based v2 roles endpoint, the invite step was dropped but the invite affordance was left behind. Since then `inviteLink` state and the `<InviteSuccess>` panel have been unreachable — `setInviteLink` was only ever called with `undefined`.

A later Mantine v8 `Select` migration reworded the option from the discouraging "You need to be an organization admin to add new users to your organization" to the actionable "Select to invite them.", which plausibly explains why reports surfaced only recently — the underlying break is older, and existed for admins in the v6 `onCreate` path too.

Existing-member assignment was never affected: those options carry a real `userUuid`.

## Changes

**1. Restore the two-step flow** (`CreateProjectAccessModal.tsx`)

- Non-member: create the invite link (`OrganizationMemberRole.MEMBER`), then upsert the project role with the returned `userUuid`, then surface the invite-link panel. `sendEmail: false` because the invite email already went out.
- Existing member: unchanged — direct upsert with `sendEmail: true`.
- The two branches are distinguished by whether the selected value matches a known org-member option, not by sniffing the string shape.
- Also replaced the `useEffect` + `setState` mirroring of `useOrganizationUsers` data with a `useMemo`, per the frontend guide. With an unstable query reference the old form was an infinite render loop.

**2. Harden the API boundary** (`ProjectRolesController.ts`, `OrganizationRolesController.ts`)

Typed the uuid-only `@Path()` params as `UUID`, so TSOA rejects a non-uuid at the request boundary with a 422 instead of letting it reach the driver and 500. This follows the convention in `packages/backend/src/controllers/CLAUDE.md`. `roleId` on `/{roleId}/duplicate` was intentionally left as `string`.

Behaviour change: these endpoints now return 422 rather than 500 for a malformed id. No first-party caller passes a non-uuid.

<!-- allow-api-breaking-change -->
**allow-api-breaking-change** — the OpenAPI breaking-change check flags 24 `request-parameter-pattern-added` / `request-parameter-type-changed` errors for the uuid pattern now applied to these path params. Accepted deliberately: the only values this newly rejects are values that could never have succeeded — they reached the Postgres driver and produced a 500 `UnexpectedServerError`. No functioning client is affected, and the change brings these routes in line with the uuid-path-param convention in `packages/backend/src/controllers/CLAUDE.md`.

## Verification

- Browser, invite path: `POST /invite-links → 201`, then `POST .../roles/assignments/user/{uuid} → 200`; invite-link panel renders and the user appears in the access list with the chosen role.
- Browser, existing-member path: single upsert, no invite call, 200.
- API: an email in the uuid path param now returns 422 `ValidateError` instead of 500.
- New RTL test covering both branches. Confirmed it fails against the pre-fix component and passes after.
- `pnpm -F backend typecheck`, `pnpm -F frontend typecheck`, frontend lint.

Closes: #26536

No Linear ticket for this one — tracked via the GitHub issue only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nyav41ysT2Fe3epJDwfbWC
