### PR TITLE
fix: render spaces added to homepage collection blocks

### DIFF
--- a/packages/backend/src/models/ContentModel/ContentConfigurations/SpaceContentConfiguration.test.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/SpaceContentConfiguration.test.ts
@@ -1,3 +1,4 @@
+import { ContentType } from '@lightdash/common';
 import knex from 'knex';
 import { MockClient } from 'knex-mock-client';
 import { ContentFilters } from '../ContentModelTypes';
@@ -22,5 +23,55 @@ describe('spaceContentConfiguration.getSummaryQuery rootSpaces search', () => {
     it('matches spaces at any nesting level when searching (issue #23887)', () => {
         const sql = buildSql({ ...baseFilters, search: 'nested space' });
         expect(sql).not.toContain('nlevel(path) = 1');
+    });
+
+    it('matches spaces at any nesting level for uuid-targeted lookups (issue #26541)', () => {
+        const sql = buildSql({
+            ...baseFilters,
+            uuids: ['00000000-0000-0000-0000-000000000002'],
+        });
+        expect(sql).not.toContain('nlevel(path) = 1');
+    });
+});
+
+describe('spaceContentConfiguration.shouldQueryBeIncluded', () => {
+    it('excludes spaces from browse queries by default', () => {
+        expect(spaceContentConfiguration.shouldQueryBeIncluded({})).toBe(false);
+        expect(
+            spaceContentConfiguration.shouldQueryBeIncluded({
+                projectUuids: ['project-uuid'],
+            }),
+        ).toBe(false);
+    });
+
+    it('includes spaces when explicitly requested via contentTypes', () => {
+        expect(
+            spaceContentConfiguration.shouldQueryBeIncluded({
+                contentTypes: [ContentType.SPACE],
+            }),
+        ).toBe(true);
+    });
+
+    it('includes spaces for uuid-targeted lookups without contentTypes (issue #26541)', () => {
+        expect(
+            spaceContentConfiguration.shouldQueryBeIncluded({
+                uuids: ['space-uuid'],
+            }),
+        ).toBe(true);
+    });
+
+    it('respects an explicit contentTypes filter that excludes spaces, even with uuids', () => {
+        expect(
+            spaceContentConfiguration.shouldQueryBeIncluded({
+                uuids: ['chart-uuid'],
+                contentTypes: [ContentType.CHART],
+            }),
+        ).toBe(false);
+    });
+
+    it('includes spaces in the deleted content "all" view', () => {
+        expect(
+            spaceContentConfiguration.shouldQueryBeIncluded({ deleted: true }),
+        ).toBe(true);
     });
 });

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/SpaceContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/SpaceContentConfiguration.ts
@@ -37,6 +37,11 @@ export const spaceContentConfiguration: ContentConfiguration<SpaceContentRow> =
             if (filters.contentTypes?.includes(ContentType.SPACE)) {
                 return true;
             }
+            // Spaces are opt-in for browse queries, but a uuid-targeted lookup
+            // names its exact items, so silently excluding a type is never right
+            if (filters.uuids?.length && !filters.contentTypes) {
+                return true;
+            }
             // Include spaces in deleted content "all" view
             if (filters.deleted && !filters.contentTypes) {
                 return true;
@@ -248,10 +253,10 @@ export const spaceContentConfiguration: ContentConfiguration<SpaceContentRow> =
                                 `${SpaceTableName}.space_uuid`,
                                 filters.spaceUuids ?? [],
                             );
-                            // When searching, match spaces at any nesting level
-                            // to stay consistent with global search. The
-                            // space_uuid filter above already enforces access.
-                            if (!filters.search) {
+                            // When searching or resolving explicit uuids, match
+                            // spaces at any nesting level. The space_uuid filter
+                            // above already enforces access.
+                            if (!filters.search && !filters.uuids?.length) {
                                 void builder.andWhereRaw('nlevel(path) = 1');
                             }
                         } else {


### PR DESCRIPTION
## Problem

Spaces can be selected into a homepage collection block, but they never render — the ref is saved correctly, then silently dropped at resolution time. When a space is the block's only item, the whole block disappears from the published homepage.

## Root cause

The homepage collection resolver looks up saved items via `GET /api/v2/content?uuids=...` with no `contentTypes` param. Two layers in the content query then drop spaces:

1. **Spaces are excluded from the query union.** `SpaceContentConfiguration.shouldQueryBeIncluded` is opt-in only — the space branch joins the union *only* when `contentTypes` explicitly includes `space`, while every other content type is include-by-default. The space uuid never comes back and the frontend silently drops the miss.
2. **Nested spaces are filtered to root-only.** Even when spaces are requested, the space query restricts to `nlevel(path) = 1` when there is no search term — but the picker's Spaces tab is search-driven and can select nested spaces, which would still vanish.

## Regression analysis

The resolver dates from #25533 (collection block with uuid content filter), before spaces were selectable. #25918 added the Spaces (and data apps) picker tab without updating the resolution path to cover the new types. Data apps escaped the bug purely because `DataAppContentConfiguration` is include-by-default; spaces are the only opt-in configuration. The same drop also affected pinned/favorited spaces in dynamic-source collections and the day-one pinned section, which funnel through the same resolver.

## Fix

Both changes live in `SpaceContentConfiguration` — the contract is fixed at the API layer rather than patching the one caller, so any uuid-based resolver gets correct behaviour:

- `shouldQueryBeIncluded` now includes spaces for uuid-targeted lookups without an explicit `contentTypes` filter. A uuid lookup names its exact items, so silently excluding a type is never right. Browse queries (no `uuids`) keep the deliberate spaces-opt-in default, and an explicit `contentTypes` filter still wins.
- The root-space-only `nlevel(path) = 1` restriction is skipped when the query targets explicit `uuids` — access is already enforced by the accessible-space-uuids `whereIn`, the same rationale as the existing search exemption.

No frontend changes.

## Tests

Extended `SpaceContentConfiguration.test.ts`: `shouldQueryBeIncluded` matrix (browse default, explicit contentTypes, uuid-targeted, contentTypes-excludes-spaces-with-uuids, deleted view) and generated-SQL assertions that uuid-targeted queries drop the `nlevel(path) = 1` restriction while root-space browse keeps it.

## Verification

Reproduced and verified live against a local dev stack running this branch's backend:

- **Before (main backend):** `GET /api/v2/content?uuids=<spaceUuid>` returns `[]` for both root and nested spaces; a published homepage collection containing only a space renders nothing (the block disappears entirely).
- **After (this branch):** the same lookups return the space, and the published collection block renders the space card (icon, "Space" label, link) for root spaces; nested-space resolution verified via the API path the resolver uses.

Typecheck, lint, and unit tests pass on backend.

Closes: PROD-9360
Closes: #26541

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzPbFQjdevf7cvP2UMFixn
