### PR TITLE
feat: show MCP tool token usage

### DIFF
--- a/docs/research/mcp-tool-token-accounting.md
+++ b/docs/research/mcp-tool-token-accounting.md
@@ -1,0 +1,90 @@
+# MCP tool-definition token accounting
+
+Date: 2026-08-03
+
+Repositories were inspected at these pinned revisions:
+
+- `anomalyco/opencode`: [`1882c33827cf0ce5c948b69ab5a87ed8f6790cf8`](https://github.com/anomalyco/opencode/tree/1882c33827cf0ce5c948b69ab5a87ed8f6790cf8)
+- `earendil-works/pi`: [`f0deb8dd8e9611e89b5bc4145ca92c03ae6ed4ee`](https://github.com/earendil-works/pi/tree/f0deb8dd8e9611e89b5bc4145ca92c03ae6ed4ee)
+- `openai/codex`: [`bb5054fe47abe73ecbbd454751066a28c89f4bb9`](https://github.com/openai/codex/tree/bb5054fe47abe73ecbbd454751066a28c89f4bb9)
+
+## Conclusion
+
+All three track provider-reported request usage at whole-request level. None exposes provider-measured usage attributed to one tool or MCP server. Pi has the closest implementation precedent for an estimate: serialize all tool definitions, then use `ceil(characters / 4)`. OpenCode also uses `ceil(characters / 4)` for an approximate context breakdown, while Codex uses `ceil(UTF-8 bytes / 4)` and explicitly calls that heuristic coarse rather than tokenizer-accurate.
+
+The proposed Lightdash UI should therefore treat these values as **definition token estimates**, not measured usage. Per-server totals should sum its enabled tool estimates. Because Lightdash lazy-loads MCP definitions, the configuration UI should say **up to N tokens when loaded** or **N enabled definition tokens**, with nearby help that explains the approximation—not **N tokens in context**.
+
+| Repository | Provider usage | Local estimate | Per-tool/MCP attribution | UI |
+| --- | --- | --- | --- | --- |
+| OpenCode | Input, output, cache and reasoning from provider events | `ceil(chars / 4)` for context categories | No; definitions fall into aggregate “Other” | Aggregate context and approximate category breakdown |
+| Pi | Input, output, cache, reasoning and cost from provider responses | `ceil(chars / 4)` over serialized tool array | Aggregate tool-definition estimate only | Aggregate session/context usage |
+| Codex | Input, output, cache and reasoning from Responses events | `ceil(UTF-8 bytes / 4)` for local history/output heuristics | No | Aggregate session/context usage |
+
+## OpenCode
+
+OpenCode's normalized usage contract is explicitly provider-reported and distinguishes inclusive input/output totals from non-cached input, cache reads, cache writes and reasoning. It also retains the raw provider payload for auditability ([usage contract](https://github.com/anomalyco/opencode/blob/1882c33827cf0ce5c948b69ab5a87ed8f6790cf8/packages/llm/src/schema/events.ts#L7-L59)). Its OpenAI adapter maps `prompt_tokens`, cached tokens, completion tokens and reasoning tokens directly from the provider event ([OpenAI mapper](https://github.com/anomalyco/opencode/blob/1882c33827cf0ce5c948b69ab5a87ed8f6790cf8/packages/llm/src/protocols/openai-chat.ts#L386-L404)). These numbers describe the complete request, not individual definitions.
+
+MCP tools are discovered, normalized into dynamic tools with their description and input schema, transformed for the selected provider, and added to the session tool set ([MCP conversion](https://github.com/anomalyco/opencode/blob/1882c33827cf0ce5c948b69ab5a87ed8f6790cf8/packages/opencode/src/mcp/catalog.ts#L38-L53), [provider schema transformation](https://github.com/anomalyco/opencode/blob/1882c33827cf0ce5c948b69ab5a87ed8f6790cf8/packages/opencode/src/session/tools.ts#L388-L398)). There is no separate metering event at that boundary.
+
+The UI builds an approximate context breakdown with `Math.ceil(chars / 4)` and assigns the residual between locally estimated categories and provider input tokens to `other` ([breakdown estimator](https://github.com/anomalyco/opencode/blob/1882c33827cf0ce5c948b69ab5a87ed8f6790cf8/packages/app/src/components/session/session-context-breakdown.ts#L12-L14), [residual calculation](https://github.com/anomalyco/opencode/blob/1882c33827cf0ce5c948b69ab5a87ed8f6790cf8/packages/app/src/components/session/session-context-breakdown.ts#L111-L131)). Its own UI copy says “Other” includes tool definitions and overhead ([copy](https://github.com/anomalyco/opencode/blob/1882c33827cf0ce5c948b69ab5a87ed8f6790cf8/packages/app/src/i18n/en.ts#L459-L465)). OpenCode therefore exposes tool definitions only as unattributed aggregate overhead, not as per-tool estimates.
+
+## Pi
+
+Pi records provider-reported input, output, cache-read, cache-write, reasoning, total tokens and cost ([usage type](https://github.com/earendil-works/pi/blob/f0deb8dd8e9611e89b5bc4145ca92c03ae6ed4ee/packages/ai/src/types.ts#L368-L388)). Its OpenAI Responses adapter separates cached/cache-write input from fresh input and copies output, reasoning and total usage from the response before calculating cost ([Responses mapping](https://github.com/earendil-works/pi/blob/f0deb8dd8e9611e89b5bc4145ca92c03ae6ed4ee/packages/ai/src/api/openai-responses-shared.ts#L541-L558)).
+
+Pi also has a local context estimator. It defines four characters per token, JSON-serializes the complete tool array, and includes that estimate alongside the system prompt and messages ([estimator constant and text calculation](https://github.com/earendil-works/pi/blob/f0deb8dd8e9611e89b5bc4145ca92c03ae6ed4ee/packages/ai/src/utils/estimate.ts#L14-L42), [tool serialization and context calculation](https://github.com/earendil-works/pi/blob/f0deb8dd8e9611e89b5bc4145ca92c03ae6ed4ee/packages/ai/src/utils/estimate.ts#L105-L142)). After a provider usage block, it estimates only definitions introduced later in the transcript, avoiding double-counting definitions already covered by provider usage ([incremental definitions](https://github.com/earendil-works/pi/blob/f0deb8dd8e9611e89b5bc4145ca92c03ae6ed4ee/packages/ai/src/utils/estimate.ts#L117-L131)). The result is used to reserve output space against the model context window ([simple options](https://github.com/earendil-works/pi/blob/f0deb8dd8e9611e89b5bc4145ca92c03ae6ed4ee/packages/ai/src/api/simple-options.ts#L5-L17)).
+
+Pi can split tools into immediate and transcript-loaded definitions ([deferred-tool split](https://github.com/earendil-works/pi/blob/f0deb8dd8e9611e89b5bc4145ca92c03ae6ed4ee/packages/ai/src/utils/deferred-tools.ts#L7-L38)), but the estimator returns only the combined serialized-tool cost. Its footer displays aggregate input, output, cache and context statistics ([footer](https://github.com/earendil-works/pi/blob/f0deb8dd8e9611e89b5bc4145ca92c03ae6ed4ee/packages/coding-agent/src/modes/interactive/components/footer.ts#L84-L108), [rendered metrics](https://github.com/earendil-works/pi/blob/f0deb8dd8e9611e89b5bc4145ca92c03ae6ed4ee/packages/coding-agent/src/modes/interactive/components/footer.ts#L128-L161)). Core Pi deliberately has no built-in MCP; MCP can be added by an extension ([README](https://github.com/earendil-works/pi/blob/f0deb8dd8e9611e89b5bc4145ca92c03ae6ed4ee/packages/coding-agent/README.md#L491-L497)). It consequently has no native per-MCP server grouping.
+
+## Codex
+
+Codex maps Responses API completion usage into input, cached input, cache-write input, output, reasoning output and total tokens ([Responses event mapping](https://github.com/openai/codex/blob/bb5054fe47abe73ecbbd454751066a28c89f4bb9/codex-rs/codex-api/src/sse/responses.rs#L112-L149)). Its protocol keeps both latest-turn and accumulated session usage ([protocol types and accumulation](https://github.com/openai/codex/blob/bb5054fe47abe73ecbbd454751066a28c89f4bb9/codex-rs/protocol/src/protocol.rs#L2064-L2125)). The status UI renders aggregate total, input, output and context-window usage ([status calculation and display](https://github.com/openai/codex/blob/bb5054fe47abe73ecbbd454751066a28c89f4bb9/codex-rs/tui/src/status/card.rs#L326-L342), [status spans](https://github.com/openai/codex/blob/bb5054fe47abe73ecbbd454751066a28c89f4bb9/codex-rs/tui/src/status/card.rs#L376-L407)).
+
+Codex's local approximation is `ceil(UTF-8 bytes / 4)` ([string utility](https://github.com/openai/codex/blob/bb5054fe47abe73ecbbd454751066a28c89f4bb9/codex-rs/utils/string/src/truncate.rs#L4-L5), [token calculation](https://github.com/openai/codex/blob/bb5054fe47abe73ecbbd454751066a28c89f4bb9/codex-rs/utils/string/src/truncate.rs#L71-L84)). The history estimator explicitly describes this as a coarse, non-tokenizer-accurate lower bound and applies it to base instructions plus history items ([history estimator](https://github.com/openai/codex/blob/bb5054fe47abe73ecbbd454751066a28c89f4bb9/codex-rs/core/src/context_manager/history.rs#L163-L188)). Tool specifications are a separate field on the model prompt ([prompt structure](https://github.com/openai/codex/blob/bb5054fe47abe73ecbbd454751066a28c89f4bb9/codex-rs/core/src/client_common.rs#L16-L32)), so that history estimate is not a per-tool estimate.
+
+When tool search is enabled, Codex registers MCP tools as deferred instead of including them in the initial model-visible tool list ([MCP exposure](https://github.com/openai/codex/blob/bb5054fe47abe73ecbbd454751066a28c89f4bb9/codex-rs/core/src/mcp_tool_exposure.rs#L18-L46)). Deferred means registered for later discovery but omitted initially ([exposure contract](https://github.com/openai/codex/blob/bb5054fe47abe73ecbbd454751066a28c89f4bb9/codex-rs/tools/src/tool_executor.rs#L13-L35)); discovered specifications are returned as client `tool_search_output` context items ([tool-search output](https://github.com/openai/codex/blob/bb5054fe47abe73ecbbd454751066a28c89f4bb9/codex-rs/core/src/tools/context.rs#L151-L189)). This is the same semantic reason Lightdash must distinguish potential enabled-definition cost from the definitions active in a specific thread.
+
+## Recommended Lightdash implementation
+
+### Estimate contract
+
+Use one deterministic pure function over the definition sent to the model:
+
+```ts
+const serializedDefinition = JSON.stringify({
+    name: canonicalRuntimeName,
+    description: description ?? '',
+    inputSchema,
+});
+const estimate = Math.ceil(
+    new TextEncoder().encode(serializedDefinition).byteLength / 4,
+);
+```
+
+Four UTF-8 bytes per token follows Codex and avoids treating multibyte text as cheaper than ASCII; for typical ASCII-heavy schemas it is equivalent to the two TypeScript precedents. `ceil`, rather than `round`, matches all three inspected estimators. This is intentionally model-agnostic. Provider-specific tokenizers and provider-specific tool wrappers can produce different actual counts, so the UI must explain that the values are approximate.
+
+Use Lightdash's runtime namespaced name (`mcp_<sanitized server>__<sanitized tool>`) if available. Estimating with only the raw MCP `toolName` slightly undercounts what the model receives. Keep the serializer near the runtime/common contract if practical so the UI does not drift from the tool shape. Compute dynamically from stored definitions; a database column is unnecessary and can become stale after MCP refreshes.
+
+### Aggregation and UI semantics
+
+- Tool row: `640` under a token column with tooltip “Approximate size of this tool definition.”
+- Server permissions row: sum enabled tools, displayed as `8.2k tokens`.
+- Page header: sum enabled tools across attached servers, displayed as “Tokens used by MCPs 33.9k,” with a help tooltip.
+- Warning threshold: presentation-only, based on the enabled-definition total.
+- Disabled tools still show their row estimate but do not contribute to server/page totals.
+- Server totals are sums of tool definitions, not separately metered server overhead.
+- Tooltip: explain that tool definitions share the model's working space with the question and answer, larger sets may increase latency/cost, and lazy loading usually makes actual usage lower.
+
+Avoid “Tool definitions in context” on this configuration screen. Lightdash's `loadMcpTools` gating makes the active set thread- and step-dependent; the settings page knows the potential enabled set, not a live thread's loaded set. A future thread UI can show “currently loaded” by applying the same estimate to the active tool names reconstructed from message history.
+
+### Validation
+
+1. Pure tests: stable serialization, empty/Unicode descriptions, nested schemas, enabled-only aggregation and compact formatting.
+2. Runtime fixture: compare the estimated object with the canonical names and schemas passed into the AI SDK.
+3. Provider A/B: send the same prompt/model once without a definition and once with one definition; compare provider-reported input tokens. Treat the delta as validation evidence, not a permanent exact attribution mechanism, because request wrappers, caching and tokenizer changes can affect it.
+
+## Final distinction
+
+- **Measured usage:** provider-reported tokens for a complete model request; authoritative for billing/context, but not attributable to a single definition.
+- **Definition estimate:** deterministic size estimate for one serialized tool definition; appropriate for per-tool and per-server configuration guidance.
+- **Loaded-definition estimate:** sum of estimates for tools active in a particular thread step; only available when runtime/message state is known.

--- a/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.ts
+++ b/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.ts
@@ -6,6 +6,7 @@ import {
 } from '@ai-sdk/mcp';
 import {
     assertUnreachable,
+    getMcpToolBaseName,
     type AiMcpCredentialScope,
     type AiMcpServerAuthType,
     type AiMcpServerConnectionStatus,
@@ -493,15 +494,6 @@ export const isMcpAuthorizationError = (error: unknown): boolean =>
     error instanceof UnauthorizedError ||
     (error instanceof Error &&
         (/401/.test(error.message) || /authorization/i.test(error.message)));
-
-const sanitizeMcpToolKeyPart = (value: string) => {
-    const sanitized = value
-        .replace(/[^a-zA-Z0-9_]+/g, '_')
-        .replace(/_+/g, '_')
-        .replace(/^_+/, '')
-        .replace(/_+$/, '');
-    return sanitized.length > 0 ? sanitized.toLowerCase() : 'tool';
-};
 
 type McpServerConnectionArgs = {
     uuid: string;
@@ -1282,9 +1274,6 @@ export class AiAgentMcpRuntimeClient {
             } else if (serverResult.mcpClient && serverResult.tools) {
                 connectedClients.push(serverResult.mcpClient);
 
-                const serverPrefix = sanitizeMcpToolKeyPart(
-                    serverResult.mcpServer.name,
-                );
                 const enabledToolNames = new Set(
                     serverResult.mcpServer.enabledToolNames ?? [],
                 );
@@ -1300,8 +1289,10 @@ export class AiAgentMcpRuntimeClient {
                         continue;
                     }
 
-                    const toolSuffix = sanitizeMcpToolKeyPart(toolName);
-                    const baseToolName = `mcp_${serverPrefix}__${toolSuffix}`;
+                    const baseToolName = getMcpToolBaseName(
+                        serverResult.mcpServer.name,
+                        toolName,
+                    );
                     let namespacedToolName = baseToolName;
                     let collisionCount = 1;
 

--- a/packages/backend/src/ee/services/ai/agents/mcpToolGating.ts
+++ b/packages/backend/src/ee/services/ai/agents/mcpToolGating.ts
@@ -1,3 +1,4 @@
+import { toolLoadMcpToolsArgsSchema } from '@lightdash/common';
 import type { ModelMessage } from 'ai';
 
 const getToolCalls = (messages: ModelMessage[]) =>
@@ -21,16 +22,16 @@ export const getMcpActiveTools = (
         if (currentMcpToolNames.has(toolCall.toolName)) {
             loadedMcpToolNames.add(toolCall.toolName);
         }
-        if (
-            toolCall.toolName === 'loadMcpTools' &&
-            toolCall.input &&
-            typeof toolCall.input === 'object' &&
-            'names' in toolCall.input &&
-            Array.isArray(toolCall.input.names)
-        ) {
-            for (const name of toolCall.input.names) {
-                if (typeof name === 'string' && currentMcpToolNames.has(name)) {
-                    loadedMcpToolNames.add(name);
+        if (toolCall.toolName === 'loadMcpTools') {
+            const parsedInput = toolLoadMcpToolsArgsSchema.safeParse(
+                toolCall.input,
+            );
+
+            if (parsedInput.success) {
+                for (const name of parsedInput.data.names) {
+                    if (currentMcpToolNames.has(name)) {
+                        loadedMcpToolNames.add(name);
+                    }
                 }
             }
         }

--- a/packages/common/src/ee/AiAgent/utils.test.ts
+++ b/packages/common/src/ee/AiAgent/utils.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { parseAiArtifactChartConfig } from './utils';
+import { getMcpToolBaseName, parseAiArtifactChartConfig } from './utils';
+
+describe('getMcpToolBaseName', () => {
+    it('matches the namespaced runtime tool name', () => {
+        expect(getMcpToolBaseName('Linear MCP', 'Get issue')).toBe(
+            'mcp_linear_mcp__get_issue',
+        );
+        expect(getMcpToolBaseName('---', '---')).toBe('mcp_tool__tool');
+    });
+});
 
 const semanticConfig = {
     title: 'Revenue by month',

--- a/packages/common/src/ee/AiAgent/utils.ts
+++ b/packages/common/src/ee/AiAgent/utils.ts
@@ -17,6 +17,22 @@ import {
 import { AiResultType } from './types';
 import { getValidAiQueryLimit } from './validators';
 
+const sanitizeMcpToolKeyPart = (value: string) => {
+    const sanitized = value
+        .replace(/[^a-zA-Z0-9_]+/g, '_')
+        .replace(/_+/g, '_')
+        .replace(/^_+/, '')
+        .replace(/_+$/, '');
+
+    return sanitized.length > 0 ? sanitized.toLowerCase() : 'tool';
+};
+
+export const getMcpToolBaseName = (
+    mcpServerName: string,
+    toolName: string,
+): string =>
+    `mcp_${sanitizeMcpToolKeyPart(mcpServerName)}__${sanitizeMcpToolKeyPart(toolName)}`;
+
 export const parseVizConfig = (
     vizConfigUnknown: object | null,
     maxLimit?: number | undefined,

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServerToolsPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServerToolsPanel.tsx
@@ -7,6 +7,7 @@ import {
     Group,
     Stack,
     Text,
+    Tooltip,
     useMantineColorScheme,
 } from '@mantine-8/core';
 import {
@@ -19,6 +20,7 @@ import MarkdownPreview from '@uiw/react-markdown-preview';
 import { useEffect, useState, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import MantineModal from '../../../../components/common/MantineModal';
+import TruncatedText from '../../../../components/common/TruncatedText';
 import {
     rehypeRemoveHeaderLinks,
     useMdEditorStyle,
@@ -29,6 +31,11 @@ import {
     useStartMcpOAuthConnectionMutation,
     useUpdateAgentAiMcpServerToolsMutation,
 } from '../hooks/useProjectAiMcpServers';
+import {
+    estimateMcpToolDefinitionTokens,
+    formatTokenEstimate,
+} from '../utils/mcpToolTokenEstimates';
+import styles from './McpToolTokenEstimate.module.css';
 
 type Props = {
     agentUuid?: string;
@@ -344,25 +351,38 @@ export const AiAgentMcpServerToolsPanel: FC<Props> = ({
                         No tools found for this MCP server yet.
                     </Text>
                 ) : (
-                    <Stack gap="xs">
-                        <Checkbox
-                            label={
-                                <Text size="sm" fw={600} c="ldGray.9">
-                                    Enable all
+                    <Stack gap={0}>
+                        <Group justify="space-between" gap="sm" pb="xs">
+                            <Checkbox
+                                label={
+                                    <Text size="sm" fw={600} c="ldGray.9">
+                                        Enable all
+                                    </Text>
+                                }
+                                checked={allToolsEnabled}
+                                indeterminate={hasMixedToolSelection}
+                                disabled={isRefreshingTools || isUpdatingTools}
+                                onChange={(event) =>
+                                    void updateTools({
+                                        toolSettings: tools.map((tool) => ({
+                                            toolName: tool.toolName,
+                                            enabled:
+                                                event.currentTarget.checked,
+                                        })),
+                                    })
+                                }
+                            />
+                            <Tooltip
+                                label="Approximate input tokens for each tool definition. Actual usage varies by model and provider."
+                                multiline
+                                w={280}
+                                withinPortal
+                            >
+                                <Text className={styles.tokenColumnHeader}>
+                                    Tokens
                                 </Text>
-                            }
-                            checked={allToolsEnabled}
-                            indeterminate={hasMixedToolSelection}
-                            disabled={isRefreshingTools || isUpdatingTools}
-                            onChange={(event) =>
-                                void updateTools({
-                                    toolSettings: tools.map((tool) => ({
-                                        toolName: tool.toolName,
-                                        enabled: event.currentTarget.checked,
-                                    })),
-                                })
-                            }
-                        />
+                            </Tooltip>
+                        </Group>
                         {tools.map((tool) => {
                             const isUpdating =
                                 isUpdatingTools &&
@@ -374,7 +394,11 @@ export const AiAgentMcpServerToolsPanel: FC<Props> = ({
                             const checkboxId = `mcp-tool-${tool.uuid}`;
 
                             return (
-                                <Box key={tool.uuid} py={2} pl="lg">
+                                <Box
+                                    key={tool.uuid}
+                                    py="xs"
+                                    className={styles.toolRow}
+                                >
                                     <Group
                                         align="center"
                                         gap="xs"
@@ -400,23 +424,24 @@ export const AiAgentMcpServerToolsPanel: FC<Props> = ({
                                                 })
                                             }
                                         />
-                                        <Box flex={1}>
-                                            <Group gap={6} wrap="nowrap">
-                                                <Text
+                                        <Box flex={1} miw={0}>
+                                            <Group gap="xxs" wrap="nowrap">
+                                                <Box
                                                     component="label"
                                                     htmlFor={checkboxId}
-                                                    size="sm"
-                                                    fw={700}
-                                                    c="ldGray.9"
-                                                    style={{
-                                                        cursor: isUpdating
-                                                            ? 'not-allowed'
-                                                            : 'pointer',
-                                                    }}
+                                                    miw={0}
+                                                    className={`${styles.toolLabel} ${isUpdating ? styles.toolLabelDisabled : ''}`}
                                                 >
-                                                    {tool.title ||
-                                                        tool.toolName}
-                                                </Text>
+                                                    <TruncatedText
+                                                        maxWidth="100%"
+                                                        fz="sm"
+                                                        fw={700}
+                                                        c="ldGray.9"
+                                                    >
+                                                        {tool.title ||
+                                                            tool.toolName}
+                                                    </TruncatedText>
+                                                </Box>
                                                 <ActionIcon
                                                     variant="subtle"
                                                     color="gray"
@@ -444,6 +469,14 @@ export const AiAgentMcpServerToolsPanel: FC<Props> = ({
                                                 </ActionIcon>
                                             </Group>
                                         </Box>
+                                        <Text className={styles.toolTokenValue}>
+                                            {formatTokenEstimate(
+                                                estimateMcpToolDefinitionTokens(
+                                                    tool,
+                                                    mcpServer.name,
+                                                ),
+                                            )}
+                                        </Text>
                                     </Group>
                                 </Box>
                             );

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
@@ -21,6 +21,7 @@ import {
     Paper,
     PasswordInput,
     SegmentedControl,
+    Skeleton,
     Stack,
     Text,
     TextInput,
@@ -36,13 +37,14 @@ import {
     IconChevronRight,
     IconDots,
     IconEye,
+    IconHelpCircle,
     IconKey,
     IconPlug,
     IconPlugConnected,
     IconRefresh,
     IconTrash,
 } from '@tabler/icons-react';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { z } from 'zod';
 import { BetaBadge } from '../../../../components/common/BetaBadge';
 import MantineIcon from '../../../../components/common/MantineIcon';
@@ -60,9 +62,15 @@ import {
     useStartMcpOAuthConnectionMutation,
     useUpdateAiMcpServerCredentialMutation,
 } from '../hooks/useProjectAiMcpServers';
+import {
+    estimateEnabledMcpToolDefinitionTokens,
+    formatTokenEstimate,
+    MCP_TOOL_TOKEN_WARNING_THRESHOLD,
+} from '../utils/mcpToolTokenEstimates';
 import { AiAgentMcpServerToolsPanel } from './AiAgentMcpServerToolsPanel';
 import { AiMcpServerIcon } from './AiMcpServerIcon';
 import { GithubMcpConnectModal } from './GithubMcpConnectModal';
+import tokenStyles from './McpToolTokenEstimate.module.css';
 
 const CREATE_NEW_MCP_OPTION_VALUE = '__create_new_mcp__';
 
@@ -676,13 +684,20 @@ const McpToolPermissionsSummary = ({
     agentUuid,
     isPersistedAttachment,
     isSavingAgent,
+    mcpServerName,
     mcpServerUuid,
+    onTokenEstimateChange,
     projectUuid,
 }: {
     agentUuid?: string;
     isPersistedAttachment: boolean;
     isSavingAgent?: boolean;
+    mcpServerName: string;
     mcpServerUuid: string;
+    onTokenEstimateChange: (
+        mcpServerUuid: string,
+        tokenEstimate: number,
+    ) => void;
     projectUuid: string;
 }) => {
     const { data } = useAgentAiMcpServerTools(
@@ -694,15 +709,48 @@ const McpToolPermissionsSummary = ({
         },
     );
 
-    if (!agentUuid || !isPersistedAttachment || isSavingAgent || !data) {
+    const tokenEstimate = useMemo(
+        () =>
+            data
+                ? estimateEnabledMcpToolDefinitionTokens(data, mcpServerName)
+                : undefined,
+        [data, mcpServerName],
+    );
+
+    useEffect(() => {
+        if (tokenEstimate !== undefined) {
+            onTokenEstimateChange(mcpServerUuid, tokenEstimate);
+        }
+    }, [mcpServerUuid, onTokenEstimateChange, tokenEstimate]);
+
+    if (
+        !agentUuid ||
+        !isPersistedAttachment ||
+        isSavingAgent ||
+        !data ||
+        tokenEstimate === undefined
+    ) {
         return null;
     }
 
     const enabledCount = data.filter((tool) => tool.enabled).length;
 
+    const isHighTokenEstimate =
+        tokenEstimate >= MCP_TOOL_TOKEN_WARNING_THRESHOLD;
+
     return (
         <Text size="sm" c="dimmed">
             {enabledCount}/{data.length} enabled
+            <Text span c="ldGray.4">
+                {' '}
+                ·{' '}
+            </Text>
+            <Text
+                span
+                className={`${tokenStyles.serverTokenValue} ${isHighTokenEstimate ? tokenStyles.serverTokenValueWarning : ''}`}
+            >
+                {formatTokenEstimate(tokenEstimate)} tokens
+            </Text>
         </Text>
     );
 };
@@ -735,6 +783,9 @@ export const AiAgentMcpServersInput = ({
     const [isPersistingSelection, setIsPersistingSelection] = useState(false);
     const [editingTokenMcpServer, setEditingTokenMcpServer] =
         useState<AiMcpServer | null>(null);
+    const [mcpServerTokenEstimates, setMcpServerTokenEstimates] = useState<
+        Record<string, number>
+    >({});
     const isPersistingSelectionRef = useRef(false);
     const { showToastSuccess } = useToaster();
     const { data: mcpServers, isLoading: isLoadingMcpServers } =
@@ -799,6 +850,32 @@ export const AiAgentMcpServersInput = ({
                 .filter((mcpServer): mcpServer is AiMcpServer => !!mcpServer),
         [value, mcpServers],
     );
+    const handleTokenEstimateChange = useCallback(
+        (mcpServerUuid: string, tokenEstimate: number) => {
+            setMcpServerTokenEstimates((currentEstimates) =>
+                currentEstimates[mcpServerUuid] === tokenEstimate
+                    ? currentEstimates
+                    : {
+                          ...currentEstimates,
+                          [mcpServerUuid]: tokenEstimate,
+                      },
+            );
+        },
+        [],
+    );
+    const persistedSelectedMcpServers = selectedMcpServers.filter((mcpServer) =>
+        persistedMcpServerUuids?.includes(mcpServer.uuid),
+    );
+    const hasCompleteTokenEstimate = persistedSelectedMcpServers.every(
+        (mcpServer) => mcpServerTokenEstimates[mcpServer.uuid] !== undefined,
+    );
+    const totalTokenEstimate = hasCompleteTokenEstimate
+        ? persistedSelectedMcpServers.reduce(
+              (total, mcpServer) =>
+                  total + (mcpServerTokenEstimates[mcpServer.uuid] ?? 0),
+              0,
+          )
+        : undefined;
 
     const availableMcpServerOptions = useMemo(
         () => [
@@ -1279,7 +1356,13 @@ export const AiAgentMcpServersInput = ({
     return (
         <>
             <Paper p="xl">
-                <Group align="center" gap="xs" mb="md">
+                <Group
+                    justify="space-between"
+                    align="center"
+                    gap="md"
+                    mb="md"
+                    wrap="wrap"
+                >
                     <Group align="center" gap="xs">
                         <Paper p="xxs" withBorder radius="sm">
                             <MantineIcon icon={IconPlug} size="md" />
@@ -1290,7 +1373,44 @@ export const AiAgentMcpServersInput = ({
                         <BetaBadge />
                     </Group>
                     {selectedMcpServers.length > 0 && (
-                        <Group align="center" gap="xs">
+                        <Group align="center" gap="sm" wrap="wrap">
+                            {persistedSelectedMcpServers.length > 0 && (
+                                <Group gap={4} wrap="nowrap">
+                                    {totalTokenEstimate === undefined ? (
+                                        <Skeleton w={88} h={18} radius="xl" />
+                                    ) : (
+                                        <Text
+                                            className={
+                                                tokenStyles.totalTokenValue
+                                            }
+                                        >
+                                            {formatTokenEstimate(
+                                                totalTokenEstimate,
+                                            )}{' '}
+                                            tokens
+                                        </Text>
+                                    )}
+                                    <Tooltip
+                                        withinPortal
+                                        multiline
+                                        w={320}
+                                        label="Tokens measure how much of the model's working space these tools can take up. A larger tool set can leave less room for your question and the agent's answer, and may make requests slower or more expensive. Lightdash loads tools only when needed, so actual usage is often lower."
+                                    >
+                                        <ActionIcon
+                                            type="button"
+                                            variant="subtle"
+                                            color="ldGray"
+                                            size="xs"
+                                            aria-label="Why tool token usage matters"
+                                        >
+                                            <MantineIcon
+                                                icon={IconHelpCircle}
+                                                size="sm"
+                                            />
+                                        </ActionIcon>
+                                    </Tooltip>
+                                </Group>
+                            )}
                             {canOneClickConnectGithub && (
                                 <Tooltip
                                     withinPortal
@@ -1624,6 +1744,12 @@ export const AiAgentMcpServersInput = ({
                                                         }
                                                         mcpServerUuid={
                                                             mcpServer.uuid
+                                                        }
+                                                        mcpServerName={
+                                                            mcpServer.name
+                                                        }
+                                                        onTokenEstimateChange={
+                                                            handleTokenEstimateChange
                                                         }
                                                         projectUuid={
                                                             projectUuid

--- a/packages/frontend/src/ee/features/aiCopilot/components/McpToolTokenEstimate.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/McpToolTokenEstimate.module.css
@@ -1,0 +1,53 @@
+.tokenColumnHeader {
+    width: 5.5rem;
+    flex-shrink: 0;
+    color: var(--mantine-color-dimmed);
+    font-size: var(--mantine-font-size-xs);
+    font-weight: 600;
+    text-align: right;
+    text-transform: uppercase;
+}
+
+.toolTokenValue {
+    width: 5.5rem;
+    flex-shrink: 0;
+    color: var(--mantine-color-dimmed);
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 13px;
+    font-variant-numeric: tabular-nums;
+    text-align: right;
+}
+
+.serverTokenValue {
+    color: var(--mantine-color-dimmed);
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 13px;
+    font-variant-numeric: tabular-nums;
+}
+
+.serverTokenValueWarning {
+    color: var(--mantine-color-orange-light-color);
+    font-weight: 600;
+}
+
+.totalTokenValue {
+    flex-shrink: 0;
+    color: var(--mantine-color-text);
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 13px;
+    font-variant-numeric: tabular-nums;
+}
+
+.toolRow {
+    border-top: 1px solid
+        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-ldDark-5));
+}
+
+.toolLabel {
+    min-width: 0;
+    cursor: pointer;
+}
+
+.toolLabelDisabled {
+    cursor: not-allowed;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/utils/mcpToolTokenEstimates.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/mcpToolTokenEstimates.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import {
+    estimateEnabledMcpToolDefinitionTokens,
+    estimateMcpToolDefinitionTokens,
+    formatTokenEstimate,
+} from './mcpToolTokenEstimates';
+
+const shortTool = {
+    toolName: 'find_issue',
+    description: 'Find one issue',
+    inputSchema: {
+        type: 'object',
+        properties: { id: { type: 'string' } },
+    },
+};
+
+describe('MCP tool token estimates', () => {
+    it('estimates larger definitions as using more tokens', () => {
+        const shortEstimate = estimateMcpToolDefinitionTokens(
+            shortTool,
+            'Linear',
+        );
+        const longEstimate = estimateMcpToolDefinitionTokens(
+            {
+                ...shortTool,
+                description:
+                    'Find one issue and return its full activity history',
+                inputSchema: {
+                    ...shortTool.inputSchema,
+                    properties: {
+                        ...shortTool.inputSchema.properties,
+                        includeComments: { type: 'boolean' },
+                        includeRelations: { type: 'boolean' },
+                    },
+                },
+            },
+            'Linear',
+        );
+
+        expect(shortEstimate).toBeGreaterThan(0);
+        expect(longEstimate).toBeGreaterThan(shortEstimate);
+    });
+
+    it('accounts for the UTF-8 size of non-ASCII definitions', () => {
+        expect(
+            estimateMcpToolDefinitionTokens(
+                {
+                    ...shortTool,
+                    description: '🔍🔍🔍🔍',
+                },
+                'Linear',
+            ),
+        ).toBeGreaterThan(
+            estimateMcpToolDefinitionTokens(
+                {
+                    ...shortTool,
+                    description: 'aaaa',
+                },
+                'Linear',
+            ),
+        );
+    });
+
+    it('counts only enabled definitions in totals', () => {
+        expect(
+            estimateEnabledMcpToolDefinitionTokens(
+                [
+                    { ...shortTool, enabled: true },
+                    {
+                        ...shortTool,
+                        toolName: 'list_issues',
+                        enabled: false,
+                    },
+                ],
+                'Linear',
+            ),
+        ).toBe(estimateMcpToolDefinitionTokens(shortTool, 'Linear'));
+    });
+
+    it('formats compact approximate counts', () => {
+        expect(formatTokenEstimate(640)).toBe('640');
+        expect(formatTokenEstimate(1_100)).toBe('1.1k');
+        expect(formatTokenEstimate(24_600)).toBe('24.6k');
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/utils/mcpToolTokenEstimates.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/mcpToolTokenEstimates.ts
@@ -1,0 +1,45 @@
+import { getMcpToolBaseName, type AiMcpServerTool } from '@lightdash/common';
+
+type McpToolDefinition = Pick<
+    AiMcpServerTool,
+    'toolName' | 'description' | 'inputSchema'
+>;
+
+type EnabledMcpToolDefinition = McpToolDefinition & { enabled: boolean };
+
+export const MCP_TOOL_TOKEN_WARNING_THRESHOLD = 20_000;
+
+export const estimateMcpToolDefinitionTokens = (
+    tool: McpToolDefinition,
+    mcpServerName: string,
+): number => {
+    const serializedDefinition = JSON.stringify({
+        name: getMcpToolBaseName(mcpServerName, tool.toolName),
+        ...(tool.description ? { description: tool.description } : {}),
+        inputSchema: tool.inputSchema,
+    });
+
+    return Math.ceil(
+        new TextEncoder().encode(serializedDefinition).byteLength / 4,
+    );
+};
+
+export const estimateEnabledMcpToolDefinitionTokens = (
+    tools: EnabledMcpToolDefinition[],
+    mcpServerName: string,
+): number =>
+    tools.reduce(
+        (total, tool) =>
+            tool.enabled
+                ? total + estimateMcpToolDefinitionTokens(tool, mcpServerName)
+                : total,
+        0,
+    );
+
+export const formatTokenEstimate = (tokenCount: number): string => {
+    if (tokenCount < 1_000) {
+        return `${tokenCount}`;
+    }
+
+    return `${(tokenCount / 1_000).toFixed(1).replace(/\.0$/, '')}k`;
+};


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/ZAP-745/show-mcp-tool-token-usage-in-agent-setup

Stacked on #26643.

### Description

- Show **Tokens used by MCPs** in the agent setup header.
- Show enabled token totals per MCP server and token values per tool.
- Exclude disabled tools from totals and update values with permission changes.
- Estimate from the serialized runtime definition, including the namespaced tool name, description, and input schema.
- Add product guidance explaining why large tool definitions matter and that lazy loading often lowers actual request usage.
- Document token-accounting approaches in OpenCode, Pi, and Codex.

### Verification

- Common: 5 focused tests; typecheck; lint.
- Backend: 18 focused tests; typecheck; lint.
- Frontend: 4 estimator tests; typecheck; lint; format check.
- Standards and Spec reviews: no findings.
- Browser: 24.4k total across 3 connected MCPs; per-server and per-tool values, tooltip, typography, and tool-description placement verified.
