### PR TITLE
fix(auth): record last-used SSO method on success, not on click

### DIFF
--- a/packages/frontend/src/components/PrivateRoute.tsx
+++ b/packages/frontend/src/components/PrivateRoute.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, type FC } from 'react';
 import { Navigate, useLocation } from 'react-router';
+import { usePromotePendingSsoLogin } from '../features/users/hooks/usePromotePendingSsoLogin';
 import { useEmailStatus } from '../hooks/useEmailVerification';
 import { useAccount } from '../hooks/user/useAccount';
 import { useAbilityContext } from '../providers/Ability/useAbilityContext';
@@ -21,6 +22,8 @@ const PrivateRoute: FC<React.PropsWithChildren> = ({ children }) => {
     const [abilityInitialized, setAbilityInitialized] = useState(
         () => ability.rules.length > 0,
     );
+
+    usePromotePendingSsoLogin();
 
     useEffect(() => {
         if (data) {

--- a/packages/frontend/src/features/users/components/LoginLanding.tsx
+++ b/packages/frontend/src/features/users/components/LoginLanding.tsx
@@ -48,8 +48,10 @@ import {
     type LoginParams,
 } from '../hooks/useLogin';
 import {
+    clearPendingSsoLoginMethod,
     readLastLoginMethod,
     writeLastLoginMethod,
+    writePendingSsoLoginMethod,
 } from '../utils/lastLoginMethod';
 import LoginWithEmailOtp from './LoginWithEmailOtp';
 
@@ -69,6 +71,13 @@ const Login: FC<{}> = () => {
             });
         }
     }, [flashMessages.data, showToastError]);
+
+    // Reaching the login page means any SSO attempt from this tab failed or was
+    // abandoned, so it must never become the recorded last-used method.
+    useEffect(() => {
+        clearPendingSsoLoginMethod();
+    }, []);
+
     const queryParams = new URLSearchParams(location.search);
     const redirectParam = queryParams.get('redirect');
 
@@ -308,16 +317,7 @@ const Login: FC<{}> = () => {
                     disabled={isFormLoading}
                     forceShow
                     lastUsed={providerName === lastUsedSsoProvider}
-                    onClick={() =>
-                        writeLastLoginMethod({
-                            issuerType: providerName,
-                            email:
-                                form.values.email ||
-                                preCheckEmail ||
-                                lastLoginMethod?.email ||
-                                '',
-                        })
-                    }
+                    onClick={() => writePendingSsoLoginMethod(providerName)}
                 />
             ))}
         </Stack>

--- a/packages/frontend/src/features/users/hooks/usePromotePendingSsoLogin.ts
+++ b/packages/frontend/src/features/users/hooks/usePromotePendingSsoLogin.ts
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+import useApp from '../../../providers/App/useApp';
+import {
+    clearPendingSsoLoginMethod,
+    readPendingSsoLoginMethod,
+    writeLastLoginMethod,
+} from '../utils/lastLoginMethod';
+
+/**
+ * Turns a pending SSO attempt into the recorded last-login method, using the
+ * authenticated user's own email. Belongs on a single mount point that only
+ * renders once the user is signed in.
+ */
+export const usePromotePendingSsoLogin = () => {
+    const { user } = useApp();
+    const email = user.data?.email;
+
+    useEffect(() => {
+        if (!email) return;
+
+        const pendingIssuerType = readPendingSsoLoginMethod();
+        if (!pendingIssuerType) return;
+
+        writeLastLoginMethod({ issuerType: pendingIssuerType, email });
+        clearPendingSsoLoginMethod();
+    }, [email]);
+};

--- a/packages/frontend/src/features/users/utils/lastLoginMethod.ts
+++ b/packages/frontend/src/features/users/utils/lastLoginMethod.ts
@@ -2,6 +2,7 @@ import {
     isOpenIdIdentityIssuerType,
     LocalIssuerTypes,
     type LoginOptionTypes,
+    type OpenIdIdentityIssuerType,
 } from '@lightdash/common';
 import { getCookie, setCookie } from '../../../utils/cookies';
 
