### PR TITLE
feat(homepage): greet pre-warehouse users with "Let's get started"

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/NoProjectHomepage.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/NoProjectHomepage.test.tsx
@@ -99,6 +99,15 @@ describe('NoProjectHomepage', () => {
         expect(stage).toContainElement(screen.getByTestId('ask-input'));
     });
 
+    it('uses the getting started heading', () => {
+        renderHomepage();
+
+        expect(
+            screen.getByRole('heading', { name: "Let's get started" }),
+        ).toBeInTheDocument();
+        expect(screen.queryByText('Good morning.')).toBeNull();
+    });
+
     it('redirects away once the organization has a project', () => {
         state.needsProject = false;
         renderHomepage();

--- a/packages/frontend/src/ee/features/homepageBuilder/NoProjectHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/NoProjectHomepage.tsx
@@ -7,18 +7,15 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import PageSpinner from '../../../components/PageSpinner';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
-import useApp from '../../../providers/App/useApp';
 import { useIsCopilotEnabled } from '../aiCopilot/hooks/useIsCopilotEnabled';
 import { RecommendedActionsChecklist } from './blocks/RecommendedActionsChecklist';
 import { useRecommendedActions } from './blocks/useRecommendedActions';
 import { DayOneAskInput } from './DayOneAskInput';
-import { getGreeting } from './greeting';
 import layout from './homepageLayout.module.css';
 import HomepageStars from './HomepageStars';
 import { useHomepageBuilderFlag } from './hooks/useProjectHomepage';
 
 const NoProjectHomepage: FC = () => {
-    const { user } = useApp();
     const { data: organization, isInitialLoading } = useOrganization();
     const orgSetupPageFlag = useServerFeatureFlag(FeatureFlags.NewOnboarding);
     const homepageBuilderFlag = useHomepageBuilderFlag();
@@ -58,7 +55,7 @@ const NoProjectHomepage: FC = () => {
                 <Box className={`${layout.hero} ${layout.heroStageContent}`}>
                     <Stack gap={16} align="center" w="100%">
                         <Text component="h1" className={layout.heroGreeting}>
-                            {getGreeting(user.data?.firstName)}.
+                            Let's get started
                         </Text>
                         {isCopilotEnabled ? (
                             <Box w="100%">

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.test.tsx
@@ -12,8 +12,21 @@ vi.mock('../../aiCopilot/hooks/useAiAgentsButtonVisibility', () => ({
 vi.mock('../../../../providers/App/useApp', () => ({
     default: () => ({ user: { data: { firstName: 'Test' } } }),
 }));
+const state = vi.hoisted(() => ({
+    isLoading: false,
+    isWarehouseConnected: true,
+}));
+
 vi.mock('./useRecommendedActions', () => ({
-    useRecommendedActions: () => ({ hasPendingActions: false }),
+    useRecommendedActions: () => ({
+        hasPendingActions: false,
+        isLoading: state.isLoading,
+        statuses: {
+            'connect-warehouse': {
+                isComplete: state.isWarehouseConnected,
+            },
+        },
+    }),
 }));
 
 const block: HomepageAskAiHeroBlock = {
@@ -26,6 +39,11 @@ const wrap = (ui: React.ReactNode) =>
     render(<MantineProvider>{ui}</MantineProvider>);
 
 describe('AskAiHeroBlockView', () => {
+    beforeEach(() => {
+        state.isLoading = false;
+        state.isWarehouseConnected = true;
+    });
+
     it('greets in the hero slot', () => {
         wrap(
             <AskAiHeroBlockView
@@ -64,6 +82,38 @@ describe('AskAiHeroBlockView', () => {
             />,
         );
         expect(screen.queryByText(/What do you want to know/)).toBeNull();
+        expect(screen.getByTestId('ask-input')).toBeInTheDocument();
+    });
+
+    it('uses the getting started heading before a warehouse is connected', () => {
+        state.isWarehouseConnected = false;
+
+        wrap(
+            <AskAiHeroBlockView
+                itemSpan={null}
+                block={block}
+                projectUuid="p1"
+            />,
+        );
+
+        expect(
+            screen.getByRole('heading', { name: "Let's get started" }),
+        ).toBeInTheDocument();
+        expect(screen.queryByText(/What do you want to know/)).toBeNull();
+    });
+
+    it('holds the heading area while the warehouse status is loading', () => {
+        state.isLoading = true;
+
+        wrap(
+            <AskAiHeroBlockView
+                itemSpan={null}
+                block={block}
+                projectUuid="p1"
+            />,
+        );
+
+        expect(screen.queryByRole('heading')).toBeNull();
         expect(screen.getByTestId('ask-input')).toBeInTheDocument();
     });
 });

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.tsx
@@ -1,5 +1,12 @@
 import { type HomepageHeroDensity } from '@lightdash/common';
-import { Box, SegmentedControl, Stack, Switch, Text } from '@mantine-8/core';
+import {
+    Box,
+    SegmentedControl,
+    Skeleton,
+    Stack,
+    Switch,
+    Text,
+} from '@mantine-8/core';
 import { type FC } from 'react';
 import useApp from '../../../../providers/App/useApp';
 import { useAiAgentButtonVisibility } from '../../aiCopilot/hooks/useAiAgentsButtonVisibility';
@@ -30,14 +37,20 @@ export const AskAiHero: FC<{
     const { user } = useApp();
     const actions = useRecommendedActions(projectUuid);
     const showChecklist = showRecommendedActions && actions.hasPendingActions;
+    const isWarehouseConnected =
+        actions.statuses['connect-warehouse'].isComplete;
     return (
         <Stack gap={16} align="center" w="100%">
-            {showGreeting && (
-                <Text component="h1" className={layout.heroGreeting}>
-                    {getGreeting(user.data?.firstName)}. What do you want to
-                    know?
-                </Text>
-            )}
+            {showGreeting &&
+                (actions.isLoading ? (
+                    <Skeleton h={34} w={320} radius="sm" />
+                ) : (
+                    <Text component="h1" className={layout.heroGreeting}>
+                        {isWarehouseConnected
+                            ? `${getGreeting(user.data?.firstName)}. What do you want to know?`
+                            : "Let's get started"}
+                    </Text>
+                ))}
             <Box w="100%">
                 <DayOneAskInput projectUuid={projectUuid} preview={preview} />
             </Box>

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
@@ -215,6 +215,7 @@ export const useRecommendedActions = (projectUuid: string | null) => {
 
     return {
         statuses,
+        isLoading,
         skippedActions,
         skipAction,
         restoreAction,


### PR DESCRIPTION
## Summary
Fresh signups saw "Good afternoon. What do you want to know?" with no warehouse connected — nothing to ask about yet. Now:

- `AskAiHero`: when the connect-warehouse recommended action is incomplete, the heading reads **"Let's get started"**; connected users keep the greeting + question. The condition reuses the checklist's `useRecommendedActions` data (no second fetch), and the heading holds a small skeleton while statuses resolve so copy never swaps after first paint (per the SPK-772 flicker work).
- `NoProjectHomepage`: heading is unconditionally "Let's get started" — that surface only exists pre-project.

## Testing
- Both heading variants covered in `AskAiHeroBlock` tests; `NoProjectHomepage` heading asserted; 13 tests green
- Frontend typecheck + homepageBuilder lint clean

Closes: SPK-776