### PR TITLE
fix(validator): batch chart lookups

### DIFF
--- a/packages/backend/src/models/SavedChartModel.test.ts
+++ b/packages/backend/src/models/SavedChartModel.test.ts
@@ -631,6 +631,15 @@ describe('moveToSpace', () => {
 });
 
 describe('findChartsForValidation', () => {
+    const makeValidationChart = (
+        uuid: string,
+        dashboardUuid: string | null,
+    ) => ({
+        uuid,
+        dashboardUuid,
+        customMetricsFilters: [],
+        pivotDimensions: [],
+    });
     const database = knex({ client: MockClient, dialect: 'pg' });
     const model = new SavedChartModel({
         database,
@@ -660,32 +669,95 @@ describe('findChartsForValidation', () => {
         expect(query.sql).toContain('"sq"."project_uuid"');
     });
 
-    test('keeps validation queries within the PostgreSQL bind parameter limit', async () => {
+    test('excludes orphan charts using only active dashboard tiles', async () => {
         const projectUuid = '22222222-2222-4222-8222-222222222222';
-        const savedCharts = Array.from({ length: 65_536 }, (_, index) => {
-            const dashboardIndex = index % 32_768;
-            return {
-                uuid: `chart-${index}`,
-                dashboardUuid:
-                    index === 0
-                        ? null
-                        : `33333333-3333-4333-8333-${dashboardIndex
-                              .toString(16)
-                              .padStart(12, '0')}`,
-                customMetricsFilters: [],
-                pivotDimensions: [],
-            };
-        });
+        const dashboardUuid = '33333333-3333-4333-8333-333333333333';
+        const chartInTileUuid = '44444444-4444-4444-8444-444444444444';
+        const orphanChartUuid = '55555555-5555-4555-8555-555555555555';
+        const spaceChartUuid = '66666666-6666-4666-8666-666666666666';
+        tracker.on
+            .select(({ sql }) => sql.includes('chart_last_version_cte'))
+            .responseOnce([
+                makeValidationChart(chartInTileUuid, dashboardUuid),
+                makeValidationChart(orphanChartUuid, dashboardUuid),
+                makeValidationChart(spaceChartUuid, null),
+            ]);
+        tracker.on
+            .select(({ sql }) => sql.includes(DashboardTileChartTableName))
+            .responseOnce([{ saved_query_uuid: chartInTileUuid }]);
+
+        const charts = await model.findChartsForValidation(projectUuid);
+
+        expect(charts.map(({ uuid }) => uuid)).toEqual([
+            chartInTileUuid,
+            spaceChartUuid,
+        ]);
+        const chartLookupQuery = tracker.history.select.find(({ sql }) =>
+            sql.includes(DashboardTileChartTableName),
+        );
+        expect(chartLookupQuery?.sql).toContain(
+            `"${DashboardsTableName}"."deleted_at" is null`,
+        );
+        expect(chartLookupQuery?.sql).toContain(
+            '"charts_in_tiles"."deleted_at" is null',
+        );
+    });
+
+    test('skips tile lookups for space-only charts', async () => {
+        const projectUuid = '22222222-2222-4222-8222-222222222222';
+        const chartUuids = [
+            '44444444-4444-4444-8444-444444444444',
+            '55555555-5555-4555-8555-555555555555',
+        ];
+        tracker.on
+            .select(({ sql }) => sql.includes('chart_last_version_cte'))
+            .responseOnce(
+                chartUuids.map((chartUuid) =>
+                    makeValidationChart(chartUuid, null),
+                ),
+            );
+
+        const charts = await model.findChartsForValidation(projectUuid);
+
+        expect(charts.map(({ uuid }) => uuid)).toEqual(chartUuids);
+        expect(
+            tracker.history.select.filter(({ sql }) =>
+                sql.includes(DashboardTileChartTableName),
+            ),
+        ).toHaveLength(0);
+    });
+
+    test('batches chart lookups independently of dashboard distribution', async () => {
+        const projectUuid = '22222222-2222-4222-8222-222222222222';
+        const dashboardUuid = '33333333-3333-4333-8333-333333333333';
+        const savedCharts = Array.from({ length: 65_536 }, (_, index) =>
+            makeValidationChart(
+                `chart-${index}`,
+                index === 0 ? null : dashboardUuid,
+            ),
+        );
         tracker.on
             .select(({ sql }) => sql.includes('chart_last_version_cte'))
             .responseOnce(savedCharts);
         tracker.on
             .select(({ sql }) => sql.includes(DashboardTileChartTableName))
-            .responseOnce([]);
+            .response([]);
 
         await model.findChartsForValidation(projectUuid);
 
-        expect(tracker.history.select).toHaveLength(2);
+        const chartLookupQueries = tracker.history.select.filter(({ sql }) =>
+            sql.includes(DashboardTileChartTableName),
+        );
+        const batchSizes = chartLookupQueries.flatMap(({ bindings }) =>
+            bindings.flatMap((binding) =>
+                Array.isArray(binding) ? [binding.length] : [],
+            ),
+        );
+        expect(chartLookupQueries).toHaveLength(7);
+        expect(batchSizes).toEqual([
+            ...Array.from({ length: 6 }, () => 10_000),
+            5_535,
+        ]);
         expect(
             Math.max(
                 ...tracker.history.select.map(

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -53,6 +53,7 @@ import {
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import { Knex } from 'knex';
+import { chunk } from 'lodash';
 import { DatabaseError } from 'pg';
 import { validate as isValidUuid } from 'uuid';
 import { LightdashConfig } from '../config/parseConfig';
@@ -1875,54 +1876,58 @@ export class SavedChartModel {
 
     private async getChartsNotInTilesUuids(
         savedCharts: Pick<SavedChartDAO, 'uuid' | 'dashboardUuid'>[],
-    ): Promise<string[]> {
-        const dashboardUuids = [
-            ...new Set(
-                savedCharts.flatMap(({ dashboardUuid }) =>
-                    dashboardUuid === null ? [] : [dashboardUuid],
-                ),
-            ),
-        ];
-        if (dashboardUuids.length === 0) {
-            return [];
+    ): Promise<Set<string>> {
+        const dashboardChartUuids = savedCharts
+            .filter(({ dashboardUuid }) => dashboardUuid !== null)
+            .map(({ uuid }) => uuid);
+        const chartsNotInTilesUuids = new Set<string>();
+        const chartsInTilesAlias = 'charts_in_tiles';
+
+        for (const chartUuidBatch of chunk(dashboardChartUuids, 10_000)) {
+            // eslint-disable-next-line no-await-in-loop -- keep batches serial to bound database load
+            const tiledChartUuids = await this.database(
+                DashboardTileChartTableName,
+            )
+                .leftJoin(
+                    DashboardVersionsTableName,
+                    `${DashboardVersionsTableName}.dashboard_version_id`,
+                    `${DashboardTileChartTableName}.dashboard_version_id`,
+                )
+                .leftJoin(
+                    DashboardsTableName,
+                    `${DashboardsTableName}.dashboard_id`,
+                    `${DashboardVersionsTableName}.dashboard_id`,
+                )
+                .leftJoin(
+                    `${SavedChartsTableName} as ${chartsInTilesAlias}`,
+                    `${chartsInTilesAlias}.saved_query_id`,
+                    `${DashboardTileChartTableName}.saved_chart_id`,
+                )
+                .whereNull(`${DashboardsTableName}.deleted_at`)
+                .whereNull(`${chartsInTilesAlias}.deleted_at`)
+                .whereRaw('?? = ANY(?::uuid[])', [
+                    `${chartsInTilesAlias}.saved_query_uuid`,
+                    chartUuidBatch,
+                ])
+                .andWhere(
+                    // filter by last version
+                    `${DashboardVersionsTableName}.dashboard_version_id`,
+                    this.database.raw(`(select dashboard_version_id
+                        from ${DashboardVersionsTableName} dv
+                        where dv.dashboard_id = ${DashboardsTableName}.dashboard_id
+                        order by dv.created_at desc
+                        limit 1)`),
+                )
+                .pluck<string[]>(`${chartsInTilesAlias}.saved_query_uuid`)
+                .distinct();
+            const tiledChartUuidSet = new Set(tiledChartUuids);
+
+            for (const chartUuid of chartUuidBatch) {
+                if (!tiledChartUuidSet.has(chartUuid)) {
+                    chartsNotInTilesUuids.add(chartUuid);
+                }
+            }
         }
-
-        const getChartsInTilesQuery = this.database(DashboardTileChartTableName)
-            .distinct('saved_chart_id')
-            .leftJoin(
-                DashboardVersionsTableName,
-                `${DashboardVersionsTableName}.dashboard_version_id`,
-                `${DashboardTileChartTableName}.dashboard_version_id`,
-            )
-            .leftJoin(
-                DashboardsTableName,
-                `${DashboardsTableName}.dashboard_id`,
-                `${DashboardVersionsTableName}.dashboard_id`,
-            )
-            .whereRaw('?? = ANY(?::uuid[])', [
-                `${DashboardsTableName}.dashboard_uuid`,
-                dashboardUuids,
-            ])
-            .andWhere(
-                // filter by last version
-                `${DashboardVersionsTableName}.dashboard_version_id`,
-                this.database.raw(`(select dashboard_version_id
-                    from ${DashboardVersionsTableName} dv
-                    where dv.dashboard_id = ${DashboardsTableName}.dashboard_id
-                    order by dv.created_at desc
-                    limit 1)`),
-            )
-            // Exclude NULL saved_chart_id to prevent NOT IN issues
-            .whereNotNull(`${DashboardTileChartTableName}.saved_chart_id`);
-
-        const chartsNotInTilesUuids = await this.database(SavedChartsTableName)
-            .pluck(`saved_query_uuid`)
-            .whereRaw('?? = ANY(?::uuid[])', [
-                `${SavedChartsTableName}.dashboard_uuid`,
-                dashboardUuids,
-            ])
-            .whereNotIn(`saved_query_id`, getChartsInTilesQuery)
-            .whereNull(`${SavedChartsTableName}.deleted_at`);
 
         return chartsNotInTilesUuids;
     }
@@ -2065,7 +2070,7 @@ export class SavedChartModel {
                 customMetricsFilters: chart.customMetricsFilters.flat(),
                 pivotDimensions: chart.pivotDimensions ?? [],
             }))
-            .filter((chart) => !chartsNotInTilesUuids.includes(chart.uuid));
+            .filter((chart) => !chartsNotInTilesUuids.has(chart.uuid));
     }
 
     async getSlugsForUuids(uuids: string[]): Promise<string[]> {
@@ -2440,7 +2445,7 @@ export class SavedChartModel {
         const chartsNotInTilesUuids =
             await this.getChartsNotInTilesUuids(savedCharts);
         return savedCharts
-            .filter((chart) => !chartsNotInTilesUuids.includes(chart.uuid))
+            .filter((chart) => !chartsNotInTilesUuids.has(chart.uuid))
             .map((chart) => ({
                 ...chart,
                 customMetrics: chart.customMetrics.map(


### PR DESCRIPTION
Related: PROD-8838

Checks dashboard-backed charts in serial groups of 10,000 and derives orphan charts with a JavaScript `Set` difference.

Each query uses one UUID-array binding and returns charts tiled on the latest version of any active dashboard. This keeps query work bounded regardless of dashboard distribution and keeps filtering linear. Charts deleted during validation are intentionally skipped.

Verified through the production validation path with 32,768 tiled charts and separately with 32,768 orphan charts. Unit coverage includes 65,535 dashboard-backed charts on one dashboard, non-empty orphan filtering, and space-only projects issuing no tile lookup.
