### PR TITLE
feat: allow tags on additional explores

### DIFF
--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -1473,6 +1473,52 @@ describe('explore-scoped additional dimensions', () => {
         expect(baseTable.dimensions).toHaveProperty('amount');
     });
 
+    it('should override model tags for additional explores', async () => {
+        const modelWithExploreTags: DbtModelNode = {
+            ...MODEL_WITH_EXPLORE_SCOPED_DIMENSIONS,
+            config: {
+                ...MODEL_WITH_EXPLORE_SCOPED_DIMENSIONS.config,
+                tags: ['model_tag'],
+            },
+            meta: {
+                explores: {
+                    tagged_orders: {
+                        tags: 'additional_explore_tag',
+                    },
+                    inherited_orders: {},
+                    untagged_orders: {
+                        tags: [],
+                    },
+                },
+            },
+        };
+
+        const explores = await convertExplores(
+            [modelWithExploreTags],
+            false,
+            SupportedDbtAdapter.POSTGRES,
+            warehouseClientMock,
+            {
+                spotlight: DEFAULT_SPOTLIGHT_CONFIG,
+            },
+        );
+
+        expect(
+            explores.find((explore) => explore.name === 'test_model')?.tags,
+        ).toEqual(['model_tag']);
+        expect(
+            explores.find((explore) => explore.name === 'tagged_orders')?.tags,
+        ).toEqual(['additional_explore_tag']);
+        expect(
+            explores.find((explore) => explore.name === 'inherited_orders')
+                ?.tags,
+        ).toEqual(['model_tag']);
+        expect(
+            explores.find((explore) => explore.name === 'untagged_orders')
+                ?.tags,
+        ).toEqual([]);
+    });
+
     const MODEL_WITH_DATE_EXPLORE_DIMENSION: DbtModelNode = {
         ...MODEL_WITH_EXPLORE_SCOPED_DIMENSIONS,
         meta: {

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -1176,6 +1176,7 @@ export const convertExplores = async (
             {
                 name: model.name,
                 label: meta.label || friendlyName(model.name),
+                tags: tags || [],
                 groupLabel: meta.group_label,
                 ...(meta.groups && meta.groups.length > 0
                     ? { groups: meta.groups }
@@ -1222,11 +1223,17 @@ export const convertExplores = async (
                               });
                           }
 
+                          const exploreTags =
+                              typeof exploreConfig.tags === 'string'
+                                  ? [exploreConfig.tags]
+                                  : exploreConfig.tags;
+
                           return {
                               name: exploreName,
                               label:
                                   exploreConfig.label ||
                                   friendlyName(exploreName),
+                              tags: exploreTags ?? tags ?? [],
                               groupLabel:
                                   exploreConfig.group_label || meta.group_label,
                               ...((exploreConfig.groups &&
@@ -1278,7 +1285,7 @@ export const convertExplores = async (
                 const compiled = exploreCompiler.compileExplore({
                     name: exploreToCreate.name,
                     label: exploreToCreate.label,
-                    tags: tags || [],
+                    tags: exploreToCreate.tags,
                     baseTable: model.name,
                     groupLabel: exploreToCreate.groupLabel,
                     ...(exploreToCreate.groups &&
@@ -1330,6 +1337,7 @@ export const convertExplores = async (
                 return {
                     name: exploreToCreate.name,
                     label: exploreToCreate.label,
+                    tags: exploreToCreate.tags,
                     groupLabel: exploreToCreate.groupLabel,
                     ...(exploreToCreate.groups &&
                     exploreToCreate.groups.length > 0

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -1139,6 +1139,20 @@
                                     "description": "Alias for default_filters (deprecated, use default_filters instead)",
                                     "items": { "$ref": "#/$defs/filterItem" }
                                 },
+                                "tags": {
+                                    "oneOf": [
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    ],
+                                    "description": "Tags for organizing and filtering this explore. Overrides model tags when set."
+                                },
                                 "sql_filter": {
                                     "type": "string",
                                     "description": "SQL filter applied to the WHERE clause of all queries using this explore"

--- a/packages/common/src/schemas/json/model-as-code-1.0.json
+++ b/packages/common/src/schemas/json/model-as-code-1.0.json
@@ -894,6 +894,20 @@
                     "type": "string",
                     "description": "Detailed description of the explore"
                 },
+                "tags": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ],
+                    "description": "Tags for organizing and filtering this explore. Overrides model tags when set."
+                },
                 "group_label": {
                     "type": "string",
                     "description": "Group this explore belongs to in the sidebar"

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -187,7 +187,9 @@ export type DbtModelLightdashConfig = ExploreConfig &
         };
         explores?: Record<
             string,
-            ExploreConfig & SharedDbtModelLightdashConfig
+            ExploreConfig &
+                SharedDbtModelLightdashConfig &
+                DbtLightdashFieldTags
         >;
         ai_hint?: string | string[];
         parameters?: LightdashProjectConfig['parameters'];

--- a/packages/common/src/types/lightdashModel.ts
+++ b/packages/common/src/types/lightdashModel.ts
@@ -50,6 +50,7 @@ export type LightdashModelMetric = DbtColumnLightdashMetric;
 export type LightdashModelExplore = {
     label?: string;
     description?: string;
+    tags?: string | string[];
     /** @deprecated Use groups instead */
     group_label?: string;
     groups?: string[];


### PR DESCRIPTION
## Summary

- support `tags` on additional explores
- override model tags when configured while preserving inheritance when omitted
- document the property in dbt and model-as-code schemas

## Validation

- `pnpm -F common typecheck`
- `pnpm -F common test -- src/compiler/translator.test.ts` — 119 files, 3,202 tests passed
- `pnpm -F common format`
- `pnpm -F common lint`
- local Jaffle Shop CLI compile and deploy — 64 explores compiled successfully
- local API confirmed distinct model and additional-explore tags
- Browser confirmed the additional explore loads with its scoped fields
- fresh review-agent pass: no findings

Closes: #22228
