### PR TITLE
feat(cli): upload a dashboard's data apps before the dashboard

### DIFF
--- a/packages/cli/src/handlers/apps/appCodeFiles.test.ts
+++ b/packages/cli/src/handlers/apps/appCodeFiles.test.ts
@@ -592,4 +592,22 @@ describe('appFolderNeedsUpdating', () => {
             appFolderNeedsUpdating(buildFolder(), {} as AnyType),
         ).resolves.toBe(true);
     });
+
+    it('is true when downloadedAt is unparseable', async () => {
+        await expect(
+            appFolderNeedsUpdating(buildFolder(), {
+                downloadedAt: 'not-a-date',
+            } as AnyType),
+        ).resolves.toBe(true);
+    });
+
+    it('is true when a nested src file was edited', async () => {
+        const dir = buildFolder();
+        mkdirSync(path.join(dir, 'src', 'components'), { recursive: true });
+        const nested = path.join(dir, 'src', 'components', 'Chart.tsx');
+        writeFileSync(nested, 'x');
+        const later = new Date('2026-07-30T13:00:00.000Z');
+        utimesSync(nested, later, later);
+        await expect(appFolderNeedsUpdating(dir, manifest)).resolves.toBe(true);
+    });
 });

--- a/packages/cli/src/handlers/apps/appCodeFiles.test.ts
+++ b/packages/cli/src/handlers/apps/appCodeFiles.test.ts
@@ -1,9 +1,20 @@
-import { type DataAppCode, type DataAppDependencies } from '@lightdash/common';
-import { promises as fs } from 'fs';
+import {
+    type AnyType,
+    type DataAppCode,
+    type DataAppDependencies,
+} from '@lightdash/common';
+import {
+    promises as fs,
+    mkdirSync,
+    mkdtempSync,
+    utimesSync,
+    writeFileSync,
+} from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import {
     appFolderName,
+    appFolderNeedsUpdating,
     applySdkMirrorToTemplateDeps,
     attachDependenciesToCode,
     buildDepsWarningLines,
@@ -513,5 +524,72 @@ describe('applySdkMirrorToTemplateDeps', () => {
         expect(applySdkMirrorToTemplateDeps(template, 'not-json')).toEqual(
             template,
         );
+    });
+});
+
+// ─── appFolderNeedsUpdating ────────────────────────────────────────────────────
+
+describe('appFolderNeedsUpdating', () => {
+    const DOWNLOADED_AT = '2026-07-30T12:00:00.000Z';
+    const manifest = { downloadedAt: DOWNLOADED_AT } as AnyType;
+
+    const buildFolder = () => {
+        const dir = mkdtempSync(path.join(os.tmpdir(), 'ld-app-folder-'));
+        mkdirSync(path.join(dir, 'src'), { recursive: true });
+        writeFileSync(path.join(dir, 'src', 'App.tsx'), 'x');
+        writeFileSync(path.join(dir, 'lightdash-app.yml'), 'slug: x');
+        mkdirSync(path.join(dir, '.lightdash', 'context'), {
+            recursive: true,
+        });
+        writeFileSync(
+            path.join(dir, '.lightdash', 'context', 'semantic-layer.yml'),
+            'models: []',
+        );
+        const at = new Date(DOWNLOADED_AT);
+        [
+            path.join(dir, 'src', 'App.tsx'),
+            path.join(dir, 'lightdash-app.yml'),
+            path.join(dir, '.lightdash', 'context', 'semantic-layer.yml'),
+        ].forEach((file) => utimesSync(file, at, at));
+        return dir;
+    };
+
+    it('is false for a freshly downloaded folder', async () => {
+        await expect(
+            appFolderNeedsUpdating(buildFolder(), manifest),
+        ).resolves.toBe(false);
+    });
+
+    it('is true when a src file was edited', async () => {
+        const dir = buildFolder();
+        const later = new Date('2026-07-30T13:00:00.000Z');
+        utimesSync(path.join(dir, 'src', 'App.tsx'), later, later);
+        await expect(appFolderNeedsUpdating(dir, manifest)).resolves.toBe(true);
+    });
+
+    it('is true when the manifest was edited', async () => {
+        const dir = buildFolder();
+        const later = new Date('2026-07-30T13:00:00.000Z');
+        utimesSync(path.join(dir, 'lightdash-app.yml'), later, later);
+        await expect(appFolderNeedsUpdating(dir, manifest)).resolves.toBe(true);
+    });
+
+    it('ignores regenerated context files', async () => {
+        const dir = buildFolder();
+        const later = new Date('2026-07-30T13:00:00.000Z');
+        utimesSync(
+            path.join(dir, '.lightdash', 'context', 'semantic-layer.yml'),
+            later,
+            later,
+        );
+        await expect(appFolderNeedsUpdating(dir, manifest)).resolves.toBe(
+            false,
+        );
+    });
+
+    it('is true when downloadedAt is missing', async () => {
+        await expect(
+            appFolderNeedsUpdating(buildFolder(), {} as AnyType),
+        ).resolves.toBe(true);
     });
 });

--- a/packages/cli/src/handlers/apps/appCodeFiles.ts
+++ b/packages/cli/src/handlers/apps/appCodeFiles.ts
@@ -305,6 +305,57 @@ export const attachDependenciesToCode = (
 ): DataAppCode =>
     Object.keys(customDeps).length > 0 ? { ...code, dependencies: deps } : code;
 
+const CHANGE_TOLERANCE_MS = 30_000;
+
+const collectMtimes = async (dir: string): Promise<number[]> => {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    const nested = await Promise.all(
+        entries.map(async (entry) => {
+            const entryPath = path.join(dir, entry.name);
+            if (entry.isDirectory()) return collectMtimes(entryPath);
+            const stats = await fs.stat(entryPath);
+            return [stats.mtime.getTime()];
+        }),
+    );
+    return nested.flat();
+};
+
+const statMtime = async (file: string): Promise<number[]> =>
+    fs
+        .stat(file)
+        .then((stats) => [stats.mtime.getTime()])
+        .catch(() => []);
+
+/**
+ * Mirrors the chart/dashboard rule: changed when a file that actually gets
+ * uploaded has drifted more than 30s from the manifest's downloadedAt.
+ */
+export const appFolderNeedsUpdating = async (
+    dir: string,
+    manifest: DataAppManifest,
+): Promise<boolean> => {
+    if (!manifest.downloadedAt) return true;
+    const downloadedAt = new Date(manifest.downloadedAt).getTime();
+    if (Number.isNaN(downloadedAt)) return true;
+
+    const srcDir = path.join(dir, 'src');
+    const srcExists = await fs
+        .stat(srcDir)
+        .then((s) => s.isDirectory())
+        .catch(() => false);
+
+    const mtimes = [
+        ...(srcExists ? await collectMtimes(srcDir) : []),
+        ...(await statMtime(path.join(dir, 'package.json'))),
+        ...(await statMtime(path.join(dir, 'pnpm-lock.yaml'))),
+        ...(await statMtime(path.join(dir, MANIFEST_FILENAME))),
+    ];
+
+    return mtimes.some(
+        (mtime) => Math.abs(mtime - downloadedAt) > CHANGE_TOLERANCE_MS,
+    );
+};
+
 export const readManifestFromDir = async (
     dir: string,
 ): Promise<DataAppManifest> => {

--- a/packages/cli/src/handlers/apps/appsDownload.test.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.test.ts
@@ -831,4 +831,18 @@ describe('shouldAutoPushApp', () => {
             }),
         ).toBe(true);
     });
