### PR TITLE
fix(homepage): resolve the hero as one wave instead of flickering stages

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.module.css
@@ -4,6 +4,18 @@
     font-size: var(--mantine-font-size-md) !important;
 }
 
+/* The composer's own footprint, reserved while agents and preferences land, so
+   the hint and chip row under it never get shoved. AgentChatInput drops to its
+   minimal chrome (no agent selector) when there is no project to ask about,
+   which is 40px shorter. */
+.inputHold {
+    height: 126px;
+}
+
+.inputHoldMinimal {
+    height: 86px;
+}
+
 /* One chip-line of height reserved up front (pill: 12px text + 8px padding =
    26px) so late-arriving chips don't shove the composer. */
 .pillRow {

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.tsx
@@ -73,6 +73,23 @@ const useAiRouterEnabledFromCache = (): boolean | undefined => {
     return enabled;
 };
 
+const inputHoldClass = (projectUuid: string | null) =>
+    projectUuid ? classes.inputHold : classes.inputHoldMinimal;
+
+// The composer's footprint on a surface that is still deciding whether it can
+// show a composer at all. Lives here so the reserved height is stated once,
+// next to the composer it stands in for.
+export const DayOneAskInputPlaceholder: FC<Props> = ({
+    projectUuid,
+    hideSuggestions,
+}) => (
+    <div className={classes.composer}>
+        <Skeleton className={inputHoldClass(projectUuid)} radius="lg" />
+        {!projectUuid && <Skeleton h={17} w={260} mt={10} mx="auto" />}
+        {!hideSuggestions && <div className={classes.pillRow} />}
+    </div>
+);
+
 // Two chips, not the full generated set. On the homepage the composer is the
 // opening view and the chips are a hint at what it can do — five of them read
 // as a menu to work through, and they cost more vertical space than the
@@ -322,11 +339,9 @@ const DayOneAskInputInner: FC<Props> = ({
         track,
     ]);
 
-    if (isLoadingAgents || isLoadingPreferences) {
-        return <Skeleton h={64} radius="lg" />;
-    }
+    const isComposerLoading = isLoadingAgents || isLoadingPreferences;
 
-    if (projectUuid && (!agents || agents.length === 0)) {
+    if (!isComposerLoading && projectUuid && (!agents || agents.length === 0)) {
         return (
             <div className={blockClasses.dashedEmpty}>
                 Set up an AI agent to enable Ask AI here —{' '}
@@ -343,36 +358,43 @@ const DayOneAskInputInner: FC<Props> = ({
         // whole subtree is `inert`: no focus, no typing, no submit — it just
         // shows what viewers will get.
         <div className={classes.composer} inert={preview}>
-            <AgentChatInput
-                projectUuid={projectUuid ?? undefined}
-                agentUuid={selectedAgent?.uuid}
-                agents={agents}
-                selectedAgent={activeSelection ?? agents?.[0]}
-                placeholder={
-                    activeSelection === 'auto'
-                        ? 'Ask anything about your data…'
-                        : activeSelection
-                          ? `Ask ${activeSelection.name}…`
-                          : 'Ask anything about your data…'
-                }
-                onSubmit={handleSubmit}
-                onStartDeepResearch={
-                    selectedAgent && deepResearchFlag.data?.enabled
-                        ? handleStartDeepResearch
-                        : undefined
-                }
-                loading={isCreatingThread}
-                showSuggestions={false}
-                fullWidth
-                revealControlsOnFocus
-                dense
-                disabled={!projectUuid || !canCreateThread}
-                disabledReason={
-                    projectUuid && !canCreateThread
-                        ? "Your role can view AI agents but can't start conversations. Ask a workspace admin for access."
-                        : undefined
-                }
-            />
+            {/* The hold sits in the input's own slot rather than replacing the
+                whole block, so the hint and chip row keep their place and the
+                composer resolves without moving anything around it. */}
+            {isComposerLoading ? (
+                <Skeleton className={inputHoldClass(projectUuid)} radius="lg" />
+            ) : (
+                <AgentChatInput
+                    projectUuid={projectUuid ?? undefined}
+                    agentUuid={selectedAgent?.uuid}
+                    agents={agents}
+                    selectedAgent={activeSelection ?? agents?.[0]}
+                    placeholder={
+                        activeSelection === 'auto'
+                            ? 'Ask anything about your data…'
+                            : activeSelection
+                              ? `Ask ${activeSelection.name}…`
+                              : 'Ask anything about your data…'
+                    }
+                    onSubmit={handleSubmit}
+                    onStartDeepResearch={
+                        selectedAgent && deepResearchFlag.data?.enabled
+                            ? handleStartDeepResearch
+                            : undefined
+                    }
+                    loading={isCreatingThread}
+                    showSuggestions={false}
+                    fullWidth
+                    revealControlsOnFocus
+                    dense
+                    disabled={!projectUuid || !canCreateThread}
+                    disabledReason={
+                        projectUuid && !canCreateThread
+                            ? "Your role can view AI agents but can't start conversations. Ask a workspace admin for access."
+                            : undefined
+                    }
+                />
+            )}
             {!projectUuid && (
                 <Text size="xs" c="dimmed" ta="center" mt={10}>
                     {canManageProject

--- a/packages/frontend/src/ee/features/homepageBuilder/NoProjectHomepage.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/NoProjectHomepage.test.tsx
@@ -9,6 +9,7 @@ const state = vi.hoisted(() => ({
     isCopilotLoading: false,
     isHomepageBuilderEnabled: true,
     hasPendingActions: false,
+    areActionsLoading: false,
 }));
 
 vi.mock('../../../providers/App/useApp', () => ({
@@ -46,6 +47,8 @@ vi.mock('./hooks/useProjectHomepage', () => ({
 vi.mock('./blocks/useRecommendedActions', () => ({
     useRecommendedActions: () => ({
         hasPendingActions: state.hasPendingActions,
+        isLoading: state.areActionsLoading,
+        visibleActions: ['connect-warehouse'],
         statuses: {
             'connect-warehouse': { url: '/onboarding/data-source' },
         },
@@ -54,10 +57,14 @@ vi.mock('./blocks/useRecommendedActions', () => ({
 
 vi.mock('./blocks/RecommendedActionsChecklist', () => ({
     RecommendedActionsChecklist: () => <div data-testid="setup-checklist" />,
+    RecommendedActionsChecklistPlaceholder: () => (
+        <div data-testid="setup-checklist-hold" />
+    ),
 }));
 
 vi.mock('./DayOneAskInput', () => ({
     DayOneAskInput: () => <div data-testid="ask-input" />,
+    DayOneAskInputPlaceholder: () => <div data-testid="ask-input-hold" />,
 }));
 
 vi.mock('./HomepageStars', () => ({
@@ -86,6 +93,7 @@ describe('NoProjectHomepage', () => {
         state.isCopilotLoading = false;
         state.isHomepageBuilderEnabled = true;
         state.hasPendingActions = false;
+        state.areActionsLoading = false;
     });
 
     it('renders the decorative sky on the stage that holds the hero', () => {
@@ -157,5 +165,33 @@ describe('NoProjectHomepage', () => {
         expect(
             screen.queryByRole('link', { name: /Connect a data warehouse/ }),
         ).toBeNull();
+        // ...while still standing the page up, rather than blanking it
+        expect(
+            screen.getByRole('heading', { name: "Let's get started" }),
+        ).toBeInTheDocument();
+    });
+
+    it('holds the hero in place while the setup statuses resolve', () => {
+        state.areActionsLoading = true;
+        state.hasPendingActions = false;
+        renderHomepage();
+
+        expect(
+            screen.getByRole('heading', { name: "Let's get started" }),
+        ).toBeInTheDocument();
+        expect(screen.getByTestId('setup-checklist-hold')).toBeInTheDocument();
+        expect(screen.getByTestId('ask-input-hold')).toBeInTheDocument();
+        expect(screen.queryByTestId('ask-input')).toBeNull();
+        expect(screen.queryByTestId('setup-checklist')).toBeNull();
+    });
+
+    it('redirects before painting the hold', () => {
+        state.needsProject = false;
+        state.areActionsLoading = true;
+        renderHomepage();
+
+        expect(screen.getByText('redirected')).toBeInTheDocument();
+        expect(screen.queryByTestId('setup-checklist-hold')).toBeNull();
+        expect(screen.queryByTestId('homepage-stars')).toBeNull();
     });
 });

--- a/packages/frontend/src/ee/features/homepageBuilder/NoProjectHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/NoProjectHomepage.tsx
@@ -8,9 +8,12 @@ import PageSpinner from '../../../components/PageSpinner';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { useIsCopilotEnabled } from '../aiCopilot/hooks/useIsCopilotEnabled';
-import { RecommendedActionsChecklist } from './blocks/RecommendedActionsChecklist';
+import {
+    RecommendedActionsChecklist,
+    RecommendedActionsChecklistPlaceholder,
+} from './blocks/RecommendedActionsChecklist';
 import { useRecommendedActions } from './blocks/useRecommendedActions';
-import { DayOneAskInput } from './DayOneAskInput';
+import { DayOneAskInput, DayOneAskInputPlaceholder } from './DayOneAskInput';
 import layout from './homepageLayout.module.css';
 import HomepageStars from './HomepageStars';
 import { useHomepageBuilderFlag } from './hooks/useProjectHomepage';
@@ -23,11 +26,12 @@ const NoProjectHomepage: FC = () => {
         useIsCopilotEnabled();
     const actions = useRecommendedActions(null);
 
+    // The redirects come first and each still waits for its own input, so a
+    // viewer who is about to be sent elsewhere never sees a frame of this page.
     if (
         isInitialLoading ||
         orgSetupPageFlag.isLoading ||
-        homepageBuilderFlag.isLoading ||
-        isCopilotLoading
+        homepageBuilderFlag.isLoading
     ) {
         return <PageSpinner />;
     }
@@ -44,6 +48,12 @@ const NoProjectHomepage: FC = () => {
         return <Navigate to="/" replace />;
     }
 
+    // Past the redirects the page is ours to paint, so the rest of the wait is
+    // held in place rather than behind a spinner: one answer covers which hero
+    // the org gets and what the checklist has to say, and the greeting above
+    // never moves because both regions keep their height throughout.
+    const isReady = !isCopilotLoading && !actions.isLoading;
+
     // Without copilot the composer would be a teaser for something the org
     // can't use — connecting a warehouse becomes the headline act instead.
     const connectWarehouse = actions.statuses['connect-warehouse'];
@@ -57,7 +67,17 @@ const NoProjectHomepage: FC = () => {
                         <Text component="h1" className={layout.heroGreeting}>
                             Let's get started
                         </Text>
-                        {isCopilotEnabled ? (
+                        {!isReady ? (
+                            // Held at the composer's footprint: it is the
+                            // opening this page is designed around, so the
+                            // common path resolves without moving at all.
+                            <Box w="100%">
+                                <DayOneAskInputPlaceholder
+                                    projectUuid={null}
+                                    hideSuggestions
+                                />
+                            </Box>
+                        ) : isCopilotEnabled ? (
                             <Box w="100%">
                                 <DayOneAskInput
                                     projectUuid={null}
@@ -86,8 +106,16 @@ const NoProjectHomepage: FC = () => {
                                 )}
                             </Stack>
                         )}
-                        {actions.hasPendingActions && (
-                            <RecommendedActionsChecklist actions={actions} />
+                        {isReady ? (
+                            actions.hasPendingActions && (
+                                <RecommendedActionsChecklist
+                                    actions={actions}
+                                />
+                            )
+                        ) : (
+                            <RecommendedActionsChecklistPlaceholder
+                                actionCount={actions.visibleActions.length}
+                            />
                         )}
                     </Stack>
                 </Box>

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.test.tsx
@@ -15,12 +15,14 @@ vi.mock('../../../../providers/App/useApp', () => ({
 const state = vi.hoisted(() => ({
     isLoading: false,
     isWarehouseConnected: true,
+    hasPendingActions: false,
 }));
 
 vi.mock('./useRecommendedActions', () => ({
     useRecommendedActions: () => ({
-        hasPendingActions: false,
+        hasPendingActions: state.hasPendingActions,
         isLoading: state.isLoading,
+        visibleActions: ['connect-warehouse'],
         statuses: {
             'connect-warehouse': {
                 isComplete: state.isWarehouseConnected,
@@ -29,10 +31,22 @@ vi.mock('./useRecommendedActions', () => ({
     }),
 }));
 
+vi.mock('./RecommendedActionsChecklist', () => ({
+    RecommendedActionsChecklist: () => <div data-testid="setup-checklist" />,
+    RecommendedActionsChecklistPlaceholder: () => (
+        <div data-testid="setup-checklist-hold" />
+    ),
+}));
+
 const block: HomepageAskAiHeroBlock = {
     id: 'b1',
     type: 'ask-ai-hero',
     config: { showGreeting: true },
+};
+
+const blockWithChecklist: HomepageAskAiHeroBlock = {
+    ...block,
+    config: { showGreeting: true, showRecommendedActions: true },
 };
 
 const wrap = (ui: React.ReactNode) =>
@@ -42,6 +56,7 @@ describe('AskAiHeroBlockView', () => {
     beforeEach(() => {
         state.isLoading = false;
         state.isWarehouseConnected = true;
+        state.hasPendingActions = false;
     });
 
     it('greets in the hero slot', () => {
@@ -115,6 +130,42 @@ describe('AskAiHeroBlockView', () => {
 
         expect(screen.queryByRole('heading')).toBeNull();
         expect(screen.getByTestId('ask-input')).toBeInTheDocument();
+    });
+
+    it('holds the heading and the checklist on the same answer', () => {
+        state.isLoading = true;
+        state.hasPendingActions = false;
+
+        wrap(
+            <AskAiHeroBlockView
+                itemSpan={null}
+                block={blockWithChecklist}
+                projectUuid="p1"
+            />,
+        );
+
+        expect(screen.queryByRole('heading')).toBeNull();
+        expect(screen.getByTestId('setup-checklist-hold')).toBeInTheDocument();
+        expect(screen.queryByTestId('setup-checklist')).toBeNull();
+        // The composer keeps fetching behind its own hold rather than waiting
+        // for the reveal to start
+        expect(screen.getByTestId('ask-input')).toBeInTheDocument();
+    });
+
+    it('reveals the heading and the checklist together', () => {
+        state.hasPendingActions = true;
+
+        wrap(
+            <AskAiHeroBlockView
+                itemSpan={null}
+                block={blockWithChecklist}
+                projectUuid="p1"
+            />,
+        );
+
+        expect(screen.getByRole('heading')).toBeInTheDocument();
+        expect(screen.getByTestId('setup-checklist')).toBeInTheDocument();
+        expect(screen.queryByTestId('setup-checklist-hold')).toBeNull();
     });
 });
 

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.tsx
@@ -13,7 +13,10 @@ import { useAiAgentButtonVisibility } from '../../aiCopilot/hooks/useAiAgentsBut
 import { DayOneAskInput } from '../DayOneAskInput';
 import { getGreeting } from '../greeting';
 import layout from '../homepageLayout.module.css';
-import { RecommendedActionsChecklist } from './RecommendedActionsChecklist';
+import {
+    RecommendedActionsChecklist,
+    RecommendedActionsChecklistPlaceholder,
+} from './RecommendedActionsChecklist';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 import { useRecommendedActions } from './useRecommendedActions';
 
@@ -36,25 +39,39 @@ export const AskAiHero: FC<{
 }) => {
     const { user } = useApp();
     const actions = useRecommendedActions(projectUuid);
-    const showChecklist = showRecommendedActions && actions.hasPendingActions;
+    // One answer for the whole hero: the greeting's wording and whether there
+    // is a checklist at all come from the same statuses, so they arrive
+    // together or not at all. The composer holds its own slot from the first
+    // render — gating its mount here would stop it fetching until the reveal
+    // and land it a beat late.
+    const isReady = !actions.isLoading;
     const isWarehouseConnected =
         actions.statuses['connect-warehouse'].isComplete;
     return (
         <Stack gap={16} align="center" w="100%">
             {showGreeting &&
-                (actions.isLoading ? (
-                    <Skeleton h={34} w={320} radius="sm" />
-                ) : (
+                (isReady ? (
                     <Text component="h1" className={layout.heroGreeting}>
                         {isWarehouseConnected
                             ? `${getGreeting(user.data?.firstName)}. What do you want to know?`
                             : "Let's get started"}
                     </Text>
+                ) : (
+                    <Skeleton h={34} w={320} radius="sm" />
                 ))}
             <Box w="100%">
                 <DayOneAskInput projectUuid={projectUuid} preview={preview} />
             </Box>
-            {showChecklist && <RecommendedActionsChecklist actions={actions} />}
+            {showRecommendedActions &&
+                (isReady ? (
+                    actions.hasPendingActions && (
+                        <RecommendedActionsChecklist actions={actions} />
+                    )
+                ) : (
+                    <RecommendedActionsChecklistPlaceholder
+                        actionCount={actions.visibleActions.length}
+                    />
+                ))}
         </Stack>
     );
 };

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/RecommendedActionsChecklist.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/RecommendedActionsChecklist.module.css
@@ -4,11 +4,14 @@
     margin-inline: auto;
 }
 
+/* Held at the arrow buttons' height so the row measures the same whether or
+ * not the stack is big enough to show them */
 .headerRow {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 12px;
+    min-height: 22px;
 }
 
 .actionRow {

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/RecommendedActionsChecklist.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/RecommendedActionsChecklist.tsx
@@ -1,5 +1,12 @@
 import { type HomepageRecommendedActionKey } from '@lightdash/common';
-import { ActionIcon, Box, Button, Stack, Tooltip } from '@mantine-8/core';
+import {
+    ActionIcon,
+    Box,
+    Button,
+    Skeleton,
+    Stack,
+    Tooltip,
+} from '@mantine-8/core';
 import {
     IconActivity,
     IconArrowBackUp,
@@ -198,6 +205,30 @@ const ActionRow: FC<{
                 </>
             )}
         </Box>
+    );
+};
+
+// Which steps exist is known from health and the project id, long before any
+// of them can say whether they are done — so the hold can reserve the exact
+// height the resolved stack will take, and the cards fill in without shifting
+// anything above them.
+export const RecommendedActionsChecklistPlaceholder: FC<{
+    actionCount: number;
+}> = ({ actionCount }) => {
+    if (actionCount === 0) return null;
+    return (
+        <Stack gap={8} className={styles.checklistRoot}>
+            <Box className={styles.headerRow}>
+                <span className={classes.sectionTitle}>Finish setting up</span>
+            </Box>
+            <Box
+                className={`${styles.cardStack} ${stackHeightClass(
+                    actionCount,
+                )}`}
+            >
+                <Skeleton className={styles.stackCard} h={68} radius={10} />
+            </Box>
+        </Stack>
     );
 };
 

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.test.tsx
@@ -34,6 +34,30 @@ vi.mock('../../../../hooks/useServerOrClientFeatureFlag');
 vi.mock('../../agentOnboarding/hooks/useAgentOnboarding');
 vi.mock('../hooks/useHomepageRecommendedActionSkips');
 
+// The hook reads settledness, not just "is a request in flight", so every
+// mocked query has to say whether it has come back — an unfetched query is
+// still pending even when nothing is loading it.
+const settled = <T,>(data: T) => ({
+    data,
+    isFetched: true,
+    isInitialLoading: false,
+    isSuccess: true,
+});
+
+const unfetched = {
+    data: undefined,
+    isFetched: false,
+    isInitialLoading: false,
+    isSuccess: false,
+};
+
+const loading = {
+    data: undefined,
+    isFetched: false,
+    isInitialLoading: true,
+    isSuccess: false,
+};
+
 const recommendedActionSkipsResult = (
     overrides: Partial<
         ReturnType<typeof useHomepageRecommendedActionSkips>
@@ -63,38 +87,41 @@ const organizationProject = (
 describe('useRecommendedActions', () => {
     beforeEach(() => {
         vi.mocked(useApp).mockReturnValue({
-            health: { data: {} },
+            health: settled({}),
             user: {
                 data: {
                     ability: { can: () => true },
                 },
             },
         } as unknown as ReturnType<typeof useApp>);
-        vi.mocked(useOrganization).mockReturnValue({
-            data: { needsProject: true },
-        } as ReturnType<typeof useOrganization>);
-        vi.mocked(useProject).mockReturnValue({
-            data: undefined,
-        } as ReturnType<typeof useProject>);
-        vi.mocked(useProjects).mockReturnValue({
-            data: [],
-        } as unknown as ReturnType<typeof useProjects>);
-        vi.mocked(useGithubConfig).mockReturnValue({
-            data: undefined,
-        } as ReturnType<typeof useGithubConfig>);
+        vi.mocked(useOrganization).mockReturnValue(
+            settled({ needsProject: true }) as ReturnType<
+                typeof useOrganization
+            >,
+        );
+        vi.mocked(useProject).mockReturnValue(
+            settled(undefined) as ReturnType<typeof useProject>,
+        );
+        vi.mocked(useProjects).mockReturnValue(
+            settled([]) as unknown as ReturnType<typeof useProjects>,
+        );
+        vi.mocked(useGithubConfig).mockReturnValue(
+            settled(undefined) as ReturnType<typeof useGithubConfig>,
+        );
         vi.mocked(useGitlabRepositories).mockReturnValue({
+            ...settled(undefined),
             isSuccess: false,
-        } as ReturnType<typeof useGitlabRepositories>);
+        } as unknown as ReturnType<typeof useGitlabRepositories>);
         vi.mocked(useGetSlack).mockReturnValue({
-            data: undefined,
+            ...settled(undefined),
             isSuccess: false,
-        } as ReturnType<typeof useGetSlack>);
-        vi.mocked(useServerFeatureFlag).mockReturnValue({
-            data: undefined,
-        } as ReturnType<typeof useServerFeatureFlag>);
-        vi.mocked(useActiveAgentOnboardingRun).mockReturnValue({
-            data: null,
-        } as ReturnType<typeof useActiveAgentOnboardingRun>);
+        } as unknown as ReturnType<typeof useGetSlack>);
+        vi.mocked(useServerFeatureFlag).mockReturnValue(
+            settled(undefined) as ReturnType<typeof useServerFeatureFlag>,
+        );
+        vi.mocked(useActiveAgentOnboardingRun).mockReturnValue(
+            settled(null) as ReturnType<typeof useActiveAgentOnboardingRun>,
+        );
         vi.mocked(useHomepageRecommendedActionSkips).mockReturnValue(
             recommendedActionSkipsResult(),
         );
@@ -132,8 +159,8 @@ describe('useRecommendedActions', () => {
     it('does not report pending actions while skipped actions are loading', () => {
         vi.mocked(useServerFeatureFlag).mockImplementation(
             (flag) =>
-                ({
-                    data: { enabled: flag === FeatureFlags.NewOnboarding },
+                settled({
+                    enabled: flag === FeatureFlags.NewOnboarding,
                 }) as ReturnType<typeof useServerFeatureFlag>,
         );
         vi.mocked(useHomepageRecommendedActionSkips).mockReturnValue(
@@ -149,17 +176,16 @@ describe('useRecommendedActions', () => {
 
     it('reports no pending actions while source control is still loading', () => {
         vi.mocked(useApp).mockReturnValue({
-            health: { data: { hasGithub: true } },
+            health: settled({ hasGithub: true }),
             user: {
                 data: {
                     ability: { can: () => true },
                 },
             },
         } as unknown as ReturnType<typeof useApp>);
-        vi.mocked(useGithubConfig).mockReturnValue({
-            data: undefined,
-            isInitialLoading: true,
-        } as ReturnType<typeof useGithubConfig>);
+        vi.mocked(useGithubConfig).mockReturnValue(
+            loading as ReturnType<typeof useGithubConfig>,
+        );
 
         const { result } = renderHook(() =>
             useRecommendedActions('project-uuid'),
@@ -170,7 +196,7 @@ describe('useRecommendedActions', () => {
 
     it('shows no source-control annotation when nothing is connected', () => {
         vi.mocked(useApp).mockReturnValue({
-            health: { data: { hasGitlab: true } },
+            health: settled({ hasGitlab: true }),
             user: {
                 data: {
                     ability: { can: () => true },
@@ -255,8 +281,8 @@ describe('useRecommendedActions', () => {
         it('has pending actions once new-onboarding is enabled', () => {
             vi.mocked(useServerFeatureFlag).mockImplementation(
                 (flag) =>
-                    ({
-                        data: { enabled: flag === FeatureFlags.NewOnboarding },
+                    settled({
+                        enabled: flag === FeatureFlags.NewOnboarding,
                     }) as ReturnType<typeof useServerFeatureFlag>,
             );
 
@@ -270,20 +296,24 @@ describe('useRecommendedActions', () => {
 
     describe('on a playground project', () => {
         beforeEach(() => {
-            vi.mocked(useOrganization).mockReturnValue({
-                data: { needsProject: false },
-            } as ReturnType<typeof useOrganization>);
-            vi.mocked(useProject).mockReturnValue({
-                data: { provisioningSource: 'playground' },
-            } as unknown as ReturnType<typeof useProject>);
-            vi.mocked(useProjects).mockReturnValue({
-                data: [
+            vi.mocked(useOrganization).mockReturnValue(
+                settled({ needsProject: false }) as ReturnType<
+                    typeof useOrganization
+                >,
+            );
+            vi.mocked(useProject).mockReturnValue(
+                settled({
+                    provisioningSource: 'playground',
+                }) as unknown as ReturnType<typeof useProject>,
+            );
+            vi.mocked(useProjects).mockReturnValue(
+                settled([
                     organizationProject({
                         projectUuid: 'playground-uuid',
                         provisioningSource: 'playground',
                     }),
-                ],
-            } as unknown as ReturnType<typeof useProjects>);
+                ]) as unknown as ReturnType<typeof useProjects>,
+            );
         });
 
         it('offers no actions so the setup checklist stays hidden', () => {
@@ -306,15 +336,15 @@ describe('useRecommendedActions', () => {
         });
 
         it('completes connect-warehouse once a real project exists', () => {
-            vi.mocked(useProjects).mockReturnValue({
-                data: [
+            vi.mocked(useProjects).mockReturnValue(
+                settled([
                     organizationProject({
                         projectUuid: 'playground-uuid',
                         provisioningSource: 'playground',
                     }),
                     organizationProject({ projectUuid: 'real-uuid' }),
-                ],
-            } as unknown as ReturnType<typeof useProjects>);
+                ]) as unknown as ReturnType<typeof useProjects>,
+            );
 
             const { result } = renderHook(() =>
                 useRecommendedActions('playground-uuid'),
@@ -330,9 +360,9 @@ describe('useRecommendedActions', () => {
         it('links to the current project agent setup flow when both flags are enabled', () => {
             vi.mocked(useServerFeatureFlag).mockImplementation(
                 () =>
-                    ({
-                        data: { enabled: true },
-                    }) as ReturnType<typeof useServerFeatureFlag>,
+                    settled({ enabled: true }) as ReturnType<
+                        typeof useServerFeatureFlag
+                    >,
             );
 
             const { result } = renderHook(() =>
@@ -350,16 +380,16 @@ describe('useRecommendedActions', () => {
         it('resumes an in-flight agent run instead of restarting the flow', () => {
             vi.mocked(useServerFeatureFlag).mockImplementation(
                 () =>
-                    ({
-                        data: { enabled: true },
-                    }) as ReturnType<typeof useServerFeatureFlag>,
+                    settled({ enabled: true }) as ReturnType<
+                        typeof useServerFeatureFlag
+                    >,
             );
-            vi.mocked(useActiveAgentOnboardingRun).mockReturnValue({
-                data: {
+            vi.mocked(useActiveAgentOnboardingRun).mockReturnValue(
+                settled({
                     agentOnboardingRunUuid: 'run-uuid',
                     projectUuid: 'project-uuid',
-                },
-            } as ReturnType<typeof useActiveAgentOnboardingRun>);
+                }) as ReturnType<typeof useActiveAgentOnboardingRun>,
+            );
 
             const { result } = renderHook(() =>
                 useRecommendedActions('project-uuid'),
@@ -376,8 +406,8 @@ describe('useRecommendedActions', () => {
         it('keeps the settings link when coding-agent onboarding is disabled', () => {
             vi.mocked(useServerFeatureFlag).mockImplementation(
                 (flag) =>
-                    ({
-                        data: { enabled: flag === FeatureFlags.NewOnboarding },
+                    settled({
+                        enabled: flag === FeatureFlags.NewOnboarding,
                     }) as ReturnType<typeof useServerFeatureFlag>,
             );
 
@@ -395,11 +425,8 @@ describe('useRecommendedActions', () => {
         it('keeps the settings link when new-onboarding is disabled', () => {
             vi.mocked(useServerFeatureFlag).mockImplementation(
                 (flag) =>
-                    ({
-                        data: {
-                            enabled:
-                                flag === FeatureFlags.CodingAgentOnboarding,
-                        },
+                    settled({
+                        enabled: flag === FeatureFlags.CodingAgentOnboarding,
                     }) as ReturnType<typeof useServerFeatureFlag>,
             );
 
@@ -412,6 +439,173 @@ describe('useRecommendedActions', () => {
             ).toStrictEqual(
                 '/generalSettings/projectManagement/project-uuid/settings',
             );
+        });
+    });
+
+    describe('readiness through the query cascade', () => {
+        // Health decides which integrations are in play and the feature flags
+        // decide whether the agent run is looked up, so those queries do not
+        // start on the first render — they sit idle, reporting exactly what a
+        // finished query reports. These stages walk that real sequence.
+        const healthInFlight = () => {
+            vi.mocked(useApp).mockReturnValue({
+                health: loading,
+                user: { data: { ability: { can: () => true } } },
+            } as unknown as ReturnType<typeof useApp>);
+            vi.mocked(useOrganization).mockReturnValue(
+                loading as ReturnType<typeof useOrganization>,
+            );
+            vi.mocked(useProject).mockReturnValue(
+                loading as ReturnType<typeof useProject>,
+            );
+            vi.mocked(useProjects).mockReturnValue(
+                loading as unknown as ReturnType<typeof useProjects>,
+            );
+            vi.mocked(useGithubConfig).mockReturnValue(
+                loading as ReturnType<typeof useGithubConfig>,
+            );
+            vi.mocked(useGetSlack).mockReturnValue(
+                loading as unknown as ReturnType<typeof useGetSlack>,
+            );
+            vi.mocked(useServerFeatureFlag).mockReturnValue(
+                loading as ReturnType<typeof useServerFeatureFlag>,
+            );
+            // Gated on health, so not started: idle, not loading
+            vi.mocked(useGitlabRepositories).mockReturnValue(
+                unfetched as unknown as ReturnType<
+                    typeof useGitlabRepositories
+                >,
+            );
+            // Gated on the flags, so not started either
+            vi.mocked(useActiveAgentOnboardingRun).mockReturnValue(
+                unfetched as ReturnType<typeof useActiveAgentOnboardingRun>,
+            );
+        };
+
+        const healthResolvedDependentsUnstarted = () => {
+            vi.mocked(useApp).mockReturnValue({
+                health: settled({
+                    hasGithub: true,
+                    hasGitlab: true,
+                    hasSlack: true,
+                }),
+                user: { data: { ability: { can: () => true } } },
+            } as unknown as ReturnType<typeof useApp>);
+            vi.mocked(useOrganization).mockReturnValue(
+                settled({ needsProject: true }) as ReturnType<
+                    typeof useOrganization
+                >,
+            );
+            vi.mocked(useProject).mockReturnValue(
+                settled(undefined) as ReturnType<typeof useProject>,
+            );
+            vi.mocked(useProjects).mockReturnValue(
+                settled([]) as unknown as ReturnType<typeof useProjects>,
+            );
+        };
+
+        const flagsResolved = () => {
+            vi.mocked(useServerFeatureFlag).mockReturnValue(
+                settled({ enabled: true }) as ReturnType<
+                    typeof useServerFeatureFlag
+                >,
+            );
+        };
+
+        const integrationsResolved = () => {
+            vi.mocked(useGithubConfig).mockReturnValue(
+                settled(undefined) as ReturnType<typeof useGithubConfig>,
+            );
+            vi.mocked(useGitlabRepositories).mockReturnValue({
+                ...settled(undefined),
+                isSuccess: false,
+            } as unknown as ReturnType<typeof useGitlabRepositories>);
+            vi.mocked(useGetSlack).mockReturnValue({
+                ...settled(undefined),
+                isSuccess: false,
+            } as unknown as ReturnType<typeof useGetSlack>);
+        };
+
+        const flagsResolvedAgentRunUnstarted = () => {
+            flagsResolved();
+            integrationsResolved();
+        };
+
+        // The flags opened its gate, so it is now genuinely in flight
+        const agentRunInFlight = () => {
+            vi.mocked(useActiveAgentOnboardingRun).mockReturnValue(
+                loading as ReturnType<typeof useActiveAgentOnboardingRun>,
+            );
+        };
+
+        const allSettled = () => {
+            vi.mocked(useActiveAgentOnboardingRun).mockReturnValue(
+                settled(null) as ReturnType<typeof useActiveAgentOnboardingRun>,
+            );
+        };
+
+        const recordCascade = (stages: (() => void)[]) => {
+            stages[0]();
+            const { result, rerender } = renderHook(() =>
+                useRecommendedActions('project-uuid'),
+            );
+            const seen = [result.current.isLoading];
+            stages.slice(1).forEach((stage) => {
+                stage();
+                rerender();
+                seen.push(result.current.isLoading);
+            });
+            return seen;
+        };
+
+        it('stays loading until every dependent query has started and come back', () => {
+            expect(
+                recordCascade([
+                    healthInFlight,
+                    healthResolvedDependentsUnstarted,
+                    flagsResolvedAgentRunUnstarted,
+                    allSettled,
+                ]),
+            ).toEqual([true, true, true, false]);
+        });
+
+        it('never returns to loading once it has reported ready', () => {
+            const seen = recordCascade([
+                healthInFlight,
+                healthResolvedDependentsUnstarted,
+                flagsResolvedAgentRunUnstarted,
+                // The moment that used to flip readiness back off: the flags
+                // land, the agent-run query they gate finally starts, and the
+                // heading it feeds regresses to a skeleton
+                agentRunInFlight,
+                allSettled,
+            ]);
+
+            const regressions = seen.filter(
+                (isLoading, index) =>
+                    index > 0 && isLoading && !seen[index - 1],
+            );
+            expect(regressions).toEqual([]);
+        });
+
+        it('rules out an integration health says the instance does not have', () => {
+            const seen = recordCascade([
+                healthInFlight,
+                () => {
+                    healthResolvedDependentsUnstarted();
+                    vi.mocked(useApp).mockReturnValue({
+                        health: settled({}),
+                        user: { data: { ability: { can: () => true } } },
+                    } as unknown as ReturnType<typeof useApp>);
+                },
+                flagsResolved,
+                allSettled,
+            ]);
+
+            // GitHub, GitLab and Slack are off on this instance, so their
+            // queries stay unresolved for the whole run and still hold nothing
+            // up — the flag-gated agent run is the only remaining term
+            expect(seen).toEqual([true, true, true, false]);
         });
     });
 });

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
@@ -27,6 +27,18 @@ import { RECOMMENDED_ACTION_KEYS } from './recommendedActionDefaults';
 
 const DEFAULT_CTA_LABEL = 'Set up';
 
+// A query whose `enabled` comes from another query's answer sits idle — not
+// loading, not resolved — until that answer lands, and an idle query reports
+// exactly the same `isInitialLoading` as a finished one. Reading idle as
+// settled is what makes readiness go ready → not ready → ready as each gate
+// opens. A term is instead pending until its gate is known, and then until the
+// query it gates has come back; a closed gate rules the term out for good, so
+// the predicate can only ever travel pending → settled.
+const isTermPending = (
+    isGateOpen: boolean | undefined,
+    query: { isFetched: boolean },
+) => isGateOpen === undefined || (isGateOpen && !query.isFetched);
+
 export type ActionStatus = {
     isVisible: boolean;
     isComplete: boolean;
@@ -58,6 +70,8 @@ const useActionStatuses = (
     const codingAgentOnboardingFlag = useServerFeatureFlag(
         FeatureFlags.CodingAgentOnboarding,
     );
+    const areFlagsSettled =
+        newOnboardingFlag.isFetched && codingAgentOnboardingFlag.isFetched;
     const hasAgentSemanticLayerEntry =
         newOnboardingFlag.data?.enabled === true &&
         codingAgentOnboardingFlag.data?.enabled === true;
@@ -70,8 +84,10 @@ const useActionStatuses = (
     );
     const activeAgentRun = activeAgentRunQuery.data ?? null;
 
+    const isHealthSettled = health.isFetched;
     const hasGithub = !!health.data?.hasGithub;
     const hasGitlab = !!health.data?.hasGitlab;
+    const hasSlack = !!health.data?.hasSlack;
     const gitlabQuery = useGitlabRepositories({
         enabled: hasGitlab,
     });
@@ -79,16 +95,28 @@ const useActionStatuses = (
     const isGithubConnected = githubConfig?.enabled === true;
 
     // Every step defaults to incomplete, so rendering before these have
-    // settled flashes steps that are already done
+    // settled flashes steps that are already done. Health decides which
+    // integrations are even in play and the flags decide whether the agent run
+    // is looked up, so those answers gate the terms below rather than each
+    // query's own idle state.
     const isLoading =
-        health.isInitialLoading ||
-        organizationQuery.isInitialLoading ||
-        projectQuery.isInitialLoading ||
-        projectsQuery.isInitialLoading ||
-        (hasGithub && githubConfigQuery.isInitialLoading) ||
-        (hasGitlab && gitlabQuery.isInitialLoading) ||
-        activeAgentRunQuery.isInitialLoading ||
-        (!!health.data?.hasSlack && slackQuery.isInitialLoading);
+        isTermPending(true, health) ||
+        isTermPending(true, organizationQuery) ||
+        isTermPending(!!projectUuid, projectQuery) ||
+        isTermPending(true, projectsQuery) ||
+        isTermPending(
+            isHealthSettled ? hasGithub : undefined,
+            githubConfigQuery,
+        ) ||
+        isTermPending(isHealthSettled ? hasGitlab : undefined, gitlabQuery) ||
+        isTermPending(isHealthSettled ? hasSlack : undefined, slackQuery) ||
+        isTermPending(
+            areFlagsSettled
+                ? !!projectUuid && hasAgentSemanticLayerEntry
+                : undefined,
+            activeAgentRunQuery,
+        ) ||
+        !areFlagsSettled;
 
     const dbtConnection = project?.dbtConnection;
     const hasSemanticLayer =
@@ -160,7 +188,7 @@ const useActionStatuses = (
                 ctaLabel: DEFAULT_CTA_LABEL,
             },
             'connect-slack': {
-                isVisible: !!health.data?.hasSlack,
+                isVisible: hasSlack,
                 isComplete: isSlackConnected,
                 annotation: slack?.slackTeamName ?? 'Connected',
                 doneIcon: null,
@@ -173,7 +201,8 @@ const useActionStatuses = (
 
 export const useRecommendedActions = (projectUuid: string | null) => {
     const { user } = useApp();
-    const { statuses, isLoading } = useActionStatuses(projectUuid);
+    const { statuses, isLoading: areStatusesLoading } =
+        useActionStatuses(projectUuid);
     const newOnboardingFlag = useServerFeatureFlag(FeatureFlags.NewOnboarding);
     const { data: project } = useProject(projectUuid ?? undefined);
     const isPlaygroundProject = isPlaygroundProvisioningSource(
@@ -198,6 +227,11 @@ export const useRecommendedActions = (projectUuid: string | null) => {
         enabled: canManageProject,
     });
 
+    // Skips are the last thing the checklist needs, so they belong in the same
+    // readiness answer — a caller that revealed on statuses alone would still
+    // have the checklist arrive in a wave of its own.
+    const isLoading = areStatusesLoading || skippedActionsLoading;
+
     // The playground is a throwaway sample-data project — the setup checklist
     // has no place there, so nothing is offered and the block hides itself.
     const visibleActions = isPlaygroundProject
@@ -207,7 +241,6 @@ export const useRecommendedActions = (projectUuid: string | null) => {
     const hasPendingActions =
         newOnboardingFlag.data?.enabled === true &&
         !isLoading &&
-        !skippedActionsLoading &&
         canManageProject &&
         visibleActions.some(
             (key) => !statuses[key].isComplete && !skippedActionKeys.has(key),


### PR DESCRIPTION
## Summary
A slowed-down recording of the homepage load showed the hero resolving in flickering stages: heading and composer skeletons with the chips already painted, the heading popping in, regressing back to a skeleton, returning, and the setup checklist arriving last with a 62px layout shove.

- **Root cause of the skeleton bounce**: `useRecommendedActions`' `isLoading` flipped false→true→false because its dependent queries (github/gitlab/slack config) only enable once `health` resolves. The hook now reports a single monotonic settling — new tests drive the real enablement cascade and assert the flag never rises after falling.
- **Single-wave reveal**: heading, composer, and checklist gate on one ready-condition derived from data the pages already load; each region holds stable geometry until the wave resolves (no new fetches, no copy swaps after paint).
- **No layout jump**: the checklist row reserves its height while statuses resolve, collapsing only on a settled no-pending result. Measured on the no-project hero: heading position moves 0px through the entire load (was 62px).
- `NoProjectHomepage`'s full-page spinner now covers only the redirect decision inputs; a user who is staying gets the stable-geometry hold instead of a blank page. Redirect semantics unchanged.

Stacked on #26631 (it reworks the heading gate introduced there).

## Testing
- homepageBuilder suite (228 tests) green, including new cascade/monotonicity tests; frontend typecheck + lint
- Before/after frame sequences captured on a throttled load of both hero variants; the recorded regression reproduced exactly pre-fix and is absent post-fix

Closes: SPK-777