### PR TITLE
test(api): skip Databricks pivot tests

### DIFF
--- a/packages/api-tests/helpers/projects.ts
+++ b/packages/api-tests/helpers/projects.ts
@@ -132,14 +132,16 @@ export type WarehouseTestEntry = {
 
 /**
  * The warehouses whose credentials are currently available, ready to drive a
- * parameterized suite. Postgres is always included (seeded locally) unless
- * `includePostgres: false` — pass that when a suite already covers Postgres via
- * the seed project.
+ * parameterized suite. Postgres and Databricks are included by default and can
+ * be excluded per suite through options.
  */
 export function getAvailableWarehouseConfigs(
-    options: { includePostgres?: boolean } = {},
+    options: {
+        includePostgres?: boolean;
+        includeDatabricks?: boolean;
+    } = {},
 ): WarehouseTestEntry[] {
-    const { includePostgres = true } = options;
+    const { includePostgres = true, includeDatabricks = true } = options;
     const entries: WarehouseTestEntry[] = [];
     if (includePostgres) {
         entries.push({ name: 'postgres', config: postgresWarehouseConfig() });
@@ -150,7 +152,7 @@ export function getAvailableWarehouseConfigs(
     if (hasBigqueryCredentials()) {
         entries.push({ name: 'bigquery', config: bigqueryWarehouseConfig() });
     }
-    if (hasDatabricksCredentials()) {
+    if (includeDatabricks && hasDatabricksCredentials()) {
         entries.push({
             name: 'databricks',
             config: databricksWarehouseConfig(),

--- a/packages/api-tests/tests/pivotQuery.test.ts
+++ b/packages/api-tests/tests/pivotQuery.test.ts
@@ -291,10 +291,11 @@ function registerPivotQueryTests(
     });
 }
 
-// Postgres is covered by the seed project below, so exclude it here and run the
-// suite against every other warehouse whose credentials are available.
+// Postgres is covered by the seed project below. Databricks is excluded to avoid
+// starting serverless compute for this suite.
 const pivotWarehouseEntries = getAvailableWarehouseConfigs({
     includePostgres: false,
+    includeDatabricks: false,
 });
 
 describe('Pivot query API', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Exclude Databricks from the pivot API test matrix to avoid starting serverless compute during backend PR checks.
Keep the shared Databricks credentials and warehouse setup available for other test suites through an opt-out option.
Validated with API-test lint and typecheck.