### PR TITLE
feat(table-calcs): surface available fields in the formula editor reference bar

### DIFF
--- a/packages/frontend/src/components/common/SuggestionList/generateFieldSuggestion.tsx
+++ b/packages/frontend/src/components/common/SuggestionList/generateFieldSuggestion.tsx
@@ -1,4 +1,8 @@
 import {
+    isAdditionalMetric,
+    isCustomDimension,
+    isDimension,
+    isMetric,
     type AdditionalMetric,
     type CustomDimension,
     type Field,
@@ -17,11 +21,43 @@ export type FieldSuggestionItem = {
     item: Field | TableCalculation | AdditionalMetric | CustomDimension;
 };
 
+type FieldSuggestionGroup = 'dimensions' | 'metrics' | 'tableCalcs';
+
+const FIELD_SUGGESTION_GROUP_LABELS: Record<FieldSuggestionGroup, string> = {
+    dimensions: 'Dimensions',
+    metrics: 'Metrics',
+    tableCalcs: 'Table calculations',
+};
+
+const GROUP_ORDER: FieldSuggestionGroup[] = [
+    'dimensions',
+    'metrics',
+    'tableCalcs',
+];
+
+const getFieldSuggestionGroup = (
+    item: FieldSuggestionItem['item'],
+): FieldSuggestionGroup => {
+    if (isCustomDimension(item) || isDimension(item)) return 'dimensions';
+    if (isMetric(item) || isAdditionalMetric(item)) return 'metrics';
+    return 'tableCalcs';
+};
+
+/** Stable-sorts fields so groups render contiguously (dimensions → metrics → table calcs). */
+export const sortFieldSuggestions = (
+    fields: FieldSuggestionItem[],
+): FieldSuggestionItem[] =>
+    [...fields].sort(
+        (a, b) =>
+            GROUP_ORDER.indexOf(getFieldSuggestionGroup(a.item)) -
+            GROUP_ORDER.indexOf(getFieldSuggestionGroup(b.item)),
+    );
+
 export const generateFieldSuggestion = (
     fields: FieldSuggestionItem[],
 ): MentionOptions['suggestion'] =>
     generateSuggestion({
-        items: fields,
+        items: sortFieldSuggestions(fields),
         command: ({ editor, range, props }) => {
             const suggestion = props as FieldSuggestionItem;
             editor
@@ -39,6 +75,9 @@ export const generateFieldSuggestion = (
                 ])
                 .run();
         },
+        getGroupKey: (item) =>
+            getFieldSuggestionGroup((item as FieldSuggestionItem).item),
+        groupLabels: FIELD_SUGGESTION_GROUP_LABELS,
         renderItem: (item, isSelected, onClick) => (
             <PolymorphicGroupButton
                 onClick={onClick}

--- a/packages/frontend/src/components/common/SuggestionList/index.ts
+++ b/packages/frontend/src/components/common/SuggestionList/index.ts
@@ -1,5 +1,6 @@
 export { generateSuggestion } from './generateSuggestion';
 export {
     generateFieldSuggestion,
+    sortFieldSuggestions,
     type FieldSuggestionItem,
 } from './generateFieldSuggestion';

--- a/packages/frontend/src/features/tableCalculation/components/FormulaForm/FormulaEditor.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/FormulaForm/FormulaEditor.tsx
@@ -18,6 +18,7 @@ import { useEffect, useMemo, useRef, useState, type FC } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import {
     generateFieldSuggestion,
+    sortFieldSuggestions,
     type FieldSuggestionItem,
 } from '../../../../components/common/SuggestionList';
 import styles from './FormulaEditor.module.css';
@@ -170,9 +171,9 @@ type Props = {
 };
 
 const PLACEHOLDER_FORMULA =
-    'Type @ for fields or # for functions. Example: =IF(@Revenue > 1000, "high", "low")';
+    'Type @ to use your selected fields or # for functions. Example: =IF(@Revenue > 1000, "high", "low")';
 const PLACEHOLDER_DUAL =
-    'Describe the calculation, or =SUM(@Revenue) for a formula';
+    'Describe the calculation, or type @ to use your selected fields — e.g. =SUM(@Revenue)';
 
 export const FormulaEditor: FC<Props> = ({
     explore,
@@ -225,17 +226,19 @@ export const FormulaEditor: FC<Props> = ({
             ...(metricQuery.tableCalculations ?? []).map((tc) => tc.name),
         ]);
 
-        return Object.entries(itemsMap)
-            .filter(([id]) => usedFieldIds.has(id))
-            .map(([id, fieldItem]) => ({
-                id,
-                label: isField(fieldItem)
-                    ? fieldItem.label
-                    : 'displayName' in fieldItem
-                      ? (fieldItem.displayName ?? fieldItem.name)
-                      : fieldItem.name,
-                item: fieldItem,
-            }));
+        return sortFieldSuggestions(
+            Object.entries(itemsMap)
+                .filter(([id]) => usedFieldIds.has(id))
+                .map(([id, fieldItem]) => ({
+                    id,
+                    label: isField(fieldItem)
+                        ? fieldItem.label
+                        : 'displayName' in fieldItem
+                          ? (fieldItem.displayName ?? fieldItem.name)
+                          : fieldItem.name,
+                    item: fieldItem,
+                })),
+        );
     }, [explore, metricQuery]);
 
     const functionSuggestions: FunctionSuggestionItem[] = useMemo(
@@ -399,6 +402,21 @@ export const FormulaEditor: FC<Props> = ({
         placeholder,
     ]);
 
+    const insertField = (field: FieldSuggestionItem) => {
+        if (!editor) return;
+        editor
+            .chain()
+            .focus()
+            .insertContent([
+                {
+                    type: 'mention',
+                    attrs: { id: field.id, label: field.label },
+                },
+                { type: 'text', text: ' ' },
+            ])
+            .run();
+    };
+
     const insertFunction = (text: string) => {
         if (!editor) return;
         if (text.endsWith('(')) {
@@ -473,6 +491,8 @@ export const FormulaEditor: FC<Props> = ({
             <FormulaReferenceBar
                 opened={referenceOpened}
                 onToggle={onReferenceToggle}
+                fields={fieldSuggestions}
+                onInsertField={insertField}
             />
         </Box>
     );

--- a/packages/frontend/src/features/tableCalculation/components/FormulaForm/FormulaReference.module.css
+++ b/packages/frontend/src/features/tableCalculation/components/FormulaForm/FormulaReference.module.css
@@ -204,6 +204,60 @@
     }
 }
 
+.availableFieldsTarget {
+    font-size: var(--mantine-font-size-xs);
+    font-weight: 500;
+    color: var(--mantine-color-blue-light-color);
+    background-color: var(--mantine-color-blue-light);
+    border-radius: var(--mantine-radius-sm);
+    padding: 2px 8px;
+    transition: background-color 120ms ease;
+}
+
+.availableFieldsTarget:hover,
+.availableFieldsTarget:focus-visible {
+    background-color: var(--mantine-color-blue-light-hover);
+    outline: none;
+}
+
+.availableFieldsHeader {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
+    border-bottom: 1px solid var(--mantine-color-ldGray-2);
+
+    @mixin dark {
+        border-bottom-color: var(--mantine-color-ldDark-3);
+    }
+}
+
+.availableFieldsList {
+    padding: 4px var(--mantine-spacing-xs);
+}
+
+.fieldRow {
+    display: flex;
+    align-items: center;
+    gap: var(--mantine-spacing-xs);
+    width: 100%;
+    padding: 3px var(--mantine-spacing-xs);
+    border-radius: var(--mantine-radius-sm);
+    cursor: pointer;
+    transition: background-color 120ms ease;
+    overflow: hidden;
+}
+
+.fieldRow:hover,
+.fieldRow:focus-visible {
+    background-color: var(--mantine-color-ldGray-1);
+    outline: none;
+
+    @mixin dark {
+        background-color: var(--mantine-color-ldDark-4);
+    }
+}
+
 .docsLink {
     color: var(--mantine-color-dimmed);
 

--- a/packages/frontend/src/features/tableCalculation/components/FormulaForm/FormulaReference.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/FormulaForm/FormulaReference.tsx
@@ -7,10 +7,12 @@ import {
     Button,
     Divider,
     Group,
+    HoverCard,
     ScrollArea,
     Text,
     TextInput,
     Tooltip,
+    UnstyledButton,
 } from '@mantine-8/core';
 import {
     IconArrowUpRight,
@@ -21,7 +23,9 @@ import {
     IconX,
 } from '@tabler/icons-react';
 import { useMemo, useState, type FC } from 'react';
+import FieldIcon from '../../../../components/common/Filters/FieldIcon';
 import MantineIcon from '../../../../components/common/MantineIcon';
+import { type FieldSuggestionItem } from '../../../../components/common/SuggestionList';
 import TruncatedText from '../../../../components/common/TruncatedText';
 import classes from './FormulaReference.module.css';
 import {
@@ -232,12 +236,99 @@ export const FormulaReferencePanel: FC<PanelProps> = ({
     );
 };
 
+type AvailableFieldsHintProps = {
+    fields: FieldSuggestionItem[];
+    onInsertField: (field: FieldSuggestionItem) => void;
+};
+
+/**
+ * Hoverable `N fields available` hint: surfaces every field the formula can
+ * reference (selected dimensions, metrics, and other table calculations)
+ * without having to type `@` first. Clicking a row inserts it. The list is
+ * sorted dimensions → metrics → table calculations and each row's icon
+ * carries the field type, so no group headers are needed — keeps the list
+ * dense when many fields are selected.
+ */
+const AvailableFieldsHint: FC<AvailableFieldsHintProps> = ({
+    fields,
+    onInsertField,
+}) => {
+    return (
+        <HoverCard
+            width={280}
+            position="top-start"
+            shadow="md"
+            openDelay={100}
+            closeDelay={200}
+            withinPortal
+        >
+            <HoverCard.Target>
+                <UnstyledButton
+                    className={classes.availableFieldsTarget}
+                    aria-label="Show available fields"
+                >
+                    <Text fz="xs" fw={500} ff="inherit">
+                        {fields.length === 1
+                            ? '1 field available'
+                            : `${fields.length} fields available`}
+                    </Text>
+                </UnstyledButton>
+            </HoverCard.Target>
+            <HoverCard.Dropdown p={0}>
+                <Box className={classes.availableFieldsHeader}>
+                    <Text size="xs" fw={600}>
+                        Available fields
+                    </Text>
+                    <Text size="xs" c="dimmed">
+                        Click to insert, or type{' '}
+                        <kbd className={classes.kbd}>@</kbd> in the formula.
+                    </Text>
+                </Box>
+                <ScrollArea.Autosize
+                    mah={280}
+                    type="auto"
+                    offsetScrollbars
+                    scrollbars="y"
+                    className={classes.availableFieldsList}
+                >
+                    {fields.length === 0 ? (
+                        <Text size="xs" c="dimmed" p="xs">
+                            No fields selected yet — add dimensions or metrics
+                            to your query first.
+                        </Text>
+                    ) : (
+                        fields.map((field) => (
+                            <UnstyledButton
+                                key={field.id}
+                                className={classes.fieldRow}
+                                onClick={() => onInsertField(field)}
+                            >
+                                <FieldIcon item={field.item} size="sm" />
+                                <Text size="xs" truncate>
+                                    {field.label}
+                                </Text>
+                            </UnstyledButton>
+                        ))
+                    )}
+                </ScrollArea.Autosize>
+            </HoverCard.Dropdown>
+        </HoverCard>
+    );
+};
+
 type BarProps = {
     opened: boolean;
     onToggle: (next: boolean) => void;
+    fields: FieldSuggestionItem[];
+    onInsertField: (field: FieldSuggestionItem) => void;
 };
 
-export const FormulaReferenceBar: FC<BarProps> = ({ opened, onToggle }) => {
+export const FormulaReferenceBar: FC<BarProps> = ({
+    opened,
+    onToggle,
+    fields,
+    onInsertField,
+}) => {
     const toggle = () => onToggle(!opened);
 
     const kbdHints = (
@@ -257,6 +348,10 @@ export const FormulaReferenceBar: FC<BarProps> = ({ opened, onToggle }) => {
         </Group>
     );
 
+    const fieldsHint = (
+        <AvailableFieldsHint fields={fields} onInsertField={onInsertField} />
+    );
+
     return (
         <Group
             className={classes.bar}
@@ -265,21 +360,27 @@ export const FormulaReferenceBar: FC<BarProps> = ({ opened, onToggle }) => {
             justify="space-between"
         >
             {opened ? (
-                kbdHints
+                <Group gap="sm" wrap="nowrap">
+                    {kbdHints}
+                    {fieldsHint}
+                </Group>
             ) : (
-                <Button
-                    variant="subtle"
-                    color="gray"
-                    size="compact-xs"
-                    onClick={toggle}
-                    leftSection={
-                        <MantineIcon icon={IconMathFunction} size="sm" />
-                    }
-                    className={classes.helperButton}
-                    aria-expanded={opened}
-                >
-                    Need help?
-                </Button>
+                <Group gap="sm" wrap="nowrap">
+                    <Button
+                        variant="subtle"
+                        color="gray"
+                        size="compact-xs"
+                        onClick={toggle}
+                        leftSection={
+                            <MantineIcon icon={IconMathFunction} size="sm" />
+                        }
+                        className={classes.helperButton}
+                        aria-expanded={opened}
+                    >
+                        Need help?
+                    </Button>
+                    {fieldsHint}
+                </Group>
             )}
 
             {opened ? (


### PR DESCRIPTION
## Summary

Makes the fields available to a formula discoverable from the table-calculation formula editor, instead of relying on the user knowing to type `@`.

## Changes

- **"N fields available" hint** in the formula reference bar. Hovering it lists every field the formula can reference, and clicking one inserts it as a mention at the cursor. Each row carries its field type icon, so the list stays dense when many fields are selected and needs no group headers.
- **Empty state** when nothing is selected yet, pointing the user at adding dimensions or metrics first.
- **Grouped ordering.** Field suggestions are now stable-sorted into dimensions → metrics → table calculations, so the `@` dropdown and the new list render each group contiguously. Extracted as `sortFieldSuggestions` and shared between the two.
- **Clearer placeholder copy** — the previous text mentioned `@` without saying what it referenced; it now says it pulls in your selected fields.

## Regression analysis

- `sortFieldSuggestions` only reorders items; it doesn't filter or transform them, so the `@` dropdown offers exactly the same set as before, just grouped.
- The reference bar gains a hint element; its existing toggle behaviour is untouched.
- `FIELD_SUGGESTION_GROUP_LABELS`, `getFieldSuggestionGroup` and the `FieldSuggestionGroup` type are no longer re-exported from the `SuggestionList` barrel, since only `sortFieldSuggestions` is consumed outside the module. They remain in place as module-internal values — no behaviour change, and it keeps the `ts-unused-exports` gate green.

## Test plan

- [x] `pnpm -F frontend typecheck` and `pnpm -F frontend run linter` pass.
- [ ] Manual check: open a table calculation formula editor, confirm the hint shows the correct count, hovering lists the selected fields grouped by type, and clicking inserts a working mention.