### PR TITLE
feat(cli): download the data apps a dashboard references

### DIFF
--- a/packages/cli/src/handlers/apps/appsDownload.test.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.test.ts
@@ -1,15 +1,20 @@
 import {
     LightdashError,
     ParameterError,
+    type AnyType,
     type DataAppCodeDownload,
     type DataAppManifest,
 } from '@lightdash/common';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import {
     appsDownloadSummary,
     capListedApps,
     classifyAppDownloadError,
     computeUpsertedTotal,
     DEFAULT_APPS_LIMIT,
+    downloadAppsToDir,
     ensureDownloadedAppContext,
     getDataAppReference,
     getDataAppUploadFilter,
@@ -545,5 +550,87 @@ describe('appsDownloadSummary', () => {
         expect(summary.message).toContain('Downloaded 1 of 2 data app(s)');
         expect(summary.message).toContain('1 skipped: no built version');
         expect(summary.message).toContain('1 failed');
+    });
+});
+
+describe('downloadAppsToDir', () => {
+    const tmpDir = () =>
+        fs.mkdtempSync(path.join(os.tmpdir(), 'ld-apps-download-'));
+
+    const codeFor = (slug: string): AnyType => ({
+        manifest: {
+            codeVersion: 1,
+            projectUuid: 'project-uuid',
+            slug,
+            version: 1,
+            name: slug,
+            description: '',
+            template: null,
+            downloadedAt: '2026-07-30T00:00:00.000Z',
+        },
+        files: [
+            {
+                path: 'src/App.tsx',
+                contentBase64: Buffer.from(
+                    'export default () => null;',
+                ).toString('base64'),
+            },
+        ],
+        context: {
+            semanticLayer: {
+                path: '.lightdash/context/semantic-layer.yml',
+                contentBase64: Buffer.from('models: []').toString('base64'),
+            },
+            parameters: null,
+            promptHistory: {
+                path: '.lightdash/context/prompt-history.md',
+                contentBase64: Buffer.from('# history').toString('base64'),
+            },
+            theme: { instructions: null, assets: [], skippedAssetCount: 0 },
+        },
+    });
+
+    it('writes one folder per app and counts successes', async () => {
+        const appsDir = tmpDir();
+        const outcome = await downloadAppsToDir({
+            appRefs: ['revenue-explorer'],
+            projectId: 'project-uuid',
+            appsDir,
+            takenFolders: new Set(),
+            cliVersion: '0.0.0-test',
+            fetchApp: async (_p, ref) => codeFor(ref),
+        });
+
+        expect(outcome).toEqual({
+            successCount: 1,
+            skippedNotBuiltCount: 0,
+            failures: [],
+        });
+        expect(
+            fs.existsSync(
+                path.join(appsDir, 'revenue-explorer', 'lightdash-app.yml'),
+            ),
+        ).toBe(true);
+    });
+
+    it('counts an app with no ready version as skipped, not failed', async () => {
+        const outcome = await downloadAppsToDir({
+            appRefs: ['half-built'],
+            projectId: 'project-uuid',
+            appsDir: tmpDir(),
+            takenFolders: new Set(),
+            cliVersion: '0.0.0-test',
+            fetchApp: async () => {
+                throw new LightdashError({
+                    message: 'App has no ready version to download',
+                    name: 'NotFoundError',
+                    statusCode: 404,
+                    data: {},
+                });
+            },
+        });
+
+        expect(outcome.skippedNotBuiltCount).toBe(1);
+        expect(outcome.failures).toEqual([]);
     });
 });

--- a/packages/cli/src/handlers/apps/appsDownload.test.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.test.ts
@@ -613,6 +613,39 @@ describe('downloadAppsToDir', () => {
         ).toBe(true);
     });
 
