### PR TITLE
refactor(ai): render research charts from query results

### DIFF
--- a/packages/backend/src/ee/controllers/AiDeepResearchController.ts
+++ b/packages/backend/src/ee/controllers/AiDeepResearchController.ts
@@ -3,6 +3,7 @@ import {
     ForbiddenError,
     type AiDeepResearchRequestBody,
     type ApiAiAgentThreadMessageVizQueryResponse,
+    type ApiAiDeepResearchChartResponse,
     type ApiAiDeepResearchEventsResponse,
     type ApiAiDeepResearchRunListResponse,
     type ApiAiDeepResearchRunResponse,
@@ -149,6 +150,33 @@ export class AiDeepResearchController extends BaseController {
                 projectUuid,
                 aiDeepResearchRunUuid,
                 chartKey,
+            }),
+        };
+    }
+
+    /**
+     * Load the retained query metadata behind a report chart.
+     * @summary Get Deep Research chart
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/{aiDeepResearchRunUuid}/charts/{queryUuid}')
+    @OperationId('getAiDeepResearchChart')
+    async getChart(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Path() aiDeepResearchRunUuid: UUID,
+        @Path() queryUuid: UUID,
+    ): Promise<ApiAiDeepResearchChartResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiDeepResearchService().getChart({
+                user: toSessionUser(req.account),
+                projectUuid,
+                aiDeepResearchRunUuid,
+                queryUuid,
             }),
         };
     }

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -227,8 +227,6 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         clients.getSchedulerClient() as CommercialSchedulerClient,
                     asyncQueryService: repository.getAsyncQueryService(),
                     queryHistoryModel: models.getQueryHistoryModel(),
-                    resultsFileStorageClient:
-                        clients.getResultsFileStorageClient(),
                     executor: executor.execute,
                 });
             },

--- a/packages/backend/src/ee/models/AiAgentModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.integration.test.ts
@@ -64,6 +64,53 @@ describe('AiAgentModel prompt activity', () => {
         );
     });
 
+    it('keeps reused tool call ids scoped to their prompts', async () => {
+        const threadUuid = await createWebAppThread();
+        const expectedResults = ['first prompt result', 'second prompt result'];
+        const promptUuids = await Promise.all(
+            expectedResults.map((result) =>
+                model.createWebAppPrompt({
+                    threadUuid,
+                    createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                    prompt: `Prompt for ${result}`,
+                }),
+            ),
+        );
+        const toolCallId = 'reused-tool-call-id';
+
+        await Promise.all(
+            promptUuids.map((promptUuid) =>
+                model.createToolCall({
+                    promptUuid,
+                    toolCallId,
+                    toolName: 'findExplores',
+                    toolArgs: {},
+                    parentToolCallId: null,
+                }),
+            ),
+        );
+        await model.createToolResults(
+            promptUuids.map((promptUuid, index) => ({
+                promptUuid,
+                toolCallId,
+                toolName: 'findExplores',
+                result: expectedResults[index],
+            })),
+        );
+
+        const histories = await Promise.all(
+            promptUuids.map((promptUuid) =>
+                model.getToolCallsAndResultsForPrompt(promptUuid),
+            ),
+        );
+
+        expect(
+            histories.map((history) =>
+                history.map(({ toolResult }) => toolResult?.result),
+            ),
+        ).toEqual(expectedResults.map((result) => [result]));
+    });
+
     it('keeps Slack prompt activity monotonic', async () => {
         const suffix = crypto.randomUUID();
         const threadUuid = await model.createSlackThread({

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -6499,11 +6499,17 @@ export class AiAgentModel {
                 `${AiAgentToolResultTableName}.created_at as result_created_at`,
                 `${AiSqlApprovalTableName}.decision as approval_decision`,
             )
-            .leftJoin(
-                AiAgentToolResultTableName,
-                `${AiAgentToolCallTableName}.tool_call_id`,
-                `${AiAgentToolResultTableName}.tool_call_id`,
-            )
+            .leftJoin(AiAgentToolResultTableName, function joinToolResult() {
+                this.on(
+                    `${AiAgentToolCallTableName}.tool_call_id`,
+                    '=',
+                    `${AiAgentToolResultTableName}.tool_call_id`,
+                ).andOn(
+                    `${AiAgentToolCallTableName}.ai_prompt_uuid`,
+                    '=',
+                    `${AiAgentToolResultTableName}.ai_prompt_uuid`,
+                );
+            })
             // Tool calls awaiting/granted SQL approval may have no result yet —
             // join the decision so history reconstruction can replay the
             // native approval request/response parts.

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.integration.test.ts
@@ -410,7 +410,7 @@ describe('AiDeepResearchRunModel integration', () => {
         await model.claimQueuedRun(run.ai_deep_research_run_uuid);
 
         await Promise.all([
-            model.markCompleted(run.ai_deep_research_run_uuid, report, {}),
+            model.markCompleted(run.ai_deep_research_run_uuid, report),
             model.requestCancellation(run.ai_deep_research_run_uuid),
         ]);
 
@@ -461,13 +461,11 @@ describe('AiDeepResearchRunModel integration', () => {
                 await model.markCompleted(
                     run.ai_deep_research_run_uuid,
                     report,
-                    {},
                 );
             } else {
                 await model.markPartiallyCompleted(
                     run.ai_deep_research_run_uuid,
                     report,
-                    {},
                     'query_limit',
                 );
             }
@@ -582,7 +580,7 @@ describe('AiDeepResearchRunModel integration', () => {
             },
         ]);
 
-        await model.markCompleted(run.ai_deep_research_run_uuid, report, {});
+        await model.markCompleted(run.ai_deep_research_run_uuid, report);
 
         expect(
             await model.findByUuid(run.ai_deep_research_run_uuid),

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.test.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.test.ts
@@ -250,7 +250,7 @@ describe('AiDeepResearchRunModel', () => {
     it('does not overwrite a cancellation request with completion', async () => {
         tracker.on.select(AiDeepResearchRunsTableName).responseOnce([]);
 
-        const updated = await model.markCompleted(RUN_UUID, reportMarkdown, {});
+        const updated = await model.markCompleted(RUN_UUID, reportMarkdown);
 
         expect(updated).toBe(false);
         expect(tracker.history.update).toHaveLength(0);
@@ -332,9 +332,7 @@ describe('AiDeepResearchRunModel', () => {
             .insert(AiDeepResearchAnalyticsOutboxTableName)
             .responseOnce([]);
 
-        await model.markCompleted(RUN_UUID, reportMarkdown, {
-            chart: {} as never,
-        });
+        await model.markCompleted(RUN_UUID, reportMarkdown);
 
         const [update] = tracker.history.update;
         expect(update.bindings).toEqual(expect.arrayContaining([4, 2, 1, 1]));
@@ -363,11 +361,10 @@ describe('AiDeepResearchRunModel', () => {
 
             const updated =
                 status === 'completed'
-                    ? await model.markCompleted(RUN_UUID, reportMarkdown, {})
+                    ? await model.markCompleted(RUN_UUID, reportMarkdown)
                     : await model.markPartiallyCompleted(
                           RUN_UUID,
                           reportMarkdown,
-                          {},
                           'query_limit',
                       );
 

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
@@ -4,6 +4,7 @@ import {
     AI_DEEP_RESEARCH_REPORT_RETENTION_DAYS,
     AI_DEEP_RESEARCH_REPORT_TOOL_NAME,
     countDeepResearchFindings,
+    findDeepResearchChartRefs,
     getErrorMessage,
     type AiDeepResearchBudget,
     type AiDeepResearchChartDataMap,
@@ -235,9 +236,9 @@ export class AiDeepResearchRunModel {
                     ? 0
                     : countDeepResearchFindings(resultMarkdown),
             chart_count:
-                resultChartData === null
-                    ? 0
-                    : Object.keys(resultChartData).length,
+                resultMarkdown === null
+                    ? Object.keys(resultChartData ?? {}).length
+                    : findDeepResearchChartRefs(resultMarkdown).length,
         };
     }
 
@@ -642,7 +643,6 @@ export class AiDeepResearchRunModel {
         aiDeepResearchRunUuid: string,
         status: 'completed' | 'partially_completed',
         resultMarkdown: string,
-        resultChartData: AiDeepResearchChartDataMap,
         terminalReason: AiDeepResearchTerminalReason | null,
     ): Promise<boolean> {
         return this.database.transaction(async (transaction) => {
@@ -661,7 +661,7 @@ export class AiDeepResearchRunModel {
                 transaction,
                 currentRun.prompt_uuid,
                 resultMarkdown,
-                resultChartData,
+                null,
             );
             const [run] = await transaction<AiDeepResearchRunsTable>(
                 AiDeepResearchRunsTableName,
@@ -672,9 +672,7 @@ export class AiDeepResearchRunModel {
                 .update({
                     status,
                     result_markdown: resultMarkdown,
-                    result_chart_data: JSON.stringify(
-                        resultChartData,
-                    ) as unknown as AiDeepResearchChartDataMap,
+                    result_chart_data: null,
                     report_expires_at: transaction.raw(
                         "now() + (? * interval '1 day')",
                         [AI_DEEP_RESEARCH_REPORT_RETENTION_DAYS],
@@ -712,13 +710,11 @@ export class AiDeepResearchRunModel {
     async markCompleted(
         aiDeepResearchRunUuid: string,
         resultMarkdown: string,
-        resultChartData: AiDeepResearchChartDataMap,
     ): Promise<boolean> {
         return this.markWithReport(
             aiDeepResearchRunUuid,
             'completed',
             resultMarkdown,
-            resultChartData,
             null,
         );
     }
@@ -726,14 +722,12 @@ export class AiDeepResearchRunModel {
     async markPartiallyCompleted(
         aiDeepResearchRunUuid: string,
         resultMarkdown: string,
-        resultChartData: AiDeepResearchChartDataMap,
         terminalReason: AiDeepResearchTerminalReason,
     ): Promise<boolean> {
         return this.markWithReport(
             aiDeepResearchRunUuid,
             'partially_completed',
             resultMarkdown,
-            resultChartData,
             terminalReason,
         );
     }

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
@@ -16,7 +16,6 @@ import {
     type MemberAbility,
     type SessionUser,
 } from '@lightdash/common';
-import { Readable } from 'stream';
 import { AiDeepResearchActiveRunError } from '../../models/AiDeepResearchRunModel';
 import { AiDeepResearchService } from './AiDeepResearchService';
 
@@ -136,6 +135,40 @@ const chartReportMarkdown = reportMarkdown.replace(
 
 const chartReport = { markdown: chartReportMarkdown, charts: [chart] };
 
+const chartToolArgs = {
+    title: chart.title,
+    description: 'Revenue remained stable across the period.',
+    queryConfig: {
+        exploreName: 'orders',
+        dimensions: chart.chartConfig.xAxisDimension
+            ? [chart.chartConfig.xAxisDimension]
+            : [],
+        metrics: chart.chartConfig.yAxisMetrics ?? [],
+        sorts: [],
+        limit: 500,
+        customMetrics: null,
+        tableCalculations: null,
+        filters: null,
+    },
+    chartConfig: chart.chartConfig,
+};
+
+const chartProvenance = (runUuid = 'run-1') => [
+    {
+        toolCall: {
+            toolName: 'generateVisualization',
+            toolArgs: chartToolArgs,
+            parentToolCallId: `deep-research:${runUuid}:hypothesis-1`,
+        },
+        toolResult: {
+            metadata: {
+                status: 'success',
+                queryUuid: chart.queryUuid,
+            },
+        },
+    },
+];
+
 const userWithProjectAccess = (): SessionUser => {
     const { build, can } = new AbilityBuilder<MemberAbility>(Ability);
     can('view', 'Project', {
@@ -210,7 +243,6 @@ const buildService = (
         schedulerClient?: Record<string, unknown>;
         asyncQueryService?: Record<string, unknown>;
         queryHistoryModel?: Record<string, unknown>;
-        resultsFileStorageClient?: Record<string, unknown>;
         executor?: AnyType;
     } = {},
 ) => {
@@ -305,10 +337,6 @@ const buildService = (
         getByQueryUuid: vi.fn(),
         ...overrides.queryHistoryModel,
     };
-    const resultsFileStorageClient = {
-        getDownloadStream: vi.fn().mockResolvedValue(Readable.from([])),
-        ...overrides.resultsFileStorageClient,
-    };
     const executor =
         overrides.executor ??
         vi.fn().mockResolvedValue({
@@ -331,7 +359,6 @@ const buildService = (
         schedulerClient: schedulerClient as AnyType,
         asyncQueryService: asyncQueryService as AnyType,
         queryHistoryModel: queryHistoryModel as AnyType,
-        resultsFileStorageClient: resultsFileStorageClient as AnyType,
         executor,
     });
     return {
@@ -345,7 +372,6 @@ const buildService = (
         schedulerClient,
         asyncQueryService,
         queryHistoryModel,
-        resultsFileStorageClient,
         executor,
         analytics,
     };
@@ -1109,7 +1135,6 @@ describe('AiDeepResearchService', () => {
             expect(model.markCompleted).toHaveBeenCalledWith(
                 'run-1',
                 reportMarkdown,
-                {},
             );
         });
 
@@ -1333,7 +1358,7 @@ describe('AiDeepResearchService', () => {
             ).toHaveBeenCalledExactlyOnceWith('analytics-retry-1');
         });
 
-        it('snapshots chart evidence returned by this research run', async () => {
+        it('accepts query-backed chart evidence returned by this research run', async () => {
             const verifiedQuery = {
                 queryUuid: chart.queryUuid,
                 createdAt: new Date('2026-07-14T12:00:00.000Z'),
@@ -1352,7 +1377,7 @@ describe('AiDeepResearchService', () => {
                 },
                 fields: { orders_order_month: { name: 'orders_order_month' } },
             };
-            const { service, model, resultsFileStorageClient } = buildService({
+            const { service, model } = buildService({
                 executor: vi.fn().mockResolvedValue({
                     status: 'completed',
                     report: chartReport,
@@ -1361,54 +1386,73 @@ describe('AiDeepResearchService', () => {
                 queryHistoryModel: {
                     getByQueryUuid: vi.fn().mockResolvedValue(verifiedQuery),
                 },
-                resultsFileStorageClient: {
-                    getDownloadStream: vi
-                        .fn()
-                        .mockResolvedValue(
-                            Readable.from([
-                                '{"orders_order_month":"2026-05","orders_total_revenue":120}\n',
-                                '{"orders_order_month":"2026-06","orders_total_revenue":90}\n',
-                            ]),
-                        ),
+            });
+
+            await service.executeRun({ aiDeepResearchRunUuid: 'run-1' });
+
+            expect(model.markCompleted).toHaveBeenCalledWith(
+                'run-1',
+                chartReportMarkdown,
+            );
+        });
+
+        it('accepts a chart that references a verified table calculation', async () => {
+            const tableCalculationChart = {
+                ...chart,
+                chartConfig: {
+                    ...chart.chartConfig,
+                    secondaryYAxisMetric: 'running_pct',
+                    secondaryYAxisLabel: 'Cumulative revenue',
+                },
+            };
+            const tableCalculationMarkdown = chartReportMarkdown.replace(
+                chart.title,
+                tableCalculationChart.title,
+            );
+            const { service, model } = buildService({
+                executor: vi.fn().mockResolvedValue({
+                    status: 'completed',
+                    report: {
+                        markdown: tableCalculationMarkdown,
+                        charts: [tableCalculationChart],
+                    },
+                    warehouseQueryUuids: [tableCalculationChart.queryUuid],
+                }),
+                queryHistoryModel: {
+                    getByQueryUuid: vi.fn().mockResolvedValue({
+                        queryUuid: tableCalculationChart.queryUuid,
+                        createdAt: new Date('2026-07-14T12:00:00.000Z'),
+                        context: QueryExecutionContext.MCP_RUN_METRIC_QUERY,
+                        projectUuid: 'project-1',
+                        organizationUuid: 'org-1',
+                        createdByUserUuid: 'user-1',
+                        createdByActorType: 'pat',
+                        status: QueryHistoryStatus.READY,
+                        resultsFileName: 'evidence.jsonl',
+                        resultsExpiresAt: new Date('2099-07-15T12:00:00.000Z'),
+                        metricQuery: {
+                            dimensions: ['orders_order_month'],
+                            metrics: ['orders_total_revenue'],
+                            tableCalculations: [
+                                {
+                                    name: 'running_pct',
+                                },
+                            ],
+                        },
+                        fields: {},
+                    }),
                 },
             });
 
             await service.executeRun({ aiDeepResearchRunUuid: 'run-1' });
 
-            expect(
-                resultsFileStorageClient.getDownloadStream,
-            ).toHaveBeenCalledWith('evidence.jsonl');
             expect(model.markCompleted).toHaveBeenCalledWith(
                 'run-1',
-                chartReportMarkdown,
-                {
-                    [chart.queryUuid]: {
-                        source: 'warehouse',
-                        title: chart.title,
-                        chartConfig: chart.chartConfig,
-                        queryUuid: chart.queryUuid,
-                        derivedFrom: null,
-                        metricQuery: verifiedQuery.metricQuery,
-                        fields: verifiedQuery.fields,
-                        snapshot: {
-                            takenAt: expect.any(String),
-                            rowCount: 2,
-                            truncated: false,
-                            columnOrder: [
-                                'orders_order_month',
-                                'orders_total_revenue',
-                            ],
-                            rows: [
-                                ['2026-05', 120],
-                                ['2026-06', 90],
-                            ],
-                        },
-                    },
-                },
+                tableCalculationMarkdown,
             );
         });
 
-        it('persists an inline chart with synthesized query metadata and run-scoped provenance', async () => {
+        it('rejects inline charts from query-backed reports', async () => {
             const inlineChart = {
                 source: 'inline' as const,
                 key: 'refund-share',
@@ -1446,42 +1490,14 @@ describe('AiDeepResearchService', () => {
                 }),
             });
 
-            await service.executeRun({ aiDeepResearchRunUuid: 'run-1' });
-
-            expect(model.markCompleted).toHaveBeenCalledWith(
-                'run-1',
-                inlineMarkdown,
-                {
-                    'refund-share': expect.objectContaining({
-                        source: 'inline',
-                        title: inlineChart.title,
-                        queryUuid: null,
-                        derivedFrom: [chart.queryUuid],
-                        metricQuery: expect.objectContaining({
-                            exploreName: 'inline',
-                            dimensions: ['month'],
-                            metrics: ['refund_share'],
-                        }),
-                        fields: expect.objectContaining({
-                            month: expect.objectContaining({
-                                fieldType: 'dimension',
-                            }),
-                            refund_share: expect.objectContaining({
-                                fieldType: 'metric',
-                            }),
-                        }),
-                        snapshot: expect.objectContaining({
-                            rowCount: 2,
-                            truncated: false,
-                            columnOrder: ['month', 'refund_share'],
-                            rows: inlineChart.rows,
-                        }),
-                    }),
-                },
-            );
+            await expect(
+                service.executeRun({ aiDeepResearchRunUuid: 'run-1' }),
+            ).rejects.toThrow('evidence could not be verified');
+            expect(model.markCompleted).not.toHaveBeenCalled();
+            expect(model.markFailed).toHaveBeenCalled();
         });
 
-        it('omits an older same-user query that was not returned by this run', async () => {
+        it('rejects a query that was not returned by this run', async () => {
             const { service, model, queryHistoryModel } = buildService({
                 executor: vi.fn().mockResolvedValue({
                     status: 'completed',
@@ -1490,20 +1506,17 @@ describe('AiDeepResearchService', () => {
                 }),
             });
 
-            await service.executeRun({ aiDeepResearchRunUuid: 'run-1' });
+            await expect(
+                service.executeRun({ aiDeepResearchRunUuid: 'run-1' }),
+            ).rejects.toThrow('evidence could not be verified');
 
             expect(queryHistoryModel.getByQueryUuid).not.toHaveBeenCalled();
-            const [, persisted, chartData] = model.markCompleted.mock.calls[0];
-            expect(chartData).toEqual({});
-            expect(persisted).not.toContain(`<chart id="${chart.queryUuid}"`);
-            expect(persisted).toContain('*(chart omitted:');
-            expect(persisted).toContain(
-                'Some proposed charts were omitted because their query evidence could not be verified.',
-            );
+            expect(model.markCompleted).not.toHaveBeenCalled();
+            expect(model.markFailed).toHaveBeenCalled();
         });
 
-        it('omits a replayed same-user query that predates this run', async () => {
-            const { service, model, resultsFileStorageClient } = buildService({
+        it('rejects a replayed same-user query that predates this run', async () => {
+            const { service, model } = buildService({
                 executor: vi.fn().mockResolvedValue({
                     status: 'completed',
                     report: chartReport,
@@ -1535,17 +1548,14 @@ describe('AiDeepResearchService', () => {
                 },
             });
 
-            await service.executeRun({ aiDeepResearchRunUuid: 'run-1' });
-
-            expect(
-                resultsFileStorageClient.getDownloadStream,
-            ).not.toHaveBeenCalled();
-            const [, persisted, chartData] = model.markCompleted.mock.calls[0];
-            expect(chartData).toEqual({});
-            expect(persisted).toContain('*(chart omitted:');
+            await expect(
+                service.executeRun({ aiDeepResearchRunUuid: 'run-1' }),
+            ).rejects.toThrow('evidence could not be verified');
+            expect(model.markCompleted).not.toHaveBeenCalled();
+            expect(model.markFailed).toHaveBeenCalled();
         });
 
-        it('omits chart fields that are absent from the verified query', async () => {
+        it('rejects chart fields that are absent from the verified query', async () => {
             const { service, model } = buildService({
                 executor: vi.fn().mockResolvedValue({
                     status: 'completed',
@@ -1573,12 +1583,11 @@ describe('AiDeepResearchService', () => {
                 },
             });
 
-            await service.executeRun({ aiDeepResearchRunUuid: 'run-1' });
-
-            const [, persisted, chartData] = model.markCompleted.mock.calls[0];
-            expect(chartData).toEqual({});
-            expect(persisted).not.toContain(`<chart id="${chart.queryUuid}"`);
-            expect(persisted).toContain('*(chart omitted:');
+            await expect(
+                service.executeRun({ aiDeepResearchRunUuid: 'run-1' }),
+            ).rejects.toThrow('evidence could not be verified');
+            expect(model.markCompleted).not.toHaveBeenCalled();
+            expect(model.markFailed).toHaveBeenCalled();
         });
 
         it('lets a concurrent cancellation request win over completion', async () => {
@@ -1630,6 +1639,98 @@ describe('AiDeepResearchService', () => {
                 }),
                 { signal: abortController.signal },
             );
+        });
+    });
+
+    describe('getChart', () => {
+        const queryHistory = {
+            queryUuid: chart.queryUuid,
+            createdAt: new Date('2026-07-14T12:00:00.000Z'),
+            context: QueryExecutionContext.AI,
+            projectUuid: 'project-1',
+            organizationUuid: 'org-1',
+            createdByUserUuid: 'user-1',
+            createdByActorType: 'session',
+            status: QueryHistoryStatus.READY,
+            resultsFileName: 'evidence.jsonl',
+            resultsExpiresAt: new Date('2099-07-15T12:00:00.000Z'),
+            metricQuery: {
+                exploreName: 'orders',
+                dimensions: ['orders_order_month'],
+                metrics: ['orders_total_revenue'],
+                filters: {},
+                sorts: [],
+                limit: 500,
+                tableCalculations: [],
+                additionalMetrics: [],
+            },
+            fields: {},
+        };
+
+        it('hydrates a referenced chart from run-scoped query provenance', async () => {
+            const { service } = buildService({
+                model: {
+                    findByUuidScoped: vi
+                        .fn()
+                        .mockResolvedValue(
+                            runRow({ result_markdown: chartReportMarkdown }),
+                        ),
+                },
+                aiAgentModel: {
+                    getToolCallsAndResultsForPrompt: vi
+                        .fn()
+                        .mockResolvedValue(chartProvenance()),
+                },
+                queryHistoryModel: {
+                    getByQueryUuid: vi.fn().mockResolvedValue(queryHistory),
+                },
+            });
+
+            await expect(
+                service.getChart({
+                    user: userWithProjectAccess(),
+                    projectUuid: 'project-1',
+                    aiDeepResearchRunUuid: 'run-1',
+                    queryUuid: chart.queryUuid,
+                }),
+            ).resolves.toMatchObject({
+                source: 'warehouse',
+                queryUuid: chart.queryUuid,
+                title: chart.title,
+                chartConfig: chart.chartConfig,
+                metricQuery: queryHistory.metricQuery,
+                snapshot: null,
+            });
+        });
+
+        it('rejects matching query metadata from a different run', async () => {
+            const { service, queryHistoryModel } = buildService({
+                model: {
+                    findByUuidScoped: vi
+                        .fn()
+                        .mockResolvedValue(
+                            runRow({ result_markdown: chartReportMarkdown }),
+                        ),
+                },
+                aiAgentModel: {
+                    getToolCallsAndResultsForPrompt: vi
+                        .fn()
+                        .mockResolvedValue(chartProvenance('foreign-run')),
+                },
+                queryHistoryModel: {
+                    getByQueryUuid: vi.fn().mockResolvedValue(queryHistory),
+                },
+            });
+
+            await expect(
+                service.getChart({
+                    user: userWithProjectAccess(),
+                    projectUuid: 'project-1',
+                    aiDeepResearchRunUuid: 'run-1',
+                    queryUuid: chart.queryUuid,
+                }),
+            ).rejects.toBeInstanceOf(NotFoundError);
+            expect(queryHistoryModel.getByQueryUuid).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
@@ -2,13 +2,10 @@ import { subject } from '@casl/ability';
 import {
     AI_DEEP_RESEARCH_DEFAULT_LIMITS,
     AiResultType,
-    buildInlineChartFields,
-    buildInlineChartMetricQuery,
     ConflictError,
     FeatureFlags,
     findDeepResearchChartRefs,
     ForbiddenError,
-    getDeepResearchChartKey,
     getErrorMessage,
     isAiDeepResearchRunTerminal,
     isUserWithOrg,
@@ -16,21 +13,17 @@ import {
     ParameterError,
     QueryExecutionContext,
     QueryHistoryStatus,
-    spliceDeepResearchRanges,
     UnexpectedServerError,
     type Account,
     type AiDeepResearchBudget,
     type AiDeepResearchChartData,
     type AiDeepResearchChartDataMap,
     type AiDeepResearchChartDefinition,
-    type AiDeepResearchChartSnapshot,
-    type AiDeepResearchChartSnapshotValue,
     type AiDeepResearchEntryPoint,
     type AiDeepResearchEvent,
     type AiDeepResearchEventPayloadMap,
     type AiDeepResearchEventsPage,
     type AiDeepResearchExecutionContextSnapshot,
-    type AiDeepResearchInlineChart,
     type AiDeepResearchJobPayload,
     type AiDeepResearchProgress,
     type AiDeepResearchRun,
@@ -42,13 +35,11 @@ import {
 } from '@lightdash/common';
 import { validate as isValidUuid } from 'uuid';
 import { type LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
-import { type S3ResultsFileStorageClient } from '../../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
 import { type FeatureFlagModel } from '../../../models/FeatureFlagModel/FeatureFlagModel';
 import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { type QueryHistoryModel } from '../../../models/QueryHistoryModel/QueryHistoryModel';
 import { type AsyncQueryService } from '../../../services/AsyncQueryService/AsyncQueryService';
 import { BaseService } from '../../../services/BaseService';
-import { splitJsonlStream } from '../../../utils/streamUtils';
 import {
     type DbAiDeepResearchAnalyticsOutbox,
     type DbAiDeepResearchEvent,
@@ -63,6 +54,7 @@ import {
 import { type AiOrganizationSettingsModel } from '../../models/AiOrganizationSettingsModel';
 import { type CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
 import { type AiAgentService } from '../AiAgentService/AiAgentService';
+import { resolveDeepResearchWarehouseChart } from './resolveDeepResearchWarehouseChart';
 
 const MAX_EVENT_PAGE_SIZE = 100;
 const DEFAULT_EVENT_PAGE_SIZE = 50;
@@ -71,19 +63,26 @@ const STALE_RUN_ERROR_MESSAGE =
     'Deep Research stopped unexpectedly before it could finish.';
 const FAILED_RUN_ERROR_MESSAGE =
     'Deep Research could not finish. Please try again.';
-const OMITTED_CHARTS_CAVEAT =
-    'Some proposed charts were omitted because their query evidence could not be verified.';
-const OMITTED_CHART_REF_REPLACEMENT =
-    '*(chart omitted: its query evidence could not be verified)*';
+const getQueryUuidFromMetadata = (metadata: unknown): string | null =>
+    metadata !== null &&
+    typeof metadata === 'object' &&
+    'queryUuid' in metadata &&
+    typeof metadata.queryUuid === 'string'
+        ? metadata.queryUuid
+        : null;
 const isChartConfigCompatible = (
     chart: AiDeepResearchWarehouseChart,
     metricQuery: {
         dimensions: string[];
         metrics: string[];
+        tableCalculations?: Array<{ name: string }> | null;
     },
 ): boolean => {
     const dimensions = new Set(metricQuery.dimensions);
-    const metrics = new Set(metricQuery.metrics);
+    const metrics = new Set([
+        ...metricQuery.metrics,
+        ...(metricQuery.tableCalculations ?? []).map(({ name }) => name),
+    ]);
     const { chartConfig } = chart;
     const referencedDimensions = [
         chartConfig.xAxisDimension,
@@ -111,48 +110,6 @@ const isChartConfigCompatible = (
 export type AiDeepResearchSubmittedReport = {
     markdown: string;
     charts: AiDeepResearchChartDefinition[];
-};
-
-const MAX_SNAPSHOT_ROWS = 500;
-
-const toSnapshotValue = (value: unknown): AiDeepResearchChartSnapshotValue => {
-    if (value === null || value === undefined) {
-        return null;
-    }
-    if (
-        typeof value === 'string' ||
-        typeof value === 'number' ||
-        typeof value === 'boolean'
-    ) {
-        return value;
-    }
-    return JSON.stringify(value);
-};
-
-const buildInlineChartData = (
-    chart: AiDeepResearchInlineChart,
-    runQueryUuids: Set<string>,
-): AiDeepResearchChartData => {
-    // Only provenance the agent can actually claim: queries run this session.
-    const derivedFrom = (chart.derivedFrom ?? []).filter((queryUuid) =>
-        runQueryUuids.has(queryUuid),
-    );
-    return {
-        source: 'inline',
-        title: chart.title,
-        chartConfig: chart.chartConfig,
-        queryUuid: null,
-        derivedFrom: derivedFrom.length > 0 ? derivedFrom : null,
-        metricQuery: buildInlineChartMetricQuery(chart),
-        fields: buildInlineChartFields(chart.columns),
-        snapshot: {
-            takenAt: new Date().toISOString(),
-            rowCount: chart.rows.length,
-            truncated: false,
-            columnOrder: chart.columns.map((column) => column.id),
-            rows: chart.rows,
-        },
-    };
 };
 
 export type AiDeepResearchExecutorResult =
@@ -205,10 +162,6 @@ type Dependencies = {
     schedulerClient: CommercialSchedulerClient;
     asyncQueryService: AsyncQueryService;
     queryHistoryModel: Pick<QueryHistoryModel, 'getByQueryUuid'>;
-    resultsFileStorageClient: Pick<
-        S3ResultsFileStorageClient,
-        'getDownloadStream'
-    >;
     executor?: AiDeepResearchExecutor;
 };
 
@@ -412,11 +365,6 @@ export class AiDeepResearchService extends BaseService {
         'getByQueryUuid'
     >;
 
-    private readonly resultsFileStorageClient: Pick<
-        S3ResultsFileStorageClient,
-        'getDownloadStream'
-    >;
-
     private readonly executor: AiDeepResearchExecutor | undefined;
 
     constructor({
@@ -430,7 +378,6 @@ export class AiDeepResearchService extends BaseService {
         schedulerClient,
         asyncQueryService,
         queryHistoryModel,
-        resultsFileStorageClient,
         executor,
     }: Dependencies) {
         super();
@@ -444,7 +391,6 @@ export class AiDeepResearchService extends BaseService {
         this.schedulerClient = schedulerClient;
         this.asyncQueryService = asyncQueryService;
         this.queryHistoryModel = queryHistoryModel;
-        this.resultsFileStorageClient = resultsFileStorageClient;
         this.executor = executor;
     }
 
@@ -873,18 +819,20 @@ export class AiDeepResearchService extends BaseService {
                 `Deep Research chart ${args.chartKey} not found`,
             );
         }
-        // Membership in the persisted chart data is the authorization gate.
-        const chart = run.result_chart_data?.[args.chartKey];
-        if (!chart) {
-            throw new NotFoundError(
-                `Deep Research chart ${args.chartKey} not found`,
-            );
-        }
-        if (chart.source !== 'warehouse') {
+        const legacyChart = run.result_chart_data?.[args.chartKey];
+        if (legacyChart?.source === 'inline') {
             throw new ParameterError(
                 'Only warehouse-backed Deep Research charts can be refreshed',
             );
         }
+        const chart =
+            legacyChart ??
+            (await this.getChart({
+                user: args.user,
+                projectUuid: args.projectUuid,
+                aiDeepResearchRunUuid: args.aiDeepResearchRunUuid,
+                queryUuid: args.chartKey,
+            }));
 
         const query = await this.asyncQueryService.executeAsyncMetricQuery({
             account: args.account,
@@ -911,6 +859,46 @@ export class AiDeepResearchService extends BaseService {
                 description: null,
             },
         };
+    }
+
+    async getChart(args: {
+        user: SessionUser;
+        projectUuid: string;
+        aiDeepResearchRunUuid: string;
+        queryUuid: string;
+    }): Promise<AiDeepResearchChartData> {
+        const run = await this.findCreatorOwnedRun(
+            args.user,
+            args.projectUuid,
+            args.aiDeepResearchRunUuid,
+        );
+        const reportExpiresAt = getReportExpiresAt(run);
+        const isExpired =
+            run.report_expired_at !== null ||
+            (reportExpiresAt && reportExpiresAt.getTime() <= Date.now());
+        const isReferenced = findDeepResearchChartRefs(
+            run.result_markdown ?? '',
+        ).some(({ key }) => key === args.queryUuid);
+        if (isExpired || !isReferenced) {
+            throw new NotFoundError(
+                `Deep Research chart ${args.queryUuid} not found`,
+            );
+        }
+
+        const chart = await this.findRunWarehouseChart(run, args.queryUuid);
+        const chartData = chart
+            ? await this.buildWarehouseChartData(
+                  run,
+                  chart,
+                  new Set([args.queryUuid]),
+              )
+            : null;
+        if (!chartData) {
+            throw new NotFoundError(
+                `Deep Research chart ${args.queryUuid} not found`,
+            );
+        }
+        return chartData;
     }
 
     async listEvents(args: {
@@ -1030,7 +1018,6 @@ export class AiDeepResearchService extends BaseService {
                     await this.aiDeepResearchRunModel.markCompleted(
                         payload.aiDeepResearchRunUuid,
                         report.markdown,
-                        report.chartData,
                     );
                 if (!completed) {
                     await this.markCancelledAfterCompletedExecution(
@@ -1053,7 +1040,6 @@ export class AiDeepResearchService extends BaseService {
                     await this.aiDeepResearchRunModel.markPartiallyCompleted(
                         payload.aiDeepResearchRunUuid,
                         report.markdown,
-                        report.chartData,
                         result.terminalReason,
                     );
                 if (!completed) {
@@ -1116,23 +1102,17 @@ export class AiDeepResearchService extends BaseService {
         }
     }
 
-    /**
-     * Turns the submitted report into the two persisted artifacts: the
-     * markdown narrative and the render data for every verified chart,
-     * including a snapshot of each warehouse chart's results. Charts that
-     * cannot be verified or snapshotted lose their reference in the markdown.
-     */
     private async prepareEvidenceReport(
         run: DbAiDeepResearchRun,
         report: AiDeepResearchSubmittedReport,
         runQueryUuids: Set<string>,
-    ): Promise<{ markdown: string; chartData: AiDeepResearchChartDataMap }> {
-        const chartData: AiDeepResearchChartDataMap = {};
+    ): Promise<{ markdown: string }> {
         const omittedKeys = new Set<string>();
 
         await Promise.all(
             report.charts.map(async (chart) => {
-                const key = getDeepResearchChartKey(chart);
+                const key =
+                    chart.source === 'warehouse' ? chart.queryUuid : chart.key;
                 try {
                     const entry =
                         chart.source === 'warehouse'
@@ -1141,10 +1121,8 @@ export class AiDeepResearchService extends BaseService {
                                   chart,
                                   runQueryUuids,
                               )
-                            : buildInlineChartData(chart, runQueryUuids);
-                    if (entry) {
-                        chartData[key] = entry;
-                    } else {
+                            : null;
+                    if (!entry) {
                         omittedKeys.add(key);
                     }
                 } catch (error) {
@@ -1157,23 +1135,43 @@ export class AiDeepResearchService extends BaseService {
         );
 
         if (omittedKeys.size === 0) {
-            return { markdown: report.markdown, chartData };
+            return { markdown: report.markdown };
+        }
+        throw new UnexpectedServerError(
+            `Deep Research report evidence could not be verified for chart(s): ${[
+                ...omittedKeys,
+            ].join(', ')}`,
+        );
+    }
+
+    private async findRunWarehouseChart(
+        run: DbAiDeepResearchRun,
+        queryUuid: string,
+    ): Promise<AiDeepResearchWarehouseChart | null> {
+        const provenance =
+            await this.aiAgentModel.getToolCallsAndResultsForPrompt(
+                run.prompt_uuid,
+                { includeSubagentToolCalls: true },
+            );
+        const match = provenance.find(
+            ({ toolCall, toolResult }) =>
+                toolCall.toolName === 'generateVisualization' &&
+                toolCall.parentToolCallId?.startsWith(
+                    `deep-research:${run.ai_deep_research_run_uuid}:hypothesis-`,
+                ) &&
+                toolResult !== null &&
+                getQueryUuidFromMetadata(toolResult.metadata) === queryUuid,
+        );
+        if (!match) {
+            return null;
         }
 
-        const failedRefs = findDeepResearchChartRefs(report.markdown).filter(
-            (ref) => omittedKeys.has(ref.key),
+        return (
+            resolveDeepResearchWarehouseChart(
+                match.toolCall.toolArgs,
+                queryUuid,
+            )?.chart ?? null
         );
-        const spliced = spliceDeepResearchRanges(
-            report.markdown,
-            failedRefs.map((ref) => ({
-                match: ref,
-                replacement: OMITTED_CHART_REF_REPLACEMENT,
-            })),
-        );
-        return {
-            markdown: `${spliced}\n\n<warning title="Caveat">\n\n${OMITTED_CHARTS_CAVEAT}\n\n</warning>\n`,
-            chartData,
-        };
     }
 
     private async buildWarehouseChartData(
@@ -1217,60 +1215,7 @@ export class AiDeepResearchService extends BaseService {
             derivedFrom: null,
             metricQuery: queryHistory.metricQuery,
             fields: queryHistory.fields,
-            snapshot: await this.takeChartSnapshot(
-                queryHistory.resultsFileName,
-                queryHistory.metricQuery,
-                queryHistory.totalRowCount,
-            ),
-        };
-    }
-
-    /** Reads the query's JSONL results file into a bounded snapshot. */
-    private async takeChartSnapshot(
-        resultsFileName: string,
-        metricQuery: { dimensions: string[]; metrics: string[] },
-        totalRowCount: number | null,
-    ): Promise<AiDeepResearchChartSnapshot> {
-        const columnOrder = [...metricQuery.dimensions, ...metricQuery.metrics];
-        const stream =
-            await this.resultsFileStorageClient.getDownloadStream(
-                resultsFileName,
-            );
-        const rows: AiDeepResearchChartSnapshotValue[][] = [];
-        try {
-            for await (const line of splitJsonlStream(stream)) {
-                if (line.trim().length === 0) {
-                    // eslint-disable-next-line no-continue
-                    continue;
-                }
-                if (rows.length >= MAX_SNAPSHOT_ROWS) {
-                    break;
-                }
-                const row: unknown = JSON.parse(line);
-                if (typeof row !== 'object' || row === null) {
-                    throw new UnexpectedServerError(
-                        `Deep Research results file ${resultsFileName} has a malformed row`,
-                    );
-                }
-                rows.push(
-                    columnOrder.map((fieldId) =>
-                        toSnapshotValue(
-                            (row as Record<string, unknown>)[fieldId],
-                        ),
-                    ),
-                );
-            }
-        } finally {
-            stream.destroy();
-        }
-
-        const rowCount = totalRowCount ?? rows.length;
-        return {
-            takenAt: new Date().toISOString(),
-            rowCount,
-            truncated: rowCount > rows.length,
-            columnOrder,
-            rows,
+            snapshot: null,
         };
     }
 

--- a/packages/backend/src/ee/services/AiDeepResearchService/resolveDeepResearchWarehouseChart.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/resolveDeepResearchWarehouseChart.ts
@@ -1,0 +1,44 @@
+import {
+    AI_DEEP_RESEARCH_MAX_CHART_DESCRIPTION_CHARS,
+    aiDeepResearchChartDefinitionSchema,
+    toolRunQueryArgsSchema,
+    type AiDeepResearchWarehouseChart,
+} from '@lightdash/common';
+
+export const resolveDeepResearchWarehouseChart = (
+    toolArgs: unknown,
+    queryUuid: string,
+): { chart: AiDeepResearchWarehouseChart; description: string } | null => {
+    const parsedToolArgs = toolRunQueryArgsSchema.safeParse(toolArgs);
+    if (!parsedToolArgs.success || !parsedToolArgs.data.chartConfig) {
+        return null;
+    }
+
+    const { chartConfig } = parsedToolArgs.data;
+    const parsedChart = aiDeepResearchChartDefinitionSchema.safeParse({
+        source: 'warehouse',
+        queryUuid,
+        title: parsedToolArgs.data.title,
+        chartConfig: {
+            ...chartConfig,
+            defaultVizType: chartConfig.groupBy?.length
+                ? 'table'
+                : chartConfig.defaultVizType,
+            groupBy: null,
+            funnelDataInput: null,
+            stackBars: chartConfig.groupBy?.length
+                ? null
+                : chartConfig.stackBars,
+        },
+    });
+    if (!parsedChart.success || parsedChart.data.source !== 'warehouse') {
+        return null;
+    }
+
+    return {
+        chart: parsedChart.data,
+        description: (
+            parsedToolArgs.data.description || parsedChart.data.title
+        ).slice(0, AI_DEEP_RESEARCH_MAX_CHART_DESCRIPTION_CHARS),
+    };
+};

--- a/packages/backend/src/ee/services/ai/tools/runQuery.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/runQuery.test.ts
@@ -1,0 +1,149 @@
+import { type AiWebAppPrompt, type SlackPrompt } from '@lightdash/common';
+import {
+    metricQueryMock,
+    validExplore,
+} from '../../../../services/ProjectService/ProjectService.mock';
+import type { RunAsyncQueryFn } from '../types/aiAgentDependencies';
+import { AgentContext } from '../utils/AgentContext';
+import { getRunQuery } from './runQuery';
+
+const makePrompt = (): AiWebAppPrompt => ({
+    organizationUuid: 'org-uuid',
+    projectUuid: 'project-uuid',
+    agentUuid: 'agent-uuid',
+    promptUuid: 'prompt-uuid',
+    threadUuid: 'thread-uuid',
+    createdByUserUuid: 'user-uuid',
+    userUuid: 'user-uuid',
+    prompt: 'Show the baseline',
+    createdAt: new Date('2026-07-31T00:00:00Z'),
+    response: null,
+    errorMessage: null,
+    humanScore: null,
+    modelConfig: null,
+});
+
+const makeSlackPrompt = (): SlackPrompt => ({
+    ...makePrompt(),
+    response_slack_ts: 'response-ts',
+    slackUserId: 'slack-user',
+    slackChannelId: 'slack-channel',
+    promptSlackTs: 'prompt-ts',
+    slackThreadTs: 'thread-ts',
+});
+
+const toolInput = {
+    title: 'Baseline',
+    description: 'One row',
+    queryConfig: {
+        exploreName: validExplore.name,
+        dimensions: metricQueryMock.dimensions,
+        metrics: metricQueryMock.metrics,
+        sorts: [],
+        limit: null,
+        customMetrics: null,
+        tableCalculations: null,
+        filters: null,
+    },
+    chartConfig: {
+        defaultVizType: 'bar' as const,
+        xAxisDimension: 'a_dim1',
+        yAxisMetrics: ['a_met1'],
+        groupBy: null,
+        xAxisType: 'category' as const,
+        stackBars: null,
+        lineType: null,
+        xAxisLabel: 'Dimension',
+        yAxisLabel: 'Metric',
+        secondaryYAxisMetric: null,
+        secondaryYAxisLabel: null,
+    },
+};
+
+const executeTool = async (
+    runAsyncQuery: RunAsyncQueryFn,
+    enableDataAccess = true,
+    prompt: AiWebAppPrompt | SlackPrompt = makePrompt(),
+) => {
+    const queryTool = getRunQuery({
+        updateProgress: vi.fn().mockResolvedValue(undefined),
+        runAsyncQuery,
+        getPrompt: vi.fn().mockResolvedValue(prompt),
+        sendFile: vi.fn().mockResolvedValue(undefined),
+        createOrUpdateArtifact: vi.fn().mockResolvedValue(undefined),
+        maxLimit: 500,
+        enableDataAccess,
+    });
+
+    const output = await queryTool.execute!(toolInput, {
+        messages: [],
+        toolCallId: 'tool-call-1',
+        experimental_context: new AgentContext([validExplore]),
+    });
+    if (Symbol.asyncIterator in output) {
+        throw new Error('Expected a non-streaming tool result');
+    }
+    return output;
+};
+
+describe('getRunQuery', () => {
+    it('returns the query UUID in successful visualization metadata', async () => {
+        const runAsyncQuery: RunAsyncQueryFn = vi.fn().mockResolvedValue({
+            queryUuid: '11111111-1111-4111-8111-111111111111',
+            rows: [{ a_dim1: 'one', a_met1: 1 }],
+            cacheMetadata: { cacheHit: false },
+            fields: {},
+        });
+
+        await expect(executeTool(runAsyncQuery)).resolves.toMatchObject({
+            metadata: {
+                status: 'success',
+                queryUuid: '11111111-1111-4111-8111-111111111111',
+            },
+        });
+    });
+
+    it('returns the query UUID when row data is hidden from the model', async () => {
+        const runAsyncQuery: RunAsyncQueryFn = vi.fn().mockResolvedValue({
+            queryUuid: '11111111-1111-4111-8111-111111111111',
+            rows: [{ a_dim1: 'one', a_met1: 1 }],
+            cacheMetadata: { cacheHit: false },
+            fields: {},
+        });
+
+        await expect(
+            executeTool(runAsyncQuery, false, makeSlackPrompt()),
+        ).resolves.toMatchObject({
+            metadata: {
+                status: 'success',
+                queryUuid: '11111111-1111-4111-8111-111111111111',
+            },
+        });
+    });
+
+    it('does not expose a query UUID for an empty result', async () => {
+        const output = await executeTool(
+            vi.fn().mockResolvedValue({
+                queryUuid: '11111111-1111-4111-8111-111111111111',
+                rows: [],
+                cacheMetadata: { cacheHit: false },
+                fields: {},
+            }) as RunAsyncQueryFn,
+        );
+
+        expect(output.metadata).toMatchObject({ status: 'success' });
+        expect(output.metadata).not.toHaveProperty('queryUuid');
+    });
+
+    it('does not expose a query UUID when execution fails', async () => {
+        const output = await executeTool(
+            vi
+                .fn()
+                .mockRejectedValue(
+                    new Error('warehouse unavailable'),
+                ) as RunAsyncQueryFn,
+        );
+
+        expect(output.metadata).toEqual({ status: 'error' });
+    });
+});

--- a/packages/backend/src/ee/services/ai/tools/runQuery.ts
+++ b/packages/backend/src/ee/services/ai/tools/runQuery.ts
@@ -334,7 +334,11 @@ export const getRunQuery = ({
                 if (!enableDataAccess) {
                     return {
                         result: `Success. ${resultSummary}`,
-                        metadata: { status: 'success', chartImageUrl },
+                        metadata: {
+                            status: 'success',
+                            chartImageUrl,
+                            queryUuid: queryResults.queryUuid,
+                        },
                     };
                 }
 
@@ -343,7 +347,11 @@ export const getRunQuery = ({
                     result: [resultSummary, serializeData(csv, 'csv')].join(
                         '\n\n',
                     ),
-                    metadata: { status: 'success', chartImageUrl },
+                    metadata: {
+                        status: 'success',
+                        chartImageUrl,
+                        queryUuid: queryResults.queryUuid,
+                    },
                 };
             } catch (e) {
                 return {

--- a/packages/common/src/ee/aiDeepResearch/types.ts
+++ b/packages/common/src/ee/aiDeepResearch/types.ts
@@ -379,6 +379,9 @@ export type ApiAiDeepResearchRunResponse = ApiSuccess<AiDeepResearchRun>;
 
 export type ApiAiDeepResearchRunListResponse = ApiSuccess<AiDeepResearchRun[]>;
 
+export type ApiAiDeepResearchChartResponse =
+    ApiSuccess<AiDeepResearchChartData>;
+
 export type ApiAiDeepResearchEventsResponse =
     ApiSuccess<AiDeepResearchEventsPage>;
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchChartTile.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchChartTile.test.tsx
@@ -190,18 +190,19 @@ describe('DeepResearchChartTile', () => {
         });
     });
 
-    it('defaults to live data when the report has no snapshot', () => {
-        mocks.useLiveQuery.mockReturnValue({
-            ...idleLiveQuery,
-            isLoading: true,
-        });
-
+    it('loads the retained query directly when the report has no snapshot', () => {
         renderTile({ snapshot: null });
 
         expect(mocks.useLiveQuery).toHaveBeenCalledWith(
-            expect.objectContaining({ enabled: true }),
+            expect.objectContaining({ enabled: false }),
         );
-        expect(screen.getByText('Loading live chart data')).toBeVisible();
+        expect(mocks.useQueryResults).toHaveBeenCalledWith(
+            'project-1',
+            QUERY_UUID,
+            chart.title,
+        );
+        expect(screen.getByText('Report data')).toBeVisible();
+        expect(screen.getByTestId('visualization')).toBeVisible();
         expect(screen.queryByText(/Snapshot from/)).not.toBeInTheDocument();
     });
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchChartTile.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchChartTile.tsx
@@ -38,21 +38,25 @@ export const DeepResearchChartTile = ({
     runUuid,
 }: Props) => {
     const hasSnapshot = chart.snapshot !== null;
-    const canRefresh = chart.source === 'warehouse';
+    const canRefresh = chart.source === 'warehouse' && hasSnapshot;
     const [view, setView] = useState<'snapshot' | 'live'>(
         hasSnapshot ? 'snapshot' : 'live',
     );
-    const isLive = view === 'live' && canRefresh;
+    const isLive = view === 'live' && chart.source === 'warehouse';
 
     const liveQuery = useDeepResearchChartLiveQuery({
         projectUuid,
         runUuid,
         chartKey,
-        enabled: isLive,
+        enabled: isLive && hasSnapshot,
     });
     const liveResults = useInfiniteQueryResults(
         projectUuid,
-        isLive ? liveQuery.data?.query.queryUuid : undefined,
+        isLive
+            ? hasSnapshot
+                ? liveQuery.data?.query.queryUuid
+                : (chart.queryUuid ?? undefined)
+            : undefined,
         chart.title,
     );
 
@@ -102,7 +106,11 @@ export const DeepResearchChartTile = ({
         };
     }, [chart]);
 
-    const vizQueryData = isLive ? liveQuery.data : snapshotVizQueryData;
+    const vizQueryData = isLive
+        ? hasSnapshot
+            ? liveQuery.data
+            : snapshotVizQueryData
+        : snapshotVizQueryData;
     const results = isLive ? liveResults : snapshotResults;
 
     const visualizationConfig = useMemo<ToolRunQueryArgs>(() => {
@@ -127,9 +135,11 @@ export const DeepResearchChartTile = ({
         };
     }, [chart]);
 
-    const liveError = liveQuery.error ?? liveResults.error;
+    const liveError =
+        (hasSnapshot ? liveQuery.error : null) ?? liveResults.error;
     const isLoadingLive =
-        isLive && (liveQuery.isLoading || liveResults.isFetchingRows);
+        isLive &&
+        ((hasSnapshot && liveQuery.isLoading) || liveResults.isFetchingRows);
     const appliedFilters = chart.metricQuery.filters;
     const displayFilterPills =
         shouldDisplayVisualizationFilters(appliedFilters);
@@ -171,7 +181,7 @@ export const DeepResearchChartTile = ({
                     ) : null}
                     {isLive ? (
                         <Text size="xs" c="dimmed">
-                            Live data
+                            {hasSnapshot ? 'Live data' : 'Report data'}
                         </Text>
                     ) : null}
                 </Group>

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchMarkdownReport.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchMarkdownReport.test.tsx
@@ -1,0 +1,43 @@
+import { type AiDeepResearchChartData } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+import { DeepResearchMarkdownReport } from './DeepResearchMarkdownReport';
+
+const mocks = vi.hoisted(() => ({ useChartQuery: vi.fn() }));
+
+vi.mock('../../hooks/useDeepResearch', () => ({
+    useDeepResearchChartQuery: mocks.useChartQuery,
+}));
+
+vi.mock('./DeepResearchChartTile', () => ({
+    DeepResearchChartTile: ({ chart }: { chart: AiDeepResearchChartData }) => (
+        <div>{chart.title}</div>
+    ),
+}));
+
+const queryUuid = '7c4b40ba-79f8-4fd2-9c43-223eca8fa76f';
+
+describe('DeepResearchMarkdownReport', () => {
+    it('hydrates a query-backed chart when no legacy snapshot exists', async () => {
+        mocks.useChartQuery.mockReturnValue({
+            isLoading: false,
+            data: { title: 'Revenue trend' },
+        });
+
+        renderWithProviders(
+            <DeepResearchMarkdownReport
+                markdown={`## Finding\n\n<chart id="${queryUuid}" title="Revenue trend" description="Revenue by month.">`}
+                chartData={null}
+                projectUuid="project-1"
+                runUuid="run-1"
+            />,
+        );
+
+        expect(await screen.findByText('Revenue trend')).toBeVisible();
+        expect(mocks.useChartQuery).toHaveBeenCalledWith({
+            projectUuid: 'project-1',
+            runUuid: 'run-1',
+            queryUuid,
+        });
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchMarkdownReport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchMarkdownReport.tsx
@@ -18,6 +18,8 @@ import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import { type StreamdownProps } from 'streamdown';
 import { AiMarkdown } from '../../../../../components/common/AiMarkdown/AiMarkdown';
 import Callout from '../../../../../components/common/Callout';
+import EmptyStateLoader from '../../../../../components/common/EmptyStateLoader';
+import { useDeepResearchChartQuery } from '../../hooks/useDeepResearch';
 import { DeepResearchChartTile } from './DeepResearchChartTile';
 import styles from './DeepResearchReport.module.css';
 
@@ -64,6 +66,36 @@ const ConfidenceBadge: FC<{ level: unknown; children?: ReactNode }> = ({
 
 const CHART_HREF_PREFIX = '#chart-';
 
+const QueryBackedChart: FC<{
+    projectUuid: string;
+    runUuid: string;
+    queryUuid: string;
+}> = ({ projectUuid, runUuid, queryUuid }) => {
+    const chartQuery = useDeepResearchChartQuery({
+        projectUuid,
+        runUuid,
+        queryUuid,
+    });
+    if (chartQuery.isLoading) {
+        return <EmptyStateLoader title="Loading report chart" />;
+    }
+    if (!chartQuery.data) {
+        return (
+            <Callout variant="warning" title="Chart unavailable">
+                This chart could not be displayed.
+            </Callout>
+        );
+    }
+    return (
+        <DeepResearchChartTile
+            chartKey={queryUuid}
+            chart={chartQuery.data}
+            projectUuid={projectUuid}
+            runUuid={runUuid}
+        />
+    );
+};
+
 /**
  * Chart tags are converted to these internal links before rendering and
  * hydrate into chart tiles from the run's persisted chart data. Every other
@@ -79,11 +111,20 @@ const ReportLink: FC<AnchorHTMLAttributes<HTMLAnchorElement>> = ({
     if (linkHref?.startsWith(CHART_HREF_PREFIX)) {
         const chartKey = linkHref.slice(CHART_HREF_PREFIX.length);
         const chart = context?.chartData?.[chartKey];
-        if (!context || !chart) {
+        if (!context) {
             return (
                 <Callout variant="warning" title="Chart unavailable">
                     This chart could not be displayed.
                 </Callout>
+            );
+        }
+        if (!chart) {
+            return (
+                <QueryBackedChart
+                    projectUuid={context.projectUuid}
+                    runUuid={context.runUuid}
+                    queryUuid={chartKey}
+                />
             );
         }
         return (

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.ts
@@ -2,11 +2,13 @@ import {
     type AnyType,
     type AiDeepResearchEntryPoint,
     type AiDeepResearchEventsPage,
+    type AiDeepResearchChartData,
     type AiDeepResearchRequestBody,
     type AiDeepResearchRun,
     type ApiAiDeepResearchEventsResponse,
     type ApiAiDeepResearchRunListResponse,
     type ApiAiDeepResearchRunResponse,
+    type ApiAiDeepResearchChartResponse,
     type ApiAiAgentThreadMessageVizQuery,
     type ApiAiAgentThreadMessageVizQueryResponse,
     type ApiError,
@@ -129,6 +131,18 @@ const refreshDeepResearchChart = (
         method: 'POST',
         body: JSON.stringify({}),
     }) as Promise<ApiAiAgentThreadMessageVizQueryResponse['results']>;
+
+const getDeepResearchChart = (
+    projectUuid: string,
+    runUuid: string,
+    queryUuid: string,
+) =>
+    lightdashApi<AnyType>({
+        version: 'v1',
+        url: `${getBaseUrl(projectUuid)}/${runUuid}/charts/${encodeURIComponent(queryUuid)}`,
+        method: 'GET',
+        body: undefined,
+    }) as Promise<ApiAiDeepResearchChartResponse['results']>;
 
 type StartMutationVariables = StartDeepResearchArgs & {
     promptUuid: string;
@@ -527,6 +541,28 @@ export const useDeepResearchChartLiveQuery = ({
         ],
         queryFn: () => refreshDeepResearchChart(projectUuid, runUuid, chartKey),
         enabled,
+        staleTime: Infinity,
+        refetchOnWindowFocus: false,
+    });
+
+export const useDeepResearchChartQuery = ({
+    projectUuid,
+    runUuid,
+    queryUuid,
+}: {
+    projectUuid: string;
+    runUuid: string;
+    queryUuid: string;
+}) =>
+    useQuery<AiDeepResearchChartData, ApiError>({
+        queryKey: [
+            DEEP_RESEARCH_QUERY_KEY,
+            projectUuid,
+            runUuid,
+            'charts',
+            queryUuid,
+        ],
+        queryFn: () => getDeepResearchChart(projectUuid, runUuid, queryUuid),
         staleTime: Infinity,
         refetchOnWindowFocus: false,
     });


### PR DESCRIPTION
## Summary

PR 2 of 3 for [PROD-9430](https://linear.app/lightdash/issue/PROD-9430/deep-research-judges-return-markdown-with-chart-candidate-references). Makes retained query results the source of truth for new report charts and removes new chart snapshots from report persistence.

Stacks on [#26664](https://github.com/lightdash/lightdash/pull/26664), which establishes the 30/31/32-day retention policy.

## Stack

1. #26664 — retain Deep Research query results
2. **#26665 — hydrate report charts from retained query results**
3. #26666 — emit judge Markdown with canonical query references

## Changes

**Backend**

- Adds an authenticated chart endpoint that resolves a report's query UUID to verified chart metadata.
- Verifies run ownership, project/organization/user scope, query context, actor type, execution time, readiness, expiry, and chart/query field compatibility.
- Accepts semantic metrics and named table calculations referenced by chart axes.
- Persists `snapshot: null` for new query-backed charts while retaining legacy snapshot reads.

**Frontend**

- Lazily loads chart metadata and retained query rows when a report chart renders.
- Preserves the existing refresh behavior and legacy report rendering.

## Source-of-truth flow

```text
report Markdown query UUID → verified query history → retained result object → chart render
```

## Test plan

- [x] `AiDeepResearchService.test.ts` — 57/57
- [x] Backend/frontend typecheck and lint
- [x] Frontend suite — 2,013/2,013
- [x] Real Postgres provenance tests — 4/4
- [x] Generated API route verified locally
- [x] 25/25 chart references hydrated through the authenticated endpoint

Part of: https://linear.app/lightdash/issue/PROD-9430
