### PR TITLE
feat: console-managed media cards for the day-0 get-started homepage

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -470,6 +470,10 @@ import {
     ExternalConnectionsTableName,
 } from '../ee/database/entities/externalConnections';
 import {
+    HomepageMediaCardsTable,
+    HomepageMediaCardsTableName,
+} from '../ee/database/entities/homepageMediaCards';
+import {
     HomepageRecommendedActionSkipsTable,
     HomepageRecommendedActionSkipsTableName,
 } from '../ee/database/entities/homepageRecommendedActionSkips';
@@ -627,6 +631,7 @@ declare module 'knex/types/tables' {
         [AiWebAppPromptTableName]: AiWebAppPromptTable;
         [AiWritebackThreadTableName]: AiWritebackThreadTable;
         [AgentOnboardingRunsTableName]: AgentOnboardingRunsTable;
+        [HomepageMediaCardsTableName]: HomepageMediaCardsTable;
         [HomepageRecommendedActionSkipsTableName]: HomepageRecommendedActionSkipsTable;
         [ProjectCiStatusTableName]: ProjectCiStatusTable;
         [AiAgentTableName]: AiAgentTable;

--- a/packages/backend/src/ee/controllers/HomepageMediaCardsController.ts
+++ b/packages/backend/src/ee/controllers/HomepageMediaCardsController.ts
@@ -1,0 +1,45 @@
+import {
+    assertRegisteredAccount,
+    type ApiErrorPayload,
+    type ApiHomepageMediaCardsResponse,
+} from '@lightdash/common';
+import {
+    Get,
+    Middlewares,
+    OperationId,
+    Request,
+    Response,
+    Route,
+    SuccessResponse,
+    Tags,
+} from '@tsoa/runtime';
+import express from 'express';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+} from '../../controllers/authentication';
+import { BaseController } from '../../controllers/baseController';
+import { type HomepageMediaCardsService } from '../services/HomepageMediaCardsService';
+
+@Route('/api/v1/ee/homepage/media-cards')
+@Response<ApiErrorPayload>('default', 'Error')
+@Tags('Homepage')
+export class HomepageMediaCardsController extends BaseController {
+    private getService(): HomepageMediaCardsService {
+        return this.services.getHomepageMediaCardsService<HomepageMediaCardsService>();
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/')
+    @OperationId('listHomepageMediaCards')
+    async list(
+        @Request() req: express.Request,
+    ): Promise<ApiHomepageMediaCardsResponse> {
+        assertRegisteredAccount(req.account);
+        return {
+            status: 'ok',
+            results: await this.getService().list(),
+        };
+    }
+}

--- a/packages/backend/src/ee/database/entities/homepageMediaCards.ts
+++ b/packages/backend/src/ee/database/entities/homepageMediaCards.ts
@@ -1,0 +1,23 @@
+import { type HomepageMediaCard, type UUID } from '@lightdash/common';
+import { Knex } from 'knex';
+
+export const HomepageMediaCardsTableName = 'homepage_media_cards';
+
+export type DbHomepageMediaCard = {
+    homepage_media_card_uuid: UUID;
+    card_key: HomepageMediaCard['cardKey'];
+    title: HomepageMediaCard['title'];
+    subtitle: HomepageMediaCard['subtitle'];
+    url: HomepageMediaCard['url'];
+    thumbnail_url: HomepageMediaCard['thumbnailUrl'];
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type HomepageMediaCardsTable = Knex.CompositeTableType<
+    DbHomepageMediaCard,
+    Pick<
+        DbHomepageMediaCard,
+        'card_key' | 'title' | 'subtitle' | 'url' | 'thumbnail_url'
+    >
+>;

--- a/packages/backend/src/ee/database/migrations/20260731120000_create_homepage_media_cards.ts
+++ b/packages/backend/src/ee/database/migrations/20260731120000_create_homepage_media_cards.ts
@@ -1,0 +1,46 @@
+import { Knex } from 'knex';
+
+const HomepageMediaCardsTableName = 'homepage_media_cards';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(HomepageMediaCardsTableName, (table) => {
+        table
+            .uuid('homepage_media_card_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table.text('card_key').notNullable().unique();
+        table.text('title').notNullable();
+        table.text('subtitle').notNullable();
+        table.text('url').notNullable();
+        table.text('thumbnail_url').nullable();
+        table
+            .timestamp('created_at', { useTz: true })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: true })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+    });
+
+    await knex(HomepageMediaCardsTableName).insert([
+        {
+            card_key: 'data-apps-video',
+            title: 'What can you build with Lightdash Data Apps? 3 real examples',
+            subtitle: 'Oliver shows us how we can build data apps!',
+            url: 'https://www.youtube.com/watch?v=BwvgHQyhI1o',
+            thumbnail_url: 'https://i.ytimg.com/vi/BwvgHQyhI1o/hqdefault.jpg',
+        },
+        {
+            card_key: 'bi-as-code',
+            title: 'BI-as-code',
+            subtitle: 'Building content with code',
+            url: 'https://www.lightdash.com/bi-as-code',
+            thumbnail_url: null,
+        },
+    ]);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTable(HomepageMediaCardsTableName);
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -43,6 +43,7 @@ import { CommercialSlackAuthenticationModel } from './models/CommercialSlackAuth
 import { DashboardSummaryModel } from './models/DashboardSummaryModel';
 import { EmbedModel } from './models/EmbedModel';
 import { ExternalConnectionModel } from './models/ExternalConnectionModel';
+import { HomepageMediaCardsModel } from './models/HomepageMediaCardsModel';
 import { HomepageRecommendedActionSkipsModel } from './models/HomepageRecommendedActionSkipsModel';
 import { ManagedAgentModel } from './models/ManagedAgentModel';
 import { McpToolCallModel } from './models/McpToolCallModel';
@@ -85,6 +86,7 @@ import { EmbedService } from './services/EmbedService/EmbedService';
 import { ExternalConnectionCoderService } from './services/ExternalConnectionCoderService/ExternalConnectionCoderService';
 import { ExternalConnectionService } from './services/ExternalConnectionService/ExternalConnectionService';
 import { GoogleServiceAccountTokenProvider } from './services/ExternalConnectionService/GoogleServiceAccountTokenProvider';
+import { HomepageMediaCardsService } from './services/HomepageMediaCardsService';
 import { HomepageRecommendedActionSkipsService } from './services/HomepageRecommendedActionSkipsService';
 import { EnterpriseLicenseService } from './services/LicenseService/LicenseService';
 import { ManagedAgentService } from './services/ManagedAgentService/ManagedAgentService';
@@ -196,6 +198,11 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     homepageRecommendedActionSkipsModel:
                         models.getHomepageRecommendedActionSkipsModel<HomepageRecommendedActionSkipsModel>(),
                     projectModel: models.getProjectModel(),
+                }),
+            homepageMediaCardsService: ({ models }) =>
+                new HomepageMediaCardsService({
+                    homepageMediaCardsModel:
+                        models.getHomepageMediaCardsModel<HomepageMediaCardsModel>(),
                 }),
             aiDeepResearchService: ({
                 context,
@@ -1057,6 +1064,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 new ProjectHomepageModel({ database }),
             homepageRecommendedActionSkipsModel: ({ database }) =>
                 new HomepageRecommendedActionSkipsModel({ database }),
+            homepageMediaCardsModel: ({ database }) =>
+                new HomepageMediaCardsModel({ database }),
             aiAgentModel: ({ database, utils }) =>
                 new AiAgentModel({
                     database,

--- a/packages/backend/src/ee/models/HomepageMediaCardsModel.test.ts
+++ b/packages/backend/src/ee/models/HomepageMediaCardsModel.test.ts
@@ -1,0 +1,61 @@
+import knex, { type Knex } from 'knex';
+import { getTracker, MockClient, type Tracker } from 'knex-mock-client';
+import { HomepageMediaCardsTableName } from '../database/entities/homepageMediaCards';
+import { HomepageMediaCardsModel } from './HomepageMediaCardsModel';
+
+describe('HomepageMediaCardsModel', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new HomepageMediaCardsModel({
+        database: database as unknown as Knex,
+    });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    it('lists media cards in deterministic creation order', async () => {
+        tracker.on.select(HomepageMediaCardsTableName).responseOnce([
+            {
+                card_key: 'data-apps-video',
+                title: 'Video title',
+                subtitle: 'Video subtitle',
+                url: 'https://example.com/video',
+                thumbnail_url: 'https://example.com/thumbnail.jpg',
+            },
+            {
+                card_key: 'bi-as-code',
+                title: 'Article title',
+                subtitle: 'Article subtitle',
+                url: 'https://example.com/article',
+                thumbnail_url: null,
+            },
+        ]);
+
+        await expect(model.list()).resolves.toEqual([
+            {
+                cardKey: 'data-apps-video',
+                title: 'Video title',
+                subtitle: 'Video subtitle',
+                url: 'https://example.com/video',
+                thumbnailUrl: 'https://example.com/thumbnail.jpg',
+            },
+            {
+                cardKey: 'bi-as-code',
+                title: 'Article title',
+                subtitle: 'Article subtitle',
+                url: 'https://example.com/article',
+                thumbnailUrl: null,
+            },
+        ]);
+
+        const query = tracker.history.select[0];
+        expect(query.sql).toContain(
+            'order by "created_at" asc, "card_key" asc',
+        );
+    });
+});

--- a/packages/backend/src/ee/models/HomepageMediaCardsModel.ts
+++ b/packages/backend/src/ee/models/HomepageMediaCardsModel.ts
@@ -1,0 +1,33 @@
+import { type HomepageMediaCard } from '@lightdash/common';
+import { Knex } from 'knex';
+import {
+    HomepageMediaCardsTableName,
+    type HomepageMediaCardsTable,
+} from '../database/entities/homepageMediaCards';
+
+export class HomepageMediaCardsModel {
+    private readonly database: Knex;
+
+    constructor({ database }: { database: Knex }) {
+        this.database = database;
+    }
+
+    async list(): Promise<HomepageMediaCard[]> {
+        const rows = await this.database<HomepageMediaCardsTable>(
+            HomepageMediaCardsTableName,
+        )
+            .select('card_key', 'title', 'subtitle', 'url', 'thumbnail_url')
+            .orderBy('created_at', 'asc')
+            .orderBy('card_key', 'asc');
+
+        return rows.map(
+            ({ card_key, title, subtitle, url, thumbnail_url }) => ({
+                cardKey: card_key,
+                title,
+                subtitle,
+                url,
+                thumbnailUrl: thumbnail_url,
+            }),
+        );
+    }
+}

--- a/packages/backend/src/ee/services/HomepageMediaCardsService.test.ts
+++ b/packages/backend/src/ee/services/HomepageMediaCardsService.test.ts
@@ -1,0 +1,36 @@
+import {
+    HomepageMediaCardsService,
+    type HomepageMediaCardsServiceArguments,
+} from './HomepageMediaCardsService';
+
+describe('HomepageMediaCardsService', () => {
+    it('lists instance media cards', async () => {
+        const homepageMediaCardsModel = vi.mocked<
+            HomepageMediaCardsServiceArguments['homepageMediaCardsModel']
+        >({
+            list: vi.fn().mockResolvedValue([
+                {
+                    cardKey: 'data-apps-video',
+                    title: 'Video title',
+                    subtitle: 'Video subtitle',
+                    url: 'https://example.com/video',
+                    thumbnailUrl: null,
+                },
+            ]),
+        });
+        const service = new HomepageMediaCardsService({
+            homepageMediaCardsModel,
+        });
+
+        await expect(service.list()).resolves.toEqual([
+            {
+                cardKey: 'data-apps-video',
+                title: 'Video title',
+                subtitle: 'Video subtitle',
+                url: 'https://example.com/video',
+                thumbnailUrl: null,
+            },
+        ]);
+        expect(homepageMediaCardsModel.list).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/backend/src/ee/services/HomepageMediaCardsService.ts
+++ b/packages/backend/src/ee/services/HomepageMediaCardsService.ts
@@ -1,0 +1,22 @@
+import { type HomepageMediaCard } from '@lightdash/common';
+import { BaseService } from '../../services/BaseService';
+import { type HomepageMediaCardsModel } from '../models/HomepageMediaCardsModel';
+
+export type HomepageMediaCardsServiceArguments = {
+    homepageMediaCardsModel: Pick<HomepageMediaCardsModel, 'list'>;
+};
+
+export class HomepageMediaCardsService extends BaseService {
+    private readonly homepageMediaCardsModel: HomepageMediaCardsServiceArguments['homepageMediaCardsModel'];
+
+    constructor({
+        homepageMediaCardsModel,
+    }: HomepageMediaCardsServiceArguments) {
+        super();
+        this.homepageMediaCardsModel = homepageMediaCardsModel;
+    }
+
+    async list(): Promise<HomepageMediaCard[]> {
+        return this.homepageMediaCardsModel.list();
+    }
+}

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -150,6 +150,7 @@ export type ModelManifest = {
     /** An implementation signature for these models are not available at this stage */
     aiAgentMemoryModel: unknown;
     aiAgentModel: unknown;
+    homepageMediaCardsModel: unknown;
     homepageRecommendedActionSkipsModel: unknown;
     projectHomepageModel: unknown;
     aiAgentDocumentModel: unknown;
@@ -824,6 +825,10 @@ export class ModelRepository
 
     public getHomepageRecommendedActionSkipsModel<ModelImplT>(): ModelImplT {
         return this.getModel('homepageRecommendedActionSkipsModel');
+    }
+
+    public getHomepageMediaCardsModel<ModelImplT>(): ModelImplT {
+        return this.getModel('homepageMediaCardsModel');
     }
 
     public getMcpToolCallModel<ModelImplT>(): ModelImplT {

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -156,6 +156,7 @@ interface ServiceManifest {
     aiWritebackService: unknown;
     aiDeepResearchService: unknown;
     aiAgentMemoryService: unknown;
+    homepageMediaCardsService: unknown;
     homepageRecommendedActionSkipsService: unknown;
     onboardingAgentService: unknown;
     aiAgentReviewNotificationService: unknown;
@@ -1457,6 +1458,12 @@ export class ServiceRepository
         HomepageRecommendedActionSkipsServiceImplT,
     >(): HomepageRecommendedActionSkipsServiceImplT {
         return this.getService('homepageRecommendedActionSkipsService');
+    }
+
+    public getHomepageMediaCardsService<
+        HomepageMediaCardsServiceImplT,
+    >(): HomepageMediaCardsServiceImplT {
+        return this.getService('homepageMediaCardsService');
     }
 
     public getAiAgentCoderService<

--- a/packages/common/src/ee/homepage/types.ts
+++ b/packages/common/src/ee/homepage/types.ts
@@ -221,6 +221,16 @@ export type ApiHomepageRecommendedActionSkipsResponse = ApiSuccess<
     SkippableHomepageRecommendedActionKey[]
 >;
 
+export type HomepageMediaCard = {
+    cardKey: string;
+    title: string;
+    subtitle: string;
+    url: string;
+    thumbnailUrl: string | null;
+};
+
+export type ApiHomepageMediaCardsResponse = ApiSuccess<HomepageMediaCard[]>;
+
 export type HomepageBlock =
     | HomepageMarkdownBlock
     | HomepageAskAiHeroBlock

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.test.tsx
@@ -1,13 +1,32 @@
+import { type HomepageMediaCard } from '@lightdash/common';
 import { MantineProvider } from '@mantine-8/core';
 import { act, fireEvent, render } from '@testing-library/react';
 import { EventName } from '../../../types/Events';
 import HomepageStars from './HomepageStars';
 
-const { track } = vi.hoisted(() => ({ track: vi.fn() }));
+const { track, useHomepageMediaCards } = vi.hoisted(() => ({
+    track: vi.fn(),
+    useHomepageMediaCards: vi.fn(),
+}));
 
 vi.mock('../../../providers/Tracking/useTracking', () => ({
     default: () => ({ track, data: { rudder: true } }),
 }));
+
+vi.mock('./hooks/useHomepageMediaCards', () => ({ useHomepageMediaCards }));
+
+type MediaCardsState =
+    | { status: 'loading' }
+    | { status: 'error' }
+    | { status: 'success'; cards: HomepageMediaCard[] };
+
+const mockMediaCards = (state: MediaCardsState) => {
+    useHomepageMediaCards.mockReturnValue({
+        isSuccess: state.status === 'success',
+        isError: state.status === 'error',
+        data: state.status === 'success' ? state.cards : undefined,
+    });
+};
 
 // Only tracking is mocked: the cards are purpose-built presentational markup,
 // so the focusability assertions below run against the real DOM.
@@ -49,6 +68,14 @@ const SKY_SELECTOR = '[data-testid="homepage-stars-sky"]';
 
 const VIDEO_HREF = 'https://www.youtube.com/watch?v=BwvgHQyhI1o';
 
+const MANAGED_CARD: HomepageMediaCard = {
+    cardKey: 'managed-webinar',
+    title: 'Managed webinar',
+    subtitle: 'Curated from the console',
+    url: 'https://www.lightdash.com/webinar',
+    thumbnailUrl: null,
+};
+
 // Every draw returns the top of its range, so the last free def is always the
 // one picked — and the media cards sit last in the catalogue.
 const forceMediaCards = () => vi.spyOn(Math, 'random').mockReturnValue(0.99);
@@ -58,6 +85,7 @@ describe('HomepageStars', () => {
         vi.useFakeTimers();
         stubMatchMedia();
         track.mockClear();
+        mockMediaCards({ status: 'error' });
     });
 
     afterEach(() => {
@@ -223,7 +251,7 @@ describe('HomepageStars', () => {
         });
     });
 
-    it('shows media cards in the rotation as new-tab links', () => {
+    it('falls back to the built-in media cards when the managed list fails', () => {
         forceMediaCards();
         const { container } = renderStars();
         const sky = container.querySelector(SKY_SELECTOR)!;
@@ -265,6 +293,85 @@ describe('HomepageStars', () => {
             name: EventName.HOMEPAGE_STARS_MEDIA_CARD_CLICKED,
             properties: { cardKey: 'data-apps-video', href: VIDEO_HREF },
         });
+    });
+
+    it('shows the managed cards instead of the fallback ones', () => {
+        mockMediaCards({ status: 'success', cards: [MANAGED_CARD] });
+        forceMediaCards();
+        const { container } = renderStars();
+        const sky = container.querySelector(SKY_SELECTOR)!;
+
+        act(() => {
+            vi.advanceTimersByTime(1000);
+        });
+        const link = sky.querySelector(`a[href="${MANAGED_CARD.url}"]`);
+        expect(link).not.toBeNull();
+        expect(link!.textContent).toContain(MANAGED_CARD.title);
+        expect(sky.querySelector(`a[href="${VIDEO_HREF}"]`)).toBeNull();
+
+        fireEvent.click(link!);
+        expect(track).toHaveBeenCalledWith({
+            name: EventName.HOMEPAGE_STARS_MEDIA_CARD_CLICKED,
+            properties: {
+                cardKey: MANAGED_CARD.cardKey,
+                href: MANAGED_CARD.url,
+            },
+        });
+    });
+
+    it('restarts the sky safely when the card list arrives late', () => {
+        forceMediaCards();
+        const { container, rerender } = renderStars();
+        const sky = container.querySelector(SKY_SELECTOR)!;
+
+        act(() => {
+            vi.advanceTimersByTime(1000);
+        });
+        expect(sky.querySelector(`a[href="${VIDEO_HREF}"]`)).not.toBeNull();
+
+        mockMediaCards({ status: 'success', cards: [MANAGED_CARD] });
+        act(() => {
+            rerender(
+                <MantineProvider>
+                    <HomepageStars />
+                </MantineProvider>,
+            );
+        });
+        expect(sky.childElementCount).toBe(0);
+
+        act(() => {
+            vi.advanceTimersByTime(1000);
+        });
+        expect(
+            sky.querySelector(`a[href="${MANAGED_CARD.url}"]`),
+        ).not.toBeNull();
+    });
+
+    it('shows no media stars when the managed list is empty', () => {
+        mockMediaCards({ status: 'success', cards: [] });
+        forceMediaCards();
+        const { container } = renderStars();
+        const sky = container.querySelector(SKY_SELECTOR)!;
+
+        act(() => {
+            vi.advanceTimersByTime(30000);
+        });
+        expect(sky.childElementCount).toBeGreaterThan(0);
+        expect(sky.querySelectorAll('a')).toHaveLength(0);
+        expect(sky.querySelectorAll('[data-star-def^="media-"]')).toHaveLength(
+            0,
+        );
+    });
+
+    it('spawns no stars until the managed card list settles', () => {
+        mockMediaCards({ status: 'loading' });
+        const { container } = renderStars();
+        const sky = container.querySelector(SKY_SELECTOR)!;
+
+        act(() => {
+            vi.advanceTimersByTime(30000);
+        });
+        expect(sky.childElementCount).toBe(0);
     });
 
     it('keeps one timer per star no matter how long the page stays open', () => {

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.test.tsx
@@ -347,6 +347,51 @@ describe('HomepageStars', () => {
         ).not.toBeNull();
     });
 
+    it('drops managed cards whose url is not http(s)', () => {
+        mockMediaCards({
+            status: 'success',
+            cards: [
+                {
+                    ...MANAGED_CARD,
+                    cardKey: 'evil',
+                    url: 'javascript:alert(1)',
+                },
+            ],
+        });
+        forceMediaCards();
+        const { container } = renderStars();
+        const sky = container.querySelector(SKY_SELECTOR)!;
+
+        act(() => {
+            vi.advanceTimersByTime(30000);
+        });
+        expect(sky.childElementCount).toBeGreaterThan(0);
+        expect(sky.querySelectorAll('a')).toHaveLength(0);
+        expect(sky.querySelector('[data-star-def="media-evil"]')).toBeNull();
+    });
+
+    it('ignores a managed thumbnail that is not https', () => {
+        const thumbnailUrl = 'http://insecure.example.com/thumb.jpg';
+        mockMediaCards({
+            status: 'success',
+            cards: [{ ...MANAGED_CARD, thumbnailUrl }],
+        });
+        forceMediaCards();
+        const { container } = renderStars();
+        const sky = container.querySelector(SKY_SELECTOR)!;
+
+        act(() => {
+            vi.advanceTimersByTime(1000);
+        });
+        const link = sky.querySelector(`a[href="${MANAGED_CARD.url}"]`);
+        expect(link).not.toBeNull();
+        expect(link!.textContent).toContain(MANAGED_CARD.title);
+        expect(sky.querySelector(`img[src="${thumbnailUrl}"]`)).toBeNull();
+        expect(
+            sky.querySelector('img[src^="https://www.google.com/s2/favicons"]'),
+        ).not.toBeNull();
+    });
+
     it('shows no media stars when the managed list is empty', () => {
         mockMediaCards({ status: 'success', cards: [] });
         forceMediaCards();

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.tsx
@@ -26,7 +26,7 @@ import {
 import MantineIcon from '../../../components/common/MantineIcon';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
-import { faviconUrl } from './blocks/resourceUrls';
+import { faviconUrl, safeImageUrl } from './blocks/resourceUrls';
 import classes from './HomepageStars.module.css';
 import { useHomepageMediaCards } from './hooks/useHomepageMediaCards';
 
@@ -467,12 +467,14 @@ const mediaStarDef = (card: MediaCard): StarDef => ({
     render: () => <MediaStarCard card={card} />,
 });
 
+const isHttpUrl = (url: string): boolean => /^https?:\/\//i.test(url);
+
 const toMediaCard = (card: HomepageMediaCard): MediaCard => ({
     key: card.cardKey,
     title: card.title,
     subtitle: card.subtitle,
     href: card.url,
-    thumbnailUrl: card.thumbnailUrl,
+    thumbnailUrl: safeImageUrl(card.thumbnailUrl ?? undefined),
 });
 
 // A star animates only while entering and leaving. In between it sits in a
@@ -619,7 +621,9 @@ const HomepageStars: FC = () => {
     const cardsSettled = mediaCardsQuery.isSuccess || mediaCardsQuery.isError;
     const starDefs = useMemo(() => {
         const mediaCards = mediaCardsQuery.isSuccess
-            ? mediaCardsQuery.data.map(toMediaCard)
+            ? mediaCardsQuery.data.flatMap((card) =>
+                  isHttpUrl(card.url) ? [toMediaCard(card)] : [],
+              )
             : FALLBACK_MEDIA_CARDS;
         return [...DECORATION_STAR_DEFS, ...mediaCards.map(mediaStarDef)];
     }, [mediaCardsQuery.isSuccess, mediaCardsQuery.data]);

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.tsx
@@ -1,4 +1,4 @@
-import { assertUnreachable } from '@lightdash/common';
+import { assertUnreachable, type HomepageMediaCard } from '@lightdash/common';
 import { Box, Group, Text } from '@mantine-8/core';
 import { useMediaQuery, useReducedMotion } from '@mantine-8/hooks';
 import {
@@ -16,6 +16,7 @@ import {
 import {
     useCallback,
     useEffect,
+    useMemo,
     useRef,
     useState,
     type CSSProperties,
@@ -27,6 +28,7 @@ import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import { faviconUrl } from './blocks/resourceUrls';
 import classes from './HomepageStars.module.css';
+import { useHomepageMediaCards } from './hooks/useHomepageMediaCards';
 
 const randomBetween = (min: number, max: number) =>
     min + Math.random() * (max - min);
@@ -218,7 +220,7 @@ type MediaCard = {
     thumbnailUrl: string | null;
 };
 
-const MEDIA_CARDS: MediaCard[] = [
+const FALLBACK_MEDIA_CARDS: MediaCard[] = [
     {
         key: 'data-apps-video',
         title: 'What can you build with Lightdash Data Apps? 3 real examples',
@@ -400,7 +402,7 @@ type StarDef = {
     render: (seed: StarSeed) => ReactElement;
 };
 
-const STAR_DEFS: StarDef[] = [
+const DECORATION_STAR_DEFS: StarDef[] = [
     ...MOCK_CHARTS.map(
         (chart): StarDef => ({
             key: `chart-${chart.name}`,
@@ -457,16 +459,21 @@ const STAR_DEFS: StarDef[] = [
             render: () => <StaticChips types={types} />,
         }),
     ),
-    ...MEDIA_CARDS.map(
-        (card): StarDef => ({
-            key: `media-${card.key}`,
-            interactive: true,
-            render: () => <MediaStarCard card={card} />,
-        }),
-    ),
 ];
 
-const STAR_DEF_MAP = new Map(STAR_DEFS.map((def) => [def.key, def]));
+const mediaStarDef = (card: MediaCard): StarDef => ({
+    key: `media-${card.key}`,
+    interactive: true,
+    render: () => <MediaStarCard card={card} />,
+});
+
+const toMediaCard = (card: HomepageMediaCard): MediaCard => ({
+    key: card.cardKey,
+    title: card.title,
+    subtitle: card.subtitle,
+    href: card.url,
+    thumbnailUrl: card.thumbnailUrl,
+});
 
 // A star animates only while entering and leaving. In between it sits in a
 // static transform so the browser paints it without a compositor layer —
@@ -546,6 +553,7 @@ const appendStar = (
     draws: StarDraws,
     forcedSide: 'left' | 'right' | null,
     tier: SkyTier,
+    defs: StarDef[],
 ): Star[] => {
     // Stars fading out still hold their slot and def, but they no longer
     // count against the cap — otherwise a replacement can't take off while
@@ -564,7 +572,7 @@ const appendStar = (
             ),
     );
     const busyDefs = new Set(current.map((s) => s.defKey));
-    const freeDefs = STAR_DEFS.filter((def) => !busyDefs.has(def.key));
+    const freeDefs = defs.filter((def) => !busyDefs.has(def.key));
     if (freeSlots.length === 0 || freeDefs.length === 0) return current;
     const sideSlots = forcedSide
         ? freeSlots.filter((slot) => slot.side === forcedSide)
@@ -607,6 +615,19 @@ const HomepageStars: FC = () => {
     const tier = wideFits ? WIDE_TIER : compactFits ? COMPACT_TIER : null;
     const disabled = reducedMotion || tier === null;
 
+    const mediaCardsQuery = useHomepageMediaCards();
+    const cardsSettled = mediaCardsQuery.isSuccess || mediaCardsQuery.isError;
+    const starDefs = useMemo(() => {
+        const mediaCards = mediaCardsQuery.isSuccess
+            ? mediaCardsQuery.data.map(toMediaCard)
+            : FALLBACK_MEDIA_CARDS;
+        return [...DECORATION_STAR_DEFS, ...mediaCards.map(mediaStarDef)];
+    }, [mediaCardsQuery.isSuccess, mediaCardsQuery.data]);
+    const starDefMap = useMemo(
+        () => new Map(starDefs.map((def) => [def.key, def])),
+        [starDefs],
+    );
+
     const [stars, setStars] = useState<Star[]>([]);
     const nextId = useRef(0);
     const starTimers = useRef(new Map<number, number>());
@@ -645,8 +666,11 @@ const HomepageStars: FC = () => {
             id: number,
             draws: StarDraws,
             side: 'left' | 'right',
-        ) => (tier ? appendStar(current, id, draws, side, tier) : current),
-        [tier],
+        ) =>
+            tier
+                ? appendStar(current, id, draws, side, tier, starDefs)
+                : current,
+        [tier, starDefs],
     );
 
     const removeStar = useCallback(
@@ -733,7 +757,7 @@ const HomepageStars: FC = () => {
         // Also resets when the tier changes, so no star keeps a width and
         // gutter drawn for a viewport that no longer applies.
         setStars((current) => (current.length > 0 ? [] : current));
-        if (disabled || !tier) return undefined;
+        if (disabled || !tier || !cardsSettled) return undefined;
 
         let cancelled = false;
         let spawnTimer: number;
@@ -756,6 +780,7 @@ const HomepageStars: FC = () => {
                         firstDraws,
                         'left',
                         tier,
+                        starDefs,
                     );
                     return appendStar(
                         withLeft,
@@ -763,6 +788,7 @@ const HomepageStars: FC = () => {
                         secondDraws,
                         'right',
                         tier,
+                        starDefs,
                     );
                 }
                 return appendStar(
@@ -771,6 +797,7 @@ const HomepageStars: FC = () => {
                     firstDraws,
                     emptySideOf(current),
                     tier,
+                    starDefs,
                 );
             });
             spawnTimer = window.setTimeout(spawn, randomBetween(450, 1400));
@@ -783,14 +810,14 @@ const HomepageStars: FC = () => {
             pendingTimers.forEach((timer) => window.clearTimeout(timer));
             pendingTimers.clear();
         };
-    }, [tier, disabled]);
+    }, [tier, disabled, cardsSettled, starDefs]);
 
     if (disabled) return null;
 
     return (
         <Box className={classes.sky} data-testid="homepage-stars-sky">
             {stars.map((star) => {
-                const def = STAR_DEF_MAP.get(star.defKey);
+                const def = starDefMap.get(star.defKey);
                 return (
                     <Box
                         key={star.id}

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useHomepageMediaCards.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useHomepageMediaCards.ts
@@ -1,0 +1,22 @@
+import {
+    type ApiError,
+    type ApiHomepageMediaCardsResponse,
+} from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../../../../api';
+
+const listMediaCards = () =>
+    lightdashApi<ApiHomepageMediaCardsResponse['results']>({
+        url: '/ee/homepage/media-cards',
+        method: 'GET',
+        body: undefined,
+    });
+
+export const useHomepageMediaCards = () =>
+    useQuery<ApiHomepageMediaCardsResponse['results'], ApiError>({
+        queryKey: ['homepage-media-cards'],
+        queryFn: listMediaCards,
+        staleTime: Infinity,
+        retry: false,
+        refetchOnWindowFocus: false,
+    });


### PR DESCRIPTION
## What

The two interactive media cards in the day-0 get-started homepage's star sky (the Data Apps video and the BI-as-code link) were hardcoded constants. This makes them DB-backed at instance level so they can be managed from the internal console (companion PR in the internal gateway repo):

- **EE migration** creating `homepage_media_cards`, seeded with exactly the two cards shipped today — existing instances render identically after deploy with no action needed.
- **`GET /api/v1/ee/homepage/media-cards`** (read-only, authenticated) mirroring the `HomepageRecommendedActionSkips` pattern end-to-end (entity → model → service → controller).
- **`HomepageStars`** fetches the managed cards and merges them into the interactive star pool. The previous hardcoded pair remains as the fallback while the query is unsettled or on error; an empty server list legitimately renders no media cards. Click tracking (`HOMEPAGE_STARS_MEDIA_CARD_CLICKED` with `cardKey`/`href`) is unchanged.
- **Sanitization**: managed values are treated as API-writable content — non-http(s) hrefs are dropped and thumbnails go through the existing `safeImageUrl` (https-only) helper.

## Testing

- Model/service unit tests; 19 `HomepageStars` tests covering fallback-on-error, server-cards-on-success, empty list, spawn gating, sanitization, and click tracking.
- E2E on a local EE instance: migration seeds the two rows; endpoint returns them; a fresh signup landing on the get-started page shows both cards in the sky with hrefs matching the DB; editing a row's title in the DB is reflected after reload.
- `pnpm generate-api` validated locally (generated artifacts not committed, per repo policy).
- react-doctor clean on touched files (one pre-existing warning on `drawStar`'s `Math.random` — decorative animation randomness, not a security context).

Closes: SPK-763