### PR TITLE
feat(cli): create data apps locally

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -1026,6 +1026,7 @@ Data apps can be **downloaded as source, versioned in git, edited, and re-upload
 
 Opt-in flags on the existing `lightdash download` / `lightdash upload` commands (off by default — core users never touch app code paths unless they ask):
 
+- **`lightdash create app "<name>"`** — create a new app locally at `lightdash/apps/<slug>/` from the E2B starter template. The command requires npm and first asks the user to accept that it will download packages and run shadcn locally. It then lists the exact direct dependencies and shadcn components for a second approval before writing anything. After approval, it checks that the slug is available in the selected project and adds the complete runnable source tree, manifest, agent skills, and a fresh project context snapshot. `--slug`, `--description`, `--project`, and `--path` override the defaults; `--assume-yes` approves installation in non-interactive environments.
 - **`lightdash download --apps <appReferences...>`** — download specific data apps by UUID, slug, or app URL into `lightdash/apps/<slug>/`; **`--include-apps`** downloads all of the project's apps (capped at `--apps-limit`, default 50). Each folder holds `lightdash-app.yml` (manifest) + the app's `src/` tree. The built `dist` is intentionally excluded — it's regenerated on upload.
 - **`lightdash upload --apps <appReferences...>`** — upload specific apps by UUID, slug, or app URL, matched against each local folder's manifest (`slug` or `appUuid`); **`--include-apps`** uploads every `lightdash/apps/<slug>/` folder on disk. The server rebuilds the source. **Fire-and-forget:** the CLI posts and returns immediately — the app shows `building` in the UI until the server finishes.
 
