### PR TITLE
feat(data-apps): propose external connection config with AI

### DIFF
--- a/packages/backend/src/analytics/aiUsage.ts
+++ b/packages/backend/src/analytics/aiUsage.ts
@@ -29,7 +29,8 @@ export type AiCallFeature =
     | 'ai-agent-memory'
     | 'llm-judge'
     | 'data-app'
-    | 'managed-agent';
+    | 'managed-agent'
+    | 'external-connection-config';
 
 /**
  * Whether the AI call ran on Lightdash's own (instance) provider key or the

--- a/packages/backend/src/ee/controllers/externalConnectionController.ts
+++ b/packages/backend/src/ee/controllers/externalConnectionController.ts
@@ -2,6 +2,8 @@ import {
     assertRegisteredAccount,
     type ApiErrorPayload,
     type ApiListExternalConnectionSamplesResponse,
+    type ApiProposeExternalConnectionConfigRequest,
+    type ApiProposeExternalConnectionConfigResponse,
     type ApiSaveExternalConnectionSampleRequest,
     type ApiSaveExternalConnectionSampleResponse,
     type ApiTestExternalConnectionConfigRequest,
@@ -407,6 +409,37 @@ export class ExternalConnectionController extends BaseController {
             },
         );
         return { status: 'ok', results };
+    }
+
+    /**
+     * Ask AI to propose a connection config from a prose description. Returns
+     * a proposal to prefill the create wizard — persists nothing and never
+     * includes a secret. Admin-only.
+     * @summary Propose an external connection config
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('external-connections/propose-config')
+    @OperationId('proposeExternalConnectionConfig')
+    async proposeExternalConnectionConfig(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Body() body: ApiProposeExternalConnectionConfigRequest,
+    ): Promise<ApiProposeExternalConnectionConfigResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getService().proposeConfig(
+                req.account,
+                projectUuid,
+                body.description,
+            ),
+        };
     }
 
     /**

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -689,6 +689,13 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         repository.getSpacePermissionService(),
                     googleTokenProvider:
                         new GoogleServiceAccountTokenProvider(),
+                    orgAiCopilotConfigResolver: new OrgAiCopilotConfigResolver({
+                        lightdashConfig: context.lightdashConfig,
+                        aiOrganizationSettingsModel:
+                            models.getAiOrganizationSettingsModel(),
+                        featureFlagService: repository.getFeatureFlagService(),
+                        aiModelCatalog,
+                    }),
                 }),
             externalConnectionCoderService: ({ models, context, repository }) =>
                 new ExternalConnectionCoderService({

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
@@ -1,14 +1,31 @@
 import {
     ForbiddenError,
+    MissingConfigError,
     NotFoundError,
     ParameterError,
     type ExternalConnection,
+    type ExternalConnectionConfigProposal,
     type ExternalConnectionSample,
     type ExternalFetchResponse,
     type RegisteredAccount,
 } from '@lightdash/common';
 import { SecureFetchError } from '../../../utils/secureFetch/secureFetch';
+import { generateExternalConnectionConfigProposal } from '../ai/agents/externalConnectionConfigGenerator';
+import { getModel } from '../ai/models';
 import { ExternalConnectionService } from './ExternalConnectionService';
+
+vi.mock('../ai/models', () => ({
+    getModel: vi.fn().mockReturnValue({
+        model: { modelId: 'claude-sonnet-4-5', provider: 'anthropic' },
+        callOptions: {},
+        providerOptions: undefined,
+        keyManagement: 'lightdash-managed',
+    }),
+}));
+
+vi.mock('../ai/agents/externalConnectionConfigGenerator', () => ({
+    generateExternalConnectionConfigProposal: vi.fn(),
+}));
 
 // -------------------------------------------------------------------
 // Shared fixtures
@@ -89,6 +106,7 @@ function buildService(opts: {
     getSampleConnectionUuidFn?: import('vitest').Mock;
     linkToAppFn?: import('vitest').Mock;
     findAppFn?: import('vitest').Mock;
+    getCopilotConfigFn?: import('vitest').Mock;
 }) {
     const model = {
         findByUuid: vi
@@ -126,6 +144,14 @@ function buildService(opts: {
                 organization_uuid: orgUuid,
             }),
     };
+    const orgAiCopilotConfigResolver = {
+        getCopilotConfig:
+            opts.getCopilotConfigFn ??
+            vi.fn().mockResolvedValue({
+                defaultProvider: 'anthropic',
+                providers: {},
+            }),
+    };
     const service = new ExternalConnectionService({
         externalConnectionModel: model as never,
         appModel: {} as never,
@@ -136,8 +162,9 @@ function buildService(opts: {
         googleTokenProvider: {
             getAccessToken: vi.fn().mockResolvedValue('test-access-token'),
         } as never,
+        orgAiCopilotConfigResolver: orgAiCopilotConfigResolver as never,
     });
-    return { service, model };
+    return { service, model, orgAiCopilotConfigResolver };
 }
 
 // Spy on createAuditedAbility to control the CASL decision
@@ -938,5 +965,120 @@ describe('ExternalConnectionService.linkToApp alias validation', () => {
             ),
         ).resolves.toBeUndefined();
         expect(linkToAppFn).toHaveBeenCalled();
+    });
+});
+
+// -------------------------------------------------------------------
+// proposeConfig — AI proposal for the create wizard
+// -------------------------------------------------------------------
+describe('ExternalConnectionService proposeConfig', () => {
+    const proposal: ExternalConnectionConfigProposal = {
+        name: 'Example API',
+        origin: 'https://api.example.com',
+        type: 'bearer_token',
+        apiKeyName: null,
+        apiKeyLocation: null,
+        oauthScopes: null,
+        customHeaders: null,
+        allowedMethods: ['GET'],
+        allowedPathPrefixes: ['/v1'],
+        instructions: null,
+        credentialGuide: '1. Get a token',
+        docsUrl: null,
+        notes: null,
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(getModel).mockReturnValue({
+            model: {
+                modelId: 'claude-sonnet-4-5',
+                provider: 'anthropic',
+            },
+            callOptions: {},
+            providerOptions: undefined,
+            keyManagement: 'lightdash-managed',
+        } as never);
+        vi.mocked(generateExternalConnectionConfigProposal).mockResolvedValue(
+            proposal,
+        );
+    });
+
+    it('rejects callers without manage permission before any AI work', async () => {
+        const { service, orgAiCopilotConfigResolver } = buildService({});
+        mockAbility(service, false);
+
+        await expect(
+            service.proposeConfig(viewerAccount, projectUuid, 'connect to X'),
+        ).rejects.toThrow(ForbiddenError);
+        expect(
+            orgAiCopilotConfigResolver.getCopilotConfig,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('rejects a blank description', async () => {
+        const { service } = buildService({});
+        mockAbility(service, true);
+
+        await expect(
+            service.proposeConfig(adminAccount, projectUuid, '   '),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    it('rejects an oversized description', async () => {
+        const { service } = buildService({});
+        mockAbility(service, true);
+
+        await expect(
+            service.proposeConfig(adminAccount, projectUuid, 'x'.repeat(2001)),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    it('maps an unconfigured provider to MissingConfigError', async () => {
+        const { service } = buildService({});
+        mockAbility(service, true);
+        vi.mocked(getModel).mockImplementationOnce(() => {
+            throw new Error('anthropic api key is not configured');
+        });
+
+        await expect(
+            service.proposeConfig(adminAccount, projectUuid, 'connect to X'),
+        ).rejects.toThrow(MissingConfigError);
+        expect(generateExternalConnectionConfigProposal).not.toHaveBeenCalled();
+    });
+
+    it('generates from the trimmed description', async () => {
+        const { service } = buildService({});
+        mockAbility(service, true);
+
+        const result = await service.proposeConfig(
+            adminAccount,
+            projectUuid,
+            '  connect to Example  ',
+        );
+
+        expect(result).toEqual(proposal);
+        expect(generateExternalConnectionConfigProposal).toHaveBeenCalledWith(
+            expect.anything(),
+            'connect to Example',
+        );
+    });
+
+    it('pins the org-configured provider on bedrock', async () => {
+        const { service } = buildService({
+            getCopilotConfigFn: vi.fn().mockResolvedValue({
+                defaultProvider: 'bedrock',
+                providers: {},
+            }),
+        });
+        mockAbility(service, true);
+
+        await service.proposeConfig(adminAccount, projectUuid, 'connect to X');
+
+        expect(getModel).toHaveBeenCalledWith(expect.anything(), {
+            provider: 'bedrock',
+            modelName: 'claude-sonnet-4-5',
+            enableReasoning: false,
+        });
     });
 });

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
@@ -2,12 +2,15 @@ import { subject } from '@casl/ability';
 import {
     EXTERNAL_CONNECTION_DEFAULTS,
     ForbiddenError,
+    getErrorMessage,
+    MissingConfigError,
     NotFoundError,
     ParameterError,
     TooManyRequestsError,
     type ApiSaveExternalConnectionSampleRequest,
     type CreateExternalConnection,
     type ExternalConnection,
+    type ExternalConnectionConfigProposal,
     type ExternalConnectionMethod,
     type ExternalConnectionSample,
     type ExternalConnectionSampleRequest,
@@ -27,6 +30,10 @@ import {
     SecureFetchError,
 } from '../../../utils/secureFetch/secureFetch';
 import { type ExternalConnectionModel } from '../../models/ExternalConnectionModel';
+import { generateExternalConnectionConfigProposal } from '../ai/agents/externalConnectionConfigGenerator';
+import { getModel } from '../ai/models';
+import { type GeneratorModelOptions } from '../ai/models/types';
+import { type OrgAiCopilotConfigResolver } from '../ai/OrgAiCopilotConfigResolver';
 import { assertCanViewApp } from '../AppGenerateService/appAuthz';
 import {
     validateExternalConnectionConfig,
@@ -48,6 +55,7 @@ type ExternalConnectionServiceArguments = {
     appModel: AppModel;
     spacePermissionService: SpacePermissionService;
     googleTokenProvider: GoogleServiceAccountTokenProvider;
+    orgAiCopilotConfigResolver: OrgAiCopilotConfigResolver;
 };
 
 export class ExternalConnectionService extends BaseService {
@@ -61,7 +69,11 @@ export class ExternalConnectionService extends BaseService {
 
     private readonly googleTokenProvider: GoogleServiceAccountTokenProvider;
 
+    private readonly orgAiCopilotConfigResolver: OrgAiCopilotConfigResolver;
+
     private static readonly DEFAULT_RATE_LIMIT_PER_MINUTE = 60;
+
+    private static readonly MAX_PROPOSAL_DESCRIPTION_CHARS = 2_000;
 
     constructor(args: ExternalConnectionServiceArguments) {
         super();
@@ -70,6 +82,7 @@ export class ExternalConnectionService extends BaseService {
         this.appModel = args.appModel;
         this.spacePermissionService = args.spacePermissionService;
         this.googleTokenProvider = args.googleTokenProvider;
+        this.orgAiCopilotConfigResolver = args.orgAiCopilotConfigResolver;
     }
 
     private assertCanManage(
@@ -1227,6 +1240,76 @@ export class ExternalConnectionService extends BaseService {
             query: req.query,
             body: req.body,
         });
+    }
+
+    /**
+     * Admin-only. Ask an LLM to propose a connection config (plus a credential
+     * how-to guide) from a prose description. Persists nothing and never
+     * touches secrets — the proposal prefills the create wizard, where the
+     * user reviews every field and pastes the credential themselves.
+     */
+    async proposeConfig(
+        account: RegisteredAccount,
+        projectUuid: string,
+        description: string,
+    ): Promise<ExternalConnectionConfigProposal> {
+        // Derive the org from the project — never trust the caller — so an org
+        // admin cannot propose against another org's project.
+        const organizationUuid =
+            await this.externalConnectionModel.getProjectOrganizationUuid(
+                projectUuid,
+            );
+        if (!organizationUuid) {
+            throw new NotFoundError('Project not found');
+        }
+        this.assertCanManage(account, projectUuid, organizationUuid);
+
+        const trimmed = description.trim();
+        if (!trimmed) {
+            throw new ParameterError('Description is required');
+        }
+        if (
+            trimmed.length >
+            ExternalConnectionService.MAX_PROPOSAL_DESCRIPTION_CHARS
+        ) {
+            throw new ParameterError(
+                `Description must be at most ${ExternalConnectionService.MAX_PROPOSAL_DESCRIPTION_CHARS} characters`,
+            );
+        }
+
+        const copilot =
+            await this.orgAiCopilotConfigResolver.getCopilotConfig(
+                organizationUuid,
+            );
+        const provider: 'anthropic' | 'bedrock' =
+            copilot.defaultProvider === 'bedrock' ? 'bedrock' : 'anthropic';
+
+        let modelOptions: GeneratorModelOptions;
+        try {
+            modelOptions = {
+                ...getModel(copilot, {
+                    provider,
+                    modelName: 'claude-sonnet-4-5',
+                    enableReasoning: false,
+                }),
+                telemetry: {
+                    organizationUuid,
+                    projectUuid,
+                    userUuid: account.user.id,
+                },
+            };
+        } catch (error) {
+            this.logger.info(
+                `Cannot propose connection config: ${provider} not configured (${getErrorMessage(
+                    error,
+                )})`,
+            );
+            throw new MissingConfigError(
+                'AI is not configured for this organization',
+            );
+        }
+
+        return generateExternalConnectionConfigProposal(modelOptions, trimmed);
     }
 
     /**

--- a/packages/backend/src/ee/services/ai/agents/externalConnectionConfigGenerator.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/externalConnectionConfigGenerator.test.ts
@@ -1,0 +1,213 @@
+import {
+    ParameterError,
+    UnexpectedServerError,
+    type ExternalConnectionAuthType,
+} from '@lightdash/common';
+import { generateObject } from 'ai';
+import {
+    buildProposalSystemPrompt,
+    generateExternalConnectionConfigProposal,
+    normalizeProposal,
+} from './externalConnectionConfigGenerator';
+
+vi.mock('ai', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('ai')>()),
+    generateObject: vi.fn(),
+}));
+
+const modelOptions = {
+    model: {
+        modelId: 'claude-sonnet-4-5',
+        provider: 'anthropic',
+    },
+} as never;
+
+type RawProposalInput = Parameters<typeof normalizeProposal>[0];
+
+const rawProposal = (
+    overrides: Partial<{
+        confident: boolean;
+        name: string;
+        origin: string | null;
+        type: ExternalConnectionAuthType;
+        apiKeyName: string | null;
+        apiKeyLocation: 'header' | 'query' | null;
+        oauthScopes: string[] | null;
+        customHeaders: Array<{ name: string; value: string }> | null;
+        allowedMethods: string[];
+        allowedPathPrefixes: string[];
+        instructions: string | null;
+        credentialGuide: string | null;
+        docsUrl: string | null;
+        notes: string | null;
+    }> = {},
+): RawProposalInput =>
+    ({
+        confident: true,
+        name: 'Example API',
+        origin: 'https://api.example.com',
+        type: 'bearer_token' as ExternalConnectionAuthType,
+        apiKeyName: null,
+        apiKeyLocation: null,
+        oauthScopes: null,
+        customHeaders: null,
+        allowedMethods: ['GET'],
+        allowedPathPrefixes: ['/v1'],
+        instructions: null,
+        credentialGuide: '1. Create a token in the console',
+        docsUrl: 'https://docs.example.com/auth',
+        notes: null,
+        ...overrides,
+    }) as RawProposalInput;
+
+const mockGenerateObject = (objects: unknown[]) => {
+    const mock = vi.mocked(generateObject);
+    mock.mockReset();
+    objects.forEach((object) => {
+        mock.mockResolvedValueOnce({
+            object,
+            usage: { inputTokens: 1, outputTokens: 1 },
+        } as never);
+    });
+    return mock;
+};
+
+describe('buildProposalSystemPrompt', () => {
+    it('contains the security guardrails', () => {
+        const prompt = buildProposalSystemPrompt();
+        expect(prompt).toContain('official documented API host');
+        expect(prompt).toContain('confident=false');
+        expect(prompt).toContain('Least privilege');
+        expect(prompt).toContain(
+            'NEVER include, invent, or placeholder any credential value',
+        );
+        expect(prompt).toContain('google_service_account');
+        expect(prompt).toContain('client_email');
+    });
+});
+
+describe('normalizeProposal', () => {
+    it('clears type-foreign auth fields and nulls credentialGuide for public APIs', () => {
+        const result = normalizeProposal(
+            rawProposal({
+                type: 'none',
+                apiKeyName: 'x-api-key',
+                apiKeyLocation: 'header',
+                oauthScopes: ['https://example.com/scope'],
+                credentialGuide: 'not needed',
+                origin: 'https://api.example.com',
+            }),
+        );
+        expect(result.apiKeyName).toBeNull();
+        expect(result.apiKeyLocation).toBeNull();
+        expect(result.oauthScopes).toBeNull();
+        expect(result.credentialGuide).toBeNull();
+    });
+
+    it('defaults the api key location to header when missing', () => {
+        const result = normalizeProposal(
+            rawProposal({
+                type: 'api_key',
+                apiKeyName: ' x-api-key ',
+                apiKeyLocation: null,
+            }),
+        );
+        expect(result.apiKeyName).toBe('x-api-key');
+        expect(result.apiKeyLocation).toBe('header');
+    });
+
+    it('converts header pairs to a record, dropping blank entries', () => {
+        const result = normalizeProposal(
+            rawProposal({
+                customHeaders: [
+                    { name: ' anthropic-version ', value: ' 2023-06-01 ' },
+                    { name: '', value: 'orphan' },
+                    { name: 'empty-value', value: '  ' },
+                ],
+            }),
+        );
+        expect(result.customHeaders).toEqual({
+            'anthropic-version': '2023-06-01',
+        });
+    });
+
+    it('falls back to safe defaults for empty methods and paths', () => {
+        const result = normalizeProposal(
+            rawProposal({
+                allowedMethods: [],
+                allowedPathPrefixes: ['v1/messages', '  '],
+            }),
+        );
+        expect(result.allowedMethods).toEqual(['GET']);
+        expect(result.allowedPathPrefixes).toEqual(['/v1/messages']);
+    });
+
+    it('strips trailing slash from origin and rejects non-https docs urls', () => {
+        const result = normalizeProposal(
+            rawProposal({
+                origin: 'https://api.example.com/',
+                docsUrl: 'http://docs.example.com/auth',
+            }),
+        );
+        expect(result.origin).toBe('https://api.example.com');
+        expect(result.docsUrl).toBeNull();
+    });
+});
+
+describe('generateExternalConnectionConfigProposal', () => {
+    const description = 'connect to Example';
+
+    it('rejects an unconfident proposal with a friendly error', async () => {
+        mockGenerateObject([rawProposal({ confident: false, origin: null })]);
+
+        await expect(
+            generateExternalConnectionConfigProposal(modelOptions, description),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    it('returns a valid proposal without a repair round', async () => {
+        const mock = mockGenerateObject([rawProposal()]);
+
+        const result = await generateExternalConnectionConfigProposal(
+            modelOptions,
+            description,
+        );
+
+        expect(result.origin).toBe('https://api.example.com');
+        expect(mock).toHaveBeenCalledTimes(1);
+    });
+
+    it('repairs an invalid proposal once with the validation error appended', async () => {
+        const invalid = rawProposal({ origin: 'https://api.example.com/v1' });
+        const mock = mockGenerateObject([invalid, rawProposal()]);
+
+        const result = await generateExternalConnectionConfigProposal(
+            modelOptions,
+            description,
+        );
+
+        expect(result.origin).toBe('https://api.example.com');
+        expect(mock).toHaveBeenCalledTimes(2);
+        const retryMessages = (mock.mock.calls[1][0] as { messages: unknown[] })
+            .messages;
+        expect(retryMessages).toEqual(
+            expect.arrayContaining([
+                { role: 'assistant', content: JSON.stringify(invalid) },
+                expect.objectContaining({
+                    role: 'user',
+                    content: expect.stringContaining('invalid'),
+                }),
+            ]),
+        );
+    });
+
+    it('gives up after a failed repair round', async () => {
+        const invalid = rawProposal({ origin: 'https://api.example.com/v1' });
+        const mock = mockGenerateObject([invalid, invalid]);
+
+        await expect(
+            generateExternalConnectionConfigProposal(modelOptions, description),
+        ).rejects.toThrow(UnexpectedServerError);
+        expect(mock).toHaveBeenCalledTimes(2);
+    });
+});

--- a/packages/backend/src/ee/services/ai/agents/externalConnectionConfigGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/externalConnectionConfigGenerator.ts
@@ -1,0 +1,335 @@
+import {
+    EXTERNAL_CONNECTION_METHODS,
+    ParameterError,
+    UnexpectedServerError,
+    type ExternalConnectionConfigProposal,
+    type ExternalConnectionMethod,
+} from '@lightdash/common';
+import { generateObject } from 'ai';
+import { z } from 'zod';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../analytics/aiUsage';
+import Logger from '../../../../logging/logger';
+import {
+    validateExternalConnectionConfig,
+    type ValidatableExternalConnectionConfig,
+} from '../../ExternalConnectionService/externalConnectionConfigValidation';
+import { GeneratorModelOptions } from '../models/types';
+import { getGeneratorTelemetry } from '../utils/aiCallTelemetry';
+
+const PROPOSAL_TIMEOUT_MS = 30_000;
+const MAX_PATH_PREFIXES = 20;
+const MAX_CUSTOM_HEADERS = 20;
+const MAX_OAUTH_SCOPES = 10;
+
+// The wizard hides content types and always creates JSON connections; the
+// proposal validates against the same default so what the user saves is what
+// was checked here.
+const PROPOSAL_ALLOWED_CONTENT_TYPES = ['application/json'];
+
+const NOT_CONFIDENT_MESSAGE =
+    'Couldn\'t identify which API to connect to. Try naming the provider explicitly, e.g. "the Google Sheets API".';
+
+// No `.max()` on arrays (Anthropic structured output rejects maxItems) and no
+// z.record (it emits additionalProperties) — caps live in the prompt and are
+// enforced in normalizeProposal; headers travel as name/value pairs.
+const ProposalSchema = z.object({
+    confident: z
+        .boolean()
+        .describe(
+            'False when no specific API service could be identified from the description',
+        ),
+    name: z
+        .string()
+        .describe('Short human-readable connection name, e.g. "Google Sheets"'),
+    origin: z
+        .string()
+        .nullable()
+        .describe(
+            'Official https base URL of the API host with no path, e.g. https://sheets.googleapis.com. Null when not confident.',
+        ),
+    type: z
+        .enum(['none', 'api_key', 'bearer_token', 'google_service_account'])
+        .describe('How the API authenticates requests'),
+    apiKeyName: z
+        .string()
+        .nullable()
+        .describe(
+            'Header or query parameter name carrying the API key; only for type api_key',
+        ),
+    apiKeyLocation: z
+        .enum(['header', 'query'])
+        .nullable()
+        .describe('Where the API key is sent; only for type api_key'),
+    oauthScopes: z
+        .array(z.string())
+        .nullable()
+        .describe(
+            'Least-privilege Google OAuth scopes; only for type google_service_account',
+        ),
+    customHeaders: z
+        .array(z.object({ name: z.string(), value: z.string() }))
+        .nullable()
+        .describe(
+            'Static non-secret headers required on every request (e.g. version headers). Never credentials.',
+        ),
+    allowedMethods: z
+        .array(z.enum(EXTERNAL_CONNECTION_METHODS))
+        .describe('HTTP methods the use case needs; least privilege'),
+    allowedPathPrefixes: z
+        .array(z.string())
+        .describe(
+            'Absolute path prefixes (starting with /) the connection may call; narrowest set that serves the use case',
+        ),
+    instructions: z
+        .string()
+        .nullable()
+        .describe(
+            'Guidance for the AI that builds data apps on this connection: key endpoints, request/response shapes, pagination, quirks',
+        ),
+    credentialGuide: z
+        .string()
+        .nullable()
+        .describe(
+            "Numbered markdown steps the user follows in the provider's console to obtain the credential; null for type none",
+        ),
+    docsUrl: z
+        .string()
+        .nullable()
+        .describe(
+            "URL of the provider's documentation page covering authentication/credentials",
+        ),
+    notes: z
+        .string()
+        .nullable()
+        .describe(
+            'Short caveats the user should double-check, e.g. region-specific hosts. Null when none.',
+        ),
+});
+
+type RawProposal = z.infer<typeof ProposalSchema>;
+
+export const buildProposalSystemPrompt = (): string =>
+    `You configure outbound HTTP connections ("external connections") for Lightdash data apps. A connection is an egress allowlist plus auth config enforced by a server-side proxy. Propose exactly one connection config for the user's described integration.
+
+FIELD SEMANTICS:
+- origin: the https base URL of the API host — bare host, no path or query (e.g. https://sheets.googleapis.com).
+- allowedPathPrefixes: absolute path prefixes (starting with /) the proxy allows, matched on whole path segments.
+- allowedMethods: HTTP methods the proxy allows.
+- type api_key: credential sent as a header or query parameter — set apiKeyName and apiKeyLocation.
+- type bearer_token: credential sent as "Authorization: Bearer <token>".
+- type google_service_account: service-account keyfile JSON with least-privilege oauthScopes.
+- type none: public API, no credential.
+- customHeaders: static NON-SECRET headers sent on every request (e.g. version headers like anthropic-version). Never put credentials here — credential-shaped header names are rejected.
+- instructions: guidance for the AI that later builds data apps on this connection — key endpoints, request/response shapes, pagination, quirks. At most ~1500 characters.
+- credentialGuide: numbered markdown steps the user follows in the provider's console to create or find the credential, using the least-privilege role/scope, ending with a link to the relevant docs page. Null only for type none.
+- docsUrl: URL of the provider's authentication/credentials docs page.
+- notes: short caveats the user must double-check (e.g. region-specific hosts, plan requirements). Null when none.
+
+RULES:
+- The origin MUST be the provider's official documented API host. Never guess lookalike domains or regional variants you are unsure about. If you cannot confidently identify a specific service, set confident=false and origin=null instead of guessing.
+- Least privilege: propose the narrowest allowedPathPrefixes and allowedMethods that serve the described use case. GET-only unless the use case clearly needs writes. Use ["/"] only when the API genuinely requires broad path access.
+- NEVER include, invent, or placeholder any credential value anywhere in the config.
+- For Google-hosted APIs prefer type google_service_account with minimal scopes, and make credentialGuide mention sharing the target resource with the service account's client_email.
+- At most ${MAX_PATH_PREFIXES} allowedPathPrefixes, ${MAX_CUSTOM_HEADERS} customHeaders, and ${MAX_OAUTH_SCOPES} oauthScopes.`;
+
+const buildUserContent = (description: string): string =>
+    `Set up a connection for this request:
+"${description}"`;
+
+const normalizeString = (value: string | null): string | null => {
+    const trimmed = value?.trim();
+    return trimmed ? trimmed : null;
+};
+
+const normalizeOrigin = (origin: string): string => {
+    const trimmed = origin.trim();
+    return trimmed.endsWith('/') && !trimmed.endsWith('//')
+        ? trimmed.slice(0, -1)
+        : trimmed;
+};
+
+const normalizeMethods = (
+    methods: ExternalConnectionMethod[],
+): ExternalConnectionMethod[] => {
+    const unique = EXTERNAL_CONNECTION_METHODS.filter((method) =>
+        methods.includes(method),
+    );
+    return unique.length > 0 ? unique : ['GET'];
+};
+
+const normalizePathPrefixes = (prefixes: string[]): string[] => {
+    const cleaned = prefixes
+        .map((prefix) => prefix.trim())
+        .filter((prefix) => prefix.length > 0)
+        .map((prefix) => (prefix.startsWith('/') ? prefix : `/${prefix}`));
+    const unique = [...new Set(cleaned)].slice(0, MAX_PATH_PREFIXES);
+    return unique.length > 0 ? unique : ['/'];
+};
+
+const normalizeCustomHeaders = (
+    headers: Array<{ name: string; value: string }> | null,
+): Record<string, string> | null => {
+    if (headers === null) return null;
+    const entries = headers
+        .map(({ name, value }) => [name.trim(), value.trim()] as const)
+        .filter(([name, value]) => name.length > 0 && value.length > 0)
+        .slice(0, MAX_CUSTOM_HEADERS);
+    if (entries.length === 0) return null;
+    return Object.fromEntries(entries);
+};
+
+const isHttpsUrl = (value: string): boolean => {
+    try {
+        return new URL(value).protocol === 'https:';
+    } catch {
+        return false;
+    }
+};
+
+export const normalizeProposal = (
+    raw: RawProposal & { origin: string },
+): ExternalConnectionConfigProposal => {
+    const origin = normalizeOrigin(raw.origin);
+    const isApiKey = raw.type === 'api_key';
+    const isGoogle = raw.type === 'google_service_account';
+    const oauthScopes = isGoogle
+        ? (raw.oauthScopes ?? [])
+              .map((scope) => scope.trim())
+              .filter((scope) => scope.length > 0)
+              .slice(0, MAX_OAUTH_SCOPES)
+        : null;
+    const docsUrl = normalizeString(raw.docsUrl);
+    let name = raw.name.trim();
+    if (name.length === 0) {
+        try {
+            name = new URL(origin).hostname;
+        } catch {
+            name = origin;
+        }
+    }
+    return {
+        name,
+        origin,
+        type: raw.type,
+        apiKeyName: isApiKey ? normalizeString(raw.apiKeyName) : null,
+        apiKeyLocation: isApiKey ? (raw.apiKeyLocation ?? 'header') : null,
+        oauthScopes,
+        customHeaders: normalizeCustomHeaders(raw.customHeaders),
+        allowedMethods: normalizeMethods(raw.allowedMethods),
+        allowedPathPrefixes: normalizePathPrefixes(raw.allowedPathPrefixes),
+        instructions: normalizeString(raw.instructions),
+        credentialGuide:
+            raw.type === 'none' ? null : normalizeString(raw.credentialGuide),
+        docsUrl: docsUrl !== null && isHttpsUrl(docsUrl) ? docsUrl : null,
+        notes: normalizeString(raw.notes),
+    };
+};
+
+const toValidatableConfig = (
+    proposal: ExternalConnectionConfigProposal,
+): ValidatableExternalConnectionConfig => ({
+    type: proposal.type,
+    origin: proposal.origin,
+    instructions: proposal.instructions,
+    allowedPathPrefixes: proposal.allowedPathPrefixes,
+    allowedMethods: proposal.allowedMethods,
+    allowedContentTypes: PROPOSAL_ALLOWED_CONTENT_TYPES,
+    apiKeyName: proposal.apiKeyName,
+    apiKeyLocation: proposal.apiKeyLocation,
+    oauthScopes: proposal.oauthScopes,
+    customHeaders: proposal.customHeaders,
+});
+
+const getValidationError = (
+    proposal: ExternalConnectionConfigProposal,
+): string | null => {
+    try {
+        validateExternalConnectionConfig(
+            toValidatableConfig(proposal),
+            proposal.type !== 'none',
+        );
+        return null;
+    } catch (error) {
+        if (error instanceof ParameterError) return error.message;
+        throw error;
+    }
+};
+
+export async function generateExternalConnectionConfigProposal(
+    modelOptions: GeneratorModelOptions,
+    description: string,
+): Promise<ExternalConnectionConfigProposal> {
+    const systemPrompt = buildProposalSystemPrompt();
+    const userContent = buildUserContent(description);
+
+    const callLLM = async (
+        extraMessages: Array<{
+            role: 'user' | 'assistant';
+            content: string;
+        }> = [],
+    ) => {
+        const telemetry = getGeneratorTelemetry(
+            modelOptions,
+            'generateExternalConnectionConfig',
+            'external-connection-config',
+        );
+        const result = await generateObject({
+            model: modelOptions.model,
+            ...modelOptions.callOptions,
+            providerOptions: modelOptions.providerOptions,
+            experimental_telemetry: telemetry,
+            schema: ProposalSchema,
+            abortSignal: AbortSignal.timeout(PROPOSAL_TIMEOUT_MS),
+            system: systemPrompt,
+            messages: [
+                { role: 'user', content: userContent },
+                ...extraMessages,
+            ],
+        });
+        emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
+        return result.object;
+    };
+
+    const assertConfident = (
+        raw: RawProposal,
+    ): RawProposal & { origin: string } => {
+        const origin = raw.origin?.trim();
+        if (!raw.confident || !origin) {
+            throw new ParameterError(NOT_CONFIDENT_MESSAGE);
+        }
+        return { ...raw, origin };
+    };
+
+    let raw = await callLLM();
+    let proposal = normalizeProposal(assertConfident(raw));
+
+    const validationError = getValidationError(proposal);
+    if (validationError) {
+        Logger.debug(
+            `AI-proposed connection config failed validation: ${validationError}. Retrying...`,
+        );
+        raw = await callLLM([
+            { role: 'assistant', content: JSON.stringify(raw) },
+            {
+                role: 'user',
+                content: `The proposed connection config is invalid: "${validationError}". Fix the config and return the corrected proposal. Remember the field rules from the system prompt.`,
+            },
+        ]);
+        proposal = normalizeProposal(assertConfident(raw));
+
+        const retryError = getValidationError(proposal);
+        if (retryError) {
+            Logger.warn(
+                `AI-proposed connection config failed validation after retry: ${retryError}`,
+            );
+            throw new UnexpectedServerError(
+                'Failed to generate a valid connection proposal. Try again, or set the connection up manually.',
+            );
+        }
+    }
+
+    return proposal;
+}

--- a/packages/common/src/ee/externalConnections/types.ts
+++ b/packages/common/src/ee/externalConnections/types.ts
@@ -157,6 +157,37 @@ export type ApiTestExternalConnectionResponse = {
     results: ExternalFetchResponse;
 };
 
+export type ApiProposeExternalConnectionConfigRequest = {
+    description: string;
+};
+
+/** AI-proposed connection config, shaped to prefill the create wizard. Never
+ *  carries a secret — the user pastes the credential themselves on the Auth
+ *  step. Kept flat for the same TSOA reason as
+ *  ApiTestExternalConnectionConfigRequest. */
+export type ExternalConnectionConfigProposal = {
+    name: string;
+    origin: string;
+    type: ExternalConnectionAuthType;
+    apiKeyName: string | null;
+    apiKeyLocation: ApiKeyLocation | null;
+    oauthScopes: string[] | null;
+    customHeaders: Record<string, string> | null;
+    allowedMethods: ExternalConnectionMethod[];
+    allowedPathPrefixes: string[];
+    instructions: string | null;
+    /** Markdown steps for obtaining the credential; null when type is 'none'. */
+    credentialGuide: string | null;
+    docsUrl: string | null;
+    /** Caveats the user should double-check before saving. */
+    notes: string | null;
+};
+
+export type ApiProposeExternalConnectionConfigResponse = {
+    status: 'ok';
+    results: ExternalConnectionConfigProposal;
+};
+
 /** The request that produced a sample (stored alongside the response). */
 export type ExternalConnectionSampleRequest = {
     method: ExternalConnectionMethod;


### PR DESCRIPTION
## Summary

Backend half of the automatic onboarding experience for data-app external connections: a new `POST /api/v1/ee/projects/{projectUuid}/external-connections/propose-config` endpoint takes a prose description ("I want to connect to Google Sheets") and returns an AI-proposed connection config plus a markdown credential how-to guide. The endpoint is inert until the follow-up frontend PR wires it into the create wizard.

## How it works

- **Single `generateObject` call from model knowledge** (~12–15s), resolved through the org copilot config (`claude-sonnet-4-5` on Anthropic or Bedrock, BYO keys respected). We prototyped a web-research phase using Anthropic's server-side web tools, but for the MVP it was cut: model knowledge produced equally good configs for every provider tested, and the research phase dominated latency (~40s) for no observed quality gain. Easy to reintroduce later for long-tail providers if needed.
- **Validated with the domain validator.** The proposal is normalized and checked with the same `validateExternalConnectionConfig` used at create time (`hasSecretAfter: true` for authed types, since the user will paste the secret). One repair round feeds the validation error back to the model; a second failure returns a generic 500.
- **No secrets anywhere.** The proposal never contains a credential; the prompt forbids inventing or placeholdering them, and the existing forbidden-header-name validation backstops `customHeaders`.
- **Gating.** `manage:ExternalConnection` via the existing `assertCanManage` (org derived from the project); `unauthorisedInDemo` since the call burns AI tokens. No feature flag — the surface is already gated by the data-apps flag on the frontend, and an unconfigured AI provider returns `MissingConfigError` (422) as the frontend's degrade signal.
- Usage attributed under a new `external-connection-config` AI-call feature bucket.

## Test plan

- Unit tests: prompt guardrails, proposal normalization, repair loop (mocked `ai`), and service-level permission/degradation branches (54 tests pass).
- Verified live against the dev stack: "connect to the Anthropic API" → correct origin, `x-api-key` header auth, `anthropic-version` custom header, least-privilege paths, numbered credential guide with console URL, in ~12s; "connect to my thing" → friendly 400.
- `pnpm generate-api` run locally to validate the TSOA contract (generated files intentionally not committed).

Relates: GLITCH-641

🤖 Generated with [Claude Code](https://claude.com/claude-code)