### PR TITLE
fix: subtotal cell font size should inherit table font size

### DIFF
--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
@@ -359,7 +359,7 @@ const getDataAndColumns = ({
                             }
 
                             return (
-                                <Text span fw={600}>
+                                <Text span inherit fw={600}>
                                     {formatItemValue(
                                         item,
                                         subtotalValue,


### PR DESCRIPTION
## Summary

Subtotal value cells in the regular (non-pivot) table visualization render at Mantine's default font size instead of inheriting the table's font size, making them visually larger than every other cell.

The subtotal `aggregatedCell` in `getDataAndColumns.tsx` wraps the value in `<Text span fw={600}>` without the `inherit` prop. The pivot table's equivalent subtotal cell (`PivotTable/index.tsx`) already uses `<Text span inherit fw={600}>` — this brings the regular table in line with it.

## Change

- Add `inherit` to the subtotal cell's `<Text>` in `packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx` so it inherits the table font size (bold weight is kept via `fw={600}`).

## Regression analysis

- One-line style-only change scoped to the subtotal `aggregatedCell` of the table visualization; no data, formatting, or interaction logic touched.
- `inherit` only changes inherited typography (font-size/line-height/family); `fw={600}` still applies, so subtotal values remain bold — matching the pivot table's existing behavior.
- Grand-total footer rows and regular value cells render through separate code paths and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019nVFHAh9621xZdkUoZth57