### PR TITLE
fix: detect and self-heal dead scheduler worker pools after Postgres connection loss

### DIFF
--- a/packages/backend/src/SchedulerApp.ts
+++ b/packages/backend/src/SchedulerApp.ts
@@ -50,6 +50,12 @@ import { VERSION } from './version';
 
 const FEATURE_FLAG_CHECK_FLUSH_INTERVAL_MS = 15 * 60 * 1000;
 
+// Delay between the pool-dead latch firing and process.exit(1): long enough
+// for the health endpoint to serve a 503 and for logs/Sentry to flush, short
+// enough that the outage stays measured in seconds. There are no in-flight
+// jobs to drain — a dead pool executes nothing by definition.
+const POOL_DEAD_EXIT_DELAY_MS = 15_000;
+
 type SchedulerAppArguments = {
     lightdashConfig: LightdashConfig;
     port: string | number;
@@ -281,6 +287,24 @@ export default class SchedulerApp {
 
     private async initWorker() {
         const workerHealth = new SchedulerWorkerHealth(derivePoolIdFromEnv());
+        // Crash-only recovery: a terminated graphile-worker pool cannot be
+        // rebuilt in-process (0.13 never respawns dead workers), and queued
+        // jobs are durable, so the correct move is to exit and let the
+        // orchestrator start a fresh pod. The probe flips 503 immediately via
+        // the poolDead latch; the delayed exit is the belt-and-braces path in
+        // case no liveness probe is configured. Fires at most once.
+        workerHealth.onPoolDead((reason) => {
+            Logger.error(
+                `[scheduler-health] worker pool is dead (${reason}); exiting in ${POOL_DEAD_EXIT_DELAY_MS}ms so the orchestrator restarts a fresh worker`,
+            );
+            Sentry.captureException(
+                new Error(`Scheduler worker pool dead: ${reason}`),
+                { extra: { poolId: workerHealth.getPoolId() } },
+            );
+            setTimeout(() => {
+                process.exit(1);
+            }, POOL_DEAD_EXIT_DELAY_MS).unref();
+        });
         wireWorkerHealthEvents(schedulerWorkerEventEmitter, workerHealth);
         const worker = this.schedulerWorkerFactory({
             lightdashConfig: this.lightdashConfig,
@@ -356,7 +380,9 @@ export default class SchedulerApp {
                 await shutdownOtelTracing();
                 if (worker && worker.runner) {
                     Logger.info('Stopping scheduler worker');
-                    await worker?.runner?.stop();
+                    // worker.stop() (not runner.stop()) so the settling runner
+                    // promise is recognised as graceful, not a pool crash.
+                    await worker.stop();
                 }
             },
             onShutdown: async () => {

--- a/packages/backend/src/SchedulerApp.ts
+++ b/packages/backend/src/SchedulerApp.ts
@@ -50,11 +50,17 @@ import { VERSION } from './version';
 
 const FEATURE_FLAG_CHECK_FLUSH_INTERVAL_MS = 15 * 60 * 1000;
 
-// Delay between the pool-dead latch firing and process.exit(1): long enough
-// for the health endpoint to serve a 503 and for logs/Sentry to flush, short
-// enough that the outage stays measured in seconds. There are no in-flight
-// jobs to drain — a dead pool executes nothing by definition.
-const POOL_DEAD_EXIT_DELAY_MS = 15_000;
+// Delay between the pool-dead latch firing and the fallback process.exit(1).
+// The PRIMARY restart path is the liveness probe: the latch flips
+// /api/v1/health to 503 immediately, the orchestrator SIGTERMs the pod, and
+// terminus runs worker.stop() so graphile fail_job-releases any in-flight
+// jobs for immediate retry (relevant when a single worker died while
+// siblings still process — the latch also fires there). The hard exit only
+// covers deployments with no liveness probe. It must stay comfortably above
+// the helm chart's scheduler liveness window (~305s: failureThreshold 20 x
+// periodSeconds 15) so the probe path, which shuts down cleanly, always wins
+// where configured.
+const POOL_DEAD_EXIT_DELAY_MS = 10 * 60_000;
 
 type SchedulerAppArguments = {
     lightdashConfig: LightdashConfig;
@@ -289,13 +295,14 @@ export default class SchedulerApp {
         const workerHealth = new SchedulerWorkerHealth(derivePoolIdFromEnv());
         // Crash-only recovery: a terminated graphile-worker pool cannot be
         // rebuilt in-process (0.13 never respawns dead workers), and queued
-        // jobs are durable, so the correct move is to exit and let the
-        // orchestrator start a fresh pod. The probe flips 503 immediately via
-        // the poolDead latch; the delayed exit is the belt-and-braces path in
-        // case no liveness probe is configured. Fires at most once.
+        // jobs are durable, so the correct move is to get this process
+        // replaced. The probe flips 503 immediately via the poolDead latch and
+        // the liveness probe restarts the pod gracefully; the delayed exit is
+        // the belt-and-braces path for deployments without a liveness probe.
+        // Fires at most once.
         workerHealth.onPoolDead((reason) => {
             Logger.error(
-                `[scheduler-health] worker pool is dead (${reason}); exiting in ${POOL_DEAD_EXIT_DELAY_MS}ms so the orchestrator restarts a fresh worker`,
+                `[scheduler-health] worker pool is dead (${reason}); health probe now reports 503, fallback exit in ${POOL_DEAD_EXIT_DELAY_MS}ms`,
             );
             Sentry.captureException(
                 new Error(`Scheduler worker pool dead: ${reason}`),

--- a/packages/backend/src/scheduler/SchedulerWorker.heartbeat.test.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.heartbeat.test.ts
@@ -1,10 +1,19 @@
 import { ALL_TASK_NAMES } from '@lightdash/common';
+import { run as runGraphileWorker, type Runner } from 'graphile-worker';
 import { type LightdashConfig } from '../config/parseConfig';
 import {
     SchedulerWorker,
     type SchedulerWorkerArguments,
 } from './SchedulerWorker';
 import { SchedulerWorkerHealth } from './SchedulerWorkerHealth';
+
+vi.mock('graphile-worker', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('graphile-worker')>();
+    return {
+        ...actual,
+        run: vi.fn(),
+    };
+});
 
 class TestableSchedulerWorker extends SchedulerWorker {
     public exposeTaskList() {
@@ -94,12 +103,17 @@ describe('SchedulerWorker — task list no longer carries heartbeat plumbing', (
 });
 
 describe('SchedulerWorker — pingPgOnce', () => {
-    it('runs SELECT 1 through withPgClient and marks pg reachable on success', async () => {
+    it('sends the jobs:insert NOTIFY heartbeat through withPgClient and marks pg reachable on success', async () => {
+        // The NOTIFY doubles as a pool liveness probe: it makes this process's
+        // own LISTEN client nudge the worker pool, so a terminated pool
+        // surfaces "nudge called after worker terminated" via
+        // pool:listen:error and trips the poolDead latch — even on an idle
+        // instance where nothing else generates NOTIFYs.
         const health = new SchedulerWorkerHealth('pod-xyz');
         const markPgReachableSpy = vi.spyOn(health, 'markPgReachable');
 
         const pgClient = {
-            query: vi.fn().mockResolvedValue({ rows: [{ '?column?': 1 }] }),
+            query: vi.fn().mockResolvedValue({ rows: [{ pg_notify: '' }] }),
         };
         const withPgClient = vi
             .fn()
@@ -113,7 +127,9 @@ describe('SchedulerWorker — pingPgOnce', () => {
         await worker.pingPgOnceExposed(health);
 
         expect(withPgClient).toHaveBeenCalledTimes(1);
-        expect(pgClient.query).toHaveBeenCalledWith('SELECT 1');
+        expect(pgClient.query).toHaveBeenCalledWith(
+            `SELECT pg_notify('jobs:insert', '')`,
+        );
         expect(markPgReachableSpy).toHaveBeenCalledTimes(1);
     });
 
@@ -185,5 +201,78 @@ describe('SchedulerWorker — pingPgOnce', () => {
         } finally {
             vi.useRealTimers();
         }
+    });
+});
+
+describe('SchedulerWorker — runner promise settlement', () => {
+    const makeFakeRunner = () => {
+        let settle!: () => void;
+        const promise = new Promise<void>((resolve) => {
+            settle = resolve;
+        });
+        const runner = {
+            promise,
+            stop: vi.fn(async () => {
+                settle();
+            }),
+            addJob: vi.fn(),
+        } as unknown as Runner;
+        return { runner, settle };
+    };
+
+    const flushSettlement = async () => {
+        // The .finally continuation registered in run() executes on the
+        // microtask queue after the runner promise settles.
+        await new Promise((resolve) => {
+            setImmediate(resolve);
+        });
+    };
+
+    beforeEach(() => {
+        vi.mocked(runGraphileWorker).mockReset();
+    });
+
+    it('latches poolDead when the runner promise settles outside a graceful stop', async () => {
+        // graphile-worker 0.13 gives up permanently after e.g. 10 consecutive
+        // failed job acquisitions (Postgres restart). When its promise
+        // settles without stop() having been called, the pool is dead.
+        const health = new SchedulerWorkerHealth('pod-crash');
+        const markPoolDeadSpy = vi.spyOn(health, 'markPoolDead');
+        const { runner, settle } = makeFakeRunner();
+        vi.mocked(runGraphileWorker).mockResolvedValue(runner);
+
+        const worker = new TestableSchedulerWorker(
+            makeWorkerArgs(vi.fn().mockResolvedValue({ rows: [] }), health),
+        );
+        await worker.run();
+        expect(worker.isRunning).toBe(true);
+
+        settle();
+        await flushSettlement();
+
+        expect(worker.isRunning).toBe(false);
+        expect(markPoolDeadSpy).toHaveBeenCalledWith(
+            'graphile runner stopped unexpectedly',
+        );
+        expect(health.isHealthy(Date.now() + 1).ok).toBe(false);
+    });
+
+    it('does not latch poolDead when stop() settles the promise gracefully', async () => {
+        const health = new SchedulerWorkerHealth('pod-graceful');
+        const markPoolDeadSpy = vi.spyOn(health, 'markPoolDead');
+        const { runner } = makeFakeRunner();
+        vi.mocked(runGraphileWorker).mockResolvedValue(runner);
+
+        const worker = new TestableSchedulerWorker(
+            makeWorkerArgs(vi.fn().mockResolvedValue({ rows: [] }), health),
+        );
+        await worker.run();
+
+        await worker.stop();
+        await flushSettlement();
+
+        expect(worker.isRunning).toBe(false);
+        expect(runner.stop).toHaveBeenCalledTimes(1);
+        expect(markPoolDeadSpy).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -59,6 +59,17 @@ const PG_PING_INTERVAL_MS = 60_000;
 // stack up overlapping client borrows from the pool.
 const PG_PING_TIMEOUT_MS = 5_000;
 
+// The ping doubles as a worker-pool liveness probe. The NOTIFY on graphile's
+// jobs:insert channel makes every listener in this database — including this
+// process's own — nudge its worker pool. A terminated pool fails that nudge
+// ("nudge called after worker terminated"), which surfaces via
+// pool:listen:error and trips the poolDead latch. Without this, an idle dead
+// worker looks healthy forever: nothing else generates NOTIFYs on a quiet
+// instance, and the wedged runner stops enqueueing even its own cron jobs.
+// The ping's pool (SchedulerClient's WorkerUtils) is separate from the
+// runner's, so it keeps working when the runner is wedged.
+const PG_PING_QUERY = `SELECT pg_notify('jobs:insert', '')`;
+
 export class SchedulerWorker extends SchedulerTask {
     runner: Runner | undefined;
 
@@ -69,6 +80,8 @@ export class SchedulerWorker extends SchedulerTask {
     protected readonly workerHealth: SchedulerWorkerHealth | undefined;
 
     private pgPingInterval: NodeJS.Timeout | null = null;
+
+    private isStopping: boolean = false;
 
     private readonly resolveOrganizationName?: OrganizationNameResolver;
 
@@ -125,7 +138,23 @@ export class SchedulerWorker extends SchedulerTask {
         void this.runner.promise.finally(() => {
             this.isRunning = false;
             this.stopPgPing();
+            // Settling outside a graceful stop() means graphile gave up — e.g.
+            // 10 consecutive failed job acquisitions after a Postgres restart.
+            // Unrecoverable in-process in 0.13: latch so the probe goes 503
+            // and the pool-dead listeners (process exit) fire.
+            if (!this.isStopping) {
+                this.workerHealth?.markPoolDead(
+                    'graphile runner stopped unexpectedly',
+                );
+            }
         });
+    }
+
+    // Graceful stop for shutdown paths (terminus onSignal). Sets the stopping
+    // flag first so the runner promise settling is not mistaken for a crash.
+    async stop() {
+        this.isStopping = true;
+        await this.runner?.stop();
     }
 
     private startPgPing(health: SchedulerWorkerHealth) {
@@ -158,7 +187,7 @@ export class SchedulerWorker extends SchedulerTask {
             // withPgClient borrows from graphile's existing pool and releases the
             // client back when the callback resolves — no long-lived client to leak.
             const ping = graphileClient.withPgClient((pgClient) =>
-                pgClient.query('SELECT 1'),
+                pgClient.query(PG_PING_QUERY),
             );
             await Promise.race([
                 ping,

--- a/packages/backend/src/scheduler/SchedulerWorkerEventEmitter.test.ts
+++ b/packages/backend/src/scheduler/SchedulerWorkerEventEmitter.test.ts
@@ -1,6 +1,9 @@
 import EventEmitter from 'events';
 import type { WorkerEvents } from 'graphile-worker';
-import { wireWorkerHealthEvents } from './SchedulerWorkerEventEmitter';
+import {
+    POOL_TERMINATED_ERROR_SIGNATURE,
+    wireWorkerHealthEvents,
+} from './SchedulerWorkerEventEmitter';
 import { SchedulerWorkerHealth } from './SchedulerWorkerHealth';
 
 const GRACE_MS = 3 * 60_000;
@@ -111,5 +114,112 @@ describe('wireWorkerHealthEvents', () => {
 
         // Past grace + staleness with the job still running.
         expect(health.isHealthy(startedAt + GRACE_MS + 60_000).ok).toBe(true);
+    });
+
+    describe('terminated-pool detection on pool:listen:error', () => {
+        it('latches poolDead immediately when the error carries the nudge signature', () => {
+            const emitter = new EventEmitter() as unknown as WorkerEvents;
+            const health = new SchedulerWorkerHealth();
+            const t = Date.now();
+            wireWorkerHealthEvents(emitter, health);
+
+            (emitter as unknown as EventEmitter).emit('pool:listen:error', {
+                error: new Error(POOL_TERMINATED_ERROR_SIGNATURE),
+            });
+
+            // Unhealthy right away — no 60s LISTEN budget for a dead pool.
+            const result = health.isHealthy(t + 1);
+            expect(result.ok).toBe(false);
+            expect(result.reason).toMatch(/^worker pool terminated:/);
+        });
+
+        it('matches the production error shape where the signature is embedded in a longer message', () => {
+            // Observed in app_logs: "Unsupported warehouse protocol message:
+            // nudge called after worker terminated" — wrapper prefixes must
+            // not defeat the match.
+            const emitter = new EventEmitter() as unknown as WorkerEvents;
+            const health = new SchedulerWorkerHealth();
+            wireWorkerHealthEvents(emitter, health);
+
+            (emitter as unknown as EventEmitter).emit('pool:listen:error', {
+                error: new Error(
+                    `Unsupported warehouse protocol message: ${POOL_TERMINATED_ERROR_SIGNATURE}`,
+                ),
+            });
+
+            expect(health.isHealthy(Date.now() + 1).ok).toBe(false);
+        });
+
+        it('cannot be cleared by the flapping listen success/error cycle', () => {
+            // Production pattern: the LISTEN client reconnects fine (success),
+            // then the next NOTIFY nudges the dead pool (error), every ~100ms.
+            // Pre-latch, the alternation kept resetting the 60s budget and the
+            // probe stayed green for 2.5 days.
+            const emitter = new EventEmitter() as unknown as WorkerEvents;
+            const health = new SchedulerWorkerHealth();
+            const t = Date.now();
+            wireWorkerHealthEvents(emitter, health);
+
+            for (let i = 0; i < 5; i += 1) {
+                (emitter as unknown as EventEmitter).emit('pool:listen:error', {
+                    error: new Error(POOL_TERMINATED_ERROR_SIGNATURE),
+                });
+                (emitter as unknown as EventEmitter).emit(
+                    'pool:listen:success',
+                    {},
+                );
+            }
+
+            expect(health.isHealthy(t + 1).ok).toBe(false);
+        });
+
+        it('fires the poolDead side effect once across repeated nudge errors', () => {
+            const emitter = new EventEmitter() as unknown as WorkerEvents;
+            const health = new SchedulerWorkerHealth();
+            const onPoolDead = vi.fn();
+            health.onPoolDead(onPoolDead);
+            wireWorkerHealthEvents(emitter, health);
+
+            for (let i = 0; i < 3; i += 1) {
+                (emitter as unknown as EventEmitter).emit('pool:listen:error', {
+                    error: new Error(POOL_TERMINATED_ERROR_SIGNATURE),
+                });
+            }
+
+            expect(onPoolDead).toHaveBeenCalledTimes(1);
+        });
+
+        it('treats ordinary listen errors as recoverable LISTEN loss, not pool death', () => {
+            const emitter = new EventEmitter() as unknown as WorkerEvents;
+            const health = new SchedulerWorkerHealth();
+            const t = Date.now();
+            wireWorkerHealthEvents(emitter, health);
+
+            (emitter as unknown as EventEmitter).emit('pool:listen:error', {
+                error: new Error('Connection terminated unexpectedly'),
+            });
+
+            // Inside the 60s budget: still healthy (recoverable).
+            expect(health.isHealthy(t + 30_000).ok).toBe(true);
+            // Recovery clears it.
+            (emitter as unknown as EventEmitter).emit(
+                'pool:listen:success',
+                {},
+            );
+            expect(health.isHealthy(t + 2 * LISTEN_BUDGET_MS).ok).toBe(true);
+        });
+
+        it('handles a payload with a non-Error error value', () => {
+            const emitter = new EventEmitter() as unknown as WorkerEvents;
+            const health = new SchedulerWorkerHealth();
+            const t = Date.now();
+            wireWorkerHealthEvents(emitter, health);
+
+            (emitter as unknown as EventEmitter).emit('pool:listen:error', {
+                error: `string error: ${POOL_TERMINATED_ERROR_SIGNATURE}`,
+            });
+
+            expect(health.isHealthy(t + 1).ok).toBe(false);
+        });
     });
 });

--- a/packages/backend/src/scheduler/SchedulerWorkerEventEmitter.ts
+++ b/packages/backend/src/scheduler/SchedulerWorkerEventEmitter.ts
@@ -121,6 +121,14 @@ schedulerWorkerEventEmitter.on('job:complete', ({ worker, job }) => {
     );
 });
 
+// graphile-worker 0.13's nudge assert message (worker.js). When the LISTEN
+// client receives a NOTIFY and nudges a terminated worker pool, this error
+// surfaces through pool:listen:error. It means the pool is permanently dead —
+// 0.13 never respawns dead workers — as opposed to an ordinary LISTEN
+// connection error, which the reconnect loop can recover from.
+export const POOL_TERMINATED_ERROR_SIGNATURE =
+    'nudge called after worker terminated';
+
 // Worker-aware liveness signals: graphile-worker 0.13 emits
 // pool:listen:success when LISTEN is established and pool:listen:error
 // when the LISTEN client dies. Job start/complete feed the activity clock.
@@ -129,7 +137,15 @@ export function wireWorkerHealthEvents(
     health: SchedulerWorkerHealth,
 ): void {
     emitter.on('pool:listen:success', () => health.markListenUp());
-    emitter.on('pool:listen:error', () => health.markListenLost());
+    emitter.on('pool:listen:error', ({ error }) => {
+        const message =
+            error instanceof Error ? error.message : String(error ?? '');
+        if (message.includes(POOL_TERMINATED_ERROR_SIGNATURE)) {
+            health.markPoolDead(message);
+            return;
+        }
+        health.markListenLost();
+    });
     emitter.on('job:start', () => health.markJobStarted());
     emitter.on('job:complete', () => health.markJobCompleted());
 }

--- a/packages/backend/src/scheduler/SchedulerWorkerHealth.test.ts
+++ b/packages/backend/src/scheduler/SchedulerWorkerHealth.test.ts
@@ -299,7 +299,13 @@ describe('SchedulerWorkerHealth', () => {
             expect(health.isHealthy(muchLater + 30_000)).toEqual({ ok: true });
         });
 
-        it('is unhealthy when a listen error is outstanding, even before the budget, once activity is stale', () => {
+        it('tolerates a transient listen blip inside the 60s budget on an idle worker', () => {
+            // The 60s LISTEN budget is the sole arbiter for reconnects — an
+            // idle worker must not flip 503 on the first blip (that would be
+            // stricter than the old pgReachableFresh behavior and cause
+            // liveness churn on ordinary reconnects). Past the budget the
+            // LISTEN branch trips as before; a dead pool is caught by the
+            // poolDead latch, not this path.
             const health = new SchedulerWorkerHealth();
             const startedAt = Date.now();
             health.markListenUp();
@@ -309,14 +315,11 @@ describe('SchedulerWorkerHealth', () => {
             health.markPgReachable();
             health.markListenLost();
 
-            // 30s after the loss: inside the 60s LISTEN budget, but with no
-            // job activity and no established LISTEN the idle-ok path must
-            // not apply.
-            const result = health.isHealthy(lostAt + 30_000);
-            expect(result.ok).toBe(false);
-            expect(result.reason).toBe(
-                'no recent job activity and LISTEN not established',
-            );
+            expect(health.isHealthy(lostAt + 30_000)).toEqual({ ok: true });
+
+            const pastBudget = health.isHealthy(lostAt + LISTEN_BUDGET_MS + 1);
+            expect(pastBudget.ok).toBe(false);
+            expect(pastBudget.reason).toMatch(/^LISTEN connection lost/);
         });
     });
 

--- a/packages/backend/src/scheduler/SchedulerWorkerHealth.test.ts
+++ b/packages/backend/src/scheduler/SchedulerWorkerHealth.test.ts
@@ -99,7 +99,7 @@ describe('SchedulerWorkerHealth', () => {
         const result = health.isHealthy(startedAt + GRACE_MS + 1);
         expect(result.ok).toBe(false);
         expect(result.reason).toBe(
-            'no job activity or pg ping within staleness threshold',
+            'no recent job activity and LISTEN not established',
         );
     });
 
@@ -125,7 +125,7 @@ describe('SchedulerWorkerHealth', () => {
         const result = health.isHealthy(activityAt + GRACE_MS + 1);
         expect(result.ok).toBe(false);
         expect(result.reason).toBe(
-            'no job activity or pg ping within staleness threshold',
+            'no recent job activity and LISTEN not established',
         );
     });
 
@@ -203,12 +203,12 @@ describe('SchedulerWorkerHealth', () => {
         });
     });
 
-    describe('pg-reachable signal', () => {
-        it('keeps the probe healthy past staleness when only pg-ping is fresh', () => {
-            // The exact scenario this refactor exists to fix: no jobs flowed
-            // for longer than the activity staleness window, but pg-ping has
-            // proven the worker can still reach pg in the last 60s. Probe
-            // must NOT trip — the worker is healthy, just idle.
+    describe('pg-reachable signal (negative only)', () => {
+        it('does NOT let a fresh pg-ping vouch for an idle worker with no LISTEN', () => {
+            // The Aug 2026 incident class: pool dead after a transient
+            // Postgres restart, no jobs flowing, but plain pg queries succeed
+            // because the DB is back. The old pgReachableFresh branch returned
+            // 200 for days in this state. A fresh ping must never vouch.
             const health = new SchedulerWorkerHealth();
             const startedAt = Date.now();
 
@@ -216,10 +216,14 @@ describe('SchedulerWorkerHealth', () => {
             Date.now = () => pingAt;
             health.markPgReachable();
 
-            expect(health.isHealthy(pingAt + 60_000)).toEqual({ ok: true });
+            const result = health.isHealthy(pingAt + 60_000);
+            expect(result.ok).toBe(false);
+            expect(result.reason).toBe(
+                'no recent job activity and LISTEN not established',
+            );
         });
 
-        it('trips when both job activity and pg-ping are stale', () => {
+        it('trips with a postgres-unreachable reason when the ping goes stale on an idle worker', () => {
             const health = new SchedulerWorkerHealth();
             const startedAt = Date.now();
 
@@ -227,12 +231,31 @@ describe('SchedulerWorkerHealth', () => {
             Date.now = () => activityAt;
             health.markJobActivity();
             health.markPgReachable();
+            health.markListenUp();
 
+            // Activity and ping both 3min+1ms old; LISTEN is up, but the
+            // stale ping (DB unreachable) must win over the idle-ok path.
             const result = health.isHealthy(activityAt + GRACE_MS + 1);
             expect(result.ok).toBe(false);
-            expect(result.reason).toBe(
-                'no job activity or pg ping within staleness threshold',
-            );
+            expect(result.reason).toMatch(/^postgres unreachable for \d+s$/);
+        });
+
+        it('does not trip on a stale ping while jobs are actively flowing', () => {
+            // Live job traffic is stronger evidence than a ping — transient
+            // ping timeouts must not restart a worker that is executing jobs.
+            const health = new SchedulerWorkerHealth();
+            const startedAt = Date.now();
+
+            Date.now = () => startedAt;
+            health.markPgReachable();
+
+            const laterActivity = startedAt + GRACE_MS + 5 * 60_000;
+            Date.now = () => laterActivity;
+            health.markJobActivity();
+
+            expect(health.isHealthy(laterActivity + 60_000)).toEqual({
+                ok: true,
+            });
         });
 
         it('reports LISTEN failure even when pg ping is still fresh', () => {
@@ -255,6 +278,118 @@ describe('SchedulerWorkerHealth', () => {
             const health = new SchedulerWorkerHealth();
             health.markPgReachable();
             expect(health.isHealthy()).toEqual({ ok: true });
+        });
+    });
+
+    describe('idle worker with LISTEN established', () => {
+        it('stays healthy indefinitely while LISTEN is up and pg is reachable', () => {
+            // Replaces the old pgReachableFresh voucher for legitimately idle
+            // instances: connected LISTEN means the worker is wired for
+            // wake-up. A dead pool cannot sustain this state — the heartbeat
+            // NOTIFY makes its own listener nudge the pool, which trips the
+            // poolDead latch.
+            const health = new SchedulerWorkerHealth();
+            const startedAt = Date.now();
+            health.markListenUp();
+
+            const muchLater = startedAt + 6 * 60 * 60_000;
+            Date.now = () => muchLater;
+            health.markPgReachable();
+
+            expect(health.isHealthy(muchLater + 30_000)).toEqual({ ok: true });
+        });
+
+        it('is unhealthy when a listen error is outstanding, even before the budget, once activity is stale', () => {
+            const health = new SchedulerWorkerHealth();
+            const startedAt = Date.now();
+            health.markListenUp();
+
+            const lostAt = startedAt + GRACE_MS + 10 * 60_000;
+            Date.now = () => lostAt;
+            health.markPgReachable();
+            health.markListenLost();
+
+            // 30s after the loss: inside the 60s LISTEN budget, but with no
+            // job activity and no established LISTEN the idle-ok path must
+            // not apply.
+            const result = health.isHealthy(lostAt + 30_000);
+            expect(result.ok).toBe(false);
+            expect(result.reason).toBe(
+                'no recent job activity and LISTEN not established',
+            );
+        });
+    });
+
+    describe('pool-dead latch', () => {
+        it('reports unhealthy with the terminating reason, overriding every other signal', () => {
+            const health = new SchedulerWorkerHealth();
+            const t = Date.now();
+            // Everything else looks healthy: fresh ping, LISTEN up, job in
+            // flight, fresh activity — the dead pool must still win.
+            health.markPgReachable();
+            health.markListenUp();
+            health.markJobStarted();
+            health.markPoolDead('nudge called after worker terminated');
+
+            const result = health.isHealthy(t + 1);
+            expect(result.ok).toBe(false);
+            expect(result.reason).toBe(
+                'worker pool terminated: nudge called after worker terminated',
+            );
+        });
+
+        it('is permanent — later recovery signals cannot clear it', () => {
+            const health = new SchedulerWorkerHealth();
+            const t = Date.now();
+            health.markPoolDead('boom');
+
+            health.markListenUp();
+            health.markJobStarted();
+            health.markJobActivity();
+            health.markPgReachable();
+
+            expect(health.isHealthy(t + 10_000).ok).toBe(false);
+            expect(health.isHealthy(t + 60 * 60_000).ok).toBe(false);
+        });
+
+        it('latches on first call only and reports whether this call latched', () => {
+            const health = new SchedulerWorkerHealth();
+            expect(health.markPoolDead('first')).toBe(true);
+            expect(health.markPoolDead('second')).toBe(false);
+
+            // The retained reason is the first one.
+            const result = health.isHealthy(Date.now() + 1);
+            expect(result.reason).toBe('worker pool terminated: first');
+        });
+
+        it('fires onPoolDead listeners exactly once despite repeated triggers', () => {
+            // The LISTEN retry loop re-raises the nudge error every ~100ms;
+            // the exit side effect must not be scheduled repeatedly.
+            const health = new SchedulerWorkerHealth();
+            const listener = vi.fn();
+            health.onPoolDead(listener);
+
+            health.markPoolDead('nudge called after worker terminated');
+            health.markPoolDead('nudge called after worker terminated');
+            health.markPoolDead('nudge called after worker terminated');
+
+            expect(listener).toHaveBeenCalledTimes(1);
+            expect(listener).toHaveBeenCalledWith(
+                'nudge called after worker terminated',
+            );
+        });
+
+        it('a throwing listener does not prevent the latch or other listeners', () => {
+            const health = new SchedulerWorkerHealth();
+            const second = vi.fn();
+            health.onPoolDead(() => {
+                throw new Error('listener bug');
+            });
+            health.onPoolDead(second);
+
+            expect(health.markPoolDead('boom')).toBe(true);
+            expect(second).toHaveBeenCalledTimes(1);
+            expect(health.isHealthy(Date.now() + 1).ok).toBe(false);
         });
     });
 });

--- a/packages/backend/src/scheduler/SchedulerWorkerHealth.ts
+++ b/packages/backend/src/scheduler/SchedulerWorkerHealth.ts
@@ -4,8 +4,9 @@ const LISTEN_RECOVERY_BUDGET_MS = 60_000;
 
 const JOB_ACTIVITY_STALENESS_MS = 3 * 60_000;
 
-// A successful pg ping within this window proves the worker process can still
-// reach the database, even when no graphile-worker job has fired recently.
+// A pg ping older than this window means the worker process cannot reach the
+// database. Negative signal only: a fresh ping never vouches for health, since
+// DB reachability is exactly what still holds when the worker pool is dead.
 const PG_REACHABLE_STALENESS_MS = 3 * 60_000;
 
 // Per-pod unique poolId — replicas sharing one would collapse to a single dedup'd heartbeat row,
@@ -35,6 +36,12 @@ export class SchedulerWorkerHealth {
     private startedAt: number = Date.now();
 
     private lastReportedState: HealthState = 'starting';
+
+    private poolDeadAt: number | null = null;
+
+    private poolDeadReason: string | null = null;
+
+    private readonly poolDeadListeners: Array<(reason: string) => void> = [];
 
     constructor(poolId?: string) {
         this.poolId = poolId ?? Math.random().toString(36).slice(2, 10);
@@ -108,6 +115,39 @@ export class SchedulerWorkerHealth {
         );
     }
 
+    // Register a callback for the pool-dead latch. Fires at most once, on the
+    // first markPoolDead call.
+    onPoolDead(listener: (reason: string) => void) {
+        this.poolDeadListeners.push(listener);
+    }
+
+    // Permanent latch: a terminated graphile-worker pool cannot recover
+    // in-process (0.13 never respawns dead workers), so once this fires the
+    // probe reports unhealthy until the process is replaced. Returns true only
+    // on the first call so callers can gate side effects; the LISTEN retry loop
+    // re-raises the same error every ~100ms and must not re-trigger them.
+    markPoolDead(reason: string): boolean {
+        if (this.poolDeadAt !== null) {
+            return false;
+        }
+        this.poolDeadAt = Date.now();
+        this.poolDeadReason = reason;
+        Logger.error(
+            `[scheduler-health] worker pool dead poolId=${this.poolId} reason="${reason}" — unhealthy until restart`,
+        );
+        this.poolDeadListeners.forEach((listener) => {
+            try {
+                listener(reason);
+            } catch (e) {
+                Logger.error(
+                    `[scheduler-health] pool-dead listener threw poolId=${this.poolId}`,
+                    e,
+                );
+            }
+        });
+        return true;
+    }
+
     getInFlightJobCount(): number {
         return this.inFlightJobCount;
     }
@@ -119,6 +159,18 @@ export class SchedulerWorkerHealth {
     }
 
     private computeHealth(now: number): HealthCheckResult {
+        // Terminated pool wins over every other signal: DB reachability, a
+        // reconnected LISTEN client, even in-flight bookkeeping. This is the
+        // Aug 2026 incident class — pool dead, everything else looks fine.
+        if (this.poolDeadAt !== null) {
+            return {
+                ok: false,
+                reason: `worker pool terminated: ${
+                    this.poolDeadReason ?? 'unknown'
+                }`,
+            };
+        }
+
         if (
             this.listenLostAt !== null &&
             now - this.listenLostAt > LISTEN_RECOVERY_BUDGET_MS
@@ -131,7 +183,8 @@ export class SchedulerWorkerHealth {
             };
         }
 
-        // Startup grace — the per-pool heartbeat takes ~1 min to fire on a fresh worker.
+        // Startup grace — the pg ping and LISTEN take a moment to establish on
+        // a fresh worker.
         const sinceStart = now - this.startedAt;
         if (sinceStart < JOB_ACTIVITY_STALENESS_MS) {
             return { ok: true };
@@ -151,18 +204,40 @@ export class SchedulerWorkerHealth {
             return { ok: true };
         }
 
-        // pg ping runs independently of the job queue, so it stays fresh during
-        // idle stretches between bursts when no job:start fires.
-        const pgReachableFresh =
+        // With no job flowing, a stale pg ping means the worker cannot reach
+        // postgres at all — jobs could not be fetched even if enqueued.
+        // Deliberately checked only on the idle path: live job traffic is
+        // stronger evidence than a ping and must not be overridden by it.
+        if (
             this.lastPgReachableAt !== null &&
-            now - this.lastPgReachableAt <= PG_REACHABLE_STALENESS_MS;
-        if (pgReachableFresh) {
+            now - this.lastPgReachableAt > PG_REACHABLE_STALENESS_MS
+        ) {
+            return {
+                ok: false,
+                reason: `postgres unreachable for ${Math.round(
+                    (now - this.lastPgReachableAt) / 1000,
+                )}s`,
+            };
+        }
+
+        // Idle is healthy only while wired for wake-up: LISTEN established and
+        // no unrecovered listen error. A dead pool cannot sustain this state —
+        // the minutely heartbeat NOTIFY makes its listener nudge the pool,
+        // which trips the poolDead latch above.
+        //
+        // Note this replaces the old `pgReachableFresh` voucher: a successful
+        // ping proves DB reachability, which is precisely the condition that
+        // still holds when the pool is dead after a transient Postgres outage.
+        // It vouched 200 for workers that had executed nothing for days.
+        const listenUp =
+            this.lastListenSuccessAt !== null && this.listenLostAt === null;
+        if (listenUp) {
             return { ok: true };
         }
 
         return {
             ok: false,
-            reason: 'no job activity or pg ping within staleness threshold',
+            reason: 'no recent job activity and LISTEN not established',
         };
     }
 

--- a/packages/backend/src/scheduler/SchedulerWorkerHealth.ts
+++ b/packages/backend/src/scheduler/SchedulerWorkerHealth.ts
@@ -220,18 +220,19 @@ export class SchedulerWorkerHealth {
             };
         }
 
-        // Idle is healthy only while wired for wake-up: LISTEN established and
-        // no unrecovered listen error. A dead pool cannot sustain this state —
+        // Idle is healthy only while wired for wake-up: LISTEN has been
+        // established at some point. An outstanding listen error is
+        // deliberately NOT checked here — the 60s budget above is the sole
+        // arbiter for transient reconnects, so an idle worker does not flip
+        // 503 on the first blip. A dead pool cannot hide behind this branch:
         // the minutely heartbeat NOTIFY makes its listener nudge the pool,
-        // which trips the poolDead latch above.
+        // which trips the poolDead latch above within a minute.
         //
         // Note this replaces the old `pgReachableFresh` voucher: a successful
         // ping proves DB reachability, which is precisely the condition that
         // still holds when the pool is dead after a transient Postgres outage.
         // It vouched 200 for workers that had executed nothing for days.
-        const listenUp =
-            this.lastListenSuccessAt !== null && this.listenLostAt === null;
-        if (listenUp) {
+        if (this.lastListenSuccessAt !== null) {
             return { ok: true };
         }
 


### PR DESCRIPTION
## Problem

When a transient Postgres outage (e.g. a Cloud SQL maintenance restart) kills the graphile-worker pool, the scheduler process stays alive but permanently stops executing background jobs. graphile-worker 0.13 never respawns dead workers, and — the killer detail — its runner promise does not settle when the pool dies, so `isRunning` stays `true`.

The health probe kept returning 200 in this state for days, across many instances at once, for a chain of three reasons:

1. **`pgReachableFresh` vouched for a corpse.** `SchedulerWorkerHealth.computeHealth` treated a fresh out-of-band pg ping as proof of health on idle workers. But DB reachability is *exactly* the condition that still holds once the DB comes back while the pool is dead.
2. **The LISTEN budget never accumulated.** After the outage the LISTEN client reconnects fine (`pool:listen:success` clears `listenLostAt`); the next NOTIFY nudges the terminated pool, fails with `nudge called after worker terminated`, and the ~100ms retry loop alternates success/error forever — the 60s failure budget resets on every cycle.
3. **Idle instances emit no distress signal at all.** The wedged runner also stops enqueueing its own cron jobs, so the queue stays flat and empty, no NOTIFYs arrive to trigger the nudge error, and every external metric looks healthy. In a recent incident wave, instances with traffic showed monotonically growing queues, while idle ones died silently with `queue_size ≤ 1` — their last executed job timestamps synchronized to the second with the Postgres restart.

## Fix

**1. Health semantics inverted for the pg ping (`SchedulerWorkerHealth.ts`)**

- A fresh pg ping never vouches for health anymore. It is a negative-only signal: a *stale* ping (worker cannot reach postgres) reports unhealthy on the idle path. Live job traffic still outranks it — a transient ping timeout must not restart a worker that is demonstrably executing jobs.
- An idle worker is healthy while LISTEN has been established at some point; an outstanding listen error is deliberately left to the existing 60s budget, so an idle worker does **not** flip 503 on a transient reconnect blip (same leniency as before this PR).
- New permanent `poolDead` latch that overrides every other signal (fresh ping, reconnected LISTEN, in-flight bookkeeping). Once latched, the probe reports 503 until the process is replaced, and registered `onPoolDead` listeners fire exactly once — the LISTEN retry loop re-raises the same error every ~100ms and must not re-trigger side effects.

**2. The minutely ping becomes a pool-liveness heartbeat (`SchedulerWorker.ts`)**

`SELECT 1` → `SELECT pg_notify('jobs:insert', '')` — the same channel graphile's own insert trigger notifies (`sql/000001.sql`).

The NOTIFY makes every listener in the database — including this process's own — nudge its worker pool. A terminated pool fails that nudge (`nudge called after worker terminated`), which surfaces via `pool:listen:error` and trips the latch within ~1 minute, **even on a fully idle instance**. This closes the silent-death gap: the ping runs on `SchedulerClient`'s WorkerUtils pool, which survives when the runner is wedged. Healthy pools just wake, poll once, and go back to sleep (they already poll every `pollInterval` anyway). In multi-replica deployments each pod's listener nudges its own local pool, so detection is per-pod without any shared-queue attribution problem.

**3. Probe-first recovery with a hard-exit fallback (`SchedulerWorkerEventEmitter.ts`, `SchedulerApp.ts`)**

- `wireWorkerHealthEvents` inspects `pool:listen:error`: the terminated-pool signature latches `poolDead`; ordinary connection errors keep the existing recoverable `markListenLost` path.
- On latch, the standalone scheduler logs, reports to Sentry, and serves 503 on `/api/v1/health` immediately. The **liveness probe is the primary restart path**: the orchestrator SIGTERMs the pod and terminus runs the new `SchedulerWorker.stop()`, so graphile's `gracefulShutdown` `fail_job`-releases any in-flight jobs for immediate retry. This matters for the partial-death case — when a single worker dies (job-release failure "seppuku") it stays in the pool's `workers` array, so the next NOTIFY nudge hits its assert and latches while sibling workers are still mid-job; a hard exit there would strand their locks for hours.
- `process.exit(1)` after 10 minutes is the fallback for deployments with **no** liveness probe. The delay sits comfortably above the helm chart's scheduler liveness window (~305s), so the graceful path always wins where a probe is configured.
- A settled runner promise outside a graceful stop also latches (`worker.stop()` sets a stopping flag first; terminus `onSignal` now calls it instead of `runner.stop()` directly).

## Failure-mode matrix

| State | Before | After |
|---|---|---|
| Pool terminated, DB back, instance busy | 200 forever (ping vouches) | latch on first NOTIFY nudge → 503 → probe restart |
| Pool terminated, DB back, instance idle | 200 forever (no signal at all) | heartbeat NOTIFY trips latch ≤ ~60s → 503 → probe restart |
| Single worker dead, siblings processing | 200 + broken NOTIFY wake-ups forever | latch → 503 → graceful SIGTERM, in-flight jobs `fail_job`-released for retry |
| Runner promise settles unexpectedly | probe 503 via `isRunning` only | latch → 503 (+ fallback exit without a probe) |
| DB actually unreachable, idle worker | 503 (old terminal branch) | 503 `postgres unreachable` — same outcome, clearer reason |
| Transient LISTEN blip, idle worker, < 60s | 200 (ping vouched) | 200 (60s budget remains the sole arbiter) |
| LISTEN down > 60s | 503 | 503 (unchanged) |
| Long jobs saturating concurrency | 200 (in-flight short-circuit) | unchanged |
| Graceful shutdown (SIGTERM) | `runner.stop()` | `worker.stop()` — settle not mistaken for crash |

## Safety review (why this cannot regress other paths)

- **Blast radius**: the heartbeat NOTIFY, the latch, and the exit path only activate when `workerHealth` is provided — i.e. the standalone scheduler (`SchedulerApp`). Combined-mode `App.ts` passes no `workerHealth` (its `initSchedulerWorker` is unchanged, see #25356) and `NatsWorkerApp` doesn't use `SchedulerWorker` at all, so behavior there is byte-identical. EE's `CommercialSchedulerWorker` only overrides `getCronItems`/`getTaskList` and inherits the rest.
- **No spurious latch during shutdown** (verified against 0.13 source): `pool.release()` nulls `listenForChangesClient` synchronously *before* releasing workers, and `handleNotification` guards on it, so a NOTIFY racing a graceful shutdown never nudges released workers; `gracefulShutdown` splices the `workers` array before releasing, so `[].some()` never nudges either.
- **Signature matching**: `nudge called after worker terminated` is an assert message unique to graphile's `worker.nudge()`; matching uses `String.includes` to survive wrapper prefixes observed in production logs, and handles non-`Error` payloads. Pinned to 0.13 — flagged for re-verification in any graphile upgrade.
- **DB-down at boot / during run**: boot failure keeps the pre-existing behavior (no HTTP server → probe fails → restart). DB-down during run trips the `postgres unreachable` branch after 3 min — the same 503 the old terminal branch produced.
- **pgbouncer-style setups where NOTIFY delivery is unreliable**: the heartbeat simply adds no detection there; nothing new fails.
- 374 test files / 5,534 backend tests pass, `tsc --noEmit` and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
