### PR TITLE
feat(homepage): spawn get-started cards above and below the hero

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.module.css
@@ -47,6 +47,16 @@
     left: calc(50% + var(--star-gutter));
 }
 
+/* Centre stars sit inside the hero column, spread across its width by their
+   slot's --star-x (a percentage of the hero band); their vertical band keeps
+   them above the greeting or below the checklist. */
+.starCenter {
+    left: calc(
+        50% + ((var(--star-x) - 50) / 100) * var(--homepage-hero-width) -
+            var(--star-width) / 2
+    );
+}
+
 .cardIcon {
     display: inline-flex;
     align-items: center;

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.test.tsx
@@ -77,12 +77,12 @@ describe('HomepageStars', () => {
             vi.advanceTimersByTime(60000);
         });
         // MAX_STARS on screen; stars still fading out keep their slot on top
-        // of that, bounded by the 12 candidate slots.
+        // of that, bounded by the 16 candidate slots.
         const visible = sky!.querySelectorAll(
             '[data-star-phase]:not([data-star-phase="leaving"])',
         );
-        expect(visible.length).toBeLessThanOrEqual(7);
-        expect(sky!.childElementCount).toBeLessThanOrEqual(12);
+        expect(visible.length).toBeLessThanOrEqual(6);
+        expect(sky!.childElementCount).toBeLessThanOrEqual(16);
     });
 
     it('never shows two stars with the same identity', () => {
@@ -101,7 +101,7 @@ describe('HomepageStars', () => {
         expect(sky.childElementCount).toBeGreaterThan(0);
     });
 
-    it('never leaves one side empty while stars are visible', () => {
+    it('never leaves a zone empty while stars are visible', () => {
         const { container } = renderStars();
         const sky = container.querySelector(SKY_SELECTOR)!;
 
@@ -109,19 +109,21 @@ describe('HomepageStars', () => {
             act(() => {
                 vi.advanceTimersByTime(1000);
             });
-            const sides = [...sky.children].map((star) =>
-                star.getAttribute('data-side'),
+            const zones = [...sky.children].map((star) =>
+                star.getAttribute('data-zone'),
             );
-            if (sides.length > 0) {
-                expect(sides).toContain('left');
-                expect(sides).toContain('right');
+            if (zones.length > 0) {
+                expect(zones).toContain('left');
+                expect(zones).toContain('right');
+                expect(zones).toContain('top');
+                expect(zones).toContain('bottom');
             }
         }
         // The loop must have actually exercised star activity.
         expect(sky.childElementCount).toBeGreaterThan(0);
     });
 
-    it('keeps stars on a side a full card apart', () => {
+    it('keeps same-zone stars a full card apart', () => {
         const { container } = renderStars();
         const sky = container.querySelector(SKY_SELECTOR)!;
 
@@ -129,20 +131,39 @@ describe('HomepageStars', () => {
             act(() => {
                 vi.advanceTimersByTime(1000);
             });
-            const bySide = new Map<string, number[]>();
+            const topsByZone = new Map<string, number[]>();
+            const xsByZone = new Map<string, number[]>();
             [...sky.children].forEach((star) => {
-                const side = star.getAttribute('data-side')!;
-                const top = Number.parseFloat(
-                    (star as HTMLElement).style.getPropertyValue('--star-top'),
-                );
-                bySide.set(side, [...(bySide.get(side) ?? []), top]);
+                const zone = star.getAttribute('data-zone')!;
+                const styles = (star as HTMLElement).style;
+                if (zone === 'left' || zone === 'right') {
+                    const top = Number.parseFloat(
+                        styles.getPropertyValue('--star-top'),
+                    );
+                    topsByZone.set(zone, [
+                        ...(topsByZone.get(zone) ?? []),
+                        top,
+                    ]);
+                } else {
+                    const x = Number.parseFloat(
+                        styles.getPropertyValue('--star-x'),
+                    );
+                    xsByZone.set(zone, [...(xsByZone.get(zone) ?? []), x]);
+                }
             });
-            bySide.forEach((tops) => {
+            topsByZone.forEach((tops) => {
                 const sorted = [...tops].sort((a, b) => a - b);
                 sorted.slice(1).forEach((top, index) => {
                     // The wide tier needs 20.6% between slot centres; the
                     // jitter is already included in these positions.
                     expect(top - sorted[index]).toBeGreaterThanOrEqual(18.6);
+                });
+            });
+            xsByZone.forEach((xs) => {
+                const sorted = [...xs].sort((a, b) => a - b);
+                sorted.slice(1).forEach((x, index) => {
+                    // Centre slots sit 50% of the hero band apart.
+                    expect(x - sorted[index]).toBeGreaterThanOrEqual(45);
                 });
             });
         }
@@ -286,9 +307,9 @@ describe('HomepageStars', () => {
             vi.advanceTimersByTime(120000);
         });
         expect(sky.childElementCount).toBeGreaterThan(0);
-        // At most one timer per star (12 slots cap the total), plus the spawn
+        // At most one timer per star (16 slots cap the total), plus the spawn
         // timer — timers must not accumulate with time on the page.
-        expect(vi.getTimerCount()).toBeLessThanOrEqual(13);
+        expect(vi.getTimerCount()).toBeLessThanOrEqual(17);
 
         unmount();
         expect(vi.getTimerCount()).toBe(0);

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.tsx
@@ -31,11 +31,12 @@ import classes from './HomepageStars.module.css';
 const randomBetween = (min: number, max: number) =>
     min + Math.random() * (max - min);
 
-// Stars drop into candidate slots either side of the centered hero. The slots
-// are deliberately uneven and differ between the sides, so the sky reads as
-// scattered rather than as two columns; spacing is enforced at spawn time
-// instead of by a fixed pitch.
-const MAX_STARS = 7;
+// Stars drop into candidate slots in four zones around the centered hero: a
+// column either side, and a band above the greeting and below the checklist.
+// The slots are deliberately uneven and differ between zones, so the sky
+// reads as scattered rather than as a grid; spacing is enforced at spawn
+// time instead of by a fixed pitch.
+const MAX_STARS = 6;
 const SLOT_TOP_JITTER_PCT = 1;
 // Cards come in three sizes, the smaller ones slightly faded, which reads as
 // depth and stops every card sharing an edge with its neighbours.
@@ -94,22 +95,54 @@ const tierMediaQuery = (tier: SkyTier) =>
         tier.minHeightPx
     }px)`;
 
-type Slot = { side: 'left' | 'right'; topPct: number };
+type SideZone = 'left' | 'right';
+type CenterZone = 'top' | 'bottom';
+type Zone = SideZone | CenterZone;
+
+const ZONES: Zone[] = ['left', 'right', 'top', 'bottom'];
+
+// Side slots scatter down a column and take their horizontal position from
+// the gutter; centre slots scatter across the hero's width (xPct of the hero
+// band) inside a fixed vertical band that clears the hero content.
+type Slot =
+    | { zone: SideZone; topPct: number }
+    | { zone: CenterZone; topPct: number; xPct: number };
+
+const isCenterSlot = (slot: Slot): slot is Extract<Slot, { xPct: number }> =>
+    slot.zone === 'top' || slot.zone === 'bottom';
+
+// Centre cards are up to ~30% of the hero band wide; a wider floor keeps two
+// coexisting centre cards clearly apart rather than edge-to-edge.
+const CENTER_X_GAP_PCT = 45;
 
 const SLOTS: Slot[] = [
-    { side: 'left', topPct: 3 },
-    { side: 'left', topPct: 17 },
-    { side: 'left', topPct: 29 },
-    { side: 'left', topPct: 44 },
-    { side: 'left', topPct: 58 },
-    { side: 'left', topPct: 72 },
-    { side: 'right', topPct: 9 },
-    { side: 'right', topPct: 23 },
-    { side: 'right', topPct: 37 },
-    { side: 'right', topPct: 51 },
-    { side: 'right', topPct: 65 },
-    { side: 'right', topPct: 78 },
+    { zone: 'left', topPct: 3 },
+    { zone: 'left', topPct: 17 },
+    { zone: 'left', topPct: 29 },
+    { zone: 'left', topPct: 44 },
+    { zone: 'left', topPct: 58 },
+    { zone: 'left', topPct: 72 },
+    { zone: 'right', topPct: 9 },
+    { zone: 'right', topPct: 23 },
+    { zone: 'right', topPct: 37 },
+    { zone: 'right', topPct: 51 },
+    { zone: 'right', topPct: 65 },
+    { zone: 'right', topPct: 78 },
+    { zone: 'top', topPct: 2, xPct: 25 },
+    { zone: 'top', topPct: 7, xPct: 75 },
+    { zone: 'bottom', topPct: 76, xPct: 24 },
+    { zone: 'bottom', topPct: 80, xPct: 76 },
 ];
+
+// Same-zone stars must not touch: side zones separate vertically, centre
+// zones horizontally. Different zones never share space by construction.
+const slotsCollide = (a: Slot, b: Slot, minGapPct: number): boolean => {
+    if (a.zone !== b.zone) return false;
+    if (isCenterSlot(a) && isCenterSlot(b)) {
+        return Math.abs(a.xPct - b.xPct) < CENTER_X_GAP_PCT;
+    }
+    return Math.abs(a.topPct - b.topPct) < minGapPct;
+};
 
 const PALETTE = [
     'var(--mantine-color-blue-6)',
@@ -514,6 +547,7 @@ type StarDraws = {
     defPick: number;
     sizePick: number;
     gutterPick: number;
+    zonePick: number;
     topJitter: number;
     tilt: number;
     seed: StarSeed;
@@ -527,6 +561,7 @@ const drawStar = (): StarDraws => ({
     defPick: Math.random(),
     sizePick: Math.random(),
     gutterPick: Math.random(),
+    zonePick: Math.random(),
     topJitter: randomBetween(-SLOT_TOP_JITTER_PCT, SLOT_TOP_JITTER_PCT),
     // Stars enter level and settle into a slight tilt, randomized
     // counter-clockwise (negative) or clockwise (positive).
@@ -537,22 +572,24 @@ const drawStar = (): StarDraws => ({
     },
 });
 
-// The side that has no star still on screen, ignoring stars already fading
-// out. null when both sides are covered — or when neither is, in which case
-// the caller is free to choose.
-const emptySideOf = (stars: Star[]): 'left' | 'right' | null => {
+// A zone with no star still on screen, ignoring stars already fading out.
+// null when every zone is covered, in which case the caller is free to
+// choose. Several zones can be empty at once; the pick decides which one is
+// refilled first.
+const pickEmptyZone = (stars: Star[], pick: number): Zone | null => {
     const visible = stars.filter((star) => star.phase !== 'leaving');
-    const hasLeft = visible.some((star) => star.slot.side === 'left');
-    const hasRight = visible.some((star) => star.slot.side === 'right');
-    if (hasLeft === hasRight) return null;
-    return hasLeft ? 'right' : 'left';
+    const empty = ZONES.filter(
+        (zone) => !visible.some((star) => star.slot.zone === zone),
+    );
+    if (empty.length === 0) return null;
+    return empty[Math.floor(pick * empty.length)];
 };
 
 const appendStar = (
     current: Star[],
     id: number,
     draws: StarDraws,
-    forcedSide: 'left' | 'right' | null,
+    forcedZone: Zone | null,
     tier: SkyTier,
 ): Star[] => {
     // Stars fading out still hold their slot and def, but they no longer
@@ -565,19 +602,15 @@ const appendStar = (
     const minGapPct = minSlotGapPct(tier);
     const freeSlots = SLOTS.filter(
         (slot) =>
-            !current.some(
-                (star) =>
-                    star.slot.side === slot.side &&
-                    Math.abs(star.slot.topPct - slot.topPct) < minGapPct,
-            ),
+            !current.some((star) => slotsCollide(star.slot, slot, minGapPct)),
     );
     const busyDefs = new Set(current.map((s) => s.defKey));
     const freeDefs = STAR_DEFS.filter((def) => !busyDefs.has(def.key));
     if (freeSlots.length === 0 || freeDefs.length === 0) return current;
-    const sideSlots = forcedSide
-        ? freeSlots.filter((slot) => slot.side === forcedSide)
+    const zoneSlots = forcedZone
+        ? freeSlots.filter((slot) => slot.zone === forcedZone)
         : freeSlots;
-    const candidateSlots = sideSlots.length > 0 ? sideSlots : freeSlots;
+    const candidateSlots = zoneSlots.length > 0 ? zoneSlots : freeSlots;
     const slot =
         candidateSlots[Math.floor(draws.slotPick * candidateSlots.length)];
     const priorityDefs = freeDefs.filter((def) => def.priority);
@@ -585,6 +618,9 @@ const appendStar = (
     const def = candidateDefs[Math.floor(draws.defPick * candidateDefs.length)];
     const sizeScale =
         SIZE_SCALES[Math.floor(draws.sizePick * SIZE_SCALES.length)];
+    const placement: CSSProperties = isCenterSlot(slot)
+        ? ({ '--star-x': `${slot.xPct}` } as CSSProperties)
+        : ({ '--star-slack': draws.gutterPick.toFixed(3) } as CSSProperties);
     return [
         ...current,
         {
@@ -592,14 +628,18 @@ const appendStar = (
             defKey: def.key,
             slot,
             className:
-                slot.side === 'left' ? classes.starLeft : classes.starRight,
+                slot.zone === 'left'
+                    ? classes.starLeft
+                    : slot.zone === 'right'
+                      ? classes.starRight
+                      : classes.starCenter,
             style: {
                 '--star-top': `${slot.topPct + draws.topJitter}%`,
                 '--star-clearance': `${tier.clearancePx}px`,
-                '--star-slack': `${draws.gutterPick.toFixed(3)}`,
                 '--star-width': `${Math.round(tier.starWidthPx * sizeScale)}px`,
                 '--star-opacity': `${(0.36 + 0.64 * sizeScale).toFixed(2)}`,
                 '--star-tilt': `${draws.tilt}deg`,
+                ...placement,
             } as CSSProperties,
             seed: draws.seed,
             phase: 'entering',
@@ -650,12 +690,8 @@ const HomepageStars: FC = () => {
 
     // Declines to plant a replacement once the sky is gated off mid-flight.
     const appendIfFits = useCallback(
-        (
-            current: Star[],
-            id: number,
-            draws: StarDraws,
-            side: 'left' | 'right',
-        ) => (tier ? appendStar(current, id, draws, side, tier) : current),
+        (current: Star[], id: number, draws: StarDraws, zone: Zone) =>
+            tier ? appendStar(current, id, draws, zone, tier) : current,
         [tier],
     );
 
@@ -670,9 +706,9 @@ const HomepageStars: FC = () => {
                 if (!current.some((star) => star.id === id)) return current;
                 const next = current.filter((star) => star.id !== id);
                 if (next.length === 0) return next;
-                const emptySide = emptySideOf(next);
-                if (!emptySide) return next;
-                return appendIfFits(next, replacementId, draws, emptySide);
+                const emptyZone = pickEmptyZone(next, draws.zonePick);
+                if (!emptyZone) return next;
+                return appendIfFits(next, replacementId, draws, emptyZone);
             });
         },
         [clearTimer, appendIfFits],
@@ -696,11 +732,11 @@ const HomepageStars: FC = () => {
                         ? { ...star, phase: 'leaving' as const }
                         : star,
                 );
-                const emptySide = emptySideOf(next);
-                if (!emptySide) return next;
+                const emptyZone = pickEmptyZone(next, draws.zonePick);
+                if (!emptyZone) return next;
                 // The replacement fades in while this star fades out, so the
-                // side is never visually empty.
-                return appendIfFits(next, replacementId, draws, emptySide);
+                // zone is never visually empty.
+                return appendIfFits(next, replacementId, draws, emptyZone);
             });
             // Belt-and-braces: if animationend never fires (hidden tab, HMR)
             // the star is removed anyway. No-op for an id already gone.
@@ -752,34 +788,34 @@ const HomepageStars: FC = () => {
         const spawn = () => {
             if (cancelled) return;
 
-            const firstDraws = drawStar();
-            const firstId = nextId.current++;
-            const secondDraws = drawStar();
-            const secondId = nextId.current++;
+            // Seeds for a first spawn (one star per zone); only the first is
+            // used once the sky is populated. Ids the updater declines are
+            // never armed with a timer, so over-drawing is harmless.
+            const seeds = ZONES.map(() => ({
+                id: nextId.current++,
+                draws: drawStar(),
+            }));
 
             setStars((current) => {
                 if (current.length === 0) {
-                    // Start balanced: one star on each side.
-                    const withLeft = appendStar(
+                    // Start balanced: one star in every zone.
+                    return ZONES.reduce(
+                        (acc, zone, index) =>
+                            appendStar(
+                                acc,
+                                seeds[index].id,
+                                seeds[index].draws,
+                                zone,
+                                tier,
+                            ),
                         current,
-                        firstId,
-                        firstDraws,
-                        'left',
-                        tier,
-                    );
-                    return appendStar(
-                        withLeft,
-                        secondId,
-                        secondDraws,
-                        'right',
-                        tier,
                     );
                 }
                 return appendStar(
                     current,
-                    firstId,
-                    firstDraws,
-                    emptySideOf(current),
+                    seeds[0].id,
+                    seeds[0].draws,
+                    pickEmptyZone(current, seeds[0].draws.zonePick),
                     tier,
                 );
             });
@@ -811,7 +847,7 @@ const HomepageStars: FC = () => {
                         // Decoration stays out of the accessibility tree; only
                         // media cards are announced, via their link text.
                         aria-hidden={def?.interactive ? undefined : true}
-                        data-side={star.slot.side}
+                        data-zone={star.slot.zone}
                         data-star-def={star.defKey}
                         data-star-phase={star.phase}
                         onAnimationEnd={(event) => {


### PR DESCRIPTION
## Summary
Floating cards previously only spawned in the two side columns beside the hero. The sky gains two centre zones — a band above the greeting and one below the setup checklist — so cards appear all around the hero:

- `Slot` becomes a discriminated union: side slots scatter vertically down a column (horizontal position from the gutter), centre slots scatter horizontally across the hero band (`xPct`) inside a fixed vertical band that clears the hero content
- The spawn balancing that kept left/right populated generalises to all four zones: first spawn seeds one star per zone, and replacements are forced into whichever zone went empty
- Density kept in check after visual review: two well-separated slots per centre zone (50% of the hero band apart) and `MAX_STARS` 7 → 6
- Centre cards sit behind the hero content (`z-index`), so worst-case small-viewport overlap degrades gracefully

Part 3 of a 3-PR stack, on #26618.

## Testing
- Zone-balancing, same-zone spacing (vertical for columns, horizontal for centre bands), and cap tests updated/extended; suite run 3× for stability
- Frontend typecheck + lint on touched files
- Verified visually on the running dev instance

Closes: SPK-770