### PR TITLE
feat(data-apps): automatic AI setup option in the connection wizard

### DIFF
--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/AddConnectionWizard.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/AddConnectionWizard.tsx
@@ -1,12 +1,12 @@
 import {
-    type ApiKeyLocation,
     type CreateExternalConnection,
     type ExternalConnectionAuthType,
-    type ExternalConnectionMethod,
+    type ExternalConnectionConfigProposal,
     type ExternalConnectionSampleRequest,
     type ExternalFetchResponse,
 } from '@lightdash/common';
 import {
+    Anchor,
     JsonInput,
     PasswordInput,
     SegmentedControl,
@@ -15,10 +15,12 @@ import {
     Stepper,
     TagsInput,
     Text,
+    Textarea,
     TextInput,
 } from '@mantine-8/core';
 import { useForm, type UseFormReturnType } from '@mantine/form';
 import { IconPlugConnected } from '@tabler/icons-react';
+import MarkdownPreview from '@uiw/react-markdown-preview';
 import { type FC, useState } from 'react';
 import { CustomHeadersField } from '../../../features/externalConnections/components/CustomHeadersField';
 import { MethodsField } from '../../../features/externalConnections/components/MethodsField';
@@ -28,21 +30,24 @@ import {
     SUGGESTED_GOOGLE_SCOPES,
 } from '../../../features/externalConnections/constants';
 import { useCreateExternalConnection } from '../../../features/externalConnections/hooks/useCreateExternalConnection';
+import { useProposeConnectionConfig } from '../../../features/externalConnections/hooks/useProposeConnectionConfig';
 import { useSaveConnectionSample } from '../../../features/externalConnections/hooks/useSaveConnectionSample';
 import {
     customHeaderRowsToRecord,
     validateCustomHeaderRows,
-    type CustomHeaderRow,
 } from '../../../features/externalConnections/utils/customHeaders';
-import {
-    resolvePathPrefixes,
-    type PathMode,
-    type PathPrefix,
-} from '../../../features/externalConnections/utils/pathRules';
+import { resolvePathPrefixes } from '../../../features/externalConnections/utils/pathRules';
+import Callout from '../../common/Callout';
 import MantineModal, {
     type MantineModalProps,
 } from '../../common/MantineModal';
+import { AutomaticSetupStep } from './AutomaticSetupStep';
+import {
+    ConnectionModeChooser,
+    type ConnectionWizardMode,
+} from './ConnectionModeChooser';
 import { WizardTestStep } from './WizardTestStep';
+import { applyProposalToWizardValues, type WizardValues } from './wizardValues';
 
 // Content types stay hidden in the onboarding wizard and the optional numeric
 // limits fall back to server defaults. Power users tune them in the Edit form.
@@ -52,20 +57,6 @@ const DEFAULT_ALLOWED_CONTENT_TYPES = ['application/json'];
 const HTTP_TOKEN = /^[A-Za-z0-9!#$%&'*+.^_`|~-]+$/;
 
 const TEST_STEP = 3;
-
-type WizardValues = {
-    name: string;
-    origin: string;
-    type: ExternalConnectionAuthType;
-    secret: string;
-    apiKeyName: string;
-    apiKeyLocation: ApiKeyLocation;
-    oauthScopes: string[];
-    customHeaders: CustomHeaderRow[];
-    allowedMethods: ExternalConnectionMethod[];
-    pathMode: PathMode;
-    allowedPathPrefixes: PathPrefix[];
-};
 
 export type ConnectionTestResult = {
     request: ExternalConnectionSampleRequest;
@@ -104,6 +95,7 @@ const toCreatePayload = (values: WizardValues): CreateExternalConnection => ({
         values.allowedPathPrefixes,
     ),
     allowedContentTypes: DEFAULT_ALLOWED_CONTENT_TYPES,
+    instructions: values.instructions.trim() || null,
 });
 
 const ConnectStep: FC<{ form: UseFormReturnType<WizardValues> }> = ({
@@ -131,7 +123,10 @@ const ConnectStep: FC<{ form: UseFormReturnType<WizardValues> }> = ({
     </Stack>
 );
 
-const AuthStep: FC<{ form: UseFormReturnType<WizardValues> }> = ({ form }) => {
+const AuthStep: FC<{
+    form: UseFormReturnType<WizardValues>;
+    proposal: ExternalConnectionConfigProposal | null;
+}> = ({ form, proposal }) => {
     const { type } = form.values;
     return (
         <Stack gap="sm" mt="xl">
@@ -156,6 +151,37 @@ const AuthStep: FC<{ form: UseFormReturnType<WizardValues> }> = ({ form }) => {
                     }
                 />
             </Stack>
+
+            {proposal?.credentialGuide && (
+                <Callout variant="info" title="How to get your credential">
+                    <Stack gap="xs" align="flex-start">
+                        <MarkdownPreview
+                            source={proposal.credentialGuide}
+                            style={{
+                                backgroundColor: 'transparent',
+                                color: 'inherit',
+                                fontSize: 'var(--mantine-font-size-sm)',
+                            }}
+                        />
+                        {proposal.docsUrl && (
+                            <Anchor
+                                href={proposal.docsUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                fz="sm"
+                            >
+                                Open the provider's docs
+                            </Anchor>
+                        )}
+                    </Stack>
+                </Callout>
+            )}
+
+            {proposal?.notes && (
+                <Callout variant="warning" title="Double-check">
+                    {proposal.notes}
+                </Callout>
+            )}
 
             {type !== 'none' && type !== 'google_service_account' && (
                 <PasswordInput
@@ -244,6 +270,14 @@ const AccessStep: FC<{ form: UseFormReturnType<WizardValues> }> = ({
             }
             error={form.errors.allowedPathPrefixes}
         />
+        <Textarea
+            label="Usage notes for app generation (optional)"
+            description="Helps the AI use this API correctly when building apps: key endpoints, pagination, quirks"
+            autosize
+            minRows={2}
+            maxRows={6}
+            {...form.getInputProps('instructions')}
+        />
     </Stack>
 );
 
@@ -256,6 +290,10 @@ export const AddConnectionWizard: FC<Props> = ({
     onClose,
     projectUuid,
 }) => {
+    const [mode, setMode] = useState<'choose' | ConnectionWizardMode>('choose');
+    const [description, setDescription] = useState('');
+    const [proposal, setProposal] =
+        useState<ExternalConnectionConfigProposal | null>(null);
     const [active, setActive] = useState(0);
     // The last successful test on the current visit to the test step. Captured
     // verbatim so it can be saved as a sample after the connection is created.
@@ -268,6 +306,7 @@ export const AddConnectionWizard: FC<Props> = ({
         useCreateExternalConnection();
     const { mutateAsync: saveConnectionSample, isLoading: isSavingSample } =
         useSaveConnectionSample();
+    const proposeMutation = useProposeConnectionConfig();
 
     const form = useForm<WizardValues>({
         initialValues: {
@@ -282,6 +321,7 @@ export const AddConnectionWizard: FC<Props> = ({
             allowedMethods: ['GET'],
             pathMode: 'all',
             allowedPathPrefixes: [],
+            instructions: '',
         },
         validate: {
             name: (value) =>
@@ -341,6 +381,29 @@ export const AddConnectionWizard: FC<Props> = ({
             setTestResult(null);
         }
     };
+
+    const handleGenerate = () => {
+        const trimmed = description.trim();
+        if (trimmed.length === 0 || proposeMutation.isLoading) return;
+        proposeMutation.mutate(
+            { projectUuid, description: trimmed },
+            {
+                onSuccess: (result) => {
+                    form.setValues(applyProposalToWizardValues(result));
+                    form.clearErrors();
+                    setProposal(result);
+                    setTestResult(null);
+                    setMode('manual');
+                    // Land on Auth so the user pastes the credential first;
+                    // Basics and Rules stay reviewable by stepping back.
+                    setActive(1);
+                },
+            },
+        );
+    };
+
+    const aiUnavailable =
+        proposeMutation.error?.error.name === 'MissingConfigError';
 
     const goToAuth = () => {
         const name = form.validateField('name');
@@ -414,12 +477,28 @@ export const AddConnectionWizard: FC<Props> = ({
         | 'cancelDisabled'
         | 'onCancel'
     > = (() => {
+        if (mode === 'choose') {
+            return { cancelLabel: 'Cancel' };
+        }
+        if (mode === 'automatic') {
+            return {
+                onConfirm: handleGenerate,
+                confirmLabel: proposeMutation.isLoading
+                    ? 'Generating…'
+                    : 'Generate',
+                confirmLoading: proposeMutation.isLoading,
+                cancelLabel: 'Back',
+                cancelDisabled: proposeMutation.isLoading,
+                onCancel: () => setMode('choose'),
+            };
+        }
         switch (active) {
             case 0:
                 return {
                     onConfirm: goToAuth,
                     confirmLabel: 'Next',
-                    cancelLabel: 'Cancel',
+                    cancelLabel: 'Back',
+                    onCancel: () => setMode('choose'),
                 };
             case 1:
                 return {
@@ -457,33 +536,51 @@ export const AddConnectionWizard: FC<Props> = ({
             modalRootProps={{ closeOnClickOutside: false }}
             {...footerProps}
         >
-            <Stepper
-                active={active}
-                onStepClick={handleStepClick}
-                allowNextStepsSelect={false}
-                wrap={false}
-                size="sm"
-            >
-                <Stepper.Step label="Basics">
-                    <ConnectStep form={form} />
-                </Stepper.Step>
-                <Stepper.Step label="Auth">
-                    <AuthStep form={form} />
-                </Stepper.Step>
-                <Stepper.Step label="Rules">
-                    <AccessStep form={form} />
-                </Stepper.Step>
-                <Stepper.Step label="Test">
-                    <WizardTestStep
-                        projectUuid={projectUuid}
-                        config={config}
-                        allowedMethods={config.allowedMethods}
-                        onTestResult={setTestResult}
-                        saveSample={saveSample}
-                        onSaveSampleChange={setSaveSample}
-                    />
-                </Stepper.Step>
-            </Stepper>
+            {mode === 'choose' && (
+                <ConnectionModeChooser
+                    onChoose={setMode}
+                    aiUnavailable={aiUnavailable}
+                />
+            )}
+            {mode === 'automatic' && (
+                <AutomaticSetupStep
+                    description={description}
+                    onDescriptionChange={setDescription}
+                    onSubmit={handleGenerate}
+                    isLoading={proposeMutation.isLoading}
+                    error={proposeMutation.error}
+                    onSwitchToManual={() => setMode('manual')}
+                />
+            )}
+            {mode === 'manual' && (
+                <Stepper
+                    active={active}
+                    onStepClick={handleStepClick}
+                    allowNextStepsSelect={false}
+                    wrap={false}
+                    size="sm"
+                >
+                    <Stepper.Step label="Basics">
+                        <ConnectStep form={form} />
+                    </Stepper.Step>
+                    <Stepper.Step label="Auth">
+                        <AuthStep form={form} proposal={proposal} />
+                    </Stepper.Step>
+                    <Stepper.Step label="Rules">
+                        <AccessStep form={form} />
+                    </Stepper.Step>
+                    <Stepper.Step label="Test">
+                        <WizardTestStep
+                            projectUuid={projectUuid}
+                            config={config}
+                            allowedMethods={config.allowedMethods}
+                            onTestResult={setTestResult}
+                            saveSample={saveSample}
+                            onSaveSampleChange={setSaveSample}
+                        />
+                    </Stepper.Step>
+                </Stepper>
+            )}
         </MantineModal>
     );
 };

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/AutomaticSetupStep.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/AutomaticSetupStep.tsx
@@ -1,0 +1,83 @@
+import { type ApiError } from '@lightdash/common';
+import { Button, Stack, Text, Textarea } from '@mantine-8/core';
+import { type FC } from 'react';
+import Callout from '../../common/Callout';
+
+type Props = {
+    description: string;
+    onDescriptionChange: (value: string) => void;
+    onSubmit: () => void;
+    isLoading: boolean;
+    error: ApiError | null;
+    onSwitchToManual: () => void;
+};
+
+export const AutomaticSetupStep: FC<Props> = ({
+    description,
+    onDescriptionChange,
+    onSubmit,
+    isLoading,
+    error,
+    onSwitchToManual,
+}) => {
+    const aiUnavailable = error?.error.name === 'MissingConfigError';
+    return (
+        <Stack gap="sm" mt="xl">
+            <Text c="ldGray.6" fz="sm">
+                Describe what you want to connect to and AI will prefill the
+                connection — you review every step and paste the credential
+                yourself.
+            </Text>
+            <Textarea
+                autosize
+                minRows={3}
+                maxRows={8}
+                data-autofocus
+                disabled={isLoading}
+                placeholder="I want to connect to Google Sheets to read spreadsheet data…"
+                value={description}
+                onChange={(event) =>
+                    onDescriptionChange(event.currentTarget.value)
+                }
+                onKeyDown={(event) => {
+                    if (event.key === 'Enter' && !event.shiftKey) {
+                        event.preventDefault();
+                        onSubmit();
+                    }
+                }}
+            />
+            {isLoading && (
+                <Text c="ldGray.6" fz="xs">
+                    This usually takes about 15 seconds.
+                </Text>
+            )}
+            {aiUnavailable ? (
+                <Callout variant="info" title="AI isn't configured">
+                    <Stack gap="xs" align="flex-start">
+                        <Text fz="sm">
+                            Your organization has no AI provider configured, so
+                            the connection can't be drafted automatically. You
+                            can still set it up manually.
+                        </Text>
+                        <Button
+                            size="xs"
+                            variant="default"
+                            onClick={onSwitchToManual}
+                        >
+                            Set up manually
+                        </Button>
+                    </Stack>
+                </Callout>
+            ) : (
+                error && (
+                    <Callout
+                        variant="danger"
+                        title="Couldn't draft the connection"
+                    >
+                        {error.error.message}
+                    </Callout>
+                )
+            )}
+        </Stack>
+    );
+};

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionModeChooser.module.css
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionModeChooser.module.css
@@ -1,0 +1,18 @@
+.card {
+    display: block;
+    width: 100%;
+    padding: var(--mantine-spacing-md);
+    border: 1px solid var(--mantine-color-default-border);
+    border-radius: var(--mantine-radius-md);
+    background-color: var(--mantine-color-body);
+    transition: border-color 100ms ease;
+}
+
+.card:hover:not(:disabled) {
+    border-color: var(--mantine-primary-color-filled);
+}
+
+.card:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+}

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionModeChooser.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionModeChooser.tsx
@@ -1,0 +1,61 @@
+import {
+    Group,
+    SimpleGrid,
+    Stack,
+    Text,
+    UnstyledButton,
+} from '@mantine-8/core';
+import { IconAdjustments, IconSparkles } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../common/MantineIcon';
+import classes from './ConnectionModeChooser.module.css';
+
+export type ConnectionWizardMode = 'automatic' | 'manual';
+
+type Props = {
+    onChoose: (mode: ConnectionWizardMode) => void;
+    aiUnavailable: boolean;
+};
+
+export const ConnectionModeChooser: FC<Props> = ({
+    onChoose,
+    aiUnavailable,
+}) => (
+    <Stack gap="sm" mt="xl">
+        <Text c="ldGray.6" fz="sm">
+            How would you like to set up the connection?
+        </Text>
+        <SimpleGrid cols={2} spacing="sm">
+            <UnstyledButton
+                className={classes.card}
+                onClick={() => onChoose('automatic')}
+                disabled={aiUnavailable}
+                data-testid="connection-mode-automatic"
+            >
+                <Group gap="xs" mb={4}>
+                    <MantineIcon icon={IconSparkles} />
+                    <Text fw={500}>Describe it</Text>
+                </Group>
+                <Text c="ldGray.6" fz="sm">
+                    {aiUnavailable
+                        ? 'AI is not configured for your organization.'
+                        : 'Tell us what you want to connect to and AI drafts the connection for you.'}
+                </Text>
+            </UnstyledButton>
+            <UnstyledButton
+                className={classes.card}
+                onClick={() => onChoose('manual')}
+                data-testid="connection-mode-manual"
+            >
+                <Group gap="xs" mb={4}>
+                    <MantineIcon icon={IconAdjustments} />
+                    <Text fw={500}>Set up manually</Text>
+                </Group>
+                <Text c="ldGray.6" fz="sm">
+                    Enter the base URL, authentication, and access rules
+                    yourself.
+                </Text>
+            </UnstyledButton>
+        </SimpleGrid>
+    </Stack>
+);

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/wizardValues.test.ts
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/wizardValues.test.ts
@@ -1,0 +1,68 @@
+import { type ExternalConnectionConfigProposal } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { applyProposalToWizardValues } from './wizardValues';
+
+const proposal = (
+    overrides: Partial<ExternalConnectionConfigProposal> = {},
+): ExternalConnectionConfigProposal => ({
+    name: 'Google Sheets',
+    origin: 'https://sheets.googleapis.com',
+    type: 'google_service_account',
+    apiKeyName: null,
+    apiKeyLocation: null,
+    oauthScopes: ['https://www.googleapis.com/auth/spreadsheets.readonly'],
+    customHeaders: null,
+    allowedMethods: ['GET'],
+    allowedPathPrefixes: ['/v4/spreadsheets'],
+    instructions: 'Read values via GET /v4/spreadsheets/{id}/values/{range}',
+    credentialGuide: '1. Create a service account',
+    docsUrl: 'https://developers.google.com/sheets/api',
+    notes: null,
+    ...overrides,
+});
+
+describe('applyProposalToWizardValues', () => {
+    it('never carries a secret and maps auth fields with fallbacks', () => {
+        const values = applyProposalToWizardValues(
+            proposal({
+                type: 'api_key',
+                apiKeyName: 'x-api-key',
+                apiKeyLocation: null,
+                oauthScopes: null,
+            }),
+        );
+        expect(values.secret).toBe('');
+        expect(values.apiKeyName).toBe('x-api-key');
+        expect(values.apiKeyLocation).toBe('header');
+        expect(values.oauthScopes).toEqual([]);
+    });
+
+    it('derives restricted path mode from specific prefixes', () => {
+        const values = applyProposalToWizardValues(proposal());
+        expect(values.pathMode).toBe('restricted');
+        expect(values.allowedPathPrefixes.map((p) => p.value)).toEqual([
+            '/v4/spreadsheets',
+        ]);
+    });
+
+    it('derives allow-all path mode from a root prefix', () => {
+        const values = applyProposalToWizardValues(
+            proposal({ allowedPathPrefixes: ['/'] }),
+        );
+        expect(values.pathMode).toBe('all');
+        expect(values.allowedPathPrefixes).toEqual([]);
+    });
+
+    it('converts custom headers to editable rows and carries instructions', () => {
+        const values = applyProposalToWizardValues(
+            proposal({
+                customHeaders: { 'anthropic-version': '2023-06-01' },
+                instructions: 'Use POST /v1/messages',
+            }),
+        );
+        expect(values.customHeaders).toEqual([
+            { name: 'anthropic-version', value: '2023-06-01' },
+        ]);
+        expect(values.instructions).toBe('Use POST /v1/messages');
+    });
+});

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/wizardValues.ts
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/wizardValues.ts
@@ -1,0 +1,52 @@
+import {
+    type ApiKeyLocation,
+    type ExternalConnectionAuthType,
+    type ExternalConnectionConfigProposal,
+    type ExternalConnectionMethod,
+} from '@lightdash/common';
+import {
+    recordToCustomHeaderRows,
+    type CustomHeaderRow,
+} from '../../../features/externalConnections/utils/customHeaders';
+import {
+    derivePathRules,
+    type PathMode,
+    type PathPrefix,
+} from '../../../features/externalConnections/utils/pathRules';
+
+export type WizardValues = {
+    name: string;
+    origin: string;
+    type: ExternalConnectionAuthType;
+    secret: string;
+    apiKeyName: string;
+    apiKeyLocation: ApiKeyLocation;
+    oauthScopes: string[];
+    customHeaders: CustomHeaderRow[];
+    allowedMethods: ExternalConnectionMethod[];
+    pathMode: PathMode;
+    allowedPathPrefixes: PathPrefix[];
+    instructions: string;
+};
+
+/** Map an AI proposal onto the wizard form. The secret is always blank — the
+ *  user pastes the credential themselves on the Auth step. */
+export const applyProposalToWizardValues = (
+    proposal: ExternalConnectionConfigProposal,
+): WizardValues => {
+    const { mode, prefixes } = derivePathRules(proposal.allowedPathPrefixes);
+    return {
+        name: proposal.name,
+        origin: proposal.origin,
+        type: proposal.type,
+        secret: '',
+        apiKeyName: proposal.apiKeyName ?? '',
+        apiKeyLocation: proposal.apiKeyLocation ?? 'header',
+        oauthScopes: proposal.oauthScopes ?? [],
+        customHeaders: recordToCustomHeaderRows(proposal.customHeaders),
+        allowedMethods: proposal.allowedMethods,
+        pathMode: mode,
+        allowedPathPrefixes: prefixes,
+        instructions: proposal.instructions ?? '',
+    };
+};

--- a/packages/frontend/src/features/externalConnections/hooks/useProposeConnectionConfig.ts
+++ b/packages/frontend/src/features/externalConnections/hooks/useProposeConnectionConfig.ts
@@ -1,0 +1,33 @@
+import {
+    type ApiError,
+    type ExternalConnectionConfigProposal,
+} from '@lightdash/common';
+import { useMutation } from '@tanstack/react-query';
+import { lightdashApi } from '../../../api';
+
+type ProposeConfigParams = {
+    projectUuid: string;
+    description: string;
+};
+
+/** Ask AI to propose a connection config from a prose description. Carries no
+ *  secret in either direction; errors are rendered inline by the wizard, not
+ *  as toasts, so the AI-unavailable case can degrade gracefully. */
+const proposeConnectionConfig = async ({
+    projectUuid,
+    description,
+}: ProposeConfigParams): Promise<ExternalConnectionConfigProposal> =>
+    lightdashApi<ExternalConnectionConfigProposal>({
+        method: 'POST',
+        url: `/ee/projects/${projectUuid}/external-connections/propose-config`,
+        body: JSON.stringify({ description }),
+    });
+
+export const useProposeConnectionConfig = () =>
+    useMutation<
+        ExternalConnectionConfigProposal,
+        ApiError,
+        ProposeConfigParams
+    >({
+        mutationFn: proposeConnectionConfig,
+    });


### PR DESCRIPTION
## Summary

Frontend half of the automatic onboarding experience (stacked on #26547). The Add-connection wizard now opens with a mode chooser:

- **Describe it** — the user types what they want to connect to ("I want to connect to Google Sheets…"), the backend `propose-config` endpoint drafts the full connection, and the wizard is prefilled. The user lands on the **Auth** step with a "How to get your credential" markdown callout (numbered console steps + docs link) and a "Double-check" callout for any caveats; Basics and Rules stay reviewable by stepping back. The secret field is always blank — the user pastes the credential themselves.
- **Set up manually** — the existing 4-step flow, unchanged.

Other changes:
- `WizardValues` moved to `wizardValues.ts` with a pure `applyProposalToWizardValues` mapper (path-mode derivation, header rows, auth-field fallbacks) + unit tests.
- The wizard gains a visible **"Usage notes for app generation"** textarea on the Rules step (for manual users too), carried into the create payload as `instructions` — previously edit-modal-only.
- Availability degradation: the propose hook shows no toast; a 422 `MissingConfigError` renders an inline "AI isn't configured" callout with a switch-to-manual button and disables the Automatic card for the rest of the modal session.
- The propose request/response carry no secret, so the hook is deliberately not marked `sensitive`.

## Test plan

- `applyProposalToWizardValues` unit tests (4 passing); frontend typecheck + lint clean.
- Verified live in the browser against the dev stack:
  - Manual path reproduces the old 4-step flow exactly.
  - "connect to the OpenF1 API" → prefilled wizard (origin `https://api.openf1.org", GET-only, restricted `/v1` prefix, rich instructions), notes callout, test request 200 through the proxy, connection created with instructions (1,497 chars) and sample persisted.
  - "connect to the Anthropic API" → API-key auth with `x-api-key` + `anthropic-version` custom header prefilled, credential-guide callout with clickable console links, empty secret field.

Closes: GLITCH-641

🤖 Generated with [Claude Code](https://claude.com/claude-code)