### PR TITLE
feat(auth): redesign pre-auth screens with split-screen brand panel

### DIFF
--- a/packages/frontend/src/components/RegisterForms/CreateEmailOnlyUserForm.tsx
+++ b/packages/frontend/src/components/RegisterForms/CreateEmailOnlyUserForm.tsx
@@ -5,6 +5,7 @@ import {
 import { Anchor, Button, Stack, Text, TextInput } from '@mantine-8/core';
 import { useForm, zodResolver } from '@mantine/form';
 import { type FC } from 'react';
+import { Link } from 'react-router';
 import { z } from 'zod';
 
 type Props = {
@@ -46,7 +47,7 @@ const CreateEmailOnlyUserForm: FC<Props> = ({ isLoading, onSubmit }) => {
                 </Button>
                 <Text mx="auto" c="ldGray.7" ta="center" fz="sm" fw={500}>
                     Already Registered?{' '}
-                    <Anchor href="/signin" fz="sm" fw={500}>
+                    <Anchor component={Link} to="/login" fz="sm" fw={500}>
                         Sign in
                     </Anchor>
                 </Text>

--- a/packages/frontend/src/components/RegisterForms/CreateUserForm.tsx
+++ b/packages/frontend/src/components/RegisterForms/CreateUserForm.tsx
@@ -14,6 +14,7 @@ import {
 } from '@mantine-8/core';
 import { useForm, zodResolver } from '@mantine/form';
 import { type FC } from 'react';
+import { Link } from 'react-router';
 import { z } from 'zod';
 import PasswordTextInput from '../PasswordTextInput';
 
@@ -92,7 +93,7 @@ const CreateUserForm: FC<Props> = ({ isLoading, readOnlyEmail, onSubmit }) => {
                 </Button>
                 <Text mx="auto" c="ldGray.7" ta="center" fz="sm" fw={500}>
                     Already Registered?{' '}
-                    <Anchor href="/signin" fz="sm" fw={500}>
+                    <Anchor component={Link} to="/login" fz="sm" fw={500}>
                         Sign in
                     </Anchor>
                 </Text>

--- a/packages/frontend/src/components/RegisterForms/VerifyEmailForm.tsx
+++ b/packages/frontend/src/components/RegisterForms/VerifyEmailForm.tsx
@@ -17,7 +17,9 @@ const VerifyEmailForm: FC<{
     isLoading?: boolean;
     emailStatusData?: EmailStatusExpiring;
     statusLoading?: boolean;
-}> = ({ isLoading, emailStatusData, statusLoading }) => {
+    align?: 'center' | 'left';
+}> = ({ isLoading, emailStatusData, statusLoading, align = 'center' }) => {
+    const isLeftAligned = align === 'left';
     const { health } = useApp();
     const { track } = useTracking();
     const { mutate: verifyCode, isLoading: verificationLoading } =
@@ -72,9 +74,15 @@ const VerifyEmailForm: FC<{
     }
 
     return (
-        <Stack gap="md" justify="center" align="center" w="100%" mx="auto">
+        <Stack
+            gap="md"
+            justify="center"
+            align={isLeftAligned ? 'stretch' : 'center'}
+            w="100%"
+            mx="auto"
+        >
             <Title order={3}>Check your inbox!</Title>
-            <Text c="ldGray.8" ta="center" fz="sm">
+            <Text c="ldGray.8" ta={align} fz="sm">
                 Verify your email address by entering the code we've just sent
                 to{' '}
                 <Text span fw={500} fz="sm" c="ldGray.8">
@@ -88,7 +96,11 @@ const VerifyEmailForm: FC<{
                     submitCode(values.code),
                 )}
             >
-                <Stack gap="xs" justify="center" align="center">
+                <Stack
+                    gap="xs"
+                    justify="center"
+                    align={isLeftAligned ? 'flex-start' : 'center'}
+                >
                     <PinInput
                         aria-label="One-time password"
                         name="code"
@@ -104,7 +116,7 @@ const VerifyEmailForm: FC<{
                         data-testid="pin-input"
                         autoFocus
                     />
-                    <Text ta="center" c="red.7">
+                    <Text ta={align} c="red.7">
                         {errorMessage?.toString()}
                     </Text>
                 </Stack>
@@ -133,10 +145,10 @@ const VerifyEmailForm: FC<{
                             <Stack
                                 gap="xs"
                                 mt="md"
-                                w="200"
-                                align="center"
-                                ml="auto"
-                                mr="auto"
+                                w={isLeftAligned ? '100%' : '200'}
+                                align={isLeftAligned ? 'stretch' : 'center'}
+                                ml={isLeftAligned ? undefined : 'auto'}
+                                mr={isLeftAligned ? undefined : 'auto'}
                             >
                                 <Button
                                     fullWidth
@@ -145,7 +157,7 @@ const VerifyEmailForm: FC<{
                                 >
                                     Submit
                                 </Button>
-                                <Text c="ldGray.6" ta="center" fz="sm" fw={500}>
+                                <Text c="ldGray.6" ta={align} fz="sm" fw={500}>
                                     Your one-time password expires in{' '}
                                     <Text span fw={500} fz="sm" c="ldGray.7">
                                         {zeroPad(minutes)}:{zeroPad(seconds)}
@@ -158,6 +170,7 @@ const VerifyEmailForm: FC<{
             </form>
             <Anchor
                 fz="sm"
+                ta={isLeftAligned ? 'left' : undefined}
                 component="button"
                 onClick={() => {
                     track({

--- a/packages/frontend/src/components/common/AuthLayout/AuthLayout.module.css
+++ b/packages/frontend/src/components/common/AuthLayout/AuthLayout.module.css
@@ -94,6 +94,16 @@
     max-width: rem(420px);
 }
 
+.formBrandMark {
+    display: none;
+}
+
+@media (max-width: $mantine-breakpoint-md) {
+    .formBrandMark {
+        display: flex;
+    }
+}
+
 .formSubtitle {
     color: var(--mantine-color-ldGray-6);
 }

--- a/packages/frontend/src/components/common/AuthLayout/AuthLayout.module.css
+++ b/packages/frontend/src/components/common/AuthLayout/AuthLayout.module.css
@@ -1,0 +1,99 @@
+.root {
+    display: flex;
+    min-height: 100vh;
+}
+
+.brandPanel {
+    position: relative;
+    overflow: hidden;
+    flex: 0 0 44%;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    gap: var(--mantine-spacing-4xl);
+    padding: var(--mantine-spacing-4xl);
+    background-color: var(--mantine-color-ldBrandGray-8);
+}
+
+@media (max-width: $mantine-breakpoint-md) {
+    .brandPanel {
+        display: none;
+    }
+}
+
+.brandMark {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: rem(40px);
+    height: rem(40px);
+    border-radius: var(--mantine-radius-md);
+    background-color: var(--mantine-color-ldBrandGray-7);
+    color: var(--mantine-color-white);
+}
+
+.brandName {
+    color: var(--mantine-color-white);
+}
+
+.headline {
+    max-width: rem(560px);
+    color: var(--mantine-color-white);
+}
+
+.subcopy {
+    max-width: rem(520px);
+    color: rgba(255, 255, 255, 0.62);
+}
+
+.highlight {
+    color: var(--mantine-color-white);
+}
+
+.brandFooter {
+    color: var(--mantine-color-ldBrandGray-4);
+}
+
+.decorationTop {
+    position: absolute;
+    top: rem(-40px);
+    right: rem(-30px);
+    width: rem(180px);
+    height: rem(180px);
+    border-radius: rem(36px);
+    background-color: var(--mantine-color-ldBrandViolet-6);
+    opacity: 0.09;
+    transform: rotate(18deg);
+    pointer-events: none;
+}
+
+.decorationBottom {
+    position: absolute;
+    bottom: rem(-35px);
+    left: rem(-25px);
+    width: rem(140px);
+    height: rem(140px);
+    border-radius: rem(28px);
+    background-color: var(--mantine-color-ldBrandViolet-4);
+    opacity: 0.07;
+    transform: rotate(-12deg);
+    pointer-events: none;
+}
+
+.formPanel {
+    display: flex;
+    flex: 1;
+    align-items: center;
+    justify-content: center;
+    padding: var(--mantine-spacing-xl);
+    background-color: var(--mantine-color-body);
+}
+
+.formContent {
+    width: 100%;
+    max-width: rem(420px);
+}
+
+.formSubtitle {
+    color: var(--mantine-color-ldGray-6);
+}

--- a/packages/frontend/src/components/common/AuthLayout/AuthLayout.module.css
+++ b/packages/frontend/src/components/common/AuthLayout/AuthLayout.module.css
@@ -9,7 +9,7 @@
     flex: 0 0 44%;
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
+    justify-content: flex-start;
     gap: var(--mantine-spacing-4xl);
     padding: var(--mantine-spacing-4xl);
     background-color: var(--mantine-color-ldBrandGray-8);
@@ -50,8 +50,8 @@
     color: var(--mantine-color-white);
 }
 
-.brandFooter {
-    color: var(--mantine-color-ldBrandGray-4);
+.brandContent {
+    margin-block: auto;
 }
 
 .decorationTop {

--- a/packages/frontend/src/components/common/AuthLayout/LightdashMark.tsx
+++ b/packages/frontend/src/components/common/AuthLayout/LightdashMark.tsx
@@ -1,0 +1,23 @@
+import { type FC } from 'react';
+
+const LightdashMark: FC = () => (
+    <svg
+        width="20"
+        height="20"
+        viewBox="0 0 36 36"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+    >
+        <path
+            d="M19.36 13.57H24.38C25.21 13.57 25.73 14.46 25.31 15.15L17.43 28.47C17.23 28.8 16.87 28.99 16.5 28.99C15.81 28.99 15.29 28.37 15.46 27.7L17.52 19.18L19.36 13.57Z"
+            fill="currentColor"
+        />
+        <path
+            d="M21.05 8.32L19.28 13.99L17.43 19.58H12.08C11.43 19.58 10.92 19.02 11.01 18.39L12.45 7.91C12.52 7.39 12.98 7 13.52 7H20.01C20.72 7 21.23 7.66 21.05 8.32Z"
+            fill="currentColor"
+        />
+    </svg>
+);
+
+export default LightdashMark;

--- a/packages/frontend/src/components/common/AuthLayout/index.tsx
+++ b/packages/frontend/src/components/common/AuthLayout/index.tsx
@@ -134,6 +134,18 @@ const AuthLayout: FC<PropsWithChildren<Props>> = ({
 
                 <Box className={classes.formPanel}>
                     <Stack id={cardId} className={classes.formContent} gap="xl">
+                        <Group
+                            gap="sm"
+                            wrap="nowrap"
+                            className={classes.formBrandMark}
+                        >
+                            <Box className={classes.brandMark}>
+                                <LightdashMark />
+                            </Box>
+                            <Text fz="xl" fw={600}>
+                                Lightdash
+                            </Text>
+                        </Group>
                         {title && (
                             <Stack gap="xs">
                                 <Title order={2}>{title}</Title>

--- a/packages/frontend/src/components/common/AuthLayout/index.tsx
+++ b/packages/frontend/src/components/common/AuthLayout/index.tsx
@@ -96,7 +96,7 @@ const AuthLayout: FC<PropsWithChildren<Props>> = ({
                         </Text>
                     </Group>
 
-                    <Stack gap="4xl">
+                    <Stack gap="4xl" className={classes.brandContent}>
                         <Stack gap="lg">
                             <Title
                                 order={1}
@@ -126,10 +126,6 @@ const AuthLayout: FC<PropsWithChildren<Props>> = ({
                             ))}
                         </Stack>
                     </Stack>
-
-                    <Text fz="sm" className={classes.brandFooter}>
-                        Open-source · unlimited seats · no lock-in
-                    </Text>
                 </Box>
 
                 <Box className={classes.formPanel}>

--- a/packages/frontend/src/components/common/AuthLayout/index.tsx
+++ b/packages/frontend/src/components/common/AuthLayout/index.tsx
@@ -1,0 +1,156 @@
+import { Box, Card, Group, Stack, Text, Title } from '@mantine-8/core';
+import { IconCheck } from '@tabler/icons-react';
+import { type FC, type PropsWithChildren, type ReactNode } from 'react';
+import LightdashLogo from '../../LightdashLogo/LightdashLogo';
+import PageSpinner from '../../PageSpinner';
+import { DocumentTitle } from '../DocumentTitle';
+import MantineIcon from '../MantineIcon';
+import Page from '../Page/Page';
+import classes from './AuthLayout.module.css';
+import LightdashMark from './LightdashMark';
+import { useAuthLayoutVariant } from './useAuthLayoutVariant';
+
+const BRAND_HIGHLIGHTS = [
+    'Agents build and refactor your dashboards',
+    'Governed by your semantic layer — no hallucinations',
+    'Open source · unlimited seats · no lock-in',
+];
+
+type Props = {
+    /** Document title, matching what each page passed to `Page` before. */
+    pageTitle: string;
+    /** Split-layout heading. Omitted when the page renders its own heading. */
+    title?: string;
+    subtitle?: string;
+    /** Centred heading inside the legacy card. */
+    legacyTitle?: string;
+    /** Bounds the form in both layouts, for `SCREENSHOT_SELECTORS.LOGIN_PAGE`. */
+    cardId?: string;
+    /** Pages that bring their own cards (Invite) opt out of the legacy card. */
+    withLegacyCard?: boolean;
+    footer?: ReactNode;
+};
+
+const AuthLayout: FC<PropsWithChildren<Props>> = ({
+    pageTitle,
+    title,
+    subtitle,
+    legacyTitle,
+    cardId,
+    withLegacyCard = true,
+    footer,
+    children,
+}) => {
+    const { isNewLayout, isInitialLoading } = useAuthLayoutVariant();
+
+    if (isInitialLoading) {
+        return <PageSpinner />;
+    }
+
+    if (!isNewLayout) {
+        return (
+            <Page title={pageTitle} withCenteredContent withNavbar={false}>
+                <Stack w={400} mt="4xl">
+                    <Box mx="auto" my="lg">
+                        <LightdashLogo />
+                    </Box>
+                    {withLegacyCard ? (
+                        <Card
+                            id={cardId}
+                            p="xl"
+                            radius="xs"
+                            withBorder
+                            shadow="xs"
+                        >
+                            {legacyTitle && (
+                                <Title order={3} ta="center" mb="md">
+                                    {legacyTitle}
+                                </Title>
+                            )}
+                            {children}
+                        </Card>
+                    ) : (
+                        children
+                    )}
+                    {footer}
+                </Stack>
+            </Page>
+        );
+    }
+
+    return (
+        <>
+            <DocumentTitle title={pageTitle} />
+
+            <Box className={classes.root}>
+                <Box className={classes.brandPanel}>
+                    <Box className={classes.decorationTop} aria-hidden />
+                    <Box className={classes.decorationBottom} aria-hidden />
+
+                    <Group gap="sm" wrap="nowrap">
+                        <Box className={classes.brandMark}>
+                            <LightdashMark />
+                        </Box>
+                        <Text fz="xl" fw={600} className={classes.brandName}>
+                            Lightdash
+                        </Text>
+                    </Group>
+
+                    <Stack gap="4xl">
+                        <Stack gap="lg">
+                            <Title
+                                order={1}
+                                fz="display"
+                                className={classes.headline}
+                            >
+                                Analytics at the speed of code.
+                            </Title>
+                            <Text fz="lg" className={classes.subcopy}>
+                                The only open-source, AI-native BI platform that
+                                lets AI build, refactor, and ship analytics in
+                                minutes. Loved by developers.
+                            </Text>
+                        </Stack>
+
+                        <Stack gap="md">
+                            {BRAND_HIGHLIGHTS.map((highlight) => (
+                                <Group key={highlight} gap="sm" wrap="nowrap">
+                                    <MantineIcon
+                                        icon={IconCheck}
+                                        color="ldBrandViolet.3"
+                                    />
+                                    <Text className={classes.highlight}>
+                                        {highlight}
+                                    </Text>
+                                </Group>
+                            ))}
+                        </Stack>
+                    </Stack>
+
+                    <Text fz="sm" className={classes.brandFooter}>
+                        Open-source · unlimited seats · no lock-in
+                    </Text>
+                </Box>
+
+                <Box className={classes.formPanel}>
+                    <Stack id={cardId} className={classes.formContent} gap="xl">
+                        {title && (
+                            <Stack gap="xs">
+                                <Title order={2}>{title}</Title>
+                                {subtitle && (
+                                    <Text className={classes.formSubtitle}>
+                                        {subtitle}
+                                    </Text>
+                                )}
+                            </Stack>
+                        )}
+                        {children}
+                        {footer}
+                    </Stack>
+                </Box>
+            </Box>
+        </>
+    );
+};
+
+export default AuthLayout;

--- a/packages/frontend/src/components/common/AuthLayout/useAuthLayoutVariant.ts
+++ b/packages/frontend/src/components/common/AuthLayout/useAuthLayoutVariant.ts
@@ -1,0 +1,14 @@
+import { FeatureFlags } from '@lightdash/common';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+
+export const useAuthLayoutVariant = () => {
+    const { data, isInitialLoading } = useServerFeatureFlag(
+        FeatureFlags.NewOnboarding,
+        { retry: 3 },
+    );
+
+    return {
+        isNewLayout: data?.enabled ?? false,
+        isInitialLoading,
+    };
+};

--- a/packages/frontend/src/components/common/ThirdPartySignInButton/index.tsx
+++ b/packages/frontend/src/components/common/ThirdPartySignInButton/index.tsx
@@ -17,7 +17,7 @@ import classes from './ThirdPartySignInButton.module.css';
 
 type ThirdPartySignInButtonProps = {
     inviteCode?: string;
-    intent?: 'signin' | 'add' | 'signup';
+    intent?: 'signin' | 'add' | 'signup' | 'continue';
     providerName: OpenIdIdentitySummary['issuerType'];
     // Default redirect is the current window.location.href
     redirect?: string;
@@ -90,6 +90,7 @@ const ThirdPartySignInButtonBase: FC<
         >
             {intent === 'signup' && `Sign up with ${providerName}`}
             {intent === 'signin' && `Sign in with ${providerName}`}
+            {intent === 'continue' && `Continue with ${providerName}`}
             {intent === 'add' && 'Add +'}
         </Button>
     );

--- a/packages/frontend/src/components/common/ThirdPartySignInButton/index.tsx
+++ b/packages/frontend/src/components/common/ThirdPartySignInButton/index.tsx
@@ -80,7 +80,7 @@ const ThirdPartySignInButtonBase: FC<
             }`}
             leftSection={
                 typeof logo === 'string' ? (
-                    <Image w={16} src={logo} alt={`${providerName} logo}`} />
+                    <Image w={16} src={logo} alt={`${providerName} logo`} />
                 ) : (
                     logo
                 )

--- a/packages/frontend/src/features/users/components/LoginLanding.tsx
+++ b/packages/frontend/src/features/users/components/LoginLanding.tsx
@@ -3,7 +3,6 @@ import {
     isOpenIdIdentityIssuerType,
     LightdashMode,
     LocalIssuerTypes,
-    LOGIN_PAGE_ID,
     SEED_ORG_1_ADMIN_EMAIL,
     SEED_ORG_1_ADMIN_PASSWORD,
     type LightdashUser,
@@ -11,16 +10,13 @@ import {
 } from '@lightdash/common';
 import {
     TextInput,
-    Box,
     Divider,
     Stack,
     Text,
-    Title,
     Button,
     ActionIcon,
     Anchor,
     PasswordInput,
-    Card,
 } from '@mantine-8/core';
 import { useTimeout } from '@mantine-8/hooks';
 import { useForm, zodResolver } from '@mantine/form';
@@ -33,11 +29,11 @@ import {
     useState,
     type FC,
 } from 'react';
-import { Navigate, useLocation } from 'react-router';
+import { Link, Navigate, useLocation } from 'react-router';
 import { z } from 'zod';
+import { useAuthLayoutVariant } from '../../../components/common/AuthLayout/useAuthLayoutVariant';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { ThirdPartySignInButton } from '../../../components/common/ThirdPartySignInButton';
-import LightdashLogo from '../../../components/LightdashLogo/LightdashLogo';
 import PageSpinner from '../../../components/PageSpinner';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { useFlashMessages } from '../../../hooks/useFlashMessages';
@@ -45,6 +41,7 @@ import useApp from '../../../providers/App/useApp';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import { sanitizeRedirectUrl } from '../../../utils/redirectUrl';
+import { resolveInternalPath } from '../../../utils/url';
 import {
     useFetchLoginOptions,
     useLoginWithEmailMutation,
@@ -60,6 +57,7 @@ const Login: FC<{}> = () => {
     const { health } = useApp();
     const { identify, track } = useTracking();
     const location = useLocation();
+    const { isNewLayout } = useAuthLayoutVariant();
 
     const { showToastError, showToastApiError } = useToaster();
     const flashMessages = useFlashMessages();
@@ -298,167 +296,163 @@ const Login: FC<{}> = () => {
         return <Navigate to={redirectUrl} />;
     }
 
+    const ssoButtons = ssoOptionsLastUsedFirst.length > 0 && (
+        <Stack>
+            {ssoOptionsLastUsedFirst.map((providerName) => (
+                <ThirdPartySignInButton
+                    key={providerName}
+                    providerName={providerName}
+                    intent={isNewLayout ? 'continue' : 'signin'}
+                    redirect={redirectUrl}
+                    loginHint={preCheckEmail ?? lastLoginMethod?.email}
+                    disabled={isFormLoading}
+                    forceShow
+                    lastUsed={providerName === lastUsedSsoProvider}
+                    onClick={() =>
+                        writeLastLoginMethod({
+                            issuerType: providerName,
+                            email:
+                                form.values.email ||
+                                preCheckEmail ||
+                                lastLoginMethod?.email ||
+                                '',
+                        })
+                    }
+                />
+            ))}
+        </Stack>
+    );
+
+    const signupUrl = health.data?.signupUrl || '/register';
+    const signupPath = resolveInternalPath(signupUrl);
+
+    const ssoDivider = (
+        <Divider
+            my="sm"
+            labelPosition="center"
+            label={
+                <Text c="ldGray.5" size="sm" fw={500}>
+                    {isNewLayout ? 'or' : 'OR'}
+                </Text>
+            }
+        />
+    );
+
     return (
-        <>
-            <Box mx="auto" my="lg">
-                <LightdashLogo />
-            </Box>
-            <Card id={LOGIN_PAGE_ID} p="xl" radius="xs" withBorder shadow="xs">
-                <Title order={3} ta="center" mb="md">
-                    Sign in
-                </Title>
-                <form
-                    name="login"
-                    onSubmit={form.onSubmit(() => handleFormSubmit())}
-                >
-                    <Stack gap="lg">
-                        <TextInput
-                            label="Email address"
-                            name="email"
-                            placeholder="Your email address"
+        <form name="login" onSubmit={form.onSubmit(() => handleFormSubmit())}>
+            <Stack gap="lg">
+                {isNewLayout && ssoButtons && (
+                    <>
+                        {ssoButtons}
+                        {ssoDivider}
+                    </>
+                )}
+                <TextInput
+                    label={isNewLayout ? 'Work email' : 'Email address'}
+                    name="email"
+                    placeholder={
+                        isNewLayout ? 'maya@acme.com' : 'Your email address'
+                    }
+                    required
+                    {...form.getInputProps('email')}
+                    disabled={isFormLoading}
+                    rightSectionPointerEvents="all"
+                    rightSection={
+                        preCheckEmail ? (
+                            <ActionIcon
+                                aria-label="Clear email address"
+                                onMouseDown={(event) => event.preventDefault()}
+                                variant="subtle"
+                                color="gray"
+                                onClick={() => {
+                                    setPreCheckEmail(undefined);
+                                    form.setValues({
+                                        email: '',
+                                        password: '',
+                                    });
+                                }}
+                            >
+                                <MantineIcon icon={IconX} />
+                            </ActionIcon>
+                        ) : null
+                    }
+                />
+                {isEmailLoginAvailable && formStage === 'login' && (
+                    <>
+                        <PasswordInput
+                            label="Password"
+                            name="password"
+                            placeholder="Your password"
+                            autoComplete="current-password"
                             required
-                            {...form.getInputProps('email')}
+                            autoFocus
+                            {...form.getInputProps('password')}
                             disabled={isFormLoading}
-                            rightSectionPointerEvents="all"
-                            rightSection={
-                                preCheckEmail ? (
-                                    <ActionIcon
-                                        aria-label="Clear email address"
-                                        onMouseDown={(event) =>
-                                            event.preventDefault()
-                                        }
-                                        variant="subtle"
-                                        color="gray"
-                                        onClick={() => {
-                                            setPreCheckEmail(undefined);
-                                            form.setValues({
-                                                email: '',
-                                                password: '',
-                                            });
-                                        }}
-                                    >
-                                        <MantineIcon icon={IconX} />
-                                    </ActionIcon>
-                                ) : null
-                            }
                         />
-                        {isEmailLoginAvailable && formStage === 'login' && (
-                            <>
-                                <PasswordInput
-                                    label="Password"
-                                    name="password"
-                                    placeholder="Your password"
-                                    autoComplete="current-password"
-                                    required
-                                    autoFocus
-                                    {...form.getInputProps('password')}
-                                    disabled={isFormLoading}
-                                />
-                                <Anchor
-                                    inherit
-                                    href="/recover-password"
-                                    mx="auto"
-                                >
-                                    Forgot your password?
-                                </Anchor>
-                                <Button
-                                    type="submit"
-                                    loading={isFormLoading}
-                                    disabled={isFormLoading}
-                                    data-cy="signin-button"
-                                >
-                                    Sign in
-                                </Button>
-                            </>
-                        )}
-                        {isEmailOtpLoginAvailable && formStage === 'login' && (
-                            <LoginWithEmailOtp
-                                email={preCheckEmail ?? form.values.email}
-                                disabled={isFormLoading}
-                                onSuccess={(data) =>
-                                    handleLoginSuccess(
-                                        data,
-                                        LocalIssuerTypes.EMAIL_OTP,
-                                    )
-                                }
-                            />
-                        )}
-                        {formStage === 'precheck' && (
-                            <Button
-                                type="submit"
-                                loading={isFormLoading}
-                                disabled={isFormLoading}
-                                data-cy="signin-button"
-                            >
-                                Continue
-                            </Button>
-                        )}
-                        {ssoOptionsLastUsedFirst.length > 0 && (
-                            <>
-                                {(isEmailLoginAvailable ||
-                                    isEmailOtpLoginAvailable ||
-                                    formStage === 'precheck') && (
-                                    <Divider
-                                        my="sm"
-                                        labelPosition="center"
-                                        label={
-                                            <Text
-                                                c="ldGray.5"
-                                                size="sm"
-                                                fw={500}
-                                            >
-                                                OR
-                                            </Text>
-                                        }
-                                    />
-                                )}
-                                <Stack>
-                                    {ssoOptionsLastUsedFirst.map(
-                                        (providerName) => (
-                                            <ThirdPartySignInButton
-                                                key={providerName}
-                                                providerName={providerName}
-                                                redirect={redirectUrl}
-                                                loginHint={
-                                                    preCheckEmail ??
-                                                    lastLoginMethod?.email
-                                                }
-                                                disabled={isFormLoading}
-                                                forceShow
-                                                lastUsed={
-                                                    providerName ===
-                                                    lastUsedSsoProvider
-                                                }
-                                                onClick={() =>
-                                                    writeLastLoginMethod({
-                                                        issuerType:
-                                                            providerName,
-                                                        email:
-                                                            form.values.email ||
-                                                            preCheckEmail ||
-                                                            lastLoginMethod?.email ||
-                                                            '',
-                                                    })
-                                                }
-                                            />
-                                        ),
-                                    )}
-                                </Stack>
-                            </>
-                        )}
-                        <Text mx="auto" mt="md" fz="sm">
-                            Don't have an account?{' '}
-                            <Anchor
-                                href={health.data?.signupUrl || '/register'}
-                                fz="sm"
-                            >
-                                Sign up
-                            </Anchor>
-                        </Text>
-                    </Stack>
-                </form>
-            </Card>
-        </>
+                        <Anchor
+                            inherit
+                            component={Link}
+                            to="/recover-password"
+                            mx="auto"
+                        >
+                            Forgot your password?
+                        </Anchor>
+                        <Button
+                            type="submit"
+                            loading={isFormLoading}
+                            disabled={isFormLoading}
+                            fullWidth={isNewLayout}
+                            data-cy="signin-button"
+                        >
+                            Sign in
+                        </Button>
+                    </>
+                )}
+                {isEmailOtpLoginAvailable && formStage === 'login' && (
+                    <LoginWithEmailOtp
+                        email={preCheckEmail ?? form.values.email}
+                        disabled={isFormLoading}
+                        onSuccess={(data) =>
+                            handleLoginSuccess(data, LocalIssuerTypes.EMAIL_OTP)
+                        }
+                    />
+                )}
+                {formStage === 'precheck' && (
+                    <Button
+                        type="submit"
+                        loading={isFormLoading}
+                        disabled={isFormLoading}
+                        fullWidth={isNewLayout}
+                        data-cy="signin-button"
+                    >
+                        Continue
+                    </Button>
+                )}
+                {!isNewLayout && ssoButtons && (
+                    <>
+                        {(isEmailLoginAvailable ||
+                            isEmailOtpLoginAvailable ||
+                            formStage === 'precheck') &&
+                            ssoDivider}
+                        {ssoButtons}
+                    </>
+                )}
+                <Text mx="auto" mt="md" fz="sm">
+                    {isNewLayout
+                        ? 'New to Lightdash?'
+                        : "Don't have an account?"}{' '}
+                    {signupPath ? (
+                        <Anchor component={Link} to={signupPath} fz="sm">
+                            {isNewLayout ? 'Create an account' : 'Sign up'}
+                        </Anchor>
+                    ) : (
+                        <Anchor href={signupUrl} fz="sm">
+                            {isNewLayout ? 'Create an account' : 'Sign up'}
+                        </Anchor>
+                    )}
+                </Text>
+            </Stack>
+        </form>
     );
 };
 

--- a/packages/frontend/src/mantine8Theme.ts
+++ b/packages/frontend/src/mantine8Theme.ts
@@ -60,7 +60,12 @@ declare module '@mantine-8/core' {
     }
 }
 
-type ExtendedCustomColors = 'ldGray' | 'ldDark' | DefaultMantineColor;
+type ExtendedCustomColors =
+    | 'ldGray'
+    | 'ldDark'
+    | 'ldBrandGray'
+    | 'ldBrandViolet'
+    | DefaultMantineColor;
 
 const subtleInputStyles = (theme: MantineTheme) => ({
     input: {

--- a/packages/frontend/src/mantineTheme.ts
+++ b/packages/frontend/src/mantineTheme.ts
@@ -29,9 +29,40 @@ const lightdashDarkGray = createColorTuple([
     '#d9d9d9',
 ]);
 
+/** Lightdash brand ramps, matching lightdash.com. Identical in both colour
+ *  schemes: the surfaces they style are always dark. */
+const lightdashBrandGray = createColorTuple([
+    '#f8fafb',
+    '#eceff3',
+    '#dfe1e7',
+    '#c1c7d0',
+    '#a4acb9',
+    '#818898',
+    '#666d80',
+    '#36394a',
+    '#1a1b25',
+    '#0d0d12',
+]);
+
+const lightdashBrandViolet = createColorTuple([
+    '#efedff',
+    '#dcd8ff',
+    '#c8c2ff',
+    '#b4acff',
+    '#9a8fff',
+    '#7c6dff',
+    '#5e4cff',
+    '#4c3ddb',
+    '#3d31af',
+    '#2e2585',
+]);
+
 const lightModeColors = {
     background: createColorTuple('#FEFEFE'),
     foreground: createColorTuple('#1A1B1E'),
+
+    ldBrandGray: lightdashBrandGray,
+    ldBrandViolet: lightdashBrandViolet,
 
     ldDark: createColorTuple([
         '#C9C9C9',
@@ -63,6 +94,9 @@ const lightModeColors = {
 const darkModeColors = {
     background: createColorTuple('#1a1a1a'),
     foreground: createColorTuple('#FEFEFE'),
+
+    ldBrandGray: lightdashBrandGray,
+    ldBrandViolet: lightdashBrandViolet,
 
     /** Overwrite Mantine's dark colors because they are too light */
     dark: createColorTuple([
@@ -173,6 +207,17 @@ export const getMantineThemeOverride = (
             '7xl': rem(96),
             '8xl': rem(128),
             '9xl': rem(160),
+        },
+
+        // Mantine's defaults restated because this key is replaced, not merged.
+        // `display` is the only addition: a hero size above the h1 scale.
+        fontSizes: {
+            xs: rem(12),
+            sm: rem(14),
+            md: rem(16),
+            lg: rem(18),
+            xl: rem(20),
+            display: rem(48),
         },
 
         fontFamily: [

--- a/packages/frontend/src/pages/Invite.tsx
+++ b/packages/frontend/src/pages/Invite.tsx
@@ -9,6 +9,7 @@ import {
 } from '@lightdash/common';
 import {
     Anchor,
+    Box,
     Button,
     Card,
     Divider,
@@ -21,6 +22,7 @@ import { useEffect, useState, type FC } from 'react';
 import { Navigate, useLocation, useParams } from 'react-router';
 import { lightdashApi } from '../api';
 import AuthLayout from '../components/common/AuthLayout';
+import { useAuthLayoutVariant } from '../components/common/AuthLayout/useAuthLayoutVariant';
 import { ThirdPartySignInButton } from '../components/common/ThirdPartySignInButton';
 import PageSpinner from '../components/PageSpinner';
 import CreateUserForm from '../components/RegisterForms/CreateUserForm';
@@ -42,34 +44,42 @@ interface WelcomeCardProps {
 
 const WelcomeCard: FC<WelcomeCardProps> = ({ email, setReadyToJoin }) => {
     const { data: org } = useOrganization();
+    const { isNewLayout } = useAuthLayoutVariant();
+    const textAlign = isNewLayout ? 'left' : 'center';
 
-    return (
-        <>
-            <Card p="xl" withBorder shadow="subtle" data-cy="welcome-user">
-                <Stack gap="md" align="center">
-                    <Title order={3}>You’ve been invited!</Title>
-                    {email && (
-                        <Text fw="600" size="md">
-                            {email}
-                        </Text>
-                    )}
-                    <Text color="ldGray.6" ta="center">
-                        {`Your teammates ${
-                            org?.name ? `at ${org.name}` : ''
-                        } are using Lightdash to discover
+    const content = (
+        <Stack gap="md" align={isNewLayout ? 'stretch' : 'center'}>
+            <Title order={3}>You’ve been invited!</Title>
+            {email && (
+                <Text fw="600" size="md">
+                    {email}
+                </Text>
+            )}
+            <Text color="ldGray.6" ta={textAlign}>
+                {`Your teammates ${
+                    org?.name ? `at ${org.name}` : ''
+                } are using Lightdash to discover
                     and share data insights. Click on the link below within the
                     next 72 hours to join your team and start exploring your
                     data!`}
-                    </Text>
-                    <Button onClick={() => setReadyToJoin(true)}>
-                        Join your team
-                    </Button>
-                </Stack>
-            </Card>
-            <Text c="ldGray.7" ta="center" fz="sm" fw={500}>
+            </Text>
+            <Button onClick={() => setReadyToJoin(true)}>Join your team</Button>
+        </Stack>
+    );
+
+    return (
+        <>
+            {isNewLayout ? (
+                <Box data-cy="welcome-user">{content}</Box>
+            ) : (
+                <Card p="xl" withBorder shadow="subtle" data-cy="welcome-user">
+                    {content}
+                </Card>
+            )}
+            <Text c="ldGray.7" ta={textAlign} fz="sm" fw={500}>
                 {`Not ${email ? email : 'for you'}?`}
                 <br />
-                <Text c="ldGray.6" ta="center" fz="xs" fw={500}>
+                <Text c="ldGray.6" ta={textAlign} fz="xs" fw={500}>
                     Ignore this invite link and contact your workspace admin.
                 </Text>
             </Text>
@@ -78,15 +88,23 @@ const WelcomeCard: FC<WelcomeCardProps> = ({ email, setReadyToJoin }) => {
 };
 
 const ErrorCard: FC<{ title: string }> = ({ title }) => {
-    return (
+    const { isNewLayout } = useAuthLayoutVariant();
+
+    const content = (
+        <Stack gap="md" align={isNewLayout ? 'stretch' : 'center'}>
+            <Title order={3}>{title}</Title>
+            <Text c="ldGray.7" ta={isNewLayout ? 'left' : 'center'}>
+                Please check with the person who shared it with you to see if
+                there’s a new link available.
+            </Text>
+        </Stack>
+    );
+
+    return isNewLayout ? (
+        <Box data-cy="welcome-user">{content}</Box>
+    ) : (
         <Card p="xl" withBorder shadow="subtle" data-cy="welcome-user">
-            <Stack gap="md" align="center">
-                <Title order={3}>{title}</Title>
-                <Text c="ldGray.7" ta="center">
-                    Please check with the person who shared it with you to see
-                    if there’s a new link available.
-                </Text>
-            </Stack>
+            {content}
         </Card>
     );
 };
@@ -128,15 +146,18 @@ const OneClickCard: FC<OneClickCardProps> = ({
     isSetupInvite,
     isLoading,
     onActivate,
-}) => (
-    <Card p="xl" withBorder shadow="subtle" data-cy="one-click-invite">
-        <Stack gap="md" align="center">
-            <Title order={3} ta="center">
+}) => {
+    const { isNewLayout } = useAuthLayoutVariant();
+    const textAlign = isNewLayout ? 'left' : 'center';
+
+    const content = (
+        <Stack gap="md" align={isNewLayout ? 'stretch' : 'center'}>
+            <Title order={3} ta={textAlign}>
                 {isSetupInvite
                     ? 'You’ve been asked to help with setup'
                     : 'You’ve been invited to Lightdash'}
             </Title>
-            <Text c="ldGray.6" ta="center">
+            <Text c="ldGray.6" ta={textAlign}>
                 {isSetupInvite
                     ? 'One click and we’ll take you straight to connecting the data warehouse.'
                     : 'One click to join your team.'}
@@ -145,8 +166,16 @@ const OneClickCard: FC<OneClickCardProps> = ({
                 Continue as {email}
             </Button>
         </Stack>
-    </Card>
-);
+    );
+
+    return isNewLayout ? (
+        <Box data-cy="one-click-invite">{content}</Box>
+    ) : (
+        <Card p="xl" withBorder shadow="subtle" data-cy="one-click-invite">
+            {content}
+        </Card>
+    );
+};
 
 const createUserQuery = async (data: ActivateUserWithInviteCode) =>
     lightdashApi<LightdashUser>({
@@ -159,6 +188,7 @@ const createUserQuery = async (data: ActivateUserWithInviteCode) =>
 const Invite: FC = () => {
     const { inviteCode } = useParams<{ inviteCode: string }>();
     const { health } = useApp();
+    const { isNewLayout } = useAuthLayoutVariant();
     const { showToastError, showToastApiError } = useToaster();
     const flashMessages = useFlashMessages();
 
@@ -281,6 +311,22 @@ const Invite: FC = () => {
             {passwordLogin}
         </>
     );
+    const signupContent = (
+        <>
+            <Title order={3} ta={isNewLayout ? 'left' : 'center'} mb="md">
+                {isSetupInvite
+                    ? 'You’ve been asked to help with setup'
+                    : 'Sign up'}
+            </Title>
+            {isSetupInvite && (
+                <Text c="ldGray.6" ta={isNewLayout ? 'left' : 'center'} mb="md">
+                    Create your account and we’ll take you straight to warehouse
+                    setup.
+                </Text>
+            )}
+            {logins}
+        </>
+    );
 
     return (
         <AuthLayout pageTitle="Register" withLegacyCard={false}>
@@ -306,20 +352,13 @@ const Invite: FC = () => {
                 </>
             ) : isLinkFromEmail || isSetupInvite ? (
                 <>
-                    <Card p="xl" withBorder shadow="subtle">
-                        <Title order={3} ta="center" mb="md">
-                            {isSetupInvite
-                                ? 'You’ve been asked to help with setup'
-                                : 'Sign up'}
-                        </Title>
-                        {isSetupInvite && (
-                            <Text c="ldGray.6" ta="center" mb="md">
-                                Create your account and we’ll take you straight
-                                to warehouse setup.
-                            </Text>
-                        )}
-                        {logins}
-                    </Card>
+                    {isNewLayout ? (
+                        signupContent
+                    ) : (
+                        <Card p="xl" withBorder shadow="subtle">
+                            {signupContent}
+                        </Card>
+                    )}
                     <PrivacyTermsFootnote />
                 </>
             ) : (

--- a/packages/frontend/src/pages/Invite.tsx
+++ b/packages/frontend/src/pages/Invite.tsx
@@ -9,7 +9,6 @@ import {
 } from '@lightdash/common';
 import {
     Anchor,
-    Box,
     Button,
     Card,
     Divider,
@@ -21,9 +20,8 @@ import { useMutation } from '@tanstack/react-query';
 import { useEffect, useState, type FC } from 'react';
 import { Navigate, useLocation, useParams } from 'react-router';
 import { lightdashApi } from '../api';
-import Page from '../components/common/Page/Page';
+import AuthLayout from '../components/common/AuthLayout';
 import { ThirdPartySignInButton } from '../components/common/ThirdPartySignInButton';
-import LightdashLogo from '../components/LightdashLogo/LightdashLogo';
 import PageSpinner from '../components/PageSpinner';
 import CreateUserForm from '../components/RegisterForms/CreateUserForm';
 import { useOrganization } from '../hooks/organization/useOrganization';
@@ -285,58 +283,52 @@ const Invite: FC = () => {
     );
 
     return (
-        <Page title="Register" withCenteredContent withNavbar={false}>
-            <Stack w={400} mt="4xl">
-                <Box mx="auto" my="lg">
-                    <LightdashLogo />
-                </Box>
-                {inviteLinkQuery.error ? (
-                    <ErrorCard
-                        title={
-                            inviteLinkQuery.error.error.name === 'ExpiredError'
-                                ? 'This invite link has expired 🙈'
-                                : inviteLinkQuery.error.error.message
+        <AuthLayout pageTitle="Register" withLegacyCard={false}>
+            {inviteLinkQuery.error ? (
+                <ErrorCard
+                    title={
+                        inviteLinkQuery.error.error.name === 'ExpiredError'
+                            ? 'This invite link has expired 🙈'
+                            : inviteLinkQuery.error.error.message
+                    }
+                />
+            ) : showOneClick && inviteLinkQuery.data ? (
+                <>
+                    <OneClickCard
+                        email={inviteLinkQuery.data.email}
+                        isSetupInvite={isSetupInvite}
+                        isLoading={
+                            activateInvite.isLoading || activateInvite.isSuccess
                         }
+                        onActivate={() => activateInvite.mutate()}
                     />
-                ) : showOneClick && inviteLinkQuery.data ? (
-                    <>
-                        <OneClickCard
-                            email={inviteLinkQuery.data.email}
-                            isSetupInvite={isSetupInvite}
-                            isLoading={
-                                activateInvite.isLoading ||
-                                activateInvite.isSuccess
-                            }
-                            onActivate={() => activateInvite.mutate()}
-                        />
-                        <PrivacyTermsFootnote />
-                    </>
-                ) : isLinkFromEmail || isSetupInvite ? (
-                    <>
-                        <Card p="xl" withBorder shadow="subtle">
-                            <Title order={3} ta="center" mb="md">
-                                {isSetupInvite
-                                    ? 'You’ve been asked to help with setup'
-                                    : 'Sign up'}
-                            </Title>
-                            {isSetupInvite && (
-                                <Text c="ldGray.6" ta="center" mb="md">
-                                    Create your account and we’ll take you
-                                    straight to warehouse setup.
-                                </Text>
-                            )}
-                            {logins}
-                        </Card>
-                        <PrivacyTermsFootnote />
-                    </>
-                ) : (
-                    <WelcomeCard
-                        email={inviteLinkQuery.data?.email}
-                        setReadyToJoin={setIsLinkFromEmail}
-                    />
-                )}
-            </Stack>
-        </Page>
+                    <PrivacyTermsFootnote />
+                </>
+            ) : isLinkFromEmail || isSetupInvite ? (
+                <>
+                    <Card p="xl" withBorder shadow="subtle">
+                        <Title order={3} ta="center" mb="md">
+                            {isSetupInvite
+                                ? 'You’ve been asked to help with setup'
+                                : 'Sign up'}
+                        </Title>
+                        {isSetupInvite && (
+                            <Text c="ldGray.6" ta="center" mb="md">
+                                Create your account and we’ll take you straight
+                                to warehouse setup.
+                            </Text>
+                        )}
+                        {logins}
+                    </Card>
+                    <PrivacyTermsFootnote />
+                </>
+            ) : (
+                <WelcomeCard
+                    email={inviteLinkQuery.data?.email}
+                    setReadyToJoin={setIsLinkFromEmail}
+                />
+            )}
+        </AuthLayout>
     );
 };
 

--- a/packages/frontend/src/pages/JoinOrganization.tsx
+++ b/packages/frontend/src/pages/JoinOrganization.tsx
@@ -2,7 +2,6 @@ import { getEmailDomain } from '@lightdash/common';
 import {
     Anchor,
     Avatar,
-    Box,
     Button,
     Card,
     Group,
@@ -13,9 +12,9 @@ import {
 import { IconAlertCircle } from '@tabler/icons-react';
 import { useEffect, type FC } from 'react';
 import { useNavigate } from 'react-router';
+import AuthLayout from '../components/common/AuthLayout';
 import Page from '../components/common/Page/Page';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
-import LightdashLogo from '../components/LightdashLogo/LightdashLogo';
 import PageSpinner from '../components/PageSpinner';
 import { useOrganizationCreateMutation } from '../hooks/organization/useOrganizationCreateMutation';
 import useAllowedOrganizations from '../hooks/user/useAllowedOrganizations';
@@ -75,9 +74,13 @@ const JoinOrganizationPage: FC = () => {
 
     const disabled = isCreatingOrg || isJoiningOrg;
 
-    return (
-        <Page title="Join a workspace" withCenteredContent withNavbar={false}>
-            {createOrgError ? (
+    if (createOrgError) {
+        return (
+            <Page
+                title="Join a workspace"
+                withCenteredContent
+                withNavbar={false}
+            >
                 <Stack mt="4xl">
                     <SuboptimalState
                         icon={IconAlertCircle}
@@ -90,68 +93,72 @@ const JoinOrganizationPage: FC = () => {
                         }
                     />
                 </Stack>
-            ) : (
-                <Stack w={400} mt="4xl">
-                    <Box mx="auto" my="lg">
-                        <LightdashLogo />
-                    </Box>
-                    <Card p="xl" radius="md" withBorder>
-                        <Stack justify="center" gap="md" mb="xs">
-                            <Title order={3} ta="center">
-                                Join a workspace
-                            </Title>
-                            <Text c="ldGray.6" ta="center">
-                                The workspaces below are open to anyone with a{' '}
-                                <Text span fw={600}>
-                                    @{emailDomain}
-                                </Text>{' '}
-                                domain
-                            </Text>
-                            {allowedOrgs?.map((org) => (
-                                <Card key={org.organizationUuid} withBorder>
-                                    <Group justify="space-between">
-                                        <Group gap="md">
-                                            <Avatar
-                                                size="md"
-                                                radius="xl"
-                                                color="ldGray.6"
-                                            >
-                                                {org.name[0]?.toUpperCase()}
-                                            </Avatar>
-                                            <Stack gap="two">
-                                                <Text truncate="end" fw={600}>
-                                                    {org.name}
-                                                </Text>
-                                                <Text fz="xs" c="gray">
-                                                    {org.membersCount} members
-                                                </Text>
-                                            </Stack>
-                                        </Group>
-                                        <Button
-                                            onClick={() =>
-                                                joinOrg(org.organizationUuid)
-                                            }
-                                            loading={isJoiningOrg}
-                                        >
-                                            Join
-                                        </Button>
-                                    </Group>
-                                </Card>
-                            ))}
-                        </Stack>
-                    </Card>
-                    <Anchor
-                        className={disabled ? styles.disabledAnchor : undefined}
-                        component="button"
-                        onClick={() => createOrg({ name: '' })}
-                        ta="center"
-                        size="sm"
-                    >
-                        Create a new workspace
-                    </Anchor>
+            </Page>
+        );
+    }
+
+    return (
+        <AuthLayout
+            pageTitle="Join a workspace"
+            withLegacyCard={false}
+            footer={
+                <Anchor
+                    className={disabled ? styles.disabledAnchor : undefined}
+                    component="button"
+                    onClick={() => createOrg({ name: '' })}
+                    ta="center"
+                    size="sm"
+                >
+                    Create a new workspace
+                </Anchor>
+            }
+        >
+            <Card p="xl" radius="md" withBorder>
+                <Stack justify="center" gap="md" mb="xs">
+                    <Title order={3} ta="center">
+                        Join a workspace
+                    </Title>
+                    <Text c="ldGray.6" ta="center">
+                        The workspaces below are open to anyone with a{' '}
+                        <Text span fw={600}>
+                            @{emailDomain}
+                        </Text>{' '}
+                        domain
+                    </Text>
+                    {allowedOrgs?.map((org) => (
+                        <Card key={org.organizationUuid} withBorder>
+                            <Group justify="space-between">
+                                <Group gap="md">
+                                    <Avatar
+                                        size="md"
+                                        radius="xl"
+                                        color="ldGray.6"
+                                    >
+                                        {org.name[0]?.toUpperCase()}
+                                    </Avatar>
+                                    <Stack gap="two">
+                                        <Text truncate="end" fw={600}>
+                                            {org.name}
+                                        </Text>
+                                        <Text fz="xs" c="gray">
+                                            {org.membersCount} members
+                                        </Text>
+                                    </Stack>
+                                </Group>
+                                <Button
+                                    onClick={() =>
+                                        joinOrg(org.organizationUuid)
+                                    }
+                                    loading={isJoiningOrg}
+                                >
+                                    Join
+                                </Button>
+                            </Group>
+                        </Card>
+                    ))}
                 </Stack>
-            )}
-        </Page>
+            </Card>
+        </AuthLayout>
     );
 };
 

--- a/packages/frontend/src/pages/JoinOrganization.tsx
+++ b/packages/frontend/src/pages/JoinOrganization.tsx
@@ -105,9 +105,52 @@ const JoinOrganizationPage: FC = () => {
         );
     }
 
+    const orgList = (
+        <Stack justify="center" gap="md" mb="xs">
+            {!isNewLayout && (
+                <Title order={3} ta="center">
+                    Join a workspace
+                </Title>
+            )}
+            <Text c="ldGray.6" ta={isNewLayout ? 'left' : 'center'}>
+                The workspaces below are open to anyone with a{' '}
+                <Text span fw={600}>
+                    @{emailDomain}
+                </Text>{' '}
+                domain
+            </Text>
+            {allowedOrgs?.map((org) => (
+                <Card key={org.organizationUuid} withBorder>
+                    <Group justify="space-between">
+                        <Group gap="md">
+                            <Avatar size="md" radius="xl" color="ldGray.6">
+                                {org.name[0]?.toUpperCase()}
+                            </Avatar>
+                            <Stack gap="two">
+                                <Text truncate="end" fw={600}>
+                                    {org.name}
+                                </Text>
+                                <Text fz="xs" c="gray">
+                                    {org.membersCount} members
+                                </Text>
+                            </Stack>
+                        </Group>
+                        <Button
+                            onClick={() => joinOrg(org.organizationUuid)}
+                            loading={isJoiningOrg}
+                        >
+                            Join
+                        </Button>
+                    </Group>
+                </Card>
+            ))}
+        </Stack>
+    );
+
     return (
         <AuthLayout
             pageTitle="Join a workspace"
+            title={isNewLayout ? 'Join a workspace' : undefined}
             withLegacyCard={false}
             footer={
                 <Anchor
@@ -121,51 +164,13 @@ const JoinOrganizationPage: FC = () => {
                 </Anchor>
             }
         >
-            <Card p="xl" radius="md" withBorder>
-                <Stack justify="center" gap="md" mb="xs">
-                    <Title order={3} ta="center">
-                        Join a workspace
-                    </Title>
-                    <Text c="ldGray.6" ta="center">
-                        The workspaces below are open to anyone with a{' '}
-                        <Text span fw={600}>
-                            @{emailDomain}
-                        </Text>{' '}
-                        domain
-                    </Text>
-                    {allowedOrgs?.map((org) => (
-                        <Card key={org.organizationUuid} withBorder>
-                            <Group justify="space-between">
-                                <Group gap="md">
-                                    <Avatar
-                                        size="md"
-                                        radius="xl"
-                                        color="ldGray.6"
-                                    >
-                                        {org.name[0]?.toUpperCase()}
-                                    </Avatar>
-                                    <Stack gap="two">
-                                        <Text truncate="end" fw={600}>
-                                            {org.name}
-                                        </Text>
-                                        <Text fz="xs" c="gray">
-                                            {org.membersCount} members
-                                        </Text>
-                                    </Stack>
-                                </Group>
-                                <Button
-                                    onClick={() =>
-                                        joinOrg(org.organizationUuid)
-                                    }
-                                    loading={isJoiningOrg}
-                                >
-                                    Join
-                                </Button>
-                            </Group>
-                        </Card>
-                    ))}
-                </Stack>
-            </Card>
+            {isNewLayout ? (
+                orgList
+            ) : (
+                <Card p="xl" radius="md" withBorder>
+                    {orgList}
+                </Card>
+            )}
         </AuthLayout>
     );
 };

--- a/packages/frontend/src/pages/JoinOrganization.tsx
+++ b/packages/frontend/src/pages/JoinOrganization.tsx
@@ -13,6 +13,7 @@ import { IconAlertCircle } from '@tabler/icons-react';
 import { useEffect, type FC } from 'react';
 import { useNavigate } from 'react-router';
 import AuthLayout from '../components/common/AuthLayout';
+import { useAuthLayoutVariant } from '../components/common/AuthLayout/useAuthLayoutVariant';
 import Page from '../components/common/Page/Page';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import PageSpinner from '../components/PageSpinner';
@@ -25,6 +26,7 @@ import styles from './JoinOrganization.module.css';
 
 const JoinOrganizationPage: FC = () => {
     const { health, user } = useApp();
+    const { isNewLayout } = useAuthLayoutVariant();
     const navigate = useNavigate();
     const { isInitialLoading: isLoadingAllowedOrgs, data: allowedOrgs } =
         useAllowedOrganizations();
@@ -75,24 +77,30 @@ const JoinOrganizationPage: FC = () => {
     const disabled = isCreatingOrg || isJoiningOrg;
 
     if (createOrgError) {
-        return (
+        const errorState = (
+            <SuboptimalState
+                icon={IconAlertCircle}
+                title="Error"
+                description={createOrgError.error.message}
+                action={
+                    <Button onClick={() => deleteUser()}>
+                        Cancel registration
+                    </Button>
+                }
+            />
+        );
+
+        return isNewLayout ? (
+            <AuthLayout pageTitle="Join a workspace" withLegacyCard={false}>
+                {errorState}
+            </AuthLayout>
+        ) : (
             <Page
                 title="Join a workspace"
                 withCenteredContent
                 withNavbar={false}
             >
-                <Stack mt="4xl">
-                    <SuboptimalState
-                        icon={IconAlertCircle}
-                        title="Error"
-                        description={createOrgError.error.message}
-                        action={
-                            <Button onClick={() => deleteUser()}>
-                                Cancel registration
-                            </Button>
-                        }
-                    />
-                </Stack>
+                <Stack mt="4xl">{errorState}</Stack>
             </Page>
         );
     }

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -1,19 +1,43 @@
-import { Stack } from '@mantine-8/core';
+import { LOGIN_PAGE_ID } from '@lightdash/common';
+import { Box, Card, Stack, Title } from '@mantine-8/core';
 import { type FC } from 'react';
-import Page from '../components/common/Page/Page';
+import AuthLayout from '../components/common/AuthLayout';
+import LightdashLogo from '../components/LightdashLogo/LightdashLogo';
 import LoginLanding from '../features/users/components/LoginLanding';
 
 const Login: FC<{ minimal?: boolean }> = ({ minimal = false }) => {
-    return minimal ? (
-        <Stack m="xl">
-            <LoginLanding />
-        </Stack>
-    ) : (
-        <Page title="Login" withCenteredContent withNavbar={false}>
-            <Stack w={400} mt="4xl">
-                <LoginLanding />
+    if (minimal) {
+        return (
+            <Stack m="xl">
+                <Box mx="auto" my="lg">
+                    <LightdashLogo />
+                </Box>
+                <Card
+                    id={LOGIN_PAGE_ID}
+                    p="xl"
+                    radius="xs"
+                    withBorder
+                    shadow="xs"
+                >
+                    <Title order={3} ta="center" mb="md">
+                        Sign in
+                    </Title>
+                    <LoginLanding />
+                </Card>
             </Stack>
-        </Page>
+        );
+    }
+
+    return (
+        <AuthLayout
+            pageTitle="Login"
+            title="Log in"
+            subtitle="Welcome back — pick up where you left off."
+            legacyTitle="Sign in"
+            cardId={LOGIN_PAGE_ID}
+        >
+            <LoginLanding />
+        </AuthLayout>
     );
 };
 

--- a/packages/frontend/src/pages/PasswordRecovery.tsx
+++ b/packages/frontend/src/pages/PasswordRecovery.tsx
@@ -1,8 +1,6 @@
-import { Box, Stack, Card } from '@mantine-8/core';
 import { type FC } from 'react';
 import { Navigate } from 'react-router';
-import Page from '../components/common/Page/Page';
-import LightdashLogo from '../components/LightdashLogo/LightdashLogo';
+import AuthLayout from '../components/common/AuthLayout';
 import PageSpinner from '../components/PageSpinner';
 import useApp from '../providers/App/useApp';
 import { PasswordRecoveryForm } from './PasswordRecoveryForm';
@@ -19,17 +17,9 @@ const PasswordRecovery: FC = () => {
     }
 
     return (
-        <Page title="Recover password" withCenteredContent withNavbar={false}>
-            {/* FIXME: use Mantine sizes for width */}
-            <Stack w={400} mt="4xl">
-                <Box mx="auto" my="lg">
-                    <LightdashLogo />
-                </Box>
-                <Card p="xl" radius="xs" withBorder shadow="xs">
-                    <PasswordRecoveryForm />
-                </Card>
-            </Stack>
-        </Page>
+        <AuthLayout pageTitle="Recover password">
+            <PasswordRecoveryForm />
+        </AuthLayout>
     );
 };
 

--- a/packages/frontend/src/pages/PasswordRecoveryForm.tsx
+++ b/packages/frontend/src/pages/PasswordRecoveryForm.tsx
@@ -13,6 +13,7 @@ import { useForm, zodResolver } from '@mantine/form';
 import { type FC } from 'react';
 import { Link } from 'react-router';
 import { z } from 'zod';
+import { useAuthLayoutVariant } from '../components/common/AuthLayout/useAuthLayoutVariant';
 import { usePasswordResetLinkMutation } from '../hooks/usePasswordReset';
 import useApp from '../providers/App/useApp';
 
@@ -20,6 +21,8 @@ type RecoverPasswordForm = { email: string };
 
 export const PasswordRecoveryForm: FC = () => {
     const { health } = useApp();
+    const { isNewLayout } = useAuthLayoutVariant();
+    const textAlign = isNewLayout ? 'left' : 'center';
     const form = useForm<RecoverPasswordForm>({
         initialValues: {
             email: '',
@@ -38,10 +41,10 @@ export const PasswordRecoveryForm: FC = () => {
         <div>
             {!isSuccess ? (
                 <>
-                    <Title order={3} ta="center" mb="sm">
+                    <Title order={3} ta={textAlign} mb="sm">
                         Forgot your password?
                     </Title>
-                    <Text ta="center" mb="md" c="dimmed">
+                    <Text ta={textAlign} mb="md" c="dimmed">
                         Enter your email address and we’ll send you a password
                         reset link
                     </Text>
@@ -78,10 +81,10 @@ export const PasswordRecoveryForm: FC = () => {
                 </>
             ) : (
                 <>
-                    <Title order={3} ta="center" mb="sm">
+                    <Title order={3} ta={textAlign} mb="sm">
                         Check your inbox!
                     </Title>
-                    <Text ta="center" mb="lg" c="dimmed">
+                    <Text ta={textAlign} mb="lg" c="dimmed">
                         We have emailed you instructions about how to reset your
                         password. Haven’t received anything yet?
                     </Text>

--- a/packages/frontend/src/pages/PasswordReset.tsx
+++ b/packages/frontend/src/pages/PasswordReset.tsx
@@ -1,5 +1,4 @@
 import {
-    Box,
     Center,
     Stack,
     Text,
@@ -7,14 +6,13 @@ import {
     Button,
     Anchor,
     PasswordInput,
-    Card,
 } from '@mantine-8/core';
 import { useForm } from '@mantine/form';
 import { type FC } from 'react';
 import { Link, useNavigate, useParams } from 'react-router';
+import AuthLayout from '../components/common/AuthLayout';
+import { useAuthLayoutVariant } from '../components/common/AuthLayout/useAuthLayoutVariant';
 import ErrorState from '../components/common/ErrorState';
-import Page from '../components/common/Page/Page';
-import LightdashLogo from '../components/LightdashLogo/LightdashLogo';
 import PageSpinner from '../components/PageSpinner';
 import {
     usePasswordResetLink,
@@ -30,6 +28,8 @@ const PasswordReset: FC = () => {
     const { health } = useApp();
     const { isInitialLoading, error } = usePasswordResetLink(code);
     const passwordResetMutation = usePasswordResetMutation();
+    const { isNewLayout } = useAuthLayoutVariant();
+    const textAlign = isNewLayout ? 'left' : 'center';
 
     const form = useForm<ResetPasswordForm>({
         initialValues: {
@@ -42,94 +42,82 @@ const PasswordReset: FC = () => {
     }
 
     return (
-        <Page title="Reset password" withCenteredContent withNavbar={false}>
-            {/* FIXME: use Mantine sizes for width */}
-            <Stack w={400} mt="4xl">
-                <Box mx="auto" my="lg">
-                    <LightdashLogo />
-                </Box>
-                <Card p="xl" radius="xs" withBorder shadow="xs">
-                    {error ? (
-                        <ErrorState error={error.error} hasMarginTop={false} />
-                    ) : (
+        <AuthLayout pageTitle="Reset password">
+            {error ? (
+                <ErrorState error={error.error} hasMarginTop={false} />
+            ) : (
+                <>
+                    {!passwordResetMutation.isSuccess ? (
                         <>
-                            {!passwordResetMutation.isSuccess ? (
-                                <>
-                                    <Title order={3} ta="center" mb="md">
-                                        Reset your password
-                                    </Title>
-                                    <form
-                                        name="password-reset"
-                                        onSubmit={form.onSubmit(
-                                            ({ password }) => {
-                                                if (!code) return;
-                                                passwordResetMutation.mutate({
-                                                    code,
-                                                    newPassword: password,
-                                                });
-                                            },
-                                        )}
-                                    >
-                                        <Stack gap="lg">
-                                            <PasswordInput
-                                                label="Password"
-                                                name="password"
-                                                placeholder="Enter a new password"
-                                                autoComplete="new-password"
-                                                disabled={
-                                                    passwordResetMutation.isLoading
-                                                }
-                                                required
-                                                {...form.getInputProps(
-                                                    'password',
-                                                )}
-                                            />
-
-                                            <Button
-                                                type="submit"
-                                                loading={
-                                                    passwordResetMutation.isLoading
-                                                }
-                                            >
-                                                Save
-                                            </Button>
-
-                                            <Center>
-                                                <Anchor
-                                                    inherit
-                                                    component={Link}
-                                                    to="/login"
-                                                >
-                                                    Cancel
-                                                </Anchor>
-                                            </Center>
-                                        </Stack>
-                                    </form>
-                                </>
-                            ) : (
-                                <>
-                                    <Title order={3} ta="center" mb="md">
-                                        Success!
-                                    </Title>
-                                    <Text ta="center" mb="lg" c="dimmed">
-                                        Your password has been successfully
-                                        updated.
-                                        <br /> Use your new password to log in.
-                                    </Text>
+                            <Title order={3} ta={textAlign} mb="md">
+                                Reset your password
+                            </Title>
+                            <form
+                                name="password-reset"
+                                onSubmit={form.onSubmit(({ password }) => {
+                                    if (!code) return;
+                                    passwordResetMutation.mutate({
+                                        code,
+                                        newPassword: password,
+                                    });
+                                })}
+                            >
+                                <Stack gap="lg">
+                                    <PasswordInput
+                                        label="Password"
+                                        name="password"
+                                        placeholder="Enter a new password"
+                                        autoComplete="new-password"
+                                        disabled={
+                                            passwordResetMutation.isLoading
+                                        }
+                                        required
+                                        {...form.getInputProps('password')}
+                                    />
 
                                     <Button
-                                        fullWidth
-                                        onClick={() => navigate('/login')}
+                                        type="submit"
+                                        loading={
+                                            passwordResetMutation.isLoading
+                                        }
+                                        fullWidth={isNewLayout}
                                     >
-                                        Log in
+                                        Save
                                     </Button>
-                                </>
-                            )}
+
+                                    <Center>
+                                        <Anchor
+                                            inherit
+                                            component={Link}
+                                            to="/login"
+                                        >
+                                            Cancel
+                                        </Anchor>
+                                    </Center>
+                                </Stack>
+                            </form>
+                        </>
+                    ) : (
+                        <>
+                            <Title order={3} ta={textAlign} mb="md">
+                                Success!
+                            </Title>
+                            <Text ta={textAlign} mb="lg" c="dimmed">
+                                Your password has been successfully updated.
+                                <br /> Use your new password to log in.
+                            </Text>
+
+                            <Button
+                                fullWidth
+                                onClick={() => navigate('/login')}
+                            >
+                                Log in
+                            </Button>
                         </>
                     )}
-                </Card>
-            </Stack>
-        </Page>
+                </>
+            )}
+        </AuthLayout>
     );
 };
 

--- a/packages/frontend/src/pages/Register.tsx
+++ b/packages/frontend/src/pages/Register.tsx
@@ -6,22 +6,13 @@ import {
     type CreateUserArgs,
     type LightdashUser,
 } from '@lightdash/common';
-import {
-    Anchor,
-    Box,
-    Card,
-    Divider,
-    Stack,
-    Text,
-    Title,
-} from '@mantine-8/core';
+import { Anchor, Divider, Stack, Text } from '@mantine-8/core';
 import { useMutation } from '@tanstack/react-query';
 import { useEffect, type FC } from 'react';
 import { useLocation } from 'react-router';
 import { lightdashApi } from '../api';
-import Page from '../components/common/Page/Page';
+import AuthLayout from '../components/common/AuthLayout';
 import { ThirdPartySignInButton } from '../components/common/ThirdPartySignInButton';
-import LightdashLogo from '../components/LightdashLogo/LightdashLogo';
 import PageSpinner from '../components/PageSpinner';
 import CreateEmailOnlyUserForm from '../components/RegisterForms/CreateEmailOnlyUserForm';
 import CreateUserForm from '../components/RegisterForms/CreateUserForm';
@@ -160,17 +151,12 @@ const Register: FC = () => {
         </>
     );
     return (
-        <Page title="Register" withCenteredContent withNavbar={false}>
-            <Stack w={400} mt="4xl">
-                <Box mx="auto" my="lg">
-                    <LightdashLogo />
-                </Box>
-                <Card p="xl" radius="xs" withBorder shadow="xs">
-                    <Title order={3} ta="center" mb="md">
-                        Sign up
-                    </Title>
-                    {logins}
-                </Card>
+        <AuthLayout
+            pageTitle="Register"
+            title="Create an account"
+            subtitle="Start building analytics in minutes."
+            legacyTitle="Sign up"
+            footer={
                 <Text c="ldGray.6" ta="center" fz="sm" fw={500}>
                     By creating an account, you agree to
                     <br />
@@ -193,8 +179,10 @@ const Register: FC = () => {
                         Terms of Service.
                     </Anchor>
                 </Text>
-            </Stack>
-        </Page>
+            }
+        >
+            {logins}
+        </AuthLayout>
     );
 };
 

--- a/packages/frontend/src/pages/Register.tsx
+++ b/packages/frontend/src/pages/Register.tsx
@@ -12,6 +12,7 @@ import { useEffect, type FC } from 'react';
 import { useLocation } from 'react-router';
 import { lightdashApi } from '../api';
 import AuthLayout from '../components/common/AuthLayout';
+import { useAuthLayoutVariant } from '../components/common/AuthLayout/useAuthLayoutVariant';
 import { ThirdPartySignInButton } from '../components/common/ThirdPartySignInButton';
 import PageSpinner from '../components/PageSpinner';
 import CreateEmailOnlyUserForm from '../components/RegisterForms/CreateEmailOnlyUserForm';
@@ -35,6 +36,7 @@ const registerQuery = async (data: CreateUserArgs | CreateEmailOnlyUserArgs) =>
 const Register: FC = () => {
     const location = useLocation();
     const { health } = useApp();
+    const { isNewLayout } = useAuthLayoutVariant();
     const { showToastError, showToastApiError } = useToaster();
     const flashMessages = useFlashMessages();
 
@@ -142,7 +144,7 @@ const Register: FC = () => {
                     labelPosition="center"
                     label={
                         <Text color="ldGray.5" size="sm" fw={500}>
-                            OR
+                            {isNewLayout ? 'or' : 'OR'}
                         </Text>
                     }
                 />

--- a/packages/frontend/src/pages/VerifyEmail.tsx
+++ b/packages/frontend/src/pages/VerifyEmail.tsx
@@ -1,7 +1,6 @@
 import { FeatureFlags } from '@lightdash/common';
 import {
     Anchor,
-    Box,
     Button,
     Card,
     Stack,
@@ -16,10 +15,9 @@ import {
 import { type FC } from 'react';
 import { Navigate, useNavigate } from 'react-router';
 import { useIntercom } from 'react-use-intercom';
+import AuthLayout from '../components/common/AuthLayout';
 import MantineIcon from '../components/common/MantineIcon';
 import MantineModal from '../components/common/MantineModal';
-import Page from '../components/common/Page/Page';
-import LightdashLogo from '../components/LightdashLogo/LightdashLogo';
 import PageSpinner from '../components/PageSpinner';
 import VerifyEmailForm from '../components/RegisterForms/VerifyEmailForm';
 import { useEmailStatus } from '../hooks/useEmailVerification';
@@ -91,17 +89,10 @@ const VerifyEmailPage: FC = () => {
     }
 
     return (
-        <Page title="Verify your email" withCenteredContent withNavbar={false}>
-            <Stack w={400} mt="4xl">
-                <Box mx="auto" my="lg">
-                    <LightdashLogo />
-                </Box>
-                <Card p="xl" withBorder shadow="subtle">
-                    <VerifyEmailForm
-                        emailStatusData={data}
-                        statusLoading={statusLoading}
-                    />
-                </Card>
+        <AuthLayout
+            pageTitle="Verify your email"
+            withLegacyCard={false}
+            footer={
                 <Text c="ldGray.6" ta="center" px="xs" fz="sm" fw={500}>
                     You need to verify your email to get access to Lightdash. If
                     you need help, you can{' '}
@@ -109,19 +100,26 @@ const VerifyEmailPage: FC = () => {
                         chat to support here.
                     </Anchor>
                 </Text>
-                {!isEmailOnlySignup && data && (
-                    <VerificationSuccess
-                        isOpen={data.isVerified}
-                        onClose={() => {
-                            void navigate('/');
-                        }}
-                        onContinue={() => {
-                            void navigate('/');
-                        }}
-                    />
-                )}
-            </Stack>
-        </Page>
+            }
+        >
+            <Card p="xl" withBorder shadow="subtle">
+                <VerifyEmailForm
+                    emailStatusData={data}
+                    statusLoading={statusLoading}
+                />
+            </Card>
+            {!isEmailOnlySignup && data && (
+                <VerificationSuccess
+                    isOpen={data.isVerified}
+                    onClose={() => {
+                        void navigate('/');
+                    }}
+                    onContinue={() => {
+                        void navigate('/');
+                    }}
+                />
+            )}
+        </AuthLayout>
     );
 };
 

--- a/packages/frontend/src/pages/VerifyEmail.tsx
+++ b/packages/frontend/src/pages/VerifyEmail.tsx
@@ -108,6 +108,7 @@ const VerifyEmailPage: FC = () => {
                 <VerifyEmailForm
                     emailStatusData={data}
                     statusLoading={statusLoading}
+                    align="left"
                 />
             ) : (
                 <Card p="xl" withBorder shadow="subtle">

--- a/packages/frontend/src/pages/VerifyEmail.tsx
+++ b/packages/frontend/src/pages/VerifyEmail.tsx
@@ -16,6 +16,7 @@ import { type FC } from 'react';
 import { Navigate, useNavigate } from 'react-router';
 import { useIntercom } from 'react-use-intercom';
 import AuthLayout from '../components/common/AuthLayout';
+import { useAuthLayoutVariant } from '../components/common/AuthLayout/useAuthLayoutVariant';
 import MantineIcon from '../components/common/MantineIcon';
 import MantineModal from '../components/common/MantineModal';
 import PageSpinner from '../components/PageSpinner';
@@ -69,6 +70,7 @@ const VerifyEmailPage: FC = () => {
         !!health.data?.isAuthenticated,
     );
     const { show: showIntercom } = useIntercom();
+    const { isNewLayout } = useAuthLayoutVariant();
     const navigate = useNavigate();
     const emailOnlySignupFlag = useServerFeatureFlag(
         FeatureFlags.NewOnboarding,
@@ -102,12 +104,19 @@ const VerifyEmailPage: FC = () => {
                 </Text>
             }
         >
-            <Card p="xl" withBorder shadow="subtle">
+            {isNewLayout ? (
                 <VerifyEmailForm
                     emailStatusData={data}
                     statusLoading={statusLoading}
                 />
-            </Card>
+            ) : (
+                <Card p="xl" withBorder shadow="subtle">
+                    <VerifyEmailForm
+                        emailStatusData={data}
+                        statusLoading={statusLoading}
+                    />
+                </Card>
+            )}
             {!isEmailOnlySignup && data && (
                 <VerificationSuccess
                     isOpen={data.isVerified}

--- a/packages/frontend/src/utils/redirectUrl.test.ts
+++ b/packages/frontend/src/utils/redirectUrl.test.ts
@@ -1,5 +1,48 @@
 import { describe, expect, it } from 'vitest';
-import { sanitizeRedirectUrl } from './redirectUrl';
+import { isRootRelativePath, sanitizeRedirectUrl } from './redirectUrl';
+
+describe('isRootRelativePath', () => {
+    it('accepts root-relative paths', () => {
+        expect(isRootRelativePath('/')).toBe(true);
+        expect(isRootRelativePath('/projects')).toBe(true);
+        expect(isRootRelativePath('/projects/abc?tab=charts#top')).toBe(true);
+    });
+
+    it('rejects missing values', () => {
+        expect(isRootRelativePath(undefined)).toBe(false);
+        expect(isRootRelativePath(null)).toBe(false);
+        expect(isRootRelativePath('')).toBe(false);
+    });
+
+    it('rejects absolute URLs, including same-origin ones', () => {
+        expect(isRootRelativePath('https://evil.example.com')).toBe(false);
+        expect(isRootRelativePath('http://evil.example.com/path')).toBe(false);
+        expect(isRootRelativePath('http://localhost:3000/projects')).toBe(
+            false,
+        );
+    });
+
+    it('rejects protocol-relative URLs and backslash variants', () => {
+        expect(isRootRelativePath('//evil.example.com')).toBe(false);
+        expect(isRootRelativePath('//evil.example.com/path')).toBe(false);
+        expect(isRootRelativePath('/\\evil.example.com')).toBe(false);
+        expect(isRootRelativePath('\\evil.example.com')).toBe(false);
+        expect(isRootRelativePath('\\\\evil.example.com')).toBe(false);
+    });
+
+    it('rejects dangerous schemes', () => {
+        expect(isRootRelativePath('javascript:alert(1)')).toBe(false);
+        expect(
+            isRootRelativePath('data:text/html,<script>alert(1)</script>'),
+        ).toBe(false);
+        expect(isRootRelativePath('vbscript:msgbox(1)')).toBe(false);
+    });
+
+    it('rejects relative paths without a leading slash', () => {
+        expect(isRootRelativePath('projects')).toBe(false);
+        expect(isRootRelativePath('evil.example.com')).toBe(false);
+    });
+});
 
 describe('sanitizeRedirectUrl', () => {
     it('keeps root-relative paths', () => {
@@ -20,6 +63,9 @@ describe('sanitizeRedirectUrl', () => {
         expect(sanitizeRedirectUrl('https://evil.example.com')).toBe('/');
         expect(sanitizeRedirectUrl('http://evil.example.com/path')).toBe('/');
         expect(sanitizeRedirectUrl('javascript:alert(1)')).toBe('/');
+        expect(
+            sanitizeRedirectUrl('data:text/html,<script>alert(1)</script>'),
+        ).toBe('/');
     });
 
     it('rejects protocol-relative URLs', () => {

--- a/packages/frontend/src/utils/redirectUrl.ts
+++ b/packages/frontend/src/utils/redirectUrl.ts
@@ -1,13 +1,24 @@
 /**
+ * The single same-origin guard for navigation targets. A value is safe only if
+ * it is a root-relative path: absolute URLs, protocol-relative (`//host`) and
+ * backslash variants (`/\host`) all leave this origin and are not.
+ *
+ * Redirect sanitisation and internal-link resolution both funnel through this,
+ * so hardening it — a newly found bypass form, say — covers both call sites.
+ */
+export const isRootRelativePath = (
+    url: string | null | undefined,
+): url is string =>
+    !!url &&
+    url.startsWith('/') &&
+    !url.startsWith('//') &&
+    !url.startsWith('/\\');
+
+/**
  * Post-login redirect targets come from the URL (`?redirect=`) or router state
  * and must stay on this origin. Anything that isn't a root-relative path —
  * absolute URLs, protocol-relative (`//host`), or backslash variants (`/\host`)
  * — falls back to `/`.
  */
 export const sanitizeRedirectUrl = (url: string | null | undefined): string =>
-    url &&
-    url.startsWith('/') &&
-    !url.startsWith('//') &&
-    !url.startsWith('/\\')
-        ? url
-        : '/';
+    isRootRelativePath(url) ? url : '/';

--- a/packages/frontend/src/utils/url.test.ts
+++ b/packages/frontend/src/utils/url.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { resolveInternalPath } from './url';
+
+// jsdom serves these tests from http://localhost:3000
+const ORIGIN = window.location.origin;
+
+describe('resolveInternalPath', () => {
+    it('keeps root-relative paths, preserving query and hash', () => {
+        expect(resolveInternalPath('/')).toBe('/');
+        expect(resolveInternalPath('/register')).toBe('/register');
+        expect(resolveInternalPath('/projects/abc?tab=charts#top')).toBe(
+            '/projects/abc?tab=charts#top',
+        );
+    });
+
+    it('resolves an absolute same-origin URL down to its path', () => {
+        expect(resolveInternalPath(`${ORIGIN}/register`)).toBe('/register');
+        expect(resolveInternalPath(`${ORIGIN}/projects?tab=charts`)).toBe(
+            '/projects?tab=charts',
+        );
+    });
+
+    it('returns null for other origins, so they stay real anchors', () => {
+        expect(
+            resolveInternalPath('https://www.lightdash.com/signup'),
+        ).toBeNull();
+        expect(resolveInternalPath('http://evil.example.com/path')).toBeNull();
+    });
+
+    it('returns null for protocol-relative and backslash variants', () => {
+        expect(resolveInternalPath('//evil.example.com')).toBeNull();
+        expect(resolveInternalPath('//evil.example.com/path')).toBeNull();
+        expect(resolveInternalPath('/\\evil.example.com')).toBeNull();
+    });
+
+    it('returns null for dangerous schemes', () => {
+        expect(resolveInternalPath('javascript:alert(1)')).toBeNull();
+        expect(
+            resolveInternalPath('data:text/html,<script>alert(1)</script>'),
+        ).toBeNull();
+    });
+
+    it('returns null rather than throwing on unparseable input', () => {
+        expect(resolveInternalPath('')).toBe('/');
+        expect(resolveInternalPath('http://')).toBeNull();
+    });
+});

--- a/packages/frontend/src/utils/url.ts
+++ b/packages/frontend/src/utils/url.ts
@@ -1,14 +1,22 @@
+import { isRootRelativePath } from './redirectUrl';
+
 /**
  * Resolve a configured URL to a client-routable path, or null when it points at
  * another origin. Lets same-origin targets navigate through react-router while
  * absolute external ones (e.g. a cloud `signupUrl`) stay real document links.
+ *
+ * Unlike `sanitizeRedirectUrl` this accepts an absolute same-origin URL, because
+ * configured links are usually written that way — it resolves one to its path
+ * rather than rejecting it. The resulting path is then checked by the same
+ * `isRootRelativePath` guard, so both share one definition of what is safe.
  */
 export const resolveInternalPath = (url: string): string | null => {
     try {
         const resolved = new URL(url, window.location.origin);
-        return resolved.origin === window.location.origin
-            ? `${resolved.pathname}${resolved.search}${resolved.hash}`
-            : null;
+        if (resolved.origin !== window.location.origin) return null;
+
+        const path = `${resolved.pathname}${resolved.search}${resolved.hash}`;
+        return isRootRelativePath(path) ? path : null;
     } catch {
         return null;
     }

--- a/packages/frontend/src/utils/url.ts
+++ b/packages/frontend/src/utils/url.ts
@@ -1,0 +1,15 @@
+/**
+ * Resolve a configured URL to a client-routable path, or null when it points at
+ * another origin. Lets same-origin targets navigate through react-router while
+ * absolute external ones (e.g. a cloud `signupUrl`) stay real document links.
+ */
+export const resolveInternalPath = (url: string): string | null => {
+    try {
+        const resolved = new URL(url, window.location.origin);
+        return resolved.origin === window.location.origin
+            ? `${resolved.pathname}${resolved.search}${resolved.hash}`
+            : null;
+    } catch {
+        return null;
+    }
+};

--- a/scripts/dev-profiles.json
+++ b/scripts/dev-profiles.json
@@ -31,7 +31,8 @@
             "env": {
                 "AI_COPILOT_ENABLED": "true",
                 "AI_DEFAULT_PROVIDER": "anthropic",
-                "SANDBOX_PROVIDER": "docker"
+                "SANDBOX_PROVIDER": "docker",
+                "AUTH_GOOGLE_ENABLED": "true"
             },
             "flags": [
                 "ai-writeback",


### PR DESCRIPTION
Redesigns all seven logged-out screens to a two-column layout — a dark brand panel on the left, the auth form on the right — replacing today's centred bordered card.

Linear: SPK-781

Screens covered: `/login`, `/register`, `/invite/:inviteCode`, `/recover-password`, `/reset-password/:code`, `/verify-email`, `/join-organization`. `/organization-setup` and `/auth/popup/:status` are deliberately out of scope — they render a different shell.

## Rollout

Gated behind the existing `new-onboarding` server feature flag, through a shared `AuthLayout` component. Flag OFF renders the previous centred-card layout unchanged.

## Notable details

**Brand palette tokens.** The app theme had drifted from the brand: the dark surface was a neutral near-black where the brand uses a blue-violet black, and there was no accent colour at all. Rather than touch `ldGray`/`ldDark` — which style the entire app — this adds two new tuples, `ldBrandGray` and `ldBrandViolet`, registered in **both** `mantineTheme.ts` and `mantine8Theme.ts`. This repo runs Mantine v6 and v8 side by side and `AuthLayout` imports from v8, so a token registered in only one theme never resolves. No raw hex.

**No new font.** Body text already matches the brand (Inter). The brand's display face is not in this repo and is a licensing question, so headings size from a new `display` font-size token rather than hardcoded px.

**Bullet checks are brand violet, not green.** The brand has no green, and the primary brand violet fails contrast on the dark panel, so the on-dark accent is used.

**Login keeps its two-stage email precheck.** The design shows email and password together, but that is a visual target only — the password field still appears only after the precheck resolves. Collapsing the stages would break SSO-only orgs (`forceRedirect`), per-org private SSO discovery, and the email-OTP path.

## Drive-by fixes included

- **`/signin` was a dead URL.** `CreateUserForm.tsx` and `CreateEmailOnlyUserForm.tsx` linked their "Sign in" text at `href="/signin"`, but the route is `/login` — and those two files were the only references to `/signin` in the codebase. The result was a full document load of a non-existent route, falling through to the catch-all and bouncing back to `/login`. Pre-existing on `main`; fixed here because the redesign made the asymmetry obvious.
- **SSO button logo alt text** carried a stray brace, so screen readers announced "Google logo}". One character, and the redesign makes that button considerably more prominent.
- **Join-organization error state escaped the layout.** `JoinOrganization.tsx` early-returned a bare centred `<Page>` for its `createOrgError` branch, before reaching `AuthLayout`. With the new layout on, an errored render therefore lost the brand panel entirely and dropped the user onto a bare page. It now routes through `AuthLayout` when the new layout is active; the legacy branch is untouched, so the flag-OFF render is unchanged. A sweep of the other six pre-auth pages found no other error state that bypasses the layout — the remaining early returns are all `PageSpinner` loading short-circuits, `<Navigate>` redirects, child components, or the `minimal` SDK shell.
- **Branding vanished between the sm and md breakpoints.** Below `md` the brand panel is hidden, and since it carried the Lightdash mark the form column was left with no branding at all. The mark and wordmark now render at the top of the form column in that band only. Note this affects roughly 768–992px, not phones: below 768px `IS_MOBILE` mounts `MobileRoutes`, which renders `<Login minimal />` and never reaches `AuthLayout`.
- **`scripts/dev-profiles.json`** — dev-env only. The `ee` profile pulled the Google OAuth credentials but never set `AUTH_GOOGLE_ENABLED`, which the backend gates `auth.google.enabled` on independently, so the Google button never rendered locally. Without this the SSO parts of this change can't be verified at all.

## Verification

- `pnpm -F frontend typecheck`, the package `linter` and `oxfmt --check` over the touched paths: all clean.
- react-doctor over the touched files: one diagnostic, `no-giant-component` on `LoginLanding.tsx`. Pre-existing on `main` and slightly improved here (464 → 458 lines). Splitting it would mean restructuring the two-stage login flow, which this PR deliberately does not change.
- Browser, flag ON: all seven screens render the split layout; the brand panel hides (rather than squashes) below the md breakpoint.
- Browser, flag OFF: legacy centred card unchanged, including the `Your email address` placeholder and `Continue` button text that `login.cy.ts` asserts on.
- `LOGIN_PAGE_ID` still bounds the form column only (checked in the DOM) — the backend headless browser crops to it, so it has to wrap the right element, not merely exist.
- `data-cy="signin-button"` unchanged.
- Client-side navigation confirmed for login → "Create an account", register → "Sign in", and login → "Forgot your password?" — no full document loads.

## Note for reviewers: preview E2E only exercises the flag-OFF path

`FeatureFlags.NewOnboarding` is in `PREVIEW_EXCLUDED_FEATURE_FLAGS`, so okteto previews do **not** force-enable it the way they do every other flag. Preview E2E therefore only ever covers the legacy branch of this diff. The new layout needs checking by hand.

## Consolidated with #26599's redirect validator

#26599 has merged, and this stack is rebased on top of it. Both branches carry its
`sanitizeRedirectUrl` on the post-login redirect in `LoginLanding.tsx` and `Register.tsx` — the
rebase conflicts in those two files were resolved by keeping **both** the new layout and the
sanitisation.

That left two same-origin validators in the tree. They answer different questions and keep
distinct call-site APIs:

- `sanitizeRedirectUrl` — guards the post-login redirect sink; returns a safe value, falls back to `/`.
- `resolveInternalPath` — decides `Link`-vs-anchor for a configured URL; returns a path, or `null` when cross-origin.

The problem was that each implemented its **own** notion of a safe target, so hardening one would
have silently missed the other. Both now funnel through a single guard, `isRootRelativePath`, which
lives in `redirectUrl.ts` alongside the sanitiser and its tests:

- `sanitizeRedirectUrl(url)` is now `isRootRelativePath(url) ? url : '/'` — behaviour identical, all of #26599's existing tests pass unchanged.
- `resolveInternalPath` keeps its URL parsing, because configured links are usually absolute and it must resolve an absolute same-origin URL down to a path rather than reject it — then passes that path through the same guard.

`url.ts` is kept rather than folded in: it still holds real logic (URL resolution plus the origin
comparison), so it is not a thin alias. Only the definition of *what is safe* is shared.

Tests were extended to cover the shared guard directly — protocol-relative `//host`, backslash
variants, `javascript:`, `data:` and `vbscript:` schemes, absolute URLs including same-origin ones —
and `resolveInternalPath` gained its own suite, which it did not have before. 24 tests pass.

**Re-verified in a browser after the rebase**, using the reproduction on #26599's ticket:

- `/login?redirect=//evil.example` → after a successful login the browser **stays on this origin** and falls back to the project home. The value is also neutralised before it reaches the SSO round-trip: the Google link carries `redirect=%2F`.
- `/login?redirect=/projects/<uuid>/tables` → the redirect is honoured exactly, landing on `/tables`. (Checked with a distinctive target: `/projects` alone resolves to the same page as `/`, so it cannot tell the two cases apart.)

## Consistency pass across all seven screens

Two follow-up decisions were taken after the original spec was written and are recorded on the ticket:

- **The brand-panel footer strapline is gone.** `Open source · unlimited seats · no lock-in` appeared both as the third bullet and as the bottom-left footer line — a verbatim duplication, both visible at once. Bullet 3 stays; the footer line and its now-unused style are removed.
- **`/invite`, `/verify-email` and `/join-organization` are no longer boxed.** They each brought their own `<Card withBorder>` and rendered centre-aligned, while the other four screens were borderless and left-aligned. All seven now match. The per-organization row cards inside `/join-organization` are kept — those are list items, not the page shell.

Both changes apply to the new layout only; the flag-OFF legacy path keeps its bordered, centred card and is unchanged. The `data-cy="welcome-user"` and `data-cy="one-click-invite"` hooks that e2e relies on were carried across onto the replacement elements rather than dropped with the cards.

`VerifyEmailForm` is shared with the in-app `VerifyEmailModal`, so rather than flipping its alignment outright it gained an opt-in `align` prop that defaults to the existing centred behaviour. Only `/verify-email` passes `left`, and only under the new layout — every other caller, the modal included, renders exactly as before.