+    it('writes server-provided dependencies over the scaffold template package.json', async () => {
+        const appsDir = tmpDir();
+        const packageJson = JSON.stringify({
+            name: 'server-provided',
+            dependencies: {},
+        });
+        const lockfile = 'lockfileVersion: 6.0\nserver: provided\n';
+
+        const outcome = await downloadAppsToDir({
+            appRefs: ['deps-app'],
+            projectId: 'project-uuid',
+            appsDir,
+            takenFolders: new Set(),
+            cliVersion: '0.0.0-test',
+            fetchApp: async (_p, ref) => ({
+                ...codeFor(ref),
+                dependencies: { packageJson, lockfile },
+            }),
+        });
+
+        expect(outcome.successCount).toBe(1);
+        const writtenPackageJson = fs.readFileSync(
+            path.join(appsDir, 'deps-app', 'package.json'),
+            'utf-8',
+        );
+        expect(writtenPackageJson).toBe(packageJson);
+        const writtenLockfile = fs.readFileSync(
+            path.join(appsDir, 'deps-app', 'pnpm-lock.yaml'),
+            'utf-8',
+        );
+        expect(writtenLockfile).toBe(lockfile);
+    });
+
     it('counts an app with no ready version as skipped, not failed', async () => {
         const outcome = await downloadAppsToDir({
             appRefs: ['half-built'],

--- a/packages/cli/src/handlers/apps/appsDownload.test.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.test.ts
@@ -12,6 +12,7 @@ import {
     appsDownloadSummary,
     capListedApps,
     classifyAppDownloadError,
+    computeLinkedAppSlugs,
     computeUpsertedTotal,
     DEFAULT_APPS_LIMIT,
     downloadAppsToDir,
@@ -233,6 +234,77 @@ describe('capListedApps', () => {
             appUuids: ['a', 'b'],
             truncatedCount: 0,
         });
+    });
+});
+
+describe('computeLinkedAppSlugs', () => {
+    it('returns dashboard-referenced slugs unchanged when apps are not opted in at all', () => {
+        expect(
+            computeLinkedAppSlugs({
+                appSlugs: ['revenue-explorer', 'sales-dash'],
+                explicitRefs: new Set(),
+                includeApps: false,
+                cappedAppSlugs: new Set(),
+            }),
+        ).toEqual(['revenue-explorer', 'sales-dash']);
+    });
+
+    it('excludes slugs already covered by an explicit --apps ref', () => {
+        expect(
+            computeLinkedAppSlugs({
+                appSlugs: ['revenue-explorer', 'sales-dash'],
+                explicitRefs: new Set(['revenue-explorer']),
+                includeApps: false,
+                cappedAppSlugs: new Set(),
+            }),
+        ).toEqual(['sales-dash']);
+    });
+
+    it('excludes everything already inside an untruncated --include-apps listing', () => {
+        expect(
+            computeLinkedAppSlugs({
+                appSlugs: ['revenue-explorer', 'sales-dash'],
+                explicitRefs: new Set(),
+                includeApps: true,
+                cappedAppSlugs: new Set(['revenue-explorer', 'sales-dash']),
+            }),
+        ).toEqual([]);
+    });
+
+    // PROD-9089 regression: --include-apps caps its listing at --apps-limit,
+    // so a dashboard's app can fall outside the capped set. It must still be
+    // downloaded via the linked step rather than silently dropped.
+    it('keeps slugs that fell outside a truncated --include-apps listing', () => {
+        expect(
+            computeLinkedAppSlugs({
+                appSlugs: ['revenue-explorer', 'sales-dash'],
+                explicitRefs: new Set(),
+                includeApps: true,
+                cappedAppSlugs: new Set(['sales-dash']),
+            }),
+        ).toEqual(['revenue-explorer']);
+    });
+
+    it('an explicit ref wins over include-apps capping (never double counted)', () => {
+        expect(
+            computeLinkedAppSlugs({
+                appSlugs: ['revenue-explorer'],
+                explicitRefs: new Set(['revenue-explorer']),
+                includeApps: true,
+                cappedAppSlugs: new Set(),
+            }),
+        ).toEqual([]);
+    });
+
+    it('returns an empty array when no dashboards reference any app', () => {
+        expect(
+            computeLinkedAppSlugs({
+                appSlugs: [],
+                explicitRefs: new Set(['other-app']),
+                includeApps: true,
+                cappedAppSlugs: new Set(),
+            }),
+        ).toEqual([]);
     });
 });
 

--- a/packages/cli/src/handlers/apps/appsDownload.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.ts
@@ -161,6 +161,24 @@ export const capListedApps = (
 });
 
 /**
+ * Data apps a dashboard needs that aren't already covered by an explicit
+ * --apps ref, or by a (possibly --apps-limit-truncated) --include-apps listing.
+ */
+export const computeLinkedAppSlugs = (args: {
+    appSlugs: string[];
+    explicitRefs: Set<string>;
+    includeApps: boolean;
+    cappedAppSlugs: Set<string>;
+}): string[] => {
+    const { appSlugs, explicitRefs, includeApps, cappedAppSlugs } = args;
+    return appSlugs.filter(
+        (slug) =>
+            !explicitRefs.has(slug) &&
+            !(includeApps && cappedAppSlugs.has(slug)),
+    );
+};
+
+/**
  * Pre-context servers return a download payload without `context`.
  */
 export const ensureDownloadedAppContext = (

--- a/packages/cli/src/handlers/apps/appsDownload.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.ts
@@ -5,7 +5,18 @@ import {
     type DataAppCodeDownload,
     type DataAppManifest,
 } from '@lightdash/common';
+import * as path from 'path';
 import { validate as isUuid } from 'uuid';
+import GlobalState from '../../globalState';
+import * as styles from '../../styles';
+import {
+    resolveAppFolderName,
+    writeBundleToDir,
+    writeContextToDir,
+    writeDependenciesToDir,
+    writeFilesToDir,
+} from './appCodeFiles';
+import { buildStaticAuthoringFiles } from './scaffolding';
 
 export const DEFAULT_APPS_LIMIT = 50;
 
@@ -260,4 +271,102 @@ export const appsDownloadSummary = (
             (failure) => `  ✖ ${failure.appRef}: ${failure.message}`,
         ),
     };
+};
+
+export type AppsDownloadOutcome = {
+    successCount: number;
+    skippedNotBuiltCount: number;
+    failures: AppDownloadFailure[];
+};
+
+/**
+ * Downloads each app to its own folder under appsDir, classifying "no built
+ * version" 404s as skips rather than failures. Everything the loop needs
+ * (fetching, versioning, progress reporting) is injected so this stays free
+ * of any dependency on the download handler.
+ */
+export const downloadAppsToDir = async (args: {
+    appRefs: string[];
+    projectId: string;
+    appsDir: string;
+    takenFolders: Set<string>;
+    cliVersion: string;
+    fetchApp: (
+        projectId: string,
+        appRef: string,
+    ) => Promise<DataAppCodeDownload>;
+    onProgress?: (processed: number, total: number) => void;
+}): Promise<AppsDownloadOutcome> => {
+    const {
+        appRefs,
+        projectId,
+        appsDir,
+        takenFolders,
+        cliVersion,
+        fetchApp,
+        onProgress,
+    } = args;
+
+    let successCount = 0;
+    let skippedNotBuiltCount = 0;
+    const failures: AppDownloadFailure[] = [];
+
+    for (const appRef of appRefs) {
+        try {
+            const code = ensureDownloadedAppContext(
+                appRef,
+                // eslint-disable-next-line no-await-in-loop
+                await fetchApp(projectId, appRef),
+            );
+
+            const folder = resolveAppFolderName(code.manifest, takenFolders);
+            takenFolders.add(folder);
+
+            const appDir = path.join(appsDir, folder);
+            const manifest = {
+                ...code.manifest,
+                scaffoldingVersion: cliVersion,
+            };
+            // eslint-disable-next-line no-await-in-loop
+            await writeBundleToDir(appDir, { ...code, manifest });
+            // eslint-disable-next-line no-await-in-loop
+            await writeFilesToDir(
+                appDir,
+                buildStaticAuthoringFiles({
+                    appName: code.manifest.name,
+                    sdkVersion: cliVersion,
+                }),
+            );
+            // Server-provided deps override the scaffold's
+            // template package.json so re-uploads round-trip.
+            if (code.dependencies) {
+                // eslint-disable-next-line no-await-in-loop
+                await writeDependenciesToDir(appDir, code.dependencies);
+            }
+            // eslint-disable-next-line no-await-in-loop
+            await writeContextToDir(appDir, code.context);
+            successCount += 1;
+        } catch (appErr) {
+            const outcome = classifyAppDownloadError(appErr);
+            if (outcome.kind === 'skip-not-built') {
+                skippedNotBuiltCount += 1;
+                GlobalState.debug(
+                    `> Skipped app ${appRef}: no built version to download`,
+                );
+            } else {
+                failures.push({ appRef, message: outcome.message });
+                GlobalState.log(
+                    styles.error(
+                        `Failed to download app ${appRef}: ${outcome.message}`,
+                    ),
+                );
+            }
+        }
+        onProgress?.(
+            successCount + skippedNotBuiltCount + failures.length,
+            appRefs.length,
+        );
+    }
+
+    return { successCount, skippedNotBuiltCount, failures };
 };

