### PR TITLE
fix: survive transient sandbox disconnects in the onboarding agent run

### DIFF
--- a/packages/backend/src/ee/services/OnboardingAgentService/OnboardingAgentService.ts
+++ b/packages/backend/src/ee/services/OnboardingAgentService/OnboardingAgentService.ts
@@ -33,29 +33,30 @@ import { type CommercialSchedulerClient } from '../../scheduler/SchedulerClient'
 import {
     interpretAgentEvent,
     resolveSandboxTemplateRef,
-    splitStreamBuffer,
     summarizeToolInput,
 } from '../AiWritebackService/utils';
 import {
     createSandboxManager,
     S3SnapshotStore,
+    SandboxCommandError,
     SandboxConnectionError,
     SandboxNotRunningError,
+    SandboxTimeoutError,
     type PersistentWorkspace,
     type SandboxHandle,
     type SandboxManager,
     type SandboxSpec,
 } from '../SandboxRuntime';
+import { pollDetachedAgentRun } from './agentStreamPoller';
 import {
-    ALLOWED_TOOLS,
+    AGENT_RUNNER_PATH,
+    AGENT_RUNNER_SCRIPT,
+    AGENT_STDERR_PATH,
     CANCELLATION_POLL_INTERVAL_MS,
     CLAUDE_BASH_GUARD_PATH,
     CLAUDE_BASH_GUARD_SCRIPT,
-    CLAUDE_MODEL,
     CLAUDE_SETTINGS,
     CLAUDE_SETTINGS_PATH,
-    CLAUDE_SKILLS_DIR,
-    CLAUDE_TOOLS,
     CLI_WRAPPER_PATH,
     CLI_WRAPPER_SCRIPT,
     FILE_SYNC_INTERVAL_MS,
@@ -618,9 +619,11 @@ export class OnboardingAgentService extends BaseService {
             CLAUDE_BASH_GUARD_SCRIPT,
         );
         await sandbox.files.write(CLAUDE_SETTINGS_PATH, CLAUDE_SETTINGS);
-        await sandbox.commands.run(`chmod +x ${CLI_WRAPPER_PATH}`);
+        await sandbox.files.write(AGENT_RUNNER_PATH, AGENT_RUNNER_SCRIPT);
+        await sandbox.commands.run(
+            `chmod +x ${CLI_WRAPPER_PATH} ${AGENT_RUNNER_PATH}`,
+        );
 
-        let buffer = '';
         let assistantText = '';
         let usage: AgentOnboardingUsage | null = null;
         let lastStep = '';
@@ -730,53 +733,63 @@ export class OnboardingAgentService extends BaseService {
             }
         };
 
