### PR TITLE
feat: manage feature flags in preview environments

### DIFF
--- a/docker/docker-compose.okteto-dev.yml
+++ b/docker/docker-compose.okteto-dev.yml
@@ -78,6 +78,12 @@ services:
             GROUPS_ENABLED: true
             EXTENDED_USAGE_ANALYTICS: true
 
+            # Enable most feature flags and the feature-flag management API so
+            # recent features can be tested here. On by default in preview
+            # (LIGHTDASH_MODE=pr) envs, so this is only needed for dev mode.
+            # See docs/preview-feature-flags.md
+            LIGHTDASH_PREVIEW_FEATURE_FLAGS_ENABLED: true
+
             HEADLESS_BROWSER_HOST: headless-browser
             HEADLESS_BROWSER_PORT: 3000
             INTERNAL_LIGHTDASH_HOST: http://lightdash-dev:3000

--- a/docker/docker-compose.preview.yml
+++ b/docker/docker-compose.preview.yml
@@ -115,6 +115,12 @@ services:
             # network. Production requires PGWIRE_SSL_CERT_PATH/KEY_PATH.
             PGWIRE_SSL_MODE: disabled
 
+            # Most feature flags are enabled automatically in LIGHTDASH_MODE=pr,
+            # and admins can toggle them at runtime via /api/v2/feature-flag.
+            # See docs/preview-feature-flags.md. The legacy per-flag env vars
+            # below are still needed because they also set config fields (e.g.
+            # the health endpoint), not just the feature flag.
+
             # Force-enable embedding flag in preview envs so e2e tests work.
             # Picked up via LEGACY_ENABLE_ENV_VARS in parseConfig.ts → unified
             # enabledFeatureFlags allowlist (step 1a).

--- a/docs/preview-feature-flags.md
+++ b/docs/preview-feature-flags.md
@@ -1,0 +1,73 @@
+# Feature flags in preview environments
+
+Preview environments (`LIGHTDASH_MODE=pr`) and the Okteto agent dev environment
+enable most feature flags by default and expose an API for toggling them, so QA
+can validate recent features without a redeploy.
+
+## Defaults
+
+`PREVIEW_ENABLED_FEATURE_FLAGS` (`packages/common/src/featureFlags/previewFeatureFlags.ts`)
+is every flag in `FeatureFlags` and `CommercialFeatureFlags` minus a short
+exclusion list. New flags are therefore on in previews by default; add an
+exclusion, with a reason, when that isn't safe. Flags are excluded when they:
+
+- block or degrade every page (trial block/warning),
+- change query or compile semantics, so QA results would mislead,
+- change the signup flow (`new-onboarding` also needs SMTP for its email OTP,
+  and the register page evaluates it anonymously so no override can undo it),
+- act outside the environment (`ai-preview-deploy-setup` opens pull requests on
+  real repos),
+- are off pending a security review, or are deprecated,
+- derive their value from instance configuration (`ai-copilot`,
+  `results-cache-enabled`, `enable-timezone-support`) — these are left to their
+  config handler so a preview never advertises an unconfigured backend. To test
+  AI copilot in a preview, configure a provider (`AI_COPILOT_ENABLED` plus
+  credentials) rather than forcing the flag.
+
+Flags that only gate UI can still be enabled while their backend is
+unconfigured (for example email whitelabel needs a Postmark token, data apps
+need an app runtime). Those surfaces render but won't work end to end.
+
+This is controlled by `LIGHTDASH_PREVIEW_FEATURE_FLAGS_ENABLED`, which defaults
+to `true` in PR mode. Set it to `false` for production-like flag resolution, or
+`true` in any other environment (the Okteto dev compose file does this).
+
+## Managing flags at runtime
+
+The management endpoints require an organization admin and only work when
+`LIGHTDASH_PREVIEW_FEATURE_FLAGS_ENABLED` resolves to true — elsewhere they
+return 404. Overrides are stored per organization in `feature_flag_overrides`.
+
+```bash
+# List every flag with its resolved value
+curl -H "Authorization: ApiKey $LDPAT" "$SITE_URL/api/v2/feature-flag"
+
+# Turn a flag off (or on) for the organization
+curl -X POST -H "Authorization: ApiKey $LDPAT" -H 'Content-Type: application/json' \
+  -d '{"enabled": false}' "$SITE_URL/api/v2/feature-flag/enable-data-apps"
+
+# Drop the override and fall back to the environment default
+curl -X DELETE -H "Authorization: ApiKey $LDPAT" \
+  "$SITE_URL/api/v2/feature-flag/enable-data-apps"
+```
+
+Unknown flag ids are rejected, so a typo can't silently create a dead override.
+
+In an Okteto dev environment the backend runs from the committed TSOA output, so
+run `pnpm generate-api` (and restart the API) if these routes 404. Preview
+environments build with `pnpm build`, which regenerates them.
+
+## Resolution order
+
+`FeatureFlagModel.get()` resolves in this order:
+
+1. `LIGHTDASH_ENABLE_FEATURE_FLAGS` and `LIGHTDASH_DISABLE_FEATURE_FLAGS`. Enable
+   wins when a flag is in both; disable is absolute — no override overrides it.
+2. In preview environments, a stored override for the user or organization,
+   consulted only for flags the environment forces on.
+3. `PREVIEW_ENABLED_FEATURE_FLAGS`, in preview environments.
+4. Per-flag config handlers (for example `EDIT_YAML_IN_UI_ENABLED`).
+5. Database: user override, then organization override, then flag default.
+
+Consulting overrides costs a couple of extra indexed lookups per flag check, in
+preview environments only.

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -445,4 +445,5 @@ export const lightdashConfigMock: LightdashConfig = {
     },
     enabledFeatureFlags: new Set<string>(),
     disabledFeatureFlags: new Set<string>(),
