### PR TITLE
fix: expand blocked dbt environment variable keys

### DIFF
--- a/packages/common/src/types/projects.test.ts
+++ b/packages/common/src/types/projects.test.ts
@@ -38,6 +38,51 @@ describe('dbt environment variable validation', () => {
         expect(getDbtEnvironmentVariableKeyError('LD_PRELOAD')).toContain(
             'cannot be used',
         );
+        expect(getDbtEnvironmentVariableKeyError('GIT_EXEC_PATH')).toContain(
+            'cannot be used',
+        );
+        expect(getDbtEnvironmentVariableKeyError('GIT_TEMPLATE_DIR')).toContain(
+            'cannot be used',
+        );
+        expect(getDbtEnvironmentVariableKeyError('BASH_ENV')).toContain(
+            'cannot be used',
+        );
+        expect(getDbtEnvironmentVariableKeyError('HOME')).toContain(
+            'cannot be used',
+        );
+        expect(getDbtEnvironmentVariableKeyError('XDG_CONFIG_HOME')).toContain(
+            'cannot be used',
+        );
+    });
+
+    test('blocks proxy and CA-bundle overrides', () => {
+        expect(getDbtEnvironmentVariableKeyError('HTTP_PROXY')).toContain(
+            'cannot be used',
+        );
+        expect(getDbtEnvironmentVariableKeyError('HTTPS_PROXY')).toContain(
+            'cannot be used',
+        );
+        expect(getDbtEnvironmentVariableKeyError('ALL_PROXY')).toContain(
+            'cannot be used',
+        );
+        expect(getDbtEnvironmentVariableKeyError('http_proxy')).toContain(
+            'cannot be used',
+        );
+        expect(getDbtEnvironmentVariableKeyError('https_proxy')).toContain(
+            'cannot be used',
+        );
+        expect(getDbtEnvironmentVariableKeyError('all_proxy')).toContain(
+            'cannot be used',
+        );
+        expect(
+            getDbtEnvironmentVariableKeyError('REQUESTS_CA_BUNDLE'),
+        ).toContain('cannot be used');
+        expect(getDbtEnvironmentVariableKeyError('CURL_CA_BUNDLE')).toContain(
+            'cannot be used',
+        );
+        expect(getDbtEnvironmentVariableKeyError('SSL_CERT_FILE')).toContain(
+            'cannot be used',
+        );
     });
 
     test('reserves Lightdash profile variables for internal use', () => {

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -691,9 +691,17 @@ export const LIGHTDASH_DBT_PROFILE_ENV_VAR_PREFIX =
 const DBT_ENVIRONMENT_VARIABLE_KEY_REGEX = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 const BLOCKED_DBT_ENVIRONMENT_VARIABLE_KEYS = new Set([
+    'ALL_PROXY',
+    'BASH_ENV',
+    'CURL_CA_BUNDLE',
     'GIT_ASKPASS',
+    'GIT_EXEC_PATH',
     'GIT_SSH',
     'GIT_SSH_COMMAND',
+    'GIT_TEMPLATE_DIR',
+    'HOME',
+    'HTTPS_PROXY',
+    'HTTP_PROXY',
     'LD_AUDIT',
     'LD_LIBRARY_PATH',
     'LD_PRELOAD',
@@ -703,9 +711,15 @@ const BLOCKED_DBT_ENVIRONMENT_VARIABLE_KEYS = new Set([
     'PERL5OPT',
     'PYTHONHOME',
     'PYTHONPATH',
+    'REQUESTS_CA_BUNDLE',
     'RUBYOPT',
     'SHELL',
     'SSH_ASKPASS',
+    'SSL_CERT_FILE',
+    'XDG_CONFIG_HOME',
+    'all_proxy',
+    'http_proxy',
+    'https_proxy',
 ]);
 
 const BLOCKED_DBT_ENVIRONMENT_VARIABLE_KEY_PREFIXES = ['DYLD_', 'GIT_CONFIG_'];


### PR DESCRIPTION
Adds execution-influencing variables (BASH_ENV, GIT_EXEC_PATH, GIT_TEMPLATE_DIR, HOME, XDG_CONFIG_HOME) and proxy/CA-bundle overrides (HTTP(S)_PROXY, ALL_PROXY, REQUESTS_CA_BUNDLE, CURL_CA_BUNDLE, SSL_CERT_FILE) to the set of keys rejected in project dbt environment settings.

Linear: SPK-599