### PR TITLE
fix(frontend): scope active-project cache invalidation and guard re-entrancy

### DIFF
--- a/packages/frontend/src/hooks/useActiveProject.test.tsx
+++ b/packages/frontend/src/hooks/useActiveProject.test.tsx
@@ -1,0 +1,141 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { PropsWithChildren } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../api', () => ({
+    lightdashApi: vi.fn(),
+}));
+
+vi.mock('./user/useAccount', () => ({
+    useAccount: () => ({ data: { user: { userUuid: 'user-1' } } }),
+}));
+
+vi.mock('./organization/useOrganization', () => ({
+    useOrganization: () => ({
+        data: { organizationUuid: 'org-1' },
+        isInitialLoading: false,
+    }),
+}));
+
+vi.mock('./useProject', () => ({
+    useProject: (projectUuid?: string) => ({
+        data: projectUuid ? { projectUuid } : undefined,
+        isInitialLoading: false,
+    }),
+}));
+
+vi.mock('./useProjects', () => ({
+    useProjects: () => ({ data: [], isInitialLoading: false }),
+}));
+
+let routeProjectUuid: string | undefined;
+vi.mock('react-router', () => ({
+    useParams: () => ({ projectUuid: routeProjectUuid }),
+}));
+
+import {
+    LAST_PROJECT_KEY,
+    useActiveProjectUuid,
+    useUpdateActiveProjectMutation,
+} from './useActiveProject';
+
+function createWrapper() {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: { retry: false },
+            mutations: { retry: false },
+        },
+    });
+    const wrapper = ({ children }: PropsWithChildren) => (
+        <QueryClientProvider client={queryClient}>
+            {children}
+        </QueryClientProvider>
+    );
+    return { wrapper, queryClient };
+}
+
+describe('useUpdateActiveProjectMutation', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        routeProjectUuid = undefined;
+    });
+
+    it('invalidates only the keys that depend on the active project', async () => {
+        const { wrapper, queryClient } = createWrapper();
+        const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+        const removeQueries = vi.spyOn(queryClient, 'removeQueries');
+
+        const { result } = renderHook(() => useUpdateActiveProjectMutation(), {
+            wrapper,
+        });
+        result.current.mutate('project-1');
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+        const invalidatedKeys = invalidateQueries.mock.calls.map(
+            ([key]) => key,
+        );
+        expect(invalidatedKeys).toEqual([
+            ['activeProject'],
+            ['validation'],
+            ['project'],
+        ]);
+        // A bare invalidateQueries() refetches the whole app
+        expect(invalidatedKeys.every((key) => key !== undefined)).toBe(true);
+        expect(removeQueries).not.toHaveBeenCalled();
+    });
+
+    it('keeps pre-warmed project caches visible instead of removing them', async () => {
+        const { wrapper, queryClient } = createWrapper();
+        queryClient.setQueryData(['projects'], [{ projectUuid: 'project-1' }]);
+        queryClient.setQueryData(['project', 'project-1'], {
+            projectUuid: 'project-1',
+        });
+
+        const { result } = renderHook(() => useUpdateActiveProjectMutation(), {
+            wrapper,
+        });
+        result.current.mutate('project-1');
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+        expect(queryClient.getQueryData(['projects'])).toEqual([
+            { projectUuid: 'project-1' },
+        ]);
+        expect(queryClient.getQueryData(['project', 'project-1'])).toEqual({
+            projectUuid: 'project-1',
+        });
+    });
+});
+
+describe('useActiveProjectUuid', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it('persists the active project once when several instances mount together', async () => {
+        routeProjectUuid = 'project-herd';
+        const setItem = vi.spyOn(Storage.prototype, 'setItem');
+        const { wrapper } = createWrapper();
+
+        renderHook(
+            () => {
+                useActiveProjectUuid();
+                useActiveProjectUuid();
+                useActiveProjectUuid();
+            },
+            { wrapper },
+        );
+
+        await waitFor(() =>
+            expect(localStorage.getItem(LAST_PROJECT_KEY)).toBe('project-herd'),
+        );
+
+        const persistCalls = setItem.mock.calls.filter(
+            ([key]) => key === LAST_PROJECT_KEY,
+        );
+        expect(persistCalls).toHaveLength(1);
+        setItem.mockRestore();
+    });
+});