-        const flushBuffer = (): void => {
-            const { lines, remainder } = splitStreamBuffer(buffer);
-            buffer = remainder;
-            for (const line of lines) {
-                if (line.trim()) {
-                    try {
-                        handleEvent(JSON.parse(line));
-                    } catch {
-                        this.logger.debug(
-                            'OnboardingAgent: received an unparseable Claude event',
-                        );
-                    }
-                }
+        const handleStreamLine = (line: string): void => {
+            try {
+                handleEvent(JSON.parse(line));
+            } catch {
+                this.logger.debug(
+                    'OnboardingAgent: received an unparseable Claude event',
+                );
             }
         };
 
         let runError: { value: unknown } | undefined;
         try {
+            // setsid keeps the runner alive after the launch shell exits.
             await sandbox.commands.run(
-                `cat ${PROMPT_PATH} | claude -p ` +
-                    `--model ${CLAUDE_MODEL} ` +
-                    '--output-format stream-json --verbose ' +
-                    `--add-dir ${CLAUDE_SKILLS_DIR} ` +
-                    `--settings ${CLAUDE_SETTINGS_PATH} ` +
-                    '--permission-mode dontAsk ' +
-                    `--tools "${CLAUDE_TOOLS}" ` +
-                    `--allowedTools "${ALLOWED_TOOLS}"`,
+                `setsid nohup ${AGENT_RUNNER_PATH} >/dev/null 2>&1 < /dev/null & echo launched`,
                 {
                     cwd: WORKDIR,
-                    timeoutMs: RUN_TIMEOUT_MS,
                     envs: {
                         ANTHROPIC_API_KEY: anthropicApiKey,
                         LIGHTDASH_URL: this.getSandboxFacingSiteUrl(),
                         LIGHTDASH_API_KEY: patToken,
                         LIGHTDASH_PROJECT: run.project_uuid,
                     },
-                    onStdout: (chunk) => {
-                        buffer += chunk;
-                        flushBuffer();
-                    },
-                    onStderr: () => {
-                        this.logger.debug(
-                            'OnboardingAgent: Claude emitted diagnostic output',
-                        );
-                    },
                 },
             );
+            const { exitCode } = await pollDetachedAgentRun({
+                sandbox,
+                onLine: handleStreamLine,
+                logger: this.logger,
+            });
+            if (exitCode === 124) {
+                throw new SandboxTimeoutError(
+                    'The onboarding agent took too long and was stopped.',
+                );
+            }
+            if (exitCode !== 0) {
+                let stderrTail = '';
+                try {
+                    const result = await sandbox.commands.run(
+                        `tail -c 2048 ${AGENT_STDERR_PATH} 2>/dev/null || true`,
+                    );
+                    stderrTail = result.stdout;
+                } catch {
+                    this.logger.debug(
+                        'OnboardingAgent: could not read agent diagnostic output',
+                    );
+                }
+                if (stderrTail) {
+                    this.logger.warn(
+                        `OnboardingAgent: Claude exited with diagnostic output: ${sanitizeOnboardingMessage(
+                            stderrTail,
+                            sensitiveValues,
+                        )}`,
+                    );
+                }
+                throw new SandboxCommandError(exitCode, stderrTail, '');
+            }
         } catch (error) {
             runError = { value: error };
         }
@@ -803,15 +816,6 @@ export class OnboardingAgentService extends BaseService {
                     sensitiveValues,
                 )}`,
             );
-        }
-        if (buffer.trim()) {
-            try {
-                handleEvent(JSON.parse(buffer));
-            } catch {
-                this.logger.debug(
-                    'OnboardingAgent: received an unparseable trailing Claude event',
-                );
-            }
         }
         await Promise.all(pendingEvents);
         if (runError) throw runError.value;

--- a/packages/backend/src/ee/services/OnboardingAgentService/OnboardingAgentService.ts
+++ b/packages/backend/src/ee/services/OnboardingAgentService/OnboardingAgentService.ts
@@ -39,6 +39,8 @@ import {
 import {
     createSandboxManager,
     S3SnapshotStore,
+    SandboxConnectionError,
+    SandboxNotRunningError,
     type PersistentWorkspace,
     type SandboxHandle,
     type SandboxManager,
@@ -1004,11 +1006,21 @@ export class OnboardingAgentService extends BaseService {
                     run.agent_onboarding_run_uuid,
                 );
             } else {
-                const message = sanitizeOnboardingMessage(
+                const sanitizedMessage = sanitizeOnboardingMessage(
                     getErrorMessage(error),
                     sensitiveValues(),
                 );
-                this.logger.error(`OnboardingAgent run failed: ${message}`);
+                const sandboxConnectionFailure =
+                    error instanceof SandboxConnectionError ||
+                    error instanceof SandboxNotRunningError;
+                const message = sandboxConnectionFailure
+                    ? "Lightdash lost the connection to the onboarding agent's workspace. Any progress was saved. Please try running the onboarding agent again."
+                    : sanitizedMessage;
+                this.logger.error(
+                    sandboxConnectionFailure
+                        ? `OnboardingAgent run failed (sandbox connection): ${sanitizedMessage}`
+                        : `OnboardingAgent run failed: ${sanitizedMessage}`,
+                );
                 await this.agentOnboardingRunModel.markFailed(
                     run.agent_onboarding_run_uuid,
                     message,

--- a/packages/backend/src/ee/services/OnboardingAgentService/agentStreamPoller.test.ts
+++ b/packages/backend/src/ee/services/OnboardingAgentService/agentStreamPoller.test.ts
@@ -1,0 +1,263 @@
+import {
+    SandboxConnectionError,
+    SandboxNotRunningError,
+    SandboxTimeoutError,
+    type CommandResult,
+    type SandboxHandle,
+} from '../SandboxRuntime';
+import { pollDetachedAgentRun } from './agentStreamPoller';
+
+const EXIT_SEPARATOR = '__LIGHTDASH_AGENT_EXIT_SECTION__';
+const PROCESS_SEPARATOR = '__LIGHTDASH_AGENT_PROCESS_SECTION__';
+
+const tickResponse = (args: {
+    exitCode: number | null;
+    processCount: number;
+    tail: string;
+}): CommandResult => {
+    const exitOutput = args.exitCode === null ? '' : `${args.exitCode}\n`;
+    return {
+        stdout:
+            `${exitOutput}\n${EXIT_SEPARATOR}\n` +
+            `${args.processCount}\n\n${PROCESS_SEPARATOR}\n${args.tail}`,
+        stderr: '',
+        exitCode: 0,
+    };
+};
+
+const makeSandbox = (responses: Array<CommandResult | Error>) => {
+    const run = vi.fn<SandboxHandle['commands']['run']>(async () => {
+        const response = responses.shift();
+        if (!response) {
+            throw new Error('No scripted sandbox response remains');
+        }
+        if (response instanceof Error) throw response;
+        return response;
+    });
+    const sandbox = { commands: { run } } as unknown as SandboxHandle;
+    return { sandbox, run };
+};
+
+const makeLogger = () => ({
+    debug: vi.fn<(message: string) => void>(),
+    warn: vi.fn<(message: string) => void>(),
+});
+
+describe('pollDetachedAgentRun', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('delivers complete lines in order and holds partial trailing lines', async () => {
+        const { sandbox, run } = makeSandbox([
+            tickResponse({
+                exitCode: null,
+                processCount: 1,
+                tail: 'first\npart',
+            }),
+            tickResponse({
+                exitCode: null,
+                processCount: 1,
+                tail: 'partial\nsecond\n',
+            }),
+            tickResponse({
+                exitCode: 0,
+                processCount: 0,
+                tail: '',
+            }),
+        ]);
+        const onLine = vi.fn<(line: string) => void>();
+        const promise = pollDetachedAgentRun({
+            sandbox,
+            onLine,
+            logger: makeLogger(),
+            timeouts: { pollIntervalMs: 1 },
+        });
+
+        await vi.advanceTimersByTimeAsync(2);
+
+        await expect(promise).resolves.toEqual({ exitCode: 0 });
+        expect(onLine.mock.calls).toEqual([['first'], ['partial'], ['second']]);
+        expect(run).toHaveBeenCalledWith(
+            expect.stringContaining("pgrep -cf 'ld-agent-runner[.]sh'"),
+        );
+    });
+
+    it('returns the exit code and flushes a final unterminated line', async () => {
+        const { sandbox } = makeSandbox([
+            tickResponse({
+                exitCode: null,
+                processCount: 1,
+                tail: 'complete\npart',
+            }),
+            tickResponse({
+                exitCode: 17,
+                processCount: 0,
+                tail: 'partial',
+            }),
+        ]);
+        const onLine = vi.fn<(line: string) => void>();
+        const promise = pollDetachedAgentRun({
+            sandbox,
+            onLine,
+            logger: makeLogger(),
+            timeouts: { pollIntervalMs: 1 },
+        });
+
+        await vi.advanceTimersByTimeAsync(1);
+
+        await expect(promise).resolves.toEqual({ exitCode: 17 });
+        expect(onLine.mock.calls).toEqual([['complete'], ['partial']]);
+    });
+
+    it('recovers from transient RPC failures within the grace period', async () => {
+        const { sandbox } = makeSandbox([
+            new Error('temporary transport failure'),
+            tickResponse({
+                exitCode: 0,
+                processCount: 0,
+                tail: '',
+            }),
+        ]);
+        const logger = makeLogger();
+        const promise = pollDetachedAgentRun({
+            sandbox,
+            onLine: vi.fn(),
+            logger,
+            timeouts: {
+                pollIntervalMs: 10,
+                disconnectGraceMs: 100,
+            },
+        });
+
+        await vi.advanceTimersByTimeAsync(10);
+
+        await expect(promise).resolves.toEqual({ exitCode: 0 });
+        expect(logger.warn).toHaveBeenCalledOnce();
+    });
+
+    it('throws SandboxConnectionError after failures exceed the grace period', async () => {
+        const { sandbox } = makeSandbox([
+            new Error('transport failure 1'),
+            new Error('transport failure 2'),
+            new Error('transport failure 3'),
+        ]);
+        const promise = pollDetachedAgentRun({
+            sandbox,
+            onLine: vi.fn(),
+            logger: makeLogger(),
+            timeouts: {
+                pollIntervalMs: 10,
+                disconnectGraceMs: 15,
+            },
+        });
+        const rejection = promise.catch((error: unknown) => error);
+
+        await vi.advanceTimersByTimeAsync(20);
+
+        await expect(rejection).resolves.toBeInstanceOf(SandboxConnectionError);
+    });
+
+    it('rethrows SandboxNotRunningError immediately', async () => {
+        const error = new SandboxNotRunningError('sandbox was destroyed');
+        const { sandbox, run } = makeSandbox([error]);
+
+        await expect(
+            pollDetachedAgentRun({
+                sandbox,
+                onLine: vi.fn(),
+                logger: makeLogger(),
+            }),
+        ).rejects.toBe(error);
+        expect(run).toHaveBeenCalledOnce();
+    });
+
+    it('throws when the runner is absent for two consecutive ticks', async () => {
+        const { sandbox } = makeSandbox([
+            tickResponse({
+                exitCode: null,
+                processCount: 0,
+                tail: '',
+            }),
+            tickResponse({
+                exitCode: null,
+                processCount: 0,
+                tail: '',
+            }),
+        ]);
+        const promise = pollDetachedAgentRun({
+            sandbox,
+            onLine: vi.fn(),
+            logger: makeLogger(),
+            timeouts: { pollIntervalMs: 1 },
+        });
+        const rejection = promise.catch((error: unknown) => error);
+
+        await vi.advanceTimersByTimeAsync(1);
+
+        await expect(rejection).resolves.toBeInstanceOf(SandboxConnectionError);
+    });
+
+    it('does not count repeated unavailable process checks as dead ticks', async () => {
+        const { sandbox } = makeSandbox([
+            tickResponse({
+                exitCode: null,
+                processCount: -1,
+                tail: '',
+            }),
+            tickResponse({
+                exitCode: null,
+                processCount: -1,
+                tail: '',
+            }),
+            tickResponse({
+                exitCode: null,
+                processCount: -1,
+                tail: '',
+            }),
+            tickResponse({
+                exitCode: 0,
+                processCount: -1,
+                tail: '',
+            }),
+        ]);
+        const promise = pollDetachedAgentRun({
+            sandbox,
+            onLine: vi.fn(),
+            logger: makeLogger(),
+            timeouts: { pollIntervalMs: 1 },
+        });
+
+        await vi.advanceTimersByTimeAsync(3);
+
+        await expect(promise).resolves.toEqual({ exitCode: 0 });
+    });
+
+    it('throws SandboxTimeoutError when the overall deadline expires', async () => {
+        const { sandbox } = makeSandbox([
+            tickResponse({
+                exitCode: null,
+                processCount: 1,
+                tail: '',
+            }),
+        ]);
+        const promise = pollDetachedAgentRun({
+            sandbox,
+            onLine: vi.fn(),
+            logger: makeLogger(),
+            timeouts: {
+                pollIntervalMs: 10,
+                deadlineMs: 10,
+            },
+        });
+        const rejection = promise.catch((error: unknown) => error);
+
+        await vi.advanceTimersByTimeAsync(10);
+
+        await expect(rejection).resolves.toBeInstanceOf(SandboxTimeoutError);
+    });
+});

--- a/packages/backend/src/ee/services/OnboardingAgentService/agentStreamPoller.test.ts
+++ b/packages/backend/src/ee/services/OnboardingAgentService/agentStreamPoller.test.ts
@@ -237,6 +237,42 @@ describe('pollDetachedAgentRun', () => {
         await expect(promise).resolves.toEqual({ exitCode: 0 });
     });
 
+    it('treats separator strings inside the stream tail as data', async () => {
+        const poisonedLines =
+            `real-line-1\n\n${EXIT_SEPARATOR}\n99\n` +
+            `\n${PROCESS_SEPARATOR}\nreal-line-2\n`;
+        const { sandbox } = makeSandbox([
+            tickResponse({
+                exitCode: null,
+                processCount: 1,
+                tail: poisonedLines,
+            }),
+            tickResponse({
+                exitCode: 0,
+                processCount: 0,
+                tail: '',
+            }),
+        ]);
+        const onLine = vi.fn<(line: string) => void>();
+        const promise = pollDetachedAgentRun({
+            sandbox,
+            onLine,
+            logger: makeLogger(),
+            timeouts: { pollIntervalMs: 1 },
+        });
+
+        await vi.advanceTimersByTimeAsync(1);
+
+        await expect(promise).resolves.toEqual({ exitCode: 0 });
+        expect(onLine.mock.calls).toEqual([
+            ['real-line-1'],
+            [EXIT_SEPARATOR],
+            ['99'],
+            [PROCESS_SEPARATOR],
+            ['real-line-2'],
+        ]);
+    });
+
     it('throws SandboxTimeoutError when the overall deadline expires', async () => {
         const { sandbox } = makeSandbox([
             tickResponse({

--- a/packages/backend/src/ee/services/OnboardingAgentService/agentStreamPoller.ts
+++ b/packages/backend/src/ee/services/OnboardingAgentService/agentStreamPoller.ts
@@ -42,30 +42,37 @@ const parseInteger = (value: string, field: string): number => {
     return Number.parseInt(trimmed, 10);
 };
 
+// Only the first occurrence of each separator is trusted: everything after the
+// process separator is agent-controlled stream output, which may itself contain
+// the separator strings.
 const parsePollTick = (stdout: string): PollTick => {
     const exitSeparator = `\n${EXIT_SEPARATOR}\n`;
     const processSeparator = `\n${PROCESS_SEPARATOR}\n`;
-    const exitSections = stdout.split(exitSeparator);
-    if (exitSections.length !== 2) {
+    const exitIndex = stdout.indexOf(exitSeparator);
+    if (exitIndex === -1) {
         throw new SandboxConnectionError(
             'Received an invalid response from the onboarding agent workspace',
         );
     }
-    const processSections = exitSections[1].split(processSeparator);
-    if (processSections.length !== 2) {
+    const afterExit = stdout.slice(exitIndex + exitSeparator.length);
+    const processIndex = afterExit.indexOf(processSeparator);
+    if (processIndex === -1) {
         throw new SandboxConnectionError(
             'Received an invalid response from the onboarding agent workspace',
         );
     }
 
-    const exitCodeText = exitSections[0].trim();
+    const exitCodeText = stdout.slice(0, exitIndex).trim();
     return {
         exitCode:
             exitCodeText.length > 0
                 ? parseInteger(exitCodeText, 'exit code')
                 : null,
-        processCount: parseInteger(processSections[0], 'process count'),
-        tail: processSections[1],
+        processCount: parseInteger(
+            afterExit.slice(0, processIndex),
+            'process count',
+        ),
+        tail: afterExit.slice(processIndex + processSeparator.length),
     };
 };
 

--- a/packages/backend/src/ee/services/OnboardingAgentService/agentStreamPoller.ts
+++ b/packages/backend/src/ee/services/OnboardingAgentService/agentStreamPoller.ts
@@ -1,0 +1,171 @@
+import { getErrorMessage } from '@lightdash/common';
+import {
+    SandboxConnectionError,
+    SandboxNotRunningError,
+    SandboxTimeoutError,
+    type SandboxHandle,
+    type SandboxLogger,
+} from '../SandboxRuntime';
+import {
+    AGENT_EXIT_CODE_PATH,
+    AGENT_STREAM_PATH,
+    RUN_TIMEOUT_MS,
+    SANDBOX_DISCONNECT_GRACE_MS,
+    STREAM_POLL_INTERVAL_MS,
+} from './constants';
+
+const EXIT_SEPARATOR = '__LIGHTDASH_AGENT_EXIT_SECTION__';
+const PROCESS_SEPARATOR = '__LIGHTDASH_AGENT_PROCESS_SECTION__';
+const DEFAULT_DEADLINE_MS = RUN_TIMEOUT_MS + 60 * 1000;
+
+type PollerLogger = Pick<SandboxLogger, 'warn'>;
+
+type PollerTimeouts = {
+    pollIntervalMs?: number;
+    disconnectGraceMs?: number;
+    deadlineMs?: number;
+};
+
+type PollTick = {
+    exitCode: number | null;
+    processCount: number;
+    tail: string;
+};
+
+const parseInteger = (value: string, field: string): number => {
+    const trimmed = value.trim();
+    if (!/^-?\d+$/.test(trimmed)) {
+        throw new SandboxConnectionError(
+            `Received an invalid ${field} from the onboarding agent workspace`,
+        );
+    }
+    return Number.parseInt(trimmed, 10);
+};
+
+const parsePollTick = (stdout: string): PollTick => {
+    const exitSeparator = `\n${EXIT_SEPARATOR}\n`;
+    const processSeparator = `\n${PROCESS_SEPARATOR}\n`;
+    const exitSections = stdout.split(exitSeparator);
+    if (exitSections.length !== 2) {
+        throw new SandboxConnectionError(
+            'Received an invalid response from the onboarding agent workspace',
+        );
+    }
+    const processSections = exitSections[1].split(processSeparator);
+    if (processSections.length !== 2) {
+        throw new SandboxConnectionError(
+            'Received an invalid response from the onboarding agent workspace',
+        );
+    }
+
+    const exitCodeText = exitSections[0].trim();
+    return {
+        exitCode:
+            exitCodeText.length > 0
+                ? parseInteger(exitCodeText, 'exit code')
+                : null,
+        processCount: parseInteger(processSections[0], 'process count'),
+        tail: processSections[1],
+    };
+};
+
+const sleep = (durationMs: number): Promise<void> =>
+    new Promise((resolve) => {
+        setTimeout(resolve, durationMs);
+    });
+
+export async function pollDetachedAgentRun(args: {
+    sandbox: SandboxHandle;
+    onLine: (line: string) => void;
+    logger: PollerLogger;
+    timeouts?: PollerTimeouts;
+}): Promise<{ exitCode: number }> {
+    const { sandbox, onLine, logger } = args;
+    const pollIntervalMs =
+        args.timeouts?.pollIntervalMs ?? STREAM_POLL_INTERVAL_MS;
+    const disconnectGraceMs =
+        args.timeouts?.disconnectGraceMs ?? SANDBOX_DISCONNECT_GRACE_MS;
+    const deadlineMs = args.timeouts?.deadlineMs ?? DEFAULT_DEADLINE_MS;
+    const startedAt = Date.now();
+    let lastSuccessfulTickAt = startedAt;
+    let consumedLines = 0;
+    let consecutiveDeadTicks = 0;
+
+    const consumeTail = (tail: string, final: boolean): void => {
+        if (tail.length === 0) return;
+        const lines = tail.split('\n');
+        if (tail.endsWith('\n')) {
+            lines.pop();
+        } else if (!final) {
+            lines.pop();
+        }
+        consumedLines += lines.length;
+        for (const line of lines) {
+            if (line.length > 0) onLine(line);
+        }
+    };
+
+    const poll = async (): Promise<{ exitCode: number }> => {
+        if (Date.now() - startedAt >= deadlineMs) {
+            throw new SandboxTimeoutError(
+                'The onboarding agent exceeded its polling deadline',
+            );
+        }
+
+        // The bracket pattern prevents pgrep from matching this poll command.
+        const command =
+            `cat ${AGENT_EXIT_CODE_PATH} 2>/dev/null; ` +
+            `printf '\\n${EXIT_SEPARATOR}\\n'; ` +
+            'if command -v pgrep >/dev/null 2>&1; then ' +
+            "pgrep -cf 'ld-agent-runner[.]sh' || true; " +
+            "else printf -- '-1\\n'; fi; " +
+            `printf '\\n${PROCESS_SEPARATOR}\\n'; ` +
+            `tail -n +${consumedLines + 1} ${AGENT_STREAM_PATH} 2>/dev/null || true`;
+
+        let stdout: string;
+        try {
+            const result = await sandbox.commands.run(command);
+            stdout = result.stdout;
+        } catch (error) {
+            if (error instanceof SandboxNotRunningError) throw error;
+            consecutiveDeadTicks = 0;
+            const disconnectedForMs = Date.now() - lastSuccessfulTickAt;
+            if (disconnectedForMs > disconnectGraceMs) {
+                throw new SandboxConnectionError(
+                    `Could not reconnect to the onboarding agent workspace after ${disconnectedForMs}ms`,
+                );
+            }
+            logger.warn(
+                `OnboardingAgent: sandbox poll failed, retrying: ${getErrorMessage(
+                    error,
+                )}`,
+            );
+            await sleep(pollIntervalMs);
+            return poll();
+        }
+
+        const tick = parsePollTick(stdout);
+        lastSuccessfulTickAt = Date.now();
+        if (tick.exitCode !== null) {
+            consumeTail(tick.tail, true);
+            return { exitCode: tick.exitCode };
+        }
+
+        consumeTail(tick.tail, false);
+        if (tick.processCount === 0) {
+            consecutiveDeadTicks += 1;
+            if (consecutiveDeadTicks >= 2) {
+                throw new SandboxConnectionError(
+                    'The onboarding agent process stopped unexpectedly',
+                );
+            }
+        } else if (tick.processCount > 0) {
+            consecutiveDeadTicks = 0;
+        }
+
+        await sleep(pollIntervalMs);
+        return poll();
+    };
+
+    return poll();
+}

--- a/packages/backend/src/ee/services/OnboardingAgentService/constants.ts
+++ b/packages/backend/src/ee/services/OnboardingAgentService/constants.ts
@@ -4,6 +4,10 @@ export const CLAUDE_SKILLS_DIR = '/home/user/.claude/skills';
 export const CLI_WRAPPER_PATH = '/tmp/ld';
 export const CLAUDE_SETTINGS_PATH = '/tmp/ld-claude-settings.json';
 export const CLAUDE_BASH_GUARD_PATH = '/tmp/ld-bash-guard.cjs';
+export const AGENT_RUNNER_PATH = '/tmp/ld-agent-runner.sh';
+export const AGENT_STREAM_PATH = '/tmp/ld-agent-stream.jsonl';
+export const AGENT_EXIT_CODE_PATH = '/tmp/ld-agent-exit-code';
+export const AGENT_STDERR_PATH = '/tmp/ld-agent-stderr.log';
 
 export const CLI_WRAPPER_SCRIPT = `#!/bin/bash
 deny() {
@@ -265,6 +269,8 @@ export const SANDBOX_TIMEOUT_MS = 60 * 60 * 1000;
 export const PAT_EXPIRY_GRACE_MS = 15 * 60 * 1000;
 export const CANCELLATION_POLL_INTERVAL_MS = 2 * 1000;
 export const FILE_SYNC_INTERVAL_MS = 2 * 1000;
+export const STREAM_POLL_INTERVAL_MS = 2 * 1000;
+export const SANDBOX_DISCONNECT_GRACE_MS = 3 * 60 * 1000;
 export const MAX_ONBOARDING_FILE_COUNT = 100;
 export const MAX_ONBOARDING_FILE_SIZE_BYTES = 1024 * 1024;
 export const MAX_ONBOARDING_TOTAL_SIZE_BYTES = 10 * 1024 * 1024;
@@ -291,3 +297,29 @@ export const ALLOWED_TOOLS = [
     'TodoWrite',
     `Bash(${CLI_WRAPPER_PATH}:*)`,
 ].join(',');
+
+export const AGENT_RUNNER_SCRIPT = `#!/bin/bash
+set -o pipefail
+
+: > ${AGENT_STREAM_PATH}
+: > ${AGENT_STDERR_PATH}
+rm -f ${AGENT_EXIT_CODE_PATH}
+
+{
+    cat ${PROMPT_PATH} | timeout --signal=TERM --kill-after=30s ${
+        RUN_TIMEOUT_MS / 1000
+    }s claude -p \\
+        --model ${CLAUDE_MODEL} \\
+        --output-format stream-json --verbose \\
+        --add-dir ${CLAUDE_SKILLS_DIR} \\
+        --settings ${CLAUDE_SETTINGS_PATH} \\
+        --permission-mode dontAsk \\
+        --tools "${CLAUDE_TOOLS}" \\
+        --allowedTools "${ALLOWED_TOOLS}"
+} > ${AGENT_STREAM_PATH} 2> ${AGENT_STDERR_PATH}
+exit_code=$?
+exit_code_tmp="${AGENT_EXIT_CODE_PATH}.$$"
+printf '%s\\n' "$exit_code" > "$exit_code_tmp"
+mv "$exit_code_tmp" ${AGENT_EXIT_CODE_PATH}
+exit "$exit_code"
+`;

--- a/packages/backend/src/ee/services/SandboxRuntime/E2bSandboxProvider.test.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/E2bSandboxProvider.test.ts
@@ -83,4 +83,16 @@ describe('normalizeError', () => {
 
         expect(getNormalizedError(error)).toBe(error);
     });
+
+    it('does not map a SandboxError subclass with an RPC-shaped message', () => {
+        const error = new NotFoundError('2: [unknown] terminated');
+
+        expect(getNormalizedError(error)).toBe(error);
+    });
+
+    it('does not map a base SandboxError without an RPC-shaped message', () => {
+        const error = new SandboxError('unexpected sandbox failure');
+
+        expect(getNormalizedError(error)).toBe(error);
+    });
 });

