### PR TITLE
fix: complete the deep research tool wiring across the shared registries

### DIFF
--- a/packages/backend/src/ee/services/AiAgentMemoryService/transcriptToolPolicy.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/transcriptToolPolicy.ts
@@ -115,6 +115,12 @@ export const DISTILL_TOOL_POLICIES = {
     editProjectContext: { result: truncate(DEFAULT_TOOL_RESULT_LIMIT) },
     updateUserName: { result: keep },
     submitResearchReport: { result: truncate(RESEARCH_REPORT_RESULT_LIMIT) },
+    submitResearchHypotheses: {
+        result: truncate(RESEARCH_REPORT_RESULT_LIMIT),
+    },
+    submitInvestigationReport: {
+        result: truncate(RESEARCH_REPORT_RESULT_LIMIT),
+    },
     generateHashes: { result: omitCall },
     generateUuids: { result: omitCall },
     submitDiscoverFieldsResult: { result: omitCall },

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -7753,6 +7753,8 @@ exports[`AI agent tool contracts > matches the shared agent tool definition name
   "getKnowledgeDocumentContent",
   "readPinnedThread",
   "submitResearchReport",
+  "submitResearchHypotheses",
+  "submitInvestigationReport",
   "findCharts",
   "findDashboards",
   "generateBarVizConfig",

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/index.ts
@@ -181,6 +181,8 @@ export const TOOL_DISPLAY_MESSAGES_AFTER_TOOL_CALL =
         getKnowledgeDocumentContent: 'Read knowledge document',
         readPinnedThread: 'Read pinned conversation',
         submitResearchReport: 'Saved research report',
+        submitResearchHypotheses: 'Planned research hypotheses',
+        submitInvestigationReport: 'Saved investigation findings',
     });
 
 export const AVAILABLE_VISUALIZATION_TYPES = VisualizationTools;


### PR DESCRIPTION
## Summary

Third and final follow-on to the deep-research tool landing, after #26558 and #26560. Registering the two tools in `builtInToolDefinitions` (#26560) changed the shared agent tool name list, which broke `backend#test` — so main went red again immediately after that merge, on a different check.

Two of these are CI-blocking, one is a display gap:

- `transcriptToolPolicy.ts` — every shared agent tool needs an explicit entry in `DISTILL_TOOL_POLICIES`; both were missing, failing the contract test's explicit-policy assertion. Each uses `truncate(RESEARCH_REPORT_RESULT_LIMIT)`, matching `submitResearchReport`.
- `agentToolContracts.snapshot.test.ts.snap` — regenerated for the two new shared names.
- `visualizations/index.ts` — the two tools had "while running" display messages but no after-tool-call ones, so completed labels rendered as `undefined`. Not a crash, and not caught by any test.

## Why the policy and labels are right

An independent review traced the runtime rather than pattern-matching. All three submission tools return the same shape (`{"submitted":true}` on success, a validation message on failure); the substantive hypothesis and report data lives in the tool *arguments*, which this policy doesn't truncate. So the limit only bounds the acknowledgement, and there's no reason for these two to differ from their sibling. Planner and investigator calls also carry a non-null `parentToolCallId`, and distillation currently excludes child calls, so these entries are contract/future-proofing today.

That review also confirmed the direction of the two merged PRs was correct: the planner toolset contains `submitResearchHypotheses`, the investigator adds `submitInvestigationReport`, both resolve through `.for('agent')`, and removing them from `ToolNameSchema` would make their persisted calls fail the built-in-tool parsing boundary.

## Verification

Run in a fully built tree, not a bare checkout — the whole battery, because the previous two fixes each passed the package I'd touched and broke a different one:

- `pnpm -F backend test` — 365 files, 5331 passed
- `pnpm -F common test` — 119 files, 3201 passed
- `pnpm -F backend typecheck`, `pnpm -F frontend typecheck`, `pnpm -F common build` — all clean

## Known gap left out of scope

`submitResearchReport` is itself absent from `TOOLS_WITHOUT_DESCRIPTION` and `TOOLS_WITHOUT_LATEST_DESCRIPTION` despite returning an empty description, so all three research tools render an expandable blank area. That's pre-existing rather than a regression from this change, so it's tracked separately instead of widening this PR.

Closes: SPK-749
Relates: SPK-748

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149dPst6zNmvtvB7or6569P