### PR TITLE
fix(e2e): fill required onboarding field in space test

### DIFF
--- a/packages/e2e/cypress/e2e/app/space.cy.ts
+++ b/packages/e2e/cypress/e2e/app/space.cy.ts
@@ -127,9 +127,12 @@ describe('Space', () => {
                 ]);
 
                 cy.visit(`/projects/${SEED_PROJECT.project_uuid}/home`);
-                // Select role
+                // Complete user onboarding
                 cy.findByPlaceholderText('Select your role').click();
                 cy.contains('Product').click();
+                cy.findByPlaceholderText(
+                    'Google, a colleague, a podcast...',
+                ).type('Cypress');
                 cy.contains('Next').click();
 
                 // Don't show private spaces in navbar


### PR DESCRIPTION
### Description:

`E2E: App (5/5)` has been failing on every PR branched after 2026-07-31, in `space.cy.ts` → "Another non-admin user cannot see private content":

```
CypressError: cy.click() failed because this element is `disabled`:
<button ... type="submit" disabled="" form="complete_user">   // "Next"
```

The test completes onboarding by picking a role and clicking Next, but #26622 made "How did you hear about us?" a required field, and `UserCompletionModal` gates Next on all three values:

```ts
disabled={!(form.values.organizationName && form.values.jobTitle && form.values.howDidYouHearAboutUs.trim())}
```

so Next can never enable and all 3 Cypress attempts fail. Preview environments hit the modal rather than the new org-setup page because `NewOnboarding` is deliberately excluded from the force-enabled preview flags, so the old flow is still the one under test.

This fills the field before submitting. Nothing else uses this onboarding flow — `space.cy.ts` is the only spec that drives it.

### Tests:

- Verified the failure is environmental, not branch-specific: identical failure on unrelated branches (this shard is red on every PR whose base includes #26622), and green on branches whose base predates it.
