### PR TITLE
feat(ai): add Deep Research organization limits

### DIFF
--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -2,6 +2,7 @@ import {
     type AiAgentModelConfig,
     type AiChartRuntimeOverrides,
     type AiDashboardRuntimeOverrides,
+    type AiDeepResearchLimits,
     type AiOrgModelVisibility,
     type AiProviderApiKeyHints,
     type AiThreadCreatedFrom,
@@ -481,6 +482,7 @@ export type DbAiOrganizationSettings = {
     organization_uuid: string;
     ai_agents_visible: boolean;
     ai_agent_reviews_enabled: boolean;
+    deep_research_limits: AiDeepResearchLimits;
     mcp_content_writes_enabled: boolean;
     require_explicit_slack_channel_linking: boolean;
     default_ai_agent_model_config: AiAgentModelConfig | null;
@@ -499,6 +501,7 @@ export type AiOrganizationSettingsTable = Knex.CompositeTableType<
             Pick<
                 DbAiOrganizationSettings,
                 | 'ai_agent_reviews_enabled'
+                | 'deep_research_limits'
                 | 'mcp_content_writes_enabled'
                 | 'require_explicit_slack_channel_linking'
                 | 'default_ai_agent_model_config'
@@ -513,6 +516,7 @@ export type AiOrganizationSettingsTable = Knex.CompositeTableType<
             DbAiOrganizationSettings,
             | 'ai_agents_visible'
             | 'ai_agent_reviews_enabled'
+            | 'deep_research_limits'
             | 'mcp_content_writes_enabled'
             | 'require_explicit_slack_channel_linking'
             | 'default_ai_agent_model_config'

--- a/packages/backend/src/ee/database/migrations/20260730200000_add_deep_research_limits_to_ai_organization_settings.ts
+++ b/packages/backend/src/ee/database/migrations/20260730200000_add_deep_research_limits_to_ai_organization_settings.ts
@@ -1,0 +1,25 @@
+import type { Knex } from 'knex';
+
+const aiOrganizationSettings = 'ai_organization_settings';
+
+const defaultLimits = {
+    maxTokens: 10_000_000,
+    maxToolCalls: 1_000,
+    maxWarehouseQueries: 100,
+    maxHypotheses: 5,
+};
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(aiOrganizationSettings, (table) => {
+        table
+            .jsonb('deep_research_limits')
+            .notNullable()
+            .defaultTo(JSON.stringify(defaultLimits));
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(aiOrganizationSettings, (table) => {
+        table.dropColumn('deep_research_limits');
+    });
+}

--- a/packages/backend/src/ee/models/AiOrganizationSettingsModel.ts
+++ b/packages/backend/src/ee/models/AiOrganizationSettingsModel.ts
@@ -1,4 +1,5 @@
 import {
+    AI_DEEP_RESEARCH_DEFAULT_LIMITS,
     AiOrganizationSettings,
     AiProviderApiKeyHints,
     BYO_AI_PROVIDERS,
@@ -110,6 +111,7 @@ export class AiOrganizationSettingsModel {
             organizationUuid: db.organization_uuid,
             aiAgentsVisible: db.ai_agents_visible,
             aiAgentReviewsEnabled: db.ai_agent_reviews_enabled,
+            deepResearchLimits: db.deep_research_limits,
             mcpContentWritesEnabled: db.mcp_content_writes_enabled,
             requireExplicitSlackChannelLinking:
                 db.require_explicit_slack_channel_linking,
@@ -181,6 +183,7 @@ export class AiOrganizationSettingsModel {
                 organization_uuid: data.organizationUuid,
                 ai_agents_visible: data.aiAgentsVisible,
                 ai_agent_reviews_enabled: data.aiAgentReviewsEnabled,
+                deep_research_limits: data.deepResearchLimits,
                 mcp_content_writes_enabled: data.mcpContentWritesEnabled,
                 require_explicit_slack_channel_linking:
                     data.requireExplicitSlackChannelLinking,
@@ -204,6 +207,7 @@ export class AiOrganizationSettingsModel {
                 DbAiOrganizationSettings,
                 | 'ai_agents_visible'
                 | 'ai_agent_reviews_enabled'
+                | 'deep_research_limits'
                 | 'mcp_content_writes_enabled'
                 | 'require_explicit_slack_channel_linking'
                 | 'default_ai_agent_model_config'
@@ -218,6 +222,9 @@ export class AiOrganizationSettingsModel {
         }
         if (data.aiAgentReviewsEnabled !== undefined) {
             updateData.ai_agent_reviews_enabled = data.aiAgentReviewsEnabled;
+        }
+        if (data.deepResearchLimits !== undefined) {
+            updateData.deep_research_limits = data.deepResearchLimits;
         }
         if (data.mcpContentWritesEnabled !== undefined) {
             updateData.mcp_content_writes_enabled =
@@ -319,6 +326,8 @@ export class AiOrganizationSettingsModel {
             organizationUuid,
             aiAgentsVisible: data.aiAgentsVisible ?? true,
             aiAgentReviewsEnabled: data.aiAgentReviewsEnabled ?? false,
+            deepResearchLimits:
+                data.deepResearchLimits ?? AI_DEEP_RESEARCH_DEFAULT_LIMITS,
             mcpContentWritesEnabled: data.mcpContentWritesEnabled ?? true,
             requireExplicitSlackChannelLinking:
                 data.requireExplicitSlackChannelLinking ?? false,

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
@@ -1,4 +1,5 @@
 import {
+    AI_DEEP_RESEARCH_DEFAULT_LIMITS,
     ForbiddenError,
     ProjectType,
     type AiAgentReviewClassifierJudgeOutput,
@@ -302,6 +303,7 @@ describe('AiAgentReviewClassifierService', () => {
             organizationUuid: ORGANIZATION_UUID,
             aiAgentsVisible: true,
             aiAgentReviewsEnabled: true,
+            deepResearchLimits: AI_DEEP_RESEARCH_DEFAULT_LIMITS,
             mcpContentWritesEnabled: true,
             requireExplicitSlackChannelLinking: false,
             defaultAiAgentModelConfig: null,
@@ -371,6 +373,7 @@ describe('AiAgentReviewClassifierService', () => {
                 organizationUuid: ORGANIZATION_UUID,
                 aiAgentsVisible: true,
                 aiAgentReviewsEnabled: false,
+                deepResearchLimits: AI_DEEP_RESEARCH_DEFAULT_LIMITS,
                 mcpContentWritesEnabled: true,
                 requireExplicitSlackChannelLinking: false,
                 defaultAiAgentModelConfig: null,

--- a/packages/backend/src/ee/services/AiOrganizationSettingsService.test.ts
+++ b/packages/backend/src/ee/services/AiOrganizationSettingsService.test.ts
@@ -1,4 +1,8 @@
-import { AiOrganizationSettings } from '@lightdash/common';
+import {
+    AI_DEEP_RESEARCH_DEFAULT_LIMITS,
+    AiOrganizationSettings,
+    ParameterError,
+} from '@lightdash/common';
 import type { ModelPreset, ModelPresetProvider } from './ai/models/presets';
 import {
     AiOrganizationSettingsService,
@@ -7,12 +11,14 @@ import {
     isModelConfigAvailable,
     maskProviderKeyExposure,
     pickReplacementDefaultModelConfig,
+    validateDeepResearchLimits,
 } from './AiOrganizationSettingsService';
 
 const settingsWithKeys: AiOrganizationSettings = {
     organizationUuid: 'org-uuid',
     aiAgentsVisible: true,
     aiAgentReviewsEnabled: false,
+    deepResearchLimits: AI_DEEP_RESEARCH_DEFAULT_LIMITS,
     mcpContentWritesEnabled: true,
     requireExplicitSlackChannelLinking: false,
     defaultAiAgentModelConfig: null,
@@ -20,6 +26,28 @@ const settingsWithKeys: AiOrganizationSettings = {
     providerApiKeysSet: { anthropic: true, openai: false },
     providerApiKeyHints: { anthropic: 'sk-ant-api03-R2D...igAA', openai: null },
 };
+
+describe('validateDeepResearchLimits', () => {
+    it('accepts the default limits', () => {
+        expect(() =>
+            validateDeepResearchLimits(AI_DEEP_RESEARCH_DEFAULT_LIMITS),
+        ).not.toThrow();
+    });
+
+    it.each([
+        ['maxTokens', 0],
+        ['maxToolCalls', -1],
+        ['maxWarehouseQueries', 0],
+        ['maxHypotheses', 2.5],
+    ] as const)('rejects invalid %s', (key, value) => {
+        expect(() =>
+            validateDeepResearchLimits({
+                ...AI_DEEP_RESEARCH_DEFAULT_LIMITS,
+                [key]: value,
+            }),
+        ).toThrow(ParameterError);
+    });
+});
 
 describe('maskProviderKeyExposure', () => {
     it('returns the settings untouched for org admins', () => {
@@ -350,6 +378,38 @@ describe('upsertSettings model validation', () => {
             defaultAiAgentModelConfig: null,
         });
         expect(upsert).toHaveBeenCalled();
+    });
+
+    it('rejects invalid Deep Research limits before writing', async () => {
+        const { service, upsert } = buildService();
+
+        await expect(
+            service.upsertSettings(user, {
+                deepResearchLimits: {
+                    maxTokens: 10_000_000,
+                    maxToolCalls: 0,
+                    maxWarehouseQueries: 7,
+                    maxHypotheses: 3,
+                },
+            }),
+        ).rejects.toThrow('maxToolCalls must be a positive integer');
+        expect(upsert).not.toHaveBeenCalled();
+    });
+
+    it('forwards valid Deep Research limits to the model', async () => {
+        const { service, upsert } = buildService();
+        const deepResearchLimits = {
+            maxTokens: 9_000_000,
+            maxToolCalls: 42,
+            maxWarehouseQueries: 7,
+            maxHypotheses: 3,
+        };
+
+        await service.upsertSettings(user, { deepResearchLimits });
+
+        expect(upsert).toHaveBeenCalledWith('org-uuid', {
+            deepResearchLimits,
+        });
     });
 
     it('repoints a stored default that the new visibility hides', async () => {

--- a/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
+++ b/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    AI_DEEP_RESEARCH_DEFAULT_LIMITS,
     AiOrganizationSettings,
     BYO_AI_PROVIDERS,
     CommercialFeatureFlags,
@@ -11,6 +12,7 @@ import {
     UpdateAiOrganizationSettings,
     UpdateAiProviderApiKeys,
     type AiAgentModelConfig,
+    type AiDeepResearchLimits,
     type AiModelOption,
     type AiOrgModelVisibility,
     type ByoAiProvider,
@@ -119,6 +121,18 @@ export const findUnconfiguredProviderKeyWrites = (
             typeof providerApiKeys[provider] === 'string' &&
             !configuredProviders[provider],
     );
+
+export const validateDeepResearchLimits = (
+    limits: AiDeepResearchLimits,
+): void => {
+    (
+        Object.entries(limits) as Array<[keyof AiDeepResearchLimits, number]>
+    ).forEach(([key, value]) => {
+        if (!Number.isInteger(value) || value <= 0) {
+            throw new ParameterError(`${key} must be a positive integer`);
+        }
+    });
+};
 
 /**
  * Reviews run on the org's own key when it has one (never the instance
@@ -330,6 +344,7 @@ export class AiOrganizationSettingsService extends BaseService {
                 isCopilotEnabled,
                 aiAgentsVisible: true,
                 aiAgentReviewsEnabled: false,
+                deepResearchLimits: AI_DEEP_RESEARCH_DEFAULT_LIMITS,
                 mcpContentWritesEnabled: true,
                 requireExplicitSlackChannelLinking: false,
                 defaultAiAgentModelConfig: null,
@@ -371,6 +386,10 @@ export class AiOrganizationSettingsService extends BaseService {
         }
 
         this.checkManageAiAgentAccess(user);
+
+        if (data.deepResearchLimits !== undefined) {
+            validateDeepResearchLimits(data.deepResearchLimits);
+        }
 
         // Set when hiding models orphans the org's configured default, so the
         // write can repoint it in the same upsert.

--- a/packages/common/src/ee/AiAgent/adminTypes.ts
+++ b/packages/common/src/ee/AiAgent/adminTypes.ts
@@ -1,4 +1,5 @@
 import type { ApiSuccess, KnexPaginatedData } from '../..';
+import type { AiDeepResearchLimits } from '../aiDeepResearch/types';
 import type { DataAppModelVisibility } from '../apps/types';
 import type {
     AiAgentEvaluationRunSummary,
@@ -325,6 +326,7 @@ export type AiOrganizationSettings = {
     organizationUuid: string;
     aiAgentsVisible: boolean;
     aiAgentReviewsEnabled: boolean;
+    deepResearchLimits: AiDeepResearchLimits;
     mcpContentWritesEnabled: boolean;
     requireExplicitSlackChannelLinking?: boolean;
     defaultAiAgentModelConfig: AiAgentModelConfig | null;
@@ -347,6 +349,7 @@ export type CreateAiOrganizationSettings = Omit<
 export type UpdateAiOrganizationSettings = {
     aiAgentsVisible?: boolean;
     aiAgentReviewsEnabled?: boolean;
+    deepResearchLimits?: AiDeepResearchLimits;
     mcpContentWritesEnabled?: boolean;
     requireExplicitSlackChannelLinking?: boolean;
     defaultAiAgentModelConfig?: AiAgentModelConfig | null;

--- a/packages/common/src/ee/aiDeepResearch/types.ts
+++ b/packages/common/src/ee/aiDeepResearch/types.ts
@@ -55,6 +55,20 @@ export type AiDeepResearchBudget = {
     maxHypotheses: number;
 };
 
+export type AiDeepResearchLimits = {
+    maxTokens: number;
+    maxToolCalls: number;
+    maxWarehouseQueries: number;
+    maxHypotheses: number;
+};
+
+export const AI_DEEP_RESEARCH_DEFAULT_LIMITS: AiDeepResearchLimits = {
+    maxTokens: 10_000_000,
+    maxToolCalls: 1_000,
+    maxWarehouseQueries: 100,
+    maxHypotheses: 5,
+};
+
 export type AiDeepResearchHypothesis = {
     id: string;
     claim: string;

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiDeepResearchSettingsPage.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiDeepResearchSettingsPage.test.tsx
@@ -1,0 +1,149 @@
+import { fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../../../testing/testUtils';
+import { AiDeepResearchSettingsPage } from './AiDeepResearchSettingsPage';
+
+const { mutationState, refetchSettings, settingsQuery, updateSettings } =
+    vi.hoisted(() => ({
+        mutationState: { current: { isLoading: false } },
+        refetchSettings: vi.fn(),
+        settingsQuery: {
+            current: {
+                data: {
+                    deepResearchLimits: {
+                        maxTokens: 10_000_000,
+                        maxToolCalls: 1000,
+                        maxWarehouseQueries: 100,
+                        maxHypotheses: 5,
+                    },
+                } as
+                    | {
+                          deepResearchLimits: {
+                              maxTokens: number;
+                              maxToolCalls: number;
+                              maxWarehouseQueries: number;
+                              maxHypotheses: number;
+                          };
+                      }
+                    | undefined,
+                isInitialLoading: false,
+                isError: false,
+                error: undefined as
+                    | {
+                          error: {
+                              name: string;
+                              message: string;
+                              statusCode: number;
+                          };
+                      }
+                    | undefined,
+            },
+        },
+        updateSettings: vi.fn(),
+    }));
+
+vi.mock('../../../hooks/useAiOrganizationSettings', () => ({
+    useAiOrganizationSettings: () => ({
+        ...settingsQuery.current,
+        refetch: refetchSettings,
+    }),
+    useUpdateAiOrganizationSettings: () => ({
+        mutate: updateSettings,
+        isLoading: mutationState.current.isLoading,
+    }),
+}));
+
+describe('AiDeepResearchSettingsPage', () => {
+    beforeEach(() => {
+        settingsQuery.current = {
+            data: {
+                deepResearchLimits: {
+                    maxTokens: 10_000_000,
+                    maxToolCalls: 1000,
+                    maxWarehouseQueries: 100,
+                    maxHypotheses: 5,
+                },
+            },
+            isInitialLoading: false,
+            isError: false,
+            error: undefined,
+        };
+        refetchSettings.mockReset();
+        updateSettings.mockReset();
+        mutationState.current.isLoading = false;
+    });
+
+    it('updates one organization limit while preserving the others', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(
+            <MemoryRouter>
+                <AiDeepResearchSettingsPage />
+            </MemoryRouter>,
+        );
+
+        const updateButtons = screen.getAllByRole('button', { name: 'Update' });
+        expect(updateButtons).toHaveLength(4);
+        updateButtons.forEach((button) => expect(button).toBeDisabled());
+
+        fireEvent.change(
+            screen.getByRole('textbox', { name: 'Maximum tokens' }),
+            { target: { value: '9000000' } },
+        );
+
+        expect(updateButtons[0]).toBeEnabled();
+        expect(updateButtons[1]).toBeDisabled();
+        expect(updateButtons[2]).toBeDisabled();
+        expect(updateButtons[3]).toBeDisabled();
+
+        updateSettings.mockImplementation(() => {
+            mutationState.current.isLoading = true;
+        });
+        await user.click(updateButtons[0]);
+
+        expect(updateButtons[0]).toHaveAttribute('data-loading');
+        updateButtons
+            .slice(1)
+            .forEach((button) =>
+                expect(button).not.toHaveAttribute('data-loading'),
+            );
+
+        expect(updateSettings).toHaveBeenCalledWith({
+            deepResearchLimits: {
+                maxTokens: 9_000_000,
+                maxToolCalls: 1000,
+                maxWarehouseQueries: 100,
+                maxHypotheses: 5,
+            },
+        });
+    });
+
+    it('shows the query error and allows retrying', async () => {
+        const user = userEvent.setup();
+        settingsQuery.current = {
+            data: undefined,
+            isInitialLoading: false,
+            isError: true,
+            error: {
+                error: {
+                    name: 'NetworkError',
+                    message: 'Could not load deep research settings',
+                    statusCode: 500,
+                },
+            },
+        };
+
+        renderWithProviders(
+            <MemoryRouter>
+                <AiDeepResearchSettingsPage />
+            </MemoryRouter>,
+        );
+
+        expect(
+            screen.getByText('Could not load deep research settings'),
+        ).toBeInTheDocument();
+        await user.click(screen.getByRole('button', { name: 'Try again' }));
+        expect(refetchSettings).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiDeepResearchSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiDeepResearchSettingsPage.tsx
@@ -1,0 +1,172 @@
+import { type AiDeepResearchLimits } from '@lightdash/common';
+import { Button, Group, Loader, Stack, Text, Title } from '@mantine-8/core';
+import { useForm } from '@mantine/form';
+import { useState } from 'react';
+import ErrorState from '../../../../../../components/common/ErrorState';
+import { NumberInput } from '../../../../../../components/common/NumberInput';
+import {
+    SettingsCard,
+    SettingsGridCard,
+} from '../../../../../../components/common/Settings/SettingsCard';
+import { SettingsPage } from '../../../../../../components/common/Settings/SettingsPage';
+import {
+    useAiOrganizationSettings,
+    useUpdateAiOrganizationSettings,
+} from '../../../hooks/useAiOrganizationSettings';
+
+const DEEP_RESEARCH_LIMIT_FIELDS: Array<{
+    key: keyof AiDeepResearchLimits;
+    label: string;
+    description: string;
+}> = [
+    {
+        key: 'maxTokens',
+        label: 'Maximum tokens',
+        description:
+            'The maximum total model tokens consumed across a deep research run.',
+    },
+    {
+        key: 'maxToolCalls',
+        label: 'Maximum tool calls',
+        description:
+            'The maximum number of tool calls across a deep research run.',
+    },
+    {
+        key: 'maxWarehouseQueries',
+        label: 'Maximum warehouse queries',
+        description:
+            'The maximum number of warehouse queries across a deep research run.',
+    },
+    {
+        key: 'maxHypotheses',
+        label: 'Maximum hypotheses',
+        description:
+            'The maximum number of hypotheses generated for one deep research run.',
+    },
+];
+
+const DeepResearchLimitsForm = ({
+    initialLimits,
+}: {
+    initialLimits: AiDeepResearchLimits;
+}) => {
+    const [updatingLimit, setUpdatingLimit] = useState<
+        keyof AiDeepResearchLimits | null
+    >(null);
+    const updateSettings = useUpdateAiOrganizationSettings({
+        onSettled: () => setUpdatingLimit(null),
+    });
+    const form = useForm({ initialValues: initialLimits });
+
+    const updateLimit = (key: keyof AiDeepResearchLimits) => {
+        setUpdatingLimit(key);
+        updateSettings.mutate({
+            deepResearchLimits: {
+                ...initialLimits,
+                [key]: form.values[key],
+            },
+        });
+    };
+
+    return (
+        <SettingsPage
+            title="Deep research"
+            description="Configure organization-wide safety limits for deep research runs."
+        >
+            <Stack gap="lg">
+                {DEEP_RESEARCH_LIMIT_FIELDS.map((field) => (
+                    <SettingsGridCard key={field.key}>
+                        <div>
+                            <Title order={5}>{field.label}</Title>
+                            <Text c="ldGray.6" fz="xs">
+                                {field.description}
+                            </Text>
+                        </div>
+
+                        <form
+                            onSubmit={(event) => {
+                                event.preventDefault();
+                                updateLimit(field.key);
+                            }}
+                        >
+                            <Stack gap="md">
+                                <NumberInput
+                                    label={field.label}
+                                    allowDecimal={false}
+                                    allowNegative={false}
+                                    thousandSeparator=","
+                                    {...form.getInputProps(field.key)}
+                                />
+                                <Group justify="flex-end">
+                                    <Button
+                                        type="submit"
+                                        loading={
+                                            updateSettings.isLoading &&
+                                            updatingLimit === field.key
+                                        }
+                                        disabled={
+                                            updateSettings.isLoading ||
+                                            form.values[field.key] ===
+                                                initialLimits[field.key]
+                                        }
+                                    >
+                                        Update
+                                    </Button>
+                                </Group>
+                            </Stack>
+                        </form>
+                    </SettingsGridCard>
+                ))}
+            </Stack>
+        </SettingsPage>
+    );
+};
+
+export const AiDeepResearchSettingsPage = () => {
+    const {
+        data: settings,
+        isInitialLoading,
+        isError,
+        error,
+        refetch,
+    } = useAiOrganizationSettings();
+
+    if (!isInitialLoading && !isError && settings) {
+        return (
+            <DeepResearchLimitsForm
+                key={[
+                    settings.deepResearchLimits.maxTokens,
+                    settings.deepResearchLimits.maxToolCalls,
+                    settings.deepResearchLimits.maxWarehouseQueries,
+                    settings.deepResearchLimits.maxHypotheses,
+                ].join('-')}
+                initialLimits={settings.deepResearchLimits}
+            />
+        );
+    }
+
+    return (
+        <SettingsPage
+            title="Deep research"
+            description="Configure organization-wide safety limits for deep research runs."
+        >
+            <SettingsCard>
+                {isInitialLoading ? (
+                    <Group justify="center">
+                        <Loader size="sm" />
+                    </Group>
+                ) : (
+                    <Stack align="center">
+                        <ErrorState error={error?.error} hasMarginTop={false} />
+                        <Button
+                            variant="default"
+                            onClick={() => void refetch()}
+                        >
+                            Try again
+                        </Button>
+                    </Stack>
+                )}
+            </SettingsCard>
+        </SettingsPage>
+    );
+};

--- a/packages/frontend/src/hooks/settings/deepResearchSettingsAccess.test.ts
+++ b/packages/frontend/src/hooks/settings/deepResearchSettingsAccess.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { canAccessDeepResearchSettings } from './deepResearchSettingsAccess';
+
+const access = (
+    overrides: Partial<
+        Parameters<typeof canAccessDeepResearchSettings>[0]
+    > = {},
+) =>
+    canAccessDeepResearchSettings({
+        isAiCopilotEnabledOrTrial: true,
+        isDeepResearchEnabled: true,
+        canManageOrgAiAgent: true,
+        hasAnyAiAgentAccess: true,
+        ...overrides,
+    });
+
+describe('canAccessDeepResearchSettings', () => {
+    it('allows organization AI admins when Deep Research is enabled', () => {
+        expect(access()).toBe(true);
+    });
+
+    it.each([
+        'isAiCopilotEnabledOrTrial',
+        'isDeepResearchEnabled',
+        'canManageOrgAiAgent',
+        'hasAnyAiAgentAccess',
+    ] as const)('denies access when %s is false', (gate) => {
+        expect(access({ [gate]: false })).toBe(false);
+    });
+});

--- a/packages/frontend/src/hooks/settings/deepResearchSettingsAccess.ts
+++ b/packages/frontend/src/hooks/settings/deepResearchSettingsAccess.ts
@@ -1,0 +1,20 @@
+import { type SettingsContext } from './types';
+
+type DeepResearchSettingsAccess = Pick<
+    SettingsContext,
+    | 'isAiCopilotEnabledOrTrial'
+    | 'isDeepResearchEnabled'
+    | 'canManageOrgAiAgent'
+    | 'hasAnyAiAgentAccess'
+>;
+
+export const canAccessDeepResearchSettings = ({
+    isAiCopilotEnabledOrTrial,
+    isDeepResearchEnabled,
+    canManageOrgAiAgent,
+    hasAnyAiAgentAccess,
+}: DeepResearchSettingsAccess) =>
+    isAiCopilotEnabledOrTrial &&
+    isDeepResearchEnabled &&
+    canManageOrgAiAgent &&
+    hasAnyAiAgentAccess;

--- a/packages/frontend/src/hooks/settings/types.ts
+++ b/packages/frontend/src/hooks/settings/types.ts
@@ -70,6 +70,7 @@ export type SettingsContext = {
     isScimTokenManagementEnabled: FeatureFlag | undefined;
     isServiceAccountsEnabled: boolean;
     isAiCopilotEnabledOrTrial: boolean;
+    isDeepResearchEnabled: boolean;
     shouldShowAiAgentReviews: boolean;
     shouldShowAiAgentMemories: boolean;
     // Org-level AI settings access (router config, org settings, review queue).
@@ -78,6 +79,7 @@ export type SettingsContext = {
     // least one project they can reach. Gates visibility of the "Ask AI" area.
     hasAnyAiAgentAccess: boolean;
     isAiOrganizationSettingsLoading: boolean;
+    isDeepResearchFlagLoading: boolean;
     dataAppsFlag: FeatureFlag | undefined;
     isDataAppsFlagLoading: boolean;
     embeddingEnabled: FeatureFlag | undefined;

--- a/packages/frontend/src/hooks/settings/useSettingsContext.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsContext.ts
@@ -35,6 +35,12 @@ export const useSettingsContext = (): SettingsContext => {
     const shouldShowAiAgentReviews =
         aiOrganizationSettingsQuery.data?.aiAgentReviewsEnabled === true;
 
+    const deepResearchFlagQuery = useServerFeatureFlag(
+        FeatureFlags.AiDeepResearch,
+    );
+    const { data: deepResearchFlag } = deepResearchFlagQuery;
+    const isDeepResearchEnabled = deepResearchFlag?.enabled ?? false;
+
     const { data: aiAgentMemoryFlag } = useServerFeatureFlag(
         FeatureFlags.AiAgentMemory,
     );
@@ -194,12 +200,14 @@ export const useSettingsContext = (): SettingsContext => {
         isScimTokenManagementEnabled,
         isServiceAccountsEnabled,
         isAiCopilotEnabledOrTrial,
+        isDeepResearchEnabled,
         shouldShowAiAgentReviews,
         shouldShowAiAgentMemories,
         canManageOrgAiAgent,
         hasAnyAiAgentAccess,
         isAiOrganizationSettingsLoading:
             aiOrganizationSettingsQuery.isInitialLoading,
+        isDeepResearchFlagLoading: deepResearchFlagQuery.isInitialLoading,
         dataAppsFlag,
         isDataAppsFlagLoading: dataAppsFlagQuery.isInitialLoading,
         embeddingEnabled,

--- a/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
@@ -35,6 +35,7 @@ import {
     IconSettings,
     IconShieldCheck,
     IconTableOptions,
+    IconTelescope,
     IconTrash,
     IconUserCircle,
     IconUserCode,
@@ -48,6 +49,7 @@ import {
 import { useMemo } from 'react';
 import useTracking from '../../providers/Tracking/useTracking';
 import { EventName } from '../../types/Events';
+import { canAccessDeepResearchSettings } from './deepResearchSettingsAccess';
 import {
     type SettingsContext,
     type SettingsNavigationItem,
@@ -81,6 +83,7 @@ export const useSettingsNavigation = (
         isScimTokenManagementEnabled,
         isServiceAccountsEnabled,
         isAiCopilotEnabledOrTrial,
+        isDeepResearchEnabled,
         shouldShowAiAgentReviews,
         shouldShowAiAgentMemories,
         canManageOrgAiAgent,
@@ -538,6 +541,24 @@ export const useSettingsNavigation = (
                 });
             }
 
+            if (
+                canAccessDeepResearchSettings({
+                    isAiCopilotEnabledOrTrial,
+                    isDeepResearchEnabled,
+                    canManageOrgAiAgent,
+                    hasAnyAiAgentAccess,
+                })
+            ) {
+                aiChildren.push({
+                    label: 'Deep research',
+                    to: '/generalSettings/ai/deep-research',
+                    icon: IconTelescope,
+                    keywords: ['research', 'limits', 'tools', 'queries'],
+                    children: [],
+                    exact: true,
+                });
+            }
+
             organizationItems.push({
                 label: 'Ask AI',
                 to: '/generalSettings/ai',
@@ -946,6 +967,7 @@ export const useSettingsNavigation = (
         isScimEnabled,
         isServiceAccountsEnabled,
         isAiCopilotEnabledOrTrial,
+        isDeepResearchEnabled,
         shouldShowAiAgentReviews,
         shouldShowAiAgentMemories,
         canManageOrgAiAgent,

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -71,6 +71,7 @@ import UsersAndGroupsPanel from '../components/UserSettings/UsersAndGroupsPanel'
 import VerifiedDomainsPanel from '../components/UserSettings/VerifiedDomains/VerifiedDomainsPanel';
 import { ReviewRemediationWorkspace } from '../ee/features/aiCopilot/components/Admin/ReviewRemediationWorkspace';
 import { AiAgentsSettingsPage } from '../ee/features/aiCopilot/components/Admin/settings/AiAgentsSettingsPage';
+import { AiDeepResearchSettingsPage } from '../ee/features/aiCopilot/components/Admin/settings/AiDeepResearchSettingsPage';
 import { AiEvalsSettingsPage } from '../ee/features/aiCopilot/components/Admin/settings/AiEvalsSettingsPage';
 import { AiGeneralSettingsPage } from '../ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage';
 import { AiMemoriesSettingsPage } from '../ee/features/aiCopilot/components/Admin/settings/AiMemoriesSettingsPage';
@@ -87,6 +88,7 @@ import { CustomRoles } from '../ee/pages/customRoles/CustomRoles';
 import Roadmap from '../ee/pages/Roadmap';
 import { DataAppActivitySettingsPage } from '../features/dataAppActivity/components/DataAppActivitySettingsPage';
 import DesignListPage from '../features/organizationDesigns/components/DesignListPage';
+import { canAccessDeepResearchSettings } from '../hooks/settings/deepResearchSettingsAccess';
 import { filterSettingsNavigation } from '../hooks/settings/filterSettingsNavigation';
 import { useSettingsContext } from '../hooks/settings/useSettingsContext';
 import { useSettingsNavigation } from '../hooks/settings/useSettingsNavigation';
@@ -153,11 +155,13 @@ const Settings: FC = () => {
         dataAppsFlag,
         isDataAppsFlagLoading,
         isAiCopilotEnabledOrTrial,
+        isDeepResearchEnabled,
         shouldShowAiAgentReviews,
         shouldShowAiAgentMemories,
         canManageOrgAiAgent,
         hasAnyAiAgentAccess,
         isAiOrganizationSettingsLoading,
+        isDeepResearchFlagLoading,
         showImpersonationPanel,
         isLeaveOrganizationEnabled,
         isCustomRolesEnabled,
@@ -655,6 +659,19 @@ const Settings: FC = () => {
                     path: '/ai/general',
                     element: <AiGeneralSettingsPage />,
                 });
+                if (
+                    canAccessDeepResearchSettings({
+                        isAiCopilotEnabledOrTrial,
+                        isDeepResearchEnabled,
+                        canManageOrgAiAgent,
+                        hasAnyAiAgentAccess,
+                    })
+                ) {
+                    allowedRoutes.push({
+                        path: '/ai/deep-research',
+                        element: <AiDeepResearchSettingsPage />,
+                    });
+                }
             }
             allowedRoutes.push({
                 path: '/ai/threads',
@@ -770,6 +787,7 @@ const Settings: FC = () => {
         isEmailWhitelabelEnabled,
         isLeaveOrganizationEnabled,
         isAiCopilotEnabledOrTrial,
+        isDeepResearchEnabled,
         shouldShowAiAgentReviews,
         shouldShowAiAgentMemories,
         canManageOrgAiAgent,
@@ -894,6 +912,11 @@ const Settings: FC = () => {
     const isAwaitingAiSettingsRoute =
         isAiOrganizationSettingsLoading &&
         Boolean(matchPath('/generalSettings/ai/*', location.pathname));
+    const isAwaitingDeepResearchRoute =
+        isDeepResearchFlagLoading &&
+        Boolean(
+            matchPath('/generalSettings/ai/deep-research', location.pathname),
+        );
     const isAwaitingRoadmapRoute =
         isOrganizationRoadmapLoading &&
         Boolean(matchPath('/generalSettings/roadmap', location.pathname));
@@ -908,6 +931,7 @@ const Settings: FC = () => {
         isActiveProjectUuidLoading ||
         isProjectLoading ||
         isAwaitingAiSettingsRoute ||
+        isAwaitingDeepResearchRoute ||
         isAwaitingRoadmapRoute ||
         isAwaitingDataAppsRoute
     ) {


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9368/make-deep-research-a-one-click-composer-toggle

## Summary

PR 1 of 3 for [PROD-9368](https://linear.app/lightdash/issue/PROD-9368/make-deep-research-a-one-click-composer-toggle). Adds a feature-flagged organization settings page for the limits inherited by every Deep research run.

This is the base of the stack.

## Changes

**Migration**

- Adds non-null `ai_organization_settings.deep_research_limits` JSONB.
- Defaults to 10M model tokens, 1,000 tool calls, 100 warehouse queries, and 5 hypotheses.

**Backend**

- Requires every configured limit to be a positive integer without imposing product-defined range bounds.
- Returns and updates the limits through the existing AI organization settings API.

**Frontend**

- Adds an admin-only Deep research entry under AI organization settings.
- Gates the navigation entry and route with `AiDeepResearch`.
- Uses the same contained card and per-field update pattern as General settings.

## Settings flow

```text
Organization admin
       │
       ▼
Deep research settings
       │ PATCH /aiAgents/admin/settings
       ▼
ai_organization_settings.deep_research_limits
       │
       ├── maxTokens
       ├── maxToolCalls
       ├── maxWarehouseQueries
       └── maxHypotheses
```

## Test plan

- [x] Common, backend, and frontend typechecks
- [x] Common, backend, and frontend lint
- [x] AI organization settings service tests
- [x] Deep research settings form interaction test
- [x] Valid limits persist as exact JSONB values
- [x] Zero, negative, and fractional limits return 400
- [x] Migration applied and column/default verified in Postgres
- [x] Generated API includes `deepResearchLimits`
