### PR TITLE
feat(ai): retain deep research query results

### DIFF
--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1,4 +1,5 @@
 import {
+    AI_DEEP_RESEARCH_QUERY_HISTORY_RETENTION_DAYS,
     AI_DEFAULT_MAX_QUERY_LIMIT,
     ALL_TASK_NAMES,
     AllowedEmailDomainsRole,
@@ -2885,7 +2886,7 @@ export const parseConfig = (): LightdashConfig => {
                     retentionDays:
                         getIntegerFromEnvironmentVariable(
                             'QUERY_HISTORY_RETENTION_DAYS',
-                        ) || 30,
+                        ) || AI_DEEP_RESEARCH_QUERY_HISTORY_RETENTION_DAYS,
                     batchSize:
                         getIntegerFromEnvironmentVariable(
                             'QUERY_HISTORY_CLEANUP_BATCH_SIZE',

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.test.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.test.ts
@@ -1,3 +1,4 @@
+import { AI_DEEP_RESEARCH_REPORT_RETENTION_DAYS } from '@lightdash/common';
 import knex, { type Knex } from 'knex';
 import { getTracker, MockClient, type Tracker } from 'knex-mock-client';
 import {
@@ -372,12 +373,15 @@ describe('AiDeepResearchRunModel', () => {
 
             expect(updated).toBe(true);
             const [update] = tracker.history.update;
-            expect(update.sql).toContain(
-                `"report_expires_at" = now() + interval '30 days'`,
-            );
+            expect(update.sql).toContain(`"report_expires_at" = now() + ($`);
             expect(update.sql).toContain('"report_expired_at" = $');
             expect(update.bindings).toEqual(
-                expect.arrayContaining([status, reportMarkdown, RUN_UUID]),
+                expect.arrayContaining([
+                    status,
+                    reportMarkdown,
+                    AI_DEEP_RESEARCH_REPORT_RETENTION_DAYS,
+                    RUN_UUID,
+                ]),
             );
         },
     );

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
@@ -1,6 +1,7 @@
 import {
     AI_DEEP_RESEARCH_HYPOTHESES_TOOL_NAME,
     AI_DEEP_RESEARCH_INVESTIGATION_TOOL_NAME,
+    AI_DEEP_RESEARCH_REPORT_RETENTION_DAYS,
     AI_DEEP_RESEARCH_REPORT_TOOL_NAME,
     countDeepResearchFindings,
     getErrorMessage,
@@ -675,7 +676,8 @@ export class AiDeepResearchRunModel {
                         resultChartData,
                     ) as unknown as AiDeepResearchChartDataMap,
                     report_expires_at: transaction.raw(
-                        "now() + interval '30 days'",
+                        "now() + (? * interval '1 day')",
+                        [AI_DEEP_RESEARCH_REPORT_RETENTION_DAYS],
                     ) as unknown as Date,
                     report_expired_at: null,
                     ...metrics,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -4,6 +4,7 @@ import {
     AGENT_SUGGESTION_TOOLS,
     AgentSuggestion,
     AgentSummaryContext,
+    AI_DEEP_RESEARCH_QUERY_RESULTS_RETENTION_DAYS,
     AiAgent,
     AiAgentEvalRunJobPayload,
     AiAgentEvaluationRun,
@@ -406,6 +407,8 @@ const ALLOWED_AGENT_AVATAR_MIME_TYPES = new Set([
 // comfortably under the usual 30-60s idle timeouts.
 const STREAM_KEEPALIVE_INTERVAL_MS = 15_000;
 const DEEP_RESEARCH_STEP_HEADROOM = 10;
+const DEEP_RESEARCH_QUERY_RESULTS_EXPIRATION_MS =
+    AI_DEEP_RESEARCH_QUERY_RESULTS_RETENTION_DAYS * 24 * 60 * 60 * 1_000;
 
 const MAX_MCP_BEARER_TOKEN_LENGTH = 8192;
 
@@ -7798,6 +7801,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             runtimeOptions?: EmbedAiAgentRuntimeOptions;
             suppressWritebackPreview?: boolean;
             onWarehouseQuery?: () => void | Promise<void>;
+            queryResultsExpirationMs?: number;
         },
     ) {
         const { projectUuid, organizationUuid } = prompt;
@@ -7819,6 +7823,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             agentUuid: runtimeAgentSettings.uuid,
             threadUuid: prompt.threadUuid,
             onWarehouseQuery: options?.onWarehouseQuery,
+            queryResultsExpirationMs: options?.queryResultsExpirationMs,
         });
 
         const getProjectContextDocument: AiAgentDependencies['getProjectContextDocument'] =
@@ -8710,6 +8715,10 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             onWarehouseQuery:
                 responseExecution.mode === 'deep_research'
                     ? responseExecution.onWarehouseQuery
+                    : undefined,
+            queryResultsExpirationMs:
+                responseExecution.mode === 'deep_research'
+                    ? DEEP_RESEARCH_QUERY_RESULTS_EXPIRATION_MS
                     : undefined,
         });
 

--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
@@ -203,6 +203,52 @@ function makeRuntimeContext(
 }
 
 describe('AiAgentToolsService', () => {
+    it('retains Deep Research query results for the runtime retention window', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-07-31T12:00:00.000Z'));
+        const executeMetricQueryAndGetResults = vi.fn().mockResolvedValue({
+            queryUuid: '11111111-1111-4111-8111-111111111111',
+            rows: [{ value: 1 }],
+            cacheMetadata: { cacheHit: false },
+            fields: {},
+        });
+        const extendQueryResultsExpiration = vi
+            .fn()
+            .mockResolvedValue(undefined);
+        const service = makeService({
+            explores: { orders: makeExplore({ name: 'orders' }) },
+            asyncQueryService: {
+                executeMetricQueryAndGetResults,
+                extendQueryResultsExpiration,
+            },
+        });
+        const runtime = service.createRuntime(
+            makeRuntimeContext({
+                queryResultsExpirationMs: 31 * 24 * 60 * 60 * 1_000,
+            }),
+        );
+
+        await runtime.runAsyncQuery({
+            exploreName: 'orders',
+            dimensions: [],
+            metrics: [],
+            filters: {},
+            sorts: [],
+            limit: 10,
+            tableCalculations: [],
+            additionalMetrics: [],
+            customMetrics: null,
+        });
+
+        expect(extendQueryResultsExpiration).toHaveBeenCalledWith({
+            account,
+            projectUuid,
+            queryUuid: '11111111-1111-4111-8111-111111111111',
+            expiresAt: new Date('2026-08-31T12:00:00.000Z'),
+        });
+        vi.useRealTimers();
+    });
+
     describe('Deep Research knowledge documents', () => {
         const run = {
             ai_deep_research_run_uuid: 'run-uuid',

--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
@@ -145,6 +145,7 @@ export type AiAgentToolsRuntimeContext = {
     agentUuid?: string;
     threadUuid?: string;
     onWarehouseQuery?: () => void | Promise<void>;
+    queryResultsExpirationMs?: number;
 };
 
 export type McpRuntimeSuccess<TData> = {
@@ -1856,20 +1857,37 @@ export class AiAgentToolsService extends BaseService {
                 );
 
                 await context.onWarehouseQuery?.();
-                return this.asyncQueryService.executeMetricQueryAndGetResults({
-                    account: context.account,
-                    projectUuid: context.projectUuid,
-                    metricQuery: {
-                        ...metricQuery,
-                        additionalMetrics: populateCustomMetricsSQL(
-                            metricQuery.additionalMetrics,
-                            explore,
+                const result =
+                    await this.asyncQueryService.executeMetricQueryAndGetResults(
+                        {
+                            account: context.account,
+                            projectUuid: context.projectUuid,
+                            metricQuery: {
+                                ...metricQuery,
+                                additionalMetrics: populateCustomMetricsSQL(
+                                    metricQuery.additionalMetrics,
+                                    explore,
+                                ),
+                            },
+                            context: context.defaultQueryExecutionContext,
+                            parameters,
+                            userAttributeOverrides:
+                                context.userAttributeOverrides,
+                        },
+                    );
+
+                if (context.queryResultsExpirationMs) {
+                    await this.asyncQueryService.extendQueryResultsExpiration({
+                        account: context.account,
+                        projectUuid: context.projectUuid,
+                        queryUuid: result.queryUuid,
+                        expiresAt: new Date(
+                            Date.now() + context.queryResultsExpirationMs,
                         ),
-                    },
-                    context: context.defaultQueryExecutionContext,
-                    parameters,
-                    userAttributeOverrides: context.userAttributeOverrides,
-                });
+                    });
+                }
+
+                return result;
             },
         );
     }

--- a/packages/backend/src/ee/services/CommercialCacheService.test.ts
+++ b/packages/backend/src/ee/services/CommercialCacheService.test.ts
@@ -1,0 +1,61 @@
+import { type LightdashConfig } from '../../config/parseConfig';
+import { CommercialCacheService } from './CommercialCacheService';
+
+const makeService = (resultsUpdatedAt: Date) =>
+    new CommercialCacheService({
+        queryHistoryModel: {
+            findMostRecentByCacheKey: vi.fn().mockResolvedValue({
+                cacheKey: 'cache-key',
+                resultsFileName: 'results.jsonl',
+                resultsCreatedAt: resultsUpdatedAt,
+                resultsUpdatedAt,
+                resultsExpiresAt: new Date('2026-09-01T00:00:00.000Z'),
+                totalRowCount: 1,
+                columns: { value: { type: 'number' } },
+                originalColumns: null,
+                pivotValuesColumns: null,
+                pivotTotalColumnCount: null,
+            }),
+        } as never,
+        lightdashConfig: {
+            results: { cacheStateTimeSeconds: 24 * 60 * 60 },
+        } as LightdashConfig,
+        storageClient: {} as never,
+        featureFlagModel: {
+            get: vi.fn().mockResolvedValue({ enabled: true }),
+        } as never,
+    });
+
+describe('CommercialCacheService', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-07-31T12:00:00.000Z'));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('does not treat retained results as fresh after the cache window', async () => {
+        const service = makeService(new Date('2026-07-30T11:00:00.000Z'));
+
+        await expect(
+            service.findCachedResultsFile('project-uuid', 'cache-key', {
+                userUuid: 'user-uuid',
+            }),
+        ).resolves.toBeNull();
+    });
+
+    it('returns the logical cache expiry for fresh retained results', async () => {
+        const service = makeService(new Date('2026-07-31T11:00:00.000Z'));
+
+        await expect(
+            service.findCachedResultsFile('project-uuid', 'cache-key', {
+                userUuid: 'user-uuid',
+            }),
+        ).resolves.toMatchObject({
+            cacheHit: true,
+            expiresAt: new Date('2026-08-01T11:00:00.000Z'),
+        });
+    });
+});

--- a/packages/backend/src/ee/services/CommercialCacheService.ts
+++ b/packages/backend/src/ee/services/CommercialCacheService.ts
@@ -81,7 +81,14 @@ export class CommercialCacheService implements ICacheService {
                 ? DEFAULT_CACHE_EXPIRY_BUFFER_MS
                 : staleTimeMilliseconds / 4;
 
-        // Case 1: Valid cache exists with sufficient buffer time
+        const cacheExpiresAt = latestMatchingQuery?.resultsUpdatedAt
+            ? new Date(
+                  latestMatchingQuery.resultsUpdatedAt.getTime() +
+                      staleTimeMilliseconds,
+              )
+            : null;
+
+        // Availability can outlive cache freshness for retained results.
         if (
             latestMatchingQuery &&
             latestMatchingQuery.resultsFileName &&
@@ -90,6 +97,8 @@ export class CommercialCacheService implements ICacheService {
             latestMatchingQuery.resultsExpiresAt &&
             latestMatchingQuery.resultsUpdatedAt &&
             latestMatchingQuery.totalRowCount !== null &&
+            cacheExpiresAt &&
+            cacheExpiresAt > new Date(Date.now() + expiryBuffer) &&
             latestMatchingQuery.resultsExpiresAt >
                 new Date(Date.now() + expiryBuffer)
         ) {
@@ -99,7 +108,7 @@ export class CommercialCacheService implements ICacheService {
                 fileName: latestMatchingQuery.resultsFileName,
                 createdAt: latestMatchingQuery.resultsCreatedAt,
                 updatedAt: latestMatchingQuery.resultsUpdatedAt,
-                expiresAt: latestMatchingQuery.resultsExpiresAt,
+                expiresAt: cacheExpiresAt,
                 totalRowCount: latestMatchingQuery.totalRowCount,
                 columns: latestMatchingQuery.columns,
                 originalColumns: latestMatchingQuery.originalColumns,

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -371,6 +371,7 @@ export type RunAsyncQueryFn = (
     additionalMetrics?: AdditionalMetric[],
     parameters?: ParametersValuesMap,
 ) => Promise<{
+    queryUuid: string;
     rows: Record<string, AnyType>[];
     cacheMetadata: CacheMetadata;
     fields: ItemsMap;

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -1488,6 +1488,84 @@ describe('AsyncQueryService', () => {
         });
     });
 
+    describe('executeMetricQueryAndGetResults', () => {
+        it('preserves the query UUID with the ready results', async () => {
+            const service = getMockedAsyncQueryService(lightdashConfigMock);
+            service.executeAsyncMetricQuery = vi.fn().mockResolvedValue({
+                queryUuid: '11111111-1111-4111-8111-111111111111',
+                cacheMetadata: { cacheHit: false },
+                fields: {},
+            });
+            service.pollForQueryCompletion = vi.fn().mockResolvedValue({
+                status: QueryHistoryStatus.READY,
+            } as QueryHistory);
+            const getReadyQueryResults = vi.fn().mockResolvedValue({
+                rows: [{ a_dim1: 'one', a_met1: 1 }],
+                cacheMetadata: { cacheHit: false },
+                fields: {},
+                pivotDetails: null,
+                displayTimezone: null,
+            });
+            (service as AnyType).getReadyQueryResults = getReadyQueryResults;
+
+            const result = await service.executeMetricQueryAndGetResults({
+                account: sessionAccount,
+                projectUuid,
+                metricQuery: metricQueryMock,
+                context: QueryExecutionContext.AI,
+            });
+
+            expect(result.queryUuid).toBe(
+                '11111111-1111-4111-8111-111111111111',
+            );
+            expect(getReadyQueryResults).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    queryUuid: '11111111-1111-4111-8111-111111111111',
+                }),
+            );
+        });
+
+        it('extends result availability without shortening longer retention', async () => {
+            const service = getMockedAsyncQueryService(lightdashConfigMock);
+            const { queryHistoryModel } = service as AnyType;
+            const expiresAt = new Date('2026-09-01T00:00:00.000Z');
+            queryHistoryModel.get = vi.fn().mockResolvedValue({
+                resultsFileName: 'results.jsonl',
+                resultsExpiresAt: new Date('2026-08-01T00:00:00.000Z'),
+            });
+            queryHistoryModel.update = vi.fn().mockResolvedValue(1);
+
+            await service.extendQueryResultsExpiration({
+                account: sessionAccount,
+                projectUuid,
+                queryUuid: '11111111-1111-4111-8111-111111111111',
+                expiresAt,
+            });
+
+            expect(queryHistoryModel.update).toHaveBeenCalledWith(
+                '11111111-1111-4111-8111-111111111111',
+                projectUuid,
+                { results_expires_at: expiresAt },
+                sessionAccount,
+            );
+
+            queryHistoryModel.get.mockResolvedValue({
+                resultsFileName: 'results.jsonl',
+                resultsExpiresAt: new Date('2026-10-01T00:00:00.000Z'),
+            });
+            queryHistoryModel.update.mockClear();
+
+            await service.extendQueryResultsExpiration({
+                account: sessionAccount,
+                projectUuid,
+                queryUuid: '11111111-1111-4111-8111-111111111111',
+                expiresAt,
+            });
+
+            expect(queryHistoryModel.update).not.toHaveBeenCalled();
+        });
+    });
+
     describe('executeAsyncMetricQuery', () => {
         test('tags warehouse queries with the originating data app from the request context', async () => {
             const service = getMockedAsyncQueryService(lightdashConfigMock);

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -6513,6 +6513,7 @@ export class AsyncQueryService extends ProjectService {
         args: ExecuteAsyncMetricQueryArgs,
         pollingOptions?: PollingOptions,
     ): Promise<{
+        queryUuid: string;
         rows: Record<string, unknown>[];
         cacheMetadata: CacheMetadata;
         fields: ItemsMap;
@@ -6531,13 +6532,47 @@ export class AsyncQueryService extends ProjectService {
             ...pollingOptions,
         });
 
-        return this.getReadyQueryResults({
+        const results = await this.getReadyQueryResults({
             account,
             projectUuid,
             queryUuid,
             cacheMetadata,
             fields,
         });
+
+        return { queryUuid, ...results };
+    }
+
+    async extendQueryResultsExpiration({
+        account,
+        projectUuid,
+        queryUuid,
+        expiresAt,
+    }: {
+        account: Account;
+        projectUuid: string;
+        queryUuid: string;
+        expiresAt: Date;
+    }): Promise<void> {
+        const queryHistory = await this.queryHistoryModel.get(
+            queryUuid,
+            projectUuid,
+            account,
+        );
+        if (
+            !queryHistory.resultsFileName ||
+            (queryHistory.resultsExpiresAt &&
+                queryHistory.resultsExpiresAt >= expiresAt)
+        ) {
+            return;
+        }
+
+        await this.queryHistoryModel.update(
+            queryUuid,
+            projectUuid,
+            { results_expires_at: expiresAt },
+            account,
+        );
     }
 
     /**

--- a/packages/common/src/ee/aiDeepResearch/types.test.ts
+++ b/packages/common/src/ee/aiDeepResearch/types.test.ts
@@ -1,0 +1,16 @@
+import {
+    AI_DEEP_RESEARCH_QUERY_HISTORY_RETENTION_DAYS,
+    AI_DEEP_RESEARCH_QUERY_RESULTS_RETENTION_DAYS,
+    AI_DEEP_RESEARCH_REPORT_RETENTION_DAYS,
+} from './types';
+
+describe('Deep Research retention policy', () => {
+    it('keeps query data and history longer than the report', () => {
+        expect(AI_DEEP_RESEARCH_QUERY_RESULTS_RETENTION_DAYS).toBeGreaterThan(
+            AI_DEEP_RESEARCH_REPORT_RETENTION_DAYS,
+        );
+        expect(AI_DEEP_RESEARCH_QUERY_HISTORY_RETENTION_DAYS).toBeGreaterThan(
+            AI_DEEP_RESEARCH_QUERY_RESULTS_RETENTION_DAYS,
+        );
+    });
+});

--- a/packages/common/src/ee/aiDeepResearch/types.ts
+++ b/packages/common/src/ee/aiDeepResearch/types.ts
@@ -2,6 +2,10 @@ import { type ApiSuccess } from '../../types/api/success';
 import { type ItemsMap } from '../../types/field';
 import { type MetricQuery } from '../../types/metricQuery';
 
+export const AI_DEEP_RESEARCH_REPORT_RETENTION_DAYS = 30;
+export const AI_DEEP_RESEARCH_QUERY_RESULTS_RETENTION_DAYS = 31;
+export const AI_DEEP_RESEARCH_QUERY_HISTORY_RETENTION_DAYS = 32;
+
 export const AI_DEEP_RESEARCH_RUN_STATUSES = [
     'queued',
     'running',


### PR DESCRIPTION
## Summary

PR 1 of 3 for [PROD-9430](https://linear.app/lightdash/issue/PROD-9430/deep-research-judges-return-markdown-with-chart-candidate-references). Establishes the retention foundation for query-backed Deep Research charts: reports live for 30 days, result objects for 31 days, and query history for 32 days.

## Stack

1. **#26664 — retain Deep Research query results**
2. #26665 — hydrate report charts from retained query results
3. #26666 — emit judge Markdown with canonical query references

## Changes

**Retention**

- Centralizes the 30/31/32-day report, result, and query-history policy.
- Marks visualization queries executed inside Deep Research for the longer result lifetime.
- Retains all Deep Research query results intentionally; no pin/refcount lifecycle is introduced.

**Judge budget**

- Keeps the judge-specific output ceiling at 16,384 tokens so long-form Markdown is not truncated at the previous 4,096-token limit.

## Product tradeoff

The global retention rule uses more cache storage than reference counting, but removes pinning, unpinning, partial-expiry, and report-deletion edge cases. The Cloud bucket lifecycle is extended separately to 32 days.

## Test plan

- [x] Backend/common typecheck and lint
- [x] Focused backend/common tests
- [x] Retention ordering coverage
- [x] Local Deep Research evaluation completed 5/5 across the full stack

Part of: https://linear.app/lightdash/issue/PROD-9430
