### PR TITLE
feat(cli): download the virtual views a dashboard's charts use

### DIFF
--- a/packages/cli/src/handlers/download.test.ts
+++ b/packages/cli/src/handlers/download.test.ts
@@ -68,13 +68,16 @@ vi.mock('./dbt/apiClient', async (importOriginal) => ({
 
 const {
     assertUniqueSpacePaths,
+    downloadLinkedVirtualViews,
     downloadSpaces,
+    extractChartTableNames,
     getDashboardAppSlugs,
     getDashboardChartSlugs,
     getFlatSpaceFileNames,
     hasContentFilters,
     isAiAgentsUnavailableError,
     isExternalConnectionsUnavailableError,
+    isVirtualViewsUnavailableError,
     downloadAiAgents,
     isFilteredWithNoDashboards,
     readAiAgentFiles,
@@ -470,6 +473,29 @@ describe('extractAppSlugsFromDashboards', () => {
     });
 });
 
+describe('extractChartTableNames', () => {
+    const chart = (tableName: string | undefined): AnyType => ({
+        slug: 'a-chart',
+        tableName,
+    });
+
+    it('dedupes table names across charts', () => {
+        expect(
+            extractChartTableNames([
+                chart('orders'),
+                chart('customers'),
+                chart('orders'),
+            ]),
+        ).toEqual(['orders', 'customers']);
+    });
+
+    it('drops missing table names (e.g. SQL charts)', () => {
+        expect(
+            extractChartTableNames([chart(undefined), chart(''), chart('one')]),
+        ).toEqual(['one']);
+    });
+});
+
 describe('getDashboardAppSlugs', () => {
     let tmpDir: string;
 
@@ -583,6 +609,125 @@ describe('sanitizeChartForDownload', () => {
             xRef: { field: 'events_date_day' },
             yRef: { field: 'orders_count' },
         });
+    });
+});
+
+describe('downloadLinkedVirtualViews', () => {
+    let tmpDir: string;
+    const virtualViewDocument = (slug: string) => ({
+        contentType: ContentAsCodeType.VIRTUAL_VIEW,
+        version: 1,
+        slug,
+        name: slug,
+        sql: 'SELECT 1 AS order_id',
+        columns: [{ reference: 'order_id', type: 'number' }],
+        parameters: null,
+    });
+
+    beforeEach(async () => {
+        vi.mocked(lightdashApi).mockReset();
+        tmpDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'linked-virtual-views-test-'),
+        );
+    });
+
+    afterEach(async () => {
+        vi.restoreAllMocks();
+        await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('writes matched virtual views and stays silent on regular dbt table names', async () => {
+        const logSpy = vi
+            .spyOn(GlobalState, 'log')
+            .mockImplementation(() => undefined);
+        vi.mocked(lightdashApi).mockResolvedValueOnce({
+            virtualViews: [virtualViewDocument('my_virtual_view')],
+            skipped: [],
+            missingSlugs: ['orders', 'customers'],
+        } as never);
+
+        const count = await downloadLinkedVirtualViews(
+            'project-uuid',
+            ['my_virtual_view', 'orders', 'customers'],
+            tmpDir,
+        );
+
+        expect(count).toBe(1);
+        expect(lightdashApi).toHaveBeenCalledExactlyOnceWith(
+            expect.objectContaining({
+                url: '/api/v1/projects/project-uuid/code/virtualViews?slugs=my_virtual_view&slugs=orders&slugs=customers',
+            }),
+        );
+        await expect(
+            fs.readFile(
+                path.join(tmpDir, 'virtual-views', 'my_virtual_view.yml'),
+                'utf-8',
+            ),
+        ).resolves.toContain('slug: my_virtual_view');
+        expect(logSpy).not.toHaveBeenCalled();
+    });
+
+    it('warns about skipped virtual views', async () => {
+        const logSpy = vi
+            .spyOn(GlobalState, 'log')
+            .mockImplementation(() => undefined);
+        vi.mocked(lightdashApi).mockResolvedValueOnce({
+            virtualViews: [],
+            skipped: [{ slug: 'broken_view', reason: 'malformed' }],
+            missingSlugs: [],
+        } as never);
+
+        await expect(
+            downloadLinkedVirtualViews('project-uuid', ['broken_view'], tmpDir),
+        ).resolves.toBe(0);
+        expect(logSpy).toHaveBeenCalledExactlyOnceWith(
+            expect.stringContaining('Skipped virtual view "broken_view"'),
+        );
+    });
+
+    it('returns null when the server has no virtual views endpoint', async () => {
+        vi.mocked(lightdashApi).mockRejectedValueOnce(
+            new LightdashError({
+                message: 'Not found',
+                name: 'NotFoundError',
+                statusCode: 404,
+                data: {},
+            }),
+        );
+
+        await expect(
+            downloadLinkedVirtualViews('project-uuid', ['orders'], tmpDir),
+        ).resolves.toBeNull();
+    });
+
+    it('rethrows unexpected errors', async () => {
+        const serverError = new LightdashError({
+            message: 'Boom',
+            name: 'UnexpectedServerError',
+            statusCode: 500,
+            data: {},
+        });
+        vi.mocked(lightdashApi).mockRejectedValueOnce(serverError);
+
+        await expect(
+            downloadLinkedVirtualViews('project-uuid', ['orders'], tmpDir),
+        ).rejects.toBe(serverError);
+    });
+
+    it('classifies permission and missing-route errors as unavailable', () => {
+        [403, 404].forEach((statusCode) => {
+            expect(
+                isVirtualViewsUnavailableError(
+                    new LightdashError({
+                        message: 'unavailable',
+                        name: 'TestError',
+                        statusCode,
+                        data: {},
+                    }),
+                ),
+            ).toBe(true);
+        });
+        expect(isVirtualViewsUnavailableError(new Error('nope'))).toBe(false);
     });
 });
 

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -779,9 +779,20 @@ const extractAppSlugsFromDashboards = (
     ),
 ];
 
