### PR TITLE
feat: add icon to memory details modal and attach the rail divider

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.module.css
@@ -1,24 +1,19 @@
+/* Owns its own padding so the column divider reaches the container's edges and
+   meets the header rule above it */
 .layout {
     display: grid;
+    min-height: 100%;
     grid-template-columns: minmax(0, 1fr) 1px 232px;
-    gap: 28px;
     align-items: stretch;
 }
 
 .main {
     min-width: 0;
+    padding: 20px 28px 28px 24px;
 }
 
 .statusCalloutText {
     font-size: var(--mantine-font-size-xs);
-}
-
-.modalTitle {
-    color: var(--mantine-color-ldGray-9);
-    font-size: 16px;
-    font-weight: 550;
-    letter-spacing: -0.014em;
-    line-height: 1.4;
 }
 
 .sectionLabel {
@@ -156,6 +151,7 @@
     align-self: start;
     position: sticky;
     top: 0;
+    padding: 20px 24px 28px 28px;
 }
 
 .railRow {
@@ -246,7 +242,10 @@
 @media (max-width: 820px) {
     .layout {
         grid-template-columns: minmax(0, 1fr);
-        gap: var(--mantine-spacing-xl);
+    }
+
+    .main {
+        padding: 20px 18px 24px;
     }
 
     .divider {
@@ -255,7 +254,7 @@
 
     .rail {
         position: static;
-        padding-top: var(--mantine-spacing-xl);
+        padding: 20px 18px 24px;
         border-top: 1px solid var(--mantine-color-ldGray-2);
     }
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.tsx
@@ -20,6 +20,7 @@ import {
     IconExternalLink,
     IconHistory,
     IconInfoCircle,
+    IconNotebook,
 } from '@tabler/icons-react';
 import { type FC, type ReactNode } from 'react';
 import { Link } from 'react-router';
@@ -377,13 +378,10 @@ export const MemoryDetailsModal: FC<MemoryDetailsModalProps> = ({
         opened={opened}
         onClose={onClose}
         size="72rem"
-        title={
-            <Text component="span" className={styles.modalTitle} lineClamp={2}>
-                {memory.title}
-            </Text>
-        }
+        icon={IconNotebook}
+        title={memory.title}
         cancelLabel={false}
-        modalBodyProps={{ py: 'lg' }}
+        modalBodyProps={{ px: 0, py: 0 }}
         bodyScrollAreaMaxHeight="calc(85vh - 120px)"
         headerActions={
             <MemoryStatusAction

--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetailsBySlugModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetailsBySlugModal.tsx
@@ -1,4 +1,5 @@
 import { Box, Loader, Text } from '@mantine-8/core';
+import { IconNotebook } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineModal from '../../../../../components/common/MantineModal';
 import { useAiAgentMemory } from '../../hooks/useAiAgentMemory';
@@ -40,7 +41,12 @@ export const MemoryDetailsBySlugModal: FC<MemoryDetailsBySlugModalProps> = ({
     }
 
     return (
-        <MantineModal opened onClose={onClose} title={title}>
+        <MantineModal
+            opened
+            onClose={onClose}
+            icon={IconNotebook}
+            title={title}
+        >
             <Box py="xl" ta="center">
                 {memoryQuery.isError ? (
                     <Text c="dimmed" fz="sm">

--- a/packages/frontend/src/ee/features/aiCopilot/components/MyMemories/MyMemoriesModal.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MyMemories/MyMemoriesModal.module.css
@@ -97,7 +97,6 @@
 .detailBody {
     min-height: 0;
     flex: 1;
-    padding: var(--mantine-spacing-lg) var(--mantine-spacing-xl);
     overflow-y: auto;
 }
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/MyMemories/MyMemoriesModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MyMemories/MyMemoriesModal.tsx
@@ -90,10 +90,12 @@ const MemoryDetailPane: FC<{
                         agentUuid={memory.agent?.uuid ?? null}
                     />
                 ) : memoryQuery.isError ? (
-                    <InlineErrorState
-                        message="Unable to load this memory."
-                        onRetry={() => void memoryQuery.refetch()}
-                    />
+                    <Box p="xl">
+                        <InlineErrorState
+                            message="Unable to load this memory."
+                            onRetry={() => void memoryQuery.refetch()}
+                        />
+                    </Box>
                 ) : (
                     <EmptyStateLoader py="xl" />
                 )}

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentMemoryPage.module.css
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentMemoryPage.module.css
@@ -42,17 +42,12 @@
     line-height: 1.4;
 }
 
-.body {
-    padding: 24px;
-}
-
 @media (max-width: 820px) {
     .page {
         padding-inline: 16px;
     }
 
-    .header,
-    .body {
+    .header {
         padding-inline: 18px;
     }
 }

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentMemoryPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentMemoryPage.tsx
@@ -59,13 +59,11 @@ const AiAgentMemoryPage = () => {
                         />
                     </Group>
                     <Divider />
-                    <Box className={styles.body}>
-                        <MemoryDetails
-                            memory={memoryQuery.data}
-                            projectUuid={projectUuid}
-                            agentUuid={agentUuid}
-                        />
-                    </Box>
+                    <MemoryDetails
+                        memory={memoryQuery.data}
+                        projectUuid={projectUuid}
+                        agentUuid={agentUuid}
+                    />
                 </Paper>
             </Stack>
         </Box>


### PR DESCRIPTION
Follow-up to #26557.

Two bits of chrome on the memory details surfaces (the modal opened from a citation or from the admin memories table, plus the standalone memory page).

- **Icon in the header.** `MemoryDetailsModal` (and its loading state in `MemoryDetailsBySlugModal`) now pass `icon={IconNotebook}`, matching the My memories modal. The hand-rolled `.modalTitle` is gone — the title is a plain string again, so it renders with `MantineModal`'s own typography.
- **The rail divider attaches to the header rule.** It used to start below the body's top padding, leaving a floating gap under the header. `MemoryDetails` now owns its padding (on `.main` / `.rail` instead of the container), so the layout is full-bleed and the vertical divider meets the horizontal one in a T. `min-height: 100%` on the grid also runs the divider the full height of the pane when the memory is short, instead of stopping mid-air.

Consumers updated to stop supplying the padding: `MemoryDetailsModal` (`modalBodyProps={{ px: 0, py: 0 }}`), `MyMemoriesModal` (`.detailBody`), `AiAgentMemoryPage` (dropped the padded wrapper `Box`).

## Testing

- Browser (Playwright, dev stack), measuring divider-top minus header-bottom on all three surfaces: admin modal 0px (0px still when scrolled), My memories detail pane 0px, standalone memory page 1px (the page's `Divider` element). Icon confirmed present in the modal header.
- `pnpm -F frontend typecheck`, `lint`, and the 45 aiCopilot test files (240 tests) pass.

Relates: ZAP-730
