### PR TITLE
fix: register the deep research hypothesis and investigation tools

### DIFF
--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -1670,6 +1670,8 @@ export const builtInToolDefinitions: readonly ToolDefinitionInstance[] = [
     getKnowledgeDocumentContentToolDefinition,
     readPinnedThreadToolDefinition,
     submitResearchReportToolDefinition,
+    submitResearchHypothesesToolDefinition,
+    submitInvestigationReportToolDefinition,
     findChartsToolDefinition,
     findDashboardsToolDefinition,
     generateBarVizConfigToolDefinition,


### PR DESCRIPTION
## Summary

**main is still red after #26558.** That fix cleared `frontend#typecheck`, which unmasked a second failure from the same half-landed change: `@lightdash/common#test` fails, so Build & Test remains red on main and on every open PR.

The failing test is `defineTool.test.ts` → "keeps ToolNameSchema aligned with agent-available definitions". `ToolNameSchema` lists `submitResearchHypotheses` and `submitInvestigationReport`, but `agentToolNames` doesn't, so the two sets differ.

Both tools declare `availability: ['agent']` and are already registered in the by-name map and the type map — they were simply never added to the `builtInToolDefinitions` array that `agentToolDefinitions`, and therefore `agentToolNames`, is derived from. `submitResearchReportToolDefinition`, added alongside them, is in the array. So this is an omission rather than a design decision, and the fix is to add the two entries.

If the intent was actually for these two to be internal-only, the correct fix is the opposite one — drop them from `ToolNameSchema` and revert #26558 — so worth a glance from whoever owns deep research.

## Verification

Ran locally against a clean checkout of this branch: `pnpm -F common test` → 119 files, 3201 passed, 1 skipped. The previously failing alignment test now passes.

Closes: SPK-749
Relates: SPK-748

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149dPst6zNmvtvB7or6569P