### PR TITLE
fix(frontend): stop redirect ping-pong on unresolved user state after signup

### DIFF
--- a/packages/frontend/src/components/PrivateRoute.test.tsx
+++ b/packages/frontend/src/components/PrivateRoute.test.tsx
@@ -1,0 +1,139 @@
+import { MantineProvider } from '@mantine-8/core';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import PrivateRoute from './PrivateRoute';
+
+const state = vi.hoisted(() => ({
+    isAuthenticated: true,
+    user: undefined as { organizationUuid?: string } | undefined,
+    isUserError: false,
+    account: undefined as { registered: boolean } | undefined,
+    isAccountError: false,
+}));
+
+vi.mock('../providers/App/useApp', () => ({
+    default: () => ({
+        health: {
+            isInitialLoading: false,
+            error: null,
+            data: { isAuthenticated: state.isAuthenticated },
+        },
+        user: {
+            data: state.user ? { ...state.user, abilityRules: [] } : undefined,
+            isInitialLoading: false,
+            isError: state.isUserError,
+        },
+    }),
+}));
+
+vi.mock('../hooks/user/useAccount', () => ({
+    useAccount: () => ({
+        data: state.account
+            ? { isRegisteredUser: () => state.account!.registered }
+            : undefined,
+        isError: state.isAccountError,
+    }),
+}));
+
+vi.mock('../hooks/useEmailVerification', () => ({
+    useEmailStatus: () => ({
+        data: { isVerified: true },
+        isInitialLoading: false,
+    }),
+}));
+
+vi.mock('../providers/Ability/useAbilityContext', () => ({
+    useAbilityContext: () => ({ rules: [], update: vi.fn() }),
+}));
+
+vi.mock('./PageSpinner', () => ({
+    default: () => <div data-testid="page-spinner" />,
+}));
+
+const renderPrivateRoute = () =>
+    render(
+        <MantineProvider>
+            <MemoryRouter initialEntries={['/']}>
+                <Routes>
+                    <Route
+                        path="/"
+                        element={
+                            <PrivateRoute>
+                                <div>app</div>
+                            </PrivateRoute>
+                        }
+                    />
+                    <Route
+                        path="/join-organization"
+                        element={<div>join organization</div>}
+                    />
+                    <Route path="/login" element={<div>login</div>} />
+                </Routes>
+            </MemoryRouter>
+        </MantineProvider>,
+    );
+
+describe('PrivateRoute', () => {
+    beforeEach(() => {
+        state.isAuthenticated = true;
+        state.user = { organizationUuid: 'org-uuid' };
+        state.isUserError = false;
+        state.account = { registered: true };
+        state.isAccountError = false;
+    });
+
+    it('renders its children for a user in an organization', () => {
+        renderPrivateRoute();
+
+        expect(screen.getByText('app')).toBeInTheDocument();
+    });
+
+    it('holds while the account is still on its way to enabling the user query', () => {
+        state.user = undefined;
+        state.account = undefined;
+
+        renderPrivateRoute();
+
+        expect(screen.getByTestId('page-spinner')).toBeInTheDocument();
+        expect(screen.queryByText('join organization')).toBeNull();
+    });
+
+    // Both queries are retry:false, so a failed /user/account never enables the
+    // user query — holding on it would be a spinner with no way out
+    it('stops holding when the account query has failed', () => {
+        state.user = undefined;
+        state.account = undefined;
+        state.isAccountError = true;
+
+        renderPrivateRoute();
+
+        expect(screen.getByText('join organization')).toBeInTheDocument();
+        expect(screen.queryByTestId('page-spinner')).toBeNull();
+    });
+
+    it('stops holding when the account is not a registered user', () => {
+        state.user = undefined;
+        state.account = { registered: false };
+
+        renderPrivateRoute();
+
+        expect(screen.getByText('join organization')).toBeInTheDocument();
+        expect(screen.queryByTestId('page-spinner')).toBeNull();
+    });
+
+    it('sends a user with no organization to join one', () => {
+        state.user = {};
+
+        renderPrivateRoute();
+
+        expect(screen.getByText('join organization')).toBeInTheDocument();
+    });
+
+    it('sends an unauthenticated visitor to log in', () => {
+        state.isAuthenticated = false;
+
+        renderPrivateRoute();
+
+        expect(screen.getByText('login')).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/components/PrivateRoute.tsx
+++ b/packages/frontend/src/components/PrivateRoute.tsx
@@ -8,7 +8,7 @@ import PageSpinner from './PageSpinner';
 const PrivateRoute: FC<React.PropsWithChildren> = ({ children }) => {
     const {
         health,
-        user: { data, isInitialLoading },
+        user: { data, isInitialLoading, isError },
     } = useApp();
     const location = useLocation();
     const ability = useAbilityContext();
@@ -59,6 +59,10 @@ const PrivateRoute: FC<React.PropsWithChildren> = ({ children }) => {
                 state={{ from: location }}
             />
         );
+    }
+
+    if (!data && !isError) {
+        return <PageSpinner />;
     }
 
     if (!data?.organizationUuid) {

--- a/packages/frontend/src/components/PrivateRoute.tsx
+++ b/packages/frontend/src/components/PrivateRoute.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, type FC } from 'react';
 import { Navigate, useLocation } from 'react-router';
 import { useEmailStatus } from '../hooks/useEmailVerification';
+import { useAccount } from '../hooks/user/useAccount';
 import { useAbilityContext } from '../providers/Ability/useAbilityContext';
 import useApp from '../providers/App/useApp';
 import PageSpinner from './PageSpinner';
@@ -11,6 +12,7 @@ const PrivateRoute: FC<React.PropsWithChildren> = ({ children }) => {
         user: { data, isInitialLoading, isError },
     } = useApp();
     const location = useLocation();
+    const account = useAccount();
     const ability = useAbilityContext();
     const emailStatus = useEmailStatus(!!health.data?.isAuthenticated);
     const isEmailServerConfigured = health.data?.hasEmailClient;
@@ -61,7 +63,17 @@ const PrivateRoute: FC<React.PropsWithChildren> = ({ children }) => {
         );
     }
 
-    if (!data && !isError) {
+    // The user query only starts once the account comes back saying it is a
+    // registered user, and neither query retries — so "no data, no error" also
+    // covers a user query that will never run. Holding on that is a spinner
+    // with no way out, which is why the hold has to end wherever the chain has
+    // stopped progressing: the account errored (a blip on /user/account), or it
+    // resolved to someone the user query is never fetched for. Both fall
+    // through to the redirect below, as they did before the hold existed.
+    const isUserStillResolving =
+        !account.isError && (!account.data || account.data.isRegisteredUser());
+
+    if (!data && !isError && isUserStillResolving) {
         return <PageSpinner />;
     }
 

--- a/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.tsx
+++ b/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.tsx
@@ -223,12 +223,8 @@ const UserCompletionModalWithUser = () => {
             health.isSuccess &&
             !isCompletingUser &&
             !hasCompletedSetup;
-        // Keyed by pathname so the redirect re-fires if a competing route
-        // redirect (e.g. AppRoute's needsProject -> /createProject) wins the
-        // same render commit.
         return shouldSetup ? (
             <Navigate
-                key={location.pathname}
                 to={
                     location.pathname && location.pathname !== '/'
                         ? `/organization-setup?redirect=${encodeURIComponent(

--- a/packages/frontend/src/pages/JoinOrganization.tsx
+++ b/packages/frontend/src/pages/JoinOrganization.tsx
@@ -71,7 +71,17 @@ const JoinOrganizationPage: FC = () => {
         }
     }, [createOrgError, hasCreatedOrg, hasJoinedOrg, navigate]);
 
-    if (health.isInitialLoading || isLoadingAllowedOrgs || isCreatingOrg) {
+    const willAutoCreateOrg =
+        !allowedOrgs?.length && !user.data?.organizationUuid && !createOrgError;
+
+    if (
+        health.isInitialLoading ||
+        isLoadingAllowedOrgs ||
+        isCreatingOrg ||
+        willAutoCreateOrg ||
+        hasCreatedOrg ||
+        hasJoinedOrg
+    ) {
         return <PageSpinner />;
     }
 

--- a/packages/frontend/src/pages/JoinOrganization.tsx
+++ b/packages/frontend/src/pages/JoinOrganization.tsx
@@ -43,27 +43,18 @@ const JoinOrganizationPage: FC = () => {
     } = useJoinOrganizationMutation();
     const emailDomain = user.data?.email ? getEmailDomain(user.data.email) : '';
 
+    // Read by both the effect that fires the auto-create and the guard that
+    // holds the page while it is on its way. Derived once: two copies of this
+    // condition can drift into a guard that spins for an effect that will
+    // never fire, with no way out of the spinner.
+    const shouldAutoCreateOrg =
+        !allowedOrgs?.length && !user.data?.organizationUuid && !createOrgError;
+
     useEffect(() => {
-        const isAllowedToJoinOrgs = allowedOrgs && allowedOrgs.length > 0;
-        const userHasOrg = user.data && !!user.data.organizationUuid;
-        if (
-            !isCreatingOrg &&
-            !isLoadingAllowedOrgs &&
-            !userHasOrg &&
-            !isAllowedToJoinOrgs &&
-            !createOrgError
-        ) {
+        if (shouldAutoCreateOrg && !isCreatingOrg && !isLoadingAllowedOrgs) {
             createOrg({ name: '' });
         }
-    }, [
-        health,
-        allowedOrgs,
-        createOrg,
-        isCreatingOrg,
-        user,
-        isLoadingAllowedOrgs,
-        createOrgError,
-    ]);
+    }, [shouldAutoCreateOrg, createOrg, isCreatingOrg, isLoadingAllowedOrgs]);
 
     useEffect(() => {
         if ((hasCreatedOrg || hasJoinedOrg) && !createOrgError) {
@@ -71,14 +62,11 @@ const JoinOrganizationPage: FC = () => {
         }
     }, [createOrgError, hasCreatedOrg, hasJoinedOrg, navigate]);
 
-    const willAutoCreateOrg =
-        !allowedOrgs?.length && !user.data?.organizationUuid && !createOrgError;
-
     if (
         health.isInitialLoading ||
         isLoadingAllowedOrgs ||
         isCreatingOrg ||
-        willAutoCreateOrg ||
+        shouldAutoCreateOrg ||
         hasCreatedOrg ||
         hasJoinedOrg
     ) {


### PR DESCRIPTION
## Summary
The post-OTP signup path produced 9 navigations in ~780ms, flashing a "Join a workspace" page and the get-started homepage at a user who should only ever see org-setup. Three coordinated changes:

- `PrivateRoute` no longer redirects to `/join-organization` while the user query is unresolved — it holds a spinner until data or error (errors keep today's fall-through, avoiding an infinite spinner)
- The completion-modal redirect's `key={location.pathname}` re-fire hack is removed — it guaranteed the losing redirect re-fired every commit, causing the org-setup ↔ get-started ping-pong
- `JoinOrganization` stays on its spinner for users whose organization is about to be auto-created (and through post-join navigation) instead of painting the picker UI it's about to leave — the actual source of the "Join a workspace" flash, refining the investigation's original attribution

Fresh-signup path verified in-browser: the nav storm collapses with no stray page flashes. Invited-user, user-query-error, and manual create-workspace paths traced in code (noted per-path in the review evidence).

Part 3 of the flicker fix stack, on #26626. Follow-ups deliberately out of scope: single redirect authority via route loaders (findings D), `Register.tsx` client-side navigate (T1), `keepPreviousData` mop-up (C), view-transition polish.

## Testing
- AppRoute + UserCompletionModal suites pass; frontend typecheck + lint on touched files

Closes: SPK-772