### PR TITLE
feat(cli): opt-in upload of the virtual views a dashboard uses

### DIFF
--- a/packages/cli/src/handlers/download.test.ts
+++ b/packages/cli/src/handlers/download.test.ts
@@ -496,6 +496,72 @@ describe('extractChartTableNames', () => {
     });
 });
 
+describe('selectVirtualViewCandidates', () => {
+    const chart = (slug: string, tableName: string | undefined): AnyType => ({
+        slug,
+        tableName,
+    });
+
+    it('collects table names of explicitly selected charts', () => {
+        expect(
+            testHelpers.selectVirtualViewCandidates({
+                chartItems: [
+                    chart('wanted', 'my_virtual_view'),
+                    chart('other', 'other_view'),
+                ],
+                chartSlugs: ['wanted'],
+                dashboardItems: [],
+                dashboardSlugs: [],
+            }),
+        ).toEqual(['my_virtual_view']);
+    });
+
+    it('collects table names of the selected dashboards charts only', () => {
+        expect(
+            testHelpers.selectVirtualViewCandidates({
+                chartItems: [
+                    chart('dash-chart', 'my_virtual_view'),
+                    chart('other-dash-chart', 'other_view'),
+                ],
+                chartSlugs: [],
+                dashboardItems: [
+                    makeLooseDashboard('wanted-dash', ['dash-chart']),
+                    makeLooseDashboard('other-dash', ['other-dash-chart']),
+                ],
+                dashboardSlugs: ['wanted-dash'],
+            }),
+        ).toEqual(['my_virtual_view']);
+    });
+
+    it('ignores dashboards entirely when none are selected', () => {
+        expect(
+            testHelpers.selectVirtualViewCandidates({
+                chartItems: [chart('dash-chart', 'my_virtual_view')],
+                chartSlugs: [],
+                dashboardItems: [
+                    makeLooseDashboard('some-dash', ['dash-chart']),
+                ],
+                dashboardSlugs: [],
+            }),
+        ).toEqual([]);
+    });
+
+    it('dedupes across sources and drops charts without a table name', () => {
+        expect(
+            testHelpers.selectVirtualViewCandidates({
+                chartItems: [
+                    chart('a-chart', 'shared_view'),
+                    chart('b-chart', 'shared_view'),
+                    chart('sql-chart', undefined),
+                ],
+                chartSlugs: ['a-chart', 'sql-chart'],
+                dashboardItems: [makeLooseDashboard('dash', ['b-chart'])],
+                dashboardSlugs: ['dash'],
+            }),
+        ).toEqual(['shared_view']);
+    });
+});
+
 describe('getDashboardAppSlugs', () => {
     let tmpDir: string;
 
@@ -830,6 +896,71 @@ version: 1
         expect(lightdashApi).not.toHaveBeenCalled();
         expect(logSpy).toHaveBeenCalledExactlyOnceWith(
             expect.stringContaining('Error uploading virtual views'),
+        );
+    });
+
+    it('uploads candidate matches only, silent on unmatched candidates', async () => {
+        const logSpy = vi
+            .spyOn(GlobalState, 'log')
+            .mockImplementation(() => undefined);
+        await fs.writeFile(
+            path.join(tmpDir, 'virtual-views', 'my_view.yml'),
+            virtualView('my_view'),
+        );
+        await fs.writeFile(
+            path.join(tmpDir, 'virtual-views', 'unrelated_view.yml'),
+            virtualView('unrelated_view'),
+        );
+        vi.mocked(lightdashApi).mockResolvedValueOnce({
+            action: 'create',
+        } as never);
+
+        const changes = await upsertVirtualViews(
+            'project-uuid',
+            [],
+            {},
+            false,
+            true,
+            tmpDir,
+            ['my_view', 'orders', 'customers'],
+        );
+
+        expect(changes).toEqual({ 'virtual views created': 1 });
+        expect(lightdashApi).toHaveBeenCalledExactlyOnceWith(
+            expect.objectContaining({
+                url: expect.stringContaining('/code/virtualViews/my_view'),
+            }),
+        );
+        expect(logSpy).not.toHaveBeenCalled();
+    });
+
+    it('still warns about explicit slugs missing locally when candidates are present', async () => {
+        const logSpy = vi
+            .spyOn(GlobalState, 'log')
+            .mockImplementation(() => undefined);
+        await fs.writeFile(
+            path.join(tmpDir, 'virtual-views', 'my_view.yml'),
+            virtualView('my_view'),
+        );
+        vi.mocked(lightdashApi).mockResolvedValueOnce({
+            action: 'update',
+        } as never);
+
+        const changes = await upsertVirtualViews(
+            'project-uuid',
+            ['missing_view'],
+            {},
+            false,
+            true,
+            tmpDir,
+            ['my_view'],
+        );
+
+        expect(changes).toEqual({ 'virtual views updated': 1 });
+        expect(logSpy).toHaveBeenCalledExactlyOnceWith(
+            expect.stringContaining(
+                'Virtual view "missing_view" was not found locally',
+            ),
         );
     });
 });

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -1084,11 +1084,18 @@ const upsertVirtualViews = async (
     force: boolean,
     canUpload: boolean,
     customPath?: string,
+    candidateSlugs: string[] = [],
 ): Promise<Record<string, number>> => {
     const virtualViews = await readVirtualViewFiles(customPath);
-    const selected = slugs.length
-        ? virtualViews.filter(({ slug }) => slugs.includes(slug))
-        : virtualViews;
+    // Candidates are chart table names, and most are regular dbt explores
+    // with no local file — unmatched candidates never warn; explicit slugs do.
+    const candidateSet = new Set(candidateSlugs);
+    const selected =
+        slugs.length > 0 || candidateSet.size > 0
+            ? virtualViews.filter(
+                  ({ slug }) => slugs.includes(slug) || candidateSet.has(slug),
+              )
+            : virtualViews;
     const selectedSlugs = new Set(selected.map(({ slug }) => slug));
     slugs
         .filter((slug) => !selectedSlugs.has(slug))
@@ -2935,6 +2942,33 @@ const selectDashboardAppSlugs = (
     ),
 ];
 