--- a/packages/backend/src/ee/services/SandboxRuntime/E2bSandboxProvider.test.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/E2bSandboxProvider.test.ts
@@ -1,0 +1,86 @@
+import {
+    CommandExitError,
+    NotFoundError,
+    SandboxError,
+    SandboxNotFoundError,
+    TimeoutError,
+} from 'e2b';
+import { normalizeError } from './E2bSandboxProvider';
+import {
+    SandboxCommandError,
+    SandboxConnectionError,
+    SandboxNotRunningError,
+    SandboxTimeoutError,
+} from './errors';
+
+const getNormalizedError = (error: unknown): unknown => {
+    try {
+        return normalizeError(error);
+    } catch (normalizedError) {
+        return normalizedError;
+    }
+};
+
+describe('normalizeError', () => {
+    it('maps an unmapped RPC SandboxError to SandboxConnectionError', () => {
+        const error = new SandboxError('2: [unknown] terminated');
+        const normalizedError = getNormalizedError(error);
+
+        expect(normalizedError).toBeInstanceOf(SandboxConnectionError);
+        expect(normalizedError).toMatchObject({ message: error.message });
+    });
+
+    it('maps SandboxNotFoundError to SandboxNotRunningError', () => {
+        const error = new SandboxNotFoundError(
+            'Sandbox is probably not running anymore',
+        );
+        const normalizedError = getNormalizedError(error);
+
+        expect(normalizedError).toBeInstanceOf(SandboxNotRunningError);
+        expect(normalizedError).toMatchObject({ message: error.message });
+    });
+
+    it('maps a fetch-failed TypeError to SandboxConnectionError', () => {
+        const error = new TypeError('fetch failed');
+        const normalizedError = getNormalizedError(error);
+
+        expect(normalizedError).toBeInstanceOf(SandboxConnectionError);
+        expect(normalizedError).toMatchObject({ message: error.message });
+    });
+
+    it('maps CommandExitError to SandboxCommandError', () => {
+        const error = new CommandExitError({
+            exitCode: 42,
+            stderr: 'failure',
+            stdout: 'progress',
+        });
+        const normalizedError = getNormalizedError(error);
+
+        expect(normalizedError).toBeInstanceOf(SandboxCommandError);
+        expect(normalizedError).toMatchObject({
+            exitCode: 42,
+            stderr: 'failure',
+            stdout: 'progress',
+        });
+    });
+
+    it('maps TimeoutError to SandboxTimeoutError', () => {
+        const error = new TimeoutError('deadline exceeded');
+        const normalizedError = getNormalizedError(error);
+
+        expect(normalizedError).toBeInstanceOf(SandboxTimeoutError);
+        expect(normalizedError).toMatchObject({ message: error.message });
+    });
+
+    it('rethrows unknown errors unchanged', () => {
+        const error = new Error('unexpected');
+
+        expect(getNormalizedError(error)).toBe(error);
+    });
+
+    it('does not map SandboxError subclasses as connection errors', () => {
+        const error = new NotFoundError('missing file');
+
+        expect(getNormalizedError(error)).toBe(error);
+    });
+});

