### PR TITLE
feat: Learn section shell — flag-gated nav, route and catalogue browser (CS-73 1/4)

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -135,6 +135,11 @@ export const lightdashConfigMock: LightdashConfig = {
     headway: {
         enabled: false,
     },
+    learn: {
+        contentBaseUrl: 'https://learn-content.test',
+        progressApiUrl: 'https://learn-progress.test',
+        serviceToken: null,
+    },
     lightdashSecret: 'look away this is a secret',
     lightdashSecrets: {
         active: 'look away this is a secret',

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1477,6 +1477,7 @@ export type LightdashConfig = {
     intercom: IntercomConfig;
     pylon: PylonConfig;
     headway: HeadwayConfig;
+    learn: LearnConfig;
     siteUrl: string;
     staticIp: string;
     signupUrl: string | undefined;
@@ -2133,6 +2134,13 @@ type PylonConfig = {
 
 type HeadwayConfig = {
     enabled: boolean;
+};
+
+export type LearnConfig = {
+    contentBaseUrl: string;
+    progressApiUrl: string;
+    /** Server-held bearer for the progress service; null ⇒ progress is client-local only. */
+    serviceToken: string | null;
 };
 
 export type RudderConfig = {
@@ -3052,6 +3060,17 @@ export const parseConfig = (): LightdashConfig => {
         },
         headway: {
             enabled: process.env.HEADWAY_ENABLED !== 'false',
+        },
+        learn: {
+            contentBaseUrl: (
+                process.env.LEARN_CONTENT_BASE_URL ||
+                'https://lu-content.onrender.com'
+            ).replace(/\/$/, ''),
+            progressApiUrl: (
+                process.env.LEARN_PROGRESS_API_URL ||
+                'https://lu-progress.onrender.com'
+            ).replace(/\/$/, ''),
+            serviceToken: process.env.LEARN_SERVICE_TOKEN || null,
         },
         siteUrl,
         helpMenuUrl: process.env.HELP_MENU_URL,

--- a/packages/backend/src/controllers/learnController.ts
+++ b/packages/backend/src/controllers/learnController.ts
@@ -1,0 +1,46 @@
+import {
+    assertRegisteredAccount,
+    type ApiErrorPayload,
+    type ApiLearnCatalogueResponse,
+} from '@lightdash/common';
+import {
+    Get,
+    Hidden,
+    Middlewares,
+    OperationId,
+    Request,
+    Response,
+    Route,
+    SuccessResponse,
+} from '@tsoa/runtime';
+import express from 'express';
+import { allowApiKeyAuthentication, isAuthenticated } from './authentication';
+import { BaseController } from './baseController';
+
+@Route('/api/v1/learn')
+// These endpoints are under development and susceptible to breaking changes.
+// Keep them hidden until the feature is GA.
+@Hidden()
+@Response<ApiErrorPayload>('default', 'Error')
+export class LearnController extends BaseController {
+    /**
+     * Get the Lightdash University course catalogue.
+     * @summary Get the Learn catalogue
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/catalogue')
+    @OperationId('getLearnCatalogue')
+    async getLearnCatalogue(
+        @Request() req: express.Request,
+    ): Promise<ApiLearnCatalogueResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getLearnService()
+                .getCatalogue(req.account),
+        };
+    }
+}

--- a/packages/backend/src/services/LearnService/LearnService.test.ts
+++ b/packages/backend/src/services/LearnService/LearnService.test.ts
@@ -1,0 +1,155 @@
+import {
+    ForbiddenError,
+    UnexpectedServerError,
+    type Account,
+} from '@lightdash/common';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { LightdashConfig } from '../../config/parseConfig';
+import { LearnService } from './LearnService';
+
+const buildAccount = (): Account =>
+    ({
+        authentication: { type: 'session', source: 'session-cookie' },
+        organization: {
+            organizationUuid: 'org-uuid',
+            name: 'Org',
+            createdAt: new Date(),
+        },
+        user: {
+            id: 'user-uuid',
+            userUuid: 'user-uuid',
+            userId: 1,
+            email: 'learner+test@example.com',
+            firstName: 'Test',
+            lastName: 'User',
+            role: 'admin',
+            type: 'registered',
+            isActive: true,
+            isTrackingAnonymized: false,
+            isMarketingOptedIn: false,
+            isSetupComplete: true,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            timezone: null,
+        },
+        isAnonymousUser: () => false,
+        isAuthenticated: () => true,
+        isJwtUser: () => false,
+        isOauthUser: () => false,
+        isPatUser: () => false,
+        isRegisteredUser: () => true,
+        isServiceAccount: () => false,
+        isSessionUser: () => true,
+    }) as Account;
+
+const catalogueEntry = {
+    id: 'viewer-fundamentals',
+    title: 'Viewer Fundamentals',
+    description: 'Learn to view.',
+    version: 1,
+    contentHash: 'abc123def456',
+    path: 'courses/viewer-fundamentals/abc123def456/course.json',
+    lessonCount: 2,
+    durationMinutes: 25,
+    tags: ['viewer'],
+    track: 'foundations',
+    publishedAt: '2026-08-01T00:00:00.000Z',
+};
+
+const cataloguePayload = {
+    generatedAt: '2026-08-01T00:00:00.000Z',
+    courses: [catalogueEntry],
+};
+
+const jsonResponse = (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), { status });
+
+const buildService = ({ flagEnabled = true } = {}) => {
+    const serviceToken = 'service-token-1';
+    const featureFlagService = {
+        get: vi.fn().mockResolvedValue({ enabled: flagEnabled }),
+    };
+    const lightdashConfig = {
+        learn: {
+            contentBaseUrl: 'https://content.test',
+            progressApiUrl: 'https://progress.test',
+            serviceToken,
+        },
+    } as LightdashConfig;
+    return {
+        service: new LearnService({ lightdashConfig, featureFlagService }),
+        featureFlagService,
+    };
+};
+
+describe('LearnService', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    describe('feature flag gate', () => {
+        it('throws ForbiddenError when the Learn flag is off', async () => {
+            const { service } = buildService({ flagEnabled: false });
+            await expect(service.getCatalogue(buildAccount())).rejects.toThrow(
+                ForbiddenError,
+            );
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('getCatalogue', () => {
+        it('returns the parsed catalogue from the content CDN', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(jsonResponse(cataloguePayload));
+            const catalogue = await service.getCatalogue(buildAccount());
+            expect(catalogue.courses).toHaveLength(1);
+            expect(fetchMock).toHaveBeenCalledWith(
+                'https://content.test/catalogue.json',
+                expect.anything(),
+            );
+        });
+
+        it('passes through unknown catalogue fields (forward compatibility)', async () => {
+            const { service } = buildService();
+            const withExtras = {
+                ...cataloguePayload,
+                courses: [
+                    {
+                        ...catalogueEntry,
+                        requires: [{ id: 'ai-copilot' }],
+                        docsUrl: 'https://docs.lightdash.com/x',
+                    },
+                ],
+            };
+            fetchMock.mockResolvedValue(jsonResponse(withExtras));
+            const catalogue = await service.getCatalogue(buildAccount());
+            expect(
+                (catalogue.courses[0] as Record<string, unknown>).docsUrl,
+            ).toBe('https://docs.lightdash.com/x');
+        });
+
+        it('maps upstream failures to UnexpectedServerError', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(jsonResponse({}, 502));
+            await expect(service.getCatalogue(buildAccount())).rejects.toThrow(
+                UnexpectedServerError,
+            );
+        });
+
+        it('maps invalid payloads to UnexpectedServerError', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(jsonResponse({ nope: true }));
+            await expect(service.getCatalogue(buildAccount())).rejects.toThrow(
+                UnexpectedServerError,
+            );
+        });
+    });
+});

--- a/packages/backend/src/services/LearnService/LearnService.ts
+++ b/packages/backend/src/services/LearnService/LearnService.ts
@@ -1,0 +1,93 @@
+import {
+    assertRegisteredAccount,
+    FeatureFlags,
+    ForbiddenError,
+    LearnCatalogueSchema,
+    UnexpectedServerError,
+    type Account,
+    type LearnCatalogue,
+} from '@lightdash/common';
+import type { LightdashConfig } from '../../config/parseConfig';
+import { BaseService } from '../BaseService';
+import type { FeatureFlagService } from '../FeatureFlag/FeatureFlagService';
+
+const LEARN_REQUEST_TIMEOUT_MS = 10_000;
+
+type Dependencies = {
+    lightdashConfig: LightdashConfig;
+    featureFlagService: Pick<FeatureFlagService, 'get'>;
+};
+
+export class LearnService extends BaseService {
+    private readonly lightdashConfig: LightdashConfig;
+
+    private readonly featureFlagService: Pick<FeatureFlagService, 'get'>;
+
+    constructor({ lightdashConfig, featureFlagService }: Dependencies) {
+        super();
+        this.lightdashConfig = lightdashConfig;
+        this.featureFlagService = featureFlagService;
+    }
+
+    private async assertLearnEnabled(account: Account): Promise<void> {
+        assertRegisteredAccount(account);
+        const flag = await this.featureFlagService.get({
+            user: {
+                userUuid: account.user.userUuid,
+                organizationUuid: account.organization?.organizationUuid,
+            },
+            featureFlagId: FeatureFlags.LearnSection,
+        });
+        if (!flag.enabled) {
+            throw new ForbiddenError('Learn is not available');
+        }
+    }
+
+    private async fetchUpstream(
+        url: string,
+        init: RequestInit = {},
+    ): Promise<Response> {
+        try {
+            return await fetch(url, {
+                ...init,
+                signal: AbortSignal.timeout(LEARN_REQUEST_TIMEOUT_MS),
+            });
+        } catch (error) {
+            this.logger.warn('Could not reach the Learn service', {
+                error: error instanceof Error ? error.message : String(error),
+            });
+            throw new UnexpectedServerError('Could not load Learn content');
+        }
+    }
+
+    private static async parseJson(response: Response): Promise<unknown> {
+        try {
+            return await response.json();
+        } catch {
+            throw new UnexpectedServerError('Could not load Learn content');
+        }
+    }
+
+    async getCatalogue(account: Account): Promise<LearnCatalogue> {
+        await this.assertLearnEnabled(account);
+        const response = await this.fetchUpstream(
+            `${this.lightdashConfig.learn.contentBaseUrl}/catalogue.json`,
+        );
+        if (!response.ok) {
+            this.logger.warn('Learn content service returned an error', {
+                statusCode: response.status,
+            });
+            throw new UnexpectedServerError('Could not load Learn content');
+        }
+        const parsed = LearnCatalogueSchema.safeParse(
+            await LearnService.parseJson(response),
+        );
+        if (!parsed.success) {
+            this.logger.warn('Learn catalogue failed validation', {
+                issueCount: parsed.error.issues.length,
+            });
+            throw new UnexpectedServerError('Could not load Learn content');
+        }
+        return parsed.data;
+    }
+}

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -45,6 +45,7 @@ import { GitlabAppService } from './GitlabAppService/GitlabAppService';
 import { GroupsService } from './GroupService';
 import { HeadlessBrowserService } from './HeadlessBrowserService';
 import { HealthService } from './HealthService/HealthService';
+import { LearnService } from './LearnService/LearnService';
 import { LicenseService } from './LicenseService/LicenseService';
 import { LightdashAnalyticsService } from './LightdashAnalyticsService/LightdashAnalyticsService';
 import { LinearAppService } from './LinearAppService/LinearAppService';
@@ -134,6 +135,7 @@ interface ServiceManifest {
     pivotTableService: PivotTableService;
     projectService: ProjectService;
     promptService: PromptService;
+    learnService: LearnService;
     savedChartService: SavedChartService;
     schedulerService: SchedulerService;
     searchService: SearchService;
@@ -1105,6 +1107,17 @@ export class ServiceRepository
                     appGenerateService: this.providers.appGenerateService
                         ? this.getAppGenerateService<AppGenerateService>()
                         : undefined,
+                }),
+        );
+    }
+
+    public getLearnService(): LearnService {
+        return this.getService(
+            'learnService',
+            () =>
+                new LearnService({
+                    lightdashConfig: this.context.lightdashConfig,
+                    featureFlagService: this.getFeatureFlagService(),
                 }),
         );
     }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -322,6 +322,7 @@ export * from './types/queryHistoryList';
 export * from './types/querySources';
 export * from './types/rename';
 export * from './types/resourceViewItem';
+export * from './types/learn';
 export * from './types/results';
 export * from './types/roadmap';
 export * from './types/roles';

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -222,6 +222,7 @@ import type {
     ApiGroupListResponse,
 } from './groups';
 import { type ApiImpersonationOrganizationSettingsResponse } from './impersonationOrganizationSettings';
+import { type ApiLearnCatalogueResponse } from './learn';
 import type { LinearInstallation, LinearProject, LinearTeam } from './linear';
 import {
     type ApiCompiledMergeQueryResults,
@@ -229,7 +230,6 @@ import {
     type MergeQuery,
     type MergeQueryError,
 } from './mergeQuery';
-import { type ApiLearnCatalogueResponse } from './learn';
 import { type MetricQuery, type QueryWarning } from './metricQuery';
 import type {
     ApiMetricsExplorerQueryResults,

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -229,6 +229,7 @@ import {
     type MergeQuery,
     type MergeQueryError,
 } from './mergeQuery';
+import { type ApiLearnCatalogueResponse } from './learn';
 import { type MetricQuery, type QueryWarning } from './metricQuery';
 import type {
     ApiMetricsExplorerQueryResults,
@@ -1305,6 +1306,7 @@ type ApiResults =
     | ApiPaginatedValidateResponse['results']
     | ApiValidationSummaryResponse['results']
     | ApiRoadmapResponse['results']
+    | ApiLearnCatalogueResponse['results']
     | ChartHistory
     | ChartVersion
     | DashboardHistory

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -109,6 +109,12 @@ export enum FeatureFlags {
     ExplorerChartGallery = 'explorer-chart-gallery',
 
     /**
+     * Show the Learn section (in-app Lightdash University training) and
+     * enable its content/progress proxy endpoints. Disabled by default.
+     */
+    LearnSection = 'learn-section',
+
+    /**
      * Per-organization gate for declaring custom npm dependencies in data
      * apps. Disabled by default; self-hosted instances can enable it globally
      * via LIGHTDASH_ENABLE_FEATURE_FLAGS.

--- a/packages/common/src/types/learn.ts
+++ b/packages/common/src/types/learn.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+
+export type LearnCatalogueEntry = {
+    id: string;
+    title: string;
+    description: string;
+    version: number;
+    contentHash: string;
+    path: string;
+    lessonCount: number;
+    durationMinutes: number | null;
+    tags: string[];
+    track: string | null;
+    publishedAt: string;
+};
+
+export type LearnCatalogue = {
+    generatedAt: string;
+    courses: LearnCatalogueEntry[];
+};
+
+export const LearnCatalogueEntrySchema: z.ZodType<LearnCatalogueEntry> = z
+    .object({
+        id: z.string().min(1),
+        title: z.string().min(1),
+        description: z.string(),
+        version: z.number().int(),
+        contentHash: z.string().min(1),
+        path: z.string().min(1),
+        lessonCount: z.number().int(),
+        durationMinutes: z.number().nullable(),
+        tags: z.array(z.string()),
+        track: z.string().nullable(),
+        publishedAt: z.string(),
+    })
+    .passthrough() as unknown as z.ZodType<LearnCatalogueEntry>;
+
+export const LearnCatalogueSchema: z.ZodType<LearnCatalogue> = z
+    .object({
+        generatedAt: z.string(),
+        courses: z.array(LearnCatalogueEntrySchema),
+    })
+    .passthrough() as unknown as z.ZodType<LearnCatalogue>;
+
+export type ApiLearnCatalogueResponse = {
+    status: 'ok';
+    results: LearnCatalogue;
+};

--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -531,6 +531,25 @@ const SPACES_ROUTES: RouteObject[] = [
     },
 ];
 
+const LEARN_ROUTES: RouteObject[] = [
+    {
+        path: 'learn',
+        lazy: async () => {
+            const Learn = await loadLazyRouteDefault(
+                './pages/Learn',
+                () => import('./pages/Learn'),
+            );
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.LEARN}>
+                        <Learn />
+                    </TrackPage>
+                ),
+            };
+        },
+    },
+];
+
 const METRICS_ROUTES: RouteObject[] = [
     {
         path: 'metrics',
@@ -611,6 +630,7 @@ const PROJECT_LAYOUT_ROUTES: RouteObject[] = [
     ...DASHBOARD_LIST_ROUTES,
     ...SPACES_ROUTES,
     ...METRICS_ROUTES,
+    ...LEARN_ROUTES,
     {
         path: 'home',
         lazy: async () => {

--- a/packages/frontend/src/components/NavBar/BrowseMenu.tsx
+++ b/packages/frontend/src/components/NavBar/BrowseMenu.tsx
@@ -40,6 +40,7 @@ import scrollAreaClasses from '../../styles/ScrollArea.module.css';
 import MantineIcon from '../common/MantineIcon';
 import { PolymorphicGroupButton } from '../common/PolymorphicGroupButton';
 import TruncatedText from '../common/TruncatedText';
+import { LearnLink } from './LearnLink';
 import { MetricsLink } from './MetricsLink';
 
 interface Props {
@@ -192,6 +193,8 @@ const BrowseMenu: FC<Props> = ({ projectUuid }) => {
                 {!hasMetrics && (
                     <MetricsLink projectUuid={projectUuid} asMenu />
                 )}
+
+                <LearnLink projectUuid={projectUuid} asMenu />
 
                 {hasFavorites ? (
                     <>

--- a/packages/frontend/src/components/NavBar/LearnLink.module.css
+++ b/packages/frontend/src/components/NavBar/LearnLink.module.css
@@ -1,0 +1,14 @@
+/* The navbar search is absolutely centered from 75em up, so the left button
+   group must not grow past the search's left edge. Below this width the Learn
+   entry lives in the Browse menu instead of the top-level group. */
+.topLevel {
+    @media (max-width: 1550px) {
+        display: none;
+    }
+}
+
+.menuItem {
+    @media (min-width: 1551px) {
+        display: none;
+    }
+}

--- a/packages/frontend/src/components/NavBar/LearnLink.tsx
+++ b/packages/frontend/src/components/NavBar/LearnLink.tsx
@@ -1,0 +1,64 @@
+import { FeatureFlags } from '@lightdash/common';
+import { Button, Menu } from '@mantine-8/core';
+import { IconSchool } from '@tabler/icons-react';
+import { useCallback, type FC } from 'react';
+import { useNavigate } from 'react-router';
+import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
+import useApp from '../../providers/App/useApp';
+import useTracking from '../../providers/Tracking/useTracking';
+import { EventName } from '../../types/Events';
+import MantineIcon from '../common/MantineIcon';
+import classes from './LearnLink.module.css';
+
+interface Props {
+    projectUuid: string;
+    asMenu?: boolean;
+}
+
+export const LearnLink: FC<Props> = ({ projectUuid, asMenu }) => {
+    const { user } = useApp();
+    const navigate = useNavigate();
+    const { track } = useTracking();
+    const learnFlag = useServerFeatureFlag(FeatureFlags.LearnSection);
+
+    const handleLearnClick = useCallback(() => {
+        track({
+            name: EventName.LEARN_CLICKED,
+            properties: {
+                userId: user?.data?.userUuid,
+                organizationId: user?.data?.organizationUuid,
+                projectId: projectUuid,
+            },
+        });
+        void navigate(`/projects/${projectUuid}/learn`);
+    }, [track, user, navigate, projectUuid]);
+
+    if (learnFlag.isLoading || !learnFlag.data?.enabled) {
+        return null;
+    }
+
+    if (asMenu) {
+        return (
+            <Menu.Item
+                className={classes.menuItem}
+                leftSection={<MantineIcon icon={IconSchool} />}
+                onClick={handleLearnClick}
+            >
+                Learn
+            </Menu.Item>
+        );
+    }
+
+    return (
+        <Button
+            className={classes.topLevel}
+            variant="default"
+            size="xs"
+            fz="sm"
+            leftSection={<MantineIcon icon={IconSchool} color="ldGray.6" />}
+            onClick={handleLearnClick}
+        >
+            Learn
+        </Button>
+    );
+};

--- a/packages/frontend/src/components/NavBar/LearnLink.tsx
+++ b/packages/frontend/src/components/NavBar/LearnLink.tsx
@@ -1,5 +1,5 @@
 import { FeatureFlags } from '@lightdash/common';
-import { Button, Menu } from '@mantine-8/core';
+import { Button, Menu } from '@mantine/core';
 import { IconSchool } from '@tabler/icons-react';
 import { useCallback, type FC } from 'react';
 import { useNavigate } from 'react-router';

--- a/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
+++ b/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
@@ -11,6 +11,7 @@ import BrowseMenu from './BrowseMenu';
 import ExploreMenu from './ExploreMenu';
 import HeadwayMenuItem from './HeadwayMenuItem';
 import HelpMenu from './HelpMenu';
+import { LearnLink } from './LearnLink';
 import classes from './MainNavBarContent.module.css';
 import { MetricsLink } from './MetricsLink';
 import { NotificationsMenu } from './NotificationsMenu';
@@ -71,6 +72,7 @@ export const MainNavBarContent: FC<Props> = ({
                             {hasMetrics && (
                                 <MetricsLink projectUuid={activeProjectUuid} />
                             )}
+                            <LearnLink projectUuid={activeProjectUuid} />
                             <Suspense fallback={null}>
                                 <AiAgentsButton
                                     projectUuid={activeProjectUuid}

--- a/packages/frontend/src/features/learn/components/LearnCataloguePanel.tsx
+++ b/packages/frontend/src/features/learn/components/LearnCataloguePanel.tsx
@@ -1,0 +1,259 @@
+import {
+    Anchor,
+    Badge,
+    Button,
+    Group,
+    Paper,
+    Progress,
+    SegmentedControl,
+    Stack,
+    Text,
+    TextInput,
+    Title,
+    Tooltip,
+} from '@mantine-8/core';
+import { IconExternalLink, IconSchool, IconSearch } from '@tabler/icons-react';
+import { useMemo, useState, type FC } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import MantineIcon from '../../../components/common/MantineIcon';
+import SuboptimalState from '../../../components/common/SuboptimalState/SuboptimalState';
+import { getLastCourseId, useLearnCatalogue, useLearnRollups } from '../hooks';
+import {
+    askMatch,
+    badgeStates,
+    pathProgress,
+    pathsFromCatalogue,
+    resumeTarget,
+    type PathName,
+} from '../model';
+
+const PATH_KEY = 'lightdash.learn.path.v1';
+
+const ASK_SUGGESTIONS = [
+    'I need to build a dashboard for my team',
+    'How do I write metrics in dbt?',
+    'Make the AI analyst give better answers',
+];
+
+const PATH_META: Record<
+    PathName,
+    { title: string; color: string; blurb: string }
+> = {
+    analyst: {
+        title: 'Analyst',
+        color: 'violet.6',
+        blurb: 'Explores, charts, dashboards and the AI analyst.',
+    },
+    builder: {
+        title: 'Builder',
+        color: 'teal.6',
+        blurb: 'Metrics as code, modelling and governance.',
+    },
+};
+
+export const LearnCataloguePanel: FC = () => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const navigate = useNavigate();
+    const catalogue = useLearnCatalogue();
+    const { rollups, serverSynced } = useLearnRollups();
+    const [selectedPath, setSelectedPath] = useState<PathName>(() =>
+        localStorage.getItem(PATH_KEY) === 'builder' ? 'builder' : 'analyst',
+    );
+    const [askQuery, setAskQuery] = useState('');
+    const [askSubmitted, setAskSubmitted] = useState<string | null>(null);
+
+    const paths = useMemo(
+        () =>
+            catalogue.data ? pathsFromCatalogue(catalogue.data.courses) : null,
+        [catalogue.data],
+    );
+
+    const openCourse = (courseId: string) =>
+        navigate(
+            `/projects/${projectUuid}/learn/courses/${encodeURIComponent(
+                courseId,
+            )}`,
+        );
+
+    const catalogueData = catalogue.data;
+
+    if (catalogue.isInitialLoading) {
+        return (
+            <SuboptimalState title="Loading Lightdash University…" loading />
+        );
+    }
+    if (catalogue.isError || !paths || !catalogueData) {
+        return (
+            <SuboptimalState
+                title="Couldn't load the course catalogue"
+                description="Learn content is fetched from Lightdash University — check the instance can reach it, then retry."
+            />
+        );
+    }
+
+    const path = paths[selectedPath];
+    const meta = PATH_META[selectedPath];
+    const progress = pathProgress(path, rollups);
+    const badges = badgeStates(path, rollups);
+    const allCourses = [...path.foundations, ...path.courses];
+    const resume = resumeTarget(allCourses, rollups, getLastCourseId());
+    const askResult = askSubmitted
+        ? askMatch(askSubmitted, catalogueData.courses)
+        : null;
+
+    return (
+        <Stack gap="lg" py="lg">
+            <Group justify="space-between" align="flex-end">
+                <Stack gap={4}>
+                    <Title order={2}>Lightdash University</Title>
+                    <Text c="dimmed" maw={560}>
+                        Learn Lightdash inside Lightdash. Every module ends in
+                        your own workspace — with your data, your dashboards,
+                        your models.
+                    </Text>
+                </Stack>
+                <Group gap="xs">
+                    <Button
+                        variant="default"
+                        component="a"
+                        href="https://docs.lightdash.com"
+                        target="_blank"
+                        rel="noreferrer"
+                        rightSection={<MantineIcon icon={IconExternalLink} />}
+                    >
+                        Docs site
+                    </Button>
+                    {resume && (
+                        <Button onClick={() => openCourse(resume.id)}>
+                            Resume module
+                        </Button>
+                    )}
+                </Group>
+            </Group>
+
+            <Group justify="space-between">
+                <SegmentedControl
+                    value={selectedPath}
+                    onChange={(value) => {
+                        localStorage.setItem(PATH_KEY, value);
+                        setSelectedPath(value as PathName);
+                    }}
+                    data={(['analyst', 'builder'] as const).map((name) => {
+                        const p = pathProgress(paths[name], rollups);
+                        return {
+                            value: name,
+                            label: `${PATH_META[name].title} path ${p.completed}/${p.total}`,
+                        };
+                    })}
+                />
+                {!serverSynced && (
+                    <Tooltip label="Progress is saved in this browser only — this instance isn't connected to the Lightdash University progress service.">
+                        <Badge variant="light" color="gray">
+                            Local progress
+                        </Badge>
+                    </Tooltip>
+                )}
+            </Group>
+
+            <Group align="stretch" grow>
+                <Paper withBorder radius="md" p="md">
+                    <Text size="xs" fw={600} tt="uppercase" c={meta.color}>
+                        {meta.title} path
+                    </Text>
+                    <Group gap={6} align="baseline" mt={4}>
+                        <Title order={1}>{progress.completed}</Title>
+                        <Text c="dimmed">
+                            of {progress.total} modules complete
+                        </Text>
+                    </Group>
+                    <Progress
+                        value={progress.pct}
+                        size="sm"
+                        mt="sm"
+                        color={meta.color}
+                    />
+                </Paper>
+                <Paper withBorder radius="md" p="md">
+                    <Text size="xs" fw={600} tt="uppercase" c="dimmed">
+                        {meta.title} badges
+                    </Text>
+                    <Group gap="xs" mt="sm">
+                        {badges.map((b) => (
+                            <Tooltip
+                                key={b.id}
+                                label={
+                                    b.earned
+                                        ? 'Earned'
+                                        : `${b.remaining} more to unlock`
+                                }
+                            >
+                                <Badge
+                                    size="lg"
+                                    variant={b.earned ? 'filled' : 'outline'}
+                                    color={b.earned ? meta.color : 'gray'}
+                                    leftSection={
+                                        <MantineIcon icon={IconSchool} />
+                                    }
+                                >
+                                    {b.name} · {b.threshold}
+                                </Badge>
+                            </Tooltip>
+                        ))}
+                    </Group>
+                </Paper>
+            </Group>
+
+            <Paper withBorder radius="md" p="md">
+                <form
+                    onSubmit={(e) => {
+                        e.preventDefault();
+                        setAskSubmitted(askQuery);
+                    }}
+                >
+                    <Group>
+                        <TextInput
+                            style={{ flex: 1 }}
+                            leftSection={<MantineIcon icon={IconSearch} />}
+                            placeholder='What do you want to learn? e.g. "I need to build a dashboard for my team"'
+                            value={askQuery}
+                            onChange={(e) => setAskQuery(e.currentTarget.value)}
+                        />
+                        <Button type="submit">Ask</Button>
+                    </Group>
+                </form>
+                <Group gap="xs" mt="sm">
+                    {ASK_SUGGESTIONS.map((s) => (
+                        <Badge
+                            key={s}
+                            variant="outline"
+                            color="gray"
+                            style={{ cursor: 'pointer', textTransform: 'none' }}
+                            onClick={() => {
+                                setAskQuery(s);
+                                setAskSubmitted(s);
+                            }}
+                        >
+                            {s}
+                        </Badge>
+                    ))}
+                </Group>
+                {askSubmitted && (
+                    <Text size="sm" mt="sm">
+                        {askResult ? (
+                            <>
+                                Best match:{' '}
+                                <Anchor
+                                    onClick={() => openCourse(askResult.id)}
+                                >
+                                    {askResult.title} →
+                                </Anchor>
+                            </>
+                        ) : (
+                            'No matching course — try different words.'
+                        )}
+                    </Text>
+                )}
+            </Paper>
+        </Stack>
+    );
+};

--- a/packages/frontend/src/features/learn/components/LearnCataloguePanel.tsx
+++ b/packages/frontend/src/features/learn/components/LearnCataloguePanel.tsx
@@ -11,7 +11,7 @@ import {
     TextInput,
     Title,
     Tooltip,
-} from '@mantine-8/core';
+} from '@mantine/core';
 import { IconExternalLink, IconSchool, IconSearch } from '@tabler/icons-react';
 import { useMemo, useState, type FC } from 'react';
 import { useNavigate, useParams } from 'react-router';

--- a/packages/frontend/src/features/learn/hooks.ts
+++ b/packages/frontend/src/features/learn/hooks.ts
@@ -1,0 +1,34 @@
+import { type ApiError, type LearnCatalogue } from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../../api';
+import { type Rollup } from './model';
+
+const LAST_COURSE_KEY = 'lightdash.learn.lastCourse.v1';
+
+const getLearnCatalogue = async () =>
+    lightdashApi<LearnCatalogue>({
+        url: '/learn/catalogue',
+        method: 'GET',
+        body: undefined,
+    });
+
+export const useLearnCatalogue = () =>
+    useQuery<LearnCatalogue, ApiError>({
+        queryKey: ['learn-catalogue'],
+        queryFn: getLearnCatalogue,
+        staleTime: 5 * 60 * 1000,
+        retry: false,
+    });
+
+/**
+ * Rollups per course. Progress arrives with the course-player and
+ * progress-sync slices — until then every course renders as not started.
+ */
+export const useLearnRollups = () => ({
+    rollups: new Map<string, Rollup>(),
+    isLoading: false,
+    serverSynced: false,
+});
+
+export const getLastCourseId = (): string | null =>
+    localStorage.getItem(LAST_COURSE_KEY);

--- a/packages/frontend/src/features/learn/model.test.ts
+++ b/packages/frontend/src/features/learn/model.test.ts
@@ -1,0 +1,93 @@
+import { type LearnCatalogueEntry } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import {
+    badgeStates,
+    cardState,
+    emptyRollup,
+    pathProgress,
+    pathsFromCatalogue,
+} from './model';
+
+const entry = (
+    overrides: Partial<LearnCatalogueEntry> & { id: string },
+): LearnCatalogueEntry => ({
+    title: overrides.id,
+    description: '',
+    version: 1,
+    contentHash: 'abc123',
+    path: `courses/${overrides.id}/abc123/course.json`,
+    lessonCount: 3,
+    durationMinutes: 20,
+    tags: [],
+    track: null,
+    publishedAt: '2026-08-01T00:00:00.000Z',
+    ...overrides,
+});
+
+describe('cardState', () => {
+    it('maps rollups to open / current / done', () => {
+        expect(cardState(undefined)).toBe('open');
+        expect(cardState(emptyRollup())).toBe('open');
+        expect(cardState({ ...emptyRollup(), started: true })).toBe('current');
+        expect(cardState({ ...emptyRollup(), completed: true })).toBe('done');
+    });
+});
+
+describe('pathsFromCatalogue / pathProgress / badgeStates', () => {
+    const entries = [
+        entry({ id: 'viewer-fundamentals', track: 'foundations' }),
+        entry({ id: 'exploring-data', track: 'analyst' }),
+        entry({ id: 'ai-agents-essentials', track: 'ai' }),
+        entry({ id: 'metrics-as-code', track: 'builder' }),
+        entry({ id: 'mystery-module', track: null }),
+    ];
+
+    it('groups foundations as shared and folds ai into the analyst path', () => {
+        const { analyst, builder } = pathsFromCatalogue(entries);
+        expect(analyst.foundations.map((e) => e.id)).toEqual([
+            'viewer-fundamentals',
+        ]);
+        expect(analyst.courses.map((e) => e.id)).toEqual([
+            'exploring-data',
+            'ai-agents-essentials',
+        ]);
+        expect(builder.courses.map((e) => e.id)).toEqual(['metrics-as-code']);
+        expect(builder.foundations.map((e) => e.id)).toEqual([
+            'viewer-fundamentals',
+        ]);
+        // unknown tracks are simply not routed into either path in the Learn port
+        expect(
+            [...analyst.courses, ...builder.courses].some(
+                (e) => e.id === 'mystery-module',
+            ),
+        ).toBe(false);
+    });
+
+    it('computes path progress from done courses only', () => {
+        const { analyst } = pathsFromCatalogue(entries);
+        const rollups = new Map([
+            ['viewer-fundamentals', { ...emptyRollup(), completed: true }],
+            ['exploring-data', { ...emptyRollup(), started: true }],
+        ]);
+        const progress = pathProgress(analyst, rollups);
+        expect(progress.total).toBe(3);
+        expect(progress.completed).toBe(1);
+        expect(progress.pct).toBe(33);
+    });
+
+    it('derives badge earned states from completion counts', () => {
+        const { analyst } = pathsFromCatalogue(entries);
+        const none = badgeStates(analyst, new Map());
+        expect(none.every((b) => !b.earned)).toBe(true);
+
+        const all = new Map(
+            [...analyst.foundations, ...analyst.courses].map((e) => [
+                e.id,
+                { ...emptyRollup(), completed: true },
+            ]),
+        );
+        const earned = badgeStates(analyst, all);
+        expect(earned.every((b) => b.earned)).toBe(true);
+        expect(earned.map((b) => b.id)).toContain('first-steps');
+    });
+});

--- a/packages/frontend/src/features/learn/model.ts
+++ b/packages/frontend/src/features/learn/model.ts
@@ -1,0 +1,250 @@
+import type { LearnCatalogueEntry } from '@lightdash/common';
+
+// Pure derivations for the Learn section, ported from the Lightdash
+// University academy so both surfaces order, group and lay out the catalogue
+// identically. No DOM access — everything computes from catalogue entries,
+// rollups and primitives.
+
+export type CardState = 'open' | 'current' | 'done';
+
+export type Rollup = {
+    started: boolean;
+    lessonsCompleted: Set<string>;
+    bestScore: number | null;
+    passed: boolean;
+    completed: boolean;
+};
+
+export function emptyRollup(): Rollup {
+    return {
+        started: false,
+        lessonsCompleted: new Set(),
+        bestScore: null,
+        passed: false,
+        completed: false,
+    };
+}
+
+export function cardState(rollup: Rollup | undefined): CardState {
+    if (!rollup) return 'open';
+    if (rollup.completed || rollup.passed) return 'done';
+    if (rollup.started) return 'current';
+    return 'open';
+}
+
+export type PathName = 'analyst' | 'builder';
+
+export type PathModel = {
+    name: PathName;
+    foundations: LearnCatalogueEntry[];
+    courses: LearnCatalogueEntry[];
+};
+
+// The catalogue is contractually id-sorted; curriculum order is a rendering
+// concern. Unknown ids append after ranked ones in catalogue order; ai's rank
+// band > analyst's keeps ai course(s) last in the analyst path.
+const CURRICULUM_RANK: Record<string, number> = {
+    'viewer-fundamentals': 0,
+    'metrics-and-dimensions': 1,
+    'semantic-layer-essentials': 2,
+    'exploring-data': 10,
+    'building-charts': 11,
+    'dashboards-and-sharing': 12,
+    'advanced-analysis': 13,
+    'ai-agents-essentials': 20,
+    'metrics-as-code': 30,
+    'advanced-modelling': 31,
+    'governance-and-trust': 32,
+};
+
+function curriculumSort(
+    entries: { entry: LearnCatalogueEntry; index: number }[],
+): LearnCatalogueEntry[] {
+    return entries
+        .slice()
+        .sort((a, b) => {
+            const ra = CURRICULUM_RANK[a.entry.id] ?? 1000 + a.index;
+            const rb = CURRICULUM_RANK[b.entry.id] ?? 1000 + b.index;
+            return ra - rb || a.index - b.index;
+        })
+        .map((e) => e.entry);
+}
+
+export function pathsFromCatalogue(entries: LearnCatalogueEntry[]): {
+    analyst: PathModel;
+    builder: PathModel;
+} {
+    const foundations: { entry: LearnCatalogueEntry; index: number }[] = [];
+    const analyst: { entry: LearnCatalogueEntry; index: number }[] = [];
+    const builder: { entry: LearnCatalogueEntry; index: number }[] = [];
+    entries.forEach((entry, index) => {
+        if (entry.track === 'foundations') foundations.push({ entry, index });
+        else if (entry.track === 'analyst' || entry.track === 'ai') {
+            analyst.push({ entry, index });
+        } else if (entry.track === 'builder') builder.push({ entry, index });
+    });
+    const sharedFoundations = curriculumSort(foundations);
+    return {
+        analyst: {
+            name: 'analyst',
+            foundations: sharedFoundations,
+            courses: curriculumSort(analyst),
+        },
+        builder: {
+            name: 'builder',
+            foundations: sharedFoundations,
+            courses: curriculumSort(builder),
+        },
+    };
+}
+
+export type PathProgress = {
+    completed: number;
+    total: number;
+    pct: number;
+};
+
+export function pathProgress(
+    path: PathModel,
+    rollups: Map<string, Rollup>,
+): PathProgress {
+    const all = [...path.foundations, ...path.courses];
+    const total = all.length;
+    const completed = all.filter(
+        (e) => cardState(rollups.get(e.id)) === 'done',
+    ).length;
+    return {
+        completed,
+        total,
+        pct: total === 0 ? 0 : Math.round((completed / total) * 100),
+    };
+}
+
+export type BadgeState = {
+    id: string;
+    name: string;
+    earned: boolean;
+    threshold: number;
+    remaining: number;
+};
+
+export function badgeStates(
+    path: PathModel,
+    rollups: Map<string, Rollup>,
+): BadgeState[] {
+    const done = (e: LearnCatalogueEntry): boolean =>
+        cardState(rollups.get(e.id)) === 'done';
+    const { completed, total } = pathProgress(path, rollups);
+    const pathTitle = path.name === 'analyst' ? 'Analyst' : 'Builder';
+    const badges: BadgeState[] = [
+        {
+            id: 'first-steps',
+            name: 'First steps',
+            threshold: 1,
+            earned: completed >= 1,
+            remaining: Math.max(0, 1 - completed),
+        },
+    ];
+    if (path.foundations.length > 0) {
+        const foundationsLeft = path.foundations.filter((e) => !done(e)).length;
+        badges.push({
+            id: 'fundamentals',
+            name: 'Fundamentals',
+            threshold: path.foundations.length,
+            earned: foundationsLeft === 0,
+            remaining: foundationsLeft,
+        });
+    }
+    const pathThreshold = Math.round((total * 2) / 3);
+    badges.push({
+        id: 'path',
+        name: pathTitle,
+        threshold: pathThreshold,
+        earned: completed >= pathThreshold,
+        remaining: Math.max(0, pathThreshold - completed),
+    });
+    badges.push({
+        id: 'certified',
+        name: `Certified ${pathTitle}`,
+        threshold: total,
+        earned: completed === total && total > 0,
+        remaining: total - completed,
+    });
+    return badges;
+}
+
+const STOPWORDS = new Set([
+    'a',
+    'an',
+    'the',
+    'i',
+    'my',
+    'do',
+    'how',
+    'for',
+    'to',
+    'in',
+    'of',
+    'and',
+    'need',
+    'want',
+    'with',
+    'make',
+    'give',
+    'better',
+    'more',
+]);
+
+function words(text: string): string[] {
+    return text.toLowerCase().match(/[a-z0-9]+/g) ?? [];
+}
+
+export function askMatch(
+    query: string,
+    entries: LearnCatalogueEntry[],
+): LearnCatalogueEntry | null {
+    const tokens = words(query).filter(
+        (t) => t.length >= 2 && !STOPWORDS.has(t),
+    );
+    if (tokens.length === 0) return null;
+    const hits = (t: string, ws: string[]): boolean =>
+        ws.some((w) => w === t || w.startsWith(t));
+    let best: LearnCatalogueEntry | null = null;
+    let bestScore = 0;
+    for (const entry of entries) {
+        const titleWords = words(entry.title);
+        const tagWords = entry.tags.map(words);
+        const descWords = words(entry.description);
+        let score = 0;
+        for (const t of tokens) {
+            if (hits(t, titleWords)) score += 3;
+            if (tagWords.some((ws) => hits(t, ws))) score += 2;
+            if (hits(t, descWords)) score += 1;
+        }
+        if (score > bestScore) {
+            bestScore = score;
+            best = entry;
+        }
+    }
+    return bestScore > 0 ? best : null;
+}
+
+export function resumeTarget(
+    entries: LearnCatalogueEntry[],
+    rollups: Map<string, Rollup>,
+    lastCourseId: string | null,
+): LearnCatalogueEntry | null {
+    if (lastCourseId) {
+        const last = entries.find((e) => e.id === lastCourseId);
+        if (last && cardState(rollups.get(last.id)) === 'current') return last;
+    }
+    const current = entries.find(
+        (e) => cardState(rollups.get(e.id)) === 'current',
+    );
+    if (current) return current;
+    const hasProgress = entries.some(
+        (e) => cardState(rollups.get(e.id)) !== 'open',
+    );
+    if (!hasProgress) return null;
+    return entries.find((e) => cardState(rollups.get(e.id)) === 'open') ?? null;
+}

--- a/packages/frontend/src/pages/Learn.tsx
+++ b/packages/frontend/src/pages/Learn.tsx
@@ -1,0 +1,33 @@
+import { FeatureFlags } from '@lightdash/common';
+import { type FC } from 'react';
+import { Navigate, useParams } from 'react-router';
+import Page from '../components/common/Page/Page';
+import { LearnCataloguePanel } from '../features/learn/components/LearnCataloguePanel';
+import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
+
+const Learn: FC = () => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const learnFlag = useServerFeatureFlag(FeatureFlags.LearnSection);
+
+    if (!projectUuid || learnFlag.isLoading) {
+        return null;
+    }
+
+    if (!learnFlag.data?.enabled) {
+        return <Navigate to={`/projects/${projectUuid}/home`} replace />;
+    }
+
+    return (
+        <Page
+            title="Learn"
+            withCenteredRoot
+            withCenteredContent
+            withXLargePaddedContent
+            withLargeContent
+        >
+            <LearnCataloguePanel />
+        </Page>
+    );
+};
+
+export default Learn;

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -274,6 +274,15 @@ export type DashboardAutoRefreshUpdateEvent = {
     };
 };
 
+type LearnClickedEvent = {
+    name: EventName.LEARN_CLICKED;
+    properties: {
+        userId: string | undefined;
+        organizationId: string | undefined;
+        projectId: string;
+    };
+};
+
 type MetricsCatalogClickedEvent = {
     name: EventName.METRICS_CATALOG_CLICKED;
     properties: {
@@ -964,6 +973,7 @@ export type EventData =
     | ViewUnderlyingDataClickedEvent
     | DrillByClickedEvent
     | DashboardAutoRefreshUpdateEvent
+    | LearnClickedEvent
     | MetricsCatalogClickedEvent
     | MetricsCatalogChartUsageClickedEvent
     | MetricsCatalogExploreClickedEvent

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -66,6 +66,7 @@ export enum PageName {
     METRICS_CATALOG = 'metrics_catalog',
     FUNNEL_BUILDER = 'funnel_builder',
     ROADMAP = 'roadmap',
+    LEARN = 'learn',
 }
 
 export enum CategoryName {
@@ -156,6 +157,7 @@ export enum EventName {
     DASHBOARD_AUTO_REFRESH_UPDATED = 'dashboard_auto_refresh.updated',
 
     // Metrics Catalog
+    LEARN_CLICKED = 'learn.clicked',
     METRICS_CATALOG_CLICKED = 'metrics_catalog.clicked',
     METRICS_CATALOG_SEARCH_APPLIED = 'metrics_catalog_search.applied',
     METRICS_CATALOG_CHART_USAGE_CLICKED = 'metrics_catalog_chart_usage.clicked',


### PR DESCRIPTION
Bottom of the CS-73 Learn stack (1/4). Flag-gated (`FeatureFlags.LearnSection`, default off) shell: nav entry (dedicated link ≥1550px, Browse menu item below), `/learn` route, and the catalogue browser — paths, progress placeholders, ask box. Backend: `LearnService.getCatalogue` proxying the lu-content CDN with schema validation, `learnController` (hidden route), instance-level `learn` config. Courses are listed but not yet openable (player lands in 3/4; course links 404 behind the flag until then — the flag stays off until the stack completes).

Stack: #26660 → #26661 → #26662 → #26663. Replaces #26659 (unsplit). Top of stack is byte-identical to the reviewed #26659 head.

Relates: CS-73

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cv7UksPT6jXZz9bwkHao4o