### PR TITLE
feat(ai): inherit Deep Research execution settings

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -34,7 +34,6 @@ import {
     type AiAgentReviewItemWritebackBlockedReason,
     type AiAgentReviewItemWritebackStrategy,
     type AiAgentRootCause,
-    type AiDeepResearchEffort,
     type AiDeepResearchEntryPoint,
     type AiDeepResearchTerminalReason,
     type AiDeepResearchTerminalStatus,
@@ -2124,11 +2123,10 @@ type AiDeepResearchRunDimensions = {
     threadId: string;
     aiAgentId: string;
     entryPoint: AiDeepResearchEntryPoint;
-    effort: AiDeepResearchEffort;
     provider: string | null;
     model: string | null;
     keyManagement: 'lightdash-managed' | 'self-managed' | null;
-    selectedMcpServerCount: number;
+    attachedMcpServerCount: number;
 };
 
 export type AiDeepResearchRunStartedEvent = BaseTrack & {

--- a/packages/backend/src/ee/controllers/AiDeepResearchController.ts
+++ b/packages/backend/src/ee/controllers/AiDeepResearchController.ts
@@ -66,10 +66,8 @@ export class AiDeepResearchController extends BaseController {
                 projectUuid,
                 prompt: body.prompt,
                 agentUuid: body.agentUuid,
-                effort: body.effort,
                 aiThreadUuid: body.threadUuid,
                 promptUuid: body.promptUuid,
-                mcpServerUuids: body.mcpServerUuids,
                 entryPoint: body.entryPoint,
             }),
         };

