### PR TITLE
fix: exclude heavy local paths from Okteto file sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,9 @@ scripts/playground-bundle/.venv/
 
 # Local pnpm store (also keeps it out of Okteto file sync via .stignore)
 .pnpm-store/
+
+# Heavy local paths already ignored via nested .gitignore or .git/info/exclude.
+# Repeated here because Okteto file sync (.stignore) only reads this root file.
+scripts/k8s-dev/terraform/.terraform/
+examples/metricflow-demo/.fusion/
+.claude/worktrees/


### PR DESCRIPTION
### Description:

Okteto file sync was shipping **13,492 files / 1.14 GiB** into the dev container, against a real repo of **6,597 files / ~120 MiB**.

**Cause.** `.stignore` is a symlink to the root `.gitignore`, and Okteto hands that single file to Syncthing (it strips `#` comment lines and prefixes each surviving pattern with `(?d)`). Syncthing matches against that root file *only*. But git also ignores paths via **nested `.gitignore` files** and **`.git/info/exclude`** — Syncthing can see neither, so anything hidden only there was being synced.

Three paths accounted for essentially all of the excess:

| Path | Size | Files | Ignored by (invisible to Syncthing) |
|---|---|---|---|
| `scripts/k8s-dev/terraform/.terraform` | 742 MiB | 405 | `scripts/k8s-dev/.gitignore` |
| `.claude/worktrees` | 133 MiB | 6,463 | `.git/info/exclude` |
| `examples/metricflow-demo/.fusion` | 233 MiB | ~27 | `examples/metricflow-demo/.gitignore` |

6,597 + 6,463 + 405 + 27 = **13,492**, exactly the reported count.

**Fix.** Repeat those three paths in the root `.gitignore`, following the existing idiom in that file (`/.context/`, `.pnpm-store/` already carry "also keeps it out of Okteto file sync via .stignore" comments).

### Verification

- Read the generated `.stignore-1` from a live Syncthing home and confirmed it is exactly the root `.gitignore`, comments stripped — no other ignore source is consulted.
- Copied the new root `.gitignore` **alone** into a throwaway `git init` repo with the same directory layout: all three paths are ignored with no help from nested files, while `packages/` and `scripts/up.sh` still sync. This matters because in the real repo `git check-ignore -v` reports the *nested* rule and hides whether the root pattern matches.

Expected result: **13,492 → 6,597 files**, roughly **1.14 GiB → ~120 MiB**. The file count is exact; treat the byte figure as approximate, since `du` counts allocated blocks and inflates the 6,463-file worktree relative to what Syncthing reports.

### Reviewer notes

- **No effect until sync restarts.** Okteto regenerates `.stignore-1` at `okteto up`, so running sessions keep the old set.
- **`.claude/worktrees/` is a genuine fix, not just a sync hack.** It was previously ignored only via `.git/info/exclude`, which is per-clone and not committed — anyone using Claude Code worktrees hit the same bloat.
- **This is whack-a-mole by nature.** Any future nested `.gitignore` or local exclude will silently re-bloat sync with no warning. The durable alternative is replacing the symlink with a purpose-built `.stignore`, but it would duplicate ~90 lines and drift. Note `#include .gitignore` is *not* an escape hatch — Okteto strips it as a `#` comment. If this recurs, a sync-size check in `agent-okteto-dev.sh` is probably the better lever.
- No production code paths are touched; this is dev-environment only.
