### PR TITLE
feat: persist homepage recommended-action skips per project

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -470,6 +470,10 @@ import {
     ExternalConnectionsTableName,
 } from '../ee/database/entities/externalConnections';
 import {
+    HomepageRecommendedActionSkipsTable,
+    HomepageRecommendedActionSkipsTableName,
+} from '../ee/database/entities/homepageRecommendedActionSkips';
+import {
     ManagedAgentActionsTable,
     ManagedAgentActionsTableName,
     ManagedAgentRunsTable,
@@ -623,6 +627,7 @@ declare module 'knex/types/tables' {
         [AiWebAppPromptTableName]: AiWebAppPromptTable;
         [AiWritebackThreadTableName]: AiWritebackThreadTable;
         [AgentOnboardingRunsTableName]: AgentOnboardingRunsTable;
+        [HomepageRecommendedActionSkipsTableName]: HomepageRecommendedActionSkipsTable;
         [ProjectCiStatusTableName]: ProjectCiStatusTable;
         [AiAgentTableName]: AiAgentTable;
         [AiAgentDocumentTableName]: AiAgentDocumentTable;

--- a/packages/backend/src/ee/controllers/HomepageRecommendedActionSkipsController.ts
+++ b/packages/backend/src/ee/controllers/HomepageRecommendedActionSkipsController.ts
@@ -1,0 +1,109 @@
+import {
+    assertRegisteredAccount,
+    type ApiErrorPayload,
+    type ApiHomepageRecommendedActionSkipsResponse,
+    type ApiSuccessEmpty,
+    type HomepageRecommendedActionKey,
+    type SkipHomepageRecommendedActionRequest,
+    type UUID,
+} from '@lightdash/common';
+import {
+    Body,
+    Delete,
+    Get,
+    Middlewares,
+    OperationId,
+    Path,
+    Post,
+    Query,
+    Request,
+    Response,
+    Route,
+    SuccessResponse,
+    Tags,
+} from '@tsoa/runtime';
+import express from 'express';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    unauthorisedInDemo,
+} from '../../controllers/authentication';
+import { BaseController } from '../../controllers/baseController';
+import { type HomepageRecommendedActionSkipsService } from '../services/HomepageRecommendedActionSkipsService';
+
+@Route('/api/v1/ee/homepage/recommended-action-skips')
+@Response<ApiErrorPayload>('default', 'Error')
+@Tags('Homepage')
+export class HomepageRecommendedActionSkipsController extends BaseController {
+    private getService(): HomepageRecommendedActionSkipsService {
+        return this.services.getHomepageRecommendedActionSkipsService<HomepageRecommendedActionSkipsService>();
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/')
+    @OperationId('listHomepageRecommendedActionSkips')
+    async list(
+        @Request() req: express.Request,
+        @Query() projectUuid?: UUID,
+    ): Promise<ApiHomepageRecommendedActionSkipsResponse> {
+        assertRegisteredAccount(req.account);
+        return {
+            status: 'ok',
+            results: await this.getService().list(
+                req.account,
+                projectUuid ?? null,
+            ),
+        };
+    }
+
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('/')
+    @OperationId('skipHomepageRecommendedAction')
+    async skip(
+        @Request() req: express.Request,
+        @Body() body: SkipHomepageRecommendedActionRequest,
+        @Query() projectUuid?: UUID,
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        await this.getService().skip(
+            req.account,
+            projectUuid ?? null,
+            body.actionKey,
+        );
+        return {
+            status: 'ok',
+            results: undefined,
+        };
+    }
+
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Delete('/{actionKey}')
+    @OperationId('unskipHomepageRecommendedAction')
+    async unskip(
+        @Request() req: express.Request,
+        @Path() actionKey: HomepageRecommendedActionKey,
+        @Query() projectUuid?: UUID,
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        await this.getService().unskip(
+            req.account,
+            projectUuid ?? null,
+            actionKey,
+        );
+        return {
+            status: 'ok',
+            results: undefined,
+        };
+    }
+}

--- a/packages/backend/src/ee/database/entities/homepageRecommendedActionSkips.ts
+++ b/packages/backend/src/ee/database/entities/homepageRecommendedActionSkips.ts
@@ -1,0 +1,28 @@
+import {
+    type SkippableHomepageRecommendedActionKey,
+    type UUID,
+} from '@lightdash/common';
+import { Knex } from 'knex';
+
+export const HomepageRecommendedActionSkipsTableName =
+    'homepage_recommended_action_skips';
+
+export type DbHomepageRecommendedActionSkip = {
+    homepage_recommended_action_skip_uuid: UUID;
+    organization_uuid: UUID;
+    project_uuid: UUID | null;
+    action_key: SkippableHomepageRecommendedActionKey;
+    created_by_user_uuid: UUID | null;
+    created_at: Date;
+};
+
+export type HomepageRecommendedActionSkipsTable = Knex.CompositeTableType<
+    DbHomepageRecommendedActionSkip,
+    Pick<
+        DbHomepageRecommendedActionSkip,
+        | 'organization_uuid'
+        | 'project_uuid'
+        | 'action_key'
+        | 'created_by_user_uuid'
+    >
+>;

--- a/packages/backend/src/ee/database/migrations/20260730120000_create_homepage_recommended_action_skips.ts
+++ b/packages/backend/src/ee/database/migrations/20260730120000_create_homepage_recommended_action_skips.ts
@@ -1,0 +1,77 @@
+import { Knex } from 'knex';
+
+const HomepageRecommendedActionSkipsTableName =
+    'homepage_recommended_action_skips';
+const ProjectContextUniqueIndexName =
+    'homepage_recommended_action_skips_project_unique_idx';
+const NoProjectContextUniqueIndexName =
+    'homepage_recommended_action_skips_no_project_unique_idx';
+const SKIPPABLE_ACTION_KEYS = [
+    'add-semantic-layer',
+    'connect-source-control',
+    'connect-slack',
+];
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(
+        HomepageRecommendedActionSkipsTableName,
+        (table) => {
+            table
+                .uuid('homepage_recommended_action_skip_uuid')
+                .primary()
+                .defaultTo(knex.raw('uuid_generate_v4()'));
+            table
+                .uuid('organization_uuid')
+                .notNullable()
+                .references('organization_uuid')
+                .inTable('organizations')
+                .onDelete('CASCADE')
+                .index();
+            table
+                .uuid('project_uuid')
+                .nullable()
+                .references('project_uuid')
+                .inTable('projects')
+                .onDelete('CASCADE')
+                .index();
+            table
+                .text('action_key')
+                .notNullable()
+                .checkIn(SKIPPABLE_ACTION_KEYS);
+            table
+                .uuid('created_by_user_uuid')
+                .nullable()
+                .references('user_uuid')
+                .inTable('users')
+                .onDelete('SET NULL')
+                .index();
+            table
+                .timestamp('created_at', { useTz: false })
+                .notNullable()
+                .defaultTo(knex.fn.now());
+        },
+    );
+
+    await knex.raw(
+        'CREATE UNIQUE INDEX ?? ON ?? (??, ??, ??) WHERE ?? IS NOT NULL',
+        [
+            ProjectContextUniqueIndexName,
+            HomepageRecommendedActionSkipsTableName,
+            'organization_uuid',
+            'project_uuid',
+            'action_key',
+            'project_uuid',
+        ],
+    );
+    await knex.raw('CREATE UNIQUE INDEX ?? ON ?? (??, ??) WHERE ?? IS NULL', [
+        NoProjectContextUniqueIndexName,
+        HomepageRecommendedActionSkipsTableName,
+        'organization_uuid',
+        'action_key',
+        'project_uuid',
+    ]);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTable(HomepageRecommendedActionSkipsTableName);
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -42,6 +42,7 @@ import { CommercialSlackAuthenticationModel } from './models/CommercialSlackAuth
 import { DashboardSummaryModel } from './models/DashboardSummaryModel';
 import { EmbedModel } from './models/EmbedModel';
 import { ExternalConnectionModel } from './models/ExternalConnectionModel';
+import { HomepageRecommendedActionSkipsModel } from './models/HomepageRecommendedActionSkipsModel';
 import { ManagedAgentModel } from './models/ManagedAgentModel';
 import { McpToolCallModel } from './models/McpToolCallModel';
 import { ProjectCiStatusModel } from './models/ProjectCiStatusModel';
@@ -83,6 +84,7 @@ import { EmbedService } from './services/EmbedService/EmbedService';
 import { ExternalConnectionCoderService } from './services/ExternalConnectionCoderService/ExternalConnectionCoderService';
 import { ExternalConnectionService } from './services/ExternalConnectionService/ExternalConnectionService';
 import { GoogleServiceAccountTokenProvider } from './services/ExternalConnectionService/GoogleServiceAccountTokenProvider';
+import { HomepageRecommendedActionSkipsService } from './services/HomepageRecommendedActionSkipsService';
 import { EnterpriseLicenseService } from './services/LicenseService/LicenseService';
 import { ManagedAgentService } from './services/ManagedAgentService/ManagedAgentService';
 import { McpService } from './services/McpService/McpService';
@@ -186,6 +188,12 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     slackAuthenticationModel:
                         models.getSlackAuthenticationModel(),
                     lightdashConfig: context.lightdashConfig,
+                }),
+            homepageRecommendedActionSkipsService: ({ models }) =>
+                new HomepageRecommendedActionSkipsService({
+                    homepageRecommendedActionSkipsModel:
+                        models.getHomepageRecommendedActionSkipsModel<HomepageRecommendedActionSkipsModel>(),
+                    projectModel: models.getProjectModel(),
                 }),
             aiDeepResearchService: ({
                 context,
@@ -1013,6 +1021,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
         modelProviders: {
             projectHomepageModel: ({ database }) =>
                 new ProjectHomepageModel({ database }),
+            homepageRecommendedActionSkipsModel: ({ database }) =>
+                new HomepageRecommendedActionSkipsModel({ database }),
             aiAgentModel: ({ database, utils }) =>
                 new AiAgentModel({
                     database,

--- a/packages/backend/src/ee/models/HomepageRecommendedActionSkipsModel.test.ts
+++ b/packages/backend/src/ee/models/HomepageRecommendedActionSkipsModel.test.ts
@@ -1,0 +1,70 @@
+import knex, { type Knex } from 'knex';
+import { getTracker, MockClient, type Tracker } from 'knex-mock-client';
+import { HomepageRecommendedActionSkipsTableName } from '../database/entities/homepageRecommendedActionSkips';
+import { HomepageRecommendedActionSkipsModel } from './HomepageRecommendedActionSkipsModel';
+
+const ORGANIZATION_UUID = '00000000-0000-0000-0000-000000000001';
+const PROJECT_UUID = '00000000-0000-0000-0000-000000000002';
+
+describe('HomepageRecommendedActionSkipsModel', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new HomepageRecommendedActionSkipsModel({
+        database: database as unknown as Knex,
+    });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    it('merges organization and project action scopes for a project context', async () => {
+        tracker.on
+            .select(HomepageRecommendedActionSkipsTableName)
+            .responseOnce([
+                { action_key: 'connect-slack' },
+                { action_key: 'add-semantic-layer' },
+            ]);
+
+        await expect(
+            model.list({
+                organizationUuid: ORGANIZATION_UUID,
+                projectUuid: PROJECT_UUID,
+            }),
+        ).resolves.toEqual(['connect-slack', 'add-semantic-layer']);
+
+        const query = tracker.history.select[0];
+        expect(query.sql).toContain('"project_uuid" is null');
+        expect(query.sql).toContain('or');
+        expect(query.bindings).toEqual(
+            expect.arrayContaining([
+                ORGANIZATION_UUID,
+                'connect-source-control',
+                'connect-slack',
+                PROJECT_UUID,
+                'add-semantic-layer',
+            ]),
+        );
+    });
+
+    it('selects only organization action scopes without a project context', async () => {
+        tracker.on
+            .select(HomepageRecommendedActionSkipsTableName)
+            .responseOnce([{ action_key: 'connect-source-control' }]);
+
+        await expect(
+            model.list({
+                organizationUuid: ORGANIZATION_UUID,
+                projectUuid: null,
+            }),
+        ).resolves.toEqual(['connect-source-control']);
+
+        const query = tracker.history.select[0];
+        expect(query.sql).toContain('"project_uuid" is null');
+        expect(query.bindings).not.toContain(PROJECT_UUID);
+        expect(query.bindings).not.toContain('add-semantic-layer');
+    });
+});

--- a/packages/backend/src/ee/models/HomepageRecommendedActionSkipsModel.ts
+++ b/packages/backend/src/ee/models/HomepageRecommendedActionSkipsModel.ts
@@ -1,4 +1,6 @@
 import {
+    HOMEPAGE_RECOMMENDED_ACTION_SCOPES,
+    SKIPPABLE_HOMEPAGE_RECOMMENDED_ACTION_KEYS,
     type SkippableHomepageRecommendedActionKey,
     type UUID,
 } from '@lightdash/common';
@@ -12,6 +14,14 @@ type HomepageRecommendedActionSkipScope = {
     organizationUuid: UUID;
     projectUuid: UUID | null;
 };
+
+const ORGANIZATION_ACTION_KEYS =
+    SKIPPABLE_HOMEPAGE_RECOMMENDED_ACTION_KEYS.filter(
+        (key) => HOMEPAGE_RECOMMENDED_ACTION_SCOPES[key] === 'organization',
+    );
+const PROJECT_ACTION_KEYS = SKIPPABLE_HOMEPAGE_RECOMMENDED_ACTION_KEYS.filter(
+    (key) => HOMEPAGE_RECOMMENDED_ACTION_SCOPES[key] === 'project',
+);
 
 export class HomepageRecommendedActionSkipsModel {
     private readonly database: Knex;
@@ -36,7 +46,24 @@ export class HomepageRecommendedActionSkipsModel {
     async list(
         scope: HomepageRecommendedActionSkipScope,
     ): Promise<SkippableHomepageRecommendedActionKey[]> {
-        const rows = await this.scopedQuery(scope)
+        const rows = await this.database<HomepageRecommendedActionSkipsTable>(
+            HomepageRecommendedActionSkipsTableName,
+        )
+            .where('organization_uuid', scope.organizationUuid)
+            .where((scopeQuery) => {
+                void scopeQuery.where((organizationQuery) => {
+                    void organizationQuery
+                        .whereNull('project_uuid')
+                        .whereIn('action_key', ORGANIZATION_ACTION_KEYS);
+                });
+                if (scope.projectUuid !== null) {
+                    void scopeQuery.orWhere((projectQuery) => {
+                        void projectQuery
+                            .where('project_uuid', scope.projectUuid)
+                            .whereIn('action_key', PROJECT_ACTION_KEYS);
+                    });
+                }
+            })
             .select('action_key')
             .orderBy('created_at', 'asc');
 

--- a/packages/backend/src/ee/models/HomepageRecommendedActionSkipsModel.ts
+++ b/packages/backend/src/ee/models/HomepageRecommendedActionSkipsModel.ts
@@ -1,0 +1,83 @@
+import {
+    type SkippableHomepageRecommendedActionKey,
+    type UUID,
+} from '@lightdash/common';
+import { Knex } from 'knex';
+import {
+    HomepageRecommendedActionSkipsTableName,
+    type HomepageRecommendedActionSkipsTable,
+} from '../database/entities/homepageRecommendedActionSkips';
+
+type HomepageRecommendedActionSkipScope = {
+    organizationUuid: UUID;
+    projectUuid: UUID | null;
+};
+
+export class HomepageRecommendedActionSkipsModel {
+    private readonly database: Knex;
+
+    constructor({ database }: { database: Knex }) {
+        this.database = database;
+    }
+
+    private scopedQuery({
+        organizationUuid,
+        projectUuid,
+    }: HomepageRecommendedActionSkipScope) {
+        const query = this.database<HomepageRecommendedActionSkipsTable>(
+            HomepageRecommendedActionSkipsTableName,
+        ).where('organization_uuid', organizationUuid);
+
+        return projectUuid === null
+            ? query.whereNull('project_uuid')
+            : query.where('project_uuid', projectUuid);
+    }
+
+    async list(
+        scope: HomepageRecommendedActionSkipScope,
+    ): Promise<SkippableHomepageRecommendedActionKey[]> {
+        const rows = await this.scopedQuery(scope)
+            .select('action_key')
+            .orderBy('created_at', 'asc');
+
+        return rows.map(({ action_key }) => action_key);
+    }
+
+    async create(
+        scope: HomepageRecommendedActionSkipScope & {
+            actionKey: SkippableHomepageRecommendedActionKey;
+            createdByUserUuid: UUID;
+        },
+    ): Promise<void> {
+        const conflictTarget =
+            scope.projectUuid === null
+                ? this.database.raw(
+                      '(organization_uuid, action_key) WHERE project_uuid IS NULL',
+                  )
+                : this.database.raw(
+                      '(organization_uuid, project_uuid, action_key) WHERE project_uuid IS NOT NULL',
+                  );
+
+        await this.database<HomepageRecommendedActionSkipsTable>(
+            HomepageRecommendedActionSkipsTableName,
+        )
+            .insert({
+                organization_uuid: scope.organizationUuid,
+                project_uuid: scope.projectUuid,
+                action_key: scope.actionKey,
+                created_by_user_uuid: scope.createdByUserUuid,
+            })
+            .onConflict(conflictTarget)
+            .ignore();
+    }
+
+    async delete(
+        scope: HomepageRecommendedActionSkipScope & {
+            actionKey: SkippableHomepageRecommendedActionKey;
+        },
+    ): Promise<void> {
+        await this.scopedQuery(scope)
+            .where('action_key', scope.actionKey)
+            .delete();
+    }
+}

--- a/packages/backend/src/ee/services/HomepageRecommendedActionSkipsService.test.ts
+++ b/packages/backend/src/ee/services/HomepageRecommendedActionSkipsService.test.ts
@@ -125,17 +125,31 @@ const organizationManager = makeAccount([
 const viewer = makeAccount([]);
 
 describe('HomepageRecommendedActionSkipsService', () => {
-    it('allows project managers to list project skips', async () => {
+    it('lists merged organization and project skips for a project context', async () => {
         const { model, projectModel, service } = makeService();
-        model.list.mockResolvedValue(['connect-slack']);
+        model.list.mockResolvedValue(['connect-slack', 'add-semantic-layer']);
 
         await expect(
             service.list(projectManager, PROJECT_UUID),
-        ).resolves.toEqual(['connect-slack']);
+        ).resolves.toEqual(['connect-slack', 'add-semantic-layer']);
         expect(projectModel.getSummary).toHaveBeenCalledWith(PROJECT_UUID);
         expect(model.list).toHaveBeenCalledWith({
             organizationUuid: ORGANIZATION_UUID,
             projectUuid: PROJECT_UUID,
+        });
+    });
+
+    it('lists only organization skips for the null-project context', async () => {
+        const { model, projectModel, service } = makeService();
+        model.list.mockResolvedValue(['connect-source-control']);
+
+        await expect(service.list(organizationManager, null)).resolves.toEqual([
+            'connect-source-control',
+        ]);
+        expect(projectModel.getSummary).not.toHaveBeenCalled();
+        expect(model.list).toHaveBeenCalledWith({
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: null,
         });
     });
 
@@ -177,6 +191,34 @@ describe('HomepageRecommendedActionSkipsService', () => {
         });
     });
 
+    it('stores organization action skips in the null scope after project-context auth', async () => {
+        const { model, projectModel, service } = makeService();
+
+        await service.skip(
+            projectManager,
+            PROJECT_UUID,
+            'connect-source-control',
+        );
+
+        expect(projectModel.getSummary).toHaveBeenCalledWith(PROJECT_UUID);
+        expect(model.create).toHaveBeenCalledWith({
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: null,
+            actionKey: 'connect-source-control',
+            createdByUserUuid: USER_UUID,
+        });
+    });
+
+    it('requires a project context for project action skips', async () => {
+        const { model, projectModel, service } = makeService();
+
+        await expect(
+            service.skip(organizationManager, null, 'add-semantic-layer'),
+        ).rejects.toBeInstanceOf(ParameterError);
+        expect(projectModel.getSummary).not.toHaveBeenCalled();
+        expect(model.create).not.toHaveBeenCalled();
+    });
+
     it('does not allow project-only managers to modify the null-project context', async () => {
         const { model, service } = makeService();
 
@@ -199,19 +241,16 @@ describe('HomepageRecommendedActionSkipsService', () => {
         },
     );
 
-    it('deletes a validated skip from the authorized scope', async () => {
-        const { model, service } = makeService();
+    it('deletes organization action skips from the null scope after project-context auth', async () => {
+        const { model, projectModel, service } = makeService();
 
-        await service.unskip(
-            projectManager,
-            PROJECT_UUID,
-            'add-semantic-layer',
-        );
+        await service.unskip(projectManager, PROJECT_UUID, 'connect-slack');
 
+        expect(projectModel.getSummary).toHaveBeenCalledWith(PROJECT_UUID);
         expect(model.delete).toHaveBeenCalledWith({
             organizationUuid: ORGANIZATION_UUID,
-            projectUuid: PROJECT_UUID,
-            actionKey: 'add-semantic-layer',
+            projectUuid: null,
+            actionKey: 'connect-slack',
         });
     });
 });

--- a/packages/backend/src/ee/services/HomepageRecommendedActionSkipsService.test.ts
+++ b/packages/backend/src/ee/services/HomepageRecommendedActionSkipsService.test.ts
@@ -1,0 +1,217 @@
+import { Ability } from '@casl/ability';
+import {
+    ForbiddenError,
+    OrganizationMemberRole,
+    ParameterError,
+    ProjectType,
+    type PossibleAbilities,
+    type ProjectSummary,
+    type SessionAccount,
+} from '@lightdash/common';
+import {
+    HomepageRecommendedActionSkipsService,
+    type HomepageRecommendedActionSkipsServiceArguments,
+} from './HomepageRecommendedActionSkipsService';
+
+const ORGANIZATION_UUID = '00000000-0000-0000-0000-000000000001';
+const OTHER_ORGANIZATION_UUID = '00000000-0000-0000-0000-000000000002';
+const PROJECT_UUID = '00000000-0000-0000-0000-000000000003';
+const USER_UUID = '00000000-0000-0000-0000-000000000004';
+const NOW = new Date('2026-07-30T12:00:00.000Z');
+
+const projectSummary = (
+    organizationUuid = ORGANIZATION_UUID,
+): ProjectSummary => ({
+    name: 'Project',
+    projectUuid: PROJECT_UUID,
+    organizationUuid,
+    type: ProjectType.DEFAULT,
+    upstreamProjectUuid: undefined,
+    createdByUserUuid: USER_UUID,
+    provisioningSource: undefined,
+});
+
+const accountMethods = {
+    isAuthenticated: () => true,
+    isRegisteredUser: () => true,
+    isAnonymousUser: () => false,
+    isSessionUser: () => true,
+    isJwtUser: () => false,
+    isServiceAccount: () => false,
+    isPatUser: () => false,
+    isOauthUser: () => false,
+};
+
+const makeAccount = (
+    rules: ConstructorParameters<typeof Ability<PossibleAbilities>>[0],
+): SessionAccount => ({
+    authentication: { type: 'session', source: 'test' },
+    organization: {
+        organizationUuid: ORGANIZATION_UUID,
+        name: 'Organization',
+        createdAt: NOW,
+    },
+    user: {
+        type: 'registered',
+        id: USER_UUID,
+        userUuid: USER_UUID,
+        email: 'admin@example.com',
+        firstName: 'Admin',
+        lastName: 'User',
+        userId: 1,
+        role: OrganizationMemberRole.ADMIN,
+        isTrackingAnonymized: false,
+        isMarketingOptedIn: false,
+        avatarUrl: null,
+        avatarGradient: null,
+        isSetupComplete: true,
+        isActive: true,
+        createdAt: NOW,
+        updatedAt: NOW,
+        timezone: null,
+        abilityRules: [],
+        ability: new Ability<PossibleAbilities>(rules),
+    },
+    ...accountMethods,
+});
+
+type ModelMocks = import('vitest').Mocked<
+    HomepageRecommendedActionSkipsServiceArguments['homepageRecommendedActionSkipsModel']
+>;
+type ProjectModelMocks = import('vitest').Mocked<
+    HomepageRecommendedActionSkipsServiceArguments['projectModel']
+>;
+
+const makeService = ({
+    model = {
+        list: vi.fn().mockResolvedValue([]),
+        create: vi.fn().mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(undefined),
+    },
+    projectModel = {
+        getSummary: vi.fn().mockResolvedValue(projectSummary()),
+    },
+}: {
+    model?: ModelMocks;
+    projectModel?: ProjectModelMocks;
+} = {}) => ({
+    model,
+    projectModel,
+    service: new HomepageRecommendedActionSkipsService({
+        homepageRecommendedActionSkipsModel: model,
+        projectModel,
+    }),
+});
+
+const projectManager = makeAccount([
+    {
+        action: 'manage',
+        subject: 'Project',
+        conditions: {
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PROJECT_UUID,
+        },
+    },
+]);
+
+const organizationManager = makeAccount([
+    {
+        action: 'manage',
+        subject: 'Project',
+        conditions: { organizationUuid: ORGANIZATION_UUID },
+    },
+]);
+
+const viewer = makeAccount([]);
+
+describe('HomepageRecommendedActionSkipsService', () => {
+    it('allows project managers to list project skips', async () => {
+        const { model, projectModel, service } = makeService();
+        model.list.mockResolvedValue(['connect-slack']);
+
+        await expect(
+            service.list(projectManager, PROJECT_UUID),
+        ).resolves.toEqual(['connect-slack']);
+        expect(projectModel.getSummary).toHaveBeenCalledWith(PROJECT_UUID);
+        expect(model.list).toHaveBeenCalledWith({
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PROJECT_UUID,
+        });
+    });
+
+    it('rejects users without project manage access', async () => {
+        const { model, service } = makeService();
+
+        await expect(service.list(viewer, PROJECT_UUID)).rejects.toBeInstanceOf(
+            ForbiddenError,
+        );
+        expect(model.list).not.toHaveBeenCalled();
+    });
+
+    it('rejects projects from another organization', async () => {
+        const { model, service } = makeService({
+            projectModel: {
+                getSummary: vi
+                    .fn()
+                    .mockResolvedValue(projectSummary(OTHER_ORGANIZATION_UUID)),
+            },
+        });
+
+        await expect(
+            service.skip(projectManager, PROJECT_UUID, 'connect-slack'),
+        ).rejects.toBeInstanceOf(ForbiddenError);
+        expect(model.create).not.toHaveBeenCalled();
+    });
+
+    it('uses organization-level project manage access for the null-project context', async () => {
+        const { model, projectModel, service } = makeService();
+
+        await service.skip(organizationManager, null, 'connect-source-control');
+
+        expect(projectModel.getSummary).not.toHaveBeenCalled();
+        expect(model.create).toHaveBeenCalledWith({
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: null,
+            actionKey: 'connect-source-control',
+            createdByUserUuid: USER_UUID,
+        });
+    });
+
+    it('does not allow project-only managers to modify the null-project context', async () => {
+        const { model, service } = makeService();
+
+        await expect(
+            service.unskip(projectManager, null, 'connect-slack'),
+        ).rejects.toBeInstanceOf(ForbiddenError);
+        expect(model.delete).not.toHaveBeenCalled();
+    });
+
+    it.each(['connect-warehouse', 'unknown-action'])(
+        'rejects the non-skippable action key %s',
+        async (actionKey) => {
+            const { model, projectModel, service } = makeService();
+
+            await expect(
+                service.skip(organizationManager, null, actionKey),
+            ).rejects.toBeInstanceOf(ParameterError);
+            expect(projectModel.getSummary).not.toHaveBeenCalled();
+            expect(model.create).not.toHaveBeenCalled();
+        },
+    );
+
+    it('deletes a validated skip from the authorized scope', async () => {
+        const { model, service } = makeService();
+
+        await service.unskip(
+            projectManager,
+            PROJECT_UUID,
+            'add-semantic-layer',
+        );
+
+        expect(model.delete).toHaveBeenCalledWith({
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PROJECT_UUID,
+            actionKey: 'add-semantic-layer',
+        });
+    });
+});

--- a/packages/backend/src/ee/services/HomepageRecommendedActionSkipsService.ts
+++ b/packages/backend/src/ee/services/HomepageRecommendedActionSkipsService.ts
@@ -1,0 +1,119 @@
+import { subject } from '@casl/ability';
+import {
+    ForbiddenError,
+    ParameterError,
+    SKIPPABLE_HOMEPAGE_RECOMMENDED_ACTION_KEYS,
+    type HomepageRecommendedActionKey,
+    type RegisteredAccount,
+    type SkippableHomepageRecommendedActionKey,
+    type UUID,
+} from '@lightdash/common';
+import { type ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import { BaseService } from '../../services/BaseService';
+import { type HomepageRecommendedActionSkipsModel } from '../models/HomepageRecommendedActionSkipsModel';
+
+export type HomepageRecommendedActionSkipsServiceArguments = {
+    homepageRecommendedActionSkipsModel: Pick<
+        HomepageRecommendedActionSkipsModel,
+        'list' | 'create' | 'delete'
+    >;
+    projectModel: Pick<ProjectModel, 'getSummary'>;
+};
+
+export class HomepageRecommendedActionSkipsService extends BaseService {
+    private readonly homepageRecommendedActionSkipsModel: HomepageRecommendedActionSkipsServiceArguments['homepageRecommendedActionSkipsModel'];
+
+    private readonly projectModel: HomepageRecommendedActionSkipsServiceArguments['projectModel'];
+
+    constructor(args: HomepageRecommendedActionSkipsServiceArguments) {
+        super();
+        this.homepageRecommendedActionSkipsModel =
+            args.homepageRecommendedActionSkipsModel;
+        this.projectModel = args.projectModel;
+    }
+
+    private static validateActionKey(
+        actionKey: HomepageRecommendedActionKey | string,
+    ): SkippableHomepageRecommendedActionKey {
+        const skippableActionKey =
+            SKIPPABLE_HOMEPAGE_RECOMMENDED_ACTION_KEYS.find(
+                (key) => key === actionKey,
+            );
+        if (!skippableActionKey) {
+            throw new ParameterError(
+                'This homepage recommended action cannot be skipped',
+            );
+        }
+
+        return skippableActionKey;
+    }
+
+    private async getAuthorizedScope(
+        account: RegisteredAccount,
+        projectUuid: UUID | null,
+    ): Promise<{ organizationUuid: UUID; projectUuid: UUID | null }> {
+        const { organizationUuid } = account.organization;
+        if (!organizationUuid) {
+            throw new ForbiddenError();
+        }
+
+        if (projectUuid !== null) {
+            const project = await this.projectModel.getSummary(projectUuid);
+            if (project.organizationUuid !== organizationUuid) {
+                throw new ForbiddenError();
+            }
+        }
+
+        const ability = this.createAuditedAbility(account);
+        if (
+            ability.cannot(
+                'manage',
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid: projectUuid ?? undefined,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        return { organizationUuid, projectUuid };
+    }
+
+    async list(
+        account: RegisteredAccount,
+        projectUuid: UUID | null,
+    ): Promise<SkippableHomepageRecommendedActionKey[]> {
+        const scope = await this.getAuthorizedScope(account, projectUuid);
+        return this.homepageRecommendedActionSkipsModel.list(scope);
+    }
+
+    async skip(
+        account: RegisteredAccount,
+        projectUuid: UUID | null,
+        actionKey: HomepageRecommendedActionKey | string,
+    ): Promise<void> {
+        const validatedActionKey =
+            HomepageRecommendedActionSkipsService.validateActionKey(actionKey);
+        const scope = await this.getAuthorizedScope(account, projectUuid);
+        await this.homepageRecommendedActionSkipsModel.create({
+            ...scope,
+            actionKey: validatedActionKey,
+            createdByUserUuid: account.user.userUuid,
+        });
+    }
+
+    async unskip(
+        account: RegisteredAccount,
+        projectUuid: UUID | null,
+        actionKey: HomepageRecommendedActionKey | string,
+    ): Promise<void> {
+        const validatedActionKey =
+            HomepageRecommendedActionSkipsService.validateActionKey(actionKey);
+        const scope = await this.getAuthorizedScope(account, projectUuid);
+        await this.homepageRecommendedActionSkipsModel.delete({
+            ...scope,
+            actionKey: validatedActionKey,
+        });
+    }
+}

--- a/packages/backend/src/ee/services/HomepageRecommendedActionSkipsService.ts
+++ b/packages/backend/src/ee/services/HomepageRecommendedActionSkipsService.ts
@@ -1,6 +1,7 @@
 import { subject } from '@casl/ability';
 import {
     ForbiddenError,
+    HOMEPAGE_RECOMMENDED_ACTION_SCOPES,
     ParameterError,
     SKIPPABLE_HOMEPAGE_RECOMMENDED_ACTION_KEYS,
     type HomepageRecommendedActionKey,
@@ -80,6 +81,24 @@ export class HomepageRecommendedActionSkipsService extends BaseService {
         return { organizationUuid, projectUuid };
     }
 
+    private static getStorageProjectUuid(
+        actionKey: SkippableHomepageRecommendedActionKey,
+        projectUuid: UUID | null,
+    ): UUID | null {
+        if (
+            HOMEPAGE_RECOMMENDED_ACTION_SCOPES[actionKey] === 'project' &&
+            projectUuid === null
+        ) {
+            throw new ParameterError(
+                'This homepage recommended action requires a project',
+            );
+        }
+
+        return HOMEPAGE_RECOMMENDED_ACTION_SCOPES[actionKey] === 'organization'
+            ? null
+            : projectUuid;
+    }
+
     async list(
         account: RegisteredAccount,
         projectUuid: UUID | null,
@@ -95,9 +114,15 @@ export class HomepageRecommendedActionSkipsService extends BaseService {
     ): Promise<void> {
         const validatedActionKey =
             HomepageRecommendedActionSkipsService.validateActionKey(actionKey);
+        const storageProjectUuid =
+            HomepageRecommendedActionSkipsService.getStorageProjectUuid(
+                validatedActionKey,
+                projectUuid,
+            );
         const scope = await this.getAuthorizedScope(account, projectUuid);
         await this.homepageRecommendedActionSkipsModel.create({
             ...scope,
+            projectUuid: storageProjectUuid,
             actionKey: validatedActionKey,
             createdByUserUuid: account.user.userUuid,
         });
@@ -110,9 +135,15 @@ export class HomepageRecommendedActionSkipsService extends BaseService {
     ): Promise<void> {
         const validatedActionKey =
             HomepageRecommendedActionSkipsService.validateActionKey(actionKey);
+        const storageProjectUuid =
+            HomepageRecommendedActionSkipsService.getStorageProjectUuid(
+                validatedActionKey,
+                projectUuid,
+            );
         const scope = await this.getAuthorizedScope(account, projectUuid);
         await this.homepageRecommendedActionSkipsModel.delete({
             ...scope,
+            projectUuid: storageProjectUuid,
             actionKey: validatedActionKey,
         });
     }

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -150,6 +150,7 @@ export type ModelManifest = {
     /** An implementation signature for these models are not available at this stage */
     aiAgentMemoryModel: unknown;
     aiAgentModel: unknown;
+    homepageRecommendedActionSkipsModel: unknown;
     projectHomepageModel: unknown;
     aiAgentDocumentModel: unknown;
     aiWritebackThreadModel: unknown;
@@ -819,6 +820,10 @@ export class ModelRepository
 
     public getProjectHomepageModel<ModelImplT>(): ModelImplT {
         return this.getModel('projectHomepageModel');
+    }
+
+    public getHomepageRecommendedActionSkipsModel<ModelImplT>(): ModelImplT {
+        return this.getModel('homepageRecommendedActionSkipsModel');
     }
 
     public getMcpToolCallModel<ModelImplT>(): ModelImplT {

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -156,6 +156,7 @@ interface ServiceManifest {
     aiWritebackService: unknown;
     aiDeepResearchService: unknown;
     aiAgentMemoryService: unknown;
+    homepageRecommendedActionSkipsService: unknown;
     onboardingAgentService: unknown;
     aiAgentReviewNotificationService: unknown;
     writebackPreviewService: unknown;
@@ -1450,6 +1451,12 @@ export class ServiceRepository
         ProjectHomepageServiceImplT,
     >(): ProjectHomepageServiceImplT {
         return this.getService('projectHomepageService');
+    }
+
+    public getHomepageRecommendedActionSkipsService<
+        HomepageRecommendedActionSkipsServiceImplT,
+    >(): HomepageRecommendedActionSkipsServiceImplT {
+        return this.getService('homepageRecommendedActionSkipsService');
     }
 
     public getAiAgentCoderService<

--- a/packages/common/src/ee/homepage/types.ts
+++ b/packages/common/src/ee/homepage/types.ts
@@ -194,6 +194,23 @@ export type HomepageRecommendedActionKey =
     | 'connect-source-control'
     | 'connect-slack';
 
+export const SKIPPABLE_HOMEPAGE_RECOMMENDED_ACTION_KEYS = [
+    'add-semantic-layer',
+    'connect-source-control',
+    'connect-slack',
+] as const satisfies readonly HomepageRecommendedActionKey[];
+
+export type SkippableHomepageRecommendedActionKey =
+    (typeof SKIPPABLE_HOMEPAGE_RECOMMENDED_ACTION_KEYS)[number];
+
+export type SkipHomepageRecommendedActionRequest = {
+    actionKey: HomepageRecommendedActionKey;
+};
+
+export type ApiHomepageRecommendedActionSkipsResponse = ApiSuccess<
+    SkippableHomepageRecommendedActionKey[]
+>;
+
 export type HomepageBlock =
     | HomepageMarkdownBlock
     | HomepageAskAiHeroBlock

--- a/packages/common/src/ee/homepage/types.ts
+++ b/packages/common/src/ee/homepage/types.ts
@@ -194,6 +194,16 @@ export type HomepageRecommendedActionKey =
     | 'connect-source-control'
     | 'connect-slack';
 
+export const HOMEPAGE_RECOMMENDED_ACTION_SCOPES: Record<
+    HomepageRecommendedActionKey,
+    'organization' | 'project'
+> = {
+    'connect-warehouse': 'organization',
+    'add-semantic-layer': 'project',
+    'connect-source-control': 'organization',
+    'connect-slack': 'organization',
+};
+
 export const SKIPPABLE_HOMEPAGE_RECOMMENDED_ACTION_KEYS = [
     'add-semantic-layer',
     'connect-source-control',

--- a/packages/frontend/src/ee/features/homepageBuilder/NoProjectHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/NoProjectHomepage.tsx
@@ -90,10 +90,7 @@ const NoProjectHomepage: FC = () => {
                             </Stack>
                         )}
                         {actions.hasPendingActions && (
-                            <RecommendedActionsChecklist
-                                projectUuid={null}
-                                actions={actions}
-                            />
+                            <RecommendedActionsChecklist actions={actions} />
                         )}
                     </Stack>
                 </Box>

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.tsx
@@ -41,12 +41,7 @@ export const AskAiHero: FC<{
             <Box w="100%">
                 <DayOneAskInput projectUuid={projectUuid} preview={preview} />
             </Box>
-            {showChecklist && (
-                <RecommendedActionsChecklist
-                    projectUuid={projectUuid}
-                    actions={actions}
-                />
-            )}
+            {showChecklist && <RecommendedActionsChecklist actions={actions} />}
         </Stack>
     );
 };

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/RecommendedActionsChecklist.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/RecommendedActionsChecklist.tsx
@@ -22,7 +22,6 @@ import classes from './blockStyles.module.css';
 import {
     RECOMMENDED_ACTION_KEYS,
     SKIPPABLE_ACTION_KEYS,
-    writeSkippedActions,
 } from './recommendedActionDefaults';
 import styles from './RecommendedActionsChecklist.module.css';
 import {
@@ -203,75 +202,65 @@ const ActionRow: FC<{
 };
 
 export const RecommendedActionsChecklist: FC<{
-    projectUuid: string | null;
     actions: RecommendedActionsState;
-}> = ({ projectUuid, actions }) => {
+}> = ({ actions }) => {
     const { track, data: trackingData } = useTracking();
     const isTrackingReady = !!trackingData.rudder;
-    const { statuses, skippedActions, setSkippedActions, visibleActions } =
-        actions;
+    const {
+        statuses,
+        skippedActions,
+        skipAction,
+        restoreAction,
+        visibleActions,
+    } = actions;
     const [carouselIndex, setCarouselIndex] = useState(0);
     const [isStackHovered, setIsStackHovered] = useState(false);
 
     const handleSkip = useCallback(
         (actionKey: HomepageRecommendedActionKey) => {
-            setSkippedActions((previous) => {
-                if (previous.includes(actionKey)) return previous;
-                const next = [...previous, actionKey];
-                writeSkippedActions(projectUuid, next);
-                // Advance to the next non-skipped card, wrapping — without
-                // this the skipped card can stay on top when the active
-                // index is past the front
-                const oldIncomplete = RECOMMENDED_ACTION_KEYS.filter(
-                    (key) =>
-                        statuses[key].isVisible &&
-                        !statuses[key].isComplete &&
-                        !previous.includes(key),
-                );
-                const skippedPosition = oldIncomplete.indexOf(actionKey);
-                const nextIncomplete = oldIncomplete.filter(
-                    (key) => key !== actionKey,
-                );
-                setCarouselIndex(
-                    nextIncomplete.length > 0 && skippedPosition >= 0
-                        ? skippedPosition % nextIncomplete.length
-                        : 0,
-                );
-                return next;
-            });
+            if (skippedActions.includes(actionKey)) return;
+            const oldIncomplete = RECOMMENDED_ACTION_KEYS.filter(
+                (key) =>
+                    statuses[key].isVisible &&
+                    !statuses[key].isComplete &&
+                    !skippedActions.includes(key),
+            );
+            const skippedPosition = oldIncomplete.indexOf(actionKey);
+            const nextIncomplete = oldIncomplete.filter(
+                (key) => key !== actionKey,
+            );
+            setCarouselIndex(
+                nextIncomplete.length > 0 && skippedPosition >= 0
+                    ? skippedPosition % nextIncomplete.length
+                    : 0,
+            );
+            skipAction(actionKey);
             track({
                 name: EventName.HOMEPAGE_RECOMMENDED_ACTION_SKIPPED,
                 properties: { actionKey },
             });
         },
-        [projectUuid, track, setSkippedActions, statuses],
+        [skipAction, skippedActions, statuses, track],
     );
 
     const handleRestore = useCallback(
         (actionKey: HomepageRecommendedActionKey) => {
-            setSkippedActions((previous) => {
-                if (!previous.includes(actionKey)) return previous;
-                const next = previous.filter((key) => key !== actionKey);
-                writeSkippedActions(projectUuid, next);
-                // Keep the restored card active — it moves groups, which
-                // would otherwise silently change what's on top
-                const nextIncomplete = RECOMMENDED_ACTION_KEYS.filter(
-                    (key) =>
-                        statuses[key].isVisible &&
-                        !statuses[key].isComplete &&
-                        !next.includes(key),
-                );
-                setCarouselIndex(
-                    Math.max(nextIncomplete.indexOf(actionKey), 0),
-                );
-                return next;
-            });
+            if (!skippedActions.includes(actionKey)) return;
+            const next = skippedActions.filter((key) => key !== actionKey);
+            const nextIncomplete = RECOMMENDED_ACTION_KEYS.filter(
+                (key) =>
+                    statuses[key].isVisible &&
+                    !statuses[key].isComplete &&
+                    !next.includes(key),
+            );
+            setCarouselIndex(Math.max(nextIncomplete.indexOf(actionKey), 0));
+            restoreAction(actionKey);
             track({
                 name: EventName.HOMEPAGE_RECOMMENDED_ACTION_RESTORED,
                 properties: { actionKey },
             });
         },
-        [projectUuid, statuses, setSkippedActions, track],
+        [restoreAction, skippedActions, statuses, track],
     );
 
     const isSkipped = (key: HomepageRecommendedActionKey) =>

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/recommendedActionDefaults.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/recommendedActionDefaults.ts
@@ -1,4 +1,7 @@
-import { type HomepageRecommendedActionKey } from '@lightdash/common';
+import {
+    SKIPPABLE_HOMEPAGE_RECOMMENDED_ACTION_KEYS,
+    type HomepageRecommendedActionKey,
+} from '@lightdash/common';
 
 export const RECOMMENDED_ACTION_KEYS: HomepageRecommendedActionKey[] = [
     'connect-warehouse',
@@ -10,40 +13,5 @@ export const RECOMMENDED_ACTION_KEYS: HomepageRecommendedActionKey[] = [
 // Connecting a warehouse gates everything else — skipping it would strand
 // the user with nothing to query
 export const SKIPPABLE_ACTION_KEYS: HomepageRecommendedActionKey[] = [
-    'add-semantic-layer',
-    'connect-source-control',
-    'connect-slack',
+    ...SKIPPABLE_HOMEPAGE_RECOMMENDED_ACTION_KEYS,
 ];
-
-const isSkippableActionKey = (
-    value: unknown,
-): value is HomepageRecommendedActionKey =>
-    typeof value === 'string' &&
-    SKIPPABLE_ACTION_KEYS.includes(value as HomepageRecommendedActionKey);
-
-const getSkippedActionsStorageKey = (projectUuid: string | null) =>
-    `lightdash:recommended-actions:skipped:${projectUuid ?? 'no-project'}`;
-
-export const readSkippedActions = (
-    projectUuid: string | null,
-): HomepageRecommendedActionKey[] => {
-    const raw = localStorage.getItem(getSkippedActionsStorageKey(projectUuid));
-    if (!raw) return [];
-    try {
-        const parsed: unknown = JSON.parse(raw);
-        if (!Array.isArray(parsed)) return [];
-        return parsed.filter(isSkippableActionKey);
-    } catch {
-        return [];
-    }
-};
-
-export const writeSkippedActions = (
-    projectUuid: string | null,
-    keys: HomepageRecommendedActionKey[],
-) => {
-    localStorage.setItem(
-        getSkippedActionsStorageKey(projectUuid),
-        JSON.stringify(keys),
-    );
-};

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.test.tsx
@@ -1,9 +1,10 @@
 import {
     FeatureFlags,
     ProjectType,
+    type HomepageRecommendedActionKey,
     type OrganizationProject,
 } from '@lightdash/common';
-import { renderHook, waitFor } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import { useGithubConfig } from '../../../../components/common/GithubIntegration/hooks/useGithubIntegration';
 import { useGitlabRepositories } from '../../../../components/common/GitlabIntegration/hooks/useGitlabIntegration';
 import { useOrganization } from '../../../../hooks/organization/useOrganization';
@@ -13,6 +14,7 @@ import { useProjects } from '../../../../hooks/useProjects';
 import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../providers/App/useApp';
 import { useActiveAgentOnboardingRun } from '../../agentOnboarding/hooks/useAgentOnboarding';
+import { useHomepageRecommendedActionSkips } from '../hooks/useHomepageRecommendedActionSkips';
 import { useRecommendedActions } from './useRecommendedActions';
 
 vi.mock(
@@ -28,6 +30,19 @@ vi.mock('../../../../hooks/useProjects');
 vi.mock('../../../../providers/App/useApp');
 vi.mock('../../../../hooks/useServerOrClientFeatureFlag');
 vi.mock('../../agentOnboarding/hooks/useAgentOnboarding');
+vi.mock('../hooks/useHomepageRecommendedActionSkips');
+
+const recommendedActionSkipsResult = (
+    overrides: Partial<
+        ReturnType<typeof useHomepageRecommendedActionSkips>
+    > = {},
+): ReturnType<typeof useHomepageRecommendedActionSkips> => ({
+    skippedActions: [],
+    isLoading: false,
+    skipAction: vi.fn(),
+    restoreAction: vi.fn(),
+    ...overrides,
+});
 
 const organizationProject = (
     overrides: Partial<OrganizationProject>,
@@ -78,17 +93,21 @@ describe('useRecommendedActions', () => {
         vi.mocked(useActiveAgentOnboardingRun).mockReturnValue({
             data: null,
         } as ReturnType<typeof useActiveAgentOnboardingRun>);
-        localStorage.clear();
+        vi.mocked(useHomepageRecommendedActionSkips).mockReturnValue(
+            recommendedActionSkipsResult(),
+        );
     });
 
-    it('reloads skipped actions when the project changes', async () => {
-        localStorage.setItem(
-            'lightdash:recommended-actions:skipped:no-project',
-            JSON.stringify(['connect-slack']),
-        );
-        localStorage.setItem(
-            'lightdash:recommended-actions:skipped:project-uuid',
-            JSON.stringify(['add-semantic-layer']),
+    it('reads skipped actions from the server query for each project context', () => {
+        vi.mocked(useHomepageRecommendedActionSkips).mockImplementation(
+            (projectUuid) =>
+                recommendedActionSkipsResult({
+                    skippedActions: [
+                        projectUuid === null
+                            ? 'connect-slack'
+                            : 'add-semantic-layer',
+                    ] satisfies HomepageRecommendedActionKey[],
+                }),
         );
 
         const { result, rerender } = renderHook(
@@ -101,11 +120,29 @@ describe('useRecommendedActions', () => {
 
         rerender({ projectUuid: 'project-uuid' });
 
-        await waitFor(() => {
-            expect(result.current.skippedActions).toEqual([
-                'add-semantic-layer',
-            ]);
-        });
+        expect(result.current.skippedActions).toEqual(['add-semantic-layer']);
+        expect(useHomepageRecommendedActionSkips).toHaveBeenLastCalledWith(
+            'project-uuid',
+            { enabled: true },
+        );
+    });
+
+    it('does not report pending actions while skipped actions are loading', () => {
+        vi.mocked(useServerFeatureFlag).mockImplementation(
+            (flag) =>
+                ({
+                    data: { enabled: flag === FeatureFlags.NewOnboarding },
+                }) as ReturnType<typeof useServerFeatureFlag>,
+        );
+        vi.mocked(useHomepageRecommendedActionSkips).mockReturnValue(
+            recommendedActionSkipsResult({ isLoading: true }),
+        );
+
+        const { result } = renderHook(() =>
+            useRecommendedActions('project-uuid'),
+        );
+
+        expect(result.current.hasPendingActions).toBe(false);
     });
 
     it('reports no pending actions while source control is still loading', () => {

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
@@ -6,7 +6,7 @@ import {
     ProjectType,
     type HomepageRecommendedActionKey,
 } from '@lightdash/common';
-import { useEffect, useState, type ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import { useGithubConfig } from '../../../../components/common/GithubIntegration/hooks/useGithubIntegration';
 import { useGitlabRepositories } from '../../../../components/common/GitlabIntegration/hooks/useGitlabIntegration';
 import {
@@ -22,10 +22,8 @@ import useApp from '../../../../providers/App/useApp';
 import { isPlaygroundProvisioningSource } from '../../../../utils/playgroundProject';
 import { useActiveAgentOnboardingRun } from '../../agentOnboarding/hooks/useAgentOnboarding';
 import { getAgentOnboardingRunUrl } from '../../agentOnboarding/utils';
-import {
-    RECOMMENDED_ACTION_KEYS,
-    readSkippedActions,
-} from './recommendedActionDefaults';
+import { useHomepageRecommendedActionSkips } from '../hooks/useHomepageRecommendedActionSkips';
+import { RECOMMENDED_ACTION_KEYS } from './recommendedActionDefaults';
 
 const DEFAULT_CTA_LABEL = 'Set up';
 
@@ -178,9 +176,6 @@ export const useRecommendedActions = (projectUuid: string | null) => {
     const isPlaygroundProject = isPlaygroundProvisioningSource(
         project?.provisioningSource,
     );
-    const [skippedActions, setSkippedActions] = useState<
-        HomepageRecommendedActionKey[]
-    >(() => readSkippedActions(projectUuid));
 
     const canManageProject =
         user.data?.ability?.can(
@@ -191,9 +186,14 @@ export const useRecommendedActions = (projectUuid: string | null) => {
             }),
         ) ?? false;
 
-    useEffect(() => {
-        setSkippedActions(readSkippedActions(projectUuid));
-    }, [projectUuid]);
+    const {
+        skippedActions = [],
+        isLoading: skippedActionsLoading,
+        skipAction,
+        restoreAction,
+    } = useHomepageRecommendedActionSkips(projectUuid, {
+        enabled: canManageProject,
+    });
 
     // The playground is a throwaway sample-data project — the setup checklist
     // has no place there, so nothing is offered and the block hides itself.
@@ -203,6 +203,7 @@ export const useRecommendedActions = (projectUuid: string | null) => {
     const hasPendingActions =
         newOnboardingFlag.data?.enabled === true &&
         !isLoading &&
+        !skippedActionsLoading &&
         canManageProject &&
         visibleActions.some(
             (key) => !statuses[key].isComplete && !skippedActions.includes(key),
@@ -211,7 +212,8 @@ export const useRecommendedActions = (projectUuid: string | null) => {
     return {
         statuses,
         skippedActions,
-        setSkippedActions,
+        skipAction,
+        restoreAction,
         visibleActions,
         hasPendingActions,
     };

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
@@ -200,13 +200,14 @@ export const useRecommendedActions = (projectUuid: string | null) => {
     const visibleActions = isPlaygroundProject
         ? []
         : RECOMMENDED_ACTION_KEYS.filter((key) => statuses[key].isVisible);
+    const skippedActionKeys = new Set<string>(skippedActions);
     const hasPendingActions =
         newOnboardingFlag.data?.enabled === true &&
         !isLoading &&
         !skippedActionsLoading &&
         canManageProject &&
         visibleActions.some(
-            (key) => !statuses[key].isComplete && !skippedActions.includes(key),
+            (key) => !statuses[key].isComplete && !skippedActionKeys.has(key),
         );
 
     return {

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useHomepageRecommendedActionSkips.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useHomepageRecommendedActionSkips.test.tsx
@@ -1,6 +1,9 @@
 import { type ApiHomepageRecommendedActionSkipsResponse } from '@lightdash/common';
-import { act, waitFor } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { type FC, type PropsWithChildren } from 'react';
 import { lightdashApi } from '../../../../api';
+import { createQueryClient } from '../../../../providers/ReactQuery/createQueryClient';
 import { renderHookWithProviders } from '../../../../testing/testUtils';
 import { useHomepageRecommendedActionSkips } from './useHomepageRecommendedActionSkips';
 
@@ -16,42 +19,102 @@ const deferred = <T,>() => {
     return { promise, resolve };
 };
 
+const queryKey = (projectUuid: string | null) => [
+    'homepage-recommended-action-skips',
+    projectUuid,
+];
+
+const renderWithQueryClient = (
+    projectUuid: string | null,
+    queryClient: ReturnType<typeof createQueryClient>,
+) => {
+    const Wrapper: FC<PropsWithChildren> = ({ children }) => (
+        <QueryClientProvider client={queryClient}>
+            {children}
+        </QueryClientProvider>
+    );
+
+    return renderHook(
+        () =>
+            useHomepageRecommendedActionSkips(projectUuid, {
+                enabled: false,
+            }),
+        { wrapper: Wrapper },
+    );
+};
+
 describe('useHomepageRecommendedActionSkips', () => {
     beforeEach(() => {
         vi.mocked(lightdashApi).mockReset();
     });
 
-    it('optimistically skips an action in a project-scoped query', async () => {
+    it('optimistically updates every cached context for organization actions', async () => {
+        const queryClient = createQueryClient();
+        queryClient.setQueryData(queryKey(null), []);
+        queryClient.setQueryData(queryKey('project-uuid'), []);
+        queryClient.setQueryData(queryKey('other-project-uuid'), [
+            'add-semantic-layer',
+        ]);
+        const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
         const mutation = deferred<undefined>();
-        vi.mocked(lightdashApi)
-            .mockResolvedValueOnce(
-                [] satisfies ApiHomepageRecommendedActionSkipsResponse['results'] as never,
-            )
-            .mockReturnValueOnce(mutation.promise as never)
-            .mockResolvedValueOnce([
-                'connect-slack',
-            ] satisfies ApiHomepageRecommendedActionSkipsResponse['results'] as never);
+        vi.mocked(lightdashApi).mockReturnValueOnce(mutation.promise as never);
 
-        const { result } = renderHookWithProviders(() =>
-            useHomepageRecommendedActionSkips('project-uuid', {
-                enabled: true,
-            }),
-        );
-
-        await waitFor(() => expect(result.current.skippedActions).toEqual([]));
+        const { result } = renderWithQueryClient('project-uuid', queryClient);
 
         act(() => result.current.skipAction('connect-slack'));
 
         await waitFor(() =>
             expect(result.current.skippedActions).toEqual(['connect-slack']),
         );
-        expect(lightdashApi).toHaveBeenNthCalledWith(2, {
+        expect(queryClient.getQueryData(queryKey(null))).toEqual([
+            'connect-slack',
+        ]);
+        expect(
+            queryClient.getQueryData(queryKey('other-project-uuid')),
+        ).toEqual(['add-semantic-layer', 'connect-slack']);
+        expect(lightdashApi).toHaveBeenCalledWith({
             url: '/ee/homepage/recommended-action-skips?projectUuid=project-uuid',
             method: 'POST',
             body: JSON.stringify({ actionKey: 'connect-slack' }),
         });
 
-        mutation.resolve(undefined);
+        act(() => mutation.resolve(undefined));
+        await waitFor(() =>
+            expect(invalidateQueries).toHaveBeenCalledWith({
+                queryKey: ['homepage-recommended-action-skips'],
+                exact: false,
+            }),
+        );
+    });
+
+    it('optimistically updates only the current context for project actions', async () => {
+        const queryClient = createQueryClient();
+        queryClient.setQueryData(queryKey(null), ['connect-slack']);
+        queryClient.setQueryData(queryKey('project-uuid'), ['connect-slack']);
+        queryClient.setQueryData(queryKey('other-project-uuid'), [
+            'connect-slack',
+        ]);
+        const mutation = deferred<undefined>();
+        vi.mocked(lightdashApi).mockReturnValueOnce(mutation.promise as never);
+
+        const { result } = renderWithQueryClient('project-uuid', queryClient);
+
+        act(() => result.current.skipAction('add-semantic-layer'));
+
+        await waitFor(() =>
+            expect(result.current.skippedActions).toEqual([
+                'connect-slack',
+                'add-semantic-layer',
+            ]),
+        );
+        expect(queryClient.getQueryData(queryKey(null))).toEqual([
+            'connect-slack',
+        ]);
+        expect(
+            queryClient.getQueryData(queryKey('other-project-uuid')),
+        ).toEqual(['connect-slack']);
+
+        act(() => mutation.resolve(undefined));
     });
 
     it('loads the null-project context without a project sentinel', async () => {

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useHomepageRecommendedActionSkips.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useHomepageRecommendedActionSkips.test.tsx
@@ -1,0 +1,77 @@
+import { type ApiHomepageRecommendedActionSkipsResponse } from '@lightdash/common';
+import { act, waitFor } from '@testing-library/react';
+import { lightdashApi } from '../../../../api';
+import { renderHookWithProviders } from '../../../../testing/testUtils';
+import { useHomepageRecommendedActionSkips } from './useHomepageRecommendedActionSkips';
+
+vi.mock('../../../../api', () => ({
+    lightdashApi: vi.fn(),
+}));
+
+const deferred = <T,>() => {
+    let resolve: (value: T) => void = () => undefined;
+    const promise = new Promise<T>((promiseResolve) => {
+        resolve = promiseResolve;
+    });
+    return { promise, resolve };
+};
+
+describe('useHomepageRecommendedActionSkips', () => {
+    beforeEach(() => {
+        vi.mocked(lightdashApi).mockReset();
+    });
+
+    it('optimistically skips an action in a project-scoped query', async () => {
+        const mutation = deferred<undefined>();
+        vi.mocked(lightdashApi)
+            .mockResolvedValueOnce(
+                [] satisfies ApiHomepageRecommendedActionSkipsResponse['results'] as never,
+            )
+            .mockReturnValueOnce(mutation.promise as never)
+            .mockResolvedValueOnce([
+                'connect-slack',
+            ] satisfies ApiHomepageRecommendedActionSkipsResponse['results'] as never);
+
+        const { result } = renderHookWithProviders(() =>
+            useHomepageRecommendedActionSkips('project-uuid', {
+                enabled: true,
+            }),
+        );
+
+        await waitFor(() => expect(result.current.skippedActions).toEqual([]));
+
+        act(() => result.current.skipAction('connect-slack'));
+
+        await waitFor(() =>
+            expect(result.current.skippedActions).toEqual(['connect-slack']),
+        );
+        expect(lightdashApi).toHaveBeenNthCalledWith(2, {
+            url: '/ee/homepage/recommended-action-skips?projectUuid=project-uuid',
+            method: 'POST',
+            body: JSON.stringify({ actionKey: 'connect-slack' }),
+        });
+
+        mutation.resolve(undefined);
+    });
+
+    it('loads the null-project context without a project sentinel', async () => {
+        vi.mocked(lightdashApi).mockResolvedValueOnce([
+            'connect-source-control',
+        ] satisfies ApiHomepageRecommendedActionSkipsResponse['results'] as never);
+
+        const { result } = renderHookWithProviders(() =>
+            useHomepageRecommendedActionSkips(null, { enabled: true }),
+        );
+
+        await waitFor(() =>
+            expect(result.current.skippedActions).toEqual([
+                'connect-source-control',
+            ]),
+        );
+        expect(lightdashApi).toHaveBeenCalledWith({
+            url: '/ee/homepage/recommended-action-skips',
+            method: 'GET',
+            body: undefined,
+        });
+    });
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useHomepageRecommendedActionSkips.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useHomepageRecommendedActionSkips.ts
@@ -1,0 +1,125 @@
+import {
+    SKIPPABLE_HOMEPAGE_RECOMMENDED_ACTION_KEYS,
+    type ApiError,
+    type ApiHomepageRecommendedActionSkipsResponse,
+    type HomepageRecommendedActionKey,
+    type SkippableHomepageRecommendedActionKey,
+    type SkipHomepageRecommendedActionRequest,
+} from '@lightdash/common';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { lightdashApi } from '../../../../api';
+import useToaster from '../../../../hooks/toaster/useToaster';
+
+const homepageRecommendedActionSkipsQueryKey = (projectUuid: string | null) =>
+    ['homepage-recommended-action-skips', projectUuid] as const;
+
+const scopeQuery = (projectUuid: string | null) =>
+    projectUuid ? `?${new URLSearchParams({ projectUuid }).toString()}` : '';
+
+const listSkips = (projectUuid: string | null) =>
+    lightdashApi<ApiHomepageRecommendedActionSkipsResponse['results']>({
+        url: `/ee/homepage/recommended-action-skips${scopeQuery(projectUuid)}`,
+        method: 'GET',
+        body: undefined,
+    });
+
+const skipAction = (
+    projectUuid: string | null,
+    actionKey: HomepageRecommendedActionKey,
+) =>
+    lightdashApi<undefined>({
+        url: `/ee/homepage/recommended-action-skips${scopeQuery(projectUuid)}`,
+        method: 'POST',
+        body: JSON.stringify({
+            actionKey,
+        } satisfies SkipHomepageRecommendedActionRequest),
+    });
+
+const unskipAction = (
+    projectUuid: string | null,
+    actionKey: HomepageRecommendedActionKey,
+) =>
+    lightdashApi<undefined>({
+        url: `/ee/homepage/recommended-action-skips/${encodeURIComponent(
+            actionKey,
+        )}${scopeQuery(projectUuid)}`,
+        method: 'DELETE',
+        body: undefined,
+    });
+
+type MutationVariables = {
+    actionKey: HomepageRecommendedActionKey;
+    skipped: boolean;
+};
+
+type MutationContext = {
+    previous: SkippableHomepageRecommendedActionKey[] | undefined;
+};
+
+export const useHomepageRecommendedActionSkips = (
+    projectUuid: string | null,
+    { enabled }: { enabled: boolean },
+) => {
+    const queryClient = useQueryClient();
+    const { showToastApiError } = useToaster();
+    const queryKey = homepageRecommendedActionSkipsQueryKey(projectUuid);
+    const query = useQuery<
+        ApiHomepageRecommendedActionSkipsResponse['results'],
+        ApiError
+    >({
+        queryKey,
+        queryFn: () => listSkips(projectUuid),
+        enabled,
+    });
+    const mutation = useMutation<
+        undefined,
+        ApiError,
+        MutationVariables,
+        MutationContext
+    >({
+        mutationFn: ({ actionKey, skipped }) =>
+            skipped
+                ? skipAction(projectUuid, actionKey)
+                : unskipAction(projectUuid, actionKey),
+        onMutate: async ({ actionKey, skipped }) => {
+            await queryClient.cancelQueries(queryKey);
+            const previous =
+                queryClient.getQueryData<
+                    ApiHomepageRecommendedActionSkipsResponse['results']
+                >(queryKey);
+            const skippableActionKey =
+                SKIPPABLE_HOMEPAGE_RECOMMENDED_ACTION_KEYS.find(
+                    (key) => key === actionKey,
+                );
+            queryClient.setQueryData<
+                ApiHomepageRecommendedActionSkipsResponse['results']
+            >(queryKey, (current = []) =>
+                skipped && skippableActionKey
+                    ? current.includes(skippableActionKey)
+                        ? current
+                        : [...current, skippableActionKey]
+                    : current.filter((key) => key !== actionKey),
+            );
+            return { previous };
+        },
+        onError: ({ error }, _variables, context) => {
+            queryClient.setQueryData(queryKey, context?.previous);
+            showToastApiError({
+                title: 'Failed to update setup checklist',
+                apiError: error,
+            });
+        },
+        onSettled: () => queryClient.invalidateQueries(queryKey),
+    });
+    const skippedActions: HomepageRecommendedActionKey[] | undefined =
+        query.data;
+
+    return {
+        skippedActions,
+        isLoading: query.isInitialLoading,
+        skipAction: (actionKey: HomepageRecommendedActionKey) =>
+            mutation.mutate({ actionKey, skipped: true }),
+        restoreAction: (actionKey: HomepageRecommendedActionKey) =>
+            mutation.mutate({ actionKey, skipped: false }),
+    };
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useHomepageRecommendedActionSkips.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useHomepageRecommendedActionSkips.ts
@@ -1,4 +1,5 @@
 import {
+    HOMEPAGE_RECOMMENDED_ACTION_SCOPES,
     SKIPPABLE_HOMEPAGE_RECOMMENDED_ACTION_KEYS,
     type ApiError,
     type ApiHomepageRecommendedActionSkipsResponse,
@@ -6,12 +7,23 @@ import {
     type SkippableHomepageRecommendedActionKey,
     type SkipHomepageRecommendedActionRequest,
 } from '@lightdash/common';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+    useMutation,
+    useQuery,
+    useQueryClient,
+    type QueryKey,
+} from '@tanstack/react-query';
 import { lightdashApi } from '../../../../api';
 import useToaster from '../../../../hooks/toaster/useToaster';
 
-const homepageRecommendedActionSkipsQueryKey = (projectUuid: string | null) =>
-    ['homepage-recommended-action-skips', projectUuid] as const;
+const HOMEPAGE_RECOMMENDED_ACTION_SKIPS_QUERY_KEY = [
+    'homepage-recommended-action-skips',
+] as const;
+
+const homepageRecommendedActionSkipsQueryKey = (projectUuid: string | null) => [
+    ...HOMEPAGE_RECOMMENDED_ACTION_SKIPS_QUERY_KEY,
+    projectUuid,
+];
 
 const scopeQuery = (projectUuid: string | null) =>
     projectUuid ? `?${new URLSearchParams({ projectUuid }).toString()}` : '';
@@ -53,7 +65,10 @@ type MutationVariables = {
 };
 
 type MutationContext = {
-    previous: SkippableHomepageRecommendedActionKey[] | undefined;
+    previousQueries: [
+        QueryKey,
+        SkippableHomepageRecommendedActionKey[] | undefined,
+    ][];
 };
 
 export const useHomepageRecommendedActionSkips = (
@@ -82,34 +97,56 @@ export const useHomepageRecommendedActionSkips = (
                 ? skipAction(projectUuid, actionKey)
                 : unskipAction(projectUuid, actionKey),
         onMutate: async ({ actionKey, skipped }) => {
-            await queryClient.cancelQueries(queryKey);
-            const previous =
-                queryClient.getQueryData<
+            const queryFilter =
+                HOMEPAGE_RECOMMENDED_ACTION_SCOPES[actionKey] === 'organization'
+                    ? {
+                          queryKey: HOMEPAGE_RECOMMENDED_ACTION_SKIPS_QUERY_KEY,
+                          exact: false,
+                      }
+                    : { queryKey, exact: true };
+            await queryClient.cancelQueries(queryFilter);
+            const previousQueries =
+                queryClient.getQueriesData<
                     ApiHomepageRecommendedActionSkipsResponse['results']
-                >(queryKey);
+                >(queryFilter);
             const skippableActionKey =
                 SKIPPABLE_HOMEPAGE_RECOMMENDED_ACTION_KEYS.find(
                     (key) => key === actionKey,
                 );
-            queryClient.setQueryData<
+            queryClient.setQueriesData<
                 ApiHomepageRecommendedActionSkipsResponse['results']
-            >(queryKey, (current = []) =>
-                skipped && skippableActionKey
-                    ? current.includes(skippableActionKey)
-                        ? current
-                        : [...current, skippableActionKey]
-                    : current.filter((key) => key !== actionKey),
+            >(queryFilter, (current) =>
+                current === undefined
+                    ? current
+                    : skipped && skippableActionKey
+                      ? current.includes(skippableActionKey)
+                          ? current
+                          : [...current, skippableActionKey]
+                      : current.filter((key) => key !== actionKey),
             );
-            return { previous };
+            return { previousQueries };
         },
         onError: ({ error }, _variables, context) => {
-            queryClient.setQueryData(queryKey, context?.previous);
+            context?.previousQueries.forEach(([previousQueryKey, previous]) => {
+                if (previous === undefined) {
+                    queryClient.removeQueries({
+                        queryKey: previousQueryKey,
+                        exact: true,
+                    });
+                } else {
+                    queryClient.setQueryData(previousQueryKey, previous);
+                }
+            });
             showToastApiError({
                 title: 'Failed to update setup checklist',
                 apiError: error,
             });
         },
-        onSettled: () => queryClient.invalidateQueries(queryKey),
+        onSettled: () =>
+            queryClient.invalidateQueries({
+                queryKey: HOMEPAGE_RECOMMENDED_ACTION_SKIPS_QUERY_KEY,
+                exact: false,
+            }),
     });
     const skippedActions: HomepageRecommendedActionKey[] | undefined =
         query.data;


### PR DESCRIPTION
### Description:

The homepage "Finish setting up" checklist stored its skip/dismiss state in localStorage, keyed per project per browser. Skips silently reset on a new machine or cleared storage, and every project admin had to re-dismiss cards a colleague already dismissed.

Skips now persist server-side, scoped by what the action is about rather than which surface dismissed it:

- **Action-intrinsic scoping**: `HOMEPAGE_RECOMMENDED_ACTION_SCOPES` in common declares each action organization- or project-scoped (`add-semantic-layer` is per-project; the integration actions are org-wide). Skipping an org-scoped action from any surface stores one org-wide row, so the card stays dismissed everywhere; project-scoped skips require and store the project.
- New EE table `homepage_recommended_action_skips` (organization + nullable project, action key checked against the skippable set, audit columns). Uniqueness via partial indexes per context; inserts are idempotent through predicate-matched `ON CONFLICT DO NOTHING` (verified against a live database).
- New EE endpoints to list, skip, and unskip actions, authorized by the `manage` Project ability with server-side action-key validation (`connect-warehouse` remains unskippable). `list` merges org-scoped skips with the current project's skips server-side.
- `useRecommendedActions` reads skips from a react-query hook with scope-aware optimistic mutations and prefix-wide cache invalidation; the localStorage helpers are removed. Existing browser-local skips are not migrated — the feature is pre-GA.

Verified in a running app: skip/restore round-trips including a second isolated browser context (org-shared semantics, empty localStorage both sides), reload persistence, concurrent double-skip producing a single row, non-skippable action rejected, and org-scoped storage confirmed at the database level when skipping from a project context.

Linear: SPK-740