### PR TITLE
fix(pre-aggregates): allow trusted S3 reads

### DIFF
--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.test.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.test.ts
@@ -1,4 +1,5 @@
 import { DimensionType, type WarehouseClient } from '@lightdash/common';
+import { DuckdbWarehouseClient } from '@lightdash/warehouses';
 import { lightdashConfigMock } from '../../../config/lightdashConfig.mock';
 import Logger from '../../../logging/logger';
 import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
@@ -163,6 +164,48 @@ describe('PreAggregationDuckDbClient', () => {
         expect(
             preAggregateModel.getActiveMaterialization,
         ).not.toHaveBeenCalled();
+    });
+
+    test('creates the explicitly scoped pre-aggregate DuckDB client', () => {
+        const createForPreAggregateSpy = vi.spyOn(
+            DuckdbWarehouseClient,
+            'createForPreAggregate',
+        );
+        const client = new PreAggregationDuckDbClient({
+            lightdashConfig: {
+                ...lightdashConfigMock,
+                preAggregates: {
+                    ...lightdashConfigMock.preAggregates,
+                    enabled: true,
+                },
+            },
+            preAggregateModel: {
+                getActiveMaterialization: vi.fn(),
+            },
+            projectModel: {
+                getExploreFromCache: vi.fn(),
+            },
+        });
+
+        const warehouseClient = client.createExecutionWarehouseClient();
+
+        expect(warehouseClient).toBeInstanceOf(DuckdbWarehouseClient);
+        expect(createForPreAggregateSpy).toHaveBeenCalledWith(
+            {
+                type: 'duckdb_s3',
+                s3Config: {
+                    endpoint: 'mock_endpoint',
+                    region: 'mock_region',
+                    accessKey: undefined,
+                    secretKey: undefined,
+                    forcePathStyle: false,
+                    useSsl: true,
+                },
+            },
+            expect.objectContaining({
+                instanceCacheKey: 'pre-aggregate-query-instance',
+            }),
+        );
     });
 
     test('returns resolved DuckDB query/client and patches pre-aggregate sqlTable', async () => {

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.ts
@@ -112,7 +112,7 @@ export class PreAggregationDuckDbClient {
         this.createDuckdbWarehouseClient =
             args.createDuckdbWarehouseClient ??
             ((warehouseArgs) =>
-                new DuckdbWarehouseClient(
+                DuckdbWarehouseClient.createForPreAggregate(
                     { type: 'duckdb_s3', s3Config: warehouseArgs.s3Config },
                     {
                         sharedResourceLimits:

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
@@ -12,9 +12,20 @@ import type { Mock } from 'vitest';
 import {
     DuckdbWarehouseClient,
     mapFieldTypeFromTypeId,
+    type DuckdbS3Credentials,
 } from './DuckdbWarehouseClient';
 
 const createInstanceMock = vi.fn();
+
+const duckdbS3Credentials = {
+    type: 'duckdb_s3',
+    s3Config: {
+        endpoint: 'localhost:9000',
+        region: 'us-east-1',
+        forcePathStyle: true,
+        useSsl: false,
+    },
+} satisfies DuckdbS3Credentials;
 
 // Must provide DuckDBTypeId since mapFieldTypeFromTypeId references it at runtime
 const DUCKDB_TYPE_IDS = {
@@ -246,7 +257,7 @@ describe('DuckdbWarehouseClient', () => {
 
         createInstanceMock.mockResolvedValue(createMockConnection(streamMock));
 
-        const client = DuckdbWarehouseClient.createForPreAggregate();
+        const client = new DuckdbWarehouseClient();
         const streamCallback = vi.fn();
         const result = await client.executeAsyncQuery(
             {
@@ -273,7 +284,7 @@ describe('DuckdbWarehouseClient', () => {
 
         createInstanceMock.mockResolvedValue(createMockConnection(streamMock));
 
-        const client = DuckdbWarehouseClient.createForPreAggregate();
+        const client = new DuckdbWarehouseClient();
         const result = await client.runQuery('SELECT id FROM empty_table');
 
         expect(result.rows).toEqual([]);
@@ -957,6 +968,118 @@ describe('DuckdbWarehouseClient', () => {
                 `SQL validation error: function '${blockedFunction}' is not allowed`,
             );
             expect(extractStatementsMock).not.toHaveBeenCalled();
+            expect(streamMock).not.toHaveBeenCalled();
+        });
+
+        it('should keep file readers blocked when only S3 is configured', async () => {
+            const streamMock = vi.fn(async () =>
+                getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+            );
+            const extractStatementsMock = createMockExtractStatements();
+
+            createInstanceMock.mockResolvedValue(
+                createMockConnection(streamMock, vi.fn(), {
+                    extractStatements: extractStatementsMock,
+                }),
+            );
+
+            const client = new DuckdbWarehouseClient(duckdbS3Credentials);
+            await expect(
+                client.runQuery(
+                    "SELECT * FROM read_parquet('s3://bucket/data.parquet')",
+                ),
+            ).rejects.toThrow(
+                "SQL validation error: function 'read_parquet' is not allowed",
+            );
+            expect(extractStatementsMock).not.toHaveBeenCalled();
+            expect(streamMock).not.toHaveBeenCalled();
+        });
+
+        it.each([
+            {
+                format: 'Parquet',
+                sql: "SELECT * FROM read_parquet('s3://bucket/data.parquet')",
+            },
+            {
+                format: 'inferred JSONL',
+                sql: "SELECT * FROM read_json_auto('s3://bucket/data.jsonl')",
+            },
+            {
+                format: 'typed JSONL',
+                sql: "SELECT * FROM read_json('s3://bucket/data.jsonl', format='newline_delimited')",
+            },
+        ])(
+            'should allow pre-aggregate clients to read S3 $format files',
+            async ({ sql }) => {
+                const rows = [{ val: 1 }];
+                const streamMock = vi.fn(async () =>
+                    getMockStreamResult([rows], [DUCKDB_TYPE_IDS.INTEGER]),
+                );
+                const extractStatementsMock = createMockExtractStatements();
+
+                createInstanceMock.mockResolvedValue(
+                    createMockConnection(streamMock, vi.fn(), {
+                        extractStatements: extractStatementsMock,
+                    }),
+                );
+
+                const client =
+                    DuckdbWarehouseClient.createForPreAggregate(
+                        duckdbS3Credentials,
+                    );
+                const result = await client.runQuery(sql);
+
+                expect(result.rows).toEqual(rows);
+                expect(extractStatementsMock).toHaveBeenCalledTimes(1);
+                expect(streamMock).toHaveBeenCalledTimes(1);
+            },
+        );
+
+        it('should keep pre-aggregate queries read-only', async () => {
+            const streamMock = vi.fn(async () =>
+                getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+            );
+
+            createInstanceMock.mockResolvedValue(
+                createMockConnection(streamMock, vi.fn(), {
+                    extractStatements: createMockExtractStatements({
+                        statementType: 11, // COPY
+                    }),
+                }),
+            );
+
+            const client =
+                DuckdbWarehouseClient.createForPreAggregate(
+                    duckdbS3Credentials,
+                );
+            await expect(
+                client.runQuery("COPY t TO 's3://bucket/data.parquet'"),
+            ).rejects.toThrow(
+                'SQL validation error: only SELECT statements are allowed',
+            );
+            expect(streamMock).not.toHaveBeenCalled();
+        });
+
+        it('should keep secret introspection blocked for pre-aggregate queries', async () => {
+            const streamMock = vi.fn(async () =>
+                getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+            );
+
+            createInstanceMock.mockResolvedValue(
+                createMockConnection(streamMock),
+            );
+
+            const client =
+                DuckdbWarehouseClient.createForPreAggregate(
+                    duckdbS3Credentials,
+                );
+            await expect(
+                client.runQuery(
+                    "SELECT current_setting('s3_secret_access_key')",
+                ),
+            ).rejects.toThrow(
+                "SQL validation error: function 'current_setting' is not allowed",
+            );
             expect(streamMock).not.toHaveBeenCalled();
         });
 

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -446,6 +446,8 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
 
     private readonly embeddedQueryTimeoutMs: number;
 
+    private allowsPreAggregateFileReads = false;
+
     constructor(
         credentials?: CreateDuckdbCredentials | DuckdbConnectionCredentials,
         options?: DuckdbWarehouseClientOptions,
@@ -570,10 +572,12 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
     }
 
     static createForPreAggregate(
-        credentials?: DuckdbConnectionCredentials,
+        credentials: DuckdbS3Credentials,
         options?: DuckdbWarehouseClientOptions,
     ): DuckdbWarehouseClient {
-        return new DuckdbWarehouseClient(credentials, options);
+        const client = new DuckdbWarehouseClient(credentials, options);
+        client.allowsPreAggregateFileReads = true;
+        return client;
     }
 
     private static getSharedInstanceSemaphore(
@@ -1832,13 +1836,10 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         }
     }
 
-    private async validateUserSql(
+    private async validateSelectSql(
         db: DuckdbConnection,
         sql: string,
     ): Promise<void> {
-        DuckdbWarehouseClient.validateSqlFunctions(sql);
-        DuckdbWarehouseClient.validateUserSqlFileAccess(sql);
-
         const extracted = await db.extractStatements(sql);
 
         if (extracted.count === 0) {
@@ -1861,6 +1862,23 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         } finally {
             stmt.destroySync();
         }
+    }
+
+    private async validateUserSql(
+        db: DuckdbConnection,
+        sql: string,
+    ): Promise<void> {
+        DuckdbWarehouseClient.validateSqlFunctions(sql);
+        DuckdbWarehouseClient.validateUserSqlFileAccess(sql);
+        await this.validateSelectSql(db, sql);
+    }
+
+    private async validatePreAggregateSql(
+        db: DuckdbConnection,
+        sql: string,
+    ): Promise<void> {
+        DuckdbWarehouseClient.validateSqlFunctions(sql);
+        await this.validateSelectSql(db, sql);
     }
 
     private async validateInternalSql(
@@ -1931,7 +1949,11 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
             if (this.embeddedConfig) {
                 await db.run("SET disabled_filesystems = 'LocalFileSystem';");
             }
-            await this.validateUserSql(db, sql);
+            if (this.allowsPreAggregateFileReads) {
+                await this.validatePreAggregateSql(db, sql);
+            } else {
+                await this.validateUserSql(db, sql);
+            }
             reportPhase?.('session', performance.now() - sessionStart);
 
             const queryStart = performance.now();


### PR DESCRIPTION
Allows only the explicitly-created pre-aggregate S3 DuckDB client to execute server-generated file-reading SELECTs.

Generic S3 and user-query clients continue to block file readers. Pre-aggregate queries remain SELECT-only and continue to block secret introspection.

Adds regression coverage for production client wiring, Parquet/JSONL reads, generic S3 isolation, mutations, and secret access.

test-all
