### PR TITLE
feat: endpoint to distill one thread on demand

### DIFF
--- a/packages/backend/src/ee/controllers/AiAgentMemoryController.ts
+++ b/packages/backend/src/ee/controllers/AiAgentMemoryController.ts
@@ -3,6 +3,7 @@ import {
     type ApiAiAgentMemoryResponse,
     type ApiAiAgentUserMemoriesResponse,
     type ApiErrorPayload,
+    type ApiTriggerAiAgentMemoryDistillResponse,
     type ApiUpdateAiAgentMemoryStatusRequest,
     type ApiUpdateAiAgentMemoryStatusResponse,
     type KnexPaginateArgs,
@@ -15,6 +16,7 @@ import {
     OperationId,
     Patch,
     Path,
+    Post,
     Query,
     Request,
     Response,
@@ -124,5 +126,39 @@ export class AiAgentMemoryController extends BaseController {
             );
 
         return { status: 'ok', results: undefined };
+    }
+
+    /**
+     * Queues distillation for one thread immediately, skipping the 6h idle wait
+     * and the every-3h sweep. Re-distills a thread that is already up to date.
+     * Requires permission to manage AI agents in the project.
+     * @summary Distill thread
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('202', 'Accepted')
+    @Post('/threads/{threadUuid}/distill')
+    @OperationId('triggerAiAgentMemoryDistill')
+    async triggerAiAgentMemoryDistill(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Path() threadUuid: UUID,
+    ): Promise<ApiTriggerAiAgentMemoryDistillResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(202);
+
+        return {
+            status: 'ok',
+            results: await this.services
+                .getAiAgentMemoryService<AiAgentMemoryService>()
+                .triggerThreadDistill(
+                    toSessionUser(req.account),
+                    projectUuid,
+                    threadUuid,
+                ),
+        };
     }
 }

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryConsolidation.integration.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryConsolidation.integration.test.ts
@@ -239,7 +239,7 @@ describe('AI agent memory consolidation integration', () => {
 
     /** Observes sweep enqueues without inserting real graphile jobs. */
     const stubSchedulerClient = () => ({
-        aiAgentMemoryDistill: vi.fn(async () => ({})),
+        aiAgentMemoryDistill: vi.fn(async () => ({ jobId: 'stub-job' })),
         aiAgentMemoryConsolidatePartition: vi.fn(async () => ({})),
     });
 

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
@@ -4,6 +4,8 @@ import {
     DimensionType,
     FeatureFlags,
     FieldType,
+    ForbiddenError,
+    NotFoundError,
     ProjectType,
     SupportedDbtAdapter,
     type AnyType,
@@ -906,6 +908,158 @@ describe('AiAgentMemoryService', () => {
             'no_op',
         );
         expect(none.distillCall).toHaveBeenCalledOnce();
+    });
+
+    it('re-distills an up-to-date thread only when the trigger forces it', async () => {
+        const activity = new Date('2026-07-22T05:00:00.000Z');
+        const payload = {
+            organizationUuid: 'org-enabled',
+            projectUuid: 'project-enabled',
+            userUuid: 'current-user',
+            threadUuid: 'thread-enabled',
+            sweptUpdatedAt: activity.toISOString(),
+        };
+        const distillOutput = {
+            result: { type: 'no_op', reason: 'no_positive_evidence' },
+        };
+
+        const swept = build();
+        swept.findThreadForDistill.mockResolvedValue(
+            distillableThread(activity, { distilledUpTo: activity }),
+        );
+        await expect(swept.service.distillThread(payload)).resolves.toBe(
+            'skipped',
+        );
+        expect(swept.distillCall).not.toHaveBeenCalled();
+
+        const forced = build();
+        forced.findThreadForDistill.mockResolvedValue(
+            distillableThread(activity, { distilledUpTo: activity }),
+        );
+        forced.distillCall.mockResolvedValue(distillOutput);
+        await expect(
+            forced.service.distillThread({ ...payload, force: true }),
+        ).resolves.toBe('no_op');
+        expect(forced.distillCall).toHaveBeenCalledOnce();
+    });
+
+    it('forcing does not override the inactive-memory guard', async () => {
+        const activity = new Date('2026-07-22T05:00:00.000Z');
+        const {
+            service,
+            findThreadForDistill,
+            resolveSourceThreadMemoryState,
+            distillCall,
+        } = build();
+        findThreadForDistill.mockResolvedValue(
+            distillableThread(activity, { distilledUpTo: activity }),
+        );
+        resolveSourceThreadMemoryState.mockResolvedValue('inactive');
+
+        await expect(
+            service.distillThread({
+                organizationUuid: 'org-enabled',
+                projectUuid: 'project-enabled',
+                userUuid: 'current-user',
+                threadUuid: 'thread-enabled',
+                sweptUpdatedAt: activity.toISOString(),
+                force: true,
+            }),
+        ).resolves.toBe('skipped');
+        expect(distillCall).not.toHaveBeenCalled();
+    });
+
+    it('enqueues a forced distill carrying the thread’s own watermark', async () => {
+        const activity = new Date('2026-07-22T05:00:00.123Z');
+        const { service, findThreadForDistill, aiAgentMemoryDistill } = build();
+        // Distinct from latestActivity so the assertion below can only pass on
+        // the thread's current activity, never on its watermark.
+        findThreadForDistill.mockResolvedValue(
+            distillableThread(activity, {
+                distilledUpTo: new Date('2026-07-21T00:00:00.000Z'),
+            }),
+        );
+        aiAgentMemoryDistill.mockResolvedValue({ jobId: 'job-1' });
+
+        await expect(
+            service.triggerThreadDistill(
+                buildUser(true, { canManageAgents: true }),
+                'project-enabled',
+                'thread-enabled',
+            ),
+        ).resolves.toEqual({ jobId: 'job-1' });
+
+        expect(aiAgentMemoryDistill).toHaveBeenCalledWith({
+            organizationUuid: 'org-enabled',
+            projectUuid: 'project-enabled',
+            userUuid: 'current-user',
+            threadUuid: 'thread-enabled',
+            sweptUpdatedAt: '2026-07-22T05:00:00.123Z',
+            force: true,
+        });
+    });
+
+    it('refuses a manual distill from a project viewer who cannot manage agents', async () => {
+        const { service, findThreadForDistill, aiAgentMemoryDistill } = build();
+
+        await expect(
+            service.triggerThreadDistill(
+                buildUser(true),
+                'project-enabled',
+                'thread-enabled',
+            ),
+        ).rejects.toThrow(ForbiddenError);
+        expect(findThreadForDistill).not.toHaveBeenCalled();
+        expect(aiAgentMemoryDistill).not.toHaveBeenCalled();
+    });
+
+    it('does not enqueue a manual distill for a thread outside the project', async () => {
+        const activity = new Date('2026-07-22T05:00:00.000Z');
+        const { service, findThreadForDistill, aiAgentMemoryDistill } = build();
+        findThreadForDistill.mockResolvedValue(
+            distillableThread(activity, { projectUuid: 'project-other' }),
+        );
+
+        await expect(
+            service.triggerThreadDistill(
+                buildUser(true, { canManageAgents: true }),
+                'project-enabled',
+                'thread-enabled',
+            ),
+        ).rejects.toThrow(NotFoundError);
+        expect(aiAgentMemoryDistill).not.toHaveBeenCalled();
+    });
+
+    it('does not enqueue a manual distill for a thread in another organization', async () => {
+        const activity = new Date('2026-07-22T05:00:00.000Z');
+        const { service, findThreadForDistill, aiAgentMemoryDistill } = build();
+        findThreadForDistill.mockResolvedValue(
+            distillableThread(activity, { organizationUuid: 'org-other' }),
+        );
+
+        await expect(
+            service.triggerThreadDistill(
+                buildUser(true, { canManageAgents: true }),
+                'project-enabled',
+                'thread-enabled',
+            ),
+        ).rejects.toThrow(NotFoundError);
+        expect(aiAgentMemoryDistill).not.toHaveBeenCalled();
+    });
+
+    it('reports a thread the distill query rejects as ineligible rather than crashing', async () => {
+        const { service, findThreadForDistill, aiAgentMemoryDistill } = build();
+        // Preview projects, eval/scheduler threads and unknown uuids all land here.
+        findThreadForDistill.mockResolvedValue(undefined);
+
+        await expect(
+            service.triggerThreadDistill(
+                buildUser(true, { canManageAgents: true }),
+                'project-enabled',
+                'thread-missing',
+            ),
+        ).rejects.toThrow(NotFoundError);
+        expect(aiAgentMemoryDistill).not.toHaveBeenCalled();
     });
 
     it('skips without writing when the memory stops being active mid-distill', async () => {

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
@@ -123,7 +123,7 @@ export { type AiAgentMemoryConsolidateOutcome };
 type MemorySchedulerClient = {
     aiAgentMemoryDistill: (
         payload: AiAgentMemoryDistillJobPayload,
-    ) => Promise<unknown>;
+    ) => Promise<{ jobId: string }>;
     aiAgentMemoryConsolidatePartition: (
         payload: AiAgentMemoryConsolidatePartitionJobPayload,
     ) => Promise<unknown>;
@@ -626,6 +626,59 @@ export class AiAgentMemoryService extends BaseService {
     }
 
     /**
+     * Manual trigger for one thread: bypasses exactly the sweep's idle window
+     * and the watermark skip, and keeps every other eligibility check inside the
+     * distill job. Enqueues rather than running inline — the job carries the
+     * LLM timeout, abort handling and per-project serialisation.
+     */
+    async triggerThreadDistill(
+        user: SessionUser,
+        projectUuid: UUID,
+        threadUuid: UUID,
+    ): Promise<{ jobId: string }> {
+        const notFoundMessage = `Thread not found: ${threadUuid}`;
+        const organizationUuid = await this.getMemoryAccessContext(
+            user,
+            projectUuid,
+            notFoundMessage,
+        );
+
+        if (
+            this.createAuditedAbility(user).cannot(
+                'manage',
+                subject('AiAgent', {
+                    organizationUuid,
+                    projectUuid,
+                    metadata: { threadUuid },
+                }),
+            )
+        ) {
+            throw new ForbiddenError('Cannot manage AI agents in this project');
+        }
+
+        // Also filters out preview projects and non-web/Slack threads, so an
+        // ineligible thread fails here instead of silently skipping in the job.
+        const thread =
+            await this.aiAgentMemoryModel.findThreadForDistill(threadUuid);
+        if (
+            !thread ||
+            thread.projectUuid !== projectUuid ||
+            thread.organizationUuid !== organizationUuid
+        ) {
+            throw new NotFoundError(notFoundMessage);
+        }
+
+        return this.schedulerClient.aiAgentMemoryDistill({
+            organizationUuid,
+            projectUuid,
+            userUuid: user.userUuid,
+            threadUuid: thread.threadUuid,
+            sweptUpdatedAt: thread.latestActivity.toISOString(),
+            force: true,
+        });
+    }
+
+    /**
      * Daily sweep over every eligible `(project, owner)` partition: one child
      * job per partition, mirroring the distill queue. The flag is checked per
      * organization here, so a flag-off organization costs nothing beyond the
@@ -1048,7 +1101,10 @@ export class AiAgentMemoryService extends BaseService {
             return 'skipped';
         }
 
+        // A manual trigger deliberately re-distills an up-to-date thread; the
+        // sweep must not, or every cron tick would re-pay for quiet threads.
         if (
+            !payload.force &&
             thread.distilledUpTo !== null &&
             thread.distilledUpTo.getTime() >= sweptUpdatedAt.getTime()
         ) {

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -506,6 +506,10 @@ export type ApiUpdateAiAgentMemoryStatusRequest = {
 
 export type ApiUpdateAiAgentMemoryStatusResponse = ApiSuccessEmpty;
 
+export type ApiTriggerAiAgentMemoryDistillResponse = ApiSuccess<{
+    jobId: string;
+}>;
+
 export type ApiAiAgentAvatarUploadResponse = ApiSuccess<AiAgent>;
 
 export type ApiAiAgentSummaryResponse = {

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -122,6 +122,10 @@ export type AiAgentEditDbtProjectPipelineJobPayload = TraceTaskBase & {
 export type AiAgentMemoryDistillJobPayload = TraceTaskBase & {
     threadUuid: UUID;
     sweptUpdatedAt: string;
+    // Manual trigger only: bypass the watermark skip so an already-distilled
+    // thread re-distills. Optional because jobs enqueued before this field
+    // existed are still in the queue.
+    force?: boolean;
 };
 
 export type AiAgentMemoryConsolidatePartitionJobPayload = TraceTaskBase & {


### PR DESCRIPTION
## What

Adds `POST /api/v1/projects/{projectUuid}/aiAgentMemories/threads/{threadUuid}/distill` — queue AI-agent-memory distillation for one thread immediately, instead of waiting for the sweep.

Returns `202` with `{ jobId }`.

## Why

Distillation only ever ran off the 3-hourly `sweepAiAgentMemoryThreads` cron, and the sweep only selects threads idle for 6h+. There was no way to distill a thread now, so demoing memories or iterating on the distill prompt meant either waiting hours or hand-deleting ledger rows and injecting graphile jobs by SQL.

This resolves the distill half of open question 5 in the design doc ("manual trigger stays REPL-only, or graduate to an admin endpoint?"). Consolidation still has no endpoint.

## How

- Gated on `manage AiAgent` — the same permission `canAccessAiAgentThread` already escalates to for reading another user's thread. No new scope, so no ability-layer or `scoped_roles` migration.
- Enqueues the existing `aiAgentMemoryDistill` job rather than running inline, so the worker keeps owning the LLM timeout, abort handling, metrics and per-project queue serialisation.
- Validates at the boundary: `findThreadForDistill` already filters preview projects and non-web/Slack sources, so an ineligible thread 404s instead of silently returning `skipped` from the job.
- New optional `force` on `AiAgentMemoryDistillJobPayload` bypasses **only** the watermark skip, so an already-up-to-date thread re-distills. Optional purely for back-compat with jobs already in the queue; the sweep never sets it.

Everything else still runs under force — feature flags, preview/source/completed-turn eligibility, and the `resolveSourceThreadMemoryState === 'inactive'` guard. That last one is deliberately *not* bypassable: skipping it would insert a second active row against the one-active-row partial index, so a retired memory stays retired.

## Notes for review

`manage AiAgent` is granted at the project `developer` role. Force re-distill therefore lets a developer overwrite the *content* of another user's settled active memory row on demand — a capability no existing endpoint offers. Flagging it explicitly as intended scope rather than an oversight.

## Testing

- 7 new unit tests: force vs no-force watermark split, inactive guard surviving force, exact enqueued payload, 403 for a viewer without manage, 404 for cross-project / cross-org / ineligible threads.
- Mutation-checked the payload assertion: swapping `latestActivity` for `distilledUpTo` in the service fails the test.
- Verified live against a local instance on a thread whose `distilled_up_to == updated_at` (one the sweep would skip): `202 {"jobId":"51714"}`, and the ledger row was rewritten (`updated_at` bumped to call time, `no_op` / `insufficient_signal`) — proving the job ran the full distill rather than returning early.