+
+    it('pushes a slug-less manifest against an older server with unknown presence', () => {
+        expect(
+            shouldAutoPushApp({
+                manifest: { slug: undefined, projectUuid: 'source-project' },
+                presence: {
+                    kind: 'unknown',
+                    targetProjectUuid: 'source-project',
+                },
+                folderChanged: false,
+                force: false,
+            }),
+        ).toBe(true);
+    });
 });

--- a/packages/cli/src/handlers/apps/appsDownload.test.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.test.ts
@@ -24,6 +24,7 @@ import {
     preSlugUploadHint,
     resolveAppsLimit,
     selectAppsToDownload,
+    shouldAutoPushApp,
     shouldFallBackToSpaceScopedListing,
     shouldWarnAllSkipped,
     unmatchedUploadRefsWarning,
@@ -737,5 +738,97 @@ describe('downloadAppsToDir', () => {
 
         expect(outcome.skippedNotBuiltCount).toBe(1);
         expect(outcome.failures).toEqual([]);
+    });
+});
+
+describe('shouldAutoPushApp', () => {
+    const manifest = {
+        slug: 'revenue-explorer',
+        projectUuid: 'source-project',
+    };
+    const known = (...slugs: string[]): AnyType => ({
+        kind: 'known',
+        slugs: new Set(slugs),
+    });
+
+    it('pushes when the target project does not have the app', () => {
+        expect(
+            shouldAutoPushApp({
+                manifest,
+                presence: known(),
+                folderChanged: false,
+                force: false,
+            }),
+        ).toBe(true);
+    });
+
+    it('pushes when the app exists and the folder changed', () => {
+        expect(
+            shouldAutoPushApp({
+                manifest,
+                presence: known('revenue-explorer'),
+                folderChanged: true,
+                force: false,
+            }),
+        ).toBe(true);
+    });
+
+    it('skips when the app exists and nothing changed', () => {
+        expect(
+            shouldAutoPushApp({
+                manifest,
+                presence: known('revenue-explorer'),
+                folderChanged: false,
+                force: false,
+            }),
+        ).toBe(false);
+    });
+
+    it('pushes an unchanged existing app under --force', () => {
+        expect(
+            shouldAutoPushApp({
+                manifest,
+                presence: known('revenue-explorer'),
+                folderChanged: false,
+                force: true,
+            }),
+        ).toBe(true);
+    });
+
+    it('falls back to the project comparison when presence is unknown', () => {
+        expect(
+            shouldAutoPushApp({
+                manifest,
+                presence: {
+                    kind: 'unknown',
+                    targetProjectUuid: 'other-project',
+                },
+                folderChanged: false,
+                force: false,
+            }),
+        ).toBe(true);
+
+        expect(
+            shouldAutoPushApp({
+                manifest,
+                presence: {
+                    kind: 'unknown',
+                    targetProjectUuid: 'source-project',
+                },
+                folderChanged: false,
+                force: false,
+            }),
+        ).toBe(false);
+    });
+
+    it('pushes a slug-less manifest so a pre-slug bundle still lands', () => {
+        expect(
+            shouldAutoPushApp({
+                manifest: { slug: undefined, projectUuid: 'source-project' },
+                presence: known('revenue-explorer'),
+                folderChanged: false,
+                force: false,
+            }),
+        ).toBe(true);
     });
 });