+// A virtual view's slug is the explore name charts store in tableName, so
+// these names double as virtual view slug candidates.
+const extractChartTableNames = (charts: ChartAsCode[]): string[] => [
+    ...new Set(
+        charts
+            .map((chart) => chart.tableName)
+            .filter((tableName): tableName is string => !!tableName),
+    ),
+];
+
 export type DownloadContentResult = {
     total: number;
     chartSlugs: string[];
+    chartTableNames: string[];
     appSlugs: string[];
     metadataEntries: MetadataEntry[];
     spaces: SpaceAsCode[];
@@ -807,6 +818,7 @@ export const downloadContent = async (
     let offset = 0;
     let total = 0;
     let chartSlugs: string[] = [];
+    let chartTableNames: string[] = [];
     let appSlugs: string[] = [];
     let allMetadataEntries: MetadataEntry[] = [];
     let allSpaces: SpaceAsCode[] = [];
@@ -911,6 +923,10 @@ export const downloadContent = async (
                 });
                 allMetadataEntries = [...allMetadataEntries, ...entries];
             }
+            chartTableNames = [
+                ...chartTableNames,
+                ...extractChartTableNames(results.charts),
+            ];
         }
 
         // Accumulate space metadata from each page
@@ -940,6 +956,7 @@ export const downloadContent = async (
     return {
         total,
         chartSlugs: [...new Set(chartSlugs)],
+        chartTableNames: [...new Set(chartTableNames)],
         appSlugs: [...new Set(appSlugs)],
         metadataEntries: allMetadataEntries,
         spaces: allSpaces,
@@ -991,6 +1008,60 @@ const downloadVirtualViews = async (
     );
     results.missingSlugs.forEach((slug) =>
         GlobalState.log(styles.warning(`Virtual view "${slug}" was not found`)),
+    );
+    return results.virtualViews.length;
+};
+
+// This download is implicit (derived from a dashboard's charts, not asked for
+// by the user), so an older server without the endpoint (404) or a user
+// without content-as-code access (403) must not fail the run.
+const isVirtualViewsUnavailableError = (error: unknown): boolean =>
+    error instanceof LightdashError && [403, 404].includes(error.statusCode);
+
+/**
+ * Downloads the virtual views backing a dashboard's charts. The candidates are
+ * chart table names, so ones the server reports as missing are just regular
+ * dbt explores — expected, never warned. Returns null when virtual views are
+ * unavailable on the server.
+ */
+const downloadLinkedVirtualViews = async (
+    projectId: string,
+    tableNames: string[],
+    customPath?: string,
+): Promise<number | null> => {
+    const query = new URLSearchParams(
+        tableNames.map((name) => ['slugs', name] as [string, string]),
+    ).toString();
+    let results: ApiVirtualViewAsCodeListResponse['results'];
+    try {
+        results = await lightdashApi<
+            ApiVirtualViewAsCodeListResponse['results']
+        >({
+            method: 'GET',
+            url: `/api/v1/projects/${projectId}/code/virtualViews?${query}`,
+            body: undefined,
+        });
+    } catch (error) {
+        if (isVirtualViewsUnavailableError(error)) {
+            GlobalState.debug(
+                `Could not download linked virtual views: ${getErrorMessage(error)}`,
+            );
+            return null;
+        }
+        throw error;
+    }
+    if (results.virtualViews.length > 0) {
+        await writeCodeResourceDocuments({
+            definition: VIRTUAL_VIEW_CODE_RESOURCE,
+            basePath: getDownloadFolder(customPath),
+            documents: results.virtualViews,
+            pruneOtherDocuments: false,
+        });
+    }
+    results.skipped.forEach(({ slug, reason }) =>
+        GlobalState.log(
+            styles.warning(`Skipped virtual view "${slug}": ${reason}`),
+        ),
     );
     return results.virtualViews.length;
 };
@@ -1946,6 +2017,7 @@ export const downloadHandler = async (
                     );
                     const {
                         total: regularCharts,
+                        chartTableNames: linkedChartTableNames,
                         metadataEntries: linkedChartMeta,
                     } = await downloadContent(
                         chartSlugs,
@@ -1987,6 +2059,32 @@ export const downloadHandler = async (
                     output.completeItem(
                         `${regularCharts + sqlCharts} downloaded`,
                     );
+
+                    // Virtual views the linked charts are built on. Skipped
+                    // when a broader step already downloaded every one.
+                    if (
+                        linkedChartTableNames.length > 0 &&
+                        !includeAllOptionalContent &&
+                        !options.includeVirtualViews
+                    ) {
+                        output.startItem('Linked virtual views');
+                        const linkedVirtualViews =
+                            await downloadLinkedVirtualViews(
+                                projectId,
+                                linkedChartTableNames,
+                                options.path,
+                            );
+                        if (linkedVirtualViews === null) {
+                            output.completeItem(
+                                'not available on this server',
+                                'warning',
+                            );
+                        } else {
+                            output.completeItem(
+                                `${linkedVirtualViews} downloaded`,
+                            );
+                        }
+                    }
                 }
 
                 // Consumed after the explicit apps step (see cappedAppSlugs).
@@ -3739,14 +3837,17 @@ export const uploadHandler = async (
 
 export const testHelpers = {
     assertUniqueSpacePaths,
+    downloadLinkedVirtualViews,
     downloadSpaces,
     extractAppSlugsFromDashboards,
+    extractChartTableNames,
     getFlatSpaceFileNames,
     getDashboardAppSlugs,
     getDashboardChartSlugs,
     hasContentFilters,
     isAiAgentsUnavailableError,
     isExternalConnectionsUnavailableError,
+    isVirtualViewsUnavailableError,
     downloadAiAgents,
     isFilteredWithNoDashboards,
     readAiAgentFiles,


### PR DESCRIPTION
## What

`lightdash download -d <dashboard>` now also downloads the virtual views backing the dashboard's charts, the same way it already pulls the charts themselves (and, recently, data apps). Previously they had to be fetched separately with `--virtual-views <slug>` or `--include-virtual-views`, and forgetting that meant re-uploading the dashboard elsewhere hit missing-explore errors.

First of two stacked PRs (upload side is #26645).

## How

- A virtual view's slug **is** the explore name charts store in `tableName` (`VirtualViewCoder.transform` uses `explore.name` for both), so the linked charts' table names double as virtual view slug candidates with no extra resolution step.
- `downloadContent` now returns the `tableName`s of the charts it downloads. After the existing "Linked charts" step, the CLI asks `/code/virtualViews?slugs=<tableNames>` and writes whatever matches to `virtual-views/`.
- Table names the server doesn't recognize are regular dbt explores — they come back in `missingSlugs` and are deliberately not warned about (unlike the explicit `--virtual-views` path, which keeps warning).
- Skipped when `--include-virtual-views` / `--include-all` already downloaded every virtual view.
- Implicit-degrade: this download is derived, not asked for, so a server without the virtualViews code endpoint (404) or a user without content-as-code view access (403) gets a "not available on this server" warning line instead of a failed run.

## Testing

`pnpm -F cli test` 462 passed; typecheck and lint clean. New unit tests cover the table-name extraction and the linked download (writes matches, silent on regular table names, warns on skipped views, null on 404, rethrows real errors).

Closes: PROD-9370
Closes: #26579

🤖 Generated with [Claude Code](https://claude.com/claude-code)