### PR TITLE
fix: autofocus the global search input when the omnibar opens

### DIFF
--- a/packages/frontend/src/features/omnibar/components/Omnibar.tsx
+++ b/packages/frontend/src/features/omnibar/components/Omnibar.tsx
@@ -106,9 +106,11 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
         openOmnibar();
     };
 
-    useHotkeys([
-        ['mod + k', handleOmnibarOpenHotkey, { preventDefault: true }],
-    ]);
+    useHotkeys(
+        [['mod + k', handleOmnibarOpenHotkey, { preventDefault: true }]],
+        [],
+        true,
+    );
 
     const handleOmnibarClose = () => {
         track({
@@ -231,6 +233,7 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
                 <Stack gap={0}>
                     <TextInput
                         size="xl"
+                        data-autofocus
                         leftSection={
                             isFetching ? (
                                 <Loader size="xs" color="ldGray.5" />


### PR DESCRIPTION
## Problem

The global search (Omnibar) modal doesn't reliably receive keyboard focus when it opens, so keystrokes keep going to whatever was previously focused instead of the search input. Two independent bugs contribute to this:

1. **Opening by click doesn't move focus into the search input.** Mantine v8's Modal `FocusTrap` looks for an element with the `data-autofocus` attribute to focus on open. Without one, it falls back to focusing the "first tabbable descendant," which can lose a race against an element that already holds focus — especially a rich-text/contenteditable composer that manages its own internal focus state (e.g. the homepage "Ask AI" box). Omnibar's `TextInput` was missing `data-autofocus`, unlike every other modal in the codebase (e.g. `CreateHomepageModal`, `AddTabModal`, `DuplicateTabModal`), which all set it explicitly.
2. **The ⌘K shortcut does nothing while an editable element has focus.** Mantine's `useHotkeys` hook silently ignores keydown events when `event.target.isContentEditable` is true (its default `triggerOnContentEditable` is `false`), and Omnibar's `useHotkeys` call didn't override that. So pressing ⌘K while typing in any contenteditable box (e.g. the AI chat composer, which is a Tiptap/ProseMirror editor) never opened the search modal at all.

## Fix

- Add `data-autofocus` to Omnibar's search `TextInput`, matching the established convention used by other modals in this codebase.
- Pass `triggerOnContentEditable: true` (and an empty `tagsToIgnore` list) to Omnibar's `useHotkeys` call so ⌘K works as a global shortcut regardless of what currently has focus.

## Test plan

- [x] Reproduced bug 1 locally: focused a pre-existing autofocusing contenteditable element, then opened the Omnibar via click — keystrokes continued landing in the other element. Verified the fix resolves it.
- [x] Reproduced bug 2 locally: with the AI chat composer focused, dispatching the ⌘K keydown never opened the Omnibar. Verified the fix resolves it — the modal opens and the search input receives focus.
- [x] `pnpm -F frontend lint` and `pnpm -F frontend typecheck` pass