### PR TITLE
fix: register deep research distill policies

### DIFF
--- a/packages/backend/src/ee/services/AiAgentMemoryService/transcriptToolPolicy.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/transcriptToolPolicy.ts
@@ -115,6 +115,12 @@ export const DISTILL_TOOL_POLICIES = {
     editProjectContext: { result: truncate(DEFAULT_TOOL_RESULT_LIMIT) },
     updateUserName: { result: keep },
     submitResearchReport: { result: truncate(RESEARCH_REPORT_RESULT_LIMIT) },
+    submitResearchHypotheses: {
+        result: truncate(RESEARCH_REPORT_RESULT_LIMIT),
+    },
+    submitInvestigationReport: {
+        result: truncate(RESEARCH_REPORT_RESULT_LIMIT),
+    },
     generateHashes: { result: omitCall },
     generateUuids: { result: omitCall },
     submitDiscoverFieldsResult: { result: omitCall },

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -7753,6 +7753,8 @@ exports[`AI agent tool contracts > matches the shared agent tool definition name
   "getKnowledgeDocumentContent",
   "readPinnedThread",
   "submitResearchReport",
+  "submitResearchHypotheses",
+  "submitInvestigationReport",
   "findCharts",
   "findDashboards",
   "generateBarVizConfig",


### PR DESCRIPTION
### Description

- Add explicit transcript distill policies for the deep-research submission tools.
- Refresh the shared agent-tool name snapshot after those tools landed on main.