### PR TITLE
feat: Learn course player — lessons, quiz and local progress (CS-73 3/4)

### DIFF
--- a/packages/backend/src/controllers/learnController.ts
+++ b/packages/backend/src/controllers/learnController.ts
@@ -2,12 +2,14 @@ import {
     assertRegisteredAccount,
     type ApiErrorPayload,
     type ApiLearnCatalogueResponse,
+    type ApiLearnCourseResponse,
 } from '@lightdash/common';
 import {
     Get,
     Hidden,
     Middlewares,
     OperationId,
+    Path,
     Request,
     Response,
     Route,
@@ -41,6 +43,28 @@ export class LearnController extends BaseController {
             results: await this.services
                 .getLearnService()
                 .getCatalogue(req.account),
+        };
+    }
+
+    /**
+     * Get a published course payload (lessons and quiz) by course id.
+     * @summary Get a Learn course
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/courses/{courseId}')
+    @OperationId('getLearnCourse')
+    async getLearnCourse(
+        @Request() req: express.Request,
+        @Path() courseId: string,
+    ): Promise<ApiLearnCourseResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getLearnService()
+                .getCourse(req.account, courseId),
         };
     }
 }

--- a/packages/backend/src/services/LearnService/LearnService.test.ts
+++ b/packages/backend/src/services/LearnService/LearnService.test.ts
@@ -1,5 +1,6 @@
 import {
     ForbiddenError,
+    NotFoundError,
     UnexpectedServerError,
     type Account,
 } from '@lightdash/common';
@@ -59,6 +60,19 @@ const catalogueEntry = {
 const cataloguePayload = {
     generatedAt: '2026-08-01T00:00:00.000Z',
     courses: [catalogueEntry],
+};
+
+const coursePayload = {
+    id: 'viewer-fundamentals',
+    title: 'Viewer Fundamentals',
+    passingScore: 80,
+    lessons: [{ id: 'l1', title: 'Lesson One', html: '<p>hi</p>' }],
+    quiz: {
+        questions: [{ id: 'q1', prompt: 'Q?', choices: ['a', 'b'], answer: 1 }],
+    },
+    version: 1,
+    contentHash: 'abc123def456',
+    publishedAt: '2026-08-01T00:00:00.000Z',
 };
 
 const jsonResponse = (body: unknown, status = 200) =>
@@ -149,6 +163,35 @@ describe('LearnService', () => {
             fetchMock.mockResolvedValue(jsonResponse({ nope: true }));
             await expect(service.getCatalogue(buildAccount())).rejects.toThrow(
                 UnexpectedServerError,
+            );
+        });
+    });
+
+    describe('getCourse', () => {
+        it('throws NotFoundError for a course missing from the catalogue', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(jsonResponse(cataloguePayload));
+            await expect(
+                service.getCourse(buildAccount(), 'not-a-course'),
+            ).rejects.toThrow(NotFoundError);
+        });
+
+        it('fetches the course payload and derives assetBaseUrl', async () => {
+            const { service } = buildService();
+            fetchMock
+                .mockResolvedValueOnce(jsonResponse(cataloguePayload))
+                .mockResolvedValueOnce(jsonResponse(coursePayload));
+            const course = await service.getCourse(
+                buildAccount(),
+                'viewer-fundamentals',
+            );
+            expect(course.assetBaseUrl).toBe(
+                'https://content.test/courses/viewer-fundamentals/abc123def456',
+            );
+            expect(fetchMock).toHaveBeenNthCalledWith(
+                2,
+                `https://content.test/${catalogueEntry.path}`,
+                expect.anything(),
             );
         });
     });

--- a/packages/backend/src/services/LearnService/LearnService.ts
+++ b/packages/backend/src/services/LearnService/LearnService.ts
@@ -3,9 +3,12 @@ import {
     FeatureFlags,
     ForbiddenError,
     LearnCatalogueSchema,
+    LearnCourseSchema,
+    NotFoundError,
     UnexpectedServerError,
     type Account,
     type LearnCatalogue,
+    type LearnCourse,
 } from '@lightdash/common';
 import type { LightdashConfig } from '../../config/parseConfig';
 import { BaseService } from '../BaseService';
@@ -89,5 +92,36 @@ export class LearnService extends BaseService {
             throw new UnexpectedServerError('Could not load Learn content');
         }
         return parsed.data;
+    }
+
+    async getCourse(account: Account, courseId: string): Promise<LearnCourse> {
+        const catalogue = await this.getCatalogue(account);
+        const entry = catalogue.courses.find((c) => c.id === courseId);
+        if (!entry) {
+            throw new NotFoundError(`Course not found: ${courseId}`);
+        }
+        const { contentBaseUrl } = this.lightdashConfig.learn;
+        const response = await this.fetchUpstream(
+            `${contentBaseUrl}/${entry.path}`,
+        );
+        if (!response.ok) {
+            this.logger.warn('Learn course payload returned an error', {
+                statusCode: response.status,
+            });
+            throw new UnexpectedServerError('Could not load Learn content');
+        }
+        const parsed = LearnCourseSchema.safeParse(
+            await LearnService.parseJson(response),
+        );
+        if (!parsed.success) {
+            this.logger.warn('Learn course failed validation', {
+                issueCount: parsed.error.issues.length,
+            });
+            throw new UnexpectedServerError('Could not load Learn content');
+        }
+        return {
+            ...parsed.data,
+            assetBaseUrl: `${contentBaseUrl}/courses/${entry.id}/${entry.contentHash}`,
+        };
     }
 }

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -222,7 +222,10 @@ import type {
     ApiGroupListResponse,
 } from './groups';
 import { type ApiImpersonationOrganizationSettingsResponse } from './impersonationOrganizationSettings';
-import { type ApiLearnCatalogueResponse } from './learn';
+import {
+    type ApiLearnCatalogueResponse,
+    type ApiLearnCourseResponse,
+} from './learn';
 import type { LinearInstallation, LinearProject, LinearTeam } from './linear';
 import {
     type ApiCompiledMergeQueryResults,
@@ -1307,6 +1310,7 @@ type ApiResults =
     | ApiValidationSummaryResponse['results']
     | ApiRoadmapResponse['results']
     | ApiLearnCatalogueResponse['results']
+    | ApiLearnCourseResponse['results']
     | ChartHistory
     | ChartVersion
     | DashboardHistory

--- a/packages/common/src/types/learn.ts
+++ b/packages/common/src/types/learn.ts
@@ -42,7 +42,102 @@ export const LearnCatalogueSchema: z.ZodType<LearnCatalogue> = z
     })
     .passthrough() as unknown as z.ZodType<LearnCatalogue>;
 
+export type LearnQuizQuestion = {
+    id: string;
+    prompt: string;
+    choices: string[];
+    answer: number;
+};
+
+export type LearnLesson = {
+    id: string;
+    title: string;
+    html: string;
+};
+
+export type LearnCourse = {
+    id: string;
+    title: string;
+    passingScore: number;
+    logo?: string;
+    lessons: LearnLesson[];
+    quiz: { questions: LearnQuizQuestion[] };
+    version: number;
+    contentHash: string;
+    publishedAt: string;
+    /** Absolute base URL lesson-relative `assets/…` refs resolve against. */
+    assetBaseUrl: string;
+};
+
+export const LearnCourseSchema = z
+    .object({
+        id: z.string().min(1),
+        title: z.string().min(1),
+        passingScore: z.number(),
+        logo: z.string().optional(),
+        lessons: z.array(
+            z
+                .object({
+                    id: z.string().min(1),
+                    title: z.string().min(1),
+                    html: z.string(),
+                })
+                .passthrough(),
+        ),
+        quiz: z
+            .object({
+                questions: z.array(
+                    z
+                        .object({
+                            id: z.string().min(1),
+                            prompt: z.string(),
+                            choices: z.array(z.string()),
+                            answer: z.number().int(),
+                        })
+                        .passthrough(),
+                ),
+            })
+            .passthrough(),
+        version: z.number().int(),
+        contentHash: z.string().min(1),
+        publishedAt: z.string(),
+    })
+    .passthrough();
+
+export type LearnEventVerb =
+    | 'started'
+    | 'progressed'
+    | 'completed'
+    | 'passed'
+    | 'failed';
+
+/**
+ * A learning event as written by the Learn section. `source` is pinned
+ * server-side to 'learn' — the client never chooses the surface.
+ */
+export type LearnEventInput = {
+    verb: LearnEventVerb;
+    object: {
+        type: 'course' | 'lesson' | 'quiz';
+        course: string;
+        lesson?: string;
+        contentHash?: string;
+        version?: number;
+    };
+    result?: {
+        score?: number;
+        passed?: boolean;
+        completion?: boolean;
+    };
+    occurredAt: string;
+};
+
 export type ApiLearnCatalogueResponse = {
     status: 'ok';
     results: LearnCatalogue;
+};
+
+export type ApiLearnCourseResponse = {
+    status: 'ok';
+    results: LearnCourse;
 };

