### PR TITLE
feat: prometheus counter for memory citations

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -9314,6 +9314,9 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                                       );
                                   }
                                   if (citedMemories.length > 0) {
+                                      this.prometheusMetrics?.incrementAiAgentMemoryCited(
+                                          citedMemories.length,
+                                      );
                                       citedMemories.forEach(
                                           ({ memoryId, slug }) =>
                                               this.analytics.track<AiAgentMemoryCitedEvent>(

--- a/packages/backend/src/prometheus/PrometheusMetrics.ts
+++ b/packages/backend/src/prometheus/PrometheusMetrics.ts
@@ -134,6 +134,8 @@ export default class PrometheusMetrics {
     public aiAgentMemoryUnknownToolPolicyCounter: prometheus.Counter | null =
         null;
 
+    public aiAgentMemoryCitedCounter: prometheus.Counter | null = null;
+
     public aiDeepResearchReportCleanupCounter: prometheus.Counter<'outcome'> | null =
         null;
 
@@ -561,6 +563,12 @@ export default class PrometheusMetrics {
                         ...rest,
                     });
 
+                this.aiAgentMemoryCitedCounter = new prometheus.Counter({
+                    name: 'ai_agent_memory_cited_total',
+                    help: 'Memories cited in an agent response, counted once per memory per response',
+                    ...rest,
+                });
+
                 this.aiDeepResearchReportCleanupCounter =
                     new prometheus.Counter({
                         name: 'ai_deep_research_report_cleanup_total',
@@ -769,6 +777,7 @@ export default class PrometheusMetrics {
                 });
                 this.aiAgentMemorySweepEnqueuedCounter?.inc(0);
                 this.aiAgentMemoryUnknownToolPolicyCounter?.inc(0);
+                this.aiAgentMemoryCitedCounter?.inc(0);
                 (['scanned', 'expired', 'failed'] as const).forEach(
                     (outcome) => {
                         this.aiDeepResearchReportCleanupCounter?.inc(
@@ -1637,6 +1646,10 @@ export default class PrometheusMetrics {
 
     public incrementAiAgentMemoryUnknownToolPolicy() {
         this.aiAgentMemoryUnknownToolPolicyCounter?.inc();
+    }
+
+    public incrementAiAgentMemoryCited(count: number) {
+        this.aiAgentMemoryCitedCounter?.inc(count);
     }
 
     public incrementAiDeepResearchReportCleanup(


### PR DESCRIPTION
Citations are recorded in two places today, neither of which is Prometheus: the `cited_count` / `last_cited_at` columns, and the `ai_agent_memory.cited` analytics event. So there is no way to see on a dashboard whether citation is happening at a healthy rate, or whether it moved after a prompt or injection change.

Adds one counter alongside the existing distill and consolidation metrics:

```
ai_agent_memory_cited_total
```

Incremented at the existing citation-telemetry call site, by the number of memories the update actually bumped — so it counts once per memory per response, matching the `cited_count` increment rather than the raw marker count. A response citing the same memory three times contributes 1, which is the same fact the DB column records.

## Notes

**No labels, deliberately.** Slugs are derived from memory content and unbounded, and were excluded from the analytics events for that reason; org and project would grow without limit per instance. `namespace` already separates instances at scrape time. If a dimension is wanted later, `channel` (`web`/`slack`) is bounded at 2 and safe to add.

**Zero-initialised at registration**, consistent with the other memory metrics, so a dashboard reads `0` rather than a gap before the first citation.

**This is not a lifetime total.** A counter resets on pod restart and is per-replica, so it answers "is citation happening, and did the rate change" — read through `rate()` / `increase()`. The durable per-memory count stays the `cited_count` column, which is also what ranks injection.

## Testing

`typecheck`, `lint` and the `src/prometheus` suite pass. No new test: the increment is one optional-chained call at an existing call site, matching how the distill and consolidation counters shipped — `PrometheusMetrics.test.ts` asserts nothing about those either.

Relates: ZAP-717