### PR TITLE
feat(homepage): prioritise media cards in the get-started rotation

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.test.tsx
@@ -48,10 +48,7 @@ const renderStars = () =>
 const SKY_SELECTOR = '[data-testid="homepage-stars-sky"]';
 
 const VIDEO_HREF = 'https://www.youtube.com/watch?v=BwvgHQyhI1o';
-
-// Every draw returns the top of its range, so the last free def is always the
-// one picked — and the media cards sit last in the catalogue.
-const forceMediaCards = () => vi.spyOn(Math, 'random').mockReturnValue(0.99);
+const BI_AS_CODE_HREF = 'https://www.lightdash.com/bi-as-code';
 
 describe('HomepageStars', () => {
     beforeEach(() => {
@@ -223,8 +220,23 @@ describe('HomepageStars', () => {
         });
     });
 
+    it('spawns both media cards ahead of decorative stars', () => {
+        const { container } = renderStars();
+        const sky = container.querySelector(SKY_SELECTOR)!;
+
+        // The first spawn plants one star per side; the priority rule means
+        // both must be media cards, whatever the random draws say.
+        act(() => {
+            vi.advanceTimersByTime(1000);
+        });
+        const hrefs = [...sky.querySelectorAll('a')].map((link) =>
+            link.getAttribute('href'),
+        );
+        expect(hrefs).toContain(VIDEO_HREF);
+        expect(hrefs).toContain(BI_AS_CODE_HREF);
+    });
+
     it('shows media cards in the rotation as new-tab links', () => {
-        forceMediaCards();
         const { container } = renderStars();
         const sky = container.querySelector(SKY_SELECTOR)!;
 
@@ -252,7 +264,6 @@ describe('HomepageStars', () => {
     });
 
     it('tracks a click on a media card', () => {
-        forceMediaCards();
         const { container } = renderStars();
 
         act(() => {

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.tsx
@@ -394,9 +394,12 @@ const buildSparklineValues = (): number[] => {
 // Catalog of distinct star identities. A def only spawns while no visible
 // star uses it, so the sky never shows duplicate cards, KPIs, or chips.
 // Only interactive defs are exposed to the accessibility tree and to clicks.
+// Priority defs spawn ahead of the decorative ones whenever they are free,
+// so the media cards are reliably on screen rather than 2-in-18 lucky draws.
 type StarDef = {
     key: string;
     interactive: boolean;
+    priority: boolean;
     render: (seed: StarSeed) => ReactElement;
 };
 
@@ -405,6 +408,7 @@ const STAR_DEFS: StarDef[] = [
         (chart): StarDef => ({
             key: `chart-${chart.name}`,
             interactive: false,
+            priority: false,
             render: (seed) => (
                 <StarCard
                     icon={chart.icon}
@@ -419,6 +423,7 @@ const STAR_DEFS: StarDef[] = [
         (name): StarDef => ({
             key: `dashboard-${name}`,
             interactive: false,
+            priority: false,
             render: (seed) => (
                 <StarCard
                     icon={IconLayoutDashboard}
@@ -433,6 +438,7 @@ const STAR_DEFS: StarDef[] = [
         (kpi): StarDef => ({
             key: `kpi-${kpi.label}`,
             interactive: false,
+            priority: false,
             render: (seed) => (
                 <Box className={classes.card} p="sm">
                     <Text size="xs" c="dimmed" lineClamp={1}>
@@ -454,6 +460,7 @@ const STAR_DEFS: StarDef[] = [
         (types, index): StarDef => ({
             key: `chips-${index}`,
             interactive: false,
+            priority: false,
             render: () => <StaticChips types={types} />,
         }),
     ),
@@ -461,6 +468,7 @@ const STAR_DEFS: StarDef[] = [
         (card): StarDef => ({
             key: `media-${card.key}`,
             interactive: true,
+            priority: true,
             render: () => <MediaStarCard card={card} />,
         }),
     ),
@@ -572,7 +580,9 @@ const appendStar = (
     const candidateSlots = sideSlots.length > 0 ? sideSlots : freeSlots;
     const slot =
         candidateSlots[Math.floor(draws.slotPick * candidateSlots.length)];
-    const def = freeDefs[Math.floor(draws.defPick * freeDefs.length)];
+    const priorityDefs = freeDefs.filter((def) => def.priority);
+    const candidateDefs = priorityDefs.length > 0 ? priorityDefs : freeDefs;
+    const def = candidateDefs[Math.floor(draws.defPick * candidateDefs.length)];
     const sizeScale =
         SIZE_SCALES[Math.floor(draws.sizePick * SIZE_SCALES.length)];
     return [


### PR DESCRIPTION
## Summary
The two media cards in the get-started card rotation (the Data Apps video and the BI-as-code page) are the only cards with real content — they link out and carry click tracking — but were picked uniformly alongside 16 decorative defs, so they rarely appeared.

Star defs gain an explicit `priority` flag (kept separate from `interactive`, which drives a11y/click behaviour): whenever a priority def is free, the spawner picks from those first. Since a def is only free while no visible star uses it, both media cards are now reliably on screen.

Part 2 of a 2-PR stack, on #26617.

## Testing
- New test: both media cards spawn on the first tick without any randomness forcing; the old `Math.random` forcing helper is no longer needed and was removed
- Frontend typecheck + lint on touched files

Closes: SPK-769