### PR TITLE
feat(ai-agents): persist last used AI model selection

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentModelSelection.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentModelSelection.ts
@@ -8,11 +8,29 @@ import { useModelOptions } from './useModelOptions';
 // Schema-bump escape hatch: bumping the version invalidates older shapes
 // rather than requiring runtime migration.
 const STORAGE_KEY_PREFIX = 'aiAgentsModelSelection:v1';
+// Storage scope for agent-less contexts (the router page).
+const NO_AGENT_SCOPE = '_';
 
 type StoredModelSelection = {
     modelKey: string | null;
     extendedThinking: boolean | null;
 };
+
+// Storage is user-writable, so narrow each field instead of trusting the shape.
+const normalizeStoredSelection = (
+    value: StoredModelSelection | null,
+): StoredModelSelection => ({
+    modelKey: typeof value?.modelKey === 'string' ? value.modelKey : null,
+    extendedThinking:
+        typeof value?.extendedThinking === 'boolean'
+            ? value.extendedThinking
+            : null,
+});
+
+const clampExtendedThinking = (
+    supportsReasoning: boolean,
+    extendedThinking: boolean | null,
+): boolean | null => (supportsReasoning ? extendedThinking : false);
 
 export const getModelOptionByKey = (
     modelOptions: AiModelOption[] | undefined,
@@ -134,9 +152,10 @@ const modelSelectionReducer = (
         case 'setModel':
             return {
                 selectedModelKey: action.modelKey,
-                extendedThinking: action.supportsReasoning
-                    ? action.extendedThinking
-                    : false,
+                extendedThinking: clampExtendedThinking(
+                    action.supportsReasoning,
+                    action.extendedThinking,
+                ),
             };
     }
 };
