### PR TITLE
feat(homepage): slow the floating card rotation on get-started

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.test.tsx
@@ -162,7 +162,7 @@ describe('HomepageStars', () => {
         const earlyStar = sky.children[0];
 
         // jsdom never fires animationend; the timeout fallback must still
-        // remove the star (max lifetime 8000ms + 300ms buffer).
+        // remove the star (max lifetime 25000ms + 300ms buffer).
         act(() => {
             vi.advanceTimersByTime(60000);
         });
@@ -189,7 +189,7 @@ describe('HomepageStars', () => {
         // turns — well inside the 300ms slack before the removal fallback.
         for (
             let i = 0;
-            i < 60 && star.getAttribute('data-star-phase') !== 'leaving';
+            i < 140 && star.getAttribute('data-star-phase') !== 'leaving';
             i++
         ) {
             act(() => {

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.tsx
@@ -514,7 +514,7 @@ type StarDraws = {
 // All randomness for a star is drawn before setState so the state updaters
 // below stay pure (StrictMode double-invokes them in dev).
 const drawStar = (): StarDraws => ({
-    lifetimeMs: randomBetween(5000, 9000),
+    lifetimeMs: randomBetween(15000, 25000),
     slotPick: Math.random(),
     defPick: Math.random(),
     sizePick: Math.random(),
@@ -773,7 +773,7 @@ const HomepageStars: FC = () => {
                     tier,
                 );
             });
-            spawnTimer = window.setTimeout(spawn, randomBetween(450, 1400));
+            spawnTimer = window.setTimeout(spawn, randomBetween(2000, 4500));
         };
 
         spawnTimer = window.setTimeout(spawn, 500);


### PR DESCRIPTION
## Summary
The floating cards on the `/get-started` no-project homepage churned constantly — a new card every 0.45–1.4s, each living only 5–9s — which pulled attention away from the hero. This slows the rotation so the decoration reads as ambient rather than distracting:

- spawn cadence: 450–1400ms → 2000–4500ms
- card lifetime: 5–9s → 15–25s

Part 1 of a 2-PR stack (part 2 prioritises the media cards).

## Testing
- `HomepageStars.test.tsx` updated for the longer lifetimes (fallback-expiry window, settle-loop budget); suite passing
- Frontend typecheck + lint on touched files

Closes: SPK-768