### PR TITLE
fix(ai): prevent overlapping Deep Research runs

### DIFF
--- a/packages/backend/src/ee/controllers/AiDeepResearchController.ts
+++ b/packages/backend/src/ee/controllers/AiDeepResearchController.ts
@@ -44,6 +44,7 @@ export class AiDeepResearchController extends BaseController {
         isAuthenticated,
         unauthorisedInDemo,
     ])
+    @Response<ApiErrorPayload>('409', 'Deep Research run already active')
     @SuccessResponse('202', 'Accepted')
     @Post('/')
     @OperationId('createAiDeepResearchRun')

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.integration.test.ts
@@ -5,6 +5,7 @@ import {
     SEED_PROJECT,
     type AiDeepResearchBudget,
     type AiDeepResearchExecutionContextSnapshot,
+    type AiDeepResearchRunStatus,
 } from '@lightdash/common';
 import { type Knex } from 'knex';
 import { getTestContext } from '../../vitest.setup.integration';
@@ -32,7 +33,10 @@ import {
     AiDeepResearchRunsTableName,
     type DbAiDeepResearchRun,
 } from '../database/entities/aiDeepResearch';
-import { AiDeepResearchRunModel } from './AiDeepResearchRunModel';
+import {
+    AiDeepResearchActiveRunError,
+    AiDeepResearchRunModel,
+} from './AiDeepResearchRunModel';
 
 const budget: AiDeepResearchBudget = {
     maxTokens: 10_000_000,
@@ -256,6 +260,67 @@ describe('AiDeepResearchRunModel integration', () => {
             'status_changed:queued',
             'status_changed:running',
         ]);
+    });
+
+    it('serializes concurrent starts and blocks queued and running runs', async () => {
+        const secondPromptUuid = await createAdditionalPrompt();
+        const attempts = await Promise.allSettled([
+            createRun(),
+            createRun({ promptUuid: secondPromptUuid }),
+        ]);
+        const winner = attempts.find(
+            (attempt): attempt is PromiseFulfilledResult<DbAiDeepResearchRun> =>
+                attempt.status === 'fulfilled',
+        )?.value;
+        const conflict = attempts.find(
+            (attempt): attempt is PromiseRejectedResult =>
+                attempt.status === 'rejected',
+        )?.reason;
+
+        expect(winner).toBeDefined();
+        expect(conflict).toBeInstanceOf(AiDeepResearchActiveRunError);
+        expect(conflict).toMatchObject({
+            activeRunUuid: winner?.ai_deep_research_run_uuid,
+        });
+
+        if (!winner) {
+            throw new Error('Expected one Deep Research run to start');
+        }
+
+        const queuedPromptUuid = await createAdditionalPrompt();
+        await expect(
+            createRun({ promptUuid: queuedPromptUuid }),
+        ).rejects.toMatchObject({
+            activeRunUuid: winner.ai_deep_research_run_uuid,
+        });
+
+        await model.claimQueuedRun(winner.ai_deep_research_run_uuid);
+        const runningPromptUuid = await createAdditionalPrompt();
+        await expect(
+            createRun({ promptUuid: runningPromptUuid }),
+        ).rejects.toMatchObject({
+            activeRunUuid: winner.ai_deep_research_run_uuid,
+        });
+    });
+
+    it.each<AiDeepResearchRunStatus>([
+        'completed',
+        'partially_completed',
+        'failed',
+        'cancelled',
+    ])('allows a new run after a %s run', async (status) => {
+        const terminalRun = await createRun();
+        await database(AiDeepResearchRunsTableName)
+            .where(
+                'ai_deep_research_run_uuid',
+                terminalRun.ai_deep_research_run_uuid,
+            )
+            .update({ status });
+        const nextPromptUuid = await createAdditionalPrompt();
+
+        await expect(
+            createRun({ promptUuid: nextPromptUuid }),
+        ).resolves.toMatchObject({ prompt_uuid: nextPromptUuid });
     });
 
     it('round-trips the persisted entry point', async () => {
@@ -540,12 +605,6 @@ describe('AiDeepResearchRunModel integration', () => {
 
     it('scrubs only expired run data, supports legacy null expiries, and is idempotent under contention', async () => {
         const expiredRun = await createRun();
-        const futurePromptUuid = await createAdditionalPrompt();
-        const futureRun = await createRun({ promptUuid: futurePromptUuid });
-        const expiredToolCallId = `expired-${crypto.randomUUID()}`;
-        const futureToolCallId = `future-${crypto.randomUUID()}`;
-        const unrelatedToolCallId = `unrelated-${crypto.randomUUID()}`;
-
         await database(AiDeepResearchRunsTableName)
             .where(
                 'ai_deep_research_run_uuid',
@@ -558,6 +617,12 @@ describe('AiDeepResearchRunModel integration', () => {
                 completed_at: database.raw("now() - interval '31 days'"),
                 report_expires_at: null,
             });
+        const futurePromptUuid = await createAdditionalPrompt();
+        const futureRun = await createRun({ promptUuid: futurePromptUuid });
+        const expiredToolCallId = `expired-${crypto.randomUUID()}`;
+        const futureToolCallId = `future-${crypto.randomUUID()}`;
+        const unrelatedToolCallId = `unrelated-${crypto.randomUUID()}`;
+
         await database(AiDeepResearchRunsTableName)
             .where(
                 'ai_deep_research_run_uuid',

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
@@ -22,9 +22,11 @@ import {
     AiAgentToolCallErrorTableName,
     AiAgentToolCallTableName,
     AiAgentToolResultTableName,
+    AiThreadTableName,
     type AiAgentToolCallErrorTable,
     type AiAgentToolCallTable,
     type AiAgentToolResultTable,
+    type AiThreadTable,
 } from '../database/entities/ai';
 import {
     AiDeepResearchAnalyticsOutboxTableName,
@@ -108,6 +110,16 @@ export type AiDeepResearchReportCleanupResult = {
     expired: number;
     failed: number;
 };
+
+export class AiDeepResearchActiveRunError extends Error {
+    readonly activeRunUuid: string;
+
+    constructor(activeRunUuid: string) {
+        super('A Deep Research run is already active in this thread');
+        this.name = 'AiDeepResearchActiveRunError';
+        this.activeRunUuid = activeRunUuid;
+    }
+}
 
 export class AiDeepResearchRunModel {
     private readonly database: Knex;
@@ -236,6 +248,26 @@ export class AiDeepResearchRunModel {
 
     async create(data: CreateAiDeepResearchRun): Promise<DbAiDeepResearchRun> {
         return this.database.transaction(async (transaction) => {
+            await transaction<AiThreadTable>(AiThreadTableName)
+                .select('ai_thread_uuid')
+                .where('ai_thread_uuid', data.aiThreadUuid)
+                .forUpdate()
+                .first();
+
+            const activeRun = await transaction<AiDeepResearchRunsTable>(
+                AiDeepResearchRunsTableName,
+            )
+                .select('ai_deep_research_run_uuid')
+                .where('ai_thread_uuid', data.aiThreadUuid)
+                .whereIn('status', ['queued', 'running'])
+                .orderBy('created_at', 'asc')
+                .first();
+            if (activeRun) {
+                throw new AiDeepResearchActiveRunError(
+                    activeRun.ai_deep_research_run_uuid,
+                );
+            }
+
             const [run] = await transaction<AiDeepResearchRunsTable>(
                 AiDeepResearchRunsTableName,
             )

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
@@ -4,6 +4,7 @@ import {
     AI_DEEP_RESEARCH_REPORT_TOOL_NAME,
     AiResultType,
     AnyType,
+    ConflictError,
     FeatureFlags,
     ForbiddenError,
     NotFoundError,
@@ -16,6 +17,7 @@ import {
     type SessionUser,
 } from '@lightdash/common';
 import { Readable } from 'stream';
+import { AiDeepResearchActiveRunError } from '../../models/AiDeepResearchRunModel';
 import { AiDeepResearchService } from './AiDeepResearchService';
 
 const budget: AiDeepResearchBudget = {
@@ -558,6 +560,27 @@ describe('AiDeepResearchService', () => {
                 projectUuid: 'project-1',
                 userUuid: 'user-1',
             });
+        });
+
+        it('returns the active run UUID when another prompt wins the thread race', async () => {
+            const { service, schedulerClient } = buildService({
+                model: {
+                    create: vi
+                        .fn()
+                        .mockRejectedValue(
+                            new AiDeepResearchActiveRunError('active-run'),
+                        ),
+                },
+            });
+
+            await expect(
+                service.createRun(validCreateRunArgs()),
+            ).rejects.toMatchObject({
+                name: ConflictError.name,
+                statusCode: 409,
+                data: { activeRunUuid: 'active-run' },
+            });
+            expect(schedulerClient.aiDeepResearch).not.toHaveBeenCalled();
         });
 
         it('rejects a prompt body that differs from the persisted message', async () => {

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
@@ -4,6 +4,7 @@ import {
     AiResultType,
     buildInlineChartFields,
     buildInlineChartMetricQuery,
+    ConflictError,
     FeatureFlags,
     findDeepResearchChartRefs,
     ForbiddenError,
@@ -55,6 +56,7 @@ import {
 } from '../../database/entities/aiDeepResearch';
 import { type AiAgentModel } from '../../models/AiAgentModel';
 import {
+    AiDeepResearchActiveRunError,
     type AiDeepResearchRunModel,
     type DbAiDeepResearchEventWithCursor,
 } from '../../models/AiDeepResearchRunModel';
@@ -763,6 +765,12 @@ export class AiDeepResearchService extends BaseService {
                     concurrentRun.ai_deep_research_run_uuid,
                 );
                 return toRun(concurrentRun);
+            }
+            if (error instanceof AiDeepResearchActiveRunError) {
+                throw new ConflictError(
+                    'Only one Deep Research run can be active in a thread at a time',
+                    { activeRunUuid: error.activeRunUuid },
+                );
             }
             throw error;
         }

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -390,12 +390,12 @@ export class AlreadyExistsError extends LightdashError {
 }
 
 export class ConflictError extends LightdashError {
-    constructor(message: string) {
+    constructor(message: string, data: { [key: string]: AnyType } = {}) {
         super({
             message,
             name: 'ConflictError',
             statusCode: 409,
-            data: {},
+            data,
         });
     }
 }


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9330/allow-multiple-sequential-deep-research-runs-in-one-thread

## Summary

Prevents multiple Deep Research runs from being queued or running in the same thread at once. A later request now receives a `409` with the active run UUID, while terminal runs immediately release the thread for another investigation.

## Root cause

The frontend disables Deep Research when it observes an active run, but backend creation previously deduplicated requests only by prompt UUID. Two tabs could submit different prompts before either observed the other run, allowing both to enter the queue.

```ts
const existingRun = await findByPromptScoped({ promptUuid });
// Different prompts in the same thread both continued to create().
```

The prompt constraint preserved idempotent retries, but it did not express the thread-wide lifecycle invariant.

## Fix

Run creation now locks the owning AI thread row and checks for a queued or running run before inserting. The service maps a different-prompt collision to `409 ConflictError` with `data.activeRunUuid`, while same-prompt retries still return their existing run.

- `AiDeepResearchRunModel` — serializes same-thread starts with `FOR UPDATE` and reports the active winner.
- `AiDeepResearchService` — returns a structured conflict containing the active run UUID.
- `AiDeepResearchController` — documents the `409` response in OpenAPI.
- No migration or frontend change: terminal history remains unrestricted and the existing UI guard stays in place.

## Before

```text
Tab A: prompt A ──► queued run A
Tab B: prompt B ──► queued run B   (overlap)
```

## After

```text
Tab A: prompt A ──► lock thread ──► queued run A
Tab B: prompt B ──► wait ─────────► 409 { activeRunUuid: A }

run A terminal ──► prompt B ──────► queued run B
```

## Test plan

- [x] Full backend unit suite — 5,493 passed, 1 skipped
- [x] `AiDeepResearchRunModel` integration suite — 17/17
- [x] Concurrent distinct-prompt starts produce exactly one winner
- [x] Both `queued` and `running` runs reject another start
- [x] `completed`, `partially_completed`, `failed`, and `cancelled` runs each release the thread
- [x] Conflict response includes `data.activeRunUuid`
- [x] Common/backend typecheck, lint, and format
- [x] Regenerate and verify OpenAPI output
