### PR TITLE
feat(omnibar): redesign global search with a preview panel

### DIFF
--- a/packages/frontend/src/components/common/ResourceIcon/index.tsx
+++ b/packages/frontend/src/components/common/ResourceIcon/index.tsx
@@ -30,6 +30,7 @@ interface IconBoxProps extends MantineIconProps {
     color: string;
     bg?: string;
     icon: TablerIconType;
+    boxSize?: number;
 }
 
 export const IconBox: FC<IconBoxProps> = ({
@@ -37,9 +38,16 @@ export const IconBox: FC<IconBoxProps> = ({
     icon,
     size = 'lg',
     bg = 'ldGray.0',
+    boxSize = 32,
     ...mantineIconProps
 }) => (
-    <Paper w={32} h={32} radius="md" bg={bg} className={classes.iconBox}>
+    <Paper
+        w={boxSize}
+        h={boxSize}
+        radius="md"
+        bg={bg}
+        className={classes.iconBox}
+    >
         <MantineIcon
             icon={icon}
             color={color}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminMemoriesTable.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminMemoriesTable.test.tsx
@@ -1,5 +1,5 @@
 import { type AiAgentAdminMemoryItem } from '@lightdash/common';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -104,11 +104,17 @@ describe('AiAgentAdminMemoriesTable', () => {
         await user.click(screen.getByRole('button', { name: /Scope/ }));
         await user.click(await screen.findByText('Project-wide'));
 
-        expect(mockUseInfiniteAiAgentAdminMemories).toHaveBeenLastCalledWith(
-            expect.objectContaining({
-                filters: expect.objectContaining({ scopes: ['project'] }),
-            }),
-            expect.anything(),
+        // The facet re-renders asynchronously, so the hook's latest call can
+        // still be the initial one at the moment the click resolves.
+        await waitFor(() =>
+            expect(
+                mockUseInfiniteAiAgentAdminMemories,
+            ).toHaveBeenLastCalledWith(
+                expect.objectContaining({
+                    filters: expect.objectContaining({ scopes: ['project'] }),
+                }),
+                expect.anything(),
+            ),
         );
     });
 });

--- a/packages/frontend/src/features/omnibar/components/Omnibar.module.css
+++ b/packages/frontend/src/features/omnibar/components/Omnibar.module.css
@@ -1,17 +1,106 @@
-.modalBody {
-    padding: 0;
+/* Fixed, viewport-aware height so the modal never jumps between states and
+   the footer always stays visible — the results area flexes to the rest. */
+.modalContent {
+    border: 1px solid
+        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-ldDark-4));
+    overflow: hidden;
+    height: min(560px, calc(100dvh - 160px));
+    display: flex;
+    flex-direction: column;
 }
 
-.inputWrapper {
-    position: sticky;
-    z-index: 1;
-    top: 0;
+.modalBody {
+    /* Mantine's Modal-body padding is var()-driven — zero it at the source
+       rather than fighting rule order. */
+    --mb-padding: 0;
+    padding: 0;
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    padding-top: 0 !important;
+}
+
+.stack {
+    flex: 1;
+    min-height: 0;
+}
+
+.inputRow {
+    height: 52px;
+    padding: 0 var(--mantine-spacing-md);
+    border-bottom: 1px solid
+        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-ldDark-4));
+    flex-shrink: 0;
 }
 
 .input {
-    border-top: 0;
-    border-right: 0;
-    border-left: 0;
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border: 0;
+    background: transparent;
+    font-size: var(--mantine-font-size-lg);
+}
+
+.resultsArea {
+    border-top: 1px solid
+        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-ldDark-4));
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+
+    > * {
+        flex: 1;
+        min-height: 0;
+    }
+}
+
+.resultsRow {
+    min-width: 0;
+    overflow: hidden;
+}
+
+.listCol {
+    flex: 1;
+    min-width: 0;
+    overflow-y: auto;
+}
+
+.listCol,
+.resultsArea {
+    scrollbar-width: thin;
+    scrollbar-color: light-dark(
+            var(--mantine-color-ldGray-3),
+            var(--mantine-color-ldDark-6)
+        )
+        transparent;
+}
+
+.listCol::-webkit-scrollbar,
+.resultsArea::-webkit-scrollbar {
+    width: 6px;
+}
+
+.listCol::-webkit-scrollbar-thumb,
+.resultsArea::-webkit-scrollbar-thumb {
+    background: light-dark(
+        var(--mantine-color-ldGray-3),
+        var(--mantine-color-ldDark-6)
+    );
+    border-radius: 999px;
+}
+
+.listCol::-webkit-scrollbar-track,
+.resultsArea::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.footer {
+    padding: var(--mantine-spacing-xs) var(--mantine-spacing-md);
+    border-top: 1px solid
+        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-ldDark-4));
+    background-color: light-dark(
+        var(--mantine-color-ldGray-0),
+        var(--mantine-color-ldDark-2)
+    );
 }