--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -548,6 +548,22 @@ const LEARN_ROUTES: RouteObject[] = [
             };
         },
     },
+    {
+        path: 'learn/courses/:courseId',
+        lazy: async () => {
+            const LearnCourse = await loadLazyRouteDefault(
+                './pages/LearnCourse',
+                () => import('./pages/LearnCourse'),
+            );
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.LEARN_COURSE}>
+                        <LearnCourse />
+                    </TrackPage>
+                ),
+            };
+        },
+    },
 ];
 
 const METRICS_ROUTES: RouteObject[] = [

--- a/packages/frontend/src/features/learn/components/LearnCoursePlayer.tsx
+++ b/packages/frontend/src/features/learn/components/LearnCoursePlayer.tsx
@@ -1,0 +1,326 @@
+import {
+    HTML_SANITIZE_MARKDOWN_TILE_RULES,
+    sanitizeHtml,
+    type LearnCourse,
+} from '@lightdash/common';
+import {
+    Anchor,
+    Button,
+    Group,
+    Paper,
+    Progress,
+    Radio,
+    Stack,
+    Text,
+    Title,
+} from '@mantine-8/core';
+import { IconArrowLeft } from '@tabler/icons-react';
+import { useEffect, useMemo, useState, type FC } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import MantineIcon from '../../../components/common/MantineIcon';
+import SuboptimalState from '../../../components/common/SuboptimalState/SuboptimalState';
+import {
+    getLessonBookmark,
+    setLastCourseId,
+    setLessonBookmark,
+    useLearnCourse,
+    useLearnRollups,
+    useRecordLearnEvent,
+} from '../hooks';
+import { cardState, emptyRollup } from '../model';
+
+function scoreQuiz(
+    questions: LearnCourse['quiz']['questions'],
+    answers: ReadonlyArray<number | null>,
+): number {
+    const correct = questions.filter((q, i) => answers[i] === q.answer).length;
+    return Math.round((correct / questions.length) * 100);
+}
+
+function lessonHtml(course: LearnCourse, index: number): string {
+    const raw = course.lessons[index].html.replace(
+        /src="assets\//g,
+        `src="${course.assetBaseUrl}/assets/`,
+    );
+    return sanitizeHtml(raw, HTML_SANITIZE_MARKDOWN_TILE_RULES);
+}
+
+export const LearnCoursePlayer: FC = () => {
+    const { projectUuid, courseId } = useParams<{
+        projectUuid: string;
+        courseId: string;
+    }>();
+    const navigate = useNavigate();
+    const course = useLearnCourse(courseId);
+    const { rollups } = useLearnRollups();
+    const { record } = useRecordLearnEvent();
+
+    const rollup = (courseId && rollups.get(courseId)) || emptyRollup();
+    const state = cardState(courseId ? rollups.get(courseId) : undefined);
+
+    // page ∈ [0, lessonCount-1] = lessons; page === lessonCount = quiz.
+    const [page, setPage] = useState<number | null>(null);
+    const [answers, setAnswers] = useState<(number | null)[]>([]);
+    const [quizResult, setQuizResult] = useState<number | null>(null);
+    const [started, setStarted] = useState(false);
+
+    useEffect(() => {
+        if (courseId) setLastCourseId(courseId);
+    }, [courseId]);
+
+    const data = course.data;
+
+    const eventObject = useMemo(
+        () =>
+            data && courseId
+                ? {
+                      course: courseId,
+                      contentHash: data.contentHash,
+                      version: data.version,
+                  }
+                : null,
+        [data, courseId],
+    );
+
+    useEffect(() => {
+        if (!data || page !== null || !courseId) return;
+        const bookmark = getLessonBookmark(courseId);
+        const bookmarkIndex = data.lessons.findIndex((l) => l.id === bookmark);
+        setPage(bookmarkIndex >= 0 ? bookmarkIndex : 0);
+        setAnswers(data.quiz.questions.map(() => null));
+    }, [data, page, courseId]);
+
+    useEffect(() => {
+        if (!data || started || state !== 'open' || !eventObject) return;
+        setStarted(true);
+        record({
+            verb: 'started',
+            object: { type: 'course', ...eventObject },
+        });
+    }, [data, started, state, eventObject, record]);
+
+    if (course.isInitialLoading || (data && page === null)) {
+        return <SuboptimalState title="Loading course…" loading />;
+    }
+    if (course.isError || !data || page === null || !eventObject) {
+        return (
+            <SuboptimalState
+                title="Couldn't load this course"
+                description="It may have been unpublished, or the content service is unreachable."
+            />
+        );
+    }
+
+    const lessonCount = data.lessons.length;
+    const onQuiz = page >= lessonCount;
+    const progressPct = Math.round(((page + 1) / (lessonCount + 1)) * 100);
+
+    const go = (next: number) => {
+        if (next > page && page < lessonCount) {
+            const lesson = data.lessons[page];
+            if (!rollup.lessonsCompleted.has(lesson.id)) {
+                record({
+                    verb: 'completed',
+                    object: {
+                        type: 'lesson',
+                        lesson: lesson.id,
+                        ...eventObject,
+                    },
+                });
+            }
+        }
+        const clamped = Math.max(0, Math.min(lessonCount, next));
+        if (clamped < lessonCount && courseId) {
+            setLessonBookmark(courseId, data.lessons[clamped].id);
+        }
+        setQuizResult(null);
+        setPage(clamped);
+    };
+
+    const submitQuiz = () => {
+        const score = scoreQuiz(data.quiz.questions, answers);
+        const passed = score >= data.passingScore;
+        record({
+            verb: passed ? 'passed' : 'failed',
+            object: { type: 'quiz', ...eventObject },
+            result: { score, passed },
+        });
+        if (passed && !rollup.completed) {
+            record({
+                verb: 'completed',
+                object: { type: 'course', ...eventObject },
+                result: { completion: true },
+            });
+        }
+        setQuizResult(score);
+    };
+
+    return (
+        <Stack gap="md" py="lg" maw={760} mx="auto">
+            <Anchor
+                size="sm"
+                onClick={() => navigate(`/projects/${projectUuid}/learn`)}
+            >
+                <Group gap={4}>
+                    <MantineIcon icon={IconArrowLeft} />
+                    All courses
+                </Group>
+            </Anchor>
+
+            <Paper withBorder radius="md" p="lg">
+                <Stack gap={4}>
+                    <Title order={2}>{data.title}</Title>
+                    <Text size="sm" c="dimmed">
+                        {lessonCount} lessons · {rollup.lessonsCompleted.size}{' '}
+                        of {lessonCount} done
+                        {rollup.passed ? ' · Passed' : ''}
+                    </Text>
+                </Stack>
+            </Paper>
+
+            <Paper withBorder radius="md">
+                <Group justify="space-between" p="md" pb="xs">
+                    <Text fw={600}>{data.title}</Text>
+                    <Text size="sm" c="dimmed">
+                        {onQuiz
+                            ? 'Quiz'
+                            : `Lesson ${page + 1} of ${lessonCount}`}
+                    </Text>
+                </Group>
+                <Progress value={progressPct} size="xs" radius={0} />
+                <Stack p="lg" gap="md">
+                    {!onQuiz && (
+                        <div
+                            // eslint-disable-next-line react/no-danger
+                            dangerouslySetInnerHTML={{
+                                __html: lessonHtml(data, page),
+                            }}
+                            style={{ lineHeight: 1.6 }}
+                        />
+                    )}
+                    {onQuiz && quizResult === null && (
+                        <Stack gap="md">
+                            <Title order={3}>Quiz</Title>
+                            <Text size="sm" c="dimmed">
+                                Answer all questions. Passing score:{' '}
+                                {data.passingScore}%.
+                            </Text>
+                            {data.quiz.questions.map((q, qi) => (
+                                <Radio.Group
+                                    key={q.id}
+                                    label={`${qi + 1}. ${q.prompt}`}
+                                    value={
+                                        answers[qi] === null
+                                            ? null
+                                            : String(answers[qi])
+                                    }
+                                    onChange={(value) =>
+                                        setAnswers((prev) => {
+                                            const next = [...prev];
+                                            next[qi] = Number(value);
+                                            return next;
+                                        })
+                                    }
+                                >
+                                    <Stack gap={6} mt="xs">
+                                        {q.choices.map((choice, ci) => (
+                                            <Radio
+                                                key={choice}
+                                                value={String(ci)}
+                                                label={choice}
+                                            />
+                                        ))}
+                                    </Stack>
+                                </Radio.Group>
+                            ))}
+                            <Button onClick={submitQuiz}>Submit answers</Button>
+                        </Stack>
+                    )}
+                    {onQuiz && quizResult !== null && (
+                        <Stack gap="md">
+                            <Title order={3}>Your result: {quizResult}%</Title>
+                            <Text
+                                c={
+                                    quizResult >= data.passingScore
+                                        ? 'green'
+                                        : 'red'
+                                }
+                            >
+                                {quizResult >= data.passingScore
+                                    ? 'You passed — nice work!'
+                                    : `You need ${data.passingScore}% to pass.`}
+                            </Text>
+                            {data.quiz.questions.map((q, qi) => {
+                                const given = answers[qi];
+                                const correct = given === q.answer;
+                                return (
+                                    <Paper
+                                        key={q.id}
+                                        withBorder
+                                        radius="md"
+                                        p="sm"
+                                        style={{
+                                            borderColor: correct
+                                                ? 'var(--mantine-color-green-4)'
+                                                : 'var(--mantine-color-red-4)',
+                                        }}
+                                    >
+                                        <Text size="sm" fw={600}>
+                                            {qi + 1}. {q.prompt}
+                                        </Text>
+                                        <Text size="sm">
+                                            Your answer:{' '}
+                                            <strong>
+                                                {given === null
+                                                    ? '—'
+                                                    : q.choices[given]}
+                                            </strong>
+                                        </Text>
+                                        {!correct && (
+                                            <Text size="sm">
+                                                Correct answer:{' '}
+                                                <strong>
+                                                    {q.choices[q.answer]}
+                                                </strong>
+                                            </Text>
+                                        )}
+                                    </Paper>
+                                );
+                            })}
+                            {quizResult < data.passingScore && (
+                                <Button
+                                    variant="default"
+                                    onClick={() => {
+                                        setAnswers(
+                                            data.quiz.questions.map(() => null),
+                                        );
+                                        setQuizResult(null);
+                                    }}
+                                >
+                                    Try again
+                                </Button>
+                            )}
+                        </Stack>
+                    )}
+                </Stack>
+                {!onQuiz && (
+                    <Group justify="space-between" p="md" pt={0}>
+                        {page > 0 ? (
+                            <Button
+                                variant="default"
+                                onClick={() => go(page - 1)}
+                            >
+                                Back
+                            </Button>
+                        ) : (
+                            <span />
+                        )}
+                        <Button onClick={() => go(page + 1)}>
+                            {page === lessonCount - 1 ? 'Start quiz' : 'Next'}
+                        </Button>
+                    </Group>
+                )}
+            </Paper>
+        </Stack>
+    );
+};

--- a/packages/frontend/src/features/learn/components/LearnCoursePlayer.tsx
+++ b/packages/frontend/src/features/learn/components/LearnCoursePlayer.tsx
@@ -13,7 +13,7 @@ import {
     Stack,
     Text,
     Title,
-} from '@mantine-8/core';
+} from '@mantine/core';
 import { IconArrowLeft } from '@tabler/icons-react';
 import { useEffect, useMemo, useState, type FC } from 'react';
 import { useNavigate, useParams } from 'react-router';