@@ -74,3 +75,42 @@ export const writeLastLoginMethod = (method: LastLoginMethod): void =>
         encodeLastLoginMethodCookie(method),
         LAST_LOGIN_COOKIE_MAX_AGE_SECONDS,
     );
+
+/**
+ * An SSO attempt that has left for the provider but has not come back
+ * authenticated yet. Kept in sessionStorage so it survives the redirect but
+ * dies with the tab, and only promoted to the cookie above once the user is
+ * actually signed in — clicking a provider is an intent, not an outcome.
+ * It is a UX hint, never authentication state.
+ */
+const PENDING_SSO_LOGIN_STORAGE_KEY = 'ld.pending_sso_login';
+
+export const writePendingSsoLoginMethod = (
+    issuerType: OpenIdIdentityIssuerType,
+): void => {
+    try {
+        sessionStorage.setItem(PENDING_SSO_LOGIN_STORAGE_KEY, issuerType);
+    } catch {
+        return;
+    }
+};
+
+export const readPendingSsoLoginMethod =
+    (): OpenIdIdentityIssuerType | null => {
+        try {
+            const stored = sessionStorage.getItem(
+                PENDING_SSO_LOGIN_STORAGE_KEY,
+            );
+            return stored && isOpenIdIdentityIssuerType(stored) ? stored : null;
+        } catch {
+            return null;
+        }
+    };
+
+export const clearPendingSsoLoginMethod = (): void => {
+    try {
+        sessionStorage.removeItem(PENDING_SSO_LOGIN_STORAGE_KEY);
+    } catch {
+        return;
+    }
+};


### PR DESCRIPTION
The "Last used" badge on the login page could be pinned to an SSO provider the user never actually signed in with.

Linear: SPK-783

Stacked on #26656 (the auth screen redesign) — review that one first.

## The bug

Reproduced in a browser: starting with no `ld.last_login_method` cookie, open `/login`, click "Continue with Google", stop at Google's consent screen **without authenticating**, then return to `/login`. The badge is pinned to Google, and the cookie holds `{"issuerType":"google","email":""}`.

`writeLastLoginMethod` was called from the SSO button's `onClick`, which fires *before* the browser follows the link. It recorded an intent to attempt, nothing ever reconciled it against the outcome, and it persisted for a year. A cancelled, failed or wrong-account attempt was indistinguishable from a real login — including a provider round-trip made for something other than logging in.

**Secondary defect:** the stored `email` was `""`. With the SSO buttons above the form the field is usually blank at click time, and the cookie stores an email specifically to forward as `login_hint` and pre-fill the field — so that feature silently did nothing.

## The fix

Record on success, not on click. Because the document unloads during the OAuth redirect, the outcome has to be observed after the callback returns:

- On click, stash a **pending marker** in `sessionStorage` — it survives the redirect within the same tab and dies with the tab.
- Promote it to the real cookie only once the user is actually authenticated, mounted at `PrivateRoute`, taking the email from the authenticated user rather than the form field.
- Clear it if the user lands back on `/login`, which means the attempt failed or was abandoned.

The email/password and email-OTP paths already wrote on success via `handleLoginSuccess` and are untouched.

The pending marker is a UX hint only — it is never read as authentication state and holds no credential.

## Rebased onto the merged open-redirect fix

This branch now sits on top of #26599 (SPK-600), which has merged. `LoginLanding.tsx` is edited by
both, so the rebase kept both behaviours: the pending-SSO marker below **and** `sanitizeRedirectUrl`
on the post-login redirect. The abandoned-attempt check was re-run after the rebase — see below.

## Verification

Both directions re-tested in a browser after the fix:

- **Abandoned attempt** (the repro above): the pending marker is set and survives the redirect, **no cookie is written**, and returning to `/login` clears the marker. No "Last used" badge appears.
- **Successful login**: the cookie is written as `{"issuerType":"email","email":"demo@lightdash.com"}` — with the real address, confirming the secondary defect is fixed rather than the feature simply being disabled.