+// Virtual views a filtered upload should carry: the table names of the local
+// charts selected explicitly (-c) or referenced by the selected dashboards'
+// tiles. Dashboards contribute only when some are selected — a filtered
+// upload without -d uploads no dashboards, so there is nothing to derive.
+const selectVirtualViewCandidates = ({
+    chartItems,
+    chartSlugs,
+    dashboardItems,
+    dashboardSlugs,
+}: {
+    chartItems: ChartAsCode[];
+    chartSlugs: string[];
+    dashboardItems: DashboardAsCode[];
+    dashboardSlugs: string[];
+}): string[] => {
+    const selectedChartSlugs = new Set([
+        ...chartSlugs,
+        ...(dashboardSlugs.length > 0
+            ? selectDashboardChartSlugs(dashboardItems, dashboardSlugs)
+            : []),
+    ]);
+    if (selectedChartSlugs.size === 0) return [];
+    return extractChartTableNames(
+        chartItems.filter((chart) => selectedChartSlugs.has(chart.slug)),
+    );
+};
+
 const getDashboardChartSlugs = async (
     dashboardSlugs: string[],
     customPath?: string,
@@ -3132,11 +3166,53 @@ export const uploadHandler = async (
             );
         }
 
+        // The Virtual views, Data apps and Charts phases all derive slugs
+        // from the same dashboard YAML; read the download folder once and
+        // share it.
+        let dashboardItemsPromise: Promise<DashboardAsCode[]> | undefined;
+        const loadDashboardItems = () => {
+            dashboardItemsPromise =
+                dashboardItemsPromise ??
+                readDashboardItems(options.path, looseFiles.dashboards);
+            return dashboardItemsPromise;
+        };
+
         if (!options.skipVirtualViews) {
-            if (hasFilters && options.virtualViews.length === 0) {
+            // --include-virtual-views on a filtered upload also pushes the
+            // virtual views backing the selected charts and dashboards. An
+            // unfiltered upload already pushes every local virtual view.
+            let virtualViewCandidates: string[] = [];
+            if (
+                options.includeVirtualViews === true &&
+                hasFilters &&
+                (options.charts.length > 0 || options.dashboards.length > 0)
+            ) {
+                virtualViewCandidates = selectVirtualViewCandidates({
+                    chartItems: [
+                        ...(await readCodeFiles<ChartAsCode>(
+                            'charts',
+                            options.path,
+                        )),
+                        ...looseFiles.charts,
+                    ],
+                    chartSlugs: options.charts,
+                    dashboardItems:
+                        options.dashboards.length > 0
+                            ? await loadDashboardItems()
+                            : [],
+                    dashboardSlugs: options.dashboards,
+                });
+            }
+            if (
+                hasFilters &&
+                options.virtualViews.length === 0 &&
+                virtualViewCandidates.length === 0
+            ) {
                 GlobalState.log(
                     styles.warning(
-                        `No virtual view filters provided, skipping`,
+                        options.includeVirtualViews === true
+                            ? `No virtual views referenced by the selected content, skipping`
+                            : `No virtual view filters provided, skipping`,
                     ),
                 );
             } else {
@@ -3152,6 +3228,7 @@ export const uploadHandler = async (
                             options.force,
                             uploadPermissions.virtualViews,
                             options.path,
+                            virtualViewCandidates,
                         ),
                 });
             }
