### PR TITLE
fix(apps): polish visualization composer

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
@@ -186,6 +186,7 @@ describe('DataAppVizConfigTabs', () => {
     const mockContext = (
         itemsMap: ItemsMap,
         dataAppVizUuid: string = 'data-app-viz-uuid',
+        optionValues: Record<string, boolean | number | string> = {},
     ) =>
         vi.mocked(useVisualizationContext).mockReturnValue({
             itemsMap,
@@ -194,7 +195,7 @@ describe('DataAppVizConfigTabs', () => {
                 chartConfig: {
                     dataAppVizUuid,
                     fieldMapping: {},
-                    optionValues: {},
+                    optionValues,
                     setDataAppVizUuid,
                     setField: vi.fn(),
                     setOption,
@@ -277,6 +278,40 @@ describe('DataAppVizConfigTabs', () => {
         await user.click(screen.getByRole('tab', { name: 'Display' }));
 
         expect(screen.getByLabelText('Bar width')).toHaveValue('8');
+    });
+
+    it('replaces option controls when the visualization contract changes', async () => {
+        const user = userEvent.setup();
+        mockContext(queryColumns, 'data-app-viz-uuid', {
+            showLegend: false,
+        });
+        mockSchema([declaredOptions[0]]);
+        const { rerender } = renderWithProviders(<ConfigTabs />);
+
+        await user.click(screen.getByRole('tab', { name: 'Style' }));
+        expect(screen.getByLabelText('Show legend')).not.toBeChecked();
+
+        mockSchema([
+            {
+                type: 'number',
+                name: 'pointSize',
+                label: 'Point size',
+                group: 'Marks',
+                default: 6,
+            },
+        ]);
+        rerender(<ConfigTabs />);
+
+        expect(
+            screen.queryByRole('tab', { name: 'Style' }),
+        ).not.toBeInTheDocument();
+        expect(screen.getByRole('tab', { name: 'General' })).toHaveAttribute(
+            'aria-selected',
+            'true',
+        );
+        await user.click(screen.getByRole('tab', { name: 'Marks' }));
+        expect(screen.getByLabelText('Point size')).toHaveValue('6');
+        expect(screen.queryByLabelText('Show legend')).not.toBeInTheDocument();
     });
 
     it('renders the standard palette picker for a declared palette', async () => {

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -52,6 +52,10 @@ export const ConfigTabs: FC = memo(() => {
         [dataAppViz],
     );
     const colorPalette = dataAppViz?.schema?.colorPalette ?? null;
+    const optionContractKey = useMemo(
+        () => JSON.stringify({ configOptions, colorPalette }),
+        [configOptions, colorPalette],
+    );
 
     // Held in a ref-free callback so the build hook can commit straight into
     // the chart config once a new visualization lands.
@@ -111,6 +115,8 @@ export const ConfigTabs: FC = memo(() => {
     );
 
     const draft = build.draft;
+    const onCancelBuild =
+        draft !== null && !dataAppVizUuid ? build.discard : build.cancel;
 
     const settings = (
         <DataAppVizSettings
@@ -144,7 +150,7 @@ export const ConfigTabs: FC = memo(() => {
                     <DataAppVizOptionTabs
                         // Remount on a viz switch so no control keeps the
                         // previous viz's draft edit.
-                        key={dataAppVizUuid}
+                        key={`${dataAppVizUuid}:${optionContractKey}`}
                         generalContent={settings}
                         configOptions={configOptions}
                         values={effectiveValues}
@@ -172,11 +178,7 @@ export const ConfigTabs: FC = memo(() => {
                                 />
                             ) : undefined
                         }
-                        onCancelBuild={
-                            build.draft !== null && !dataAppVizUuid
-                                ? build.discard
-                                : build.cancel
-                        }
+                        onCancelBuild={onCancelBuild}
                         footer={
                             <DataAppVizComposer
                                 projectUuid={projectUuid}
@@ -187,6 +189,7 @@ export const ConfigTabs: FC = memo(() => {
                                         : 'Describe a new visualization…'
                                 }
                                 isBuilding={build.isBuilding}
+                                onCancel={onCancelBuild}
                                 onSubmit={build.send}
                             />
                         }

--- a/packages/frontend/src/features/apps/components/DataAppVizComposer.test.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizComposer.test.tsx
@@ -16,17 +16,20 @@ vi.mock(
                 {
                     attachments?: React.ReactNode;
                     toolbarLeft?: React.ReactNode;
+                    toolbarRight?: React.ReactNode;
+                    onPaste?: React.ClipboardEventHandler<HTMLDivElement>;
                 }
-            >(({ attachments, toolbarLeft }, ref) => {
+            >(({ attachments, toolbarLeft, toolbarRight, onPaste }, ref) => {
                 React.useImperativeHandle(ref, () => ({
                     getText: () => '',
                     clear: vi.fn(),
                 }));
 
                 return (
-                    <div>
+                    <div data-testid="prompt-composer" onPaste={onPaste}>
                         {attachments}
                         {toolbarLeft}
+                        {toolbarRight}
                     </div>
                 );
             }),
@@ -49,6 +52,7 @@ describe('DataAppVizComposer', () => {
             projectUuid: 'project-1',
             placeholder: 'Describe a visualization',
             isBuilding: false,
+            onCancel: vi.fn(),
             onSubmit: vi.fn(),
         };
         const { container, rerender } = renderWithProviders(
@@ -70,5 +74,90 @@ describe('DataAppVizComposer', () => {
 
         expect(screen.queryByAltText('Attached')).not.toBeInTheDocument();
         expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:chart');
+    });
+
+    it('attaches an image pasted from the clipboard', async () => {
+        const uploadFile = vi.fn().mockResolvedValue({ fileId: 'file-1' });
+        vi.mocked(useAppFileUpload).mockReturnValue({
+            mutateAsync: uploadFile,
+        } as unknown as ReturnType<typeof useAppFileUpload>);
+        renderWithProviders(
+            <DataAppVizComposer
+                projectUuid="project-1"
+                appUuid="app-1"
+                placeholder="Describe a visualization"
+                isBuilding={false}
+                onCancel={vi.fn()}
+                onSubmit={vi.fn()}
+            />,
+        );
+        const image = new File(['image'], 'pasted.png', {
+            type: 'image/png',
+        });
+
+        fireEvent.paste(screen.getByTestId('prompt-composer'), {
+            clipboardData: { files: [image] },
+        });
+
+        expect(await screen.findByAltText('Attached')).toBeInTheDocument();
+        expect(uploadFile).toHaveBeenCalledWith({
+            projectUuid: 'project-1',
+            appUuid: 'app-1',
+            file: image,
+        });
+    });
+
+    it('attaches a file dropped on the composer', async () => {
+        const uploadFile = vi.fn().mockResolvedValue({ fileId: 'file-1' });
+        vi.mocked(useAppFileUpload).mockReturnValue({
+            mutateAsync: uploadFile,
+        } as unknown as ReturnType<typeof useAppFileUpload>);
+        renderWithProviders(
+            <DataAppVizComposer
+                projectUuid="project-1"
+                appUuid="app-1"
+                placeholder="Describe a visualization"
+                isBuilding={false}
+                onCancel={vi.fn()}
+                onSubmit={vi.fn()}
+            />,
+        );
+        const file = new File(['image'], 'dropped.png', {
+            type: 'image/png',
+        });
+
+        fireEvent.drop(screen.getByTestId('prompt-composer').parentElement!, {
+            dataTransfer: { files: [file] },
+        });
+
+        expect(await screen.findByAltText('Attached')).toBeInTheDocument();
+        expect(uploadFile).toHaveBeenCalledWith({
+            projectUuid: 'project-1',
+            appUuid: 'app-1',
+            file,
+        });
+    });
+
+    it('offers Stop generation while a build runs', () => {
+        const onCancel = vi.fn();
+        renderWithProviders(
+            <DataAppVizComposer
+                projectUuid="project-1"
+                appUuid="app-1"
+                placeholder="Describe a visualization"
+                isBuilding
+                onCancel={onCancel}
+                onSubmit={vi.fn()}
+            />,
+        );
+
+        fireEvent.click(
+            screen.getByRole('button', { name: 'Stop generation' }),
+        );
+
+        expect(onCancel).toHaveBeenCalledOnce();
+        expect(
+            screen.queryByRole('button', { name: 'Send' }),
+        ).not.toBeInTheDocument();
     });
 });

--- a/packages/frontend/src/features/apps/components/DataAppVizComposer.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizComposer.tsx
@@ -1,6 +1,16 @@
-import { ActionIcon, Tooltip } from '@mantine-8/core';
-import { IconArrowUp, IconPaperclip } from '@tabler/icons-react';
-import { useRef, useState, type FC } from 'react';
+import { ActionIcon, Box, Tooltip } from '@mantine-8/core';
+import {
+    IconArrowUp,
+    IconPaperclip,
+    IconPlayerStop,
+} from '@tabler/icons-react';
+import {
+    useRef,
+    useState,
+    type ClipboardEventHandler,
+    type DragEventHandler,
+    type FC,
+} from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { ComposerSubmitButton } from '../../../components/common/PromptComposer/ComposerSubmitButton';
 import PromptComposer, {
@@ -16,6 +26,7 @@ type Props = {
     placeholder: string;
     /** True while a build is running: keep typing, block sending. */
     isBuilding: boolean;
+    onCancel: (() => void) | null;
     onSubmit: (request: VizBuildRequest) => void;
 };
 
@@ -32,6 +43,7 @@ const DataAppVizComposerContent: FC<Props> = ({
     appUuid,
     placeholder,
     isBuilding,
+    onCancel,
     onSubmit,
 }) => {
     const attachments = useVizComposerAttachments({ projectUuid, appUuid });
@@ -49,62 +61,93 @@ const DataAppVizComposerContent: FC<Props> = ({
         attachments.clear();
     };
 
+    const handlePaste: ClipboardEventHandler = (event) => {
+        if (isBuilding || event.clipboardData.files.length === 0) return;
+        event.preventDefault();
+        attachments.add(Array.from(event.clipboardData.files));
+    };
+
+    const handleDragOver: DragEventHandler = (event) => {
+        event.preventDefault();
+    };
+
+    const handleDrop: DragEventHandler = (event) => {
+        event.preventDefault();
+        if (isBuilding) return;
+        attachments.add(Array.from(event.dataTransfer.files));
+    };
+
     return (
-        <PromptComposer
-            ref={composerRef}
-            size="md"
-            placeholder={placeholder}
-            submitDisabled={!canSend}
-            onEmptyChange={setIsEmpty}
-            onSubmit={handleSubmit}
-            attachments={
-                <SelectedAttachmentSection
-                    attachments={attachments.attachments.map((a) => ({
-                        id: a.key,
-                        previewUrl: a.previewUrl,
-                        filename: a.filename,
-                    }))}
-                    onRemove={attachments.remove}
-                    disabled={isBuilding}
-                />
-            }
-            toolbarLeft={
-                <>
-                    <input
-                        ref={fileInputRef}
-                        type="file"
-                        multiple
-                        hidden
-                        onChange={(e) => {
-                            attachments.add(Array.from(e.target.files ?? []));
-                            e.target.value = '';
-                        }}
+        <Box onDragOver={handleDragOver} onDrop={handleDrop}>
+            <PromptComposer
+                ref={composerRef}
+                size="md"
+                placeholder={placeholder}
+                submitDisabled={!canSend}
+                onEmptyChange={setIsEmpty}
+                onSubmit={handleSubmit}
+                onPaste={handlePaste}
+                attachments={
+                    <SelectedAttachmentSection
+                        attachments={attachments.attachments.map((a) => ({
+                            id: a.key,
+                            previewUrl: a.previewUrl,
+                            filename: a.filename,
+                        }))}
+                        onRemove={attachments.remove}
+                        disabled={isBuilding}
                     />
-                    <Tooltip withArrow label="Attach an image or file">
-                        <ActionIcon
-                            variant="subtle"
-                            color="gray"
+                }
+                toolbarLeft={
+                    <>
+                        <input
+                            ref={fileInputRef}
+                            type="file"
+                            multiple
+                            hidden
+                            onChange={(e) => {
+                                attachments.add(
+                                    Array.from(e.target.files ?? []),
+                                );
+                                e.target.value = '';
+                            }}
+                        />
+                        <Tooltip withArrow label="Attach an image or file">
+                            <ActionIcon
+                                variant="subtle"
+                                color="gray"
+                                size="sm"
+                                disabled={isBuilding}
+                                aria-label="Attach"
+                                onClick={() => fileInputRef.current?.click()}
+                            >
+                                <MantineIcon icon={IconPaperclip} />
+                            </ActionIcon>
+                        </Tooltip>
+                    </>
+                }
+                toolbarRight={
+                    isBuilding && onCancel ? (
+                        <ComposerSubmitButton
+                            icon={IconPlayerStop}
+                            label="Stop generation"
                             size="sm"
-                            disabled={isBuilding}
-                            aria-label="Attach"
-                            onClick={() => fileInputRef.current?.click()}
-                        >
-                            <MantineIcon icon={IconPaperclip} />
-                        </ActionIcon>
-                    </Tooltip>
-                </>
-            }
-            toolbarRight={
-                <ComposerSubmitButton
-                    icon={IconArrowUp}
-                    label="Send"
-                    size="sm"
-                    disabled={isEmpty || !canSend}
-                    loading={isBuilding}
-                    onClick={handleSubmit}
-                />
-            }
-        />
+                            destructive
+                            onClick={onCancel}
+                        />
+                    ) : (
+                        <ComposerSubmitButton
+                            icon={IconArrowUp}
+                            label="Send"
+                            size="sm"
+                            disabled={isEmpty || !canSend}
+                            loading={isBuilding}
+                            onClick={handleSubmit}
+                        />
+                    )
+                }
+            />
+        </Box>
     );
 };
 

--- a/packages/frontend/src/features/apps/components/DataAppVizDock.module.css
+++ b/packages/frontend/src/features/apps/components/DataAppVizDock.module.css
@@ -48,6 +48,7 @@
     display: flex;
     align-items: center;
     gap: var(--mantine-spacing-xs);
+    min-width: 0;
     min-height: 22px;
 }
 
@@ -91,6 +92,15 @@
     background: none;
     text-align: left;
     cursor: pointer;
+}
+
+.fixedChrome {
+    flex: 0 0 auto;
+}
+
+.provenance {
+    flex: 1 1 auto;
+    min-width: 0;
 }
 
 .toggle {

--- a/packages/frontend/src/features/apps/components/DataAppVizDock.test.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizDock.test.tsx
@@ -14,6 +14,7 @@ import {
 } from '../testing/appVersionHistory';
 import { buildStub } from '../testing/dataAppVizBuildStub';
 import DataAppVizDock from './DataAppVizDock';
+import classes from './DataAppVizDock.module.css';
 
 vi.mock('../hooks/useGetApp', () => ({ useGetApp: vi.fn() }));
 vi.mock('../hooks/useAppBuildPoller', () => ({ useAppBuildPoller: vi.fn() }));
@@ -68,6 +69,20 @@ describe('DataAppVizDock', () => {
 
         expect(screen.getByText(/Built by Katie Jones/)).toBeInTheDocument();
         expect(screen.getByText('v2')).toBeInTheDocument();
+    });
+
+    it('lets provenance truncate before the version chrome shrinks', () => {
+        setVersions([version(), version({ version: 12 })]);
+        render();
+
+        const provenance = screen.getByText(/Built by Katie Jones/);
+        const trigger = provenance.closest('button');
+
+        expect(trigger?.querySelector('svg')).toHaveClass(classes.fixedChrome);
+        expect(screen.getByText('v12').parentElement).toHaveClass(
+            classes.fixedChrome,
+        );
+        expect(provenance).toHaveClass(classes.provenance);
     });
 
     it('does not claim origin when earlier versions are still unloaded', () => {

--- a/packages/frontend/src/features/apps/components/DataAppVizDock.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizDock.tsx
@@ -29,7 +29,12 @@ const Provenance: FC<{
     const timeAgo = useTimeAgo(at);
     const verb = isOrigin ? 'Built' : 'Last updated';
     return (
-        <Text size="xs" c="dimmed" truncate="end">
+        <Text
+            size="xs"
+            c="dimmed"
+            truncate="end"
+            className={classes.provenance}
+        >
             {authorName
                 ? `${verb} by ${authorName} · ${timeAgo}`
                 : `${verb} ${timeAgo}`}
@@ -98,7 +103,12 @@ const DataAppVizDock: FC<Props> = ({
     // finished version. A build that failed or is still running has not
     // replaced it.
     const versionBadge = latestReadyVersion !== null && (
-        <Badge size="xs" variant="light" color="violet">
+        <Badge
+            size="xs"
+            variant="light"
+            color="violet"
+            className={classes.fixedChrome}
+        >
             {`v${latestReadyVersion}`}
         </Badge>
     );
@@ -220,7 +230,11 @@ const DataAppVizDock: FC<Props> = ({
                     aria-expanded={false}
                     onClick={toggle}
                 >
-                    <MantineIcon icon={IconPuzzle} size={13} />
+                    <MantineIcon
+                        icon={IconPuzzle}
+                        size={13}
+                        className={classes.fixedChrome}
+                    />
                     {status ?? (
                         <>
                             {versionBadge}

--- a/packages/frontend/src/features/apps/components/DataAppVizVersionLog.test.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizVersionLog.test.tsx
@@ -278,6 +278,9 @@ describe('DataAppVizVersionLog', () => {
 
         await userEvent.click(screen.getByRole('button', { name: 'Restore' }));
         expect(restoreMutate).not.toHaveBeenCalled();
+        expect(screen.getByRole('dialog')).toHaveTextContent(
+            'All charts using this visualization will use the restored version. Selected fields unavailable in that version will be cleared.',
+        );
 
         await userEvent.click(
             screen.getByRole('button', { name: 'Restore version' }),

--- a/packages/frontend/src/features/apps/components/DataAppVizVersionLog.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizVersionLog.tsx
@@ -385,12 +385,9 @@ const DataAppVizVersionLog: FC<Props> = ({
                 >
                     <Stack gap="sm">
                         <Text fz="sm">
-                            This adds a new version on top that duplicates
-                            version {restoreTarget}. Every chart using this
-                            visualization follows the latest version, so they
-                            will all show it — and any chart bound to a field
-                            that version {restoreTarget} does not declare will
-                            lose that binding.
+                            All charts using this visualization will use the
+                            restored version. Selected fields unavailable in
+                            that version will be cleared.
                         </Text>
                         {restoreError && (
                             <Callout variant="danger">

--- a/packages/frontend/src/features/apps/hooks/useAppBuildPoller.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppBuildPoller.test.ts
@@ -1,6 +1,10 @@
 import { type ApiAppVersionSummary } from '@lightdash/common';
-import { describe, expect, it } from 'vitest';
-import { mergePolledVersions } from './useAppBuildPoller';
+import { type QueryClient } from '@tanstack/react-query';
+import { describe, expect, it, vi } from 'vitest';
+import {
+    invalidateDataAppVisualizationOnReady,
+    mergePolledVersions,
+} from './useAppBuildPoller';
 
 const version = (n: number, status = 'ready'): ApiAppVersionSummary =>
     ({ version: n, status }) as ApiAppVersionSummary;
@@ -40,5 +44,35 @@ describe('mergePolledVersions', () => {
 
     it('handles an empty poll', () => {
         expect(mergePolledVersions([version(1)], [])).toEqual([version(1)]);
+    });
+});
+
+describe('invalidateDataAppVisualizationOnReady', () => {
+    it('refreshes the visualization contract after a ready build', () => {
+        const invalidateQueries = vi.fn();
+
+        invalidateDataAppVisualizationOnReady(
+            { invalidateQueries } as unknown as QueryClient,
+            'project-1',
+            'app-1',
+            version(2, 'ready'),
+        );
+
+        expect(invalidateQueries).toHaveBeenCalledWith({
+            queryKey: ['data-app-viz', 'project-1', 'app-1'],
+        });
+    });
+
+    it('does not refresh the contract for an errored build', () => {
+        const invalidateQueries = vi.fn();
+
+        invalidateDataAppVisualizationOnReady(
+            { invalidateQueries } as unknown as QueryClient,
+            'project-1',
+            'app-1',
+            version(2, 'error'),
+        );
+
+        expect(invalidateQueries).not.toHaveBeenCalled();
     });
 });

--- a/packages/frontend/src/features/apps/hooks/useAppBuildPoller.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppBuildPoller.ts
@@ -3,7 +3,7 @@ import {
     type ApiAppVersionSummary,
     type ApiGetAppResponse,
 } from '@lightdash/common';
-import { useQueryClient } from '@tanstack/react-query';
+import { type QueryClient, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useRef } from 'react';
 
 type GetAppResult = ApiGetAppResponse['results'];
@@ -55,6 +55,18 @@ export const mergePolledVersions = (
         ...polled,
         ...existing.filter((v) => !polledNumbers.has(v.version)),
     ].sort((a, b) => b.version - a.version);
+};
+
+export const invalidateDataAppVisualizationOnReady = (
+    queryClient: QueryClient,
+    projectUuid: string,
+    appUuid: string,
+    version: ApiAppVersionSummary,
+): void => {
+    if (version.status !== 'ready') return;
+    void queryClient.invalidateQueries({
+        queryKey: ['data-app-viz', projectUuid, appUuid],
+    });
 };
 
 /**
@@ -131,6 +143,12 @@ export function useAppBuildPoller(
                         APP_VERSION_TERMINAL_STATUSES as readonly string[]
                     ).includes(latest.status)
                 ) {
+                    invalidateDataAppVisualizationOnReady(
+                        queryClient,
+                        projectUuid,
+                        appUuid,
+                        latest,
+                    );
                     onDoneRef.current(latest);
                 }
             }

--- a/packages/frontend/src/features/apps/hooks/useVizComposerAttachments.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useVizComposerAttachments.test.ts
@@ -72,6 +72,31 @@ describe('useVizComposerAttachments', () => {
         expect(showToastError).toHaveBeenCalledTimes(1);
     });
 
+    it('refuses binary files the generator cannot attach', async () => {
+        const uploadFile = vi.fn();
+        const { result } = setup(uploadFile);
+        const binary = new File(
+            [new Uint8Array([0x89, 0x00, 0xff])],
+            'archive.bin',
+            { type: 'application/octet-stream' },
+        );
+        vi.spyOn(binary, 'slice').mockReturnValue({
+            arrayBuffer: async () => Uint8Array.from([0x89, 0x00, 0xff]).buffer,
+        } as Blob);
+
+        act(() => result.current.add([binary]));
+
+        expect(result.current.attachments).toEqual([]);
+        expect(uploadFile).not.toHaveBeenCalled();
+        await waitFor(() =>
+            expect(showToastError).toHaveBeenCalledWith({
+                title: 'Unsupported file type',
+                subtitle:
+                    'archive.bin: attach images (PNG, JPEG, GIF, WEBP), PDFs, or text-based files (JSON, CSV, Markdown, TWB, code, …).',
+            }),
+        );
+    });
+
     it('takes what fits and warns once for a batch over the cap', () => {
         const uploadFile = vi.fn().mockResolvedValue({ fileId: 'f' });
         const { result } = setup(uploadFile);
@@ -87,6 +112,35 @@ describe('useVizComposerAttachments', () => {
         );
         // One warning for the batch, not one per rejected file.
         expect(showToastWarning).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps an inspected file from racing past the attachment cap', async () => {
+        const uploadFile = vi.fn().mockResolvedValue({ fileId: 'f' });
+        const { result } = setup(uploadFile);
+        let resolveSample: (value: ArrayBuffer) => void = () => undefined;
+        const sample = new Promise<ArrayBuffer>((resolve) => {
+            resolveSample = resolve;
+        });
+        const textFile = file('notes.txt', 10, 'text/plain');
+        vi.spyOn(textFile, 'slice').mockReturnValue({
+            arrayBuffer: () => sample,
+        } as Blob);
+
+        act(() => result.current.add([textFile]));
+        act(() =>
+            result.current.add(
+                Array.from({ length: MAX_APP_FILES_PER_VERSION }, (_, i) =>
+                    file(`image-${i}.png`),
+                ),
+            ),
+        );
+        resolveSample(Uint8Array.from([0x78]).buffer);
+
+        await waitFor(() => expect(showToastWarning).toHaveBeenCalledTimes(1));
+        expect(result.current.attachments).toHaveLength(
+            MAX_APP_FILES_PER_VERSION,
+        );
+        expect(uploadFile).toHaveBeenCalledTimes(MAX_APP_FILES_PER_VERSION);
     });
 
     it('drops an attachment whose upload failed', async () => {

--- a/packages/frontend/src/features/apps/hooks/useVizComposerAttachments.ts
+++ b/packages/frontend/src/features/apps/hooks/useVizComposerAttachments.ts
@@ -1,9 +1,12 @@
 import { MAX_APP_FILES_PER_VERSION } from '@lightdash/common';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import useToaster from '../../../hooks/toaster/useToaster';
+import {
+    getAppFileSizeError,
+    getAppFileValidationError,
+    isSupportedAppImage,
+} from '../utils/appFileAttachments';
 import { useAppFileUpload } from './useAppFileUpload';
-
-const MAX_FILE_SIZE = 10 * 1024 * 1024;
 
 export type VizAttachment = {
     fileId: string | null;
@@ -35,6 +38,9 @@ export const useVizComposerAttachments = ({
     const { showToastError, showToastWarning } = useToaster();
     const nextKey = useRef(0);
     const previewUrls = useRef(new Map<string, string>());
+    const activeKeys = useRef(new Set<string>());
+    const clearGeneration = useRef(0);
+    const isActive = useRef(true);
 
     const revokePreview = useCallback((key: string) => {
         const url = previewUrls.current.get(key);
@@ -49,67 +55,105 @@ export const useVizComposerAttachments = ({
         previewUrls.current.clear();
     }, []);
 
-    useEffect(() => () => releasePreviews(), [releasePreviews]);
+    useEffect(() => {
+        const keys = activeKeys.current;
+        isActive.current = true;
+        return () => {
+            isActive.current = false;
+            keys.clear();
+            releasePreviews();
+        };
+    }, [releasePreviews]);
 
     const add = useCallback(
         (files: File[]) => {
             if (!projectUuid) return;
-            const withinSize = files.filter((file) => {
-                if (file.size <= MAX_FILE_SIZE) return true;
-                showToastError({
-                    title: 'File too large',
-                    subtitle: `${file.name} exceeds the 10MB limit.`,
-                });
-                return false;
+            const withinSize = files.flatMap((file) => {
+                const error = getAppFileSizeError(file);
+                if (!error) return [file];
+                showToastError(error);
+                return [];
             });
-            // Computing this outside the updater prevents duplicate toasts.
-            const room = Math.max(
-                0,
-                MAX_APP_FILES_PER_VERSION - attachments.length,
+            const images = withinSize.filter(isSupportedAppImage);
+            const filesToInspect = withinSize.filter(
+                (file) => !isSupportedAppImage(file),
             );
-            if (withinSize.length > room) {
+            let warnedAboutLimit = false;
+            const warnAboutLimit = () => {
+                if (warnedAboutLimit) return;
+                warnedAboutLimit = true;
                 showToastWarning({
                     title: 'Attachment limit reached',
                     subtitle: `You can attach up to ${MAX_APP_FILES_PER_VERSION} files per message.`,
                 });
-            }
+            };
 
-            withinSize.slice(0, room).forEach((file) => {
-                const key = String(nextKey.current++);
-                const previewUrl = file.type.startsWith('image/')
-                    ? URL.createObjectURL(file)
-                    : null;
-                if (previewUrl) previewUrls.current.set(key, previewUrl);
+            const attach = (validatedFiles: File[]) => {
+                validatedFiles.forEach((file) => {
+                    if (activeKeys.current.size >= MAX_APP_FILES_PER_VERSION) {
+                        warnAboutLimit();
+                        return;
+                    }
+                    const key = String(nextKey.current++);
+                    activeKeys.current.add(key);
+                    const previewUrl = isSupportedAppImage(file)
+                        ? URL.createObjectURL(file)
+                        : null;
+                    if (previewUrl) previewUrls.current.set(key, previewUrl);
 
-                setAttachments((prev) => [
-                    ...prev,
-                    { fileId: null, filename: file.name, previewUrl, key },
-                ]);
+                    setAttachments((prev) => [
+                        ...prev,
+                        { fileId: null, filename: file.name, previewUrl, key },
+                    ]);
 
-                void uploadFile({ projectUuid, appUuid, file })
-                    .then(({ fileId }) =>
-                        setAttachments((prev) =>
-                            prev.map((a) =>
-                                a.key === key ? { ...a, fileId } : a,
+                    void uploadFile({ projectUuid, appUuid, file })
+                        .then(({ fileId }) =>
+                            setAttachments((prev) =>
+                                prev.map((a) =>
+                                    a.key === key ? { ...a, fileId } : a,
+                                ),
                             ),
-                        ),
-                    )
-                    .catch(() => {
-                        revokePreview(key);
-                        setAttachments((prev) =>
-                            prev.filter((a) => a.key !== key),
-                        );
-                        showToastError({
-                            title: 'Upload failed',
-                            subtitle: 'Please try again or contact support.',
+                        )
+                        .catch(() => {
+                            if (!activeKeys.current.delete(key)) return;
+                            revokePreview(key);
+                            setAttachments((prev) =>
+                                prev.filter((a) => a.key !== key),
+                            );
+                            showToastError({
+                                title: 'Upload failed',
+                                subtitle:
+                                    'Please try again or contact support.',
+                            });
                         });
-                    });
+                });
+            };
+
+            attach(images);
+            const generation = clearGeneration.current;
+            void Promise.all(
+                filesToInspect.map(async (file) => ({
+                    file,
+                    error: await getAppFileValidationError(file),
+                })),
+            ).then((inspected) => {
+                if (
+                    !isActive.current ||
+                    generation !== clearGeneration.current
+                ) {
+                    return;
+                }
+                const inspectedFiles = inspected.flatMap(({ file, error }) => {
+                    if (!error) return [file];
+                    showToastError(error);
+                    return [];
+                });
+                attach(inspectedFiles);
             });
         },
         [
             projectUuid,
             appUuid,
-            attachments.length,
             uploadFile,
             showToastError,
             showToastWarning,
@@ -119,6 +163,7 @@ export const useVizComposerAttachments = ({
 
     const remove = useCallback(
         (key: string) => {
+            activeKeys.current.delete(key);
             revokePreview(key);
             setAttachments((prev) => prev.filter((a) => a.key !== key));
         },
@@ -126,6 +171,8 @@ export const useVizComposerAttachments = ({
     );
 
     const clear = useCallback(() => {
+        clearGeneration.current += 1;
+        activeKeys.current.clear();
         releasePreviews();
         setAttachments([]);
     }, [releasePreviews]);

--- a/packages/frontend/src/features/apps/utils/appFileAttachments.test.ts
+++ b/packages/frontend/src/features/apps/utils/appFileAttachments.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+    getAppFileValidationError,
+    MAX_APP_FILE_SIZE,
+} from './appFileAttachments';
+
+const sampledFile = (name: string, bytes: number[], type = ''): File => {
+    const file = new File([Uint8Array.from(bytes)], name, { type });
+    vi.spyOn(file, 'slice').mockReturnValue({
+        arrayBuffer: async () => Uint8Array.from(bytes).buffer,
+    } as Blob);
+    return file;
+};
+
+describe('getAppFileValidationError', () => {
+    it('accepts supported image types without inspecting their contents', async () => {
+        const file = sampledFile('chart.png', [], 'image/png');
+
+        await expect(getAppFileValidationError(file)).resolves.toBeNull();
+        expect(file.slice).not.toHaveBeenCalled();
+    });
+
+    it('accepts a PDF by its signature', async () => {
+        const file = sampledFile('report', [0x25, 0x50, 0x44, 0x46, 0x00]);
+
+        await expect(getAppFileValidationError(file)).resolves.toBeNull();
+    });
+
+    it('accepts UTF-8 text regardless of extension or MIME type', async () => {
+        const file = sampledFile('workbook.twb', [0x3c, 0x78, 0x6d, 0x6c]);
+
+        await expect(getAppFileValidationError(file)).resolves.toBeNull();
+    });
+
+    it('rejects binary content', async () => {
+        const file = sampledFile('archive.bin', [0x89, 0x00, 0xff]);
+
+        await expect(getAppFileValidationError(file)).resolves.toMatchObject({
+            title: 'Unsupported file type',
+        });
+    });
+
+    it('rejects files over 10MB before reading them', async () => {
+        const file = sampledFile('huge.png', [0x78], 'image/png');
+        Object.defineProperty(file, 'size', {
+            value: MAX_APP_FILE_SIZE + 1,
+        });
+
+        await expect(getAppFileValidationError(file)).resolves.toMatchObject({
+            title: 'File too large',
+        });
+        expect(file.slice).not.toHaveBeenCalled();
+    });
+});

--- a/packages/frontend/src/features/apps/utils/appFileAttachments.ts
+++ b/packages/frontend/src/features/apps/utils/appFileAttachments.ts
@@ -1,0 +1,62 @@
+export const MAX_APP_FILE_SIZE = 10 * 1024 * 1024;
+
+const ACCEPTED_IMAGE_TYPES = new Set([
+    'image/png',
+    'image/jpeg',
+    'image/gif',
+    'image/webp',
+]);
+
+export type AppFileValidationError = {
+    title: string;
+    subtitle: string;
+};
+
+export const isSupportedAppImage = (file: File): boolean =>
+    ACCEPTED_IMAGE_TYPES.has(file.type);
+
+export const getAppFileSizeError = (
+    file: File,
+): AppFileValidationError | null =>
+    file.size > MAX_APP_FILE_SIZE
+        ? {
+              title: 'File too large',
+              subtitle: `${file.name} exceeds the 10MB limit.`,
+          }
+        : null;
+
+const isSupportedNonImageFile = async (file: File): Promise<boolean> => {
+    try {
+        const sample = new Uint8Array(await file.slice(0, 8192).arrayBuffer());
+        if (sample.length === 0) return false;
+        if (
+            sample[0] === 0x25 &&
+            sample[1] === 0x50 &&
+            sample[2] === 0x44 &&
+            sample[3] === 0x46
+        ) {
+            return true;
+        }
+        if (sample.includes(0)) return false;
+        new TextDecoder('utf-8', { fatal: true }).decode(sample, {
+            stream: true,
+        });
+        return true;
+    } catch {
+        return false;
+    }
+};
+
+export const getAppFileValidationError = async (
+    file: File,
+): Promise<AppFileValidationError | null> => {
+    const sizeError = getAppFileSizeError(file);
+    if (sizeError) return sizeError;
+    if (!isSupportedAppImage(file) && !(await isSupportedNonImageFile(file))) {
+        return {
+            title: 'Unsupported file type',
+            subtitle: `${file.name}: attach images (PNG, JPEG, GIF, WEBP), PDFs, or text-based files (JSON, CSV, Markdown, TWB, code, …).`,
+        };
+    }
+    return null;
+};

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -137,6 +137,10 @@ import { useTrackedExternalRequests } from '../features/apps/hooks/useTrackedExt
 import { usePreviewOrigin } from '../features/apps/previewOrigin';
 import { getTemplate } from '../features/apps/templates';
 import {
+    getAppFileValidationError,
+    isSupportedAppImage,
+} from '../features/apps/utils/appFileAttachments';
+import {
     emptyChatMessage,
     mergeChatMessages,
     type ChatAttachedFile,
@@ -1453,61 +1457,13 @@ const AppGenerate: FC = () => {
         return <Box>Missing project UUID</Box>;
     }
 
-    const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
-    const ACCEPTED_IMAGE_TYPES = [
-        'image/png',
-        'image/jpeg',
-        'image/gif',
-        'image/webp',
-    ];
-
-    // Mirrors the backend's content classification: PDFs by %PDF signature,
-    // everything else accepted only when the first bytes sniff as UTF-8 text
-    // (no NUL, streaming decode tolerates a cut-off multi-byte sequence).
-    // Extension/MIME lists don't work here — browsers report an empty type
-    // for extensions they don't know (.twb, .yml, …).
-    const isSupportedNonImageFile = async (file: File): Promise<boolean> => {
-        try {
-            const sample = new Uint8Array(
-                await file.slice(0, 8192).arrayBuffer(),
-            );
-            if (sample.length === 0) return false;
-            if (
-                sample[0] === 0x25 &&
-                sample[1] === 0x50 &&
-                sample[2] === 0x44 &&
-                sample[3] === 0x46
-            ) {
-                return true; // %PDF
-            }
-            if (sample.includes(0)) return false;
-            new TextDecoder('utf-8', { fatal: true }).decode(sample, {
-                stream: true,
-            });
-            return true;
-        } catch {
-            // Invalid UTF-8, or the entry isn't readable at all (e.g. a
-            // dropped folder rejects with NotReadableError).
-            return false;
-        }
-    };
-
     const handleFileAttach = async (file: File, kind?: 'screenshot') => {
-        if (file.size > MAX_FILE_SIZE) {
-            showToastError({
-                title: 'File too large',
-                subtitle: `${file.name} exceeds the 10MB limit.`,
-            });
+        const validationError = await getAppFileValidationError(file);
+        if (validationError) {
+            showToastError(validationError);
             return;
         }
-        const isImage = ACCEPTED_IMAGE_TYPES.includes(file.type);
-        if (!isImage && !(await isSupportedNonImageFile(file))) {
-            showToastError({
-                title: 'Unsupported file type',
-                subtitle: `${file.name}: attach images (PNG, JPEG, GIF, WEBP), PDFs, or text-based files (JSON, CSV, Markdown, TWB, code, …).`,
-            });
-            return;
-        }
+        const isImage = isSupportedAppImage(file);
         setFileAttachments((prev) => {
             if (prev.length >= MAX_APP_FILES_PER_VERSION) {
                 showToastWarning({


### PR DESCRIPTION
Brings the visualization composer up to parity with the app generator: paste and drag/drop attachments share the same validation, builds can be stopped, and ready revisions refresh option contracts so stale controls disappear.

Also keeps the collapsed dock usable at narrow widths and replaces the restore confirmation with concise user-facing copy.

Tests: focused frontend suites (61 passed, plus 16 version-log tests); frontend typecheck, lint, and formatting.

Closes: GLITCH-630