### PR TITLE
feat(deep-research): expire reports after 30 days

### DIFF
--- a/packages/backend/src/ee/database/entities/aiDeepResearch.ts
+++ b/packages/backend/src/ee/database/entities/aiDeepResearch.ts
@@ -29,6 +29,8 @@ export type DbAiDeepResearchRun = {
     effort: AiDeepResearchEffort;
     result_markdown: string | null;
     result_chart_data: AiDeepResearchChartDataMap | null;
+    report_expires_at: Date | null;
+    report_expired_at: Date | null;
     /** Rows persisted before hypothesis fan-out lack `maxHypotheses`. */
     budget_snapshot: Omit<AiDeepResearchBudget, 'maxHypotheses'> &
         Partial<Pick<AiDeepResearchBudget, 'maxHypotheses'>>;
@@ -65,6 +67,8 @@ export type AiDeepResearchRunsTable = Knex.CompositeTableType<
             | 'status'
             | 'result_markdown'
             | 'result_chart_data'
+            | 'report_expires_at'
+            | 'report_expired_at'
             | 'error_message'
             | 'cancellation_requested_at'
             | 'started_at'

--- a/packages/backend/src/ee/database/migrations/20260730180000_add_ai_deep_research_report_expiry.ts
+++ b/packages/backend/src/ee/database/migrations/20260730180000_add_ai_deep_research_report_expiry.ts
@@ -1,0 +1,37 @@
+import { Knex } from 'knex';
+
+const AiDeepResearchRunsTableName = 'ai_deep_research_runs';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AiDeepResearchRunsTableName, (table) => {
+        table.timestamp('report_expires_at', { useTz: true }).nullable();
+        table.timestamp('report_expired_at', { useTz: true }).nullable();
+        table.index(
+            ['report_expires_at', 'report_expired_at'],
+            'ai_deep_research_runs_report_expiry_idx',
+        );
+    });
+
+    await knex(AiDeepResearchRunsTableName)
+        .whereIn('status', ['completed', 'partially_completed'])
+        .whereNotNull('completed_at')
+        .where((query) =>
+            query
+                .whereNotNull('result_markdown')
+                .orWhereNotNull('result_chart_data'),
+        )
+        .update({
+            report_expires_at: knex.raw("completed_at + interval '30 days'"),
+        });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AiDeepResearchRunsTableName, (table) => {
+        table.dropIndex(
+            ['report_expires_at', 'report_expired_at'],
+            'ai_deep_research_runs_report_expiry_idx',
+        );
+        table.dropColumn('report_expired_at');
+        table.dropColumn('report_expires_at');
+    });
+}

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.integration.test.ts
@@ -1,4 +1,5 @@
 import {
+    AI_DEEP_RESEARCH_REPORT_TOOL_NAME,
     SEED_ORG_1,
     SEED_ORG_1_ADMIN,
     SEED_PROJECT,
@@ -8,9 +9,15 @@ import {
 import { type Knex } from 'knex';
 import { getTestContext } from '../../vitest.setup.integration';
 import {
+    AiAgentToolCallTableName,
+    AiAgentToolResultTableName,
     AiPromptTableName,
+    AiSqlApprovalTableName,
     AiThreadTableName,
+    type AiAgentToolCallTable,
+    type AiAgentToolResultTable,
     type AiPromptTable,
+    type AiSqlApprovalTable,
     type AiThreadTable,
 } from '../database/entities/ai';
 import {
@@ -90,6 +97,7 @@ describe('AiDeepResearchRunModel integration', () => {
     let threadUuid = '';
     let promptUuid = '';
     const runUuids = new Set<string>();
+    const additionalPromptUuids = new Set<string>();
 
     beforeAll(async () => {
         database = getTestContext().db;
@@ -155,19 +163,25 @@ describe('AiDeepResearchRunModel integration', () => {
     });
 
     afterEach(async () => {
-        if (runUuids.size === 0) {
-            return;
+        if (runUuids.size > 0) {
+            await database(AiDeepResearchRunsTableName)
+                .whereIn('ai_deep_research_run_uuid', [...runUuids])
+                .delete();
+            runUuids.clear();
         }
-        await database(AiDeepResearchRunsTableName)
-            .whereIn('ai_deep_research_run_uuid', [...runUuids])
-            .delete();
-        runUuids.clear();
+        if (additionalPromptUuids.size > 0) {
+            await database(AiPromptTableName)
+                .whereIn('ai_prompt_uuid', [...additionalPromptUuids])
+                .delete();
+            additionalPromptUuids.clear();
+        }
     });
 
     const createRun = async (
         dimensions: {
             entryPoint?: 'homepage' | 'ask_ai';
             effort?: 'low' | 'medium' | 'high' | 'xhigh';
+            promptUuid?: string;
         } = {},
     ): Promise<DbAiDeepResearchRun> => {
         const run = await model.create({
@@ -176,7 +190,7 @@ describe('AiDeepResearchRunModel integration', () => {
             createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
             agentUuid,
             aiThreadUuid: threadUuid,
-            promptUuid,
+            promptUuid: dimensions.promptUuid ?? promptUuid,
             toolCallId: null,
             prompt: `Integration race ${crypto.randomUUID()}`,
             selectedMcpServerUuids: [],
@@ -193,6 +207,18 @@ describe('AiDeepResearchRunModel integration', () => {
         });
         runUuids.add(run.ai_deep_research_run_uuid);
         return run;
+    };
+
+    const createAdditionalPrompt = async (): Promise<string> => {
+        const [prompt] = await database<AiPromptTable>(AiPromptTableName)
+            .insert({
+                ai_thread_uuid: threadUuid,
+                created_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+                prompt: `Deep Research integration prompt ${crypto.randomUUID()}`,
+            })
+            .returning('ai_prompt_uuid');
+        additionalPromptUuids.add(prompt.ai_prompt_uuid);
+        return prompt.ai_prompt_uuid;
     };
 
     const getAnalyticsOutbox = async (runUuid: string) =>
@@ -361,6 +387,297 @@ describe('AiDeepResearchRunModel integration', () => {
                       'status_changed:cancelled',
                   ],
         );
+    });
+
+    it.each(['completed', 'partially_completed'] as const)(
+        'persists a 30-day expiry for a successfully %s report',
+        async (status) => {
+            const run = await createRun();
+            await model.claimQueuedRun(run.ai_deep_research_run_uuid);
+
+            if (status === 'completed') {
+                await model.markCompleted(
+                    run.ai_deep_research_run_uuid,
+                    report,
+                    {},
+                );
+            } else {
+                await model.markPartiallyCompleted(
+                    run.ai_deep_research_run_uuid,
+                    report,
+                    {},
+                    'query_limit',
+                );
+            }
+
+            const persisted = await model.findByUuid(
+                run.ai_deep_research_run_uuid,
+            );
+            expect(persisted?.status).toBe(status);
+            expect(persisted?.report_expired_at).toBeNull();
+            expect(
+                persisted!.report_expires_at!.getTime() -
+                    persisted!.completed_at!.getTime(),
+            ).toBe(30 * 24 * 60 * 60 * 1_000);
+        },
+    );
+
+    it('scrubs only expired run data, supports legacy null expiries, and is idempotent under contention', async () => {
+        const expiredRun = await createRun();
+        const futurePromptUuid = await createAdditionalPrompt();
+        const futureRun = await createRun({ promptUuid: futurePromptUuid });
+        const expiredToolCallId = `expired-${crypto.randomUUID()}`;
+        const futureToolCallId = `future-${crypto.randomUUID()}`;
+        const unrelatedToolCallId = `unrelated-${crypto.randomUUID()}`;
+
+        await database(AiDeepResearchRunsTableName)
+            .where(
+                'ai_deep_research_run_uuid',
+                expiredRun.ai_deep_research_run_uuid,
+            )
+            .update({
+                status: 'completed',
+                result_markdown: 'expired report',
+                result_chart_data: JSON.stringify({}),
+                completed_at: database.raw("now() - interval '31 days'"),
+                report_expires_at: null,
+            });
+        await database(AiDeepResearchRunsTableName)
+            .where(
+                'ai_deep_research_run_uuid',
+                futureRun.ai_deep_research_run_uuid,
+            )
+            .update({
+                status: 'completed',
+                result_markdown: 'future report',
+                result_chart_data: JSON.stringify({}),
+                completed_at: database.raw("now() - interval '1 day'"),
+                report_expires_at: database.raw("now() + interval '29 days'"),
+            });
+
+        await database<AiAgentToolCallTable>(AiAgentToolCallTableName).insert([
+            {
+                ai_prompt_uuid: promptUuid,
+                tool_call_id: expiredToolCallId,
+                tool_name: 'runSql',
+                tool_args: {},
+                ai_mcp_server_uuid: null,
+                parent_tool_call_id: `deep-research:${expiredRun.ai_deep_research_run_uuid}:investigation:1`,
+            },
+            {
+                ai_prompt_uuid: futurePromptUuid,
+                tool_call_id: futureToolCallId,
+                tool_name: 'runSql',
+                tool_args: {},
+                ai_mcp_server_uuid: null,
+                parent_tool_call_id: `deep-research:${futureRun.ai_deep_research_run_uuid}:investigation:1`,
+            },
+            {
+                ai_prompt_uuid: promptUuid,
+                tool_call_id: unrelatedToolCallId,
+                tool_name: 'runSql',
+                tool_args: {},
+                ai_mcp_server_uuid: null,
+                parent_tool_call_id: null,
+            },
+        ]);
+        await database<AiAgentToolResultTable>(
+            AiAgentToolResultTableName,
+        ).insert(
+            [
+                { promptUuid, toolCallId: expiredToolCallId },
+                {
+                    promptUuid: futurePromptUuid,
+                    toolCallId: futureToolCallId,
+                },
+                { promptUuid, toolCallId: unrelatedToolCallId },
+            ].map(({ promptUuid: toolPromptUuid, toolCallId }) => ({
+                ai_prompt_uuid: toolPromptUuid,
+                tool_call_id: toolCallId,
+                tool_name: 'runSql',
+                result: JSON.stringify({ rows: [{ value: 1 }] }),
+            })),
+        );
+        await database<AiSqlApprovalTable>(AiSqlApprovalTableName).insert({
+            tool_call_id: expiredToolCallId,
+            decision: 'approved',
+        });
+
+        try {
+            expect(
+                await database(AiAgentToolCallTableName)
+                    .where('ai_prompt_uuid', promptUuid)
+                    .where(
+                        'parent_tool_call_id',
+                        'like',
+                        `deep-research:${expiredRun.ai_deep_research_run_uuid}:%`,
+                    )
+                    .pluck('tool_call_id'),
+            ).toEqual([expiredToolCallId]);
+
+            const results = await Promise.all([
+                model.cleanExpiredReports(100),
+                model.cleanExpiredReports(100),
+            ]);
+
+            expect(
+                results.reduce((sum, result) => sum + result.expired, 0),
+            ).toBe(1);
+            expect(results.every((result) => result.failed === 0)).toBe(true);
+            expect(
+                await model.findByPromptUuidsScoped({
+                    promptUuids: [promptUuid, futurePromptUuid],
+                    organizationUuid: SEED_ORG_1.organization_uuid,
+                    projectUuid: SEED_PROJECT.project_uuid,
+                }),
+            ).toEqual([
+                {
+                    prompt_uuid: futurePromptUuid,
+                    result_markdown: 'future report',
+                },
+            ]);
+            expect(
+                await model.findReportByUuidThreadScoped({
+                    aiDeepResearchRunUuid: expiredRun.ai_deep_research_run_uuid,
+                    aiThreadUuid: threadUuid,
+                    organizationUuid: SEED_ORG_1.organization_uuid,
+                    projectUuid: SEED_PROJECT.project_uuid,
+                    createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                }),
+            ).toBeUndefined();
+            expect(
+                await model.findReportSummariesByThreadScoped({
+                    aiThreadUuid: threadUuid,
+                    organizationUuid: SEED_ORG_1.organization_uuid,
+                    projectUuid: SEED_PROJECT.project_uuid,
+                    createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                }),
+            ).toEqual([
+                expect.objectContaining({
+                    ai_deep_research_run_uuid:
+                        futureRun.ai_deep_research_run_uuid,
+                }),
+            ]);
+
+            const persistedExpired = await model.findByUuid(
+                expiredRun.ai_deep_research_run_uuid,
+            );
+            expect(persistedExpired).toMatchObject({
+                result_markdown: null,
+                result_chart_data: null,
+            });
+            expect(persistedExpired?.report_expires_at).not.toBeNull();
+            expect(persistedExpired?.report_expired_at).not.toBeNull();
+            expect(
+                (
+                    await database(AiAgentToolCallTableName)
+                        .whereIn('tool_call_id', [
+                            expiredToolCallId,
+                            futureToolCallId,
+                            unrelatedToolCallId,
+                        ])
+                        .pluck('tool_call_id')
+                ).sort(),
+            ).toEqual([futureToolCallId, unrelatedToolCallId].sort());
+            expect(
+                (
+                    await database(AiAgentToolResultTableName)
+                        .whereIn('tool_call_id', [
+                            expiredToolCallId,
+                            futureToolCallId,
+                            unrelatedToolCallId,
+                        ])
+                        .pluck('tool_call_id')
+                ).sort(),
+            ).toEqual([futureToolCallId, unrelatedToolCallId].sort());
+            expect(
+                await database(AiSqlApprovalTableName)
+                    .where('tool_call_id', expiredToolCallId)
+                    .first(),
+            ).toBeDefined();
+            expect(await model.cleanExpiredReports(100)).toEqual({
+                scanned: 0,
+                expired: 0,
+                failed: 0,
+            });
+        } finally {
+            await database(AiSqlApprovalTableName)
+                .where('tool_call_id', expiredToolCallId)
+                .delete();
+        }
+    });
+
+    it('rolls provenance deletion back when scrubbing the report fails', async () => {
+        const run = await createRun();
+        const toolCallId = `rollback-${crypto.randomUUID()}`;
+        const triggerName = `fail_report_cleanup_${crypto.randomUUID().replaceAll('-', '')}`;
+        const functionName = `${triggerName}_fn`;
+
+        await database(AiDeepResearchRunsTableName)
+            .where('ai_deep_research_run_uuid', run.ai_deep_research_run_uuid)
+            .update({
+                status: 'completed',
+                result_markdown: 'must survive',
+                result_chart_data: JSON.stringify({}),
+                completed_at: database.raw("now() - interval '31 days'"),
+                report_expires_at: database.raw("now() - interval '1 day'"),
+            });
+        await database<AiAgentToolCallTable>(AiAgentToolCallTableName).insert({
+            ai_prompt_uuid: promptUuid,
+            tool_call_id: toolCallId,
+            tool_name: AI_DEEP_RESEARCH_REPORT_TOOL_NAME,
+            tool_args: {},
+            ai_mcp_server_uuid: null,
+            parent_tool_call_id: null,
+        });
+        await database<AiAgentToolResultTable>(
+            AiAgentToolResultTableName,
+        ).insert({
+            ai_prompt_uuid: promptUuid,
+            tool_call_id: toolCallId,
+            tool_name: AI_DEEP_RESEARCH_REPORT_TOOL_NAME,
+            result: JSON.stringify({ report: 'must survive' }),
+        });
+
+        try {
+            await database.raw(`
+                create function ${functionName}() returns trigger as $$
+                begin
+                    if old.ai_deep_research_run_uuid = '${run.ai_deep_research_run_uuid}' then
+                        raise exception 'forced cleanup failure';
+                    end if;
+                    return new;
+                end;
+                $$ language plpgsql;
+                create trigger ${triggerName}
+                before update on ${AiDeepResearchRunsTableName}
+                for each row execute function ${functionName}();
+            `);
+
+            expect(await model.cleanExpiredReports(100)).toEqual({
+                scanned: 1,
+                expired: 0,
+                failed: 1,
+            });
+            expect(
+                await model.findByUuid(run.ai_deep_research_run_uuid),
+            ).toMatchObject({ result_markdown: 'must survive' });
+            expect(
+                await database(AiAgentToolCallTableName)
+                    .where('tool_call_id', toolCallId)
+                    .first(),
+            ).toBeDefined();
+            expect(
+                await database(AiAgentToolResultTableName)
+                    .where('tool_call_id', toolCallId)
+                    .first(),
+            ).toBeDefined();
+        } finally {
+            await database.raw(
+                `drop trigger if exists ${triggerName} on ${AiDeepResearchRunsTableName}`,
+            );
+            await database.raw(`drop function if exists ${functionName}()`);
+        }
     });
 
     it('fails a stale running run and records one terminal event', async () => {

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.test.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.test.ts
@@ -1,6 +1,11 @@
 import knex, { type Knex } from 'knex';
 import { getTracker, MockClient, type Tracker } from 'knex-mock-client';
 import {
+    AiAgentToolCallErrorTableName,
+    AiAgentToolCallTableName,
+    AiAgentToolResultTableName,
+} from '../database/entities/ai';
+import {
     AiDeepResearchAnalyticsOutboxTableName,
     AiDeepResearchEventsTableName,
     AiDeepResearchRunsTableName,
@@ -113,6 +118,12 @@ describe('AiDeepResearchRunModel', () => {
         expect(tracker.history.select[0].sql).not.toContain(
             'result_chart_data',
         );
+        expect(tracker.history.select[0].sql).toContain(
+            'coalesce(report_expires_at, completed_at + interval',
+        );
+        expect(tracker.history.select[0].sql).toContain(
+            '"report_expired_at" is null',
+        );
     });
 
     it('does not query for an empty conversation', async () => {
@@ -139,7 +150,10 @@ describe('AiDeepResearchRunModel', () => {
 
         const [query] = tracker.history.select;
         expect(query.sql).toContain(
-            'coalesce(octet_length(result_markdown), 0) > 0 as has_report',
+            'coalesce(octet_length(result_markdown), 0) > 0',
+        );
+        expect(query.sql).toContain(
+            'coalesce(\n                            report_expires_at',
         );
         expect(query.sql).not.toContain('select "result_markdown"');
         expect(query.bindings).toEqual([
@@ -166,6 +180,10 @@ describe('AiDeepResearchRunModel', () => {
         );
         expect(query.sql).not.toContain('select "result_markdown"');
         expect(query.sql).toContain('octet_length(result_markdown) > 0');
+        expect(query.sql).toContain(
+            'coalesce(report_expires_at, completed_at + interval',
+        );
+        expect(query.sql).toContain('"report_expired_at" is null');
         expect(query.bindings).toEqual([
             'thread-1',
             'organization-1',
@@ -190,6 +208,10 @@ describe('AiDeepResearchRunModel', () => {
             'select "ai_deep_research_run_uuid", "prompt", "result_markdown"',
         );
         expect(query.sql).toContain('octet_length(result_markdown) > 0');
+        expect(query.sql).toContain(
+            'coalesce(report_expires_at, completed_at + interval',
+        );
+        expect(query.sql).toContain('"report_expired_at" is null');
         expect(query.bindings).toEqual([
             RUN_UUID,
             'thread-1',
@@ -229,6 +251,39 @@ describe('AiDeepResearchRunModel', () => {
         );
         expect(tracker.history.insert).toHaveLength(0);
     });
+
+    it.each(['completed', 'partially_completed'] as const)(
+        'persists the 30-day report expiry when a run is %s',
+        async (status) => {
+            tracker.on
+                .update(AiDeepResearchRunsTableName)
+                .responseOnce([runRow({ status })]);
+            tracker.on.insert(AiDeepResearchEventsTableName).responseOnce([]);
+            tracker.on
+                .insert(AiDeepResearchAnalyticsOutboxTableName)
+                .responseOnce([]);
+
+            const updated =
+                status === 'completed'
+                    ? await model.markCompleted(RUN_UUID, reportMarkdown, {})
+                    : await model.markPartiallyCompleted(
+                          RUN_UUID,
+                          reportMarkdown,
+                          {},
+                          'query_limit',
+                      );
+
+            expect(updated).toBe(true);
+            const [update] = tracker.history.update;
+            expect(update.sql).toContain(
+                `"report_expires_at" = now() + interval '30 days'`,
+            );
+            expect(update.sql).toContain('"report_expired_at" = $');
+            expect(update.bindings).toEqual(
+                expect.arrayContaining([status, reportMarkdown, RUN_UUID]),
+            );
+        },
+    );
 
     it('deletes only an unstarted failed run so enqueue failures can retry', async () => {
         tracker.on.delete(AiDeepResearchRunsTableName).responseOnce(1);
@@ -329,5 +384,40 @@ describe('AiDeepResearchRunModel', () => {
         expect(tracker.history.insert).toHaveLength(4);
         expect(tracker.history.insert[2].bindings).toContain('internal_error');
         expect(tracker.history.insert[3].bindings).toContain('internal_error');
+    });
+
+    it('scrubs an expired report and its run-scoped provenance', async () => {
+        tracker.on.select(AiDeepResearchRunsTableName).responseOnce([
+            {
+                ai_deep_research_run_uuid: RUN_UUID,
+                prompt_uuid: 'prompt-1',
+            },
+        ]);
+        tracker.on.select(AiDeepResearchRunsTableName).responseOnce([
+            {
+                ai_deep_research_run_uuid: RUN_UUID,
+            },
+        ]);
+        tracker.on.select(AiAgentToolCallTableName).responseOnce([
+            {
+                ai_agent_tool_call_uuid: '00000000-0000-0000-0000-000000000003',
+                tool_call_id: 'tool-1',
+            },
+        ]);
+        tracker.on.delete(AiAgentToolResultTableName).responseOnce(1);
+        tracker.on.delete(AiAgentToolCallErrorTableName).responseOnce(0);
+        tracker.on.delete(AiAgentToolCallTableName).responseOnce(1);
+        tracker.on.update(AiDeepResearchRunsTableName).responseOnce(1);
+
+        const result = await model.cleanExpiredReports(100);
+
+        expect(result).toEqual({ scanned: 1, expired: 1, failed: 0 });
+        expect(tracker.history.delete).toHaveLength(3);
+        expect(tracker.history.update.at(-1)?.sql).toContain(
+            '"result_markdown" = $1',
+        );
+        expect(tracker.history.update.at(-1)?.sql).toContain(
+            '"result_chart_data" = $2',
+        );
     });
 });

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
@@ -1,4 +1,8 @@
 import {
+    AI_DEEP_RESEARCH_HYPOTHESES_TOOL_NAME,
+    AI_DEEP_RESEARCH_INVESTIGATION_TOOL_NAME,
+    AI_DEEP_RESEARCH_REPORT_TOOL_NAME,
+    getErrorMessage,
     type AiDeepResearchBudget,
     type AiDeepResearchChartDataMap,
     type AiDeepResearchEffort,
@@ -12,6 +16,15 @@ import {
     type AiDeepResearchTerminalReason,
 } from '@lightdash/common';
 import { Knex } from 'knex';
+import Logger from '../../logging/logger';
+import {
+    AiAgentToolCallErrorTableName,
+    AiAgentToolCallTableName,
+    AiAgentToolResultTableName,
+    type AiAgentToolCallErrorTable,
+    type AiAgentToolCallTable,
+    type AiAgentToolResultTable,
+} from '../database/entities/ai';
 import {
     AiDeepResearchAnalyticsOutboxTableName,
     AiDeepResearchEventsTable,
@@ -80,6 +93,12 @@ export type DbAiDeepResearchEventWithCursor = DbAiDeepResearchEvent & {
 };
 
 type Queryable = Knex | Knex.Transaction;
+
+export type AiDeepResearchReportCleanupResult = {
+    scanned: number;
+    expired: number;
+    failed: number;
+};
 
 export class AiDeepResearchRunModel {
     private readonly database: Knex;
@@ -245,7 +264,11 @@ export class AiDeepResearchRunModel {
             .select('prompt_uuid', 'result_markdown')
             .whereIn('prompt_uuid', args.promptUuids)
             .where('organization_uuid', args.organizationUuid)
-            .where('project_uuid', args.projectUuid);
+            .where('project_uuid', args.projectUuid)
+            .whereNull('report_expired_at')
+            .whereRaw(
+                "coalesce(report_expires_at, completed_at + interval '30 days') > now()",
+            );
     }
 
     async findByThreadScoped(args: {
@@ -281,7 +304,14 @@ export class AiDeepResearchRunModel {
                 'started_at',
                 'completed_at',
                 this.database.raw(
-                    'coalesce(octet_length(result_markdown), 0) > 0 as has_report',
+                    `(
+                        report_expired_at is null
+                        and coalesce(
+                            report_expires_at,
+                            completed_at + interval '30 days'
+                        ) > now()
+                        and coalesce(octet_length(result_markdown), 0) > 0
+                    ) as has_report`,
                 ),
             )
             .where('ai_thread_uuid', args.aiThreadUuid)
@@ -318,6 +348,10 @@ export class AiDeepResearchRunModel {
             .where('organization_uuid', args.organizationUuid)
             .where('project_uuid', args.projectUuid)
             .where('created_by_user_uuid', args.createdByUserUuid)
+            .whereNull('report_expired_at')
+            .whereRaw(
+                "coalesce(report_expires_at, completed_at + interval '30 days') > now()",
+            )
             .whereRaw('octet_length(result_markdown) > 0')
             .orderBy('created_at', 'asc');
 
@@ -346,6 +380,10 @@ export class AiDeepResearchRunModel {
             .where('organization_uuid', args.organizationUuid)
             .where('project_uuid', args.projectUuid)
             .where('created_by_user_uuid', args.createdByUserUuid)
+            .whereNull('report_expired_at')
+            .whereRaw(
+                "coalesce(report_expires_at, completed_at + interval '30 days') > now()",
+            )
             .whereRaw('octet_length(result_markdown) > 0')
             .first();
     }
@@ -445,6 +483,10 @@ export class AiDeepResearchRunModel {
                     result_chart_data: JSON.stringify(
                         resultChartData,
                     ) as unknown as AiDeepResearchChartDataMap,
+                    report_expires_at: transaction.raw(
+                        "now() + interval '30 days'",
+                    ) as unknown as Date,
+                    report_expired_at: null,
                     error_message: null,
                     completed_at: transaction.fn.now() as unknown as Date,
                     updated_at: transaction.fn.now() as unknown as Date,
@@ -752,6 +794,174 @@ export class AiDeepResearchRunModel {
             );
             return runs;
         });
+    }
+
+    async cleanExpiredReports(
+        batchSize: number,
+    ): Promise<AiDeepResearchReportCleanupResult> {
+        const candidates = await this.database<AiDeepResearchRunsTable>(
+            AiDeepResearchRunsTableName,
+        )
+            .select('ai_deep_research_run_uuid', 'prompt_uuid')
+            .whereNull('report_expired_at')
+            .where((query) =>
+                query
+                    .where('report_expires_at', '<=', this.database.fn.now())
+                    .orWhere((legacyQuery) =>
+                        legacyQuery
+                            .whereNull('report_expires_at')
+                            .whereNotNull('completed_at')
+                            .whereRaw(
+                                "completed_at + interval '30 days' <= now()",
+                            ),
+                    ),
+            )
+            .where((query) =>
+                query
+                    .whereNotNull('result_markdown')
+                    .orWhereNotNull('result_chart_data'),
+            )
+            .orderByRaw(
+                "coalesce(report_expires_at, completed_at + interval '30 days') asc",
+            )
+            .limit(batchSize);
+
+        const results = await Promise.all(
+            candidates.map(async (candidate) => {
+                try {
+                    return await this.database.transaction(
+                        async (transaction) => {
+                            const lockedCandidate =
+                                await transaction<AiDeepResearchRunsTable>(
+                                    AiDeepResearchRunsTableName,
+                                )
+                                    .select('ai_deep_research_run_uuid')
+                                    .where(
+                                        'ai_deep_research_run_uuid',
+                                        candidate.ai_deep_research_run_uuid,
+                                    )
+                                    .whereNull('report_expired_at')
+                                    .whereRaw(
+                                        "coalesce(report_expires_at, completed_at + interval '30 days') <= now()",
+                                    )
+                                    .where((query) =>
+                                        query
+                                            .whereNotNull('result_markdown')
+                                            .orWhereNotNull(
+                                                'result_chart_data',
+                                            ),
+                                    )
+                                    .forUpdate()
+                                    .first();
+                            if (!lockedCandidate) {
+                                return 'skipped' as const;
+                            }
+
+                            const toolCalls =
+                                await transaction<AiAgentToolCallTable>(
+                                    AiAgentToolCallTableName,
+                                )
+                                    .select(
+                                        'ai_agent_tool_call_uuid',
+                                        'tool_call_id',
+                                    )
+                                    .where(
+                                        'ai_prompt_uuid',
+                                        candidate.prompt_uuid,
+                                    )
+                                    .where((query) =>
+                                        query
+                                            .where(
+                                                'parent_tool_call_id',
+                                                'like',
+                                                `deep-research:${candidate.ai_deep_research_run_uuid}:%`,
+                                            )
+                                            .orWhereIn('tool_name', [
+                                                AI_DEEP_RESEARCH_HYPOTHESES_TOOL_NAME,
+                                                AI_DEEP_RESEARCH_INVESTIGATION_TOOL_NAME,
+                                                AI_DEEP_RESEARCH_REPORT_TOOL_NAME,
+                                            ]),
+                                    );
+                            const toolCallIds = toolCalls.map(
+                                (toolCall) => toolCall.tool_call_id,
+                            );
+
+                            if (toolCallIds.length > 0) {
+                                await transaction<AiAgentToolResultTable>(
+                                    AiAgentToolResultTableName,
+                                )
+                                    .where(
+                                        'ai_prompt_uuid',
+                                        candidate.prompt_uuid,
+                                    )
+                                    .whereIn('tool_call_id', toolCallIds)
+                                    .delete();
+                                await transaction<AiAgentToolCallErrorTable>(
+                                    AiAgentToolCallErrorTableName,
+                                )
+                                    .where(
+                                        'ai_prompt_uuid',
+                                        candidate.prompt_uuid,
+                                    )
+                                    .whereIn('tool_call_id', toolCallIds)
+                                    .delete();
+                                await transaction<AiAgentToolCallTable>(
+                                    AiAgentToolCallTableName,
+                                )
+                                    .whereIn(
+                                        'ai_agent_tool_call_uuid',
+                                        toolCalls.map(
+                                            (toolCall) =>
+                                                toolCall.ai_agent_tool_call_uuid,
+                                        ),
+                                    )
+                                    .delete();
+                            }
+
+                            const expired =
+                                await transaction<AiDeepResearchRunsTable>(
+                                    AiDeepResearchRunsTableName,
+                                )
+                                    .where(
+                                        'ai_deep_research_run_uuid',
+                                        candidate.ai_deep_research_run_uuid,
+                                    )
+                                    .whereNull('report_expired_at')
+                                    .whereRaw(
+                                        "coalesce(report_expires_at, completed_at + interval '30 days') <= now()",
+                                    )
+                                    .update({
+                                        result_markdown: null,
+                                        result_chart_data: null,
+                                        report_expires_at: transaction.raw(
+                                            "coalesce(report_expires_at, completed_at + interval '30 days')",
+                                        ) as unknown as Date,
+                                        report_expired_at:
+                                            transaction.fn.now() as unknown as Date,
+                                        updated_at:
+                                            transaction.fn.now() as unknown as Date,
+                                    });
+                            return expired > 0
+                                ? ('expired' as const)
+                                : ('skipped' as const);
+                        },
+                    );
+                } catch (error) {
+                    Logger.error(
+                        `Failed to clean Deep Research report ${candidate.ai_deep_research_run_uuid}: ${getErrorMessage(error)}`,
+                    );
+                    return 'failed' as const;
+                }
+            }),
+        );
+
+        const expired = results.filter((result) => result === 'expired').length;
+        const failed = results.filter((result) => result === 'failed').length;
+        return {
+            scanned: candidates.length,
+            expired,
+            failed,
+        };
     }
 
     async listPendingAnalyticsEvents(args?: {

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.test.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.test.ts
@@ -1,0 +1,74 @@
+import { EE_SCHEDULER_TASKS } from '@lightdash/common';
+import { describe, expect, it, vi } from 'vitest';
+import {
+    AI_DEEP_RESEARCH_REPORT_CLEANUP_BATCH_SIZE,
+    cleanAiDeepResearchReports,
+} from './SchedulerWorker';
+
+describe('cleanAiDeepResearchReports', () => {
+    const buildDependencies = (result: {
+        scanned: number;
+        expired: number;
+        failed: number;
+    }) => ({
+        aiDeepResearchService: {
+            cleanExpiredReports: vi.fn().mockResolvedValue(result),
+        },
+        cleanupMetrics: {
+            incrementAiDeepResearchReportCleanup: vi.fn(),
+        },
+        addJob: vi.fn().mockResolvedValue({}),
+    });
+
+    it('records all cleanup counts without continuing a partial batch', async () => {
+        const dependencies = buildDependencies({
+            scanned: 4,
+            expired: 3,
+            failed: 0,
+        });
+
+        await cleanAiDeepResearchReports(dependencies);
+
+        expect(
+            dependencies.aiDeepResearchService.cleanExpiredReports,
+        ).toHaveBeenCalledWith(AI_DEEP_RESEARCH_REPORT_CLEANUP_BATCH_SIZE);
+        expect(
+            dependencies.cleanupMetrics.incrementAiDeepResearchReportCleanup
+                .mock.calls,
+        ).toEqual([
+            ['scanned', 4],
+            ['expired', 3],
+            ['failed', 0],
+        ]);
+        expect(dependencies.addJob).not.toHaveBeenCalled();
+    });
+
+    it('queues another bounded batch when the current batch is full', async () => {
+        const dependencies = buildDependencies({
+            scanned: AI_DEEP_RESEARCH_REPORT_CLEANUP_BATCH_SIZE,
+            expired: AI_DEEP_RESEARCH_REPORT_CLEANUP_BATCH_SIZE,
+            failed: 0,
+        });
+
+        await cleanAiDeepResearchReports(dependencies);
+
+        expect(dependencies.addJob).toHaveBeenCalledWith(
+            EE_SCHEDULER_TASKS.CLEAN_AI_DEEP_RESEARCH_REPORTS,
+            {},
+            { maxAttempts: 3 },
+        );
+    });
+
+    it('throws for retry and does not continue when any row fails', async () => {
+        const dependencies = buildDependencies({
+            scanned: AI_DEEP_RESEARCH_REPORT_CLEANUP_BATCH_SIZE,
+            expired: AI_DEEP_RESEARCH_REPORT_CLEANUP_BATCH_SIZE - 1,
+            failed: 1,
+        });
+
+        await expect(cleanAiDeepResearchReports(dependencies)).rejects.toThrow(
+            'Failed to clean 1 Deep Research reports',
+        );
+        expect(dependencies.addJob).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -6,9 +6,11 @@ import {
     SCHEDULER_TASKS,
     SchedulerJobStatus,
 } from '@lightdash/common';
+import type { AddJobFunction } from 'graphile-worker';
 import Logger from '../../logging/logger';
 import { type OpenIdIdentityModel } from '../../models/OpenIdIdentitiesModel';
 import { type ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import type PrometheusMetrics from '../../prometheus/PrometheusMetrics';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { tryJobOrTimeout } from '../../scheduler/SchedulerJobTimeout';
 import {
@@ -34,6 +36,7 @@ import { ProjectContextService } from '../services/ProjectContextService/Project
 import { sendReviewNotification } from './tasks/sendReviewNotification';
 
 const MCP_TOOL_CALL_RETENTION_DAYS = 90;
+export const AI_DEEP_RESEARCH_REPORT_CLEANUP_BATCH_SIZE = 100;
 const AI_AGENT_EVAL_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 const AI_AGENT_REVIEW_REMEDIATION_RUN_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 const AI_AGENT_REVIEW_CLASSIFIER_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes
@@ -47,6 +50,51 @@ const AI_AGENT_MEMORY_CONSOLIDATE_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 const APP_GENERATE_TIMEOUT_MS = 60 * 60 * 1000; // 60 minutes
 const AI_WRITEBACK_TIMEOUT_MS = 30 * 60 * 1000;
 const AGENT_ONBOARDING_TIMEOUT_MS = 60 * 60 * 1000;
+
+export const cleanAiDeepResearchReports = async ({
+    aiDeepResearchService,
+    cleanupMetrics,
+    addJob,
+}: {
+    aiDeepResearchService: Pick<AiDeepResearchService, 'cleanExpiredReports'>;
+    cleanupMetrics: Pick<
+        PrometheusMetrics,
+        'incrementAiDeepResearchReportCleanup'
+    > | null;
+    addJob: AddJobFunction;
+}): Promise<void> => {
+    Logger.info('Starting Deep Research report cleanup job');
+    const result = await aiDeepResearchService.cleanExpiredReports(
+        AI_DEEP_RESEARCH_REPORT_CLEANUP_BATCH_SIZE,
+    );
+    cleanupMetrics?.incrementAiDeepResearchReportCleanup(
+        'scanned',
+        result.scanned,
+    );
+    cleanupMetrics?.incrementAiDeepResearchReportCleanup(
+        'expired',
+        result.expired,
+    );
+    cleanupMetrics?.incrementAiDeepResearchReportCleanup(
+        'failed',
+        result.failed,
+    );
+    Logger.info(
+        `Deep Research report cleanup completed. Scanned: ${result.scanned}; expired: ${result.expired}; failed: ${result.failed}`,
+    );
+    if (result.failed > 0) {
+        throw new Error(
+            `Failed to clean ${result.failed} Deep Research reports`,
+        );
+    }
+    if (result.scanned === AI_DEEP_RESEARCH_REPORT_CLEANUP_BATCH_SIZE) {
+        await addJob(
+            EE_SCHEDULER_TASKS.CLEAN_AI_DEEP_RESEARCH_REPORTS,
+            {},
+            { maxAttempts: 3 },
+        );
+    }
+};
 
 type CommercialSchedulerWorkerArguments = SchedulerWorkerArguments & {
     aiAgentService: AiAgentService;
@@ -103,6 +151,8 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
 
     protected readonly mcpToolCallModel: McpToolCallModel;
 
+    private readonly cleanupMetrics: PrometheusMetrics | null;
+
     constructor(args: CommercialSchedulerWorkerArguments) {
         super(args);
         this.aiAgentService = args.aiAgentService;
@@ -125,6 +175,7 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
         this.projectModel = args.projectModel;
         this.openIdIdentityModel = args.openIdIdentityModel;
         this.mcpToolCallModel = args.mcpToolCallModel;
+        this.cleanupMetrics = args.prometheusMetrics ?? null;
     }
 
     protected getCronItems() {
@@ -178,6 +229,14 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                     maxAttempts: 3,
                 },
             },
+            {
+                task: EE_SCHEDULER_TASKS.CLEAN_AI_DEEP_RESEARCH_REPORTS,
+                pattern: '41 * * * *',
+                options: {
+                    backfillPeriod: 2 * 60 * 60 * 1000,
+                    maxAttempts: 3,
+                },
+            },
         ];
     }
 
@@ -209,6 +268,15 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                     `MCP tool call cleanup completed. Records deleted: ${deleted}`,
                 );
             },
+            [EE_SCHEDULER_TASKS.CLEAN_AI_DEEP_RESEARCH_REPORTS]: async (
+                _payload,
+                helpers,
+            ) =>
+                cleanAiDeepResearchReports({
+                    aiDeepResearchService: this.aiDeepResearchService,
+                    cleanupMetrics: this.cleanupMetrics,
+                    addJob: helpers.addJob,
+                }),
             [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_PREVIEW]: async (
                 payload,
                 _helpers,

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.test.ts
@@ -128,6 +128,8 @@ const run = (
     effort: 'low',
     result_markdown: null,
     result_chart_data: null,
+    report_expires_at: null,
+    report_expired_at: null,
     budget_snapshot: budget,
     execution_context_snapshot: executionContextSnapshot,
     error_message: null,

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
@@ -194,6 +194,8 @@ const runRow = (overrides: Record<string, unknown> = {}) => ({
     effort: 'medium',
     result_markdown: null,
     result_chart_data: null,
+    report_expires_at: null,
+    report_expired_at: null,
     budget_snapshot: budget,
     execution_context_snapshot: executionContextSnapshot,
     error_message: null,
@@ -1054,6 +1056,37 @@ describe('AiDeepResearchService', () => {
                     threadUuid: 'thread-1',
                 },
             );
+        });
+
+        it('redacts report data immediately after its expiry boundary', async () => {
+            const reportExpiresAt = new Date('2026-07-01T00:00:00.000Z');
+            const { service } = buildService({
+                model: {
+                    findByUuidScoped: vi.fn().mockResolvedValue(
+                        runRow({
+                            status: 'completed',
+                            completed_at: new Date('2026-06-01T00:00:00.000Z'),
+                            result_markdown: 'Expired private report',
+                            result_chart_data: {
+                                private: { source: 'inline' },
+                            },
+                            report_expires_at: reportExpiresAt,
+                        }),
+                    ),
+                },
+            });
+
+            const run = await service.getRun(
+                userWithProjectAccess(),
+                'project-1',
+                'run-1',
+            );
+
+            expect(run.resultMarkdown).toBeNull();
+            expect(run.resultChartData).toBeNull();
+            expect(run.reportExpiresAt).toBe(reportExpiresAt.toISOString());
+            expect(run.reportExpiredAt).toBeNull();
+            expect(run.isReportExpired).toBe(true);
         });
 
         it("does not expose another creator's run to a project viewer", async () => {

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
@@ -266,29 +266,51 @@ export const getAiDeepResearchRunBudget = (
         AI_DEEP_RESEARCH_DEFAULT_BUDGET.maxHypotheses,
 });
 
-const toRun = (row: DbAiDeepResearchRun): AiDeepResearchRun => ({
-    aiDeepResearchRunUuid: row.ai_deep_research_run_uuid,
-    projectUuid: row.project_uuid,
-    agentUuid: row.agent_uuid,
-    aiThreadUuid: row.ai_thread_uuid,
-    promptUuid: row.prompt_uuid,
-    mcpServerUuids: row.selected_mcp_server_uuids,
-    entryPoint: row.entry_point,
-    effort: row.effort,
-    prompt: row.prompt,
-    status: row.status,
-    resultMarkdown: row.result_markdown,
-    resultChartData: row.result_chart_data,
-    budget: getAiDeepResearchRunBudget(row.budget_snapshot),
-    executionContextSnapshot: row.execution_context_snapshot,
-    errorMessage: row.error_message,
-    cancellationRequestedAt:
-        row.cancellation_requested_at?.toISOString() ?? null,
-    createdAt: row.created_at.toISOString(),
-    updatedAt: row.updated_at.toISOString(),
-    startedAt: row.started_at?.toISOString() ?? null,
-    completedAt: row.completed_at?.toISOString() ?? null,
-});
+const getReportExpiresAt = (row: DbAiDeepResearchRun): Date | null => {
+    if (row.report_expires_at) {
+        return row.report_expires_at;
+    }
+    if (
+        row.completed_at &&
+        (row.result_markdown !== null || row.result_chart_data !== null)
+    ) {
+        return new Date(row.completed_at.getTime() + 30 * 24 * 60 * 60 * 1_000);
+    }
+    return null;
+};
+
+const toRun = (row: DbAiDeepResearchRun): AiDeepResearchRun => {
+    const reportExpiresAt = getReportExpiresAt(row);
+    const isReportExpired =
+        row.report_expired_at !== null ||
+        (reportExpiresAt !== null && reportExpiresAt.getTime() <= Date.now());
+    return {
+        aiDeepResearchRunUuid: row.ai_deep_research_run_uuid,
+        projectUuid: row.project_uuid,
+        agentUuid: row.agent_uuid,
+        aiThreadUuid: row.ai_thread_uuid,
+        promptUuid: row.prompt_uuid,
+        mcpServerUuids: row.selected_mcp_server_uuids,
+        entryPoint: row.entry_point,
+        effort: row.effort,
+        prompt: row.prompt,
+        status: row.status,
+        resultMarkdown: isReportExpired ? null : row.result_markdown,
+        resultChartData: isReportExpired ? null : row.result_chart_data,
+        reportExpiresAt: reportExpiresAt?.toISOString() ?? null,
+        reportExpiredAt: row.report_expired_at?.toISOString() ?? null,
+        isReportExpired,
+        budget: getAiDeepResearchRunBudget(row.budget_snapshot),
+        executionContextSnapshot: row.execution_context_snapshot,
+        errorMessage: row.error_message,
+        cancellationRequestedAt:
+            row.cancellation_requested_at?.toISOString() ?? null,
+        createdAt: row.created_at.toISOString(),
+        updatedAt: row.updated_at.toISOString(),
+        startedAt: row.started_at?.toISOString() ?? null,
+        completedAt: row.completed_at?.toISOString() ?? null,
+    };
+};
 
 const toEvent = (row: DbAiDeepResearchEvent): AiDeepResearchEvent => {
     const event = {
@@ -877,6 +899,10 @@ export class AiDeepResearchService extends BaseService {
         return runs.map(toRun);
     }
 
+    async cleanExpiredReports(batchSize: number) {
+        return this.aiDeepResearchRunModel.cleanExpiredReports(batchSize);
+    }
+
     async refreshChart(args: {
         account: Account;
         user: SessionUser;
@@ -889,6 +915,15 @@ export class AiDeepResearchService extends BaseService {
             args.projectUuid,
             args.aiDeepResearchRunUuid,
         );
+        const reportExpiresAt = getReportExpiresAt(run);
+        if (
+            run.report_expired_at ||
+            (reportExpiresAt && reportExpiresAt.getTime() <= Date.now())
+        ) {
+            throw new NotFoundError(
+                `Deep Research chart ${args.chartKey} not found`,
+            );
+        }
         // Membership in the persisted chart data is the authorization gate.
         const chart = run.result_chart_data?.[args.chartKey];
         if (!chart) {

--- a/packages/backend/src/prometheus/PrometheusMetrics.ts
+++ b/packages/backend/src/prometheus/PrometheusMetrics.ts
@@ -134,6 +134,9 @@ export default class PrometheusMetrics {
     public aiAgentMemoryUnknownToolPolicyCounter: prometheus.Counter | null =
         null;
 
+    public aiDeepResearchReportCleanupCounter: prometheus.Counter<'outcome'> | null =
+        null;
+
     // AI agent memory consolidation pass (daily cron)
     public aiAgentMemoryConsolidateCounter: prometheus.Counter<'outcome'> | null =
         null;
@@ -558,6 +561,14 @@ export default class PrometheusMetrics {
                         ...rest,
                     });
 
+                this.aiDeepResearchReportCleanupCounter =
+                    new prometheus.Counter({
+                        name: 'ai_deep_research_report_cleanup_total',
+                        help: 'Deep Research reports processed by cleanup outcome',
+                        labelNames: ['outcome'],
+                        ...rest,
+                    });
+
                 // AI agent memory consolidation pass
                 this.aiAgentMemoryConsolidateCounter = new prometheus.Counter({
                     name: 'ai_agent_memory_consolidate_total',
@@ -758,6 +769,14 @@ export default class PrometheusMetrics {
                 });
                 this.aiAgentMemorySweepEnqueuedCounter?.inc(0);
                 this.aiAgentMemoryUnknownToolPolicyCounter?.inc(0);
+                (['scanned', 'expired', 'failed'] as const).forEach(
+                    (outcome) => {
+                        this.aiDeepResearchReportCleanupCounter?.inc(
+                            { outcome },
+                            0,
+                        );
+                    },
+                );
                 AI_AGENT_MEMORY_CONSOLIDATE_OUTCOMES.forEach((outcome) => {
                     this.aiAgentMemoryConsolidateCounter?.inc({ outcome }, 0);
                     this.aiAgentMemoryConsolidateDurationHistogram?.zero({
@@ -1618,6 +1637,13 @@ export default class PrometheusMetrics {
 
     public incrementAiAgentMemoryUnknownToolPolicy() {
         this.aiAgentMemoryUnknownToolPolicyCounter?.inc();
+    }
+
+    public incrementAiDeepResearchReportCleanup(
+        outcome: 'scanned' | 'expired' | 'failed',
+        count: number,
+    ) {
+        this.aiDeepResearchReportCleanupCounter?.inc({ outcome }, count);
     }
 
     public trackAiAgentMemoryConsolidate(

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -271,6 +271,7 @@ const getTagsForTask: {
         'ai_agent_memory.owner_user_uuid': payload.ownerUserUuid,
     }),
     [SCHEDULER_TASKS.CLEAN_MCP_TOOL_CALLS]: () => ({}),
+    [SCHEDULER_TASKS.CLEAN_AI_DEEP_RESEARCH_REPORTS]: () => ({}),
     [SCHEDULER_TASKS.AI_WRITEBACK_PIPELINE]: (payload) => ({
         'organization.uuid': payload.organizationUuid,
         'user.uuid': payload.userUuid,

--- a/packages/common/src/ee/aiDeepResearch/types.ts
+++ b/packages/common/src/ee/aiDeepResearch/types.ts
@@ -339,6 +339,9 @@ export type AiDeepResearchRun = {
     resultMarkdown: string | null;
     /** Render data for each referenced chart, keyed by chart key. */
     resultChartData: AiDeepResearchChartDataMap | null;
+    reportExpiresAt: string | null;
+    reportExpiredAt: string | null;
+    isReportExpired: boolean;
     budget: AiDeepResearchBudget;
     executionContextSnapshot: AiDeepResearchExecutionContextSnapshot | null;
     errorMessage: string | null;

--- a/packages/common/src/types/schedulerTaskList.test.ts
+++ b/packages/common/src/types/schedulerTaskList.test.ts
@@ -11,4 +11,7 @@ test('AI_DEEP_RESEARCH tasks are registered', () => {
     expect(EE_SCHEDULER_TASKS.SWEEP_STALE_AI_DEEP_RESEARCH_RUNS).toBe(
         'sweepStaleAiDeepResearchRuns',
     );
+    expect(EE_SCHEDULER_TASKS.CLEAN_AI_DEEP_RESEARCH_REPORTS).toBe(
+        'cleanAiDeepResearchReports',
+    );
 });

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -153,6 +153,7 @@ export const EE_SCHEDULER_TASKS = {
     CONSOLIDATE_AI_AGENT_MEMORIES: 'consolidateAiAgentMemories',
     CONSOLIDATE_AI_AGENT_MEMORY_PARTITION: 'consolidateAiAgentMemoryPartition',
     CLEAN_MCP_TOOL_CALLS: 'cleanMcpToolCalls',
+    CLEAN_AI_DEEP_RESEARCH_REPORTS: 'cleanAiDeepResearchReports',
 } as const;
 
 export const SCHEDULER_TASKS = {
@@ -260,6 +261,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.CONSOLIDATE_AI_AGENT_MEMORIES]: TraceTaskBase;
     [SCHEDULER_TASKS.CONSOLIDATE_AI_AGENT_MEMORY_PARTITION]: AiAgentMemoryConsolidatePartitionJobPayload;
     [SCHEDULER_TASKS.CLEAN_MCP_TOOL_CALLS]: TraceTaskBase;
+    [SCHEDULER_TASKS.CLEAN_AI_DEEP_RESEARCH_REPORTS]: TraceTaskBase;
     [SCHEDULER_TASKS.AI_WRITEBACK_PIPELINE]: AiWritebackPipelineJobPayload;
     [SCHEDULER_TASKS.AI_DEEP_RESEARCH]: AiDeepResearchPipelineJobPayload;
     [SCHEDULER_TASKS.AGENT_ONBOARDING_RUN]: AgentOnboardingPipelineJobPayload;
@@ -287,6 +289,7 @@ export interface EETaskPayloadMap {
     [EE_SCHEDULER_TASKS.CONSOLIDATE_AI_AGENT_MEMORIES]: TraceTaskBase;
     [EE_SCHEDULER_TASKS.CONSOLIDATE_AI_AGENT_MEMORY_PARTITION]: AiAgentMemoryConsolidatePartitionJobPayload;
     [EE_SCHEDULER_TASKS.CLEAN_MCP_TOOL_CALLS]: TraceTaskBase;
+    [EE_SCHEDULER_TASKS.CLEAN_AI_DEEP_RESEARCH_REPORTS]: TraceTaskBase;
     [EE_SCHEDULER_TASKS.AI_WRITEBACK_PIPELINE]: AiWritebackPipelineJobPayload;
     [EE_SCHEDULER_TASKS.AI_DEEP_RESEARCH]: AiDeepResearchPipelineJobPayload;
     [EE_SCHEDULER_TASKS.AGENT_ONBOARDING_RUN]: AgentOnboardingPipelineJobPayload;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
@@ -18,6 +18,7 @@ import {
     type PropsWithChildren,
 } from 'react';
 import ErrorBoundary from '../../../../../features/errorBoundary/ErrorBoundary';
+import { type DeepResearchRunRegistration } from '../../deepResearch/types';
 import { useDeepResearchThreadRunRegistrations } from '../../hooks/useDeepResearch';
 import { useAgentAiMcpServers } from '../../hooks/useProjectAiMcpServers';
 import { AddToEvalModal } from '../Admin/AddToEvalModal';
@@ -43,6 +44,9 @@ type Props = {
     showAddToEvalsButton?: boolean;
     onDashboardLinkClick?: (url: string) => void;
     canRetryDeepResearch?: boolean;
+    onRunDeepResearchAgain?: (
+        registration: DeepResearchRunRegistration,
+    ) => void;
 };
 
 const CompactionDivider = () => (
@@ -103,6 +107,7 @@ export const AgentChatDisplay: FC<PropsWithChildren<Props>> = ({
     showAddToEvalsButton = false,
     onDashboardLinkClick,
     canRetryDeepResearch = false,
+    onRunDeepResearchAgain,
 }) => {
     const viewport = useRef<HTMLDivElement>(null);
     const { data: mcpServers } = useAgentAiMcpServers(projectUuid, agentUuid, {
@@ -253,6 +258,7 @@ export const AgentChatDisplay: FC<PropsWithChildren<Props>> = ({
                                             ) ?? []
                                         }
                                         canRetry={canRetryDeepResearch}
+                                        onRunAgain={onRunDeepResearchAgain}
                                     />
                                 )}
                             </Fragment>
@@ -264,6 +270,7 @@ export const AgentChatDisplay: FC<PropsWithChildren<Props>> = ({
                                     unanchoredDeepResearchRegistrations
                                 }
                                 canRetry={canRetryDeepResearch}
+                                onRunAgain={onRunDeepResearchAgain}
                             />
                         )}
                     </Stack>

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.module.css
@@ -2,6 +2,10 @@
     border: 1px solid var(--mantine-color-ldGray-3);
 }
 
+.statusBadge {
+    flex-shrink: 0;
+}
+
 .answer {
     border-left: 3px solid var(--mantine-color-indigo-outline);
     background: light-dark(

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.test.tsx
@@ -160,6 +160,39 @@ describe('DeepResearchRunCard', () => {
         ).toBeInTheDocument();
     });
 
+    it('replaces expired report content with a stable rerun action', async () => {
+        const user = userEvent.setup();
+        const onRunAgain = vi.fn();
+        renderWithProviders(
+            <DeepResearchRunCard
+                run={{
+                    ...deepResearchRunFixture,
+                    resultMarkdown: null,
+                    resultChartData: null,
+                    findingCount: 0,
+                    isReportExpired: true,
+                    reportExpiredAt: '2026-07-30T09:18:00.000Z',
+                }}
+                projectUuid="project-1"
+                canRunAgain
+                onRunAgain={onRunAgain}
+            />,
+        );
+
+        expect(
+            screen.getByText(
+                'This Deep research report expired after 30 days.',
+            ),
+        ).toBeInTheDocument();
+        expect(
+            screen.getAllByText(deepResearchRunFixture.question),
+        ).toHaveLength(2);
+        expect(screen.queryByText('Executive answer')).not.toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Run again' }));
+        expect(onRunAgain).toHaveBeenCalledOnce();
+    });
+
     it('tracks explicitly opening the full report', async () => {
         const user = userEvent.setup();
         renderWithProviders(

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
@@ -122,6 +122,8 @@ const useElapsedMs = (run: DeepResearchRunView, isTerminal: boolean) => {
 type Props = {
     run: DeepResearchRunView;
     projectUuid: string;
+    canRunAgain?: boolean;
+    onRunAgain?: () => void;
     onReconnect?: (integrationName?: string) => void;
     onContinueWithoutSource?: (integrationName?: string) => void;
 };
@@ -129,6 +131,8 @@ type Props = {
 export const DeepResearchRunCard = ({
     run,
     projectUuid,
+    canRunAgain = false,
+    onRunAgain,
     onReconnect,
     onContinueWithoutSource,
 }: Props) => {
@@ -146,6 +150,7 @@ export const DeepResearchRunCard = ({
     }, [announcedStatus, run.status]);
 
     const hasReport = !!run.resultMarkdown;
+    const isReportExpired = run.isReportExpired;
     const isTerminal = isDeepResearchRunTerminal(run.status);
     const elapsedMs = useElapsedMs(run, isTerminal);
     const isActionRequired = !!run.actionRequired;
@@ -193,9 +198,9 @@ export const DeepResearchRunCard = ({
                         </Stack>
                     </Group>
                     <Badge
+                        className={styles.statusBadge}
                         color={status.color}
                         variant="light"
-                        style={{ flexShrink: 0 }}
                     >
                         {status.label}
                     </Badge>
@@ -315,11 +320,38 @@ export const DeepResearchRunCard = ({
                     </Alert>
                 )}
 
-                {run.status === 'partially_completed' && (
+                {run.status === 'partially_completed' && !isReportExpired && (
                     <Alert color="yellow" icon={<IconAlertCircle size={16} />}>
                         The report is incomplete, but all validated findings and
                         completed queries have been preserved.
                     </Alert>
+                )}
+
+                {isReportExpired && (
+                    <Paper variant="dotted" p="md" radius="sm">
+                        <Stack gap="xs">
+                            <Text size="sm" fw={600}>
+                                This Deep research report expired after 30 days.
+                            </Text>
+                            <Text size="sm">{run.question}</Text>
+                            {run.completedAt && (
+                                <Text size="xs" c="dimmed">
+                                    Completed{' '}
+                                    {new Date(
+                                        run.completedAt,
+                                    ).toLocaleDateString()}
+                                </Text>
+                            )}
+                            <Button
+                                size="xs"
+                                w="fit-content"
+                                disabled={!canRunAgain || !onRunAgain}
+                                onClick={onRunAgain}
+                            >
+                                Run again
+                            </Button>
+                        </Stack>
+                    </Paper>
                 )}
 
                 {hasReport && (

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchThreadRuns.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchThreadRuns.tsx
@@ -9,9 +9,11 @@ import { DeepResearchRunCard } from './DeepResearchRunCard';
 const DeepResearchThreadRun = ({
     registration,
     canRetry,
+    onRunAgain,
 }: {
     registration: DeepResearchRunRegistration;
     canRetry: boolean;
+    onRunAgain?: (registration: DeepResearchRunRegistration) => void;
 }) => {
     const runQuery = useDeepResearchRun(registration);
     const continueMutation = useContinueDeepResearchMutation({
@@ -102,6 +104,8 @@ const DeepResearchThreadRun = ({
         <DeepResearchRunCard
             run={runQuery.data}
             projectUuid={registration.projectUuid}
+            canRunAgain={canRetry}
+            onRunAgain={onRunAgain ? () => onRunAgain(registration) : undefined}
         />
     );
 };
@@ -109,9 +113,11 @@ const DeepResearchThreadRun = ({
 export const DeepResearchThreadRuns = ({
     registrations,
     canRetry = false,
+    onRunAgain,
 }: {
     registrations: DeepResearchRunRegistration[];
     canRetry?: boolean;
+    onRunAgain?: (registration: DeepResearchRunRegistration) => void;
 }) => {
     if (!registrations.length) {
         return null;
@@ -123,6 +129,7 @@ export const DeepResearchThreadRuns = ({
                     key={registration.runUuid}
                     registration={registration}
                     canRetry={canRetry}
+                    onRunAgain={onRunAgain}
                 />
             ))}
         </Stack>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
@@ -27,7 +27,11 @@ import { LightdashUserAvatar } from '../../../../../components/Avatar';
 import { useServerFeatureFlag } from '../../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../../providers/App/useApp';
 import { findRetryableDeepResearchRun } from '../../deepResearch/deepResearchRegistry';
-import { type StartDeepResearchArgs } from '../../deepResearch/types';
+import { runDeepResearchAgain } from '../../deepResearch/runAgain';
+import {
+    type DeepResearchRunRegistration,
+    type StartDeepResearchArgs,
+} from '../../deepResearch/types';
 import { useAiAgentSqlModeAvailable } from '../../hooks/useAiAgentSqlModeAvailable';
 import { useDashboardPageContextCuration } from '../../hooks/useDashboardPageContextCuration';
 import {
@@ -504,7 +508,12 @@ const ExistingThreadPanel: FC<{
         });
 
     const isThreadFromCurrentUser = thread?.user.uuid === user?.data?.userUuid;
-    const isBusy = Boolean(isCreatingMessage || isStreaming || isPending);
+    const isBusy = Boolean(
+        isCreatingMessage ||
+        isStreaming ||
+        isPending ||
+        startDeepResearch.isLoading,
+    );
     const isInputDisabled =
         thread?.createdFrom === 'slack' || !isThreadFromCurrentUser;
     const contentMentionItems = useMemo(
@@ -573,6 +582,20 @@ const ExistingThreadPanel: FC<{
         });
     };
 
+    const handleRunDeepResearchAgain = async (
+        registration: DeepResearchRunRegistration,
+    ) =>
+        runDeepResearchAgain({
+            registration,
+            createPrompt: (question) =>
+                createAgentThreadMessage({
+                    prompt: question,
+                    modelConfig,
+                    skipAgentResponse: true,
+                }),
+            startRun: startDeepResearch.mutateAsync,
+        });
+
     const headerTitle =
         thread?.title || thread?.firstMessage?.message || agent.name;
 
@@ -625,6 +648,11 @@ const ExistingThreadPanel: FC<{
                     renderArtifactsInline
                     onDashboardLinkClick={handleDashboardLinkClick}
                     canRetryDeepResearch={!isInputDisabled && !isBusy}
+                    onRunDeepResearchAgain={(registration) => {
+                        void handleRunDeepResearchAgain(registration).catch(
+                            () => undefined,
+                        );
+                    }}
                 >
                     <AgentChatInput
                         disabled={isInputDisabled}

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/fixtures.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/fixtures.ts
@@ -154,5 +154,8 @@ export const deepResearchRunFixture: DeepResearchRunView = {
     ],
     resultMarkdown: deepResearchReportMarkdownFixture,
     resultChartData: deepResearchChartDataFixture,
+    reportExpiresAt: '2026-08-29T09:18:00.000Z',
+    reportExpiredAt: null,
+    isReportExpired: false,
     errorMessage: null,
 };

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/runAgain.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/runAgain.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import { runDeepResearchAgain } from './runAgain';
+import { type DeepResearchRunRegistration } from './types';
+
+const registration: DeepResearchRunRegistration = {
+    runUuid: 'run-1',
+    projectUuid: 'project-1',
+    agentUuid: 'agent-1',
+    threadUuid: 'thread-1',
+    promptUuid: 'prompt-1',
+    mcpServerUuids: ['mcp-1', 'mcp-2'],
+    userUuid: 'user-1',
+    question: 'Why did retention change?',
+    depth: 'deep',
+    createdAt: '2026-07-01T00:00:00.000Z',
+    state: 'started',
+};
+
+describe('runDeepResearchAgain', () => {
+    it('creates a fresh prompt before starting a separate run with the original configuration', async () => {
+        const createPrompt = vi.fn().mockResolvedValue({ uuid: 'prompt-2' });
+        const startRun = vi.fn().mockResolvedValue(undefined);
+
+        await runDeepResearchAgain({
+            registration,
+            createPrompt,
+            startRun,
+        });
+
+        expect(createPrompt).toHaveBeenCalledWith(registration.question);
+        expect(startRun).toHaveBeenCalledWith({
+            question: registration.question,
+            depth: registration.depth,
+            mcpServerUuids: registration.mcpServerUuids,
+            promptUuid: 'prompt-2',
+        });
+        expect(createPrompt.mock.invocationCallOrder[0]).toBeLessThan(
+            startRun.mock.invocationCallOrder[0],
+        );
+    });
+
+    it('does not start a run when fresh prompt creation fails', async () => {
+        const createPrompt = vi
+            .fn()
+            .mockRejectedValue(new Error('prompt failed'));
+        const startRun = vi.fn();
+
+        await expect(
+            runDeepResearchAgain({
+                registration,
+                createPrompt,
+                startRun,
+            }),
+        ).rejects.toThrow('prompt failed');
+        expect(startRun).not.toHaveBeenCalled();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/runAgain.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/runAgain.ts
@@ -1,0 +1,26 @@
+import {
+    type DeepResearchRunRegistration,
+    type StartDeepResearchArgs,
+} from './types';
+
+type RunDeepResearchAgainArgs = {
+    registration: DeepResearchRunRegistration;
+    createPrompt: (question: string) => Promise<{ uuid: string }>;
+    startRun: (
+        args: StartDeepResearchArgs & { promptUuid: string },
+    ) => Promise<unknown>;
+};
+
+export const runDeepResearchAgain = async ({
+    registration,
+    createPrompt,
+    startRun,
+}: RunDeepResearchAgainArgs): Promise<void> => {
+    const promptUuid = (await createPrompt(registration.question)).uuid;
+    await startRun({
+        question: registration.question,
+        depth: registration.depth,
+        mcpServerUuids: registration.mcpServerUuids,
+        promptUuid,
+    });
+};

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/runPolling.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/runPolling.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import {
+    DEEP_RESEARCH_TERMINAL_REFETCH_MAX_MS,
+    getDeepResearchRunRefetchInterval,
+} from './runPolling';
+
+const now = Date.parse('2026-07-30T12:00:00.000Z');
+
+describe('getDeepResearchRunRefetchInterval', () => {
+    it('keeps active runs on the normal polling interval', () => {
+        expect(
+            getDeepResearchRunRefetchInterval(
+                {
+                    status: 'running',
+                    isReportExpired: false,
+                    reportExpiresAt: null,
+                },
+                2_000,
+                now,
+            ),
+        ).toBe(2_000);
+    });
+
+    it('refetches a terminal run at its expiry boundary', () => {
+        expect(
+            getDeepResearchRunRefetchInterval(
+                {
+                    status: 'completed',
+                    isReportExpired: false,
+                    reportExpiresAt: '2026-07-30T12:05:00.000Z',
+                },
+                2_000,
+                now,
+            ),
+        ).toBe(5 * 60 * 1_000);
+    });
+
+    it('caps long waits and stops after the report expires', () => {
+        expect(
+            getDeepResearchRunRefetchInterval(
+                {
+                    status: 'completed',
+                    isReportExpired: false,
+                    reportExpiresAt: '2026-08-29T12:00:00.000Z',
+                },
+                2_000,
+                now,
+            ),
+        ).toBe(DEEP_RESEARCH_TERMINAL_REFETCH_MAX_MS);
+        expect(
+            getDeepResearchRunRefetchInterval(
+                {
+                    status: 'completed',
+                    isReportExpired: true,
+                    reportExpiresAt: '2026-07-30T12:00:00.000Z',
+                },
+                2_000,
+                now,
+            ),
+        ).toBe(false);
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/runPolling.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/runPolling.ts
@@ -1,0 +1,27 @@
+import { type AiDeepResearchRun } from '@lightdash/common';
+import { isDeepResearchRunTerminal } from './runProgress';
+
+export const DEEP_RESEARCH_TERMINAL_REFETCH_MAX_MS = 24 * 60 * 60 * 1_000;
+
+export const getDeepResearchRunRefetchInterval = (
+    run:
+        | Pick<
+              AiDeepResearchRun,
+              'status' | 'isReportExpired' | 'reportExpiresAt'
+          >
+        | undefined,
+    activePollIntervalMs: number,
+    nowMs = Date.now(),
+): number | false => {
+    if (!run || !isDeepResearchRunTerminal(run.status)) {
+        return activePollIntervalMs;
+    }
+    if (run.isReportExpired || !run.reportExpiresAt) {
+        return false;
+    }
+    const untilExpiry = new Date(run.reportExpiresAt).getTime() - nowMs;
+    return Math.min(
+        Math.max(untilExpiry, 1_000),
+        DEEP_RESEARCH_TERMINAL_REFETCH_MAX_MS,
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/runProgress.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/runProgress.ts
@@ -209,6 +209,9 @@ export const adaptDeepResearchRun = ({
             })),
         resultMarkdown: run.resultMarkdown,
         resultChartData: run.resultChartData,
+        reportExpiresAt: run.reportExpiresAt,
+        reportExpiredAt: run.reportExpiredAt,
+        isReportExpired: run.isReportExpired,
         errorMessage: run.errorMessage,
     };
 };

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/types.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/types.ts
@@ -56,6 +56,9 @@ export type DeepResearchRunView = {
     resultMarkdown: string | null;
     /** Render data for each referenced chart, keyed by chart key. */
     resultChartData: AiDeepResearchChartDataMap | null;
+    reportExpiresAt: string | null;
+    reportExpiredAt: string | null;
+    isReportExpired: boolean;
     errorMessage: string | null;
 };
 

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.ts
@@ -27,6 +27,7 @@ import {
     updateDeepResearchRun,
     useDeepResearchRunsForThread,
 } from '../deepResearch/deepResearchRegistry';
+import { getDeepResearchRunRefetchInterval } from '../deepResearch/runPolling';
 import {
     adaptDeepResearchRun,
     DEEP_RESEARCH_DEPTH_CONFIG,
@@ -392,9 +393,10 @@ export const useDeepResearchRun = (
             getDeepResearchRun(registration.projectUuid, registration.runUuid),
         enabled: registration.state === 'started',
         refetchInterval: (run) =>
-            run && isDeepResearchRunTerminal(run.status)
-                ? false
-                : DEEP_RESEARCH_POLL_INTERVAL_MS,
+            getDeepResearchRunRefetchInterval(
+                run,
+                DEEP_RESEARCH_POLL_INTERVAL_MS,
+            ),
     });
     const isRunActive = runQuery.data
         ? !isDeepResearchRunTerminal(runQuery.data.status)

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -16,7 +16,11 @@ import {
 } from '../../features/aiCopilot/components/ChatElements/contentMentions';
 import { ThreadWorkstreamsPanel } from '../../features/aiCopilot/components/ChatElements/ThreadWorkstreamsPanel';
 import { findRetryableDeepResearchRun } from '../../features/aiCopilot/deepResearch/deepResearchRegistry';
-import { type StartDeepResearchArgs } from '../../features/aiCopilot/deepResearch/types';
+import { runDeepResearchAgain } from '../../features/aiCopilot/deepResearch/runAgain';
+import {
+    type DeepResearchRunRegistration,
+    type StartDeepResearchArgs,
+} from '../../features/aiCopilot/deepResearch/types';
 import { isEmbedAiAgentRoute } from '../../features/aiCopilot/hooks/aiAgentRouting';
 import { emitEmbedAiAgentThreadChange } from '../../features/aiCopilot/hooks/embedAiAgentThreadChange';
 import {
@@ -327,7 +331,27 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
             promptUuid,
         });
     };
-    const isBusy = Boolean(isCreatingMessage || isStreaming || isPending);
+    const handleRunDeepResearchAgain = async (
+        registration: DeepResearchRunRegistration,
+    ) =>
+        runDeepResearchAgain({
+            registration,
+            createPrompt: (question) =>
+                createAgentThreadMessage({
+                    prompt: question,
+                    modelConfig: threadModelConfig ?? undefined,
+                    context: pageContextInput,
+                    optimisticContext: pagePreviewItems,
+                    skipAgentResponse: true,
+                }),
+            startRun: startDeepResearch.mutateAsync,
+        });
+    const isBusy = Boolean(
+        isCreatingMessage ||
+        isStreaming ||
+        isPending ||
+        startDeepResearch.isLoading,
+    );
     const retryPrompt = reviewItem?.remediation?.retryPrompt ?? null;
     const handleRetryOriginalQuestion = () => {
         if (!retryPrompt) return;
@@ -369,6 +393,11 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
                     showAddToEvalsButton={canManage}
                     onDashboardLinkClick={handleDashboardLinkClick}
                     canRetryDeepResearch={!inputDisabled && !isBusy}
+                    onRunDeepResearchAgain={(registration) => {
+                        void handleRunDeepResearchAgain(registration).catch(
+                            () => undefined,
+                        );
+                    }}
                 >
                     {workstreams && workstreams.length > 0 && (
                         <ThreadWorkstreamsPanel workstreams={workstreams} />


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9352/expire-deep-research-report-data-after-30-days

## Summary

Expires Deep Research report snapshots after 30 days to meet the query-result retention requirement while preserving non-report run history.

## How it works

```text
report completes
      │
      ├─ report_expires_at = completed_at + 30 days
      │
      ├─ reads redact report data at the cutoff
      │
      └─ hourly worker scrubs report + provenance
                    │
                    └─ run metadata remains → Run again creates a new run
```

### Backend

- Adds `report_expires_at` and `report_expired_at`, including a 30-day backfill for existing completed reports.
- Derives the cutoff from `completed_at` for legacy null-expiry rows so rolling deployments cannot leave an unprotected report.
- Redacts expired report payloads at read time and rejects expired chart refreshes before physical cleanup runs.
- Runs bounded, idempotent cleanup batches with row locking, automatic continuation, structured counts, and Prometheus metrics.
- Removes run-scoped report and query provenance while retaining run metadata and SQL approval audit rows.

### Frontend

- Replaces expired report content with a stable placeholder showing the original question and completion date.
- Refetches terminal reports at the expiry boundary so an open thread transitions without a reload.
- Creates a separate run from the original question, depth, and MCP configuration when the user selects **Run again**.

## Regression analysis

| Group | Effect |
|---|---|
| Active and unexpired Deep Research runs | Existing report and progress behavior is unchanged. |
| Reports at least 30 days old | Report content and live chart refreshes become unavailable, then stored payloads are scrubbed. |
| Existing rows completed during a rolling deploy | A derived cutoff protects rows even when an old pod leaves `report_expires_at` null. |
| Non-report run history and audit metadata | Status, question, configuration, lifecycle timestamps, and SQL approval decisions remain available. |
| Open-source deployments | The schema and read-time contract apply, while the physical cleanup task runs in the commercial scheduler. |

## Migration

```bash
pnpm -F backend migrate
```

Adds two nullable `timestamptz` columns and an expiry lookup index to `ai_deep_research_runs`, then backfills completed report rows from `completed_at`.

## Test plan

- [x] Backend, frontend, and common typechecks pass.
- [x] Backend, frontend, and common lint and format checks pass with baseline warnings only.
- [x] Backend focused suites pass: 3 files, 84 tests.
- [x] Frontend focused suites pass: 4 files, 23 tests.
- [x] Common scheduler task suite passes: 1 file, 2 tests.
- [x] Postgres integration suite passes: 11 tests covering completion expiry, legacy rows, isolation, concurrency, idempotency, and rollback.
- [x] Migration rollback and forward migration preserve the expected schema and backfill.
- [x] Live worker cleanup scrubs an exactly-due report, retains run metadata, and leaves a future report untouched.
- [x] Live API reads redact expired payloads and expired chart refresh returns HTTP 404.

## Example payload

An expired run distinguishes logical expiry from the later physical scrub:

```json
{
  "resultMarkdown": null,
  "resultChartData": null,
  "reportExpiresAt": "2026-07-30T12:00:00.000Z",
  "reportExpiredAt": null,
  "isReportExpired": true
}
```
