### PR TITLE
fix: register the two new AI tool names in the frontend tool registries

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ToolCallDescription.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ToolCallDescription.tsx
@@ -375,6 +375,8 @@ export const ToolCallDescription: FC<{
         case 'runSavedChart':
         case 'readPinnedThread':
         case 'submitResearchReport':
+        case 'submitResearchHypotheses':
+        case 'submitInvestigationReport':
         case 'resolveUrl':
             return <> </>;
         default:

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/toolIcons.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/toolIcons.ts
@@ -90,6 +90,8 @@ export const getToolIcon = (toolName: AiAgentToolName) => {
             getKnowledgeDocumentContent: IconFileText,
             readPinnedThread: IconMessages,
             submitResearchReport: IconFileText,
+            submitResearchHypotheses: IconListDetails,
+            submitInvestigationReport: IconFileText,
         };
 
     return isToolName(toolName) ? iconMap[toolName] : IconPlugConnected;


### PR DESCRIPTION
## Summary

`main` currently fails `@lightdash/frontend#typecheck`, which fails **Build & Test on every open PR** (confirmed across five of them). The deep-research change added `submitResearchHypotheses` and `submitInvestigationReport` to the tool definitions in `packages/common` without updating the two frontend registries that are typed against the `ToolName` union:

- `toolIcons.ts` — TS2739, the icon map was missing both keys.
- `ToolCallDescription.tsx` — TS2345, both names were unhandled in the exhaustive switch.

This adds the two icon entries and routes both names through the existing no-description fall-through group — four lines, no behaviour change beyond the two tools now rendering an icon instead of crashing the typecheck.

**Two notes for review:** the icon choices are placeholders (`IconListDetails` for hypotheses, `IconFileText` for the investigation report, matching `submitResearchReport`) and should be confirmed by whoever owns the deep-research tools — happy to change them. And I could not typecheck locally (this was cut in a bare checkout without an install), so CI on this PR is the verification; the change adds exactly the two keys CI named as missing.

Found while raising an unrelated onboarding PR; not caused by that change.

Closes: SPK-748

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149dPst6zNmvtvB7or6569P