### PR TITLE
feat(data-apps): expose local authoring context

### DIFF
--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -17,6 +17,7 @@ import {
     type ApiGenerateAppResponse,
     type ApiGetAppCodeResponse,
     type ApiGetAppResponse,
+    type ApiGetDataAppAuthoringContextResponse,
     type ApiGetDataAppVizResponse,
     type ApiImportAppCodeResponse,
     type ApiListDataAppVizsResponse,
@@ -255,6 +256,34 @@ export class AppGenerateController extends BaseController {
     ): Promise<ApiAppFileUploadResponse> {
         this.setStatus(200);
         return this.handleUploadFile(req, projectUuid, appUuid, filename, kind);
+    }
+
+    /**
+     * Get project context for authoring a new data app locally.
+     * @summary Get data app authoring context
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/authoring-context')
+    @OperationId('getDataAppAuthoringContext')
+    async getDataAppAuthoringContext(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Query() slug: string,
+        @Query() designUuid?: string,
+    ): Promise<ApiGetDataAppAuthoringContextResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results:
+                await this.getAppGenerateService().getDataAppAuthoringContext(
+                    toSessionUser(req.account),
+                    projectUuid,
+                    slug,
+                    designUuid ?? null,
+                ),
+        };
     }
 
     private async handleUploadFile(

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.getAppCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.getAppCode.test.ts
@@ -175,11 +175,13 @@ function buildService(overrides: {
         getAppWithVersions: vi
             .fn()
             .mockResolvedValue({ versions: [], hasMore: false }),
+        hasAppSlug: vi.fn().mockResolvedValue(false),
         ...appModel,
     };
 
     const fullProjectModel = {
         getAllExploresFromCache: vi.fn().mockResolvedValue({}),
+        getSummary: vi.fn().mockResolvedValue({ organizationUuid: ORG_UUID }),
         ...projectModel,
     };
 
@@ -228,6 +230,14 @@ function buildService(overrides: {
         externalConnectionModel: fullExternalConnectionModel as never,
         sandboxRegistryModel: {} as never,
         orgAiCopilotConfigResolver: {} as never,
+    });
+
+    vi.spyOn(
+        svc as unknown as { createAuditedAbility: () => unknown },
+        'createAuditedAbility',
+    ).mockReturnValue({
+        can: () => true,
+        cannot: () => false,
     });
 
     if (s3ClientOverride) {
@@ -725,5 +735,70 @@ describe('AppGenerateService.getAppCode', () => {
         expect(result.context.theme.skippedAssetCount).toBe(0);
         expect(result.context.theme.assets).toHaveLength(0);
         expect(result.context.theme.instructions).toBeNull();
+    });
+});
+
+describe('AppGenerateService.getDataAppAuthoringContext', () => {
+    it('returns project context with empty prompt history for a new local app', async () => {
+        const getAppWithVersions = vi.fn();
+        const hasAppSlug = vi.fn().mockResolvedValue(false);
+        const svc = buildService({
+            appModel: { getAppWithVersions, hasAppSlug },
+        });
+
+        const context = await svc.getDataAppAuthoringContext(
+            fakeUser,
+            PROJECT_UUID,
+            'revenue-explorer',
+            null,
+        );
+
+        expect(hasAppSlug).toHaveBeenCalledWith(
+            PROJECT_UUID,
+            'revenue-explorer',
+        );
+        expect(getAppWithVersions).not.toHaveBeenCalled();
+        expect(context.semanticLayer.path).toBe(
+            '.lightdash/context/semantic-layer.yml',
+        );
+        expect(context.parameters).toBeNull();
+        expect(
+            Buffer.from(context.promptHistory.contentBase64, 'base64').toString(
+                'utf8',
+            ),
+        ).toContain('No previous versions');
+        expect(context.theme).toEqual({
+            instructions: null,
+            assets: [],
+            skippedAssetCount: 0,
+        });
+    });
+
+    it('rejects a slug already reserved in the project', async () => {
+        const svc = buildService({
+            appModel: { hasAppSlug: vi.fn().mockResolvedValue(true) },
+        });
+
+        await expect(
+            svc.getDataAppAuthoringContext(
+                fakeUser,
+                PROJECT_UUID,
+                APP_SLUG,
+                null,
+            ),
+        ).rejects.toThrow(`A data app with slug "${APP_SLUG}" already exists`);
+    });
+
+    it('rejects an invalid local app slug', async () => {
+        const svc = buildService({});
+
+        await expect(
+            svc.getDataAppAuthoringContext(
+                fakeUser,
+                PROJECT_UUID,
+                '../invalid',
+                null,
+            ),
+        ).rejects.toThrow('Invalid data app slug');
     });
 });

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -13,6 +13,7 @@ import {
 } from '@aws-sdk/client-s3';
 import { subject } from '@casl/ability';
 import {
+    AlreadyExistsError,
     APP_VERSION_CANCELLED_BY_USER,
     assertEmbeddedAuth,
     assertUnreachable,
@@ -9186,7 +9187,10 @@ export class AppGenerateService extends BaseService {
         });
 
         const context = await this.assembleAppContext(
-            app,
+            {
+                appUuid: app.app_id,
+                designUuid: app.design_uuid,
+            },
             projectUuid,
             app.organization_uuid,
         );
@@ -9245,8 +9249,40 @@ export class AppGenerateService extends BaseService {
         };
     }
 
+    async getDataAppAuthoringContext(
+        user: SessionUser,
+        projectUuid: string,
+        slug: string,
+        designUuid: string | null,
+    ): Promise<DataAppContext> {
+        await this.assertDataAppsEnabled(user);
+        const organizationUuid = await this.getProjectOrgUuid(projectUuid);
+        this.assertDataAppAbility(
+            user,
+            'create',
+            organizationUuid,
+            projectUuid,
+            'Insufficient permissions to create data apps',
+        );
+        if (!isValidDataAppSlug(slug)) {
+            throw new ParameterError(
+                `Invalid data app slug "${slug}". Slugs must start with a lowercase letter or digit and contain only lowercase letters, digits, and hyphens, up to 255 characters.`,
+            );
+        }
+        if (await this.appModel.hasAppSlug(projectUuid, slug)) {
+            throw new AlreadyExistsError(
+                `A data app with slug "${slug}" already exists in this project. Download it with lightdash download --apps ${slug}.`,
+            );
+        }
+        return this.assembleAppContext(
+            { appUuid: null, designUuid },
+            projectUuid,
+            organizationUuid,
+        );
+    }
+
     private async assembleAppContext(
-        app: { app_id: string; design_uuid: string | null },
+        app: { appUuid: string | null; designUuid: string | null },
         projectUuid: string,
         organizationUuid: string,
     ): Promise<DataAppContext> {
@@ -9298,9 +9334,15 @@ export class AppGenerateService extends BaseService {
         })();
 
         const promptHistory = await (async () => {
+            if (app.appUuid === null) {
+                return contextFile(
+                    'prompt-history.md',
+                    '# Prompt history\n\n_No previous versions._\n',
+                );
+            }
             try {
                 const withVersions = await this.appModel.getAppWithVersions(
-                    app.app_id,
+                    app.appUuid,
                     projectUuid,
                     { limit: 100 },
                 );
@@ -9317,7 +9359,7 @@ export class AppGenerateService extends BaseService {
                 return contextFile('prompt-history.md', promptMd);
             } catch (err) {
                 this.logger.warn(
-                    `assembleAppContext: prompt history unavailable for app ${app.app_id}`,
+                    `assembleAppContext: prompt history unavailable for app ${app.appUuid}`,
                     err,
                 );
                 return contextFile(
@@ -9328,6 +9370,9 @@ export class AppGenerateService extends BaseService {
         })();
 
         const theme = await (async () => {
+            if (app.designUuid === null) {
+                return { instructions: null, assets: [], skippedAssetCount: 0 };
+            }
             try {
                 const { client: s3Client, bucket } = this.getS3Client();
                 return await readDesignForDownload({
@@ -9335,7 +9380,7 @@ export class AppGenerateService extends BaseService {
                     bucket,
                     organizationDesignModel: this.organizationDesignModel,
                     organizationUuid,
-                    designUuid: app.design_uuid,
+                    designUuid: app.designUuid,
                     logger: this.logger,
                 });
             } catch (err) {

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -474,6 +474,14 @@ export class AppModel {
             .first();
     }
 
+    async hasAppSlug(projectUuid: string, slug: string): Promise<boolean> {
+        const app = await this.database(AppsTableName)
+            .select('app_id')
+            .where({ project_uuid: projectUuid, slug })
+            .first();
+        return app !== undefined;
+    }
+
     /**
      * Resolve an app by uuid or slug. A value that parses as a UUID may
      * still be a slug (slugs aren't guaranteed non-uuid-shaped), so

--- a/packages/common/src/ee/apps/code.ts
+++ b/packages/common/src/ee/apps/code.ts
@@ -91,6 +91,8 @@ export type DataAppCodeDownload = DataAppCode & { context: DataAppContext };
 
 export type ApiGetAppCodeResponse = ApiSuccess<DataAppCodeDownload>;
 
+export type ApiGetDataAppAuthoringContextResponse = ApiSuccess<DataAppContext>;
+
 export type ImportAppCodeRequestBody = {
     code: DataAppCode;
     // Legacy identity for pre-slug bundles and old CLIs: append when this app

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -64,6 +64,7 @@ import type {
     ApiGenerateAppResponse,
     ApiGetAppCodeResponse,
     ApiGetAppResponse,
+    ApiGetDataAppAuthoringContextResponse,
     ApiGetDataAppVizResponse,
     ApiGetUserAgentPreferencesResponse,
     ApiHomepageLinkMetadataResponse,
@@ -1325,6 +1326,7 @@ type ApiResults =
     | CreateOAuthClientResponse
     | ApiGenerateAppResponse['results']
     | ApiGetAppCodeResponse['results']
+    | ApiGetDataAppAuthoringContextResponse['results']
     | ApiGetAppResponse['results']
     | ApiListDataAppVizsResponse['results']
     | ApiGetDataAppVizResponse['results']


### PR DESCRIPTION
### Description

- Add an authenticated authoring-context endpoint for new local data apps.
- Enforce the data-app feature flag, `create:DataApp` permission, slug validation, and project-wide slug availability.
- Return a fresh semantic-layer snapshot, parameters, empty prompt history, and optional design context.
- Reuse the context assembler used by downloaded apps.

### Stack

1. **This PR:** project authoring-context API
2. #26556 — `lightdash create app` CLI command

### Validation

- 17 focused backend tests
- Focused backend lint and formatting
- Common typecheck
- TSOA API route generation
- Local endpoint verified after regenerating release-managed API artifacts