### PR TITLE
fix: allow valid existing Okta identities

### DIFF
--- a/packages/backend/src/controllers/authentication/strategies/oktaStrategy.test.ts
+++ b/packages/backend/src/controllers/authentication/strategies/oktaStrategy.test.ts
@@ -1,5 +1,9 @@
-import { OrganizationSsoProvider } from '@lightdash/common';
+import {
+    OpenIdIdentityIssuerType,
+    OrganizationSsoProvider,
+} from '@lightdash/common';
 import { Request } from 'express';
+import { UserinfoResponse } from 'openid-client';
 
 // oktaStrategy reads the lightdashConfig singleton; mock it with a mutable
 // `okta` block so each test can toggle the instance-level env config.
@@ -39,7 +43,11 @@ vi.mock('../../../config/lightdashConfig', async () => {
 });
 
 // eslint-disable-next-line import/first
-import { getOktaConfigFromEnv, resolveOktaConfig } from './oktaStrategy';
+import {
+    createOpenIdUserFromUserInfo,
+    getOktaConfigFromEnv,
+    resolveOktaConfig,
+} from './oktaStrategy';
 
 const FULL_ENV = {
     oauth2Issuer: 'https://env.okta.com',
@@ -105,6 +113,37 @@ const makeReq = ({
 
 beforeEach(() => {
     setEnv({});
+});
+
+describe('createOpenIdUserFromUserInfo', () => {
+    test('accepts Okta profiles with explicitly unverified email claims', () => {
+        const fail = vi.fn();
+
+        const openIdUser = createOpenIdUserFromUserInfo(
+            {
+                sub: 'okta-user-1',
+                email: 'user@example.com',
+                email_verified: false,
+                given_name: 'Test',
+                family_name: 'User',
+            } as UserinfoResponse,
+            'https://example.okta.com',
+            OpenIdIdentityIssuerType.OKTA,
+            fail,
+        );
+
+        expect(openIdUser).toEqual({
+            openId: {
+                email: 'user@example.com',
+                issuer: 'https://example.okta.com',
+                subject: 'okta-user-1',
+                firstName: 'Test',
+                lastName: 'User',
+                issuerType: OpenIdIdentityIssuerType.OKTA,
+            },
+        });
+        expect(fail).not.toHaveBeenCalled();
+    });
 });
 
 describe('getOktaConfigFromEnv', () => {

--- a/packages/backend/src/controllers/authentication/strategies/oktaStrategy.ts
+++ b/packages/backend/src/controllers/authentication/strategies/oktaStrategy.ts
@@ -21,22 +21,12 @@ import { getLoginHint } from '../utils';
 const getIssuerHint = (req: Request) =>
     isString(req.query?.iss) ? req.query.iss : undefined;
 
-const createOpenIdUserFromUserInfo = (
+export const createOpenIdUserFromUserInfo = (
     userInfo: UserinfoResponse,
     issuer: string,
     issuerType: OpenIdIdentityIssuerType,
     fail: OpenIDClientOktaStrategy['fail'],
 ) => {
-    if (userInfo.email_verified === false) {
-        return fail(
-            {
-                message:
-                    'Authentication failed: email is not verified in OpenID profile.',
-            },
-            401,
-        );
-    }
-
     if (!userInfo.email || !userInfo.sub) {
         return fail(
             {
@@ -255,6 +245,7 @@ export class OpenIDClientOktaStrategy extends Strategy {
                                 ip: req.ip,
                                 userAgent: req.get('user-agent'),
                             },
+                            { emailVerified: userInfo.email_verified },
                         );
                     return this.success(user);
                 }

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -2758,6 +2758,61 @@ describe('UserService', () => {
             ).toHaveBeenCalledTimes(0);
         });
 
+        test('allows an unverified provider email for an existing OpenID identity without trusting the email', async () => {
+            (
+                userModel.findSessionUserByOpenId as import('vitest').Mock
+            ).mockResolvedValueOnce(sessionUser);
+            const openIdUserWithUnverifiedEmail = {
+                openId: {
+                    ...openIdUser.openId,
+                    email: 'unverified@example.com',
+                },
+            };
+
+            await userService.loginWithOpenId(
+                openIdUserWithUnverifiedEmail,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                { emailVerified: false },
+            );
+
+            expect(
+                openIdIdentityModel.updateIdentityByOpenId,
+            ).not.toHaveBeenCalled();
+            expect(emailModel.verifyUserEmailIfExists).not.toHaveBeenCalled();
+        });
+
+        test('rejects an unverified provider email before linking a new OpenID identity', async () => {
+            const service = createUserService({
+                ...lightdashConfigMock,
+                auth: {
+                    ...lightdashConfigMock.auth,
+                    enableOidcLinking: true,
+                    enableOidcToEmailLinking: true,
+                },
+            });
+
+            await expect(
+                service.loginWithOpenId(
+                    openIdUser,
+                    undefined,
+                    undefined,
+                    undefined,
+                    undefined,
+                    { emailVerified: false },
+                ),
+            ).rejects.toThrowError(
+                new ForbiddenError(
+                    'Authentication failed: email is not verified in OpenID profile.',
+                ),
+            );
+
+            expect(openIdIdentityModel.createIdentity).not.toHaveBeenCalled();
+            expect(userModel.createUser).not.toHaveBeenCalled();
+        });
+
         test('should emit allowed audit event on successful OpenID login', async () => {
             (
                 userModel.findSessionUserByOpenId as import('vitest').Mock

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -171,6 +171,7 @@ export type AuthAuditContext = {
 
 type LoginWithOpenIdOptions = {
     isLinkFlow?: boolean;
+    emailVerified?: boolean;
 };
 
 const emitAuthAuditEvent = ({
@@ -1008,6 +1009,12 @@ export class UserService extends BaseService {
             }`,
         );
 
+        if (options?.emailVerified === false && !openIdSession) {
+            throw new ForbiddenError(
+                'Authentication failed: email is not verified in OpenID profile.',
+            );
+        }
+
         if (
             (await this.isLoginMethodAllowed(
                 openIdUser.openId.email,
@@ -1073,15 +1080,17 @@ export class UserService extends BaseService {
                 }
             }
 
-            await this.openIdIdentityModel.updateIdentityByOpenId({
-                ...openIdUser.openId,
-                refreshToken,
-            });
-            await this.tryVerifyUserEmail(
-                loginUser,
-                openIdUser.openId.email,
-                'sso',
-            );
+            if (options?.emailVerified !== false) {
+                await this.openIdIdentityModel.updateIdentityByOpenId({
+                    ...openIdUser.openId,
+                    refreshToken,
+                });
+                await this.tryVerifyUserEmail(
+                    loginUser,
+                    openIdUser.openId.email,
+                    'sso',
+                );
+            }
             this.identifyUser(loginUser);
             this.analytics.track({
                 userId: loginUser.userUuid,


### PR DESCRIPTION
## Summary

- Allow Okta profiles with `email_verified: false` only when the exact issuer and subject are already linked
- Continue rejecting unverified profiles before new identity linking or account creation
- Avoid updating the stored identity email or verifying the asserted email when Okta reports it as unverified
- Keep generic OIDC verification behavior unchanged

Follow-up to #24927.

## Testing

- `pnpm -F backend exec vitest run --config vitest.config.ts src/services/UserService.test.ts src/controllers/authentication/strategies/oktaStrategy.test.ts src/controllers/authentication/strategies/oidcStrategy.test.ts`
- `NODE_OPTIONS="--max-old-space-size=8192" pnpm -F backend typecheck`
- Targeted backend lint and formatting checks

Closes: SPK-778
Relates: SPK-529