### PR TITLE
feat: Learn server progress sync — proxy, events and rollup merge (CS-73 4/4)

### DIFF
--- a/packages/backend/src/controllers/learnController.ts
+++ b/packages/backend/src/controllers/learnController.ts
@@ -3,13 +3,18 @@ import {
     type ApiErrorPayload,
     type ApiLearnCatalogueResponse,
     type ApiLearnCourseResponse,
+    type ApiLearnEventsResponse,
+    type ApiLearnProgressResponse,
+    type LearnEventInput,
 } from '@lightdash/common';
 import {
+    Body,
     Get,
     Hidden,
     Middlewares,
     OperationId,
     Path,
+    Post,
     Request,
     Response,
     Route,
@@ -65,6 +70,51 @@ export class LearnController extends BaseController {
             results: await this.services
                 .getLearnService()
                 .getCourse(req.account, courseId),
+        };
+    }
+
+    /**
+     * Get the signed-in user's Learn progress rollups. `courses` is null when
+     * the instance has no Learn service token configured (client-local mode).
+     * @summary Get Learn progress
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/progress')
+    @OperationId('getLearnProgress')
+    async getLearnProgress(
+        @Request() req: express.Request,
+    ): Promise<ApiLearnProgressResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getLearnService()
+                .getProgress(req.account),
+        };
+    }
+
+    /**
+     * Append learning events for the signed-in user. The event source is
+     * always recorded as 'learn' server-side.
+     * @summary Record Learn events
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/events')
+    @OperationId('recordLearnEvents')
+    async recordLearnEvents(
+        @Request() req: express.Request,
+        @Body() body: LearnEventInput[],
+    ): Promise<ApiLearnEventsResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getLearnService()
+                .recordEvents(req.account, body),
         };
     }
 }

--- a/packages/backend/src/services/LearnService/LearnService.test.ts
+++ b/packages/backend/src/services/LearnService/LearnService.test.ts
@@ -1,6 +1,7 @@
 import {
     ForbiddenError,
     NotFoundError,
+    ParameterError,
     UnexpectedServerError,
     type Account,
 } from '@lightdash/common';
@@ -78,8 +79,8 @@ const coursePayload = {
 const jsonResponse = (body: unknown, status = 200) =>
     new Response(JSON.stringify(body), { status });
 
-const buildService = ({ flagEnabled = true } = {}) => {
-    const serviceToken = 'service-token-1';
+const buildService = ({ flagEnabled = true, withToken = true } = {}) => {
+    const serviceToken = withToken ? 'service-token-1' : undefined;
     const featureFlagService = {
         get: vi.fn().mockResolvedValue({ enabled: flagEnabled }),
     };
@@ -193,6 +194,90 @@ describe('LearnService', () => {
                 `https://content.test/${catalogueEntry.path}`,
                 expect.anything(),
             );
+        });
+    });
+
+    describe('getProgress', () => {
+        it('reports serverSynced: false without a service token and never calls upstream', async () => {
+            const { service } = buildService({ withToken: false });
+            const result = await service.getProgress(buildAccount());
+            expect(result).toEqual({ courses: null, serverSynced: false });
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+
+        it('proxies with the server-held token and the session email', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(
+                jsonResponse({
+                    email: 'learner+test@example.com',
+                    courses: [],
+                }),
+            );
+            const result = await service.getProgress(buildAccount());
+            expect(result).toEqual({ courses: [], serverSynced: true });
+            const [url, init] = fetchMock.mock.calls[0];
+            expect(url).toBe(
+                'https://progress.test/api/v1/progress?email=learner%2Btest%40example.com',
+            );
+            expect((init.headers as Record<string, string>).authorization).toBe(
+                'Bearer service-token-1',
+            );
+        });
+    });
+
+    describe('recordEvents', () => {
+        const validEvent = {
+            verb: 'started',
+            object: { type: 'course', course: 'viewer-fundamentals' },
+            occurredAt: '2026-08-01T00:00:00.000Z',
+        };
+
+        it('rejects invalid payloads with ParameterError', async () => {
+            const { service } = buildService();
+            await expect(
+                service.recordEvents(buildAccount(), [{ nope: true }]),
+            ).rejects.toThrow(ParameterError);
+            await expect(
+                service.recordEvents(buildAccount(), []),
+            ).rejects.toThrow(ParameterError);
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+
+        it('rejects batches over 100 events', async () => {
+            const { service } = buildService();
+            const events = Array.from({ length: 101 }, () => validEvent);
+            await expect(
+                service.recordEvents(buildAccount(), events),
+            ).rejects.toThrow(ParameterError);
+        });
+
+        it('accepts and drops events when no service token is configured', async () => {
+            const { service } = buildService({ withToken: false });
+            const result = await service.recordEvents(buildAccount(), [
+                validEvent,
+            ]);
+            expect(result).toEqual({ accepted: 0 });
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+
+        it('stamps source: learn on every event before forwarding', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(jsonResponse({ accepted: 1 }));
+            const result = await service.recordEvents(buildAccount(), [
+                validEvent,
+            ]);
+            expect(result).toEqual({ accepted: 1 });
+            const [, init] = fetchMock.mock.calls[0];
+            const body = JSON.parse(init.body as string);
+            expect(body[0].source).toBe('learn');
+        });
+
+        it('maps upstream write failures to UnexpectedServerError', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(jsonResponse({}, 500));
+            await expect(
+                service.recordEvents(buildAccount(), [validEvent]),
+            ).rejects.toThrow(UnexpectedServerError);
         });
     });
 });

--- a/packages/backend/src/services/LearnService/LearnService.ts
+++ b/packages/backend/src/services/LearnService/LearnService.ts
@@ -4,17 +4,24 @@ import {
     ForbiddenError,
     LearnCatalogueSchema,
     LearnCourseSchema,
+    LearnEventInputSchema,
+    LearnProgressResponseSchema,
     NotFoundError,
+    ParameterError,
     UnexpectedServerError,
     type Account,
+    type ApiLearnEventsResponse,
     type LearnCatalogue,
     type LearnCourse,
+    type LearnEventInput,
+    type LearnProgressResults,
 } from '@lightdash/common';
 import type { LightdashConfig } from '../../config/parseConfig';
 import { BaseService } from '../BaseService';
 import type { FeatureFlagService } from '../FeatureFlag/FeatureFlagService';
 
 const LEARN_REQUEST_TIMEOUT_MS = 10_000;
+const MAX_EVENTS_PER_REQUEST = 100;
 
 type Dependencies = {
     lightdashConfig: LightdashConfig;
@@ -123,5 +130,87 @@ export class LearnService extends BaseService {
             ...parsed.data,
             assetBaseUrl: `${contentBaseUrl}/courses/${entry.id}/${entry.contentHash}`,
         };
+    }
+
+    private progressRequest(
+        account: Account,
+        path: string,
+        init: RequestInit = {},
+    ): Promise<Response> {
+        const { progressApiUrl, serviceToken } = this.lightdashConfig.learn;
+        if (!serviceToken) {
+            throw new UnexpectedServerError('Learn progress is not configured');
+        }
+        const email = encodeURIComponent(account.user?.email ?? '');
+        return this.fetchUpstream(`${progressApiUrl}${path}?email=${email}`, {
+            ...init,
+            headers: {
+                'content-type': 'application/json',
+                authorization: `Bearer ${serviceToken}`,
+                ...(init.headers ?? {}),
+            },
+        });
+    }
+
+    async getProgress(account: Account): Promise<LearnProgressResults> {
+        await this.assertLearnEnabled(account);
+        if (!this.lightdashConfig.learn.serviceToken) {
+            return { courses: null, serverSynced: false };
+        }
+        const response = await this.progressRequest(
+            account,
+            '/api/v1/progress',
+        );
+        if (!response.ok) {
+            this.logger.warn('Learn progress service returned an error', {
+                statusCode: response.status,
+            });
+            throw new UnexpectedServerError('Could not load Learn progress');
+        }
+        const parsed = LearnProgressResponseSchema.safeParse(
+            await LearnService.parseJson(response),
+        );
+        if (!parsed.success) {
+            this.logger.warn('Learn progress failed validation', {
+                issueCount: parsed.error.issues.length,
+            });
+            throw new UnexpectedServerError('Could not load Learn progress');
+        }
+        return { courses: parsed.data.courses, serverSynced: true };
+    }
+
+    async recordEvents(
+        account: Account,
+        events: unknown,
+    ): Promise<ApiLearnEventsResponse['results']> {
+        await this.assertLearnEnabled(account);
+        const parsed = LearnEventInputSchema.array()
+            .min(1)
+            .max(MAX_EVENTS_PER_REQUEST)
+            .safeParse(events);
+        if (!parsed.success) {
+            throw new ParameterError('Invalid Learn events payload');
+        }
+        if (!this.lightdashConfig.learn.serviceToken) {
+            // No server sync configured: accept and drop — the client also
+            // keeps local progress, so learners lose nothing they can see.
+            return { accepted: 0 };
+        }
+        const body: Array<LearnEventInput & { source: 'learn' }> =
+            parsed.data.map((event) => ({ ...event, source: 'learn' }));
+        const response = await this.progressRequest(account, '/api/v1/events', {
+            method: 'POST',
+            body: JSON.stringify(body),
+        });
+        if (!response.ok) {
+            this.logger.warn('Learn events write failed', {
+                statusCode: response.status,
+            });
+            throw new UnexpectedServerError('Could not save Learn progress');
+        }
+        const payload = (await LearnService.parseJson(response)) as {
+            accepted?: number;
+        };
+        return { accepted: payload.accepted ?? body.length };
     }
 }

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -225,6 +225,8 @@ import { type ApiImpersonationOrganizationSettingsResponse } from './impersonati
 import {
     type ApiLearnCatalogueResponse,
     type ApiLearnCourseResponse,
+    type ApiLearnEventsResponse,
+    type ApiLearnProgressResponse,
 } from './learn';
 import type { LinearInstallation, LinearProject, LinearTeam } from './linear';
 import {
@@ -1311,6 +1313,8 @@ type ApiResults =
     | ApiRoadmapResponse['results']
     | ApiLearnCatalogueResponse['results']
     | ApiLearnCourseResponse['results']
+    | ApiLearnProgressResponse['results']
+    | ApiLearnEventsResponse['results']
     | ChartHistory
     | ChartVersion
     | DashboardHistory

--- a/packages/common/src/types/learn.ts
+++ b/packages/common/src/types/learn.ts
@@ -104,6 +104,44 @@ export const LearnCourseSchema = z
     })
     .passthrough();
 
+export type LearnCourseProgress = {
+    courseId: string;
+    startedAt: string | null;
+    completedAt: string | null;
+    lessonsCompleted: string[];
+    quiz: {
+        bestScore: number | null;
+        passed: boolean;
+        passedAt: string | null;
+    } | null;
+    lastEventAt: string | null;
+};
+
+export const LearnProgressResponseSchema = z
+    .object({
+        email: z.string(),
+        courses: z.array(
+            z
+                .object({
+                    courseId: z.string(),
+                    startedAt: z.string().nullable(),
+                    completedAt: z.string().nullable(),
+                    lessonsCompleted: z.array(z.string()),
+                    quiz: z
+                        .object({
+                            bestScore: z.number().nullable(),
+                            passed: z.boolean(),
+                            passedAt: z.string().nullable(),
+                        })
+                        .passthrough()
+                        .nullable(),
+                    lastEventAt: z.string().nullable(),
+                })
+                .passthrough(),
+        ),
+    })
+    .passthrough();
+
 export type LearnEventVerb =
     | 'started'
     | 'progressed'
@@ -132,6 +170,42 @@ export type LearnEventInput = {
     occurredAt: string;
 };
 
+export const LearnEventInputSchema: z.ZodType<LearnEventInput> = z
+    .object({
+        verb: z.enum([
+            'started',
+            'progressed',
+            'completed',
+            'passed',
+            'failed',
+        ]),
+        object: z
+            .object({
+                type: z.enum(['course', 'lesson', 'quiz']),
+                course: z.string().min(1),
+                lesson: z.string().optional(),
+                contentHash: z.string().optional(),
+                version: z.number().int().optional(),
+            })
+            .strict(),
+        result: z
+            .object({
+                score: z.number().min(0).max(100).optional(),
+                passed: z.boolean().optional(),
+                completion: z.boolean().optional(),
+            })
+            .strict()
+            .optional(),
+        occurredAt: z.string().datetime({ offset: true }),
+    })
+    .strict() as unknown as z.ZodType<LearnEventInput>;
+
+export type LearnProgressResults = {
+    /** Null when the instance has no Learn service token — progress is client-local. */
+    courses: LearnCourseProgress[] | null;
+    serverSynced: boolean;
+};
+
 export type ApiLearnCatalogueResponse = {
     status: 'ok';
     results: LearnCatalogue;
@@ -140,4 +214,14 @@ export type ApiLearnCatalogueResponse = {
 export type ApiLearnCourseResponse = {
     status: 'ok';
     results: LearnCourse;
+};
+
+export type ApiLearnProgressResponse = {
+    status: 'ok';
+    results: LearnProgressResults;
+};
+
+export type ApiLearnEventsResponse = {
+    status: 'ok';
+    results: { accepted: number };
 };

--- a/packages/frontend/src/features/learn/hooks.ts
+++ b/packages/frontend/src/features/learn/hooks.ts
@@ -3,11 +3,17 @@ import {
     type LearnCatalogue,
     type LearnCourse,
     type LearnEventInput,
+    type LearnProgressResults,
 } from '@lightdash/common';
-import { useQuery } from '@tanstack/react-query';
-import { useCallback, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useMemo } from 'react';
 import { lightdashApi } from '../../api';
-import { rollupFromEvents, type Rollup } from './model';
+import {
+    mergeRollups,
+    rollupFromEvents,
+    rollupFromServer,
+    type Rollup,
+} from './model';
 
 const LOCAL_EVENTS_KEY = 'lightdash.learn.events.v1';
 const LAST_COURSE_KEY = 'lightdash.learn.lastCourse.v1';
@@ -27,6 +33,20 @@ const getLearnCourse = async (courseId: string) =>
         body: undefined,
     });
 
