### PR TITLE
refactor(cli): move app creation under apps command

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -1026,7 +1026,7 @@ Data apps can be **downloaded as source, versioned in git, edited, and re-upload
 
 Opt-in flags on the existing `lightdash download` / `lightdash upload` commands (off by default — core users never touch app code paths unless they ask):
 
-- **`lightdash create app "<name>"`** — create a new app locally at `lightdash/apps/<slug>/` from the E2B starter template. The command requires npm and first asks the user to accept that it will download packages and run shadcn locally. It then lists the exact direct dependencies and shadcn components for a second approval before writing anything. After approval, it checks that the slug is available in the selected project and adds the complete runnable source tree, manifest, agent skills, and a fresh project context snapshot. `--slug`, `--description`, `--project`, and `--path` override the defaults; `--assume-yes` approves installation in non-interactive environments.
+- **`lightdash apps create "<name>"`** — create a new app locally at `lightdash/apps/<slug>/` from the E2B starter template. The command requires npm and first asks the user to accept that it will download packages and run shadcn locally. It then lists the exact direct dependencies and shadcn components for a second approval before writing anything. After approval, it checks that the slug is available in the selected project and adds the complete runnable source tree, manifest, agent skills, and a fresh project context snapshot. `--slug`, `--description`, `--project`, and `--path` override the defaults; `--assume-yes` approves installation in non-interactive environments.
 - **`lightdash download --apps <appReferences...>`** — download specific data apps by UUID, slug, or app URL into `lightdash/apps/<slug>/`; **`--include-apps`** downloads all of the project's apps (capped at `--apps-limit`, default 50). Each folder holds `lightdash-app.yml` (manifest) + the app's `src/` tree. The built `dist` is intentionally excluded — it's regenerated on upload.
 - **`lightdash upload --apps <appReferences...>`** — upload specific apps by UUID, slug, or app URL, matched against each local folder's manifest (`slug` or `appUuid`); **`--include-apps`** uploads every `lightdash/apps/<slug>/` folder on disk. The server rebuilds the source. **Fire-and-forget:** the CLI posts and returns immediately — the app shows `building` in the UI until the server finishes.
 
@@ -1056,7 +1056,7 @@ Cross-project and cross-instance upload are both a plain **slug upsert** against
 
 ### Local authoring
 
-Apps created with `lightdash create app "<name>"` and apps checked out with `lightdash download --apps <slug>` use the same locally-buildable structure, so you can verify changes compile before uploading.
+Apps created with `lightdash apps create "<name>"` and apps checked out with `lightdash download --apps <slug>` use the same locally-buildable structure, so you can verify changes compile before uploading.
 
 #### What a local app includes
 
