### PR TITLE
fix(frontend): keep the active agent onboarding run cache in sync

### DIFF
--- a/packages/frontend/src/ee/features/agentOnboarding/hooks/useAgentOnboarding.test.tsx
+++ b/packages/frontend/src/ee/features/agentOnboarding/hooks/useAgentOnboarding.test.tsx
@@ -1,0 +1,83 @@
+import { type AgentOnboardingRun } from '@lightdash/common';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { type PropsWithChildren } from 'react';
+import {
+    useCancelAgentOnboardingRun,
+    useStartAgentOnboardingRun,
+} from './useAgentOnboarding';
+
+const run: AgentOnboardingRun = {
+    agentOnboardingRunUuid: 'run-uuid',
+    projectUuid: 'project-uuid',
+    status: 'queued',
+    stage: null,
+    events: [],
+    handoff: null,
+    usage: null,
+    files: [],
+    errorMessage: null,
+    createdAt: '2026-07-30T00:00:00.000Z',
+    updatedAt: '2026-07-30T00:00:00.000Z',
+    startedAt: null,
+    completedAt: null,
+};
+
+const lightdashApi = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../../api', () => ({ lightdashApi }));
+
+vi.mock('../../../../hooks/toaster/useToaster', () => ({
+    default: () => ({ showToastApiError: vi.fn() }),
+}));
+
+const activeRunKey = ['agent-onboarding-active-run', 'project-uuid'];
+
+const renderWithClient = <T,>(hook: () => T) => {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: PropsWithChildren) => (
+        <QueryClientProvider client={queryClient}>
+            {children}
+        </QueryClientProvider>
+    );
+
+    return { queryClient, ...renderHook(hook, { wrapper }) };
+};
+
+describe('agent onboarding run mutations', () => {
+    beforeEach(() => {
+        lightdashApi.mockReset();
+    });
+
+    it('caches the started run as the active run so the step card resumes it', async () => {
+        lightdashApi.mockResolvedValue(run);
+        const { queryClient, result } = renderWithClient(
+            useStartAgentOnboardingRun,
+        );
+
+        await result.current.mutateAsync('project-uuid');
+
+        await waitFor(() =>
+            expect(queryClient.getQueryData(activeRunKey)).toEqual(run),
+        );
+    });
+
+    it('clears the active run when a run is cancelled', async () => {
+        lightdashApi.mockResolvedValue({ ...run, status: 'cancelled' });
+        const { queryClient, result } = renderWithClient(
+            useCancelAgentOnboardingRun,
+        );
+        queryClient.setQueryData(activeRunKey, run);
+
+        await result.current.mutateAsync({
+            projectUuid: 'project-uuid',
+            runUuid: 'run-uuid',
+        });
+
+        await waitFor(() =>
+            expect(queryClient.getQueryData(activeRunKey)).toBeNull(),
+        );
+    });
+});

--- a/packages/frontend/src/ee/features/agentOnboarding/hooks/useAgentOnboarding.ts
+++ b/packages/frontend/src/ee/features/agentOnboarding/hooks/useAgentOnboarding.ts
@@ -24,6 +24,9 @@ const agentOnboardingRunQueryKey = (
     runUuid: string | undefined,
 ) => ['agent-onboarding-run', projectUuid, runUuid] as const;
 
+const agentOnboardingActiveRunQueryKey = (projectUuid: string | undefined) =>
+    ['agent-onboarding-active-run', projectUuid] as const;
+
 const getAgentOnboardingRefetchInterval = (
     run: AgentOnboardingRun | undefined,
 ): number | false =>
@@ -89,9 +92,12 @@ export const useActiveAgentOnboardingRun = (
     >,
 ) =>
     useQuery<AgentOnboardingRun | null, ApiError>({
-        queryKey: ['agent-onboarding-active-run', projectUuid],
+        queryKey: agentOnboardingActiveRunQueryKey(projectUuid),
         queryFn: () => getActiveRun(projectUuid!),
         enabled: !!projectUuid && (options?.enabled ?? true),
+        // A run can start or finish elsewhere in the app, so this must not be
+        // served stale on remount (e.g. after a back navigation)
+        staleTime: 0,
     });
 
 export const useAgentOnboardingFile = (
@@ -112,10 +118,24 @@ export const useAgentOnboardingFile = (
     });
 
 export const useStartAgentOnboardingRun = () => {
+    const queryClient = useQueryClient();
     const { showToastApiError } = useToaster();
 
     return useMutation<AgentOnboardingRun, ApiError, string>({
         mutationFn: startRun,
+        onSuccess: (run) => {
+            queryClient.setQueryData(
+                agentOnboardingRunQueryKey(
+                    run.projectUuid,
+                    run.agentOnboardingRunUuid,
+                ),
+                run,
+            );
+            queryClient.setQueryData(
+                agentOnboardingActiveRunQueryKey(run.projectUuid),
+                run,
+            );
+        },
         onError: ({ error }) => {
             showToastApiError({
                 title: 'Failed to start project setup',
@@ -144,6 +164,11 @@ export const useCancelAgentOnboardingRun = () => {
                     run.agentOnboardingRunUuid,
                 ),
                 run,
+            );
+            // Cancelled runs are terminal, so nothing is active any more
+            queryClient.setQueryData(
+                agentOnboardingActiveRunQueryKey(run.projectUuid),
+                null,
             );
         },
         onError: ({ error }) => {


### PR DESCRIPTION
### Description:

Starting an agentic semantic-layer run never touched the `agent-onboarding-active-run` query cache, so navigating back to the homepage within the 30s default `staleTime` re-used the cached `null` and the semantic layer step card showed "Set up" until a refresh.

- Seed both the run and active-run caches from `useStartAgentOnboardingRun`
- Clear the active-run cache on cancel (cancelled runs are terminal, so "Resume" would have been wrong there too)
- Set `staleTime: 0` on the active-run query so a remount (back navigation) always revalidates, which also covers a run finishing while the user is on the run page
- Add tests for the two mutation cache updates
