### PR TITLE
fix(ai): stub native chart rendering in runQuery unit test

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/runQuery.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/runQuery.test.ts
@@ -5,7 +5,15 @@ import {
 } from '../../../../services/ProjectService/ProjectService.mock';
 import type { RunAsyncQueryFn } from '../types/aiAgentDependencies';
 import { AgentContext } from '../utils/AgentContext';
+import { renderEcharts } from '../utils/renderEcharts';
 import { getRunQuery } from './runQuery';
+
+// The Slack path renders a real chart via echarts + node-canvas. A native
+// render has no place in a unit test — it's slow and fails on runners without
+// the canvas binding or fonts — so it's stubbed with a fake PNG buffer.
+vi.mock('../utils/renderEcharts', () => ({
+    renderEcharts: vi.fn().mockResolvedValue(Buffer.from('fake-png')),
+}));
 
 const makePrompt = (): AiWebAppPrompt => ({
     organizationUuid: 'org-uuid',
@@ -119,6 +127,8 @@ describe('getRunQuery', () => {
                 queryUuid: '11111111-1111-4111-8111-111111111111',
             },
         });
+        // Proves the Slack chart path ran rather than short-circuiting.
+        expect(vi.mocked(renderEcharts)).toHaveBeenCalled();
     });
 
     it('does not expose a query UUID for an empty result', async () => {


### PR DESCRIPTION
## Summary

Fixes the flaky unit test:

```
FAIL  backend-unit-tests  src/ee/services/ai/tools/runQuery.test.ts > getRunQuery > returns the query UUID when row data is hidden from the model
```

## Root cause

Of the four tests in this file, the failing one is the only one that reaches the Slack-prompt branch of `getRunQuery` — and that branch renders a **real chart**: `getSlackAiEchartsConfig` → `renderEcharts` → `echarts.init` on a native `node-canvas` canvas → PNG buffer. Locally it takes ~165ms (its siblings take 1–3ms) and passes; on a CI runner the render depends on the native `canvas` binding, fontconfig/fonts, and runner load — any of which turns into a throw that `getRunQuery`'s catch-all converts to `metadata: { status: 'error' }`, failing the `status: 'success'` assertion. It cannot be reproduced locally (5 solo runs + the full `ai` suite pass).

## Fix

`vi.mock` the `renderEcharts` module with a stub that resolves a fake PNG buffer — a unit test for the tool's result contract shouldn't perform native chart rendering at all. Added an explicit `expect(renderEcharts).toHaveBeenCalled()` so the test still proves the Slack chart path executed rather than short-circuiting. Test time drops 165ms → 1ms.

## Regression analysis

Test-only change; no production code touched. Coverage is preserved: the tool's success metadata, query-UUID exposure rules, and the Slack render path invocation are all still asserted — only the actual PNG rasterisation (echarts + node-canvas behavior, which belongs to those libraries, not this tool) is stubbed.

Relates: PROD-9430

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LV1MMyxQQZ1ieg6bJLy1Ts
