### PR TITLE
feat(onboarding): guided dbt setup flow behind the get-started checklist

### DIFF
--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -887,6 +887,23 @@ const PRIVATE_ROUTES: RouteObject[] = [
                         },
                     },
                     {
+                        path: '/onboarding/dbt/:method?',
+                        handle: { hideAILauncher: true },
+                        lazy: async () => {
+                            const OnboardingDbt = await loadLazyRouteDefault(
+                                './pages/OnboardingDbt',
+                                () => import('./pages/OnboardingDbt'),
+                            );
+                            return {
+                                Component: () => (
+                                    <TrackPage name={PageName.ONBOARDING_DBT}>
+                                        <OnboardingDbt />
+                                    </TrackPage>
+                                ),
+                            };
+                        },
+                    },
+                    {
                         path: '/onboarding/invite-expert',
                         handle: { hideAILauncher: true },
                         lazy: async () => {

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/RecommendedActionsChecklist.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/RecommendedActionsChecklist.tsx
@@ -51,8 +51,8 @@ const ACTION_DEFINITIONS: Record<
     },
     'connect-source-control': {
         icon: IconGitBranch,
-        title: 'Connect source control',
-        subtitle: 'Sync dbt models & version control',
+        title: 'Set up your dbt',
+        subtitle: 'Deploy with the CLI or connect your repo',
     },
     'connect-slack': {
         icon: IconBrandSlack,

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.test.tsx
@@ -1,4 +1,6 @@
 import {
+    DbtProjectType,
+    DbtProjectTypeLabels,
     FeatureFlags,
     ProjectType,
     type HomepageRecommendedActionKey,
@@ -189,6 +191,53 @@ describe('useRecommendedActions', () => {
         expect(
             result.current.statuses['connect-source-control'].annotation,
         ).toBeNull();
+    });
+
+    it('completes the dbt step from a dbt connection when no repo is linked', () => {
+        vi.mocked(useApp).mockReturnValue({
+            health: { data: { hasGithub: true } },
+            user: {
+                data: {
+                    ability: { can: () => true },
+                },
+            },
+        } as unknown as ReturnType<typeof useApp>);
+        vi.mocked(useProject).mockReturnValue({
+            data: { dbtConnection: { type: DbtProjectType.DBT_CLOUD_IDE } },
+        } as unknown as ReturnType<typeof useProject>);
+
+        const { result } = renderHook(() =>
+            useRecommendedActions('project-uuid'),
+        );
+
+        expect(
+            result.current.statuses['connect-source-control'].isComplete,
+        ).toBe(true);
+        expect(
+            result.current.statuses['connect-source-control'].annotation,
+        ).toBe(DbtProjectTypeLabels[DbtProjectType.DBT_CLOUD_IDE]);
+    });
+
+    it('leaves the dbt step incomplete for a NONE dbt connection', () => {
+        vi.mocked(useApp).mockReturnValue({
+            health: { data: { hasGithub: true } },
+            user: {
+                data: {
+                    ability: { can: () => true },
+                },
+            },
+        } as unknown as ReturnType<typeof useApp>);
+        vi.mocked(useProject).mockReturnValue({
+            data: { dbtConnection: { type: DbtProjectType.NONE } },
+        } as unknown as ReturnType<typeof useProject>);
+
+        const { result } = renderHook(() =>
+            useRecommendedActions('project-uuid'),
+        );
+
+        expect(
+            result.current.statuses['connect-source-control'].isComplete,
+        ).toBe(false);
     });
 
     describe('new-onboarding gate', () => {

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
@@ -146,14 +146,17 @@ const useActionStatuses = (
             },
             'connect-source-control': {
                 isVisible: hasGithub || hasGitlab,
-                isComplete: isGithubConnected || isGitlabConnected,
+                isComplete:
+                    isGithubConnected || isGitlabConnected || hasSemanticLayer,
                 annotation: isGithubConnected
                     ? 'GitHub'
                     : isGitlabConnected
                       ? 'GitLab'
-                      : null,
+                      : hasSemanticLayer
+                        ? DbtProjectTypeLabels[dbtConnection.type]
+                        : null,
                 doneIcon: null,
-                url: '/generalSettings/integrations',
+                url: '/onboarding/dbt',
                 ctaLabel: DEFAULT_CTA_LABEL,
             },
             'connect-slack': {

--- a/packages/frontend/src/pages/OnboardingDbt.module.css
+++ b/packages/frontend/src/pages/OnboardingDbt.module.css
@@ -1,0 +1,66 @@
+.page {
+    min-height: calc(100vh - var(--navbar-height));
+    background-color: var(--mantine-color-white);
+    display: flex;
+    flex-direction: column;
+}
+
+.column {
+    flex: 1;
+    width: 100%;
+    max-width: 640px;
+    margin: 0 auto;
+    padding: 56px var(--mantine-spacing-xxl) var(--mantine-spacing-xl);
+    display: flex;
+    flex-direction: column;
+    gap: var(--mantine-spacing-xl);
+}
+
+.methodCard {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: var(--mantine-spacing-md);
+    padding: 20px 24px;
+    cursor: pointer;
+    transition:
+        box-shadow 100ms ease,
+        border-color 100ms ease;
+}
+
+.methodCard:hover {
+    box-shadow: var(--mantine-shadow-md);
+    border-color: var(--mantine-color-ldGray-4);
+}
+
+.methodText {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.methodName {
+    font-weight: 600;
+    font-size: 18px;
+}
+
+.stepsCard {
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: var(--mantine-spacing-lg);
+}
+
+.stepNumber {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background-color: var(--mantine-color-ldGray-1);
+    font-size: 12px;
+    font-weight: 600;
+}

--- a/packages/frontend/src/pages/OnboardingDbt.test.tsx
+++ b/packages/frontend/src/pages/OnboardingDbt.test.tsx
@@ -1,0 +1,141 @@
+import { FeatureFlags, type HealthState } from '@lightdash/common';
+import { screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useProject } from '../hooks/useProject';
+import { useProjects } from '../hooks/useProjects';
+import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
+import { renderWithProviders } from '../testing/testUtils';
+import OnboardingDbt from './OnboardingDbt';
+
+vi.mock('../hooks/useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: vi.fn(),
+}));
+
+vi.mock('../hooks/useProjects', () => ({
+    useProjects: vi.fn(),
+}));
+
+vi.mock('../hooks/useProject', () => ({
+    useProject: vi.fn(),
+}));
+
+vi.mock('../hooks/useActiveProject', () => ({
+    useActiveProjectUuid: () => ({
+        activeProjectUuid: 'project-1',
+        isLoading: false,
+    }),
+}));
+
+const health = (overrides?: Partial<HealthState>): Partial<HealthState> => ({
+    siteUrl: 'https://lightdash.example.com',
+    version: '1.51.0',
+    ...overrides,
+});
+
+const LocationProbe = () => {
+    const location = useLocation();
+    return <div data-testid="location">{location.pathname}</div>;
+};
+
+const renderAt = (path: string, healthOverrides?: Partial<HealthState>) =>
+    renderWithProviders(
+        <MemoryRouter initialEntries={[path]}>
+            <Routes>
+                <Route
+                    path="/onboarding/dbt/:method?"
+                    element={<OnboardingDbt />}
+                />
+                <Route path="/get-started" element={<LocationProbe />} />
+                <Route
+                    path="/generalSettings/integrations"
+                    element={<LocationProbe />}
+                />
+            </Routes>
+        </MemoryRouter>,
+        { health: health(healthOverrides) },
+    );
+
+const mockProjects = (projectUuids: string[]) => {
+    vi.mocked(useProjects).mockReturnValue({
+        data: projectUuids.map((projectUuid) => ({ projectUuid })),
+    } as unknown as ReturnType<typeof useProjects>);
+};
+
+describe('OnboardingDbt', () => {
+    beforeEach(() => {
+        vi.mocked(useServerFeatureFlag).mockReturnValue({
+            data: { id: FeatureFlags.NewOnboarding, enabled: true },
+            isLoading: false,
+        } as ReturnType<typeof useServerFeatureFlag>);
+        mockProjects(['project-1']);
+        vi.mocked(useProject).mockReturnValue({
+            data: undefined,
+        } as unknown as ReturnType<typeof useProject>);
+    });
+
+    it('offers both setup paths and a docs link on the choice screen', async () => {
+        renderAt('/onboarding/dbt');
+
+        expect(
+            await screen.findByText("Let's get you set up!"),
+        ).toBeInTheDocument();
+        expect(screen.getByText('Using your CLI')).toBeInTheDocument();
+        expect(screen.getByText('with lightdash deploy')).toBeInTheDocument();
+        expect(screen.getByText('Manually')).toBeInTheDocument();
+        expect(
+            screen.getByText('Pull project from git repository'),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('link', { name: 'View docs' }),
+        ).toBeInTheDocument();
+    });
+
+    it('shows the CLI commands with the site url and version substituted', async () => {
+        renderAt('/onboarding/dbt/cli');
+
+        expect(await screen.findByText('Waiting for data')).toBeInTheDocument();
+        expect(
+            screen.getByText('npm install -g @lightdash/cli@1.51.0'),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText('lightdash login https://lightdash.example.com'),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText('lightdash deploy --create'),
+        ).toBeInTheDocument();
+    });
+
+    it('redirects to get-started once a new project is detected', async () => {
+        const { rerender } = renderAt('/onboarding/dbt/cli');
+
+        expect(await screen.findByText('Waiting for data')).toBeInTheDocument();
+
+        mockProjects(['project-1', 'project-2']);
+        rerender(
+            <MemoryRouter initialEntries={['/onboarding/dbt/cli']}>
+                <Routes>
+                    <Route
+                        path="/onboarding/dbt/:method?"
+                        element={<OnboardingDbt />}
+                    />
+                    <Route path="/get-started" element={<LocationProbe />} />
+                </Routes>
+            </MemoryRouter>,
+        );
+
+        await waitFor(() =>
+            expect(screen.getByTestId('location')).toHaveTextContent(
+                '/get-started',
+            ),
+        );
+    });
+
+    it('sends an unknown method back to the choice screen', async () => {
+        renderAt('/onboarding/dbt/nonsense');
+
+        expect(
+            await screen.findByText("Let's get you set up!"),
+        ).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/pages/OnboardingDbt.tsx
+++ b/packages/frontend/src/pages/OnboardingDbt.tsx
@@ -1,0 +1,344 @@
+import { DbtProjectType, type OrganizationProject } from '@lightdash/common';
+import {
+    Anchor,
+    Box,
+    Group,
+    Loader,
+    Paper,
+    Stack,
+    Tabs,
+    Text,
+    Title,
+} from '@mantine-8/core';
+import { useOs } from '@mantine-8/hooks';
+import {
+    IconChecklist,
+    IconChevronRight,
+    IconTerminal,
+} from '@tabler/icons-react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useRef, useState, type FC } from 'react';
+import { Navigate, useNavigate, useParams } from 'react-router';
+import AboutFooter from '../components/AboutFooter';
+import CodeBlock from '../components/common/CodeBlock/CodeBlock';
+import { DocumentTitle } from '../components/common/DocumentTitle';
+import MantineIcon from '../components/common/MantineIcon';
+import useToaster from '../hooks/toaster/useToaster';
+import { useActiveProjectUuid } from '../hooks/useActiveProject';
+import { useOnboardingPageGuard } from '../hooks/useOnboardingPageGuard';
+import { useProject } from '../hooks/useProject';
+import { useProjects } from '../hooks/useProjects';
+import useApp from '../providers/App/useApp';
+import useTracking from '../providers/Tracking/useTracking';
+import { EventName } from '../types/Events';
+import classes from './OnboardingDbt.module.css';
+
+const DOCS_URL =
+    'https://docs.lightdash.com/get-started/setup-lightdash/get-project-lightdash-ready';
+const INTEGRATIONS_ROUTE = '/generalSettings/integrations';
+const GET_STARTED_ROUTE = '/get-started';
+const CLI_ROUTE_PARAM = 'cli';
+const DETECTION_POLL_INTERVAL_MS = 3000;
+
+const DocsLink: FC = () => {
+    const { track } = useTracking();
+    return (
+        <Anchor
+            href={DOCS_URL}
+            target="_blank"
+            rel="noreferrer noopener"
+            size="sm"
+            c="dimmed"
+            mx="auto"
+            onClick={() => {
+                track({
+                    name: EventName.DOCUMENTATION_BUTTON_CLICKED,
+                    properties: { action: 'getting_started' },
+                });
+            }}
+        >
+            View docs
+        </Anchor>
+    );
+};
+
+const DbtMethodPicker: FC = () => {
+    const navigate = useNavigate();
+    const { track } = useTracking();
+
+    const methods = [
+        {
+            to: `/onboarding/dbt/${CLI_ROUTE_PARAM}`,
+            icon: IconTerminal,
+            label: 'Using your CLI',
+            description: 'with lightdash deploy',
+            onTrack: () =>
+                track({ name: EventName.CREATE_PROJECT_CLI_BUTTON_CLICKED }),
+        },
+        {
+            to: INTEGRATIONS_ROUTE,
+            icon: IconChecklist,
+            label: 'Manually',
+            description: 'Pull project from git repository',
+            onTrack: () =>
+                track({
+                    name: EventName.CREATE_PROJECT_MANUALLY_BUTTON_CLICKED,
+                }),
+        },
+    ];
+
+    return (
+        <Box className={classes.column}>
+            <Stack align="center" gap="xs">
+                <Title order={1} ta="center" fw={700}>
+                    Let's get you set up!
+                </Title>
+                <Text size="md" c="dimmed" ta="center">
+                    Choose how you want to upload your dbt project.
+                </Text>
+            </Stack>
+
+            <Stack gap="md">
+                {methods.map((method) => (
+                    <Paper
+                        key={method.to}
+                        withBorder
+                        radius="md"
+                        className={classes.methodCard}
+                        onClick={() => {
+                            method.onTrack();
+                            void navigate(method.to);
+                        }}
+                    >
+                        <MantineIcon
+                            icon={method.icon}
+                            size="xl"
+                            color="ldGray.6"
+                        />
+                        <Box className={classes.methodText}>
+                            <Text className={classes.methodName}>
+                                {method.label}
+                            </Text>
+                            <Text size="sm" c="dimmed">
+                                {method.description}
+                            </Text>
+                        </Box>
+                        <MantineIcon icon={IconChevronRight} color="ldGray.6" />
+                    </Paper>
+                ))}
+            </Stack>
+
+            <DocsLink />
+        </Box>
+    );
+};
+
+const useDbtSetupDetection = (isEnabled: boolean) => {
+    const { activeProjectUuid } = useActiveProjectUuid();
+    const pollOptions = {
+        refetchInterval: isEnabled ? DETECTION_POLL_INTERVAL_MS : false,
+        refetchIntervalInBackground: true,
+        staleTime: 0,
+    } as const;
+
+    const { data: projects } = useProjects(pollOptions);
+    const { data: project } = useProject(activeProjectUuid, pollOptions);
+
+    const baselineProjectUuids = useRef<string[] | null>(null);
+    const [isDetected, setIsDetected] = useState(false);
+
+    useEffect(() => {
+        if (!projects) return;
+        const uuids = projects.map(
+            ({ projectUuid }: OrganizationProject) => projectUuid,
+        );
+        if (baselineProjectUuids.current === null) {
+            baselineProjectUuids.current = uuids;
+            return;
+        }
+        if (
+            uuids.some((uuid) => !baselineProjectUuids.current?.includes(uuid))
+        ) {
+            setIsDetected(true);
+        }
+    }, [projects]);
+
+    useEffect(() => {
+        const dbtType = project?.dbtConnection?.type;
+        if (dbtType && dbtType !== DbtProjectType.NONE) {
+            setIsDetected(true);
+        }
+    }, [project]);
+
+    return { isDetected, activeProjectUuid };
+};
+
+const DbtCliWaiting: FC = () => {
+    const navigate = useNavigate();
+    const queryClient = useQueryClient();
+    const { health } = useApp();
+    const { track } = useTracking();
+    const { showToastSuccess } = useToaster();
+    const os = useOs();
+
+    const siteUrl = health.data?.siteUrl ?? '';
+    const version = health.data?.version ?? '';
+
+    const { isDetected } = useDbtSetupDetection(true);
+    const hasCompletedRef = useRef(false);
+
+    useEffect(() => {
+        if (!isDetected || hasCompletedRef.current) return;
+        hasCompletedRef.current = true;
+
+        void (async () => {
+            try {
+                await Promise.all([
+                    queryClient.refetchQueries({
+                        queryKey: ['projects'],
+                        type: 'all',
+                    }),
+                    queryClient.refetchQueries({
+                        queryKey: ['organization'],
+                        type: 'all',
+                    }),
+                    queryClient.refetchQueries({
+                        queryKey: ['project'],
+                        type: 'all',
+                    }),
+                ]);
+            } catch {
+                // The destination reads these itself if priming failed
+            }
+            showToastSuccess({ title: 'Your dbt project is connected!' });
+            void navigate(GET_STARTED_ROUTE, { replace: true });
+        })();
+    }, [isDetected, navigate, queryClient, showToastSuccess]);
+
+    const handleCopy = useCallback(() => {
+        track({ name: EventName.COPY_CREATE_PROJECT_CODE_BUTTON_CLICKED });
+    }, [track]);
+
+    const npmInstall = version
+        ? `npm install -g @lightdash/cli@${version}`
+        : 'npm install -g @lightdash/cli';
+    const brewInstall = 'brew tap lightdash/lightdash\nbrew install lightdash';
+
+    const steps = [
+        {
+            title: 'Install the Lightdash CLI',
+            content:
+                os === 'macos' ? (
+                    <Tabs defaultValue="npm">
+                        <Tabs.List>
+                            <Tabs.Tab value="npm">npm</Tabs.Tab>
+                            <Tabs.Tab value="brew">Homebrew</Tabs.Tab>
+                        </Tabs.List>
+                        <Tabs.Panel value="npm" pt="xs">
+                            <CodeBlock
+                                code={npmInstall}
+                                language="bash"
+                                onCopy={handleCopy}
+                            />
+                        </Tabs.Panel>
+                        <Tabs.Panel value="brew" pt="xs">
+                            <CodeBlock
+                                code={brewInstall}
+                                language="bash"
+                                onCopy={handleCopy}
+                            />
+                        </Tabs.Panel>
+                    </Tabs>
+                ) : (
+                    <CodeBlock
+                        code={npmInstall}
+                        language="bash"
+                        onCopy={handleCopy}
+                    />
+                ),
+        },
+        {
+            title: 'Log in to Lightdash',
+            content: (
+                <CodeBlock
+                    code={`lightdash login ${siteUrl}`}
+                    language="bash"
+                    onCopy={handleCopy}
+                />
+            ),
+        },
+        {
+            title: 'Deploy your dbt project',
+            content: (
+                <CodeBlock
+                    code="lightdash deploy --create"
+                    language="bash"
+                    onCopy={handleCopy}
+                />
+            ),
+        },
+    ];
+
+    return (
+        <Box className={classes.column}>
+            <Stack align="center" gap="xs">
+                <Loader size="sm" />
+                <Title order={1} ta="center" fw={700}>
+                    Waiting for data
+                </Title>
+                <Text size="md" c="dimmed" ta="center">
+                    Inside your dbt project, run the steps below. We'll pick it
+                    up automatically.
+                </Text>
+            </Stack>
+
+            <Paper withBorder radius="md" className={classes.stepsCard}>
+                {steps.map((step, index) => (
+                    <Stack key={step.title} gap="xs">
+                        <Group gap="sm" wrap="nowrap">
+                            <Box className={classes.stepNumber}>
+                                {index + 1}
+                            </Box>
+                            <Text fw={500}>{step.title}</Text>
+                        </Group>
+                        {step.content}
+                    </Stack>
+                ))}
+            </Paper>
+
+            <DocsLink />
+        </Box>
+    );
+};
+
+const OnboardingDbtContent: FC = () => {
+    const { method } = useParams<{ method?: string }>();
+
+    if (method && method !== CLI_ROUTE_PARAM) {
+        return <Navigate to="/onboarding/dbt" replace />;
+    }
+
+    return (
+        <Box className={classes.page}>
+            <DocumentTitle title="Set up your dbt" />
+            {method === CLI_ROUTE_PARAM ? (
+                <DbtCliWaiting />
+            ) : (
+                <DbtMethodPicker />
+            )}
+            <AboutFooter />
+        </Box>
+    );
+};
+
+const OnboardingDbt: FC = () => {
+    const guard = useOnboardingPageGuard();
+
+    if (guard.status === 'blocked') {
+        return guard.element;
+    }
+
+    return <OnboardingDbtContent key={guard.user.userUuid} />;
+};
+
+export default OnboardingDbt;

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -51,6 +51,7 @@ export enum PageName {
     JOIN_ORGANIZATION = 'join_organization',
     ORGANIZATION_SETUP = 'organization_setup',
     ONBOARDING_DATA_SOURCE = 'onboarding_data_source',
+    ONBOARDING_DBT = 'onboarding_dbt',
     ONBOARDING_INVITE_EXPERT = 'onboarding_invite_expert',
     AGENT_ONBOARDING_START = 'agent_onboarding_start',
     AGENT_ONBOARDING_RUN = 'agent_onboarding_run',


### PR DESCRIPTION
## Summary
The get-started checklist's dbt step now opens a guided flow at `/onboarding/dbt` (previously it linked to the integrations settings page), modelled on the classic project-connect screens and restyled to the new-onboarding language:

- **Choice screen** — "Using your CLI" (`lightdash deploy`) vs "Manually" (connect your git repository), with a View docs link
- **CLI path** — copyable install (npm/Homebrew), `lightdash login <site-url>`, `lightdash deploy --create` steps with live detection of the arriving project
- **Repo path** — routes into the existing source-control connect surface (the github/gitlab integration itself is untouched)
- New route lives under the shared onboarding `NavBarLayout`; no copy swaps after paint, no new full-page spinner gates

## Product-facing behaviour changes (please review deliberately)
1. **The card self-completes from a dbt connection, not just a linked repo** — any project with a non-NONE `dbtConnection.type` shows the step complete the first time an org sees the checklist. Completion rate will jump discontinuously on release (not climb from zero), and this step + add-semantic-layer will often tick together.
2. **Card copy is now "Set up your dbt / Deploy with the CLI or connect your repo"** while the persisted action key stays `connect-source-control` (skip records and analytics dashboards keep working, but the label no longer matches the key — a key rename would need a data migration). Don't read this action's analytics as GitHub/GitLab connections after this ships.

Stacked on the SPK-772 fix stack (#26625–#26627) because it builds on the shared layout route.

## Testing
- New page tests (choice screen, CLI command substitution, detection/completion redirect) + completion-derivation tests; homepageBuilder suite (224 tests) green
- Frontend typecheck + lint on touched paths
- Browser-verified on the local dev env: full CLI-path walkthrough via a real project-creation event, repo path up to the github surface; not verifiable locally: an actual `lightdash deploy` from a real dbt project, the GitLab branch, and the dbtConnection-flip detection arm (new-project arm fires first)

Closes: SPK-775

## Static analysis notes
react-doctor flags two `no-adjust-state-on-prop-change` warnings in the CLI-detection hook — both are deliberate one-way event latches over polled queries (baseline-diff for new-project arrival, dbt-connection flip), not state mirroring; a latch is required so detection survives refetch jitter. One `js-set-map-lookups` nit on the uuid baseline comparison (bounded by the org's project count) left as-is. `Routes.tsx` warnings (`no-multi-comp` per inline route component) are the file's pre-existing idiom.
