### PR TITLE
feat(scheduler): enable csv/xlsx delivery formats for data apps

### DIFF
--- a/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
@@ -293,6 +293,145 @@ describe('SchedulerService', () => {
                 undefined,
             );
         });
+
+        describe('app payloads', () => {
+            const sendAppUuid = 'appUuid';
+            const sendAppRow = {
+                app_uuid: sendAppUuid,
+                organization_uuid: organizationUuid,
+                project_uuid: projectUuid,
+                space_uuid: null,
+                created_by_user_uuid: 'userUuid',
+                name: 'Sales App',
+            };
+
+            const buildAppSendService = () => {
+                const appSendSchedulerClient = {
+                    addScheduledDeliveryJob: vi.fn(async () => ({})),
+                };
+                const appSendSlackClient = {
+                    joinChannels: vi.fn(async () => {}),
+                };
+                const appSendService = new SchedulerService({
+                    lightdashConfig: lightdashConfigMock,
+                    analytics: analyticsMock,
+                    schedulerModel: {} as SchedulerModel,
+                    dashboardModel: {} as DashboardModel,
+                    savedChartModel: {} as SavedChartModel,
+                    savedSqlModel: {} as SavedSqlModel,
+                    appModel: {
+                        findAppByUuid: vi.fn(async () => sendAppRow),
+                    } as unknown as AppModel,
+                    projectModel: {} as ProjectModel,
+                    schedulerClient:
+                        appSendSchedulerClient as unknown as SchedulerClient,
+                    slackClient: appSendSlackClient as unknown as SlackClient,
+                    emailClient: {} as EmailClient,
+                    userModel: {} as UserModel,
+                    googleDriveClient: {} as GoogleDriveClient,
+                    userService: {} as UserService,
+                    jobModel: {} as JobModel,
+                    spacePermissionService:
+                        spacePermissionService as unknown as SpacePermissionService,
+                });
+                return { appSendService, appSendSchedulerClient };
+            };
+
+            const appSendActor = buildUser([
+                {
+                    subject: 'DataApp',
+                    action: ['view'],
+                    conditions: { organizationUuid },
+                },
+                {
+                    subject: 'ScheduledDeliveries',
+                    action: ['create'],
+                    conditions: { organizationUuid },
+                },
+            ]);
+
+            const appSendPayload = (
+                format: SchedulerFormat,
+                options: unknown,
+            ) =>
+                ({
+                    name: 'send now app delivery',
+                    format,
+                    cron: '0 0 * * *',
+                    timezone: 'UTC',
+                    options,
+                    savedChartUuid: null,
+                    dashboardUuid: null,
+                    savedSqlUuid: null,
+                    appUuid: sendAppUuid,
+                    createdBy: 'userUuid',
+                    enabled: true,
+                    includeLinks: true,
+                    targets: [{ recipient: 'recipient@example.com' }],
+                }) as unknown as CreateSchedulerAndTargets;
+
+            test.each([SchedulerFormat.GSHEETS, SchedulerFormat.PDF])(
+                'rejects a %s send-now app payload',
+                async (format) => {
+                    const { appSendService, appSendSchedulerClient } =
+                        buildAppSendService();
+
+                    await expect(
+                        appSendService.sendScheduler(
+                            appSendActor,
+                            appSendPayload(format, {}),
+                        ),
+                    ).rejects.toThrowError(ParameterError);
+
+                    expect(
+                        appSendSchedulerClient.addScheduledDeliveryJob,
+                    ).not.toHaveBeenCalled();
+                },
+            );
+
+            test('rejects a send-now app payload with a csv limit other than table', async () => {
+                const { appSendService, appSendSchedulerClient } =
+                    buildAppSendService();
+
+                await expect(
+                    appSendService.sendScheduler(
+                        appSendActor,
+                        appSendPayload(SchedulerFormat.CSV, {
+                            formatted: true,
+                            limit: 'all',
+                        }),
+                    ),
+                ).rejects.toThrowError(ParameterError);
+
+                expect(
+                    appSendSchedulerClient.addScheduledDeliveryJob,
+                ).not.toHaveBeenCalled();
+            });
+
+            test('accepts a send-now csv app payload with limit table', async () => {
+                const { appSendService, appSendSchedulerClient } =
+                    buildAppSendService();
+
+                await appSendService.sendScheduler(
+                    appSendActor,
+                    appSendPayload(SchedulerFormat.CSV, {
+                        formatted: true,
+                        limit: 'table',
+                    }),
+                );
+
+                expect(
+                    appSendSchedulerClient.addScheduledDeliveryJob,
+                ).toHaveBeenCalledWith(
+                    expect.any(Date),
+                    expect.objectContaining({
+                        format: SchedulerFormat.CSV,
+                        appUuid: sendAppUuid,
+                    }),
+                    undefined,
+                );
+            });
+        });
     });
 
     describe('getScheduler', () => {

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -1589,6 +1589,12 @@ export class SchedulerService extends BaseService {
             }
         }
 
+        // Send-now payloads can be unsaved, so the create/update format gate
+        // never runs for them otherwise.
+        if (isAppScheduler(scheduler)) {
+            SchedulerService.validateAppSchedulerDelivery(scheduler);
+        }
+
         const { organizationUuid, projectUuid } =
             await this.getSchedulerProjectContext(scheduler);
 

--- a/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
+++ b/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
@@ -100,6 +100,9 @@ type Props = {
      *  `useSdkUpgradeStatus`). Null on surfaces without an upgrade flow (the
      *  viewer). `disabled` while a build is already in flight. */
     upgrade: (SdkUpgradeOffer & { disabled: boolean }) | null;
+    /** Count of ready queries captured by the live preview, forwarded to the
+     *  scheduler modal so it can gate/caption csv/xlsx delivery formats. */
+    capturedQueryCount?: number;
 };
 
 /**
@@ -133,6 +136,7 @@ const AppHeaderActions: FC<Props> = ({
     captureThumbnail,
     capturePreviewScreenshot,
     upgrade,
+    capturedQueryCount,
 }) => {
     const navigate = useNavigate();
 
@@ -543,6 +547,7 @@ const AppHeaderActions: FC<Props> = ({
                     name={getAppDisplayName(appName, appUuid)}
                     isOpen
                     onClose={() => setSchedulerModalOpen(false)}
+                    capturedQueryCount={capturedQueryCount}
                 />
             )}
             {isPromoteModalOpen && (

--- a/packages/frontend/src/features/apps/hooks/useTrackedAppQueries.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useTrackedAppQueries.test.ts
@@ -171,6 +171,107 @@ describe('useTrackedAppQueries', () => {
 
             expect(result.current.queries).toHaveLength(1);
         });
+
+        // The parent-owned fetch/poll isn't torn down by an iframe reload, so
+        // a query in flight at reset time can still deliver its terminal
+        // event afterwards — it must be dropped, not appended as a phantom
+        // row inflating the new boundary's count.
+        it('drops a late terminal event (same id) for a query that was in-flight before the reset', () => {
+            const { result, rerender } = renderHook(
+                (resetKey: number | undefined) =>
+                    useTrackedAppQueries(resetKey),
+                { initialProps: 1 },
+            );
+
+            act(() => {
+                result.current.handleQueryEvent(
+                    baseEvent({ id: 'q1', status: 'pending' }),
+                );
+            });
+
+            rerender(2);
+            expect(result.current.queries).toHaveLength(0);
+
+            act(() => {
+                result.current.handleQueryEvent(
+                    baseEvent({
+                        id: 'q1',
+                        status: 'ready',
+                        queryUuid: 'q1-uuid',
+                    }),
+                );
+            });
+
+            expect(result.current.queries).toHaveLength(0);
+        });
+
+        // Results-cache dedupe can fold a second POST onto the same
+        // queryUuid under a DIFFERENT id — id-only exclusion would miss this,
+        // so the late event must also be blocked by queryUuid.
+        it('drops a late terminal event (different id, same queryUuid) for a query in-flight before the reset', () => {
+            const { result, rerender } = renderHook(
+                (resetKey: number | undefined) =>
+                    useTrackedAppQueries(resetKey),
+                { initialProps: 1 },
+            );
+
+            act(() => {
+                result.current.handleQueryEvent(
+                    baseEvent({ id: 'post-a', status: 'pending' }),
+                );
+            });
+            act(() => {
+                result.current.handleQueryEvent(
+                    baseEvent({
+                        id: 'post-a',
+                        status: 'running',
+                        queryUuid: 'shared-uuid',
+                    }),
+                );
+            });
+
+            rerender(2);
+            expect(result.current.queries).toHaveLength(0);
+
+            act(() => {
+                result.current.handleQueryEvent(
+                    baseEvent({
+                        id: 'post-b',
+                        status: 'ready',
+                        queryUuid: 'shared-uuid',
+                    }),
+                );
+            });
+
+            expect(result.current.queries).toHaveLength(0);
+        });
+
+        it('resetQueries() called directly also blocks a late event for a previously-tracked id', () => {
+            const { result } = renderHook(() => useTrackedAppQueries());
+
+            act(() => {
+                result.current.handleQueryEvent(
+                    baseEvent({ id: 'q1', status: 'pending' }),
+                );
+            });
+
+            act(() => {
+                result.current.resetQueries();
+            });
+            expect(result.current.queries).toHaveLength(0);
+
+            act(() => {
+                result.current.handleQueryEvent(
+                    baseEvent({
+                        id: 'q1',
+                        status: 'ready',
+                        queryUuid: 'q1-uuid',
+                    }),
+                );
+            });
+
+            expect(result.current.queries).toHaveLength(0);
+        });
     });
 });
 

--- a/packages/frontend/src/features/apps/hooks/useTrackedAppQueries.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useTrackedAppQueries.test.ts
@@ -246,6 +246,197 @@ describe('useTrackedAppQueries', () => {
             expect(result.current.queries).toHaveLength(0);
         });
 
+        // The backend can hand a NEW submission the SAME queryUuid as a wiped
+        // one (results-cache dedupe). A permanent uuid blacklist would accept
+        // the new request's pending event and drop its running/ready ones,
+        // stranding it pending and zeroing capturedQueryCount for a valid app.
+        it('reclaims an excluded queryUuid recycled by a live post-reset request', () => {
+            const { result, rerender } = renderHook(
+                (resetKey: number | undefined) =>
+                    useTrackedAppQueries(resetKey),
+                { initialProps: 1 },
+            );
+
+            act(() => {
+                result.current.handleQueryEvent(
+                    baseEvent({ id: POST_ID_A, status: 'pending' }),
+                );
+            });
+            act(() => {
+                result.current.handleQueryEvent(
+                    baseEvent({
+                        id: POST_ID_A,
+                        status: 'running',
+                        queryUuid: QUERY_UUID,
+                    }),
+                );
+            });
+
+            rerender(2);
+            expect(result.current.queries).toHaveLength(0);
+
+            // New version's identical query: fresh request id, recycled uuid.
+            act(() => {
+                result.current.handleQueryEvent(
+                    baseEvent({ id: POST_ID_B, status: 'pending' }),
+                );
+            });
+            act(() => {
+                result.current.handleQueryEvent(
+                    baseEvent({
+                        id: POST_ID_B,
+                        status: 'running',
+                        queryUuid: QUERY_UUID,
+                    }),
+                );
+            });
+            act(() => {
+                result.current.handleQueryEvent(
+                    baseEvent({
+                        id: POST_ID_B,
+                        status: 'ready',
+                        queryUuid: QUERY_UUID,
+                        rowCount: 7,
+                    }),
+                );
+            });
+
+            expect(result.current.queries).toHaveLength(1);
+            expect(result.current.queries[0]).toMatchObject({
+                id: POST_ID_B,
+                status: 'ready',
+                queryUuid: QUERY_UUID,
+                rowCount: 7,
+            });
+            expect(
+                countReadyQueriesSinceBoundary(result.current.queries, 0),
+            ).toBe(1);
+        });
+
+        // Ordering matters: the pre-reset request's own late terminal must not
+        // reclaim the uuid on its way out, or the new request that recycles it
+        // afterwards inherits a phantom row instead of its own entry.
+        it('drops the old late terminal first, then still lets the recycled uuid through', () => {
+            const { result, rerender } = renderHook(
+                (resetKey: number | undefined) =>
+                    useTrackedAppQueries(resetKey),
+                { initialProps: 1 },
+            );
+
+            act(() => {
+                result.current.handleQueryEvent(
+                    baseEvent({ id: POST_ID_A, status: 'pending' }),
+                );
+            });
+            act(() => {
+                result.current.handleQueryEvent(
+                    baseEvent({
+                        id: POST_ID_A,
+                        status: 'running',
+                        queryUuid: QUERY_UUID,
+                    }),
+                );
+            });
+
+            rerender(2);
+
+            // Late terminal for the PRE-reset request, re-keyed to its POST id.
+            act(() => {
+                result.current.handleQueryEvent(
+                    baseEvent({
+                        id: POST_ID_A,
+                        status: 'ready',
+                        queryUuid: QUERY_UUID,
+                        rowCount: 99,
+                    }),
+                );
+            });
+            expect(result.current.queries).toHaveLength(0);
+
+            act(() => {
+                result.current.handleQueryEvent(
+                    baseEvent({ id: POST_ID_B, status: 'pending' }),
+                );
+            });
+            act(() => {
+                result.current.handleQueryEvent(
+                    baseEvent({
+                        id: POST_ID_B,
+                        status: 'running',
+                        queryUuid: QUERY_UUID,
+                    }),
+                );
+            });
+            act(() => {
+                result.current.handleQueryEvent(
+                    baseEvent({
+                        id: POST_ID_B,
+                        status: 'ready',
+                        queryUuid: QUERY_UUID,
+                        rowCount: 7,
+                    }),
+                );
+            });
+
+            expect(result.current.queries).toHaveLength(1);
+            expect(result.current.queries[0]).toMatchObject({
+                id: POST_ID_B,
+                status: 'ready',
+                rowCount: 7,
+            });
+        });
+
+        // Linked charts emit no `pending` placeholder — their first event is
+        // the POST-response `running`, so reclamation can't require a tracked
+        // entry to already exist under the fresh id.
+        it('reclaims a recycled uuid for a chart query whose first event is running', () => {
+            const { result, rerender } = renderHook(
+                (resetKey: number | undefined) =>
+                    useTrackedAppQueries(resetKey),
+                { initialProps: 1 },
+            );
+
+            act(() => {
+                result.current.handleQueryEvent(
+                    baseEvent({
+                        id: POST_ID_A,
+                        status: 'running',
+                        queryUuid: QUERY_UUID,
+                    }),
+                );
+            });
+
+            rerender(2);
+            expect(result.current.queries).toHaveLength(0);
+
+            act(() => {
+                result.current.handleQueryEvent(
+                    baseEvent({
+                        id: POST_ID_B,
+                        status: 'running',
+                        queryUuid: QUERY_UUID,
+                    }),
+                );
+            });
+            act(() => {
+                result.current.handleQueryEvent(
+                    baseEvent({
+                        id: POST_ID_B,
+                        status: 'ready',
+                        queryUuid: QUERY_UUID,
+                        rowCount: 4,
+                    }),
+                );
+            });
+
+            expect(result.current.queries).toHaveLength(1);
+            expect(result.current.queries[0]).toMatchObject({
+                id: POST_ID_B,
+                status: 'ready',
+                rowCount: 4,
+            });
+        });
+
         it('resetQueries() called directly also blocks a late event for a previously-tracked id', () => {
             const { result } = renderHook(() => useTrackedAppQueries());
 

--- a/packages/frontend/src/features/apps/hooks/useTrackedAppQueries.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useTrackedAppQueries.test.ts
@@ -1,7 +1,10 @@
 import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import type { QueryEvent } from './useAppSdkBridge';
-import { useTrackedAppQueries } from './useTrackedAppQueries';
+import {
+    countReadyQueriesSinceBoundary,
+    useTrackedAppQueries,
+} from './useTrackedAppQueries';
 
 const QUERY_UUID = 'q-shared-uuid';
 const POST_ID_A = 'post-a';
@@ -105,5 +108,96 @@ describe('useTrackedAppQueries', () => {
 
         // No blank ghost rows left over from the displaced-close signal.
         expect(result.current.queries).toHaveLength(1);
+    });
+
+    describe('resetKey', () => {
+        it('does not clear on mount', () => {
+            const { result } = renderHook(() => useTrackedAppQueries(1));
+
+            act(() => {
+                result.current.handleQueryEvent(
+                    baseEvent({
+                        id: 'q1',
+                        status: 'ready',
+                        queryUuid: 'q1-uuid',
+                    }),
+                );
+            });
+
+            expect(result.current.queries).toHaveLength(1);
+        });
+
+        it('clears queries when the reset key changes (e.g. app version navigation)', () => {
+            const { result, rerender } = renderHook(
+                (resetKey: number | undefined) =>
+                    useTrackedAppQueries(resetKey),
+                { initialProps: 1 },
+            );
+
+            act(() => {
+                result.current.handleQueryEvent(
+                    baseEvent({
+                        id: 'q1',
+                        status: 'ready',
+                        queryUuid: 'q1-uuid',
+                    }),
+                );
+            });
+            expect(result.current.queries).toHaveLength(1);
+
+            rerender(2);
+
+            expect(result.current.queries).toHaveLength(0);
+        });
+
+        it('does not clear queries when the reset key is unchanged across a rerender', () => {
+            const { result, rerender } = renderHook(
+                (resetKey: number | undefined) =>
+                    useTrackedAppQueries(resetKey),
+                { initialProps: 1 },
+            );
+
+            act(() => {
+                result.current.handleQueryEvent(
+                    baseEvent({
+                        id: 'q1',
+                        status: 'ready',
+                        queryUuid: 'q1-uuid',
+                    }),
+                );
+            });
+
+            rerender(1);
+
+            expect(result.current.queries).toHaveLength(1);
+        });
+    });
+});
+
+describe('countReadyQueriesSinceBoundary', () => {
+    const readyQuery = (id: string) =>
+        baseEvent({ id, status: 'ready', queryUuid: `${id}-uuid` });
+    const pendingQuery = (id: string) => baseEvent({ id, status: 'pending' });
+
+    it('counts all ready queries when the boundary is zero', () => {
+        expect(
+            countReadyQueriesSinceBoundary(
+                [readyQuery('a'), readyQuery('b'), pendingQuery('c')],
+                0,
+            ),
+        ).toBe(2);
+    });
+
+    it('subtracts the boundary from the ready count', () => {
+        expect(
+            countReadyQueriesSinceBoundary(
+                [readyQuery('a'), readyQuery('b'), readyQuery('c')],
+                2,
+            ),
+        ).toBe(1);
+    });
+
+    it('never goes negative', () => {
+        expect(countReadyQueriesSinceBoundary([readyQuery('a')], 5)).toBe(0);
     });
 });

--- a/packages/frontend/src/features/apps/hooks/useTrackedAppQueries.ts
+++ b/packages/frontend/src/features/apps/hooks/useTrackedAppQueries.ts
@@ -10,6 +10,7 @@ export type UseTrackedAppQueriesResult = {
     setPersistLogs: (value: boolean) => void;
     handleQueryEvent: (event: QueryEvent) => void;
     clearQueries: () => void;
+    resetQueries: () => void;
     interruptInFlightQueries: () => void;
 };
 
@@ -40,7 +41,8 @@ export const countReadyQueriesSinceBoundary = (
  * between clearing and interrupting based on "Persist").
  *
  * @param resetKey - When this changes (e.g. the previewed app version),
- * queries are cleared automatically. Omit to manage resets manually.
+ * queries are reset automatically (see resetQueries). Omit to manage resets
+ * manually.
  */
 export const useTrackedAppQueries = (
     resetKey?: string | number,
@@ -62,19 +64,44 @@ export const useTrackedAppQueries = (
     // as a fresh ghost entry. The set grows for the page session; entries are
     // short request IDs, so the footprint is negligible.
     const interruptedRequestIdsRef = useRef<Set<string>>(new Set());
+    // queryUuids of entries wiped by resetQueries(). A late event can arrive
+    // under a DIFFERENT id than the one we interrupted (results-cache dedupe
+    // folds a second POST onto the same queryUuid) — id-only exclusion misses
+    // that case, so terminal events are also checked against this set.
+    const interruptedQueryUuidsRef = useRef<Set<string>>(new Set());
 
     const clearQueries = useCallback(() => {
         setQueries([]);
     }, []);
 
-    // Clears on every resetKey change but not on mount, so a caller passing
+    // Like clearQueries(), but for a resource-boundary reset (version switch)
+    // rather than an explicit "clear the log" action: the parent-owned
+    // fetch/poll isn't torn down by an iframe reload, so a query in flight at
+    // reset time can still deliver its terminal event afterwards. Without
+    // remembering the wiped entries' ids/queryUuids, that late event finds
+    // nothing to merge into and gets appended as a phantom row inflating the
+    // new boundary's count — mirroring why interruptInFlightQueries registers
+    // ids instead of just dropping entries.
+    const resetQueries = useCallback(() => {
+        setQueries((prev) => {
+            prev.forEach((q) => {
+                interruptedRequestIdsRef.current.add(q.id);
+                if (q.queryUuid) {
+                    interruptedQueryUuidsRef.current.add(q.queryUuid);
+                }
+            });
+            return [];
+        });
+    }, []);
+
+    // Resets on every resetKey change but not on mount, so a caller passing
     // e.g. the previewed version never loses queries fired during initial load.
     const previousResetKeyRef = useRef(resetKey);
     useEffect(() => {
         if (previousResetKeyRef.current === resetKey) return;
         previousResetKeyRef.current = resetKey;
-        clearQueries();
-    }, [resetKey, clearQueries]);
+        resetQueries();
+    }, [resetKey, resetQueries]);
 
     // Move pending/running entries into a terminal `error` state. Used when
     // the preview iframe reloads with persistLogs on — the iframe that would
