### PR TITLE
fix: render nested spaces added to homepage collection blocks

### DIFF
--- a/packages/backend/src/models/ContentModel/ContentConfigurations/SpaceContentConfiguration.test.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/SpaceContentConfiguration.test.ts
@@ -23,4 +23,12 @@ describe('spaceContentConfiguration.getSummaryQuery rootSpaces search', () => {
         const sql = buildSql({ ...baseFilters, search: 'nested space' });
         expect(sql).not.toContain('nlevel(path) = 1');
     });
+
+    it('matches spaces at any nesting level when looking up explicit uuids', () => {
+        const sql = buildSql({
+            ...baseFilters,
+            uuids: ['00000000-0000-0000-0000-000000000002'],
+        });
+        expect(sql).not.toContain('nlevel(path) = 1');
+    });
 });

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/SpaceContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/SpaceContentConfiguration.ts
@@ -248,10 +248,10 @@ export const spaceContentConfiguration: ContentConfiguration<SpaceContentRow> =
                                 `${SpaceTableName}.space_uuid`,
                                 filters.spaceUuids ?? [],
                             );
-                            // When searching, match spaces at any nesting level
-                            // to stay consistent with global search. The
-                            // space_uuid filter above already enforces access.
-                            if (!filters.search) {
+                            // When searching or looking up explicit uuids, match
+                            // spaces at any nesting level. The space_uuid filter
+                            // above already enforces access.
+                            if (!filters.search && !filters.uuids) {
                                 void builder.andWhereRaw('nlevel(path) = 1');
                             }
                         } else {


### PR DESCRIPTION
### Description:

Collection blocks resolve their items through `GET /api/v2/content?uuids=...`. Because that request sends no `spaceUuids`, `ContentService.find()` treats it as a top-level browse and sets `space.rootSpaces: true`, which makes `SpaceContentConfiguration` add `nlevel(path) = 1`. Any **nested** space added to a block was therefore filtered out of the response and silently dropped by `useCollectionContent` — the tile just never appeared (and if all items were nested spaces, the block collapsed as runtime-empty).

An explicit uuid lookup is a direct request for known content, not a browse, so it now skips the root-only restriction — same exemption `search` already has. Access control is unaffected: the `space_uuid IN (allowedSpaceUuids)` filter still applies. `uuids` has no other consumer than the homepage collection hook, so the blast radius is limited to this path.

Nested spaces are still only findable in the picker's Spaces tab by typing a search term (browsing lists root spaces only) — worth a separate look, but with this fix a space found that way now actually renders.