--- a/packages/cli/src/handlers/apps/appsDownload.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.ts
@@ -207,6 +207,33 @@ export const preSlugUploadHint = (args: {
             : ''
     }. Uploads keep working via uuid matching meanwhile.`;
 
+export type AppPresence =
+    // Slugs the target project already has. Authoritative.
+    | { kind: 'known'; slugs: Set<string> }
+    // Listing unavailable or slug-less (older server): fall back to comparing
+    // the manifest's source project against the upload target.
+    | { kind: 'unknown'; targetProjectUuid: string };
+
+/**
+ * Auto-pushed apps normally upload only when the folder changed, because every
+ * upload triggers a sandbox rebuild. The exception is an app the target project
+ * does not have yet — without it a dashboard moved to a new project or instance
+ * lands with its tile skipped.
+ */
+export const shouldAutoPushApp = (args: {
+    manifest: Pick<DataAppManifest, 'slug' | 'projectUuid'>;
+    presence: AppPresence;
+    folderChanged: boolean;
+    force: boolean;
+}): boolean => {
+    if (args.force || args.folderChanged) return true;
+    if (args.manifest.slug === undefined) return true;
+    if (args.presence.kind === 'known') {
+        return !args.presence.slugs.has(args.manifest.slug);
+    }
+    return args.manifest.projectUuid !== args.presence.targetProjectUuid;
+};
+
 export type AppDownloadFailure = { appRef: string; message: string };
 
 export type AppDownloadErrorOutcome =

--- a/packages/cli/src/handlers/download.test.ts
+++ b/packages/cli/src/handlers/download.test.ts
@@ -69,6 +69,7 @@ vi.mock('./dbt/apiClient', async (importOriginal) => ({
 const {
     assertUniqueSpacePaths,
     downloadSpaces,
+    getDashboardAppSlugs,
     getDashboardChartSlugs,
     getFlatSpaceFileNames,
     hasContentFilters,
@@ -246,6 +247,34 @@ const writeFolderDashboard = async (
             (s) =>
                 `  - properties:\n      chartSlug: ${s}\n    type: saved_chart`,
         )
+        .join('\n');
+    const yaml = `contentType: dashboard\nname: ${slug}\nslug: ${slug}\nspaceSlug: test-space\ntiles:\n${tilesYaml}\nversion: 1\n`;
+    await fs.writeFile(path.join(baseDir, 'dashboards', `${slug}.yml`), yaml);
+};
+
+const makeLooseAppDashboard = (
+    slug: string,
+    appSlugs: (string | null)[],
+): LooseDashboard =>
+    ({
+        slug,
+        name: slug,
+        spaceSlug: 'test-space',
+        version: 1,
+        tiles: appSlugs.map((appSlug) => ({
+            type: 'data_app',
+            properties: { appSlug },
+        })),
+        needsUpdating: false,
+    }) as unknown as LooseDashboard;
+
+const writeFolderAppDashboard = async (
+    baseDir: string,
+    slug: string,
+    appSlugs: string[],
+) => {
+    const tilesYaml = appSlugs
+        .map((s) => `  - properties:\n      appSlug: ${s}\n    type: data_app`)
         .join('\n');
     const yaml = `contentType: dashboard\nname: ${slug}\nslug: ${slug}\nspaceSlug: test-space\ntiles:\n${tilesYaml}\nversion: 1\n`;
     await fs.writeFile(path.join(baseDir, 'dashboards', `${slug}.yml`), yaml);
@@ -437,6 +466,48 @@ describe('extractAppSlugsFromDashboards', () => {
                 ]),
             ]),
         ).toEqual(['one']);
+    });
+});
+
+describe('getDashboardAppSlugs', () => {
+    let tmpDir: string;
+
+    beforeEach(async () => {
+        tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'download-test-'));
+        await fs.mkdir(path.join(tmpDir, 'dashboards'));
+    });
+
+    afterEach(async () => {
+        await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('extracts app slugs from folder dashboards', async () => {
+        await writeFolderAppDashboard(tmpDir, 'folder-dash', [
+            'app-a',
+            'app-b',
+        ]);
+        const slugs = await getDashboardAppSlugs([], tmpDir);
+        expect(slugs.sort()).toEqual(['app-a', 'app-b']);
+    });
+
+    it('filters to the selected dashboards only', async () => {
+        await writeFolderAppDashboard(tmpDir, 'wanted', ['wanted-app']);
+        const loose = makeLooseAppDashboard('other', ['other-app']);
+        const slugs = await getDashboardAppSlugs(['wanted'], tmpDir, [loose]);
+        expect(slugs).toEqual(['wanted-app']);
+    });
+
+    it('dedupes across dashboards and drops null slugs', async () => {
+        await writeFolderAppDashboard(tmpDir, 'folder-dash', ['shared-app']);
+        const loose = makeLooseAppDashboard('loose-dash', ['shared-app', null]);
+        const slugs = await getDashboardAppSlugs([], tmpDir, [loose]);
+        expect(slugs).toEqual(['shared-app']);
+    });
+
+    it('returns an empty array when no dashboard has an app tile', async () => {
+        await writeFolderDashboard(tmpDir, 'chart-only', ['chart-a']);
+        const slugs = await getDashboardAppSlugs([], tmpDir);
+        expect(slugs).toEqual([]);
     });
 });
 

--- a/packages/cli/src/handlers/download.test.ts
+++ b/packages/cli/src/handlers/download.test.ts
@@ -76,6 +76,7 @@ const {
     isAiAgentsUnavailableError,
     isExternalConnectionsUnavailableError,
     downloadAiAgents,
+    isFilteredWithNoDashboards,
     readAiAgentFiles,
     readSpaceFiles,
     readSpaceNames,
@@ -508,6 +509,20 @@ describe('getDashboardAppSlugs', () => {
         await writeFolderDashboard(tmpDir, 'chart-only', ['chart-a']);
         const slugs = await getDashboardAppSlugs([], tmpDir);
         expect(slugs).toEqual([]);
+    });
+});
+
+describe('isFilteredWithNoDashboards', () => {
+    it('is true for a filtered upload that selects no dashboards (e.g. --charts only)', () => {
+        expect(isFilteredWithNoDashboards(true, [])).toBe(true);
+    });
+
+    it('is false for an unfiltered upload even with no dashboard slugs', () => {
+        expect(isFilteredWithNoDashboards(false, [])).toBe(false);
+    });
+
+    it('is false once dashboard slugs are provided', () => {
+        expect(isFilteredWithNoDashboards(true, ['my-dashboard'])).toBe(false);
     });
 });
 

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -45,6 +45,7 @@ import {
     SqlChartAsCode,
     validateDataAppDependencies,
     VirtualViewAsCode,
+    type DashboardAsCodeUpsertResult,
     type DataAppCodeDownload,
     type SpaceAsCode,
 } from '@lightdash/common';
@@ -66,6 +67,7 @@ import {
     type ContentAsCodeOutputVariant,
 } from '../terminal/contentAsCodeOutput';
 import {
+    appFolderNeedsUpdating,
     applySdkMirrorToTemplateDeps,
     attachDependenciesToCode,
     buildDepsWarningLines,
@@ -85,9 +87,11 @@ import {
     preSlugUploadHint,
     resolveAppsLimit,
     selectAppsToDownload,
+    shouldAutoPushApp,
     shouldFallBackToSpaceScopedListing,
     unmatchedUploadRefsWarning,
     uploadFilterMatches,
+    type AppPresence,
 } from './apps/appsDownload';
 import { loadTemplateDependencies } from './apps/scaffolding';
 import {
@@ -2459,7 +2463,8 @@ const upsertSingleItem = async <T extends ChartAsCode | DashboardAsCode>(
             : `/api/v1/projects/${projectId}/code/${type}/${item.slug}`;
 
         const upsertData = await lightdashApi<
-            ApiChartAsCodeUpsertResponse['results']
+            ApiChartAsCodeUpsertResponse['results'] &
+                Pick<DashboardAsCodeUpsertResult, 'warnings'>
         >({
             method: 'POST',
             url: endpoint,
@@ -2475,6 +2480,9 @@ const upsertSingleItem = async <T extends ChartAsCode | DashboardAsCode>(
 
         GlobalState.debug(
             `${type} "${item.name}": ${upsertData[type]?.[0].action}`,
+        );
+        (upsertData.warnings ?? []).forEach((warning) =>
+            GlobalState.log(styles.warning(`  ⚠ ${item.slug}: ${warning}`)),
         );
 
         // Merge storeUploadChanges result into changes in-place
@@ -2803,6 +2811,26 @@ const getDashboardChartSlugs = async (
     }, []);
 };
 
+const getDashboardAppSlugs = async (
+    dashboardSlugs: string[],
+    customPath?: string,
+    looseDashboards: (DashboardAsCode & { needsUpdating: boolean })[] = [],
+): Promise<string[]> => {
+    const folderDashboards = await readCodeFiles<DashboardAsCode>(
+        'dashboards',
+        customPath,
+    );
+    const dashboardItems = [...folderDashboards, ...looseDashboards];
+    const selected =
+        dashboardSlugs.length > 0
+            ? dashboardItems.filter((dashboard) =>
+                  dashboardSlugs.includes(dashboard.slug),
+              )
+            : dashboardItems;
+
+    return [...new Set(extractAppSlugsFromDashboards(selected))];
+};
+
 export const uploadHandler = async (
     options: DownloadHandlerOptions,
 ): Promise<void> => {
@@ -2998,217 +3026,22 @@ export const uploadHandler = async (
             }
         }
 
-        changes = await runUploadChangesPhase({
-            output,
-            label: 'Charts',
-            changes,
-            action: async () => {
-                const chartSlugs = options.includeCharts
-                    ? Array.from(
-                          new Set([
-                              ...options.charts,
-                              ...(await getDashboardChartSlugs(
-                                  options.dashboards,
-                                  options.path,
-                                  looseFiles.dashboards,
-                              )),
-                          ]),
-                      )
-                    : options.charts;
-                if (hasFilters && chartSlugs.length === 0) {
-                    GlobalState.log(
-                        styles.warning(`No charts filters provided, skipping`),
-                    );
-                    return changes;
-                }
-                const result = await upsertResources<ChartAsCode>(
-                    'charts',
-                    projectId,
-                    changes,
-                    options.force,
-                    chartSlugs,
-                    uploadPermissions.charts,
-                    options.path,
-                    options.skipSpaceCreate,
-                    options.public,
-                    options.validate,
-                    concurrency,
-                    looseFiles.charts,
-                    spaceNames,
-                );
-                chartTotal = result.total;
-                return result.changes;
-            },
-        });
-
-        changes = await runUploadChangesPhase({
-            output,
-            label: 'Dashboards',
-            changes,
-            action: async () => {
-                if (hasFilters && options.dashboards.length === 0) {
-                    GlobalState.log(
-                        styles.warning(
-                            `No dashboard filters provided, skipping`,
-                        ),
-                    );
-                    return changes;
-                }
-                const result = await upsertResources<DashboardAsCode>(
-                    'dashboards',
-                    projectId,
-                    changes,
-                    options.force,
-                    options.dashboards,
-                    uploadPermissions.dashboards,
-                    options.path,
-                    options.skipSpaceCreate,
-                    options.public,
-                    options.validate,
-                    concurrency,
-                    looseFiles.dashboards,
-                    spaceNames,
-                );
-                dashboardTotal = result.total;
-                return result.changes;
-            },
-        });
-
-        if (!options.skipAgents) {
-            if (hasFilters && options.agents.length === 0) {
-                GlobalState.log(
-                    styles.warning(`No AI agent filters provided, skipping`),
-                );
-            } else {
-                try {
-                    changes = await runUploadChangesPhase({
-                        output,
-                        label: 'AI agents',
-                        changes,
-                        action: () =>
-                            upsertAiAgents(
-                                projectId,
-                                options.agents,
-                                changes,
-                                options.force,
-                                options.path,
-                                options.agents.length === 0,
-                            ),
-                    });
-                } catch (error) {
-                    throw new AiAgentAsCodeUploadError(error);
-                }
-            }
-        }
-
-        if (!options.skipAlerts) {
-            if (hasFilters && options.alerts.length === 0) {
-                GlobalState.log(
-                    styles.warning(`No alert filters provided, skipping`),
-                );
-            } else {
-                changes = await runUploadChangesPhase({
-                    output,
-                    label: 'Alerts',
-                    changes,
-                    action: () =>
-                        upsertScheduledContent(
-                            projectId,
-                            options.alerts,
-                            changes,
-                            options.force,
-                            ContentAsCodeTypeEnum.ALERT,
-                            uploadPermissions.alerts,
-                            options.path,
-                        ),
-                });
-            }
-        }
-
-        if (!options.skipScheduledDeliveries) {
-            if (hasFilters && options.scheduledDeliveries.length === 0) {
-                GlobalState.log(
-                    styles.warning(
-                        `No scheduled delivery filters provided, skipping`,
-                    ),
-                );
-            } else {
-                changes = await runUploadChangesPhase({
-                    output,
-                    label: 'Scheduled deliveries',
-                    changes,
-                    action: () =>
-                        upsertScheduledContent(
-                            projectId,
-                            options.scheduledDeliveries,
-                            changes,
-                            options.force,
-                            ContentAsCodeTypeEnum.SCHEDULED_DELIVERY,
-                            uploadPermissions.scheduledDeliveries,
-                            options.path,
-                        ),
-                });
-            }
-        }
-
-        if (!options.skipGoogleSheets) {
-            if (hasFilters && options.googleSheets.length === 0) {
-                GlobalState.log(
-                    styles.warning(
-                        `No Google Sheets sync filters provided, skipping`,
-                    ),
-                );
-            } else {
-                changes = await runUploadChangesPhase({
-                    output,
-                    label: 'Google Sheets syncs',
-                    changes,
-                    action: () =>
-                        upsertScheduledContent(
-                            projectId,
-                            options.googleSheets,
-                            changes,
-                            options.force,
-                            ContentAsCodeTypeEnum.GOOGLE_SHEETS_SYNC,
-                            uploadPermissions.googleSheets,
-                            options.path,
-                        ),
-                });
-            }
-        }
-
-        if (!options.skipExternalConnections) {
-            if (hasFilters && options.externalConnections.length === 0) {
-                GlobalState.log(
-                    styles.warning(
-                        `No external connection filters provided, skipping`,
-                    ),
-                );
-            } else {
-                changes = await runUploadChangesPhase({
-                    output,
-                    label: 'External connections',
-                    changes,
-                    action: () =>
-                        upsertExternalConnections(
-                            projectId,
-                            options.externalConnections,
-                            changes,
-                            options.force,
-                            uploadPermissions.externalConnections,
-                            options.path,
-                        ),
-                });
-            }
-        }
-
         // Upload data apps (enterprise, opt-in via --apps <references...> or
-        // --include-apps, fire-and-forget)
+        // --include-apps; also auto-pushed when a dashboard being uploaded
+        // references one, so its tiles resolve in the target project). Apps
+        // must land before dashboards — mirrors PromoteService.upsertDataApps.
         const explicitAppReferences = Array.isArray(options.apps)
             ? options.apps
             : [];
-        const shouldUploadApps =
+        const isExplicitAppSelection =
             options.includeApps === true || explicitAppReferences.length > 0;
+        const autoPushAppSlugs = await getDashboardAppSlugs(
+            options.dashboards,
+            options.path,
+            looseFiles.dashboards,
+        );
+        const shouldUploadApps =
+            isExplicitAppSelection || autoPushAppSlugs.length > 0;
 
         let appsCreated = 0;
         let appsUpdated = 0;
@@ -3220,19 +3053,54 @@ export const uploadHandler = async (
         if (shouldUploadApps && !uploadPermissions.dataApps) {
             output.startItem('Data apps');
             GlobalState.log(
-                styles.error(
-                    `Error uploading data apps: create:DataApp or manage:DataApp permission is required`,
+                styles.warning(
+                    `Skipping data apps: create:DataApp or manage:DataApp permission is required. Dashboard tiles will resolve only if their apps already exist in this project.`,
                 ),
             );
             output.completeItem('permission denied', 'warning');
         } else if (shouldUploadApps) {
             output.startItem('Data apps');
             // --include-apps uploads every folder on disk; explicit references
-            // filter folders by their manifest slug or appUuid
-            const uploadFilter = getDataAppUploadFilter(
-                explicitAppReferences,
-                options.includeApps === true,
-            );
+            // filter folders by their manifest slug or appUuid. A pure
+            // auto-push run keeps no filter here — candidacy is decided per
+            // folder below instead, against the dashboards' referenced slugs.
+            const uploadFilter = isExplicitAppSelection
+                ? getDataAppUploadFilter(
+                      explicitAppReferences,
+                      options.includeApps === true,
+                  )
+                : null;
+
+            // The manifest keeps naming the source project forever, so
+            // comparing it to the target would re-push on every run against
+            // prod. Listing the target's apps settles after the first push.
+            let presence: AppPresence = {
+                kind: 'unknown',
+                targetProjectUuid: projectId,
+            };
+            if (autoPushAppSlugs.length > 0) {
+                try {
+                    const projectApps = await lightdashApi<
+                        ApiEmbedProjectAppsResponse['results']
+                    >({
+                        method: 'GET',
+                        url: `/api/v1/ee/projects/${projectId}/apps`,
+                        body: undefined,
+                    });
+                    // An older server answers without slugs; that is not an
+                    // error, but it is not an answer either.
+                    if (projectApps.every((app) => app.slug !== undefined)) {
+                        presence = {
+                            kind: 'known',
+                            slugs: new Set(projectApps.map((app) => app.slug)),
+                        };
+                    }
+                } catch (listErr) {
+                    GlobalState.debug(
+                        `Could not list target project apps: ${getErrorMessage(listErr)}`,
+                    );
+                }
+            }
 
             const baseDir = getDownloadFolder(options.path);
             const appsDir = path.join(baseDir, 'apps');
@@ -3281,6 +3149,36 @@ export const uploadHandler = async (
                         matchedUploadRefs(uploadFilter, code.manifest).forEach(
                             (ref) => matchedRefs.add(ref),
                         );
+                    }
+
+                    if (!isExplicitAppSelection) {
+                        const isAutoPushCandidate =
+                            code.manifest.slug !== undefined &&
+                            autoPushAppSlugs.includes(code.manifest.slug);
+                        if (!isAutoPushCandidate) {
+                            // eslint-disable-next-line no-continue
+                            continue;
+                        }
+                        // eslint-disable-next-line no-await-in-loop
+                        const folderChanged = await appFolderNeedsUpdating(
+                            folderPath,
+                            code.manifest,
+                        );
+                        if (
+                            !shouldAutoPushApp({
+                                manifest: code.manifest,
+                                presence,
+                                folderChanged,
+                                force: options.force === true,
+                            })
+                        ) {
+                            GlobalState.debug(
+                                `Skipping app "${subDir.name}" — unchanged and already in the target project`,
+                            );
+                            appsSkipped += 1;
+                            // eslint-disable-next-line no-continue
+                            continue;
+                        }
                     }
 
                     // Read declared dependencies from the app folder (optional).
@@ -3509,6 +3407,210 @@ export const uploadHandler = async (
             }
         }
 
+        changes = await runUploadChangesPhase({
+            output,
+            label: 'Charts',
+            changes,
+            action: async () => {
+                const chartSlugs = options.includeCharts
+                    ? Array.from(
+                          new Set([
+                              ...options.charts,
+                              ...(await getDashboardChartSlugs(
+                                  options.dashboards,
+                                  options.path,
+                                  looseFiles.dashboards,
+                              )),
+                          ]),
+                      )
+                    : options.charts;
+                if (hasFilters && chartSlugs.length === 0) {
+                    GlobalState.log(
+                        styles.warning(`No charts filters provided, skipping`),
+                    );
+                    return changes;
+                }
+                const result = await upsertResources<ChartAsCode>(
+                    'charts',
+                    projectId,
+                    changes,
+                    options.force,
+                    chartSlugs,
+                    uploadPermissions.charts,
+                    options.path,
+                    options.skipSpaceCreate,
+                    options.public,
+                    options.validate,
+                    concurrency,
+                    looseFiles.charts,
+                    spaceNames,
+                );
+                chartTotal = result.total;
+                return result.changes;
+            },
+        });
+
+        changes = await runUploadChangesPhase({
+            output,
+            label: 'Dashboards',
+            changes,
+            action: async () => {
+                if (hasFilters && options.dashboards.length === 0) {
+                    GlobalState.log(
+                        styles.warning(
+                            `No dashboard filters provided, skipping`,
+                        ),
+                    );
+                    return changes;
+                }
+                const result = await upsertResources<DashboardAsCode>(
+                    'dashboards',
+                    projectId,
+                    changes,
+                    options.force,
+                    options.dashboards,
+                    uploadPermissions.dashboards,
+                    options.path,
+                    options.skipSpaceCreate,
+                    options.public,
+                    options.validate,
+                    concurrency,
+                    looseFiles.dashboards,
+                    spaceNames,
+                );
+                dashboardTotal = result.total;
+                return result.changes;
+            },
+        });
+
+        if (!options.skipAgents) {
+            if (hasFilters && options.agents.length === 0) {
+                GlobalState.log(
+                    styles.warning(`No AI agent filters provided, skipping`),
+                );
+            } else {
+                try {
+                    changes = await runUploadChangesPhase({
+                        output,
+                        label: 'AI agents',
+                        changes,
+                        action: () =>
+                            upsertAiAgents(
+                                projectId,
+                                options.agents,
+                                changes,
+                                options.force,
+                                options.path,
+                                options.agents.length === 0,
+                            ),
+                    });
+                } catch (error) {
+                    throw new AiAgentAsCodeUploadError(error);
+                }
+            }
+        }
+
+        if (!options.skipAlerts) {
+            if (hasFilters && options.alerts.length === 0) {
+                GlobalState.log(
+                    styles.warning(`No alert filters provided, skipping`),
+                );
+            } else {
+                changes = await runUploadChangesPhase({
+                    output,
+                    label: 'Alerts',
+                    changes,
+                    action: () =>
+                        upsertScheduledContent(
+                            projectId,
+                            options.alerts,
+                            changes,
+                            options.force,
+                            ContentAsCodeTypeEnum.ALERT,
+                            uploadPermissions.alerts,
+                            options.path,
+                        ),
+                });
+            }
+        }
+
+        if (!options.skipScheduledDeliveries) {
+            if (hasFilters && options.scheduledDeliveries.length === 0) {
+                GlobalState.log(
+                    styles.warning(
+                        `No scheduled delivery filters provided, skipping`,
+                    ),
+                );
+            } else {
+                changes = await runUploadChangesPhase({
+                    output,
+                    label: 'Scheduled deliveries',
+                    changes,
+                    action: () =>
+                        upsertScheduledContent(
+                            projectId,
+                            options.scheduledDeliveries,
+                            changes,
+                            options.force,
+                            ContentAsCodeTypeEnum.SCHEDULED_DELIVERY,
+                            uploadPermissions.scheduledDeliveries,
+                            options.path,
+                        ),
+                });
+            }
+        }
+
+        if (!options.skipGoogleSheets) {
+            if (hasFilters && options.googleSheets.length === 0) {
+                GlobalState.log(
+                    styles.warning(
+                        `No Google Sheets sync filters provided, skipping`,
+                    ),
+                );
+            } else {
+                changes = await runUploadChangesPhase({
+                    output,
+                    label: 'Google Sheets syncs',
+                    changes,
+                    action: () =>
+                        upsertScheduledContent(
+                            projectId,
+                            options.googleSheets,
+                            changes,
+                            options.force,
+                            ContentAsCodeTypeEnum.GOOGLE_SHEETS_SYNC,
+                            uploadPermissions.googleSheets,
+                            options.path,
+                        ),
+                });
+            }
+        }
+
+        if (!options.skipExternalConnections) {
+            if (hasFilters && options.externalConnections.length === 0) {
+                GlobalState.log(
+                    styles.warning(
+                        `No external connection filters provided, skipping`,
+                    ),
+                );
+            } else {
+                changes = await runUploadChangesPhase({
+                    output,
+                    label: 'External connections',
+                    changes,
+                    action: () =>
+                        upsertExternalConnections(
+                            projectId,
+                            options.externalConnections,
+                            changes,
+                            options.force,
+                            uploadPermissions.externalConnections,
+                            options.path,
+                        ),
+                });
+            }
+        }
+
         const end = Date.now();
 
         await LightdashAnalytics.track({
@@ -3546,6 +3648,7 @@ export const testHelpers = {
     downloadSpaces,
     extractAppSlugsFromDashboards,
     getFlatSpaceFileNames,
+    getDashboardAppSlugs,
     getDashboardChartSlugs,
     hasContentFilters,
     isAiAgentsUnavailableError,

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -2777,59 +2777,81 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
     return { changes, total: filteredItems.length };
 };
 
-const getDashboardChartSlugs = async (
-    dashboardSlugs: string[],
+// readCodeFiles walks the whole download folder recursively, so callers that
+// need both chart and app slugs should read once and reuse the result.
+const readDashboardItems = async (
     customPath?: string,
     looseDashboards: (DashboardAsCode & { needsUpdating: boolean })[] = [],
-) => {
+): Promise<DashboardAsCode[]> => {
     const folderDashboards = await readCodeFiles<DashboardAsCode>(
         'dashboards',
         customPath,
     );
-    const dashboardItems = [...folderDashboards, ...looseDashboards];
-
-    const filteredDashboardItems =
-        dashboardSlugs.length > 0
-            ? dashboardItems.filter((dashboard) =>
-                  dashboardSlugs.includes(dashboard.slug),
-              )
-            : dashboardItems;
-
-    return filteredDashboardItems.reduce<string[]>((acc, dashboard) => {
-        const dashboardChartSlugs = dashboard.tiles
-            .map((tile) =>
-                'chartSlug' in tile.properties
-                    ? tile.properties.chartSlug
-                    : undefined,
-            )
-            .filter(
-                (dashboardChartSlug): dashboardChartSlug is string =>
-                    !!dashboardChartSlug,
-            );
-
-        return [...acc, ...dashboardChartSlugs];
-    }, []);
+    return [...folderDashboards, ...looseDashboards];
 };
+
+const selectDashboards = (
+    dashboardItems: DashboardAsCode[],
+    dashboardSlugs: string[],
+): DashboardAsCode[] =>
+    dashboardSlugs.length > 0
+        ? dashboardItems.filter((dashboard) =>
+              dashboardSlugs.includes(dashboard.slug),
+          )
+        : dashboardItems;
+
+const selectDashboardChartSlugs = (
+    dashboardItems: DashboardAsCode[],
+    dashboardSlugs: string[],
+): string[] =>
+    selectDashboards(dashboardItems, dashboardSlugs).reduce<string[]>(
+        (acc, dashboard) => {
+            const dashboardChartSlugs = dashboard.tiles
+                .map((tile) =>
+                    'chartSlug' in tile.properties
+                        ? tile.properties.chartSlug
+                        : undefined,
+                )
+                .filter(
+                    (dashboardChartSlug): dashboardChartSlug is string =>
+                        !!dashboardChartSlug,
+                );
+
+            return [...acc, ...dashboardChartSlugs];
+        },
+        [],
+    );
+
+const selectDashboardAppSlugs = (
+    dashboardItems: DashboardAsCode[],
+    dashboardSlugs: string[],
+): string[] => [
+    ...new Set(
+        extractAppSlugsFromDashboards(
+            selectDashboards(dashboardItems, dashboardSlugs),
+        ),
+    ),
+];
+
+const getDashboardChartSlugs = async (
+    dashboardSlugs: string[],
+    customPath?: string,
+    looseDashboards: (DashboardAsCode & { needsUpdating: boolean })[] = [],
+): Promise<string[]> =>
+    selectDashboardChartSlugs(
+        await readDashboardItems(customPath, looseDashboards),
+        dashboardSlugs,
+    );
 
 const getDashboardAppSlugs = async (
     dashboardSlugs: string[],
     customPath?: string,
     looseDashboards: (DashboardAsCode & { needsUpdating: boolean })[] = [],
-): Promise<string[]> => {
-    const folderDashboards = await readCodeFiles<DashboardAsCode>(
-        'dashboards',
-        customPath,
+): Promise<string[]> =>
+    selectDashboardAppSlugs(
+        await readDashboardItems(customPath, looseDashboards),
+        dashboardSlugs,
     );
-    const dashboardItems = [...folderDashboards, ...looseDashboards];
-    const selected =
-        dashboardSlugs.length > 0
-            ? dashboardItems.filter((dashboard) =>
-                  dashboardSlugs.includes(dashboard.slug),
-              )
-            : dashboardItems;
-
-    return [...new Set(extractAppSlugsFromDashboards(selected))];
-};
 
 // Mirrors the Dashboards phase's own guard: a filtered upload with no
 // dashboard slugs uploads no dashboards, so there is nothing to derive from.
@@ -3033,6 +3055,43 @@ export const uploadHandler = async (
             }
         }
 
+        // Apps resolve their external connection links by slug in the target
+        // project, so connections must exist before any app is uploaded.
+        if (!options.skipExternalConnections) {
+            if (hasFilters && options.externalConnections.length === 0) {
+                GlobalState.log(
+                    styles.warning(
+                        `No external connection filters provided, skipping`,
+                    ),
+                );
+            } else {
+                changes = await runUploadChangesPhase({
+                    output,
+                    label: 'External connections',
+                    changes,
+                    action: () =>
+                        upsertExternalConnections(
+                            projectId,
+                            options.externalConnections,
+                            changes,
+                            options.force,
+                            uploadPermissions.externalConnections,
+                            options.path,
+                        ),
+                });
+            }
+        }
+
+        // Both the Data apps and Charts phases derive slugs from the same
+        // dashboard YAML; read the download folder once and share it.
+        let dashboardItemsPromise: Promise<DashboardAsCode[]> | undefined;
+        const loadDashboardItems = () => {
+            dashboardItemsPromise =
+                dashboardItemsPromise ??
+                readDashboardItems(options.path, looseFiles.dashboards);
+            return dashboardItemsPromise;
+        };
+
         // Upload data apps (enterprise; explicit --apps/--include-apps, or
         // auto-pushed for a dashboard's apps). Must land before dashboards.
         const explicitAppReferences = Array.isArray(options.apps)
@@ -3045,10 +3104,9 @@ export const uploadHandler = async (
             options.dashboards,
         )
             ? []
-            : await getDashboardAppSlugs(
+            : selectDashboardAppSlugs(
+                  await loadDashboardItems(),
                   options.dashboards,
-                  options.path,
-                  looseFiles.dashboards,
               );
         const shouldUploadApps =
             isExplicitAppSelection || autoPushAppSlugs.length > 0;
@@ -3058,6 +3116,7 @@ export const uploadHandler = async (
         let appsUnchanged = 0;
         let appsFailed = 0;
         let appsSkipped = 0;
+        let eeAppRoutesUnavailable = false;
         const changesBeforeApps = { ...changes };
 
         if (shouldUploadApps && !uploadPermissions.dataApps) {
@@ -3121,11 +3180,6 @@ export const uploadHandler = async (
                 });
             } catch (err) {
                 if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
-                    GlobalState.log(
-                        styles.warning(
-                            `No apps directory found at ${appsDir}. Run 'lightdash download --include-apps' first.`,
-                        ),
-                    );
                     appFolderEntries = [];
                 } else {
                     throw err;
@@ -3136,7 +3190,11 @@ export const uploadHandler = async (
 
             if (subDirs.length === 0) {
                 GlobalState.log(
-                    styles.warning(`No app folders found in ${appsDir}.`),
+                    styles.warning(
+                        isExplicitAppSelection
+                            ? `No app folders found in ${appsDir}. Run 'lightdash download --include-apps' first.`
+                            : `No app folders found in ${appsDir} for the dashboard(s) being uploaded. Re-run 'lightdash download' to fetch their apps.`,
+                    ),
                 );
             }
 
@@ -3374,11 +3432,22 @@ export const uploadHandler = async (
                         );
                     }
                 } catch (appErr) {
-                    appsFailed += 1;
                     const status =
                         appErr instanceof LightdashError
                             ? appErr.statusCode
                             : undefined;
+                    // Auto-push is flag-free, so a server without the EE app
+                    // routes must not fail an upload the user never asked for.
+                    if (!isExplicitAppSelection && status === 404) {
+                        eeAppRoutesUnavailable = true;
+                        GlobalState.log(
+                            styles.warning(
+                                `Skipping data apps: the enterprise "data apps" feature is not available on this instance. Dashboard tiles will resolve only if their apps already exist in this project.`,
+                            ),
+                        );
+                        break;
+                    }
+                    appsFailed += 1;
                     const hint =
                         status === 404
                             ? ' — the enterprise "data apps" feature may not be enabled on this instance'
@@ -3412,7 +3481,11 @@ export const uploadHandler = async (
                 changesBeforeApps,
                 changes,
             );
-            output.completeItem(appSummary.detail, appSummary.variant);
+            if (eeAppRoutesUnavailable) {
+                output.completeItem('not available on this server', 'warning');
+            } else {
+                output.completeItem(appSummary.detail, appSummary.variant);
+            }
 
             if (appsFailed > 0) {
                 // App uploads are fire-and-forget per folder, so failures are
@@ -3436,11 +3509,10 @@ export const uploadHandler = async (
                     ? Array.from(
                           new Set([
                               ...options.charts,
-                              ...(await getDashboardChartSlugs(
+                              ...selectDashboardChartSlugs(
+                                  await loadDashboardItems(),
                                   options.dashboards,
-                                  options.path,
-                                  looseFiles.dashboards,
-                              )),
+                              ),
                           ]),
                       )
                     : options.charts;
@@ -3600,31 +3672,6 @@ export const uploadHandler = async (
                             options.force,
                             ContentAsCodeTypeEnum.GOOGLE_SHEETS_SYNC,
                             uploadPermissions.googleSheets,
-                            options.path,
-                        ),
-                });
-            }
-        }
-
-        if (!options.skipExternalConnections) {
-            if (hasFilters && options.externalConnections.length === 0) {
-                GlobalState.log(
-                    styles.warning(
-                        `No external connection filters provided, skipping`,
-                    ),
-                );
-            } else {
-                changes = await runUploadChangesPhase({
-                    output,
-                    label: 'External connections',
-                    changes,
-                    action: () =>
-                        upsertExternalConnections(
-                            projectId,
-                            options.externalConnections,
-                            changes,
-                            options.force,
-                            uploadPermissions.externalConnections,
                             options.path,
                         ),
                 });

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -2831,6 +2831,13 @@ const getDashboardAppSlugs = async (
     return [...new Set(extractAppSlugsFromDashboards(selected))];
 };
 
+// Mirrors the Dashboards phase's own guard: a filtered upload with no
+// dashboard slugs uploads no dashboards, so there is nothing to derive from.
+const isFilteredWithNoDashboards = (
+    hasFilters: boolean,
+    dashboardSlugs: string[],
+): boolean => hasFilters && dashboardSlugs.length === 0;
+
 export const uploadHandler = async (
     options: DownloadHandlerOptions,
 ): Promise<void> => {
@@ -3026,20 +3033,23 @@ export const uploadHandler = async (
             }
         }
 
-        // Upload data apps (enterprise, opt-in via --apps <references...> or
-        // --include-apps; also auto-pushed when a dashboard being uploaded
-        // references one, so its tiles resolve in the target project). Apps
-        // must land before dashboards — mirrors PromoteService.upsertDataApps.
+        // Upload data apps (enterprise; explicit --apps/--include-apps, or
+        // auto-pushed for a dashboard's apps). Must land before dashboards.
         const explicitAppReferences = Array.isArray(options.apps)
             ? options.apps
             : [];
         const isExplicitAppSelection =
             options.includeApps === true || explicitAppReferences.length > 0;
-        const autoPushAppSlugs = await getDashboardAppSlugs(
+        const autoPushAppSlugs = isFilteredWithNoDashboards(
+            hasFilters,
             options.dashboards,
-            options.path,
-            looseFiles.dashboards,
-        );
+        )
+            ? []
+            : await getDashboardAppSlugs(
+                  options.dashboards,
+                  options.path,
+                  looseFiles.dashboards,
+              );
         const shouldUploadApps =
             isExplicitAppSelection || autoPushAppSlugs.length > 0;
 
@@ -3060,10 +3070,8 @@ export const uploadHandler = async (
             output.completeItem('permission denied', 'warning');
         } else if (shouldUploadApps) {
             output.startItem('Data apps');
-            // --include-apps uploads every folder on disk; explicit references
-            // filter folders by their manifest slug or appUuid. A pure
-            // auto-push run keeps no filter here — candidacy is decided per
-            // folder below instead, against the dashboards' referenced slugs.
+            // Explicit refs filter by slug/appUuid; --include-apps uploads all.
+            // A pure auto-push run applies no filter — gated per folder below.
             const uploadFilter = isExplicitAppSelection
                 ? getDataAppUploadFilter(
                       explicitAppReferences,
@@ -3071,14 +3079,15 @@ export const uploadHandler = async (
                   )
                 : null;
 
-            // The manifest keeps naming the source project forever, so
-            // comparing it to the target would re-push on every run against
-            // prod. Listing the target's apps settles after the first push.
+            // The manifest always names the source project, so comparing it
+            // to the target would re-push every run — list the target instead.
             let presence: AppPresence = {
                 kind: 'unknown',
                 targetProjectUuid: projectId,
             };
-            if (autoPushAppSlugs.length > 0) {
+            // Only the auto-push gate below (skipped entirely when explicit)
+            // reads presence, so an explicit run never needs the listing.
+            if (!isExplicitAppSelection && autoPushAppSlugs.length > 0) {
                 try {
                     const projectApps = await lightdashApi<
                         ApiEmbedProjectAppsResponse['results']
@@ -3139,9 +3148,20 @@ export const uploadHandler = async (
                     const code = await readBundleFromDir(folderPath);
 
                     if (!uploadFilterMatches(uploadFilter, code.manifest)) {
-                        GlobalState.debug(
-                            `Skipping app folder "${subDir.name}" (not in filter)`,
-                        );
+                        const isAutoPushCandidate =
+                            code.manifest.slug !== undefined &&
+                            autoPushAppSlugs.includes(code.manifest.slug);
+                        if (isAutoPushCandidate) {
+                            GlobalState.log(
+                                styles.warning(
+                                    `Skipping app "${subDir.name}" — excluded by --apps, but a dashboard being uploaded references it. Its tile may fail to resolve unless the app already exists in the target project.`,
+                                ),
+                            );
+                        } else {
+                            GlobalState.debug(
+                                `Skipping app folder "${subDir.name}" (not in filter)`,
+                            );
+                        }
                         // eslint-disable-next-line no-continue
                         continue;
                     }
@@ -3654,6 +3674,7 @@ export const testHelpers = {
     isAiAgentsUnavailableError,
     isExternalConnectionsUnavailableError,
     downloadAiAgents,
+    isFilteredWithNoDashboards,
     readAiAgentFiles,
     readExternalConnectionFiles,
     readSpaceFiles,


### PR DESCRIPTION
## What

`lightdash upload -d <dashboard>` now pushes the data apps that dashboard references, **before** the dashboard itself, so the server can resolve each tile's `appSlug` against an app that exists in the target project. Uploading a dashboard with a data app tile previously failed outright — `dashboard_tile_data_apps.app_uuid` is `NOT NULL` with an FK to `apps.app_id`, so a missing app took the whole upsert down.

Last of three stacked PRs.

## Changes

- **The data apps phase moved above Charts and Dashboards** in `uploadHandler`. This is the ordering `PromoteService.upsertDataApps` already follows, for the same reason.
- **Apps a dashboard references are pushed automatically** — no flag. `getDashboardAppSlugs` reads the dashboards actually selected for upload (folder-based and loose), and matches app folders by their manifest `slug`.
- **Change-gated, with one deliberate exception.** Every app upload mints a version and triggers an E2B sandbox rebuild, so an auto-pushed app uploads only when its folder changed — *unless the target project has no app with that slug yet*, in which case it pushes regardless. Without that exception, moving a dashboard to a new project or instance lands it with the tile silently skipped, which is the whole point of the feature.

  | App slug in target project | Folder changed | Push? |
  |---|---|---|
  | no | — | **yes** (new project / new instance) |
  | yes | yes | yes |
  | yes | no | no |

  "Folder changed" reuses the rule charts and dashboards already use (`processYamlItem`): an mtime more than 30s from the manifest's `downloadedAt`, across `src/**`, `package.json`, `pnpm-lock.yaml`, and the manifest. `.lightdash/context/` is excluded — it is regenerated on every download and would otherwise mark every folder dirty.

- **Presence comes from one listing call**, not from comparing `manifest.projectUuid` to the target. The manifest keeps naming the *source* project forever — nothing rewrites it, and nothing should, since that would commit a downstream project's uuid into a shared repo — so a manifest comparison would re-push on every run against prod. Live presence settles after the first push, because the server creates the app under the same slug. An older server (listing fails, or returns entries with no `slug`) falls back to the manifest comparison.
- **Explicit selections are unchanged.** `--apps <slug>` and `--include-apps` always upload and skip the presence check, exactly as `--charts <slug>` is documented to force upload. Only dashboard-derived pushes are gated.
- **Skipped tiles are reported.** The CLI prints the `warnings` the dashboard upsert returns, so a tile dropped because its app is missing is visible rather than silent.

## Behaviour notes

- With no data-app permission, or on a server without EE app routes, auto-push is skipped with one warning and dashboards still upload. Their tiles resolve if the app already exists in the target project.
- A filtered upload that selects no dashboards (e.g. `lightdash upload --charts my-chart`) does not touch apps at all — it mirrors the Dashboards phase's own bail condition.
- **External connections upload before data apps.** An app manifest's `externalConnections` links resolve by slug *in the target project*, and an unresolved slug is dropped with a warning rather than an error — so on a fresh project the connections have to exist first, or the app lands unlinked.
- **A server without EE app routes no longer fails the run.** On a flag-free auto-push, the first 404 from the app upload endpoint is treated as "data apps unavailable here": one warning, remaining folders skipped, exit code untouched. Explicit `--apps`/`--include-apps` still fail loudly, because the user asked for those.
- Known limitation: combining `--apps X` with `-d dash` where the dashboard needs a different app `Y` will not push `Y`; the explicit/auto-push choice is a single mode, not per-folder. The CLI now warns and names `--apps` as the cause, and the server's tile warning is the backstop.

## Testing

`pnpm -F cli test` 383 passed, typecheck and lint clean. The decision logic (`shouldAutoPushApp`, `appFolderNeedsUpdating`, `isFilteredWithNoDashboards`, `getDashboardAppSlugs`) is extracted into pure, unit-tested functions rather than living inline in the handler.

Coverage gap worth knowing: `uploadHandler` itself has no test harness in this package, so the phase ordering and the exit-code behaviour above rest on code review rather than a test. The decision helpers around them are covered.

Not yet done: end-to-end verification against a live instance — download a dashboard with an app tile, upload it to a second project, confirm the app is created and the tile resolves, then re-run and confirm nothing rebuilds. Worth doing before this stack leaves draft.

Closes: PROD-9245
Relates: PROD-9089
