### PR TITLE
feat(content-as-code): portable data app references in dashboard YAML

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -7534,7 +7534,11 @@ export class AppGenerateService extends BaseService {
             throw new ForbiddenError('Insufficient permissions');
         }
         const apps = await this.appModel.listAppsByProject(projectUuid);
-        return apps.map((app) => ({ appUuid: app.app_id, name: app.name }));
+        return apps.map((app) => ({
+            appUuid: app.app_id,
+            name: app.name,
+            slug: app.slug,
+        }));
     }
 
     // Validate the generator's declared schema. Pure (no IO); null when the

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -482,6 +482,32 @@ export class AppModel {
         return app !== undefined;
     }
 
+    /** Batch slug→uuid resolution for content-as-code dashboard tiles. */
+    async findAppsBySlugs(
+        projectUuid: string,
+        slugs: string[],
+    ): Promise<Pick<DbApp, 'app_id' | 'slug'>[]> {
+        if (slugs.length === 0) return [];
+        return this.database(AppsTableName)
+            .select('app_id', 'slug')
+            .where('project_uuid', projectUuid)
+            .whereIn('slug', slugs)
+            .whereNull('deleted_at');
+    }
+
+    /** Batch uuid filter, for legacy content-as-code tiles that predate app slugs. */
+    async findAppsByUuids(
+        projectUuid: string,
+        appUuids: string[],
+    ): Promise<Pick<DbApp, 'app_id' | 'slug'>[]> {
+        if (appUuids.length === 0) return [];
+        return this.database(AppsTableName)
+            .select('app_id', 'slug')
+            .where('project_uuid', projectUuid)
+            .whereIn('app_id', appUuids)
+            .whereNull('deleted_at');
+    }
+
     /**
      * Resolve an app by uuid or slug. A value that parses as a UUID may
      * still be a slug (slugs aren't guaranteed non-uuid-shaped), so

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -958,6 +958,7 @@ export class DashboardModel {
                     tab_uuid: string;
                     chart_slug: string;
                     app_uuid: string | null;
+                    app_slug: string | null;
                     data_app_deleted_at: Date | null;
                 }[]
             >(
@@ -1009,6 +1010,7 @@ export class DashboardModel {
                 `${DashboardTileHeadingsTableName}.text`,
                 `${DashboardTileHeadingsTableName}.show_divider`,
                 `${DashboardTileDataAppsTableName}.app_uuid`,
+                this.database.raw(`${AppsTableName}.slug AS app_slug`),
                 this.database.raw(
                     `${AppsTableName}.deleted_at AS data_app_deleted_at`,
                 ),
@@ -1193,6 +1195,7 @@ export class DashboardModel {
                     tab_uuid,
                     chart_slug,
                     app_uuid,
+                    app_slug,
                     data_app_deleted_at,
                 }) => {
                     const base: Omit<
@@ -1272,6 +1275,7 @@ export class DashboardModel {
                                 properties: {
                                     ...commonProperties,
                                     appUuid: app_uuid ?? '',
+                                    appSlug: app_slug ?? null,
                                     appDeletedAt:
                                         data_app_deleted_at?.toISOString() ??
                                         null,
@@ -2148,6 +2152,7 @@ export class DashboardModel {
                     tab_uuid: string;
                     chart_slug: string;
                     app_uuid: string | null;
+                    app_slug: string | null;
                     data_app_deleted_at: Date | null;
                 }[]
             >(
@@ -2199,6 +2204,7 @@ export class DashboardModel {
                 `${DashboardTileHeadingsTableName}.text`,
                 `${DashboardTileHeadingsTableName}.show_divider`,
                 `${DashboardTileDataAppsTableName}.app_uuid`,
+                this.database.raw(`${AppsTableName}.slug AS app_slug`),
                 this.database.raw(
                     `${AppsTableName}.deleted_at AS data_app_deleted_at`,
                 ),
@@ -2368,6 +2374,7 @@ export class DashboardModel {
                     tab_uuid,
                     chart_slug,
                     app_uuid,
+                    app_slug,
                     data_app_deleted_at,
                 }) => {
                     const base: Omit<
@@ -2447,6 +2454,7 @@ export class DashboardModel {
                                 properties: {
                                     ...commonProperties,
                                     appUuid: app_uuid ?? '',
+                                    appSlug: app_slug ?? null,
                                     appDeletedAt:
                                         data_app_deleted_at?.toISOString() ??
                                         null,

--- a/packages/backend/src/services/CoderService/CoderService.contentVerification.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.contentVerification.test.ts
@@ -7,6 +7,7 @@ import {
 } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { AppModel } from '../../models/AppModel';
 import { ContentVerificationModel } from '../../models/ContentVerificationModel';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
@@ -79,6 +80,7 @@ const buildService = () =>
         projectModel: {} as unknown as ProjectModel,
         savedChartModel: {} as unknown as SavedChartModel,
         savedSqlModel: {} as unknown as SavedSqlModel,
+        appModel: {} as unknown as AppModel,
         dashboardModel: {} as unknown as DashboardModel,
         spaceModel: {} as unknown as SpaceModel,
         schedulerModel: {} as unknown as SchedulerModel,

--- a/packages/backend/src/services/CoderService/CoderService.scheduledDeliveries.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.scheduledDeliveries.test.ts
@@ -293,6 +293,7 @@ const buildService = ({
             find: vi.fn(async () => [{ uuid: chartUuid, slug: 'orders' }]),
         } as never,
         savedSqlModel: {} as never,
+        appModel: {} as never,
         dashboardModel: {
             find: vi.fn(async () => [
                 { uuid: dashboardUuid, slug: 'orders-dashboard' },

--- a/packages/backend/src/services/CoderService/CoderService.spaces.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.spaces.test.ts
@@ -197,6 +197,7 @@ const buildService = ({
         projectModel: projectModel as AnyType,
         savedChartModel: {} as AnyType,
         savedSqlModel: {} as AnyType,
+        appModel: {} as AnyType,
         dashboardModel: {} as AnyType,
         spaceModel: spaceModel as AnyType,
         schedulerModel: {} as AnyType,

--- a/packages/backend/src/services/CoderService/CoderService.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.test.ts
@@ -234,7 +234,7 @@ describe('CoderService', () => {
         });
     });
 
-    describe('getChartSlugForTileUuid', () => {
+    describe('getTileSlugForTileUuid', () => {
         it('should return undefined when chart tile slug is null', () => {
             const mockDashboard = {
                 tiles: [
@@ -247,7 +247,58 @@ describe('CoderService', () => {
             } as AnyType;
 
             expect(
-                CoderService.getChartSlugForTileUuid(mockDashboard, 'uuid-1'),
+                CoderService.getTileSlugForTileUuid(mockDashboard, 'uuid-1'),
+            ).toBeUndefined();
+        });
+    });
+
+    describe('getTileSlugForTileUuid - data app tiles', () => {
+        const dashboardWith = (tiles: AnyType[]) => ({ tiles }) as AnyType;
+
+        it('returns the app slug for a data app tile', () => {
+            const dashboard = dashboardWith([
+                {
+                    uuid: 'tile-1',
+                    type: DashboardTileTypes.DATA_APP,
+                    properties: { appSlug: 'revenue-explorer' },
+                },
+            ]);
+
+            expect(
+                CoderService.getTileSlugForTileUuid(dashboard, 'tile-1'),
+            ).toBe('revenue-explorer');
+        });
+
+        it('suffixes when one app appears in two tiles', () => {
+            const dashboard = dashboardWith([
+                {
+                    uuid: 'tile-1',
+                    type: DashboardTileTypes.DATA_APP,
+                    properties: { appSlug: 'revenue-explorer' },
+                },
+                {
+                    uuid: 'tile-2',
+                    type: DashboardTileTypes.DATA_APP,
+                    properties: { appSlug: 'revenue-explorer' },
+                },
+            ]);
+
+            expect(
+                CoderService.getTileSlugForTileUuid(dashboard, 'tile-2'),
+            ).toBe('revenue-explorer-2');
+        });
+
+        it('returns undefined when the app slug is missing', () => {
+            const dashboard = dashboardWith([
+                {
+                    uuid: 'tile-1',
+                    type: DashboardTileTypes.DATA_APP,
+                    properties: { appSlug: null },
+                },
+            ]);
+
+            expect(
+                CoderService.getTileSlugForTileUuid(dashboard, 'tile-1'),
             ).toBeUndefined();
         });
     });

--- a/packages/backend/src/services/CoderService/CoderService.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.test.ts
@@ -500,6 +500,119 @@ describe('CoderService', () => {
         });
     });
 
+    describe('data app tile filter target round-trip', () => {
+        it('should preserve a single data app tile filter target through download then upload', () => {
+            const mockDashboard = {
+                filters: {
+                    dimensions: [
+                        {
+                            tileTargets: {
+                                'original-uuid': { fieldId: 'field-1' },
+                            },
+                        },
+                    ],
+                },
+                tiles: [
+                    {
+                        uuid: 'original-uuid',
+                        type: DashboardTileTypes.DATA_APP,
+                        properties: { appSlug: 'revenue-explorer' },
+                    },
+                ],
+            } as AnyType;
+
+            const asCodeFilters =
+                CoderService.getFiltersWithTileSlugs(mockDashboard);
+
+            expect(
+                Object.keys(asCodeFilters.dimensions[0].tileTargets ?? {}),
+            ).toEqual(['revenue-explorer']);
+
+            const tilesWithNewUuids = [
+                {
+                    uuid: 'regenerated-uuid',
+                    type: DashboardTileTypes.DATA_APP,
+                    tileSlug: 'revenue-explorer',
+                    properties: { appSlug: 'revenue-explorer' },
+                },
+            ];
+
+            const restoredFilters = CoderService.getFiltersWithTileUuids(
+                { filters: asCodeFilters } as AnyType,
+                tilesWithNewUuids as AnyType,
+            );
+
+            expect(restoredFilters.dimensions[0].tileTargets).toEqual({
+                'regenerated-uuid': { fieldId: 'field-1' },
+            });
+        });
+
+        it('should resolve the correct tile when the same app appears in two tiles', () => {
+            const mockDashboard = {
+                filters: {
+                    dimensions: [
+                        {
+                            tileTargets: {
+                                'tile-1-uuid': { fieldId: 'field-1' },
+                                'tile-2-uuid': { fieldId: 'field-2' },
+                            },
+                        },
+                    ],
+                },
+                tiles: [
+                    {
+                        uuid: 'tile-1-uuid',
+                        type: DashboardTileTypes.DATA_APP,
+                        properties: { appSlug: 'revenue-explorer' },
+                    },
+                    {
+                        uuid: 'tile-2-uuid',
+                        type: DashboardTileTypes.DATA_APP,
+                        properties: { appSlug: 'revenue-explorer' },
+                    },
+                ],
+            } as AnyType;
+
+            const asCodeFilters =
+                CoderService.getFiltersWithTileSlugs(mockDashboard);
+
+            // Download disambiguates the two tiles sharing an app slug
+            expect(asCodeFilters.dimensions[0].tileTargets).toEqual({
+                'revenue-explorer-1': { fieldId: 'field-1' },
+                'revenue-explorer-2': { fieldId: 'field-2' },
+            });
+
+            // Upload: both tiles are re-created with brand new UUIDs, each
+            // carrying the disambiguated tileSlug from the YAML
+            const tilesWithNewUuids = [
+                {
+                    uuid: 'new-tile-1-uuid',
+                    type: DashboardTileTypes.DATA_APP,
+                    tileSlug: 'revenue-explorer-1',
+                    properties: { appSlug: 'revenue-explorer' },
+                },
+                {
+                    uuid: 'new-tile-2-uuid',
+                    type: DashboardTileTypes.DATA_APP,
+                    tileSlug: 'revenue-explorer-2',
+                    properties: { appSlug: 'revenue-explorer' },
+                },
+            ];
+
+            const restoredFilters = CoderService.getFiltersWithTileUuids(
+                { filters: asCodeFilters } as AnyType,
+                tilesWithNewUuids as AnyType,
+            );
+
+            // The target aimed at tile 2 resolves to tile 2's new uuid,
+            // not tile 1's, and neither target is dropped
+            expect(restoredFilters.dimensions[0].tileTargets).toEqual({
+                'new-tile-1-uuid': { fieldId: 'field-1' },
+                'new-tile-2-uuid': { fieldId: 'field-2' },
+            });
+        });
+    });
+
     describe('getConfigWithDateZoomTileSlugs', () => {
         it('should convert date zoom tileTargets tile UUIDs to slugs', () => {
             const mockDashboard = {
@@ -755,6 +868,98 @@ describe('CoderService', () => {
             // The target is re-attached to the new tile UUID, not lost
             expect(restoredConfig.dateZoomConfig?.tileTargets).toEqual({
                 'regenerated-uuid': {
+                    controlUuid: 'control-1',
+                    fieldId: 'orders_order_date',
+                    tableName: 'orders',
+                },
+            });
+        });
+
+        it('should resolve each tile when the same data app appears in two tiles', () => {
+            const mockDashboard = {
+                config: {
+                    isDateZoomDisabled: false,
+                    dateZoomConfig: {
+                        controls: [
+                            {
+                                uuid: 'control-1',
+                                name: 'Revenue zoom',
+                                granularity: 'WEEK',
+                            },
+                        ],
+                        tileTargets: {
+                            'tile-1-uuid': {
+                                controlUuid: 'control-1',
+                                fieldId: 'orders_order_date',
+                                tableName: 'orders',
+                            },
+                            'tile-2-uuid': {
+                                controlUuid: 'control-1',
+                                fieldId: 'orders_order_date',
+                                tableName: 'orders',
+                            },
+                        },
+                    },
+                },
+                tiles: [
+                    {
+                        uuid: 'tile-1-uuid',
+                        type: DashboardTileTypes.DATA_APP,
+                        properties: { appSlug: 'revenue-explorer' },
+                    },
+                    {
+                        uuid: 'tile-2-uuid',
+                        type: DashboardTileTypes.DATA_APP,
+                        properties: { appSlug: 'revenue-explorer' },
+                    },
+                ],
+            } as AnyType;
+
+            const asCodeConfig =
+                CoderService.getConfigWithDateZoomTileSlugs(mockDashboard);
+
+            expect(asCodeConfig?.dateZoomConfig?.tileTargets).toEqual({
+                'revenue-explorer-1': {
+                    controlUuid: 'control-1',
+                    fieldId: 'orders_order_date',
+                    tableName: 'orders',
+                },
+                'revenue-explorer-2': {
+                    controlUuid: 'control-1',
+                    fieldId: 'orders_order_date',
+                    tableName: 'orders',
+                },
+            });
+
+            const tilesWithNewUuids = [
+                {
+                    uuid: 'new-tile-1-uuid',
+                    type: DashboardTileTypes.DATA_APP,
+                    tileSlug: 'revenue-explorer-1',
+                    properties: { appSlug: 'revenue-explorer' },
+                },
+                {
+                    uuid: 'new-tile-2-uuid',
+                    type: DashboardTileTypes.DATA_APP,
+                    tileSlug: 'revenue-explorer-2',
+                    properties: { appSlug: 'revenue-explorer' },
+                },
+            ];
+
+            const restoredConfig = CoderService.getConfigWithDateZoomTileUuids(
+                asCodeConfig as AnyType,
+                tilesWithNewUuids as AnyType,
+            );
+
+            // The target aimed at tile 2 resolves to tile 2's new uuid,
+            // not tile 1's, and neither target is dropped
+            expect(restoredConfig.dateZoomConfig?.tileTargets).toEqual({
+                'new-tile-1-uuid': {
+                    controlUuid: 'control-1',
+                    fieldId: 'orders_order_date',
+                    tableName: 'orders',
+                },
+                'new-tile-2-uuid': {
                     controlUuid: 'control-1',
                     fieldId: 'orders_order_date',
                     tableName: 'orders',
@@ -1315,6 +1520,48 @@ describe('CoderService', () => {
             expect(result.tiles[0].properties).not.toHaveProperty(
                 'appDeletedAt',
             );
+        });
+
+        it('bakes in the disambiguated tileSlug, mirroring chart tiles', () => {
+            const result = transform([
+                {
+                    uuid: 'tile-1',
+                    type: DashboardTileTypes.DATA_APP,
+                    x: 0,
+                    y: 0,
+                    h: 9,
+                    w: 18,
+                    tabUuid: null,
+                    properties: {
+                        title: 'Revenue explorer A',
+                        hideTitle: false,
+                        appUuid: 'app-uuid',
+                        appSlug: 'revenue-explorer',
+                        appDeletedAt: null,
+                    },
+                },
+                {
+                    uuid: 'tile-2',
+                    type: DashboardTileTypes.DATA_APP,
+                    x: 0,
+                    y: 9,
+                    h: 9,
+                    w: 18,
+                    tabUuid: null,
+                    properties: {
+                        title: 'Revenue explorer B',
+                        hideTitle: false,
+                        appUuid: 'app-uuid',
+                        appSlug: 'revenue-explorer',
+                        appDeletedAt: null,
+                    },
+                },
+            ]);
+
+            expect(result.tiles.map((tile: AnyType) => tile.tileSlug)).toEqual([
+                'revenue-explorer-1',
+                'revenue-explorer-2',
+            ]);
         });
     });
 });

--- a/packages/backend/src/services/CoderService/CoderService.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.test.ts
@@ -726,6 +726,9 @@ describe('CoderService', () => {
                 savedSqlModel: {
                     find: vi.fn(),
                 } as AnyType,
+                appModel: {
+                    findAppsBySlugs: vi.fn(async () => []),
+                } as AnyType,
                 schedulerModel: {} as AnyType,
                 schedulerService: {} as AnyType,
                 savedChartService: {} as AnyType,
@@ -738,7 +741,7 @@ describe('CoderService', () => {
                 userModel: {} as AnyType,
             });
 
-            const result = await service.convertTileWithSlugsToUuids(
+            const { tiles: result } = await service.convertTileWithSlugsToUuids(
                 'project-uuid',
                 [
                     {
@@ -802,6 +805,9 @@ describe('CoderService', () => {
                 promoteService: {} as AnyType,
                 savedChartModel: { find: vi.fn() } as AnyType,
                 savedSqlModel: { find: vi.fn() } as AnyType,
+                appModel: {
+                    findAppsBySlugs: vi.fn(async () => []),
+                } as AnyType,
                 schedulerModel: {} as AnyType,
                 schedulerService: {} as AnyType,
                 savedChartService: {} as AnyType,
@@ -814,7 +820,7 @@ describe('CoderService', () => {
                 userModel: {} as AnyType,
             });
 
-            const result = await service.convertTileWithSlugsToUuids(
+            const { tiles: result } = await service.convertTileWithSlugsToUuids(
                 'project-uuid',
                 [
                     {
@@ -836,6 +842,118 @@ describe('CoderService', () => {
                 { tabUuid: 'legacy-tab-uuid' },
             ]);
             expect(result[0]).not.toHaveProperty('tabSlug');
+        });
+
+        const buildServiceWithApps = (
+            apps: { app_id: string; slug: string }[],
+        ) =>
+            new CoderService({
+                analytics: {} as AnyType,
+                contentVerificationModel: {} as AnyType,
+                dashboardModel: {} as AnyType,
+                lightdashConfig: {} as AnyType,
+                projectModel: {} as AnyType,
+                promoteService: {} as AnyType,
+                savedChartModel: { find: vi.fn(async () => []) } as AnyType,
+                savedSqlModel: { find: vi.fn(async () => []) } as AnyType,
+                appModel: {
+                    findAppsBySlugs: vi.fn(async () => apps),
+                    findAppsByUuids: vi.fn(async () => apps),
+                } as AnyType,
+                schedulerModel: {} as AnyType,
+                schedulerService: {} as AnyType,
+                savedChartService: {} as AnyType,
+                dashboardService: {} as AnyType,
+                schedulerClient: {} as AnyType,
+                spaceModel: {} as AnyType,
+                spacePermissionService: {} as AnyType,
+                groupsModel: {} as AnyType,
+                organizationMemberProfileModel: {} as AnyType,
+                userModel: {} as AnyType,
+            });
+
+        const dataAppTile = (properties: AnyType) => ({
+            type: DashboardTileTypes.DATA_APP,
+            uuid: undefined,
+            tileSlug: undefined,
+            x: 0,
+            y: 0,
+            h: 9,
+            w: 18,
+            tabUuid: null,
+            properties,
+        });
+
+        it('resolves appSlug to the target project app uuid', async () => {
+            const service = buildServiceWithApps([
+                { app_id: 'target-app-uuid', slug: 'revenue-explorer' },
+            ]);
+
+            const { tiles, warnings } =
+                await service.convertTileWithSlugsToUuids('project-uuid', [
+                    dataAppTile({
+                        title: 'Revenue explorer',
+                        appSlug: 'revenue-explorer',
+                    }),
+                ] as AnyType);
+
+            expect(warnings).toEqual([]);
+            expect(tiles).toHaveLength(1);
+            expect(tiles[0].properties).toMatchObject({
+                appUuid: 'target-app-uuid',
+                appSlug: 'revenue-explorer',
+            });
+            expect(tiles[0].uuid).toEqual(expect.any(String));
+        });
+
+        it('skips a tile whose app is missing and warns', async () => {
+            const service = buildServiceWithApps([]);
+
+            const { tiles, warnings } =
+                await service.convertTileWithSlugsToUuids('project-uuid', [
+                    dataAppTile({ title: 'Gone', appSlug: 'revenue-explorer' }),
+                ] as AnyType);
+
+            expect(tiles).toEqual([]);
+            expect(warnings).toEqual([
+                'Data app "revenue-explorer" was not found in this project — tile skipped. Upload the app first, then re-upload the dashboard.',
+            ]);
+        });
+
+        it('falls back to a legacy appUuid when the tile has no appSlug', async () => {
+            const service = buildServiceWithApps([
+                { app_id: 'legacy-app-uuid', slug: 'legacy-app' },
+            ]);
+
+            const { tiles, warnings } =
+                await service.convertTileWithSlugsToUuids('project-uuid', [
+                    dataAppTile({
+                        title: 'Legacy',
+                        appUuid: 'legacy-app-uuid',
+                    }),
+                ] as AnyType);
+
+            expect(warnings).toEqual([]);
+            expect(tiles[0].properties).toMatchObject({
+                appUuid: 'legacy-app-uuid',
+            });
+        });
+
+        it('skips a legacy appUuid that is not in the target project', async () => {
+            const service = buildServiceWithApps([
+                { app_id: 'some-other-app', slug: 'other' },
+            ]);
+
+            const { tiles, warnings } =
+                await service.convertTileWithSlugsToUuids('project-uuid', [
+                    dataAppTile({
+                        title: 'Foreign',
+                        appUuid: 'foreign-app-uuid',
+                    }),
+                ] as AnyType);
+
+            expect(tiles).toEqual([]);
+            expect(warnings).toHaveLength(1);
         });
     });
 

--- a/packages/backend/src/services/CoderService/CoderService.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.test.ts
@@ -946,4 +946,87 @@ describe('CoderService', () => {
             );
         });
     });
+
+    describe('transformDashboard - data app tiles', () => {
+        const spaceSummary = [
+            { uuid: 'space-uuid', name: 'My space', path: 'my_space' },
+        ];
+
+        const transform = (tiles: AnyType[]) =>
+            (
+                CoderService as unknown as {
+                    transformDashboard: (...args: AnyType[]) => AnyType;
+                }
+            ).transformDashboard(
+                {
+                    name: 'Dash',
+                    description: '',
+                    slug: 'dash',
+                    spaceUuid: 'space-uuid',
+                    tabs: [],
+                    tiles,
+                    filters: {
+                        dimensions: [],
+                        metrics: [],
+                        tableCalculations: [],
+                    },
+                    updatedAt: new Date('2026-01-01'),
+                },
+                spaceSummary,
+                new Map(),
+            );
+
+        it('emits appSlug and drops appUuid and appDeletedAt', () => {
+            const result = transform([
+                {
+                    uuid: 'tile-uuid',
+                    type: DashboardTileTypes.DATA_APP,
+                    x: 0,
+                    y: 0,
+                    h: 9,
+                    w: 18,
+                    tabUuid: null,
+                    properties: {
+                        title: 'Revenue explorer',
+                        hideTitle: false,
+                        appUuid: 'app-uuid',
+                        appSlug: 'revenue-explorer',
+                        appDeletedAt: null,
+                    },
+                },
+            ]);
+
+            expect(result.tiles[0].properties).toEqual({
+                title: 'Revenue explorer',
+                hideTitle: false,
+                appSlug: 'revenue-explorer',
+            });
+            expect(result.tiles[0].uuid).toBeUndefined();
+        });
+
+        it('emits a null appSlug when the app row is gone', () => {
+            const result = transform([
+                {
+                    uuid: 'tile-uuid',
+                    type: DashboardTileTypes.DATA_APP,
+                    x: 0,
+                    y: 0,
+                    h: 9,
+                    w: 18,
+                    tabUuid: null,
+                    properties: {
+                        title: 'Orphaned',
+                        appUuid: 'app-uuid',
+                        appSlug: null,
+                        appDeletedAt: '2026-01-01T00:00:00.000Z',
+                    },
+                },
+            ]);
+
+            expect(result.tiles[0].properties.appSlug).toBeNull();
+            expect(result.tiles[0].properties).not.toHaveProperty(
+                'appDeletedAt',
+            );
+        });
+    });
 });

--- a/packages/backend/src/services/CoderService/CoderService.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.test.ts
@@ -9,6 +9,7 @@ import {
     DashboardTileTypes,
 } from '@lightdash/common';
 import { CoderService } from './CoderService';
+import { withTileWarnings } from './dashboardReferences';
 
 describe('CoderService', () => {
     describe('transformChart', () => {
@@ -954,6 +955,124 @@ describe('CoderService', () => {
 
             expect(tiles).toEqual([]);
             expect(warnings).toHaveLength(1);
+        });
+
+        it('resolves a chart tile and a data app tile together (main return path)', async () => {
+            const service = new CoderService({
+                analytics: {} as AnyType,
+                contentVerificationModel: {} as AnyType,
+                dashboardModel: {} as AnyType,
+                lightdashConfig: {} as AnyType,
+                projectModel: {} as AnyType,
+                promoteService: {} as AnyType,
+                savedChartModel: {
+                    find: vi.fn(async () => [
+                        { uuid: 'chart-uuid', slug: 'revenue-chart' },
+                    ]),
+                } as AnyType,
+                savedSqlModel: { find: vi.fn(async () => []) } as AnyType,
+                appModel: {
+                    findAppsBySlugs: vi.fn(async () => [
+                        { app_id: 'target-app-uuid', slug: 'revenue-explorer' },
+                    ]),
+                    findAppsByUuids: vi.fn(async () => []),
+                } as AnyType,
+                schedulerModel: {} as AnyType,
+                schedulerService: {} as AnyType,
+                savedChartService: {} as AnyType,
+                dashboardService: {} as AnyType,
+                schedulerClient: {} as AnyType,
+                spaceModel: {} as AnyType,
+                spacePermissionService: {} as AnyType,
+                groupsModel: {} as AnyType,
+                organizationMemberProfileModel: {} as AnyType,
+                userModel: {} as AnyType,
+            });
+
+            const { tiles, warnings } =
+                await service.convertTileWithSlugsToUuids('project-uuid', [
+                    {
+                        type: DashboardTileTypes.SAVED_CHART,
+                        uuid: undefined,
+                        tileSlug: undefined,
+                        x: 0,
+                        y: 0,
+                        h: 2,
+                        w: 4,
+                        tabUuid: null,
+                        properties: {
+                            chartSlug: 'revenue-chart',
+                            chartName: 'Revenue',
+                        },
+                    },
+                    dataAppTile({
+                        title: 'Revenue explorer',
+                        appSlug: 'revenue-explorer',
+                    }),
+                ] as AnyType);
+
+            expect(warnings).toEqual([]);
+            expect(tiles).toHaveLength(2);
+            expect(tiles[0].properties).toMatchObject({
+                chartSlug: 'revenue-chart',
+                savedChartUuid: 'chart-uuid',
+            });
+            expect(tiles[1].properties).toMatchObject({
+                appUuid: 'target-app-uuid',
+                appSlug: 'revenue-explorer',
+            });
+        });
+
+        it('produces one warning per skipped data app tile when there are multiple', async () => {
+            const service = buildServiceWithApps([]);
+
+            const { tiles, warnings } =
+                await service.convertTileWithSlugsToUuids('project-uuid', [
+                    dataAppTile({ title: 'Gone 1', appSlug: 'app-one' }),
+                    dataAppTile({ title: 'Gone 2', appSlug: 'app-two' }),
+                ] as AnyType);
+
+            expect(tiles).toEqual([]);
+            expect(warnings).toEqual([
+                'Data app "app-one" was not found in this project — tile skipped. Upload the app first, then re-upload the dashboard.',
+                'Data app "app-two" was not found in this project — tile skipped. Upload the app first, then re-upload the dashboard.',
+            ]);
+        });
+
+        it('names the tile by title when it has no app reference to resolve', async () => {
+            const service = buildServiceWithApps([]);
+
+            const { tiles, warnings } =
+                await service.convertTileWithSlugsToUuids('project-uuid', [
+                    dataAppTile({ title: 'Orphaned tile', appSlug: null }),
+                ] as AnyType);
+
+            expect(tiles).toEqual([]);
+            expect(warnings).toEqual([
+                'Data app tile "Orphaned tile" has no app reference to resolve — tile skipped.',
+            ]);
+        });
+    });
+
+    describe('withTileWarnings', () => {
+        it('omits the key when there is nothing to report', () => {
+            expect(withTileWarnings({ dashboards: [] } as AnyType, [])).toEqual(
+                {
+                    dashboards: [],
+                },
+            );
+        });
+
+        it('attaches warnings when tiles were skipped', () => {
+            expect(
+                withTileWarnings({ dashboards: [] } as AnyType, ['nope']),
+            ).toEqual({ dashboards: [], warnings: ['nope'] });
+        });
+
+        it('does not mutate the changes it was given', () => {
+            const changes = { dashboards: [] } as AnyType;
+            withTileWarnings(changes, ['nope']);
+            expect(changes).not.toHaveProperty('warnings');
         });
     });
 

--- a/packages/backend/src/services/CoderService/CoderService.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.test.ts
@@ -1101,10 +1101,16 @@ describe('CoderService', () => {
             expect(result[0]).not.toHaveProperty('tabSlug');
         });
 
-        const buildServiceWithApps = (
-            apps: { app_id: string; slug: string }[],
-        ) =>
-            new CoderService({
+        type AppRow = { app_id: string; slug: string };
+        const buildAppModelMock = (apps: AppRow[]) => ({
+            findAppsBySlugs: vi.fn(async (): Promise<AppRow[]> => apps),
+            findAppsByUuids: vi.fn(async (): Promise<AppRow[]> => apps),
+        });
+        let appModelMock = buildAppModelMock([]);
+
+        const buildServiceWithApps = (apps: AppRow[]) => {
+            appModelMock = buildAppModelMock(apps);
+            return new CoderService({
                 analytics: {} as AnyType,
                 contentVerificationModel: {} as AnyType,
                 dashboardModel: {} as AnyType,
@@ -1113,10 +1119,7 @@ describe('CoderService', () => {
                 promoteService: {} as AnyType,
                 savedChartModel: { find: vi.fn(async () => []) } as AnyType,
                 savedSqlModel: { find: vi.fn(async () => []) } as AnyType,
-                appModel: {
-                    findAppsBySlugs: vi.fn(async () => apps),
-                    findAppsByUuids: vi.fn(async () => apps),
-                } as AnyType,
+                appModel: appModelMock as AnyType,
                 schedulerModel: {} as AnyType,
                 schedulerService: {} as AnyType,
                 savedChartService: {} as AnyType,
@@ -1128,6 +1131,7 @@ describe('CoderService', () => {
                 organizationMemberProfileModel: {} as AnyType,
                 userModel: {} as AnyType,
             });
+        };
 
         const dataAppTile = (properties: AnyType) => ({
             type: DashboardTileTypes.DATA_APP,
@@ -1161,6 +1165,11 @@ describe('CoderService', () => {
                 appSlug: 'revenue-explorer',
             });
             expect(tiles[0].uuid).toEqual(expect.any(String));
+            // App lookups must be scoped to the target project
+            expect(appModelMock.findAppsBySlugs).toHaveBeenCalledWith(
+                'project-uuid',
+                ['revenue-explorer'],
+            );
         });
 
         it('skips a tile whose app is missing and warns', async () => {
@@ -1194,6 +1203,10 @@ describe('CoderService', () => {
             expect(tiles[0].properties).toMatchObject({
                 appUuid: 'legacy-app-uuid',
             });
+            expect(appModelMock.findAppsByUuids).toHaveBeenCalledWith(
+                'project-uuid',
+                ['legacy-app-uuid'],
+            );
         });
 
         it('skips a legacy appUuid that is not in the target project', async () => {

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -28,6 +28,7 @@ import {
     currentVersion,
     DashboardAsCode,
     DashboardAsCodeInternalization,
+    DashboardAsCodeUpsertResult,
     DashboardChartTileAsCode,
     DashboardDAO,
     DashboardDataAppTileAsCode,
@@ -128,6 +129,7 @@ import {
     getFiltersWithTileSlugs,
     getFiltersWithTileUuids,
     isAnyChartTile,
+    withTileWarnings,
 } from './dashboardReferences';
 import { normalizeFilterIds, stripFilterIds } from './filterIds';
 import { ScheduledContentCoder } from './handlers/ScheduledContentCoder';
@@ -1771,9 +1773,11 @@ export class CoderService extends BaseService {
                 }
                 if (!resolvedAppUuid) {
                     warnings.push(
-                        `Data app "${
-                            appSlug ?? legacyAppUuid ?? 'unknown'
-                        }" was not found in this project — tile skipped. Upload the app first, then re-upload the dashboard.`,
+                        appSlug || legacyAppUuid
+                            ? `Data app "${
+                                  appSlug ?? legacyAppUuid
+                              }" was not found in this project — tile skipped. Upload the app first, then re-upload the dashboard.`
+                            : `Data app tile "${tile.properties.title}" has no app reference to resolve — tile skipped.`,
                     );
                     return null;
                 }
@@ -3573,7 +3577,7 @@ export class CoderService extends BaseService {
         slug: string,
         dashboardAsCode: DashboardAsCode,
         options: UpsertContentAsCodeOptions = {},
-    ): Promise<PromotionChanges> {
+    ): Promise<DashboardAsCodeUpsertResult> {
         const {
             skipSpaceCreate,
             publicSpaceCreate,
@@ -3625,7 +3629,7 @@ export class CoderService extends BaseService {
             ...dashboardWithDefaults,
             tabs: tabsWithUuids,
         };
-        const { tiles: tilesWithUuids } =
+        const { tiles: tilesWithUuids, warnings: tileWarnings } =
             await this.convertTileWithSlugsToUuids(
                 projectUuid,
                 dashboardWithResolvedTabs.tiles,
@@ -3707,24 +3711,27 @@ export class CoderService extends BaseService {
                 verified: dashboardAsCode.verified,
             });
 
-            return {
-                dashboards: [
-                    {
-                        action: PromotionAction.CREATE,
-                        data: {
-                            ...newDashboard,
-                            spaceSlug: dashboardWithDefaults.spaceSlug,
-                            spacePath: getContentAsCodePathFromLtreePath(
-                                dashboardWithDefaults.spaceSlug,
-                            ),
+            return withTileWarnings(
+                {
+                    dashboards: [
+                        {
+                            action: PromotionAction.CREATE,
+                            data: {
+                                ...newDashboard,
+                                spaceSlug: dashboardWithDefaults.spaceSlug,
+                                spacePath: getContentAsCodePathFromLtreePath(
+                                    dashboardWithDefaults.spaceSlug,
+                                ),
+                            },
                         },
-                    },
-                ],
-                charts: [],
-                spaces: spaceCreated
-                    ? [{ action: PromotionAction.CREATE, data: space }]
-                    : [],
-            };
+                    ],
+                    charts: [],
+                    spaces: spaceCreated
+                        ? [{ action: PromotionAction.CREATE, data: space }]
+                        : [],
+                },
+                tileWarnings,
+            );
         }
         // Use promote service to update existing dashboard
 
@@ -3861,6 +3868,6 @@ export class CoderService extends BaseService {
         console.info(
             `Finished updating dashboard "${dashboard.name}" on project ${projectUuid}: ${promotionChanges.dashboards[0].action}`,
         );
-        return promotionChanges;
+        return withTileWarnings(promotionChanges, tileWarnings);
     }
 }

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -1710,22 +1710,18 @@ export class CoderService extends BaseService {
         }, []);
 
         const appTiles = tiles.filter(
-            (tile) => tile.type === DashboardTileTypes.DATA_APP,
+            (tile): tile is DashboardDataAppTileAsCode =>
+                tile.type === DashboardTileTypes.DATA_APP,
         );
         const appSlugs = appTiles.reduce<string[]>((acc, tile) => {
-            const { appSlug } = tile.properties as { appSlug?: string | null };
+            const { appSlug } = tile.properties;
             return appSlug ? [...acc, appSlug] : acc;
         }, []);
         // Pre-slug YAML carries appUuid instead of appSlug; resolve those too
         // so legacy content-as-code files keep working.
         const legacyAppUuids = appTiles.reduce<string[]>((acc, tile) => {
-            const props = tile.properties as {
-                appSlug?: string | null;
-                appUuid?: string;
-            };
-            return !props.appSlug && props.appUuid
-                ? [...acc, props.appUuid]
-                : acc;
+            const { appSlug, appUuid } = tile.properties;
+            return !appSlug && appUuid ? [...acc, appUuid] : acc;
         }, []);
         const [slugRows, legacyRows] =
             appTiles.length > 0
@@ -1762,10 +1758,7 @@ export class CoderService extends BaseService {
             }
 
             if (tile.type === DashboardTileTypes.DATA_APP) {
-                const { appSlug, appUuid: legacyAppUuid } = tile.properties as {
-                    appSlug?: string | null;
-                    appUuid?: string;
-                };
+                const { appSlug, appUuid: legacyAppUuid } = tile.properties;
                 // Pre-slug YAML carries appUuid; accept it only when the app
                 // actually lives in this project.
                 let resolvedAppUuid: string | undefined;

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -123,11 +123,11 @@ import {
     type CurrentChartSqlItems,
 } from './chartPermissions';
 import {
-    getChartSlugForTileUuid,
     getConfigWithDateZoomTileSlugs,
     getConfigWithDateZoomTileUuids,
     getFiltersWithTileSlugs,
     getFiltersWithTileUuids,
+    getTileSlugForTileUuid,
     isAnyChartTile,
     withTileWarnings,
 } from './dashboardReferences';
@@ -1477,7 +1477,7 @@ export class CoderService extends BaseService {
         );
     }
 
-    static getChartSlugForTileUuid = getChartSlugForTileUuid;
+    static getTileSlugForTileUuid = getTileSlugForTileUuid;
 
     static getFiltersWithTileSlugs = getFiltersWithTileSlugs;
 
@@ -1521,7 +1521,7 @@ export class CoderService extends BaseService {
                             uuid: undefined,
                             tabUuid: undefined,
                             tabSlug,
-                            tileSlug: CoderService.getChartSlugForTileUuid(
+                            tileSlug: CoderService.getTileSlugForTileUuid(
                                 dashboard,
                                 tile.uuid,
                             ),
@@ -1542,7 +1542,7 @@ export class CoderService extends BaseService {
                         uuid: undefined,
                         tabUuid: undefined,
                         tabSlug,
-                        tileSlug: CoderService.getChartSlugForTileUuid(
+                        tileSlug: CoderService.getTileSlugForTileUuid(
                             dashboard,
                             tile.uuid,
                         ),

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -30,6 +30,7 @@ import {
     DashboardAsCodeInternalization,
     DashboardChartTileAsCode,
     DashboardDAO,
+    DashboardDataAppTileAsCode,
     DashboardFilterRule,
     DashboardGoogleSheetsSyncAsCode,
     DashboardMarkdownTileAsCode,
@@ -1562,6 +1563,23 @@ export class CoderService extends BaseService {
                         },
                     };
                     return markdownTile;
+                }
+
+                if (tile.type === DashboardTileTypes.DATA_APP) {
+                    const dataAppTile: DashboardDataAppTileAsCode = {
+                        ...tile,
+                        type: DashboardTileTypes.DATA_APP,
+                        uuid: undefined,
+                        tabUuid: undefined,
+                        tabSlug,
+                        tileSlug: undefined,
+                        properties: {
+                            title: tile.properties.title,
+                            hideTitle: tile.properties.hideTitle,
+                            appSlug: tile.properties.appSlug ?? null,
+                        },
+                    };
+                    return dataAppTile;
                 }
 
                 // Other non-chart tiles already match the as-code shape

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -1580,7 +1580,10 @@ export class CoderService extends BaseService {
                         uuid: undefined,
                         tabUuid: undefined,
                         tabSlug,
-                        tileSlug: undefined,
+                        tileSlug: CoderService.getTileSlugForTileUuid(
+                            dashboard,
+                            tile.uuid,
+                        ),
                         properties: {
                             title: tile.properties.title,
                             hideTitle: tile.properties.hideTitle,

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -93,6 +93,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { getAccountApiAccessContext } from '../../auth/account';
 import { LightdashConfig } from '../../config/parseConfig';
+import { AppModel } from '../../models/AppModel';
 import { ContentVerificationModel } from '../../models/ContentVerificationModel';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { GroupsModel } from '../../models/GroupsModel';
@@ -154,6 +155,7 @@ type CoderServiceArguments = {
     projectModel: ProjectModel;
     savedChartModel: SavedChartModel;
     savedSqlModel: SavedSqlModel;
+    appModel: AppModel;
     dashboardModel: DashboardModel;
     spaceModel: SpaceModel;
     schedulerModel: SchedulerModel;
@@ -188,6 +190,8 @@ export class CoderService extends BaseService {
     savedChartModel: SavedChartModel;
 
     savedSqlModel: SavedSqlModel;
+
+    appModel: AppModel;
 
     dashboardModel: DashboardModel;
 
@@ -234,6 +238,7 @@ export class CoderService extends BaseService {
         projectModel,
         savedChartModel,
         savedSqlModel,
+        appModel,
         dashboardModel,
         spaceModel,
         schedulerModel,
@@ -255,6 +260,7 @@ export class CoderService extends BaseService {
         this.projectModel = projectModel;
         this.savedChartModel = savedChartModel;
         this.savedSqlModel = savedSqlModel;
+        this.appModel = appModel;
         this.dashboardModel = dashboardModel;
         this.spaceModel = spaceModel;
         this.schedulerModel = schedulerModel;
@@ -1689,7 +1695,7 @@ export class CoderService extends BaseService {
         projectUuid: string,
         tiles: DashboardTileAsCode[],
         tabUuidsBySlug: ReadonlyMap<string, string> = new Map(),
-    ): Promise<DashboardTileWithSlug[]> {
+    ): Promise<{ tiles: DashboardTileWithSlug[]; warnings: string[] }> {
         const chartSlugs: string[] = tiles.reduce<string[]>((acc, tile) => {
             if (!isAnyChartTile(tile) || tile.properties.chartSlug == null) {
                 return acc;
@@ -1698,10 +1704,45 @@ export class CoderService extends BaseService {
             return [...acc, tile.properties.chartSlug];
         }, []);
 
+        const appTiles = tiles.filter(
+            (tile) => tile.type === DashboardTileTypes.DATA_APP,
+        );
+        const appSlugs = appTiles.reduce<string[]>((acc, tile) => {
+            const { appSlug } = tile.properties as { appSlug?: string | null };
+            return appSlug ? [...acc, appSlug] : acc;
+        }, []);
+        // Pre-slug YAML carries appUuid instead of appSlug; resolve those too
+        // so legacy content-as-code files keep working.
+        const legacyAppUuids = appTiles.reduce<string[]>((acc, tile) => {
+            const props = tile.properties as {
+                appSlug?: string | null;
+                appUuid?: string;
+            };
+            return !props.appSlug && props.appUuid
+                ? [...acc, props.appUuid]
+                : acc;
+        }, []);
+        const [slugRows, legacyRows] =
+            appTiles.length > 0
+                ? await Promise.all([
+                      this.appModel.findAppsBySlugs(projectUuid, appSlugs),
+                      this.appModel.findAppsByUuids(
+                          projectUuid,
+                          legacyAppUuids,
+                      ),
+                  ])
+                : [[], []];
+        const appRows = [...slugRows, ...legacyRows];
+        const appUuidBySlug = new Map(
+            appRows.map((row) => [row.slug, row.app_id]),
+        );
+        const knownAppUuids = new Set(appRows.map((row) => row.app_id));
+        const warnings: string[] = [];
+
         const withResolvedTileUuid = (
             tile: DashboardTileAsCode,
             chartInfo?: { uuid: string; isSql: boolean },
-        ): DashboardTileWithSlug => {
+        ): DashboardTileWithSlug | null => {
             const { tabSlug, ...tileWithoutTabSlug } = tile;
             let { tabUuid } = tile;
             if (tabSlug === null) {
@@ -1713,6 +1754,38 @@ export class CoderService extends BaseService {
                 throw new NotFoundError(
                     `Dashboard tab "${tabSlug}" referenced by tile was not found`,
                 );
+            }
+
+            if (tile.type === DashboardTileTypes.DATA_APP) {
+                const { appSlug, appUuid: legacyAppUuid } = tile.properties as {
+                    appSlug?: string | null;
+                    appUuid?: string;
+                };
+                // Pre-slug YAML carries appUuid; accept it only when the app
+                // actually lives in this project.
+                let resolvedAppUuid: string | undefined;
+                if (appSlug) {
+                    resolvedAppUuid = appUuidBySlug.get(appSlug);
+                } else if (legacyAppUuid && knownAppUuids.has(legacyAppUuid)) {
+                    resolvedAppUuid = legacyAppUuid;
+                }
+                if (!resolvedAppUuid) {
+                    warnings.push(
+                        `Data app "${
+                            appSlug ?? legacyAppUuid ?? 'unknown'
+                        }" was not found in this project — tile skipped. Upload the app first, then re-upload the dashboard.`,
+                    );
+                    return null;
+                }
+                return {
+                    ...tileWithoutTabSlug,
+                    tabUuid,
+                    uuid: tile.uuid ?? uuidv4(),
+                    properties: {
+                        ...tile.properties,
+                        appUuid: resolvedAppUuid,
+                    },
+                } as DashboardTileWithSlug;
             }
 
             if (!isAnyChartTile(tile)) {
@@ -1754,7 +1827,14 @@ export class CoderService extends BaseService {
         };
 
         if (chartSlugs.length === 0) {
-            return tiles.map((tile) => withResolvedTileUuid(tile));
+            return {
+                tiles: tiles
+                    .map((tile) => withResolvedTileUuid(tile))
+                    .filter(
+                        (tile): tile is DashboardTileWithSlug => tile !== null,
+                    ),
+                warnings,
+            };
         }
 
         // Query both regular charts and SQL charts in parallel
@@ -1786,18 +1866,23 @@ export class CoderService extends BaseService {
             }),
         );
 
-        return tiles.map((tile) => {
-            if (isAnyChartTile(tile)) {
-                const { chartSlug } = tile.properties;
-                if (chartSlug == null) {
-                    return withResolvedTileUuid(tile);
-                }
-                const chartInfo = chartSlugToInfo.get(chartSlug);
-                return withResolvedTileUuid(tile, chartInfo);
-            }
+        return {
+            tiles: tiles
+                .map((tile) => {
+                    if (isAnyChartTile(tile)) {
+                        const { chartSlug } = tile.properties;
+                        if (chartSlug == null) {
+                            return withResolvedTileUuid(tile);
+                        }
+                        const chartInfo = chartSlugToInfo.get(chartSlug);
+                        return withResolvedTileUuid(tile, chartInfo);
+                    }
 
-            return withResolvedTileUuid(tile);
-        });
+                    return withResolvedTileUuid(tile);
+                })
+                .filter((tile): tile is DashboardTileWithSlug => tile !== null),
+            warnings,
+        };
     }
 
     /*
@@ -3540,11 +3625,12 @@ export class CoderService extends BaseService {
             ...dashboardWithDefaults,
             tabs: tabsWithUuids,
         };
-        const tilesWithUuids = await this.convertTileWithSlugsToUuids(
-            projectUuid,
-            dashboardWithResolvedTabs.tiles,
-            tabUuidsBySlug,
-        );
+        const { tiles: tilesWithUuids } =
+            await this.convertTileWithSlugsToUuids(
+                projectUuid,
+                dashboardWithResolvedTabs.tiles,
+                tabUuidsBySlug,
+            );
         if (!canUploadAnyContent) {
             await this.assertTileChartsViewAccess({
                 userUuid: user.userUuid,

--- a/packages/backend/src/services/CoderService/CoderService.upsertContentAccess.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.upsertContentAccess.test.ts
@@ -83,6 +83,7 @@ const buildService = () =>
         savedSqlModel: {
             find: vi.fn(async () => []),
         } as AnyType,
+        appModel: {} as AnyType,
         dashboardModel: {
             find: vi.fn(async () => []),
             create: vi.fn(),

--- a/packages/backend/src/services/CoderService/CoderService.upsertSqlChart.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.upsertSqlChart.test.ts
@@ -10,6 +10,7 @@ import {
 } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { AppModel } from '../../models/AppModel';
 import { ContentVerificationModel } from '../../models/ContentVerificationModel';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
@@ -84,6 +85,7 @@ const buildService = (
         } as unknown as ProjectModel,
         savedChartModel: {} as unknown as SavedChartModel,
         savedSqlModel: savedSqlModel as unknown as SavedSqlModel,
+        appModel: {} as unknown as AppModel,
         dashboardModel: {} as unknown as DashboardModel,
         spaceModel: {
             find: vi.fn(async () => [{ uuid: SPACE_UUID }]),

--- a/packages/backend/src/services/CoderService/CoderService.virtualViews.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.virtualViews.test.ts
@@ -97,6 +97,7 @@ const buildService = (existing: Explore | null = virtualView) => {
         projectModel: projectModel as never,
         savedChartModel: {} as never,
         savedSqlModel: {} as never,
+        appModel: {} as never,
         dashboardModel: {} as never,
         spaceModel: {} as never,
         schedulerModel: {} as never,

--- a/packages/backend/src/services/CoderService/dashboardReferences.ts
+++ b/packages/backend/src/services/CoderService/dashboardReferences.ts
@@ -1,6 +1,7 @@
 import {
     DashboardTileTypes,
     type DashboardAsCode,
+    type DashboardAsCodeUpsertResult,
     type DashboardConfig,
     type DashboardDAO,
     type DashboardTile,
@@ -8,6 +9,7 @@ import {
     type DashboardTileTarget,
     type DashboardTileWithSlug,
     type DateZoomTileTarget,
+    type PromotionChanges,
 } from '@lightdash/common';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -114,6 +116,13 @@ export const getConfigWithDateZoomTileSlugs = (
         dateZoomConfig: { ...config.dateZoomConfig, tileTargets },
     };
 };
+
+/** Attaches skipped-tile warnings to a promotion result, omitting the key when there are none. */
+export const withTileWarnings = (
+    changes: PromotionChanges,
+    warnings: string[],
+): DashboardAsCodeUpsertResult =>
+    warnings.length > 0 ? { ...changes, warnings } : changes;
 
 export const getConfigWithDateZoomTileUuids = (
     config: DashboardConfig,

--- a/packages/backend/src/services/CoderService/dashboardReferences.ts
+++ b/packages/backend/src/services/CoderService/dashboardReferences.ts
@@ -26,24 +26,34 @@ export const isAnyChartTile = (
     tile.type === DashboardTileTypes.SAVED_CHART ||
     tile.type === DashboardTileTypes.SQL_CHART;
 
-export const getChartSlugForTileUuid = (
+// The portable per-tile identity: a chart tile's chart slug, or a data app
+// tile's app slug. Suffixed when several tiles reference the same content.
+const getTileContentSlug = (
+    tile: DashboardTile | DashboardTileAsCode,
+): string | undefined => {
+    if (isAnyChartTile(tile)) return tile.properties.chartSlug ?? undefined;
+    if (tile.type === DashboardTileTypes.DATA_APP)
+        return tile.properties.appSlug ?? undefined;
+    return undefined;
+};
+
+export const getTileSlugForTileUuid = (
     dashboard: DashboardDAO,
     uuid: string,
 ): string | undefined => {
     const tile = dashboard.tiles.find((item) => item.uuid === uuid);
-    if (!tile || !isAnyChartTile(tile) || tile.properties.chartSlug == null) {
+    const contentSlug = tile ? getTileContentSlug(tile) : undefined;
+    if (!tile || contentSlug === undefined) {
         return undefined;
     }
     const matchingTiles = dashboard.tiles.filter(
-        (item) =>
-            isAnyChartTile(item) &&
-            item.properties.chartSlug === tile.properties.chartSlug,
+        (item) => getTileContentSlug(item) === contentSlug,
     );
     if (matchingTiles.length > 1) {
         const index = matchingTiles.findIndex((item) => item.uuid === uuid);
-        return `${tile.properties.chartSlug}-${index + 1}`;
+        return `${contentSlug}-${index + 1}`;
     }
-    return tile.properties.chartSlug;
+    return contentSlug;
 };
 
 export const getFiltersWithTileSlugs = (
@@ -56,7 +66,7 @@ export const getFiltersWithTileSlugs = (
         tileTargets: Object.entries(filter.tileTargets ?? {}).reduce<
             Record<string, DashboardTileTarget>
         >((result, [tileUuid, target]) => {
-            const tileSlug = getChartSlugForTileUuid(dashboard, tileUuid);
+            const tileSlug = getTileSlugForTileUuid(dashboard, tileUuid);
             return tileSlug ? { ...result, [tileSlug]: target } : result;
         }, {}),
     })),
@@ -68,9 +78,7 @@ const findTileUuid = (
 ): string | undefined =>
     tiles.find(
         (tile) =>
-            isAnyChartTile(tile) &&
-            (tile.tileSlug === tileSlug ||
-                tile.properties.chartSlug === tileSlug),
+            tile.tileSlug === tileSlug || getTileContentSlug(tile) === tileSlug,
     )?.uuid;
 
 export const getFiltersWithTileUuids = (
@@ -106,7 +114,7 @@ export const getConfigWithDateZoomTileSlugs = (
         config.dateZoomConfig.tileTargets ?? {},
     ).reduce<Record<string, DateZoomTileTarget>>(
         (result, [tileUuid, target]) => {
-            const tileSlug = getChartSlugForTileUuid(dashboard, tileUuid);
+            const tileSlug = getTileSlugForTileUuid(dashboard, tileUuid);
             return tileSlug ? { ...result, [tileSlug]: target } : result;
         },
         {},

--- a/packages/backend/src/services/CoderService/scheduledContent.ts
+++ b/packages/backend/src/services/CoderService/scheduledContent.ts
@@ -16,7 +16,7 @@ import {
     type SchedulerAndTargets,
 } from '@lightdash/common';
 import { v4 as uuidv4 } from 'uuid';
-import { getChartSlugForTileUuid } from './dashboardReferences';
+import { getTileSlugForTileUuid } from './dashboardReferences';
 
 export const getScheduledDeliveryTargetsAsCode = (
     scheduler: SchedulerAndTargets,
@@ -63,7 +63,7 @@ export const getDashboardScheduledDeliveryFiltersWithTileSlugs = (
         tileTargets: Object.entries(filter.tileTargets ?? {}).reduce<
             Record<string, DashboardTileTarget>
         >((result, [tileUuid, target]) => {
-            const tileSlug = getChartSlugForTileUuid(dashboard, tileUuid);
+            const tileSlug = getTileSlugForTileUuid(dashboard, tileUuid);
             return tileSlug ? { ...result, [tileSlug]: target } : result;
         }, {}),
     }));
@@ -82,7 +82,7 @@ export const getDashboardScheduledDeliveryFiltersWithTileUuids = (
         >((result, [tileSlug, target]) => {
             const tileUuid = dashboard.tiles.find(
                 (tile) =>
-                    getChartSlugForTileUuid(dashboard, tile.uuid) === tileSlug,
+                    getTileSlugForTileUuid(dashboard, tile.uuid) === tileSlug,
             )?.uuid;
             if (!tileUuid) {
                 throw new NotFoundError(

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1196,6 +1196,7 @@ export class ServiceRepository
                     projectModel: this.models.getProjectModel(),
                     savedChartModel: this.models.getSavedChartModel(),
                     savedSqlModel: this.models.getSavedSqlModel(),
+                    appModel: this.models.getAppModel(),
                     dashboardModel: this.models.getDashboardModel(),
                     spaceModel: this.models.getSpaceModel(),
                     schedulerModel: this.models.getSchedulerModel(),

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -579,6 +579,9 @@ export type ApiAppSummary = {
 export type EmbedProjectApp = {
     appUuid: string;
     name: string;
+    // Project-scoped identity, used by the CLI to tell whether a dashboard's
+    // app already exists in an upload target.
+    slug: string;
 };
 
 export type ApiEmbedProjectAppsResponse = ApiSuccess<EmbedProjectApp[]>;

--- a/packages/common/src/schemas/json/dashboard-as-code-1.0.json
+++ b/packages/common/src/schemas/json/dashboard-as-code-1.0.json
@@ -164,8 +164,17 @@
                     "additionalProperties": false,
                     "description": "From T, pick a set of properties whose keys are in the union K",
                     "properties": {
-                        "appSlug": {
+                        "appDeletedAt": {
+                            "description": "Legacy read-only deletion marker. Ignored on upload, never written by download.",
                             "type": ["string", "null"]
+                        },
+                        "appSlug": {
+                            "description": "Portable project-scoped reference written by download.",
+                            "type": ["string", "null"]
+                        },
+                        "appUuid": {
+                            "description": "Legacy project-local reference. Accepted on upload, never written by download.",
+                            "type": "string"
                         },
                         "hideTitle": {
                             "type": "boolean"
@@ -174,7 +183,7 @@
                             "type": "string"
                         }
                     },
-                    "required": ["title", "appSlug"],
+                    "required": ["title"],
                     "type": "object"
                 },
                 "tabSlug": {

--- a/packages/common/src/schemas/json/dashboard-as-code-1.0.json
+++ b/packages/common/src/schemas/json/dashboard-as-code-1.0.json
@@ -162,12 +162,10 @@
                 },
                 "properties": {
                     "additionalProperties": false,
+                    "description": "From T, pick a set of properties whose keys are in the union K",
                     "properties": {
-                        "appDeletedAt": {
+                        "appSlug": {
                             "type": ["string", "null"]
-                        },
-                        "appUuid": {
-                            "type": "string"
                         },
                         "hideTitle": {
                             "type": "boolean"
@@ -176,7 +174,7 @@
                             "type": "string"
                         }
                     },
-                    "required": ["appUuid", "title"],
+                    "required": ["title", "appSlug"],
                     "type": "object"
                 },
                 "tabSlug": {
@@ -864,6 +862,19 @@
                     "type": "string"
                 }
             },
+            "type": "object"
+        },
+        "Pick_DashboardDataAppTileProperties-at-properties.title-or-hideTitle_": {
+            "description": "From T, pick a set of properties whose keys are in the union K",
+            "properties": {
+                "hideTitle": {
+                    "type": "boolean"
+                },
+                "title": {
+                    "type": "string"
+                }
+            },
+            "required": ["title"],
             "type": "object"
         },
         "Pick_DashboardFilterRule.Exclude_keyofDashboardFilterRule.id__": {

--- a/packages/common/src/types/contentAsCode/dashboards.ts
+++ b/packages/common/src/types/contentAsCode/dashboards.ts
@@ -82,7 +82,14 @@ export type DashboardDataAppTileAsCode = DashboardTileAsCodeBase & {
     properties: Pick<
         DashboardDataAppTileProperties['properties'],
         'title' | 'hideTitle'
-    > & { appSlug: string | null };
+    > & {
+        /** Portable project-scoped reference written by download. */
+        appSlug?: string | null;
+        /** Legacy project-local reference. Accepted on upload, never written by download. */
+        appUuid?: string;
+        /** Legacy read-only deletion marker. Ignored on upload, never written by download. */
+        appDeletedAt?: string | null;
+    };
 };
 
 export type DashboardTileAsCode =

--- a/packages/common/src/types/contentAsCode/dashboards.ts
+++ b/packages/common/src/types/contentAsCode/dashboards.ts
@@ -170,7 +170,12 @@ export type ApiDashboardAsCodeListResponse = {
         offset: number;
     };
 };
+export type DashboardAsCodeUpsertResult = PromotionChanges & {
+    /** Non-fatal issues, e.g. a data app tile whose app is not in this project. */
+    warnings?: string[];
+};
+
 export type ApiDashboardAsCodeUpsertResponse = {
     status: 'ok';
-    results: PromotionChanges;
+    results: DashboardAsCodeUpsertResult;
 };

--- a/packages/common/src/types/contentAsCode/dashboards.ts
+++ b/packages/common/src/types/contentAsCode/dashboards.ts
@@ -79,7 +79,10 @@ export type DashboardHeadingTileAsCode = DashboardTileAsCodeBase & {
 
 export type DashboardDataAppTileAsCode = DashboardTileAsCodeBase & {
     type: DashboardTileTypes.DATA_APP;
-    properties: DashboardDataAppTileProperties['properties'];
+    properties: Pick<
+        DashboardDataAppTileProperties['properties'],
+        'title' | 'hideTitle'
+    > & { appSlug: string | null };
 };
 
 export type DashboardTileAsCode =

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -93,6 +93,9 @@ export type DashboardDataAppTileProperties = {
         title: string;
         hideTitle?: boolean;
         appUuid: string;
+        // Portable project-scoped identity, set by the backend on read.
+        // Mirrors `chartSlug` on chart tiles.
+        appSlug?: string | null;
         // Set by the backend when the referenced app has been soft-deleted,
         // so the frontend can render a placeholder instead of trying to load
         // a missing iframe.


### PR DESCRIPTION
## What

Backend + common foundation for moving a dashboard that contains data app tiles between projects and instances as code. First of three stacked PRs; on its own it changes what the dashboard-as-code API emits and accepts, with no CLI changes yet.

Data app tiles previously round-tripped their raw `appUuid` into dashboard YAML. That is a project-local id, so a dashboard uploaded anywhere else referenced an app that did not exist there — and because `dashboard_tile_data_apps.app_uuid` is `NOT NULL` with an FK to `apps.app_id`, the upsert failed outright rather than degrading. Chart tiles already solved this by carrying a portable `chartSlug`; data apps now have a project-scoped `slug` of their own, so this PR gives them the same treatment.

## Changes

- **Tiles reference apps by `appSlug`.** `apps` was already left-joined into both dashboard tile queries, so this is one extra select column plus the mapping. The as-code tile now carries `appSlug` and drops `appUuid`/`appDeletedAt` — the latter is server-derived state that never belonged in a file.
- **Upload resolves the slug against the target project** via new batched `AppModel.findAppsBySlugs` / `findAppsByUuids` lookups, both filtering `deleted_at IS NULL`.
- **Unresolvable tiles are skipped, not persisted.** The FK forbids the null-reference placeholder chart tiles get. Skipping is self-healing: the local YAML keeps the tile, so re-uploading once the app exists restores it.
- **Skips are reported.** `ApiDashboardAsCodeUpsertResponse` gains `warnings?: string[]`, following the existing `ApiImportAppCodeResponse.warnings` precedent. Without this a dashboard uploads "successfully" minus a tile and the user never learns why.
- **Legacy `appUuid` still accepted** on upload for YAML downloaded before this change — but only when that app actually lives in the target project. This is strictly tighter than before: the FK is global, not project-scoped, so a cross-project uuid previously inserted happily.
- **Fixes an unticketed round-trip bug found while designing this:** `getChartSlugForTileUuid` only understood chart tiles, so dashboard filter `tileTargets` (and date-zoom targets) aimed at a data app tile were silently dropped on download. Data app tiles do consume tile-scoped filters. Generalised to `getTileSlugForTileUuid`, which also fixes the same loss for scheduled deliveries.
- **`EmbedProjectApp` gains `slug`**, so a later PR in this stack can tell which apps a target project already has.

## Notes for reviewers

- **`allow-api-breaking-change`** — the data app tile's as-code shape changes: `appSlug` is added, and `appUuid`/`appDeletedAt` go from present-in-response to optional. oasdiff flags that as ERR. It is the intended change, and it is back-compatible in the direction that matters: the server still accepts `appUuid` on upload, and the JSON schema still validates YAML downloaded before this PR (verified with ajv against the committed schema — legacy `{title, appUuid, appDeletedAt}` passes, current `{title, appSlug}` passes, a bogus extra property is still rejected).
- No migration. `dashboard_tile_data_apps` is untouched.
- `packages/common/src/schemas/json/dashboard-as-code-1.0.json` is regenerated and committed; `generated/routes.ts` and `swagger.json` are deliberately not.
- One consequence of the above worth knowing: a tile carrying *neither* `appSlug` nor `appUuid` now passes `lightdash lint`, where it previously failed. TSOA cannot express "at least one of". Upload degrades gracefully — the tile is skipped with a warning naming it.
- Data app tiles now bake their disambiguated `tileSlug` into the YAML exactly as chart tiles do. Without it, a filter target survives download but cannot be matched back on upload whenever one app occupies two or more tiles.
- Known gap, pre-existing and not addressed here: chart tiles are gated by `assertTileChartsViewAccess` on upload, data app tiles have no equivalent, so an uploader can bind a tile to an app in a space they cannot view. This PR narrows the blast radius from instance-wide to project-scoped but does not close it. Happy to file a follow-up.

## Testing

`pnpm -F common test` (3181 passed) and `pnpm -F backend test` (5301 passed) green, typecheck and lint clean across common, backend, and frontend, `pnpm check:dashboard-as-code-schema` clean. End-to-end verification of the full download/upload loop lands with the CLI PRs above this one.

Relates: PROD-9089
Relates: PROD-9245
