### PR TITLE
fix(deps): bump data app Vite to 8.0.16

### DIFF
--- a/sandboxes/data-apps/template/package.json
+++ b/sandboxes/data-apps/template/package.json
@@ -56,6 +56,6 @@
         "postcss": "8.5.18",
         "tailwindcss": "3.4.17",
         "typescript": "7.0.2",
-        "vite": "8.0.5"
+        "vite": "8.0.16"
     }
 }


### PR DESCRIPTION
## Summary

- bump the data app template from Vite 8.0.5 to 8.0.16
- pick up the first patched Vite release for the Windows dev-server vulnerabilities reported by npm audit
- ensure newly created apps and the E2B data-app image install the patched version

This addresses:
- GHSA-fx2h-pf6j-xcff (high)
- GHSA-v6wh-96g9-6wx3 (moderate)

## Testing

- copied an app generated by the CLI and installed the template dependency tree with Vite 8.0.16
- `npm audit --json`: 0 vulnerabilities
- `npm run build`: passed with Vite 8.0.16
- CLI build: passed; vendored template contains Vite 8.0.16
- CLI scaffolding tests: 15 passed