@@ -104,6 +131,14 @@ export const useTrackedAppQueries = (
         // for requests we already marked interrupted — without this they
         // either un-terminal the entry or get appended as a ghost.
         if (interruptedRequestIdsRef.current.has(event.id)) {
+            return;
+        }
+        // Same drop, keyed by queryUuid — catches a late event arriving under
+        // a fresh id that a dedupe fold ties back to an already-wiped query.
+        if (
+            event.queryUuid &&
+            interruptedQueryUuidsRef.current.has(event.queryUuid)
+        ) {
             return;
         }
         setQueries((prev) => {
@@ -192,6 +227,7 @@ export const useTrackedAppQueries = (
         setPersistLogs,
         handleQueryEvent,
         clearQueries,
+        resetQueries,
         interruptInFlightQueries,
     };
 };

--- a/packages/frontend/src/features/apps/hooks/useTrackedAppQueries.ts
+++ b/packages/frontend/src/features/apps/hooks/useTrackedAppQueries.ts
@@ -67,7 +67,9 @@ export const useTrackedAppQueries = (
     // queryUuids of entries wiped by resetQueries(). A late event can arrive
     // under a DIFFERENT id than the one we interrupted (results-cache dedupe
     // folds a second POST onto the same queryUuid) — id-only exclusion misses
-    // that case, so terminal events are also checked against this set.
+    // that case, so terminal events are also checked against this set. Not
+    // permanent: handleQueryEvent hands a uuid back to a live request that
+    // the backend gave the same uuid to, so a valid new version isn't muted.
     const interruptedQueryUuidsRef = useRef<Set<string>>(new Set());
 
     const clearQueries = useCallback(() => {
@@ -133,15 +135,21 @@ export const useTrackedAppQueries = (
         if (interruptedRequestIdsRef.current.has(event.id)) {
             return;
         }
-        // Same drop, keyed by queryUuid — catches a late event arriving under
-        // a fresh id that a dedupe fold ties back to an already-wiped query.
-        if (
-            event.queryUuid &&
-            interruptedQueryUuidsRef.current.has(event.queryUuid)
-        ) {
-            return;
-        }
         setQueries((prev) => {
+            // Same drop, keyed by queryUuid — but reclaimable, because the
+            // backend can hand a NEW submission a recycled uuid: a tracked id
+            // or a non-terminal event means a live request owns it now.
+            if (
+                event.queryUuid &&
+                interruptedQueryUuidsRef.current.has(event.queryUuid)
+            ) {
+                const isLiveRequest =
+                    event.status === 'pending' ||
+                    event.status === 'running' ||
+                    prev.some((q) => q.id === event.id);
+                if (!isLiveRequest) return prev;
+                interruptedQueryUuidsRef.current.delete(event.queryUuid);
+            }
             // If this event has a queryUuid, merge it with an existing entry
             if (event.queryUuid) {
                 const existing = prev.find(

--- a/packages/frontend/src/features/apps/hooks/useTrackedAppQueries.ts
+++ b/packages/frontend/src/features/apps/hooks/useTrackedAppQueries.ts
@@ -1,5 +1,5 @@
 import { useLocalStorage } from '@mantine-8/hooks';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { QueryEvent } from './useAppSdkBridge';
 
 const PERSIST_LOGS_STORAGE_KEY = 'data-apps:persist-logs';
@@ -14,6 +14,18 @@ export type UseTrackedAppQueriesResult = {
 };
 
 /**
+ * Count of `ready` entries beyond a previously-recorded boundary. Used to
+ * scope a live query count (e.g. the scheduler's app csv/xlsx gate) to "since
+ * the last version switch" while the full list — kept around for "Persist" —
+ * still carries earlier versions' entries.
+ */
+export const countReadyQueriesSinceBoundary = (
+    queries: QueryEvent[],
+    boundary: number,
+): number =>
+    Math.max(0, queries.filter((q) => q.status === 'ready').length - boundary);
+
+/**
  * Tracks metric queries emitted by the app preview iframe SDK bridge.
  *
  * Owns the merge logic that turns POST initiations + poll results into a
@@ -22,11 +34,17 @@ export type UseTrackedAppQueriesResult = {
  *
  * Shared between the builder (`AppGenerate`) where the queries panel is
  * always-on, and the preview (`AppPreviewTest`) where it's opt-in via a menu.
- * Preview uses only `queries`, `handleQueryEvent`, and `clearQueries` — the
- * persist/interrupt machinery is builder-specific (preview iframe never
- * reloads mid-session) but is harmless to expose.
+ * Preview uses only `queries`, `handleQueryEvent`, `clearQueries`, and
+ * `resetKey` — the persist/interrupt machinery is builder-specific (the
+ * builder handles its own version-switch reset because it must choose
+ * between clearing and interrupting based on "Persist").
+ *
+ * @param resetKey - When this changes (e.g. the previewed app version),
+ * queries are cleared automatically. Omit to manage resets manually.
  */
-export const useTrackedAppQueries = (): UseTrackedAppQueriesResult => {
+export const useTrackedAppQueries = (
+    resetKey?: string | number,
+): UseTrackedAppQueriesResult => {
     const [queries, setQueries] = useState<QueryEvent[]>([]);
     // Mirrors Chrome DevTools "Preserve log". When off (default), the queries
     // panel is cleared on iframe refresh and on new-version load — fresh
@@ -48,6 +66,15 @@ export const useTrackedAppQueries = (): UseTrackedAppQueriesResult => {
     const clearQueries = useCallback(() => {
         setQueries([]);
     }, []);
+
+    // Clears on every resetKey change but not on mount, so a caller passing
+    // e.g. the previewed version never loses queries fired during initial load.
+    const previousResetKeyRef = useRef(resetKey);
+    useEffect(() => {
+        if (previousResetKeyRef.current === resetKey) return;
+        previousResetKeyRef.current = resetKey;
+        clearQueries();
+    }, [resetKey, clearQueries]);
 
     // Move pending/running entries into a terminal `error` state. Used when
     // the preview iframe reloads with persistLogs on — the iframe that would

--- a/packages/frontend/src/features/scheduler/components/CsvFormattingOptions.tsx
+++ b/packages/frontend/src/features/scheduler/components/CsvFormattingOptions.tsx
@@ -36,6 +36,10 @@ type CsvFormattingOptionsProps = {
     onXlsxFileLayoutChange: (value: XlsxFileLayout) => void;
     /** Render the options directly (two-column grid) instead of behind a collapsible */
     inline?: boolean;
+    /** Suppresses the row-limit control — app deliveries always use each query's own limit */
+    hideLimit?: boolean;
+    /** Suppresses the pivot layout control — meaningless without chart config (e.g. apps) */
+    hideExportPivotedData?: boolean;
 };
 
 const HelpTooltip: FC<{ label: string }> = ({ label }) => (
@@ -66,6 +70,8 @@ export const CsvFormattingOptions: FC<CsvFormattingOptionsProps> = ({
     xlsxFileLayout,
     onXlsxFileLayoutChange,
     inline = false,
+    hideLimit = false,
+    hideExportPivotedData = false,
 }) => {
     const health = useHealth();
     const [showFormatting, setShowFormatting] = useState(false);
@@ -82,57 +88,64 @@ export const CsvFormattingOptions: FC<CsvFormattingOptionsProps> = ({
                     <Radio label="Raw" value={Values.RAW} />
                 </Stack>
             </Radio.Group>
-            <Radio.Group
-                label={
-                    <>
-                        Layout
-                        <HelpTooltip label="Applies to cartesian charts with pivoted dimensions. Grouped keeps the chart's column structure; Flat returns the raw rows from the query." />
-                    </>
-                }
-                value={exportPivotedData ? 'pivoted' : 'unpivoted'}
-                onChange={(value) =>
-                    onExportPivotedDataChange(value === 'pivoted')
-                }
-            >
-                <Stack gap="xxs" pt="xs">
-                    <Radio label="Grouped" value="pivoted" />
-                    <Radio label="Flat" value="unpivoted" />
-                </Stack>
-            </Radio.Group>
-            <Stack gap="xs">
+            {!hideExportPivotedData && (
                 <Radio.Group
-                    label="Limit"
-                    value={limit}
-                    onChange={(value) => onLimitChange(value as Limit)}
+                    label={
+                        <>
+                            Layout
+                            <HelpTooltip label="Applies to cartesian charts with pivoted dimensions. Grouped keeps the chart's column structure; Flat returns the raw rows from the query." />
+                        </>
+                    }
+                    value={exportPivotedData ? 'pivoted' : 'unpivoted'}
+                    onChange={(value) =>
+                        onExportPivotedDataChange(value === 'pivoted')
+                    }
                 >
                     <Stack gap="xxs" pt="xs">
-                        <Radio label="Results in Table" value={Limit.TABLE} />
-                        <Radio label="All Results" value={Limit.ALL} />
-                        <Radio label="Custom..." value={Limit.CUSTOM} />
+                        <Radio label="Grouped" value="pivoted" />
+                        <Radio label="Flat" value="unpivoted" />
                     </Stack>
                 </Radio.Group>
-                {limit === Limit.CUSTOM && (
-                    <NumberInput
-                        w={150}
-                        min={1}
-                        required
-                        value={customLimit}
-                        onChange={(value) =>
-                            onCustomLimitChange(Number(value) || 1)
-                        }
-                    />
-                )}
+            )}
+            {!hideLimit && (
+                <Stack gap="xs">
+                    <Radio.Group
+                        label="Limit"
+                        value={limit}
+                        onChange={(value) => onLimitChange(value as Limit)}
+                    >
+                        <Stack gap="xxs" pt="xs">
+                            <Radio
+                                label="Results in Table"
+                                value={Limit.TABLE}
+                            />
+                            <Radio label="All Results" value={Limit.ALL} />
+                            <Radio label="Custom..." value={Limit.CUSTOM} />
+                        </Stack>
+                    </Radio.Group>
+                    {limit === Limit.CUSTOM && (
+                        <NumberInput
+                            w={150}
+                            min={1}
+                            required
+                            value={customLimit}
+                            onChange={(value) =>
+                                onCustomLimitChange(Number(value) || 1)
+                            }
+                        />
+                    )}
 
-                {(limit === Limit.ALL || limit === Limit.CUSTOM) && (
-                    <i>
-                        Results are limited to{' '}
-                        {Number(
-                            health.data?.query.csvCellsLimit || 100000,
-                        ).toLocaleString()}{' '}
-                        cells for each file
-                    </i>
-                )}
-            </Stack>
+                    {(limit === Limit.ALL || limit === Limit.CUSTOM) && (
+                        <i>
+                            Results are limited to{' '}
+                            {Number(
+                                health.data?.query.csvCellsLimit || 100000,
+                            ).toLocaleString()}{' '}
+                            cells for each file
+                        </i>
+                    )}
+                </Stack>
+            )}
             {format === SchedulerFormat.XLSX && (
                 <Radio.Group
                     label={

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.test.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.test.tsx
@@ -186,10 +186,14 @@ describe('SchedulerDataFormatSection - app formats', () => {
             await user.click(screen.getByRole('radio', { name: '.csv' }));
 
             expect(formRef.current?.values.format).toBe(SchedulerFormat.CSV);
-            expect(formRef.current?.values.options).toMatchObject({
-                formatted: Values.FORMATTED,
-                limit: Limit.TABLE,
-            });
+            // Full-object equality (not toMatchObject): a handler that drops
+            // customLimit/exportPivotedData/xlsxFileLayout etc. from the
+            // spread must fail this, not just the two fields the switch cares
+            // about. nonLegalCsvOptions only perturbs formatted/limit, so the
+            // normalized result is exactly DEFAULT_VALUES.options.
+            expect(formRef.current?.values.options).toEqual(
+                DEFAULT_VALUES.options,
+            );
         });
 
         it('sets options to the only backend-legal xlsx shape when switched to xlsx', async () => {
@@ -208,10 +212,9 @@ describe('SchedulerDataFormatSection - app formats', () => {
             await user.click(screen.getByRole('radio', { name: '.xlsx' }));
 
             expect(formRef.current?.values.format).toBe(SchedulerFormat.XLSX);
-            expect(formRef.current?.values.options).toMatchObject({
-                formatted: Values.FORMATTED,
-                limit: Limit.TABLE,
-            });
+            expect(formRef.current?.values.options).toEqual(
+                DEFAULT_VALUES.options,
+            );
         });
 
         it('restores the image-appropriate options when switched back to image', async () => {
@@ -231,12 +234,13 @@ describe('SchedulerDataFormatSection - app formats', () => {
             await user.click(screen.getByRole('radio', { name: 'Image' }));
 
             expect(formRef.current?.values.format).toBe(SchedulerFormat.IMAGE);
-            // Switching to csv/xlsx only ever touches `formatted`/`limit` —
-            // the image-specific fields must still hold the form's defaults.
-            expect(formRef.current?.values.options).toMatchObject({
-                withPdf: DEFAULT_VALUES.options.withPdf,
-                pagePerTab: DEFAULT_VALUES.options.pagePerTab,
-            });
+            // Switching format to Image is a no-op on `options` — the whole
+            // object must still be exactly what the csv switch normalized it
+            // to (DEFAULT_VALUES.options), not just the withPdf/pagePerTab
+            // fields the Image checkbox happens to read.
+            expect(formRef.current?.values.options).toEqual(
+                DEFAULT_VALUES.options,
+            );
         });
     });
 });

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.test.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.test.tsx
@@ -1,0 +1,151 @@
+import {
+    SchedulerFormat,
+    type AppScheduler,
+    type SchedulerAndTargets,
+} from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import { type FC, type ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+import {
+    DEFAULT_VALUES,
+    getFormValuesFromScheduler,
+    SchedulerFormProvider,
+    useSchedulerForm,
+    type SchedulerFormValues,
+} from '../schedulerFormContext';
+import { SchedulerDataFormatSection } from './SchedulerDataFormatSection';
+
+vi.mock('../../../../../hooks/health/useHealth', () => ({
+    default: vi.fn(() => ({
+        data: {
+            hasHeadlessBrowser: true,
+            query: { csvCellsLimit: 100000 },
+        },
+    })),
+}));
+
+vi.mock('../../../../../hooks/useProjectUuid', () => ({
+    useProjectUuid: vi.fn(() => 'project-uuid'),
+}));
+
+const FormWrapper: FC<{
+    initialValues: SchedulerFormValues;
+    children: ReactNode;
+}> = ({ initialValues, children }) => {
+    const form = useSchedulerForm({ initialValues });
+    return (
+        <SchedulerFormProvider form={form}>{children}</SchedulerFormProvider>
+    );
+};
+
+const renderSection = (
+    props: Partial<
+        React.ComponentProps<typeof SchedulerDataFormatSection>
+    > = {},
+    initialValues: SchedulerFormValues = DEFAULT_VALUES,
+) =>
+    renderWithProviders(
+        <FormWrapper initialValues={initialValues}>
+            <SchedulerDataFormatSection
+                dashboard={undefined}
+                savedSchedulerData={undefined}
+                isApp
+                appUuid="app-uuid"
+                currentAppState={null}
+                isDashboardTabsAvailable={false}
+                loading={false}
+                {...props}
+            />
+        </FormWrapper>,
+    );
+
+const savedCsvAppScheduler: SchedulerAndTargets = {
+    schedulerUuid: 'scheduler-uuid',
+    slug: 'app-delivery',
+    name: 'App delivery',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    createdBy: 'user-uuid',
+    createdByName: 'User',
+    format: SchedulerFormat.CSV,
+    cron: '0 9 * * 1',
+    savedChartUuid: null,
+    savedChartName: null,
+    dashboardUuid: null,
+    dashboardName: null,
+    savedSqlUuid: null,
+    savedSqlName: null,
+    appUuid: 'app-uuid',
+    appName: 'App',
+    options: { formatted: true, limit: 'table' },
+    enabled: true,
+    includeLinks: true,
+    targets: [],
+} as AppScheduler & { targets: [] };
+
+describe('SchedulerDataFormatSection - app formats', () => {
+    it('shows csv/xlsx/image (no PDF) and the query-count caption when the app has captured queries', () => {
+        renderSection({ capturedQueryCount: 3 });
+
+        expect(screen.getByRole('radio', { name: '.csv' })).toBeEnabled();
+        expect(screen.getByRole('radio', { name: '.xlsx' })).toBeEnabled();
+        expect(screen.getByRole('radio', { name: 'Image' })).toBeVisible();
+        expect(
+            screen.queryByRole('radio', { name: 'PDF' }),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.getByText('3 data queries detected — each becomes a file'),
+        ).toBeInTheDocument();
+    });
+
+    it('uses singular copy for exactly one captured query', () => {
+        renderSection({ capturedQueryCount: 1 });
+
+        expect(
+            screen.getByText('1 data query detected — it becomes a file'),
+        ).toBeInTheDocument();
+    });
+
+    it('disables csv/xlsx and shows the zero-state copy when the app ran no data queries', () => {
+        renderSection({ capturedQueryCount: 0 });
+
+        expect(screen.getByRole('radio', { name: '.csv' })).toBeDisabled();
+        expect(screen.getByRole('radio', { name: '.xlsx' })).toBeDisabled();
+        expect(
+            screen.getByText('This app ran no data queries'),
+        ).toBeInTheDocument();
+    });
+
+    it('preserves and enables a saved csv format when editing without a live query count', () => {
+        renderSection(
+            {
+                savedSchedulerData: savedCsvAppScheduler,
+                capturedQueryCount: undefined,
+            },
+            getFormValuesFromScheduler(savedCsvAppScheduler),
+        );
+
+        const csvRadio = screen.getByRole('radio', { name: '.csv' });
+        expect(csvRadio).toBeEnabled();
+        expect(csvRadio).toBeChecked();
+    });
+
+    it('hides the row-limit control for apps', () => {
+        renderSection(
+            { capturedQueryCount: 3 },
+            { ...DEFAULT_VALUES, format: SchedulerFormat.CSV },
+        );
+
+        expect(screen.queryByText('Limit')).not.toBeInTheDocument();
+    });
+
+    it('shows the row-limit control for non-app deliveries', () => {
+        renderSection(
+            { isApp: false, appUuid: undefined, capturedQueryCount: 3 },
+            { ...DEFAULT_VALUES, format: SchedulerFormat.CSV },
+        );
+
+        expect(screen.getByText('Limit')).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.test.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.test.tsx
@@ -4,9 +4,11 @@ import {
     type SchedulerAndTargets,
 } from '@lightdash/common';
 import { screen } from '@testing-library/react';
-import { type FC, type ReactNode } from 'react';
+import userEvent from '@testing-library/user-event';
+import { type FC, type MutableRefObject, type ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../../../testing/testUtils';
+import { Limit, Values } from '../../types';
 import {
     DEFAULT_VALUES,
     getFormValuesFromScheduler,
@@ -15,6 +17,8 @@ import {
     type SchedulerFormValues,
 } from '../schedulerFormContext';
 import { SchedulerDataFormatSection } from './SchedulerDataFormatSection';
+
+type SchedulerForm = ReturnType<typeof useSchedulerForm>;
 
 vi.mock('../../../../../hooks/health/useHealth', () => ({
     default: vi.fn(() => ({
@@ -31,9 +35,11 @@ vi.mock('../../../../../hooks/useProjectUuid', () => ({
 
 const FormWrapper: FC<{
     initialValues: SchedulerFormValues;
+    formRef?: MutableRefObject<SchedulerForm | null>;
     children: ReactNode;
-}> = ({ initialValues, children }) => {
+}> = ({ initialValues, formRef, children }) => {
     const form = useSchedulerForm({ initialValues });
+    if (formRef) formRef.current = form;
     return (
         <SchedulerFormProvider form={form}>{children}</SchedulerFormProvider>
     );
@@ -44,9 +50,10 @@ const renderSection = (
         React.ComponentProps<typeof SchedulerDataFormatSection>
     > = {},
     initialValues: SchedulerFormValues = DEFAULT_VALUES,
+    formRef?: MutableRefObject<SchedulerForm | null>,
 ) =>
     renderWithProviders(
-        <FormWrapper initialValues={initialValues}>
+        <FormWrapper initialValues={initialValues} formRef={formRef}>
             <SchedulerDataFormatSection
                 dashboard={undefined}
                 savedSchedulerData={undefined}
@@ -147,5 +154,89 @@ describe('SchedulerDataFormatSection - app formats', () => {
         );
 
         expect(screen.getByText('Limit')).toBeInTheDocument();
+    });
+
+    describe('format-switch side effect', () => {
+        const createFormRef = (): MutableRefObject<SchedulerForm | null> => ({
+            current: null,
+        });
+
+        // Deliberately NOT the app-legal csv shape (formatted/limit differ
+        // from DEFAULT_VALUES.options) — otherwise a no-op switch handler
+        // would pass these assertions by coincidence.
+        const nonLegalCsvOptions: SchedulerFormValues['options'] = {
+            ...DEFAULT_VALUES.options,
+            formatted: Values.RAW,
+            limit: Limit.ALL,
+        };
+
+        it('sets options to the only backend-legal csv shape when switched to csv', async () => {
+            const formRef = createFormRef();
+            const user = userEvent.setup();
+            renderSection(
+                { capturedQueryCount: 3 },
+                {
+                    ...DEFAULT_VALUES,
+                    format: SchedulerFormat.IMAGE,
+                    options: nonLegalCsvOptions,
+                },
+                formRef,
+            );
+
+            await user.click(screen.getByRole('radio', { name: '.csv' }));
+
+            expect(formRef.current?.values.format).toBe(SchedulerFormat.CSV);
+            expect(formRef.current?.values.options).toMatchObject({
+                formatted: Values.FORMATTED,
+                limit: Limit.TABLE,
+            });
+        });
+
+        it('sets options to the only backend-legal xlsx shape when switched to xlsx', async () => {
+            const formRef = createFormRef();
+            const user = userEvent.setup();
+            renderSection(
+                { capturedQueryCount: 3 },
+                {
+                    ...DEFAULT_VALUES,
+                    format: SchedulerFormat.IMAGE,
+                    options: nonLegalCsvOptions,
+                },
+                formRef,
+            );
+
+            await user.click(screen.getByRole('radio', { name: '.xlsx' }));
+
+            expect(formRef.current?.values.format).toBe(SchedulerFormat.XLSX);
+            expect(formRef.current?.values.options).toMatchObject({
+                formatted: Values.FORMATTED,
+                limit: Limit.TABLE,
+            });
+        });
+
+        it('restores the image-appropriate options when switched back to image', async () => {
+            const formRef = createFormRef();
+            const user = userEvent.setup();
+            renderSection(
+                { capturedQueryCount: 3 },
+                {
+                    ...DEFAULT_VALUES,
+                    format: SchedulerFormat.IMAGE,
+                    options: nonLegalCsvOptions,
+                },
+                formRef,
+            );
+
+            await user.click(screen.getByRole('radio', { name: '.csv' }));
+            await user.click(screen.getByRole('radio', { name: 'Image' }));
+
+            expect(formRef.current?.values.format).toBe(SchedulerFormat.IMAGE);
+            // Switching to csv/xlsx only ever touches `formatted`/`limit` —
+            // the image-specific fields must still hold the form's defaults.
+            expect(formRef.current?.values.options).toMatchObject({
+                withPdf: DEFAULT_VALUES.options.withPdf,
+                pagePerTab: DEFAULT_VALUES.options.pagePerTab,
+            });
+        });
     });
 });

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.tsx
@@ -10,7 +10,6 @@ import {
 } from '@lightdash/common';
 import {
     Anchor,
-    Badge,
     Box,
     Checkbox,
     Code,
@@ -29,10 +28,21 @@ import { useMemo, type FC } from 'react';
 import useHealth from '../../../../../hooks/health/useHealth';
 import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
 import { CsvFormattingOptions } from '../../CsvFormattingOptions';
+import { Limit, Values } from '../../types';
 import { useSchedulerFormContext } from '../schedulerFormContext';
 import { SchedulerFormFiltersTab } from '../SchedulerFormFiltersTab';
 import { SchedulerFormParametersTab } from '../SchedulerFormParametersTab';
 import classes from './SchedulerDeliveryModal.module.css';
+
+const getAppQueryCountCaption = (
+    capturedQueryCount: number | undefined,
+): string | null => {
+    if (capturedQueryCount === undefined) return null;
+    if (capturedQueryCount === 0) return 'This app ran no data queries';
+    if (capturedQueryCount === 1)
+        return '1 data query detected — it becomes a file';
+    return `${capturedQueryCount} data queries detected — each becomes a file`;
+};
 
 type Props = {
     dashboard: Dashboard | undefined;
@@ -41,6 +51,10 @@ type Props = {
     appUuid?: string;
     /** App deliveries only: the app state currently reflected in the page URL. */
     currentAppState?: SchedulerAppState | null;
+    /** App deliveries only: count of ready queries captured by the live preview.
+     *  Undefined when the host page has no live query data (e.g. editing without
+     *  a preview open) — csv/xlsx are then left enabled rather than gated shut. */
+    capturedQueryCount?: number;
     isDashboardTabsAvailable: boolean;
     currentParameterValues?: ParametersValuesMap;
     availableParameters?: ParameterDefinitions;
@@ -53,6 +67,7 @@ export const SchedulerDataFormatSection: FC<Props> = ({
     isApp,
     appUuid,
     currentAppState,
+    capturedQueryCount,
     isDashboardTabsAvailable,
     currentParameterValues,
     availableParameters,
@@ -91,6 +106,7 @@ export const SchedulerDataFormatSection: FC<Props> = ({
     );
 
     const format = form.values.format;
+    const appQueryCountCaption = getAppQueryCountCaption(capturedQueryCount);
 
     return (
         <Stack gap="lg">
@@ -98,9 +114,46 @@ export const SchedulerDataFormatSection: FC<Props> = ({
                 <Input.Label>Format</Input.Label>
                 <Group gap="xs" wrap="nowrap">
                     {isApp ? (
-                        <Badge variant="light" radius="sm" size="lg" px="sm">
-                            Image
-                        </Badge>
+                        <SegmentedControl
+                            radius="md"
+                            fullWidth
+                            data={[
+                                {
+                                    label: '.csv',
+                                    value: SchedulerFormat.CSV,
+                                    disabled: capturedQueryCount === 0,
+                                },
+                                {
+                                    label: '.xlsx',
+                                    value: SchedulerFormat.XLSX,
+                                    disabled: capturedQueryCount === 0,
+                                },
+                                {
+                                    label: 'Image',
+                                    value: SchedulerFormat.IMAGE,
+                                    disabled: isImageDisabled,
+                                },
+                            ]}
+                            w="100%"
+                            value={format}
+                            onChange={(value) => {
+                                form.setFieldValue(
+                                    'format',
+                                    value as SchedulerFormat,
+                                );
+                                if (
+                                    value === SchedulerFormat.CSV ||
+                                    value === SchedulerFormat.XLSX
+                                ) {
+                                    // The only limit shape the backend accepts for app deliveries.
+                                    form.setFieldValue('options', {
+                                        ...form.values.options,
+                                        formatted: Values.FORMATTED,
+                                        limit: Limit.TABLE,
+                                    });
+                                }
+                            }}
+                        />
                     ) : (
                         <SegmentedControl
                             radius="md"
@@ -129,6 +182,11 @@ export const SchedulerDataFormatSection: FC<Props> = ({
                         />
                     )}
                 </Group>
+                {isApp && appQueryCountCaption && (
+                    <Text size="xs" c="ldGray.6">
+                        {appQueryCountCaption}
+                    </Text>
+                )}
                 {isImageDisabled && !isApp && (
                     <Text size="xs" c="ldGray.6">
                         You must enable the
@@ -254,6 +312,8 @@ export const SchedulerDataFormatSection: FC<Props> = ({
                                     value,
                                 )
                             }
+                            hideLimit={isApp}
+                            hideExportPivotedData={isApp}
                         />
                     </Box>
                 )}

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.tsx
@@ -52,8 +52,7 @@ type Props = {
     /** App deliveries only: the app state currently reflected in the page URL. */
     currentAppState?: SchedulerAppState | null;
     /** App deliveries only: count of ready queries captured by the live preview.
-     *  Undefined when the host page has no live query data (e.g. editing without
-     *  a preview open) — csv/xlsx are then left enabled rather than gated shut. */
+     *  Undefined (no live data) leaves csv/xlsx enabled rather than gated shut. */
     capturedQueryCount?: number;
     isDashboardTabsAvailable: boolean;
     currentParameterValues?: ParametersValuesMap;

--- a/packages/frontend/src/features/scheduler/components/SchedulerModal.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModal.tsx
@@ -38,6 +38,7 @@ const SchedulersModal: FC<
         | 'isChart'
         | 'isApp'
         | 'currentAppState'
+        | 'capturedQueryCount'
         | 'currentParameterValues'
         | 'availableParameters'
     > & {
@@ -72,6 +73,7 @@ const SchedulersModal: FC<
     isThresholdAlert,
     itemsMap,
     currentAppState,
+    capturedQueryCount,
     currentParameterValues,
     availableParameters,
     onClose = () => {},
@@ -252,6 +254,7 @@ const SchedulersModal: FC<
                 isThresholdAlert={isThresholdAlert}
                 itemsMap={itemsMap}
                 currentAppState={currentAppState}
+                capturedQueryCount={capturedQueryCount}
                 currentParameterValues={currentParameterValues}
                 availableParameters={availableParameters}
             />

--- a/packages/frontend/src/features/scheduler/components/SchedulerModalCreateOrEdit.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModalCreateOrEdit.tsx
@@ -63,6 +63,8 @@ interface Props {
     itemsMap?: ItemsMap;
     /** App deliveries only: the app state currently reflected in the page URL. */
     currentAppState?: SchedulerAppState | null;
+    /** App deliveries only: count of ready queries captured by the live preview. */
+    capturedQueryCount?: number;
     currentParameterValues?: ParametersValuesMap;
     availableParameters?: ParameterDefinitions;
     /** undefined = create mode, string = edit mode */
@@ -82,6 +84,7 @@ export const SchedulerModalCreateOrEdit: FC<Props> = ({
     isThresholdAlert,
     itemsMap,
     currentAppState,
+    capturedQueryCount,
     currentParameterValues,
     availableParameters,
     onClose,
@@ -197,6 +200,7 @@ export const SchedulerModalCreateOrEdit: FC<Props> = ({
                         isApp={!!isApp}
                         appUuid={isApp ? resourceUuid : undefined}
                         currentAppState={currentAppState}
+                        capturedQueryCount={capturedQueryCount}
                         isDashboardTabsAvailable={isDashboardTabsAvailable}
                         currentParameterValues={currentParameterValues}
                         availableParameters={availableParameters}

--- a/packages/frontend/src/features/scheduler/components/SchedulerModals.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModals.tsx
@@ -89,6 +89,8 @@ interface AppSchedulersProps {
     onClose: () => void;
     /** If provided, opens directly in edit mode for this scheduler */
     initialSchedulerUuid?: string;
+    /** Count of ready queries captured by the live preview. */
+    capturedQueryCount?: number;
 }
 
 export const AppSchedulersModal: FC<AppSchedulersProps> = ({

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -132,7 +132,10 @@ import { useGetApp } from '../features/apps/hooks/useGetApp';
 import { useIterateApp } from '../features/apps/hooks/useIterateApp';
 import { useRestoreAppVersion } from '../features/apps/hooks/useRestoreAppVersion';
 import { useSdkUpgradeStatus } from '../features/apps/hooks/useSdkUpgradeStatus';
-import { useTrackedAppQueries } from '../features/apps/hooks/useTrackedAppQueries';
+import {
+    countReadyQueriesSinceBoundary,
+    useTrackedAppQueries,
+} from '../features/apps/hooks/useTrackedAppQueries';
 import { useTrackedExternalRequests } from '../features/apps/hooks/useTrackedExternalRequests';
 import { usePreviewOrigin } from '../features/apps/previewOrigin';
 import { getTemplate } from '../features/apps/templates';
@@ -1319,7 +1322,14 @@ const AppGenerate: FC = () => {
     // in-flight entries to a terminal "interrupted" state — the iframe that
     // would have polled their queryUuids is gone, so they'd otherwise sit
     // non-terminal forever. Without persist we just clear the log.
+    //
+    // "Persist" deliberately keeps prior versions' `ready` entries visible in
+    // the log, so a raw ready-count would inflate/mask the scheduler's app
+    // csv/xlsx gate for the version currently previewed. We snapshot the
+    // ready-count as a boundary on every switch and subtract it back out via
+    // `countReadyQueriesSinceBoundary` wherever the live count is read.
     const lastPreviewVersionRef = useRef<number | null>(null);
+    const versionQueryBoundaryRef = useRef(0);
     useEffect(() => {
         const next = previewApp?.version ?? null;
         if (lastPreviewVersionRef.current === next) return;
@@ -1329,9 +1339,13 @@ const AppGenerate: FC = () => {
         if (persistLogs) {
             interruptInFlightQueries();
             interruptInFlightRequests();
+            versionQueryBoundaryRef.current = trackedQueries.filter(
+                (q) => q.status === 'ready',
+            ).length;
         } else {
             clearQueries();
             clearExternalRequests();
+            versionQueryBoundaryRef.current = 0;
         }
     }, [
         previewApp?.version,
@@ -1340,6 +1354,7 @@ const AppGenerate: FC = () => {
         clearQueries,
         interruptInFlightRequests,
         clearExternalRequests,
+        trackedQueries,
     ]);
 
     // Manual refresh counter for the preview iframe. The iframe URL embeds
@@ -3286,11 +3301,10 @@ const AppGenerate: FC = () => {
                                             onViewNetwork={() =>
                                                 setNetworkPanelHidden(false)
                                             }
-                                            capturedQueryCount={
-                                                trackedQueries.filter(
-                                                    (q) => q.status === 'ready',
-                                                ).length
-                                            }
+                                            capturedQueryCount={countReadyQueriesSinceBoundary(
+                                                trackedQueries,
+                                                versionQueryBoundaryRef.current,
+                                            )}
                                             onDeleted={() =>
                                                 void navigate(
                                                     `/projects/${projectUuid}/apps/generate`,

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -608,6 +608,7 @@ const AppGenerate: FC = () => {
         setPersistLogs,
         handleQueryEvent,
         clearQueries,
+        resetQueries,
         interruptInFlightQueries,
     } = useTrackedAppQueries();
     const {
@@ -1343,15 +1344,20 @@ const AppGenerate: FC = () => {
                 (q) => q.status === 'ready',
             ).length;
         } else {
-            clearQueries();
+            // resetQueries (not clearQueries): the old version's fetch/poll
+            // isn't torn down by the iframe reload, so a still-in-flight
+            // query's late terminal event must not resurrect as a phantom row.
+            resetQueries();
             clearExternalRequests();
             versionQueryBoundaryRef.current = 0;
         }
+        // trackedQueries is read above (persistLogs branch) to snapshot the
+        // boundary; the guard above makes any extra re-invocation a no-op.
     }, [
         previewApp?.version,
         persistLogs,
         interruptInFlightQueries,
-        clearQueries,
+        resetQueries,
         interruptInFlightRequests,
         clearExternalRequests,
         trackedQueries,

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -3286,6 +3286,11 @@ const AppGenerate: FC = () => {
                                             onViewNetwork={() =>
                                                 setNetworkPanelHidden(false)
                                             }
+                                            capturedQueryCount={
+                                                trackedQueries.filter(
+                                                    (q) => q.status === 'ready',
+                                                ).length
+                                            }
                                             onDeleted={() =>
                                                 void navigate(
                                                     `/projects/${projectUuid}/apps/generate`,

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -1331,6 +1331,10 @@ const AppGenerate: FC = () => {
     // `countReadyQueriesSinceBoundary` wherever the live count is read.
     const lastPreviewVersionRef = useRef<number | null>(null);
     const versionQueryBoundaryRef = useRef(0);
+    // Latest-ref so the version-switch effect can snapshot the ready count
+    // without re-running on every query event.
+    const trackedQueriesRef = useRef(trackedQueries);
+    trackedQueriesRef.current = trackedQueries;
     useEffect(() => {
         const next = previewApp?.version ?? null;
         if (lastPreviewVersionRef.current === next) return;
@@ -1340,7 +1344,7 @@ const AppGenerate: FC = () => {
         if (persistLogs) {
             interruptInFlightQueries();
             interruptInFlightRequests();
-            versionQueryBoundaryRef.current = trackedQueries.filter(
+            versionQueryBoundaryRef.current = trackedQueriesRef.current.filter(
                 (q) => q.status === 'ready',
             ).length;
         } else {
@@ -1351,8 +1355,6 @@ const AppGenerate: FC = () => {
             clearExternalRequests();
             versionQueryBoundaryRef.current = 0;
         }
-        // trackedQueries is read above (persistLogs branch) to snapshot the
-        // boundary; the guard above makes any extra re-invocation a no-op.
     }, [
         previewApp?.version,
         persistLogs,
@@ -1360,7 +1362,6 @@ const AppGenerate: FC = () => {
         resetQueries,
         interruptInFlightRequests,
         clearExternalRequests,
-        trackedQueries,
     ]);
 
     // Manual refresh counter for the preview iframe. The iframe URL embeds

--- a/packages/frontend/src/pages/AppPreviewTest.capturedQueryCount.test.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.capturedQueryCount.test.tsx
@@ -1,0 +1,140 @@
+import { act } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { QueryEvent } from '../features/apps/hooks/useAppSdkBridge';
+import { renderWithProviders } from '../testing/testUtils';
+
+type IframePreviewProps = {
+    onQueryEvent?: (event: QueryEvent) => void;
+};
+
+type HeaderActionsProps = {
+    capturedQueryCount?: number;
+};
+
+const mocks = vi.hoisted(() => ({
+    iframePreview: vi.fn((_props: IframePreviewProps) => null),
+    headerActions: vi.fn((_props: HeaderActionsProps) => null),
+    versionParam: '1' as string | undefined,
+}));
+
+vi.mock('react-router', () => ({
+    Navigate: () => null,
+    useNavigate: () => vi.fn(),
+    useParams: () => ({
+        projectUuid: 'project-uuid',
+        appUuid: 'app-uuid',
+        version: mocks.versionParam,
+    }),
+}));
+
+vi.mock('../features/apps/AppIframePreview', () => ({
+    default: mocks.iframePreview,
+}));
+
+vi.mock('../features/apps/components/AppHeaderActions', () => ({
+    default: mocks.headerActions,
+}));
+
+vi.mock('../features/apps/hooks/useAppPreviewToken', () => ({
+    useAppPreviewToken: () => ({
+        data: 'preview-token',
+        isLoading: false,
+        error: undefined,
+    }),
+}));
+
+vi.mock('../features/apps/hooks/useGetApp', () => ({
+    useGetApp: () => ({
+        data: {
+            pages: [
+                {
+                    name: 'Sales app',
+                    description: null,
+                    spaceUuid: null,
+                    spaceName: null,
+                    createdByUserUuid: 'user-uuid',
+                    latestReadyVersion: 5,
+                    versions: [{ status: 'ready' }],
+                },
+            ],
+        },
+        isLoading: false,
+        error: undefined,
+    }),
+}));
+
+vi.mock('../features/apps/hooks/useCanEditDataApp', () => ({
+    useCanEditDataApp: () => false,
+}));
+
+vi.mock('../features/apps/hooks/useAppBuildPoller', () => ({
+    useAppBuildPoller: () => {},
+}));
+
+vi.mock('../features/apps/previewOrigin', () => ({
+    usePreviewOrigin: () => 'https://preview.example.com',
+}));
+
+vi.mock('../hooks/useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: () => ({
+        isLoading: false,
+        data: { enabled: true },
+    }),
+}));
+
+// eslint-disable-next-line import/first
+import AppPreviewTest from './AppPreviewTest';
+
+const latestIframeProps = (): IframePreviewProps => {
+    const { calls } = mocks.iframePreview.mock;
+    return calls[calls.length - 1][0];
+};
+
+const latestHeaderActionsProps = (): HeaderActionsProps => {
+    const { calls } = mocks.headerActions.mock;
+    return calls[calls.length - 1][0];
+};
+
+const readyEvent = (id: string): QueryEvent => ({
+    id,
+    timestamp: Date.now(),
+    label: null,
+    exploreName: '',
+    dimensions: [],
+    metrics: [],
+    filters: {},
+    sorts: [],
+    tableCalculations: [],
+    additionalMetrics: [],
+    limit: 0,
+    queryUuid: `${id}-uuid`,
+    status: 'ready',
+    rowCount: 1,
+    durationMs: 10,
+    error: null,
+    rawMetricQuery: null,
+});
+
+describe('AppPreviewTest capturedQueryCount', () => {
+    it('resets the captured query count when the previewed version changes', () => {
+        mocks.versionParam = '1';
+        const { rerender } = renderWithProviders(<AppPreviewTest />);
+
+        act(() => {
+            latestIframeProps().onQueryEvent?.(readyEvent('q1'));
+        });
+        expect(latestHeaderActionsProps().capturedQueryCount).toBe(1);
+
+        // Same route re-render with an unchanged version must NOT reset —
+        // only the version identity is the reset signal.
+        rerender(<AppPreviewTest />);
+        expect(latestHeaderActionsProps().capturedQueryCount).toBe(1);
+
+        // Navigating to a different version re-renders this component (no
+        // remount) — the previous version's ready query must not survive.
+        mocks.versionParam = '2';
+        rerender(<AppPreviewTest />);
+
+        expect(latestHeaderActionsProps().capturedQueryCount).toBe(0);
+    });
+});

--- a/packages/frontend/src/pages/AppPreviewTest.capturedQueryCount.test.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.capturedQueryCount.test.tsx
@@ -63,6 +63,14 @@ vi.mock('../features/apps/hooks/useGetApp', () => ({
     }),
 }));
 
+vi.mock('../providers/Fullscreen/useNativeFullscreenToggle', () => ({
+    default: () => ({
+        enabled: false,
+        isFullscreen: false,
+        handleToggleFullscreen: vi.fn(),
+    }),
+}));
+
 vi.mock('../features/apps/hooks/useCanEditDataApp', () => ({
     useCanEditDataApp: () => false,
 }));

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -109,8 +109,12 @@ export default function AppPreviewTest() {
     // Query tracking from the preview iframe. The panel is opt-in (hidden by
     // default in preview because most viewers aren't technical), but we wire
     // up the SDK bridge callback unconditionally so queries that run before
-    // the user opens the panel are still captured.
-    const { queries, handleQueryEvent, clearQueries } = useTrackedAppQueries();
+    // the user opens the panel are still captured. `version` as the reset key
+    // clears stale entries on version navigation — this component re-renders
+    // rather than remounting, so without it a previous version's queries
+    // would survive and corrupt the live capturedQueryCount gate.
+    const { queries, handleQueryEvent, clearQueries } =
+        useTrackedAppQueries(version);
     const {
         externalRequests,
         handleExternalRequestEvent,

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -332,6 +332,10 @@ export default function AppPreviewTest() {
                     }}
                     rightSection={
                         <AppHeaderActions
+                            capturedQueryCount={
+                                queries.filter((q) => q.status === 'ready')
+                                    .length
+                            }
                             fullscreenToggle={
                                 isFullscreenFeatureEnabled &&
                                 document.fullscreenEnabled ? (

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -16,7 +16,10 @@ import { useAppBuildPoller } from '../features/apps/hooks/useAppBuildPoller';
 import { useAppPreviewToken } from '../features/apps/hooks/useAppPreviewToken';
 import { useCanEditDataApp } from '../features/apps/hooks/useCanEditDataApp';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
-import { useTrackedAppQueries } from '../features/apps/hooks/useTrackedAppQueries';
+import {
+    countReadyQueriesSinceBoundary,
+    useTrackedAppQueries,
+} from '../features/apps/hooks/useTrackedAppQueries';
 import { useTrackedExternalRequests } from '../features/apps/hooks/useTrackedExternalRequests';
 import { usePreviewOrigin } from '../features/apps/previewOrigin';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
@@ -336,10 +339,12 @@ export default function AppPreviewTest() {
                     }}
                     rightSection={
                         <AppHeaderActions
-                            capturedQueryCount={
-                                queries.filter((q) => q.status === 'ready')
-                                    .length
-                            }
+                            // Boundary 0: no persist mode here, and
+                            // useTrackedAppQueries(version) resets on switch.
+                            capturedQueryCount={countReadyQueriesSinceBoundary(
+                                queries,
+                                0,
+                            )}
                             fullscreenToggle={
                                 isFullscreenFeatureEnabled &&
                                 document.fullscreenEnabled ? (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

**Note:** UI-enabling PR — the stack below it is feature-dark. Known fast-follow (ledgered): manual refresh handlers still use bare clearQueries(); scheduled with the follow-up basket.

Closes: PROD-8374
Relates: #24475