--- a/packages/frontend/src/features/omnibar/components/Omnibar.tsx
+++ b/packages/frontend/src/features/omnibar/components/Omnibar.tsx
@@ -1,3 +1,4 @@
+import { subject } from '@casl/ability';
 import {
     getSearchResultId,
     SearchItemType,
@@ -5,10 +6,15 @@ import {
 } from '@lightdash/common';
 import {
     ActionIcon,
+    Box,
+    Button,
+    Group,
+    Kbd,
     Loader,
     Modal,
     rem,
     Stack,
+    Text,
     TextInput,
     Transition,
 } from '@mantine-8/core';
@@ -18,7 +24,12 @@ import {
     useHotkeys,
     useScrollIntoView,
 } from '@mantine-8/hooks';
-import { IconCircleXFilled, IconSearch } from '@tabler/icons-react';
+import {
+    IconSearch,
+    IconSettings,
+    IconTable,
+    IconX,
+} from '@tabler/icons-react';
 import {
     useEffect,
     useMemo,
@@ -28,23 +39,29 @@ import {
 } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
-import { PAGE_CONTENT_WIDTH } from '../../../components/common/Page/constants';
+import { AiAgentIcon } from '../../../ee/features/aiCopilot/components/AiAgentIcon';
+import { useAiAgentButtonVisibility } from '../../../ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility';
 import { useProject } from '../../../hooks/useProject';
+import { useSpaceSummaries } from '../../../hooks/useSpaces';
 import { useValidationUserAbility } from '../../../hooks/validation/useValidation';
+import useApp from '../../../providers/App/useApp';
+import Mantine8Provider from '../../../providers/Mantine8Provider';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import { useOmnibarSettingsItems } from '../hooks/useOmnibarSettingsItems';
 import useSearch, { hasMinQueryLength } from '../hooks/useSearch';
 import {
-    allSearchItemTypes,
     type FocusedItemIndex,
+    type OmnibarGroup,
     type SearchItem,
 } from '../types/searchItem';
+import { getSearchItemLabel } from '../utils/getSearchItemLabel';
 import classes from './Omnibar.module.css';
 import OmnibarEmptyState from './OmnibarEmptyState';
 import OmnibarFilters from './OmnibarFilters';
 import OmnibarItemGroups from './OmnibarItemGroups';
 import { OmnibarKeyboardNav } from './OmnibarKeyboardNav';
+import OmnibarPreview from './OmnibarPreview';
 import OmnibarTarget from './OmnibarTarget';
 import { getSearchResultsGroupsSorted } from './utils';
 
@@ -62,11 +79,12 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
     const [query, setQuery] = useState<string>();
     const [debouncedValue] = useDebouncedValue(query, 300);
     const { targetRef: scrollRef } = useScrollIntoView<HTMLDivElement>(); // couldn't get scroll to work with mantine's function
-    const [openPanels, setOpenPanels] =
-        useState<SearchItemType[]>(allSearchItemTypes);
 
-    const [focusedItemIndex, setFocusedItemIndex] =
-        useState<FocusedItemIndex>();
+    // undefined = default (top hit highlighted); 'input' = the user arrowed
+    // back up to the search input, so no row is highlighted.
+    const [focusedItemIndex, setFocusedItemIndex] = useState<
+        FocusedItemIndex | 'input'
+    >();
 
     const { data: searchResults, isFetching } = useSearch({
         projectUuid,
@@ -79,6 +97,36 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
 
     const [isOmnibarOpen, { open: openOmnibar, close: closeOmnibar }] =
         useDisclosure(false);
+
+    const { data: spaceSummaries } = useSpaceSummaries(projectUuid, true, {
+        enabled: isOmnibarOpen,
+    });
+    const spaceNamesByUuid = useMemo(
+        () =>
+            new Map(
+                (spaceSummaries ?? []).map((space) => [space.uuid, space.name]),
+            ),
+        [spaceSummaries],
+    );
+
+    const { user } = useApp();
+    const isAiAgentsEnabled = useAiAgentButtonVisibility();
+    const canManageExplore =
+        user.data?.ability?.can(
+            'manage',
+            subject('Explore', {
+                organizationUuid: user.data.organizationUuid,
+                projectUuid,
+            }),
+        ) ?? false;
+    const canManageProject =
+        user.data?.ability?.can(
+            'manage',
+            subject('Project', {
+                organizationUuid: user.data.organizationUuid,
+                projectUuid,
+            }),
+        ) ?? false;
 
     const handleOmnibarOpenInputClick: MouseEventHandler<HTMLInputElement> = (
         e,
@@ -111,6 +159,12 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
         [],
         true,
     );
+
+    const handleQuickAction = (pathname: string) => {
+        closeOmnibar();
+        setQuery(undefined);
+        void navigate(pathname);
+    };
 
     const handleOmnibarClose = () => {
         track({
@@ -166,8 +220,14 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
     const hasEnteredQuery = query !== undefined && query !== '';
     const hasEnteredMinQueryLength =
         hasEnteredQuery && hasMinQueryLength(query);
+    const hasActiveFilters = Boolean(
+        searchFilters?.type ||
+        searchFilters?.fromDate ||
+        searchFilters?.toDate ||
+        searchFilters?.createdByUuid,
+    );
 
-    const sortedGroupEntries = useMemo(() => {
+    const searchGroups = useMemo<OmnibarGroup[]>(() => {
         const contentGroups = searchResults
             ? getSearchResultsGroupsSorted(searchResults)
             : [];
@@ -177,7 +237,7 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
             (!searchFilters?.type ||
                 searchFilters.type === SearchItemType.SETTINGS);
 
-        return showSettings
+        const entries = showSettings
             ? [
                   ...contentGroups,
                   [SearchItemType.SETTINGS, settingsItems] as [
@@ -186,19 +246,87 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
                   ],
               ]
             : contentGroups;
+
+        return entries.map(([type, items]) => ({
+            key: type,
+            label: getSearchItemLabel(type),
+            items,
+            totalCount: items.length,
+            collapsed: false,
+        }));
     }, [searchResults, settingsItems, searchFilters?.type]);
 
-    const hasSearchResults = sortedGroupEntries.length > 0;
+    const [collapsedGroupKeys, setCollapsedGroupKeys] = useState<string[]>([]);
+
+    const handleToggleGroup = (key: string) => {
+        setCollapsedGroupKeys((keys) =>
+            keys.includes(key) ? keys.filter((k) => k !== key) : [...keys, key],
+        );
+    };
+
+    const displayGroups = useMemo<OmnibarGroup[]>(() => {
+        const groups =
+            !hasEnteredQuery || !hasEnteredMinQueryLength || !searchResults
+                ? []
+                : searchGroups;
+
+        return groups.map((group) =>
+            collapsedGroupKeys.includes(group.key)
+                ? { ...group, items: [], collapsed: true }
+                : group,
+        );
+    }, [
+        hasEnteredQuery,
+        hasEnteredMinQueryLength,
+        searchResults,
+        searchGroups,
+        collapsedGroupKeys,
+    ]);
+
     useEffect(() => {
         setFocusedItemIndex(undefined);
     }, [query, searchFilters]);
 
+    // Default to the first row so Enter works immediately and the preview
+    // panel always has content; clamp stale indices after the groups change.
+    // 'input' means the user arrowed back to the search field — no highlight.
+    const firstNavigableGroupIndex = displayGroups.findIndex(
+        (group) => group.items.length > 0,
+    );
+
+    const highlightedIndex = useMemo<FocusedItemIndex | undefined>(() => {
+        if (firstNavigableGroupIndex === -1) return undefined;
+        if (focusedItemIndex === 'input') return undefined;
+        if (
+            focusedItemIndex &&
+            displayGroups[focusedItemIndex.groupIndex]?.items[
+                focusedItemIndex.itemIndex
+            ]
+        ) {
+            return focusedItemIndex;
+        }
+        return { groupIndex: firstNavigableGroupIndex, itemIndex: 0 };
+    }, [focusedItemIndex, displayGroups, firstNavigableGroupIndex]);
+
+    // The preview keeps showing the top hit even when nothing is highlighted,
+    // and Enter opens it — the pane never goes dead.
+    const focusedItem = highlightedIndex
+        ? displayGroups[highlightedIndex.groupIndex]?.items[
+              highlightedIndex.itemIndex
+          ]
+        : firstNavigableGroupIndex !== -1
+          ? displayGroups[firstNavigableGroupIndex]?.items[0]
+          : undefined;
+
     return (
         <OmnibarKeyboardNav
-            groupedItems={sortedGroupEntries}
+            groupedItems={displayGroups}
             onEnterPressed={handleItemClick}
-            onFocusedItemChange={setFocusedItemIndex}
-            currentFocusedItemIndex={focusedItemIndex}
+            onFocusedItemChange={(index) =>
+                setFocusedItemIndex(index ?? 'input')
+            }
+            currentFocusedItemIndex={highlightedIndex}
+            fallbackEnterItem={focusedItem}
         >
             <Transition
                 mounted={!isOmnibarOpen}
@@ -217,95 +345,235 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
                 )}
             </Transition>
 
-            <Modal
-                withCloseButton={false}
-                size={`calc(${rem(PAGE_CONTENT_WIDTH)} - var(--mantine-spacing-lg) * 2)`}
-                closeOnClickOutside
-                closeOnEscape
-                radius="md"
-                opened={isOmnibarOpen}
-                onClose={handleOmnibarClose}
-                yOffset={100}
-                classNames={{
-                    body: classes.modalBody,
-                }}
-            >
-                <Stack gap={0}>
-                    <TextInput
-                        size="xl"
-                        data-autofocus
-                        leftSection={
-                            isFetching ? (
+            {/* The navbar renders inside a forced-dark provider, but this
+                modal portals onto the page — re-anchor the subtree to the
+                app's real color scheme so JS-resolved component colors match
+                the page instead of the navbar. */}
+            <Mantine8Provider withCssVariables={false}>
+                <Modal
+                    withCloseButton={false}
+                    size={rem(960)}
+                    closeOnClickOutside
+                    closeOnEscape
+                    radius="lg"
+                    opened={isOmnibarOpen}
+                    onClose={handleOmnibarClose}
+                    yOffset={100}
+                    classNames={{
+                        content: classes.modalContent,
+                        body: classes.modalBody,
+                    }}
+                >
+                    <Stack gap={0} className={classes.stack}>
+                        <Group
+                            gap="sm"
+                            wrap="nowrap"
+                            className={classes.inputRow}
+                        >
+                            {isFetching ? (
                                 <Loader size="xs" color="ldGray.5" />
                             ) : (
-                                <MantineIcon icon={IconSearch} size="lg" />
-                            )
-                        }
-                        rightSection={
-                            query ? (
-                                <ActionIcon
-                                    variant="transparent"
+                                <MantineIcon
+                                    icon={IconSearch}
                                     size="lg"
+                                    color="ldGray.6"
+                                />
+                            )}
+                            <TextInput
+                                variant="unstyled"
+                                size="md"
+                                data-autofocus
+                                flex={1}
+                                placeholder={`Search ${
+                                    projectData?.name ?? 'in your project'
+                                }...`}
+                                classNames={{
+                                    input: classes.input,
+                                }}
+                                value={query ?? ''}
+                                onChange={(
+                                    e: React.ChangeEvent<HTMLInputElement>,
+                                ) => setQuery(e.currentTarget.value)}
+                            />
+                            {query ? (
+                                <ActionIcon
+                                    variant="subtle"
+                                    size="sm"
                                     color="gray"
                                     onClick={() => setQuery('')}
                                 >
-                                    <MantineIcon
-                                        icon={IconCircleXFilled}
-                                        size="lg"
-                                    />
+                                    <MantineIcon icon={IconX} size="md" />
                                 </ActionIcon>
-                            ) : null
-                        }
-                        placeholder={`Search ${
-                            projectData?.name ?? 'in your project'
-                        }...`}
-                        classNames={{
-                            wrapper: classes.inputWrapper,
-                            input: classes.input,
-                        }}
-                        value={query ?? ''}
-                        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                            setQuery(e.currentTarget.value)
-                        }
-                    />
+                            ) : null}
+                        </Group>
 
-                    <OmnibarFilters
-                        filters={searchFilters}
-                        onSearchFilterChange={(filters) => {
-                            setSearchFilters(filters);
-                        }}
-                    />
+                        <OmnibarFilters
+                            filters={searchFilters}
+                            onSearchFilterChange={(filters) => {
+                                setSearchFilters(filters);
+                            }}
+                        />
 
-                    {!hasEnteredQuery ? (
-                        <OmnibarEmptyState
-                            message={`Start typing to search for everything in ${
-                                projectData?.name ?? 'your project'
-                            }.`}
-                        />
-                    ) : !hasEnteredMinQueryLength ? (
-                        <OmnibarEmptyState
-                            message={`Keep typing to search for everything in ${
-                                projectData?.name ?? 'your project'
-                            }.`}
-                        />
-                    ) : !searchResults ? (
-                        <OmnibarEmptyState message="Searching..." />
-                    ) : !hasSearchResults ? (
-                        <OmnibarEmptyState message="No results found." />
-                    ) : (
-                        <OmnibarItemGroups
-                            projectUuid={projectUuid}
-                            canUserManageValidation={canUserManageValidation}
-                            openPanels={openPanels}
-                            onOpenPanelsChange={setOpenPanels}
-                            onClick={handleItemClick}
-                            focusedItemIndex={focusedItemIndex}
-                            groupedItems={sortedGroupEntries}
-                            scrollRef={scrollRef}
-                        />
-                    )}
-                </Stack>
-            </Modal>
+                        <Box className={classes.resultsArea}>
+                            {displayGroups.length === 0 ? (
+                                !hasEnteredQuery && hasActiveFilters ? (
+                                    <OmnibarEmptyState
+                                        title="Search with these filters"
+                                        hint="Start typing to apply them."
+                                    />
+                                ) : !hasEnteredQuery ? (
+                                    <OmnibarEmptyState
+                                        title={`Search ${
+                                            projectData?.name ?? 'your project'
+                                        }`}
+                                        hint="Find dashboards, charts, spaces, tables, fields and more."
+                                    />
+                                ) : !hasEnteredMinQueryLength ? (
+                                    <OmnibarEmptyState
+                                        title="Keep typing..."
+                                        hint="Search kicks in at 3 characters."
+                                    />
+                                ) : !searchResults ? (
+                                    <OmnibarEmptyState
+                                        variant="loading"
+                                        title="Searching..."
+                                    />
+                                ) : (
+                                    <OmnibarEmptyState
+                                        variant="no-results"
+                                        title={`No results for "${query}"`}
+                                        hint="Try a different term, or adjust the filters."
+                                    />
+                                )
+                            ) : (
+                                <Group
+                                    gap={0}
+                                    wrap="nowrap"
+                                    align="stretch"
+                                    className={classes.resultsRow}
+                                >
+                                    <Box className={classes.listCol}>
+                                        <OmnibarItemGroups
+                                            projectUuid={projectUuid}
+                                            canUserManageValidation={
+                                                canUserManageValidation
+                                            }
+                                            onClick={handleItemClick}
+                                            focusedItemIndex={highlightedIndex}
+                                            onFocusedItemChange={
+                                                setFocusedItemIndex
+                                            }
+                                            onToggleGroup={handleToggleGroup}
+                                            groups={displayGroups}
+                                            scrollRef={scrollRef}
+                                        />
+                                    </Box>
+                                    <OmnibarPreview
+                                        item={focusedItem}
+                                        spaceName={
+                                            focusedItem?.item &&
+                                            'spaceUuid' in focusedItem.item &&
+                                            focusedItem.item.spaceUuid
+                                                ? spaceNamesByUuid.get(
+                                                      focusedItem.item
+                                                          .spaceUuid,
+                                                  )
+                                                : undefined
+                                        }
+                                    />
+                                </Group>
+                            )}
+                        </Box>
+
+                        <Group
+                            className={classes.footer}
+                            gap="lg"
+                            justify="space-between"
+                            wrap="nowrap"
+                        >
+                            <Group gap="lg" wrap="nowrap">
+                                <Group gap="xxs">
+                                    <Kbd size="xs">↑</Kbd>
+                                    <Kbd size="xs">↓</Kbd>
+                                    <Text size="xs" c="dimmed">
+                                        Navigate
+                                    </Text>
+                                </Group>
+                                <Group gap="xxs">
+                                    <Kbd size="xs">↵</Kbd>
+                                    <Text size="xs" c="dimmed">
+                                        Open
+                                    </Text>
+                                </Group>
+                                <Group gap="xxs">
+                                    <Kbd size="xs">esc</Kbd>
+                                    <Text size="xs" c="dimmed">
+                                        Close
+                                    </Text>
+                                </Group>
+                            </Group>
+
+                            <Group gap="two" wrap="nowrap">
+                                {isAiAgentsEnabled && (
+                                    <Button
+                                        size="compact-xs"
+                                        variant="subtle"
+                                        color="gray"
+                                        leftSection={<AiAgentIcon size={14} />}
+                                        onClick={() =>
+                                            handleQuickAction(
+                                                `/projects/${projectUuid}/ai-agents`,
+                                            )
+                                        }
+                                    >
+                                        Ask AI
+                                    </Button>
+                                )}
+                                {canManageExplore && (
+                                    <Button
+                                        size="compact-xs"
+                                        variant="subtle"
+                                        color="gray"
+                                        leftSection={
+                                            <MantineIcon
+                                                icon={IconTable}
+                                                strokeWidth={1.5}
+                                            />
+                                        }
+                                        onClick={() =>
+                                            handleQuickAction(
+                                                `/projects/${projectUuid}/tables`,
+                                            )
+                                        }
+                                    >
+                                        Run query
+                                    </Button>
+                                )}
+                                {canManageProject && (
+                                    <Button
+                                        size="compact-xs"
+                                        variant="subtle"
+                                        color="gray"
+                                        leftSection={
+                                            <MantineIcon
+                                                icon={IconSettings}
+                                                strokeWidth={1.5}
+                                            />
+                                        }
+                                        onClick={() =>
+                                            handleQuickAction(
+                                                `/generalSettings/projectManagement/${projectUuid}/settings`,
+                                            )
+                                        }
+                                    >
+                                        Settings
+                                    </Button>
+                                )}
+                            </Group>
+                        </Group>
+                    </Stack>
+                </Modal>
+            </Mantine8Provider>
         </OmnibarKeyboardNav>
     );
 };

--- a/packages/frontend/src/features/omnibar/components/OmnibarEmptyState.module.css
+++ b/packages/frontend/src/features/omnibar/components/OmnibarEmptyState.module.css
@@ -1,0 +1,24 @@
+.iconCircle {
+    background-color: light-dark(
+        var(--mantine-color-ldGray-1),
+        var(--mantine-color-ldDark-4)
+    );
+    color: light-dark(
+        var(--mantine-color-ldGray-6),
+        var(--mantine-color-ldGray-7)
+    );
+}
+
+.title {
+    color: light-dark(
+        var(--mantine-color-ldGray-9),
+        var(--mantine-color-ldGray-9)
+    );
+}
+
+.hint {
+    color: light-dark(
+        var(--mantine-color-ldGray-6),
+        var(--mantine-color-ldGray-7)
+    );
+}

--- a/packages/frontend/src/features/omnibar/components/OmnibarEmptyState.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarEmptyState.tsx
@@ -1,16 +1,49 @@
-import { Center, Text } from '@mantine-8/core';
+import { Center, Loader, Stack, Text, ThemeIcon } from '@mantine-8/core';
+import { IconSearch, IconSearchOff } from '@tabler/icons-react';
 import { type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import classes from './OmnibarEmptyState.module.css';
 
 type Props = {
-    message: string;
+    title: string;
+    hint?: string;
+    variant?: 'search' | 'no-results' | 'loading';
 };
 
-const OmnibarEmptyState: FC<Props> = ({ message }) => {
+const OmnibarEmptyState: FC<Props> = ({ title, hint, variant = 'search' }) => {
     return (
-        <Center py="xl">
-            <Text c="dimmed" size="lg" fw={500}>
-                {message}
-            </Text>
+        <Center py="xl" h="100%">
+            <Stack gap="xs" align="center" maw={320}>
+                {variant === 'loading' ? (
+                    <Loader size="sm" color="ldGray.5" />
+                ) : (
+                    <ThemeIcon
+                        size={40}
+                        radius="xl"
+                        variant="light"
+                        color="gray"
+                        className={classes.iconCircle}
+                    >
+                        <MantineIcon
+                            icon={
+                                variant === 'no-results'
+                                    ? IconSearchOff
+                                    : IconSearch
+                            }
+                            size="lg"
+                            strokeWidth={1.5}
+                        />
+                    </ThemeIcon>
+                )}
+                <Text size="sm" fw={500} ta="center" className={classes.title}>
+                    {title}
+                </Text>
+                {hint ? (
+                    <Text size="xs" ta="center" className={classes.hint}>
+                        {hint}
+                    </Text>
+                ) : null}
+            </Stack>
         </Center>
     );
 };

--- a/packages/frontend/src/features/omnibar/components/OmnibarFilters.module.css
+++ b/packages/frontend/src/features/omnibar/components/OmnibarFilters.module.css
@@ -1,0 +1,53 @@
+/* The subtle-variant colors come from the theme's Button vars; these rules
+   only add the states the variant doesn't cover. */
+.filterButton :global(.mantine-8-Button-section)[data-position='left'] {
+    margin-inline-end: 6px;
+}
+
+.filterButton :global(.mantine-8-Button-section)[data-position='right'] {
+    margin-inline-start: 4px;
+}
+
+.filterButton[data-expanded],
+.filterButton.filterButtonActive {
+    background-color: light-dark(
+        var(--mantine-color-ldGray-1),
+        var(--mantine-color-ldDark-5)
+    );
+    color: light-dark(
+        var(--mantine-color-ldGray-9),
+        var(--mantine-color-ldGray-9)
+    );
+}
+
+.clearSection {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--mantine-radius-sm);
+    cursor: pointer;
+    color: light-dark(
+        var(--mantine-color-ldGray-6),
+        var(--mantine-color-ldGray-7)
+    );
+}
+
+.clearSection:hover {
+    color: light-dark(
+        var(--mantine-color-ldGray-9),
+        var(--mantine-color-ldGray-9)
+    );
+}
+
+/* Match Button's size="compact-xs" height exactly so expanding "Created by"
+   into this input never shifts the filter row. */
+.createdByInput {
+    min-height: var(--button-height-compact-xs);
+    height: var(--button-height-compact-xs);
+}
+
+/* Belt-and-braces: pin the row height so swapping the button for the taller
+   Select wrapper can't reflow the modal, whatever Mantine renders inside. */
+.filtersRow {
+    height: 38px;
+}

--- a/packages/frontend/src/features/omnibar/components/OmnibarFilters.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarFilters.tsx
@@ -4,7 +4,7 @@ import {
     type OrganizationMemberProfile,
     type SearchFilters,
 } from '@lightdash/common';
-import { Button, Flex, Group, Menu, Select } from '@mantine-8/core';
+import { Box, Button, Flex, Group, Menu, Select } from '@mantine-8/core';
 import { useDisclosure } from '@mantine-8/hooks';
 import { DatePicker } from '@mantine/dates';
 import {
@@ -24,12 +24,13 @@ import {
     IconUser,
     IconX,
 } from '@tabler/icons-react';
-import { useMemo, type FC } from 'react';
+import { useEffect, useMemo, useRef, useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useOrganizationUsers } from '../../../hooks/useOrganizationUsers';
 import { allSearchItemTypes } from '../types/searchItem';
 import { getDateFilterLabel } from '../utils/getDateFilterLabel';
 import { getSearchItemLabel } from '../utils/getSearchItemLabel';
+import classes from './OmnibarFilters.module.css';
 import { getOmnibarItemColor } from './utils';
 
 const getOmnibarItemIcon = (itemType: SearchItemType) => {
@@ -81,16 +82,50 @@ function findUserName(
 
 function getFilterButtonProps(hasFilter: boolean) {
     return {
-        variant: hasFilter ? 'outline' : 'default',
-        color: hasFilter ? 'ldGray.5' : undefined,
-        c: hasFilter ? 'ldGray.7' : undefined,
+        variant: 'subtle',
+        radius: 'md',
+        className: hasFilter
+            ? `${classes.filterButton} ${classes.filterButtonActive}`
+            : classes.filterButton,
     } as const;
 }
 
+/** An active filter swaps its caret for an × that drops just that filter,
+ *  without opening the panel behind it. */
+const FilterRightSection: FC<{ isActive: boolean; onClear: () => void }> = ({
+    isActive,
+    onClear,
+}) =>
+    isActive ? (
+        <Box
+            component="span"
+            role="button"
+            aria-label="Clear filter"
+            className={classes.clearSection}
+            onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}
+            onClick={(e: React.MouseEvent) => {
+                e.stopPropagation();
+                e.preventDefault();
+                onClear();
+            }}
+        >
+            <MantineIcon icon={IconX} strokeWidth={1.5} />
+        </Box>
+    ) : (
+        <MantineIcon icon={IconChevronDown} strokeWidth={1.5} />
+    );
+
 const OmnibarFilters: FC<Props> = ({ filters, onSearchFilterChange }) => {
     const [isDateMenuOpen, dateMenuHandlers] = useDisclosure(false);
-    const [isCreatedByMenuOpen, createdByMenuHelpers] = useDisclosure(false);
+    const [isCreatedByExpanded, setIsCreatedByExpanded] = useState(false);
+    const createdByInputRef = useRef<HTMLInputElement>(null);
     const { data: organizationUsers } = useOrganizationUsers();
+
+    useEffect(() => {
+        if (isCreatedByExpanded) {
+            createdByInputRef.current?.focus();
+        }
+    }, [isCreatedByExpanded]);
 
     const canClearFilters = useMemo(() => {
         return (
@@ -111,7 +146,14 @@ const OmnibarFilters: FC<Props> = ({ filters, onSearchFilterChange }) => {
     );
 
     return (
-        <Group px="md" py="sm">
+        <Group
+            px="xs"
+            py="xxs"
+            gap="two"
+            align="center"
+            wrap="nowrap"
+            className={classes.filtersRow}
+        >
             <Menu
                 position="bottom-start"
                 withArrow
@@ -121,10 +163,36 @@ const OmnibarFilters: FC<Props> = ({ filters, onSearchFilterChange }) => {
             >
                 <Menu.Target>
                     <Button
-                        radius="lg"
                         size="compact-xs"
-                        leftSection={<MantineIcon icon={IconAdjustments} />}
-                        rightSection={<MantineIcon icon={IconChevronDown} />}
+                        leftSection={
+                            filters?.type ? (
+                                <MantineIcon
+                                    icon={getOmnibarItemIcon(
+                                        filters.type as SearchItemType,
+                                    )}
+                                    color={getOmnibarItemColor(
+                                        filters.type as SearchItemType,
+                                    )}
+                                    strokeWidth={1.5}
+                                />
+                            ) : (
+                                <MantineIcon
+                                    icon={IconAdjustments}
+                                    strokeWidth={1.5}
+                                />
+                            )
+                        }
+                        rightSection={
+                            <FilterRightSection
+                                isActive={!!filters?.type}
+                                onClear={() =>
+                                    onSearchFilterChange({
+                                        ...filters,
+                                        type: undefined,
+                                    })
+                                }
+                            />
+                        }
                         {...getFilterButtonProps(!!filters?.type)}
                     >
                         {filters?.type
@@ -171,10 +239,27 @@ const OmnibarFilters: FC<Props> = ({ filters, onSearchFilterChange }) => {
             >
                 <Menu.Target>
                     <Button
-                        radius="lg"
                         size="compact-xs"
-                        leftSection={<MantineIcon icon={IconCalendar} />}
-                        rightSection={<MantineIcon icon={IconChevronDown} />}
+                        leftSection={
+                            <MantineIcon
+                                icon={IconCalendar}
+                                strokeWidth={1.5}
+                            />
+                        }
+                        rightSection={
+                            <FilterRightSection
+                                isActive={
+                                    !!filters?.fromDate || !!filters?.toDate
+                                }
+                                onClear={() =>
+                                    onSearchFilterChange({
+                                        ...filters,
+                                        fromDate: undefined,
+                                        toDate: undefined,
+                                    })
+                                }
+                            />
+                        }
                         {...getFilterButtonProps(
                             !!filters?.fromDate || !!filters?.toDate,
                         )}
@@ -227,57 +312,67 @@ const OmnibarFilters: FC<Props> = ({ filters, onSearchFilterChange }) => {
                     </Flex>
                 </Menu.Dropdown>
             </Menu>
-            <Menu
-                position="bottom-start"
-                withArrow
-                shadow="md"
-                arrowOffset={11}
-                offset={2}
-                opened={isCreatedByMenuOpen}
-                onOpen={createdByMenuHelpers.open}
-                onClose={createdByMenuHelpers.close}
-            >
-                <Menu.Target>
-                    <Button
-                        radius="lg"
-                        size="compact-xs"
-                        leftSection={<MantineIcon icon={IconUser} />}
-                        rightSection={<MantineIcon icon={IconChevronDown} />}
-                        {...getFilterButtonProps(!!filters?.createdByUuid)}
-                    >
-                        {filters?.createdByUuid
-                            ? findUserName(
-                                  filters.createdByUuid,
-                                  organizationUsers,
-                              )
-                            : 'Created by'}
-                    </Button>
-                </Menu.Target>
-
-                <Menu.Dropdown>
-                    <Select
-                        placeholder="Select a user"
-                        searchable
-                        // null keeps the Select controlled; if uncontrolled, Mantine resets the search text mid-click
-                        value={filters?.createdByUuid ?? null}
-                        clearable
-                        allowDeselect={false}
-                        // keep options inside the Menu so clicking one isn't an outside click that closes it
-                        comboboxProps={{ withinPortal: false }}
-                        data={userOptions}
-                        onChange={(value) => {
-                            onSearchFilterChange({
-                                ...filters,
-                                createdByUuid: value || undefined,
-                            });
-                        }}
-                        // onChange doesn't fire when re-selecting the current value
-                        onOptionSubmit={() => {
-                            createdByMenuHelpers.close();
-                        }}
-                    />
-                </Menu.Dropdown>
-            </Menu>
+            {isCreatedByExpanded ? (
+                <Select
+                    ref={createdByInputRef}
+                    size="xs"
+                    radius="md"
+                    w={200}
+                    classNames={{ input: classes.createdByInput }}
+                    placeholder="Search a user..."
+                    searchable
+                    // null keeps the Select controlled; if uncontrolled, Mantine resets the search text mid-click
+                    value={filters?.createdByUuid ?? null}
+                    clearable
+                    allowDeselect={false}
+                    data={userOptions}
+                    leftSection={
+                        <MantineIcon icon={IconUser} strokeWidth={1.5} />
+                    }
+                    onChange={(value) => {
+                        onSearchFilterChange({
+                            ...filters,
+                            createdByUuid: value || undefined,
+                        });
+                    }}
+                    // The × clears the input text on its own; drop the filter too
+                    onClear={() =>
+                        onSearchFilterChange({
+                            ...filters,
+                            createdByUuid: undefined,
+                        })
+                    }
+                    // onChange doesn't fire when re-selecting the current value
+                    onOptionSubmit={() => setIsCreatedByExpanded(false)}
+                    // Collapsing on dropdown close would unmount this mid-click
+                    // and swallow the × — only collapse once focus truly leaves
+                    onBlur={() => setIsCreatedByExpanded(false)}
+                />
+            ) : (
+                <Button
+                    size="compact-xs"
+                    leftSection={
+                        <MantineIcon icon={IconUser} strokeWidth={1.5} />
+                    }
+                    rightSection={
+                        <FilterRightSection
+                            isActive={!!filters?.createdByUuid}
+                            onClear={() =>
+                                onSearchFilterChange({
+                                    ...filters,
+                                    createdByUuid: undefined,
+                                })
+                            }
+                        />
+                    }
+                    {...getFilterButtonProps(!!filters?.createdByUuid)}
+                    onClick={() => setIsCreatedByExpanded(true)}
+                >
+                    {filters?.createdByUuid
+                        ? findUserName(filters.createdByUuid, organizationUsers)
+                        : 'Created by'}
+                </Button>
+            )}
 
             {canClearFilters && (
                 <Button

--- a/packages/frontend/src/features/omnibar/components/OmnibarItem.module.css
+++ b/packages/frontend/src/features/omnibar/components/OmnibarItem.module.css
@@ -1,13 +1,14 @@
 .action {
     display: flex;
     align-items: center;
-    height: var(--mantine-spacing-4xl);
+    height: 38px;
     padding-left: var(--mantine-spacing-xs);
     padding-right: var(--mantine-spacing-xs);
     border-radius: var(--mantine-radius-sm);
     cursor: pointer;
 
-    &:hover,
+    /* Highlight is driven ONLY by the focused-item state (data-hovered) so
+       mouse and keyboard can never highlight two rows at once. */
     &[data-hovered] {
         background-color: light-dark(
             var(--mantine-color-ldGray-1),
@@ -30,11 +31,28 @@
 .content {
     flex-grow: 1;
     overflow: hidden;
+    align-items: baseline;
+}
+
+.title {
+    flex-shrink: 1;
+    min-width: 0;
+    color: light-dark(
+        var(--mantine-color-ldGray-8),
+        var(--mantine-color-ldGray-9)
+    );
 }
 
 .secondaryText {
+    flex: 1;
+    min-width: 0;
     color: light-dark(
         var(--mantine-color-ldGray-6),
         var(--mantine-color-ldGray-7)
     );
+}
+
+.verifiedBadge {
+    flex-shrink: 0;
+    margin-left: auto;
 }

--- a/packages/frontend/src/features/omnibar/components/OmnibarItem.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarItem.tsx
@@ -1,4 +1,4 @@
-import { Badge, Box, Group, Stack, Text } from '@mantine-8/core';
+import { Badge, Box, Group, Text } from '@mantine-8/core';
 import { IconCircleCheckFilled } from '@tabler/icons-react';
 import { type FC, type MutableRefObject } from 'react';
 import { type SearchItem } from '../types/searchItem';
@@ -7,6 +7,7 @@ import {
     OmnibarItemIcon,
     OmnibarItemIconWithIndicator,
 } from './OmnibarItemIcon';
+import { itemHasValidationError, itemHasVerification } from './utils';
 
 type Props = {
     projectUuid: string;
@@ -15,19 +16,10 @@ type Props = {
     hovered?: boolean;
     scrollRef?: MutableRefObject<HTMLDivElement>;
     onClick?: (e: React.MouseEvent) => void;
+    /** Fired on real pointer movement (not scroll-induced mouseenter), so
+     * keyboard-scrolling rows under a parked cursor can't steal the focus. */
+    onMouseMove?: () => void;
 };
-
-const itemHasValidationError = (searchItem: SearchItem) =>
-    searchItem.item &&
-    ['dashboard', 'saved_chart', 'table'].includes(searchItem.type) &&
-    'validationErrors' in searchItem.item &&
-    searchItem.item.validationErrors?.length > 0;
-
-const itemHasVerification = (searchItem: SearchItem) =>
-    searchItem.item &&
-    'verification' in searchItem.item &&
-    searchItem.item.verification !== null &&
-    searchItem.item.verification !== undefined;
 
 const OmnibarItem: FC<Props> = ({
     item,
@@ -35,6 +27,7 @@ const OmnibarItem: FC<Props> = ({
     canUserManageValidation,
     hovered,
     onClick,
+    onMouseMove,
     scrollRef,
 }) => {
     return (
@@ -44,6 +37,7 @@ const OmnibarItem: FC<Props> = ({
             className={classes.action}
             tabIndex={-1}
             onClick={onClick}
+            onMouseMove={onMouseMove}
             gap="sm"
             wrap="nowrap"
         >
@@ -55,41 +49,50 @@ const OmnibarItem: FC<Props> = ({
                         canUserManageValidation={canUserManageValidation}
                     />
                 ) : (
-                    <OmnibarItemIcon item={item} />
+                    <OmnibarItemIcon item={item} boxSize={26} />
                 )}
             </Box>
 
-            <Stack gap="two" className={classes.content}>
-                <Group gap="xs" wrap="nowrap">
-                    <Text fw={500} size="sm" truncate ref={scrollRef}>
-                        {item.prefix ? <>{item.prefix} </> : null}
-                        {item.title}
-                    </Text>
-                    {itemHasVerification(item) && (
-                        <Badge
-                            size="xs"
-                            variant="light"
-                            color="green"
-                            leftSection={<IconCircleCheckFilled size={10} />}
-                            style={{ flexShrink: 0 }}
-                        >
-                            Verified
-                        </Badge>
-                    )}
-                </Group>
+            <Group gap="xs" wrap="nowrap" className={classes.content}>
+                <Text
+                    fw={400}
+                    size="sm"
+                    truncate
+                    ref={scrollRef}
+                    className={classes.title}
+                >
+                    {item.prefix ? <>{item.prefix} </> : null}
+                    {item.title}
+                </Text>
 
-                {item.contextLabel ? (
+                {item.contextLabel || item.description || item.typeLabel ? (
                     <Text size="xs" truncate className={classes.secondaryText}>
-                        {item.contextLabel}
-                    </Text>
-                ) : item.description || item.typeLabel ? (
-                    <Text size="xs" truncate className={classes.secondaryText}>
-                        {item.typeLabel}
-                        {item.typeLabel && item.description ? <> · </> : null}
-                        {item.description}
+                        {item.contextLabel ? (
+                            item.contextLabel
+                        ) : (
+                            <>
+                                {item.typeLabel}
+                                {item.typeLabel && item.description
+                                    ? ' · '
+                                    : null}
+                                {item.description}
+                            </>
+                        )}
                     </Text>
                 ) : null}
-            </Stack>
+
+                {itemHasVerification(item) && (
+                    <Badge
+                        size="xs"
+                        variant="light"
+                        color="green"
+                        leftSection={<IconCircleCheckFilled size={10} />}
+                        className={classes.verifiedBadge}
+                    >
+                        Verified
+                    </Badge>
+                )}
+            </Group>
         </Group>
     );
 };

--- a/packages/frontend/src/features/omnibar/components/OmnibarItemGroups.module.css
+++ b/packages/frontend/src/features/omnibar/components/OmnibarItemGroups.module.css
@@ -1,31 +1,47 @@
-.accordionControl {
-    height: var(--mantine-spacing-xxl);
-    padding-left: var(--mantine-spacing-md);
-    padding-right: var(--mantine-spacing-md);
-    background-color: light-dark(
-        var(--mantine-color-ldGray-0),
-        var(--mantine-color-ldDark-2)
-    );
+.groups {
+    padding: var(--mantine-spacing-xxs) var(--mantine-spacing-xs)
+        var(--mantine-spacing-xs);
+}
+
+.group {
+    padding-top: var(--mantine-spacing-xs);
+}
+
+.group:first-child {
+    padding-top: 0;
+}
+
+.groupLabel {
+    display: block;
+    width: 100%;
+    padding: var(--mantine-spacing-xxs) var(--mantine-spacing-xs);
+    border-radius: var(--mantine-radius-sm);
 
     &:hover {
         background-color: light-dark(
-            var(--mantine-color-ldGray-1),
+            var(--mantine-color-ldGray-0),
             var(--mantine-color-ldDark-3)
         );
     }
 }
 
-.accordionLabel {
-    padding: 0;
-}
-
-.groupLabel {
+.groupChevron {
     color: light-dark(
-        var(--mantine-color-ldGray-6),
+        var(--mantine-color-ldGray-5),
         var(--mantine-color-ldGray-7)
     );
 }
 
-.accordionContent {
-    padding: var(--mantine-spacing-xs);
+.groupLabelText {
+    color: light-dark(
+        var(--mantine-color-ldGray-7),
+        var(--mantine-color-ldGray-7)
+    );
+}
+
+.groupCount {
+    color: light-dark(
+        var(--mantine-color-ldGray-5),
+        var(--mantine-color-ldGray-7)
+    );
 }

--- a/packages/frontend/src/features/omnibar/components/OmnibarItemGroups.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarItemGroups.tsx
@@ -1,102 +1,109 @@
-import { type SearchItemType } from '@lightdash/common';
-import { Accordion, Text } from '@mantine-8/core';
+import { Box, Group, Text, UnstyledButton } from '@mantine-8/core';
+import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 import { useEffect, type FC, type MutableRefObject } from 'react';
-import { type FocusedItemIndex, type SearchItem } from '../types/searchItem';
-import { getSearchItemLabel } from '../utils/getSearchItemLabel';
+import MantineIcon from '../../../components/common/MantineIcon';
+import {
+    type FocusedItemIndex,
+    type OmnibarGroup,
+    type SearchItem,
+} from '../types/searchItem';
 import OmnibarItem from './OmnibarItem';
 import classes from './OmnibarItemGroups.module.css';
 
 type Props = {
-    openPanels: SearchItemType[];
-    onOpenPanelsChange: (panels: SearchItemType[]) => void;
     projectUuid: string;
     canUserManageValidation: boolean;
     onClick: (item: SearchItem, redirect: boolean) => void;
     focusedItemIndex?: FocusedItemIndex;
-    groupedItems: [SearchItemType, SearchItem[]][];
+    onFocusedItemChange: (index: FocusedItemIndex) => void;
+    onToggleGroup: (key: string) => void;
+    groups: OmnibarGroup[];
     scrollRef?: MutableRefObject<HTMLDivElement>;
 };
 
 const OmnibarItemGroups: FC<Props> = ({
-    openPanels,
-    onOpenPanelsChange,
     projectUuid,
-    groupedItems,
+    groups,
     canUserManageValidation,
     onClick,
     focusedItemIndex,
+    onFocusedItemChange,
+    onToggleGroup,
     scrollRef,
 }) => {
     useEffect(() => {
         if (scrollRef?.current && focusedItemIndex) {
             scrollRef.current.scrollIntoView({
-                block: 'center',
+                block: 'nearest',
             });
         }
     }, [scrollRef, focusedItemIndex]);
 
-    useEffect(() => {
-        if (focusedItemIndex) {
-            const currentGroupItemType =
-                groupedItems[focusedItemIndex.groupIndex][0];
-
-            if (
-                currentGroupItemType &&
-                !openPanels.includes(currentGroupItemType)
-            ) {
-                onOpenPanelsChange([currentGroupItemType, ...openPanels]);
-            }
-        }
-    }, [focusedItemIndex, openPanels, onOpenPanelsChange, groupedItems]);
-
     return (
-        <Accordion
-            classNames={{
-                control: classes.accordionControl,
-                label: classes.accordionLabel,
-                content: classes.accordionContent,
-            }}
-            multiple
-            value={openPanels}
-            onChange={(newPanels) =>
-                onOpenPanelsChange(newPanels as SearchItemType[])
-            }
-        >
-            {groupedItems.map(([groupType, groupItems], groupIndex) => (
-                <Accordion.Item key={groupType} value={groupType}>
-                    <Accordion.Control>
-                        <Text className={classes.groupLabel} fw={500} fz="xs">
-                            {getSearchItemLabel(groupType)}
-                        </Text>
-                    </Accordion.Control>
+        <Box className={classes.groups}>
+            {groups.map((group, groupIndex) => (
+                <Box key={group.key} className={classes.group}>
+                    <UnstyledButton
+                        className={classes.groupLabel}
+                        onClick={() => onToggleGroup(group.key)}
+                        aria-expanded={!group.collapsed}
+                    >
+                        <Group gap={6} wrap="nowrap">
+                            <MantineIcon
+                                icon={
+                                    group.collapsed
+                                        ? IconChevronRight
+                                        : IconChevronDown
+                                }
+                                size="sm"
+                                strokeWidth={1.5}
+                                className={classes.groupChevron}
+                            />
+                            <Text
+                                fz="xs"
+                                fw={600}
+                                className={classes.groupLabelText}
+                            >
+                                {group.label}
+                            </Text>
+                            <Text fz="xs" className={classes.groupCount}>
+                                {group.totalCount}
+                            </Text>
+                        </Group>
+                    </UnstyledButton>
 
-                    <Accordion.Panel>
-                        {groupItems.map((item, itemIndex) => {
-                            const isFocused =
-                                groupIndex === focusedItemIndex?.groupIndex &&
-                                itemIndex === focusedItemIndex?.itemIndex;
-                            return (
-                                <OmnibarItem
-                                    key={itemIndex}
-                                    item={item}
-                                    scrollRef={
-                                        isFocused ? scrollRef : undefined
-                                    }
-                                    onClick={(e: React.MouseEvent) => {
-                                        onClick(item, e.metaKey);
-                                    }}
-                                    projectUuid={projectUuid}
-                                    canUserManageValidation={
-                                        canUserManageValidation
-                                    }
-                                    hovered={isFocused}
-                                />
-                            );
-                        })}
-                    </Accordion.Panel>
-                </Accordion.Item>
+                    {group.items.map((item, itemIndex) => {
+                        const isFocused =
+                            groupIndex === focusedItemIndex?.groupIndex &&
+                            itemIndex === focusedItemIndex?.itemIndex;
+                        return (
+                            <OmnibarItem
+                                key={itemIndex}
+                                item={item}
+                                scrollRef={isFocused ? scrollRef : undefined}
+                                onClick={(e: React.MouseEvent) => {
+                                    onClick(item, e.metaKey);
+                                }}
+                                onMouseMove={
+                                    isFocused
+                                        ? undefined
+                                        : () =>
+                                              onFocusedItemChange({
+                                                  groupIndex,
+                                                  itemIndex,
+                                              })
+                                }
+                                projectUuid={projectUuid}
+                                canUserManageValidation={
+                                    canUserManageValidation
+                                }
+                                hovered={isFocused}
+                            />
+                        );
+                    })}
+                </Box>
             ))}
-        </Accordion>
+        </Box>
     );
 };
 

--- a/packages/frontend/src/features/omnibar/components/OmnibarItemIcon.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarItemIcon.tsx
@@ -12,13 +12,16 @@ import { getOmnibarItemColor, getOmnibarItemIcon } from './utils';
 
 type Props = {
     item: SearchItem;
+    boxSize?: number;
 };
 
-export const OmnibarItemIcon: FC<Props> = ({ item }) => {
+export const OmnibarItemIcon: FC<Props> = ({ item, boxSize }) => {
     return (
         <IconBox
             color={getOmnibarItemColor(item.type)}
             icon={getOmnibarItemIcon(item)}
+            boxSize={boxSize}
+            size={boxSize !== undefined && boxSize < 32 ? 'md' : 'lg'}
         />
     );
 };

--- a/packages/frontend/src/features/omnibar/components/OmnibarKeyboardNav.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarKeyboardNav.tsx
@@ -1,13 +1,18 @@
-import { type SearchItemType } from '@lightdash/common';
 import { Box } from '@mantine-8/core';
 import { useCallback, type PropsWithChildren } from 'react';
-import { type FocusedItemIndex, type SearchItem } from '../types/searchItem';
+import {
+    type FocusedItemIndex,
+    type OmnibarGroup,
+    type SearchItem,
+} from '../types/searchItem';
 
 interface Props {
-    groupedItems: [SearchItemType, SearchItem[]][];
+    groupedItems: OmnibarGroup[];
     onEnterPressed: (item: SearchItem) => void;
     onFocusedItemChange: (index?: FocusedItemIndex) => void;
     currentFocusedItemIndex?: FocusedItemIndex;
+    /** Opened on Enter while no row is highlighted (the "top hit"). */
+    fallbackEnterItem?: SearchItem;
 }
 
 export const OmnibarKeyboardNav = ({
@@ -16,79 +21,82 @@ export const OmnibarKeyboardNav = ({
     currentFocusedItemIndex,
     onEnterPressed,
     onFocusedItemChange,
+    fallbackEnterItem,
 }: PropsWithChildren<Props>) => {
-    const handleArrowDown = useCallback(
-        (maxGroupIndex: number, maxCurrentGroupItemIndex: number) => {
-            if (!currentFocusedItemIndex) {
-                return {
-                    groupIndex: 0,
-                    itemIndex: 0,
-                };
-            }
-
-            if (currentFocusedItemIndex.itemIndex < maxCurrentGroupItemIndex) {
-                // move to next item in the same group
-                return {
-                    groupIndex: currentFocusedItemIndex.groupIndex,
-                    itemIndex: currentFocusedItemIndex.itemIndex + 1,
-                };
-            }
-
-            if (
-                currentFocusedItemIndex.groupIndex < maxGroupIndex &&
-                currentFocusedItemIndex.itemIndex === maxCurrentGroupItemIndex
+    // Collapsed groups keep empty item arrays — skip them in both directions.
+    const findNextNavigableGroup = useCallback(
+        (fromGroupIndex: number, direction: 1 | -1) => {
+            for (
+                let i = fromGroupIndex + direction;
+                i >= 0 && i < groupedItems.length;
+                i += direction
             ) {
-                // move to the first item in the next group
-                return {
-                    groupIndex: currentFocusedItemIndex.groupIndex + 1,
-                    itemIndex: 0,
-                };
+                if (groupedItems[i].items.length > 0) return i;
             }
-
-            return {
-                groupIndex: 0,
-                itemIndex: 0,
-            };
+            return -1;
         },
-        [currentFocusedItemIndex],
+        [groupedItems],
     );
 
-    const handleArrowUp = useCallback(
-        (maxGroupIndex: number, lastItemIndex: number) => {
-            if (!currentFocusedItemIndex) {
-                return {
-                    groupIndex: maxGroupIndex,
-                    itemIndex: lastItemIndex,
-                };
-            }
+    const handleArrowDown = useCallback((): FocusedItemIndex | undefined => {
+        if (!currentFocusedItemIndex) {
+            const firstGroup = findNextNavigableGroup(-1, 1);
+            return firstGroup === -1
+                ? undefined
+                : { groupIndex: firstGroup, itemIndex: 0 };
+        }
 
-            if (currentFocusedItemIndex.itemIndex > 0) {
-                // move to previous item in the same group
-                return {
-                    groupIndex: currentFocusedItemIndex.groupIndex,
-                    itemIndex: currentFocusedItemIndex.itemIndex - 1,
-                };
-            }
-
-            if (
-                currentFocusedItemIndex.groupIndex > 0 &&
-                currentFocusedItemIndex.itemIndex === 0
-            ) {
-                // move to the last item in the previous group
-                const prevGroupIndex = currentFocusedItemIndex.groupIndex - 1;
-                return {
-                    groupIndex: prevGroupIndex,
-                    itemIndex: groupedItems[prevGroupIndex][1].length - 1,
-                };
-            }
-
+        const groupItems =
+            groupedItems[currentFocusedItemIndex.groupIndex]?.items ?? [];
+        if (currentFocusedItemIndex.itemIndex < groupItems.length - 1) {
+            // move to next item in the same group
             return {
-                groupIndex: maxGroupIndex,
-                itemIndex: lastItemIndex,
+                groupIndex: currentFocusedItemIndex.groupIndex,
+                itemIndex: currentFocusedItemIndex.itemIndex + 1,
             };
-        },
-        [currentFocusedItemIndex, groupedItems],
-    );
+        }
+
+        const nextGroup = findNextNavigableGroup(
+            currentFocusedItemIndex.groupIndex,
+            1,
+        );
+        if (nextGroup !== -1) {
+            // move to the first item in the next navigable group
+            return { groupIndex: nextGroup, itemIndex: 0 };
+        }
+
+        // stay on the last item — no wrap-around
+        return currentFocusedItemIndex;
+    }, [currentFocusedItemIndex, groupedItems, findNextNavigableGroup]);
+
+    const handleArrowUp = useCallback((): FocusedItemIndex | undefined => {
+        if (!currentFocusedItemIndex) {
+            return undefined;
+        }
+
+        if (currentFocusedItemIndex.itemIndex > 0) {
+            // move to previous item in the same group
+            return {
+                groupIndex: currentFocusedItemIndex.groupIndex,
+                itemIndex: currentFocusedItemIndex.itemIndex - 1,
+            };
+        }
+
+        const prevGroup = findNextNavigableGroup(
+            currentFocusedItemIndex.groupIndex,
+            -1,
+        );
+        if (prevGroup !== -1) {
+            // move to the last item in the previous navigable group
+            return {
+                groupIndex: prevGroup,
+                itemIndex: groupedItems[prevGroup].items.length - 1,
+            };
+        }
+
+        // at the very top — hand the highlight back to the search input
+        return undefined;
+    }, [currentFocusedItemIndex, groupedItems, findNextNavigableGroup]);
 
     const onKeyDown = useCallback(
         (event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -96,44 +104,32 @@ export const OmnibarKeyboardNav = ({
                 return;
             }
 
-            const maxGroupIndex = groupedItems.length - 1;
-            const lastItemIndex = groupedItems[maxGroupIndex][1].length - 1;
-            const maxCurrentGroupItemIndex = currentFocusedItemIndex
-                ? groupedItems[currentFocusedItemIndex.groupIndex][1].length - 1
-                : -1;
-
             switch (event.key) {
                 case 'ArrowDown':
                     event.preventDefault();
 
-                    onFocusedItemChange(
-                        handleArrowDown(
-                            maxGroupIndex,
-                            maxCurrentGroupItemIndex,
-                        ),
-                    );
+                    onFocusedItemChange(handleArrowDown());
 
                     break;
                 case 'ArrowUp':
                     event.preventDefault();
 
-                    onFocusedItemChange(
-                        handleArrowUp(maxGroupIndex, lastItemIndex),
-                    );
+                    onFocusedItemChange(handleArrowUp());
 
                     break;
-                case 'Enter':
+                case 'Enter': {
                     event.preventDefault();
 
-                    if (currentFocusedItemIndex) {
-                        const item =
-                            groupedItems[currentFocusedItemIndex.groupIndex][1][
-                                currentFocusedItemIndex.itemIndex
-                            ];
+                    const item = currentFocusedItemIndex
+                        ? groupedItems[currentFocusedItemIndex.groupIndex]
+                              .items[currentFocusedItemIndex.itemIndex]
+                        : fallbackEnterItem;
+                    if (item) {
                         onEnterPressed(item);
                     }
 
                     break;
+                }
             }
         },
         [
@@ -143,6 +139,7 @@ export const OmnibarKeyboardNav = ({
             handleArrowUp,
             onEnterPressed,
             onFocusedItemChange,
+            fallbackEnterItem,
         ],
     );
 

--- a/packages/frontend/src/features/omnibar/components/OmnibarPreview.module.css
+++ b/packages/frontend/src/features/omnibar/components/OmnibarPreview.module.css
@@ -1,0 +1,83 @@
+.container {
+    width: 260px;
+    flex-shrink: 0;
+    padding: var(--mantine-spacing-md);
+    border-left: 1px solid
+        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-ldDark-4));
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+    scrollbar-width: thin;
+    scrollbar-color: light-dark(
+            var(--mantine-color-ldGray-3),
+            var(--mantine-color-ldDark-6)
+        )
+        transparent;
+}
+
+.container::-webkit-scrollbar {
+    width: 6px;
+}
+
+.container::-webkit-scrollbar-thumb {
+    background: light-dark(
+        var(--mantine-color-ldGray-3),
+        var(--mantine-color-ldDark-6)
+    );
+    border-radius: 999px;
+}
+
+.container::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.empty {
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+}
+
+.kicker {
+    color: light-dark(
+        var(--mantine-color-ldGray-6),
+        var(--mantine-color-ldGray-7)
+    );
+}
+
+.title {
+    overflow-wrap: break-word;
+}
+
+.description {
+    overflow-wrap: break-word;
+    color: light-dark(
+        var(--mantine-color-ldGray-7),
+        var(--mantine-color-ldGray-7)
+    );
+    line-height: 1.5;
+}
+
+.facts {
+    border-top: 1px solid
+        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-ldDark-4));
+    padding-top: var(--mantine-spacing-xs);
+}
+
+.factLabel {
+    flex-shrink: 0;
+    color: light-dark(
+        var(--mantine-color-ldGray-6),
+        var(--mantine-color-ldGray-7)
+    );
+}
+
+.factValue {
+    color: light-dark(
+        var(--mantine-color-ldGray-9),
+        var(--mantine-color-ldGray-9)
+    );
+}
+
+.flagBadge {
+    align-self: flex-start;
+}

--- a/packages/frontend/src/features/omnibar/components/OmnibarPreview.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarPreview.tsx
@@ -1,0 +1,131 @@
+import { SearchItemType } from '@lightdash/common';
+import { Badge, Box, Group, Stack, Text } from '@mantine-8/core';
+import { IconAlertTriangle, IconCircleCheckFilled } from '@tabler/icons-react';
+import { type FC, type ReactNode } from 'react';
+import { type SearchItem } from '../types/searchItem';
+import { getSearchItemLabel } from '../utils/getSearchItemLabel';
+import { OmnibarItemIcon } from './OmnibarItemIcon';
+import classes from './OmnibarPreview.module.css';
+import { itemHasValidationError, itemHasVerification } from './utils';
+
+type Props = {
+    item?: SearchItem;
+    spaceName?: string;
+};
+
+const getKickerLabel = (item: SearchItem) => {
+    if (item.typeLabel) return item.typeLabel;
+    const label = getSearchItemLabel(item.type);
+    // Group labels are plural; the kicker names a single item.
+    return item.type === SearchItemType.SETTINGS
+        ? label
+        : label.replace(/s$/, '');
+};
+
+const Fact: FC<{ label: string; children: ReactNode }> = ({
+    label,
+    children,
+}) => (
+    <Group justify="space-between" wrap="nowrap" gap="xs">
+        <Text size="xs" className={classes.factLabel}>
+            {label}
+        </Text>
+        <Text size="xs" fw={500} truncate className={classes.factValue}>
+            {children}
+        </Text>
+    </Group>
+);
+
+const OmnibarPreview: FC<Props> = ({ item, spaceName }) => {
+    if (!item) {
+        return (
+            <Box className={`${classes.container} ${classes.empty}`}>
+                <Text size="xs" c="dimmed" ta="center">
+                    Hover or navigate to a result to preview it here.
+                </Text>
+            </Box>
+        );
+    }
+
+    const hasError = itemHasValidationError(item);
+    const hasVerification = itemHasVerification(item);
+
+    const viewsCount =
+        item.item && 'viewsCount' in item.item
+            ? item.item.viewsCount
+            : undefined;
+    const createdBy =
+        item.item && 'createdBy' in item.item && item.item.createdBy
+            ? `${item.item.createdBy.firstName} ${item.item.createdBy.lastName}`
+            : undefined;
+
+    const hasFacts =
+        spaceName !== undefined ||
+        viewsCount !== undefined ||
+        createdBy !== undefined;
+
+    return (
+        <Box className={classes.container}>
+            <Group gap="xs" wrap="nowrap">
+                <OmnibarItemIcon item={item} />
+                <Text size="xs" fw={500} className={classes.kicker}>
+                    {getKickerLabel(item)}
+                </Text>
+            </Group>
+
+            <Text size="sm" fw={600} mt="sm" className={classes.title}>
+                {item.prefix ? `${item.prefix} ` : ''}
+                {item.title}
+            </Text>
+
+            {item.contextLabel || item.description ? (
+                <Text size="xs" mt={6} className={classes.description}>
+                    {item.contextLabel ?? item.description}
+                </Text>
+            ) : null}
+
+            {hasFacts && (
+                <Stack gap={6} mt="md" className={classes.facts}>
+                    {spaceName !== undefined && (
+                        <Fact label="Space">{spaceName}</Fact>
+                    )}
+                    {viewsCount !== undefined && (
+                        <Fact label="Views">{viewsCount}</Fact>
+                    )}
+                    {createdBy !== undefined && (
+                        <Fact label="Created by">{createdBy}</Fact>
+                    )}
+                </Stack>
+            )}
+
+            {(hasVerification || hasError) && (
+                <Stack gap={6} mt="md">
+                    {hasVerification && (
+                        <Badge
+                            size="xs"
+                            variant="light"
+                            color="green"
+                            leftSection={<IconCircleCheckFilled size={10} />}
+                            className={classes.flagBadge}
+                        >
+                            Verified
+                        </Badge>
+                    )}
+                    {hasError && (
+                        <Group gap={4} wrap="nowrap">
+                            <IconAlertTriangle
+                                size={12}
+                                color="var(--mantine-color-red-6)"
+                            />
+                            <Text size="xs" c="red">
+                                Has a validation error
+                            </Text>
+                        </Group>
+                    )}
+                </Stack>
+            )}
+        </Box>
+    );
+};
+
+export default OmnibarPreview;

--- a/packages/frontend/src/features/omnibar/components/utils.ts
+++ b/packages/frontend/src/features/omnibar/components/utils.ts
@@ -88,6 +88,18 @@ export const getOmnibarItemIcon = (item: SearchItem) => {
     }
 };
 
+export const itemHasValidationError = (searchItem: SearchItem) =>
+    searchItem.item &&
+    ['dashboard', 'saved_chart', 'table'].includes(searchItem.type) &&
+    'validationErrors' in searchItem.item &&
+    searchItem.item.validationErrors?.length > 0;
+
+export const itemHasVerification = (searchItem: SearchItem) =>
+    searchItem.item &&
+    'verification' in searchItem.item &&
+    searchItem.item.verification !== null &&
+    searchItem.item.verification !== undefined;
+
 export const getSearchResultsGroupsSorted = (results: SearchResultMap) =>
     Object.entries(results)
         .map((items) => {

--- a/packages/frontend/src/features/omnibar/types/searchItem.ts
+++ b/packages/frontend/src/features/omnibar/types/searchItem.ts
@@ -35,3 +35,16 @@ export type FocusedItemIndex = {
     groupIndex: number;
     itemIndex: number;
 };
+
+/** A labelled section of omnibar rows — search-result type groups and the
+ * recently-viewed section share this shape so keyboard navigation, hover
+ * focus and the preview panel behave identically for both. Collapsed groups
+ * keep `items` empty (so keyboard nav skips them) while `totalCount` still
+ * reports how many results the section holds. */
+export type OmnibarGroup = {
+    key: string;
+    label: string;
+    items: SearchItem[];
+    totalCount: number;
+    collapsed: boolean;
+};

--- a/packages/frontend/src/mantine8Theme.ts
+++ b/packages/frontend/src/mantine8Theme.ts
@@ -4,6 +4,7 @@ import {
     Button,
     Card,
     Loader,
+    Menu,
     Modal,
     MultiSelect,
     NumberInput,
@@ -260,6 +261,13 @@ export const getMantine8ThemeOverride = (
                 defaultProps: {
                     loaders: { ...Loader.defaultLoaders, dots: DotsLoader },
                 },
+            }),
+
+            Menu: Menu.extend({
+                styles: (theme) => ({
+                    dropdown: { fontFamily: theme.fontFamily },
+                    item: { fontFamily: theme.fontFamily },
+                }),
             }),
 
             Select: Select.extend({

--- a/packages/frontend/src/providers/Mantine8Provider.tsx
+++ b/packages/frontend/src/providers/Mantine8Provider.tsx
@@ -15,6 +15,10 @@ type Props = {
     cssVariablesSelector?: string;
     getRootElement?: () => HTMLElement | undefined;
     env?: 'default' | 'test';
+    /** Skip emitting the CSS-variables stylesheet. For nested providers that
+     * only need to fix the JS theme context (e.g. escaping the navbar's
+     * forced-dark scheme) while the page-level variables stay authoritative. */
+    withCssVariables?: boolean;
 };
 
 const Mantine8Provider: FC<React.PropsWithChildren<Props>> = ({
@@ -24,6 +28,7 @@ const Mantine8Provider: FC<React.PropsWithChildren<Props>> = ({
     cssVariablesSelector,
     getRootElement,
     env,
+    withCssVariables = true,
 }) => {
     const { colorScheme } = useMantineColorScheme();
     const effectiveColorScheme = forceColorScheme || colorScheme;
@@ -46,6 +51,7 @@ const Mantine8Provider: FC<React.PropsWithChildren<Props>> = ({
             getRootElement={getRootElement}
             classNamesPrefix="mantine-8"
             env={env}
+            withCssVariables={withCssVariables}
         >
             <CodeHighlightProvider>{children}</CodeHighlightProvider>
         </MantineProviderBase>


### PR DESCRIPTION
## Summary

A redesign of the global search modal (Omnibar). Frontend only — no backend, no migration.

## Changes

- **Preview panel** showing the focused item's type, title, description, verification/validation state, and Space / Views / Created by. No extra requests: views and creator already come back in the search payload, and space names come from the existing cached spaces query.
- **Unified group model.** Result groups share one `OmnibarGroup` shape, so keyboard navigation, hover focus and the preview all read from the same structure.
- **Keyboard.** The top hit is highlighted by default so Enter works immediately; ArrowUp from the first row hands focus back to the search input; no wrap-around; collapsed groups are skipped.
- **Hover/keyboard conflict fixed.** The row highlight now has a single source of truth, and mouse focus fires on real pointer movement — so a stationary cursor can no longer fight the arrow keys or leave a stale highlighted row behind.
- **Groups are collapsible** with sentence-case headings and result counts, replacing the Accordion.
- **Shell** — borderless input (no focus underline), hairline-divided sections, fixed height so the modal doesn't resize between states, slim scrollbars in both panes, and a footer with the keyboard legend plus permission-gated Ask AI / Run query / Settings shortcuts.
- **Empty states** for pristine, below-min-length, searching and no-results, each with an icon and a hint.
- **Filters** restyled; an active filter shows an × that clears just that filter, and Created by expands into an inline autofocused user search.

### Two theme fixes with effects outside the Omnibar

- `Mantine8Provider` gained an optional `withCssVariables` prop. The Omnibar renders inside the NavBar's `forceColorScheme="dark"` provider but portals onto the page, so JS-resolved component colors (e.g. Button hover) came out dark on a light surface. The modal now re-anchors to the app's real color scheme. This affects any modal opened from the NavBar.
- v8 `Menu` dropdowns fell back to the default `sans-serif` instead of Inter. Fixed at the theme level, matching the existing `Select` fix — applies to every v8 Menu in the app.

### Test hardening

`AiAgentAdminMemoriesTable`'s scope-facet test asserted `toHaveBeenLastCalledWith` synchronously after a click, so it could observe the hook's initial call instead of the post-click one. Wrapped in `waitFor`. Relevant here because the `Menu` theme change above touches every Menu render, including that facet.

## Deliberately not included

An earlier revision added a "Recently viewed by you" section backed by a new OSS endpoint. That was dropped: the underlying query filters `analytics_chart_views` / `analytics_dashboard_views` by `user_uuid`, and neither table has an index on that column, so it degrades to a sequential scan. The Omnibar opens far more often than a page load, so it was not a good place to add another caller of that query. The idea can come back once an index exists on those tables.

## Regression analysis

- `Mantine8Provider`'s new prop defaults to the previous behaviour, so existing call sites are unaffected.
- The `Menu` font fix changes rendering wherever a v8 Menu is used; it aligns those dropdowns with the rest of the app rather than changing intended styling.
- No API, schema or query changes.

## Test plan

- [x] Verified in the running app in both light and dark mode: search results, no-results, filtered states, collapse/expand, keyboard navigation in and out of the list, and the preview panel.
- [x] Frontend suite passes (251 files / 1994 tests).
- [x] lint + typecheck pass for `common`, `backend` and `frontend`.