### PR TITLE
fix(onboarding): enable homepage-builder and coding-agent onboarding flags at org creation

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -928,6 +928,17 @@ type OnboardingHomepageFailedEvent = BaseTrack & {
     };
 };
 
+type OnboardingOrgFlagsProvisionedEvent = BaseTrack & {
+    event: 'onboarding_org_flags.provisioned';
+    userId: string;
+    properties: {
+        organizationId: string;
+        onboardingFlow: OnboardingFlow;
+        homepageBuilderEnablement: HomepageBuilderEnablement;
+        codingAgentOnboardingEnablement: CodingAgentOnboardingEnablement;
+    };
+};
+
 export type HomepageBuilderEnablement =
     | EnsureOrganizationOverrideOutcome
     | 'failed';
@@ -3169,6 +3180,7 @@ type TypedEvent =
     | OnboardingHomepageProvisionedEvent
     | OnboardingHomepageSkippedEvent
     | OnboardingHomepageFailedEvent
+    | OnboardingOrgFlagsProvisionedEvent
     | PlaygroundProjectProvisionedEvent
     | PlaygroundProjectSkippedEvent
     | PlaygroundProjectFailedEvent

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -18,6 +18,7 @@ import { registerPreAggregateStream } from '../nats/natsConfig';
 import { AsyncQueryService } from '../services/AsyncQueryService/AsyncQueryService';
 import { DeployService } from '../services/DeployService';
 import { InstanceConfigurationService } from '../services/InstanceConfigurationService/InstanceConfigurationService';
+import { OrganizationService } from '../services/OrganizationService/OrganizationService';
 import { ProjectService } from '../services/ProjectService/ProjectService';
 import { RolesService } from '../services/RolesService/RolesService';
 import { EncryptionUtil } from '../utils/EncryptionUtil/EncryptionUtil';
@@ -89,6 +90,7 @@ import { EnterpriseLicenseService } from './services/LicenseService/LicenseServi
 import { ManagedAgentService } from './services/ManagedAgentService/ManagedAgentService';
 import { McpService } from './services/McpService/McpService';
 import { OnboardingAgentService } from './services/OnboardingAgentService/OnboardingAgentService';
+import { provisionOnboardingOrgFlags } from './services/OrganizationService/provisionOnboardingOrgFlags';
 import { OrganizationWarehouseCredentialsService } from './services/OrganizationWarehouseCredentialsService';
 import { PreviewDeploySetupService } from './services/PreviewDeploySetupService/PreviewDeploySetupService';
 import { ProjectContextService } from './services/ProjectContextService/ProjectContextService';
@@ -725,6 +727,29 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     unfurlService: repository.getUnfurlService(),
                     projectService: repository.getProjectService(),
                     lightdashConfig: context.lightdashConfig,
