### PR TITLE
fix: correct data-app link on homepage content cards

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
@@ -25,7 +25,7 @@ const contentUrl = (projectUuid: string, content: SummaryContent): string => {
         case ContentType.SPACE:
             return `/projects/${projectUuid}/spaces/${content.uuid}`;
         case ContentType.DATA_APP:
-            return `/projects/${projectUuid}/n${content.uuid}`;
+            return `/projects/${projectUuid}/apps/${content.uuid}/view`;
         default:
             return `/projects/${projectUuid}/saved/${content.uuid}`;
     }


### PR DESCRIPTION
On the new homepage, `ContentCard` built data-app links as `/projects/{projectUuid}/n{appUuid}` instead of `/projects/{projectUuid}/apps/{appUuid}/view`, so pinned/collection data-app cards led to a 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)