### PR TITLE
fix(charts): show all top labels on grouped bars

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
@@ -25,6 +25,7 @@ import {
     filterSeriesWithNoData,
     getAxisDefaultMaxValue,
     getAxisDefaultMinValue,
+    getCartesianLabelLayout,
     getCategoryDateAxisConfig,
     getLongestLabelsForAxis,
     getMinAndMaxValues,
@@ -44,6 +45,58 @@ dayjs.extend(utcPlugin);
 dayjs.extend(timezonePlugin);
 
 vi.mock('./../../providers/TrackingProvider');
+
+describe('getCartesianLabelLayout', () => {
+    test('shows every top label in grouped bar charts', () => {
+        expect(
+            getCartesianLabelLayout({
+                isGroupedBarChart: true,
+                isStacked: false,
+                seriesType: CartesianSeriesType.BAR,
+                position: 'top',
+            }),
+        ).toEqual({ hideOverlap: false });
+    });
+
+    test.each([
+        {
+            isGroupedBarChart: false,
+            isStacked: false,
+            seriesType: CartesianSeriesType.BAR,
+            position: 'top' as const,
+        },
+        {
+            isGroupedBarChart: true,
+            isStacked: true,
+            seriesType: CartesianSeriesType.BAR,
+            position: 'top' as const,
+        },
+        {
+            isGroupedBarChart: true,
+            isStacked: false,
+            seriesType: CartesianSeriesType.BAR,
+            position: 'inside' as const,
+        },
+        {
+            isGroupedBarChart: true,
+            isStacked: false,
+            seriesType: CartesianSeriesType.LINE,
+            position: 'top' as const,
+        },
+    ])(
+        'hides overlapping labels for non-affected series layouts',
+        ({ isGroupedBarChart, isStacked, seriesType, position }) => {
+            expect(
+                getCartesianLabelLayout({
+                    isGroupedBarChart,
+                    isStacked,
+                    seriesType,
+                    position,
+                }),
+            ).toEqual({ hideOverlap: true });
+        },
+    );
+});
 
 describe('resolveCartesianGranularityLabels', () => {
     test('resolves x-axis and y-axis name placeholders', () => {

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -957,6 +957,25 @@ const isStack100Normalized = (series: Series) =>
     !!series.stack &&
     (series.type === CartesianSeriesType.BAR || !!series.areaStyle);
 
+export const getCartesianLabelLayout = ({
+    isGroupedBarChart,
+    isStacked,
+    seriesType,
+    position,
+}: {
+    isGroupedBarChart: boolean;
+    isStacked: boolean;
+    seriesType: CartesianSeriesType;
+    position: NonNullable<Series['label']>['position'];
+}) => ({
+    hideOverlap: !(
+        isGroupedBarChart &&
+        !isStacked &&
+        seriesType === CartesianSeriesType.BAR &&
+        position === 'top'
+    ),
+});
+
 /**
  * Create a labelLayout configuration for stacked bar charts.
  * When showOverlappingLabels is enabled, uses smaller font for labels that don't fit
@@ -3451,6 +3470,8 @@ const useEchartsCartesianConfig = (
         const barSeries = series.filter(
             (s) => s.type === CartesianSeriesType.BAR,
         );
+        const isGroupedBarChart =
+            barSeries.filter((s) => getValidStack(s) === undefined).length > 1;
         const hasCustomColorsStacking =
             barSeries.some((s) => Boolean(s.stack)) ||
             (validCartesianConfig?.layout?.stack !== undefined &&
@@ -3494,7 +3515,12 @@ const useEchartsCartesianConfig = (
                                 computedColor,
                             ),
                         },
-                        labelLayout: { hideOverlap: true },
+                        labelLayout: getCartesianLabelLayout({
+                            isGroupedBarChart,
+                            isStacked: getValidStack(serie) !== undefined,
+                            seriesType: serie.type,
+                            position: serie.label.position,
+                        }),
                     }),
                     // Apply reference line styling with readable colors
                     ...(serie.markLine && {


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9384/charts-value-labels-hidden-on-shorter-bars-in-grouped-bar-chart-when

## Summary

Grouped bar charts now keep every value label visible when the label position is `Top`. Shorter-bar values no longer require hovering, while stacked, single-series, inside-label, and non-bar overlap behavior remains unchanged.

## Root cause

The final ECharts series styling forced overlap suppression for every visible value label. ECharts then treated labels from sibling grouped bars as collisions and removed some of them, even though each series explicitly enabled top labels.

```ts
labelLayout: { hideOverlap: true }
```

Grouped bars had no equivalent of the stacked-chart “Show overlapping labels” control, so users could not restore the configured labels.

## Fix

The final series layout now disables overlap suppression only for top-position labels on grouped, non-stacked bars.

- `packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts` — scopes label visibility by chart grouping, series type, stack state, and label position.
- `packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts` — covers grouped top labels and unchanged stacked, single-series, inside, and non-bar layouts.

## Before

```text
2026-01
Total order amount    █████████  $259.50  ✓ label
Average order amount  █           $32.44  ✗ tooltip only
```

## After

```text
2026-01
Total order amount    █████████  $259.50  ✓ label
Average order amount  █           $32.44  ✓ label
```

## Test plan

- [x] `pnpm -F frontend test src/hooks/echarts/useEchartsCartesianConfig.test.ts` — 142 tests pass.
- [x] `pnpm -F frontend typecheck`.
- [x] Targeted frontend lint, format, and `git diff --check`.
- [x] Manual: reproduced the linked ticket in Chrome before the fix, including a missing `$32.44` label that remained present in the tooltip.
- [x] Manual: verified all grouped top labels render after the fix and match the results table and tooltip.
- [x] Manual: verified grouped `Inside` and single-series `Top` retain overlap suppression, with no browser console errors.