--- a/packages/frontend/src/features/learn/hooks.ts
+++ b/packages/frontend/src/features/learn/hooks.ts
@@ -1,13 +1,28 @@
-import { type ApiError, type LearnCatalogue } from '@lightdash/common';
+import {
+    type ApiError,
+    type LearnCatalogue,
+    type LearnCourse,
+    type LearnEventInput,
+} from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
+import { useCallback, useState } from 'react';
 import { lightdashApi } from '../../api';
-import { type Rollup } from './model';
+import { rollupFromEvents, type Rollup } from './model';
 
+const LOCAL_EVENTS_KEY = 'lightdash.learn.events.v1';
 const LAST_COURSE_KEY = 'lightdash.learn.lastCourse.v1';
+const LOCATION_PREFIX = 'lightdash.learn.location.';
 
 const getLearnCatalogue = async () =>
     lightdashApi<LearnCatalogue>({
         url: '/learn/catalogue',
+        method: 'GET',
+        body: undefined,
+    });
+
+const getLearnCourse = async (courseId: string) =>
+    lightdashApi<LearnCourse>({
+        url: `/learn/courses/${encodeURIComponent(courseId)}`,
         method: 'GET',
         body: undefined,
     });
@@ -20,15 +35,72 @@ export const useLearnCatalogue = () =>
         retry: false,
     });
 