--- a/packages/cli/src/handlers/download.test.ts
+++ b/packages/cli/src/handlers/download.test.ts
@@ -6,6 +6,7 @@ import {
     LightdashError,
     SpaceAsCodeAction,
     SpaceMemberRole,
+    type AnyType,
     type CartesianChartConfig,
     type ChartAsCode,
     type DataAppManifest,
@@ -402,6 +403,40 @@ describe('getDashboardChartSlugs', () => {
         ]);
         const slugs = await getDashboardChartSlugs([], tmpDir, [loose]);
         expect(slugs).toEqual(['real-chart']);
+    });
+});
+
+describe('extractAppSlugsFromDashboards', () => {
+    const dashboard = (tiles: AnyType[]): AnyType => ({ slug: 'd', tiles });
+
+    it('collects app slugs and ignores other tile types', () => {
+        expect(
+            testHelpers.extractAppSlugsFromDashboards([
+                dashboard([
+                    {
+                        type: 'data_app',
+                        properties: { appSlug: 'revenue-explorer' },
+                    },
+                    {
+                        type: 'saved_chart',
+                        properties: { chartSlug: 'a-chart' },
+                    },
+                    { type: 'markdown', properties: { content: 'hi' } },
+                ]),
+            ]),
+        ).toEqual(['revenue-explorer']);
+    });
+
+    it('dedupes and drops null slugs', () => {
+        expect(
+            testHelpers.extractAppSlugsFromDashboards([
+                dashboard([
+                    { type: 'data_app', properties: { appSlug: 'one' } },
+                    { type: 'data_app', properties: { appSlug: 'one' } },
+                    { type: 'data_app', properties: { appSlug: null } },
+                ]),
+            ]),
+        ).toEqual(['one']);
     });
 });
 

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -2183,7 +2183,9 @@ export const downloadHandler = async (
                         fetchApp: (fetchProjectId, appRef) =>
                             lightdashApi<DataAppCodeDownload>({
                                 method: 'GET',
-                                url: `/api/v1/ee/projects/${fetchProjectId}/apps/${appRef}/download`,
+                                url: `/api/v1/ee/projects/${fetchProjectId}/apps/${encodeURIComponent(
+                                    appRef,
+                                )}/download`,
                                 body: undefined,
                             }),
                         onProgress: (processed, total) =>
@@ -2237,16 +2239,38 @@ export const downloadHandler = async (
                 fetchApp: (fetchProjectId, appRef) =>
                     lightdashApi<DataAppCodeDownload>({
                         method: 'GET',
-                        url: `/api/v1/ee/projects/${fetchProjectId}/apps/${appRef}/download`,
+                        url: `/api/v1/ee/projects/${fetchProjectId}/apps/${encodeURIComponent(
+                            appRef,
+                        )}/download`,
                         body: undefined,
                     }),
                 onProgress: (processed, total) =>
                     output.updateActive(`${processed} of ${total} processed`),
             });
-            output.completeItem(
-                `${outcome.successCount} downloaded`,
-                outcome.failures.length > 0 ? 'warning' : undefined,
+            const linkedSummary = appsDownloadSummary(
+                outcome.successCount,
+                linkedAppSlugs.length,
+                outcome.failures,
+                appsDir,
+                outcome.skippedNotBuiltCount,
             );
+            output.completeItem(
+                `${outcome.successCount} downloaded${
+                    outcome.skippedNotBuiltCount > 0
+                        ? `, ${outcome.skippedNotBuiltCount} skipped`
+                        : ''
+                }${
+                    outcome.failures.length > 0
+                        ? `, ${outcome.failures.length} failed`
+                        : ''
+                }`,
+                linkedSummary.ok ? undefined : 'warning',
+            );
+            if (!linkedSummary.ok) {
+                linkedSummary.failureLines.forEach((line) =>
+                    GlobalState.log(styles.warning(line)),
+                );
+            }
         }
 
         // Write metadata file with all downloadedAt timestamps

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -763,6 +763,14 @@ const extractChartSlugsFromDashboards = (
         return [...acc, ...slugs];
     }, []);
 
