### PR TITLE
feat(onboarding): make "How did you hear about us?" required

### DIFF
--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -421,6 +421,7 @@ describe('UserService', () => {
         test('does not track an absent answer', async () => {
             await userService.completeUserSetup(sessionUser, {
                 jobTitle: '',
+                howDidYouHearAboutUs: 'a podcast',
                 enableEmailDomainAccess: false,
                 isMarketingOptedIn: true,
                 isTrackingAnonymized: false,
@@ -433,14 +434,19 @@ describe('UserService', () => {
                     isSetupComplete: true,
                     isTrackingAnonymized: false,
                     isMarketingOptedIn: true,
-                    howDidYouHearAboutUs: undefined,
+                    howDidYouHearAboutUs: 'a podcast',
                 },
             );
-            expect(vi.mocked(analyticsMock.track)).not.toHaveBeenCalledWith(
-                expect.objectContaining({
-                    event: 'hear_about_us.submitted',
-                }),
-            );
+            expect(vi.mocked(analyticsMock.track)).toHaveBeenCalledWith({
+                event: 'hear_about_us.submitted',
+                userId: sessionUser.userUuid,
+                properties: {
+                    organizationId: sessionUser.organizationUuid,
+                    onboardingFlow: 'legacy',
+                    answered: true,
+                    answer: 'a podcast',
+                },
+            });
         });
     });
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -608,7 +608,11 @@ export const hasSpecialCharacters = (text: string) => /[^a-zA-Z ]/g.test(text);
 export const CompleteUserSchema = z.object({
     organizationName: getOrganizationNameSchema().optional(),
     jobTitle: z.string().min(0),
-    howDidYouHearAboutUs: z.string().trim().max(1000).optional(),
+    howDidYouHearAboutUs: z
+        .string()
+        .trim()
+        .min(1, 'Please let us know how you heard about Lightdash')
+        .max(1000),
     enableEmailDomainAccess: z.boolean().default(false),
     isMarketingOptedIn: z.boolean().default(true),
     isTrackingAnonymized: z.boolean().default(false),

--- a/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.test.tsx
+++ b/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.test.tsx
@@ -1,6 +1,6 @@
 import { LightdashMode } from '@lightdash/common';
 import { useQueryClient } from '@tanstack/react-query';
-import { screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { MemoryRouter, Route, Routes, useNavigate } from 'react-router';
@@ -271,6 +271,11 @@ describe('UserCompletionModal', () => {
         const roleOption = await screen.findByText('Software Engineer');
         await user.click(roleOption);
 
+        const referralInput = await screen.findByRole('textbox', {
+            name: /How did you hear about us/,
+        });
+        await user.type(referralInput, 'a podcast');
+
         // uncheck email domain checkbox (checked by default)
         const emailDomainCheckbox = await screen.findByRole('checkbox', {
             name: `Allow users with @lightdash.com to join the organization as a viewer`,
@@ -303,7 +308,7 @@ describe('UserCompletionModal', () => {
             .patch('/api/v1/user/me/complete', {
                 organizationName: 'test organization',
                 jobTitle: 'Software Engineer',
-                howDidYouHearAboutUs: '',
+                howDidYouHearAboutUs: 'a podcast',
                 enableEmailDomainAccess: false,
                 isMarketingOptedIn: false,
                 isTrackingAnonymized: true,
@@ -352,6 +357,11 @@ describe('UserCompletionModal', () => {
         const roleOption = await screen.findByText('Software Engineer');
         await user.click(roleOption);
 
+        const referralInput = await screen.findByRole('textbox', {
+            name: /How did you hear about us/,
+        });
+        await user.type(referralInput, 'a podcast');
+
         // submit button should be enabled now
         expect(submitButton).toBeEnabled();
 
@@ -359,7 +369,7 @@ describe('UserCompletionModal', () => {
         const scope = nock(BASE_API_URL)
             .patch('/api/v1/user/me/complete', {
                 jobTitle: 'Software Engineer',
-                howDidYouHearAboutUs: '',
+                howDidYouHearAboutUs: 'a podcast',
                 enableEmailDomainAccess: false,
                 isMarketingOptedIn: true,
                 isTrackingAnonymized: false,
@@ -384,7 +394,9 @@ describe('UserCompletionModal', () => {
 
         const welcomeModal = await screen.findByRole('dialog');
         expect(
-            within(welcomeModal).getByLabelText('How did you hear about us?'),
+            within(welcomeModal).getByRole('textbox', {
+                name: /How did you hear about us/,
+            }),
         ).toBeInTheDocument();
     });
 
@@ -408,9 +420,9 @@ describe('UserCompletionModal', () => {
         const roleOption = await screen.findByText('Software Engineer');
         await user.click(roleOption);
 
-        const referralInput = await screen.findByLabelText(
-            'How did you hear about us?',
-        );
+        const referralInput = await screen.findByRole('textbox', {
+            name: /How did you hear about us/,
+        });
         await user.type(referralInput, '  a podcast  ');
 
         const scope = nock(BASE_API_URL)
@@ -427,6 +439,56 @@ describe('UserCompletionModal', () => {
 
         scope.done();
         await waitFor(() => expect(scope.isDone()).toBe(true));
+    });
+
+    it('should not submit completion request when referral field is empty', async () => {
+        const user = userEvent.setup();
+
+        renderModal({
+            user: {
+                isSetupComplete: false,
+                organizationName: 'test organization',
+            },
+        });
+
+        const submitButton = await screen.findByRole('button', {
+            name: 'Next',
+        });
+
+        const roleSelect =
+            await screen.findByPlaceholderText('Select your role');
+        await user.click(roleSelect);
+        const roleOption = await screen.findByText('Software Engineer');
+        await user.click(roleOption);
+
+        const referralInput = await screen.findByRole('textbox', {
+            name: /How did you hear about us/,
+        });
+        await user.type(referralInput, '   ');
+
+        expect(submitButton).toBeDisabled();
+
+        let completionRequestCount = 0;
+        nock(BASE_API_URL)
+            .patch('/api/v1/user/me/complete')
+            .optionally()
+            .reply(() => {
+                completionRequestCount += 1;
+                return [200];
+            });
+
+        fireEvent.submit(screen.getByRole('form'));
+
+        await waitFor(() =>
+            expect(
+                screen.getByText((content) =>
+                    content.includes(
+                        'Please let us know how you heard about Lightdash',
+                    ),
+                ),
+            ).toBeInTheDocument(),
+        );
+        expect(completionRequestCount).toBe(0);
     });
 
     it('should redirect to the organization setup page when the flag is enabled and setup is incomplete', async () => {

--- a/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.tsx
+++ b/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.tsx
@@ -11,7 +11,7 @@ import { useForm } from '@mantine/form';
 import { IconConfetti } from '@tabler/icons-react';
 import { useIsMutating } from '@tanstack/react-query';
 import { zodResolver } from 'mantine-form-zod-resolver';
-import { useEffect, useMemo, useState, type FC } from 'react';
+import { type FC, useEffect, useMemo, useState } from 'react';
 import { Navigate, useLocation } from 'react-router';
 import { useUserCompleteMutation } from '../../hooks/user/useUserCompleteMutation';
 import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
@@ -110,7 +110,11 @@ const UserCompletionModal: FC = () => {
                     form="complete_user"
                     loading={isLoading}
                     disabled={
-                        !(form.values.organizationName && form.values.jobTitle)
+                        !(
+                            form.values.organizationName &&
+                            form.values.jobTitle &&
+                            form.values.howDidYouHearAboutUs.trim()
+                        )
                     }
                 >
                     Next
@@ -150,6 +154,7 @@ const UserCompletionModal: FC = () => {
                         label="How did you hear about us?"
                         placeholder="Google, a colleague, a podcast..."
                         disabled={isLoading}
+                        required
                         {...form.getInputProps('howDidYouHearAboutUs')}
                     />
 

--- a/packages/frontend/src/pages/OrganizationSetup.test.tsx
+++ b/packages/frontend/src/pages/OrganizationSetup.test.tsx
@@ -72,16 +72,14 @@ describe('OrganizationSetup', () => {
             },
         });
 
-        expect(
-            await screen.findByText('Tell us about you'),
-        ).toBeInTheDocument();
+        await screen.findByPlaceholderText('Select your role');
         expect(
             screen.queryByPlaceholderText('Acme Analytics'),
         ).not.toBeInTheDocument();
 
-        const referralInput = await screen.findByLabelText(
-            'How did you hear about us?',
-        );
+        const referralInput = await screen.findByRole('textbox', {
+            name: /How did you hear about us/,
+        });
         expect(referralInput).toBeInTheDocument();
 
         const submitButton = await screen.findByRole('button', {
@@ -91,17 +89,21 @@ describe('OrganizationSetup', () => {
 
         await selectRole(user);
 
-        expect(submitButton).toBeEnabled();
-
         const scope = nock(BASE_API_URL)
             .patch('/api/v1/user/me/complete', {
                 jobTitle: 'Software Engineer',
-                howDidYouHearAboutUs: '',
+                howDidYouHearAboutUs: 'a podcast',
                 enableEmailDomainAccess: false,
                 isMarketingOptedIn: true,
                 isTrackingAnonymized: false,
             })
             .reply(200);
+
+        const referralInputCreate = await screen.findByRole('textbox', {
+            name: /How did you hear about us/,
+        });
+        await user.type(referralInputCreate, 'a podcast');
+        expect(submitButton).toBeEnabled();
 
         await user.click(submitButton);
 
@@ -130,15 +132,13 @@ describe('OrganizationSetup', () => {
             await screen.findByRole('button', { name: 'Continue' }),
         );
 
-        expect(
-            await screen.findByText('Tell us about you'),
-        ).toBeInTheDocument();
+        await screen.findByPlaceholderText('Select your role');
 
         await selectRole(user);
 
-        const referralInput = await screen.findByLabelText(
-            'How did you hear about us?',
-        );
+        const referralInput = await screen.findByRole('textbox', {
+            name: /How did you hear about us/,
+        });
         await user.type(referralInput, '  a podcast  ');
 
         const scope = nock(BASE_API_URL)
@@ -176,9 +176,7 @@ describe('OrganizationSetup', () => {
             },
         });
 
-        expect(
-            await screen.findByText('Tell us about you'),
-        ).toBeInTheDocument();
+        await screen.findByPlaceholderText('Select your role');
         expect(
             screen.queryByPlaceholderText('Acme Analytics'),
         ).not.toBeInTheDocument();
@@ -188,16 +186,81 @@ describe('OrganizationSetup', () => {
         const scope = nock(BASE_API_URL)
             .patch('/api/v1/user/me/complete', {
                 jobTitle: 'Software Engineer',
-                howDidYouHearAboutUs: '',
+                howDidYouHearAboutUs: 'a podcast',
                 enableEmailDomainAccess: false,
                 isMarketingOptedIn: true,
                 isTrackingAnonymized: false,
             })
             .reply(200);
 
+        const referralInput = await screen.findByRole('textbox', {
+            name: /How did you hear about us/,
+        });
+        await user.type(referralInput, 'a podcast');
+
         await user.click(await screen.findByRole('button', { name: 'Finish' }));
 
         await waitFor(() => expect(scope.isDone()).toBe(true));
+    });
+
+    it('does not submit when referral field is empty', async () => {
+        const user = userEvent.setup();
+
+        mockOrgApi('');
+        renderSetupPage({
+            user: {
+                isSetupComplete: false,
+                organizationName: '',
+                email: 'demo@lightdash.com',
+            },
+            health: {
+                mode: LightdashMode.DEFAULT,
+            },
+        });
+
+        const nameInput = await screen.findByPlaceholderText('Acme Analytics');
+        await user.clear(nameInput);
+        await user.type(nameInput, 'test organization');
+        await user.click(
+            await screen.findByRole('button', { name: 'Continue' }),
+        );
+
+        await screen.findByRole('textbox', {
+            name: /How did you hear about us/,
+        });
+        await selectRole(user);
+
+        const referralInput = await screen.findByRole('textbox', {
+            name: /How did you hear about us/,
+        });
+        await user.type(referralInput, '   ');
+
+        const submitButton = await screen.findByRole('button', {
+            name: 'Finish',
+        });
+        expect(submitButton).toBeEnabled();
+
+        let completionRequestCount = 0;
+        nock(BASE_API_URL)
+            .patch('/api/v1/user/me/complete')
+            .optionally()
+            .reply(() => {
+                completionRequestCount += 1;
+                return [200];
+            });
+
+        await user.click(submitButton);
+
+        await waitFor(() =>
+            expect(
+                screen.getByText((content) =>
+                    content.includes(
+                        'Please let us know how you heard about Lightdash',
+                    ),
+                ),
+            ).toBeInTheDocument(),
+        );
+        expect(completionRequestCount).toBe(0);
     });
 
     it('redirects to the redirect target when setup is already complete', async () => {

--- a/packages/frontend/src/pages/OrganizationSetup.tsx
+++ b/packages/frontend/src/pages/OrganizationSetup.tsx
@@ -22,7 +22,7 @@ import {
 } from '@mantine-8/core';
 import { useForm } from '@mantine/form';
 import { zodResolver } from 'mantine-form-zod-resolver';
-import { useEffect, useRef, useState, type FC } from 'react';
+import { type FC, type FormEvent, useEffect, useRef, useState } from 'react';
 import { Navigate, useNavigate, useSearchParams } from 'react-router';
 import AboutFooter from '../components/AboutFooter';
 import { DocumentTitle } from '../components/common/DocumentTitle';
@@ -232,17 +232,24 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
     const stepLabel = isWorkspaceStep ? 'Set up your workspace' : 'About you';
     const displayStep = showWorkspaceStep ? step : 1;
 
-    const handleSubmit = form.onSubmit((values) => {
+    const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
         if (isWorkspaceStep) {
-            if (values.organizationName.trim()) {
-                track({
-                    name: EventName.ORGANIZATION_SETUP_STEP_COMPLETED,
-                    properties: { step: 'workspace' },
-                });
-                setStep(2);
-            }
+            if (!form.values.organizationName.trim()) return;
+
+            track({
+                name: EventName.ORGANIZATION_SETUP_STEP_COMPLETED,
+                properties: { step: 'workspace' },
+            });
+            setStep(2);
             return;
         }
+
+        const result = form.validate();
+        if (result.hasErrors) return;
+
+        const values = form.values;
 
         track({
             name: EventName.ORGANIZATION_SETUP_STEP_COMPLETED,
@@ -290,7 +297,7 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
                 fonts: detectedBrand?.fonts ?? [],
             });
         }
-    });
+    };
 
     const logoTileInitial = (form.values.organizationName || '?')
         .charAt(0)
@@ -449,6 +456,7 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
                                     label="How did you hear about us?"
                                     placeholder="Google, a colleague, a podcast..."
                                     size="md"
+                                    required
                                     {...form.getInputProps(
                                         'howDidYouHearAboutUs',
                                     )}


### PR DESCRIPTION
## Summary
"How did you hear about us?" was optional on both surfaces that collect it, so most signups skip it. It's now required:

- `CompleteUserSchema` requires a non-empty trimmed answer (`min(1)` with a friendly message) — both forms validate through this schema via `zodResolver`
- Both inputs are marked `required`; the completion modal's Next button is additionally gated on the field
- The org-setup page's step-1 (workspace) submit no longer runs whole-form validation, since the field's input only renders on step 2
- Enforcement is frontend-only: the API keeps accepting empty strings, so no API-compat change (one backend test payload updated for the stricter inferred type)

## Testing
- New tests on both surfaces: whitespace-only input shows the validation message and fires no completion request; existing submit tests fill the field
- Frontend + common + backend typecheck, both vitest suites (23 tests) and backend UserService suite (111 tests) green

Note: react-doctor flags two pre-existing warnings in `OrganizationSetup.tsx` (`no-giant-component`, `no-pass-data-to-parent`) that predate this diff — left out of scope.

Closes: SPK-771