+    previewFeatureFlags: { enabled: false },
 };

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -1472,6 +1472,20 @@ describe('feature flag env-var allowlists', () => {
         expect(config.disabledFeatureFlags.has('killed-flag')).toBe(true);
     });
 
+    test('previewFeatureFlags is off by default and on in PR mode', () => {
+        expect(parseConfig().previewFeatureFlags.enabled).toBe(false);
+        process.env.LIGHTDASH_MODE = LightdashMode.PR;
+        expect(parseConfig().previewFeatureFlags.enabled).toBe(true);
+    });
+
+    test('LIGHTDASH_PREVIEW_FEATURE_FLAGS_ENABLED overrides the mode default', () => {
+        process.env.LIGHTDASH_PREVIEW_FEATURE_FLAGS_ENABLED = 'true';
+        expect(parseConfig().previewFeatureFlags.enabled).toBe(true);
+        process.env.LIGHTDASH_MODE = LightdashMode.PR;
+        process.env.LIGHTDASH_PREVIEW_FEATURE_FLAGS_ENABLED = 'false';
+        expect(parseConfig().previewFeatureFlags.enabled).toBe(false);
+    });
+
     test('dashboardComments.enabled defaults to true when DISABLE_DASHBOARD_COMMENTS is unset', () => {
         delete process.env.DISABLE_DASHBOARD_COMMENTS;
         const config = parseConfig();

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1622,6 +1622,14 @@ export type LightdashConfig = {
     appRuntime: AppRuntimeConfig;
     enabledFeatureFlags: Set<string>;
     disabledFeatureFlags: Set<string>;
+    previewFeatureFlags: {
+        /**
+         * Preview/Okteto environments only: enables `PREVIEW_ENABLED_FEATURE_FLAGS`
+         * by default and exposes the feature-flag management API so QA can toggle
+         * flags at runtime. Defaults on in PR mode.
+         */
+        enabled: boolean;
+    };
 };
 
 export type SlackConfig = {
@@ -3157,5 +3165,13 @@ export const parseConfig = (): LightdashConfig => {
                 ([envVar]) => process.env[envVar] === 'true',
             ).map(([, flagId]) => flagId),
         ]),
+        previewFeatureFlags: {
+            enabled:
+                process.env.LIGHTDASH_PREVIEW_FEATURE_FLAGS_ENABLED ===
+                    'true' ||
+                (process.env.LIGHTDASH_PREVIEW_FEATURE_FLAGS_ENABLED !==
+                    'false' &&
+                    lightdashMode === LightdashMode.PR),
+        },
     };
 };