--- a/packages/backend/src/ee/services/SandboxRuntime/E2bSandboxProvider.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/E2bSandboxProvider.ts
@@ -1,5 +1,17 @@
-import { ALL_TRAFFIC, CommandExitError, Sandbox, TimeoutError } from 'e2b';
-import { SandboxCommandError, SandboxTimeoutError } from './errors';
+import {
+    ALL_TRAFFIC,
+    CommandExitError,
+    Sandbox,
+    SandboxError,
+    SandboxNotFoundError,
+    TimeoutError,
+} from 'e2b';
+import {
+    SandboxCommandError,
+    SandboxConnectionError,
+    SandboxNotRunningError,
+    SandboxTimeoutError,
+} from './errors';
 import {
     type CommandResult,
     type GitAddTarget,
@@ -27,8 +39,8 @@ const toArrayBuffer = (bytes: Uint8Array): ArrayBuffer =>
         bytes.byteOffset + bytes.byteLength,
     ) as ArrayBuffer;
 
-/** Rethrow E2B's command/timeout errors as vendor-neutral ones. */
-const normalizeError = (error: unknown): never => {
+/** Rethrow E2B errors as vendor-neutral ones. */
+export const normalizeError = (error: unknown): never => {
     if (error instanceof CommandExitError) {
         throw new SandboxCommandError(
             error.exitCode,
@@ -38,6 +50,17 @@ const normalizeError = (error: unknown): never => {
     }
     if (error instanceof TimeoutError) {
         throw new SandboxTimeoutError(error.message);
+    }
+    if (error instanceof SandboxNotFoundError) {
+        throw new SandboxNotRunningError(error.message);
+    }
+    if (
+        (error instanceof SandboxError &&
+            error.name === 'SandboxError' &&
+            /^\d+: \[\w+\] /.test(error.message)) ||
+        (error instanceof TypeError && error.message.includes('fetch failed'))
+    ) {
+        throw new SandboxConnectionError(error.message);
     }
     throw error;
 };
@@ -74,26 +97,44 @@ class E2bSandboxHandle implements SandboxHandle {
     };
 
     readonly files = {
-        read: (path: string): Promise<string> => this.sandbox.files.read(path),
+        read: async (path: string): Promise<string> => {
+            try {
+                return await this.sandbox.files.read(path);
+            } catch (error) {
+                return normalizeError(error);
+            }
+        },
         readBytes: async (path: string): Promise<Buffer> => {
-            const bytes = await this.sandbox.files.read(path, {
-                format: 'bytes',
-            });
-            return Buffer.from(bytes);
+            try {
+                const bytes = await this.sandbox.files.read(path, {
+                    format: 'bytes',
+                });
+                return Buffer.from(bytes);
+            } catch (error) {
+                return normalizeError(error);
+            }
         },
         write: async (
             path: string,
             contents: string | Uint8Array,
         ): Promise<void> => {
-            await this.sandbox.files.write(
-                path,
-                typeof contents === 'string'
-                    ? contents
-                    : toArrayBuffer(contents),
-            );
+            try {
+                await this.sandbox.files.write(
+                    path,
+                    typeof contents === 'string'
+                        ? contents
+                        : toArrayBuffer(contents),
+                );
+            } catch (error) {
+                normalizeError(error);
+            }
         },
         remove: async (path: string): Promise<void> => {
-            await this.sandbox.files.remove(path);
+            try {
+                await this.sandbox.files.remove(path);
+            } catch (error) {
+                normalizeError(error);
+            }
         },
     };
 

--- a/packages/backend/src/ee/services/SandboxRuntime/errors.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/errors.ts
@@ -23,3 +23,19 @@ export class SandboxTimeoutError extends Error {
         this.name = 'SandboxTimeoutError';
     }
 }
+
+/** Thrown when communication with the sandbox fails at the transport level. */
+export class SandboxConnectionError extends Error {
+    constructor(message = 'Lost connection to the sandbox') {
+        super(message);
+        this.name = 'SandboxConnectionError';
+    }
+}
+
+/** Thrown when the sandbox backing a run is no longer running. */
+export class SandboxNotRunningError extends Error {
+    constructor(message = 'The sandbox is no longer running') {
+        super(message);
+        this.name = 'SandboxNotRunningError';
+    }
+}


### PR DESCRIPTION
## Summary

A production onboarding agent run died ~15 minutes in when the connection to its sandbox was severed mid-run. Two structural gaps turned a transient network blip into a fully lost run:

1. **The run could not survive any transport failure.** The whole 45-minute agent session rode on a single long-lived streaming RPC (`commands.run` with `onStdout`); one dropped stream killed the run. It could also never be retried: the job is enqueued with `maxAttempts: 1` *and* `executeRun` catches its own errors, so the queue considered the job successful.
2. **The raw SDK error string reached the user.** The E2B SDK's unmapped-RPC fallback message (`2: [unknown] terminated`) was stored verbatim on the run and rendered in the UI.

## What changed

### Vendor-neutral connection errors

- New `SandboxConnectionError` and `SandboxNotRunningError` in `SandboxRuntime/errors.ts`.
- `E2bSandboxProvider.normalizeError` now maps the SDK's transport-failure shapes to them: the unmapped Connect-RPC fallback (`SandboxError` with a `"<code>: [<name>] …"` message — the only way that shape is produced), raw `fetch failed` `TypeError`s, and `SandboxNotFoundError` ("sandbox is probably not running anymore"). The `files.*` surface is now normalized too, not just `commands.run`. Since the mapping lives in the shared provider, other sandbox consumers benefit automatically.
- `executeRun` classifies these errors: the run row gets a fixed, actionable message ("Lightdash lost the connection to the onboarding agent's workspace…") instead of the raw SDK string, and the log line is prefixed distinctly so transport failures are separable from genuine agent failures in production logs.

### Detached agent process + polled stream

`runAgentInSandbox` no longer drives `claude -p` through one long-lived streaming RPC. Instead:

- The agent is launched as a detached (`setsid nohup`) process inside the sandbox via a runner script that writes its stream-JSON output to a file and its exit code to a sentinel file (with an in-sandbox `timeout` as a backstop).
- The backend consumes the stream file with short polling RPCs (one compound command every 2s: exit-code check, process-liveness check, `tail` of new complete lines). Line-based accounting keeps the accounting UTF-8-safe; partial trailing lines wait for the next tick.
- Transient transport failures now just make individual polls fail; the loop keeps retrying until a 3-minute disconnect grace window is exhausted, and only then fails the run with the friendly connection error. The disconnect that killed the production run (≈1 minute) would have been absorbed invisibly.

### Why this design (and not alternatives)

- **Why not raise `maxAttempts` / blindly re-run?** A full re-run repeats a 15-minute agent session and re-creates warehouse/project resources. `maxAttempts: 1` is deliberately unchanged.
- **Why not re-attach to the stream (`commands.connect(pid)`)?** Verified against `e2b@2.16.0`: `connect(pid)` opens a fresh server-side stream with no replay of output missed while disconnected. Losing the gap output can silently lose the final assistant message (which carries the dashboard URL the run's success check requires). Once a file inside the sandbox has to be the source of truth for the stream, the long-lived RPC is redundant — so it was removed rather than patched.
- The root cause of the production incident is transport-level and (from our logs) most likely outside our infrastructure; regardless of which side dropped the connection, the run loop is now resilient to it.

### Known limitations

- Progress events now arrive with up to one poll interval (2s) of latency — same cadence as the existing file-sync loop; not user-visible.
- An outage longer than the 3-minute grace window still fails the run (with an actionable message). Resuming a run across a backend worker restart remains out of scope.
- ~~The detachment behavior was not live-tested against E2B~~ — it now has been; see "Live validation" below.

The same `maxAttempts: 1` + swallowed-error shape exists in the AI writeback and deep-research pipelines; that is deliberately not touched here and is tracked in SPK-739.

## Testing

- New unit tests for the error normalization (`E2bSandboxProvider.test.ts`) covering the fallback-shape mapping, subclass non-matches, and the pre-existing command/timeout mappings.
- New unit tests for the poll loop (`agentStreamPoller.test.ts`): multi-tick line delivery and ordering, partial-line holdback, exit-code completion, transient-failure recovery inside the grace window, grace-window exhaustion, immediate abort on `SandboxNotRunningError`, runner-death detection, deadline enforcement.
- `pnpm -F backend typecheck` and lint on touched paths.

### Live validation against real E2B (production template)

A local harness drove the real `E2bSandboxProvider` + `pollDetachedAgentRun` code against real sandboxes created from the production onboarding template, with a stub `claude` binary emitting a timed stream-JSON sequence. All six checks passed:

1. **Template audit** — `pgrep`, `setsid`, `nohup`, `timeout`, `bash` all present in the template.
2. **Detachment** — the runner survives the launch RPC returning (process alive and streaming afterwards).
3. **Happy path** — all stream lines delivered in order via polling; exit code read from the sentinel file.
4. **Disconnect resilience** — a 75-second forced transport outage (packets to the sandbox's data-plane host rejected mid-run) reproduced the exact incident error shape (`2: [unknown] fetch failed`) on 74 consecutive polls; the loop absorbed the outage, recovered, and completed with **all 240 stream lines intact and zero loss**.
5. **Runner death** — SIGKILLing the agent process inside the sandbox is detected via the liveness check and surfaces as `SandboxConnectionError` ("stopped unexpectedly") within seconds.
6. **Sandbox death** — destroying the sandbox mid-run aborts the poll loop in ~15s with `SandboxNotRunningError` (no grace-window grind).

Closes: SPK-737
Relates: SPK-739

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPRiKUA2tget9r8de26iyU
