### PR TITLE
docs: clarify branch-scoped Okteto sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,13 @@ cd lightdash
 
 See the [contributing guide](https://github.com/lightdash/lightdash/blob/main/.github/CONTRIBUTING.md) for the full local setup, package scripts, and development workflow.
 
+Coding-agent sessions that use the shared Okteto environment treat its warm
+image only as a startup cache. Initial synchronization uses the files tracked
+by commits on the checked-out branch as its source of truth, even when the warm
+image contains newer changes from `main`; subsequent workspace edits continue
+to synchronize normally. See the
+[coding-agent Okteto guide](docs/agent-okteto.md) for details.
+
 ## Stack
 
 Lightdash is a TypeScript monorepo built with:

--- a/docs/agent-okteto.md
+++ b/docs/agent-okteto.md
@@ -14,6 +14,15 @@ The manifest uses the stable development environment name `lightdash` so pool
 provisioning and agent synchronization update the same Okteto environment
 record regardless of the checkout directory name.
 
+The warm image is only a startup cache; the checked-out branch is the source of
+truth. Before live editing begins, initial synchronization must reconcile the
+development container with the files tracked by commits at the branch's
+`HEAD`. Files that exist only in the warm image, including changes from a newer
+`main`, must be removed from the container rather than copied into the
+workspace, shown as untracked changes, or committed to the task branch. After
+that reconciliation, edits made in the workspace continue to synchronize
+normally.
+
 ## What you need
 
 Ask a Lightdash administrator for the shared coding-agent Okteto token. This is


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Documents that warm Okteto images are startup caches and that the checked-out branch commit tree is the synchronization source of truth.
Clarifies that newer `main` files must not enter the workspace or task branch while subsequent workspace edits continue syncing normally.