+                }),
+            organizationService: ({ models, context, repository }) =>
+                new OrganizationService({
+                    lightdashConfig: context.lightdashConfig,
+                    analytics: context.lightdashAnalytics,
+                    organizationModel: models.getOrganizationModel(),
+                    projectModel: models.getProjectModel(),
+                    onboardingModel: models.getOnboardingModel(),
+                    organizationMemberProfileModel:
+                        models.getOrganizationMemberProfileModel(),
+                    userModel: models.getUserModel(),
+                    organizationAllowedEmailDomainsModel:
+                        models.getOrganizationAllowedEmailDomainsModel(),
+                    groupsModel: models.getGroupsModel(),
+                    featureFlagModel: models.getFeatureFlagModel(),
+                    onOrganizationCreated: ({ user, organizationUuid }) =>
+                        provisionOnboardingOrgFlags({
+                            user,
+                            organizationUuid,
+                            featureFlagService:
+                                repository.getFeatureFlagService(),
+                            analytics: context.lightdashAnalytics,
+                        }),
                 }),
             organizationWarehouseCredentialsService: ({ models, context }) =>
                 new OrganizationWarehouseCredentialsService({

--- a/packages/backend/src/ee/services/OrganizationService/provisionOnboardingOrgFlags.test.ts
+++ b/packages/backend/src/ee/services/OrganizationService/provisionOnboardingOrgFlags.test.ts
@@ -1,0 +1,179 @@
+import { Ability } from '@casl/ability';
+import {
+    CommercialFeatureFlags,
+    FeatureFlags,
+    OrganizationMemberRole,
+    type PossibleAbilities,
+    type SessionUser,
+} from '@lightdash/common';
+import * as Sentry from '@sentry/node';
+import Logger from '../../../logging/logger';
+import {
+    provisionOnboardingOrgFlags,
+    type ProvisionOnboardingOrgFlagsArguments,
+} from './provisionOnboardingOrgFlags';
+
+vi.mock('@sentry/node', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@sentry/node')>();
+    return {
+        ...actual,
+        captureException: vi.fn(),
+    };
+});
+
+const ORGANIZATION_UUID = '00000000-0000-0000-0000-000000000001';
+const USER_UUID = '00000000-0000-0000-0000-000000000002';
+const NOW = new Date('2026-07-30T10:00:00.000Z');
+
+const user: SessionUser = {
+    userUuid: USER_UUID,
+    email: 'admin@example.com',
+    firstName: 'Admin',
+    lastName: 'User',
+    organizationUuid: ORGANIZATION_UUID,
+    organizationName: 'Organization',
+    organizationCreatedAt: NOW,
+    userId: 1,
+    role: OrganizationMemberRole.ADMIN,
+    isTrackingAnonymized: false,
+    isMarketingOptedIn: false,
+    avatarUrl: null,
+    avatarGradient: null,
+    isSetupComplete: true,
+    isActive: true,
+    createdAt: NOW,
+    updatedAt: NOW,
+    timezone: null,
+    abilityRules: [],
+    ability: new Ability<PossibleAbilities>([]),
+};
+
+const buildArguments = () => {
+    const get =
+        vi.fn<
+            ProvisionOnboardingOrgFlagsArguments['featureFlagService']['get']
+        >();
+    const ensureOrganizationOverrideEnabled =
+        vi.fn<
+            ProvisionOnboardingOrgFlagsArguments['featureFlagService']['ensureOrganizationOverrideEnabled']
+        >();
+    const track =
+        vi.fn<ProvisionOnboardingOrgFlagsArguments['analytics']['track']>();
+
+    vi.mocked(get).mockImplementation(async ({ featureFlagId }) => ({
+        id: featureFlagId,
+        enabled: true,
+    }));
+    vi.mocked(ensureOrganizationOverrideEnabled).mockResolvedValue('enabled');
+
+    return {
+        args: {
+            user,
+            organizationUuid: ORGANIZATION_UUID,
+            featureFlagService: {
+                get,
+                ensureOrganizationOverrideEnabled,
+            },
+            analytics: { track },
+        } satisfies ProvisionOnboardingOrgFlagsArguments,
+        get: vi.mocked(get),
+        ensureOrganizationOverrideEnabled: vi.mocked(
+            ensureOrganizationOverrideEnabled,
+        ),
+        track: vi.mocked(track),
+    };
+};
+
+describe('provisionOnboardingOrgFlags', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+        vi.restoreAllMocks();
+    });
+
+    it('enables both flags and tracks their outcomes', async () => {
+        const mocks = buildArguments();
+        mocks.ensureOrganizationOverrideEnabled.mockImplementation(
+            async ({ featureFlagId }) =>
+                featureFlagId === CommercialFeatureFlags.HomepageBuilder
+                    ? 'already_enabled'
+                    : 'kept_disabled',
+        );
+
+        await provisionOnboardingOrgFlags(mocks.args);
+
+        expect(mocks.get).toHaveBeenCalledExactlyOnceWith({
+            user,
+            featureFlagId: FeatureFlags.NewOnboarding,
+        });
+        expect(mocks.ensureOrganizationOverrideEnabled).toHaveBeenCalledTimes(
+            2,
+        );
+        expect(mocks.ensureOrganizationOverrideEnabled).toHaveBeenCalledWith({
+            user,
+            featureFlagId: CommercialFeatureFlags.HomepageBuilder,
+        });
+        expect(mocks.ensureOrganizationOverrideEnabled).toHaveBeenCalledWith({
+            user,
+            featureFlagId: FeatureFlags.CodingAgentOnboarding,
+        });
+        expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
+            event: 'onboarding_org_flags.provisioned',
+            userId: USER_UUID,
+            properties: {
+                organizationId: ORGANIZATION_UUID,
+                onboardingFlow: 'new',
+                homepageBuilderEnablement: 'already_enabled',
+                codingAgentOnboardingEnablement: 'kept_disabled',
+            },
+        });
+    });
+
+    it('does nothing when new onboarding is disabled', async () => {
+        const mocks = buildArguments();
+        mocks.get.mockResolvedValue({
+            id: FeatureFlags.NewOnboarding,
+            enabled: false,
+        });
+
+        await provisionOnboardingOrgFlags(mocks.args);
+
+        expect(mocks.ensureOrganizationOverrideEnabled).not.toHaveBeenCalled();
+        expect(mocks.track).not.toHaveBeenCalled();
+    });
+
+    it('swallows an enablement failure and tracks the failed outcome', async () => {
+        const error = new Error('Enable failed');
+        const errorSpy = vi
+            .spyOn(Logger, 'error')
+            .mockImplementation(() => Logger);
+        const mocks = buildArguments();
+        mocks.ensureOrganizationOverrideEnabled.mockImplementation(
+            async ({ featureFlagId }) => {
+                if (featureFlagId === CommercialFeatureFlags.HomepageBuilder) {
+                    throw error;
+                }
+                return 'enabled';
+            },
+        );
+
+        await expect(
+            provisionOnboardingOrgFlags(mocks.args),
+        ).resolves.toBeUndefined();
+
+        expect(mocks.ensureOrganizationOverrideEnabled).toHaveBeenCalledTimes(
+            2,
+        );
+        expect(Sentry.captureException).toHaveBeenCalledExactlyOnceWith(error);
+        expect(errorSpy).toHaveBeenCalledOnce();
+        expect(mocks.track).toHaveBeenCalledExactlyOnceWith({
+            event: 'onboarding_org_flags.provisioned',
+            userId: USER_UUID,
+            properties: {
+                organizationId: ORGANIZATION_UUID,
+                onboardingFlow: 'new',
+                homepageBuilderEnablement: 'failed',
+                codingAgentOnboardingEnablement: 'enabled',
+            },
+        });
+    });
+});

