### PR TITLE
fix(dev): restore fixed Okteto debugger port

### DIFF
--- a/okteto.dev.yaml
+++ b/okteto.dev.yaml
@@ -84,9 +84,8 @@ dev:
                 memory: 8Gi
         forward:
             # Node.js debugger (tsx watch --inspect). Local 9230 because a
-            # local dev stack usually holds 9229 already. Overridable so
-            # concurrent agent sessions don't collide on the local port
-            - ${OKTETO_DEBUG_PORT:-9230}:9229
+            # local dev stack usually holds 9229 already
+            - 9230:9229
         # No persistent volume: it would shadow the warm image's baked
         # /usr/app. A pod restart re-syncs (~1 min) — acceptable for
         # ephemeral dev namespaces

--- a/scripts/agent-okteto-dev.sh
+++ b/scripts/agent-okteto-dev.sh
@@ -569,33 +569,15 @@ wait_until_ready() {
     fail "Timed out waiting for $PUBLIC_URL. See $LOG_FILE."
 }
 
-debug_forward_port() {
-    local attempts=0 port
-
-    # Stable per-session port so concurrent sessions don't collide on the
-    # manifest's default 9230 forward
-    port=$((9300 + 16#${SESSION_HASH:0:4} % 500))
-    if command -v lsof >/dev/null 2>&1; then
-        while lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1 &&
-            ((attempts < 50)); do
-            port=$((port + 1))
-            attempts=$((attempts + 1))
-        done
-    fi
-    printf '%s' "$port"
-}
-
 start_tmux_session() {
-    local debug_port up_command pipe_command
+    local up_command pipe_command
 
     mkdir -p "$RUN_DIR"
     : >"$LOG_FILE"
 
-    debug_port="$(debug_forward_port)"
     printf -v up_command \
-        'DEV_WARM_IMAGE=%q OKTETO_DEBUG_PORT=%q exec okteto up %q -f %q -n %q --env %q --env %q --env %q' \
+        'DEV_WARM_IMAGE=%q exec okteto up %q -f %q -n %q --env %q --env %q --env %q' \
         "$ACTIVE_WARM_IMAGE" \
-        "$debug_port" \
         "$OKTETO_SERVICE" \
         "$OKTETO_MANIFEST" \
         "$OKTETO_NAMESPACE" \


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates: SPK-565

### Description:
Restores the fixed local 9230 debugger forward so Okteto 3.21.0 can parse the development manifest.
Removes the dynamic port launcher code while leaving dev-warm image builds and warm namespace provisioning unchanged.
Validated with Bash syntax checking and Okteto manifest validation.