### PR TITLE
feat: preview memory disclosure content when collapsed

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.test.tsx
@@ -160,13 +160,19 @@ describe('MemoryCitation', () => {
         expect(evidenceControl).toHaveAttribute('aria-expanded', 'false');
         expect(applyControl).toHaveAttribute('aria-expanded', 'false');
         expect(sourceControl).toHaveAttribute('aria-expanded', 'false');
-        expect(
-            within(dialog).getByText('Extracted from one thread'),
-        ).toBeInTheDocument();
+        // collapsed rows preview their own content, not a static description
+        expect(evidenceControl).toHaveTextContent(
+            'The user explicitly adopted this definition.',
+        );
+        expect(applyControl).toHaveTextContent(
+            'Use net revenue for future revenue questions.',
+        );
+        expect(sourceControl).toHaveTextContent('Revenue conventions');
 
         fireEvent.click(sourceControl);
 
         expect(sourceControl).toHaveAttribute('aria-expanded', 'true');
+        expect(sourceControl).not.toHaveTextContent('Revenue conventions');
         expect(within(dialog).getByText('Defined')).toHaveAttribute(
             'data-streamdown',
             'strong',

--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.module.css
@@ -41,6 +41,10 @@
 }
 
 .disclosures {
+    --disclosure-label-width: 84px;
+    --disclosure-gap: var(--mantine-spacing-md);
+    --disclosure-line-height: 20px;
+
     margin-top: 28px;
     border-top: 1px solid var(--mantine-color-ldGray-2);
 }
@@ -50,9 +54,19 @@
 }
 
 .disclosureControl {
-    min-height: 60px;
-    padding: 10px 4px;
+    padding: 12px 4px;
     border-radius: 8px;
+}
+
+.disclosureControl[data-active] {
+    padding-bottom: 0;
+}
+
+/* Open: the panel rides up onto the label's line so the label reads as that
+   row's heading. Its gutter is click-through, so the control stays toggleable. */
+.disclosureItem[data-active] .disclosurePanel {
+    margin-top: calc(-1 * var(--disclosure-line-height));
+    pointer-events: none;
 }
 
 .disclosureControl:hover {
@@ -71,21 +85,32 @@
 }
 
 .disclosureContent {
-    padding: 2px 28px 20px 4px;
+    padding: 0 28px 20px
+        calc(var(--disclosure-label-width) + var(--disclosure-gap) + 4px);
 }
 
-.disclosureTitle {
+.disclosureContent > * {
+    pointer-events: auto;
+}
+
+.disclosureRow {
+    display: grid;
+    grid-template-columns: var(--disclosure-label-width) minmax(0, 1fr);
+    gap: var(--disclosure-gap);
+    align-items: baseline;
+}
+
+.disclosureLabelText {
     color: var(--mantine-color-ldGray-9);
     font-size: 13px;
-    font-weight: 550;
-    line-height: 1.4;
+    font-weight: 600;
+    line-height: var(--disclosure-line-height);
 }
 
-.disclosureDescription {
-    margin-top: 2px;
+.disclosurePreview {
     color: var(--mantine-color-ldGray-6);
-    font-size: 11.5px;
-    line-height: 1.4;
+    font-size: 13px;
+    line-height: var(--disclosure-line-height);
 }
 
 .disclosureMarkdown {

--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.tsx
@@ -21,12 +21,15 @@ import {
     IconHistory,
     IconInfoCircle,
 } from '@tabler/icons-react';
-import { type FC, type ReactNode } from 'react';
+import { useState, type FC, type ReactNode } from 'react';
 import { Link } from 'react-router';
 import { AiMarkdown } from '../../../../../components/common/AiMarkdown';
 import Callout from '../../../../../components/common/Callout';
 import MantineModal from '../../../../../components/common/MantineModal';
-import { parseAiAgentMemorySections } from '../../utils/memory';
+import {
+    getMarkdownPlainText,
+    parseAiAgentMemorySections,
+} from '../../utils/memory';
 import { MEMORY_SCOPE_LABELS } from '../Admin/memoryScope';
 import styles from './MemoryDetails.module.css';
 import { MemoryStatusAction, MemoryStatusMenu } from './MemoryStatusControls';
@@ -56,14 +59,26 @@ const RailRow: FC<{ label: ReactNode; children: ReactNode }> = ({
     </Group>
 );
 
-const DisclosureLabel: FC<{ title: string; description: string }> = ({
-    title,
-    description,
-}) => (
-    <Box>
-        <Text className={styles.disclosureTitle}>{title}</Text>
-        <Text className={styles.disclosureDescription}>{description}</Text>
-    </Box>
+const Disclosure: FC<{
+    value: string;
+    label: string;
+    preview: string;
+    isOpen: boolean;
+    children: ReactNode;
+}> = ({ value, label, preview, isOpen, children }) => (
+    <Accordion.Item value={value}>
+        <Accordion.Control>
+            <Box className={styles.disclosureRow}>
+                <Text className={styles.disclosureLabelText}>{label}</Text>
+                {isOpen ? null : (
+                    <Text className={styles.disclosurePreview} lineClamp={1}>
+                        {preview}
+                    </Text>
+                )}
+            </Box>
+        </Accordion.Control>
+        <Accordion.Panel>{children}</Accordion.Panel>
+    </Accordion.Item>
 );
 
 const SourceRow: FC<{
@@ -105,6 +120,7 @@ export const MemoryDetails: FC<MemoryDetailsProps> = ({
     projectUuid,
     agentUuid,
 }) => {
+    const [openSections, setOpenSections] = useState<string[]>([]);
     const replacementPath =
         memory.replacementSlug && agentUuid
             ? `/projects/${projectUuid}/ai-agents/${agentUuid}/memories/${memory.replacementSlug}`
@@ -114,12 +130,12 @@ export const MemoryDetails: FC<MemoryDetailsProps> = ({
             ? [memory.provenance.source]
             : memory.provenance.sources;
     const sections = parseAiAgentMemorySections(memory.rawMemory);
-    const sourceDescription =
-        memory.provenance.type === 'consolidated'
-            ? sources.length > 0
-                ? `Consolidated from ${sources.length} memories`
-                : 'Consolidated memory'
-            : 'Extracted from one thread';
+    const sourcePreview =
+        sources.length > 0
+            ? sources
+                  .map((source) => source.threadTitle ?? 'AI agent thread')
+                  .join(', ')
+            : 'No source threads recorded';
 
     return (
         <Box className={styles.layout}>
@@ -161,77 +177,66 @@ export const MemoryDetails: FC<MemoryDetailsProps> = ({
 
                 <Accordion
                     multiple
-                    defaultValue={[]}
+                    value={openSections}
+                    onChange={setOpenSections}
                     className={styles.disclosures}
                     classNames={{
                         item: styles.disclosureItem,
                         control: styles.disclosureControl,
                         label: styles.disclosureLabel,
                         chevron: styles.disclosureChevron,
+                        panel: styles.disclosurePanel,
                         content: styles.disclosureContent,
                     }}
                 >
                     {sections.evidence ? (
-                        <Accordion.Item value="evidence">
-                            <Accordion.Control>
-                                <DisclosureLabel
-                                    title="Evidence"
-                                    description="Why this memory was learned"
-                                />
-                            </Accordion.Control>
-                            <Accordion.Panel>
-                                <AiMarkdown
-                                    className={styles.disclosureMarkdown}
-                                >
-                                    {sections.evidence}
-                                </AiMarkdown>
-                            </Accordion.Panel>
-                        </Accordion.Item>
+                        <Disclosure
+                            value="evidence"
+                            label="Evidence"
+                            preview={getMarkdownPlainText(sections.evidence)}
+                            isOpen={openSections.includes('evidence')}
+                        >
+                            <AiMarkdown className={styles.disclosureMarkdown}>
+                                {sections.evidence}
+                            </AiMarkdown>
+                        </Disclosure>
                     ) : null}
 
                     {sections.apply ? (
-                        <Accordion.Item value="apply">
-                            <Accordion.Control>
-                                <DisclosureLabel
-                                    title="Apply"
-                                    description="When and how to use it"
-                                />
-                            </Accordion.Control>
-                            <Accordion.Panel>
-                                <AiMarkdown
-                                    className={styles.disclosureMarkdown}
-                                >
-                                    {sections.apply}
-                                </AiMarkdown>
-                            </Accordion.Panel>
-                        </Accordion.Item>
+                        <Disclosure
+                            value="apply"
+                            label="Apply"
+                            preview={getMarkdownPlainText(sections.apply)}
+                            isOpen={openSections.includes('apply')}
+                        >
+                            <AiMarkdown className={styles.disclosureMarkdown}>
+                                {sections.apply}
+                            </AiMarkdown>
+                        </Disclosure>
                     ) : null}
 
-                    <Accordion.Item value="source">
-                        <Accordion.Control>
-                            <DisclosureLabel
-                                title="Source"
-                                description={sourceDescription}
-                            />
-                        </Accordion.Control>
-                        <Accordion.Panel>
-                            <Box className={styles.sourceList}>
-                                {sources.length > 0 ? (
-                                    sources.map((source) => (
-                                        <SourceRow
-                                            key={source.slug}
-                                            source={source}
-                                            projectUuid={projectUuid}
-                                        />
-                                    ))
-                                ) : (
-                                    <Text size="xs" c="dimmed" p="md">
-                                        No source threads recorded
-                                    </Text>
-                                )}
-                            </Box>
-                        </Accordion.Panel>
-                    </Accordion.Item>
+                    <Disclosure
+                        value="source"
+                        label="Source"
+                        preview={sourcePreview}
+                        isOpen={openSections.includes('source')}
+                    >
+                        <Box className={styles.sourceList}>
+                            {sources.length > 0 ? (
+                                sources.map((source) => (
+                                    <SourceRow
+                                        key={source.slug}
+                                        source={source}
+                                        projectUuid={projectUuid}
+                                    />
+                                ))
+                            ) : (
+                                <Text size="xs" c="dimmed" p="md">
+                                    No source threads recorded
+                                </Text>
+                            )}
+                        </Box>
+                    </Disclosure>
                 </Accordion>
             </Stack>
 

--- a/packages/frontend/src/ee/features/aiCopilot/utils/memory.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/memory.test.ts
@@ -1,10 +1,31 @@
-import { getAiAgentMemoryPreview, parseAiAgentMemorySections } from './memory';
+import {
+    getAiAgentMemoryPreview,
+    getMarkdownPlainText,
+    parseAiAgentMemorySections,
+} from './memory';
 
 describe('getAiAgentMemoryPreview', () => {
     it('preserves markdown and limits the preview to 256 characters', () => {
         const memory = `**Revenue definition** ${'a'.repeat(300)}`;
 
         expect(getAiAgentMemoryPreview(memory)).toBe(memory.slice(0, 256));
+    });
+});
+
+describe('getMarkdownPlainText', () => {
+    it('flattens lists, emphasis and code to one line', () => {
+        expect(
+            getMarkdownPlainText(`- The user preferred the **direct** join.
+- The query failed with \`bytesBilledLimitExceeded\`.`),
+        ).toBe(
+            'The user preferred the direct join. The query failed with bytesBilledLimitExceeded.',
+        );
+    });
+
+    it('drops link syntax but keeps the link text', () => {
+        expect(getMarkdownPlainText('See [the thread](/threads/1).')).toBe(
+            'See the thread.',
+        );
     });
 });
 

--- a/packages/frontend/src/ee/features/aiCopilot/utils/memory.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/memory.ts
@@ -3,6 +3,40 @@ import { unified } from 'unified';
 
 export const getAiAgentMemoryPreview = (value: string) => value.slice(0, 256);
 
+type MarkdownNode = {
+    type: string;
+    value?: string;
+    children?: MarkdownNode[];
+};
+
+// Runs of text within these read as one sentence; anything else is a block and
+// gets a space so a list doesn't collapse into "join.The query failed"
+const INLINE_CONTAINER_TYPES = new Set([
+    'paragraph',
+    'heading',
+    'emphasis',
+    'strong',
+    'delete',
+    'link',
+    'linkReference',
+    'tableCell',
+]);
+
+/** Flattens markdown to one line of prose, for collapsed previews. */
+export const getMarkdownPlainText = (value: string): string => {
+    const collect = (node: MarkdownNode): string => {
+        if (typeof node.value === 'string') return node.value;
+
+        return (node.children ?? [])
+            .map(collect)
+            .join(INLINE_CONTAINER_TYPES.has(node.type) ? '' : ' ');
+    };
+
+    return collect(markdownParser.parse(value) as MarkdownNode)
+        .replace(/\s+/g, ' ')
+        .trim();
+};
+
 export type AiAgentMemorySections = {
     memory: string;
     evidence: string | null;


### PR DESCRIPTION
Stacked on #26557.

Reshapes the memory disclosures (Evidence / Apply / Source) into a definition-list layout: a fixed label column on the left, content on the right.

- **Collapsed rows preview their own content** instead of a static description ("Why this memory was learned"). The preview is the section's markdown flattened to one line of prose (`getMarkdownPlainText`, an mdast walk — lists, emphasis, code and link syntax are stripped, link text kept) and clamped to a single line. Source previews its thread title(s).
- **Expanded rows keep the label on the first content line**, so it reads as that row's heading. The panel rides up onto the label's line via a negative margin; its left gutter is click-through so the control stays toggleable (verified: clicking the label while open still collapses it, as does the chevron).
- Bullets appear only where the markdown actually has a list — nothing is faked; `AiMarkdown` renders whatever the section contains.

Affects both surfaces that use `MemoryDetails`: the My memories modal and the in-thread memory citation modal.

## Testing

- Unit: `getMarkdownPlainText` (list/emphasis/code flattening, link syntax); updated `MemoryCitation.test.tsx` to assert per-row previews and that the preview disappears on expand.
- Browser (Playwright, dev stack): collapsed rows are single-line and ellipsised on long content; expanded label/content tops align (536/536, 590/591); label and chevron both still toggle while open; detail pane still scrolls without overflowing the modal.

Relates: ZAP-730
