### PR TITLE
fix(onboarding): give the demo playground its own Aurora agent

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -40,6 +40,7 @@ import { type FileStorageClient } from '../../clients/FileStorage/FileStorageCli
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import { type LightdashConfig } from '../../config/parseConfig';
 import { PreAggregateModel } from '../../ee/models/PreAggregateModel';
+import type { AiAgentService } from '../../ee/services/AiAgentService/AiAgentService';
 import { AnalyticsModel } from '../../models/AnalyticsModel';
 import type { CatalogModel } from '../../models/CatalogModel/CatalogModel';
 import { ContentModel } from '../../models/ContentModel/ContentModel';
@@ -172,6 +173,7 @@ vi.mock('@lightdash/warehouses', () => ({
 const projectModel = {
     getWithSensitiveFields: vi.fn(async () => projectWithSensitiveFields),
     get: vi.fn(async () => projectWithSensitiveFields),
+    getAllByOrganizationUuid: vi.fn<ProjectModel['getAllByOrganizationUuid']>(),
     getSummary: vi.fn(async () => projectSummary),
     getTablesConfiguration: vi.fn(async () => tablesConfiguration),
     updateTablesConfiguration: vi.fn(),
@@ -283,6 +285,16 @@ const projectCompileLogModel = {
     insert: vi.fn(async () => undefined),
 };
 
+const getMockedAiAgentService = () => {
+    const provisionDefaultAgent =
+        vi.fn<AiAgentService['provisionDefaultAgent']>();
+    return {
+        provisionDefaultAgent,
+        getAiAgentService: () =>
+            ({ provisionDefaultAgent }) as unknown as AiAgentService,
+    };
+};
+
 const getMockedProjectService = (
     lightdashConfig: LightdashConfig,
     overrides: Partial<
@@ -291,6 +303,7 @@ const getMockedProjectService = (
             | 'spacePermissionService'
             | 'provisionPlaygroundProject'
             | 'downloadFileModel'
+            | 'getAiAgentService'
         >
     > = {},
 ) =>
@@ -358,6 +371,7 @@ const getMockedProjectService = (
         spacePermissionService:
             overrides.spacePermissionService ?? ({} as SpacePermissionService),
         provisionPlaygroundProject: overrides.provisionPlaygroundProject,
+        getAiAgentService: overrides.getAiAgentService,
         organizationSettingsModel: {
             get: vi.fn(async () => ({
                 queryLimit: null,
@@ -603,6 +617,137 @@ describe('ProjectService', () => {
         ).rejects.toThrow(
             'Embedded DuckDB connections can only be provisioned internally',
         );
+    });
+
+    describe('default AI agent provisioning', () => {
+        test('provisions a default AI agent for a playground when the organization already has another project', async () => {
+            const createdProjectUuid = 'created-playground-project-uuid';
+            const { provisionDefaultAgent, getAiAgentService } =
+                getMockedAiAgentService();
+            const serviceWithAiAgent = getMockedProjectService(
+                lightdashConfigMock,
+                { getAiAgentService },
+            );
+            const creationUser: SessionUser = {
+                ...user,
+                organizationUuid: projectWithSensitiveFields.organizationUuid,
+                organizationName: 'Organization',
+                organizationCreatedAt: new Date(),
+            };
+            const organizationProjects = [
+                {
+                    ...defaultProject,
+                    projectUuid: createdProjectUuid,
+                },
+                {
+                    ...defaultProject,
+                    projectUuid: 'existing-project-uuid',
+                },
+            ];
+            projectModel.createWithOptionalCredentials.mockResolvedValueOnce(
+                createdProjectUuid,
+            );
+            projectModel.getAllByOrganizationUuid.mockResolvedValueOnce(
+                organizationProjects,
+            );
+            const validateSpy = vi
+                .spyOn(
+                    serviceWithAiAgent as unknown as {
+                        validateProjectCreationPermissions: () => Promise<true>;
+                    },
+                    'validateProjectCreationPermissions',
+                )
+                .mockResolvedValue(true);
+
+            try {
+                await serviceWithAiAgent.createWithoutCompile(
+                    creationUser,
+                    {
+                        name: 'Playground',
+                        type: ProjectType.DEFAULT,
+                        dbtConnection: { type: DbtProjectType.NONE },
+                        dbtVersion: projectWithSensitiveFields.dbtVersion,
+                        warehouseConnection: {
+                            type: WarehouseTypes.DUCKDB,
+                            connectionType: DuckdbConnectionType.EMBEDDED,
+                            dataset: 'jaffle_shop',
+                        },
+                    },
+                    RequestMethod.WEB_APP,
+                    { source: 'playground' },
+                );
+
+                expect(provisionDefaultAgent).toHaveBeenCalledWith(
+                    creationUser,
+                    createdProjectUuid,
+                );
+            } finally {
+                validateSpy.mockRestore();
+                projectModel.getAllByOrganizationUuid.mockReset();
+            }
+        });
+
+        test('does not provision a default AI agent for normal creation when the organization already has multiple projects', async () => {
+            const createdProjectUuid = 'created-project-uuid';
+            const { provisionDefaultAgent, getAiAgentService } =
+                getMockedAiAgentService();
+            const serviceWithAiAgent = getMockedProjectService(
+                lightdashConfigMock,
+                { getAiAgentService },
+            );
+            const creationUser: SessionUser = {
+                ...user,
+                organizationUuid: projectWithSensitiveFields.organizationUuid,
+                organizationName: 'Organization',
+                organizationCreatedAt: new Date(),
+            };
+            const organizationProjects = [
+                {
+                    ...defaultProject,
+                    projectUuid: createdProjectUuid,
+                },
+                {
+                    ...defaultProject,
+                    projectUuid: 'existing-project-uuid-1',
+                },
+                {
+                    ...defaultProject,
+                    projectUuid: 'existing-project-uuid-2',
+                },
+            ];
+            projectModel.createWithOptionalCredentials.mockResolvedValueOnce(
+                createdProjectUuid,
+            );
+            projectModel.getAllByOrganizationUuid.mockResolvedValueOnce(
+                organizationProjects,
+            );
+            const validateSpy = vi
+                .spyOn(
+                    serviceWithAiAgent as unknown as {
+                        validateProjectCreationPermissions: () => Promise<true>;
+                    },
+                    'validateProjectCreationPermissions',
+                )
+                .mockResolvedValue(true);
+
+            try {
+                await serviceWithAiAgent.createWithoutCompile(
+                    creationUser,
+                    {
+                        name: 'Project',
+                        type: ProjectType.DEFAULT,
+                        dbtConnection: { type: DbtProjectType.NONE },
+                        dbtVersion: projectWithSensitiveFields.dbtVersion,
+                    },
+                    RequestMethod.WEB_APP,
+                );
+
+                expect(provisionDefaultAgent).not.toHaveBeenCalled();
+            } finally {
+                validateSpy.mockRestore();
+                projectModel.getAllByOrganizationUuid.mockReset();
+            }
+        });
     });
 
     test('rejects embedded DuckDB credentials inherited from an upstream preview', async () => {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -639,6 +639,7 @@ export class ProjectService extends BaseService {
         user: SessionUser,
         projectUuid: string,
         projectType: ProjectType,
+        provisioningSource?: 'playground',
     ): Promise<void> {
         if (projectType === ProjectType.PREVIEW) {
             return;
@@ -650,18 +651,22 @@ export class ProjectService extends BaseService {
         }
 
         try {
-            const projects =
-                await this.projectModel.getAllByOrganizationUuid(
-                    organizationUuid,
+            // Playgrounds are provisioned alongside a user's own project, so
+            // they never pass the first-project check but still need an agent
+            if (provisioningSource !== 'playground') {
+                const projects =
+                    await this.projectModel.getAllByOrganizationUuid(
+                        organizationUuid,
+                    );
+                const nonPreviewProjects = projects.filter(
+                    (project) => project.type !== ProjectType.PREVIEW,
                 );
-            const nonPreviewProjects = projects.filter(
-                (project) => project.type !== ProjectType.PREVIEW,
-            );
-            if (
-                nonPreviewProjects.length !== 1 ||
-                nonPreviewProjects[0].projectUuid !== projectUuid
-            ) {
-                return;
+                if (
+                    nonPreviewProjects.length !== 1 ||
+                    nonPreviewProjects[0].projectUuid !== projectUuid
+                ) {
+                    return;
+                }
             }
 
             await this.getAiAgentService?.()?.provisionDefaultAgent(
@@ -692,7 +697,12 @@ export class ProjectService extends BaseService {
         projectType: ProjectType,
         provisioningSource?: 'playground',
     ): Promise<void> {
-        await this.provisionDefaultAiAgent(user, projectUuid, projectType);
+        await this.provisionDefaultAiAgent(
+            user,
+            projectUuid,
+            projectType,
+            provisioningSource,
+        );
 
         try {
             await this.onProjectCreated?.({


### PR DESCRIPTION
## What

When a user kicks off semantic-layer generation, the "Building your Lightdash project" page offers a demo project to explore while they wait. Accepting it provisions a sample-data playground **alongside** the project they are already building.

`provisionDefaultAiAgent` only provisions the default "Aurora" agent when the new project is the organization's *only* non-preview project. A playground provisioned during an onboarding wait never passes that check, so it landed with a dead Ask AI prompt — "Set up an AI agent to enable Ask AI here" — on the demo project's homepage, which is the one surface the demo exists to show off.

This skips the first-project check when the project being created is a playground. The invite-expert path was unaffected (there the playground *is* the org's first project), which is why the gap only showed on this surface.

## Why it's safe

`provisionDefaultAgent` already returns early if the project has any agent, so the relaxed guard cannot double-provision. It also still gates on copilot enablement and runs `createAgent`'s own permission checks. Agents are project-scoped, so an org that hits this path ends up with one Aurora on its own project and one on the demo project — each visible only in its own project.

## Verification

Runtime, against a local instance with an active onboarding run and an org that already had a project:

| Playground | Trigger | Default agent |
|---|---|---|
| provisioned via invite-expert (org's first project) | `invite_expert` | ✅ Aurora |
| provisioned during onboarding wait, **before** this fix | `agent_onboarding_wait` | ❌ none |
| provisioned during onboarding wait, **after** this fix | `agent_onboarding_wait` | ✅ Aurora |

`POST /api/v1/org/playground-projects/ensure` returned `created: true`, and the new playground's homepage renders a live "Ask Aurora…" composer instead of the empty-agent state.

## Tests

Two black-box tests through `createWithoutCompile`: a playground provisioned into an org that already has a project provisions the agent; normal project creation into an org with multiple projects still does not. Both were confirmed to fail/pass correctly against the unfixed service.

`pnpm -F backend exec vitest run src/services/ProjectService/ProjectService.test.ts` (93 passed), backend typecheck and file-scoped lint clean.

Closes: SPK-780