--- a/packages/backend/src/controllers/v2/FeatureFlagController.ts
+++ b/packages/backend/src/controllers/v2/FeatureFlagController.ts
@@ -1,8 +1,17 @@
-import { ApiErrorPayload, FeatureFlag, isJwtUser } from '@lightdash/common';
 import {
+    ApiErrorPayload,
+    assertRegisteredAccount,
+    FeatureFlag,
+    isJwtUser,
+} from '@lightdash/common';
+import {
+    Body,
+    Delete,
     Get,
+    Middlewares,
     OperationId,
     Path,
+    Post,
     Request,
     Response,
     Route,
@@ -11,12 +20,39 @@ import {
 } from '@tsoa/runtime';
 import express from 'express';
 import { toSessionUser } from '../../auth/account';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+} from '../authentication/middlewares';
 import { BaseController } from '../baseController';
 
 @Route('/api/v2/feature-flag')
 @Response<ApiErrorPayload>('default', 'Error')
 @Tags('v2', 'Feature Flag')
 export class FeatureFlagController extends BaseController {
+    /**
+     * List every known feature flag with its resolved value for the requesting
+     * user. Preview environments only.
+     * @summary List feature flags
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/')
+    @OperationId('List feature flags')
+    async listFeatureFlags(@Request() req: express.Request): Promise<{
+        status: 'ok';
+        results: FeatureFlag[];
+    }> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getFeatureFlagService()
+                .list(req.account),
+        };
+    }
+
     /**
      * Get feature flag
      * @summary Get feature flag
@@ -41,6 +77,66 @@ export class FeatureFlagController extends BaseController {
                         : undefined,
                 featureFlagId,
             }),
+        };
+    }
+
+    /**
+     * Override a feature flag for the requesting user's organization. Preview
+     * environments only — lets QA toggle flags without a redeploy.
+     * @summary Set feature flag override
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/{featureFlagId}')
+    @OperationId('Set feature flag override')
+    async setFeatureFlagOverride(
+        @Request() req: express.Request,
+        @Path() featureFlagId: string,
+        @Body() body: { enabled: boolean },
+    ): Promise<{
+        status: 'ok';
+        results: FeatureFlag;
+    }> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getFeatureFlagService()
+                .setOrganizationOverride({
+                    account: req.account,
+                    featureFlagId,
+                    enabled: body.enabled,
+                }),
+        };
+    }
+
+    /**
+     * Remove the organization override for a feature flag, restoring the
+     * environment default. Preview environments only.
+     * @summary Delete feature flag override
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Delete('/{featureFlagId}')
+    @OperationId('Delete feature flag override')
+    async deleteFeatureFlagOverride(
+        @Request() req: express.Request,
+        @Path() featureFlagId: string,
+    ): Promise<{
+        status: 'ok';
+        results: FeatureFlag;
+    }> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getFeatureFlagService()
+                .deleteOrganizationOverride({
+                    account: req.account,
+                    featureFlagId,
+                }),
         };
     }
 }

--- a/packages/backend/src/database/entities/featureFlags.ts
+++ b/packages/backend/src/database/entities/featureFlags.ts
@@ -31,5 +31,6 @@ export type FeatureFlagOverridesTable = Knex.CompositeTableType<
     DbFeatureFlagOverride,
     Pick<DbFeatureFlagOverride, 'flag_id' | 'enabled'> &
         Partial<Pick<DbFeatureFlagOverride, 'user_uuid' | 'organization_uuid'>>,
-    Pick<DbFeatureFlagOverride, 'enabled'>
+    Pick<DbFeatureFlagOverride, 'enabled'> &
+        Partial<Pick<DbFeatureFlagOverride, 'updated_at'>>
 >;

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
@@ -174,6 +174,19 @@ describe('FeatureFlagModel', () => {
             );
         });
 
+        it('does not record when the caller opts out', async () => {
+            const model = buildModel({
+                enabledFeatureFlags: new Set(['telemetry-flag']),
+            });
+
+            await model.get(
+                { featureFlagId: 'telemetry-flag' },
+                { recordCheck: false },
+            );
+
+            expect(vi.mocked(record)).not.toHaveBeenCalled();
+        });
+
         it('does not break resolution when recording throws', async () => {
             vi.mocked(record).mockImplementationOnce(() => {
                 throw new Error('telemetry failure');
@@ -279,6 +292,135 @@ describe('FeatureFlagModel', () => {
 
             const result = await model.get({
                 featureFlagId: FeatureFlags.UserGroupsEnabled,
+            });
+
+            expect(result.enabled).toBe(true);
+        });
+    });
+
+    describe('preview environment defaults', () => {
+        const previewConfig = { previewFeatureFlags: { enabled: true } };
+
+        it('enables flags in the preview set ahead of config handlers', async () => {
+            const model = buildModel({
+                ...previewConfig,
+                appRuntime: {
+                    ...lightdashConfigMock.appRuntime,
+                    enabled: false,
+                },
+            });
+
+            const result = await model.get({
+                featureFlagId: FeatureFlags.EnableDataApps,
+            });
+
+            expect(result.enabled).toBe(true);
+        });
+
+        it('leaves excluded flags to the normal resolution order', async () => {
+            const model = buildModel(
+                previewConfig,
+                buildFakeDatabase({ flag: { default_enabled: false } }),
+            );
+
+            const result = await model.get({
+                featureFlagId: FeatureFlags.OrganizationTrialBlock,
+                user: dbUser,
+            });
+
+            expect(result.enabled).toBe(false);
+        });
+
+        it('respects the disable-allowlist over the preview default', async () => {
+            const model = buildModel({
+                ...previewConfig,
+                disabledFeatureFlags: new Set([FeatureFlags.EnableDataApps]),
+            });
+
+            const result = await model.get({
+                featureFlagId: FeatureFlags.EnableDataApps,
+            });
+
+            expect(result.enabled).toBe(false);
+        });
+
+        it('keeps the disable-allowlist absolute against a stored override', async () => {
+            const model = buildModel(
+                {
+                    ...previewConfig,
+                    disabledFeatureFlags: new Set([
+                        FeatureFlags.EnableDataApps,
+                    ]),
+                },
+                buildFakeDatabase({ orgOverride: { enabled: true } }),
+            );
+
+            const result = await model.get({
+                featureFlagId: FeatureFlags.EnableDataApps,
+                user: dbUser,
+            });
+
+            expect(result.enabled).toBe(false);
+        });
+
+        it('leaves config-derived flags to their handler', async () => {
+            // ai-copilot, results-cache-enabled and enable-timezone-support are
+            // excluded so previews never advertise unconfigured backends.
+            const model = buildModel({
+                ...previewConfig,
+                results: {
+                    ...lightdashConfigMock.results,
+                    cacheEnabled: false,
+                },
+            });
+
+            const result = await model.get({
+                featureFlagId: FeatureFlags.ResultsCacheEnabled,
+            });
+
+            expect(result.enabled).toBe(false);
+        });
+
+        it('lets a stored organization override win over the preview default', async () => {
+            const model = buildModel(
+                previewConfig,
+                buildFakeDatabase({ orgOverride: { enabled: false } }),
+            );
+
+            const result = await model.get({
+                featureFlagId: FeatureFlags.EnableDataApps,
+                user: dbUser,
+            });
+
+            expect(result.enabled).toBe(false);
+        });
+
+        it('lets a stored organization override win over the enable-allowlist', async () => {
+            const model = buildModel(
+                {
+                    ...previewConfig,
+                    enabledFeatureFlags: new Set([FeatureFlags.EditYamlInUi]),
+                },
+                buildFakeDatabase({ orgOverride: { enabled: false } }),
+            );
+
+            const result = await model.get({
+                featureFlagId: FeatureFlags.EditYamlInUi,
+                user: dbUser,
+            });
+
+            expect(result.enabled).toBe(false);
+        });
+
+        it('ignores stored overrides outside preview environments', async () => {
+            const model = buildModel(
+                { enabledFeatureFlags: new Set([FeatureFlags.EditYamlInUi]) },
+                buildFakeDatabase({ orgOverride: { enabled: false } }),
+            );
+
+            const result = await model.get({
+                featureFlagId: FeatureFlags.EditYamlInUi,
+                user: dbUser,
             });
 
             expect(result.enabled).toBe(true);
@@ -513,7 +655,9 @@ describe('FeatureFlagModel', () => {
             await expect(
                 model.ensureOrganizationOverrideEnabled(FLAG_ID, ORG_UUID),
             ).resolves.toBe('enabled');
-            expect(fake.flagInserts).toEqual([{ flag_id: FLAG_ID }]);
+            expect(fake.flagInserts).toEqual([
+                { flag_id: FLAG_ID, default_enabled: null },
+            ]);
             expect(fake.overrideInserts).toEqual([
                 {
                     flag_id: FLAG_ID,

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -1,4 +1,9 @@
-import { FeatureFlag, FeatureFlags, LightdashUser } from '@lightdash/common';
+import {
+    FeatureFlag,
+    FeatureFlags,
+    LightdashUser,
+    PREVIEW_ENABLED_FEATURE_FLAGS,
+} from '@lightdash/common';
 import { Knex } from 'knex';
 import { LightdashConfig } from '../../config/parseConfig';
 import {
@@ -11,6 +16,10 @@ import { record } from './flagCheckAggregator';
 const UUID_REGEX =
     /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+// Matches the feature_flag_overrides_org_idx partial unique index.
+const ORG_OVERRIDE_CONFLICT_TARGET =
+    '(flag_id, organization_uuid) WHERE organization_uuid IS NOT NULL AND user_uuid IS NULL';
+
 export type FeatureFlagLogicArgs = {
     user?: Pick<LightdashUser, 'userUuid' | 'organizationUuid'>;
     featureFlagId: string;
@@ -21,7 +30,11 @@ export type EnsureOrganizationOverrideOutcome =
     | 'already_enabled'
     | 'kept_disabled';
 
-type FeatureFlagQueryOptions = { trx?: Knex };
+type FeatureFlagQueryOptions = {
+    trx?: Knex;
+    /** Set false for admin listings so they don't inflate flag-usage telemetry. */
+    recordCheck?: boolean;
+};
 
 export class FeatureFlagModel {
     protected readonly database: Knex;
@@ -59,39 +72,72 @@ export class FeatureFlagModel {
         args: FeatureFlagLogicArgs,
         options: FeatureFlagQueryOptions = {},
     ): Promise<FeatureFlag> {
-        let result: FeatureFlag;
+        const result = await this.resolve(args, options);
 
-        // 1a. Check env var enable-allowlist (self-hosted escape hatch)
-        if (this.lightdashConfig.enabledFeatureFlags.has(args.featureFlagId)) {
-            result = { id: args.featureFlagId, enabled: true };
-        } else if (
-            this.lightdashConfig.disabledFeatureFlags.has(args.featureFlagId)
-        ) {
-            // 1b. Check env var disable-allowlist (self-hosted kill switch)
-            result = { id: args.featureFlagId, enabled: false };
-        } else {
-            // 2. Check per-flag config handlers
-            const handler = this.featureFlagHandlers[args.featureFlagId];
-            if (handler) {
-                result = await handler(args, options);
-            } else {
-                // 3. Check database (user override > org override > flag default)
-                const dbResult = await this.tryGetFromDatabase(args, options);
-                result = dbResult ?? { id: args.featureFlagId, enabled: false };
+        if (options.recordCheck !== false) {
+            try {
+                record(
+                    args.featureFlagId,
+                    args.user?.organizationUuid ?? null,
+                    result.enabled,
+                );
+            } catch {
+                return result;
             }
         }
 
-        try {
-            record(
-                args.featureFlagId,
-                args.user?.organizationUuid ?? null,
-                result.enabled,
-            );
-        } catch {
-            return result;
+        return result;
+    }
+
+    private async resolve(
+        args: FeatureFlagLogicArgs,
+        options: FeatureFlagQueryOptions,
+    ): Promise<FeatureFlag> {
+        // 1a. Env var enable-allowlist (self-hosted escape hatch) still wins
+        // over the disable-allowlist when a flag is in both.
+        const envEnabled = this.lightdashConfig.enabledFeatureFlags.has(
+            args.featureFlagId,
+        );
+
+        // 1b. Env var disable-allowlist is an absolute kill switch: not even a
+        // stored override may resurrect the flag.
+        if (
+            !envEnabled &&
+            this.lightdashConfig.disabledFeatureFlags.has(args.featureFlagId)
+        ) {
+            return { id: args.featureFlagId, enabled: false };
         }
 
-        return result;
+        // 2. Instance-wide enablement: the enable-allowlist and, in preview
+        // environments, the curated default set.
+        const forcedOn =
+            envEnabled ||
+            (this.lightdashConfig.previewFeatureFlags.enabled &&
+                PREVIEW_ENABLED_FEATURE_FLAGS.has(args.featureFlagId));
+        if (forcedOn) {
+            // Preview environments let a stored override win over the forced
+            // value so QA can toggle flags without a redeploy.
+            if (this.lightdashConfig.previewFeatureFlags.enabled) {
+                const override = await this.tryGetOverrideFromDatabase(
+                    args,
+                    options,
+                );
+                if (override) {
+                    return override;
+                }
+            }
+            return { id: args.featureFlagId, enabled: true };
+        }
+
+        // 3. Check per-flag config handlers
+        const handler = this.featureFlagHandlers[args.featureFlagId];
+        if (handler) {
+            return handler(args, options);
+        }
+
+        // 4. Check database (user override > org override > flag default)
+        const dbResult = await this.tryGetFromDatabase(args, options);
+        return dbResult ?? { id: args.featureFlagId, enabled: false };
     }
 
     private async getEditYamlInUiEnabled({
@@ -142,6 +188,26 @@ export class FeatureFlagModel {
         return dbResult ?? { id: args.featureFlagId, enabled: fallback };
     }
 
+    private static organizationOverrideQuery(
+        trx: Knex,
+        featureFlagId: string,
+        organizationUuid: string,
+    ) {
+        return trx(FeatureFlagOverridesTableName)
+            .where('flag_id', featureFlagId)
+            .where('organization_uuid', organizationUuid)
+            .whereNull('user_uuid');
+    }
+
+    // `default_enabled: null` means "no opinion", so a flag row created purely
+    // to hang an override off never disables the flag once the override is gone.
+    private static ensureFlagRow(trx: Knex, featureFlagId: string) {
+        return trx(FeatureFlagsTableName)
+            .insert({ flag_id: featureFlagId, default_enabled: null })
+            .onConflict('flag_id')
+            .ignore();
+    }
+
     // Insert-only enablement: an existing override row (including an explicit
     // enabled=false) is never modified.
     public async ensureOrganizationOverrideEnabled(
@@ -149,21 +215,18 @@ export class FeatureFlagModel {
         organizationUuid: string,
     ): Promise<EnsureOrganizationOverrideOutcome> {
         const getOrganizationOverride = () =>
-            this.database(FeatureFlagOverridesTableName)
-                .where('flag_id', featureFlagId)
-                .where('organization_uuid', organizationUuid)
-                .whereNull('user_uuid')
-                .first();
+            FeatureFlagModel.organizationOverrideQuery(
+                this.database,
+                featureFlagId,
+                organizationUuid,
+            ).first();
 
         const existing = await getOrganizationOverride();
         if (existing) {
             return existing.enabled ? 'already_enabled' : 'kept_disabled';
         }
 
-        await this.database(FeatureFlagsTableName)
-            .insert({ flag_id: featureFlagId })
-            .onConflict('flag_id')
-            .ignore();
+        await FeatureFlagModel.ensureFlagRow(this.database, featureFlagId);
 
         const inserted = await this.database(FeatureFlagOverridesTableName)
             .insert({
@@ -171,11 +234,7 @@ export class FeatureFlagModel {
                 organization_uuid: organizationUuid,
                 enabled: true,
             })
-            .onConflict(
-                this.database.raw(
-                    '(flag_id, organization_uuid) WHERE organization_uuid IS NOT NULL AND user_uuid IS NULL',
-                ),
-            )
+            .onConflict(this.database.raw(ORG_OVERRIDE_CONFLICT_TARGET))
             .ignore()
             .returning('feature_flag_override_id');
         if (inserted.length > 0) {
@@ -214,6 +273,40 @@ export class FeatureFlagModel {
         }
 
         // Priority: user override > org override > flag default
+        const override = await FeatureFlagModel.getOverrideFromDatabase(
+            args,
+            trx,
+        );
+        if (override) {
+            return override;
+        }
+
+        if (flag.default_enabled === null) {
+            return null;
+        }
+
+        return { id: args.featureFlagId, enabled: flag.default_enabled };
+    }
+
+    protected async tryGetOverrideFromDatabase(
+        args: FeatureFlagLogicArgs,
+        { trx = this.database }: FeatureFlagQueryOptions = {},
+    ): Promise<FeatureFlag | null> {
+        try {
+            return await FeatureFlagModel.getOverrideFromDatabase(args, trx);
+        } catch (e) {
+            Logger.warn(
+                `Failed to check feature flag override ${args.featureFlagId} from database, falling through: ${e}`,
+            );
+            return null;
+        }
+    }
+
+    // User override > org override. Returns null when neither exists.
+    private static async getOverrideFromDatabase(
+        args: FeatureFlagLogicArgs,
+        trx: Knex,
+    ): Promise<FeatureFlag | null> {
         // Skip the user-override lookup unless the userUuid is a real UUID.
         // Anonymous (embed/JWT) accounts use a non-UUID externalId for
         // `user.userUuid`; passing it to a `uuid` column raises a Postgres
@@ -245,10 +338,38 @@ export class FeatureFlagModel {
             }
         }
 
-        if (flag.default_enabled === null) {
-            return null;
-        }
+        return null;
+    }
 
-        return { id: args.featureFlagId, enabled: flag.default_enabled };
+    // Upserts the organization-level override, creating the parent flag row
+    // when it doesn't exist yet.
+    public async upsertOrganizationOverride(
+        featureFlagId: string,
+        organizationUuid: string,
+        enabled: boolean,
+    ): Promise<void> {
+        await this.database.transaction(async (trx) => {
+            await FeatureFlagModel.ensureFlagRow(trx, featureFlagId);
+
+            await trx(FeatureFlagOverridesTableName)
+                .insert({
+                    flag_id: featureFlagId,
+                    organization_uuid: organizationUuid,
+                    enabled,
+                })
+                .onConflict(trx.raw(ORG_OVERRIDE_CONFLICT_TARGET))
+                .merge({ enabled, updated_at: new Date() });
+        });
+    }
+
+    public async deleteOrganizationOverride(
+        featureFlagId: string,
+        organizationUuid: string,
+    ): Promise<void> {
+        await FeatureFlagModel.organizationOverrideQuery(
+            this.database,
+            featureFlagId,
+            organizationUuid,
+        ).delete();
     }
 }

--- a/packages/backend/src/services/FeatureFlag/FeatureFlagService.test.ts
+++ b/packages/backend/src/services/FeatureFlag/FeatureFlagService.test.ts
@@ -1,7 +1,9 @@
 import { Ability } from '@casl/ability';
 import {
+    ALL_FEATURE_FLAG_IDS,
     OrganizationMemberRole,
     type PossibleAbilities,
+    type RegisteredAccount,
     type SessionUser,
 } from '@lightdash/common';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
@@ -35,17 +37,51 @@ const buildUser = (ability: Ability<PossibleAbilities>): SessionUser =>
         timezone: null,
     }) as unknown as SessionUser;
 
-const buildService = () => {
+const buildService = ({
+    previewFeatureFlagsEnabled = false,
+}: { previewFeatureFlagsEnabled?: boolean } = {}) => {
     const ensureOrganizationOverrideEnabled = vi.fn(async () => 'enabled');
+    const upsertOrganizationOverride = vi.fn(async () => {});
+    const deleteOrganizationOverride = vi.fn(async () => {});
+    const get = vi.fn(async ({ featureFlagId }: { featureFlagId: string }) => ({
+        id: featureFlagId,
+        enabled: true,
+    }));
     const featureFlagModel = {
         ensureOrganizationOverrideEnabled,
+        upsertOrganizationOverride,
+        deleteOrganizationOverride,
+        get,
     } as unknown as FeatureFlagModel;
     const service = new FeatureFlagService({
-        lightdashConfig: lightdashConfigMock,
+        lightdashConfig: {
+            ...lightdashConfigMock,
+            previewFeatureFlags: { enabled: previewFeatureFlagsEnabled },
+        },
         featureFlagModel,
     });
-    return { service, ensureOrganizationOverrideEnabled };
+    return {
+        service,
+        ensureOrganizationOverrideEnabled,
+        upsertOrganizationOverride,
+        deleteOrganizationOverride,
+        get,
+    };
 };
+
+const adminAbility = () =>
+    new Ability<PossibleAbilities>([
+        { action: 'manage', subject: 'Organization' },
+    ]);
+
+const buildAccount = (ability: Ability<PossibleAbilities>) =>
+    ({
+        organization: { organizationUuid, name: 'Organization' },
+        user: { userUuid: '00000000-0000-0000-0000-000000000002', ability },
+        authentication: { type: 'session' },
+        isAnonymousUser: () => false,
+        isServiceAccount: () => false,
+    }) as unknown as RegisteredAccount;
 
 describe('FeatureFlagService', () => {
     describe('ensureOrganizationOverrideEnabled', () => {
@@ -109,6 +145,112 @@ describe('FeatureFlagService', () => {
                 }),
             ).toThrow('User is not part of an organization');
             expect(ensureOrganizationOverrideEnabled).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('preview flag management', () => {
+        it('upserts an organization override and returns the resolved flag', async () => {
+            const { service, upsertOrganizationOverride } = buildService({
+                previewFeatureFlagsEnabled: true,
+            });
+
+            await expect(
+                service.setOrganizationOverride({
+                    account: buildAccount(adminAbility()),
+                    featureFlagId: 'enable-data-apps',
+                    enabled: false,
+                }),
+            ).resolves.toEqual({ id: 'enable-data-apps', enabled: true });
+            expect(upsertOrganizationOverride).toHaveBeenCalledExactlyOnceWith(
+                'enable-data-apps',
+                organizationUuid,
+                false,
+            );
+        });
+
+        it('deletes an organization override', async () => {
+            const { service, deleteOrganizationOverride } = buildService({
+                previewFeatureFlagsEnabled: true,
+            });
+
+            await service.deleteOrganizationOverride({
+                account: buildAccount(adminAbility()),
+                featureFlagId: 'enable-data-apps',
+            });
+            expect(deleteOrganizationOverride).toHaveBeenCalledExactlyOnceWith(
+                'enable-data-apps',
+                organizationUuid,
+            );
+        });
+
+        it('rejects an unknown flag id without writing', async () => {
+            const { service, upsertOrganizationOverride } = buildService({
+                previewFeatureFlagsEnabled: true,
+            });
+
+            await expect(
+                service.setOrganizationOverride({
+                    account: buildAccount(adminAbility()),
+                    featureFlagId: 'enable-data-app',
+                    enabled: true,
+                }),
+            ).rejects.toThrow('Unknown feature flag "enable-data-app"');
+            expect(upsertOrganizationOverride).not.toHaveBeenCalled();
+        });
+
+        it('lists every known flag without recording a flag check', async () => {
+            const { service, get } = buildService({
+                previewFeatureFlagsEnabled: true,
+            });
+
+            const results = await service.list(buildAccount(adminAbility()));
+
+            expect(results.map(({ id }) => id)).toEqual([
+                ...ALL_FEATURE_FLAG_IDS,
+            ]);
+            expect(get).toHaveBeenCalledTimes(ALL_FEATURE_FLAG_IDS.length);
+            expect(get).toHaveBeenLastCalledWith(expect.anything(), {
+                recordCheck: false,
+            });
+        });
+
+        it('is unavailable outside preview environments', async () => {
+            const { service, upsertOrganizationOverride } = buildService();
+            const account = buildAccount(adminAbility());
+
+            await expect(service.list(account)).rejects.toThrow(
+                'only available in preview environments',
+            );
+            await expect(
+                service.setOrganizationOverride({
+                    account,
+                    featureFlagId: 'enable-data-apps',
+                    enabled: true,
+                }),
+            ).rejects.toThrow('only available in preview environments');
+            expect(upsertOrganizationOverride).not.toHaveBeenCalled();
+        });
+
+        it('rejects a user without manage permission on the organization', async () => {
+            const { service, upsertOrganizationOverride } = buildService({
+                previewFeatureFlagsEnabled: true,
+            });
+            const account = buildAccount(
+                new Ability<PossibleAbilities>([
+                    { action: 'view', subject: 'Project' },
+                ]),
+            );
+
+            await expect(
+                service.setOrganizationOverride({
+                    account,
+                    featureFlagId: 'enable-data-apps',
+                    enabled: true,
+                }),
+            ).rejects.toThrow(
+                "You don't have access to this resource or action",
+            );
+            expect(upsertOrganizationOverride).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/backend/src/services/FeatureFlag/FeatureFlagService.ts
+++ b/packages/backend/src/services/FeatureFlag/FeatureFlagService.ts
@@ -1,12 +1,22 @@
 import { subject } from '@casl/ability';
 import {
+    ALL_FEATURE_FLAG_IDS,
     ForbiddenError,
-    LightdashUser,
+    isAccount,
+    isKnownFeatureFlagId,
+    NotFoundError,
+    ParameterError,
+    type FeatureFlag,
+    type LightdashUser,
+    type RegisteredAccount,
     type SessionUser,
 } from '@lightdash/common';
+import pLimit from 'p-limit';
 import { LightdashConfig } from '../../config/parseConfig';
 import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import { BaseService } from '../BaseService';
+
+const LIST_CONCURRENCY = 5;
 
 type FeatureFlagServiceArguments = {
     lightdashConfig: LightdashConfig;
@@ -34,6 +44,27 @@ export class FeatureFlagService extends BaseService {
         return this.featureFlagModel.get({ user, featureFlagId });
     }
 
+    // Returns the organization the caller is allowed to manage.
+    private assertOrganizationAdmin(
+        accountOrUser: RegisteredAccount | SessionUser,
+    ): string {
+        const organizationUuid = isAccount(accountOrUser)
+            ? accountOrUser.organization.organizationUuid
+            : accountOrUser.organizationUuid;
+        if (!organizationUuid) {
+            throw new ForbiddenError('User is not part of an organization');
+        }
+        if (
+            this.createAuditedAbility(accountOrUser).cannot(
+                'manage',
+                subject('Organization', { organizationUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+        return organizationUuid;
+    }
+
     ensureOrganizationOverrideEnabled({
         user,
         featureFlagId,
@@ -41,21 +72,97 @@ export class FeatureFlagService extends BaseService {
         user: SessionUser;
         featureFlagId: string;
     }) {
-        const { organizationUuid } = user;
-        if (!organizationUuid) {
-            throw new ForbiddenError('User is not part of an organization');
-        }
-        if (
-            this.createAuditedAbility(user).cannot(
-                'manage',
-                subject('Organization', { organizationUuid }),
-            )
-        ) {
-            throw new ForbiddenError();
-        }
+        const organizationUuid = this.assertOrganizationAdmin(user);
         return this.featureFlagModel.ensureOrganizationOverrideEnabled(
             featureFlagId,
             organizationUuid,
         );
+    }
+
+    /**
+     * Preview/Okteto environments only: lets QA list and toggle every flag for
+     * their organization without a redeploy.
+     */
+    private assertCanManageFlags(account: RegisteredAccount): string {
+        if (!this.lightdashConfig.previewFeatureFlags.enabled) {
+            throw new NotFoundError(
+                'Feature flag management is only available in preview environments',
+            );
+        }
+        return this.assertOrganizationAdmin(account);
+    }
+
+    private static assertKnownFlag(featureFlagId: string): void {
+        if (!isKnownFeatureFlagId(featureFlagId)) {
+            throw new ParameterError(`Unknown feature flag "${featureFlagId}"`);
+        }
+    }
+
+    private static toFlagUser(
+        account: RegisteredAccount,
+    ): Pick<LightdashUser, 'userUuid' | 'organizationUuid'> {
+        return {
+            userUuid: account.user.userUuid,
+            organizationUuid: account.organization.organizationUuid,
+        };
+    }
+
+    async list(account: RegisteredAccount): Promise<FeatureFlag[]> {
+        this.assertCanManageFlags(account);
+        const user = FeatureFlagService.toFlagUser(account);
+        // Bounded: resolving a flag costs up to three queries, and the preview
+        // connection pool also serves the rest of the app.
+        const limit = pLimit(LIST_CONCURRENCY);
+        return Promise.all(
+            ALL_FEATURE_FLAG_IDS.map((featureFlagId) =>
+                limit(() =>
+                    this.featureFlagModel.get(
+                        { user, featureFlagId },
+                        { recordCheck: false },
+                    ),
+                ),
+            ),
+        );
+    }
+
+    async setOrganizationOverride({
+        account,
+        featureFlagId,
+        enabled,
+    }: {
+        account: RegisteredAccount;
+        featureFlagId: string;
+        enabled: boolean;
+    }): Promise<FeatureFlag> {
+        const organizationUuid = this.assertCanManageFlags(account);
+        FeatureFlagService.assertKnownFlag(featureFlagId);
+        await this.featureFlagModel.upsertOrganizationOverride(
+            featureFlagId,
+            organizationUuid,
+            enabled,
+        );
+        return this.featureFlagModel.get({
+            user: FeatureFlagService.toFlagUser(account),
+            featureFlagId,
+        });
+    }
+
+    async deleteOrganizationOverride({
+        account,
+        featureFlagId,
+    }: {
+        account: RegisteredAccount;
+        featureFlagId: string;
+    }): Promise<FeatureFlag> {
+        const organizationUuid = this.assertCanManageFlags(account);
+        FeatureFlagService.assertKnownFlag(featureFlagId);
+        await this.featureFlagModel.deleteOrganizationOverride(
+            featureFlagId,
+            organizationUuid,
+        );
+        return this.featureFlagModel.get({
+            user: FeatureFlagService.toFlagUser(account),
+            featureFlagId,
+        });
     }
 }

--- a/packages/common/src/featureFlags/previewFeatureFlags.ts
+++ b/packages/common/src/featureFlags/previewFeatureFlags.ts
@@ -1,0 +1,53 @@
+import { CommercialFeatureFlags } from '../ee/commercialFeatureFlags';
+import { FeatureFlags } from '../types/featureFlags';
+
+/**
+ * Flags that must NOT be force-enabled in preview environments. Everything
+ * else is on by default there so QA can exercise recent features without a
+ * redeploy. Keep the reason next to each entry.
+ */
+const PREVIEW_EXCLUDED_FEATURE_FLAGS: ReadonlySet<string> = new Set<string>([
+    // Blocks or degrades every page.
+    FeatureFlags.OrganizationTrialBlock,
+    FeatureFlags.OrganizationTrialWarning,
+    // Changes query or compile semantics, so QA results would be misleading.
+    FeatureFlags.NaiveTimestampFilterRebase,
+    FeatureFlags.CalculateSeriesColor,
+    FeatureFlags.ReplaceCustomMetricsOnCompile,
+    // Needs per-org worker queues that previews don't run.
+    FeatureFlags.ScheduledDeliveryPerOrgQueue,
+    // Changes the signup flow and needs SMTP for the email OTP. The register
+    // page evaluates it anonymously, so an override can't switch it back off.
+    FeatureFlags.NewOnboarding,
+    // Acts outside the environment: opens pull requests on real repos.
+    FeatureFlags.AiPreviewDeploySetup,
+    // Off pending a security review, or only meaningful for eval orgs.
+    FeatureFlags.SsoOrganizationSettings,
+    FeatureFlags.AiReviewReplayCapture,
+    // Deprecated, kept only for persisted config.
+    FeatureFlags.AiAgentRevamp,
+    // Derived from instance configuration: left to their config handler so a
+    // preview never advertises a feature whose backend isn't configured.
+    CommercialFeatureFlags.AiCopilot,
+    FeatureFlags.ResultsCacheEnabled,
+    FeatureFlags.EnableTimezoneSupport,
+]);
+
+export const ALL_FEATURE_FLAG_IDS: readonly string[] = [
+    ...Object.values(FeatureFlags),
+    ...Object.values(CommercialFeatureFlags),
+].sort();
+
+const KNOWN_FEATURE_FLAG_IDS: ReadonlySet<string> = new Set(
+    ALL_FEATURE_FLAG_IDS,
+);
+
+export const isKnownFeatureFlagId = (flagId: string): boolean =>
+    KNOWN_FEATURE_FLAG_IDS.has(flagId);
+
+/** Flags enabled by default in preview/Okteto environments. */
+export const PREVIEW_ENABLED_FEATURE_FLAGS: ReadonlySet<string> = new Set(
+    ALL_FEATURE_FLAG_IDS.filter(
+        (flagId) => !PREVIEW_EXCLUDED_FEATURE_FLAGS.has(flagId),
+    ),
+);

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -123,6 +123,7 @@ export * from './types/email';
 export * from './types/errors';
 export * from './types/explore';
 export * from './types/favorites';
+export * from './featureFlags/previewFeatureFlags';
 export * from './types/featureFlags';
 export * from './types/impersonationOrganizationSettings';
 export * from './types/previewExpirationProjectSettings';


### PR DESCRIPTION
Closes:

### Description:

Release QA on a preview env couldn't validate several changes because Data Apps, AI agents and other flags were off. Preview/Okteto environments now enable most flags by default and expose an admin API to toggle them, so no redeploy is needed.

- **`PREVIEW_ENABLED_FEATURE_FLAGS`** (`packages/common/src/featureFlags/previewFeatureFlags.ts`) is every flag in `FeatureFlags` + `CommercialFeatureFlags` minus a documented exclusion list, so new flags are testable in previews by default. Excluded: flags that block/degrade every page, change query or compile semantics, change the signup flow (`new-onboarding` needs SMTP and is evaluated anonymously, so an override can't undo it), act outside the environment (`ai-preview-deploy-setup` opens PRs on real repos), are security-gated or deprecated, or derive their value from instance config (`ai-copilot`, `results-cache-enabled`, `enable-timezone-support` — left to their handler so a preview never advertises an unconfigured backend).
- **`GET`/`POST`/`DELETE /api/v2/feature-flag`** list and override flags per organization. Org admin only, 404 outside preview envs, and unknown flag ids are rejected so a typo can't create a dead override.
- In preview envs a stored override beats the forced-on value (that's what makes toggling work), but `LIGHTDASH_DISABLE_FEATURE_FLAGS` stays an absolute kill switch, and the existing "enable-allowlist wins when a flag is in both" contract is unchanged.

Gated by `LIGHTDASH_PREVIEW_FEATURE_FLAGS_ENABLED`, defaulting on in `LIGHTDASH_MODE=pr`; set explicitly for the Okteto dev compose file. `docs/preview-feature-flags.md` covers the flag set, the API and the full resolution order.

Notes for review:
- Turning ~35 flags on in previews changes what the e2e suite runs against. This PR's own preview build is the test of that — worth watching the e2e job, and the exclusion list is the place to fix any fallout.
- Consulting overrides adds a couple of indexed lookups per flag check, in preview envs only. `list()` is bounded with `p-limit` and skips flag-usage telemetry so it can't skew the "is this flag still used" signal.

Verified with `pnpm -F backend test` (5274 pass), `pnpm -F common test` (3181 pass), typecheck and lint on both packages, plus `pnpm generate-api` to confirm the three new routes register. No app was running in this sandbox, so the endpoints were not exercised against a live instance.
