### PR TITLE
feat(homepage): put connect-dbt ahead of semantic layer in setup checklist

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/recommendedActionDefaults.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/recommendedActionDefaults.ts
@@ -5,8 +5,8 @@ import {
 
 export const RECOMMENDED_ACTION_KEYS: HomepageRecommendedActionKey[] = [
     'connect-warehouse',
-    'add-semantic-layer',
     'connect-source-control',
+    'add-semantic-layer',
     'connect-slack',
 ];
 


### PR DESCRIPTION
## Summary
The get-started checklist showed "add semantic layer" before "connect source control", presenting them as parallel options after connecting a warehouse. Product feedback: dbt should always come first — ~95%+ of customers have a dbt project they expect to link, and a generated semantic layer should build on that project, not on raw warehouse tables.

One-line reorder of `RECOMMENDED_ACTION_KEYS`: the checklist renders pending actions in array order, so the dbt card is now the first card once the warehouse is connected.

## Testing
- Full homepageBuilder suite (218 tests) passes unchanged — no test encoded the old order
- Frontend typecheck + lint on the touched file

Closes: SPK-774