### PR TITLE
feat: Learn section — in-app Lightdash University catalogue and course player

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -123,6 +123,11 @@ export const lightdashConfigMock: LightdashConfig = {
     headway: {
         enabled: false,
     },
+    learn: {
+        contentBaseUrl: 'https://learn-content.test',
+        progressApiUrl: 'https://learn-progress.test',
+        serviceToken: null,
+    },
     lightdashSecret: 'look away this is a secret',
     logging: {
         level: 'debug',

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1331,6 +1331,7 @@ export type LightdashConfig = {
     intercom: IntercomConfig;
     pylon: PylonConfig;
     headway: HeadwayConfig;
+    learn: LearnConfig;
     siteUrl: string;
     staticIp: string;
     signupUrl: string | undefined;
@@ -1923,6 +1924,13 @@ type PylonConfig = {
 
 type HeadwayConfig = {
     enabled: boolean;
+};
+
+export type LearnConfig = {
+    contentBaseUrl: string;
+    progressApiUrl: string;
+    /** Server-held bearer for the progress service; null ⇒ progress is client-local only. */
+    serviceToken: string | null;
 };
 
 export type RudderConfig = {
@@ -2705,6 +2713,17 @@ export const parseConfig = (): LightdashConfig => {
         },
         headway: {
             enabled: process.env.HEADWAY_ENABLED !== 'false',
+        },
+        learn: {
+            contentBaseUrl: (
+                process.env.LEARN_CONTENT_BASE_URL ||
+                'https://lu-content.onrender.com'
+            ).replace(/\/$/, ''),
+            progressApiUrl: (
+                process.env.LEARN_PROGRESS_API_URL ||
+                'https://lu-progress.onrender.com'
+            ).replace(/\/$/, ''),
+            serviceToken: process.env.LEARN_SERVICE_TOKEN || null,
         },
         siteUrl,
         helpMenuUrl: process.env.HELP_MENU_URL,

--- a/packages/backend/src/controllers/learnController.ts
+++ b/packages/backend/src/controllers/learnController.ts
@@ -1,0 +1,120 @@
+import {
+    assertRegisteredAccount,
+    type ApiErrorPayload,
+    type ApiLearnCatalogueResponse,
+    type ApiLearnCourseResponse,
+    type ApiLearnEventsResponse,
+    type ApiLearnProgressResponse,
+    type LearnEventInput,
+} from '@lightdash/common';
+import {
+    Body,
+    Get,
+    Hidden,
+    Middlewares,
+    OperationId,
+    Path,
+    Post,
+    Request,
+    Response,
+    Route,
+    SuccessResponse,
+} from '@tsoa/runtime';
+import express from 'express';
+import { allowApiKeyAuthentication, isAuthenticated } from './authentication';
+import { BaseController } from './baseController';
+
+@Route('/api/v1/learn')
+// These endpoints are under development and susceptible to breaking changes.
+// Keep them hidden until the feature is GA.
+@Hidden()
+@Response<ApiErrorPayload>('default', 'Error')
+export class LearnController extends BaseController {
+    /**
+     * Get the Lightdash University course catalogue.
+     * @summary Get the Learn catalogue
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/catalogue')
+    @OperationId('getLearnCatalogue')
+    async getLearnCatalogue(
+        @Request() req: express.Request,
+    ): Promise<ApiLearnCatalogueResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getLearnService()
+                .getCatalogue(req.account),
+        };
+    }
+
+    /**
+     * Get a published course payload (lessons and quiz) by course id.
+     * @summary Get a Learn course
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/courses/{courseId}')
+    @OperationId('getLearnCourse')
+    async getLearnCourse(
+        @Request() req: express.Request,
+        @Path() courseId: string,
+    ): Promise<ApiLearnCourseResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getLearnService()
+                .getCourse(req.account, courseId),
+        };
+    }
+
+    /**
+     * Get the signed-in user's Learn progress rollups. `courses` is null when
+     * the instance has no Learn service token configured (client-local mode).
+     * @summary Get Learn progress
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/progress')
+    @OperationId('getLearnProgress')
+    async getLearnProgress(
+        @Request() req: express.Request,
+    ): Promise<ApiLearnProgressResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getLearnService()
+                .getProgress(req.account),
+        };
+    }
+
+    /**
+     * Append learning events for the signed-in user. The event source is
+     * always recorded as 'learn' server-side.
+     * @summary Record Learn events
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/events')
+    @OperationId('recordLearnEvents')
+    async recordLearnEvents(
+        @Request() req: express.Request,
+        @Body() body: LearnEventInput[],
+    ): Promise<ApiLearnEventsResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getLearnService()
+                .recordEvents(req.account, body),
+        };
+    }
+}

--- a/packages/backend/src/services/LearnService/LearnService.test.ts
+++ b/packages/backend/src/services/LearnService/LearnService.test.ts
@@ -1,0 +1,283 @@
+import {
+    ForbiddenError,
+    NotFoundError,
+    ParameterError,
+    UnexpectedServerError,
+    type Account,
+} from '@lightdash/common';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { LightdashConfig } from '../../config/parseConfig';
+import { LearnService } from './LearnService';
+
+const buildAccount = (): Account =>
+    ({
+        authentication: { type: 'session', source: 'session-cookie' },
+        organization: {
+            organizationUuid: 'org-uuid',
+            name: 'Org',
+            createdAt: new Date(),
+        },
+        user: {
+            id: 'user-uuid',
+            userUuid: 'user-uuid',
+            userId: 1,
+            email: 'learner+test@example.com',
+            firstName: 'Test',
+            lastName: 'User',
+            role: 'admin',
+            type: 'registered',
+            isActive: true,
+            isTrackingAnonymized: false,
+            isMarketingOptedIn: false,
+            isSetupComplete: true,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            timezone: null,
+        },
+        isAnonymousUser: () => false,
+        isAuthenticated: () => true,
+        isJwtUser: () => false,
+        isOauthUser: () => false,
+        isPatUser: () => false,
+        isRegisteredUser: () => true,
+        isServiceAccount: () => false,
+        isSessionUser: () => true,
+    }) as Account;
+
+const catalogueEntry = {
+    id: 'viewer-fundamentals',
+    title: 'Viewer Fundamentals',
+    description: 'Learn to view.',
+    version: 1,
+    contentHash: 'abc123def456',
+    path: 'courses/viewer-fundamentals/abc123def456/course.json',
+    lessonCount: 2,
+    durationMinutes: 25,
+    tags: ['viewer'],
+    track: 'foundations',
+    publishedAt: '2026-08-01T00:00:00.000Z',
+};
+
+const cataloguePayload = {
+    generatedAt: '2026-08-01T00:00:00.000Z',
+    courses: [catalogueEntry],
+};
+
+const coursePayload = {
+    id: 'viewer-fundamentals',
+    title: 'Viewer Fundamentals',
+    passingScore: 80,
+    lessons: [{ id: 'l1', title: 'Lesson One', html: '<p>hi</p>' }],
+    quiz: {
+        questions: [{ id: 'q1', prompt: 'Q?', choices: ['a', 'b'], answer: 1 }],
+    },
+    version: 1,
+    contentHash: 'abc123def456',
+    publishedAt: '2026-08-01T00:00:00.000Z',
+};
+
+const jsonResponse = (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), { status });
+
+const buildService = ({ flagEnabled = true, withToken = true } = {}) => {
+    const serviceToken = withToken ? 'service-token-1' : undefined;
+    const featureFlagService = {
+        get: vi.fn().mockResolvedValue({ enabled: flagEnabled }),
+    };
+    const lightdashConfig = {
+        learn: {
+            contentBaseUrl: 'https://content.test',
+            progressApiUrl: 'https://progress.test',
+            serviceToken,
+        },
+    } as LightdashConfig;
+    return {
+        service: new LearnService({ lightdashConfig, featureFlagService }),
+        featureFlagService,
+    };
+};
+
+describe('LearnService', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    describe('feature flag gate', () => {
+        it('throws ForbiddenError when the Learn flag is off', async () => {
+            const { service } = buildService({ flagEnabled: false });
+            await expect(service.getCatalogue(buildAccount())).rejects.toThrow(
+                ForbiddenError,
+            );
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('getCatalogue', () => {
+        it('returns the parsed catalogue from the content CDN', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(jsonResponse(cataloguePayload));
+            const catalogue = await service.getCatalogue(buildAccount());
+            expect(catalogue.courses).toHaveLength(1);
+            expect(fetchMock).toHaveBeenCalledWith(
+                'https://content.test/catalogue.json',
+                expect.anything(),
+            );
+        });
+
+        it('passes through unknown catalogue fields (forward compatibility)', async () => {
+            const { service } = buildService();
+            const withExtras = {
+                ...cataloguePayload,
+                courses: [
+                    {
+                        ...catalogueEntry,
+                        requires: [{ id: 'ai-copilot' }],
+                        docsUrl: 'https://docs.lightdash.com/x',
+                    },
+                ],
+            };
+            fetchMock.mockResolvedValue(jsonResponse(withExtras));
+            const catalogue = await service.getCatalogue(buildAccount());
+            expect(
+                (catalogue.courses[0] as Record<string, unknown>).docsUrl,
+            ).toBe('https://docs.lightdash.com/x');
+        });
+
+        it('maps upstream failures to UnexpectedServerError', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(jsonResponse({}, 502));
+            await expect(service.getCatalogue(buildAccount())).rejects.toThrow(
+                UnexpectedServerError,
+            );
+        });
+
+        it('maps invalid payloads to UnexpectedServerError', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(jsonResponse({ nope: true }));
+            await expect(service.getCatalogue(buildAccount())).rejects.toThrow(
+                UnexpectedServerError,
+            );
+        });
+    });
+
+    describe('getCourse', () => {
+        it('throws NotFoundError for a course missing from the catalogue', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(jsonResponse(cataloguePayload));
+            await expect(
+                service.getCourse(buildAccount(), 'not-a-course'),
+            ).rejects.toThrow(NotFoundError);
+        });
+
+        it('fetches the course payload and derives assetBaseUrl', async () => {
+            const { service } = buildService();
+            fetchMock
+                .mockResolvedValueOnce(jsonResponse(cataloguePayload))
+                .mockResolvedValueOnce(jsonResponse(coursePayload));
+            const course = await service.getCourse(
+                buildAccount(),
+                'viewer-fundamentals',
+            );
+            expect(course.assetBaseUrl).toBe(
+                'https://content.test/courses/viewer-fundamentals/abc123def456',
+            );
+            expect(fetchMock).toHaveBeenNthCalledWith(
+                2,
+                `https://content.test/${catalogueEntry.path}`,
+                expect.anything(),
+            );
+        });
+    });
+
+    describe('getProgress', () => {
+        it('reports serverSynced: false without a service token and never calls upstream', async () => {
+            const { service } = buildService({ withToken: false });
+            const result = await service.getProgress(buildAccount());
+            expect(result).toEqual({ courses: null, serverSynced: false });
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+
+        it('proxies with the server-held token and the session email', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(
+                jsonResponse({
+                    email: 'learner+test@example.com',
+                    courses: [],
+                }),
+            );
+            const result = await service.getProgress(buildAccount());
+            expect(result).toEqual({ courses: [], serverSynced: true });
+            const [url, init] = fetchMock.mock.calls[0];
+            expect(url).toBe(
+                'https://progress.test/api/v1/progress?email=learner%2Btest%40example.com',
+            );
+            expect((init.headers as Record<string, string>).authorization).toBe(
+                'Bearer service-token-1',
+            );
+        });
+    });
+
+    describe('recordEvents', () => {
+        const validEvent = {
+            verb: 'started',
+            object: { type: 'course', course: 'viewer-fundamentals' },
+            occurredAt: '2026-08-01T00:00:00.000Z',
+        };
+
+        it('rejects invalid payloads with ParameterError', async () => {
+            const { service } = buildService();
+            await expect(
+                service.recordEvents(buildAccount(), [{ nope: true }]),
+            ).rejects.toThrow(ParameterError);
+            await expect(
+                service.recordEvents(buildAccount(), []),
+            ).rejects.toThrow(ParameterError);
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+
+        it('rejects batches over 100 events', async () => {
+            const { service } = buildService();
+            const events = Array.from({ length: 101 }, () => validEvent);
+            await expect(
+                service.recordEvents(buildAccount(), events),
+            ).rejects.toThrow(ParameterError);
+        });
+
+        it('accepts and drops events when no service token is configured', async () => {
+            const { service } = buildService({ withToken: false });
+            const result = await service.recordEvents(buildAccount(), [
+                validEvent,
+            ]);
+            expect(result).toEqual({ accepted: 0 });
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+
+        it('stamps source: learn on every event before forwarding', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(jsonResponse({ accepted: 1 }));
+            const result = await service.recordEvents(buildAccount(), [
+                validEvent,
+            ]);
+            expect(result).toEqual({ accepted: 1 });
+            const [, init] = fetchMock.mock.calls[0];
+            const body = JSON.parse(init.body as string);
+            expect(body[0].source).toBe('learn');
+        });
+
+        it('maps upstream write failures to UnexpectedServerError', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(jsonResponse({}, 500));
+            await expect(
+                service.recordEvents(buildAccount(), [validEvent]),
+            ).rejects.toThrow(UnexpectedServerError);
+        });
+    });
+});

--- a/packages/backend/src/services/LearnService/LearnService.ts
+++ b/packages/backend/src/services/LearnService/LearnService.ts
@@ -1,0 +1,216 @@
+import {
+    assertRegisteredAccount,
+    FeatureFlags,
+    ForbiddenError,
+    LearnCatalogueSchema,
+    LearnCourseSchema,
+    LearnEventInputSchema,
+    LearnProgressResponseSchema,
+    NotFoundError,
+    ParameterError,
+    UnexpectedServerError,
+    type Account,
+    type ApiLearnEventsResponse,
+    type LearnCatalogue,
+    type LearnCourse,
+    type LearnEventInput,
+    type LearnProgressResults,
+} from '@lightdash/common';
+import type { LightdashConfig } from '../../config/parseConfig';
+import { BaseService } from '../BaseService';
+import type { FeatureFlagService } from '../FeatureFlag/FeatureFlagService';
+
+const LEARN_REQUEST_TIMEOUT_MS = 10_000;
+const MAX_EVENTS_PER_REQUEST = 100;
+
+type Dependencies = {
+    lightdashConfig: LightdashConfig;
+    featureFlagService: Pick<FeatureFlagService, 'get'>;
+};
+
+export class LearnService extends BaseService {
+    private readonly lightdashConfig: LightdashConfig;
+
+    private readonly featureFlagService: Pick<FeatureFlagService, 'get'>;
+
+    constructor({ lightdashConfig, featureFlagService }: Dependencies) {
+        super();
+        this.lightdashConfig = lightdashConfig;
+        this.featureFlagService = featureFlagService;
+    }
+
+    private async assertLearnEnabled(account: Account): Promise<void> {
+        assertRegisteredAccount(account);
+        const flag = await this.featureFlagService.get({
+            user: {
+                userUuid: account.user.userUuid,
+                organizationUuid: account.organization?.organizationUuid,
+            },
+            featureFlagId: FeatureFlags.LearnSection,
+        });
+        if (!flag.enabled) {
+            throw new ForbiddenError('Learn is not available');
+        }
+    }
+
+    private async fetchUpstream(
+        url: string,
+        init: RequestInit = {},
+    ): Promise<Response> {
+        try {
+            return await fetch(url, {
+                ...init,
+                signal: AbortSignal.timeout(LEARN_REQUEST_TIMEOUT_MS),
+            });
+        } catch (error) {
+            this.logger.warn('Could not reach the Learn service', {
+                error: error instanceof Error ? error.message : String(error),
+            });
+            throw new UnexpectedServerError('Could not load Learn content');
+        }
+    }
+
+    private static async parseJson(response: Response): Promise<unknown> {
+        try {
+            return await response.json();
+        } catch {
+            throw new UnexpectedServerError('Could not load Learn content');
+        }
+    }
+
+    async getCatalogue(account: Account): Promise<LearnCatalogue> {
+        await this.assertLearnEnabled(account);
+        const response = await this.fetchUpstream(
+            `${this.lightdashConfig.learn.contentBaseUrl}/catalogue.json`,
+        );
+        if (!response.ok) {
+            this.logger.warn('Learn content service returned an error', {
+                statusCode: response.status,
+            });
+            throw new UnexpectedServerError('Could not load Learn content');
+        }
+        const parsed = LearnCatalogueSchema.safeParse(
+            await LearnService.parseJson(response),
+        );
+        if (!parsed.success) {
+            this.logger.warn('Learn catalogue failed validation', {
+                issueCount: parsed.error.issues.length,
+            });
+            throw new UnexpectedServerError('Could not load Learn content');
+        }
+        return parsed.data;
+    }
+
+    async getCourse(account: Account, courseId: string): Promise<LearnCourse> {
+        const catalogue = await this.getCatalogue(account);
+        const entry = catalogue.courses.find((c) => c.id === courseId);
+        if (!entry) {
+            throw new NotFoundError(`Course not found: ${courseId}`);
+        }
+        const { contentBaseUrl } = this.lightdashConfig.learn;
+        const response = await this.fetchUpstream(
+            `${contentBaseUrl}/${entry.path}`,
+        );
+        if (!response.ok) {
+            this.logger.warn('Learn course payload returned an error', {
+                statusCode: response.status,
+            });
+            throw new UnexpectedServerError('Could not load Learn content');
+        }
+        const parsed = LearnCourseSchema.safeParse(
+            await LearnService.parseJson(response),
+        );
+        if (!parsed.success) {
+            this.logger.warn('Learn course failed validation', {
+                issueCount: parsed.error.issues.length,
+            });
+            throw new UnexpectedServerError('Could not load Learn content');
+        }
+        return {
+            ...parsed.data,
+            assetBaseUrl: `${contentBaseUrl}/courses/${entry.id}/${entry.contentHash}`,
+        };
+    }
+
+    private progressRequest(
+        account: Account,
+        path: string,
+        init: RequestInit = {},
+    ): Promise<Response> {
+        const { progressApiUrl, serviceToken } = this.lightdashConfig.learn;
+        if (!serviceToken) {
+            throw new UnexpectedServerError('Learn progress is not configured');
+        }
+        const email = encodeURIComponent(account.user?.email ?? '');
+        return this.fetchUpstream(`${progressApiUrl}${path}?email=${email}`, {
+            ...init,
+            headers: {
+                'content-type': 'application/json',
+                authorization: `Bearer ${serviceToken}`,
+                ...(init.headers ?? {}),
+            },
+        });
+    }
+
+    async getProgress(account: Account): Promise<LearnProgressResults> {
+        await this.assertLearnEnabled(account);
+        if (!this.lightdashConfig.learn.serviceToken) {
+            return { courses: null, serverSynced: false };
+        }
+        const response = await this.progressRequest(
+            account,
+            '/api/v1/progress',
+        );
+        if (!response.ok) {
+            this.logger.warn('Learn progress service returned an error', {
+                statusCode: response.status,
+            });
+            throw new UnexpectedServerError('Could not load Learn progress');
+        }
+        const parsed = LearnProgressResponseSchema.safeParse(
+            await LearnService.parseJson(response),
+        );
+        if (!parsed.success) {
+            this.logger.warn('Learn progress failed validation', {
+                issueCount: parsed.error.issues.length,
+            });
+            throw new UnexpectedServerError('Could not load Learn progress');
+        }
+        return { courses: parsed.data.courses, serverSynced: true };
+    }
+
+    async recordEvents(
+        account: Account,
+        events: unknown,
+    ): Promise<ApiLearnEventsResponse['results']> {
+        await this.assertLearnEnabled(account);
+        const parsed = LearnEventInputSchema.array()
+            .min(1)
+            .max(MAX_EVENTS_PER_REQUEST)
+            .safeParse(events);
+        if (!parsed.success) {
+            throw new ParameterError('Invalid Learn events payload');
+        }
+        if (!this.lightdashConfig.learn.serviceToken) {
+            // No server sync configured: accept and drop — the client also
+            // keeps local progress, so learners lose nothing they can see.
+            return { accepted: 0 };
+        }
+        const body: Array<LearnEventInput & { source: 'learn' }> =
+            parsed.data.map((event) => ({ ...event, source: 'learn' }));
+        const response = await this.progressRequest(account, '/api/v1/events', {
+            method: 'POST',
+            body: JSON.stringify(body),
+        });
+        if (!response.ok) {
+            this.logger.warn('Learn events write failed', {
+                statusCode: response.status,
+            });
+            throw new UnexpectedServerError('Could not save Learn progress');
+        }
+        const payload = (await LearnService.parseJson(response)) as {
+            accepted?: number;
+        };
+        return { accepted: payload.accepted ?? body.length };
+    }
+}

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -41,6 +41,7 @@ import { GitIntegrationService } from './GitIntegrationService/GitIntegrationSer
 import { GitlabAppService } from './GitlabAppService/GitlabAppService';
 import { GroupsService } from './GroupService';
 import { HealthService } from './HealthService/HealthService';
+import { LearnService } from './LearnService/LearnService';
 import { LicenseService } from './LicenseService/LicenseService';
 import { LightdashAnalyticsService } from './LightdashAnalyticsService/LightdashAnalyticsService';
 import { MetricsExplorerService } from './MetricsExplorerService/MetricsExplorerService';
@@ -122,6 +123,7 @@ interface ServiceManifest {
     pivotTableService: PivotTableService;
     projectService: ProjectService;
     promptService: PromptService;
+    learnService: LearnService;
     savedChartService: SavedChartService;
     schedulerService: SchedulerService;
     searchService: SearchService;
@@ -1007,6 +1009,17 @@ export class ServiceRepository
                     appGenerateService: this.providers.appGenerateService
                         ? this.getAppGenerateService<AppGenerateService>()
                         : undefined,
+                }),
+        );
+    }
+
+    public getLearnService(): LearnService {
+        return this.getService(
+            'learnService',
+            () =>
+                new LearnService({
+                    lightdashConfig: this.context.lightdashConfig,
+                    featureFlagService: this.getFeatureFlagService(),
                 }),
         );
     }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -291,6 +291,7 @@ export * from './types/promotion';
 export * from './types/queryHistory';
 export * from './types/rename';
 export * from './types/resourceViewItem';
+export * from './types/learn';
 export * from './types/results';
 export * from './types/roadmap';
 export * from './types/roles';

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -197,6 +197,12 @@ import type {
     ApiGroupListResponse,
 } from './groups';
 import { type ApiImpersonationOrganizationSettingsResponse } from './impersonationOrganizationSettings';
+import {
+    type ApiLearnCatalogueResponse,
+    type ApiLearnCourseResponse,
+    type ApiLearnEventsResponse,
+    type ApiLearnProgressResponse,
+} from './learn';
 import { type MetricQuery, type QueryWarning } from './metricQuery';
 import type {
     ApiMetricsExplorerQueryResults,
@@ -1143,6 +1149,10 @@ type ApiResults =
     | ValidationResponse[]
     | ApiPaginatedValidateResponse['results']
     | ApiRoadmapResponse['results']
+    | ApiLearnCatalogueResponse['results']
+    | ApiLearnCourseResponse['results']
+    | ApiLearnProgressResponse['results']
+    | ApiLearnEventsResponse['results']
     | ChartHistory
     | ChartVersion
     | DashboardHistory

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -108,6 +108,12 @@ export enum FeatureFlags {
     EnableDataApps = 'enable-data-apps',
 
     /**
+     * Show the Learn section (in-app Lightdash University training) and
+     * enable its content/progress proxy endpoints. Disabled by default.
+     */
+    LearnSection = 'learn-section',
+
+    /**
      * Per-organization gate for declaring custom npm dependencies in data
      * apps. Disabled by default; self-hosted instances can enable it globally
      * via LIGHTDASH_ENABLE_FEATURE_FLAGS.

--- a/packages/common/src/types/learn.ts
+++ b/packages/common/src/types/learn.ts
@@ -1,0 +1,227 @@
+import { z } from 'zod';
+
+export type LearnCatalogueEntry = {
+    id: string;
+    title: string;
+    description: string;
+    version: number;
+    contentHash: string;
+    path: string;
+    lessonCount: number;
+    durationMinutes: number | null;
+    tags: string[];
+    track: string | null;
+    publishedAt: string;
+};
+
+export type LearnCatalogue = {
+    generatedAt: string;
+    courses: LearnCatalogueEntry[];
+};
+
+export const LearnCatalogueEntrySchema: z.ZodType<LearnCatalogueEntry> = z
+    .object({
+        id: z.string().min(1),
+        title: z.string().min(1),
+        description: z.string(),
+        version: z.number().int(),
+        contentHash: z.string().min(1),
+        path: z.string().min(1),
+        lessonCount: z.number().int(),
+        durationMinutes: z.number().nullable(),
+        tags: z.array(z.string()),
+        track: z.string().nullable(),
+        publishedAt: z.string(),
+    })
+    .passthrough() as unknown as z.ZodType<LearnCatalogueEntry>;
+
+export const LearnCatalogueSchema: z.ZodType<LearnCatalogue> = z
+    .object({
+        generatedAt: z.string(),
+        courses: z.array(LearnCatalogueEntrySchema),
+    })
+    .passthrough() as unknown as z.ZodType<LearnCatalogue>;
+
+export type LearnQuizQuestion = {
+    id: string;
+    prompt: string;
+    choices: string[];
+    answer: number;
+};
+
+export type LearnLesson = {
+    id: string;
+    title: string;
+    html: string;
+};
+
+export type LearnCourse = {
+    id: string;
+    title: string;
+    passingScore: number;
+    logo?: string;
+    lessons: LearnLesson[];
+    quiz: { questions: LearnQuizQuestion[] };
+    version: number;
+    contentHash: string;
+    publishedAt: string;
+    /** Absolute base URL lesson-relative `assets/…` refs resolve against. */
+    assetBaseUrl: string;
+};
+
+export const LearnCourseSchema = z
+    .object({
+        id: z.string().min(1),
+        title: z.string().min(1),
+        passingScore: z.number(),
+        logo: z.string().optional(),
+        lessons: z.array(
+            z
+                .object({
+                    id: z.string().min(1),
+                    title: z.string().min(1),
+                    html: z.string(),
+                })
+                .passthrough(),
+        ),
+        quiz: z
+            .object({
+                questions: z.array(
+                    z
+                        .object({
+                            id: z.string().min(1),
+                            prompt: z.string(),
+                            choices: z.array(z.string()),
+                            answer: z.number().int(),
+                        })
+                        .passthrough(),
+                ),
+            })
+            .passthrough(),
+        version: z.number().int(),
+        contentHash: z.string().min(1),
+        publishedAt: z.string(),
+    })
+    .passthrough();
+
+export type LearnCourseProgress = {
+    courseId: string;
+    startedAt: string | null;
+    completedAt: string | null;
+    lessonsCompleted: string[];
+    quiz: {
+        bestScore: number | null;
+        passed: boolean;
+        passedAt: string | null;
+    } | null;
+    lastEventAt: string | null;
+};
+
+export const LearnProgressResponseSchema = z
+    .object({
+        email: z.string(),
+        courses: z.array(
+            z
+                .object({
+                    courseId: z.string(),
+                    startedAt: z.string().nullable(),
+                    completedAt: z.string().nullable(),
+                    lessonsCompleted: z.array(z.string()),
+                    quiz: z
+                        .object({
+                            bestScore: z.number().nullable(),
+                            passed: z.boolean(),
+                            passedAt: z.string().nullable(),
+                        })
+                        .passthrough()
+                        .nullable(),
+                    lastEventAt: z.string().nullable(),
+                })
+                .passthrough(),
+        ),
+    })
+    .passthrough();
+
+export type LearnEventVerb =
+    | 'started'
+    | 'progressed'
+    | 'completed'
+    | 'passed'
+    | 'failed';
+
+/**
+ * A learning event as written by the Learn section. `source` is pinned
+ * server-side to 'learn' — the client never chooses the surface.
+ */
+export type LearnEventInput = {
+    verb: LearnEventVerb;
+    object: {
+        type: 'course' | 'lesson' | 'quiz';
+        course: string;
+        lesson?: string;
+        contentHash?: string;
+        version?: number;
+    };
+    result?: {
+        score?: number;
+        passed?: boolean;
+        completion?: boolean;
+    };
+    occurredAt: string;
+};
+
+export const LearnEventInputSchema: z.ZodType<LearnEventInput> = z
+    .object({
+        verb: z.enum([
+            'started',
+            'progressed',
+            'completed',
+            'passed',
+            'failed',
+        ]),
+        object: z
+            .object({
+                type: z.enum(['course', 'lesson', 'quiz']),
+                course: z.string().min(1),
+                lesson: z.string().optional(),
+                contentHash: z.string().optional(),
+                version: z.number().int().optional(),
+            })
+            .strict(),
+        result: z
+            .object({
+                score: z.number().min(0).max(100).optional(),
+                passed: z.boolean().optional(),
+                completion: z.boolean().optional(),
+            })
+            .strict()
+            .optional(),
+        occurredAt: z.string().datetime({ offset: true }),
+    })
+    .strict() as unknown as z.ZodType<LearnEventInput>;
+
+export type LearnProgressResults = {
+    /** Null when the instance has no Learn service token — progress is client-local. */
+    courses: LearnCourseProgress[] | null;
+    serverSynced: boolean;
+};
+
+export type ApiLearnCatalogueResponse = {
+    status: 'ok';
+    results: LearnCatalogue;
+};
+
+export type ApiLearnCourseResponse = {
+    status: 'ok';
+    results: LearnCourse;
+};
+
+export type ApiLearnProgressResponse = {
+    status: 'ok';
+    results: LearnProgressResults;
+};
+
+export type ApiLearnEventsResponse = {
+    status: 'ok';
+    results: { accepted: number };
+};

--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -499,6 +499,41 @@ const SPACES_ROUTES: RouteObject[] = [
     },
 ];
 
+const LEARN_ROUTES: RouteObject[] = [
+    {
+        path: 'learn',
+        lazy: async () => {
+            const Learn = await loadLazyRouteDefault(
+                './pages/Learn',
+                () => import('./pages/Learn'),
+            );
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.LEARN}>
+                        <Learn />
+                    </TrackPage>
+                ),
+            };
+        },
+    },
+    {
+        path: 'learn/courses/:courseId',
+        lazy: async () => {
+            const LearnCourse = await loadLazyRouteDefault(
+                './pages/LearnCourse',
+                () => import('./pages/LearnCourse'),
+            );
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.LEARN_COURSE}>
+                        <LearnCourse />
+                    </TrackPage>
+                ),
+            };
+        },
+    },
+];
+
 const METRICS_ROUTES: RouteObject[] = [
     {
         path: 'metrics',
@@ -579,6 +614,7 @@ const PROJECT_LAYOUT_ROUTES: RouteObject[] = [
     ...DASHBOARD_LIST_ROUTES,
     ...SPACES_ROUTES,
     ...METRICS_ROUTES,
+    ...LEARN_ROUTES,
     {
         path: 'home',
         lazy: async () => {

--- a/packages/frontend/src/components/NavBar/BrowseMenu.tsx
+++ b/packages/frontend/src/components/NavBar/BrowseMenu.tsx
@@ -37,6 +37,7 @@ import scrollAreaClasses from '../../styles/ScrollArea.module.css';
 import MantineIcon from '../common/MantineIcon';
 import { PolymorphicGroupButton } from '../common/PolymorphicGroupButton';
 import TruncatedText from '../common/TruncatedText';
+import { LearnLink } from './LearnLink';
 import { MetricsLink } from './MetricsLink';
 
 interface Props {
@@ -163,6 +164,8 @@ const BrowseMenu: FC<Props> = ({ projectUuid }) => {
                 {!hasMetrics && (
                     <MetricsLink projectUuid={projectUuid} asMenu />
                 )}
+
+                <LearnLink projectUuid={projectUuid} asMenu />
 
                 {hasFavorites ? (
                     <>

--- a/packages/frontend/src/components/NavBar/LearnLink.module.css
+++ b/packages/frontend/src/components/NavBar/LearnLink.module.css
@@ -1,0 +1,14 @@
+/* The navbar search is absolutely centered from 75em up, so the left button
+   group must not grow past the search's left edge. Below this width the Learn
+   entry lives in the Browse menu instead of the top-level group. */
+.topLevel {
+    @media (max-width: 1550px) {
+        display: none;
+    }
+}
+
+.menuItem {
+    @media (min-width: 1551px) {
+        display: none;
+    }
+}

--- a/packages/frontend/src/components/NavBar/LearnLink.tsx
+++ b/packages/frontend/src/components/NavBar/LearnLink.tsx
@@ -1,0 +1,49 @@
+import { FeatureFlags } from '@lightdash/common';
+import { Button } from '@mantine-8/core';
+import { IconSchool } from '@tabler/icons-react';
+import { useCallback, type FC } from 'react';
+import { useNavigate } from 'react-router';
+import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
+import useApp from '../../providers/App/useApp';
+import useTracking from '../../providers/Tracking/useTracking';
+import { EventName } from '../../types/Events';
+import MantineIcon from '../common/MantineIcon';
+
+interface Props {
+    projectUuid: string;
+}
+
+export const LearnLink: FC<Props> = ({ projectUuid }) => {
+    const { user } = useApp();
+    const navigate = useNavigate();
+    const { track } = useTracking();
+    const learnFlag = useServerFeatureFlag(FeatureFlags.LearnSection);
+
+    const handleLearnClick = useCallback(() => {
+        track({
+            name: EventName.LEARN_CLICKED,
+            properties: {
+                userId: user?.data?.userUuid,
+                organizationId: user?.data?.organizationUuid,
+                projectId: projectUuid,
+            },
+        });
+        void navigate(`/projects/${projectUuid}/learn`);
+    }, [track, user, navigate, projectUuid]);
+
+    if (learnFlag.isLoading || !learnFlag.data?.enabled) {
+        return null;
+    }
+
+    return (
+        <Button
+            variant="default"
+            size="xs"
+            fz="sm"
+            leftSection={<MantineIcon icon={IconSchool} color="ldGray.6" />}
+            onClick={handleLearnClick}
+        >
+            Learn
+        </Button>
+    );
+};

--- a/packages/frontend/src/components/NavBar/LearnLink.tsx
+++ b/packages/frontend/src/components/NavBar/LearnLink.tsx
@@ -1,5 +1,5 @@
 import { FeatureFlags } from '@lightdash/common';
-import { Button } from '@mantine-8/core';
+import { Button, Menu } from '@mantine-8/core';
 import { IconSchool } from '@tabler/icons-react';
 import { useCallback, type FC } from 'react';
 import { useNavigate } from 'react-router';
@@ -8,12 +8,14 @@ import useApp from '../../providers/App/useApp';
 import useTracking from '../../providers/Tracking/useTracking';
 import { EventName } from '../../types/Events';
 import MantineIcon from '../common/MantineIcon';
+import classes from './LearnLink.module.css';
 
 interface Props {
     projectUuid: string;
+    asMenu?: boolean;
 }
 
-export const LearnLink: FC<Props> = ({ projectUuid }) => {
+export const LearnLink: FC<Props> = ({ projectUuid, asMenu }) => {
     const { user } = useApp();
     const navigate = useNavigate();
     const { track } = useTracking();
@@ -35,8 +37,21 @@ export const LearnLink: FC<Props> = ({ projectUuid }) => {
         return null;
     }
 
+    if (asMenu) {
+        return (
+            <Menu.Item
+                className={classes.menuItem}
+                leftSection={<MantineIcon icon={IconSchool} />}
+                onClick={handleLearnClick}
+            >
+                Learn
+            </Menu.Item>
+        );
+    }
+
     return (
         <Button
+            className={classes.topLevel}
             variant="default"
             size="xs"
             fz="sm"

--- a/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
+++ b/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
@@ -10,6 +10,7 @@ import BrowseMenu from './BrowseMenu';
 import ExploreMenu from './ExploreMenu';
 import HeadwayMenuItem from './HeadwayMenuItem';
 import HelpMenu from './HelpMenu';
+import { LearnLink } from './LearnLink';
 import classes from './MainNavBarContent.module.css';
 import { MetricsLink } from './MetricsLink';
 import { NotificationsMenu } from './NotificationsMenu';
@@ -62,6 +63,7 @@ export const MainNavBarContent: FC<Props> = ({
                             {hasMetrics && (
                                 <MetricsLink projectUuid={activeProjectUuid} />
                             )}
+                            <LearnLink projectUuid={activeProjectUuid} />
                             <Suspense fallback={null}>
                                 <AiAgentsButton
                                     projectUuid={activeProjectUuid}

--- a/packages/frontend/src/features/learn/components/LearnCataloguePanel.tsx
+++ b/packages/frontend/src/features/learn/components/LearnCataloguePanel.tsx
@@ -1,0 +1,294 @@
+import {
+    Anchor,
+    Badge,
+    Button,
+    Group,
+    Paper,
+    Progress,
+    SegmentedControl,
+    Stack,
+    Text,
+    TextInput,
+    Title,
+    Tooltip,
+} from '@mantine-8/core';
+import { IconExternalLink, IconSchool, IconSearch } from '@tabler/icons-react';
+import { useMemo, useState, type FC } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import MantineIcon from '../../../components/common/MantineIcon';
+import SuboptimalState from '../../../components/common/SuboptimalState/SuboptimalState';
+import { getLastCourseId, useLearnCatalogue, useLearnRollups } from '../hooks';
+import {
+    askMatch,
+    badgeStates,
+    pathProgress,
+    pathsFromCatalogue,
+    resumeTarget,
+    type PathName,
+} from '../model';
+import { LearnGraph } from './LearnGraph';
+
+const PATH_KEY = 'lightdash.learn.path.v1';
+
+const ASK_SUGGESTIONS = [
+    'I need to build a dashboard for my team',
+    'How do I write metrics in dbt?',
+    'Make the AI analyst give better answers',
+];
+
+const PATH_META: Record<
+    PathName,
+    { title: string; color: string; blurb: string }
+> = {
+    analyst: {
+        title: 'Analyst',
+        color: 'violet.6',
+        blurb: 'Explores, charts, dashboards and the AI analyst.',
+    },
+    builder: {
+        title: 'Builder',
+        color: 'teal.6',
+        blurb: 'Metrics as code, modelling and governance.',
+    },
+};
+
+export const LearnCataloguePanel: FC = () => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const navigate = useNavigate();
+    const catalogue = useLearnCatalogue();
+    const { rollups, serverSynced } = useLearnRollups();
+    const [selectedPath, setSelectedPath] = useState<PathName>(() =>
+        localStorage.getItem(PATH_KEY) === 'builder' ? 'builder' : 'analyst',
+    );
+    const [askQuery, setAskQuery] = useState('');
+    const [askSubmitted, setAskSubmitted] = useState<string | null>(null);
+
+    const paths = useMemo(
+        () =>
+            catalogue.data ? pathsFromCatalogue(catalogue.data.courses) : null,
+        [catalogue.data],
+    );
+
+    const openCourse = (courseId: string) =>
+        navigate(
+            `/projects/${projectUuid}/learn/courses/${encodeURIComponent(
+                courseId,
+            )}`,
+        );
+
+    const catalogueData = catalogue.data;
+
+    if (catalogue.isInitialLoading) {
+        return (
+            <SuboptimalState title="Loading Lightdash University…" loading />
+        );
+    }
+    if (catalogue.isError || !paths || !catalogueData) {
+        return (
+            <SuboptimalState
+                title="Couldn't load the course catalogue"
+                description="Learn content is fetched from Lightdash University — check the instance can reach it, then retry."
+            />
+        );
+    }
+
+    const path = paths[selectedPath];
+    const meta = PATH_META[selectedPath];
+    const progress = pathProgress(path, rollups);
+    const badges = badgeStates(path, rollups);
+    const allCourses = [...path.foundations, ...path.courses];
+    const resume = resumeTarget(allCourses, rollups, getLastCourseId());
+    const askResult = askSubmitted
+        ? askMatch(askSubmitted, catalogueData.courses)
+        : null;
+
+    return (
+        <Stack gap="lg" py="lg">
+            <Group justify="space-between" align="flex-end">
+                <Stack gap={4}>
+                    <Title order={2}>Lightdash University</Title>
+                    <Text c="dimmed" maw={560}>
+                        Learn Lightdash inside Lightdash. Every module ends in
+                        your own workspace — with your data, your dashboards,
+                        your models.
+                    </Text>
+                </Stack>
+                <Group gap="xs">
+                    <Button
+                        variant="default"
+                        component="a"
+                        href="https://docs.lightdash.com"
+                        target="_blank"
+                        rel="noreferrer"
+                        rightSection={<MantineIcon icon={IconExternalLink} />}
+                    >
+                        Docs site
+                    </Button>
+                    {resume && (
+                        <Button onClick={() => openCourse(resume.id)}>
+                            Resume module
+                        </Button>
+                    )}
+                </Group>
+            </Group>
+
+            <Group justify="space-between">
+                <SegmentedControl
+                    value={selectedPath}
+                    onChange={(value) => {
+                        localStorage.setItem(PATH_KEY, value);
+                        setSelectedPath(value as PathName);
+                    }}
+                    data={(['analyst', 'builder'] as const).map((name) => {
+                        const p = pathProgress(paths[name], rollups);
+                        return {
+                            value: name,
+                            label: `${PATH_META[name].title} path ${p.completed}/${p.total}`,
+                        };
+                    })}
+                />
+                {!serverSynced && (
+                    <Tooltip label="Progress is saved in this browser only — this instance isn't connected to the Lightdash University progress service.">
+                        <Badge variant="light" color="gray">
+                            Local progress
+                        </Badge>
+                    </Tooltip>
+                )}
+            </Group>
+
+            <Group align="stretch" grow>
+                <Paper withBorder radius="md" p="md">
+                    <Text size="xs" fw={600} tt="uppercase" c={meta.color}>
+                        {meta.title} path
+                    </Text>
+                    <Group gap={6} align="baseline" mt={4}>
+                        <Title order={1}>{progress.completed}</Title>
+                        <Text c="dimmed">
+                            of {progress.total} modules complete
+                        </Text>
+                    </Group>
+                    <Progress
+                        value={progress.pct}
+                        size="sm"
+                        mt="sm"
+                        color={meta.color}
+                    />
+                </Paper>
+                <Paper withBorder radius="md" p="md">
+                    <Text size="xs" fw={600} tt="uppercase" c="dimmed">
+                        {meta.title} badges
+                    </Text>
+                    <Group gap="xs" mt="sm">
+                        {badges.map((b) => (
+                            <Tooltip
+                                key={b.id}
+                                label={
+                                    b.earned
+                                        ? 'Earned'
+                                        : `${b.remaining} more to unlock`
+                                }
+                            >
+                                <Badge
+                                    size="lg"
+                                    variant={b.earned ? 'filled' : 'outline'}
+                                    color={b.earned ? meta.color : 'gray'}
+                                    leftSection={
+                                        <MantineIcon icon={IconSchool} />
+                                    }
+                                >
+                                    {b.name} · {b.threshold}
+                                </Badge>
+                            </Tooltip>
+                        ))}
+                    </Group>
+                </Paper>
+            </Group>
+
+            <Paper withBorder radius="md" p="md">
+                <form
+                    onSubmit={(e) => {
+                        e.preventDefault();
+                        setAskSubmitted(askQuery);
+                    }}
+                >
+                    <Group>
+                        <TextInput
+                            style={{ flex: 1 }}
+                            leftSection={<MantineIcon icon={IconSearch} />}
+                            placeholder='What do you want to learn? e.g. "I need to build a dashboard for my team"'
+                            value={askQuery}
+                            onChange={(e) => setAskQuery(e.currentTarget.value)}
+                        />
+                        <Button type="submit">Ask</Button>
+                    </Group>
+                </form>
+                <Group gap="xs" mt="sm">
+                    {ASK_SUGGESTIONS.map((s) => (
+                        <Badge
+                            key={s}
+                            variant="outline"
+                            color="gray"
+                            style={{ cursor: 'pointer', textTransform: 'none' }}
+                            onClick={() => {
+                                setAskQuery(s);
+                                setAskSubmitted(s);
+                            }}
+                        >
+                            {s}
+                        </Badge>
+                    ))}
+                </Group>
+                {askSubmitted && (
+                    <Text size="sm" mt="sm">
+                        {askResult ? (
+                            <>
+                                Best match:{' '}
+                                <Anchor
+                                    onClick={() => openCourse(askResult.id)}
+                                >
+                                    {askResult.title} →
+                                </Anchor>
+                            </>
+                        ) : (
+                            'No matching course — try different words.'
+                        )}
+                    </Text>
+                )}
+            </Paper>
+
+            <Paper withBorder radius="md">
+                <Group justify="space-between" p="md">
+                    <Group gap="xs">
+                        <Text fw={600}>{meta.title} learning graph</Text>
+                        <Text size="sm" c="dimmed">
+                            {meta.blurb}
+                        </Text>
+                    </Group>
+                    <Group gap="md">
+                        {(
+                            [
+                                ['green', 'Complete'],
+                                ['violet', 'In progress'],
+                                ['gray', 'Not started'],
+                            ] as const
+                        ).map(([color, label]) => (
+                            <Group key={label} gap={6}>
+                                <Badge size="xs" circle color={color} />
+                                <Text size="xs" c="dimmed">
+                                    {label}
+                                </Text>
+                            </Group>
+                        ))}
+                    </Group>
+                </Group>
+                <LearnGraph
+                    path={path}
+                    rollups={rollups}
+                    pathColor={meta.color}
+                    pathTitle={meta.title}
+                    onOpenCourse={openCourse}
+                />
+            </Paper>
+        </Stack>
+    );
+};

--- a/packages/frontend/src/features/learn/components/LearnCoursePlayer.tsx
+++ b/packages/frontend/src/features/learn/components/LearnCoursePlayer.tsx
@@ -1,0 +1,326 @@
+import {
+    HTML_SANITIZE_MARKDOWN_TILE_RULES,
+    sanitizeHtml,
+    type LearnCourse,
+} from '@lightdash/common';
+import {
+    Anchor,
+    Button,
+    Group,
+    Paper,
+    Progress,
+    Radio,
+    Stack,
+    Text,
+    Title,
+} from '@mantine-8/core';
+import { IconArrowLeft } from '@tabler/icons-react';
+import { useEffect, useMemo, useState, type FC } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import MantineIcon from '../../../components/common/MantineIcon';
+import SuboptimalState from '../../../components/common/SuboptimalState/SuboptimalState';
+import {
+    getLessonBookmark,
+    setLastCourseId,
+    setLessonBookmark,
+    useLearnCourse,
+    useLearnRollups,
+    useRecordLearnEvent,
+} from '../hooks';
+import { cardState, emptyRollup } from '../model';
+
+function scoreQuiz(
+    questions: LearnCourse['quiz']['questions'],
+    answers: ReadonlyArray<number | null>,
+): number {
+    const correct = questions.filter((q, i) => answers[i] === q.answer).length;
+    return Math.round((correct / questions.length) * 100);
+}
+
+function lessonHtml(course: LearnCourse, index: number): string {
+    const raw = course.lessons[index].html.replace(
+        /src="assets\//g,
+        `src="${course.assetBaseUrl}/assets/`,
+    );
+    return sanitizeHtml(raw, HTML_SANITIZE_MARKDOWN_TILE_RULES);
+}
+
+export const LearnCoursePlayer: FC = () => {
+    const { projectUuid, courseId } = useParams<{
+        projectUuid: string;
+        courseId: string;
+    }>();
+    const navigate = useNavigate();
+    const course = useLearnCourse(courseId);
+    const { rollups } = useLearnRollups();
+    const { record } = useRecordLearnEvent();
+
+    const rollup = (courseId && rollups.get(courseId)) || emptyRollup();
+    const state = cardState(courseId ? rollups.get(courseId) : undefined);
+
+    // page ∈ [0, lessonCount-1] = lessons; page === lessonCount = quiz.
+    const [page, setPage] = useState<number | null>(null);
+    const [answers, setAnswers] = useState<(number | null)[]>([]);
+    const [quizResult, setQuizResult] = useState<number | null>(null);
+    const [started, setStarted] = useState(false);
+
+    useEffect(() => {
+        if (courseId) setLastCourseId(courseId);
+    }, [courseId]);
+
+    const data = course.data;
+
+    const eventObject = useMemo(
+        () =>
+            data && courseId
+                ? {
+                      course: courseId,
+                      contentHash: data.contentHash,
+                      version: data.version,
+                  }
+                : null,
+        [data, courseId],
+    );
+
+    useEffect(() => {
+        if (!data || page !== null || !courseId) return;
+        const bookmark = getLessonBookmark(courseId);
+        const bookmarkIndex = data.lessons.findIndex((l) => l.id === bookmark);
+        setPage(bookmarkIndex >= 0 ? bookmarkIndex : 0);
+        setAnswers(data.quiz.questions.map(() => null));
+    }, [data, page, courseId]);
+
+    useEffect(() => {
+        if (!data || started || state !== 'open' || !eventObject) return;
+        setStarted(true);
+        record({
+            verb: 'started',
+            object: { type: 'course', ...eventObject },
+        });
+    }, [data, started, state, eventObject, record]);
+
+    if (course.isInitialLoading || (data && page === null)) {
+        return <SuboptimalState title="Loading course…" loading />;
+    }
+    if (course.isError || !data || page === null || !eventObject) {
+        return (
+            <SuboptimalState
+                title="Couldn't load this course"
+                description="It may have been unpublished, or the content service is unreachable."
+            />
+        );
+    }
+
+    const lessonCount = data.lessons.length;
+    const onQuiz = page >= lessonCount;
+    const progressPct = Math.round(((page + 1) / (lessonCount + 1)) * 100);
+
+    const go = (next: number) => {
+        if (next > page && page < lessonCount) {
+            const lesson = data.lessons[page];
+            if (!rollup.lessonsCompleted.has(lesson.id)) {
+                record({
+                    verb: 'completed',
+                    object: {
+                        type: 'lesson',
+                        lesson: lesson.id,
+                        ...eventObject,
+                    },
+                });
+            }
+        }
+        const clamped = Math.max(0, Math.min(lessonCount, next));
+        if (clamped < lessonCount && courseId) {
+            setLessonBookmark(courseId, data.lessons[clamped].id);
+        }
+        setQuizResult(null);
+        setPage(clamped);
+    };
+
+    const submitQuiz = () => {
+        const score = scoreQuiz(data.quiz.questions, answers);
+        const passed = score >= data.passingScore;
+        record({
+            verb: passed ? 'passed' : 'failed',
+            object: { type: 'quiz', ...eventObject },
+            result: { score, passed },
+        });
+        if (passed && !rollup.completed) {
+            record({
+                verb: 'completed',
+                object: { type: 'course', ...eventObject },
+                result: { completion: true },
+            });
+        }
+        setQuizResult(score);
+    };
+
+    return (
+        <Stack gap="md" py="lg" maw={760} mx="auto">
+            <Anchor
+                size="sm"
+                onClick={() => navigate(`/projects/${projectUuid}/learn`)}
+            >
+                <Group gap={4}>
+                    <MantineIcon icon={IconArrowLeft} />
+                    All courses
+                </Group>
+            </Anchor>
+
+            <Paper withBorder radius="md" p="lg">
+                <Stack gap={4}>
+                    <Title order={2}>{data.title}</Title>
+                    <Text size="sm" c="dimmed">
+                        {lessonCount} lessons · {rollup.lessonsCompleted.size}{' '}
+                        of {lessonCount} done
+                        {rollup.passed ? ' · Passed' : ''}
+                    </Text>
+                </Stack>
+            </Paper>
+
+            <Paper withBorder radius="md">
+                <Group justify="space-between" p="md" pb="xs">
+                    <Text fw={600}>{data.title}</Text>
+                    <Text size="sm" c="dimmed">
+                        {onQuiz
+                            ? 'Quiz'
+                            : `Lesson ${page + 1} of ${lessonCount}`}
+                    </Text>
+                </Group>
+                <Progress value={progressPct} size="xs" radius={0} />
+                <Stack p="lg" gap="md">
+                    {!onQuiz && (
+                        <div
+                            // eslint-disable-next-line react/no-danger
+                            dangerouslySetInnerHTML={{
+                                __html: lessonHtml(data, page),
+                            }}
+                            style={{ lineHeight: 1.6 }}
+                        />
+                    )}
+                    {onQuiz && quizResult === null && (
+                        <Stack gap="md">
+                            <Title order={3}>Quiz</Title>
+                            <Text size="sm" c="dimmed">
+                                Answer all questions. Passing score:{' '}
+                                {data.passingScore}%.
+                            </Text>
+                            {data.quiz.questions.map((q, qi) => (
+                                <Radio.Group
+                                    key={q.id}
+                                    label={`${qi + 1}. ${q.prompt}`}
+                                    value={
+                                        answers[qi] === null
+                                            ? null
+                                            : String(answers[qi])
+                                    }
+                                    onChange={(value) =>
+                                        setAnswers((prev) => {
+                                            const next = [...prev];
+                                            next[qi] = Number(value);
+                                            return next;
+                                        })
+                                    }
+                                >
+                                    <Stack gap={6} mt="xs">
+                                        {q.choices.map((choice, ci) => (
+                                            <Radio
+                                                key={choice}
+                                                value={String(ci)}
+                                                label={choice}
+                                            />
+                                        ))}
+                                    </Stack>
+                                </Radio.Group>
+                            ))}
+                            <Button onClick={submitQuiz}>Submit answers</Button>
+                        </Stack>
+                    )}
+                    {onQuiz && quizResult !== null && (
+                        <Stack gap="md">
+                            <Title order={3}>Your result: {quizResult}%</Title>
+                            <Text
+                                c={
+                                    quizResult >= data.passingScore
+                                        ? 'green'
+                                        : 'red'
+                                }
+                            >
+                                {quizResult >= data.passingScore
+                                    ? 'You passed — nice work!'
+                                    : `You need ${data.passingScore}% to pass.`}
+                            </Text>
+                            {data.quiz.questions.map((q, qi) => {
+                                const given = answers[qi];
+                                const correct = given === q.answer;
+                                return (
+                                    <Paper
+                                        key={q.id}
+                                        withBorder
+                                        radius="md"
+                                        p="sm"
+                                        style={{
+                                            borderColor: correct
+                                                ? 'var(--mantine-color-green-4)'
+                                                : 'var(--mantine-color-red-4)',
+                                        }}
+                                    >
+                                        <Text size="sm" fw={600}>
+                                            {qi + 1}. {q.prompt}
+                                        </Text>
+                                        <Text size="sm">
+                                            Your answer:{' '}
+                                            <strong>
+                                                {given === null
+                                                    ? '—'
+                                                    : q.choices[given]}
+                                            </strong>
+                                        </Text>
+                                        {!correct && (
+                                            <Text size="sm">
+                                                Correct answer:{' '}
+                                                <strong>
+                                                    {q.choices[q.answer]}
+                                                </strong>
+                                            </Text>
+                                        )}
+                                    </Paper>
+                                );
+                            })}
+                            {quizResult < data.passingScore && (
+                                <Button
+                                    variant="default"
+                                    onClick={() => {
+                                        setAnswers(
+                                            data.quiz.questions.map(() => null),
+                                        );
+                                        setQuizResult(null);
+                                    }}
+                                >
+                                    Try again
+                                </Button>
+                            )}
+                        </Stack>
+                    )}
+                </Stack>
+                {!onQuiz && (
+                    <Group justify="space-between" p="md" pt={0}>
+                        {page > 0 ? (
+                            <Button
+                                variant="default"
+                                onClick={() => go(page - 1)}
+                            >
+                                Back
+                            </Button>
+                        ) : (
+                            <span />
+                        )}
+                        <Button onClick={() => go(page + 1)}>
+                            {page === lessonCount - 1 ? 'Start quiz' : 'Next'}
+                        </Button>
+                    </Group>
+                )}
+            </Paper>
+        </Stack>
+    );
+};

--- a/packages/frontend/src/features/learn/components/LearnGraph.module.css
+++ b/packages/frontend/src/features/learn/components/LearnGraph.module.css
@@ -1,0 +1,30 @@
+.canvas {
+    position: relative;
+    overflow-x: auto;
+    border-top: 1px solid var(--mantine-color-ldGray-2);
+    background-image: radial-gradient(
+        var(--mantine-color-ldGray-3) 1px,
+        transparent 1px
+    );
+    background-size: 22px 22px;
+}
+
+.node {
+    position: absolute;
+    width: 230px;
+    cursor: pointer;
+    transition: box-shadow 100ms ease;
+}
+
+.node:hover {
+    box-shadow: var(--mantine-shadow-md);
+}
+
+.overline {
+    position: absolute;
+    top: 14px;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}

--- a/packages/frontend/src/features/learn/components/LearnGraph.tsx
+++ b/packages/frontend/src/features/learn/components/LearnGraph.tsx
@@ -1,0 +1,167 @@
+import { Badge, Group, Paper, Progress, Text } from '@mantine-8/core';
+import type { FC } from 'react';
+import {
+    CARD_H,
+    CARD_W,
+    cardState,
+    graphLayout,
+    PAD,
+    type CardState,
+    type PathModel,
+    type Rollup,
+} from '../model';
+import classes from './LearnGraph.module.css';
+
+const EDGE_COLOR: Record<CardState, string> = {
+    done: 'var(--mantine-color-green-5)',
+    current: 'var(--mantine-color-violet-5)',
+    open: 'var(--mantine-color-ldGray-4)',
+};
+
+const STATE_LABEL: Record<CardState, string> = {
+    done: 'Complete',
+    current: 'In progress',
+    open: 'Not started',
+};
+
+const STATE_COLOR: Record<CardState, string> = {
+    done: 'green',
+    current: 'violet',
+    open: 'gray',
+};
+
+type Props = {
+    path: PathModel;
+    rollups: Map<string, Rollup>;
+    pathColor: string;
+    pathTitle: string;
+    onOpenCourse: (courseId: string) => void;
+};
+
+export const LearnGraph: FC<Props> = ({
+    path,
+    rollups,
+    pathColor,
+    pathTitle,
+    onOpenCourse,
+}) => {
+    const layout = graphLayout(path);
+    const nodeById = new Map(layout.nodes.map((n) => [n.entry.id, n]));
+
+    return (
+        <div className={classes.canvas}>
+            <div
+                style={{
+                    position: 'relative',
+                    width: layout.width,
+                    height: layout.height,
+                }}
+            >
+                {path.foundations.length > 0 && (
+                    <Text
+                        className={classes.overline}
+                        style={{ left: PAD }}
+                        c="blue.6"
+                    >
+                        Foundations
+                    </Text>
+                )}
+                {path.courses.length > 0 && (
+                    <Text
+                        className={classes.overline}
+                        style={{ left: layout.pathLeft }}
+                        c={pathColor}
+                    >
+                        {pathTitle} path
+                    </Text>
+                )}
+                <svg
+                    width={layout.width}
+                    height={layout.height}
+                    style={{ position: 'absolute', inset: 0 }}
+                >
+                    {layout.edges.map((edge) => {
+                        const from = nodeById.get(edge.from);
+                        const to = nodeById.get(edge.to);
+                        if (!from || !to) return null;
+                        const state = cardState(rollups.get(edge.to));
+                        const x1 = from.x + CARD_W;
+                        const y1 = from.y + CARD_H / 2;
+                        const x2 = to.x;
+                        const y2 = to.y + CARD_H / 2;
+                        const pull = 0.55 * (x2 - x1);
+                        return (
+                            <path
+                                key={`${edge.from}-${edge.to}`}
+                                d={`M ${x1} ${y1} C ${x1 + pull} ${y1}, ${
+                                    x2 - pull
+                                } ${y2}, ${x2} ${y2}`}
+                                fill="none"
+                                stroke={EDGE_COLOR[state]}
+                                strokeWidth={state === 'open' ? 1.5 : 2}
+                                strokeLinecap="round"
+                            />
+                        );
+                    })}
+                </svg>
+                {layout.nodes.map(({ entry, x, y }) => {
+                    const state = cardState(rollups.get(entry.id));
+                    const rollup = rollups.get(entry.id);
+                    const lessonsDone = rollup?.lessonsCompleted.size ?? 0;
+                    const pct =
+                        state === 'done'
+                            ? 100
+                            : entry.lessonCount === 0
+                              ? 0
+                              : Math.round(
+                                    (lessonsDone / entry.lessonCount) * 100,
+                                );
+                    return (
+                        <Paper
+                            key={entry.id}
+                            className={classes.node}
+                            style={{ left: x, top: y, minHeight: CARD_H }}
+                            withBorder
+                            radius="md"
+                            p="sm"
+                            role="link"
+                            tabIndex={0}
+                            onClick={() => onOpenCourse(entry.id)}
+                            onKeyDown={(e) => {
+                                if (e.key === 'Enter' || e.key === ' ') {
+                                    e.preventDefault();
+                                    onOpenCourse(entry.id);
+                                }
+                            }}
+                        >
+                            <Group justify="space-between" wrap="nowrap" mb={4}>
+                                <Text size="sm" fw={600} lineClamp={2}>
+                                    {entry.title}
+                                </Text>
+                                <Badge
+                                    size="xs"
+                                    variant="light"
+                                    color={STATE_COLOR[state]}
+                                >
+                                    {STATE_LABEL[state]}
+                                </Badge>
+                            </Group>
+                            <Text size="xs" c="dimmed">
+                                {entry.lessonCount} lessons
+                                {entry.durationMinutes !== null
+                                    ? ` · ${entry.durationMinutes} min`
+                                    : ''}
+                            </Text>
+                            <Progress
+                                value={pct}
+                                size="xs"
+                                mt={8}
+                                color={STATE_COLOR[state]}
+                            />
+                        </Paper>
+                    );
+                })}
+            </div>
+        </div>
+    );
+};

--- a/packages/frontend/src/features/learn/hooks.ts
+++ b/packages/frontend/src/features/learn/hooks.ts
@@ -1,0 +1,159 @@
+import {
+    type ApiError,
+    type LearnCatalogue,
+    type LearnCourse,
+    type LearnEventInput,
+    type LearnProgressResults,
+} from '@lightdash/common';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useMemo } from 'react';
+import { lightdashApi } from '../../api';
+import {
+    mergeRollups,
+    rollupFromEvents,
+    rollupFromServer,
+    type Rollup,
+} from './model';
+
+const LOCAL_EVENTS_KEY = 'lightdash.learn.events.v1';
+const LAST_COURSE_KEY = 'lightdash.learn.lastCourse.v1';
+const LOCATION_PREFIX = 'lightdash.learn.location.';
+
+const getLearnCatalogue = async () =>
+    lightdashApi<LearnCatalogue>({
+        url: '/learn/catalogue',
+        method: 'GET',
+        body: undefined,
+    });
+
+const getLearnCourse = async (courseId: string) =>
+    lightdashApi<LearnCourse>({
+        url: `/learn/courses/${encodeURIComponent(courseId)}`,
+        method: 'GET',
+        body: undefined,
+    });
+
+const getLearnProgress = async () =>
+    lightdashApi<LearnProgressResults>({
+        url: '/learn/progress',
+        method: 'GET',
+        body: undefined,
+    });
+
+const postLearnEvents = async (events: LearnEventInput[]) =>
+    lightdashApi<{ accepted: number }>({
+        url: '/learn/events',
+        method: 'POST',
+        body: JSON.stringify(events),
+    });
+
+export const useLearnCatalogue = () =>
+    useQuery<LearnCatalogue, ApiError>({
+        queryKey: ['learn-catalogue'],
+        queryFn: getLearnCatalogue,
+        staleTime: 5 * 60 * 1000,
+        retry: false,
+    });
+
+export const useLearnCourse = (courseId: string | undefined) =>
+    useQuery<LearnCourse, ApiError>({
+        queryKey: ['learn-course', courseId],
+        queryFn: () => getLearnCourse(courseId!),
+        enabled: courseId !== undefined,
+        staleTime: 5 * 60 * 1000,
+        retry: false,
+    });
+
+const useLearnServerProgress = () =>
+    useQuery<LearnProgressResults, ApiError>({
+        queryKey: ['learn-progress'],
+        queryFn: getLearnProgress,
+        retry: false,
+    });
+
+function readLocalEvents(): LearnEventInput[] {
+    const raw = localStorage.getItem(LOCAL_EVENTS_KEY);
+    if (!raw) return [];
+    try {
+        return JSON.parse(raw) as LearnEventInput[];
+    } catch {
+        return [];
+    }
+}
+
+/**
+ * Rollups per course, merging server progress (when the instance syncs) with
+ * locally recorded events (always kept, so an unconfigured instance still has
+ * per-browser progress and a later-configured one back-fills nothing worse
+ * than what the learner already saw).
+ */
+export const useLearnRollups = () => {
+    const serverProgress = useLearnServerProgress();
+    const rollups = useMemo(() => {
+        const map = new Map<string, Rollup>();
+        const local = readLocalEvents();
+        for (const courseId of new Set(local.map((ev) => ev.object.course))) {
+            map.set(courseId, rollupFromEvents(local, courseId));
+        }
+        for (const course of serverProgress.data?.courses ?? []) {
+            const server = rollupFromServer(course);
+            const existing = map.get(course.courseId);
+            map.set(
+                course.courseId,
+                existing ? mergeRollups(server, existing) : server,
+            );
+        }
+        return map;
+    }, [serverProgress.data]);
+    return {
+        rollups,
+        isLoading: serverProgress.isInitialLoading,
+        serverSynced: serverProgress.data?.serverSynced ?? false,
+    };
+};
+
+export const useRecordLearnEvent = () => {
+    const queryClient = useQueryClient();
+    const mutation = useMutation<
+        { accepted: number },
+        ApiError,
+        LearnEventInput[]
+    >({
+        mutationFn: postLearnEvents,
+        onSettled: () => queryClient.invalidateQueries(['learn-progress']),
+    });
+    const { mutate } = mutation;
+    const record = useCallback(
+        (event: Omit<LearnEventInput, 'occurredAt'>) => {
+            const full: LearnEventInput = {
+                ...event,
+                occurredAt: new Date().toISOString(),
+            };
+            // Local copy first: progress must never depend on the network.
+            try {
+                const local = readLocalEvents();
+                local.push(full);
+                localStorage.setItem(LOCAL_EVENTS_KEY, JSON.stringify(local));
+            } catch {
+                // Storage full or unavailable — server sync still applies.
+            }
+            mutate([full]);
+        },
+        [mutate],
+    );
+    return { record, isRecording: mutation.isLoading };
+};
+
+export const getLastCourseId = (): string | null =>
+    localStorage.getItem(LAST_COURSE_KEY);
+
+export const setLastCourseId = (courseId: string): void => {
+    localStorage.setItem(LAST_COURSE_KEY, courseId);
+};
+
+export const getLessonBookmark = (courseId: string): string =>
+    localStorage.getItem(LOCATION_PREFIX + courseId) ?? '';
+
+export const setLessonBookmark = (courseId: string, lessonId: string): void => {
+    localStorage.setItem(LOCATION_PREFIX + courseId, lessonId);
+};

--- a/packages/frontend/src/features/learn/model.test.ts
+++ b/packages/frontend/src/features/learn/model.test.ts
@@ -1,0 +1,185 @@
+import {
+    type LearnCatalogueEntry,
+    type LearnEventInput,
+} from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import {
+    badgeStates,
+    cardState,
+    emptyRollup,
+    mergeRollups,
+    pathProgress,
+    pathsFromCatalogue,
+    rollupFromEvents,
+    rollupFromServer,
+} from './model';
+
+const entry = (
+    overrides: Partial<LearnCatalogueEntry> & { id: string },
+): LearnCatalogueEntry => ({
+    title: overrides.id,
+    description: '',
+    version: 1,
+    contentHash: 'abc123',
+    path: `courses/${overrides.id}/abc123/course.json`,
+    lessonCount: 3,
+    durationMinutes: 20,
+    tags: [],
+    track: null,
+    publishedAt: '2026-08-01T00:00:00.000Z',
+    ...overrides,
+});
+
+const event = (
+    overrides: Partial<LearnEventInput> & {
+        object: LearnEventInput['object'];
+    },
+): LearnEventInput => ({
+    verb: 'started',
+    occurredAt: '2026-08-01T00:00:00.000Z',
+    ...overrides,
+});
+
+describe('rollupFromEvents', () => {
+    it('derives lessons, best score, pass and completion from events', () => {
+        const events: LearnEventInput[] = [
+            event({ object: { type: 'course', course: 'a' } }),
+            event({
+                verb: 'completed',
+                object: { type: 'lesson', course: 'a', lesson: 'l1' },
+            }),
+            event({
+                verb: 'failed',
+                object: { type: 'quiz', course: 'a' },
+                result: { score: 40 },
+            }),
+            event({
+                verb: 'passed',
+                object: { type: 'quiz', course: 'a' },
+                result: { score: 90 },
+            }),
+            // different course — must be ignored
+            event({
+                verb: 'completed',
+                object: { type: 'lesson', course: 'b', lesson: 'x' },
+            }),
+        ];
+        const rollup = rollupFromEvents(events, 'a');
+        expect(rollup.started).toBe(true);
+        expect([...rollup.lessonsCompleted]).toEqual(['l1']);
+        expect(rollup.bestScore).toBe(90);
+        expect(rollup.passed).toBe(true);
+        // quiz pass implies completion
+        expect(rollup.completed).toBe(true);
+    });
+
+    it('returns an empty rollup when no events match the course', () => {
+        expect(rollupFromEvents([], 'a')).toEqual(emptyRollup());
+    });
+});
+
+describe('rollupFromServer / mergeRollups', () => {
+    it('maps server progress rows onto the rollup shape', () => {
+        const rollup = rollupFromServer({
+            courseId: 'a',
+            startedAt: '2026-08-01T00:00:00.000Z',
+            completedAt: null,
+            lessonsCompleted: ['l1', 'l2'],
+            quiz: { bestScore: 70, passed: false, passedAt: null },
+            lastEventAt: '2026-08-01T00:00:00.000Z',
+        });
+        expect(rollup.started).toBe(true);
+        expect(rollup.completed).toBe(false);
+        expect(rollup.bestScore).toBe(70);
+        expect(rollup.lessonsCompleted.size).toBe(2);
+    });
+
+    it('merges local and server rollups by union / max', () => {
+        const local = {
+            ...emptyRollup(),
+            started: true,
+            lessonsCompleted: new Set(['l1']),
+            bestScore: 50,
+        };
+        const server = {
+            ...emptyRollup(),
+            lessonsCompleted: new Set(['l2']),
+            bestScore: 90,
+            passed: true,
+            completed: true,
+        };
+        const merged = mergeRollups(local, server);
+        expect([...merged.lessonsCompleted].sort()).toEqual(['l1', 'l2']);
+        expect(merged.bestScore).toBe(90);
+        expect(merged.passed).toBe(true);
+        expect(cardState(merged)).toBe('done');
+    });
+});
+
+describe('cardState', () => {
+    it('maps rollups to open / current / done', () => {
+        expect(cardState(undefined)).toBe('open');
+        expect(cardState(emptyRollup())).toBe('open');
+        expect(cardState({ ...emptyRollup(), started: true })).toBe('current');
+        expect(cardState({ ...emptyRollup(), completed: true })).toBe('done');
+    });
+});
+
+describe('pathsFromCatalogue / pathProgress / badgeStates', () => {
+    const entries = [
+        entry({ id: 'viewer-fundamentals', track: 'foundations' }),
+        entry({ id: 'exploring-data', track: 'analyst' }),
+        entry({ id: 'ai-agents-essentials', track: 'ai' }),
+        entry({ id: 'metrics-as-code', track: 'builder' }),
+        entry({ id: 'mystery-module', track: null }),
+    ];
+
+    it('groups foundations as shared and folds ai into the analyst path', () => {
+        const { analyst, builder } = pathsFromCatalogue(entries);
+        expect(analyst.foundations.map((e) => e.id)).toEqual([
+            'viewer-fundamentals',
+        ]);
+        expect(analyst.courses.map((e) => e.id)).toEqual([
+            'exploring-data',
+            'ai-agents-essentials',
+        ]);
+        expect(builder.courses.map((e) => e.id)).toEqual(['metrics-as-code']);
+        expect(builder.foundations.map((e) => e.id)).toEqual([
+            'viewer-fundamentals',
+        ]);
+        // unknown tracks are simply not routed into either path in the Learn port
+        expect(
+            [...analyst.courses, ...builder.courses].some(
+                (e) => e.id === 'mystery-module',
+            ),
+        ).toBe(false);
+    });
+
+    it('computes path progress from done courses only', () => {
+        const { analyst } = pathsFromCatalogue(entries);
+        const rollups = new Map([
+            ['viewer-fundamentals', { ...emptyRollup(), completed: true }],
+            ['exploring-data', { ...emptyRollup(), started: true }],
+        ]);
+        const progress = pathProgress(analyst, rollups);
+        expect(progress.total).toBe(3);
+        expect(progress.completed).toBe(1);
+        expect(progress.pct).toBe(33);
+    });
+
+    it('derives badge earned states from completion counts', () => {
+        const { analyst } = pathsFromCatalogue(entries);
+        const none = badgeStates(analyst, new Map());
+        expect(none.every((b) => !b.earned)).toBe(true);
+
+        const all = new Map(
+            [...analyst.foundations, ...analyst.courses].map((e) => [
+                e.id,
+                { ...emptyRollup(), completed: true },
+            ]),
+        );
+        const earned = badgeStates(analyst, all);
+        expect(earned.every((b) => b.earned)).toBe(true);
+        expect(earned.map((b) => b.id)).toContain('first-steps');
+    });
+});

--- a/packages/frontend/src/features/learn/model.ts
+++ b/packages/frontend/src/features/learn/model.ts
@@ -1,0 +1,399 @@
+import type {
+    LearnCatalogueEntry,
+    LearnCourseProgress,
+    LearnEventInput,
+} from '@lightdash/common';
+
+// Pure derivations for the Learn section, ported from the Lightdash
+// University academy so both surfaces order, group and lay out the catalogue
+// identically. No DOM access — everything computes from catalogue entries,
+// rollups and primitives.
+
+export type CardState = 'open' | 'current' | 'done';
+
+export type Rollup = {
+    started: boolean;
+    lessonsCompleted: Set<string>;
+    bestScore: number | null;
+    passed: boolean;
+    completed: boolean;
+};
+
+export function emptyRollup(): Rollup {
+    return {
+        started: false,
+        lessonsCompleted: new Set(),
+        bestScore: null,
+        passed: false,
+        completed: false,
+    };
+}
+
+export function rollupFromEvents(
+    events: LearnEventInput[],
+    courseId: string,
+): Rollup {
+    const rollup = emptyRollup();
+    for (const ev of events) {
+        if (ev.object.course !== courseId) continue;
+        rollup.started = true;
+        if (
+            ev.verb === 'completed' &&
+            ev.object.type === 'lesson' &&
+            ev.object.lesson
+        ) {
+            rollup.lessonsCompleted.add(ev.object.lesson);
+        }
+        if (
+            ev.object.type === 'quiz' &&
+            (ev.verb === 'passed' || ev.verb === 'failed')
+        ) {
+            const score = ev.result?.score;
+            if (
+                typeof score === 'number' &&
+                (rollup.bestScore === null || score > rollup.bestScore)
+            ) {
+                rollup.bestScore = score;
+            }
+            if (ev.verb === 'passed') rollup.passed = true;
+        }
+        if (ev.verb === 'completed' && ev.object.type === 'course') {
+            rollup.completed = true;
+        }
+    }
+    if (rollup.passed) rollup.completed = true;
+    return rollup;
+}
+
+export function rollupFromServer(progress: LearnCourseProgress): Rollup {
+    return {
+        started: progress.startedAt !== null,
+        lessonsCompleted: new Set(progress.lessonsCompleted),
+        bestScore: progress.quiz?.bestScore ?? null,
+        passed: progress.quiz?.passed ?? false,
+        completed:
+            progress.completedAt !== null || (progress.quiz?.passed ?? false),
+    };
+}
+
+export function mergeRollups(a: Rollup, b: Rollup): Rollup {
+    const bestScore =
+        a.bestScore === null
+            ? b.bestScore
+            : b.bestScore === null
+              ? a.bestScore
+              : Math.max(a.bestScore, b.bestScore);
+    return {
+        started: a.started || b.started,
+        lessonsCompleted: new Set([
+            ...a.lessonsCompleted,
+            ...b.lessonsCompleted,
+        ]),
+        bestScore,
+        passed: a.passed || b.passed,
+        completed: a.completed || b.completed,
+    };
+}
+
+export function cardState(rollup: Rollup | undefined): CardState {
+    if (!rollup) return 'open';
+    if (rollup.completed || rollup.passed) return 'done';
+    if (rollup.started) return 'current';
+    return 'open';
+}
+
+export type PathName = 'analyst' | 'builder';
+
+export type PathModel = {
+    name: PathName;
+    foundations: LearnCatalogueEntry[];
+    courses: LearnCatalogueEntry[];
+};
+
+// The catalogue is contractually id-sorted; curriculum order is a rendering
+// concern. Unknown ids append after ranked ones in catalogue order; ai's rank
+// band > analyst's keeps ai course(s) last in the analyst path.
+const CURRICULUM_RANK: Record<string, number> = {
+    'viewer-fundamentals': 0,
+    'metrics-and-dimensions': 1,
+    'semantic-layer-essentials': 2,
+    'exploring-data': 10,
+    'building-charts': 11,
+    'dashboards-and-sharing': 12,
+    'advanced-analysis': 13,
+    'ai-agents-essentials': 20,
+    'metrics-as-code': 30,
+    'advanced-modelling': 31,
+    'governance-and-trust': 32,
+};
+
+function curriculumSort(
+    entries: { entry: LearnCatalogueEntry; index: number }[],
+): LearnCatalogueEntry[] {
+    return entries
+        .slice()
+        .sort((a, b) => {
+            const ra = CURRICULUM_RANK[a.entry.id] ?? 1000 + a.index;
+            const rb = CURRICULUM_RANK[b.entry.id] ?? 1000 + b.index;
+            return ra - rb || a.index - b.index;
+        })
+        .map((e) => e.entry);
+}
+
+export function pathsFromCatalogue(entries: LearnCatalogueEntry[]): {
+    analyst: PathModel;
+    builder: PathModel;
+} {
+    const foundations: { entry: LearnCatalogueEntry; index: number }[] = [];
+    const analyst: { entry: LearnCatalogueEntry; index: number }[] = [];
+    const builder: { entry: LearnCatalogueEntry; index: number }[] = [];
+    entries.forEach((entry, index) => {
+        if (entry.track === 'foundations') foundations.push({ entry, index });
+        else if (entry.track === 'analyst' || entry.track === 'ai') {
+            analyst.push({ entry, index });
+        } else if (entry.track === 'builder') builder.push({ entry, index });
+    });
+    const sharedFoundations = curriculumSort(foundations);
+    return {
+        analyst: {
+            name: 'analyst',
+            foundations: sharedFoundations,
+            courses: curriculumSort(analyst),
+        },
+        builder: {
+            name: 'builder',
+            foundations: sharedFoundations,
+            courses: curriculumSort(builder),
+        },
+    };
+}
+
+export type PathProgress = {
+    completed: number;
+    total: number;
+    pct: number;
+};
+
+export function pathProgress(
+    path: PathModel,
+    rollups: Map<string, Rollup>,
+): PathProgress {
+    const all = [...path.foundations, ...path.courses];
+    const total = all.length;
+    const completed = all.filter(
+        (e) => cardState(rollups.get(e.id)) === 'done',
+    ).length;
+    return {
+        completed,
+        total,
+        pct: total === 0 ? 0 : Math.round((completed / total) * 100),
+    };
+}
+
+export type BadgeState = {
+    id: string;
+    name: string;
+    earned: boolean;
+    threshold: number;
+    remaining: number;
+};
+
+export function badgeStates(
+    path: PathModel,
+    rollups: Map<string, Rollup>,
+): BadgeState[] {
+    const done = (e: LearnCatalogueEntry): boolean =>
+        cardState(rollups.get(e.id)) === 'done';
+    const { completed, total } = pathProgress(path, rollups);
+    const pathTitle = path.name === 'analyst' ? 'Analyst' : 'Builder';
+    const badges: BadgeState[] = [
+        {
+            id: 'first-steps',
+            name: 'First steps',
+            threshold: 1,
+            earned: completed >= 1,
+            remaining: Math.max(0, 1 - completed),
+        },
+    ];
+    if (path.foundations.length > 0) {
+        const foundationsLeft = path.foundations.filter((e) => !done(e)).length;
+        badges.push({
+            id: 'fundamentals',
+            name: 'Fundamentals',
+            threshold: path.foundations.length,
+            earned: foundationsLeft === 0,
+            remaining: foundationsLeft,
+        });
+    }
+    const pathThreshold = Math.round((total * 2) / 3);
+    badges.push({
+        id: 'path',
+        name: pathTitle,
+        threshold: pathThreshold,
+        earned: completed >= pathThreshold,
+        remaining: Math.max(0, pathThreshold - completed),
+    });
+    badges.push({
+        id: 'certified',
+        name: `Certified ${pathTitle}`,
+        threshold: total,
+        earned: completed === total && total > 0,
+        remaining: total - completed,
+    });
+    return badges;
+}
+
+const STOPWORDS = new Set([
+    'a',
+    'an',
+    'the',
+    'i',
+    'my',
+    'do',
+    'how',
+    'for',
+    'to',
+    'in',
+    'of',
+    'and',
+    'need',
+    'want',
+    'with',
+    'make',
+    'give',
+    'better',
+    'more',
+]);
+
+function words(text: string): string[] {
+    return text.toLowerCase().match(/[a-z0-9]+/g) ?? [];
+}
+
+export function askMatch(
+    query: string,
+    entries: LearnCatalogueEntry[],
+): LearnCatalogueEntry | null {
+    const tokens = words(query).filter(
+        (t) => t.length >= 2 && !STOPWORDS.has(t),
+    );
+    if (tokens.length === 0) return null;
+    const hits = (t: string, ws: string[]): boolean =>
+        ws.some((w) => w === t || w.startsWith(t));
+    let best: LearnCatalogueEntry | null = null;
+    let bestScore = 0;
+    for (const entry of entries) {
+        const titleWords = words(entry.title);
+        const tagWords = entry.tags.map(words);
+        const descWords = words(entry.description);
+        let score = 0;
+        for (const t of tokens) {
+            if (hits(t, titleWords)) score += 3;
+            if (tagWords.some((ws) => hits(t, ws))) score += 2;
+            if (hits(t, descWords)) score += 1;
+        }
+        if (score > bestScore) {
+            bestScore = score;
+            best = entry;
+        }
+    }
+    return bestScore > 0 ? best : null;
+}
+
+export function resumeTarget(
+    entries: LearnCatalogueEntry[],
+    rollups: Map<string, Rollup>,
+    lastCourseId: string | null,
+): LearnCatalogueEntry | null {
+    if (lastCourseId) {
+        const last = entries.find((e) => e.id === lastCourseId);
+        if (last && cardState(rollups.get(last.id)) === 'current') return last;
+    }
+    const current = entries.find(
+        (e) => cardState(rollups.get(e.id)) === 'current',
+    );
+    if (current) return current;
+    const hasProgress = entries.some(
+        (e) => cardState(rollups.get(e.id)) !== 'open',
+    );
+    if (!hasProgress) return null;
+    return entries.find((e) => cardState(rollups.get(e.id)) === 'open') ?? null;
+}
+
+// Graph layout: rank-per-column — the root foundation sits alone in column 0,
+// remaining foundations fill the next column(s), then path courses pack up to
+// MAX_ROWS per column, so prerequisite depth reads strictly left → right on a
+// short canvas that scrolls horizontally. Short columns centre vertically.
+export const CARD_W = 230;
+export const CARD_H = 96;
+const ROW_H = 150;
+const COL_PITCH = 300;
+const MAX_ROWS = 3;
+const HEADER_H = 44;
+export const PAD = 24;
+
+export type GraphNode = {
+    entry: LearnCatalogueEntry;
+    x: number;
+    y: number;
+};
+
+export type GraphEdge = {
+    from: string;
+    to: string;
+};
+
+function chunk<T>(items: T[], size: number): T[][] {
+    const out: T[][] = [];
+    for (let i = 0; i < items.length; i += size)
+        out.push(items.slice(i, i + size));
+    return out;
+}
+
+export function graphLayout(path: PathModel): {
+    nodes: GraphNode[];
+    edges: GraphEdge[];
+    width: number;
+    height: number;
+    pathLeft: number;
+} {
+    const F = path.foundations;
+    const P = path.courses;
+    const columns: LearnCatalogueEntry[][] = [];
+    if (F.length > 0) {
+        columns.push([F[0]]);
+        if (F.length > 1) columns.push(...chunk(F.slice(1), MAX_ROWS));
+    }
+    const firstPathCol = columns.length;
+    columns.push(...chunk(P, MAX_ROWS));
+    const rows = Math.max(1, ...columns.map((c) => c.length));
+    const nodes: GraphNode[] = [];
+    columns.forEach((col, c) => {
+        const top = HEADER_H + Math.round(((rows - col.length) * ROW_H) / 2);
+        col.forEach((entry, r) =>
+            nodes.push({ entry, x: PAD + c * COL_PITCH, y: top + r * ROW_H }),
+        );
+    });
+    // Card i in a column hangs off card min(i, last) of the previous column:
+    // every card gets exactly one incoming edge and no edge ever points left.
+    const edges: GraphEdge[] = [];
+    for (let c = 0; c + 1 < columns.length; c += 1) {
+        const a = columns[c];
+        const b = columns[c + 1];
+        b.forEach((entry, i) =>
+            edges.push({
+                from: a[Math.min(i, a.length - 1)].id,
+                to: entry.id,
+            }),
+        );
+    }
+    const cols = Math.max(1, columns.length);
+    const width = PAD + (cols - 1) * COL_PITCH + CARD_W + PAD;
+    const height = HEADER_H + (rows - 1) * ROW_H + CARD_H + PAD;
+    return {
+        nodes,
+        edges,
+        width,
+        height,
+        pathLeft: PAD + firstPathCol * COL_PITCH,
+    };
+}

--- a/packages/frontend/src/pages/Learn.tsx
+++ b/packages/frontend/src/pages/Learn.tsx
@@ -1,0 +1,33 @@
+import { FeatureFlags } from '@lightdash/common';
+import { type FC } from 'react';
+import { Navigate, useParams } from 'react-router';
+import Page from '../components/common/Page/Page';
+import { LearnCataloguePanel } from '../features/learn/components/LearnCataloguePanel';
+import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
+
+const Learn: FC = () => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const learnFlag = useServerFeatureFlag(FeatureFlags.LearnSection);
+
+    if (!projectUuid || learnFlag.isLoading) {
+        return null;
+    }
+
+    if (!learnFlag.data?.enabled) {
+        return <Navigate to={`/projects/${projectUuid}/home`} replace />;
+    }
+
+    return (
+        <Page
+            title="Learn"
+            withCenteredRoot
+            withCenteredContent
+            withXLargePaddedContent
+            withLargeContent
+        >
+            <LearnCataloguePanel />
+        </Page>
+    );
+};
+
+export default Learn;

--- a/packages/frontend/src/pages/LearnCourse.tsx
+++ b/packages/frontend/src/pages/LearnCourse.tsx
@@ -1,0 +1,33 @@
+import { FeatureFlags } from '@lightdash/common';
+import { type FC } from 'react';
+import { Navigate, useParams } from 'react-router';
+import Page from '../components/common/Page/Page';
+import { LearnCoursePlayer } from '../features/learn/components/LearnCoursePlayer';
+import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
+
+const LearnCourse: FC = () => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const learnFlag = useServerFeatureFlag(FeatureFlags.LearnSection);
+
+    if (!projectUuid || learnFlag.isLoading) {
+        return null;
+    }
+
+    if (!learnFlag.data?.enabled) {
+        return <Navigate to={`/projects/${projectUuid}/home`} replace />;
+    }
+
+    return (
+        <Page
+            title="Learn"
+            withCenteredRoot
+            withCenteredContent
+            withXLargePaddedContent
+            withLargeContent
+        >
+            <LearnCoursePlayer />
+        </Page>
+    );
+};
+
+export default LearnCourse;

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -226,6 +226,15 @@ export type DashboardAutoRefreshUpdateEvent = {
     };
 };
 
+type LearnClickedEvent = {
+    name: EventName.LEARN_CLICKED;
+    properties: {
+        userId: string | undefined;
+        organizationId: string | undefined;
+        projectId: string;
+    };
+};
+
 type MetricsCatalogClickedEvent = {
     name: EventName.METRICS_CATALOG_CLICKED;
     properties: {
@@ -839,6 +848,7 @@ export type EventData =
     | ViewUnderlyingDataClickedEvent
     | DrillByClickedEvent
     | DashboardAutoRefreshUpdateEvent
+    | LearnClickedEvent
     | MetricsCatalogClickedEvent
     | MetricsCatalogChartUsageClickedEvent
     | MetricsCatalogExploreClickedEvent

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -64,6 +64,8 @@ export enum PageName {
     METRICS_CATALOG = 'metrics_catalog',
     FUNNEL_BUILDER = 'funnel_builder',
     ROADMAP = 'roadmap',
+    LEARN = 'learn',
+    LEARN_COURSE = 'learn_course',
 }
 
 export enum CategoryName {
@@ -146,6 +148,7 @@ export enum EventName {
     DASHBOARD_AUTO_REFRESH_UPDATED = 'dashboard_auto_refresh.updated',
 
     // Metrics Catalog
+    LEARN_CLICKED = 'learn.clicked',
     METRICS_CATALOG_CLICKED = 'metrics_catalog.clicked',
     METRICS_CATALOG_SEARCH_APPLIED = 'metrics_catalog_search.applied',
     METRICS_CATALOG_CHART_USAGE_CLICKED = 'metrics_catalog_chart_usage.clicked',


### PR DESCRIPTION
## Summary

Native **Learn** section inside the Lightdash app (CS-73): a nav destination where any signed-in user browses the Lightdash University catalogue (paths, learning graph, ask box) and takes courses (lessons + quizzes) without leaving the product. Ships core OSS behind a feature flag (default off).

- **Frontend**: `features/learn/` (catalogue panel, learning graph, course player as Mantine components; pure derivations in `model.ts`), `Learn`/`LearnCourse` pages, responsive nav entry (dedicated link ≥1550px, Browse menu item below).
- **Backend**: `learnController` + `LearnService` — thin proxy so the lu-progress service token stays server-side; learner identity is the session user's email (reuses the trusted-surface auth already live on the progress service). Content comes from the lu-content CDN, so course updates need zero app deploys.
- **Config**: instance-level env for content/progress base URLs + service token; feature flag gates the whole surface, no new permission scope.

Rebased onto current main (previously developed 2026-07; the unrelated roadmap commit from the original branch already landed via #26424 and dropped out). `common`/`backend`/`frontend` typecheck + lint clean; `pnpm generate-api` validated (generated files intentionally not committed).

## Draft because

- **No tests yet** on `LearnService` or `features/learn/model.ts` — both are cheap to cover (thin proxy + pure functions); happy to add before marking ready.
- Rollout notes (cloud flag flip, self-hosted env docs) tracked on the Linear ticket.

Relates: CS-73

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cv7UksPT6jXZz9bwkHao4o