### PR TITLE
fix: make content as code backups reliable on non enterprise

### DIFF
--- a/packages/backend/src/services/RolesService/RolesService.test.ts
+++ b/packages/backend/src/services/RolesService/RolesService.test.ts
@@ -25,6 +25,7 @@ import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { RolesModel } from '../../models/RolesModel';
 import { UserModel } from '../../models/UserModel';
 import { AdminNotificationService } from '../AdminNotificationService/AdminNotificationService';
+import { LicenseService } from '../LicenseService/LicenseService';
 import { RolesService } from './RolesService';
 import {
     mockAccount,
@@ -45,22 +46,30 @@ import {
 } from './RolesService.mock';
 
 describe('RolesService', () => {
-    const service = new RolesService({
-        lightdashConfig: {} as LightdashConfig,
-        analytics: mockAnalytics as unknown as LightdashAnalytics,
-        rolesModel: mockRolesModel as unknown as RolesModel,
-        userModel: mockUserModel as unknown as UserModel,
-        organizationModel:
-            mockOrganizationModel as unknown as OrganizationModel,
-        groupsModel: mockGroupsModel as unknown as GroupsModel,
-        projectModel: mockProjectModel as unknown as ProjectModel,
-        emailClient: mockEmailClient as unknown as EmailClient,
-        adminNotificationService:
-            mockAdminNotificationService as unknown as AdminNotificationService,
-        inviteLinkModel: mockInviteLinkModel as unknown as InviteLinkModel,
-        organizationMemberProfileModel:
-            mockOrganizationMemberProfileModel as unknown as OrganizationMemberProfileModel,
-    });
+    const buildService = (licenseValid = true) =>
+        new RolesService({
+            lightdashConfig: {} as LightdashConfig,
+            licenseService: {
+                getLicenseStatus: () => ({
+                    hasLicenseKey: licenseValid,
+                    valid: licenseValid,
+                }),
+            } as LicenseService,
+            analytics: mockAnalytics as unknown as LightdashAnalytics,
+            rolesModel: mockRolesModel as unknown as RolesModel,
+            userModel: mockUserModel as unknown as UserModel,
+            organizationModel:
+                mockOrganizationModel as unknown as OrganizationModel,
+            groupsModel: mockGroupsModel as unknown as GroupsModel,
+            projectModel: mockProjectModel as unknown as ProjectModel,
+            emailClient: mockEmailClient as unknown as EmailClient,
+            adminNotificationService:
+                mockAdminNotificationService as unknown as AdminNotificationService,
+            inviteLinkModel: mockInviteLinkModel as unknown as InviteLinkModel,
+            organizationMemberProfileModel:
+                mockOrganizationMemberProfileModel as unknown as OrganizationMemberProfileModel,
+        });
+    const service = buildService();
     beforeEach(() => {
         vi.clearAllMocks();
     });
@@ -98,6 +107,41 @@ describe('RolesService', () => {
             expect(
                 mockRolesModel.getRolesWithScopesByOrganizationUuid,
             ).toHaveBeenCalledWith('test-org-uuid', 'user');
+        });
+
+        it('keeps custom role exports available without an Enterprise license', async () => {
+            mockRolesModel.getRolesWithScopesByOrganizationUuid.mockResolvedValue(
+                [mockCustomRoleWithScopes],
+            );
+
+            await expect(
+                buildService(false).getCustomRolesAsCode(
+                    mockAccount,
+                    'test-org-uuid',
+                ),
+            ).resolves.toHaveLength(1);
+        });
+
+        it('rejects custom role upserts without an Enterprise license', async () => {
+            await expect(
+                buildService(false).upsertCustomRoleAsCode(
+                    mockAccount,
+                    'test-org-uuid',
+                    roleAsCode,
+                ),
+            ).rejects.toThrow(
+                'Custom roles require a Lightdash Enterprise license',
+            );
+        });
+
+        it('keeps regular custom role mutations available without an Enterprise license', async () => {
+            mockRolesModel.createRole.mockResolvedValue(mockNewRole);
+
+            await expect(
+                buildService(false).createRole(mockAccount, 'test-org-uuid', {
+                    name: 'New role',
+                }),
+            ).resolves.toStrictEqual(mockNewRole);
         });
 
         it('creates a missing custom role', async () => {
@@ -199,6 +243,64 @@ describe('RolesService', () => {
                 [
                     {
                         ...mockCustomRoleWithScopes,
+                        scopes: legacyRole.scopes,
+                    },
+                ],
+            );
+
+            await expect(
+                service.upsertCustomRoleAsCode(
+                    mockAccount,
+                    'test-org-uuid',
+                    legacyRole,
+                ),
+            ).resolves.toStrictEqual({
+                action: PromotionAction.NO_CHANGES,
+            });
+        });
+
+        it('creates a missing legacy role with organization scopes at organization level', async () => {
+            const legacyRole: CustomRoleAsCode = {
+                ...roleAsCode,
+                scopes: ['view:Dashboard', 'view:Organization'],
+            };
+            mockRolesModel.getRolesWithScopesByOrganizationUuid.mockResolvedValue(
+                [],
+            );
+            const createRole = vi
+                .spyOn(service, 'createRole')
+                .mockResolvedValue(mockNewRole);
+
+            await expect(
+                service.upsertCustomRoleAsCode(
+                    mockAccount,
+                    'test-org-uuid',
+                    legacyRole,
+                ),
+            ).resolves.toStrictEqual({ action: PromotionAction.CREATE });
+            expect(createRole).toHaveBeenCalledWith(
+                mockAccount,
+                'test-org-uuid',
+                {
+                    name: legacyRole.name,
+                    description: legacyRole.description,
+                    level: 'organization',
+                    scopes: legacyRole.scopes,
+                },
+            );
+            createRole.mockRestore();
+        });
+
+        it('treats a retried normalized legacy role as unchanged', async () => {
+            const legacyRole: CustomRoleAsCode = {
+                ...roleAsCode,
+                scopes: ['view:Dashboard', 'view:Organization'],
+            };
+            mockRolesModel.getRolesWithScopesByOrganizationUuid.mockResolvedValue(
+                [
+                    {
+                        ...mockCustomRoleWithScopes,
+                        level: 'organization',
                         scopes: legacyRole.scopes,
                     },
                 ],

--- a/packages/backend/src/services/RolesService/RolesService.ts
+++ b/packages/backend/src/services/RolesService/RolesService.ts
@@ -49,9 +49,11 @@ import { UserModel } from '../../models/UserModel';
 import { wrapSentryTransaction } from '../../utils';
 import { AdminNotificationService } from '../AdminNotificationService/AdminNotificationService';
 import { BaseService } from '../BaseService';
+import { LicenseService } from '../LicenseService/LicenseService';
 
 type RolesServiceArguments = {
     lightdashConfig: LightdashConfig;
+    licenseService: LicenseService;
     analytics: LightdashAnalytics;
     rolesModel: RolesModel;
     userModel: UserModel;
@@ -66,6 +68,8 @@ type RolesServiceArguments = {
 
 export class RolesService extends BaseService {
     private readonly lightdashConfig: LightdashConfig;
+
+    private readonly licenseService: LicenseService;
 
     private readonly analytics: LightdashAnalytics;
 
@@ -89,6 +93,7 @@ export class RolesService extends BaseService {
 
     constructor({
         lightdashConfig,
+        licenseService,
         analytics,
         rolesModel,
         userModel,
@@ -102,6 +107,7 @@ export class RolesService extends BaseService {
     }: RolesServiceArguments) {
         super({ serviceName: 'RolesService' });
         this.lightdashConfig = lightdashConfig;
+        this.licenseService = licenseService;
         this.analytics = analytics;
         this.rolesModel = rolesModel;
         this.userModel = userModel;
@@ -261,6 +267,14 @@ export class RolesService extends BaseService {
         }
     }
 
+    private assertCustomRolesLicensed(): void {
+        if (!this.licenseService.getLicenseStatus().valid) {
+            throw new ForbiddenError(
+                'Custom roles require a Lightdash Enterprise license',
+            );
+        }
+    }
+
     private static validateCustomRoleAsCode(role: CustomRoleAsCode): void {
         const expectedKeys = [
             'version',
@@ -341,6 +355,20 @@ export class RolesService extends BaseService {
         }
     }
 
+    private static normalizeLegacyCustomRoleLevel(
+        role: CustomRoleAsCode,
+    ): CustomRoleAsCode {
+        if (
+            role.level === 'project' &&
+            role.scopes.some(
+                (scopeName) => !isScopeAssignableAtLevel(scopeName, role.level),
+            )
+        ) {
+            return { ...role, level: 'organization' };
+        }
+        return role;
+    }
+
     private static validateCustomRoleLevel(
         role: Pick<Role, 'name' | 'level'>,
         level: RoleLevel,
@@ -404,6 +432,7 @@ export class RolesService extends BaseService {
         organizationUuid: string,
         desiredRole: CustomRoleAsCode,
     ): Promise<ApiCustomRoleAsCodeUpsertResponse['results']> {
+        this.assertCustomRolesLicensed();
         const auditedAbility = this.createAuditedAbility(account);
         RolesService.validateOrganizationAccess(
             account,
@@ -420,39 +449,48 @@ export class RolesService extends BaseService {
         const existingRole = existingRoles.find(
             (role) => role.name === desiredRole.name,
         );
+        const normalizedDesiredRole =
+            RolesService.normalizeLegacyCustomRoleLevel(desiredRole);
+        const effectiveDesiredRole =
+            existingRole?.level === desiredRole.level
+                ? desiredRole
+                : normalizedDesiredRole;
 
         if (!existingRole) {
             RolesService.validateScopesLevel(
-                desiredRole.scopes,
-                desiredRole.level,
+                effectiveDesiredRole.scopes,
+                effectiveDesiredRole.level,
             );
             await this.createRole(account, organizationUuid, {
-                name: desiredRole.name,
-                description: desiredRole.description ?? undefined,
-                level: desiredRole.level,
-                scopes: desiredRole.scopes,
+                name: effectiveDesiredRole.name,
+                description: effectiveDesiredRole.description ?? undefined,
+                level: effectiveDesiredRole.level,
+                scopes: effectiveDesiredRole.scopes,
             });
             return { action: PromotionAction.CREATE };
         }
 
-        if (existingRole.level !== desiredRole.level) {
+        if (existingRole.level !== effectiveDesiredRole.level) {
             throw new ParameterError(
-                `Cannot change custom role "${desiredRole.name}" level from ${existingRole.level} to ${desiredRole.level}. Create a new role instead.`,
+                `Cannot change custom role "${effectiveDesiredRole.name}" level from ${existingRole.level} to ${effectiveDesiredRole.level}. Create a new role instead.`,
             );
         }
 
         const existingScopes = new Set(existingRole.scopes);
-        const desiredScopes = new Set(desiredRole.scopes);
-        const scopesToAdd = desiredRole.scopes.filter(
+        const desiredScopes = new Set(effectiveDesiredRole.scopes);
+        const scopesToAdd = effectiveDesiredRole.scopes.filter(
             (scope) => !existingScopes.has(scope),
         );
         const scopesToRemove = existingRole.scopes
             .filter((scope) => !desiredScopes.has(scope))
             .sort();
         const descriptionChanged =
-            existingRole.description !== desiredRole.description;
+            existingRole.description !== effectiveDesiredRole.description;
 
-        RolesService.validateScopesLevel(scopesToAdd, desiredRole.level);
+        RolesService.validateScopesLevel(
+            scopesToAdd,
+            effectiveDesiredRole.level,
+        );
 
         if (
             scopesToAdd.length === 0 &&
@@ -468,7 +506,7 @@ export class RolesService extends BaseService {
             existingRole.roleUuid,
             {
                 ...(descriptionChanged
-                    ? { description: desiredRole.description }
+                    ? { description: effectiveDesiredRole.description }
                     : {}),
                 scopes: {
                     add: scopesToAdd,

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1521,6 +1521,7 @@ export class ServiceRepository
             () =>
                 new RolesService({
                     lightdashConfig: this.context.lightdashConfig,
+                    licenseService: this.getLicenseService(),
                     analytics: this.context.lightdashAnalytics,
                     rolesModel: this.models.getRolesModel(),
                     userModel: this.models.getUserModel(),

--- a/packages/cli/src/handlers/contentAsCode/resource.ts
+++ b/packages/cli/src/handlers/contentAsCode/resource.ts
@@ -55,6 +55,7 @@ export type CodeResourceUploadSummary = {
     created: number;
     updated: number;
     unchanged: number;
+    skipped?: number;
     failed: number;
     failures: CodeFileFailure[];
 };
@@ -283,10 +284,12 @@ export const uploadCodeResource = async <Document>({
     definition,
     basePath,
     upsert,
+    skipError,
 }: {
     definition: CodeResourceDefinition<Document>;
     basePath: string;
     upsert: (document: Document) => Promise<ContentAsCodeUpsertAction>;
+    skipError?: (error: unknown) => boolean;
 }): Promise<CodeResourceUploadSummary> => {
     const { files, failures } = await readCodeResourceFiles({
         definition,
@@ -303,9 +306,13 @@ export const uploadCodeResource = async <Document>({
         try {
             summary[getActionCountKey(await upsert(document))] += 1;
         } catch (error) {
-            summary.failures.push({
-                message: `Invalid ${definition.displayLabel} file "${filePath}": ${getErrorMessage(error)}`,
-            });
+            if (skipError?.(error)) {
+                summary.skipped = (summary.skipped ?? 0) + 1;
+            } else {
+                summary.failures.push({
+                    message: `Invalid ${definition.displayLabel} file "${filePath}": ${getErrorMessage(error)}`,
+                });
+            }
         }
     }
     summary.failed = summary.failures.length;

--- a/packages/cli/src/handlers/download.test.ts
+++ b/packages/cli/src/handlers/download.test.ts
@@ -21,15 +21,47 @@ import {
     getDataAppUploadFilter,
     uploadFilterMatches,
 } from './apps/appsDownload';
-import { lightdashApi } from './dbt/apiClient';
+import {
+    getContentAsCodeUploadPermissions,
+    lightdashApi,
+} from './dbt/apiClient';
 import {
     downloadContent,
+    downloadHandler,
     getExternalConnectionSecretEnvVar,
     testHelpers,
+    uploadHandler,
+    type DownloadHandlerOptions,
 } from './download';
+
+vi.mock('../analytics/analytics', () => ({
+    LightdashAnalytics: {
+        track: vi.fn(),
+    },
+}));
+
+vi.mock('../config', () => ({
+    getConfig: vi.fn().mockResolvedValue({
+        user: {
+            userUuid: 'user-uuid',
+            organizationUuid: 'organization-uuid',
+        },
+        context: {
+            apiKey: 'api-key',
+            serverUrl: 'http://lightdash.test',
+            project: 'project-uuid',
+            projectName: 'Test project',
+        },
+        answers: {
+            metadataFileGitignoreNoticeShown: true,
+        },
+    }),
+    setAnswer: vi.fn(),
+}));
 
 vi.mock('./dbt/apiClient', async (importOriginal) => ({
     ...(await importOriginal<typeof import('./dbt/apiClient')>()),
+    getContentAsCodeUploadPermissions: vi.fn(),
     lightdashApi: vi.fn(),
 }));
 
@@ -39,7 +71,9 @@ const {
     getDashboardChartSlugs,
     getFlatSpaceFileNames,
     hasContentFilters,
+    isAiAgentsUnavailableError,
     isExternalConnectionsUnavailableError,
+    downloadAiAgents,
     readAiAgentFiles,
     readSpaceFiles,
     readSpaceNames,
@@ -47,12 +81,56 @@ const {
     shouldFallBackToEmbeddedSpaces,
     shouldDownloadAiAgents,
     summarizeUploadChanges,
+    upsertAiAgents,
     upsertExternalConnections,
     upsertSpaces,
     upsertVirtualViews,
     validateSpaceIdentity,
     writeSpaceFiles,
 } = testHelpers;
+
+const makeDownloadHandlerOptions = (
+    overrides: Partial<DownloadHandlerOptions> = {},
+): DownloadHandlerOptions => ({
+    verbose: false,
+    charts: [],
+    dashboards: [],
+    alerts: [],
+    agents: [],
+    googleSheets: [],
+    scheduledDeliveries: [],
+    virtualViews: [],
+    externalConnections: [],
+    apps: [],
+    includeAgents: false,
+    includeApps: false,
+    force: false,
+    languageMap: false,
+    skipSpaceCreate: false,
+    public: false,
+    includeCharts: false,
+    nested: false,
+    rootSpaces: false,
+    skipSpaces: true,
+    skipCharts: true,
+    skipDashboards: true,
+    skipAlerts: false,
+    skipAgents: false,
+    skipGoogleSheets: false,
+    skipScheduledDeliveries: false,
+    skipVirtualViews: false,
+    skipExternalConnections: false,
+    includeAlerts: false,
+    includeGoogleSheets: false,
+    includeScheduledDeliveries: false,
+    includeVirtualViews: false,
+    includeExternalConnections: false,
+    includeAll: false,
+    stripPivotSeries: false,
+    concurrency: 1,
+    organization: false,
+    ...overrides,
+});
 
 const makeContentFilterOptions = (
     overrides: Partial<Parameters<typeof hasContentFilters>[0]> = {},
@@ -708,6 +786,174 @@ describe('isExternalConnectionsUnavailableError', () => {
     });
 });
 
+describe('AI agent downloads', () => {
+    const unavailableError = new LightdashError({
+        message:
+            "Unable to initialize service 'aiAgentCoderService' - no factory or provider.",
+        name: 'MissingConfigError',
+        statusCode: 422,
+        data: {},
+    });
+
+    beforeEach(() => {
+        vi.mocked(lightdashApi).mockReset();
+    });
+
+    it('classifies permission, missing-route and non-EE errors as unavailable', () => {
+        [403, 404, 422].forEach((statusCode) => {
+            expect(
+                isAiAgentsUnavailableError(
+                    new LightdashError({
+                        message: 'AI agents unavailable',
+                        name: 'TestError',
+                        statusCode,
+                        data: {},
+                    }),
+                ),
+            ).toBe(true);
+        });
+    });
+
+    it('skips unavailable AI agents when selected implicitly', async () => {
+        vi.mocked(lightdashApi).mockRejectedValueOnce(unavailableError);
+
+        await expect(downloadAiAgents('project-uuid', [], true)).resolves.toBe(
+            0,
+        );
+    });
+
+    it('keeps explicit AI agent downloads strict', async () => {
+        vi.mocked(lightdashApi).mockRejectedValueOnce(unavailableError);
+
+        await expect(downloadAiAgents('project-uuid', [], false)).rejects.toBe(
+            unavailableError,
+        );
+    });
+});
+
+describe('downloadHandler failures', () => {
+    const unavailableError = new LightdashError({
+        message:
+            "Unable to initialize service 'aiAgentCoderService' - no factory or provider.",
+        name: 'MissingConfigError',
+        statusCode: 422,
+        data: {},
+    });
+
+    beforeEach(() => {
+        vi.mocked(lightdashApi).mockReset();
+    });
+
+    it('continues to scheduled content after implicitly skipping unavailable AI agents', async () => {
+        const tmpDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'include-all-download-test-'),
+        );
+        vi.mocked(lightdashApi).mockImplementation(async ({ url }) => {
+            if (url.startsWith('/api/v1/health')) {
+                return { version: '0.0.0' } as never;
+            }
+            if (url === '/api/v1/projects/project-uuid') {
+                return { name: 'Test project' } as never;
+            }
+            if (url.includes('/code/virtualViews')) {
+                return {
+                    virtualViews: [],
+                    skipped: [],
+                    missingSlugs: [],
+                } as never;
+            }
+            if (url.includes('/code/aiAgents')) {
+                throw unavailableError;
+            }
+            if (url.includes('/code/alerts')) {
+                return { alerts: [], skipped: [] } as never;
+            }
+            if (url.includes('/code/scheduledDeliveries')) {
+                return { scheduledDeliveries: [], skipped: [] } as never;
+            }
+            if (url.includes('/code/googleSheets')) {
+                return { googleSheetsSyncs: [], skipped: [] } as never;
+            }
+            if (url.includes('/code/externalConnections')) {
+                throw unavailableError;
+            }
+            if (url.includes('/ee/projects/project-uuid/apps')) {
+                throw unavailableError;
+            }
+            throw new Error(`Unexpected request: ${url}`);
+        });
+
+        try {
+            await expect(
+                downloadHandler(
+                    makeDownloadHandlerOptions({
+                        includeAll: true,
+                        path: tmpDir,
+                        project: 'project-uuid',
+                    }),
+                ),
+            ).resolves.toBeUndefined();
+
+            expect(vi.mocked(lightdashApi)).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    url: expect.stringContaining('/code/scheduledDeliveries'),
+                }),
+            );
+        } finally {
+            await fs.rm(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    it('rethrows fatal project download errors', async () => {
+        vi.mocked(lightdashApi).mockImplementation(async ({ url }) => {
+            if (url.startsWith('/api/v1/health')) {
+                return { version: '0.0.0' } as never;
+            }
+            if (url === '/api/v1/projects/project-uuid') {
+                return { name: 'Test project' } as never;
+            }
+            if (url.includes('/code/aiAgents')) {
+                throw unavailableError;
+            }
+            throw new Error(`Unexpected request: ${url}`);
+        });
+
+        await expect(
+            downloadHandler(
+                makeDownloadHandlerOptions({
+                    agents: ['sales-agent'],
+                    project: 'project-uuid',
+                }),
+            ),
+        ).rejects.toBe(unavailableError);
+    });
+});
+
+describe('uploadHandler failures', () => {
+    beforeEach(() => {
+        vi.mocked(lightdashApi).mockReset();
+        vi.mocked(getContentAsCodeUploadPermissions).mockReset();
+    });
+
+    it('rethrows fatal project upload errors', async () => {
+        const fatalError = new Error('Failed to load dbt credentials');
+        vi.mocked(lightdashApi).mockResolvedValue({
+            version: '0.0.0',
+        } as never);
+        vi.mocked(getContentAsCodeUploadPermissions).mockRejectedValueOnce(
+            fatalError,
+        );
+
+        await expect(
+            uploadHandler(
+                makeDownloadHandlerOptions({
+                    project: 'project-uuid',
+                }),
+            ),
+        ).rejects.toBe(fatalError);
+    });
+});
+
 describe('readAiAgentFiles', () => {
     let tmpDir: string;
 
@@ -760,6 +1006,65 @@ describe('readAiAgentFiles', () => {
                 ],
             },
         ]);
+    });
+});
+
+describe('upsertAiAgents', () => {
+    let tmpDir: string;
+    const unavailableError = new LightdashError({
+        message:
+            "Unable to initialize service 'aiAgentCoderService' - no factory or provider.",
+        name: 'MissingConfigError',
+        statusCode: 422,
+        data: {},
+    });
+
+    beforeEach(async () => {
+        vi.mocked(lightdashApi).mockReset();
+        vi.spyOn(GlobalState, 'log').mockImplementation(() => undefined);
+        tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agent-upload-test-'));
+        await fs.mkdir(path.join(tmpDir, 'ai-agents'));
+        await fs.writeFile(
+            path.join(tmpDir, 'ai-agents', 'revenue-agent.yml'),
+            [
+                'contentType: ai_agent',
+                'version: 1',
+                'slug: revenue-agent',
+                '',
+            ].join('\n'),
+        );
+    });
+
+    afterEach(async () => {
+        vi.restoreAllMocks();
+        await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('skips unavailable AI agents when their upload is implicit', async () => {
+        vi.mocked(lightdashApi).mockRejectedValueOnce(unavailableError);
+
+        await expect(
+            upsertAiAgents('project-uuid', [], {}, false, tmpDir, true),
+        ).resolves.toStrictEqual({});
+
+        expect(GlobalState.log).toHaveBeenCalledWith(
+            expect.stringContaining('Skipping AI agents'),
+        );
+    });
+
+    it('fails when unavailable AI agents were selected explicitly', async () => {
+        vi.mocked(lightdashApi).mockRejectedValueOnce(unavailableError);
+
+        await expect(
+            upsertAiAgents(
+                'project-uuid',
+                ['revenue-agent'],
+                {},
+                false,
+                tmpDir,
+                false,
+            ),
+        ).rejects.toBe(unavailableError);
     });
 });
 

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -137,9 +137,7 @@ import {
     getFlatSpaceFileNames,
     getSpaceNames,
     getUniqueExistingSpaceFilePathsBySlug,
-    isSpaceAsCodeDownloadError,
     isSpaceAsCodeFetchError,
-    isSpaceAsCodeUploadError,
     logUploadChanges,
     readSpaceFiles,
     readSpaceNames,
@@ -1065,6 +1063,10 @@ const isExternalConnectionsUnavailableError = (error: unknown): boolean =>
     error instanceof LightdashError &&
     [403, 404, 422].includes(error.statusCode);
 
+const isAiAgentsUnavailableError = (error: unknown): boolean =>
+    error instanceof LightdashError &&
+    [403, 404, 422].includes(error.statusCode);
+
 const downloadExternalConnections = async (
     projectId: string,
     slugs: string[],
@@ -1288,6 +1290,7 @@ const getScheduledContentConfig = (
 const downloadAiAgents = async (
     projectId: string,
     ids: string[],
+    implicit: boolean,
     customPath?: string,
 ): Promise<number> => {
     const idQuery = ids.map((id) => ['ids', id] as [string, string]);
@@ -1296,35 +1299,50 @@ const downloadAiAgents = async (
     let downloaded = 0;
     const agents: AgentAsCode[] = [];
 
-    do {
-        const query = new URLSearchParams([
-            ...idQuery,
-            ['offset', String(offset)],
-        ]).toString();
-        const results = await lightdashApi<
-            ApiAgentAsCodeListResponse['results']
-        >({
-            method: 'GET',
-            url: `/api/v1/projects/${projectId}/code/aiAgents?${query}`,
-            body: undefined,
+    try {
+        do {
+            const query = new URLSearchParams([
+                ...idQuery,
+                ['offset', String(offset)],
+            ]).toString();
+            const results = await lightdashApi<
+                ApiAgentAsCodeListResponse['results']
+            >({
+                method: 'GET',
+                url: `/api/v1/projects/${projectId}/code/aiAgents?${query}`,
+                body: undefined,
+            });
+
+            agents.push(...results.agents);
+
+            results.missingIds.forEach((id) =>
+                GlobalState.debug(`No AI agent with id "${id}"`),
+            );
+            downloaded += results.agents.length;
+            offset = results.offset;
+            total = results.total;
+        } while (offset < total);
+
+        await writeCodeResourceDocuments({
+            definition: AI_AGENT_CODE_RESOURCE,
+            basePath: getDownloadFolder(customPath),
+            documents: agents,
+            pruneOtherDocuments: ids.length === 0,
         });
-
-        agents.push(...results.agents);
-
-        results.missingIds.forEach((id) =>
-            GlobalState.debug(`No AI agent with id "${id}"`),
-        );
-        downloaded += results.agents.length;
-        offset = results.offset;
-        total = results.total;
-    } while (offset < total);
-
-    await writeCodeResourceDocuments({
-        definition: AI_AGENT_CODE_RESOURCE,
-        basePath: getDownloadFolder(customPath),
-        documents: agents,
-        pruneOtherDocuments: ids.length === 0,
-    });
+    } catch (error) {
+        if (implicit && isAiAgentsUnavailableError(error)) {
+            GlobalState.log(
+                styles.warning(
+                    'Skipping AI agents: they require Lightdash Enterprise and AI agent access.',
+                ),
+            );
+            GlobalState.debug(
+                `Could not download AI agents: ${getErrorMessage(error)}`,
+            );
+            return 0;
+        }
+        throw error;
+    }
 
     return downloaded;
 };
@@ -1358,6 +1376,7 @@ const upsertAiAgents = async (
     changes: Record<string, number>,
     force: boolean,
     customPath?: string,
+    implicit: boolean = false,
 ): Promise<Record<string, number>> => {
     const agents = await readAiAgentFiles(customPath);
     const filteredAgents = slugs.length
@@ -1374,13 +1393,27 @@ const upsertAiAgents = async (
     }
     logContentAsCodeDiscovery(`Found ${filteredAgents.length} AI agent files`);
 
-    const results = await lightdashApi<ApiAgentAsCodeUpsertResponse['results']>(
-        {
+    let results: ApiAgentAsCodeUpsertResponse['results'];
+    try {
+        results = await lightdashApi<ApiAgentAsCodeUpsertResponse['results']>({
             method: 'POST',
             url: `/api/v1/projects/${projectId}/code/aiAgents?force=${force}`,
             body: JSON.stringify({ agents: filteredAgents }),
-        },
-    );
+        });
+    } catch (error) {
+        if (implicit && isAiAgentsUnavailableError(error)) {
+            GlobalState.log(
+                styles.warning(
+                    'Skipping AI agents: they require Lightdash Enterprise and AI agent access.',
+                ),
+            );
+            GlobalState.debug(
+                `Could not upload AI agents: ${getErrorMessage(error)}`,
+            );
+            return changes;
+        }
+        throw error;
+    }
 
     const counts = {
         'AI agents created': results.created.length,
@@ -1899,10 +1932,19 @@ export const downloadHandler = async (
         }
 
         if (!options.spacesOnly && shouldDownloadAiAgents(options)) {
+            const implicit =
+                includeAllOptionalContent &&
+                options.includeAgents !== true &&
+                options.agents.length === 0;
             await output.runItem({
                 label: 'AI agents',
                 action: () =>
-                    downloadAiAgents(projectId, options.agents, options.path),
+                    downloadAiAgents(
+                        projectId,
+                        options.agents,
+                        implicit,
+                        options.path,
+                    ),
                 detail: (total) => `${total} downloaded`,
             });
         }
@@ -2223,7 +2265,7 @@ export const downloadHandler = async (
                 error: `${error}`,
             },
         });
-        if (isSpaceAsCodeDownloadError(error)) throw error;
+        throw error;
     }
 };
 
@@ -2985,6 +3027,7 @@ export const uploadHandler = async (
                                 changes,
                                 options.force,
                                 options.path,
+                                options.agents.length === 0,
                             ),
                     });
                 } catch (error) {
@@ -3414,9 +3457,9 @@ export const uploadHandler = async (
                 error: getErrorMessage(error),
             },
         });
-        if (isSpaceAsCodeUploadError(error)) throw error;
         if (error instanceof AiAgentAsCodeUploadError)
             throw error.originalError;
+        throw error;
     }
 };
 
@@ -3426,7 +3469,9 @@ export const testHelpers = {
     getFlatSpaceFileNames,
     getDashboardChartSlugs,
     hasContentFilters,
+    isAiAgentsUnavailableError,
     isExternalConnectionsUnavailableError,
+    downloadAiAgents,
     readAiAgentFiles,
     readExternalConnectionFiles,
     readSpaceFiles,
@@ -3436,6 +3481,7 @@ export const testHelpers = {
     shouldDownloadAiAgents,
     sortSpaceFilesParentFirst,
     summarizeUploadChanges,
+    upsertAiAgents,
     upsertExternalConnections,
     upsertSpaces,
     upsertVirtualViews,

--- a/packages/cli/src/handlers/organizationContent/customRoles.test.ts
+++ b/packages/cli/src/handlers/organizationContent/customRoles.test.ts
@@ -1,4 +1,8 @@
-import { PromotionAction, type CustomRoleAsCode } from '@lightdash/common';
+import {
+    LightdashError,
+    PromotionAction,
+    type CustomRoleAsCode,
+} from '@lightdash/common';
 import { promises as fs } from 'fs';
 import * as yaml from 'js-yaml';
 import * as os from 'os';
@@ -229,5 +233,28 @@ describe('custom roles as code', () => {
             'Unknown custom role scopes: delete:VirtualViewsss',
         );
         expect(lightdashApi).toHaveBeenCalledTimes(2);
+    });
+
+    it('skips custom roles when the target has no Enterprise license', async () => {
+        await writeCustomRole('role.yml', customRole('Enterprise role'));
+        vi.mocked(lightdashApi).mockRejectedValueOnce(
+            new LightdashError({
+                message: 'Custom roles require a Lightdash Enterprise license',
+                name: 'ForbiddenError',
+                statusCode: 403,
+                data: {},
+            }),
+        );
+
+        const summary = await uploadCustomRoles('organization-uuid', tmpDir);
+
+        expect(summary).toMatchObject({
+            created: 0,
+            updated: 0,
+            unchanged: 0,
+            skipped: 1,
+            failed: 0,
+            failures: [],
+        });
     });
 });

--- a/packages/cli/src/handlers/organizationContent/customRoles.ts
+++ b/packages/cli/src/handlers/organizationContent/customRoles.ts
@@ -1,4 +1,5 @@
 import {
+    LightdashError,
     parseCustomRoleAsCode,
     type ApiCustomRoleAsCodeListResponse,
     type ApiCustomRoleAsCodeUpsertResponse,
@@ -21,6 +22,7 @@ export type CustomRoleUploadSummary = {
     created: number;
     updated: number;
     unchanged: number;
+    skipped?: number;
     failed: number;
     failures: CustomRoleUploadFailure[];
 };
@@ -50,8 +52,21 @@ export const getCustomRolesFolder = (organizationContentPath: string): string =>
 
 export const formatCustomRoleUploadSummary = (
     summary: CustomRoleUploadSummary,
-): string =>
-    `${summary.created} created, ${summary.updated} updated, ${summary.unchanged} unchanged, ${summary.failed} failed`;
+): string => {
+    const skipped =
+        summary.skipped && summary.skipped > 0
+            ? `, ${summary.skipped} skipped`
+            : '';
+    return `${summary.created} created, ${summary.updated} updated, ${summary.unchanged} unchanged${skipped}, ${summary.failed} failed`;
+};
+
+const isCustomRolesUnavailableError = (error: unknown): boolean =>
+    error instanceof LightdashError &&
+    ([404, 422].includes(error.statusCode) ||
+        (error.statusCode === 403 &&
+            error.message.includes(
+                'Custom roles require a Lightdash Enterprise license',
+            )));
 
 export const readCustomRoleFiles = async (
     organizationContentPath: string,
@@ -81,6 +96,7 @@ export const uploadCustomRoles = async (
             });
             return result.action;
         },
+        skipError: isCustomRolesUnavailableError,
     });
 
 export const downloadCustomRoles = async (

--- a/packages/cli/src/handlers/organizationContent/index.ts
+++ b/packages/cli/src/handlers/organizationContent/index.ts
@@ -203,7 +203,17 @@ export const uploadOrganizationContent = async ({
                 `Processed custom roles: ${summaryMessage}`,
             );
         }
-        output.completeItem(summaryMessage);
+        if (summary.skipped && summary.skipped > 0) {
+            GlobalState.log(
+                styles.warning(
+                    'Skipped custom roles because they require a Lightdash Enterprise license.',
+                ),
+            );
+        }
+        output.completeItem(
+            summaryMessage,
+            summary.skipped && summary.skipped > 0 ? 'warning' : undefined,
+        );
         output.startItem('Users');
         const userSummary = await uploadUsers(
             organizationUuid,


### PR DESCRIPTION

<img width="515" height="335" alt="CleanShot 2026-07-31 at 10 09 52" src="https://github.com/user-attachments/assets/a504161b-89a8-4ef9-b3e5-78ef7c5127eb" />
<img width="1265" height="1179" alt="image" src="https://github.com/user-attachments/assets/10cd3117-396e-459d-9b56-2774c2403d4f" />


## Summary

- skip unavailable AI agents when selected implicitly by `download --include-all` or a normal project upload, allowing alerts, scheduled deliveries, and later resources to continue
- skip unavailable custom roles during unlicensed organization uploads so users and groups can still be restored
- normalize legacy custom-role files that are marked project-level but contain organization-only scopes when restoring into a new organization
- return a non-zero exit code for fatal project download and upload failures
- require a valid Enterprise license only when importing custom roles through Content as Code; exports and ordinary custom-role operations remain available after license removal

## Testing

- `pnpm -F cli test src/handlers/download.test.ts src/handlers/organizationContent/customRoles.test.ts src/handlers/organizationContent/index.test.ts src/handlers/contentAsCode/resource.test.ts` (82 tests)
- `pnpm -F backend test --run src/services/RolesService/RolesService.test.ts` (50 tests)
- `pnpm -F cli typecheck`
- `pnpm -F cli lint`
- `pnpm -F cli format`
- `NODE_OPTIONS="--max-old-space-size=8192" pnpm -F backend typecheck`
- `NODE_OPTIONS="--max-old-space-size=8192" pnpm -F backend lint`
- live unlicensed `download --include-all` continued through scheduled deliveries and completed successfully
- live unlicensed project upload skipped AI agents, continued through scheduled deliveries, and exited 0
- live explicit AI-agent upload failed with exit code 1
- live unlicensed organization upload skipped custom roles, continued through users and groups, and exited 0
- live unlicensed custom-role Content as Code import returned 403 while export and ordinary role mutations remained available
- legacy custom-role regression tests cover first import, retry idempotency, and preservation of existing legacy project roles

Closes: SPK-754
Closes: SPK-755
Closes: SPK-756
Closes: SPK-757
Closes: SPK-758
