### PR TITLE
fix: remove stale homepage assertions from project E2E

### DIFF
--- a/packages/e2e/cypress/e2e/app/createProjects.cy.ts
+++ b/packages/e2e/cypress/e2e/app/createProjects.cy.ts
@@ -198,10 +198,6 @@ const testCompile = (): Cypress.Chainable<string> => {
     // Configure
     cy.contains('button', 'Save changes').click();
     cy.url({ timeout: 30000 }).should('include', '/home');
-    cy.contains('Welcome, David');
-    cy.findByText('Charts and Dashboards');
-    cy.findByText('get started by creating some charts');
-    cy.wait(1000);
     return cy.url().then(
         (url) =>
             // get new project uuid


### PR DESCRIPTION
### Description

- Keep the create-project E2E focused on compile success and the `/home` redirect.
- Remove legacy homepage copy assertions that no longer apply to the day-one homepage.

### Verification

- Confirmed the CI failure across Postgres, BigQuery, and Snowflake; all reached `/home` and rendered the new homepage.
- E2E lint passed.
- E2E format check passed.
- Local Cypress launched; the focused run stopped earlier because the local server lacks the CI `/dbt` mount.

Relates: SPK-776