### PR TITLE
fix: restrict post-login redirect targets to root-relative paths

### DIFF
--- a/packages/frontend/src/features/users/components/LoginLanding.tsx
+++ b/packages/frontend/src/features/users/components/LoginLanding.tsx
@@ -44,6 +44,7 @@ import { useFlashMessages } from '../../../hooks/useFlashMessages';
 import useApp from '../../../providers/App/useApp';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
+import { sanitizeRedirectUrl } from '../../../utils/redirectUrl';
 import {
     useFetchLoginOptions,
     useLoginWithEmailMutation,
@@ -88,11 +89,11 @@ const Login: FC<{}> = () => {
             ? lastLoginMethod.issuerType
             : undefined;
 
-    const redirectUrl = location.state?.from
-        ? `${location.state.from.pathname}${location.state.from.search}`
-        : redirectParam
-          ? redirectParam
-          : '/';
+    const redirectUrl = sanitizeRedirectUrl(
+        location.state?.from
+            ? `${location.state.from.pathname}${location.state.from.search}`
+            : redirectParam,
+    );
 
     const form = useForm<LoginParams>({
         initialValues: {

--- a/packages/frontend/src/pages/Register.tsx
+++ b/packages/frontend/src/pages/Register.tsx
@@ -31,6 +31,7 @@ import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import useApp from '../providers/App/useApp';
 import useTracking from '../providers/Tracking/useTracking';
 import { EventName } from '../types/Events';
+import { sanitizeRedirectUrl } from '../utils/redirectUrl';
 
 const registerQuery = async (data: CreateUserArgs | CreateEmailOnlyUserArgs) =>
     lightdashApi<LightdashUser>({
@@ -61,9 +62,11 @@ const Register: FC = () => {
         { retry: 3 },
     );
     const { identify, track } = useTracking();
-    const redirectUrl = location.state?.from
-        ? `${location.state.from.pathname}${location.state.from.search}`
-        : '/';
+    const redirectUrl = sanitizeRedirectUrl(
+        location.state?.from
+            ? `${location.state.from.pathname}${location.state.from.search}`
+            : undefined,
+    );
     const { isLoading, mutate, isSuccess } = useMutation<
         LightdashUser,
         ApiError,

--- a/packages/frontend/src/utils/redirectUrl.test.ts
+++ b/packages/frontend/src/utils/redirectUrl.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeRedirectUrl } from './redirectUrl';
+
+describe('sanitizeRedirectUrl', () => {
+    it('keeps root-relative paths', () => {
+        expect(sanitizeRedirectUrl('/')).toBe('/');
+        expect(sanitizeRedirectUrl('/projects')).toBe('/projects');
+        expect(sanitizeRedirectUrl('/projects/abc?tab=charts#top')).toBe(
+            '/projects/abc?tab=charts#top',
+        );
+    });
+
+    it('falls back to / for missing values', () => {
+        expect(sanitizeRedirectUrl(undefined)).toBe('/');
+        expect(sanitizeRedirectUrl(null)).toBe('/');
+        expect(sanitizeRedirectUrl('')).toBe('/');
+    });
+
+    it('rejects absolute URLs', () => {
+        expect(sanitizeRedirectUrl('https://evil.example.com')).toBe('/');
+        expect(sanitizeRedirectUrl('http://evil.example.com/path')).toBe('/');
+        expect(sanitizeRedirectUrl('javascript:alert(1)')).toBe('/');
+    });
+
+    it('rejects protocol-relative URLs', () => {
+        expect(sanitizeRedirectUrl('//evil.example.com')).toBe('/');
+        expect(sanitizeRedirectUrl('//evil.example.com/path')).toBe('/');
+    });
+
+    it('rejects backslash variants of protocol-relative URLs', () => {
+        expect(sanitizeRedirectUrl('/\\evil.example.com')).toBe('/');
+        expect(sanitizeRedirectUrl('\\evil.example.com')).toBe('/');
+        expect(sanitizeRedirectUrl('\\\\evil.example.com')).toBe('/');
+    });
+
+    it('rejects relative paths without a leading slash', () => {
+        expect(sanitizeRedirectUrl('projects')).toBe('/');
+        expect(sanitizeRedirectUrl('evil.example.com')).toBe('/');
+    });
+});

--- a/packages/frontend/src/utils/redirectUrl.ts
+++ b/packages/frontend/src/utils/redirectUrl.ts
@@ -1,0 +1,13 @@
+/**
+ * Post-login redirect targets come from the URL (`?redirect=`) or router state
+ * and must stay on this origin. Anything that isn't a root-relative path —
+ * absolute URLs, protocol-relative (`//host`), or backslash variants (`/\host`)
+ * — falls back to `/`.
+ */
+export const sanitizeRedirectUrl = (url: string | null | undefined): string =>
+    url &&
+    url.startsWith('/') &&
+    !url.startsWith('//') &&
+    !url.startsWith('/\\')
+        ? url
+        : '/';


### PR DESCRIPTION
Adds a `sanitizeRedirectUrl` helper that only keeps root-relative paths (falling back to `/`) and applies it where the login and register pages build their post-auth redirect target, with unit tests.

Linear: SPK-600