### PR TITLE
fix(ai): disable deep research during active runs

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.deepResearch.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.deepResearch.test.tsx
@@ -57,7 +57,7 @@ describe('AgentChatInput Deep Research mode', () => {
 
         expect(
             screen
-                .getByRole('button', { name: 'Turn on Deep research' })
+                .getByRole('button', { name: 'Enable deep research' })
                 .closest('[data-accent]'),
         ).toBeNull();
     });
@@ -67,7 +67,7 @@ describe('AgentChatInput Deep Research mode', () => {
 
         expect(
             screen
-                .getByRole('button', { name: 'Turn on Deep research' })
+                .getByRole('button', { name: 'Enable deep research' })
                 .closest('[data-accent]'),
         ).not.toBeNull();
     });
@@ -77,10 +77,10 @@ describe('AgentChatInput Deep Research mode', () => {
         const { onStartDeepResearch, onSubmit } = renderInput();
 
         await user.click(
-            screen.getByRole('button', { name: 'Turn on Deep research' }),
+            screen.getByRole('button', { name: 'Enable deep research' }),
         );
         expect(
-            screen.getByRole('button', { name: 'Turn off Deep research' }),
+            screen.getByRole('button', { name: 'Disable deep research' }),
         ).toHaveAttribute('aria-pressed', 'true');
 
         await user.click(
@@ -92,7 +92,7 @@ describe('AgentChatInput Deep Research mode', () => {
         });
         expect(onSubmit).not.toHaveBeenCalled();
         expect(
-            screen.getByRole('button', { name: 'Turn on Deep research' }),
+            screen.getByRole('button', { name: 'Enable deep research' }),
         ).toHaveAttribute('aria-pressed', 'false');
     });
 
@@ -105,14 +105,14 @@ describe('AgentChatInput Deep Research mode', () => {
         });
 
         await user.click(
-            screen.getByRole('button', { name: 'Turn on Deep research' }),
+            screen.getByRole('button', { name: 'Enable deep research' }),
         );
         await user.click(
             screen.getByRole('button', { name: 'Start research' }),
         );
 
         expect(
-            screen.getByRole('button', { name: 'Turn off Deep research' }),
+            screen.getByRole('button', { name: 'Disable deep research' }),
         ).toHaveAttribute('aria-pressed', 'true');
         expect(
             screen.getByText('Why did enterprise retention fall?'),
@@ -123,7 +123,7 @@ describe('AgentChatInput Deep Research mode', () => {
         renderInput({ onStartDeepResearch: null });
 
         expect(
-            screen.queryByRole('button', { name: 'Turn on Deep research' }),
+            screen.queryByRole('button', { name: 'Enable deep research' }),
         ).not.toBeInTheDocument();
     });
 
@@ -133,7 +133,7 @@ describe('AgentChatInput Deep Research mode', () => {
         renderInput({ onStartDeepResearch, disabled: true });
 
         await user.click(
-            screen.getByRole('button', { name: 'Turn on Deep research' }),
+            screen.getByRole('button', { name: 'Enable deep research' }),
         );
 
         expect(
@@ -142,13 +142,13 @@ describe('AgentChatInput Deep Research mode', () => {
         expect(onStartDeepResearch).not.toHaveBeenCalled();
     });
 
-    it('keeps regular chat available while Deep research is active', async () => {
+    it('keeps regular chat available while deep research is active', async () => {
         const user = userEvent.setup();
         useHasActiveDeepResearchRunMock.mockReturnValue(true);
         const { onStartDeepResearch, onSubmit } = renderInput();
 
         expect(
-            screen.getByRole('button', { name: 'Turn on Deep research' }),
+            screen.getByRole('button', { name: 'Enable deep research' }),
         ).toBeDisabled();
 
         await user.click(screen.getByRole('button', { name: 'Send message' }));

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.deepResearch.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.deepResearch.test.tsx
@@ -2,10 +2,18 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../../../testing/testUtils';
 import { store } from '../../store';
 import { AgentChatInput } from './AgentChatInput';
+
+const { useHasActiveDeepResearchRunMock } = vi.hoisted(() => ({
+    useHasActiveDeepResearchRunMock: vi.fn(() => false),
+}));
+
+vi.mock('../../hooks/useDeepResearch', () => ({
+    useHasActiveDeepResearchRun: useHasActiveDeepResearchRunMock,
+}));
 
 const renderInput = ({
     onStartDeepResearch = vi.fn().mockResolvedValue(undefined),
@@ -40,6 +48,10 @@ const renderInput = ({
 };
 
 describe('AgentChatInput Deep Research mode', () => {
+    beforeEach(() => {
+        useHasActiveDeepResearchRunMock.mockReturnValue(false);
+    });
+
     it('renders the toggle outside the composer in an existing conversation', () => {
         renderInput();
 
@@ -127,6 +139,24 @@ describe('AgentChatInput Deep Research mode', () => {
         expect(
             screen.getByRole('button', { name: 'Start research' }),
         ).toBeDisabled();
+        expect(onStartDeepResearch).not.toHaveBeenCalled();
+    });
+
+    it('keeps regular chat available while Deep research is active', async () => {
+        const user = userEvent.setup();
+        useHasActiveDeepResearchRunMock.mockReturnValue(true);
+        const { onStartDeepResearch, onSubmit } = renderInput();
+
+        expect(
+            screen.getByRole('button', { name: 'Turn on Deep research' }),
+        ).toBeDisabled();
+
+        await user.click(screen.getByRole('button', { name: 'Send message' }));
+
+        expect(onSubmit).toHaveBeenCalledWith({
+            message: 'Why did enterprise retention fall?',
+            toolHints: [],
+        });
         expect(onStartDeepResearch).not.toHaveBeenCalled();
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -27,6 +27,7 @@ import { subscribeToDeepResearchComposerPrompt } from '../../deepResearch/deepRe
 import { type StartDeepResearchArgs } from '../../deepResearch/types';
 import { isEmbedAiAgentRoute } from '../../hooks/aiAgentRouting';
 import { useAgentSuggestions } from '../../hooks/useAgentSuggestions';
+import { useHasActiveDeepResearchRun } from '../../hooks/useDeepResearch';
 import { useDeepResearchComposer } from '../../hooks/useDeepResearchComposer';
 import {
     useCreateAiAgentThreadMessageSteerMutation,
@@ -50,6 +51,8 @@ import {
 import { getAgentSuggestionModes } from './suggestionModes';
 
 const SUGGESTION_CHIP_MENTION_NAME = 'suggestionChip';
+const ACTIVE_DEEP_RESEARCH_DISABLED_REASON =
+    'Only one Deep research run can be active in a thread at a time.';
 
 const SuggestionChipMention = Mention.extend({
     name: SUGGESTION_CHIP_MENTION_NAME,
@@ -423,9 +426,17 @@ export const AgentChatInput = ({
     const canStartDeepResearch = Boolean(
         onStartDeepResearch && !isEmbedAiAgentRoute(),
     );
+    const hasActiveDeepResearchRun = useHasActiveDeepResearchRun({
+        projectUuid,
+        threadUuid,
+    });
     const { isStarting: isStartingDeepResearch, startDeepResearch } =
         useDeepResearchComposer({
-            canStart: canStartDeepResearch && !disabled && !loading,
+            canStart:
+                canStartDeepResearch &&
+                !disabled &&
+                !loading &&
+                !hasActiveDeepResearchRun,
             onStart: onStartDeepResearch,
         });
     const showSqlModeControl = Boolean(onSqlModeChange && !disabled);
@@ -518,21 +529,25 @@ export const AgentChatInput = ({
     };
 
     useEffect(() => {
-        if (!canStartDeepResearch) {
+        if (!canStartDeepResearch || hasActiveDeepResearchRun) {
             setComposerMode('ask');
         }
-    }, [canStartDeepResearch]);
+    }, [canStartDeepResearch, hasActiveDeepResearchRun]);
 
     const deepResearchControl = canStartDeepResearch ? (
         <DeepResearchModeControl
             mode={composerMode}
             onModeChange={setComposerMode}
+            disabled={hasActiveDeepResearchRun}
+            disabledReason={ACTIVE_DEEP_RESEARCH_DISABLED_REASON}
         />
     ) : null;
     const compactDeepResearchControl = canStartDeepResearch ? (
         <DeepResearchModeControl
             mode={composerMode}
             onModeChange={setComposerMode}
+            disabled={hasActiveDeepResearchRun}
+            disabledReason={ACTIVE_DEEP_RESEARCH_DISABLED_REASON}
             iconOnly
             actionSize="sm"
             iconSize={14}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -52,7 +52,7 @@ import { getAgentSuggestionModes } from './suggestionModes';
 
 const SUGGESTION_CHIP_MENTION_NAME = 'suggestionChip';
 const ACTIVE_DEEP_RESEARCH_DISABLED_REASON =
-    'Only one Deep research run can be active in a thread at a time.';
+    'Only one deep research run can be active in a thread at a time.';
 
 const SuggestionChipMention = Mention.extend({
     name: SUGGESTION_CHIP_MENTION_NAME,

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.test.tsx
@@ -17,21 +17,21 @@ describe('DeepResearchModeControl', () => {
         renderWithProviders(<ModeHarness />);
 
         const enable = screen.getByRole('button', {
-            name: 'Turn on Deep research',
+            name: 'Enable deep research',
         });
         expect(enable).toHaveAttribute('aria-pressed', 'false');
 
         await user.click(enable);
 
         const disable = screen.getByRole('button', {
-            name: 'Turn off Deep research',
+            name: 'Disable deep research',
         });
         expect(disable).toHaveAttribute('aria-pressed', 'true');
         expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 
         await user.click(disable);
         expect(
-            screen.getByRole('button', { name: 'Turn on Deep research' }),
+            screen.getByRole('button', { name: 'Enable deep research' }),
         ).toHaveAttribute('aria-pressed', 'false');
     });
 
@@ -42,12 +42,12 @@ describe('DeepResearchModeControl', () => {
                 mode="ask"
                 onModeChange={() => undefined}
                 iconOnly
-                disabledReason="Only one Deep research run can be active in a thread at a time."
+                disabledReason="Only one deep research run can be active in a thread at a time."
             />,
         );
 
         const button = screen.getByRole('button', {
-            name: 'Turn on Deep research',
+            name: 'Enable deep research',
         });
         expect(button).toBeEnabled();
         expect(screen.queryByText('Deep research')).not.toBeInTheDocument();
@@ -55,14 +55,14 @@ describe('DeepResearchModeControl', () => {
         await user.hover(button);
 
         expect(await screen.findByRole('tooltip')).toHaveTextContent(
-            'Turn on Deep research',
+            'Enable deep research',
         );
     });
 
-    it('disables Deep research while another run is active', async () => {
+    it('disables deep research while another run is active', async () => {
         const user = userEvent.setup();
         const disabledReason =
-            'Only one Deep research run can be active in a thread at a time.';
+            'Only one deep research run can be active in a thread at a time.';
         const activeRunProps = {
             disabled: true,
             disabledReason,
@@ -77,7 +77,7 @@ describe('DeepResearchModeControl', () => {
         );
 
         expect(
-            screen.getByRole('button', { name: 'Turn on Deep research' }),
+            screen.getByRole('button', { name: 'Enable deep research' }),
         ).toBeDisabled();
 
         const explanationTrigger = screen.getByLabelText(disabledReason);
@@ -92,7 +92,7 @@ describe('DeepResearchModeControl', () => {
     it('shows the active-run explanation on keyboard focus', async () => {
         const user = userEvent.setup();
         const disabledReason =
-            'Only one Deep research run can be active in a thread at a time.';
+            'Only one deep research run can be active in a thread at a time.';
 
         renderWithProviders(
             <DeepResearchModeControl

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
 import { describe, expect, it } from 'vitest';
@@ -48,5 +48,58 @@ describe('DeepResearchModeControl', () => {
             screen.getByRole('button', { name: 'Turn on Deep research' }),
         ).toBeInTheDocument();
         expect(screen.queryByText('Deep research')).not.toBeInTheDocument();
+    });
+
+    it('disables Deep research while another run is active', async () => {
+        const user = userEvent.setup();
+        const disabledReason =
+            'Only one Deep research run can be active in a thread at a time.';
+        const activeRunProps = {
+            disabled: true,
+            disabledReason,
+        };
+
+        renderWithProviders(
+            <DeepResearchModeControl
+                mode="ask"
+                onModeChange={() => undefined}
+                {...activeRunProps}
+            />,
+        );
+
+        expect(
+            screen.getByRole('button', { name: 'Turn on Deep research' }),
+        ).toBeDisabled();
+
+        const explanationTrigger = screen.getByLabelText(disabledReason);
+        await user.hover(explanationTrigger);
+
+        const tooltip = await screen.findByRole('tooltip');
+        expect(tooltip).toHaveTextContent(disabledReason);
+        expect(within(tooltip).queryByRole('button')).not.toBeInTheDocument();
+        expect(within(tooltip).queryByRole('link')).not.toBeInTheDocument();
+    });
+
+    it('shows the active-run explanation on keyboard focus', async () => {
+        const user = userEvent.setup();
+        const disabledReason =
+            'Only one Deep research run can be active in a thread at a time.';
+
+        renderWithProviders(
+            <DeepResearchModeControl
+                mode="ask"
+                onModeChange={() => undefined}
+                disabled
+                disabledReason={disabledReason}
+                iconOnly
+            />,
+        );
+
+        await user.tab();
+
+        expect(screen.getByLabelText(disabledReason)).toHaveFocus();
+        expect(await screen.findByRole('tooltip')).toHaveTextContent(
+            disabledReason,
+        );
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.test.tsx
@@ -35,19 +35,28 @@ describe('DeepResearchModeControl', () => {
         ).toHaveAttribute('aria-pressed', 'false');
     });
 
-    it('renders a compact icon toggle without a visible label', () => {
+    it('renders a compact icon toggle with the normal tooltip', async () => {
+        const user = userEvent.setup();
         renderWithProviders(
             <DeepResearchModeControl
                 mode="ask"
                 onModeChange={() => undefined}
                 iconOnly
+                disabledReason="Only one Deep research run can be active in a thread at a time."
             />,
         );
 
-        expect(
-            screen.getByRole('button', { name: 'Turn on Deep research' }),
-        ).toBeInTheDocument();
+        const button = screen.getByRole('button', {
+            name: 'Turn on Deep research',
+        });
+        expect(button).toBeEnabled();
         expect(screen.queryByText('Deep research')).not.toBeInTheDocument();
+
+        await user.hover(button);
+
+        expect(await screen.findByRole('tooltip')).toHaveTextContent(
+            'Turn on Deep research',
+        );
     });
 
     it('disables Deep research while another run is active', async () => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.tsx
@@ -25,8 +25,8 @@ export const DeepResearchModeControl = ({
 }: Props) => {
     const isDeepResearch = mode === 'deep_research';
     const label = isDeepResearch
-        ? 'Turn off Deep research'
-        : 'Turn on Deep research';
+        ? 'Disable deep research'
+        : 'Enable deep research';
     const toggleMode = () =>
         onModeChange(isDeepResearch ? 'ask' : 'deep_research');
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Button, Tooltip } from '@mantine-8/core';
+import { ActionIcon, Box, Button, Tooltip } from '@mantine-8/core';
 import { IconTelescope } from '@tabler/icons-react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 
@@ -10,6 +10,8 @@ type Props = {
     iconOnly?: boolean;
     actionSize?: number | 'sm' | 'md';
     iconSize?: number;
+    disabled?: boolean;
+    disabledReason?: string;
 };
 
 export const DeepResearchModeControl = ({
@@ -18,6 +20,8 @@ export const DeepResearchModeControl = ({
     iconOnly = false,
     actionSize = 'sm',
     iconSize = 14,
+    disabled = false,
+    disabledReason,
 }: Props) => {
     const isDeepResearch = mode === 'deep_research';
     const label = isDeepResearch
@@ -26,30 +30,25 @@ export const DeepResearchModeControl = ({
     const toggleMode = () =>
         onModeChange(isDeepResearch ? 'ask' : 'deep_research');
 
-    if (iconOnly) {
-        return (
-            <Tooltip withArrow position="top" label={label}>
-                <ActionIcon
-                    variant={isDeepResearch ? 'light' : 'subtle'}
-                    color={isDeepResearch ? 'indigo' : 'gray'}
-                    size={actionSize}
-                    radius="xl"
-                    onClick={toggleMode}
-                    aria-label={label}
-                    aria-pressed={isDeepResearch}
-                >
-                    <MantineIcon
-                        icon={IconTelescope}
-                        size={iconSize}
-                        stroke={1.8}
-                        color={isDeepResearch ? 'indigo.5' : 'ldGray.6'}
-                    />
-                </ActionIcon>
-            </Tooltip>
-        );
-    }
-
-    return (
+    const control = iconOnly ? (
+        <ActionIcon
+            variant={isDeepResearch ? 'light' : 'subtle'}
+            color={isDeepResearch ? 'indigo' : 'gray'}
+            size={actionSize}
+            radius="xl"
+            onClick={toggleMode}
+            aria-label={label}
+            aria-pressed={isDeepResearch}
+            disabled={disabled}
+        >
+            <MantineIcon
+                icon={IconTelescope}
+                size={iconSize}
+                stroke={1.8}
+                color={isDeepResearch ? 'indigo.5' : 'ldGray.6'}
+            />
+        </ActionIcon>
+    ) : (
         <Button
             pl="xs"
             pr="xs"
@@ -63,8 +62,33 @@ export const DeepResearchModeControl = ({
             onClick={toggleMode}
             aria-label={label}
             aria-pressed={isDeepResearch}
+            disabled={disabled}
         >
             Deep research
         </Button>
+    );
+
+    if (!iconOnly && (!disabled || !disabledReason)) {
+        return control;
+    }
+
+    const tooltipLabel = disabledReason ?? label;
+
+    return (
+        <Tooltip
+            withArrow
+            position="top"
+            label={tooltipLabel}
+            events={{ hover: true, focus: true, touch: false }}
+        >
+            <Box
+                component="span"
+                display="inline-flex"
+                tabIndex={disabled ? 0 : undefined}
+                aria-label={disabled ? tooltipLabel : undefined}
+            >
+                {control}
+            </Box>
+        </Tooltip>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.tsx
@@ -72,7 +72,7 @@ export const DeepResearchModeControl = ({
         return control;
     }
 
-    const tooltipLabel = disabledReason ?? label;
+    const tooltipLabel = disabled && disabledReason ? disabledReason : label;
 
     return (
         <Tooltip

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.test.tsx
@@ -2,9 +2,13 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { type PropsWithChildren } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { subscribeToDeepResearchComposerPrompt } from '../deepResearch/deepResearchRegistry';
+import {
+    registerDeepResearchRun,
+    subscribeToDeepResearchComposerPrompt,
+} from '../deepResearch/deepResearchRegistry';
 import { type DeepResearchRunRegistration } from '../deepResearch/types';
 import {
+    useHasActiveDeepResearchRun,
     useDeepResearchRun,
     useStartDeepResearchMutation,
     useTrackDeepResearchFollowUp,
@@ -172,6 +176,74 @@ describe('useStartDeepResearchMutation', () => {
             }),
         ]);
         unsubscribe();
+    });
+});
+
+describe('useHasActiveDeepResearchRun', () => {
+    afterEach(() => {
+        window.localStorage.clear();
+        lightdashApiMock.mockReset();
+    });
+
+    it('reports an active persisted run in the current thread', async () => {
+        lightdashApiMock.mockResolvedValue([getRun('running')]);
+
+        const { result } = renderHook(
+            () =>
+                useHasActiveDeepResearchRun({
+                    projectUuid: 'project-1',
+                    threadUuid: 'thread-1',
+                }),
+            { wrapper: getWrapper() },
+        );
+
+        await waitFor(() => expect(result.current).toBe(true));
+    });
+
+    it('reports no active run after a terminal state', async () => {
+        lightdashApiMock.mockResolvedValue([getRun('completed')]);
+
+        const { result } = renderHook(
+            () =>
+                useHasActiveDeepResearchRun({
+                    projectUuid: 'project-1',
+                    threadUuid: 'thread-1',
+                }),
+            { wrapper: getWrapper() },
+        );
+
+        await waitFor(() => expect(lightdashApiMock).toHaveBeenCalledOnce());
+        expect(result.current).toBe(false);
+    });
+
+    it('includes an optimistic start only in its own thread', async () => {
+        lightdashApiMock.mockResolvedValue([]);
+        registerDeepResearchRun({
+            ...registration,
+            runUuid: 'starting-run',
+            threadUuid: 'thread-with-run',
+            state: 'starting',
+        });
+
+        const currentThread = renderHook(
+            () =>
+                useHasActiveDeepResearchRun({
+                    projectUuid: 'project-1',
+                    threadUuid: 'thread-with-run',
+                }),
+            { wrapper: getWrapper() },
+        );
+        const otherThread = renderHook(
+            () =>
+                useHasActiveDeepResearchRun({
+                    projectUuid: 'project-1',
+                    threadUuid: 'thread-without-run',
+                }),
+            { wrapper: getWrapper() },
+        );
+
+        expect(currentThread.result.current).toBe(true);
+        expect(otherThread.result.current).toBe(false);
     });
 });
 

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.ts
@@ -258,7 +258,11 @@ const useDeepResearchThreadRuns = (
     useQuery<AiDeepResearchRun[], ApiError>({
         queryKey: [DEEP_RESEARCH_QUERY_KEY, projectUuid, 'thread', threadUuid],
         queryFn: () => listDeepResearchRuns(projectUuid ?? '', threadUuid),
-        enabled: !!projectUuid,
+        enabled: !!projectUuid && !!threadUuid,
+        refetchInterval: (runs) =>
+            runs?.some((run) => !isAiDeepResearchRunTerminal(run.status))
+                ? DEEP_RESEARCH_POLL_INTERVAL_MS
+                : false,
     });
 
 type DeepResearchEngagementRun = Pick<
@@ -371,6 +375,46 @@ export const useDeepResearchThreadRunRegistrations = ({
             ),
         ];
     }, [serverRuns.data, localRegistrations, threadUuid, userUuid]);
+};
+
+export const useHasActiveDeepResearchRun = ({
+    projectUuid,
+    threadUuid,
+}: {
+    projectUuid: string | undefined;
+    threadUuid: string | undefined;
+}) => {
+    const user = useUser(true);
+    const userUuid = user.data?.userUuid;
+    const serverRuns = useDeepResearchThreadRuns(projectUuid, threadUuid ?? '');
+    const localRegistrations = useDeepResearchRunsForThread(
+        projectUuid ?? '',
+        threadUuid ?? '',
+        userUuid,
+    );
+
+    return useMemo(() => {
+        if (!projectUuid || !threadUuid) {
+            return false;
+        }
+
+        const serverRunUuids = new Set(
+            serverRuns.data?.map((run) => run.aiDeepResearchRunUuid),
+        );
+        const hasLocalActiveRun = localRegistrations.some(
+            (registration) =>
+                registration.state === 'starting' ||
+                (registration.state === 'started' &&
+                    !serverRunUuids.has(registration.runUuid)),
+        );
+
+        return (
+            hasLocalActiveRun ||
+            serverRuns.data?.some(
+                (run) => !isAiDeepResearchRunTerminal(run.status),
+            ) === true
+        );
+    }, [localRegistrations, projectUuid, serverRuns.data, threadUuid]);
 };
 
 export const useDeepResearchRun = (


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9372/disable-deep-research-while-another-run-is-active-in-the-thread

## Summary

Disables the Deep research composer control while the current thread has a starting, queued, or running research run. Regular chat stays available, and the control returns when the run completes, partially completes, fails, or is cancelled.

## Root cause

The one-click control owned only local composer mode. Although the Deep research registry and server list already tracked thread-scoped run lifecycles, the composer never consumed that state.

```tsx
<DeepResearchModeControl
    mode={composerMode}
    onModeChange={setComposerMode}
/>
```

PR #26589 introduced the direct toggle and left same-thread concurrency feedback for this follow-up. Without active-run state, the control stayed interactive throughout an existing run.

## Fix

Derives one active state from optimistic registrations and persisted non-terminal runs, then applies it only to the Deep research path.

- `useDeepResearch.ts` reconciles optimistic and server runs by UUID and polls while a run remains non-terminal.
- `AgentChatInput.tsx` disables duplicate research starts, resets active composers to Ask, and keeps normal messages available.
- `DeepResearchModeControl.tsx` exposes an actionless explanation on hover and keyboard focus for both control variants.
- Backend execution, API contracts, and database state remain unchanged.

## Before

```text
same-thread run active
        |
        v
Deep research toggle enabled ---> second start remains selectable
```

## After

```text
same-thread run active
        |
        +--> Deep research disabled + hover/focus explanation
        |
        +--> Ask composer enabled ------> regular message sends

terminal run state ---------------------> Deep research re-enabled
```

## Test plan

- [x] Focused Vitest: 3 files, 21 tests pass, including the original failing regression.
- [x] Full frontend Vitest: 241 files, 1,903 tests pass.
- [x] `pnpm -F frontend typecheck`
- [x] `pnpm -F frontend lint` — zero errors; unrelated existing warnings only.
- [x] `pnpm -F frontend format`
- [x] Verify optimistic and persisted active states, terminal states, thread isolation, no-thread behavior, regular Send, and actionless hover/focus explanation.