### PR TITLE
fix: show custom metric filters that target hidden dimensions

### DIFF
--- a/packages/frontend/src/components/Explorer/CustomMetricModal/FilterForm.tsx
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/FilterForm.tsx
@@ -43,9 +43,12 @@ export const FilterForm: FC<{
         useFiltersContext<Record<string, FilterableDimension>>();
 
     const dimensions = Object.values(dimensionsMap);
+    // Hidden dimensions can be targeted by existing filters, but shouldn't be
+    // offered when adding a new one
+    const selectableDimensions = dimensions.filter(({ hidden }) => !hidden);
 
     const addFieldRule = useCallback(() => {
-        const fallbackField = dimensions[0];
+        const fallbackField = selectableDimensions[0];
         const defaultField = defaultFilterRuleFieldId
             ? dimensionsMap[defaultFilterRuleFieldId]
             : undefined;
@@ -71,7 +74,7 @@ export const FilterForm: FC<{
     }, [
         customMetricFiltersWithIds,
         defaultFilterRuleFieldId,
-        dimensions,
+        selectableDimensions,
         dimensionsMap,
         setCustomMetricFiltersWithIds,
     ]);
@@ -122,7 +125,7 @@ export const FilterForm: FC<{
                 onClick={() => {
                     addFieldRule();
                 }}
-                disabled={dimensions.length <= 0}
+                disabled={selectableDimensions.length <= 0}
             >
                 Add filter
             </Button>

--- a/packages/frontend/src/components/Explorer/CustomMetricModal/hooks/useDataForFiltersProvider.ts
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/hooks/useDataForFiltersProvider.ts
@@ -31,6 +31,8 @@ export const useDataForFiltersProvider = () => {
         customDimensions,
         additionalMetrics,
         tableCalculations,
+        // Metric filters can target hidden dimensions, so they must resolve here
+        includeHiddenFields: true,
     });
 
     return {

--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -226,6 +226,7 @@ const FiltersCard: FC = memo(() => {
         customDimensions,
         additionalMetrics,
         tableCalculations,
+        includeHiddenFields: false,
     });
 
     // Pre-compute filter rule labels for tooltip

--- a/packages/frontend/src/components/Explorer/FiltersCard/useFieldsWithSuggestions.test.ts
+++ b/packages/frontend/src/components/Explorer/FiltersCard/useFieldsWithSuggestions.test.ts
@@ -1,0 +1,75 @@
+import {
+    DimensionType,
+    FieldType,
+    SupportedDbtAdapter,
+    type CompiledDimension,
+    type Explore,
+} from '@lightdash/common';
+import { renderHook } from '@testing-library/react';
+import { useFieldsWithSuggestions } from './useFieldsWithSuggestions';
+
+const makeDimension = (name: string, hidden: boolean): CompiledDimension => ({
+    compiledSql: '',
+    tablesReferences: [],
+    fieldType: FieldType.DIMENSION,
+    type: DimensionType.STRING,
+    name,
+    label: name,
+    table: 'orders',
+    tableLabel: 'Orders',
+    sql: '',
+    hidden,
+});
+
+const explore: Explore = {
+    name: 'orders',
+    label: 'Orders',
+    tags: [],
+    baseTable: 'orders',
+    joinedTables: [],
+    tables: {
+        orders: {
+            name: 'orders',
+            label: 'Orders',
+            database: '',
+            schema: '',
+            sqlTable: 'orders',
+            dimensions: {
+                status: makeDimension('status', false),
+                order_notes: makeDimension('order_notes', true),
+            },
+            metrics: {},
+            lineageGraph: {},
+        },
+    },
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+};
+
+const renderFieldsWithSuggestions = (includeHiddenFields: boolean) =>
+    renderHook(() =>
+        useFieldsWithSuggestions({
+            exploreData: explore,
+            rows: undefined,
+            customDimensions: undefined,
+            additionalMetrics: undefined,
+            tableCalculations: undefined,
+            includeHiddenFields,
+        }),
+    );
+
+describe('useFieldsWithSuggestions', () => {
+    it('excludes hidden fields by default', () => {
+        const { result } = renderFieldsWithSuggestions(false);
+
+        expect(Object.keys(result.current)).toEqual(['orders_status']);
+    });
+
+    it('includes hidden fields when requested', () => {
+        const { result } = renderFieldsWithSuggestions(true);
+
+        expect(Object.keys(result.current).sort()).toEqual([
+            'orders_order_notes',
+            'orders_status',
+        ]);
+    });
+});

--- a/packages/frontend/src/components/Explorer/FiltersCard/useFieldsWithSuggestions.ts
+++ b/packages/frontend/src/components/Explorer/FiltersCard/useFieldsWithSuggestions.ts
@@ -1,9 +1,9 @@
 import {
     convertAdditionalMetric,
     DimensionType,
+    getFields,
     getItemId,
     getResultValueArray,
-    getVisibleFields,
     isCustomSqlDimension,
     isDimension,
     isFilterableField,
@@ -23,6 +23,11 @@ interface FieldsWithSuggestionsHookParams {
     customDimensions: CustomDimension[] | undefined;
     additionalMetrics: AdditionalMetric[] | undefined;
     tableCalculations: TableCalculation[] | undefined;
+    /**
+     * Hidden fields are excluded from field pickers, but they can still be
+     * targeted by existing filters that need to resolve their field.
+     */
+    includeHiddenFields: boolean;
 }
 
 export type FieldWithSuggestions = FilterableField & {
@@ -37,6 +42,7 @@ export const useFieldsWithSuggestions = ({
     customDimensions,
     additionalMetrics,
     tableCalculations,
+    includeHiddenFields,
 }: FieldsWithSuggestionsHookParams) => {
     const [fieldsWithSuggestions, setFieldsWithSuggestions] =
         useState<FieldsWithSuggestions>({});
@@ -44,7 +50,9 @@ export const useFieldsWithSuggestions = ({
     useEffect(() => {
         if (exploreData) {
             setFieldsWithSuggestions((prev) => {
-                const visibleFields = getVisibleFields(exploreData);
+                const exploreFields = getFields(exploreData).filter(
+                    ({ hidden }) => includeHiddenFields || !hidden,
+                );
                 const customMetrics = (additionalMetrics || []).reduce<
                     Metric[]
                 >((acc, additionalMetric) => {
@@ -60,7 +68,7 @@ export const useFieldsWithSuggestions = ({
                 }, []);
 
                 return [
-                    ...visibleFields,
+                    ...exploreFields,
                     ...(customDimensions || []),
                     ...customMetrics,
                     ...(tableCalculations || []),
@@ -118,6 +126,7 @@ export const useFieldsWithSuggestions = ({
         additionalMetrics,
         tableCalculations,
         customDimensions,
+        includeHiddenFields,
     ]);
 
     return fieldsWithSuggestions;

--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.test.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.test.tsx
@@ -1,0 +1,75 @@
+import {
+    createFilterRuleFromField,
+    DimensionType,
+    FieldType,
+    type FilterableDimension,
+} from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../../../testing/testUtils';
+import FilterRuleForm from './FilterRuleForm';
+import FiltersProvider from './FiltersProvider';
+
+const dimension = (name: string, hidden: boolean): FilterableDimension => ({
+    fieldType: FieldType.DIMENSION,
+    type: DimensionType.NUMBER,
+    name,
+    label: name,
+    table: 'orders',
+    tableLabel: 'Orders',
+    sql: `\${TABLE}.${name}`,
+    hidden,
+});
+
+const visibleDimension = dimension('amount', false);
+const hiddenDimension = dimension('credit_card_amount', true);
+const fields = [visibleDimension, hiddenDimension];
+
+const renderFilterRuleForm = (field: FilterableDimension) =>
+    renderWithProviders(
+        <FiltersProvider itemsMap={{}}>
+            <FilterRuleForm
+                fields={fields}
+                filterRule={createFilterRuleFromField(field)}
+                isEditMode
+                onChange={vi.fn()}
+                onDelete={vi.fn()}
+            />
+        </FiltersProvider>,
+    );
+
+describe('FilterRuleForm', () => {
+    // jsdom does not implement scrollIntoView, which Mantine's combobox calls
+    beforeAll(() => {
+        Object.defineProperty(Element.prototype, 'scrollIntoView', {
+            configurable: true,
+            writable: true,
+            value: vi.fn(),
+        });
+    });
+
+    afterAll(() => {
+        delete (Element.prototype as Partial<Element>).scrollIntoView;
+    });
+
+    it('renders a rule that targets a hidden field', () => {
+        renderFilterRuleForm(hiddenDimension);
+
+        expect(screen.getByTestId('FilterRuleForm/filter-rule')).toBeTruthy();
+        expect(screen.getByDisplayValue(hiddenDimension.label)).toBeTruthy();
+    });
+
+    it('excludes hidden fields from the field options', async () => {
+        const user = userEvent.setup();
+        renderFilterRuleForm(visibleDimension);
+
+        await user.click(screen.getByDisplayValue(visibleDimension.label));
+
+        expect(
+            await screen.findByRole('option', { name: visibleDimension.label }),
+        ).toBeTruthy();
+        expect(
+            screen.queryByRole('option', { name: hiddenDimension.label }),
+        ).toBeNull();
+    });
+});

--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
@@ -6,6 +6,7 @@ import {
     getFilterTypeFromItem,
     getItemId,
     isDateItem,
+    isField,
     type FilterableField,
     type FilterRule,
 } from '@lightdash/common';
@@ -28,6 +29,9 @@ type Props = {
     onDelete: () => void;
     onConvertToGroup?: () => void;
 };
+
+const isHiddenField = (field: FilterableField) =>
+    isField(field) && field.hidden;
 
 const FilterRuleForm: FC<Props> = memo(
     ({
@@ -92,10 +96,16 @@ const FilterRuleForm: FC<Props> = memo(
             : '';
 
         const availableFields = useMemo(() => {
-            if (!isRequired) return fields;
-            // For required filters, restrict to same-type sub-dimensions
             const baseFieldId = filterRule.target.fieldId;
-            return fields.filter(
+            // Hidden fields aren't offered as options, but the rule's own field
+            // stays selectable so filters on hidden fields still render
+            const selectableFields = fields.filter(
+                (field) =>
+                    !isHiddenField(field) || getItemId(field) === baseFieldId,
+            );
+            if (!isRequired) return selectableFields;
+            // For required filters, restrict to same-type sub-dimensions
+            return selectableFields.filter(
                 (field) =>
                     getItemId(field).startsWith(baseFieldId) &&
                     getFilterTypeFromItem(field) === filterType,


### PR DESCRIPTION
The **Create custom metric** modal counted every filter on the source metric, but built its field lookup from `getVisibleFields()`. A filter targeting a hidden dimension was therefore counted in the `Filters(N)` header and then silently dropped when rendering (`FilterRuleForm` returns `null` when it can't resolve the field) — so a metric with 4 filters, one on a hidden dim, showed `Filters(4)` with only 3 rows.

`useFieldsWithSuggestions` now takes an explicit `includeHiddenFields` flag; the custom metric modal passes `true` so hidden dimensions resolve, and `FilterRuleForm` / the "Add filter" button exclude hidden fields from the pickers (keeping the rule's own field selectable). The explore Filters card keeps its current behaviour with `false`.

Added tests covering the hook's flag and that `FilterRuleForm` renders a hidden-field rule without offering hidden fields as options.

No data change — the modal's state already kept all filters, so created metrics were always correct.
