### PR TITLE
feat(data-apps): add fullscreen presentation mode to the app viewer

### DIFF
--- a/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
+++ b/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
@@ -74,6 +74,10 @@ type Props = {
      *  "Preview latest" in the builder, "Continue building" in the viewer.
      *  Rendered at the top of the menu; pass null to omit it. */
     navItem: ReactNode;
+    /** Fullscreen/presentation toggle, rendered between the refresh button
+     *  and the overflow menu to match the dashboard header's ordering. Pass
+     *  null on surfaces without it (the builder). */
+    fullscreenToggle: ReactNode;
     /** Builder-only action that captures the live preview and saves it as the
      *  app thumbnail. Pass null on surfaces without a capture pipeline (the
      *  viewer). Disabled until the iframe announces screenshot capability. */
@@ -116,6 +120,7 @@ const AppHeaderActions: FC<Props> = ({
     onViewNetwork,
     onDeleted,
     navItem,
+    fullscreenToggle,
     captureThumbnail,
     capturePreviewScreenshot,
     upgrade,
@@ -246,6 +251,7 @@ const AppHeaderActions: FC<Props> = ({
                     <MantineIcon icon={IconRefresh} size={16} />
                 </ActionIcon>
             </Tooltip>
+            {fullscreenToggle}
             <Menu
                 position="bottom-end"
                 shadow="md"

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -3287,6 +3287,7 @@ const AppGenerate: FC = () => {
                                     }
                                     rightSection={
                                         <AppHeaderActions
+                                            fullscreenToggle={null}
                                             projectUuid={projectUuid}
                                             appUuid={activeAppUuid}
                                             upgrade={{

--- a/packages/frontend/src/pages/AppPreviewTest.module.css
+++ b/packages/frontend/src/pages/AppPreviewTest.module.css
@@ -14,6 +14,14 @@
     height: calc(100vh - 50px - 35px);
 }
 
+/* Presentation mode: the navbar hides itself, so reclaim the full viewport.
+   Repeats the banner selectors above to out-rank their id-based specificity. */
+.previewContainerFullscreen,
+:global(body:has(#preview-banner)) .previewContainerFullscreen,
+:global(body:has(#impersonation-banner)) .previewContainerFullscreen {
+    height: 100vh;
+}
+
 .previewBody {
     flex: 1;
     min-height: 0;

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -1,6 +1,14 @@
 import { FeatureFlags, isAppVersionInProgress } from '@lightdash/common';
-import { Box, Loader, Menu, Stack, Text } from '@mantine-8/core';
-import { IconAppsOff, IconCode } from '@tabler/icons-react';
+import {
+    ActionIcon,
+    Box,
+    Loader,
+    Menu,
+    Stack,
+    Text,
+    Tooltip,
+} from '@mantine-8/core';
+import { IconAppsOff, IconCode, IconMaximize } from '@tabler/icons-react';
 import { useCallback, useRef, useState, type ReactNode } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router';
 import MantineIcon from '../components/common/MantineIcon';
@@ -21,6 +29,7 @@ import { useTrackedAppQueries } from '../features/apps/hooks/useTrackedAppQuerie
 import { useTrackedExternalRequests } from '../features/apps/hooks/useTrackedExternalRequests';
 import { usePreviewOrigin } from '../features/apps/previewOrigin';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
+import useNativeFullscreenToggle from '../providers/Fullscreen/useNativeFullscreenToggle';
 import classes from './AppPreviewTest.module.css';
 
 export default function AppPreviewTest() {
@@ -144,6 +153,15 @@ export default function AppPreviewTest() {
 
     const previewOrigin = usePreviewOrigin();
 
+    // Presentation mode: native fullscreen with all Lightdash chrome hidden
+    // (navbar hides itself via the shared context). Esc exits via the
+    // browser's own fullscreen handling.
+    const {
+        enabled: isFullscreenFeatureEnabled,
+        isFullscreen,
+        handleToggleFullscreen,
+    } = useNativeFullscreenToggle();
+
     // Live-preview capture for the move modal's thumbnail checkbox — same
     // handshake pattern as the builder. Older templates never announce, so
     // the modal falls back to a default-state render for them.
@@ -266,7 +284,7 @@ export default function AppPreviewTest() {
                     }
                     onLineageCancelled={handleLineageCancelled}
                 />
-                {!networkPanelHidden && (
+                {!networkPanelHidden && !isFullscreen && (
                     <AppInspectorPanel
                         queries={queries}
                         projectUuid={projectUuid}
@@ -288,80 +306,111 @@ export default function AppPreviewTest() {
     }
 
     return (
-        <Box className={classes.previewContainer}>
-            <AppHeader
-                appUuid={appUuid}
-                name={appName}
-                description={appDescription}
-                spaceChip={
-                    <AppSpaceChip
-                        projectUuid={projectUuid}
-                        spaceName={appSpaceName}
-                        capturePreviewScreenshot={
-                            screenshotAvailable
-                                ? capturePreviewScreenshot
-                                : null
-                        }
-                        app={{
-                            uuid: appUuid,
-                            name: appName,
-                            description: appDescription ?? undefined,
-                            spaceUuid: appSpaceUuid,
-                            createdByUserUuid: appCreatedByUserUuid,
-                            latestVersionNumber: latestReadyVersion ?? null,
-                            latestVersionStatus: latestReadyVersion
-                                ? 'ready'
-                                : null,
-                        }}
-                    />
-                }
-                rightSection={
-                    <AppHeaderActions
-                        projectUuid={projectUuid}
-                        appUuid={appUuid}
-                        upgrade={null}
-                        appName={appName}
-                        appDescription={appDescription}
-                        appSpaceUuid={appSpaceUuid}
-                        appCreatedByUserUuid={appCreatedByUserUuid}
-                        latestVersionNumber={latestReadyVersion ?? null}
-                        latestVersionStatus={
-                            latestReadyVersion ? 'ready' : null
-                        }
-                        onRefresh={handleRefresh}
-                        refreshDisabled={version === undefined}
-                        captureThumbnail={null}
-                        capturePreviewScreenshot={
-                            screenshotAvailable
-                                ? capturePreviewScreenshot
-                                : null
-                        }
-                        onViewNetwork={() => setNetworkPanelHidden(false)}
-                        onDeleted={() => {
-                            void navigate(`/projects/${projectUuid}/home`);
-                        }}
-                        navItem={
-                            canEditApp ? (
-                                <Menu.Item
-                                    leftSection={
-                                        <MantineIcon
-                                            icon={IconCode}
-                                            size={14}
-                                        />
-                                    }
-                                    onClick={() =>
-                                        navigate(
-                                            `/projects/${projectUuid}/apps/${appUuid}`,
-                                        )
-                                    }
-                                >
-                                    Continue building
-                                </Menu.Item>
-                            ) : null
-                        }
-                    />
-                }
-            />
+        <Box
+            className={
+                isFullscreen
+                    ? `${classes.previewContainer} ${classes.previewContainerFullscreen}`
+                    : classes.previewContainer
+            }
+        >
+            {!isFullscreen && (
+                <AppHeader
+                    appUuid={appUuid}
+                    name={appName}
+                    description={appDescription}
+                    spaceChip={
+                        <AppSpaceChip
+                            projectUuid={projectUuid}
+                            spaceName={appSpaceName}
+                            capturePreviewScreenshot={
+                                screenshotAvailable
+                                    ? capturePreviewScreenshot
+                                    : null
+                            }
+                            app={{
+                                uuid: appUuid,
+                                name: appName,
+                                description: appDescription ?? undefined,
+                                spaceUuid: appSpaceUuid,
+                                createdByUserUuid: appCreatedByUserUuid,
+                                latestVersionNumber: latestReadyVersion ?? null,
+                                latestVersionStatus: latestReadyVersion
+                                    ? 'ready'
+                                    : null,
+                            }}
+                        />
+                    }
+                    rightSection={
+                        <AppHeaderActions
+                            fullscreenToggle={
+                                isFullscreenFeatureEnabled &&
+                                document.fullscreenEnabled ? (
+                                    <Tooltip
+                                        label="Enter Fullscreen Mode"
+                                        withArrow
+                                        position="bottom"
+                                    >
+                                        <ActionIcon
+                                            variant="subtle"
+                                            size="sm"
+                                            color="ldGray.6"
+                                            onClick={handleToggleFullscreen}
+                                            aria-label="Enter Fullscreen Mode"
+                                        >
+                                            <MantineIcon
+                                                icon={IconMaximize}
+                                                size={16}
+                                            />
+                                        </ActionIcon>
+                                    </Tooltip>
+                                ) : null
+                            }
+                            projectUuid={projectUuid}
+                            appUuid={appUuid}
+                            upgrade={null}
+                            appName={appName}
+                            appDescription={appDescription}
+                            appSpaceUuid={appSpaceUuid}
+                            appCreatedByUserUuid={appCreatedByUserUuid}
+                            latestVersionNumber={latestReadyVersion ?? null}
+                            latestVersionStatus={
+                                latestReadyVersion ? 'ready' : null
+                            }
+                            onRefresh={handleRefresh}
+                            refreshDisabled={version === undefined}
+                            captureThumbnail={null}
+                            capturePreviewScreenshot={
+                                screenshotAvailable
+                                    ? capturePreviewScreenshot
+                                    : null
+                            }
+                            onViewNetwork={() => setNetworkPanelHidden(false)}
+                            onDeleted={() => {
+                                void navigate(`/projects/${projectUuid}/home`);
+                            }}
+                            navItem={
+                                canEditApp ? (
+                                    <Menu.Item
+                                        leftSection={
+                                            <MantineIcon
+                                                icon={IconCode}
+                                                size={14}
+                                            />
+                                        }
+                                        onClick={() =>
+                                            navigate(
+                                                `/projects/${projectUuid}/apps/${appUuid}`,
+                                            )
+                                        }
+                                    >
+                                        Continue building
+                                    </Menu.Item>
+                                ) : null
+                            }
+                        />
+                    }
+                />
+            )}
             <Box className={classes.previewBody}>{body}</Box>
         </Box>
     );

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -47,7 +47,7 @@ import DashboardAiAgentContextBridge from '../providers/Dashboard/DashboardAiAge
 import DashboardProvider from '../providers/Dashboard/DashboardProvider';
 import useDashboardContext from '../providers/Dashboard/useDashboardContext';
 import useDashboardTileStatusContext from '../providers/Dashboard/useDashboardTileStatusContext';
-import useFullscreen from '../providers/Fullscreen/useFullscreen';
+import useNativeFullscreenToggle from '../providers/Fullscreen/useNativeFullscreenToggle';
 import '../styles/react-grid.css';
 
 const Dashboard: FC = () => {
@@ -226,8 +226,8 @@ const Dashboard: FC = () => {
     const {
         enabled: isFullScreenFeatureEnabled,
         isFullscreen,
-        toggleFullscreen,
-    } = useFullscreen();
+        handleToggleFullscreen,
+    } = useNativeFullscreenToggle();
     const { user } = useApp();
     const { showToastError } = useToaster();
 
@@ -407,44 +407,6 @@ const Dashboard: FC = () => {
         dashboardTabs,
         activeTab,
     ]);
-
-    const handleToggleFullscreen = useCallback(async () => {
-        if (!isFullScreenFeatureEnabled) return;
-
-        const willBeFullscreen = !isFullscreen;
-
-        if (document.fullscreenElement && !willBeFullscreen) {
-            await document.exitFullscreen();
-        } else if (
-            document.fullscreenEnabled &&
-            !document.fullscreenElement &&
-            willBeFullscreen
-        ) {
-            await document.documentElement.requestFullscreen();
-        }
-
-        toggleFullscreen();
-    }, [isFullScreenFeatureEnabled, isFullscreen, toggleFullscreen]);
-
-    useEffect(() => {
-        if (!isFullScreenFeatureEnabled) return;
-
-        const onFullscreenChange = () => {
-            if (isFullscreen && !document.fullscreenElement) {
-                toggleFullscreen(false);
-            } else if (!isFullscreen && document.fullscreenElement) {
-                toggleFullscreen(true);
-            }
-        };
-
-        document.addEventListener('fullscreenchange', onFullscreenChange);
-
-        return () =>
-            document.removeEventListener(
-                'fullscreenchange',
-                onFullscreenChange,
-            );
-    });
 
     const handleParameterChange = useDashboardContext((c) => c.setParameter);
 

--- a/packages/frontend/src/providers/Fullscreen/useNativeFullscreenToggle.ts
+++ b/packages/frontend/src/providers/Fullscreen/useNativeFullscreenToggle.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect } from 'react';
+import useFullscreen from './useFullscreen';
+
+/**
+ * Fullscreen context state paired with the browser's native Fullscreen API.
+ * Toggling enters/exits native fullscreen and keeps the context in sync when
+ * the browser exits on its own (e.g. the user presses Esc).
+ */
+const useNativeFullscreenToggle = () => {
+    const { enabled, isFullscreen, toggleFullscreen } = useFullscreen();
+
+    const handleToggleFullscreen = useCallback(async () => {
+        if (!enabled) return;
+
+        const willBeFullscreen = !isFullscreen;
+
+        if (document.fullscreenElement && !willBeFullscreen) {
+            await document.exitFullscreen();
+        } else if (
+            document.fullscreenEnabled &&
+            !document.fullscreenElement &&
+            willBeFullscreen
+        ) {
+            await document.documentElement.requestFullscreen();
+        }
+
+        toggleFullscreen();
+    }, [enabled, isFullscreen, toggleFullscreen]);
+
+    useEffect(() => {
+        if (!enabled) return;
+
+        const onFullscreenChange = () => {
+            if (isFullscreen && !document.fullscreenElement) {
+                toggleFullscreen(false);
+            } else if (!isFullscreen && document.fullscreenElement) {
+                toggleFullscreen(true);
+            }
+        };
+
+        document.addEventListener('fullscreenchange', onFullscreenChange);
+
+        return () =>
+            document.removeEventListener(
+                'fullscreenchange',
+                onFullscreenChange,
+            );
+    }, [enabled, isFullscreen, toggleFullscreen]);
+
+    return { enabled, isFullscreen, handleToggleFullscreen };
+};
+
+export default useNativeFullscreenToggle;


### PR DESCRIPTION
## Summary

Adds a presentation mode to the data app viewer, mirroring the fullscreen mode dashboards already have. A new button in the app header enters native browser fullscreen and hides all Lightdash chrome — navbar, app header, and inspector panel — leaving only the app content visible. Esc exits (handled by the browser's native fullscreen behavior) and restores the normal view.

## Implementation

- Extracted the native Fullscreen API logic previously inlined in `Dashboard.tsx` (toggle + `fullscreenchange` sync, which is what makes Esc work) into a shared `useNativeFullscreenToggle` hook; the dashboard now uses the hook with no behavior change.
- The app viewer (`AppPreviewTest`) uses the same hook: the navbar already hides itself for any page that flips the shared fullscreen context, so the viewer only hides its own header/inspector panel and stretches the preview container to `100vh`.
- The height override repeats the preview/impersonation-banner selectors to out-rank their id-based specificity.

Out of scope (ticket's Full/GA item): the same presentation experience in the embed React SDK — the embed surface is already chrome-free and needs its own design.

## Testing

- Verified in the local app: entering hides navbar + header + inspector panel with the container at exactly viewport height; exiting fullscreen (the Esc path — `fullscreenchange`) restores all chrome and the `100vh - 50px` layout.
- Regression-checked dashboard fullscreen after the hook extraction: enter/exit still hides/restores the navbar and swaps the maximize/minimize icon.
- `pnpm -F frontend typecheck`, oxlint, and oxfmt all pass.

Relates: #26620

🤖 Generated with [Claude Code](https://claude.com/claude-code)