### PR TITLE
chore: fix all lint warnings across packages

### DIFF
--- a/packages/api-tests/tests/embedChart.test.ts
+++ b/packages/api-tests/tests/embedChart.test.ts
@@ -267,6 +267,7 @@ describe('Embed Chart JWT API', () => {
 
         describe('POST query chart', () => {
             // This is the method used for the explore to get results from a chart
+            // oxlint-disable-next-line vitest-js/no-disabled-tests -- FIXME below documents why this can't run yet
             it.skip('should get chart query results using JWT token (authorized)', async () => {
                 // FIXME this doesn't work
                 // Currently throws a 403
@@ -310,6 +311,7 @@ describe('Embed Chart JWT API', () => {
         });
 
         describe('GET chart history', () => {
+            // oxlint-disable-next-line vitest-js/no-disabled-tests -- FIXME below documents why this can't run yet
             it.skip('should get chart history using JWT token (authorized)', async () => {
                 // FIXME this doesn't work
                 // SavedChartController.getChartHistory doesn't support embed JWT accounts
@@ -341,6 +343,7 @@ describe('Embed Chart JWT API', () => {
         });
 
         describe('GET chart views', () => {
+            // oxlint-disable-next-line vitest-js/no-disabled-tests -- FIXME below documents why this can't run yet
             it.skip('should get chart views using JWT token (authorized)', async () => {
                 // FIXME this doesn't work
                 // > 500: Internal Server Error
@@ -373,6 +376,7 @@ describe('Embed Chart JWT API', () => {
         // This method is deprecated, but still supported for backwards compatibility
         // We still need to make sure we can get access using the JWT token if the chart matches
         describe('POST chart results deprecated', () => {
+            // oxlint-disable-next-line vitest-js/no-disabled-tests -- FIXME below documents why this can't run yet
             it.skip('should get chart results using JWT token (authorized)', async () => {
                 // FIXME this doesn't work currently because SavedChartController.postChartResults
                 // is not supporting account, so fails to get userUuid parameter

--- a/packages/api-tests/tests/savedChartGet.test.ts
+++ b/packages/api-tests/tests/savedChartGet.test.ts
@@ -621,6 +621,7 @@ describe('Saved chart get API behavior', () => {
                 (item) => item.uuid === chart.uuid,
             );
             if (!isInTrash) {
+                // oxlint-disable-next-line vitest-js/no-disabled-tests -- runtime skip when soft delete is disabled on the server
                 ctx.skip();
                 return;
             }

--- a/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
@@ -237,6 +237,7 @@ describe('ProjectModel', () => {
         // TODO: this test is skipped because there is an issue in our version of knex-mock-client
         // which makes it not handle batch inserts correctly. If we upgrade to a newer version,
         // we can remove the skip. There are a lot of breaking changes in the new version though.
+        // oxlint-disable-next-line vitest-js/no-disabled-tests -- blocked on knex-mock-client upgrade, see TODO above
         test.skip('should discard explores with duplicate name', async () => {
             // Mock for selecting custom explores/virtual views
             tracker.on

--- a/packages/backend/src/services/SpaceService/SpaceService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.test.ts
@@ -883,6 +883,7 @@ describe('SpaceService', () => {
     // These tests should pass but they don't - could be a mock problem.
     // It could also be because in the app we actually build project abilities for every group membership before
     // we build the space abilities (here we only test space access for a single project).
+    // oxlint-disable-next-line vitest-js/no-commented-out-tests -- kept as documentation of the untested group-role cases above
     // it.each([
     //     {
     //         name: 'user with multiple project group roles gets highest role (admin over viewer)',

--- a/packages/common/src/authorization/roleToScopeParity.test.ts
+++ b/packages/common/src/authorization/roleToScopeParity.test.ts
@@ -366,6 +366,7 @@ describe('Role to Scope Parity', () => {
     });
 
     // This is helpful for debugging, but it's not a test
+    // oxlint-disable-next-line vitest-js/no-disabled-tests -- debugging helper, intentionally not run
     describe.skip('Rule Count Analysis', () => {
         it('should report rule counts for documentation', () => {
             console.log('\n=== ROLE PERMISSION RULE COUNTS ===');

--- a/packages/common/src/compiler/parameters.ts
+++ b/packages/common/src/compiler/parameters.ts
@@ -249,6 +249,7 @@ const getParametersSchemaAndValidator = ():
         const parametersSchema =
             lightdashDbtYamlSchema.$defs?.modelMeta?.properties?.parameters;
         if (!parametersSchema) {
+            // eslint-disable-next-line no-console
             console.warn(
                 'Parameters schema not found in lightdash-dbt-2.0.json — expected $defs.modelMeta.properties.parameters. Skipping parameter config validation.',
             );

--- a/packages/common/src/schemas/generateChartAsCodeSchema.ts
+++ b/packages/common/src/schemas/generateChartAsCodeSchema.ts
@@ -531,6 +531,7 @@ const run = (): void => {
             JSON.parse(currentContent) as JsonObject,
         );
         if (normalizedCurrentContent !== nextContent) {
+            // eslint-disable-next-line no-console
             console.error(
                 'chart-as-code schema is out of date. Run `pnpm generate:chart-as-code-schema`.',
             );

--- a/packages/common/src/schemas/generateDashboardAsCodeSchema.ts
+++ b/packages/common/src/schemas/generateDashboardAsCodeSchema.ts
@@ -431,6 +431,7 @@ const run = (): void => {
             JSON.parse(currentContent) as JsonObject,
         );
         if (normalizedCurrentContent !== nextContent) {
+            // eslint-disable-next-line no-console
             console.error(
                 'dashboard-as-code schema is out of date. Run `pnpm generate:dashboard-as-code-schema`.',
             );

--- a/packages/common/src/schemas/generateMcpToolsSnapshot.ts
+++ b/packages/common/src/schemas/generateMcpToolsSnapshot.ts
@@ -108,6 +108,7 @@ const run = (): void => {
             JSON.parse(currentContent) as JsonObject,
         );
         if (normalizedCurrentContent !== nextContent) {
+            // eslint-disable-next-line no-console
             console.error(
                 'mcp-tools snapshot is out of date. Run `pnpm generate:mcp-tools-snapshot`.',
             );

--- a/packages/common/src/utils/loadLightdashProjectConfig.ts
+++ b/packages/common/src/utils/loadLightdashProjectConfig.ts
@@ -74,6 +74,7 @@ export const loadLightdashProjectConfig = async (
 
     // Collisions with a reserved name don't fail config load: the user param wins; warn.
     if (reservedParameters.length > 0) {
+        // eslint-disable-next-line no-console
         console.warn(
             `lightdash.config.yml: parameter${
                 reservedParameters.length > 1 ? 's' : ''

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallChip.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallChip.tsx
@@ -39,7 +39,11 @@ export const ToolCallChip: FC<ToolCallChipProps> = ({
         style={{
             textTransform: 'none',
             fontWeight: 400,
-            ...(typeof style === 'object' && style !== null ? style : {}),
+            ...(typeof style === 'object' &&
+            style !== null &&
+            !Array.isArray(style)
+                ? style
+                : {}),
         }}
     >
         {typeof children === 'string' ? (

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadStreamSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadStreamSlice.ts
@@ -7,7 +7,7 @@ import { type AiAgentToolCall } from '../types';
 
 type ToolCall = AiAgentToolCall & {
     toolCallId: string;
-    toolResult: AiAgentToolCall['toolResult'] | null;
+    toolResult: AiAgentToolCall['toolResult'];
 };
 
 type Reasoning = {

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/parseStreamRawToolResult.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/parseStreamRawToolResult.ts
@@ -50,7 +50,7 @@ type BuiltInToolResult = {
 type McpToolCall = {
     toolName: McpStreamToolName;
     toolArgs: object;
-    toolResult?: unknown | null;
+    toolResult?: unknown;
     isPreliminary?: boolean;
 };
 

--- a/packages/frontend/src/testing/vitest.setup.ts
+++ b/packages/frontend/src/testing/vitest.setup.ts
@@ -11,12 +11,12 @@ import ReactMarkdownPreview from './__mocks__/modules/ReactMarkdwnPreview.mock';
 // hermetic, matching what `isomorphic-fetch` resolved to here before.
 vi.stubGlobal('fetch', nodeFetch);
 
+vi.mock('@uiw/react-markdown-preview', () => ({
+    default: ReactMarkdownPreview,
+}));
+
 beforeAll(() => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
-
-    vi.mock('@uiw/react-markdown-preview', () => ({
-        default: ReactMarkdownPreview,
-    }));
 
     mockMatchMedia();
     mockResizeObserver();

--- a/packages/warehouses/src/warehouseClients/PgQueryStream.ts
+++ b/packages/warehouses/src/warehouseClients/PgQueryStream.ts
@@ -98,4 +98,4 @@ class QueryStream extends Readable implements Submittable {
     }
 }
 
-export = QueryStream;
+export default QueryStream;


### PR DESCRIPTION
## Summary

`pnpm lint` reported 18 warnings across five packages. This clears all of them so lint runs clean.

**Code fixes:**
- `warehouses/PgQueryStream.ts`: replace legacy `export =` with `export default` — its only importer already uses a default import, and the module is not part of the package's public API
- `frontend/testing/vitest.setup.ts`: move `vi.mock('@uiw/react-markdown-preview', …)` out of `beforeAll` to the top level; vitest hoists it there anyway, so this makes the actual behavior explicit
- `frontend` aiCopilot types: drop redundant `| null` from unions that already resolve to `unknown`
- `ToolCallChip`: exclude arrays from the `style`-spread guard so an array style can't spread numeric indices into the style object

**Intentional code kept, with targeted disable comments:**
- Five `no-console` sites in `common` (runtime config warnings and `--check`-mode generator messages), using the repo-conventional `eslint-disable-next-line no-console`
- Skipped/commented-out tests that document known gaps (embed-JWT api-tests, knex-mock-client-blocked backend test, debugging-only describe block, conditional runtime skip), each with a reason on the directive

## Verification

- `pnpm lint` — 0 warnings, 0 errors in all packages
- `pnpm format` — clean
- Typecheck green for common, backend, frontend, warehouses
- Warehouses test suite passes (292 tests), covering the Postgres streaming path touched by the export change

Closes: none — lint housekeeping, no Linear ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)