--- a/packages/frontend/src/hooks/useActiveProject.test.tsx
+++ b/packages/frontend/src/hooks/useActiveProject.test.tsx
@@ -36,6 +36,7 @@ vi.mock('react-router', () => ({
 
 import {
     LAST_PROJECT_KEY,
+    resetPersistingProjectUuidForTests,
     useActiveProjectUuid,
     useUpdateActiveProjectMutation,
 } from './useActiveProject';
@@ -59,6 +60,7 @@ describe('useUpdateActiveProjectMutation', () => {
     beforeEach(() => {
         localStorage.clear();
         routeProjectUuid = undefined;
+        resetPersistingProjectUuidForTests();
     });
 
     it('invalidates only the keys that depend on the active project', async () => {
@@ -81,8 +83,9 @@ describe('useUpdateActiveProjectMutation', () => {
             ['validation'],
             ['project'],
         ]);
-        // A bare invalidateQueries() refetches the whole app
-        expect(invalidatedKeys.every((key) => key !== undefined)).toBe(true);
+        // The regression this guards: invalidateQueries() with no arguments
+        // matches every key, refetching the whole app on a project switch
+        expect(invalidateQueries).not.toHaveBeenCalledWith();
         expect(removeQueries).not.toHaveBeenCalled();
     });
 
@@ -112,6 +115,7 @@ describe('useUpdateActiveProjectMutation', () => {
 describe('useActiveProjectUuid', () => {
     beforeEach(() => {
         localStorage.clear();
+        resetPersistingProjectUuidForTests();
     });
 
     it('persists the active project once when several instances mount together', async () => {

--- a/packages/frontend/src/hooks/useActiveProject.ts
+++ b/packages/frontend/src/hooks/useActiveProject.ts
@@ -47,11 +47,25 @@ export const useActiveProject = () => {
     );
 };
 
-const clearProjectCache = async (queryClient: QueryClient) => {
-    queryClient.removeQueries(['project']);
-    queryClient.removeQueries(['projects']);
-    await queryClient.invalidateQueries();
-};
+// Project-scoped queries keyed by projectUuid need nothing here — a switch
+// changes their key. These don't: the pointer query reads localStorage, and
+// useValidation serves the active project under an unscoped key.
+const ACTIVE_PROJECT_DEPENDENT_KEYS = [
+    ['activeProject'],
+    ['validation'],
+    ['project'],
+];
+
+const clearProjectCache = (queryClient: QueryClient) =>
+    Promise.all(
+        ACTIVE_PROJECT_DEPENDENT_KEYS.map((queryKey) =>
+            queryClient.invalidateQueries(queryKey),
+        ),
+    );
+
+// Shared by every useActiveProjectUuid instance: the project a persist is
+// already in flight for. localStorage is global, so this guard has to be too.
+let persistingProjectUuid: string | undefined;
 
 export const useUpdateActiveProjectMutation = () => {
     const queryClient = useQueryClient();
@@ -63,8 +77,9 @@ export const useUpdateActiveProjectMutation = () => {
             ),
         onSuccess: async () => {
             await clearProjectCache(queryClient);
-            await queryClient.invalidateQueries(['validations']);
-            await queryClient.invalidateQueries(['activeProject']);
+        },
+        onSettled: () => {
+            persistingProjectUuid = undefined;
         },
     });
 };
@@ -188,8 +203,10 @@ export const useActiveProjectUuid = (useQueryFetchOptions?: {
             !isLoading &&
             shouldPersistProject &&
             newValue &&
-            newValue !== lastProjectUuid
+            newValue !== lastProjectUuid &&
+            persistingProjectUuid !== newValue
         ) {
+            persistingProjectUuid = newValue;
             mutate(newValue);
         }
     }, [

--- a/packages/frontend/src/hooks/useActiveProject.ts
+++ b/packages/frontend/src/hooks/useActiveProject.ts
@@ -49,7 +49,8 @@ export const useActiveProject = () => {
 
 // Project-scoped queries keyed by projectUuid need nothing here — a switch
 // changes their key. These don't: the pointer query reads localStorage, and
-// useValidation serves the active project under an unscoped key.
+// useValidation keys on ['validation', fromSettings] — scoped to where it is
+// read from, but not to the project, so its key survives a switch.
 const ACTIVE_PROJECT_DEPENDENT_KEYS = [
     ['activeProject'],
     ['validation'],
@@ -67,6 +68,12 @@ const clearProjectCache = (queryClient: QueryClient) =>
 // already in flight for. localStorage is global, so this guard has to be too.
 let persistingProjectUuid: string | undefined;
 
+// Module state outlives a test, so a spec that leaves a mutation unsettled
+// would hand its guard to the next one.
+export const resetPersistingProjectUuidForTests = () => {
+    persistingProjectUuid = undefined;
+};
+
 export const useUpdateActiveProjectMutation = () => {
     const queryClient = useQueryClient();
 
@@ -78,8 +85,13 @@ export const useUpdateActiveProjectMutation = () => {
         onSuccess: async () => {
             await clearProjectCache(queryClient);
         },
-        onSettled: () => {
-            persistingProjectUuid = undefined;
+        // Every mutate() builds its own Mutation but they all share the one
+        // guard, so an earlier settle must not release a later project's
+        // persist: clear only the value this settle was for.
+        onSettled: (_data, _error, projectUuid) => {
+            if (persistingProjectUuid === projectUuid) {
+                persistingProjectUuid = undefined;
+            }
         },
     });
 };


### PR DESCRIPTION
## Summary
Switching the active project ran `queryClient.invalidateQueries()` with **no key** and removed the project caches outright, while the persisting effect re-fired during its own mutation — instrumented at 13 invalidation rounds, ~449 API requests and ~900ms of full-page spinner on project creation (project-to-project switches measured worse: 474 requests, 1.6s).

- Invalidation scoped to the queries that depend on the active-project pointer (`activeProject`, `validation`, `project`) — fixing a dead `['validations']` key in passing (real keys are singular)
- `removeQueries` → `invalidateQueries`, so existing data stays visible during refetch instead of re-tripping `isInitialLoading` gates
- In-flight guard collapses the re-entrant persist loop to a single mutation
- Preserves the cache pre-warming `CreateProjectconnection` does before navigating

Re-instrumented after the change: 449 → 44 requests, ~895ms → 229ms spinner on creation; 474 → 13 requests on project switch, NavBar no longer unmounts. Residual spinner is the cold `useProject` fetch (findings item C, follow-up).

Part 1 of a 3-PR stack fixing the onboarding flicker investigation's findings.

## Testing
- New unit tests for the scoped invalidation and re-entrancy guard
- Frontend typecheck + lint; before/after verified in-browser against the instrumented traces

Relates: SPK-772