@@ -1072,7 +1072,7 @@ All scaffolding and context files are read-only reference — see [Upload is sou
 #### The local loop
 
 ```sh
-lightdash create app "<name>"  →  edit src/  →  npm run build  →  lightdash apps preview  →  lightdash upload --apps <slug>  →  server rebuilds
+lightdash apps create "<name>"  →  edit src/  →  npm run build  →  lightdash apps preview  →  lightdash upload --apps <slug>  →  server rebuilds
 ```
 
 1. Edit files under `src/`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -48,7 +48,7 @@ Create a new data app locally from the same starter used by Lightdash's data
 app builder:
 
 ```shell
-lightdash create app "Revenue explorer"
+lightdash apps create "Revenue explorer"
 ```
 
 This requires npm. Before writing anything, the command first warns that it

--- a/packages/cli/src/handlers/apps/authoring/AGENTS.md.tmpl
+++ b/packages/cli/src/handlers/apps/authoring/AGENTS.md.tmpl
@@ -6,7 +6,7 @@ Two skills in `.claude/skills/` describe how to edit this app:
 
 Edit only `src/`. Root config files are read-only reference — the server rebuilds against a trusted template.
 
-The local build is an optional pre-check. Apps made with `lightdash create app` already have dependencies installed and can run `npm run build`; after `lightdash download`, use `npm install && npm run build` if you choose to build locally. If install fails, skip it and upload — never modify machine config, npmrc, or dependency files to force it; the server rebuild is authoritative.
+The local build is an optional pre-check. Apps made with `lightdash apps create` already have dependencies installed and can run `npm run build`; after `lightdash download`, use `npm install && npm run build` if you choose to build locally. If install fails, skip it and upload — never modify machine config, npmrc, or dependency files to force it; the server rebuild is authoritative.
 
 Build with the template's preinstalled dependency set (see `package.json`). Adding new npm packages only works when the instance has custom dependencies enabled — assume it does not; ask the user before considering a new library, and never vendor library source into `src/` as a workaround. Where enabled, adding a dependency is the one workflow that still requires pnpm: upload requires a matching `pnpm-lock.yaml`, so `pnpm add <pkg>` (or `pnpm install --lockfile-only`) must succeed locally. If it fails, stop and report the error — hand-editing `package.json` without the lockfile makes the upload fail.
 

--- a/packages/cli/src/handlers/apps/authoring/README.md.tmpl
+++ b/packages/cli/src/handlers/apps/authoring/README.md.tmpl
@@ -4,7 +4,7 @@ Created or downloaded with the Lightdash CLI.
 
 ## Edit → build → upload
 1. Edit files under `src/`.
-2. Optionally, run `npm run build` to check it compiles locally. `lightdash create app` installs the initial dependencies after asking permission; after `lightdash download`, run `npm install` first if `node_modules` is absent. If install fails in your environment, skip the local build — the server build on upload is authoritative and surfaces errors on the app page. Don't change machine or registry config to force it.
+2. Optionally, run `npm run build` to check it compiles locally. `lightdash apps create` installs the initial dependencies after asking permission; after `lightdash download`, run `npm install` first if `node_modules` is absent. If install fails in your environment, skip the local build — the server build on upload is authoritative and surfaces errors on the app page. Don't change machine or registry config to force it.
 3. Optionally, preview against real data: `lightdash apps preview` (needs a successful `npm install`).
 4. `lightdash upload --apps <slug>` (the `slug` from `lightdash-app.yml`) — Lightdash rebuilds and serves the app.
 

--- a/packages/cli/src/handlers/apps/authoring/developing-data-apps-locally/SKILL.md
+++ b/packages/cli/src/handlers/apps/authoring/developing-data-apps-locally/SKILL.md
@@ -28,7 +28,7 @@ You are editing a Lightdash **data app** that was created or downloaded with the
 ## The edit → build → upload loop
 
 1. Edit files under `src/` only.
-2. Optionally, run `npm run build` to check it compiles. Apps made with `lightdash create app` already have their initial dependencies installed. After `lightdash download`, if you choose to do the local pre-check and `node_modules` is absent, run `npm install` first. This is an **optional local pre-check** — see below.
+2. Optionally, run `npm run build` to check it compiles. Apps made with `lightdash apps create` already have their initial dependencies installed. After `lightdash download`, if you choose to do the local pre-check and `node_modules` is absent, run `npm install` first. This is an **optional local pre-check** — see below.
 3. `lightdash upload --apps <slug>` (the `slug` from this folder's `lightdash-app.yml`) — the **server** rebuilds and serves the app. The server rebuild, not your local build, is what ships.
 
 ## The local build is optional — never fight a failing install

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -181,39 +181,6 @@ ${styles.bold('Examples:')}
 `,
     );
 
-const createProgram = program
-    .command('create')
-    .description('Creates Lightdash content locally');
-
-createProgram
-    .command('app <name>')
-    .description('Creates a new data app locally')
-    .option('--description <text>', 'Set the app description', '')
-    .option('--slug <slug>', 'Override the app slug')
-    .option(
-        '-p, --path <path>',
-        'Specify the Lightdash content root (default: ./lightdash)',
-    )
-    .option(
-        '--project <project uuid>',
-        'Specify the project the app will use',
-        parseProjectArgument,
-        undefined,
-    )
-    .option('-y, --assume-yes', 'approve npm package installation', false)
-    .option('--verbose', undefined, false)
-    .addHelpText(
-        'after',
-        `\n${styles.bold('Example:')}\n  ${styles.title(
-            '⚡',
-        )}️lightdash ${styles.bold(
-            'create app "Revenue explorer"',
-        )} ${styles.secondary(
-            '-- creates ./lightdash/apps/revenue-explorer',
-        )}\n`,
-    )
-    .action(createAppHandler);
-
 program
     .command('connect-snowflake')
     .description('Connects Lightdash to Snowflake using browser-based SSO')
@@ -1110,6 +1077,34 @@ uploadCommand.action(withOrganizationMode(uploadHandler));
 const appsProgram = program
     .command('apps')
     .description('Work with data apps (enterprise)');
+appsProgram
+    .command('create <name>')
+    .description('Creates a new data app locally')
+    .option('--description <text>', 'Set the app description', '')
+    .option('--slug <slug>', 'Override the app slug')
+    .option(
+        '-p, --path <path>',
+        'Specify the Lightdash content root (default: ./lightdash)',
+    )
+    .option(
+        '--project <project uuid>',
+        'Specify the project the app will use',
+        parseProjectArgument,
+        undefined,
+    )
+    .option('-y, --assume-yes', 'approve npm package installation', false)
+    .option('--verbose', undefined, false)
+    .addHelpText(
+        'after',
+        `\n${styles.bold('Example:')}\n  ${styles.title(
+            '⚡',
+        )}️lightdash ${styles.bold(
+            'apps create "Revenue explorer"',
+        )} ${styles.secondary(
+            '-- creates ./lightdash/apps/revenue-explorer',
+        )}\n`,
+    )
+    .action(createAppHandler);
 appsProgram
     .command('preview [path]')
     .description(


### PR DESCRIPTION
## What changed

- move local data app creation from `lightdash create app <name>` to `lightdash apps create <name>`
- remove the unshipped top-level `create` namespace without a compatibility alias
- update CLI docs and bundled local-authoring guidance to use the new command

## Why

Data app creation and preview are both app-specific workflows. Keeping them under `lightdash apps` gives the CLI one consistent namespace and avoids introducing a top-level command before the feature ships.

## User impact

New local data apps are now created with:

```sh
lightdash apps create "Revenue explorer"
```

## Validation

- 27 focused CLI app-creation tests
- CLI TypeScript typecheck
- CLI lint and formatting
- CLI build
- verified `lightdash apps create --help`
- verified the old `lightdash create app` form is rejected