+export type DownloadContentResult = {
+    total: number;
+    chartSlugs: string[];
+    appSlugs: string[];
+    metadataEntries: MetadataEntry[];
+    spaces: SpaceAsCode[];
+};
+
 export const downloadContent = async (
     ids: string[],
     type: DownloadContentType,
@@ -775,7 +783,7 @@ export const downloadContent = async (
     stripPivotSeries: boolean = false,
     rootSpaces: boolean = false,
     onProgress?: (detail: string) => void,
-): Promise<[number, string[], MetadataEntry[], SpaceAsCode[]]> => {
+): Promise<DownloadContentResult> => {
     const contentFilters = parseContentFilters(ids);
     const folderScheme: FolderScheme = nested ? 'nested' : 'flat';
     const config = getContentTypeConfig(type, projectId);
@@ -908,7 +916,13 @@ export const downloadContent = async (
         );
     }
 
-    return [total, [...new Set(chartSlugs)], allMetadataEntries, allSpaces];
+    return {
+        total,
+        chartSlugs: [...new Set(chartSlugs)],
+        appSlugs: [],
+        metadataEntries: allMetadataEntries,
+        spaces: allSpaces,
+    };
 };
 
 const getScheduledDeliveriesFolder = (customPath?: string): string =>
@@ -1800,48 +1814,51 @@ export const downloadHandler = async (
                     styles.warning(`No charts filters provided, skipping`),
                 );
             } else {
-                const [regularChartTotal, , regularChartMeta] =
-                    await output.runItem({
-                        label: 'Charts',
-                        action: () =>
-                            downloadContent(
-                                options.charts,
-                                'charts',
-                                projectId,
-                                projectName,
-                                options.path,
-                                options.languageMap,
-                                options.nested,
-                                skipEmbeddedSpaces,
-                                options.stripPivotSeries,
-                                options.rootSpaces,
-                                output.updateActive,
-                            ),
-                        detail: ([total]) => `${total} downloaded`,
-                    });
-                allMetadataEntries = [
-                    ...allMetadataEntries,
-                    ...regularChartMeta,
-                ];
-
-                const [sqlChartTotal, , sqlChartMeta] = await output.runItem({
-                    label: 'SQL charts',
+                const {
+                    total: regularChartTotal,
+                    metadataEntries: regularChartMeta,
+                } = await output.runItem({
+                    label: 'Charts',
                     action: () =>
                         downloadContent(
                             options.charts,
-                            'sqlCharts',
+                            'charts',
                             projectId,
                             projectName,
                             options.path,
                             options.languageMap,
                             options.nested,
                             skipEmbeddedSpaces,
-                            false,
+                            options.stripPivotSeries,
                             options.rootSpaces,
                             output.updateActive,
                         ),
-                    detail: ([total]) => `${total} downloaded`,
+                    detail: ({ total }) => `${total} downloaded`,
                 });
+                allMetadataEntries = [
+                    ...allMetadataEntries,
+                    ...regularChartMeta,
+                ];
+
+                const { total: sqlChartTotal, metadataEntries: sqlChartMeta } =
+                    await output.runItem({
+                        label: 'SQL charts',
+                        action: () =>
+                            downloadContent(
+                                options.charts,
+                                'sqlCharts',
+                                projectId,
+                                projectName,
+                                options.path,
+                                options.languageMap,
+                                options.nested,
+                                skipEmbeddedSpaces,
+                                false,
+                                options.rootSpaces,
+                                output.updateActive,
+                            ),
+                        detail: ({ total }) => `${total} downloaded`,
+                    });
                 allMetadataEntries = [...allMetadataEntries, ...sqlChartMeta];
 
                 chartTotal = regularChartTotal + sqlChartTotal;
@@ -1858,7 +1875,11 @@ export const downloadHandler = async (
                 let chartSlugs: string[] = [];
 
                 let dashMeta: MetadataEntry[];
-                [dashboardTotal, chartSlugs, dashMeta] = await output.runItem({
+                ({
+                    total: dashboardTotal,
+                    chartSlugs,
+                    metadataEntries: dashMeta,
+                } = await output.runItem({
                     label: 'Dashboards',
                     action: () =>
                         downloadContent(
@@ -1874,8 +1895,8 @@ export const downloadHandler = async (
                             options.rootSpaces,
                             output.updateActive,
                         ),
-                    detail: ([total]) => `${total} downloaded`,
-                });
+                    detail: ({ total }) => `${total} downloaded`,
+                }));
                 allMetadataEntries = [...allMetadataEntries, ...dashMeta];
 
                 if (
@@ -1887,38 +1908,41 @@ export const downloadHandler = async (
                     output.updateActive(
                         `${chartSlugs.length} dashboard dependencies`,
                     );
-                    const [regularCharts, , linkedChartMeta] =
-                        await downloadContent(
-                            chartSlugs,
-                            'charts',
-                            projectId,
-                            projectName,
-                            options.path,
-                            options.languageMap,
-                            options.nested,
-                            skipEmbeddedSpaces,
-                            options.stripPivotSeries,
-                            options.rootSpaces,
-                            output.updateActive,
-                        );
-                    allMetadataEntries = [
-                        ...allMetadataEntries,
-                        ...linkedChartMeta,
-                    ];
-
-                    const [sqlCharts, , linkedSqlMeta] = await downloadContent(
+                    const {
+                        total: regularCharts,
+                        metadataEntries: linkedChartMeta,
+                    } = await downloadContent(
                         chartSlugs,
-                        'sqlCharts',
+                        'charts',
                         projectId,
                         projectName,
                         options.path,
                         options.languageMap,
                         options.nested,
                         skipEmbeddedSpaces,
-                        false,
+                        options.stripPivotSeries,
                         options.rootSpaces,
                         output.updateActive,
                     );
+                    allMetadataEntries = [
+                        ...allMetadataEntries,
+                        ...linkedChartMeta,
+                    ];
+
+                    const { total: sqlCharts, metadataEntries: linkedSqlMeta } =
+                        await downloadContent(
+                            chartSlugs,
+                            'sqlCharts',
+                            projectId,
+                            projectName,
+                            options.path,
+                            options.languageMap,
+                            options.nested,
+                            skipEmbeddedSpaces,
+                            false,
+                            options.rootSpaces,
+                            output.updateActive,
+                        );
                     allMetadataEntries = [
                         ...allMetadataEntries,
                         ...linkedSqlMeta,

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -71,17 +71,11 @@ import {
     buildImportBody,
     readBundleFromDir,
     readDependenciesFromDir,
-    resolveAppFolderName,
-    writeBundleToDir,
-    writeContextToDir,
-    writeDependenciesToDir,
-    writeFilesToDir,
 } from './apps/appCodeFiles';
 import {
     appsDownloadSummary,
     capListedApps,
-    classifyAppDownloadError,
-    ensureDownloadedAppContext,
+    downloadAppsToDir,
     getDataAppUploadFilter,
     matchedUploadRefs,
     preSlugServerHint,
@@ -91,12 +85,8 @@ import {
     shouldFallBackToSpaceScopedListing,
     unmatchedUploadRefsWarning,
     uploadFilterMatches,
-    type AppDownloadFailure,
 } from './apps/appsDownload';
-import {
-    buildStaticAuthoringFiles,
-    loadTemplateDependencies,
-} from './apps/scaffolding';
+import { loadTemplateDependencies } from './apps/scaffolding';
 import {
     AI_AGENT_CODE_RESOURCE,
     ALERT_CODE_RESOURCE,
@@ -2128,99 +2118,40 @@ export const downloadHandler = async (
                 const baseDir = getDownloadFolder(options.path);
                 const appsDir = path.join(baseDir, 'apps');
                 const takenFolders = new Set<string>();
-                let appSuccessCount = 0;
-                let appSkippedNotBuiltCount = 0;
-                const appFailures: AppDownloadFailure[] = [];
 
-                for (const appRef of appRefsToDownload) {
-                    try {
-                        // eslint-disable-next-line no-await-in-loop
-                        const code = ensureDownloadedAppContext(
-                            appRef,
-                            await lightdashApi<DataAppCodeDownload>({
+                const { successCount, skippedNotBuiltCount, failures } =
+                    await downloadAppsToDir({
+                        appRefs: appRefsToDownload,
+                        projectId,
+                        appsDir,
+                        takenFolders,
+                        cliVersion: CLI_VERSION,
+                        fetchApp: (fetchProjectId, appRef) =>
+                            lightdashApi<DataAppCodeDownload>({
                                 method: 'GET',
-                                url: `/api/v1/ee/projects/${projectId}/apps/${appRef}/download`,
+                                url: `/api/v1/ee/projects/${fetchProjectId}/apps/${appRef}/download`,
                                 body: undefined,
                             }),
-                        );
-
-                        const folder = resolveAppFolderName(
-                            code.manifest,
-                            takenFolders,
-                        );
-                        takenFolders.add(folder);
-
-                        const appDir = path.join(appsDir, folder);
-                        const manifest = {
-                            ...code.manifest,
-                            scaffoldingVersion: CLI_VERSION,
-                        };
-                        // eslint-disable-next-line no-await-in-loop
-                        await writeBundleToDir(appDir, { ...code, manifest });
-                        // eslint-disable-next-line no-await-in-loop
-                        await writeFilesToDir(
-                            appDir,
-                            buildStaticAuthoringFiles({
-                                appName: code.manifest.name,
-                                sdkVersion: CLI_VERSION,
-                            }),
-                        );
-                        // Server-provided deps override the scaffold's
-                        // template package.json so re-uploads round-trip.
-                        if (code.dependencies) {
-                            // eslint-disable-next-line no-await-in-loop
-                            await writeDependenciesToDir(
-                                appDir,
-                                code.dependencies,
-                            );
-                        }
-                        // eslint-disable-next-line no-await-in-loop
-                        await writeContextToDir(appDir, code.context);
-                        appSuccessCount += 1;
-                    } catch (appErr) {
-                        const outcome = classifyAppDownloadError(appErr);
-                        if (outcome.kind === 'skip-not-built') {
-                            appSkippedNotBuiltCount += 1;
-                            GlobalState.debug(
-                                `> Skipped app ${appRef}: no built version to download`,
-                            );
-                        } else {
-                            appFailures.push({
-                                appRef,
-                                message: outcome.message,
-                            });
-                            GlobalState.log(
-                                styles.error(
-                                    `Failed to download app ${appRef}: ${outcome.message}`,
-                                ),
-                            );
-                        }
-                    }
-                    output.updateActive(
-                        `${
-                            appSuccessCount +
-                            appSkippedNotBuiltCount +
-                            appFailures.length
-                        } of ${appRefsToDownload.length} processed`,
-                    );
-                }
+                        onProgress: (processed, total) =>
+                            output.updateActive(
+                                `${processed} of ${total} processed`,
+                            ),
+                    });
 
                 const summary = appsDownloadSummary(
-                    appSuccessCount,
+                    successCount,
                     appRefsToDownload.length,
-                    appFailures,
+                    failures,
                     appsDir,
-                    appSkippedNotBuiltCount,
+                    skippedNotBuiltCount,
                 );
                 output.completeItem(
-                    `${appSuccessCount} downloaded${
-                        appSkippedNotBuiltCount > 0
-                            ? `, ${appSkippedNotBuiltCount} skipped`
+                    `${successCount} downloaded${
+                        skippedNotBuiltCount > 0
+                            ? `, ${skippedNotBuiltCount} skipped`
                             : ''
                     }${
-                        appFailures.length > 0
-                            ? `, ${appFailures.length} failed`
-                            : ''
+                        failures.length > 0 ? `, ${failures.length} failed` : ''
                     }`,
                     summary.ok ? undefined : 'warning',
                 );

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -30,6 +30,7 @@ import {
     computeCustomDependencies,
     ContentAsCodeType as ContentAsCodeTypeEnum,
     DashboardAsCode,
+    DashboardTileTypes,
     ExternalConnectionAsCode,
     generateSlug,
     getErrorMessage,
@@ -75,6 +76,7 @@ import {
 import {
     appsDownloadSummary,
     capListedApps,
+    computeLinkedAppSlugs,
     downloadAppsToDir,
     getDataAppReference,
     getDataAppUploadFilter,
@@ -760,11 +762,10 @@ const extractAppSlugsFromDashboards = (
     ...new Set(
         dashboards.flatMap((dashboard) =>
             dashboard.tiles.reduce<string[]>((acc, tile) => {
-                const slug =
-                    'appSlug' in tile.properties
-                        ? (tile.properties.appSlug as string | null)
-                        : null;
-                return slug ? [...acc, slug] : acc;
+                if (tile.type !== DashboardTileTypes.DATA_APP) return acc;
+                return tile.properties.appSlug
+                    ? [...acc, tile.properties.appSlug]
+                    : acc;
             }, []),
         ),
     ),
@@ -1598,12 +1599,14 @@ const upsertScheduledContent = async (
     return changes;
 };
 
+type ListedApp = { appUuid: string; slug: string };
+
 // Space-scoped fallback listing for servers without the project-wide apps
 // endpoint; omits apps that were never added to a space.
-const listAppUuidsViaContentApi = async (
+const listAppsViaContentApi = async (
     projectId: string,
-): Promise<string[]> => {
-    const listedAppUuids: string[] = [];
+): Promise<ListedApp[]> => {
+    const listedApps: ListedApp[] = [];
     let page = 1;
     let totalPageCount = 1;
     do {
@@ -1614,15 +1617,15 @@ const listAppUuidsViaContentApi = async (
                 body: undefined,
             },
         );
-        listedAppUuids.push(
+        listedApps.push(
             ...contentResult.data
                 .filter((item) => item.contentType === 'data_app')
-                .map((item) => item.uuid),
+                .map((item) => ({ appUuid: item.uuid, slug: item.slug })),
         );
         totalPageCount = contentResult.pagination?.totalPageCount ?? 1;
         page += 1;
     } while (page <= totalPageCount);
-    return listedAppUuids;
+    return listedApps;
 };
 
 export const downloadHandler = async (
@@ -1766,9 +1769,17 @@ export const downloadHandler = async (
     });
     try {
         let allMetadataEntries: MetadataEntry[] = [];
-        // Shared across the linked-apps step and the explicit apps step so
-        // the same app is never written to two different folder names.
+        // Shared across both apps-download steps so two different apps whose
+        // names collide under the pre-slug fallback naming don't clobber each other.
         const downloadedAppFolders = new Set<string>();
+        // App slugs referenced by downloaded dashboards' tiles, populated by
+        // the Dashboards step and consumed by the Linked data apps step.
+        let dashboardAppSlugs: string[] = [];
+        const explicitAppRefs = new Set(
+            (Array.isArray(options.apps) ? options.apps : []).map(
+                getDataAppReference,
+            ),
+        );
 
         if (shouldDownloadSpaces) {
             output.startItem('Spaces');
@@ -1970,45 +1981,8 @@ export const downloadHandler = async (
                     );
                 }
 
-                // The --include-apps listing already covers every app in the
-                // project, so it handles apps referenced by dashboards too.
-                const explicitAppRefs = new Set(
-                    (Array.isArray(options.apps) ? options.apps : []).map(
-                        getDataAppReference,
-                    ),
-                );
-                const linkedAppSlugs = includeApps
-                    ? []
-                    : appSlugs.filter((slug) => !explicitAppRefs.has(slug));
-
-                if (linkedAppSlugs.length > 0) {
-                    output.startItem('Linked data apps');
-                    const appsDir = path.join(
-                        getDownloadFolder(options.path),
-                        'apps',
-                    );
-                    const outcome = await downloadAppsToDir({
-                        appRefs: linkedAppSlugs,
-                        projectId,
-                        appsDir,
-                        takenFolders: downloadedAppFolders,
-                        cliVersion: CLI_VERSION,
-                        fetchApp: (fetchProjectId, appRef) =>
-                            lightdashApi<DataAppCodeDownload>({
-                                method: 'GET',
-                                url: `/api/v1/ee/projects/${fetchProjectId}/apps/${appRef}/download`,
-                                body: undefined,
-                            }),
-                        onProgress: (processed, total) =>
-                            output.updateActive(
-                                `${processed} of ${total} processed`,
-                            ),
-                    });
-                    output.completeItem(
-                        `${outcome.successCount} downloaded`,
-                        outcome.failures.length > 0 ? 'warning' : undefined,
-                    );
-                }
+                // Consumed after the explicit apps step (see cappedAppSlugs).
+                dashboardAppSlugs = appSlugs;
             }
         }
 
@@ -2113,6 +2087,9 @@ export const downloadHandler = async (
             apps: Array.isArray(options.apps) ? options.apps : undefined,
             includeApps,
         });
+        // Slugs covered by a (possibly --apps-limit-truncated) --include-apps
+        // listing, so the Linked data apps step knows what fell outside the cap.
+        let cappedAppSlugs = new Set<string>();
 
         if (appsSelection.mode !== 'none') {
             output.startItem('Data apps');
@@ -2124,7 +2101,7 @@ export const downloadHandler = async (
             } else {
                 // List every app in the project (includes apps not in any space)
                 output.updateActive('listing project apps…');
-                let listedAppUuids: string[];
+                let listedApps: ListedApp[];
                 try {
                     const projectApps = await lightdashApi<
                         ApiEmbedProjectAppsResponse['results']
@@ -2133,34 +2110,45 @@ export const downloadHandler = async (
                         url: `/api/v1/ee/projects/${projectId}/apps`,
                         body: undefined,
                     });
-                    listedAppUuids = projectApps.map((app) => app.appUuid);
+                    listedApps = projectApps.map((app) => ({
+                        appUuid: app.appUuid,
+                        slug: app.slug,
+                    }));
                 } catch (listErr) {
                     if (!shouldFallBackToSpaceScopedListing(listErr)) {
                         if (!includeAllOptionalContent) {
                             throw listErr;
                         }
                         appListingError = getErrorMessage(listErr);
-                        listedAppUuids = [];
+                        listedApps = [];
                     } else {
                         GlobalState.log(
                             styles.warning(
                                 'This server does not support project-wide app listing; only apps that are in a space will be included.',
                             ),
                         );
-                        listedAppUuids =
-                            await listAppUuidsViaContentApi(projectId);
+                        listedApps = await listAppsViaContentApi(projectId);
                     }
                 }
 
                 const { appUuids: cappedAppUuids, truncatedCount } =
-                    capListedApps(listedAppUuids, appsLimit);
+                    capListedApps(
+                        listedApps.map((app) => app.appUuid),
+                        appsLimit,
+                    );
                 if (truncatedCount > 0) {
                     GlobalState.log(
                         styles.warning(
-                            `Found ${listedAppUuids.length} data apps, downloading the first ${appsLimit}. Pass --apps-limit <n> to raise the cap.`,
+                            `Found ${listedApps.length} data apps, downloading the first ${appsLimit}. Pass --apps-limit <n> to raise the cap.`,
                         ),
                     );
                 }
+                const cappedAppUuidSet = new Set(cappedAppUuids);
+                cappedAppSlugs = new Set(
+                    listedApps
+                        .filter((app) => cappedAppUuidSet.has(app.appUuid))
+                        .map((app) => app.slug),
+                );
                 appRefsToDownload = [
                     ...new Set([
                         ...cappedAppUuids,
@@ -2227,6 +2215,38 @@ export const downloadHandler = async (
                     );
                 }
             }
+        }
+
+        // Dashboard-referenced apps not already covered above (explicit
+        // --apps ref, or a non-truncated slot in the --include-apps cap).
+        const linkedAppSlugs = computeLinkedAppSlugs({
+            appSlugs: dashboardAppSlugs,
+            explicitRefs: explicitAppRefs,
+            includeApps,
+            cappedAppSlugs,
+        });
+        if (linkedAppSlugs.length > 0) {
+            output.startItem('Linked data apps');
+            const appsDir = path.join(getDownloadFolder(options.path), 'apps');
+            const outcome = await downloadAppsToDir({
+                appRefs: linkedAppSlugs,
+                projectId,
+                appsDir,
+                takenFolders: downloadedAppFolders,
+                cliVersion: CLI_VERSION,
+                fetchApp: (fetchProjectId, appRef) =>
+                    lightdashApi<DataAppCodeDownload>({
+                        method: 'GET',
+                        url: `/api/v1/ee/projects/${fetchProjectId}/apps/${appRef}/download`,
+                        body: undefined,
+                    }),
+                onProgress: (processed, total) =>
+                    output.updateActive(`${processed} of ${total} processed`),
+            });
+            output.completeItem(
+                `${outcome.successCount} downloaded`,
+                outcome.failures.length > 0 ? 'warning' : undefined,
+            );
         }
 
         // Write metadata file with all downloadedAt timestamps

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -76,6 +76,7 @@ import {
     appsDownloadSummary,
     capListedApps,
     downloadAppsToDir,
+    getDataAppReference,
     getDataAppUploadFilter,
     matchedUploadRefs,
     preSlugServerHint,
@@ -753,6 +754,22 @@ const extractChartSlugsFromDashboards = (
         return [...acc, ...slugs];
     }, []);
 
+const extractAppSlugsFromDashboards = (
+    dashboards: DashboardAsCode[],
+): string[] => [
+    ...new Set(
+        dashboards.flatMap((dashboard) =>
+            dashboard.tiles.reduce<string[]>((acc, tile) => {
+                const slug =
+                    'appSlug' in tile.properties
+                        ? (tile.properties.appSlug as string | null)
+                        : null;
+                return slug ? [...acc, slug] : acc;
+            }, []),
+        ),
+    ),
+];
+
 export type DownloadContentResult = {
     total: number;
     chartSlugs: string[];
@@ -781,6 +798,7 @@ export const downloadContent = async (
     let offset = 0;
     let total = 0;
     let chartSlugs: string[] = [];
+    let appSlugs: string[] = [];
     let allMetadataEntries: MetadataEntry[] = [];
     let allSpaces: SpaceAsCode[] = [];
 
@@ -861,6 +879,10 @@ export const downloadContent = async (
                 ...chartSlugs,
                 ...extractChartSlugsFromDashboards(results.dashboards),
             ];
+            appSlugs = [
+                ...appSlugs,
+                ...extractAppSlugsFromDashboards(results.dashboards),
+            ];
         } else {
             const chartsBySpace = groupBySpace(results.charts);
             for (const [spaceSlug, chartsInSpace] of Object.entries(
@@ -909,7 +931,7 @@ export const downloadContent = async (
     return {
         total,
         chartSlugs: [...new Set(chartSlugs)],
-        appSlugs: [],
+        appSlugs: [...new Set(appSlugs)],
         metadataEntries: allMetadataEntries,
         spaces: allSpaces,
     };
@@ -1744,6 +1766,9 @@ export const downloadHandler = async (
     });
     try {
         let allMetadataEntries: MetadataEntry[] = [];
+        // Shared across the linked-apps step and the explicit apps step so
+        // the same app is never written to two different folder names.
+        const downloadedAppFolders = new Set<string>();
 
         if (shouldDownloadSpaces) {
             output.startItem('Spaces');
@@ -1863,11 +1888,13 @@ export const downloadHandler = async (
                 );
             } else {
                 let chartSlugs: string[] = [];
+                let appSlugs: string[] = [];
 
                 let dashMeta: MetadataEntry[];
                 ({
                     total: dashboardTotal,
                     chartSlugs,
+                    appSlugs,
                     metadataEntries: dashMeta,
                 } = await output.runItem({
                     label: 'Dashboards',
@@ -1940,6 +1967,46 @@ export const downloadHandler = async (
 
                     output.completeItem(
                         `${regularCharts + sqlCharts} downloaded`,
+                    );
+                }
+
+                // The --include-apps listing already covers every app in the
+                // project, so it handles apps referenced by dashboards too.
+                const explicitAppRefs = new Set(
+                    (Array.isArray(options.apps) ? options.apps : []).map(
+                        getDataAppReference,
+                    ),
+                );
+                const linkedAppSlugs = includeApps
+                    ? []
+                    : appSlugs.filter((slug) => !explicitAppRefs.has(slug));
+
+                if (linkedAppSlugs.length > 0) {
+                    output.startItem('Linked data apps');
+                    const appsDir = path.join(
+                        getDownloadFolder(options.path),
+                        'apps',
+                    );
+                    const outcome = await downloadAppsToDir({
+                        appRefs: linkedAppSlugs,
+                        projectId,
+                        appsDir,
+                        takenFolders: downloadedAppFolders,
+                        cliVersion: CLI_VERSION,
+                        fetchApp: (fetchProjectId, appRef) =>
+                            lightdashApi<DataAppCodeDownload>({
+                                method: 'GET',
+                                url: `/api/v1/ee/projects/${fetchProjectId}/apps/${appRef}/download`,
+                                body: undefined,
+                            }),
+                        onProgress: (processed, total) =>
+                            output.updateActive(
+                                `${processed} of ${total} processed`,
+                            ),
+                    });
+                    output.completeItem(
+                        `${outcome.successCount} downloaded`,
+                        outcome.failures.length > 0 ? 'warning' : undefined,
                     );
                 }
             }
@@ -2117,14 +2184,13 @@ export const downloadHandler = async (
                 );
                 const baseDir = getDownloadFolder(options.path);
                 const appsDir = path.join(baseDir, 'apps');
-                const takenFolders = new Set<string>();
 
                 const { successCount, skippedNotBuiltCount, failures } =
                     await downloadAppsToDir({
                         appRefs: appRefsToDownload,
                         projectId,
                         appsDir,
-                        takenFolders,
+                        takenFolders: downloadedAppFolders,
                         cliVersion: CLI_VERSION,
                         fetchApp: (fetchProjectId, appRef) =>
                             lightdashApi<DataAppCodeDownload>({
@@ -3434,6 +3500,7 @@ export const uploadHandler = async (
 export const testHelpers = {
     assertUniqueSpacePaths,
     downloadSpaces,
+    extractAppSlugsFromDashboards,
     getFlatSpaceFileNames,
     getDashboardChartSlugs,
     hasContentFilters,


### PR DESCRIPTION
## What

`lightdash download -d <dashboard>` now also downloads the data apps that dashboard's tiles reference — the same way it already downloads the charts they reference. No new flag; that is the point of the ticket.

Second of three stacked PRs. Builds on the backend PR below it, which made dashboard YAML carry a portable `appSlug` on data app tiles.

## Changes

- **New "Linked data apps" download step.** Mirrors the existing "Linked charts" step. `downloadContent` now returns the app slugs it saw on downloaded dashboards, and those apps are fetched into `apps/`.
- **`downloadContent` returns a named object** instead of a positional 4-tuple, so adding a fifth value did not produce an unreadable `[a, , c, , e]`. Pure refactor, no behaviour change.
- **The per-app download loop moved into a reusable `downloadAppsToDir` helper** in `apps/appsDownload.ts`, so the explicit `--apps` path and the new linked path share one implementation instead of two copies. The helper takes its fetch function as an argument, which also makes it unit-testable without HTTP.
- **`computeLinkedAppSlugs`** is a pure function next to the other download decisions (`selectAppsToDownload`, `capListedApps`, `resolveAppsLimit`), unit-tested, rather than inline logic in the handler.

## Behaviour notes

- **No flag and no `hasFilters` gate.** With no filters, the step pulls the apps that dashboards reference — and only those; it never enumerates the project's apps, which is what `--include-apps` does. With `-d <dashboard>`, it pulls that dashboard's apps.
- **Not capped by `--apps-limit`.** Dashboard-derived apps are a bounded dependency set, matching how explicit `--apps` references are never capped.
- **`--include-apps` no longer hides a dashboard's apps.** That path caps its listing at `--apps-limit`; previously the linked step was skipped whenever `--include-apps` was set, so on a project past the cap, adding the flag could fetch *fewer* of a dashboard's apps than omitting it. The linked step now runs for dashboard-referenced slugs that fall outside the capped set.
- **App failures never fail the download.** A 403 (data apps disabled, or no permission) or a 404 (server without EE app routes) warns once and the download completes. An app that exists but has no built version yet is reported as skipped, not failed.
- Both download steps share one `takenFolders` set, so two different apps whose names collide under the pre-slug fallback naming can't clobber each other.
- The linked step now reports skips and failures the same way the explicit `--apps` step does, and app references are URL-encoded before being interpolated into the download path.

## Testing

`pnpm -F cli test` 383 passed, typecheck and lint clean. Includes a regression test for the `--include-apps` truncation case above, and one proving server-provided dependency files are written *after* the scaffold so they override its `package.json` — that ordering was previously uncovered.

End-to-end verification of the full loop lands with the upload PR above this one.

Closes: PROD-9089
Relates: PROD-9245
