### PR TITLE
fix: only apply new-onboarding completion flow to new signups

### DIFF
--- a/packages/backend/src/database/migrations/20260731111612_grandfather_existing_incomplete_users_setup_complete.ts
+++ b/packages/backend/src/database/migrations/20260731111612_grandfather_existing_incomplete_users_setup_complete.ts
@@ -1,0 +1,12 @@
+import { type Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex('users')
+        .where('is_setup_complete', false)
+        .where('created_at', '<', knex.raw('NOW() - interval 1 day'))
+        .update({ is_setup_complete: true });
+}
+
+export async function down(_knex: Knex): Promise<void> {
+    // no-op
+}

--- a/packages/backend/src/database/migrations/20260731111612_grandfather_existing_incomplete_users_setup_complete.ts
+++ b/packages/backend/src/database/migrations/20260731111612_grandfather_existing_incomplete_users_setup_complete.ts
@@ -3,7 +3,6 @@ import { type Knex } from 'knex';
 export async function up(knex: Knex): Promise<void> {
     await knex('users')
         .where('is_setup_complete', false)
-        .where('created_at', '<', knex.raw("NOW() - interval '1 day'"))
         .update({ is_setup_complete: true });
 }
 

--- a/packages/backend/src/database/migrations/20260731111612_grandfather_existing_incomplete_users_setup_complete.ts
+++ b/packages/backend/src/database/migrations/20260731111612_grandfather_existing_incomplete_users_setup_complete.ts
@@ -3,7 +3,7 @@ import { type Knex } from 'knex';
 export async function up(knex: Knex): Promise<void> {
     await knex('users')
         .where('is_setup_complete', false)
-        .where('created_at', '<', knex.raw('NOW() - interval 1 day'))
+        .where('created_at', '<', knex.raw("NOW() - interval '1 day'"))
         .update({ is_setup_complete: true });
 }
 


### PR DESCRIPTION
Marks every existing user with `is_setup_complete = false` as complete. The onboarding completion flow is intended for completely new signups only: the new-onboarding flag is not yet rolled out, so everyone existing at migration time is grandfathered wholesale — no date cutoff needed. Users created after this migration start incomplete as usual and go through the flow once the flag is enabled.

The `down` migration is intentionally a no-op: the original `false` set is unrecoverable and this is a one-way product decision.

Fixes SPK-761