@@ -168,18 +187,14 @@ export const useAiAgentModelSelection = ({
     // admin-configured default of another.
     const [storedSelection, setStoredSelection] =
         useLocalStorage<StoredModelSelection | null>({
-            key: `${STORAGE_KEY_PREFIX}:${agentUuid ?? '_'}`,
+            key: `${STORAGE_KEY_PREFIX}:${agentUuid ?? NO_AGENT_SCOPE}`,
             defaultValue: null,
             getInitialValueInEffect: false,
         });
-    const storedModelKey =
-        typeof storedSelection?.modelKey === 'string'
-            ? storedSelection.modelKey
-            : null;
-    const storedExtendedThinking =
-        typeof storedSelection?.extendedThinking === 'boolean'
-            ? storedSelection.extendedThinking
-            : null;
+    const {
+        modelKey: storedModelKey,
+        extendedThinking: storedExtendedThinking,
+    } = normalizeStoredSelection(storedSelection);
     const organizationDefaultModelConfig =
         aiOrganizationSettings?.defaultAiAgentModelConfig;
     const resolvedDefaultModelConfig =
@@ -215,7 +230,9 @@ export const useAiAgentModelSelection = ({
 
     const effectiveExtendedThinking =
         extendedThinking ??
-        (selectedModel?.supportsReasoning ? storedExtendedThinking : null) ??
+        (storedModel && selectedModel?.supportsReasoning
+            ? storedExtendedThinking
+            : null) ??
         defaultModelSelection?.extendedThinking ??
         false;
 
@@ -231,14 +248,22 @@ export const useAiAgentModelSelection = ({
                 supportsReasoning,
                 extendedThinking: effectiveExtendedThinking,
             });
+            // Persist the raw toggle (null = untouched) so a displayed default
+            // isn't captured as a user preference.
             setStoredSelection({
                 modelKey,
-                extendedThinking: supportsReasoning
-                    ? effectiveExtendedThinking
-                    : false,
+                extendedThinking: clampExtendedThinking(
+                    supportsReasoning,
+                    extendedThinking,
+                ),
             });
         },
-        [effectiveExtendedThinking, modelOptions, setStoredSelection],
+        [
+            effectiveExtendedThinking,
+            extendedThinking,
+            modelOptions,
+            setStoredSelection,
+        ],
     );
 
     const handleExtendedThinkingChange = useCallback(
@@ -247,13 +272,17 @@ export const useAiAgentModelSelection = ({
                 type: 'setExtendedThinking',
                 extendedThinking: extendedThinkingValue,
             });
-            // Keeps modelKey untouched so toggling reasoning alone doesn't pin
-            // the current default model as a user preference.
-            setStoredSelection((prev) => ({
-                modelKey:
-                    typeof prev?.modelKey === 'string' ? prev.modelKey : null,
-                extendedThinking: extendedThinkingValue,
-            }));
+            // Persist only alongside a stored model pick — a thinking-only
+            // toggle must not pin the current default model as a preference.
+            setStoredSelection((prev) => {
+                const normalized = normalizeStoredSelection(prev ?? null);
+                return normalized.modelKey === null
+                    ? normalized
+                    : {
+                          ...normalized,
+                          extendedThinking: extendedThinkingValue,
+                      };
+            });
         },
         [setStoredSelection],
     );
@@ -270,8 +299,7 @@ export const useAiAgentModelSelection = ({
         isModelSelectionExplicit:
             selectedModelKey !== null ||
             extendedThinking !== null ||
-            storedModel !== undefined ||
-            storedExtendedThinking !== null,
+            storedModel !== undefined,
         modelConfig,
         modelOptions,
         selectedModel,

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentModelSelection.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentModelSelection.ts
@@ -5,10 +5,7 @@ import { getModelKey } from '../../../../components/common/ModelSelector/utils';
 import { useAiOrganizationSettings } from './useAiOrganizationSettings';
 import { useModelOptions } from './useModelOptions';
 
-// Schema-bump escape hatch: bumping the version invalidates older shapes
-// rather than requiring runtime migration.
 const STORAGE_KEY_PREFIX = 'aiAgentsModelSelection:v1';
-// Storage scope for agent-less contexts (the router page).
 const NO_AGENT_SCOPE = '_';
 
 type StoredModelSelection = {
@@ -16,7 +13,6 @@ type StoredModelSelection = {
     extendedThinking: boolean | null;
 };
 
-// Storage is user-writable, so narrow each field instead of trusting the shape.
 const normalizeStoredSelection = (
     value: StoredModelSelection | null,
 ): StoredModelSelection => ({
@@ -183,8 +179,7 @@ export const useAiAgentModelSelection = ({
             selectedModelKey: null,
         },
     );
-    // Scoped per agent so a user's pick in one agent doesn't shadow the
-    // admin-configured default of another.
+    // Scoped per agent so a pick in one agent doesn't shadow another's default.
     const [storedSelection, setStoredSelection] =
         useLocalStorage<StoredModelSelection | null>({
             key: `${STORAGE_KEY_PREFIX}:${agentUuid ?? NO_AGENT_SCOPE}`,
@@ -213,8 +208,6 @@ export const useAiAgentModelSelection = ({
                 : undefined,
         [isDefaultModelConfigReady, modelOptions, resolvedDefaultModelConfig],
     );
-    // A stored model only applies if it still exists in the current options —
-    // models removed by an admin fall back to the default.
     const storedModel = getModelOptionByKey(modelOptions, storedModelKey);
     const effectiveSelectedModelKey =
         selectedModelKey ??
@@ -248,8 +241,7 @@ export const useAiAgentModelSelection = ({
                 supportsReasoning,
                 extendedThinking: effectiveExtendedThinking,
             });
-            // Persist the raw toggle (null = untouched) so a displayed default
-            // isn't captured as a user preference.
+            // Raw toggle (null = untouched), so defaults aren't stored.
             setStoredSelection({
                 modelKey,
                 extendedThinking: clampExtendedThinking(
@@ -272,8 +264,7 @@ export const useAiAgentModelSelection = ({
                 type: 'setExtendedThinking',
                 extendedThinking: extendedThinkingValue,
             });
-            // Persist only alongside a stored model pick — a thinking-only
-            // toggle must not pin the current default model as a preference.
+            // A thinking-only toggle must not pin the current default model.
             setStoredSelection((prev) => {
                 const normalized = normalizeStoredSelection(prev ?? null);
                 return normalized.modelKey === null

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentModelSelection.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentModelSelection.ts
@@ -1,8 +1,18 @@
 import type { AiAgentModelConfig, AiModelOption } from '@lightdash/common';
+import { useLocalStorage } from '@mantine-8/hooks';
 import { useCallback, useMemo, useReducer } from 'react';
 import { getModelKey } from '../../../../components/common/ModelSelector/utils';
 import { useAiOrganizationSettings } from './useAiOrganizationSettings';
 import { useModelOptions } from './useModelOptions';
+
+// Schema-bump escape hatch: bumping the version invalidates older shapes
+// rather than requiring runtime migration.
+const STORAGE_KEY_PREFIX = 'aiAgentsModelSelection:v1';
+
+type StoredModelSelection = {
+    modelKey: string | null;
+    extendedThinking: boolean | null;
+};
 
 export const getModelOptionByKey = (
     modelOptions: AiModelOption[] | undefined,
@@ -154,6 +164,22 @@ export const useAiAgentModelSelection = ({
             selectedModelKey: null,
         },
     );
+    // Scoped per agent so a user's pick in one agent doesn't shadow the
+    // admin-configured default of another.
+    const [storedSelection, setStoredSelection] =
+        useLocalStorage<StoredModelSelection | null>({
+            key: `${STORAGE_KEY_PREFIX}:${agentUuid ?? '_'}`,
+            defaultValue: null,
+            getInitialValueInEffect: false,
+        });
+    const storedModelKey =
+        typeof storedSelection?.modelKey === 'string'
+            ? storedSelection.modelKey
+            : null;
+    const storedExtendedThinking =
+        typeof storedSelection?.extendedThinking === 'boolean'
+            ? storedSelection.extendedThinking
+            : null;
     const organizationDefaultModelConfig =
         aiOrganizationSettings?.defaultAiAgentModelConfig;
     const resolvedDefaultModelConfig =
@@ -172,32 +198,47 @@ export const useAiAgentModelSelection = ({
                 : undefined,
         [isDefaultModelConfigReady, modelOptions, resolvedDefaultModelConfig],
     );
+    // A stored model only applies if it still exists in the current options —
+    // models removed by an admin fall back to the default.
+    const storedModel = getModelOptionByKey(modelOptions, storedModelKey);
     const effectiveSelectedModelKey =
         selectedModelKey ??
+        (storedModel ? getModelKey(storedModel) : null) ??
         (defaultModelSelection?.model
             ? getModelKey(defaultModelSelection.model)
             : null);
-    const effectiveExtendedThinking =
-        extendedThinking ?? defaultModelSelection?.extendedThinking ?? false;
 
     const selectedModel = useMemo(
         () => getModelOptionByKey(modelOptions, effectiveSelectedModelKey),
         [effectiveSelectedModelKey, modelOptions],
     );
 
+    const effectiveExtendedThinking =
+        extendedThinking ??
+        (selectedModel?.supportsReasoning ? storedExtendedThinking : null) ??
+        defaultModelSelection?.extendedThinking ??
+        false;
+
     const showExtendedThinking = selectedModel?.supportsReasoning ?? false;
 
     const handleSelectedModelKeyChange = useCallback(
         (modelKey: string) => {
             const model = getModelOptionByKey(modelOptions, modelKey);
+            const supportsReasoning = model?.supportsReasoning ?? false;
             dispatch({
                 type: 'setModel',
                 modelKey,
-                supportsReasoning: model?.supportsReasoning ?? false,
+                supportsReasoning,
                 extendedThinking: effectiveExtendedThinking,
             });
+            setStoredSelection({
+                modelKey,
+                extendedThinking: supportsReasoning
+                    ? effectiveExtendedThinking
+                    : false,
+            });
         },
-        [effectiveExtendedThinking, modelOptions],
+        [effectiveExtendedThinking, modelOptions, setStoredSelection],
     );
 
     const handleExtendedThinkingChange = useCallback(
@@ -206,8 +247,15 @@ export const useAiAgentModelSelection = ({
                 type: 'setExtendedThinking',
                 extendedThinking: extendedThinkingValue,
             });
+            // Keeps modelKey untouched so toggling reasoning alone doesn't pin
+            // the current default model as a user preference.
+            setStoredSelection((prev) => ({
+                modelKey:
+                    typeof prev?.modelKey === 'string' ? prev.modelKey : null,
+                extendedThinking: extendedThinkingValue,
+            }));
         },
-        [],
+        [setStoredSelection],
     );
 
     const modelConfig = useMemo(
@@ -220,7 +268,10 @@ export const useAiAgentModelSelection = ({
         handleExtendedThinkingChange,
         handleSelectedModelKeyChange,
         isModelSelectionExplicit:
-            selectedModelKey !== null || extendedThinking !== null,
+            selectedModelKey !== null ||
+            extendedThinking !== null ||
+            storedModel !== undefined ||
+            storedExtendedThinking !== null,
         modelConfig,
         modelOptions,
         selectedModel,


### PR DESCRIPTION
The model picked in the AI chat model switcher (and its extended-thinking toggle) is now persisted to localStorage, scoped per agent, and restored on load. Stored selections are validated against the currently available models, so a model removed by an admin falls back to the default, and users who never picked a model keep following admin-configured defaults.

Closes: ZAP-144
Closes: #18618

🤖 Generated with [Claude Code](https://claude.com/claude-code)