### PR TITLE
fix: enforce explore permission on embed raw metric query endpoints

### DIFF
--- a/packages/api-tests/tests/embedChart.test.ts
+++ b/packages/api-tests/tests/embedChart.test.ts
@@ -488,6 +488,63 @@ describe('Embed Chart JWT API', () => {
                 expect(resp.body).toHaveProperty('error');
             });
         });
+
+        describe('Calculate Total from Raw Query (Explore scope)', () => {
+            // Chart JWTs grant view:Explore scoped to the chart's own explore
+            // (payments for the test chart). Raw metric queries must be allowed
+            // on that explore and rejected on any other.
+
+            it('should calculate totals on the chart own explore', async () => {
+                const client = embedClient();
+                const resp = await client.post<Body<unknown>>(
+                    `/api/v1/embed/${SEED_PROJECT.project_uuid}/calculate-total`,
+                    {
+                        explore: 'payments',
+                        metricQuery: {
+                            exploreName: 'payments',
+                            dimensions: ['payments_payment_method'],
+                            metrics: ['payments_total_revenue'],
+                            filters: {},
+                            sorts: [],
+                            limit: 500,
+                            tableCalculations: [],
+                        },
+                    },
+                    {
+                        headers: embedHeaders(chartJwtToken),
+                        failOnStatusCode: false,
+                    },
+                );
+                expect(resp.status).toBe(200);
+                expect(resp.body.status).toBe('ok');
+                expect(typeof resp.body.results).toBe('object');
+            });
+
+            it('should fail to calculate totals on another explore', async () => {
+                const client = embedClient();
+                const resp = await client.post(
+                    `/api/v1/embed/${SEED_PROJECT.project_uuid}/calculate-total`,
+                    {
+                        explore: 'customers',
+                        metricQuery: {
+                            exploreName: 'customers',
+                            dimensions: ['customers_customer_id'],
+                            metrics: [],
+                            filters: {},
+                            sorts: [],
+                            limit: 500,
+                            tableCalculations: [],
+                        },
+                    },
+                    {
+                        headers: embedHeaders(chartJwtToken),
+                        failOnStatusCode: false,
+                    },
+                );
+                expect(resp.status).toBe(403);
+                expect(resp.body).toHaveProperty('error');
+            });
+        });
     });
 
     describe('Chart JWT with different permissions', () => {

--- a/packages/api-tests/tests/embedDashboard.test.ts
+++ b/packages/api-tests/tests/embedDashboard.test.ts
@@ -204,6 +204,29 @@ describe('Embed Dashboard JWT API', () => {
             return resp.body.results.url.split('#')[1];
         }
 
+        // Same dashboard token, opted into explore mode
+        async function freshExploreDashboardJwt(): Promise<string> {
+            const resp = await getEmbedUrl(admin, {
+                user: {
+                    externalId: 'dashboard-user@example.com',
+                    email: 'dashboard-user@example.com',
+                },
+                content: {
+                    type: 'dashboard',
+                    dashboardUuid: testDashboardUuid,
+                    canExportCsv: true,
+                    canExportImages: false,
+                    canViewUnderlyingData: true,
+                    canDateZoom: true,
+                    canExplore: true,
+                    projectUuid: SEED_PROJECT.project_uuid,
+                },
+                expiresIn: '24h',
+            });
+            expect(resp.status).toBe(200);
+            return resp.body.results.url.split('#')[1];
+        }
+
         // Refresh JWT before each test so it uses the current embed secret
         beforeEach(async () => {
             dashboardJwtToken = await freshDashboardJwt();
@@ -339,6 +362,46 @@ describe('Embed Dashboard JWT API', () => {
                 // Raw metric queries require view:Explore, granted only by canExplore
                 expect(resp.status).toBe(403);
                 expect(resp.body).toHaveProperty('error');
+            });
+
+            it('should calculate totals from raw metricQuery with canExplore', async () => {
+                const client = embedClient();
+                const resp = await client.post<Body<unknown>>(
+                    `/api/v1/embed/${SEED_PROJECT.project_uuid}/calculate-total`,
+                    {
+                        explore: 'orders',
+                        metricQuery: testMetricQuery,
+                    },
+                    {
+                        headers: embedHeaders(await freshExploreDashboardJwt()),
+                        failOnStatusCode: false,
+                    },
+                );
+                expect(resp.status).toBe(200);
+                expect(resp.body.status).toBe('ok');
+                expect(typeof resp.body.results).toBe('object');
+            });
+
+            it('should calculate subtotals from raw metricQuery with canExplore', async () => {
+                const client = embedClient();
+                const resp = await client.post<Body<unknown>>(
+                    `/api/v1/embed/${SEED_PROJECT.project_uuid}/calculate-subtotals`,
+                    {
+                        explore: 'orders',
+                        metricQuery: testMetricQuery,
+                        columnOrder: [
+                            'orders_status',
+                            'orders_total_order_amount',
+                        ],
+                    },
+                    {
+                        headers: embedHeaders(await freshExploreDashboardJwt()),
+                        failOnStatusCode: false,
+                    },
+                );
+                expect(resp.status).toBe(200);
+                expect(resp.body.status).toBe('ok');
+                expect(typeof resp.body.results).toBe('object');
             });
 
             it('should fail to calculate totals without embed JWT', async () => {

--- a/packages/api-tests/tests/embedDashboard.test.ts
+++ b/packages/api-tests/tests/embedDashboard.test.ts
@@ -301,7 +301,7 @@ describe('Embed Dashboard JWT API', () => {
                 tableCalculations: [],
             };
 
-            it('should calculate totals from raw metricQuery with embed JWT', async () => {
+            it('should fail to calculate totals from raw metricQuery without canExplore', async () => {
                 const client = embedClient();
                 const resp = await client.post<Body<unknown>>(
                     `/api/v1/embed/${SEED_PROJECT.project_uuid}/calculate-total`,
@@ -314,13 +314,12 @@ describe('Embed Dashboard JWT API', () => {
                         failOnStatusCode: false,
                     },
                 );
-                // Should succeed - embed JWT can calculate totals from raw query
-                expect(resp.status).toBe(200);
-                expect(resp.body.status).toBe('ok');
-                expect(typeof resp.body.results).toBe('object');
+                // Raw metric queries require view:Explore, granted only by canExplore
+                expect(resp.status).toBe(403);
+                expect(resp.body).toHaveProperty('error');
             });
 
-            it('should calculate subtotals from raw metricQuery with embed JWT', async () => {
+            it('should fail to calculate subtotals from raw metricQuery without canExplore', async () => {
                 const client = embedClient();
                 const resp = await client.post<Body<unknown>>(
                     `/api/v1/embed/${SEED_PROJECT.project_uuid}/calculate-subtotals`,
@@ -337,10 +336,9 @@ describe('Embed Dashboard JWT API', () => {
                         failOnStatusCode: false,
                     },
                 );
-                // Should succeed - embed JWT can calculate subtotals from raw query
-                expect(resp.status).toBe(200);
-                expect(resp.body.status).toBe('ok');
-                expect(typeof resp.body.results).toBe('object');
+                // Raw metric queries require view:Explore, granted only by canExplore
+                expect(resp.status).toBe(403);
+                expect(resp.body).toHaveProperty('error');
             });
 
             it('should fail to calculate totals without embed JWT', async () => {

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
@@ -513,6 +513,73 @@ describe('EmbedService', () => {
                 ),
             ).rejects.toThrow('reached explore lookup');
         });
+
+        // Chart tokens grant Explore scoped to the chart's own explores
+        const buildChartEmbedAccount = (explores: string[]) =>
+            ({
+                authentication: { type: 'jwt', source: 'embed-token' },
+                access: { content: { chartUuid: 'chart-1' } },
+                user: {
+                    id: mockUserUuid,
+                    ability: new Ability<PossibleAbilities>([
+                        {
+                            subject: 'Explore',
+                            action: ['view'],
+                            conditions: {
+                                organizationUuid: mockOrganizationUuid,
+                                projectUuid: mockProjectUuid,
+                                exploreNames: { $all: explores },
+                            },
+                        },
+                    ]),
+                },
+                organization: { organizationUuid: mockOrganizationUuid },
+                isAnonymousUser: vi.fn().mockReturnValue(true),
+            }) as unknown as AnonymousAccount;
+
+        test('calculateTotalFromQuery allows chart tokens on their own explore', async () => {
+            await expect(
+                gatedService().calculateTotalFromQuery(
+                    buildChartEmbedAccount(['customers']),
+                    mockProjectUuid,
+                    totalsQuery,
+                ),
+            ).rejects.toThrow('reached explore lookup');
+        });
+
+        test('calculateTotalFromQuery rejects chart tokens on another explore', async () => {
+            await expect(
+                gatedService().calculateTotalFromQuery(
+                    buildChartEmbedAccount(['orders']),
+                    mockProjectUuid,
+                    totalsQuery,
+                ),
+            ).rejects.toThrow(ForbiddenError);
+
+            expect(getExploreFromCache).not.toHaveBeenCalled();
+        });
+
+        test('calculateSubtotalsFromQuery allows chart tokens on their own explore', async () => {
+            await expect(
+                gatedService().calculateSubtotalsFromQuery(
+                    buildChartEmbedAccount(['customers']),
+                    mockProjectUuid,
+                    subtotalsQuery,
+                ),
+            ).rejects.toThrow('reached explore lookup');
+        });
+
+        test('calculateSubtotalsFromQuery rejects chart tokens on another explore', async () => {
+            await expect(
+                gatedService().calculateSubtotalsFromQuery(
+                    buildChartEmbedAccount(['orders']),
+                    mockProjectUuid,
+                    subtotalsQuery,
+                ),
+            ).rejects.toThrow(ForbiddenError);
+
+            expect(getExploreFromCache).not.toHaveBeenCalled();
+        });
     });
 
     describe('searchFilterValues', () => {

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
@@ -1,7 +1,9 @@
+import { Ability } from '@casl/ability';
 import {
     ForbiddenError,
     type AnonymousAccount,
     type CreateEmbedJwt,
+    type PossibleAbilities,
     type SessionUser,
 } from '@lightdash/common';
 import { EmbedService } from './EmbedService';
@@ -411,6 +413,105 @@ describe('EmbedService', () => {
                     email: "x''/**/OR/**/1=1/**/--@example.com",
                 },
             });
+        });
+    });
+
+    describe('raw metric queries', () => {
+        const buildEmbedAccount = (canExplore: boolean) =>
+            ({
+                authentication: { type: 'jwt', source: 'embed-token' },
+                access: { content: { dashboardUuid: 'dashboard-1' } },
+                user: {
+                    id: mockUserUuid,
+                    ability: new Ability<PossibleAbilities>(
+                        canExplore
+                            ? [
+                                  {
+                                      subject: 'Explore',
+                                      action: ['view'],
+                                      conditions: {
+                                          organizationUuid:
+                                              mockOrganizationUuid,
+                                          projectUuid: mockProjectUuid,
+                                      },
+                                  },
+                              ]
+                            : [],
+                    ),
+                },
+                organization: { organizationUuid: mockOrganizationUuid },
+                isAnonymousUser: vi.fn().mockReturnValue(true),
+            }) as unknown as AnonymousAccount;
+
+        // Reaching the explore lookup means the permission gate let the request through
+        const getExploreFromCache = vi
+            .fn()
+            .mockRejectedValue(new Error('reached explore lookup'));
+
+        const gatedService = () =>
+            new EmbedService({
+                ...EmbedServiceArgumentsMock,
+                projectModel: {
+                    getSummary: vi.fn().mockResolvedValue({
+                        projectUuid: mockProjectUuid,
+                        organizationUuid: mockOrganizationUuid,
+                    }),
+                    getExploreFromCache,
+                },
+            } as unknown as ConstructorParameters<typeof EmbedService>[0]);
+
+        const totalsQuery = {
+            explore: 'customers',
+            metricQuery: {} as never,
+        } as never;
+        const subtotalsQuery = {
+            explore: 'customers',
+            metricQuery: {} as never,
+            columnOrder: [],
+        } as never;
+
+        test('calculateTotalFromQuery rejects tokens without explore access', async () => {
+            await expect(
+                gatedService().calculateTotalFromQuery(
+                    buildEmbedAccount(false),
+                    mockProjectUuid,
+                    totalsQuery,
+                ),
+            ).rejects.toThrow(ForbiddenError);
+
+            expect(getExploreFromCache).not.toHaveBeenCalled();
+        });
+
+        test('calculateSubtotalsFromQuery rejects tokens without explore access', async () => {
+            await expect(
+                gatedService().calculateSubtotalsFromQuery(
+                    buildEmbedAccount(false),
+                    mockProjectUuid,
+                    subtotalsQuery,
+                ),
+            ).rejects.toThrow(ForbiddenError);
+
+            expect(getExploreFromCache).not.toHaveBeenCalled();
+        });
+
+        test('calculateTotalFromQuery allows tokens with explore access', async () => {
+            await expect(
+                gatedService().calculateTotalFromQuery(
+                    buildEmbedAccount(true),
+                    mockProjectUuid,
+                    totalsQuery,
+                ),
+            ).rejects.toThrow('reached explore lookup');
+        });
+
+        test('calculateSubtotalsFromQuery allows tokens with explore access', async () => {
+            await expect(
+                gatedService().calculateSubtotalsFromQuery(
+                    buildEmbedAccount(true),
+                    mockProjectUuid,
+                    subtotalsQuery,
+                ),
+            ).rejects.toThrow('reached explore lookup');
         });
     });
 

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -2005,13 +2005,15 @@ export class EmbedService extends BaseService {
     }
 
     /**
-     * Raw metric queries are only available to embed tokens granted `canExplore`,
-     * which is what backs `view:Explore` in the JWT ability.
+     * Raw metric queries need `view:Explore` on the requested explore: unscoped
+     * for tokens granted `canExplore`, scoped to `content.explores` for tokens
+     * that only embed a chart.
      */
-    private assertCanExploreProject(
+    private assertCanQueryExplore(
         account: AnonymousAccount,
         organizationUuid: string,
         projectUuid: string,
+        exploreName: string,
     ) {
         const auditedAbility = this.createAuditedAbility(account);
         if (
@@ -2020,6 +2022,8 @@ export class EmbedService extends BaseService {
                 subject('Explore', {
                     organizationUuid,
                     projectUuid,
+                    exploreNames: [exploreName],
+                    metadata: { exploreName },
                 }),
             )
         ) {
@@ -2042,7 +2046,12 @@ export class EmbedService extends BaseService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
-        this.assertCanExploreProject(account, organizationUuid, projectUuid);
+        this.assertCanQueryExplore(
+            account,
+            organizationUuid,
+            projectUuid,
+            data.explore,
+        );
 
         const explore = await this.projectModel.getExploreFromCache(
             projectUuid,
@@ -2124,7 +2133,12 @@ export class EmbedService extends BaseService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
-        this.assertCanExploreProject(account, organizationUuid, projectUuid);
+        this.assertCanQueryExplore(
+            account,
+            organizationUuid,
+            projectUuid,
+            data.explore,
+        );
 
         const explore = await this.projectModel.getExploreFromCache(
             projectUuid,

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -2005,6 +2005,31 @@ export class EmbedService extends BaseService {
     }
 
     /**
+     * Raw metric queries are only available to embed tokens granted `canExplore`,
+     * which is what backs `view:Explore` in the JWT ability.
+     */
+    private assertCanExploreProject(
+        account: AnonymousAccount,
+        organizationUuid: string,
+        projectUuid: string,
+    ) {
+        const auditedAbility = this.createAuditedAbility(account);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('Explore', {
+                    organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'You do not have permission to explore this project',
+            );
+        }
+    }
+
+    /**
      * Calculate totals from a raw metric query in embed context.
      * This is used when exploring data directly (not from a saved chart).
      * @deprecated Superseded by AsyncQueryService.executeAsyncCalculateTotalFromQueryHistory.
@@ -2016,6 +2041,8 @@ export class EmbedService extends BaseService {
     ): Promise<Record<string, number>> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+
+        this.assertCanExploreProject(account, organizationUuid, projectUuid);
 
         const explore = await this.projectModel.getExploreFromCache(
             projectUuid,
@@ -2096,6 +2123,8 @@ export class EmbedService extends BaseService {
     ) {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+
+        this.assertCanExploreProject(account, organizationUuid, projectUuid);
 
         const explore = await this.projectModel.getExploreFromCache(
             projectUuid,


### PR DESCRIPTION
## Problem

The embed API's two raw-metric-query endpoints — `POST /api/v1/embed/{projectUuid}/calculate-total` and `/calculate-subtotals` — accepted an arbitrary `explore` name and `metricQuery` from the request body after only asserting that the caller was using JWT auth (`assertEmbeddedAuth`). No CASL check ran, so an embed token scoped to a single dashboard could query any explore in the project.

This matters more for subtotals than for totals: subtotals group by the requested dimensions, so the response is a row per distinct value rather than a single aggregate. That turns the endpoint into a general-purpose read interface over the whole project, including fields the embed was never granted.

Secondary issue: the pre-existing explore-resolution error path ran before any permission check, so an unauthorized caller could tell which explores exist by the difference between a 404 and a 200.

## Fix

Added `assertCanQueryExplore()` in `EmbedService` and called it from `calculateTotalFromQuery` and `calculateSubtotalsFromQuery` — the only two embed methods that take a raw explore name.

The check requires `view:Explore` **on the requested explore**, with the subject built the same way `AsyncQueryService` builds it (`exploreNames: [exploreName]` + `metadata`). That matters because `jwtAbility.ts` grants Explore two different ways:

- `exploreAbilities` — **unscoped** grant when the token sets `canExplore` (same for `canViewDataApps` and data-app tokens)
- `chartAbilities` — grant **scoped** to the chart's own explore (`exploreNames: { $all: content.explores }`; chart tokens always carry exactly one explore, `explores: [chart.tableName]`)

An earlier revision of this PR asked for unscoped `view:Explore`, which the scoped chart grant can never satisfy — it would have broken chart embeds calculating totals on their own explore. Scoping the subject to the requested explore fixes that while still denying everything the vulnerability allowed:

| Token | Requested explore | Before | After |
|---|---|---|---|
| chart embed | its own explore | ✅ | ✅ |
| chart embed | any other explore | ✅ ← the hole | ❌ 403 |
| dashboard + `canExplore` (or `canViewDataApps`) | anything | ✅ | ✅ |
| dashboard, no explore flag | anything | ✅ ← the hole | ❌ 403 |
| unauthenticated | anything | ❌ | ❌ |

The check runs **before the explore is resolved**, so the explore-existence oracle is closed too, and the 403 message doesn't echo the explore name. There's no `explore` vs `metricQuery.exploreName` mismatch bypass: the SQL is compiled against the explore loaded from the gated `data.explore`, so field refs from another explore fail compilation.

Uses `createAuditedAbility` rather than reading `account.ability` directly, per the services convention, so denials are audited.

## Regression analysis

1. **These routes have zero production traffic.** Sentry (90d): 154k calls/30d on the v2 `/query/{queryUuid}/calculate-total` path and ~9k/30d on the embed `/chart/{savedChartUuid}/` routes (all untouched), vs **0 calls in 60 days** to the two gated routes — the 98 hits in 90d were all `cloud_beta`. The frontend hooks that called them were deleted in #23590/#23857, the same dates as the routes' `@deprecated` middleware stamps (sunset 2026-08-29 / 2026-09-04).
2. **Embedded dashboard totals don't use these endpoints.** They go through the v2 route, which authorizes on query-history ownership specifically so embed JWTs work without `view:Explore`.
3. **Old pinned `@lightdash/sdk` bundles** (pre-#23590) still contain the callers, but only reachable from embed explore mode, which the frontend gates on the same `canExplore` flag — a token that would now be 403'd never rendered the affordance that makes the call.
4. **If anyone is affected anyway**, the fix on their side is `canExplore: true` in the JWT content — the flag they'd already need for explore mode — not a rollback. With a zero-traffic baseline, a single post-release `ForbiddenError` on these transactions in Sentry is a real signal.

## Verification

- **Unit** (`EmbedService.test.ts`, 8 new cases): deny + allow per endpoint for the unscoped grant, and chart-scoped grant allowed on its own explore / denied on another. Deny cases assert the explore lookup is never reached, so they fail without the fix rather than passing vacuously.
- **API tests against a live instance** (`embedDashboard.test.ts`, `embedChart.test.ts`): dashboard JWT without `canExplore` → 403 on both endpoints; dashboard JWT with `canExplore: true` → 200 + results; real chart JWT → 200 on its own explore (`payments`), 403 on `customers`; unauthenticated → 403. All green locally, plus a browser check that an embedded dashboard with a `canExplore: false` token still renders fully.
- `pnpm -F backend typecheck`, `pnpm -F api-tests typecheck`, lint clean.

Closes: PROD-9308
