### PR TITLE
feat: add okteto CLI passthrough to agent-okteto-dev.sh

### DIFF
--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -2,13 +2,19 @@
 
 ## Claude Code Okteto Environment
 
-### `agent-okteto-dev.sh <start|wait|url>`
+### `agent-okteto-dev.sh <start|wait|url|okteto>`
 
 When `LIGHTDASH_OKTETO_TOKEN` is set, atomically claims a ready Okteto namespace
 for the session, keeps source changes synchronized through `okteto up` in tmux,
 waits for synchronization and application health, and reports the public test
 URL. See
 `docs/agent-okteto.md` for setup.
+
+Use `agent-okteto-dev.sh okteto <args...>` to run any `okteto` CLI command
+(e.g. `status`, `namespace list`) against this session's environment without
+hand-wiring `OKTETO_HOME`, `KUBECONFIG`, the authenticated context, or the
+claimed namespace — it sets those up and execs `okteto` with your args,
+defaulting `-n <namespace>` unless you already pass one.
 
 ### `maintain-agent-okteto-pool.sh [minimum_ready]`
 

--- a/scripts/agent-okteto-dev.sh
+++ b/scripts/agent-okteto-dev.sh
@@ -29,13 +29,18 @@ fail() {
 
 usage() {
     cat <<'EOF'
-Usage: ./scripts/agent-okteto-dev.sh <start|wait|url>
+Usage: ./scripts/agent-okteto-dev.sh <start|wait|url|okteto>
 
 Requires LIGHTDASH_OKTETO_TOKEN. Commands safely skip when it is unset.
 
-  start  Claim or create this agent session's Okteto environment.
-  wait   Wait for file synchronization and application health.
-  url    Print the public URL for this Claude session.
+  start          Claim or create this agent session's Okteto environment.
+  wait           Wait for file synchronization and application health.
+  url            Print the public URL for this Claude session.
+  okteto <args>  Run any `okteto` CLI command with this session's
+                 OKTETO_HOME, KUBECONFIG, authenticated context, and
+                 namespace already wired up (e.g. `okteto status`,
+                 `okteto namespace list`). Adds -n <namespace> unless you
+                 already pass -n/--namespace yourself.
 EOF
 }
 
@@ -661,6 +666,52 @@ wait_for_environment() {
     wait_until_ready
 }
 
+okteto_subcommand_takes_manifest_flags() {
+    case "$1" in
+        up | down | deploy | destroy | exec | doctor | endpoints | build | status)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+run_okteto_passthrough() {
+    local arg has_namespace_flag=false has_file_flag=false args=("$@")
+
+    [ "$#" -gt 0 ] || fail "Usage: ./scripts/agent-okteto-dev.sh okteto <args...>"
+
+    require_client_runtime
+    prepare_runtime_dir
+    authenticate
+
+    okteto namespace use "$OKTETO_NAMESPACE" >/dev/null 2>&1 || true
+    okteto kubeconfig >/dev/null 2>&1 || true
+
+    if okteto_subcommand_takes_manifest_flags "$1"; then
+        for arg in "$@"; do
+            case "$arg" in
+                -n | --namespace | --namespace=*)
+                    has_namespace_flag=true
+                    ;;
+                -f | --file | --file=*)
+                    has_file_flag=true
+                    ;;
+            esac
+        done
+
+        if [ "$has_file_flag" = false ]; then
+            args=("${args[0]}" -f "$OKTETO_MANIFEST" "${args[@]:1}")
+        fi
+        if [ "$has_namespace_flag" = false ]; then
+            args=("${args[0]}" -n "$OKTETO_NAMESPACE" "${args[@]:1}")
+        fi
+    fi
+
+    exec okteto "${args[@]}"
+}
+
 setup_status() {
     local detail state
 
@@ -696,6 +747,15 @@ main() {
             ;;
         hook-stop)
             hook_stop
+            ;;
+        okteto)
+            shift
+            if [ -z "${LIGHTDASH_OKTETO_TOKEN:-}" ]; then
+                echo "SKIPPED: $TOKEN_ENV_VAR is not set."
+                return
+            fi
+            load_session_config
+            run_okteto_passthrough "$@"
             ;;
         start | wait | url | check-ready | setup-status)
             if [ -z "${LIGHTDASH_OKTETO_TOKEN:-}" ]; then


### PR DESCRIPTION
## Summary
- Adds an `okteto` passthrough subcommand to `scripts/agent-okteto-dev.sh` so agents/engineers can run any `okteto` CLI command (`status`, `namespace list`, `exec`, etc.) against their session's Okteto environment without hand-wiring `OKTETO_HOME`, `KUBECONFIG`, the authenticated context, or the claimed namespace.
- For manifest-aware subcommands (`up`, `down`, `deploy`, `destroy`, `exec`, `doctor`, `endpoints`, `build`, `status`), it defaults `-n <namespace>` and `-f <manifest>` unless the caller already passed those flags — verified against the installed `okteto` CLI's own `--help` output for which subcommands accept those flags. Other subcommands (`namespace list`, `kubeconfig`, `context use`, ...) are passed through untouched since they don't accept those flags.
- Skips with a message when `LIGHTDASH_OKTETO_TOKEN` is unset, matching the other subcommands' opt-in behavior.
- Documents the new subcommand in the script's `usage()` text and in `scripts/CLAUDE.md`.

## Test plan
- [x] `bash -n scripts/agent-okteto-dev.sh` passes
- [x] `./scripts/agent-okteto-dev.sh okteto status` with no token set prints `SKIPPED: ...`
- [x] Isolated unit tests of the new arg-building logic (against a fake `okteto` binary) confirm: `status` gets `-n`/`-f` defaults; a user-supplied `-n`/`-f` is respected and not duplicated; `namespace list`, `namespace use`, and `kubeconfig` pass through unmodified
- [ ] End-to-end run of `./scripts/agent-okteto-dev.sh okteto status` against a live claimed namespace (pending)