@@ -3183,16 +3260,6 @@ export const uploadHandler = async (
                 });
             }
         }
-
-        // Both the Data apps and Charts phases derive slugs from the same
-        // dashboard YAML; read the download folder once and share it.
-        let dashboardItemsPromise: Promise<DashboardAsCode[]> | undefined;
-        const loadDashboardItems = () => {
-            dashboardItemsPromise =
-                dashboardItemsPromise ??
-                readDashboardItems(options.path, looseFiles.dashboards);
-            return dashboardItemsPromise;
-        };
 
         // Upload data apps (enterprise; explicit --apps/--include-apps, or
         // auto-pushed for a dashboard's apps). Must land before dashboards.
@@ -3855,6 +3922,7 @@ export const testHelpers = {
     readSpaceFiles,
     readSpaceNames,
     sanitizeChartForDownload,
+    selectVirtualViewCandidates,
     shouldFallBackToEmbeddedSpaces,
     shouldDownloadAiAgents,
     sortSpaceFilesParentFirst,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1045,6 +1045,11 @@ const uploadCommand = program
         'Include charts updates when uploading dashboards',
         false,
     )
+    .option(
+        '--include-virtual-views',
+        'Include the virtual views used by the charts and dashboards being uploaded',
+        false,
+    )
     .option('--validate', 'Validate charts and dashboards after upload', false)
     .option('--gzip', 'Enable gzip compression for request bodies', false)
     .option(


### PR DESCRIPTION
## What

Adds `--include-virtual-views` to `lightdash upload`. On a filtered upload (`-d <dashboard>` / `-c <chart>`), it also pushes the virtual views those charts are built on, so the uploaded content doesn't land with missing explores in the target project. Mirrors how `--include-charts` opts a dashboard's charts into the upload.

Second of two stacked PRs (download side is #26644).

## How

- Candidates are resolved locally: selected dashboards' tiles → chart slugs → local chart YAML `tableName`s (plus the `-c` charts' own table names), matched against the files in `virtual-views/`. A table name with no local virtual view file is a regular dbt explore and is skipped silently; explicit `--virtual-views <slug>` selections keep warning when missing.
- Dashboards contribute candidates only when some are selected — a filtered upload without `-d` uploads no dashboards, so nothing is derived from them (same guard the data apps auto-push uses).
- Dashboard-derived virtual views are pushed even without `--include-charts`: the dashboard's tiles resolve against charts already in the target project, and those need their explores regardless of whether the chart YAML is re-uploaded.
- No phase reordering needed: Virtual views already upload before Charts and Dashboards, so the explores exist by the time dependent content lands. The upsert endpoint already returns `NO_CHANGES` for identical views, so re-runs are cheap — no client-side change gating needed.
- An unfiltered `lightdash upload` already pushes every local virtual view; the flag changes nothing there.
- A virtual view the dashboard needs but that was never downloaded locally can't be pushed (there is nothing to read) — same limitation `--include-charts` has.

## Testing

`pnpm -F cli test` 462 passed; typecheck and lint clean. New unit tests cover candidate selection (explicit charts, dashboard tiles, dedupe, no-dashboard guard, SQL charts dropped) and the upsert selection semantics (candidates upload without warnings, explicit missing slugs still warn).

Closes: PROD-9371
Closes: #26580

🤖 Generated with [Claude Code](https://claude.com/claude-code)