### PR TITLE
fix: keep compaction summary before agent memory

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -376,6 +376,11 @@ type ThreadCompaction = NonNullable<
     Awaited<ReturnType<AiAgentModel['findLatestThreadCompaction']>>
 >;
 
+type AgentConversationContext = {
+    messageHistory: ModelMessage[];
+    compactionSummary: string | null;
+};
+
 type AgentResponseStream = {
     pipeUIMessageStreamToResponse: (
         response: Parameters<
@@ -4823,7 +4828,6 @@ export class AiAgentService extends BaseService {
                 retrieveRelevantArtifacts:
                     retrieveRelevantArtifacts &&
                     this.getIsVerifiedArtifactsEnabled(),
-                compaction: applicableCompaction,
                 currentPromptUuid: prompt.promptUuid,
             },
         );
@@ -4859,6 +4863,7 @@ export class AiAgentService extends BaseService {
                 user: validatedUser,
                 chatHistoryMessages,
                 prompt,
+                compaction,
             } = await this.prepareAgentThreadResponse(user, {
                 agentUuid,
                 threadUuid,
@@ -4903,7 +4908,10 @@ export class AiAgentService extends BaseService {
 
             return await this.generateOrStreamAgentResponse(
                 validatedUser,
-                chatHistoryMessages,
+                {
+                    messageHistory: chatHistoryMessages,
+                    compactionSummary: compaction?.summary ?? null,
+                },
                 {
                     prompt,
                     stream: true,
@@ -5344,6 +5352,7 @@ export class AiAgentService extends BaseService {
                 user: validatedUser,
                 chatHistoryMessages,
                 prompt,
+                compaction,
             } = await this.prepareAgentThreadResponse(user, {
                 agentUuid,
                 threadUuid,
@@ -5367,7 +5376,10 @@ export class AiAgentService extends BaseService {
 
             const response = await this.generateOrStreamAgentResponse(
                 validatedUser,
-                chatHistoryMessages,
+                {
+                    messageHistory: chatHistoryMessages,
+                    compactionSummary: compaction?.summary ?? null,
+                },
                 {
                     prompt,
                     stream: false,
@@ -5402,7 +5414,7 @@ export class AiAgentService extends BaseService {
     ): Promise<string> {
         try {
             // Reuse existing validation and data fetching logic
-            const { chatHistoryMessages } =
+            const { chatHistoryMessages, compaction } =
                 await this.prepareAgentThreadResponse(user, {
                     agentUuid,
                     threadUuid,
@@ -5428,10 +5440,12 @@ export class AiAgentService extends BaseService {
             };
 
             // Generate title using the dedicated title generator
-            const title = await generateTitleFromMessages(
-                modelOptions,
-                chatHistoryMessages,
-            );
+            const title = await generateTitleFromMessages(modelOptions, [
+                ...(compaction
+                    ? [Compaction.createSummaryMessage(compaction.summary)]
+                    : []),
+                ...chatHistoryMessages,
+            ]);
 
             // Save the title to the database
             await this.aiAgentModel.updateThreadTitle({
@@ -7220,7 +7234,6 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             projectUuid: string;
             agentUuid: string;
             retrieveRelevantArtifacts: boolean;
-            compaction: ThreadCompaction | null;
             currentPromptUuid: string;
         },
     ): Promise<ModelMessage[]> {
@@ -7335,25 +7348,16 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             messagesWithToolCalls.flat(),
         );
 
-        if (!options.compaction) {
-            if (history.length === 0) {
-                return [
-                    {
-                        role: 'user',
-                        content:
-                            "The user hasn't asked anything yet. Greet them and ask what they'd like to know about their data.",
-                    } satisfies UserModelMessage,
-                ];
-            }
-            return history;
+        if (history.length === 0) {
+            return [
+                {
+                    role: 'user',
+                    content:
+                        "The user hasn't asked anything yet. Greet them and ask what they'd like to know about their data.",
+                } satisfies UserModelMessage,
+            ];
         }
-
-        // `agentV2.getAgentMessages()` prepends the canonical system prompt first,
-        // so the compaction summary is injected immediately after that prompt.
-        return [
-            Compaction.createSummaryMessage(options.compaction.summary),
-            ...history,
-        ];
+        return history;
     }
 
     private async waitForOriginalResponseWritten(
@@ -8504,7 +8508,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
 
     async generateOrStreamAgentResponse(
         user: SessionUser,
-        messageHistory: ModelMessage[],
+        conversation: AgentConversationContext,
         options: {
             prompt: AiWebAppPrompt;
             stream: true;
@@ -8523,7 +8527,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
     ): Promise<AgentResponseStream>;
     async generateOrStreamAgentResponse(
         user: SessionUser,
-        messageHistory: ModelMessage[],
+        conversation: AgentConversationContext,
         options: {
             prompt: AiWebAppPrompt;
             stream: false;
@@ -8552,7 +8556,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
     ): Promise<string>;
     async generateOrStreamAgentResponse(
         user: SessionUser,
-        messageHistory: ModelMessage[],
+        conversation: AgentConversationContext,
         options: {
             prompt: SlackPrompt;
             stream: false;
@@ -8574,8 +8578,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
     ): Promise<string>;
     async generateOrStreamAgentResponse(
         user: SessionUser,
-
-        messageHistory: ModelMessage[],
+        conversation: AgentConversationContext,
         options: {
             canManageAgent: boolean;
             enableSqlMode?: boolean;
@@ -8621,6 +8624,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         }
 
         const { prompt, stream } = options;
+        const { messageHistory, compactionSummary } = conversation;
 
         // Web prompts get a transient `data-step-progress` channel on the
         // SSE stream so the bubble can show "Starting sandbox…" /
@@ -9085,6 +9089,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             aiAgentMemoryEnabled,
             mcpServers,
 
+            compactionSummary,
             messageHistory,
             threadUuid: prompt.threadUuid,
             promptUuid: prompt.promptUuid,
@@ -10671,7 +10676,10 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         try {
             const response = await this.generateOrStreamAgentResponse(
                 user,
-                chatHistoryMessages,
+                {
+                    messageHistory: chatHistoryMessages,
+                    compactionSummary: null,
+                },
                 {
                     prompt: slackPrompt,
                     stream: false,
@@ -10967,9 +10975,6 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     retrieveRelevantArtifacts:
                         agent !== undefined &&
                         this.getIsVerifiedArtifactsEnabled(),
-                    // TODO: add Slack compaction support once Slack has an
-                    // equivalent persisted marker / summary UX.
-                    compaction: null,
                     currentPromptUuid: promptUuid,
                 });
 

--- a/packages/backend/src/ee/services/AiAgentService/deepResearchContextMessage.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/deepResearchContextMessage.test.ts
@@ -108,7 +108,6 @@ describe('AiAgentService deep research conversation history', () => {
                 projectUuid: 'project-1',
                 agentUuid: 'agent-1',
                 retrieveRelevantArtifacts: false,
-                compaction: null,
                 currentPromptUuid: 'follow-up-prompt',
             },
         );

--- a/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
@@ -5,9 +5,9 @@ import {
 } from '../../../../analytics/aiUsage';
 import type { AiAgentArgs, AiAgentDependencies } from '../types/aiAgent';
 import {
+    buildAgentMessages,
     buildDeepResearchExecutionContextSnapshot,
     buildForcedFirstStep,
-    buildMessagesWithMemoryBlock,
     getAgentTools,
     getDeepResearchBudgetInstruction,
     normalizeToolOutput,
@@ -587,7 +587,7 @@ describe('getAgentTools workstream tool gate', () => {
     });
 });
 
-describe('getAgentMessages memory injection', () => {
+describe('buildAgentMessages', () => {
     const systemPrompt: ModelMessage = {
         role: 'system',
         content: 'Cached system prompt',
@@ -600,16 +600,16 @@ describe('getAgentMessages memory injection', () => {
     ];
 
     it('injects an uncached user message immediately after the system prompt', () => {
-        const withoutBlock = buildMessagesWithMemoryBlock({
+        const withoutBlock = buildAgentMessages({
             systemPrompt,
+            compactionSummary: null,
             messageHistory,
-            memoryEnabled: true,
             memoryBlock: null,
         });
-        const withBlock = buildMessagesWithMemoryBlock({
+        const withBlock = buildAgentMessages({
             systemPrompt,
+            compactionSummary: null,
             messageHistory,
-            memoryEnabled: true,
             memoryBlock: '<ld-memories></ld-memories>',
         });
 
@@ -623,21 +623,15 @@ describe('getAgentMessages memory injection', () => {
         expect(withBlock[2]).toEqual({ role: 'user', content: 'Question' });
     });
 
-    it.each([
-        { memoryEnabled: false, block: '<ld-memories></ld-memories>' },
-        { memoryEnabled: true, block: null },
-    ])(
-        'does not inject for disabled or empty memory',
-        ({ memoryEnabled, block }) => {
-            const messages = buildMessagesWithMemoryBlock({
-                systemPrompt,
-                messageHistory,
-                memoryEnabled,
-                memoryBlock: block,
-            });
+    it('does not inject memory without a block', () => {
+        const messages = buildAgentMessages({
+            systemPrompt,
+            compactionSummary: null,
+            messageHistory,
+            memoryBlock: null,
+        });
 
-            expect(messages).toHaveLength(2);
-            expect(messages[1]).toEqual({ role: 'user', content: 'Question' });
-        },
-    );
+        expect(messages).toHaveLength(2);
+        expect(messages[1]).toEqual({ role: 'user', content: 'Question' });
+    });
 });

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -28,6 +28,7 @@ import {
     getAiDeepResearchJudgeInstructions,
     getAiDeepResearchPlannerInstructions,
 } from '../../AiDeepResearchService/AiDeepResearchAgent';
+import { Compaction } from '../compaction';
 import { AI_DEEP_RESEARCH_INSTRUCTIONS } from '../prompts/deepResearch';
 import { getSystemPromptV2 } from '../prompts/systemV2';
 import { getAnalyzeFieldImpact } from '../tools/analyzeFieldImpact';
@@ -1089,21 +1090,22 @@ const getUnauthenticatedMcpServerNames = (
         .map((server) => server.serverName);
 };
 
-export const buildMessagesWithMemoryBlock = ({
+export const buildAgentMessages = ({
     systemPrompt,
+    compactionSummary,
     messageHistory,
-    memoryEnabled,
     memoryBlock,
 }: {
     systemPrompt: ModelMessage;
+    compactionSummary: string | null;
     messageHistory: ModelMessage[];
-    memoryEnabled: boolean;
     memoryBlock: string | null;
 }): ModelMessage[] => [
     systemPrompt,
-    ...(memoryEnabled && memoryBlock
-        ? [{ role: 'user' as const, content: memoryBlock }]
+    ...(compactionSummary
+        ? [Compaction.createSummaryMessage(compactionSummary)]
         : []),
+    ...(memoryBlock ? [{ role: 'user' as const, content: memoryBlock }] : []),
     ...messageHistory,
 ];
 
@@ -1202,10 +1204,10 @@ const getAgentMessages = (
             mcpToolSetup,
         ),
     });
-    const messages = buildMessagesWithMemoryBlock({
+    const messages = buildAgentMessages({
         systemPrompt,
+        compactionSummary: args.compactionSummary,
         messageHistory,
-        memoryEnabled: args.aiAgentMemoryEnabled,
         memoryBlock,
     });
 

--- a/packages/backend/src/ee/services/ai/agents/compactionMemory.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/compactionMemory.test.ts
@@ -1,0 +1,74 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { streamText, type ModelMessage } from 'ai';
+import { buildAgentMessages } from './agentV2';
+
+const systemPrompt: ModelMessage = {
+    role: 'system',
+    content: 'You are Aurora.',
+};
+
+const history: ModelMessage[] = [
+    { role: 'user', content: "who's using the metrics explorer?" },
+    { role: 'assistant', content: 'Here you go.' },
+    { role: 'user', content: 'always filter out Lightdash Internal' },
+];
+
+const offlineRequestError = 'offline Anthropic request reached';
+
+const streamErrors = async (messages: ModelMessage[]): Promise<string[]> => {
+    const anthropic = createAnthropic({
+        apiKey: 'test-key',
+        fetch: async () => {
+            throw new Error(offlineRequestError);
+        },
+    });
+    const result = streamText({
+        model: anthropic('claude-sonnet-5'),
+        messages,
+    });
+    const errors: string[] = [];
+    // eslint-disable-next-line no-restricted-syntax
+    for await (const part of result.fullStream) {
+        if (part.type === 'error') {
+            errors.push(String((part.error as Error)?.message ?? part.error));
+        }
+    }
+    return errors;
+};
+
+describe('compaction and memory block ordering', () => {
+    it('keeps the compaction summary before the memory block for Anthropic', async () => {
+        const messages = buildAgentMessages({
+            systemPrompt,
+            compactionSummary: 'earlier summary',
+            messageHistory: history,
+            memoryBlock: '## Memories\n- user prefers org-level breakdowns',
+        });
+
+        expect(messages.map((m) => m.role)).toEqual([
+            'system',
+            'system',
+            'user',
+            'user',
+            'assistant',
+            'user',
+        ]);
+
+        const errors = await streamErrors(messages);
+        expect(errors.join('\n')).toContain(offlineRequestError);
+        expect(errors.join('\n')).not.toMatch(/Multiple system messages/);
+    });
+
+    it('does not throw when memory is disabled', async () => {
+        const messages = buildAgentMessages({
+            systemPrompt,
+            compactionSummary: 'earlier summary',
+            messageHistory: history,
+            memoryBlock: null,
+        });
+
+        const errors = await streamErrors(messages);
+        expect(errors.join('\n')).toContain(offlineRequestError);
+        expect(errors.join('\n')).not.toMatch(/Multiple system messages/);
+    });
+});

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -200,6 +200,7 @@ export type AiAgentArgs = AnyAiModel & {
     projectContextEnabled: boolean;
     aiAgentMemoryEnabled: boolean;
     mcpServers: AiAgentMcpServer[];
+    compactionSummary: string | null;
     messageHistory: ModelMessage[];
     promptUuid: string;
     threadUuid: string;


### PR DESCRIPTION
## Summary

- carry the compaction summary separately from ordinary message history
- assemble agent messages explicitly as system prompt, compaction summary, memory block, then history
- cover Anthropic prompt conversion through the real provider adapter without network access

## Validation

- 29 focused backend tests pass
- backend typecheck, changed-file formatting, lint, and diff checks pass
- full backend suite: 5,428 pass, 1 skipped; 2 out-of-scope SchedulerTaskTracer assertions fail identically in isolation
- Browser: a compacted Claude thread with memory completed successfully after the refactor
- Jaeger: the live prompt order is system prompt, compaction summary, memory block, then remaining history

Closes: ZAP-739