+const getLearnProgress = async () =>
+    lightdashApi<LearnProgressResults>({
+        url: '/learn/progress',
+        method: 'GET',
+        body: undefined,
+    });
+
+const postLearnEvents = async (events: LearnEventInput[]) =>
+    lightdashApi<{ accepted: number }>({
+        url: '/learn/events',
+        method: 'POST',
+        body: JSON.stringify(events),
+    });
+
 export const useLearnCatalogue = () =>
     useQuery<LearnCatalogue, ApiError>({
         queryKey: ['learn-catalogue'],
@@ -44,6 +64,13 @@ export const useLearnCourse = (courseId: string | undefined) =>
         retry: false,
     });
 
+const useLearnServerProgress = () =>
+    useQuery<LearnProgressResults, ApiError>({
+        queryKey: ['learn-progress'],
+        queryFn: getLearnProgress,
+        retry: false,
+    });
+
 function readLocalEvents(): LearnEventInput[] {
     const raw = localStorage.getItem(LOCAL_EVENTS_KEY);
     if (!raw) return [];
@@ -55,40 +82,66 @@ function readLocalEvents(): LearnEventInput[] {
 }
 
 /**
- * Rollups per course from locally recorded events. Server-synced progress
- * arrives with the progress-sync slice — local events are always kept, so an
- * unconfigured instance still has per-browser progress.
+ * Rollups per course, merging server progress (when the instance syncs) with
+ * locally recorded events (always kept, so an unconfigured instance still has
+ * per-browser progress and a later-configured one back-fills nothing worse
+ * than what the learner already saw).
  */
 export const useLearnRollups = () => {
-    // Computed once per mount; the progress-sync slice makes this live-update
-    // by keying recomputation off the server progress query.
-    const [rollups] = useState(() => {
+    const serverProgress = useLearnServerProgress();
+    const rollups = useMemo(() => {
         const map = new Map<string, Rollup>();
         const local = readLocalEvents();
         for (const courseId of new Set(local.map((ev) => ev.object.course))) {
             map.set(courseId, rollupFromEvents(local, courseId));
         }
+        for (const course of serverProgress.data?.courses ?? []) {
+            const server = rollupFromServer(course);
+            const existing = map.get(course.courseId);
+            map.set(
+                course.courseId,
+                existing ? mergeRollups(server, existing) : server,
+            );
+        }
         return map;
-    });
-    return { rollups, isLoading: false, serverSynced: false };
+    }, [serverProgress.data]);
+    return {
+        rollups,
+        isLoading: serverProgress.isInitialLoading,
+        serverSynced: serverProgress.data?.serverSynced ?? false,
+    };
 };
 
 export const useRecordLearnEvent = () => {
-    const record = useCallback((event: Omit<LearnEventInput, 'occurredAt'>) => {
-        const full: LearnEventInput = {
-            ...event,
-            occurredAt: new Date().toISOString(),
-        };
-        // Local copy: progress must never depend on the network.
-        try {
-            const local = readLocalEvents();
-            local.push(full);
-            localStorage.setItem(LOCAL_EVENTS_KEY, JSON.stringify(local));
-        } catch {
-            // Storage full or unavailable — nothing else to do locally.
-        }
-    }, []);
-    return { record, isRecording: false };
+    const queryClient = useQueryClient();
+    const mutation = useMutation<
+        { accepted: number },
+        ApiError,
+        LearnEventInput[]
+    >({
+        mutationFn: postLearnEvents,
+        onSettled: () => queryClient.invalidateQueries(['learn-progress']),
+    });
+    const { mutate } = mutation;
+    const record = useCallback(
+        (event: Omit<LearnEventInput, 'occurredAt'>) => {
+            const full: LearnEventInput = {
+                ...event,
+                occurredAt: new Date().toISOString(),
+            };
+            // Local copy first: progress must never depend on the network.
+            try {
+                const local = readLocalEvents();
+                local.push(full);
+                localStorage.setItem(LOCAL_EVENTS_KEY, JSON.stringify(local));
+            } catch {
+                // Storage full or unavailable — server sync still applies.
+            }
+            mutate([full]);
+        },
+        [mutate],
+    );
+    return { record, isRecording: mutation.isLoading };
 };
 
 export const getLastCourseId = (): string | null =>

--- a/packages/frontend/src/features/learn/model.test.ts
+++ b/packages/frontend/src/features/learn/model.test.ts
@@ -7,9 +7,11 @@ import {
     badgeStates,
     cardState,
     emptyRollup,
+    mergeRollups,
     pathProgress,
     pathsFromCatalogue,
     rollupFromEvents,
+    rollupFromServer,
 } from './model';
 
 const entry = (
@@ -73,6 +75,44 @@ describe('rollupFromEvents', () => {
 
     it('returns an empty rollup when no events match the course', () => {
         expect(rollupFromEvents([], 'a')).toEqual(emptyRollup());
+    });
+});
+
+describe('rollupFromServer / mergeRollups', () => {
+    it('maps server progress rows onto the rollup shape', () => {
+        const rollup = rollupFromServer({
+            courseId: 'a',
+            startedAt: '2026-08-01T00:00:00.000Z',
+            completedAt: null,
+            lessonsCompleted: ['l1', 'l2'],
+            quiz: { bestScore: 70, passed: false, passedAt: null },
+            lastEventAt: '2026-08-01T00:00:00.000Z',
+        });
+        expect(rollup.started).toBe(true);
+        expect(rollup.completed).toBe(false);
+        expect(rollup.bestScore).toBe(70);
+        expect(rollup.lessonsCompleted.size).toBe(2);
+    });
+
+    it('merges local and server rollups by union / max', () => {
+        const local = {
+            ...emptyRollup(),
+            started: true,
+            lessonsCompleted: new Set(['l1']),
+            bestScore: 50,
+        };
+        const server = {
+            ...emptyRollup(),
+            lessonsCompleted: new Set(['l2']),
+            bestScore: 90,
+            passed: true,
+            completed: true,
+        };
+        const merged = mergeRollups(local, server);
+        expect([...merged.lessonsCompleted].sort()).toEqual(['l1', 'l2']);
+        expect(merged.bestScore).toBe(90);
+        expect(merged.passed).toBe(true);
+        expect(cardState(merged)).toBe('done');
     });
 });
 

--- a/packages/frontend/src/features/learn/model.ts
+++ b/packages/frontend/src/features/learn/model.ts
@@ -1,4 +1,8 @@
-import type { LearnCatalogueEntry, LearnEventInput } from '@lightdash/common';
+import type {
+    LearnCatalogueEntry,
+    LearnCourseProgress,
+    LearnEventInput,
+} from '@lightdash/common';
 
 // Pure derivations for the Learn section, ported from the Lightdash
 // University academy so both surfaces order, group and lay out the catalogue
@@ -59,6 +63,36 @@ export function rollupFromEvents(
     }
     if (rollup.passed) rollup.completed = true;
     return rollup;
+}
+
+export function rollupFromServer(progress: LearnCourseProgress): Rollup {
+    return {
+        started: progress.startedAt !== null,
+        lessonsCompleted: new Set(progress.lessonsCompleted),
+        bestScore: progress.quiz?.bestScore ?? null,
+        passed: progress.quiz?.passed ?? false,
+        completed:
+            progress.completedAt !== null || (progress.quiz?.passed ?? false),
+    };
+}
+
+export function mergeRollups(a: Rollup, b: Rollup): Rollup {
+    const bestScore =
+        a.bestScore === null
+            ? b.bestScore
+            : b.bestScore === null
+              ? a.bestScore
+              : Math.max(a.bestScore, b.bestScore);
+    return {
+        started: a.started || b.started,
+        lessonsCompleted: new Set([
+            ...a.lessonsCompleted,
+            ...b.lessonsCompleted,
+        ]),
+        bestScore,
+        passed: a.passed || b.passed,
+        completed: a.completed || b.completed,
+    };
 }
 
 export function cardState(rollup: Rollup | undefined): CardState {


### PR DESCRIPTION
CS-73 Learn stack 4/4 (top): server progress sync — `getProgress`/`recordEvents` proxy to the lu-progress service (service token held server-side, learner identity = session email, event source pinned to 'learn'), and the client merges server rollups with local events. This head is **byte-identical** to the previously-reviewed #26659.

Stack: #26660 → #26661 → #26662 → #26663.

Relates: CS-73

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cv7UksPT6jXZz9bwkHao4o