+export const useLearnCourse = (courseId: string | undefined) =>
+    useQuery<LearnCourse, ApiError>({
+        queryKey: ['learn-course', courseId],
+        queryFn: () => getLearnCourse(courseId!),
+        enabled: courseId !== undefined,
+        staleTime: 5 * 60 * 1000,
+        retry: false,
+    });
+
+function readLocalEvents(): LearnEventInput[] {
+    const raw = localStorage.getItem(LOCAL_EVENTS_KEY);
+    if (!raw) return [];
+    try {
+        return JSON.parse(raw) as LearnEventInput[];
+    } catch {
+        return [];
+    }
+}
+
 /**
- * Rollups per course. Progress arrives with the course-player and
- * progress-sync slices — until then every course renders as not started.
+ * Rollups per course from locally recorded events. Server-synced progress
+ * arrives with the progress-sync slice — local events are always kept, so an
+ * unconfigured instance still has per-browser progress.
  */
-export const useLearnRollups = () => ({
-    rollups: new Map<string, Rollup>(),
-    isLoading: false,
-    serverSynced: false,
-});
+export const useLearnRollups = () => {
+    // Computed once per mount; the progress-sync slice makes this live-update
+    // by keying recomputation off the server progress query.
+    const [rollups] = useState(() => {
+        const map = new Map<string, Rollup>();
+        const local = readLocalEvents();
+        for (const courseId of new Set(local.map((ev) => ev.object.course))) {
+            map.set(courseId, rollupFromEvents(local, courseId));
+        }
+        return map;
+    });
+    return { rollups, isLoading: false, serverSynced: false };
+};
+
+export const useRecordLearnEvent = () => {
+    const record = useCallback((event: Omit<LearnEventInput, 'occurredAt'>) => {
+        const full: LearnEventInput = {
+            ...event,
+            occurredAt: new Date().toISOString(),
+        };
+        // Local copy: progress must never depend on the network.
+        try {
+            const local = readLocalEvents();
+            local.push(full);
+            localStorage.setItem(LOCAL_EVENTS_KEY, JSON.stringify(local));
+        } catch {
+            // Storage full or unavailable — nothing else to do locally.
+        }
+    }, []);
+    return { record, isRecording: false };
+};
 
 export const getLastCourseId = (): string | null =>
     localStorage.getItem(LAST_COURSE_KEY);