--- a/packages/backend/src/ee/database/entities/aiDeepResearch.ts
+++ b/packages/backend/src/ee/database/entities/aiDeepResearch.ts
@@ -1,7 +1,6 @@
 import {
     type AiDeepResearchBudget,
     type AiDeepResearchChartDataMap,
-    type AiDeepResearchEffort,
     type AiDeepResearchEntryPoint,
     type AiDeepResearchEventPayload,
     type AiDeepResearchEventType,
@@ -24,16 +23,12 @@ export type DbAiDeepResearchRun = {
     tool_call_id: string | null;
     prompt: string;
     status: AiDeepResearchRunStatus;
-    selected_mcp_server_uuids: string[];
     entry_point: AiDeepResearchEntryPoint;
-    effort: AiDeepResearchEffort;
     result_markdown: string | null;
     result_chart_data: AiDeepResearchChartDataMap | null;
     report_expires_at: Date | null;
     report_expired_at: Date | null;
-    /** Rows persisted before hypothesis fan-out lack `maxHypotheses`. */
-    budget_snapshot: Omit<AiDeepResearchBudget, 'maxHypotheses'> &
-        Partial<Pick<AiDeepResearchBudget, 'maxHypotheses'>>;
+    budget_snapshot: AiDeepResearchBudget;
     execution_context_snapshot: AiDeepResearchExecutionContextSnapshot;
     error_message: string | null;
     cancellation_requested_at: Date | null;
@@ -55,9 +50,7 @@ export type AiDeepResearchRunsTable = Knex.CompositeTableType<
         | 'prompt_uuid'
         | 'tool_call_id'
         | 'prompt'
-        | 'selected_mcp_server_uuids'
         | 'entry_point'
-        | 'effort'
         | 'budget_snapshot'
         | 'execution_context_snapshot'
     >,

--- a/packages/backend/src/ee/database/migrations/20260730210000_remove_deep_research_run_configuration.ts
+++ b/packages/backend/src/ee/database/migrations/20260730210000_remove_deep_research_run_configuration.ts
@@ -1,0 +1,16 @@
+import type { Knex } from 'knex';
+
+const aiDeepResearchRuns = 'ai_deep_research_runs';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(aiDeepResearchRuns, (table) => {
+        table.dropColumns('selected_mcp_server_uuids', 'effort');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(aiDeepResearchRuns, (table) => {
+        table.jsonb('selected_mcp_server_uuids').notNullable().defaultTo('[]');
+        table.text('effort').notNullable().defaultTo('medium');
+    });
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -219,6 +219,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     aiAgentModel: models.getAiAgentModel<AiAgentModel>(),
                     aiAgentService:
                         repository.getAiAgentService<AiAgentService>(),
+                    aiOrganizationSettingsModel:
+                        models.getAiOrganizationSettingsModel<AiOrganizationSettingsModel>(),
                     projectModel: models.getProjectModel(),
                     featureFlagModel: models.getFeatureFlagModel(),
                     schedulerClient:

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.integration.test.ts
@@ -33,6 +33,7 @@ import {
 import { AiDeepResearchRunModel } from './AiDeepResearchRunModel';
 
 const budget: AiDeepResearchBudget = {
+    maxTokens: 10_000_000,
     maxToolCalls: 20,
     maxWarehouseQueries: 10,
     maxResultRows: 1_000,
@@ -64,7 +65,7 @@ const executionContextSnapshot: AiDeepResearchExecutionContextSnapshot = {
     },
     tools: {
         availableToolNames: [],
-        selectedMcpServers: [],
+        attachedMcpServers: [],
     },
     knowledgeDocuments: [],
     repository: {
@@ -180,7 +181,6 @@ describe('AiDeepResearchRunModel integration', () => {
     const createRun = async (
         dimensions: {
             entryPoint?: 'homepage' | 'ask_ai';
-            effort?: 'low' | 'medium' | 'high' | 'xhigh';
             promptUuid?: string;
         } = {},
     ): Promise<DbAiDeepResearchRun> => {
@@ -193,9 +193,7 @@ describe('AiDeepResearchRunModel integration', () => {
             promptUuid: dimensions.promptUuid ?? promptUuid,
             toolCallId: null,
             prompt: `Integration race ${crypto.randomUUID()}`,
-            selectedMcpServerUuids: [],
             entryPoint: dimensions.entryPoint ?? 'ask_ai',
-            effort: dimensions.effort ?? 'medium',
             budget,
             executionContextSnapshot: {
                 ...executionContextSnapshot,
@@ -258,21 +256,18 @@ describe('AiDeepResearchRunModel integration', () => {
         ]);
     });
 
-    it('round-trips persisted analytics dimensions', async () => {
+    it('round-trips the persisted entry point', async () => {
         const run = await createRun({
             entryPoint: 'homepage',
-            effort: 'high',
         });
 
         expect(run).toMatchObject({
             entry_point: 'homepage',
-            effort: 'high',
         });
         expect(
             await model.findByUuid(run.ai_deep_research_run_uuid),
         ).toMatchObject({
             entry_point: 'homepage',
-            effort: 'high',
         });
     });
 

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
@@ -5,7 +5,6 @@ import {
     getErrorMessage,
     type AiDeepResearchBudget,
     type AiDeepResearchChartDataMap,
-    type AiDeepResearchEffort,
     type AiDeepResearchEntryPoint,
     type AiDeepResearchEventPayload,
     type AiDeepResearchEventPayloadMap,
@@ -51,9 +50,7 @@ type CreateAiDeepResearchRun = {
     promptUuid: string;
     toolCallId: string | null;
     prompt: string;
-    selectedMcpServerUuids: string[];
     entryPoint: AiDeepResearchEntryPoint;
-    effort: AiDeepResearchEffort;
     budget: AiDeepResearchBudget;
     executionContextSnapshot: AiDeepResearchExecutionContextSnapshot;
 };
@@ -155,11 +152,7 @@ export class AiDeepResearchRunModel {
                     prompt_uuid: data.promptUuid,
                     tool_call_id: data.toolCallId,
                     prompt: data.prompt,
-                    selected_mcp_server_uuids: JSON.stringify(
-                        data.selectedMcpServerUuids,
-                    ) as unknown as string[],
                     entry_point: data.entryPoint,
-                    effort: data.effort,
                     budget_snapshot: data.budget,
                     execution_context_snapshot: data.executionContextSnapshot,
                 })

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -412,7 +412,6 @@ type GenerateAgentExecutionOptions =
     | {
           mode: 'deep_research';
           budget: AiDeepResearchBudget;
-          selectedMcpServerUuids: string[];
           abortSignal?: AbortSignal;
           initialTokenUsage?: number;
           onStepUsage?: (tokens: number) => void | Promise<void>;
@@ -420,9 +419,14 @@ type GenerateAgentExecutionOptions =
           onExecutionContextResolved?: (
               snapshot: AiDeepResearchExecutionContextSnapshot,
           ) => void | Promise<void>;
-          research?: AiDeepResearchExecutionRole;
+          research: AiDeepResearchExecutionRole;
           parentToolCallId?: string | null;
       };
+
+export const shouldIncludeAttachedMcpServers = (
+    executionMode: GenerateAgentExecutionOptions['mode'],
+    researchRole?: AiDeepResearchExecutionRole['role'],
+) => executionMode === 'standard' || researchRole === 'investigator';
 
 // Planner and judge are single-purpose structured calls: enough steps for a
 // submission plus schema-correction retries, nothing more.
@@ -3244,15 +3248,18 @@ export class AiAgentService extends BaseService {
         user,
         projectUuid,
         agentUuid,
-        selectedMcpServerUuids,
+        includeAttachedMcpServers = true,
     }: {
         user: SessionUser;
         projectUuid: string;
         agentUuid: string;
-        selectedMcpServerUuids?: string[];
+        includeAttachedMcpServers?: boolean;
     }): Promise<AiAgentMcpServer[]> {
         if (!user.organizationUuid) {
             throw new ForbiddenError('Organization not found');
+        }
+        if (!includeAttachedMcpServers) {
+            return [];
         }
 
         const attachedServers = await this.refreshGithubMcpCredentials(
@@ -3262,36 +3269,11 @@ export class AiAgentService extends BaseService {
                 user.userUuid,
             ),
         );
-        const selectedServerUuids =
-            selectedMcpServerUuids === undefined
-                ? null
-                : new Set(selectedMcpServerUuids);
-
-        if (selectedServerUuids) {
-            const attachedServerUuids = new Set(
-                attachedServers.map((server) => server.uuid),
-            );
-            const unknownServerUuids = [...selectedServerUuids].filter(
-                (serverUuid) => !attachedServerUuids.has(serverUuid),
-            );
-            if (unknownServerUuids.length > 0) {
-                throw new ParameterError(
-                    'One or more selected MCP servers are not attached to this agent',
-                );
-            }
-        }
-
-        const selectedServers = selectedServerUuids
-            ? attachedServers.filter((server) =>
-                  selectedServerUuids.has(server.uuid),
-              )
-            : attachedServers;
-
         return this.aiAgentMcpRuntimeClient.attachRuntimeProviders({
             projectUuid,
             userUuid: user.userUuid,
             mcpServers: await Promise.all(
-                selectedServers.map(async (mcpServer) => ({
+                attachedServers.map(async (mcpServer) => ({
                     ...mcpServer,
                     enabledToolNames:
                         await this.aiAgentModel.getEnabledMcpServerToolNames({
@@ -3303,17 +3285,15 @@ export class AiAgentService extends BaseService {
         });
     }
 
-    public async validateDeepResearchMcpSelection(
+    public async resolveDeepResearchExecutionContext(
         user: SessionUser,
         {
             projectUuid,
             agentUuid,
-            mcpServerUuids,
             modelConfig,
         }: {
             projectUuid: string;
             agentUuid: string;
-            mcpServerUuids: string[];
             modelConfig: AiAgentModelConfig | null;
         },
     ): Promise<AiDeepResearchExecutionContextSnapshot> {
@@ -3322,7 +3302,6 @@ export class AiAgentService extends BaseService {
             user,
             projectUuid,
             agentUuid,
-            selectedMcpServerUuids: mcpServerUuids,
         });
         const setup = await this.aiAgentMcpRuntimeClient.resolveTools({
             mcpServers,
@@ -3396,7 +3375,7 @@ export class AiAgentService extends BaseService {
                 },
                 tools: {
                     availableToolNames: Object.keys(setup.tools).sort(),
-                    selectedMcpServers: mcpServers.map((server) => ({
+                    attachedMcpServers: mcpServers.map((server) => ({
                         uuid: server.uuid,
                         name: server.name,
                         enabledToolNames: Object.entries(
@@ -8831,10 +8810,12 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             user,
             projectUuid: prompt.projectUuid,
             agentUuid: agentSettings.uuid,
-            selectedMcpServerUuids:
+            includeAttachedMcpServers: shouldIncludeAttachedMcpServers(
+                responseExecution.mode,
                 responseExecution.mode === 'deep_research'
-                    ? responseExecution.selectedMcpServerUuids
+                    ? responseExecution.research?.role
                     : undefined,
+            ),
         });
         const { enabled: grepFieldsEnabled } =
             await this.featureFlagService.get({
@@ -9044,13 +9025,12 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         let execution: AiAgentExecutionConfig;
         if (responseExecution.mode === 'deep_research') {
             const getMaxSteps = () => {
-                switch (responseExecution.research?.role) {
+                switch (responseExecution.research.role) {
                     case 'planner':
                         return DEEP_RESEARCH_PLANNER_MAX_STEPS;
                     case 'judge':
                         return DEEP_RESEARCH_JUDGE_MAX_STEPS;
                     case 'investigator':
-                    case undefined:
                         // The executor counts tool calls directly. Leave room
                         // for planning and the final report-only model step.
                         return (
@@ -9170,7 +9150,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         ) {
             await mcpToolSetup.closeMcpClients();
             throw new ParameterError(
-                `Selected MCP servers became unavailable: ${mcpToolSetup.unavailableMcpServers
+                `Attached MCP servers became unavailable: ${mcpToolSetup.unavailableMcpServers
                     .map((server) => server.serverName)
                     .join(', ')}`,
             );

--- a/packages/backend/src/ee/services/AiAgentService/deepResearchMcpInheritance.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/deepResearchMcpInheritance.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { shouldIncludeAttachedMcpServers } from './AiAgentService';
+
+describe('shouldIncludeAttachedMcpServers', () => {
+    it('includes attached MCP servers for standard and investigator execution', () => {
+        expect(shouldIncludeAttachedMcpServers('standard')).toBe(true);
+        expect(
+            shouldIncludeAttachedMcpServers('deep_research', 'investigator'),
+        ).toBe(true);
+    });
+
+    it('excludes attached MCP servers from planning and synthesis', () => {
+        expect(
+            shouldIncludeAttachedMcpServers('deep_research', 'planner'),
+        ).toBe(false);
+        expect(shouldIncludeAttachedMcpServers('deep_research', 'judge')).toBe(
+            false,
+        );
+    });
+});

--- a/packages/backend/src/ee/services/AiAgentService/mcpBearerCredential.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/mcpBearerCredential.test.ts
@@ -173,62 +173,45 @@ const buildPreflightService = ({
     };
 };
 
-describe('validateDeepResearchMcpSelection', () => {
-    it('resolves only selected attached servers with their enabled tools', async () => {
+describe('resolveDeepResearchExecutionContext', () => {
+    it('resolves all attached servers with their enabled tools', async () => {
         const secondServer = { ...bearerServer, uuid: 'server-2' };
         const { service, aiAgentMcpRuntimeClient, closeMcpClients } =
             buildPreflightService({
                 attachedServers: [bearerServer, secondServer],
             });
 
-        const snapshot = await service.validateDeepResearchMcpSelection(user, {
-            projectUuid: PROJECT_UUID,
-            agentUuid: 'agent-1',
-            mcpServerUuids: [secondServer.uuid],
-            modelConfig: null,
-        });
+        const snapshot = await service.resolveDeepResearchExecutionContext(
+            user,
+            {
+                projectUuid: PROJECT_UUID,
+                agentUuid: 'agent-1',
+                modelConfig: null,
+            },
+        );
 
         expect(
             aiAgentMcpRuntimeClient.attachRuntimeProviders,
         ).toHaveBeenCalledWith({
             projectUuid: PROJECT_UUID,
             userUuid: USER_UUID,
-            mcpServers: [
-                expect.objectContaining({
-                    uuid: secondServer.uuid,
-                    enabledToolNames: ['search_issues'],
-                }),
-            ],
+            mcpServers: expect.arrayContaining([
+                expect.objectContaining({ uuid: bearerServer.uuid }),
+                expect.objectContaining({ uuid: secondServer.uuid }),
+            ]),
         });
         expect(snapshot).toMatchObject({
             schemaVersion: 1,
             resolutionStage: 'preflight',
             tools: {
                 availableToolNames: ['mcp_github__search_issues'],
-                selectedMcpServers: [
-                    {
-                        uuid: secondServer.uuid,
-                        name: secondServer.name,
-                        enabledToolNames: ['mcp_github__search_issues'],
-                    },
-                ],
+                attachedMcpServers: expect.arrayContaining([
+                    expect.objectContaining({ uuid: bearerServer.uuid }),
+                    expect.objectContaining({ uuid: secondServer.uuid }),
+                ]),
             },
         });
         expect(closeMcpClients).toHaveBeenCalledOnce();
-    });
-
-    it('rejects servers that are not attached to the selected agent', async () => {
-        const { service, aiAgentMcpRuntimeClient } = buildPreflightService();
-
-        await expect(
-            service.validateDeepResearchMcpSelection(user, {
-                projectUuid: PROJECT_UUID,
-                agentUuid: 'agent-1',
-                mcpServerUuids: ['other-server'],
-                modelConfig: null,
-            }),
-        ).rejects.toBeInstanceOf(ParameterError);
-        expect(aiAgentMcpRuntimeClient.resolveTools).not.toHaveBeenCalled();
     });
 
     it('rejects unavailable credentials and closes connected MCP clients', async () => {
@@ -244,10 +227,9 @@ describe('validateDeepResearchMcpSelection', () => {
         });
 
         await expect(
-            service.validateDeepResearchMcpSelection(user, {
+            service.resolveDeepResearchExecutionContext(user, {
                 projectUuid: PROJECT_UUID,
                 agentUuid: 'agent-1',
-                mcpServerUuids: [SERVER_UUID],
                 modelConfig: null,
             }),
         ).rejects.toThrow(

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.test.ts
@@ -15,6 +15,7 @@ import {
 import { AiDeepResearchExecutor } from './AiDeepResearchExecutor';
 
 const budget = {
+    maxTokens: 10_000,
     maxToolCalls: 20,
     maxWarehouseQueries: 10,
     maxResultRows: 1_000,
@@ -46,7 +47,7 @@ const executionContextSnapshot: AiDeepResearchExecutionContextSnapshot = {
     },
     tools: {
         availableToolNames: ['submitResearchReport'],
-        selectedMcpServers: [],
+        attachedMcpServers: [],
     },
     knowledgeDocuments: [],
     repository: {
@@ -123,9 +124,7 @@ const run = (
     tool_call_id: null,
     prompt: 'Investigate revenue',
     status: 'running',
-    selected_mcp_server_uuids: ['mcp-1'],
     entry_point: 'ask_ai',
-    effort: 'low',
     result_markdown: null,
     result_chart_data: null,
     report_expires_at: null,
@@ -402,7 +401,6 @@ describe('AiDeepResearchExecutor', () => {
             toolHints: [AI_DEEP_RESEARCH_HYPOTHESES_TOOL_NAME],
             forceToolHints: true,
             execution: {
-                selectedMcpServerUuids: [],
                 parentToolCallId: 'deep-research:run-1:planner',
                 research: { maxHypotheses: 2 },
             },
@@ -416,7 +414,6 @@ describe('AiDeepResearchExecutor', () => {
             'deep-research:run-1:hypothesis-2',
         ]);
         investigatorCalls.forEach(([, options]: AnyType[]) => {
-            expect(options.execution.selectedMcpServerUuids).toEqual(['mcp-1']);
             expect(options.execution.budget).toMatchObject({
                 maxToolCalls: 7,
                 maxWarehouseQueries: 5,
@@ -678,6 +675,35 @@ describe('AiDeepResearchExecutor', () => {
         ).toContain('maxWarehouseQueries');
     });
 
+    it('enforces the aggregate token budget across phases', async () => {
+        const generateAgentThreadResponse = respondByRole({
+            onInvestigate: async (options: AnyType) => {
+                await options.execution.onStepUsage(60);
+                options.execution.research.onReport(investigationReport());
+                return 'investigated';
+            },
+        });
+        const { executor } = buildExecutor({
+            generateAgentThreadResponse,
+            provenance: [],
+            childProvenance: [],
+        });
+
+        const result = await executor.execute(
+            run({ budget_snapshot: { ...budget, maxTokens: 100 } }),
+            { signal: new AbortController().signal },
+        );
+
+        expect(result.status).toBe('partially_completed');
+        expect(result.terminalReason).toBe('token_limit');
+        expect(
+            result.status === 'partially_completed' && result.report.markdown,
+        ).toContain('maxTokens');
+        expect(callsByRole(generateAgentThreadResponse, 'judge')).toHaveLength(
+            0,
+        );
+    });
+
     it('retries each investigator once with forced submission before giving up on it', async () => {
         const attemptsByHypothesis = new Map<string, number>();
         const generateAgentThreadResponse = respondByRole({
@@ -753,29 +779,6 @@ describe('AiDeepResearchExecutor', () => {
             toolHints: [AI_DEEP_RESEARCH_REPORT_TOOL_NAME],
             forceToolHints: true,
         });
-    });
-
-    it('defaults the hypothesis count for runs persisted before hypothesis fan-out', async () => {
-        const generateAgentThreadResponse = respondByRole();
-        const { executor } = buildExecutor({ generateAgentThreadResponse });
-        const legacyBudget = {
-            maxToolCalls: 125,
-            maxWarehouseQueries: 25,
-            maxResultRows: 10_000,
-        } as DbAiDeepResearchRun['budget_snapshot'];
-
-        await executor.execute(run({ budget_snapshot: legacyBudget }), {
-            signal: new AbortController().signal,
-        });
-
-        const plannerCalls = callsByRole(
-            generateAgentThreadResponse,
-            'planner',
-        );
-        expect(plannerCalls[0][1].execution.research.maxHypotheses).toBe(3);
-        expect(
-            callsByRole(generateAgentThreadResponse, 'investigator'),
-        ).toHaveLength(3);
     });
 
     it('returns a partial result when execution fails after a valid report was saved', async () => {

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.ts
@@ -131,7 +131,7 @@ ${reason}
 
 ## Conclusion
 
-- Run Deep Research again with a larger depth to continue investigating: ${run.prompt}`,
+- Run Deep Research again to continue investigating: ${run.prompt}`,
     charts: [],
 });
 
@@ -311,7 +311,11 @@ export class AiDeepResearchExecutor {
         const controller = new AbortController();
         let cancelledByUser = false;
         let authorizationRevokedReason: string | null = null;
-        let budgetExceeded: keyof typeof budget | null = null;
+        let budgetExceeded:
+            | 'maxTokens'
+            | 'maxToolCalls'
+            | 'maxWarehouseQueries'
+            | null = null;
         const stopRunMonitor = this.startRunMonitor(
             run,
             controller,
@@ -330,6 +334,14 @@ export class AiDeepResearchExecutor {
 
         const trackTokens = (stepTokens: number) => {
             tokens += stepTokens;
+            if (tokens > budget.maxTokens) {
+                budgetExceeded = 'maxTokens';
+                const error = new Error(
+                    'Deep Research exceeded its token budget',
+                );
+                controller.abort(error);
+                throw error;
+            }
         };
         const trackWarehouseQuery = () => {
             warehouseQueries += 1;
@@ -431,7 +443,6 @@ export class AiDeepResearchExecutor {
                     execution: {
                         mode: 'deep_research',
                         budget: phaseBudgets.planner,
-                        selectedMcpServerUuids: [],
                         abortSignal: runSignal,
                         initialTokenUsage: 0,
                         onStepUsage: trackTokens,
@@ -480,8 +491,6 @@ export class AiDeepResearchExecutor {
                         execution: {
                             mode: 'deep_research',
                             budget: phaseBudgets.investigator,
-                            selectedMcpServerUuids:
-                                run.selected_mcp_server_uuids,
                             abortSignal: runSignal,
                             initialTokenUsage: 0,
                             onStepUsage: trackTokens,
@@ -551,7 +560,6 @@ export class AiDeepResearchExecutor {
                 execution: {
                     mode: 'deep_research',
                     budget: phaseBudgets.judge,
-                    selectedMcpServerUuids: [],
                     abortSignal: runSignal,
                     initialTokenUsage: tokens,
                     onStepUsage: trackTokens,
@@ -663,10 +671,11 @@ export class AiDeepResearchExecutor {
                         `The ${budgetExceeded} budget was exhausted.`,
                     ),
                 warehouseQueryUuids: queryUuids,
-                terminalReason:
-                    budgetExceeded === 'maxToolCalls'
-                        ? 'tool_limit'
-                        : 'query_limit',
+                terminalReason: {
+                    maxTokens: 'token_limit' as const,
+                    maxToolCalls: 'tool_limit' as const,
+                    maxWarehouseQueries: 'query_limit' as const,
+                }[budgetExceeded],
             };
         }
         if (executionError) {

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
@@ -1,5 +1,6 @@
 import { Ability, AbilityBuilder } from '@casl/ability';
 import {
+    AI_DEEP_RESEARCH_DEFAULT_LIMITS,
     AI_DEEP_RESEARCH_REPORT_TOOL_NAME,
     AiResultType,
     AnyType,
@@ -18,6 +19,7 @@ import { Readable } from 'stream';
 import { AiDeepResearchService } from './AiDeepResearchService';
 
 const budget: AiDeepResearchBudget = {
+    maxTokens: 10_000_000,
     maxToolCalls: 20,
     maxWarehouseQueries: 10,
     maxResultRows: 1_000,
@@ -49,7 +51,7 @@ const executionContextSnapshot: AiDeepResearchExecutionContextSnapshot = {
     },
     tools: {
         availableToolNames: [],
-        selectedMcpServers: [],
+        attachedMcpServers: [],
     },
     knowledgeDocuments: [],
     repository: {
@@ -71,45 +73,6 @@ const executionContextSnapshot: AiDeepResearchExecutionContextSnapshot = {
         autoApproveSql: true,
     },
 };
-
-const effortBudgets = [
-    {
-        effort: 'low',
-        budget: {
-            maxToolCalls: 50,
-            maxWarehouseQueries: 10,
-            maxResultRows: 5_000,
-            maxHypotheses: 2,
-        },
-    },
-    {
-        effort: 'medium',
-        budget: {
-            maxToolCalls: 125,
-            maxWarehouseQueries: 25,
-            maxResultRows: 10_000,
-            maxHypotheses: 3,
-        },
-    },
-    {
-        effort: 'high',
-        budget: {
-            maxToolCalls: 250,
-            maxWarehouseQueries: 50,
-            maxResultRows: 25_000,
-            maxHypotheses: 4,
-        },
-    },
-    {
-        effort: 'xhigh',
-        budget: {
-            maxToolCalls: 500,
-            maxWarehouseQueries: 100,
-            maxResultRows: 50_000,
-            maxHypotheses: 6,
-        },
-    },
-] as const;
 
 const chart = {
     source: 'warehouse' as const,
@@ -189,9 +152,7 @@ const runRow = (overrides: Record<string, unknown> = {}) => ({
     tool_call_id: null,
     prompt: 'Investigate revenue',
     status: 'queued',
-    selected_mcp_server_uuids: ['mcp-1'],
     entry_point: 'ask_ai',
-    effort: 'medium',
     result_markdown: null,
     result_chart_data: null,
     report_expires_at: null,
@@ -212,6 +173,7 @@ const buildService = (
         model?: Record<string, unknown>;
         aiAgentModel?: Record<string, unknown>;
         aiAgentService?: Record<string, unknown>;
+        aiOrganizationSettingsModel?: Record<string, unknown>;
         projectModel?: Record<string, unknown>;
         featureFlagModel?: Record<string, unknown>;
         schedulerClient?: Record<string, unknown>;
@@ -273,10 +235,21 @@ const buildService = (
     };
     const aiAgentService = {
         assertDeepResearchAccess: vi.fn().mockResolvedValue(undefined),
-        validateDeepResearchMcpSelection: vi
+        resolveDeepResearchExecutionContext: vi
             .fn()
             .mockResolvedValue(executionContextSnapshot),
         ...overrides.aiAgentService,
+    };
+    const aiOrganizationSettingsModel = {
+        findByOrganizationUuid: vi.fn().mockResolvedValue({
+            deepResearchLimits: {
+                maxTokens: budget.maxTokens,
+                maxToolCalls: budget.maxToolCalls,
+                maxWarehouseQueries: budget.maxWarehouseQueries,
+                maxHypotheses: budget.maxHypotheses,
+            },
+        }),
+        ...overrides.aiOrganizationSettingsModel,
     };
     const projectModel = {
         getSummary: vi.fn().mockResolvedValue({ organizationUuid: 'org-1' }),
@@ -321,6 +294,7 @@ const buildService = (
         aiDeepResearchRunModel: model as AnyType,
         aiAgentModel: aiAgentModel as AnyType,
         aiAgentService: aiAgentService as AnyType,
+        aiOrganizationSettingsModel: aiOrganizationSettingsModel as AnyType,
         projectModel: projectModel as AnyType,
         featureFlagModel: featureFlagModel as AnyType,
         schedulerClient: schedulerClient as AnyType,
@@ -334,6 +308,7 @@ const buildService = (
         model,
         aiAgentModel,
         aiAgentService,
+        aiOrganizationSettingsModel,
         projectModel,
         featureFlagModel,
         schedulerClient,
@@ -352,13 +327,12 @@ const validCreateRunArgs = () => ({
     agentUuid: 'agent-1',
     aiThreadUuid: 'thread-1',
     promptUuid: 'prompt-1',
-    mcpServerUuids: ['mcp-1'],
     entryPoint: 'ask_ai' as const,
 });
 
 describe('AiDeepResearchService', () => {
     describe('createRun', () => {
-        it('preflights and persists the exact agent, prompt, and MCP selection before enqueueing', async () => {
+        it('preflights the inherited agent configuration and persists organization limits before enqueueing', async () => {
             const {
                 service,
                 model,
@@ -371,8 +345,6 @@ describe('AiDeepResearchService', () => {
             const run = await service.createRun({
                 ...validCreateRunArgs(),
                 prompt: '  Investigate revenue  ',
-                mcpServerUuids: ['mcp-1', 'mcp-1', 'mcp-2'],
-                budget,
             });
 
             expect(aiAgentModel.findThreadOwnership).toHaveBeenCalledWith({
@@ -383,13 +355,12 @@ describe('AiDeepResearchService', () => {
                 'prompt-1',
             );
             expect(
-                aiAgentService.validateDeepResearchMcpSelection,
+                aiAgentService.resolveDeepResearchExecutionContext,
             ).toHaveBeenCalledWith(
                 expect.objectContaining({ userUuid: 'user-1' }),
                 {
                     projectUuid: 'project-1',
                     agentUuid: 'agent-1',
-                    mcpServerUuids: ['mcp-1', 'mcp-2'],
                     modelConfig: null,
                 },
             );
@@ -402,10 +373,8 @@ describe('AiDeepResearchService', () => {
                 promptUuid: 'prompt-1',
                 toolCallId: null,
                 prompt: 'Investigate revenue',
-                selectedMcpServerUuids: ['mcp-1', 'mcp-2'],
                 entryPoint: 'ask_ai',
-                effort: 'medium',
-                budget,
+                budget: { ...budget, maxResultRows: 10_000 },
                 executionContextSnapshot,
             });
             expect(schedulerClient.aiDeepResearch).toHaveBeenCalledWith({
@@ -451,23 +420,29 @@ describe('AiDeepResearchService', () => {
                     threadId: 'thread-1',
                     aiAgentId: 'agent-1',
                     entryPoint: 'ask_ai',
-                    effort: 'medium',
                     provider: null,
                     model: null,
                     keyManagement: null,
-                    selectedMcpServerCount: 1,
+                    attachedMcpServerCount: 0,
                 },
             });
         });
 
-        it('uses the server-owned default budget when none is provided', async () => {
-            const { service, model } = buildService();
+        it('uses default limits when the organization has no settings row', async () => {
+            const { service, model } = buildService({
+                aiOrganizationSettingsModel: {
+                    findByOrganizationUuid: vi.fn().mockResolvedValue(null),
+                },
+            });
 
             await service.createRun(validCreateRunArgs());
 
             expect(model.create).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    budget: effortBudgets[1].budget,
+                    budget: {
+                        ...AI_DEEP_RESEARCH_DEFAULT_LIMITS,
+                        maxResultRows: 10_000,
+                    },
                 }),
             );
         });
@@ -484,7 +459,7 @@ describe('AiDeepResearchService', () => {
 
             expect(run.aiDeepResearchRunUuid).toBe('run-1');
             expect(
-                aiAgentService.validateDeepResearchMcpSelection,
+                aiAgentService.resolveDeepResearchExecutionContext,
             ).not.toHaveBeenCalled();
             expect(
                 aiAgentService.assertDeepResearchAccess,
@@ -604,24 +579,9 @@ describe('AiDeepResearchService', () => {
                     service.createRun(validCreateRunArgs()),
                 ).rejects.toBeInstanceOf(ParameterError);
                 expect(
-                    aiAgentService.validateDeepResearchMcpSelection,
+                    aiAgentService.resolveDeepResearchExecutionContext,
                 ).not.toHaveBeenCalled();
                 expect(model.create).not.toHaveBeenCalled();
-            },
-        );
-
-        it.each(effortBudgets)(
-            'maps $effort effort to its server-owned budget',
-            async ({ effort, budget: expectedBudget }) => {
-                const { service, model } = buildService();
-
-                await service.createRun({ ...validCreateRunArgs(), effort });
-
-                expect(model.create).toHaveBeenCalledWith(
-                    expect.objectContaining({
-                        budget: expectedBudget,
-                    }),
-                );
             },
         );
 
@@ -797,7 +757,7 @@ describe('AiDeepResearchService', () => {
                     service.createRun(validCreateRunArgs()),
                 ).rejects.toBeInstanceOf(NotFoundError);
                 expect(
-                    aiAgentService.validateDeepResearchMcpSelection,
+                    aiAgentService.resolveDeepResearchExecutionContext,
                 ).not.toHaveBeenCalled();
                 expect(model.create).not.toHaveBeenCalled();
             },
@@ -809,7 +769,7 @@ describe('AiDeepResearchService', () => {
             );
             const { service, model, schedulerClient } = buildService({
                 aiAgentService: {
-                    validateDeepResearchMcpSelection: vi
+                    resolveDeepResearchExecutionContext: vi
                         .fn()
                         .mockRejectedValue(preflightError),
                 },
@@ -831,10 +791,7 @@ describe('AiDeepResearchService', () => {
             });
 
             await expect(
-                service.createRun({
-                    ...validCreateRunArgs(),
-                    budget,
-                }),
+                service.createRun(validCreateRunArgs()),
             ).rejects.toThrow('queue unavailable');
             expect(model.markFailed).toHaveBeenCalledWith(
                 'run-1',
@@ -847,128 +804,26 @@ describe('AiDeepResearchService', () => {
             expect(analytics.track).not.toHaveBeenCalled();
         });
 
-        it('rejects invalid budget snapshots before persistence', async () => {
-            const { service, model } = buildService();
+        it('rejects invalid organization limits before persistence', async () => {
+            const { service, model } = buildService({
+                aiOrganizationSettingsModel: {
+                    findByOrganizationUuid: vi.fn().mockResolvedValue({
+                        deepResearchLimits: {
+                            ...AI_DEEP_RESEARCH_DEFAULT_LIMITS,
+                            maxToolCalls: 0,
+                        },
+                    }),
+                },
+            });
 
             await expect(
-                service.createRun({
-                    ...validCreateRunArgs(),
-                    budget: { ...budget, maxToolCalls: 0 },
-                }),
-            ).rejects.toBeInstanceOf(ParameterError);
-            expect(model.create).not.toHaveBeenCalled();
-        });
-
-        it('rejects budget snapshots above server limits', async () => {
-            const { service, model } = buildService();
-
-            await expect(
-                service.createRun({
-                    ...validCreateRunArgs(),
-                    budget: {
-                        ...budget,
-                        maxToolCalls: 501,
-                    },
-                }),
-            ).rejects.toBeInstanceOf(ParameterError);
-            expect(model.create).not.toHaveBeenCalled();
-        });
-
-        it('rejects budgets with fewer than two hypotheses', async () => {
-            const { service, model } = buildService();
-
-            await expect(
-                service.createRun({
-                    ...validCreateRunArgs(),
-                    budget: { ...budget, maxHypotheses: 1 },
-                }),
-            ).rejects.toBeInstanceOf(ParameterError);
-            expect(model.create).not.toHaveBeenCalled();
-        });
-
-        it('rejects budgets with more hypotheses than the server limit', async () => {
-            const { service, model } = buildService();
-
-            await expect(
-                service.createRun({
-                    ...validCreateRunArgs(),
-                    budget: { ...budget, maxHypotheses: 7 },
-                }),
-            ).rejects.toBeInstanceOf(ParameterError);
-            expect(model.create).not.toHaveBeenCalled();
-        });
-
-        it('rejects budgets whose tool-call limit cannot cover the hypotheses', async () => {
-            const { service, model } = buildService();
-
-            await expect(
-                service.createRun({
-                    ...validCreateRunArgs(),
-                    budget: {
-                        ...budget,
-                        maxToolCalls: 2,
-                        maxHypotheses: 2,
-                    },
-                }),
+                service.createRun(validCreateRunArgs()),
             ).rejects.toBeInstanceOf(ParameterError);
             expect(model.create).not.toHaveBeenCalled();
         });
     });
 
     describe('access and cancellation', () => {
-        it('omits legacy limits from returned budget snapshots', async () => {
-            const legacyBudget = {
-                ...budget,
-                maxRuntimeMs: 30 * 60 * 1_000,
-                maxTokens: 1_000_000,
-            } as AiDeepResearchBudget;
-            const { service } = buildService({
-                model: {
-                    findByUuidScoped: vi
-                        .fn()
-                        .mockResolvedValue(
-                            runRow({ budget_snapshot: legacyBudget }),
-                        ),
-                },
-            });
-
-            const run = await service.getRun(
-                userWithProjectAccess(),
-                'project-1',
-                'run-1',
-            );
-
-            expect(run.budget).toEqual(budget);
-        });
-
-        it('defaults the hypothesis count for budgets persisted before hypothesis fan-out', async () => {
-            const preHypothesisBudget = {
-                maxToolCalls: budget.maxToolCalls,
-                maxWarehouseQueries: budget.maxWarehouseQueries,
-                maxResultRows: budget.maxResultRows,
-            };
-            const { service } = buildService({
-                model: {
-                    findByUuidScoped: vi
-                        .fn()
-                        .mockResolvedValue(
-                            runRow({ budget_snapshot: preHypothesisBudget }),
-                        ),
-                },
-            });
-
-            const run = await service.getRun(
-                userWithProjectAccess(),
-                'project-1',
-                'run-1',
-            );
-
-            expect(run.budget).toEqual({
-                ...preHypothesisBudget,
-                maxHypotheses: 3,
-            });
-        });
-
         it('does not expose a run through a different project path', async () => {
             const { service, model, projectModel } = buildService({
                 model: {

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    AI_DEEP_RESEARCH_DEFAULT_LIMITS,
     AI_DEEP_RESEARCH_REPORT_TOOL_NAME,
     AiResultType,
     buildInlineChartFields,
@@ -24,7 +25,6 @@ import {
     type AiDeepResearchChartDefinition,
     type AiDeepResearchChartSnapshot,
     type AiDeepResearchChartSnapshotValue,
-    type AiDeepResearchEffort,
     type AiDeepResearchEntryPoint,
     type AiDeepResearchEvent,
     type AiDeepResearchEventPayloadMap,
@@ -59,6 +59,7 @@ import {
     type AiDeepResearchRunModel,
     type DbAiDeepResearchEventWithCursor,
 } from '../../models/AiDeepResearchRunModel';
+import { type AiOrganizationSettingsModel } from '../../models/AiOrganizationSettingsModel';
 import { type CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
 import { type AiAgentService } from '../AiAgentService/AiAgentService';
 import { isDeepResearchWarehouseTool } from './toolClassification';
@@ -193,7 +194,11 @@ type Dependencies = {
     >;
     aiAgentService: Pick<
         AiAgentService,
-        'assertDeepResearchAccess' | 'validateDeepResearchMcpSelection'
+        'assertDeepResearchAccess' | 'resolveDeepResearchExecutionContext'
+    >;
+    aiOrganizationSettingsModel: Pick<
+        AiOrganizationSettingsModel,
+        'findByOrganizationUuid'
     >;
     projectModel: ProjectModel;
     featureFlagModel: FeatureFlagModel;
@@ -212,59 +217,11 @@ type EventCursorPayload = {
     eventUuid: string;
 };
 
-export const AI_DEEP_RESEARCH_BUDGETS_BY_EFFORT: Record<
-    AiDeepResearchEffort,
-    AiDeepResearchBudget
-> = {
-    low: {
-        maxToolCalls: 50,
-        maxWarehouseQueries: 10,
-        maxResultRows: 5_000,
-        maxHypotheses: 2,
-    },
-    medium: {
-        maxToolCalls: 125,
-        maxWarehouseQueries: 25,
-        maxResultRows: 10_000,
-        maxHypotheses: 3,
-    },
-    high: {
-        maxToolCalls: 250,
-        maxWarehouseQueries: 50,
-        maxResultRows: 25_000,
-        maxHypotheses: 4,
-    },
-    xhigh: {
-        maxToolCalls: 500,
-        maxWarehouseQueries: 100,
-        maxResultRows: 50_000,
-        maxHypotheses: 6,
-    },
-};
+const AI_DEEP_RESEARCH_MAX_RESULT_ROWS = 10_000;
 
-export const AI_DEEP_RESEARCH_DEFAULT_EFFORT: AiDeepResearchEffort = 'medium';
-
-export const AI_DEEP_RESEARCH_DEFAULT_BUDGET =
-    AI_DEEP_RESEARCH_BUDGETS_BY_EFFORT[AI_DEEP_RESEARCH_DEFAULT_EFFORT];
-
-export const AI_DEEP_RESEARCH_MAX_BUDGET =
-    AI_DEEP_RESEARCH_BUDGETS_BY_EFFORT.xhigh;
-
-/**
- * Normalizes a persisted budget snapshot: drops legacy limits that are no
- * longer part of the budget, and defaults the hypothesis count for rows
- * persisted before hypothesis fan-out existed.
- */
 export const getAiDeepResearchRunBudget = (
     budgetSnapshot: DbAiDeepResearchRun['budget_snapshot'],
-): AiDeepResearchBudget => ({
-    maxToolCalls: budgetSnapshot.maxToolCalls,
-    maxWarehouseQueries: budgetSnapshot.maxWarehouseQueries,
-    maxResultRows: budgetSnapshot.maxResultRows,
-    maxHypotheses:
-        budgetSnapshot.maxHypotheses ??
-        AI_DEEP_RESEARCH_DEFAULT_BUDGET.maxHypotheses,
-});
+): AiDeepResearchBudget => budgetSnapshot;
 
 const getReportExpiresAt = (row: DbAiDeepResearchRun): Date | null => {
     if (row.report_expires_at) {
@@ -290,9 +247,7 @@ const toRun = (row: DbAiDeepResearchRun): AiDeepResearchRun => {
         agentUuid: row.agent_uuid,
         aiThreadUuid: row.ai_thread_uuid,
         promptUuid: row.prompt_uuid,
-        mcpServerUuids: row.selected_mcp_server_uuids,
         entryPoint: row.entry_point,
-        effort: row.effort,
         prompt: row.prompt,
         status: row.status,
         resultMarkdown: isReportExpired ? null : row.result_markdown,
@@ -413,16 +368,6 @@ const assertValidBudget = (budget: AiDeepResearchBudget): void => {
             'Deep Research maxToolCalls must exceed maxHypotheses',
         );
     }
-    const exceededBudget = Object.entries(budget).find(
-        ([key, value]) =>
-            value >
-            AI_DEEP_RESEARCH_MAX_BUDGET[key as keyof AiDeepResearchBudget],
-    );
-    if (exceededBudget) {
-        throw new ParameterError(
-            `Deep Research ${exceededBudget[0]} exceeds the server limit`,
-        );
-    }
 };
 
 export class AiDeepResearchService extends BaseService {
@@ -434,8 +379,10 @@ export class AiDeepResearchService extends BaseService {
 
     private readonly aiAgentService: Pick<
         AiAgentService,
-        'assertDeepResearchAccess' | 'validateDeepResearchMcpSelection'
+        'assertDeepResearchAccess' | 'resolveDeepResearchExecutionContext'
     >;
+
+    private readonly aiOrganizationSettingsModel: Dependencies['aiOrganizationSettingsModel'];
 
     private readonly projectModel: ProjectModel;
 
@@ -462,6 +409,7 @@ export class AiDeepResearchService extends BaseService {
         aiDeepResearchRunModel,
         aiAgentModel,
         aiAgentService,
+        aiOrganizationSettingsModel,
         projectModel,
         featureFlagModel,
         schedulerClient,
@@ -475,6 +423,7 @@ export class AiDeepResearchService extends BaseService {
         this.aiDeepResearchRunModel = aiDeepResearchRunModel;
         this.aiAgentModel = aiAgentModel;
         this.aiAgentService = aiAgentService;
+        this.aiOrganizationSettingsModel = aiOrganizationSettingsModel;
         this.projectModel = projectModel;
         this.featureFlagModel = featureFlagModel;
         this.schedulerClient = schedulerClient;
@@ -492,11 +441,11 @@ export class AiDeepResearchService extends BaseService {
             threadId: run.ai_thread_uuid,
             aiAgentId: run.agent_uuid,
             entryPoint: run.entry_point,
-            effort: run.effort,
             provider: run.execution_context_snapshot.model.provider,
             model: run.execution_context_snapshot.model.modelName,
             keyManagement: run.execution_context_snapshot.model.keyManagement,
-            selectedMcpServerCount: run.selected_mcp_server_uuids.length,
+            attachedMcpServerCount:
+                run.execution_context_snapshot.tools.attachedMcpServers.length,
         };
     }
 
@@ -681,11 +630,8 @@ export class AiDeepResearchService extends BaseService {
         projectUuid: string;
         prompt: string;
         agentUuid: string;
-        effort?: AiDeepResearchEffort;
-        budget?: AiDeepResearchBudget;
         aiThreadUuid: string;
         promptUuid: string;
-        mcpServerUuids: string[];
         entryPoint: AiDeepResearchEntryPoint;
         toolCallId?: string;
     }): Promise<AiDeepResearchRun> {
@@ -700,11 +646,6 @@ export class AiDeepResearchService extends BaseService {
         if (args.prompt.trim().length === 0) {
             throw new ParameterError('Deep Research prompt is required');
         }
-        const effort = args.effort ?? AI_DEEP_RESEARCH_DEFAULT_EFFORT;
-        const budget =
-            args.budget ?? AI_DEEP_RESEARCH_BUDGETS_BY_EFFORT[effort];
-        assertValidBudget(budget);
-
         await this.assertCanCreateRun(args.user, args.projectUuid);
         const featureFlag = await this.featureFlagModel.get({
             user: args.user,
@@ -713,6 +654,16 @@ export class AiDeepResearchService extends BaseService {
         if (!featureFlag.enabled) {
             throw new ForbiddenError('Deep Research is not enabled');
         }
+        const organizationSettings =
+            await this.aiOrganizationSettingsModel.findByOrganizationUuid(
+                args.user.organizationUuid,
+            );
+        const budget: AiDeepResearchBudget = {
+            ...(organizationSettings?.deepResearchLimits ??
+                AI_DEEP_RESEARCH_DEFAULT_LIMITS),
+            maxResultRows: AI_DEEP_RESEARCH_MAX_RESULT_ROWS,
+        };
+        assertValidBudget(budget);
 
         const ownership = await this.aiAgentModel.findThreadOwnership({
             organizationUuid: args.user.organizationUuid,
@@ -776,14 +727,12 @@ export class AiDeepResearchService extends BaseService {
             );
         }
 
-        const mcpServerUuids = [...new Set(args.mcpServerUuids)];
         const executionContextSnapshot: AiDeepResearchExecutionContextSnapshot =
-            await this.aiAgentService.validateDeepResearchMcpSelection(
+            await this.aiAgentService.resolveDeepResearchExecutionContext(
                 args.user,
                 {
                     projectUuid: args.projectUuid,
                     agentUuid: args.agentUuid,
-                    mcpServerUuids,
                     modelConfig: prompt.modelConfig ?? null,
                 },
             );
@@ -799,9 +748,7 @@ export class AiDeepResearchService extends BaseService {
                 promptUuid: args.promptUuid,
                 toolCallId: args.toolCallId ?? null,
                 prompt: prompt.prompt.trim(),
-                selectedMcpServerUuids: mcpServerUuids,
                 entryPoint: args.entryPoint,
-                effort,
                 budget,
                 executionContextSnapshot,
             });

--- a/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
@@ -14,6 +14,7 @@ import {
 describe('getDeepResearchBudgetInstruction', () => {
     it('advertises only enforceable Deep Research limits', () => {
         const instruction = getDeepResearchBudgetInstruction({
+            maxTokens: 10_000,
             maxToolCalls: 20,
             maxWarehouseQueries: 10,
             maxResultRows: 1_000,
@@ -23,7 +24,7 @@ describe('getDeepResearchBudgetInstruction', () => {
         expect(instruction).toContain('20 tool calls');
         expect(instruction).toContain('10 warehouse queries');
         expect(instruction).toContain('1000 rows per query result');
-        expect(instruction).not.toContain('token');
+        expect(instruction).toContain('10000 total model tokens');
     });
 });
 
@@ -137,7 +138,7 @@ describe('buildDeepResearchExecutionContextSnapshot', () => {
                     'generateVisualization',
                     'mcp_github__search_issues',
                 ],
-                selectedMcpServers: [
+                attachedMcpServers: [
                     {
                         uuid: 'mcp-1',
                         name: 'GitHub',
@@ -378,12 +379,24 @@ describe('getAgentTools workstream tool gate', () => {
             mode: 'deep_research',
             maxSteps: 30,
             budget: {
+                maxTokens: 10_000,
                 maxToolCalls: 20,
                 maxWarehouseQueries: 10,
                 maxResultRows: 1_000,
                 maxHypotheses: 2,
             },
             initialTokenUsage: 0,
+            research: {
+                role: 'investigator',
+                hypothesis: {
+                    id: 'hypothesis-1',
+                    claim: 'The data supports the hypothesis',
+                    rationale: 'Test rationale',
+                    supportingEvidence: 'A matching trend',
+                    falsifyingEvidence: 'No matching trend',
+                },
+                onReport: vi.fn(),
+            },
         };
         const tools = getAgentTools(
             args,
@@ -400,7 +413,7 @@ describe('getAgentTools workstream tool gate', () => {
 
         expect(Object.keys(tools)).toEqual(
             expect.arrayContaining([
-                'submitResearchReport',
+                'submitInvestigationReport',
                 'editDbtProject',
                 'generateVisualization',
                 'mcp_github__create_issue',

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -277,7 +277,7 @@ export const buildDeepResearchExecutionContextSnapshot = (
     },
     tools: {
         availableToolNames: Object.keys(tools).sort(),
-        selectedMcpServers: args.mcpServers.map((server) => ({
+        attachedMcpServers: args.mcpServers.map((server) => ({
             uuid: server.uuid,
             name: server.name,
             enabledToolNames: Object.entries(
@@ -1050,7 +1050,7 @@ export const buildMessagesWithMemoryBlock = ({
 export const getDeepResearchBudgetInstruction = (
     budget: AiDeepResearchBudget,
 ): string =>
-    `Run limits: at most ${budget.maxToolCalls} tool calls, ${budget.maxWarehouseQueries} warehouse queries, and ${budget.maxResultRows} rows per query result. Submit the best report available before a limit is exhausted.`;
+    `Run limits: at most ${budget.maxTokens} total model tokens, ${budget.maxToolCalls} tool calls, ${budget.maxWarehouseQueries} warehouse queries, and ${budget.maxResultRows} rows per query result. Submit the best report available before a limit is exhausted.`;
 
 const getAgentMessages = (
     args: AiAgentArgs,

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -153,7 +153,7 @@ export type AiAgentExecutionConfig =
           onExecutionContextResolved?: (
               snapshot: AiDeepResearchExecutionContextSnapshot,
           ) => void | Promise<void>;
-          research?: AiDeepResearchExecutionRole;
+          research: AiDeepResearchExecutionRole;
           /**
            * Persists this call's tool activity as subagent children so it
            * stays out of rebuilt model history; null keeps it top-level.

--- a/packages/common/src/ee/aiDeepResearch/types.ts
+++ b/packages/common/src/ee/aiDeepResearch/types.ts
@@ -34,6 +34,7 @@ export const AI_DEEP_RESEARCH_TERMINAL_REASONS = [
     'permission_revoked',
     'tool_limit',
     'query_limit',
+    'token_limit',
     'provider_error',
     'internal_error',
 ] as const;
@@ -48,11 +49,8 @@ export const isAiDeepResearchRunTerminal = (
         status as AiDeepResearchTerminalStatus,
     );
 
-export type AiDeepResearchBudget = {
-    maxToolCalls: number;
-    maxWarehouseQueries: number;
+export type AiDeepResearchBudget = AiDeepResearchLimits & {
     maxResultRows: number;
-    maxHypotheses: number;
 };
 
 export type AiDeepResearchLimits = {
@@ -140,7 +138,7 @@ export type AiDeepResearchExecutionContextSnapshot = {
     };
     tools: {
         availableToolNames: string[];
-        selectedMcpServers: {
+        attachedMcpServers: {
             uuid: string;
             name: string;
             enabledToolNames: string[];
@@ -172,27 +170,14 @@ export type AiDeepResearchExecutionContextSnapshot = {
     };
 };
 
-export const AI_DEEP_RESEARCH_EFFORTS = [
-    'low',
-    'medium',
-    'high',
-    'xhigh',
-] as const;
-
-export type AiDeepResearchEffort = (typeof AI_DEEP_RESEARCH_EFFORTS)[number];
-
 export type AiDeepResearchRequestBody = {
     prompt: string;
     /** Agent whose complete runtime configuration will execute this run. */
     agentUuid: string;
-    /** Server-owned execution budget tier. Defaults to medium. */
-    effort?: AiDeepResearchEffort;
     /** Agent thread to attach the run to. Must be owned by the caller. */
     threadUuid: string;
     /** Thread message that captured this prompt. */
     promptUuid: string;
-    /** Agent-attached MCP servers enabled for this run. */
-    mcpServerUuids: string[];
     /** Product surface that accepted the run. */
     entryPoint: AiDeepResearchEntryPoint;
 };
@@ -344,9 +329,7 @@ export type AiDeepResearchRun = {
     agentUuid: string;
     aiThreadUuid: string;
     promptUuid: string;
-    mcpServerUuids: string[];
     entryPoint: AiDeepResearchEntryPoint;
-    effort: AiDeepResearchEffort;
     prompt: string;
     status: AiDeepResearchRunStatus;
     /** The report narrative with compact <chart> references. */

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/runProgress.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/runProgress.ts
@@ -3,7 +3,6 @@ import {
     countDeepResearchFindings,
     type AiDeepResearchActivity,
     type AiDeepResearchBudget,
-    type AiDeepResearchEffort,
     type AiDeepResearchEvent,
     type AiDeepResearchPhase,
     type AiDeepResearchRun,
@@ -20,33 +19,28 @@ export const DEEP_RESEARCH_DEPTH_CONFIG: Record<
     DeepResearchDepth,
     {
         label: string;
-        effort: AiDeepResearchEffort;
         warehouseQueries: number;
         description: string;
     }
 > = {
     quick: {
         label: 'Low',
-        effort: 'low',
         warehouseQueries: 10,
         description: 'A focused check of the strongest available evidence.',
     },
     standard: {
         label: 'Medium',
-        effort: 'medium',
         warehouseQueries: 25,
         description:
             'A balanced investigation with validation and alternatives.',
     },
     deep: {
         label: 'High',
-        effort: 'high',
         warehouseQueries: 50,
         description: 'A broad investigation with more competing explanations.',
     },
     exhaustive: {
         label: 'Extra High',
-        effort: 'xhigh',
         warehouseQueries: 100,
         description: 'The widest evidence review for high-stakes questions.',
     },
@@ -138,7 +132,7 @@ export const toDeepResearchRegistration = (
     agentUuid: run.agentUuid,
     threadUuid: args.threadUuid,
     promptUuid: run.promptUuid,
-    mcpServerUuids: run.mcpServerUuids,
+    mcpServerUuids: [],
     userUuid: args.userUuid,
     question: run.prompt,
     depth: getDepthFromBudget(run.budget),

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.ts
@@ -30,7 +30,6 @@ import {
 import { getDeepResearchRunRefetchInterval } from '../deepResearch/runPolling';
 import {
     adaptDeepResearchRun,
-    DEEP_RESEARCH_DEPTH_CONFIG,
     isDeepResearchRunTerminal,
     toDeepResearchRegistration,
 } from '../deepResearch/runProgress';
@@ -180,10 +179,8 @@ const useStartDeepResearchMutationBase = <
             return startDeepResearch(projectUuid, {
                 prompt: variables.question,
                 agentUuid,
-                effort: DEEP_RESEARCH_DEPTH_CONFIG[variables.depth].effort,
                 threadUuid,
                 promptUuid: variables.promptUuid,
-                mcpServerUuids: variables.mcpServerUuids,
                 entryPoint,
             });
         },


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9368/make-deep-research-a-one-click-composer-toggle

## Summary

PR 2 of 3 for [PROD-9368](https://linear.app/lightdash/issue/PROD-9368/make-deep-research-a-one-click-composer-toggle). Makes Deep research execution configuration-free by inheriting organization limits and the agent's attached MCP servers.

Stacks on top of PR 1 ([#26587](https://github.com/lightdash/lightdash/pull/26587)), which adds the organization policy and settings UI.

## Changes

**API and storage**

- Removes effort and MCP selection from run requests and responses.
- Drops the obsolete run configuration columns.
- Snapshots the effective organization limits into each run budget.

**Execution**

- Resolves every MCP server and enabled tool attached to the selected agent.
- Gives inherited MCP tools only to investigator phases; planner and judge remain tool-free.
- Enforces the configured token limit across planning, parallel investigations, and judging.
- Returns the best available partial report with `token_limit` when aggregate model usage exceeds the limit.

## Execution flow

```text
configuration-free request
       │
       ├── organization limits ──► durable run budget
       │                              │
       │                              └── aggregate token accounting
       └── selected agent
                │
        ┌───────┼──────────┐
        ▼       ▼          ▼
     planner investigators judge
     no MCPs   all attached no MCPs
```

## Test plan

- [x] Backend, common, and frontend typechecks
- [x] Backend and common lint
- [x] Deep research service and executor tests
- [x] Aggregate token-limit regression test
- [x] Role-based MCP inheritance tests
- [x] Generated API omits effort and MCP selection
- [x] Removed columns are absent in Postgres
- [x] London API and scheduler restart cleanly