@@ -1034,6 +1035,7 @@ Opt-in flags on the existing `lightdash download` / `lightdash upload` commands 
 ### What the endpoints do
 
 - **Download** — `GET /api/v1/ee/projects/{projectUuid}/apps/{appUuidOrSlug}/download` (accepts either a uuid or the app's slug) reads the version's `source.tar` from S3, extracts it in-process (`tar-stream`), and returns the `src/` files + manifest (`AppGenerateService.getAppCode`).
+- **Create locally** — `GET /api/v1/ee/projects/{projectUuid}/apps/authoring-context?slug=<slug>` checks `create:DataApp`, validates that the slug is available (including soft-deleted apps), and returns the selected project's semantic layer plus empty prompt history and theme context. The CLI supplies static files from the same `sandboxes/data-apps/template/` tree packaged into the published CLI, installs the declared dependencies with lifecycle scripts disabled, and runs the same pinned shadcn generator used by the E2B image build.
 - **Upload** — `POST /api/v1/ee/projects/{projectUuid}/apps/upload` (`AppGenerateService.importAppCode`) validates the source (`validateDataAppCode` rejects path traversal), re-tars it, stores `source.tar` at the new version's prefix, creates a `pending` version, and enqueues the **build-only pipeline** `APP_BUILD_FROM_SOURCE` (`runBuildFromSourcePipeline`): sandbox → restore source → `pnpm build` (**fail-loud, no AI autofix**) → package → store → `ready`. Concurrent builds are **rate-limited per project** (`MAX_CONCURRENT_APP_BUILDS_PER_PROJECT`, HTTP 429 when exceeded).
 
 ### Moving an app between projects or instances
@@ -1052,13 +1054,13 @@ Cross-project and cross-instance upload are both a plain **slug upsert** against
 - **Data app vizs round-trip their schema via the manifest.** A viz's declared schema (`app_versions.viz_schema`) exists only in the database — it is emitted as structured output during generation, never written into the source tree. So `lightdash-app.yml` carries a `vizSchema` field for `data_app_viz` apps, and upload validates it (fail-loud) and persists it on the new version. Without it the uploaded viz would never appear in the viz picker (the picker requires a non-null schema on the latest ready version). Bundles downloaded before this field existed re-upload without a schema — re-download from the source project to fix.
 - **Security:** because the server only ever builds source in its trusted, network-locked sandbox and never serves client-supplied *built* code, the runtime trust model is unchanged from AI-generated apps. See [Security Model](#security-model). (Follow-up: the query bridge runs as the *viewing* user — a pre-existing consideration for any app, generated or uploaded.)
 
-### Local authoring (Phase 2)
+### Local authoring
 
-Phase 1 makes apps [downloadable and uploadable from source](#cli); Phase 2 makes the downloaded tree **locally buildable**, so you can verify changes compile before uploading.
+Apps created with `lightdash create app "<name>"` and apps checked out with `lightdash download --apps <slug>` use the same locally-buildable structure, so you can verify changes compile before uploading.
 
-#### What downloading an app now includes
+#### What a local app includes
 
-The download folder adds to the Phase 1 output (`src/` + `lightdash-app.yml`):
+The app folder contains `src/` + `lightdash-app.yml`, along with:
 
 - **Build scaffolding:** `package.json` (Lightdash App SDK pinned to the same published version the server uses), `vite.config.js`, `tailwind.config.js`, `postcss.config.js`, `tsconfig.json`, `index.html`
 - **Agent skills:** `.claude/skills/lightdash-data-app` (SDK reference) and `.claude/skills/developing-data-apps-locally` (local authoring workflow)
@@ -1070,7 +1072,7 @@ All scaffolding and context files are read-only reference — see [Upload is sou
 #### The local loop
 
 ```sh
-edit src/  →  npm install && npm run build  →  lightdash apps preview  →  lightdash upload --apps <slug>  →  server rebuilds
+lightdash create app "<name>"  →  edit src/  →  npm run build  →  lightdash apps preview  →  lightdash upload --apps <slug>  →  server rebuilds
 ```
 
 1. Edit files under `src/`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -42,6 +42,36 @@ the AI agent runtime version.
 Access lists, Slack integrations, MCP servers, documents, conversations, and
 other runtime state stay managed in the target environment.
 
+## Data apps as code
+
+Create a new data app locally from the same starter used by Lightdash's data
+app builder:
+
+```shell
+lightdash create app "Revenue explorer"
+```
+
+This requires npm. Before writing anything, the command first warns that it
+will download packages and run shadcn locally, then asks whether to show and
+approve the exact direct dependencies and shadcn components. It creates
+`lightdash/apps/revenue-explorer/` with runnable source, the
+Lightdash data app and local-development agent skills, and a point-in-time
+snapshot of the selected project's semantic layer. Use `--project`, `--slug`,
+`--description`, or `--path` to override the defaults; use `--assume-yes` to
+approve installation in a non-interactive environment.
+
+Build and upload it with:
+
+```shell
+cd lightdash/apps/revenue-explorer
+npm run build
+lightdash upload --apps revenue-explorer
+```
+
+The local build is a pre-flight check; Lightdash rebuilds the source when it is
+uploaded. Existing apps can still be checked out with
+`lightdash download --apps <slug>`.
+
 ## Development
 
 First build the package

--- a/packages/cli/src/handlers/apps/authoring/AGENTS.md.tmpl
+++ b/packages/cli/src/handlers/apps/authoring/AGENTS.md.tmpl
@@ -2,11 +2,11 @@
 
 Two skills in `.claude/skills/` describe how to edit this app:
 - `lightdash-data-app` — the Lightdash SDK surface (querying data, filters, downloads).
-- `developing-data-apps-locally` — the local workflow: edit `src/`, `npm run build`, `lightdash upload --apps <appUuid>` (uuid in `lightdash-app.yml`); the SDK is the only data access; `.lightdash/context/` holds the project's semantic layer and theme.
+- `developing-data-apps-locally` — the local workflow: edit `src/`, `npm run build`, `lightdash apps preview`, `lightdash upload --apps <slug>`; the SDK is the only data access; `.lightdash/context/` holds the project's semantic layer and theme.
 
 Edit only `src/`. Root config files are read-only reference — the server rebuilds against a trusted template.
 
-The local `npm install && npm run build` is an optional pre-check. If install fails, skip it and upload — never modify machine config, npmrc, or dependency files to force it; the server rebuild is authoritative.
+The local build is an optional pre-check. Apps made with `lightdash create app` already have dependencies installed and can run `npm run build`; after `lightdash download`, use `npm install && npm run build` if you choose to build locally. If install fails, skip it and upload — never modify machine config, npmrc, or dependency files to force it; the server rebuild is authoritative.
 
 Build with the template's preinstalled dependency set (see `package.json`). Adding new npm packages only works when the instance has custom dependencies enabled — assume it does not; ask the user before considering a new library, and never vendor library source into `src/` as a workaround. Where enabled, adding a dependency is the one workflow that still requires pnpm: upload requires a matching `pnpm-lock.yaml`, so `pnpm add <pkg>` (or `pnpm install --lockfile-only`) must succeed locally. If it fails, stop and report the error — hand-editing `package.json` without the lockfile makes the upload fail.
 

--- a/packages/cli/src/handlers/apps/authoring/README.md.tmpl
+++ b/packages/cli/src/handlers/apps/authoring/README.md.tmpl
@@ -1,12 +1,12 @@
 # {{APP_NAME}} — Lightdash data app (local copy)
 
-Downloaded with the Lightdash CLI (`lightdash download`).
+Created or downloaded with the Lightdash CLI.
 
 ## Edit → build → upload
 1. Edit files under `src/`.
-2. Optionally, `npm install && npm run build` to check it compiles locally. If install fails in your environment, skip it — the server build on upload is authoritative and surfaces errors on the app page. Don't change machine or registry config to force it.
+2. Optionally, run `npm run build` to check it compiles locally. `lightdash create app` installs the initial dependencies after asking permission; after `lightdash download`, run `npm install` first if `node_modules` is absent. If install fails in your environment, skip the local build — the server build on upload is authoritative and surfaces errors on the app page. Don't change machine or registry config to force it.
 3. Optionally, preview against real data: `lightdash apps preview` (needs a successful `npm install`).
-4. `lightdash upload --apps` — Lightdash rebuilds and serves the app.
+4. `lightdash upload --apps <slug>` (the `slug` from `lightdash-app.yml`) — Lightdash rebuilds and serves the app.
 
 Local preview uses your existing CLI login through a project- and route-restricted loopback proxy; the credential is not written into this folder or exposed to browser code. It runs local tooling as your OS user (with access to that user's files, including the existing CLI config) and shows data under your own permissions, so preview only source/dependencies you trust. Host-mediated features such as external connections and data-app-viz context still need testing after upload.
 

--- a/packages/cli/src/handlers/apps/authoring/developing-data-apps-locally/SKILL.md
+++ b/packages/cli/src/handlers/apps/authoring/developing-data-apps-locally/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: developing-data-apps-locally
-description: Use when editing a downloaded Lightdash data app on your machine — how local editing, building, and re-uploading work, and what is read-only.
+description: Use when editing a locally created or downloaded Lightdash data app — how local editing, building, and uploading work, and what is read-only.
 ---
 
 # Developing Lightdash Data Apps Locally
 
-You are editing a Lightdash **data app** that was downloaded with the Lightdash CLI (`lightdash download`).
+You are editing a Lightdash **data app** that was created or downloaded with the Lightdash CLI.
 
 ## The only way to reach data is the SDK
 
@@ -28,8 +28,8 @@ You are editing a Lightdash **data app** that was downloaded with the Lightdash 
 ## The edit → build → upload loop
 
 1. Edit files under `src/` only.
-2. Optionally, `npm install` then `npm run build` to check it compiles. This is an **optional local pre-check** — see below.
-3. `lightdash upload --apps <appUuid>` (the `appUuid` from this folder's `lightdash-app.yml`) — the **server** rebuilds and serves the app. The server rebuild, not your local build, is what ships.
+2. Optionally, run `npm run build` to check it compiles. Apps made with `lightdash create app` already have their initial dependencies installed. After `lightdash download`, if you choose to do the local pre-check and `node_modules` is absent, run `npm install` first. This is an **optional local pre-check** — see below.
+3. `lightdash upload --apps <slug>` (the `slug` from this folder's `lightdash-app.yml`) — the **server** rebuilds and serves the app. The server rebuild, not your local build, is what ships.
 
 ## The local build is optional — never fight a failing install
 
@@ -37,7 +37,7 @@ You are editing a Lightdash **data app** that was downloaded with the Lightdash 
 - Do **not** modify machine configuration, `.npmrc` files, registry settings, or the project's dependency files to force an install to work.
 - A missing `node_modules` is a normal state, not a problem to fix. Never run installs just because it is absent.
 - **Exception — adding a dependency** (only on instances with custom dependencies enabled — see "Library boundaries" above). This is the one workflow that still requires pnpm: upload rejects new dependencies unless `pnpm-lock.yaml` was regenerated to match `package.json`, so dependency resolution MUST succeed locally. Use `pnpm add <pkg>` — prefixed with Socket Firewall when available (`sfw pnpm add <pkg>`; check with `command -v sfw`) to block known-malicious packages — or after editing `package.json` run `pnpm install --lockfile-only` (updates the lockfile without installing). If resolution fails, **stop and report the exact pnpm error to the user** — never hand-edit `package.json` and proceed without the lockfile; the upload will fail.
-- **Never run dependency lifecycle scripts.** The app's `.npmrc` sets `ignore-scripts=true` — leave it. A downloaded app can be authored by someone else, and their dependencies' install scripts must not execute on this machine. Explicit commands such as `npm run build` still work.
+- **Never run dependency lifecycle scripts.** The app's `.npmrc` sets `ignore-scripts=true` — leave it. A downloaded app can be authored by someone else, and their dependencies' install scripts must not execute on this machine. Explicit `npm run build`/`npm run dev` and `pnpm build`/`pnpm dev` commands still work.
 
 ## Preview locally against real data
 

--- a/packages/cli/src/handlers/apps/createApp.test.ts
+++ b/packages/cli/src/handlers/apps/createApp.test.ts
@@ -1,0 +1,384 @@
+import execa from 'execa';
+import { promises as fs } from 'fs';
+import inquirer from 'inquirer';
+import * as os from 'os';
+import * as path from 'path';
+import type { Mock } from 'vitest';
+import { LightdashAnalytics } from '../../analytics/analytics';
+import { getConfig } from '../../config';
+import GlobalState from '../../globalState';
+import { checkLightdashVersion, lightdashApi } from '../dbt/apiClient';
+import { selectProject } from '../selectProject';
+import { readBundleFromDir } from './appCodeFiles';
+import {
+    buildLocalAppManifest,
+    createAppHandler,
+    resolveLocalAppSlug,
+} from './createApp';
+
+vi.mock('../../config', () => ({ getConfig: vi.fn() }));
+vi.mock('../dbt/apiClient', () => ({
+    checkLightdashVersion: vi.fn(),
+    lightdashApi: vi.fn(),
+}));
+vi.mock('../selectProject', () => ({
+    selectProject: vi.fn(),
+    logSelectedProject: vi.fn(),
+}));
+vi.mock('../../analytics/analytics', () => ({
+    LightdashAnalytics: { track: vi.fn() },
+}));
+vi.mock('execa');
+vi.mock('inquirer', () => ({
+    default: { prompt: vi.fn() },
+}));
+
+const execaMock = execa as unknown as Mock;
+const promptMock = inquirer.prompt as unknown as Mock;
+
+const PROJECT_UUID = '11111111-1111-4111-8111-111111111111';
+
+const context = {
+    semanticLayer: {
+        path: '.lightdash/context/semantic-layer.yml',
+        contentBase64: Buffer.from('models: []\n').toString('base64'),
+    },
+    parameters: null,
+    promptHistory: {
+        path: '.lightdash/context/prompt-history.md',
+        contentBase64: Buffer.from(
+            '# Prompt history\n\n_No previous versions._\n',
+        ).toString('base64'),
+    },
+    theme: { instructions: null, assets: [], skippedAssetCount: 0 },
+};
+
+describe('resolveLocalAppSlug', () => {
+    it('generates a slug from the app name', () => {
+        expect(resolveLocalAppSlug('Revenue Explorer')).toBe(
+            'revenue-explorer',
+        );
+    });
+
+    it('accepts a valid explicit slug', () => {
+        expect(resolveLocalAppSlug('Revenue Explorer', 'sales-overview')).toBe(
+            'sales-overview',
+        );
+    });
+
+    it('rejects an invalid explicit slug', () => {
+        expect(() =>
+            resolveLocalAppSlug('Revenue Explorer', '../invalid'),
+        ).toThrow('Invalid data app slug');
+    });
+});
+
+describe('buildLocalAppManifest', () => {
+    it('builds a slug-identified manifest without an app uuid', () => {
+        const manifest = buildLocalAppManifest({
+            name: 'Revenue Explorer',
+            description: 'Revenue by customer',
+            projectUuid: PROJECT_UUID,
+            slug: 'revenue-explorer',
+            now: new Date('2026-07-30T10:00:00.000Z'),
+        });
+
+        expect(manifest).toMatchObject({
+            codeVersion: 1,
+            projectUuid: PROJECT_UUID,
+            slug: 'revenue-explorer',
+            version: 1,
+            name: 'Revenue Explorer',
+            description: 'Revenue by customer',
+            template: null,
+            downloadedAt: '2026-07-30T10:00:00.000Z',
+        });
+        expect(manifest.appUuid).toBeUndefined();
+    });
+});
+
+describe('createAppHandler', () => {
+    beforeEach(() => {
+        execaMock.mockImplementation(
+            async (
+                command: string,
+                args: string[] = [],
+                options?: { cwd?: string },
+            ) => {
+                if (
+                    command === 'npx' &&
+                    args.includes('init') &&
+                    options?.cwd
+                ) {
+                    await fs.writeFile(
+                        path.join(options.cwd, 'package.json'),
+                        '{}\n',
+                    );
+                    await fs.writeFile(
+                        path.join(options.cwd, 'tailwind.config.js'),
+                        '// rewritten by shadcn\n',
+                    );
+                }
+                if (command === 'npx' && args.includes('add') && options?.cwd) {
+                    const uiDir = path.join(options.cwd, 'src/components/ui');
+                    await fs.mkdir(uiDir, { recursive: true });
+                    await fs.writeFile(
+                        path.join(uiDir, 'button.tsx'),
+                        'export const Button = () => null;\n',
+                    );
+                }
+                return { stdout: '' };
+            },
+        );
+        promptMock.mockResolvedValue({ confirmed: true });
+        vi.mocked(getConfig).mockResolvedValue({
+            context: {
+                apiKey: 'token',
+                serverUrl: 'https://lightdash.example.com',
+                project: PROJECT_UUID,
+            },
+        } as never);
+        vi.mocked(selectProject).mockResolvedValue({
+            projectUuid: PROJECT_UUID,
+            isPreview: false,
+        });
+        vi.mocked(lightdashApi).mockResolvedValue(context);
+        vi.mocked(checkLightdashVersion).mockResolvedValue(undefined);
+        vi.spyOn(GlobalState, 'log').mockImplementation(() => undefined);
+        vi.spyOn(GlobalState, 'isNonInteractive').mockReturnValue(false);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.clearAllMocks();
+    });
+
+    it('creates a complete local app scaffold and project context', async () => {
+        const root = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-create-app-'));
+
+        await createAppHandler('Revenue Explorer', {
+            description: 'Revenue by customer',
+            path: root,
+            verbose: false,
+        });
+
+        const appDir = path.join(root, 'apps', 'revenue-explorer');
+        const bundle = await readBundleFromDir(appDir);
+        expect(bundle.manifest.slug).toBe('revenue-explorer');
+        expect(bundle.manifest.appUuid).toBeUndefined();
+        expect(bundle.files.map((file) => file.path)).toContain('src/App.jsx');
+        expect(bundle.files.map((file) => file.path)).toContain(
+            'src/components/ui/button.tsx',
+        );
+        expect(
+            await fs.readFile(path.join(appDir, 'package.json'), 'utf8'),
+        ).toContain('@lightdash/query-sdk');
+        expect(
+            await fs.readFile(path.join(appDir, 'tailwind.config.js'), 'utf8'),
+        ).not.toContain('rewritten by shadcn');
+        await expect(
+            fs.access(
+                path.join(appDir, '.claude/skills/lightdash-data-app/SKILL.md'),
+            ),
+        ).resolves.toBeUndefined();
+        await expect(
+            fs.access(
+                path.join(
+                    appDir,
+                    '.claude/skills/developing-data-apps-locally/SKILL.md',
+                ),
+            ),
+        ).resolves.toBeUndefined();
+        expect(
+            await fs.readFile(
+                path.join(appDir, '.lightdash/context/semantic-layer.yml'),
+                'utf8',
+            ),
+        ).toBe('models: []\n');
+        expect(lightdashApi).toHaveBeenCalledWith({
+            method: 'GET',
+            url: `/api/v1/ee/projects/${PROJECT_UUID}/apps/authoring-context?slug=revenue-explorer`,
+            body: undefined,
+        });
+        expect(LightdashAnalytics.track).toHaveBeenCalledWith({
+            event: 'command.executed',
+            properties: expect.objectContaining({
+                command: 'create-app',
+                success: true,
+            }),
+        });
+        expect(GlobalState.log).toHaveBeenCalledWith(
+            expect.stringContaining('react@19.2.5'),
+        );
+        expect(GlobalState.log).toHaveBeenCalledWith(
+            expect.stringContaining('⚠ Local package installation'),
+        );
+        expect(GlobalState.log).toHaveBeenCalledWith(
+            expect.stringContaining('shadcn@2.3.0'),
+        );
+        expect(promptMock).toHaveBeenCalledTimes(2);
+        expect(promptMock).toHaveBeenNthCalledWith(1, [
+            expect.objectContaining({
+                type: 'confirm',
+                name: 'confirmed',
+                message: 'Continue and review the packages to be installed?',
+                default: false,
+            }),
+        ]);
+        expect(promptMock).toHaveBeenNthCalledWith(2, [
+            expect.objectContaining({
+                type: 'confirm',
+                name: 'confirmed',
+                message: 'Install these packages and create the app?',
+                default: false,
+            }),
+        ]);
+        expect(execaMock).toHaveBeenCalledWith('npm', ['--version']);
+        expect(execaMock).toHaveBeenCalledWith(
+            'npm',
+            [
+                'install',
+                '--include=dev',
+                '--ignore-scripts',
+                '--no-package-lock',
+            ],
+            expect.objectContaining({
+                cwd: expect.any(String),
+                stdio: 'inherit',
+            }),
+        );
+        expect(execaMock).toHaveBeenCalledWith(
+            'npx',
+            expect.arrayContaining(['shadcn@2.3.0', 'init']),
+            expect.objectContaining({
+                cwd: expect.any(String),
+                input: '\u001B[B\n',
+            }),
+        );
+        expect(execaMock).toHaveBeenCalledWith(
+            'npx',
+            expect.arrayContaining(['shadcn@2.3.0', 'add', 'button']),
+            expect.objectContaining({
+                cwd: expect.any(String),
+                input: '\u001B[B\n',
+            }),
+        );
+    });
+
+    it('requires npm before requesting app context', async () => {
+        const root = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-create-app-'));
+        execaMock.mockRejectedValueOnce(new Error('npm not found'));
+
+        await expect(
+            createAppHandler('Revenue Explorer', {
+                path: root,
+                verbose: false,
+            }),
+        ).rejects.toThrow('npm is required to create a data app');
+        expect(lightdashApi).not.toHaveBeenCalled();
+        await expect(
+            fs.access(path.join(root, 'apps', 'revenue-explorer')),
+        ).rejects.toThrow();
+    });
+
+    it('does not create anything when package installation is declined', async () => {
+        const root = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-create-app-'));
+        promptMock
+            .mockResolvedValueOnce({ confirmed: true })
+            .mockResolvedValueOnce({ confirmed: false });
+
+        await expect(
+            createAppHandler('Revenue Explorer', {
+                path: root,
+                verbose: false,
+            }),
+        ).rejects.toThrow('Data app creation cancelled');
+        expect(lightdashApi).not.toHaveBeenCalled();
+        await expect(
+            fs.access(path.join(root, 'apps', 'revenue-explorer')),
+        ).rejects.toThrow();
+    });
+
+    it('does not list packages when local tooling approval is declined', async () => {
+        const root = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-create-app-'));
+        promptMock.mockResolvedValueOnce({ confirmed: false });
+
+        await expect(
+            createAppHandler('Revenue Explorer', {
+                path: root,
+                verbose: false,
+            }),
+        ).rejects.toThrow('Data app creation cancelled');
+        expect(promptMock).toHaveBeenCalledTimes(1);
+        expect(GlobalState.log).not.toHaveBeenCalledWith(
+            expect.stringContaining('react@19.2.5'),
+        );
+        expect(lightdashApi).not.toHaveBeenCalled();
+    });
+
+    it('requires explicit approval in non-interactive mode', async () => {
+        const root = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-create-app-'));
+        vi.mocked(GlobalState.isNonInteractive).mockReturnValueOnce(true);
+
+        await expect(
+            createAppHandler('Revenue Explorer', {
+                path: root,
+                verbose: false,
+            }),
+        ).rejects.toThrow('--assume-yes');
+        expect(promptMock).not.toHaveBeenCalled();
+    });
+
+    it('accepts --assume-yes in non-interactive mode', async () => {
+        const root = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-create-app-'));
+        vi.mocked(GlobalState.isNonInteractive).mockReturnValueOnce(true);
+
+        await createAppHandler('Revenue Explorer', {
+            assumeYes: true,
+            path: root,
+            verbose: false,
+        });
+
+        expect(promptMock).not.toHaveBeenCalled();
+        await expect(
+            fs.access(path.join(root, 'apps', 'revenue-explorer')),
+        ).resolves.toBeUndefined();
+    });
+
+    it('cleans up the temporary app when installation fails', async () => {
+        const root = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-create-app-'));
+        execaMock.mockImplementation(
+            async (command: string, args: string[] = []) => {
+                if (command === 'npm' && args[0] === 'install') {
+                    throw new Error('registry unavailable');
+                }
+                return { stdout: '' };
+            },
+        );
+
+        await expect(
+            createAppHandler('Revenue Explorer', {
+                path: root,
+                verbose: false,
+            }),
+        ).rejects.toThrow('registry unavailable');
+        expect(await fs.readdir(path.join(root, 'apps'))).toEqual([]);
+    });
+
+    it('does not overwrite an existing app directory', async () => {
+        const root = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-create-app-'));
+        const appDir = path.join(root, 'apps', 'revenue-explorer');
+        await fs.mkdir(appDir, { recursive: true });
+        await fs.writeFile(path.join(appDir, 'keep.txt'), 'keep');
+
+        await expect(
+            createAppHandler('Revenue Explorer', {
+                path: root,
+                verbose: false,
+            }),
+        ).rejects.toThrow('already exists');
+        expect(await fs.readFile(path.join(appDir, 'keep.txt'), 'utf8')).toBe(
+            'keep',
+        );
+    });
+});

--- a/packages/cli/src/handlers/apps/createApp.ts
+++ b/packages/cli/src/handlers/apps/createApp.ts
@@ -1,0 +1,368 @@
+import {
+    AuthorizationError,
+    generateSlug,
+    isValidDataAppSlug,
+    LightdashError,
+    ParameterError,
+    type DataAppContext,
+    type DataAppManifest,
+} from '@lightdash/common';
+import execa from 'execa';
+import { promises as fs } from 'fs';
+import inquirer from 'inquirer';
+import * as path from 'path';
+import { LightdashAnalytics } from '../../analytics/analytics';
+import { getConfig } from '../../config';
+import { CLI_VERSION } from '../../env';
+import GlobalState from '../../globalState';
+import * as styles from '../../styles';
+import { getDownloadFolder } from '../contentAsCodePaths';
+import { checkLightdashVersion, lightdashApi } from '../dbt/apiClient';
+import { logSelectedProject, selectProject } from '../selectProject';
+import {
+    writeBundleToDir,
+    writeContextToDir,
+    writeFilesToDir,
+} from './appCodeFiles';
+import {
+    buildStaticAuthoringFiles,
+    loadVendoredStarterSource,
+} from './scaffolding';
+
+export type CreateAppHandlerOptions = {
+    assumeYes?: boolean;
+    description?: string;
+    path?: string;
+    project?: string;
+    slug?: string;
+    verbose: boolean;
+};
+
+export const SHADCN_VERSION = '2.3.0';
+
+export const SHADCN_COMPONENTS = [
+    'button',
+    'badge',
+    'card',
+    'table',
+    'dialog',
+    'tabs',
+    'select',
+    'input',
+    'label',
+    'popover',
+    'tooltip',
+    'separator',
+    'skeleton',
+    'dropdown-menu',
+    'sheet',
+    'scroll-area',
+    'switch',
+    'checkbox',
+    'avatar',
+    'alert',
+    'progress',
+    'resizable',
+] as const;
+
+export const resolveLocalAppSlug = (
+    name: string,
+    explicitSlug?: string,
+): string => {
+    if (name.trim().length === 0) {
+        throw new ParameterError('Data app name cannot be empty.');
+    }
+    const slug = explicitSlug ?? generateSlug(name);
+    if (!isValidDataAppSlug(slug)) {
+        throw new ParameterError(
+            `Invalid data app slug "${slug}". Slugs must start with a lowercase letter or digit and contain only lowercase letters, digits, and hyphens, up to 255 characters.`,
+        );
+    }
+    return slug;
+};
+
+export const buildLocalAppManifest = (args: {
+    name: string;
+    description: string;
+    projectUuid: string;
+    slug: string;
+    now: Date;
+}): DataAppManifest => ({
+    codeVersion: 1,
+    projectUuid: args.projectUuid,
+    slug: args.slug,
+    version: 1,
+    name: args.name,
+    description: args.description,
+    template: null,
+    downloadedAt: args.now.toISOString(),
+    scaffoldingVersion: CLI_VERSION,
+});
+
+const assertAppDirectoryAvailable = async (appDir: string): Promise<void> => {
+    try {
+        await fs.access(appDir);
+        throw new ParameterError(
+            `Cannot create data app: ${appDir} already exists. Choose another slug or download the existing app.`,
+        );
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            return;
+        }
+        throw error;
+    }
+};
+
+const parseDirectPackages = (
+    staticFiles: ReturnType<typeof buildStaticAuthoringFiles>,
+): string[] => {
+    const packageJson = staticFiles.find(
+        (file) => file.path === 'package.json',
+    );
+    if (!packageJson) {
+        throw new Error('Data app template is missing package.json.');
+    }
+    const parsed = JSON.parse(
+        Buffer.from(packageJson.contentBase64, 'base64').toString('utf8'),
+    ) as {
+        dependencies?: Record<string, string>;
+        devDependencies?: Record<string, string>;
+    };
+    return Object.entries({
+        ...parsed.dependencies,
+        ...parsed.devDependencies,
+    })
+        .map(([packageName, version]) => `${packageName}@${version}`)
+        .sort();
+};
+
+const assertNpmAvailable = async (): Promise<void> => {
+    try {
+        await execa('npm', ['--version']);
+    } catch {
+        throw new ParameterError(
+            'npm is required to create a data app because Lightdash generates its shadcn UI locally. Install Node.js (which includes npm), then run this command again.',
+        );
+    }
+};
+
+const confirmLocalPackageTooling = async (
+    assumeYes: boolean,
+): Promise<void> => {
+    GlobalState.log(
+        styles.warning(
+            [
+                '⚠ Local package installation',
+                `Creating a data app downloads third-party packages through npm into the new app folder and runs shadcn@${SHADCN_VERSION} to generate UI files.`,
+                'Dependency lifecycle scripts are disabled, but npm and shadcn will access the network and write files on this machine.',
+                'Only continue if you trust these package sources and are comfortable running this tooling locally.',
+            ].join('\n'),
+        ),
+    );
+
+    if (assumeYes) return;
+    if (GlobalState.isNonInteractive()) {
+        throw new ParameterError(
+            'Creating a data app requires approval to download and install npm packages. Rerun with --assume-yes to approve in non-interactive mode.',
+        );
+    }
+
+    const { confirmed } = await inquirer.prompt<{ confirmed: boolean }>([
+        {
+            type: 'confirm',
+            name: 'confirmed',
+            message: 'Continue and review the packages to be installed?',
+            default: false,
+        },
+    ]);
+    if (!confirmed) {
+        throw new ParameterError('Data app creation cancelled.');
+    }
+};
+
+const confirmDependencyInstall = async (
+    directPackages: string[],
+    assumeYes: boolean,
+): Promise<void> => {
+    GlobalState.log(
+        [
+            'Creating this data app will install these direct npm packages:',
+            ...directPackages.map((packageSpec) => `  - ${packageSpec}`),
+            `\nIt will also run shadcn@${SHADCN_VERSION} to generate:`,
+            `  ${SHADCN_COMPONENTS.join(', ')}`,
+            "\nDependency lifecycle scripts will be disabled. React 19 peer dependencies will use npm's legacy-peer-deps mode.",
+        ].join('\n'),
+    );
+
+    if (assumeYes) return;
+    if (GlobalState.isNonInteractive()) {
+        throw new ParameterError(
+            'Creating a data app requires approval to install npm packages. Rerun with --assume-yes to approve in non-interactive mode.',
+        );
+    }
+
+    const { confirmed } = await inquirer.prompt<{ confirmed: boolean }>([
+        {
+            type: 'confirm',
+            name: 'confirmed',
+            message: 'Install these packages and create the app?',
+            default: false,
+        },
+    ]);
+    if (!confirmed) {
+        throw new ParameterError('Data app creation cancelled.');
+    }
+};
+
+const installDependenciesAndShadcn = async (appDir: string): Promise<void> => {
+    const npmEnv = {
+        ...process.env,
+        npm_config_ignore_scripts: 'true',
+        npm_config_package_lock: 'false',
+    };
+    const subprocessOptions = {
+        cwd: appDir,
+        env: npmEnv,
+        stdio: 'inherit' as const,
+    };
+    const shadcnOptions = {
+        cwd: appDir,
+        env: npmEnv,
+        input: '\u001B[B\n',
+        stdin: 'pipe' as const,
+        stdout: 'inherit' as const,
+        stderr: 'inherit' as const,
+    };
+
+    await execa(
+        'npm',
+        ['install', '--include=dev', '--ignore-scripts', '--no-package-lock'],
+        subprocessOptions,
+    );
+    await execa(
+        'npx',
+        ['--yes', `shadcn@${SHADCN_VERSION}`, 'init', '--defaults', '--force'],
+        shadcnOptions,
+    );
+    await execa(
+        'npx',
+        [
+            '--yes',
+            `shadcn@${SHADCN_VERSION}`,
+            'add',
+            '--overwrite',
+            '--yes',
+            ...SHADCN_COMPONENTS,
+        ],
+        shadcnOptions,
+    );
+};
+
+export const createAppHandler = async (
+    name: string,
+    options: CreateAppHandlerOptions,
+): Promise<void> => {
+    const startTime = Date.now();
+    let success = false;
+    GlobalState.setVerbose(options.verbose);
+
+    try {
+        const slug = resolveLocalAppSlug(name, options.slug);
+        const appDir = path.join(getDownloadFolder(options.path), 'apps', slug);
+        await assertAppDirectoryAvailable(appDir);
+        await assertNpmAvailable();
+        await confirmLocalPackageTooling(options.assumeYes ?? false);
+
+        const staticFiles = buildStaticAuthoringFiles({
+            appName: name,
+            sdkVersion: CLI_VERSION,
+        });
+        await confirmDependencyInstall(
+            parseDirectPackages(staticFiles),
+            options.assumeYes ?? false,
+        );
+
+        await checkLightdashVersion();
+        const config = await getConfig();
+        if (!config.context?.apiKey || !config.context.serverUrl) {
+            throw new AuthorizationError(
+                `Not logged in. Run 'lightdash login --help'`,
+            );
+        }
+
+        const projectSelection = await selectProject(config, options.project);
+        if (!projectSelection) {
+            throw new LightdashError({
+                message:
+                    'No project selected. Run lightdash config set-project',
+                name: 'Not Found',
+                statusCode: 404,
+                data: {},
+            });
+        }
+        const { projectUuid } = projectSelection;
+        logSelectedProject(projectSelection, config, 'Creating app for');
+
+        const context = await lightdashApi<DataAppContext>({
+            method: 'GET',
+            url: `/api/v1/ee/projects/${projectUuid}/apps/authoring-context?slug=${encodeURIComponent(slug)}`,
+            body: undefined,
+        });
+        const manifest = buildLocalAppManifest({
+            name,
+            description: options.description ?? '',
+            projectUuid,
+            slug,
+            now: new Date(),
+        });
+        const appsDir = path.dirname(appDir);
+        await fs.mkdir(appsDir, { recursive: true });
+        const temporaryAppDir = await fs.mkdtemp(
+            path.join(appsDir, `.${slug}-`),
+        );
+
+        try {
+            await writeBundleToDir(temporaryAppDir, {
+                manifest,
+                files: loadVendoredStarterSource(),
+            });
+            await writeFilesToDir(temporaryAppDir, staticFiles);
+            await writeContextToDir(temporaryAppDir, context);
+            await installDependenciesAndShadcn(temporaryAppDir);
+
+            // shadcn rewrites package versions and tailwind colors while it
+            // generates source. Restore the reviewed template declarations so
+            // the approval list stays exact and uploads do not mistake the
+            // generated app for one with custom dependencies.
+            await writeFilesToDir(
+                temporaryAppDir,
+                staticFiles.filter(
+                    (file) =>
+                        file.path === 'package.json' ||
+                        file.path === 'tailwind.config.js',
+                ),
+            );
+            await fs.rename(temporaryAppDir, appDir);
+        } catch (error) {
+            await fs.rm(temporaryAppDir, { recursive: true, force: true });
+            throw error;
+        }
+
+        GlobalState.log(
+            styles.success(`Created data app "${name}" at ${appDir}`),
+        );
+        GlobalState.log(
+            `\nNext:\n  cd ${JSON.stringify(appDir)}\n  npm run build\n  lightdash upload --apps ${slug}`,
+        );
+        success = true;
+    } finally {
+        await LightdashAnalytics.track({
+            event: 'command.executed',
+            properties: {
+                command: 'create-app',
+                durationMs: Date.now() - startTime,
+                success,
+            },
+        });
+    }
+};

--- a/packages/cli/src/handlers/apps/scaffolding.test.ts
+++ b/packages/cli/src/handlers/apps/scaffolding.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'os';
 import {
     buildStaticAuthoringFiles,
     firstExistingDir,
+    loadVendoredStarterSource,
     rewriteWorkspaceDeps,
 } from './scaffolding';
 
@@ -65,13 +66,14 @@ describe('buildStaticAuthoringFiles', () => {
     const text = (p: string) =>
         Buffer.from(byPath(p)!.contentBase64, 'base64').toString('utf-8');
 
-    it('ships both skills', () => {
-        expect(
-            byPath('.claude/skills/lightdash-data-app/SKILL.md'),
-        ).toBeDefined();
-        expect(
-            byPath('.claude/skills/developing-data-apps-locally/SKILL.md'),
-        ).toBeDefined();
+    it.each([
+        'lightdash-data-app',
+        'developing-data-apps-locally',
+        'frontend-design',
+        'reusable-visualization',
+        'sdk-features',
+    ])('ships the %s skill', (skill) => {
+        expect(byPath(`.claude/skills/${skill}/SKILL.md`)).toBeDefined();
     });
 
     it('pins the SDK to a concrete version in package.json', () => {
@@ -87,16 +89,34 @@ describe('buildStaticAuthoringFiles', () => {
     });
 
     it('uses npm for the standard local workflow', () => {
-        expect(text('README.md')).toContain('npm install && npm run build');
+        expect(text('README.md')).toContain('run `npm install` first');
         expect(text('AGENTS.md')).toContain('npm install && npm run build');
         expect(
             text('.claude/skills/developing-data-apps-locally/SKILL.md'),
-        ).toContain('`npm install` then `npm run build`');
+        ).toContain('run `npm install` first');
         expect(text('.npmrc')).toContain('ignore-scripts=true');
         expect(text('.npmrc')).not.toContain('shamefully-hoist');
     });
 
     it('never writes app source (no src/ files)', () => {
         expect(files.every((f) => !f.path.startsWith('src/'))).toBe(true);
+    });
+});
+
+describe('loadVendoredStarterSource', () => {
+    const files = loadVendoredStarterSource();
+
+    it('loads the starter app source with bundle-relative paths', () => {
+        expect(files.map((file) => file.path)).toEqual(
+            expect.arrayContaining([
+                'src/App.jsx',
+                'src/main.jsx',
+                'src/index.css',
+            ]),
+        );
+        expect(files.every((file) => file.path.startsWith('src/'))).toBe(true);
+        expect(
+            files.some((file) => file.path.startsWith('src/components/ui/')),
+        ).toBe(false);
     });
 });

--- a/packages/cli/src/handlers/apps/scaffolding.ts
+++ b/packages/cli/src/handlers/apps/scaffolding.ts
@@ -115,6 +115,11 @@ export const loadVendoredTemplate = (): DataAppCodeFile[] => {
     return walkDir(templateDir, templateDir, SKIP);
 };
 
+export const loadVendoredStarterSource = (): DataAppCodeFile[] => {
+    const { templateDir } = resolveVendorDirs();
+    return walkDir(path.join(templateDir, 'src'), templateDir, new Set());
+};
+
 /**
  * Assembles static authoring files (configs, skills, templates) to deploy alongside a data app.
  */

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,6 +16,7 @@ import {
 } from './env';
 import { getDiagnosticsHint } from './error';
 import GlobalState from './globalState';
+import { createAppHandler } from './handlers/apps/createApp';
 import { appsPreviewHandler } from './handlers/apps/preview';
 import { compileHandler } from './handlers/compile';
 import { connectSnowflakeHandler } from './handlers/connectSnowflake';
@@ -179,6 +180,39 @@ ${styles.bold('Examples:')}
   )} ${styles.secondary('-- logs in to a Lightdash instance')}
 `,
     );
+
+const createProgram = program
+    .command('create')
+    .description('Creates Lightdash content locally');
+
+createProgram
+    .command('app <name>')
+    .description('Creates a new data app locally')
+    .option('--description <text>', 'Set the app description', '')
+    .option('--slug <slug>', 'Override the app slug')
+    .option(
+        '-p, --path <path>',
+        'Specify the Lightdash content root (default: ./lightdash)',
+    )
+    .option(
+        '--project <project uuid>',
+        'Specify the project the app will use',
+        parseProjectArgument,
+        undefined,
+    )
+    .option('-y, --assume-yes', 'approve npm package installation', false)
+    .option('--verbose', undefined, false)
+    .addHelpText(
+        'after',
+        `\n${styles.bold('Example:')}\n  ${styles.title(
+            '⚡',
+        )}️lightdash ${styles.bold(
+            'create app "Revenue explorer"',
+        )} ${styles.secondary(
+            '-- creates ./lightdash/apps/revenue-explorer',
+        )}\n`,
+    )
+    .action(createAppHandler);
 
 program
     .command('connect-snowflake')


### PR DESCRIPTION
### Description

- Add `lightdash create app "<name>"` with optional slug, description, project, and output path overrides.
- Require npm and show a yellow local-tooling warning before presenting the exact dependency and shadcn component set.
- Ask separately whether to review the packages and whether to install them; `--assume-yes` approves both for non-interactive use.
- Install dependencies with lifecycle scripts disabled and generate the same pinned shadcn component set used by the E2B Docker build.
- Build transactionally in a temporary directory so failed or declined installs leave no partial app behind.
- Include the data-app skills and a fresh project context snapshot, then refuse server-side slug collisions and existing local directories.
- Preserve the current local-preview and custom-dependency security guidance from `main`.

### Stack

1. #26554 — project authoring-context API
2. **This PR:** `lightdash create app` CLI command

### Validation

- 27 focused create/scaffolding tests
- 9 local-preview proxy tests
- Focused CLI lint and formatting
- CLI TypeScript build
- Manual warning prompt and cancellation check
- Real npm install plus shadcn init/add in a fresh scaffold
- Production Vite build of the generated scaffold