--- a/packages/backend/src/ee/services/OrganizationService/provisionOnboardingOrgFlags.ts
+++ b/packages/backend/src/ee/services/OrganizationService/provisionOnboardingOrgFlags.ts
@@ -1,0 +1,83 @@
+import {
+    CommercialFeatureFlags,
+    FeatureFlags,
+    type SessionUser,
+} from '@lightdash/common';
+import * as Sentry from '@sentry/node';
+import {
+    type CodingAgentOnboardingEnablement,
+    type HomepageBuilderEnablement,
+    type LightdashAnalytics,
+} from '../../../analytics/LightdashAnalytics';
+import Logger from '../../../logging/logger';
+import { type FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
+
+export type ProvisionOnboardingOrgFlagsArguments = {
+    user: SessionUser;
+    organizationUuid: string;
+    featureFlagService: Pick<
+        FeatureFlagService,
+        'get' | 'ensureOrganizationOverrideEnabled'
+    >;
+    analytics: Pick<LightdashAnalytics, 'track'>;
+};
+
+export const provisionOnboardingOrgFlags = async ({
+    user,
+    organizationUuid,
+    featureFlagService,
+    analytics,
+}: ProvisionOnboardingOrgFlagsArguments): Promise<void> => {
+    const newOnboardingFlag = await featureFlagService.get({
+        user,
+        featureFlagId: FeatureFlags.NewOnboarding,
+    });
+    if (!newOnboardingFlag.enabled) {
+        return;
+    }
+
+    let homepageBuilderEnablement: HomepageBuilderEnablement;
+    try {
+        homepageBuilderEnablement =
+            await featureFlagService.ensureOrganizationOverrideEnabled({
+                user,
+                featureFlagId: CommercialFeatureFlags.HomepageBuilder,
+            });
+    } catch (error) {
+        Sentry.captureException(error);
+        Logger.error(
+            `Failed to enable homepage builder for organization ${organizationUuid}: ${
+                error instanceof Error ? error.message : String(error)
+            }`,
+        );
+        homepageBuilderEnablement = 'failed';
+    }
+
+    let codingAgentOnboardingEnablement: CodingAgentOnboardingEnablement;
+    try {
+        codingAgentOnboardingEnablement =
+            await featureFlagService.ensureOrganizationOverrideEnabled({
+                user,
+                featureFlagId: FeatureFlags.CodingAgentOnboarding,
+            });
+    } catch (error) {
+        Sentry.captureException(error);
+        Logger.error(
+            `Failed to enable coding agent onboarding for organization ${organizationUuid}: ${
+                error instanceof Error ? error.message : String(error)
+            }`,
+        );
+        codingAgentOnboardingEnablement = 'failed';
+    }
+
+    analytics.track({
+        event: 'onboarding_org_flags.provisioned',
+        userId: user.userUuid,
+        properties: {
+            organizationId: organizationUuid,
+            onboardingFlow: 'new',
+            homepageBuilderEnablement,
+            codingAgentOnboardingEnablement,
+        },
+    });
+};

--- a/packages/backend/src/services/OrganizationService/OrganizationService.test.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.test.ts
@@ -5,9 +5,11 @@ import {
     type PossibleAbilities,
     type SessionUser,
 } from '@lightdash/common';
+import * as Sentry from '@sentry/node';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { buildAccount } from '../../auth/account/account.mock';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import Logger from '../../logging/logger';
 import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import { GroupsModel } from '../../models/GroupsModel';
 import { OnboardingModel } from '../../models/OnboardingModel/OnboardingModel';
@@ -16,8 +18,19 @@ import { OrganizationMemberProfileModel } from '../../models/OrganizationMemberP
 import { OrganizationModel } from '../../models/OrganizationModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { UserModel } from '../../models/UserModel';
-import { OrganizationService } from './OrganizationService';
+import {
+    OrganizationService,
+    type OrganizationServiceArguments,
+} from './OrganizationService';
 import { organization, user } from './OrganizationService.mock';
+
+vi.mock('@sentry/node', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@sentry/node')>();
+    return {
+        ...actual,
+        captureException: vi.fn(),
+    };
+});
 
 const projectModel = {
     hasProjects: vi.fn(async () => true),
@@ -31,6 +44,9 @@ const organizationModel = {
 const userModel = {
     hasUsers: vi.fn<UserModel['hasUsers']>(async () => false),
     joinOrg: vi.fn<UserModel['joinOrg']>(async () => user),
+    findSessionUserAndOrgByUuid: vi.fn<
+        UserModel['findSessionUserAndOrgByUuid']
+    >(async () => user),
 };
 const featureFlagModel = {
     get: vi.fn<FeatureFlagModel['get']>(async ({ featureFlagId }) => ({
@@ -44,20 +60,26 @@ const organizationMemberProfileModel = {
 };
 
 describe('organization service', () => {
-    const organizationService = new OrganizationService({
-        lightdashConfig: lightdashConfigMock,
-        analytics: analyticsMock,
-        organizationModel: organizationModel as unknown as OrganizationModel,
-        projectModel: projectModel as unknown as ProjectModel,
-        onboardingModel: {} as OnboardingModel,
-        organizationMemberProfileModel:
-            organizationMemberProfileModel as unknown as OrganizationMemberProfileModel,
-        userModel: userModel as unknown as UserModel,
-        organizationAllowedEmailDomainsModel:
-            {} as OrganizationAllowedEmailDomainsModel,
-        groupsModel: {} as GroupsModel,
-        featureFlagModel: featureFlagModel as unknown as FeatureFlagModel,
-    });
+    const buildOrganizationService = (
+        onOrganizationCreated?: OrganizationServiceArguments['onOrganizationCreated'],
+    ) =>
+        new OrganizationService({
+            lightdashConfig: lightdashConfigMock,
+            analytics: analyticsMock,
+            organizationModel:
+                organizationModel as unknown as OrganizationModel,
+            projectModel: projectModel as unknown as ProjectModel,
+            onboardingModel: {} as OnboardingModel,
+            organizationMemberProfileModel:
+                organizationMemberProfileModel as unknown as OrganizationMemberProfileModel,
+            userModel: userModel as unknown as UserModel,
+            organizationAllowedEmailDomainsModel:
+                {} as OrganizationAllowedEmailDomainsModel,
+            groupsModel: {} as GroupsModel,
+            featureFlagModel: featureFlagModel as unknown as FeatureFlagModel,
+            onOrganizationCreated,
+        });
+    const organizationService = buildOrganizationService();
 
     afterEach(() => {
         vi.clearAllMocks();
@@ -83,6 +105,72 @@ describe('organization service', () => {
                 organizationId: organization.organizationUuid,
                 organizationName: organization.name,
                 onboardingFlow: 'new',
+            },
+        });
+    });
+
+    it('awaits the organization-created hook', async () => {
+        let resolveHook = () => {};
+        const hookPending = new Promise<void>((resolve) => {
+            resolveHook = resolve;
+        });
+        const onOrganizationCreated = vi.fn<
+            NonNullable<OrganizationServiceArguments['onOrganizationCreated']>
+        >(async () => hookPending);
+        const service = buildOrganizationService(onOrganizationCreated);
+        let completed = false;
+
+        const creation = service
+            .createAndJoinOrg(
+                { ...user, organizationUuid: undefined },
+                { name: 'Organization' },
+            )
+            .then(() => {
+                completed = true;
+            });
+
+        await vi.waitFor(() => {
+            expect(onOrganizationCreated).toHaveBeenCalledExactlyOnceWith({
+                user,
+                organizationUuid: organization.organizationUuid,
+            });
+        });
+        expect(completed).toBe(false);
+
+        resolveHook();
+        await creation;
+
+        expect(completed).toBe(true);
+    });
+
+    it('survives an organization-created hook failure', async () => {
+        const error = new Error('Hook failed');
+        const errorSpy = vi
+            .spyOn(Logger, 'error')
+            .mockImplementation(() => Logger);
+        const onOrganizationCreated = vi.fn<
+            NonNullable<OrganizationServiceArguments['onOrganizationCreated']>
+        >(async () => {
+            throw error;
+        });
+        const service = buildOrganizationService(onOrganizationCreated);
+
+        await expect(
+            service.createAndJoinOrg(
+                { ...user, organizationUuid: undefined },
+                { name: 'Organization' },
+            ),
+        ).resolves.toBeUndefined();
+
+        expect(Sentry.captureException).toHaveBeenCalledExactlyOnceWith(error);
+        expect(errorSpy).toHaveBeenCalledOnce();
+        expect(analyticsMock.track).toHaveBeenCalledWith({
+            userId: user.userUuid,
+            event: 'user.joined_organization',
+            properties: {
+                organizationId: organization.organizationUuid,
+                role: OrganizationMemberRole.ADMIN,
+                projectIds: [],
             },
         });
     });

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -42,6 +42,7 @@ import {
     validateOrganizationEmailDomains,
     validateOrganizationNameOrThrow,
 } from '@lightdash/common';
+import * as Sentry from '@sentry/node';
 import { groupBy } from 'lodash';
 import fetch from 'node-fetch';
 import {
@@ -49,6 +50,7 @@ import {
     OnboardingFlow,
 } from '../../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../../config/parseConfig';
+import Logger from '../../logging/logger';
 import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import { GroupsModel } from '../../models/GroupsModel';
 import { OnboardingModel } from '../../models/OnboardingModel/OnboardingModel';
@@ -87,7 +89,7 @@ type BrandfetchBrandResponse = {
     }> | null;
 };
 
-type OrganizationServiceArguments = {
+export type OrganizationServiceArguments = {
     lightdashConfig: LightdashConfig;
     analytics: LightdashAnalytics;
     organizationModel: OrganizationModel;
@@ -98,6 +100,10 @@ type OrganizationServiceArguments = {
     groupsModel: GroupsModel;
     organizationAllowedEmailDomainsModel: OrganizationAllowedEmailDomainsModel;
     featureFlagModel: FeatureFlagModel;
+    onOrganizationCreated?: (args: {
+        user: SessionUser;
+        organizationUuid: string;
+    }) => Promise<void>;
 };
 
 export class OrganizationService extends BaseService {
@@ -121,6 +127,8 @@ export class OrganizationService extends BaseService {
 
     private readonly featureFlagModel: FeatureFlagModel;
 
+    private readonly onOrganizationCreated: OrganizationServiceArguments['onOrganizationCreated'];
+
     constructor({
         lightdashConfig,
         analytics,
@@ -132,6 +140,7 @@ export class OrganizationService extends BaseService {
         groupsModel,
         organizationAllowedEmailDomainsModel,
         featureFlagModel,
+        onOrganizationCreated,
     }: OrganizationServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -145,6 +154,7 @@ export class OrganizationService extends BaseService {
             organizationAllowedEmailDomainsModel;
         this.groupsModel = groupsModel;
         this.featureFlagModel = featureFlagModel;
+        this.onOrganizationCreated = onOrganizationCreated;
     }
 
     async get(account: Account): Promise<Organization> {
@@ -906,6 +916,29 @@ export class OrganizationService extends BaseService {
             OrganizationMemberRole.ADMIN,
             undefined,
         );
+        if (this.onOrganizationCreated) {
+            try {
+                const organizationUser =
+                    await this.userModel.findSessionUserAndOrgByUuid(
+                        user.userUuid,
+                        org.organizationUuid,
+                    );
+                // Await before returning so the frontend's feature-flag refetch sees the overrides.
+                await this.onOrganizationCreated({
+                    user: organizationUser,
+                    organizationUuid: org.organizationUuid,
+                });
+            } catch (error) {
+                Sentry.captureException(error);
+                Logger.error(
+                    `Failed to run organization creation hook for organization ${
+                        org.organizationUuid
+                    }: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+            }
+        }
         await this.analytics.track({
             userId: user.userUuid,
             event: 'user.joined_organization',


### PR DESCRIPTION
## Problem

With `new-onboarding` enabled, a fresh signup finished org setup and looped on `/onboarding/data-source` instead of landing on `/get-started`. The programmatic enablement of `homepage-builder` + `coding-agent-onboarding` (#26428) is hooked at `onProjectCreated`, which is too late for day-0: a brand-new org has zero projects, so the flags were never enabled and the redirect fell through to the data-source page. Verified on a cloud instance: a fresh org got zero `feature_flag_overrides` rows.

## Solution

- Core `OrganizationService` gains an optional `onOrganizationCreated` hook, awaited synchronously inside `createAndJoinOrg` (the frontend refetches feature flags in the org-create mutation's `onSuccess`, so fire-and-forget would race it). Errors are swallowed (Sentry + Logger) so org creation never fails because of the hook.
- EE wires the hook in `ee/index.ts` to a new `provisionOnboardingOrgFlags` helper: it resolves `new-onboarding` and, when enabled, calls `ensureOrganizationOverrideEnabled` for both flags and tracks an `onboarding_org_flags.provisioned` analytics event with both enablement outcomes.
- OSS passes no hook, so existing routing to the data-source page is unchanged.
- The existing enablement in `provisionOnboardingHomepage` stays as a backstop.

Note: `InstanceConfigurationService.initializeInstance` also creates orgs (env-driven initial setup) and intentionally does not use the hook — it is not the day-0 signup flow.

## Testing

- Unit: new `provisionOnboardingOrgFlags.test.ts` (enablement outcomes, disabled-flag no-op, failure swallowing) + extended `OrganizationService.test.ts` (hook invocation, error swallowing). Backend typecheck, lint on touched paths.
- Manual, prod-like (local EE, preview flag-forcing off, both flags with no default rows and no overrides, `new-onboarding` DB default true): fresh signup lands on `/get-started` and both org-scoped override rows are written `enabled=true`. Negative: with `new-onboarding` off, signup follows the old `/createProject` flow and no override rows are written.

Closes: SPK-750

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FobQVSbAxBxSN2TJSYwmca