+
+export const setLastCourseId = (courseId: string): void => {
+    localStorage.setItem(LAST_COURSE_KEY, courseId);
+};
+
+export const getLessonBookmark = (courseId: string): string =>
+    localStorage.getItem(LOCATION_PREFIX + courseId) ?? '';
+
+export const setLessonBookmark = (courseId: string, lessonId: string): void => {
+    localStorage.setItem(LOCATION_PREFIX + courseId, lessonId);
+};

--- a/packages/frontend/src/features/learn/model.test.ts
+++ b/packages/frontend/src/features/learn/model.test.ts
@@ -1,4 +1,7 @@
-import { type LearnCatalogueEntry } from '@lightdash/common';
+import {
+    type LearnCatalogueEntry,
+    type LearnEventInput,
+} from '@lightdash/common';
 import { describe, expect, it } from 'vitest';
 import {
     badgeStates,
@@ -6,6 +9,7 @@ import {
     emptyRollup,
     pathProgress,
     pathsFromCatalogue,
+    rollupFromEvents,
 } from './model';
 
 const entry = (
@@ -22,6 +26,54 @@ const entry = (
     track: null,
     publishedAt: '2026-08-01T00:00:00.000Z',
     ...overrides,
+});
+
+const event = (
+    overrides: Partial<LearnEventInput> & {
+        object: LearnEventInput['object'];
+    },
+): LearnEventInput => ({
+    verb: 'started',
+    occurredAt: '2026-08-01T00:00:00.000Z',
+    ...overrides,
+});
+
+describe('rollupFromEvents', () => {
+    it('derives lessons, best score, pass and completion from events', () => {
+        const events: LearnEventInput[] = [
+            event({ object: { type: 'course', course: 'a' } }),
+            event({
+                verb: 'completed',
+                object: { type: 'lesson', course: 'a', lesson: 'l1' },
+            }),
+            event({
+                verb: 'failed',
+                object: { type: 'quiz', course: 'a' },
+                result: { score: 40 },
+            }),
+            event({
+                verb: 'passed',
+                object: { type: 'quiz', course: 'a' },
+                result: { score: 90 },
+            }),
+            // different course — must be ignored
+            event({
+                verb: 'completed',
+                object: { type: 'lesson', course: 'b', lesson: 'x' },
+            }),
+        ];
+        const rollup = rollupFromEvents(events, 'a');
+        expect(rollup.started).toBe(true);
+        expect([...rollup.lessonsCompleted]).toEqual(['l1']);
+        expect(rollup.bestScore).toBe(90);
+        expect(rollup.passed).toBe(true);
+        // quiz pass implies completion
+        expect(rollup.completed).toBe(true);
+    });
+
+    it('returns an empty rollup when no events match the course', () => {
+        expect(rollupFromEvents([], 'a')).toEqual(emptyRollup());
+    });
 });
 
 describe('cardState', () => {

--- a/packages/frontend/src/features/learn/model.ts
+++ b/packages/frontend/src/features/learn/model.ts
@@ -1,4 +1,4 @@
-import type { LearnCatalogueEntry } from '@lightdash/common';
+import type { LearnCatalogueEntry, LearnEventInput } from '@lightdash/common';
 
 // Pure derivations for the Learn section, ported from the Lightdash
 // University academy so both surfaces order, group and lay out the catalogue
@@ -23,6 +23,42 @@ export function emptyRollup(): Rollup {
         passed: false,
         completed: false,
     };
+}
+
+export function rollupFromEvents(
+    events: LearnEventInput[],
+    courseId: string,
+): Rollup {
+    const rollup = emptyRollup();
+    for (const ev of events) {
+        if (ev.object.course !== courseId) continue;
+        rollup.started = true;
+        if (
+            ev.verb === 'completed' &&
+            ev.object.type === 'lesson' &&
+            ev.object.lesson
+        ) {
+            rollup.lessonsCompleted.add(ev.object.lesson);
+        }
+        if (
+            ev.object.type === 'quiz' &&
+            (ev.verb === 'passed' || ev.verb === 'failed')
+        ) {
+            const score = ev.result?.score;
+            if (
+                typeof score === 'number' &&
+                (rollup.bestScore === null || score > rollup.bestScore)
+            ) {
+                rollup.bestScore = score;
+            }
+            if (ev.verb === 'passed') rollup.passed = true;
+        }
+        if (ev.verb === 'completed' && ev.object.type === 'course') {
+            rollup.completed = true;
+        }
+    }
+    if (rollup.passed) rollup.completed = true;
+    return rollup;
 }
 
 export function cardState(rollup: Rollup | undefined): CardState {

--- a/packages/frontend/src/pages/LearnCourse.tsx
+++ b/packages/frontend/src/pages/LearnCourse.tsx
@@ -1,0 +1,33 @@
+import { FeatureFlags } from '@lightdash/common';
+import { type FC } from 'react';
+import { Navigate, useParams } from 'react-router';
+import Page from '../components/common/Page/Page';
+import { LearnCoursePlayer } from '../features/learn/components/LearnCoursePlayer';
+import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
+
+const LearnCourse: FC = () => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const learnFlag = useServerFeatureFlag(FeatureFlags.LearnSection);
+
+    if (!projectUuid || learnFlag.isLoading) {
+        return null;
+    }
+
+    if (!learnFlag.data?.enabled) {
+        return <Navigate to={`/projects/${projectUuid}/home`} replace />;
+    }
+
+    return (
+        <Page
+            title="Learn"
+            withCenteredRoot
+            withCenteredContent
+            withXLargePaddedContent
+            withLargeContent
+        >
+            <LearnCoursePlayer />
+        </Page>
+    );
+};
+
+export default LearnCourse;

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -67,6 +67,7 @@ export enum PageName {
     FUNNEL_BUILDER = 'funnel_builder',
     ROADMAP = 'roadmap',
     LEARN = 'learn',
+    LEARN_COURSE = 'learn_course',
 }
 
 export enum CategoryName {


### PR DESCRIPTION
CS-73 Learn stack 3/4: the course player — `/learn/courses/:courseId`, lessons, quiz with scoring, resume bookmarks, and local (per-browser) progress derived from recorded events. Backend adds `LearnService.getCourse` (catalogue-validated, assetBaseUrl derived). Progress stays client-local in this slice; server sync lands in 4/4.

Stack: #26660 → #26661 → #26662 → #26663.

Relates: CS-73

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cv7UksPT6jXZz9bwkHao4o