### PR TITLE
fix: pin agent onboarding sandbox CLI to the server version

### DIFF
--- a/packages/backend/src/ee/services/OnboardingAgentService/OnboardingAgentService.ts
+++ b/packages/backend/src/ee/services/OnboardingAgentService/OnboardingAgentService.ts
@@ -23,6 +23,7 @@ import { BaseService } from '../../../services/BaseService';
 import { type PersonalAccessTokenService } from '../../../services/PersonalAccessTokenService';
 import { type PromptService } from '../../../services/PromptService/PromptService';
 import { type UserService } from '../../../services/UserService';
+import { VERSION } from '../../../version';
 import {
     type DbAgentOnboardingFile,
     type DbAgentOnboardingRun,
@@ -438,6 +439,7 @@ export class OnboardingAgentService extends BaseService {
                 allow: [
                     new URL(this.getSandboxFacingSiteUrl()).hostname,
                     'api.anthropic.com',
+                    'registry.npmjs.org',
                 ],
             },
         };
@@ -612,6 +614,26 @@ export class OnboardingAgentService extends BaseService {
         await sandbox.commands.run(
             `mkdir -p ${WORKDIR}/lightdash/models ${WORKDIR}/lightdash/charts ${WORKDIR}/lightdash/dashboards && chmod -R a+rwX ${WORKDIR}`,
         );
+        if (/^\d+\.\d+\.\d+$/.test(VERSION)) {
+            try {
+                const result = await sandbox.commands.run(
+                    `npm install -g @lightdash/cli@${VERSION}`,
+                );
+                if (result.exitCode !== 0) {
+                    this.logger.warn(
+                        `OnboardingAgent: could not pin CLI to ${VERSION}, using template CLI`,
+                    );
+                } else {
+                    this.logger.info(
+                        `OnboardingAgent: pinned CLI to ${VERSION}`,
+                    );
+                }
+            } catch {
+                this.logger.warn(
+                    `OnboardingAgent: could not pin CLI to ${VERSION}, using template CLI`,
+                );
+            }
+        }
         await sandbox.files.write(PROMPT_PATH, prompt);
         await sandbox.files.write(CLI_WRAPPER_PATH, CLI_WRAPPER_SCRIPT);
         await sandbox.files.write(

--- a/sandboxes/agent-onboarding/e2b.Dockerfile
+++ b/sandboxes/agent-onboarding/e2b.Dockerfile
@@ -11,6 +11,7 @@ RUN npm install -g sfw
 
 RUN sfw npm install -g @anthropic-ai/claude-code
 
+# The service pins the CLI to the server version at run start; this is a fallback.
 RUN sfw npm install -g @lightdash/cli
 
 RUN lightdash install-skills --path /home/user


### PR DESCRIPTION
The sandbox template bakes the latest CLI, while older servers can lack endpoints that newer CLI versions call, causing deploys to silently not land.

The CLI is now pinned to the running server version at sandbox setup, with fallback to the baked CLI if installation fails. The npm registry is included in sandbox egress for the install.

Fixes SPK-762