### PR TITLE
refactor(homepage): remove dead code, fix chart URLs, perf cleanups

### DIFF
--- a/packages/backend/src/ee/services/HomepageRecommendedActionSkipsService.test.ts
+++ b/packages/backend/src/ee/services/HomepageRecommendedActionSkipsService.test.ts
@@ -4,6 +4,7 @@ import {
     OrganizationMemberRole,
     ParameterError,
     ProjectType,
+    type HomepageRecommendedActionKey,
     type PossibleAbilities,
     type ProjectSummary,
     type SessionAccount,
@@ -228,18 +229,19 @@ describe('HomepageRecommendedActionSkipsService', () => {
         expect(model.delete).not.toHaveBeenCalled();
     });
 
-    it.each(['connect-warehouse', 'unknown-action'])(
-        'rejects the non-skippable action key %s',
-        async (actionKey) => {
-            const { model, projectModel, service } = makeService();
+    it.each<HomepageRecommendedActionKey>([
+        'connect-warehouse',
+        // Not a real key: exercises the runtime guard behind the type boundary
+        'unknown-action' as HomepageRecommendedActionKey,
+    ])('rejects the non-skippable action key %s', async (actionKey) => {
+        const { model, projectModel, service } = makeService();
 
-            await expect(
-                service.skip(organizationManager, null, actionKey),
-            ).rejects.toBeInstanceOf(ParameterError);
-            expect(projectModel.getSummary).not.toHaveBeenCalled();
-            expect(model.create).not.toHaveBeenCalled();
-        },
-    );
+        await expect(
+            service.skip(organizationManager, null, actionKey),
+        ).rejects.toBeInstanceOf(ParameterError);
+        expect(projectModel.getSummary).not.toHaveBeenCalled();
+        expect(model.create).not.toHaveBeenCalled();
+    });
 
     it('deletes organization action skips from the null scope after project-context auth', async () => {
         const { model, projectModel, service } = makeService();

--- a/packages/backend/src/ee/services/HomepageRecommendedActionSkipsService.ts
+++ b/packages/backend/src/ee/services/HomepageRecommendedActionSkipsService.ts
@@ -34,7 +34,7 @@ export class HomepageRecommendedActionSkipsService extends BaseService {
     }
 
     private static validateActionKey(
-        actionKey: HomepageRecommendedActionKey | string,
+        actionKey: HomepageRecommendedActionKey,
     ): SkippableHomepageRecommendedActionKey {
         const skippableActionKey =
             SKIPPABLE_HOMEPAGE_RECOMMENDED_ACTION_KEYS.find(
@@ -110,7 +110,7 @@ export class HomepageRecommendedActionSkipsService extends BaseService {
     async skip(
         account: RegisteredAccount,
         projectUuid: UUID | null,
-        actionKey: HomepageRecommendedActionKey | string,
+        actionKey: HomepageRecommendedActionKey,
     ): Promise<void> {
         const validatedActionKey =
             HomepageRecommendedActionSkipsService.validateActionKey(actionKey);
@@ -119,9 +119,12 @@ export class HomepageRecommendedActionSkipsService extends BaseService {
                 validatedActionKey,
                 projectUuid,
             );
-        const scope = await this.getAuthorizedScope(account, projectUuid);
+        const { organizationUuid } = await this.getAuthorizedScope(
+            account,
+            projectUuid,
+        );
         await this.homepageRecommendedActionSkipsModel.create({
-            ...scope,
+            organizationUuid,
             projectUuid: storageProjectUuid,
             actionKey: validatedActionKey,
             createdByUserUuid: account.user.userUuid,
@@ -131,7 +134,7 @@ export class HomepageRecommendedActionSkipsService extends BaseService {
     async unskip(
         account: RegisteredAccount,
         projectUuid: UUID | null,
-        actionKey: HomepageRecommendedActionKey | string,
+        actionKey: HomepageRecommendedActionKey,
     ): Promise<void> {
         const validatedActionKey =
             HomepageRecommendedActionSkipsService.validateActionKey(actionKey);
@@ -140,9 +143,12 @@ export class HomepageRecommendedActionSkipsService extends BaseService {
                 validatedActionKey,
                 projectUuid,
             );
-        const scope = await this.getAuthorizedScope(account, projectUuid);
+        const { organizationUuid } = await this.getAuthorizedScope(
+            account,
+            projectUuid,
+        );
         await this.homepageRecommendedActionSkipsModel.delete({
-            ...scope,
+            organizationUuid,
             projectUuid: storageProjectUuid,
             actionKey: validatedActionKey,
         });

--- a/packages/frontend/src/ee/features/homepageBuilder/CreateHomepageModal.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/CreateHomepageModal.tsx
@@ -1,7 +1,7 @@
 import { type ProjectHomepage } from '@lightdash/common';
 import { Card, Radio, Stack, Text, TextInput } from '@mantine-8/core';
 import { IconSquareRoundedPlus } from '@tabler/icons-react';
-import { useEffect, useState, type FC } from 'react';
+import { useState, type FC } from 'react';
 import MantineModal from '../../../components/common/MantineModal';
 import { useCreateHomepage } from './hooks/useProjectHomepage';
 
@@ -24,14 +24,17 @@ export const CreateHomepageModal: FC<Props> = ({
     const [name, setName] = useState('');
     const [startFrom, setStartFrom] = useState('blank');
 
-    // Reset the form each time the modal opens fresh, rather than carrying
-    // over the previous attempt's values.
-    useEffect(() => {
-        if (opened) {
-            setName('');
-            setStartFrom('blank');
-        }
-    }, [opened]);
+    // Reset on close (not via an opened-effect) so the next open starts fresh
+    // without a flash of the previous attempt's values.
+    const resetForm = () => {
+        setName('');
+        setStartFrom('blank');
+    };
+
+    const handleClose = () => {
+        resetForm();
+        onClose();
+    };
 
     const handleCreate = () => {
         const trimmed = name.trim();
@@ -41,14 +44,19 @@ export const CreateHomepageModal: FC<Props> = ({
                 name: trimmed,
                 duplicateFrom: startFrom === 'blank' ? undefined : startFrom,
             },
-            { onSuccess: onCreated },
+            {
+                onSuccess: (homepage) => {
+                    resetForm();
+                    onCreated(homepage);
+                },
+            },
         );
     };
 
     return (
         <MantineModal
             opened={opened}
-            onClose={onClose}
+            onClose={handleClose}
             title="Create a homepage"
             icon={IconSquareRoundedPlus}
             onConfirm={handleCreate}

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.tsx
@@ -79,10 +79,9 @@ const inputHoldClass = (projectUuid: string | null) =>
 // The composer's footprint on a surface that is still deciding whether it can
 // show a composer at all. Lives here so the reserved height is stated once,
 // next to the composer it stands in for.
-export const DayOneAskInputPlaceholder: FC<Props> = ({
-    projectUuid,
-    hideSuggestions,
-}) => (
+export const DayOneAskInputPlaceholder: FC<
+    Pick<Props, 'projectUuid' | 'hideSuggestions'>
+> = ({ projectUuid, hideSuggestions }) => (
     <div className={classes.composer}>
         <Skeleton className={inputHoldClass(projectUuid)} radius="lg" />
         {!projectUuid && <Skeleton h={17} w={260} mt={10} mx="auto" />}

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.tsx
@@ -102,7 +102,7 @@ export const DayOneHomepage: FC<Props> = ({ projectUuid, pinnedItems }) => {
                             </Text>
                         </Box>
                         <QuickActionCards
-                            actions={getDefaultQuickActions(false)}
+                            actions={getDefaultQuickActions()}
                             projectUuid={projectUuid}
                         />
                     </Stack>

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.module.css
@@ -534,11 +534,6 @@
     );
 }
 
-.endZoneActive {
-    border-color: var(--mantine-color-blue-5);
-    background: var(--mantine-color-blue-0);
-}
-
 .savedIndicator {
     display: inline-flex;
     align-items: center;

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
@@ -120,6 +120,77 @@ const locateBlock = (
     return undefined;
 };
 
+// Dragging is reorder-only: dropping on a block moves the dragged block to
+// a new row above/below it. It never splits two blocks into a shared row —
+// columns are created deliberately via the explicit gutter affordance
+// (rail click / drop slot, which emit `slot:` ids). The one exception is
+// reordering columns *within* the dragged block's own multi-block row.
+const computeTarget = (
+    config: HomepageConfig,
+    event: DragOverEvent | DragEndEvent,
+    source: DragSource,
+): DropTarget | null => {
+    const draggedBlockId = source.kind === 'existing' ? source.blockId : null;
+    // Cell targets the guards would refuse are not advertised at all.
+    const legalise = (target: DropTarget): DropTarget | null =>
+        target.kind === 'cell' &&
+        !canPlaceBlockInRow(
+            config,
+            target.rowIndex,
+            source.definition.type,
+            draggedBlockId ?? undefined,
+        )
+            ? null
+            : target;
+    const over = event.over;
+    if (!over) return null;
+    const overId = String(over.id);
+    if (overId === END_ZONE_ID) return { kind: 'end' };
+    if (overId.startsWith('gap:')) {
+        return { kind: 'row', rowIndex: Number(overId.split(':')[1]) };
+    }
+    if (overId.startsWith('slot:')) {
+        const [, rowIdx, blockIdx] = overId.split(':');
+        return legalise({
+            kind: 'cell',
+            rowIndex: Number(rowIdx),
+            blockIndex: Number(blockIdx),
+        });
+    }
+    const location = locateBlock(config, overId);
+    if (!location) return null;
+    const activeRect = event.active.rect.current.translated;
+
+    const draggedLocation = draggedBlockId
+        ? locateBlock(config, draggedBlockId)
+        : undefined;
+    const sameMultiBlockRow =
+        !!draggedLocation &&
+        draggedLocation.rowIndex === location.rowIndex &&
+        config.rows[location.rowIndex].blocks.length > 1;
+
+    if (sameMultiBlockRow) {
+        const activeCenterX = activeRect
+            ? activeRect.left + activeRect.width / 2
+            : over.rect.left;
+        const relX = (activeCenterX - over.rect.left) / over.rect.width;
+        return {
+            kind: 'cell',
+            rowIndex: location.rowIndex,
+            blockIndex: location.blockIndex + (relX < 0.5 ? 0 : 1),
+        };
+    }
+
+    const activeCenterY = activeRect
+        ? activeRect.top + activeRect.height / 2
+        : over.rect.top;
+    const relY = (activeCenterY - over.rect.top) / over.rect.height;
+    return {
+        kind: 'row',
+        rowIndex: location.rowIndex + (relY < 0.5 ? 0 : 1),
+    };
+};
+
 // Prefer the zone the pointer is literally within; corners as a fallback so
 // the thin row gaps stay reachable while dragging fast.
 const collisionDetectionStrategy: CollisionDetection = (args) => {
@@ -213,20 +284,10 @@ const RowGap: FC<{
     );
 };
 
-const EndDropZone: FC<{ isEmpty: boolean; active: boolean }> = ({
-    isEmpty,
-    active,
-}) => {
+const EndDropZone: FC<{ isEmpty: boolean }> = ({ isEmpty }) => {
     const { setNodeRef } = useDroppable({ id: END_ZONE_ID });
     return (
-        <div
-            ref={setNodeRef}
-            className={
-                active
-                    ? `${classes.endZone} ${classes.endZoneActive}`
-                    : classes.endZone
-            }
-        >
+        <div ref={setNodeRef} className={classes.endZone}>
             <MantineIcon
                 icon={IconPlus}
                 size={15}
@@ -523,17 +584,26 @@ export const HomepageEditor: FC<Props> = ({
     const [justPlacedId, setJustPlacedId] = useState<string | null>(null);
 
     // Singleton blocks (e.g. metrics) drop out of the library once placed.
-    const usedSingletonTypes = new Set(
-        draft.rows.flatMap((row) => row.blocks).map((block) => block.type),
-    );
-    const availableBlocks = blockLibrary.filter(
-        (definition) =>
-            (!definition.requiresAi || canAskAi) &&
-            !(definition.singleton && usedSingletonTypes.has(definition.type)),
-    );
+    const availableBlocks = useMemo(() => {
+        const usedSingletonTypes = new Set(
+            draft.rows.flatMap((row) => row.blocks.map((block) => block.type)),
+        );
+        return blockLibrary.filter(
+            (definition) =>
+                (!definition.requiresAi || canAskAi) &&
+                !(
+                    definition.singleton &&
+                    usedSingletonTypes.has(definition.type)
+                ),
+        );
+    }, [draft.rows, canAskAi]);
     // Full-row blocks never appear in into-row (column) menus.
-    const columnBlocks = availableBlocks.filter(
-        (definition) => !traitFor(definition.type).fullRowOnly,
+    const columnBlocks = useMemo(
+        () =>
+            availableBlocks.filter(
+                (definition) => !traitFor(definition.type).fullRowOnly,
+            ),
+        [availableBlocks],
     );
 
     const { mutate: saveDraft } = updateMutation;
@@ -563,30 +633,38 @@ export const HomepageEditor: FC<Props> = ({
         );
     }, [debouncedDraft, hasConflict, activeDrag, saveDraft]);
 
+    // Re-entry guard: a fast double-click on Publish must not fire the save
+    // twice or open the modal before the first save settles.
+    const isOpeningPublishRef = useRef(false);
     const handleOpenPublish = async () => {
-        if (hasConflict) return;
-        if (draft !== lastSavedRef.current) {
-            lastSavedRef.current = draft;
-            try {
-                const saved = await updateMutation.mutateAsync(
-                    {
-                        draftConfig: draft,
-                        baseUpdatedAt: baseUpdatedAtRef.current,
-                    },
-                    {
-                        onError: (error) => {
-                            if (error.error.statusCode === 409) {
-                                setHasConflict(true);
-                            }
+        if (hasConflict || isOpeningPublishRef.current) return;
+        isOpeningPublishRef.current = true;
+        try {
+            if (draft !== lastSavedRef.current) {
+                lastSavedRef.current = draft;
+                try {
+                    const saved = await updateMutation.mutateAsync(
+                        {
+                            draftConfig: draft,
+                            baseUpdatedAt: baseUpdatedAtRef.current,
                         },
-                    },
-                );
-                baseUpdatedAtRef.current = saved.updatedAt;
-            } catch {
-                return;
+                        {
+                            onError: (error) => {
+                                if (error.error.statusCode === 409) {
+                                    setHasConflict(true);
+                                }
+                            },
+                        },
+                    );
+                    baseUpdatedAtRef.current = saved.updatedAt;
+                } catch {
+                    return;
+                }
             }
+            setIsPublishModalOpen(true);
+        } finally {
+            isOpeningPublishRef.current = false;
         }
-        setIsPublishModalOpen(true);
     };
 
     const handleDiscardDraft = () => {
@@ -617,78 +695,6 @@ export const HomepageEditor: FC<Props> = ({
     const sensors = useSensors(
         useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
     );
-
-    // Dragging is reorder-only: dropping on a block moves the dragged block to
-    // a new row above/below it. It never splits two blocks into a shared row —
-    // columns are created deliberately via the explicit gutter affordance
-    // (rail click / drop slot, which emit `slot:` ids). The one exception is
-    // reordering columns *within* the dragged block's own multi-block row.
-    const computeTarget = (
-        config: HomepageConfig,
-        event: DragOverEvent | DragEndEvent,
-        source: DragSource,
-    ): DropTarget | null => {
-        const draggedBlockId =
-            source.kind === 'existing' ? source.blockId : null;
-        // Cell targets the guards would refuse are not advertised at all.
-        const legalise = (target: DropTarget): DropTarget | null =>
-            target.kind === 'cell' &&
-            !canPlaceBlockInRow(
-                config,
-                target.rowIndex,
-                source.definition.type,
-                draggedBlockId ?? undefined,
-            )
-                ? null
-                : target;
-        const over = event.over;
-        if (!over) return null;
-        const overId = String(over.id);
-        if (overId === END_ZONE_ID) return { kind: 'end' };
-        if (overId.startsWith('gap:')) {
-            return { kind: 'row', rowIndex: Number(overId.split(':')[1]) };
-        }
-        if (overId.startsWith('slot:')) {
-            const [, rowIdx, blockIdx] = overId.split(':');
-            return legalise({
-                kind: 'cell',
-                rowIndex: Number(rowIdx),
-                blockIndex: Number(blockIdx),
-            });
-        }
-        const location = locateBlock(config, overId);
-        if (!location) return null;
-        const activeRect = event.active.rect.current.translated;
-
-        const draggedLocation = draggedBlockId
-            ? locateBlock(config, draggedBlockId)
-            : undefined;
-        const sameMultiBlockRow =
-            !!draggedLocation &&
-            draggedLocation.rowIndex === location.rowIndex &&
-            config.rows[location.rowIndex].blocks.length > 1;
-
-        if (sameMultiBlockRow) {
-            const activeCenterX = activeRect
-                ? activeRect.left + activeRect.width / 2
-                : over.rect.left;
-            const relX = (activeCenterX - over.rect.left) / over.rect.width;
-            return {
-                kind: 'cell',
-                rowIndex: location.rowIndex,
-                blockIndex: location.blockIndex + (relX < 0.5 ? 0 : 1),
-            };
-        }
-
-        const activeCenterY = activeRect
-            ? activeRect.top + activeRect.height / 2
-            : over.rect.top;
-        const relY = (activeCenterY - over.rect.top) / over.rect.height;
-        return {
-            kind: 'row',
-            rowIndex: location.rowIndex + (relY < 0.5 ? 0 : 1),
-        };
-    };
 
     const handleDragStart = (event: DragStartEvent) => {
         const source = event.active.data.current as DragSource | undefined;
@@ -1211,7 +1217,6 @@ export const HomepageEditor: FC<Props> = ({
                                     )}
                                     <EndDropZone
                                         isEmpty={draft.rows.length === 0}
-                                        active={false}
                                     />
                                 </Stack>
                             )}

--- a/packages/frontend/src/ee/features/homepageBuilder/PreviewPane.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PreviewPane.tsx
@@ -1,4 +1,5 @@
 import {
+    assertUnreachable,
     ProjectMemberRole,
     ProjectMemberRoleLabels,
     type HomepageConfig,
@@ -35,7 +36,7 @@ const reasonLabel = (
         case 'default':
             return 'org default';
         default:
-            return '';
+            return assertUnreachable(reason, 'Unknown view-as reason');
     }
 };
 

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
@@ -7,7 +7,6 @@ import { Box, Paper, Text } from '@mantine-8/core';
 import { type FC, type ReactNode } from 'react';
 import { TIER_CLASS } from './blockLayout';
 import { getBlockDefinition } from './blocks/registry';
-import { type BlockPresentation } from './blocks/types';
 import layout from './homepageLayout.module.css';
 import { useRuntimeEmptyBlocks } from './hooks/useRuntimeEmptyBlocks';
 import {
@@ -16,33 +15,21 @@ import {
 } from './resolveHomepageLayout';
 import { RuntimeEmptyBlocksProvider } from './RuntimeEmptyBlocks';
 
-const PERSONAL_BLOCK_TYPES: HomepageBlock['type'][] = ['favorites', 'recent'];
-
 // Unknown block types render nothing so newer configs degrade gracefully
 const BlockRenderer: FC<{
     block: HomepageBlock;
     projectUuid: string;
     personalPlaceholders: boolean;
-    presentation?: BlockPresentation;
     itemSpan: number | null;
     standalone: boolean;
-}> = ({
-    block,
-    projectUuid,
-    personalPlaceholders,
-    presentation,
-    itemSpan,
-    standalone,
-}) => {
+}> = ({ block, projectUuid, personalPlaceholders, itemSpan, standalone }) => {
     const definition = getBlockDefinition(block.type);
     if (!definition) return null;
-    if (personalPlaceholders && PERSONAL_BLOCK_TYPES.includes(block.type)) {
+    if (personalPlaceholders && definition.personal) {
         return (
             <Paper withBorder p="md" h="100%">
                 <Text size="sm" fw={600}>
-                    {block.type === 'favorites'
-                        ? 'Favorites'
-                        : 'Recently viewed'}
+                    {definition.label}
                 </Text>
                 <Text size="xs" c="dimmed">
                     Personal to each viewer — the target user sees their own
@@ -56,7 +43,6 @@ const BlockRenderer: FC<{
         <View
             block={block}
             projectUuid={projectUuid}
-            presentation={presentation}
             itemSpan={itemSpan}
             standalone={standalone}
         />
@@ -157,7 +143,6 @@ export const PublishedHomepage: FC<Props> = ({
                                 block={hero.row.columns[0].block}
                                 projectUuid={projectUuid}
                                 personalPlaceholders={personalPlaceholders}
-                                presentation="hero"
                                 itemSpan={hero.row.columns[0].itemSpan}
                                 standalone={hero.row.columns.length === 1}
                             />

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.test.tsx
@@ -65,7 +65,6 @@ describe('AskAiHeroBlockView', () => {
                 itemSpan={null}
                 block={block}
                 projectUuid="p1"
-                presentation="hero"
             />,
         );
         expect(

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/BlockShell.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/BlockShell.tsx
@@ -1,6 +1,6 @@
 import { Box } from '@mantine-8/core';
 import { type Icon } from '@tabler/icons-react';
-import { type FC, type PropsWithChildren, type ReactNode } from 'react';
+import { type FC, type PropsWithChildren } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import classes from './blockStyles.module.css';
 
@@ -10,52 +10,33 @@ export const MiniPill: FC<PropsWithChildren> = ({ children }) => (
 
 type BlockHeaderProps = {
     icon: Icon;
-    iconColor?: string;
-    title: ReactNode;
+    title: string;
     pill?: string;
-    mb?: number;
     /** Centre the header — used when the block's content is centred too, so
      * header and content read as one unit. */
     centered?: boolean;
 };
 
-export const BlockHeader: FC<PropsWithChildren<BlockHeaderProps>> = ({
+export const BlockHeader: FC<BlockHeaderProps> = ({
     icon,
-    iconColor,
     title,
     pill,
-    mb = 10,
     centered = false,
-    children,
 }) => (
     <Box
         className={`${classes.sectionHeader}${
             centered ? ` ${classes.sectionHeaderCentered}` : ''
         }`}
-        mb={mb}
+        mb={10}
     >
-        <MantineIcon icon={icon} size={14} color={iconColor ?? 'ldGray.6'} />
-        {typeof title === 'string' ? (
-            <span className={classes.sectionTitle}>{title}</span>
-        ) : (
-            title
-        )}
+        <MantineIcon icon={icon} size={14} color="ldGray.6" />
+        <span className={classes.sectionTitle}>{title}</span>
         {pill ? <MiniPill>{pill}</MiniPill> : null}
-        {children}
     </Box>
 );
 
-export const IconSquare: FC<{
-    icon: Icon;
-    size?: 'md' | 'lg';
-}> = ({ icon, size = 'md' }) => (
-    <div
-        className={
-            size === 'lg'
-                ? `${classes.iconSquare} ${classes.iconSquareLg}`
-                : classes.iconSquare
-        }
-    >
-        <MantineIcon icon={icon} size={size === 'lg' ? 18 : 16} />
+export const IconSquare: FC<{ icon: Icon }> = ({ icon }) => (
+    <div className={classes.iconSquare}>
+        <MantineIcon icon={icon} size={16} />
     </div>
 );

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
@@ -522,6 +522,16 @@ const EMPTY_CONFIG: HomepageCollectionBlock['config'] = {
     items: [],
 };
 
+const SkeletonGrid: FC<{ itemSpan: number | null }> = ({ itemSpan }) => (
+    <PageGrid itemSpan={itemSpan} elastic>
+        {[0, 1, 2].map((i) => (
+            <PageGridItem key={i}>
+                <Skeleton h={108} radius="md" />
+            </PageGridItem>
+        ))}
+    </PageGrid>
+);
+
 export const CollectionBlockView: FC<BlockComponentProps> = ({
     itemSpan,
     block,
@@ -537,24 +547,19 @@ export const CollectionBlockView: FC<BlockComponentProps> = ({
     // Emptiness of a dynamic source is only knowable once its data lands, so
     // the page is told rather than inferring it from config.
     useReportRuntimeEmpty(block.id, contents.length === 0, isLoading);
+    const favoriteUuids = useMemo(
+        () => new Set((favorites ?? []).map((item) => item.data.uuid)),
+        [favorites],
+    );
     if (block.type !== 'collection') return null;
     // Nothing to show, and nothing on the way: render no header at all. The
     // page drops the row on the next commit.
     if (!isLoading && contents.length === 0) return null;
-    const favoriteUuids = new Set(
-        (favorites ?? []).map((item) => item.data.uuid),
-    );
     return (
         <Stack gap={0}>
             <BlockHeader icon={IconLayoutGrid} title={block.config.title} />
             {isLoading ? (
-                <PageGrid itemSpan={itemSpan ?? null} elastic>
-                    {[0, 1, 2].map((i) => (
-                        <PageGridItem key={i}>
-                            <Skeleton h={108} radius="md" />
-                        </PageGridItem>
-                    ))}
-                </PageGrid>
+                <SkeletonGrid itemSpan={itemSpan ?? null} />
             ) : (
                 <PageGrid itemSpan={itemSpan ?? null} elastic>
                     {contents.map((content) => {
@@ -735,15 +740,7 @@ const DynamicSourcePreview: FC<{
     );
     const isPersonal = isPersonalCollectionSource(collectionSourceOf(config));
     if (isLoading) {
-        return (
-            <PageGrid itemSpan={itemSpan} elastic>
-                {[0, 1, 2].map((i) => (
-                    <PageGridItem key={i}>
-                        <Skeleton h={108} radius="md" />
-                    </PageGridItem>
-                ))}
-            </PageGrid>
-        );
+        return <SkeletonGrid itemSpan={itemSpan} />;
     }
     return (
         <Stack gap={6}>

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
@@ -1,5 +1,4 @@
 import {
-    ContentType,
     contentToResourceViewItem,
     type SummaryContent,
 } from '@lightdash/common';
@@ -15,21 +14,9 @@ import { type FC, type PropsWithChildren } from 'react';
 import { Link } from 'react-router';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { ResourceIcon } from '../../../../components/common/ResourceIcon';
+import { getResourceUrl } from '../../../../components/common/ResourceView/resourceUtils';
 import { useTimeAgo } from '../../../../hooks/useTimeAgo';
 import classes from './blockStyles.module.css';
-
-const contentUrl = (projectUuid: string, content: SummaryContent): string => {
-    switch (content.contentType) {
-        case ContentType.DASHBOARD:
-            return `/projects/${projectUuid}/dashboards/${content.uuid}/view`;
-        case ContentType.SPACE:
-            return `/projects/${projectUuid}/spaces/${content.uuid}`;
-        case ContentType.DATA_APP:
-            return `/projects/${projectUuid}/apps/${content.uuid}/view`;
-        default:
-            return `/projects/${projectUuid}/saved/${content.uuid}`;
-    }
-};
 
 type Props = {
     content: SummaryContent;
@@ -144,7 +131,9 @@ export const ContentCard: FC<Props> = ({
     star,
     variant = 'row',
 }) => {
-    const to = onRemove ? null : contentUrl(projectUuid, content);
+    const to = onRemove
+        ? null
+        : getResourceUrl(projectUuid, contentToResourceViewItem(content));
     const cardClass = `${classes.hoverCard}${to ? ` ${classes.clickable}` : ''}`;
 
     if (variant === 'tile') {

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/FavoritesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/FavoritesBlock.tsx
@@ -38,17 +38,8 @@ const FavoritePills: FC<{
     /** Text shown when the user has no favorites. Pass `null` to render nothing
      * (used by the top-bar variant, which hides itself when empty). */
     emptyText: string | null;
-    maxVisible?: number;
-    wrap?: 'wrap' | 'nowrap';
     justify?: 'flex-start' | 'center';
-}> = ({
-    projectUuid,
-    isInteractive,
-    emptyText,
-    maxVisible = FAVORITES_DEFAULT_VISIBLE,
-    wrap = 'wrap',
-    justify = 'flex-start',
-}) => {
+}> = ({ projectUuid, isInteractive, emptyText, justify = 'flex-start' }) => {
     const { data: favorites } = useFavorites(projectUuid);
     const { mutate: toggleFavorite } = useFavoriteMutation(projectUuid);
     const [expanded, setExpanded] = useState(false);
@@ -67,13 +58,14 @@ const FavoritePills: FC<{
         });
     };
 
+    const maxVisible = FAVORITES_DEFAULT_VISIBLE;
     const canTruncate = favorites.length > maxVisible;
     const visible =
         canTruncate && !expanded ? favorites.slice(0, maxVisible) : favorites;
     const hiddenCount = favorites.length - maxVisible;
 
     return (
-        <Group gap={8} wrap={expanded ? 'wrap' : wrap} justify={justify}>
+        <Group gap={8} wrap="wrap" justify={justify}>
             {visible.map((item) => (
                 <Link
                     key={item.data.uuid}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
@@ -202,16 +202,20 @@ const MetricsPickerModal: FC<{
         sortDirection: 'desc',
         pageSize: 25,
     });
-    const results = (data?.pages ?? [])
-        .flatMap((page) => page.data)
-        .filter(
-            (metric) =>
-                !selected.some(
-                    (ref) =>
-                        ref.tableName === metric.tableName &&
-                        ref.metricName === metric.name,
+    const results = useMemo(
+        () =>
+            (data?.pages ?? [])
+                .flatMap((page) => page.data)
+                .filter(
+                    (metric) =>
+                        !selected.some(
+                            (ref) =>
+                                ref.tableName === metric.tableName &&
+                                ref.metricName === metric.name,
+                        ),
                 ),
-        );
+        [data, selected],
+    );
 
     const scrollRef = useRef<HTMLDivElement>(null);
 

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/QuickActionsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/QuickActionsBlock.tsx
@@ -74,6 +74,11 @@ const STATIC_ACTIONS: Record<
     },
 };
 
+const actionKey = (action: HomepageQuickAction): string =>
+    action.type === 'dashboard'
+        ? `dashboard-${action.dashboardUuid}`
+        : action.type;
+
 const actionPresentation = (
     action: HomepageQuickAction,
     projectUuid: string,
@@ -104,7 +109,7 @@ export const QuickActionCards: FC<{
     if (visibleActions.length === 0) return null;
     return (
         <Group gap={8} justify={justify}>
-            {visibleActions.map((action, index) => {
+            {visibleActions.map((action) => {
                 const presentation = actionPresentation(action, projectUuid);
                 const trackClick = () =>
                     track({
@@ -114,7 +119,7 @@ export const QuickActionCards: FC<{
                 // The primary action is the same chip, inverted.
                 return (
                     <Anchor
-                        key={`${action.type}-${index}`}
+                        key={actionKey(action)}
                         component={Link}
                         to={presentation.url}
                         underline="never"
@@ -253,7 +258,7 @@ export const QuickActionsBlockBuild: FC<BuildComponentProps> = ({
                     if (action.type === 'ask-ai' && !canAskAi) return null;
                     return (
                         <Group
-                            key={`${action.type}-${index}`}
+                            key={actionKey(action)}
                             gap="xs"
                             wrap="nowrap"
                             p="xs"
@@ -399,10 +404,17 @@ export const QuickActionsBlockBuild: FC<BuildComponentProps> = ({
                 onClose={() => setIsDashboardPickerOpen(false)}
                 projectUuid={projectUuid}
                 onPick={(dashboardUuid, label) => {
-                    setActions([
-                        ...block.config.actions,
-                        { type: 'dashboard', dashboardUuid, label },
-                    ]);
+                    const alreadyAdded = block.config.actions.some(
+                        (action) =>
+                            action.type === 'dashboard' &&
+                            action.dashboardUuid === dashboardUuid,
+                    );
+                    if (!alreadyAdded) {
+                        setActions([
+                            ...block.config.actions,
+                            { type: 'dashboard', dashboardUuid, label },
+                        ]);
+                    }
                     setIsDashboardPickerOpen(false);
                 }}
             />

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/RecentBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/RecentBlock.tsx
@@ -1,4 +1,8 @@
-import { ContentType, type SummaryContent } from '@lightdash/common';
+import {
+    ContentType,
+    contentToResourceViewItem,
+    type SummaryContent,
+} from '@lightdash/common';
 import { Skeleton, Stack } from '@mantine-8/core';
 import {
     IconChartBar,
@@ -7,17 +11,13 @@ import {
 } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { Link } from 'react-router';
+import { getResourceUrl } from '../../../../components/common/ResourceView/resourceUtils';
 import TruncatedText from '../../../../components/common/TruncatedText';
 import { useTimeAgo } from '../../../../hooks/useTimeAgo';
 import { useRecentContents } from '../hooks/useRecentContents';
 import { BlockHeader } from './BlockShell';
 import classes from './blockStyles.module.css';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
-
-const contentUrl = (projectUuid: string, content: SummaryContent): string =>
-    content.contentType === ContentType.DASHBOARD
-        ? `/projects/${projectUuid}/dashboards/${content.uuid}/view`
-        : `/projects/${projectUuid}/saved/${content.uuid}`;
 
 const RecentRow: FC<{
     content: SummaryContent;
@@ -28,7 +28,7 @@ const RecentRow: FC<{
     const isDashboard = content.contentType === ContentType.DASHBOARD;
     return (
         <Link
-            to={contentUrl(projectUuid, content)}
+            to={getResourceUrl(projectUuid, contentToResourceViewItem(content))}
             className={`${classes.listRow} ${classes.clickable} ${classes.plainLink}`}
         >
             <div className={classes.iconSquare}>

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/RecommendedActionsChecklist.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/RecommendedActionsChecklist.tsx
@@ -1,4 +1,7 @@
-import { type HomepageRecommendedActionKey } from '@lightdash/common';
+import {
+    SKIPPABLE_HOMEPAGE_RECOMMENDED_ACTION_KEYS,
+    type HomepageRecommendedActionKey,
+} from '@lightdash/common';
 import {
     ActionIcon,
     Box,
@@ -26,15 +29,19 @@ import MantineIcon from '../../../../components/common/MantineIcon';
 import useTracking from '../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../types/Events';
 import classes from './blockStyles.module.css';
-import {
-    RECOMMENDED_ACTION_KEYS,
-    SKIPPABLE_ACTION_KEYS,
-} from './recommendedActionDefaults';
+import { RECOMMENDED_ACTION_KEYS } from './recommendedActionDefaults';
 import styles from './RecommendedActionsChecklist.module.css';
 import {
     type ActionStatus,
     type RecommendedActionsState,
 } from './useRecommendedActions';
+
+// Connecting a warehouse gates everything else — skipping it would strand
+// the user with nothing to query.
+const isSkippableActionKey = (key: HomepageRecommendedActionKey): boolean =>
+    (
+        SKIPPABLE_HOMEPAGE_RECOMMENDED_ACTION_KEYS as readonly HomepageRecommendedActionKey[]
+    ).includes(key);
 
 type ActionDefinition = {
     icon: Icon;
@@ -188,7 +195,7 @@ const ActionRow: FC<{
                     >
                         {status.ctaLabel}
                     </Button>
-                    {SKIPPABLE_ACTION_KEYS.includes(actionKey) && (
+                    {isSkippableActionKey(actionKey) && (
                         <Tooltip label="Skip this step" withinPortal>
                             <ActionIcon
                                 className={styles.skipButton}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
@@ -99,10 +99,11 @@ const isDefaultFavicon = (img: HTMLImageElement) => img.naturalWidth < 32;
 // never a full-size coloured placeholder. A fallback should be quieter than
 // the real thing, not louder. Kind stays legible in text on the card body.
 // Shared by the published card and the editor canvas so they can't drift.
-const DataAppCardMedia: FC<{
+const DataAppThumb: FC<{
     item: HomepageResourceItem;
     projectUuid: string;
-}> = ({ item, projectUuid }) => {
+    variant: 'card' | 'row';
+}> = ({ item, projectUuid, variant }) => {
     const [failed, setFailed] = useState(false);
     const { data } = useAppThumbnailUrl(
         projectUuid,
@@ -111,49 +112,27 @@ const DataAppCardMedia: FC<{
     );
     const thumbnailUrl = failed ? undefined : data?.thumbnailUrl;
     if (!thumbnailUrl) {
-        return (
+        // Same neutral square a link with no favicon falls back to — no kind tint.
+        return variant === 'card' ? (
             <div className={classes.mediaIcon}>
                 <IconSquare icon={IconAppWindow} />
             </div>
+        ) : (
+            <IconSquare icon={IconAppWindow} />
         );
     }
     return (
-        <div className={classes.resThumb}>
+        <div
+            className={variant === 'card' ? classes.resThumb : classes.rowThumb}
+        >
             <img
                 src={thumbnailUrl}
-                alt={item.title}
+                alt={variant === 'card' ? item.title : ''}
                 loading="lazy"
                 onError={() => setFailed(true)}
             />
         </div>
     );
-};
-
-const DataAppRowThumb: FC<{
-    item: HomepageResourceItem;
-    projectUuid: string;
-}> = ({ item, projectUuid }) => {
-    const [failed, setFailed] = useState(false);
-    const { data } = useAppThumbnailUrl(
-        projectUuid,
-        item.appUuid,
-        !!item.appUuid,
-    );
-    const thumbnailUrl = data?.thumbnailUrl;
-    if (thumbnailUrl && !failed) {
-        return (
-            <div className={classes.rowThumb}>
-                <img
-                    src={thumbnailUrl}
-                    alt=""
-                    loading="lazy"
-                    onError={() => setFailed(true)}
-                />
-            </div>
-        );
-    }
-    // Same neutral square a link with no favicon falls back to — no kind tint.
-    return <IconSquare icon={IconAppWindow} />;
 };
 
 const UrlCardThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => {
@@ -211,7 +190,7 @@ const CardThumb: FC<{ item: HomepageResourceItem; projectUuid: string }> = ({
     projectUuid,
 }) =>
     item.kind === 'data-app' ? (
-        <DataAppCardMedia item={item} projectUuid={projectUuid} />
+        <DataAppThumb item={item} projectUuid={projectUuid} variant="card" />
     ) : (
         <UrlCardThumb item={item} />
     );
@@ -235,7 +214,7 @@ const RowThumb: FC<{ item: HomepageResourceItem; projectUuid: string }> = ({
     projectUuid,
 }) =>
     item.kind === 'data-app' ? (
-        <DataAppRowThumb item={item} projectUuid={projectUuid} />
+        <DataAppThumb item={item} projectUuid={projectUuid} variant="row" />
     ) : (
         <UrlRowThumb item={item} />
     );

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -161,12 +161,6 @@ a .hoverCard:hover,
     flex-shrink: 0;
 }
 
-.iconSquareLg {
-    width: 34px;
-    height: 34px;
-    border-radius: 8px;
-}
-
 .dashedEmpty {
     font-size: 12.5px;
     color: var(--mantine-color-ldGray-5);
@@ -202,13 +196,6 @@ a .hoverCard:hover,
     box-shadow: var(--mantine-shadow-heavy);
     transform: translateY(-1px);
     text-decoration: none;
-}
-
-.favPillName {
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
 }
 
 /* Icons are flex children, so a long name squeezed them instead of itself —
@@ -274,35 +261,9 @@ a .hoverCard:hover,
     white-space: nowrap;
 }
 
-.announcementDot {
-    width: 7px;
-    height: 7px;
-    border-radius: 50%;
-    background: var(--mantine-color-ldGray-4);
-    margin-top: 6px;
-    flex-shrink: 0;
-}
-
-.listRowTop {
-    align-items: flex-start;
-}
-
 .flexFill {
     flex: 1;
     min-width: 0;
-}
-
-.announcementText {
-    font-size: 13.5px;
-    line-height: 1.45;
-}
-
-.rowAsideSpaced {
-    margin-top: 2px;
-}
-
-.listCardSpaced {
-    margin-bottom: 8px;
 }
 
 /* KPI cards stack top-down with their comparison line pinned to the bottom.

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/quickActionDefaults.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/quickActionDefaults.ts
@@ -1,17 +1,9 @@
 import { type HomepageQuickAction } from '@lightdash/common';
 
-// AI-first when available (encouraged behaviour); dashboard-first otherwise
-export const getDefaultQuickActions = (
-    isAiEnabled: boolean,
-): HomepageQuickAction[] =>
-    isAiEnabled
-        ? [
-              { type: 'ask-ai' },
-              { type: 'browse-dashboards' },
-              { type: 'run-query' },
-          ]
-        : [
-              { type: 'browse-dashboards' },
-              { type: 'run-query' },
-              { type: 'browse-spaces' },
-          ];
+// Day-0 and the block library pair quick actions with the greeting (non-AI)
+// layout; the AI hero stands alone, so there is no AI-first variant.
+export const getDefaultQuickActions = (): HomepageQuickAction[] => [
+    { type: 'browse-dashboards' },
+    { type: 'run-query' },
+    { type: 'browse-spaces' },
+];

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/recommendedActionDefaults.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/recommendedActionDefaults.ts
@@ -1,17 +1,8 @@
-import {
-    SKIPPABLE_HOMEPAGE_RECOMMENDED_ACTION_KEYS,
-    type HomepageRecommendedActionKey,
-} from '@lightdash/common';
+import { type HomepageRecommendedActionKey } from '@lightdash/common';
 
 export const RECOMMENDED_ACTION_KEYS: HomepageRecommendedActionKey[] = [
     'connect-warehouse',
     'connect-source-control',
     'add-semantic-layer',
     'connect-slack',
-];
-
-// Connecting a warehouse gates everything else — skipping it would strand
-// the user with nothing to query
-export const SKIPPABLE_ACTION_KEYS: HomepageRecommendedActionKey[] = [
-    ...SKIPPABLE_HOMEPAGE_RECOMMENDED_ACTION_KEYS,
 ];

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/registry.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/registry.tsx
@@ -41,6 +41,8 @@ export type BlockDefinition = {
     requiresAi?: boolean;
     /** Can only be added once per homepage. */
     singleton?: boolean;
+    /** Renders per-viewer content, so admin previews show a placeholder. */
+    personal?: boolean;
     create: () => HomepageBlock;
     View: FC<BlockComponentProps>;
     Build: FC<BuildComponentProps>;
@@ -85,7 +87,7 @@ export const blockLibrary: BlockDefinition[] = [
         create: () => ({
             id: uuidv4(),
             type: 'quick-actions',
-            config: { actions: getDefaultQuickActions(false) },
+            config: { actions: getDefaultQuickActions() },
         }),
         View: QuickActionsBlockView,
         Build: QuickActionsBlockBuild,
@@ -151,6 +153,7 @@ export const blockLibrary: BlockDefinition[] = [
         label: 'Favorites',
         description: 'Each viewer’s starred content, only visible to them.',
         icon: IconStar,
+        personal: true,
         create: () => ({
             id: uuidv4(),
             type: 'favorites',
@@ -165,6 +168,7 @@ export const blockLibrary: BlockDefinition[] = [
         description: 'Each viewer’s recently opened charts and dashboards.',
         icon: IconClock,
         singleton: true,
+        personal: true,
         create: () => ({
             id: uuidv4(),
             type: 'recent',

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/types.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/types.ts
@@ -1,13 +1,8 @@
 import { type HomepageBlock } from '@lightdash/common';
 
-// Where a block view renders: the page's centred hero slot or an inline body
-// row. Omission means 'inline'. Only ask-ai-hero currently differentiates.
-export type BlockPresentation = 'hero' | 'inline';
-
 export type BlockComponentProps = {
     block: HomepageBlock;
     projectUuid: string;
-    presentation?: BlockPresentation;
     // Page-grid columns one of this block's cards spans, from the resolver.
     // null for blocks that don't render a card grid, or that render outside a
     // resolved row (the hero slot). Required, not optional: a call site that

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/rankKeySpaces.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/rankKeySpaces.ts
@@ -11,7 +11,6 @@ export type KeySpace = {
     uuid: string;
     name: string;
     itemCount: number;
-    isPinned: boolean;
 };
 
 /**
@@ -50,9 +49,4 @@ export const rankKeySpaces = (
                 a.name.localeCompare(b.name),
         )
         .slice(0, limit)
-        .map(({ uuid, name, itemCount, isPinned }) => ({
-            uuid,
-            name,
-            itemCount,
-            isPinned,
-        }));
+        .map(({ uuid, name, itemCount }) => ({ uuid, name, itemCount }));

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useCollectionSourceContent.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useCollectionSourceContent.ts
@@ -1,4 +1,5 @@
 import {
+    assertUnreachable,
     collectionLimitOf,
     collectionSourceOf,
     type HomepageCollectionBlock,
@@ -85,7 +86,7 @@ export const useCollectionSourceContent = (
             case 'recently-viewed':
                 return [];
             default:
-                return [];
+                return assertUnreachable(source, 'Unknown collection source');
         }
     }, [source, popular.data, pinned.data, favorites.data]);
 

--- a/packages/frontend/src/ee/features/homepageBuilder/starterHomepage.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/starterHomepage.ts
@@ -65,7 +65,7 @@ export const buildStarterHomepage = (
             row({
                 id: uuidv4(),
                 type: 'quick-actions',
-                config: { actions: getDefaultQuickActions(false) },
+                config: { actions: getDefaultQuickActions() },
             }),
             row({
                 id: uuidv4(),


### PR DESCRIPTION
## Summary

Cleanup pass over the Homepage Builder (homepage v2) feature: dead/no-op code removal, a broken-link fix, and performance fixes surfaced by a `react-doctor` scan. Net **−101 lines**, no intended behavior change except the two fixes called out below.

### Fix: SQL-runner charts linked to a broken URL
`ContentCard` and `RecentBlock` each hand-rolled a URL builder that sent every chart to `/projects/{uuid}/saved/{uuid}` — an SQL-runner chart in a collection/favorites/recent block was a dead link. Both now use the shared `getResourceUrl` (which `FavoritesBlock` already used), which routes SQL charts to `/sql-runner/{slug}`.

### Fix: duplicate quick-action dashboards
The dashboard picker appended unconditionally, so the same dashboard could be added twice to a Quick Actions block. Now a no-op, which also makes the new stable list keys (`dashboard-{uuid}`) safe.

### Dead / no-op code removed
- `presentation`/`BlockPresentation` prop plumbed through `PublishedHomepage` into every block View — no block ever read it
- Never-passed props: `BlockHeader.iconColor/mb/children`, `IconSquare size="lg"`, `EndDropZone.active` (hardcoded `false`), `FavoritePills.wrap/maxVisible`, `DayOneAskInputPlaceholder.preview`
- 8 unreferenced CSS-module classes
- `getDefaultQuickActions(isAiEnabled)` — every caller passed literal `false` (the AI hero stands alone by design), so the AI-first branch was unreachable; now zero-arg
- `SKIPPABLE_ACTION_KEYS` re-spread of the common constant; `KeySpace.isPinned` computed but never rendered
- Backend: `HomepageRecommendedActionSkipsService` drops the `| string` widening on `actionKey` and a dead spread-then-override of `projectUuid`
- The `PublishedHomepage` personal-block placeholder now derives from the block registry (`personal: true` on the definition) instead of a hardcoded type list + label ternary — adding a third personal block type can no longer silently mislabel as "Recently viewed"
- Two silent `default: return []/''` switch branches replaced with `assertUnreachable`

### Performance (react-doctor findings)
- Memoized `favoriteUuids` Set in `CollectionBlockView` (was rebuilt per render, probed per card) and the metrics picker's `results`
- Hoisted the ~65-line pure `computeTarget` out of `HomepageEditor`'s render; memoized `availableBlocks`/`columnBlocks`
- Re-entry guard on the Publish button (fast double-click fired the draft save twice / opened the modal before the save settled)
- `CreateHomepageModal`: reset-on-`opened`-effect replaced with reset-on-close (frontend style-guide pattern)
- Stable keys replacing array-index keys in QuickActionsBlock
- Consolidated duplicated components: one `SkeletonGrid` (was two byte-identical copies), one `DataAppThumb variant="card"|"row"` (was two near-identical thumbnail components)

## Regression analysis
- The URL change strictly widens correct behavior: dashboards/spaces/data-apps produce identical URLs via `getResourceUrl`; only SQL-source charts change, from a 404 route to the correct one. `contentToResourceViewItem` spreads the full summary so `source`/`slug` are present.
- Prop deletions were verified dead by project-wide reference sweeps (every call site enumerated), not just type-checking.
- `getDefaultQuickActions` output is byte-identical for every existing caller.
- The publish re-entry guard only suppresses re-entrant calls; the single-click path is unchanged.
- Verified: frontend + backend typecheck, oxlint, 231 frontend homepageBuilder tests, backend skips-service tests all green.

Relates: ZAP-646

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LV1MMyxQQZ1ieg6bJLy1Ts
