### PR TITLE
fix: prevent duplicate project creation from a second "Test & save"

### DIFF
--- a/packages/backend/src/database/entities/jobs.ts
+++ b/packages/backend/src/database/entities/jobs.ts
@@ -14,6 +14,7 @@ export type DbJobs = {
     job_uuid: string;
     project_uuid: string | undefined;
     user_uuid: string | undefined;
+    is_preview: boolean;
     created_at: Date;
     updated_at: Date;
     job_status: JobStatusType;
@@ -23,7 +24,12 @@ export type DbJobs = {
 
 type CreateJob = Pick<
     DbJobs,
-    'project_uuid' | 'job_uuid' | 'job_status' | 'job_type' | 'user_uuid'
+    | 'project_uuid'
+    | 'job_uuid'
+    | 'job_status'
+    | 'job_type'
+    | 'user_uuid'
+    | 'is_preview'
 >;
 
 type UpdateJob = Partial<

--- a/packages/backend/src/database/migrations/20260803094000_add_is_preview_to_jobs.ts
+++ b/packages/backend/src/database/migrations/20260803094000_add_is_preview_to_jobs.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex';
+
+const JOBS_TABLE_NAME = 'jobs';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(JOBS_TABLE_NAME, (table) => {
+        table.boolean('is_preview').notNullable().defaultTo(false);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(JOBS_TABLE_NAME, (table) => {
+        table.dropColumn('is_preview');
+    });
+}

--- a/packages/backend/src/models/JobModel/JobModel.test.ts
+++ b/packages/backend/src/models/JobModel/JobModel.test.ts
@@ -32,6 +32,10 @@ describe('JobModel.findActiveCreateProjectJob', () => {
         job_type: JobType.CREATE_PROJECT,
         results: undefined,
     };
+    const otherUserActiveJobRow: DbJobs = {
+        ...activeJobRow,
+        user_uuid: 'other-user-uuid',
+    };
     const createJob: CreateJob = {
         jobUuid: activeJobRow.job_uuid,
         projectUuid: undefined,
@@ -59,6 +63,7 @@ describe('JobModel.findActiveCreateProjectJob', () => {
 
         const result = await model.findActiveCreateProjectJob({
             organizationUuid: 'organization-uuid',
+            userUuid: 'user-uuid',
             createdAfter,
         });
 
@@ -85,6 +90,7 @@ describe('JobModel.findActiveCreateProjectJob', () => {
         expect(query.bindings).toEqual(
             expect.arrayContaining([
                 'organization-uuid',
+                'user-uuid',
                 JobType.CREATE_PROJECT,
                 JobStatusType.STARTED,
                 JobStatusType.RUNNING,
@@ -94,15 +100,20 @@ describe('JobModel.findActiveCreateProjectJob', () => {
         );
     });
 
-    test('returns null when no recent active non-preview create job exists', async () => {
+    test("returns null when the organization's active job belongs to another user", async () => {
         tracker.on.select(JobsTableName).responseOnce(undefined);
 
         await expect(
             model.findActiveCreateProjectJob({
                 organizationUuid: 'organization-uuid',
+                userUuid: 'user-uuid',
                 createdAfter,
             }),
         ).resolves.toBeNull();
+
+        expect(tracker.history.select[0].bindings).toEqual(
+            expect.arrayContaining(['organization-uuid', 'user-uuid']),
+        );
     });
 
     test('inserts a create job and its steps inside the organization advisory lock', async () => {
@@ -146,7 +157,7 @@ describe('JobModel.findActiveCreateProjectJob', () => {
 
     test('reports the active job without inserting after taking the lock', async () => {
         tracker.on.select('pg_advisory_xact_lock').responseOnce({});
-        tracker.on.select(JobsTableName).responseOnce(activeJobRow);
+        tracker.on.select(JobsTableName).responseOnce(otherUserActiveJobRow);
         tracker.on.select(JobStepsTableName).responseOnce([]);
 
         const result = await model.createProjectJobIfNoActive({
@@ -159,6 +170,7 @@ describe('JobModel.findActiveCreateProjectJob', () => {
             isCreated: false,
             activeJob: expect.objectContaining({
                 jobUuid: activeJobRow.job_uuid,
+                userUuid: otherUserActiveJobRow.user_uuid,
             }),
         });
         expect(tracker.history.insert).toHaveLength(0);

--- a/packages/backend/src/models/JobModel/JobModel.test.ts
+++ b/packages/backend/src/models/JobModel/JobModel.test.ts
@@ -1,0 +1,166 @@
+import {
+    JobStatusType,
+    JobStepType,
+    JobType,
+    type CreateJob,
+    type Job,
+} from '@lightdash/common';
+import knex from 'knex';
+import { getTracker, MockClient, type Tracker } from 'knex-mock-client';
+import {
+    JobsTableName,
+    JobStepsTableName,
+    type DbJobs,
+} from '../../database/entities/jobs';
+import { OrganizationMembershipsTableName } from '../../database/entities/organizationMemberships';
+import { OrganizationTableName } from '../../database/entities/organizations';
+import { UserTableName } from '../../database/entities/users';
+import { JobModel } from './JobModel';
+
+describe('JobModel.findActiveCreateProjectJob', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new JobModel({ database });
+    const createdAfter = new Date('2026-08-03T08:00:00.000Z');
+    const activeJobRow: DbJobs = {
+        job_uuid: 'active-job-uuid',
+        project_uuid: undefined,
+        user_uuid: 'user-uuid',
+        is_preview: false,
+        created_at: new Date('2026-08-03T08:30:00.000Z'),
+        updated_at: new Date('2026-08-03T08:31:00.000Z'),
+        job_status: JobStatusType.RUNNING,
+        job_type: JobType.CREATE_PROJECT,
+        results: undefined,
+    };
+    const createJob: CreateJob = {
+        jobUuid: activeJobRow.job_uuid,
+        projectUuid: undefined,
+        userUuid: activeJobRow.user_uuid,
+        jobStatus: JobStatusType.STARTED,
+        jobType: JobType.CREATE_PROJECT,
+        steps: [
+            { stepType: JobStepType.TESTING_ADAPTOR },
+            { stepType: JobStepType.CREATING_PROJECT },
+        ],
+    };
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    test('returns the most recent hydrated non-preview create job for the organization', async () => {
+        tracker.on.select(JobsTableName).responseOnce(activeJobRow);
+        tracker.on.select(JobStepsTableName).responseOnce([]);
+
+        const result = await model.findActiveCreateProjectJob({
+            organizationUuid: 'organization-uuid',
+            createdAfter,
+        });
+
+        expect(result).toEqual<Job>({
+            jobUuid: activeJobRow.job_uuid,
+            projectUuid: activeJobRow.project_uuid,
+            userUuid: activeJobRow.user_uuid,
+            createdAt: activeJobRow.created_at,
+            updatedAt: activeJobRow.updated_at,
+            jobStatus: activeJobRow.job_status,
+            jobType: JobType.CREATE_PROJECT,
+            jobResults: undefined,
+            steps: [],
+        });
+        const query = tracker.history.select[0];
+        expect(query.sql).toContain(`join "${UserTableName}"`);
+        expect(query.sql).toContain(
+            `join "${OrganizationMembershipsTableName}"`,
+        );
+        expect(query.sql).toContain(`join "${OrganizationTableName}"`);
+        expect(query.sql).toContain(
+            `order by "${JobsTableName}"."created_at" desc`,
+        );
+        expect(query.bindings).toEqual(
+            expect.arrayContaining([
+                'organization-uuid',
+                JobType.CREATE_PROJECT,
+                JobStatusType.STARTED,
+                JobStatusType.RUNNING,
+                false,
+                createdAfter,
+            ]),
+        );
+    });
+
+    test('returns null when no recent active non-preview create job exists', async () => {
+        tracker.on.select(JobsTableName).responseOnce(undefined);
+
+        await expect(
+            model.findActiveCreateProjectJob({
+                organizationUuid: 'organization-uuid',
+                createdAfter,
+            }),
+        ).resolves.toBeNull();
+    });
+
+    test('inserts a create job and its steps inside the organization advisory lock', async () => {
+        tracker.on.select('pg_advisory_xact_lock').responseOnce({});
+        tracker.on
+            .select(
+                ({ sql }) =>
+                    sql.includes(`from "${JobsTableName}"`) &&
+                    sql.includes('inner join'),
+            )
+            .responseOnce(undefined);
+        tracker.on.insert(JobsTableName).responseOnce([]);
+        tracker.on.insert(JobStepsTableName).response([]);
+        tracker.on
+            .select(
+                ({ sql }) =>
+                    sql.includes(`from "${JobsTableName}"`) &&
+                    !sql.includes('inner join'),
+            )
+            .responseOnce([activeJobRow]);
+        tracker.on.select(JobStepsTableName).responseOnce([]);
+
+        const result = await model.createProjectJobIfNoActive({
+            job: createJob,
+            organizationUuid: 'organization-uuid',
+            createdAfter,
+        });
+
+        expect(result).toMatchObject({
+            isCreated: true,
+            job: { jobUuid: activeJobRow.job_uuid },
+        });
+        const lockQuery = tracker.history.select.find(({ sql }) =>
+            sql.includes('pg_advisory_xact_lock'),
+        );
+        expect(lockQuery?.bindings).toEqual([
+            'create_project:organization-uuid',
+        ]);
+        expect(tracker.history.insert).toHaveLength(3);
+    });
+
+    test('reports the active job without inserting after taking the lock', async () => {
+        tracker.on.select('pg_advisory_xact_lock').responseOnce({});
+        tracker.on.select(JobsTableName).responseOnce(activeJobRow);
+        tracker.on.select(JobStepsTableName).responseOnce([]);
+
+        const result = await model.createProjectJobIfNoActive({
+            job: createJob,
+            organizationUuid: 'organization-uuid',
+            createdAfter,
+        });
+
+        expect(result).toEqual({
+            isCreated: false,
+            activeJob: expect.objectContaining({
+                jobUuid: activeJobRow.job_uuid,
+            }),
+        });
+        expect(tracker.history.insert).toHaveLength(0);
+    });
+});

--- a/packages/backend/src/models/JobModel/JobModel.test.ts
+++ b/packages/backend/src/models/JobModel/JobModel.test.ts
@@ -20,7 +20,7 @@ import { JobModel } from './JobModel';
 describe('JobModel.findActiveCreateProjectJob', () => {
     const database = knex({ client: MockClient, dialect: 'pg' });
     const model = new JobModel({ database });
-    const createdAfter = new Date('2026-08-03T08:00:00.000Z');
+    const completedAfter = new Date('2026-08-03T08:00:00.000Z');
     const activeJobRow: DbJobs = {
         job_uuid: 'active-job-uuid',
         project_uuid: undefined,
@@ -64,7 +64,7 @@ describe('JobModel.findActiveCreateProjectJob', () => {
         const result = await model.findActiveCreateProjectJob({
             organizationUuid: 'organization-uuid',
             userUuid: 'user-uuid',
-            createdAfter,
+            completedAfter,
         });
 
         expect(result).toEqual<Job>({
@@ -95,7 +95,8 @@ describe('JobModel.findActiveCreateProjectJob', () => {
                 JobStatusType.STARTED,
                 JobStatusType.RUNNING,
                 false,
-                createdAfter,
+                JobStatusType.DONE,
+                completedAfter,
             ]),
         );
     });
@@ -107,7 +108,7 @@ describe('JobModel.findActiveCreateProjectJob', () => {
             model.findActiveCreateProjectJob({
                 organizationUuid: 'organization-uuid',
                 userUuid: 'user-uuid',
-                createdAfter,
+                completedAfter,
             }),
         ).resolves.toBeNull();
 
@@ -139,7 +140,6 @@ describe('JobModel.findActiveCreateProjectJob', () => {
         const result = await model.createProjectJobIfNoActive({
             job: createJob,
             organizationUuid: 'organization-uuid',
-            createdAfter,
         });
 
         expect(result).toMatchObject({
@@ -163,7 +163,6 @@ describe('JobModel.findActiveCreateProjectJob', () => {
         const result = await model.createProjectJobIfNoActive({
             job: createJob,
             organizationUuid: 'organization-uuid',
-            createdAfter,
         });
 
         expect(result).toEqual({

--- a/packages/backend/src/models/JobModel/JobModel.test.ts
+++ b/packages/backend/src/models/JobModel/JobModel.test.ts
@@ -20,7 +20,6 @@ import { JobModel } from './JobModel';
 describe('JobModel.findActiveCreateProjectJob', () => {
     const database = knex({ client: MockClient, dialect: 'pg' });
     const model = new JobModel({ database });
-    const completedAfter = new Date('2026-08-03T08:00:00.000Z');
     const activeJobRow: DbJobs = {
         job_uuid: 'active-job-uuid',
         project_uuid: undefined,
@@ -64,7 +63,6 @@ describe('JobModel.findActiveCreateProjectJob', () => {
         const result = await model.findActiveCreateProjectJob({
             organizationUuid: 'organization-uuid',
             userUuid: 'user-uuid',
-            completedAfter,
         });
 
         expect(result).toEqual<Job>({
@@ -95,8 +93,6 @@ describe('JobModel.findActiveCreateProjectJob', () => {
                 JobStatusType.STARTED,
                 JobStatusType.RUNNING,
                 false,
-                JobStatusType.DONE,
-                completedAfter,
             ]),
         );
     });
@@ -108,7 +104,6 @@ describe('JobModel.findActiveCreateProjectJob', () => {
             model.findActiveCreateProjectJob({
                 organizationUuid: 'organization-uuid',
                 userUuid: 'user-uuid',
-                completedAfter,
             }),
         ).resolves.toBeNull();
 

--- a/packages/backend/src/models/JobModel/JobModel.ts
+++ b/packages/backend/src/models/JobModel/JobModel.ts
@@ -30,7 +30,6 @@ type JobModelArguments = {
 type ActiveCreateProjectJobArgs = {
     organizationUuid: string;
     userUuid: string;
-    completedAfter?: Date;
 };
 
 type ActiveCreateProjectJobLookupArgs = Omit<
@@ -73,11 +72,7 @@ export class JobModel {
     }
 
     private async findActiveCreateProjectJobWithDatabase(
-        {
-            organizationUuid,
-            userUuid,
-            completedAfter,
-        }: ActiveCreateProjectJobLookupArgs,
+        { organizationUuid, userUuid }: ActiveCreateProjectJobLookupArgs,
         database: Knex,
     ): Promise<Job | null> {
         const jobQuery = database(JobsTableName)
@@ -102,29 +97,10 @@ export class JobModel {
             )
             .where(`${JobsTableName}.job_type`, JobType.CREATE_PROJECT)
             .where(`${JobsTableName}.is_preview`, false)
-            .where((statusQuery) => {
-                statusQuery.whereIn(`${JobsTableName}.job_status`, [
-                    JobStatusType.STARTED,
-                    JobStatusType.RUNNING,
-                ]);
-                if (completedAfter) {
-                    statusQuery.orWhere((completedQuery) => {
-                        completedQuery
-                            .where(
-                                `${JobsTableName}.job_status`,
-                                JobStatusType.DONE,
-                            )
-                            .where(
-                                `${JobsTableName}.updated_at`,
-                                '>=',
-                                completedAfter,
-                            )
-                            .whereRaw(`??->>'projectUuid' IS NOT NULL`, [
-                                `${JobsTableName}.results`,
-                            ]);
-                    });
-                }
-            });
+            .whereIn(`${JobsTableName}.job_status`, [
+                JobStatusType.STARTED,
+                JobStatusType.RUNNING,
+            ]);
 
         if (userUuid) {
             jobQuery.where(`${JobsTableName}.user_uuid`, userUuid);

--- a/packages/backend/src/models/JobModel/JobModel.ts
+++ b/packages/backend/src/models/JobModel/JobModel.ts
@@ -30,7 +30,13 @@ type JobModelArguments = {
 type ActiveCreateProjectJobArgs = {
     organizationUuid: string;
     createdAfter: Date;
+    userUuid: string;
 };
+
+type ActiveCreateProjectJobLookupArgs = Omit<
+    ActiveCreateProjectJobArgs,
+    'userUuid'
+> & { userUuid?: string };
 
 type CreateProjectJobResult =
     | { isCreated: true; job: Job }
@@ -67,10 +73,14 @@ export class JobModel {
     }
 
     private async findActiveCreateProjectJobWithDatabase(
-        { organizationUuid, createdAfter }: ActiveCreateProjectJobArgs,
+        {
+            organizationUuid,
+            createdAfter,
+            userUuid,
+        }: ActiveCreateProjectJobLookupArgs,
         database: Knex,
     ): Promise<Job | null> {
-        const row = await database(JobsTableName)
+        const query = database(JobsTableName)
             .innerJoin(
                 UserTableName,
                 `${JobsTableName}.user_uuid`,
@@ -96,7 +106,13 @@ export class JobModel {
                 JobStatusType.RUNNING,
             ])
             .where(`${JobsTableName}.is_preview`, false)
-            .where(`${JobsTableName}.created_at`, '>=', createdAfter)
+            .where(`${JobsTableName}.created_at`, '>=', createdAfter);
+
+        if (userUuid) {
+            query.where(`${JobsTableName}.user_uuid`, userUuid);
+        }
+
+        const row = await query
             .select(`${JobsTableName}.*`)
             .orderBy(`${JobsTableName}.created_at`, 'desc')
             .first();

--- a/packages/backend/src/models/JobModel/JobModel.ts
+++ b/packages/backend/src/models/JobModel/JobModel.ts
@@ -29,8 +29,8 @@ type JobModelArguments = {
 
 type ActiveCreateProjectJobArgs = {
     organizationUuid: string;
-    createdAfter: Date;
     userUuid: string;
+    completedAfter?: Date;
 };
 
 type ActiveCreateProjectJobLookupArgs = Omit<
@@ -75,12 +75,12 @@ export class JobModel {
     private async findActiveCreateProjectJobWithDatabase(
         {
             organizationUuid,
-            createdAfter,
             userUuid,
+            completedAfter,
         }: ActiveCreateProjectJobLookupArgs,
         database: Knex,
     ): Promise<Job | null> {
-        const query = database(JobsTableName)
+        const jobQuery = database(JobsTableName)
             .innerJoin(
                 UserTableName,
                 `${JobsTableName}.user_uuid`,
@@ -101,18 +101,36 @@ export class JobModel {
                 organizationUuid,
             )
             .where(`${JobsTableName}.job_type`, JobType.CREATE_PROJECT)
-            .whereIn(`${JobsTableName}.job_status`, [
-                JobStatusType.STARTED,
-                JobStatusType.RUNNING,
-            ])
             .where(`${JobsTableName}.is_preview`, false)
-            .where(`${JobsTableName}.created_at`, '>=', createdAfter);
+            .where((statusQuery) => {
+                statusQuery.whereIn(`${JobsTableName}.job_status`, [
+                    JobStatusType.STARTED,
+                    JobStatusType.RUNNING,
+                ]);
+                if (completedAfter) {
+                    statusQuery.orWhere((completedQuery) => {
+                        completedQuery
+                            .where(
+                                `${JobsTableName}.job_status`,
+                                JobStatusType.DONE,
+                            )
+                            .where(
+                                `${JobsTableName}.updated_at`,
+                                '>=',
+                                completedAfter,
+                            )
+                            .whereRaw(`??->>'projectUuid' IS NOT NULL`, [
+                                `${JobsTableName}.results`,
+                            ]);
+                    });
+                }
+            });
 
         if (userUuid) {
-            query.where(`${JobsTableName}.user_uuid`, userUuid);
+            jobQuery.where(`${JobsTableName}.user_uuid`, userUuid);
         }
 
-        const row = await query
+        const row = await jobQuery
             .select(`${JobsTableName}.*`)
             .orderBy(`${JobsTableName}.created_at`, 'desc')
             .first();
@@ -194,11 +212,9 @@ export class JobModel {
     async createProjectJobIfNoActive({
         job,
         organizationUuid,
-        createdAfter,
     }: {
         job: CreateJob;
         organizationUuid: string;
-        createdAfter: Date;
     }): Promise<CreateProjectJobResult> {
         return this.database.transaction(async (trx) => {
             await trx.raw(
@@ -207,7 +223,7 @@ export class JobModel {
             );
 
             const activeJob = await this.findActiveCreateProjectJobWithDatabase(
-                { organizationUuid, createdAfter },
+                { organizationUuid },
                 trx,
             );
             if (activeJob) {
@@ -220,6 +236,60 @@ export class JobModel {
                 job: await this.getWithDatabase(job.jobUuid, trx),
             };
         });
+    }
+
+    async findStaleCreateProjectJobUuids({
+        organizationUuid,
+        updatedBefore,
+    }: {
+        organizationUuid: string;
+        updatedBefore: Date;
+    }): Promise<string[]> {
+        const rows = await this.database(JobsTableName)
+            .innerJoin(
+                UserTableName,
+                `${JobsTableName}.user_uuid`,
+                `${UserTableName}.user_uuid`,
+            )
+            .innerJoin(
+                OrganizationMembershipsTableName,
+                `${UserTableName}.user_id`,
+                `${OrganizationMembershipsTableName}.user_id`,
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationMembershipsTableName}.organization_id`,
+                `${OrganizationTableName}.organization_id`,
+            )
+            .where(
+                `${OrganizationTableName}.organization_uuid`,
+                organizationUuid,
+            )
+            .where(`${JobsTableName}.job_type`, JobType.CREATE_PROJECT)
+            .whereIn(`${JobsTableName}.job_status`, [
+                JobStatusType.STARTED,
+                JobStatusType.RUNNING,
+            ])
+            .where(`${JobsTableName}.is_preview`, false)
+            .where(`${JobsTableName}.updated_at`, '<', updatedBefore)
+            .select(`${JobsTableName}.job_uuid`);
+
+        return rows.map(({ job_uuid }) => job_uuid);
+    }
+
+    async markCreateProjectJobsAsError(jobUuids: string[]): Promise<void> {
+        if (jobUuids.length === 0) return;
+
+        await this.database(JobsTableName)
+            .whereIn('job_uuid', jobUuids)
+            .whereIn('job_status', [
+                JobStatusType.STARTED,
+                JobStatusType.RUNNING,
+            ])
+            .update({
+                job_status: JobStatusType.ERROR,
+                updated_at: new Date(),
+            });
     }
 
     private async insert(

--- a/packages/backend/src/models/JobModel/JobModel.ts
+++ b/packages/backend/src/models/JobModel/JobModel.ts
@@ -10,6 +10,7 @@ import {
     JobStep,
     JobStepStatusType,
     JobStepType,
+    JobType,
     NotFoundError,
 } from '@lightdash/common';
 import { Knex } from 'knex';
@@ -18,10 +19,22 @@ import {
     JobsTableName,
     JobStepsTableName,
 } from '../../database/entities/jobs';
+import { OrganizationMembershipsTableName } from '../../database/entities/organizationMemberships';
+import { OrganizationTableName } from '../../database/entities/organizations';
+import { UserTableName } from '../../database/entities/users';
 
 type JobModelArguments = {
     database: Knex;
 };
+
+type ActiveCreateProjectJobArgs = {
+    organizationUuid: string;
+    createdAfter: Date;
+};
+
+type CreateProjectJobResult =
+    | { isCreated: true; job: Job }
+    | { isCreated: false; activeJob: Job };
 
 export class JobModel {
     private database: Knex;
@@ -31,20 +44,71 @@ export class JobModel {
     }
 
     async get(jobUuid: string): Promise<Job> {
-        const [row] = await this.database(JobsTableName).where(
-            'job_uuid',
-            jobUuid,
-        );
+        return this.getWithDatabase(jobUuid, this.database);
+    }
+
+    private async getWithDatabase(
+        jobUuid: string,
+        database: Knex,
+    ): Promise<Job> {
+        const [row] = await database(JobsTableName).where('job_uuid', jobUuid);
         if (row === undefined)
             throw new NotFoundError(
                 `job with jobUuid ${jobUuid} does not exist`,
             );
 
-        return this.convertRowToJob(row);
+        return this.convertRowToJob(row, database);
     }
 
-    async convertRowToJob(row: DbJobs): Promise<Job> {
-        const steps = await this.getSteps(row.job_uuid);
+    async findActiveCreateProjectJob(
+        args: ActiveCreateProjectJobArgs,
+    ): Promise<Job | null> {
+        return this.findActiveCreateProjectJobWithDatabase(args, this.database);
+    }
+
+    private async findActiveCreateProjectJobWithDatabase(
+        { organizationUuid, createdAfter }: ActiveCreateProjectJobArgs,
+        database: Knex,
+    ): Promise<Job | null> {
+        const row = await database(JobsTableName)
+            .innerJoin(
+                UserTableName,
+                `${JobsTableName}.user_uuid`,
+                `${UserTableName}.user_uuid`,
+            )
+            .innerJoin(
+                OrganizationMembershipsTableName,
+                `${UserTableName}.user_id`,
+                `${OrganizationMembershipsTableName}.user_id`,
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationMembershipsTableName}.organization_id`,
+                `${OrganizationTableName}.organization_id`,
+            )
+            .where(
+                `${OrganizationTableName}.organization_uuid`,
+                organizationUuid,
+            )
+            .where(`${JobsTableName}.job_type`, JobType.CREATE_PROJECT)
+            .whereIn(`${JobsTableName}.job_status`, [
+                JobStatusType.STARTED,
+                JobStatusType.RUNNING,
+            ])
+            .where(`${JobsTableName}.is_preview`, false)
+            .where(`${JobsTableName}.created_at`, '>=', createdAfter)
+            .select(`${JobsTableName}.*`)
+            .orderBy(`${JobsTableName}.created_at`, 'desc')
+            .first();
+
+        return row ? this.convertRowToJob(row, database) : null;
+    }
+
+    async convertRowToJob(
+        row: DbJobs,
+        database: Knex = this.database,
+    ): Promise<Job> {
+        const steps = await this.getSteps(row.job_uuid, database);
         const baseJob: BaseJob = {
             createdAt: row.created_at,
             updatedAt: row.updated_at,
@@ -62,8 +126,11 @@ export class JobModel {
         return job;
     }
 
-    async getSteps(jobUuid: string): Promise<JobStep[]> {
-        const steps = await this.database(JobStepsTableName)
+    async getSteps(
+        jobUuid: string,
+        database: Knex = this.database,
+    ): Promise<JobStep[]> {
+        const steps = await database(JobStepsTableName)
             .where('job_uuid', jobUuid)
             .orderBy('step_id', 'asc');
 
@@ -101,27 +168,65 @@ export class JobModel {
             .where('job_uuid', jobUuid);
     }
 
-    async create(job: CreateJob): Promise<Job> {
+    async create(job: CreateJob, isPreview: boolean): Promise<Job> {
         await this.database.transaction(async (trx) => {
-            await trx(JobsTableName)
-                .insert({
-                    project_uuid: job.projectUuid,
-                    user_uuid: job.userUuid,
-                    job_uuid: job.jobUuid,
-                    job_type: job.jobType,
-                    job_status: job.jobStatus,
-                })
-                .returning('*');
-            await job.steps.reduce(async (previousPromise, step) => {
-                await previousPromise;
-                return trx(JobStepsTableName).insert({
-                    job_uuid: job.jobUuid,
-                    step_status: JobStepStatusType.PENDING,
-                    step_type: step.stepType,
-                });
-            }, Promise.resolve());
+            await this.insert(job, isPreview, trx);
         });
         return this.get(job.jobUuid);
+    }
+
+    async createProjectJobIfNoActive({
+        job,
+        organizationUuid,
+        createdAfter,
+    }: {
+        job: CreateJob;
+        organizationUuid: string;
+        createdAfter: Date;
+    }): Promise<CreateProjectJobResult> {
+        return this.database.transaction(async (trx) => {
+            await trx.raw(
+                'SELECT pg_advisory_xact_lock(hashtextextended(?, 0))',
+                [`create_project:${organizationUuid}`],
+            );
+
+            const activeJob = await this.findActiveCreateProjectJobWithDatabase(
+                { organizationUuid, createdAfter },
+                trx,
+            );
+            if (activeJob) {
+                return { isCreated: false, activeJob };
+            }
+
+            await this.insert(job, false, trx);
+            return {
+                isCreated: true,
+                job: await this.getWithDatabase(job.jobUuid, trx),
+            };
+        });
+    }
+
+    private async insert(
+        job: CreateJob,
+        isPreview: boolean,
+        database: Knex,
+    ): Promise<void> {
+        await database(JobsTableName).insert({
+            project_uuid: job.projectUuid,
+            user_uuid: job.userUuid,
+            job_uuid: job.jobUuid,
+            job_type: job.jobType,
+            job_status: job.jobStatus,
+            is_preview: isPreview,
+        });
+        await job.steps.reduce(async (previousPromise, step) => {
+            await previousPromise;
+            return database(JobStepsTableName).insert({
+                job_uuid: job.jobUuid,
+                step_status: JobStepStatusType.PENDING,
+                step_type: step.stepType,
+            });
+        }, Promise.resolve());
     }
 
     async startJobStep(jobUuid: string, stepType: JobStepType): Promise<void> {

--- a/packages/backend/src/routers/organizationRouter.ts
+++ b/packages/backend/src/routers/organizationRouter.ts
@@ -55,6 +55,26 @@ organizationRouter.post(
             .catch(next),
 );
 
+organizationRouter.get(
+    '/jobs/create-project/active',
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    async (req, res, next) => {
+        try {
+            const results = await req.services
+                .getProjectService()
+                .getActiveCreateProjectJob(req.user!);
+
+            res.json({
+                status: 'ok',
+                results,
+            });
+        } catch (e) {
+            next(e);
+        }
+    },
+);
+
 organizationRouter.delete(
     '/projects/:projectUuid',
     allowApiKeyAuthentication,

--- a/packages/backend/src/scheduler/SchedulerClient.test.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.test.ts
@@ -213,3 +213,27 @@ describe('SchedulerClient per-org delivery queue', () => {
         }
     });
 });
+
+describe('SchedulerClient create project job lookup', () => {
+    afterEach(() => vi.restoreAllMocks());
+
+    it('finds a queued create project job by its Lightdash job UUID', async () => {
+        const client = makeClient(false, vi.fn());
+        const query = vi.fn().mockResolvedValue({
+            rows: [{ exists: true }],
+        });
+        client.graphileUtils = Promise.resolve({
+            withPgClient: async (
+                callback: (client: { query: typeof query }) => unknown,
+            ) => callback({ query }),
+        } as unknown as Awaited<typeof client.graphileUtils>);
+
+        await expect(
+            client.hasCreateProjectWithCompileJob('lightdash-job-uuid'),
+        ).resolves.toBe(true);
+        expect(query).toHaveBeenCalledWith(
+            expect.stringContaining("payload->>'jobUuid' = $2"),
+            ['createProjectWithCompile', 'lightdash-job-uuid'],
+        );
+    });
+});

--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -1435,6 +1435,22 @@ export class SchedulerClient {
         return { jobId };
     }
 
+    async hasCreateProjectWithCompileJob(jobUuid: string): Promise<boolean> {
+        const graphileClient = await this.graphileUtils;
+        const result = await graphileClient.withPgClient((pgClient) =>
+            pgClient.query<{ exists: boolean }>(
+                `SELECT EXISTS (
+                    SELECT 1
+                    FROM graphile_worker.jobs
+                    WHERE task_identifier = $1
+                      AND payload->>'jobUuid' = $2
+                ) AS exists`,
+                [SCHEDULER_TASKS.CREATE_PROJECT_WITH_COMPILE, jobUuid],
+            ),
+        );
+        return result.rows[0]?.exists ?? false;
+    }
+
     async testAndCompileProject(payload: CompileProjectPayload) {
         const graphileClient = await this.graphileUtils;
         const now = new Date();

--- a/packages/backend/src/services/ProjectService/ProjectService.integration.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.integration.test.ts
@@ -1,0 +1,286 @@
+import {
+    ConflictError,
+    DbtProjectType,
+    DbtVersionOptionLatest,
+    JobStatusType,
+    JobType,
+    ProjectType,
+    RequestMethod,
+    WarehouseTypes,
+    type CreateProject,
+} from '@lightdash/common';
+import { randomUUID } from 'crypto';
+import { JobsTableName } from '../../database/entities/jobs';
+import { getServices, getTestContext } from '../../vitest.setup.integration';
+
+describe('ProjectService create project scheduling', () => {
+    const createProject: CreateProject = {
+        name: 'Integration test project',
+        type: ProjectType.DEFAULT,
+        dbtConnection: { type: DbtProjectType.NONE },
+        dbtVersion: DbtVersionOptionLatest.LATEST,
+        warehouseConnection: {
+            type: WarehouseTypes.POSTGRES,
+            host: 'localhost',
+            port: 5432,
+            user: 'postgres',
+            password: 'password',
+            dbname: 'postgres',
+            schema: 'public',
+        },
+    };
+
+    const deleteCreateProjectJobs = async () => {
+        const { db, testUser } = getTestContext();
+        await db(JobsTableName)
+            .where('user_uuid', testUser.userUuid)
+            .where('job_type', JobType.CREATE_PROJECT)
+            .where('is_preview', false)
+            .delete();
+    };
+
+    beforeEach(deleteCreateProjectJobs);
+
+    afterEach(async () => {
+        vi.restoreAllMocks();
+        await deleteCreateProjectJobs();
+    });
+
+    test('recovers from an enqueue failure without leaving a zombie lockout', async () => {
+        const { app, testUser } = getTestContext();
+        const { projectService } = getServices(app);
+        vi.spyOn(projectService.schedulerClient, 'createProjectWithCompile')
+            .mockRejectedValueOnce(new Error('enqueue failed'))
+            .mockResolvedValue({ jobId: 'scheduler-job-id' });
+
+        await expect(
+            projectService.scheduleCreate(
+                testUser,
+                createProject,
+                RequestMethod.WEB_APP,
+            ),
+        ).rejects.toThrow('enqueue failed');
+
+        const [deadJob] = await getTestContext()
+            .db(JobsTableName)
+            .where('user_uuid', testUser.userUuid)
+            .where('job_type', JobType.CREATE_PROJECT)
+            .select('job_uuid', 'job_status');
+        const recovery =
+            await projectService.getActiveCreateProjectJob(testUser);
+        const retry = await projectService
+            .scheduleCreate(testUser, createProject, RequestMethod.WEB_APP)
+            .then(
+                () => ({ outcome: 'succeeded' as const }),
+                (error: unknown) => ({ outcome: 'failed' as const, error }),
+            );
+
+        expect({
+            failedJobStatus: deadJob.job_status,
+            recoveryJobUuid: recovery?.jobUuid ?? null,
+            retryOutcome: retry.outcome,
+            retryStatusCode:
+                retry.outcome === 'failed' &&
+                retry.error instanceof ConflictError
+                    ? retry.error.statusCode
+                    : null,
+        }).toEqual({
+            failedJobStatus: JobStatusType.ERROR,
+            recoveryJobUuid: null,
+            retryOutcome: 'succeeded',
+            retryStatusCode: null,
+        });
+    });
+
+    test('rejects a duplicate while an old create job is still running', async () => {
+        const { app, db, testUser } = getTestContext();
+        const { projectService } = getServices(app);
+        const oldJobUuid = randomUUID();
+        await db(JobsTableName).insert({
+            job_uuid: oldJobUuid,
+            project_uuid: undefined,
+            user_uuid: testUser.userUuid,
+            is_preview: false,
+            job_status: JobStatusType.RUNNING,
+            job_type: JobType.CREATE_PROJECT,
+        });
+        await db.raw(
+            'UPDATE ?? SET created_at = ?, updated_at = ? WHERE job_uuid = ?',
+            [
+                JobsTableName,
+                new Date(Date.now() - 2 * 60 * 60 * 1000),
+                new Date(),
+                oldJobUuid,
+            ],
+        );
+        const enqueue = vi
+            .spyOn(projectService.schedulerClient, 'createProjectWithCompile')
+            .mockResolvedValue({ jobId: 'scheduler-job-id' });
+
+        const error = await projectService
+            .scheduleCreate(testUser, createProject, RequestMethod.WEB_APP)
+            .catch((caughtError: unknown) => caughtError);
+
+        expect(error).toBeInstanceOf(ConflictError);
+        expect(error).toMatchObject({
+            statusCode: 409,
+            data: { jobUuid: oldJobUuid },
+        });
+        expect(enqueue).not.toHaveBeenCalled();
+    });
+
+    test('reaps a stale create job with no backing scheduler job', async () => {
+        const { app, db, testUser } = getTestContext();
+        const { projectService } = getServices(app);
+        const staleJobUuid = randomUUID();
+        await db(JobsTableName).insert({
+            job_uuid: staleJobUuid,
+            project_uuid: undefined,
+            user_uuid: testUser.userUuid,
+            is_preview: false,
+            job_status: JobStatusType.STARTED,
+            job_type: JobType.CREATE_PROJECT,
+        });
+        const staleAt = new Date(Date.now() - 20 * 60 * 1000);
+        await db.raw(
+            'UPDATE ?? SET created_at = ?, updated_at = ? WHERE job_uuid = ?',
+            [JobsTableName, staleAt, staleAt, staleJobUuid],
+        );
+        vi.spyOn(
+            projectService.schedulerClient,
+            'createProjectWithCompile',
+        ).mockResolvedValue({ jobId: 'scheduler-job-id' });
+
+        const recovery =
+            await projectService.getActiveCreateProjectJob(testUser);
+        const retry = await projectService
+            .scheduleCreate(testUser, createProject, RequestMethod.WEB_APP)
+            .then(
+                () => ({ outcome: 'succeeded' as const }),
+                (error: unknown) => ({ outcome: 'failed' as const, error }),
+            );
+        const [staleJob] = await db(JobsTableName)
+            .where('job_uuid', staleJobUuid)
+            .select('job_status');
+
+        expect({
+            recoveryJobUuid: recovery?.jobUuid ?? null,
+            retryOutcome: retry.outcome,
+            staleJobStatus: staleJob.job_status,
+        }).toEqual({
+            recoveryJobUuid: null,
+            retryOutcome: 'succeeded',
+            staleJobStatus: JobStatusType.ERROR,
+        });
+    });
+
+    test('preserves a stale create job with a backing scheduler job', async () => {
+        const { app, db, testUser } = getTestContext();
+        const { projectService } = getServices(app);
+        const liveJobUuid = randomUUID();
+        await db(JobsTableName).insert({
+            job_uuid: liveJobUuid,
+            project_uuid: undefined,
+            user_uuid: testUser.userUuid,
+            is_preview: false,
+            job_status: JobStatusType.RUNNING,
+            job_type: JobType.CREATE_PROJECT,
+        });
+        const staleAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
+        await db.raw(
+            'UPDATE ?? SET created_at = ?, updated_at = ? WHERE job_uuid = ?',
+            [JobsTableName, staleAt, staleAt, liveJobUuid],
+        );
+        const hasSchedulerJob = vi
+            .spyOn(
+                projectService.schedulerClient,
+                'hasCreateProjectWithCompileJob',
+            )
+            .mockResolvedValue(true);
+
+        const recovery =
+            await projectService.getActiveCreateProjectJob(testUser);
+        const [liveJob] = await db(JobsTableName)
+            .where('job_uuid', liveJobUuid)
+            .select('job_status');
+
+        expect(recovery).toMatchObject({ jobUuid: liveJobUuid });
+        expect(liveJob.job_status).toBe(JobStatusType.RUNNING);
+        expect(hasSchedulerJob).toHaveBeenCalledWith(liveJobUuid);
+    });
+
+    test('serializes concurrent creates for the same organization', async () => {
+        const { app, db, testUser } = getTestContext();
+        const { projectService } = getServices(app);
+        const enqueue = vi
+            .spyOn(projectService.schedulerClient, 'createProjectWithCompile')
+            .mockResolvedValue({ jobId: 'scheduler-job-id' });
+
+        const results = await Promise.allSettled([
+            projectService.scheduleCreate(
+                testUser,
+                createProject,
+                RequestMethod.WEB_APP,
+            ),
+            projectService.scheduleCreate(
+                testUser,
+                createProject,
+                RequestMethod.WEB_APP,
+            ),
+        ]);
+        const fulfilled = results.filter(
+            (result) => result.status === 'fulfilled',
+        );
+        const rejected = results.filter(
+            (result) => result.status === 'rejected',
+        );
+        const rows = await db(JobsTableName)
+            .where('user_uuid', testUser.userUuid)
+            .where('job_type', JobType.CREATE_PROJECT)
+            .where('is_preview', false);
+
+        expect(fulfilled).toHaveLength(1);
+        expect(rejected).toHaveLength(1);
+        expect(rejected[0]).toMatchObject({
+            reason: { statusCode: 409 },
+        });
+        expect(rows).toHaveLength(1);
+        expect(enqueue).toHaveBeenCalledOnce();
+    });
+
+    test('recovers a recently completed create job with its project UUID', async () => {
+        const { app, db, testProjectUuid, testUser } = getTestContext();
+        const { projectService } = getServices(app);
+        const jobUuid = randomUUID();
+        const projectUuid = testProjectUuid;
+        await db(JobsTableName).insert({
+            job_uuid: jobUuid,
+            project_uuid: projectUuid,
+            user_uuid: testUser.userUuid,
+            is_preview: false,
+            job_status: JobStatusType.DONE,
+            job_type: JobType.CREATE_PROJECT,
+        });
+        await db(JobsTableName).where('job_uuid', jobUuid).update({
+            results: { projectUuid },
+        });
+        await db.raw(
+            'UPDATE ?? SET created_at = ?, updated_at = ? WHERE job_uuid = ?',
+            [
+                JobsTableName,
+                new Date(Date.now() - 2 * 60 * 60 * 1000),
+                new Date(),
+                jobUuid,
+            ],
+        );
+
+        const recovery =
+            await projectService.getActiveCreateProjectJob(testUser);
+
+        expect(recovery).toMatchObject({
+            jobUuid,
+            jobStatus: JobStatusType.DONE,
+            jobResults: { projectUuid },
+        });
+    });
+});

--- a/packages/backend/src/services/ProjectService/ProjectService.integration.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.integration.test.ts
@@ -248,7 +248,7 @@ describe('ProjectService create project scheduling', () => {
         expect(enqueue).toHaveBeenCalledOnce();
     });
 
-    test('recovers a recently completed create job with its project UUID', async () => {
+    test('does not recover a recently completed create job', async () => {
         const { app, db, testProjectUuid, testUser } = getTestContext();
         const { projectService } = getServices(app);
         const jobUuid = randomUUID();
@@ -277,10 +277,6 @@ describe('ProjectService create project scheduling', () => {
         const recovery =
             await projectService.getActiveCreateProjectJob(testUser);
 
-        expect(recovery).toMatchObject({
-            jobUuid,
-            jobStatus: JobStatusType.DONE,
-            jobResults: { projectUuid },
-        });
+        expect(recovery).toBeNull();
     });
 });

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -641,9 +641,14 @@ describe('ProjectService', () => {
             ...job,
             jobUuid: 'active-create-job-uuid',
             projectUuid: undefined,
+            userUuid: projectCreator.userUuid,
             jobType: JobType.CREATE_PROJECT,
             jobStatus: JobStatusType.RUNNING,
             jobResults: undefined,
+        };
+        const otherUserActiveCreateJob: Job = {
+            ...activeCreateJob,
+            userUuid: 'other-user-uuid',
         };
 
         test('rejects a second non-preview create with the active job UUID', async () => {
@@ -668,6 +673,34 @@ describe('ProjectService', () => {
                 data: { jobUuid: activeCreateJob.jobUuid },
             });
             expect(jobModel.create).not.toHaveBeenCalled();
+            expect(
+                schedulerClient.createProjectWithCompile,
+            ).not.toHaveBeenCalled();
+        });
+
+        test("rejects another user's active job without exposing its UUID", async () => {
+            vi.mocked(
+                jobModel.createProjectJobIfNoActive,
+            ).mockResolvedValueOnce({
+                isCreated: false,
+                activeJob: otherUserActiveCreateJob,
+            });
+
+            const error = await service
+                .scheduleCreate(
+                    projectCreator,
+                    createProject,
+                    RequestMethod.WEB_APP,
+                )
+                .catch((caughtError) => caughtError);
+
+            expect(error).toBeInstanceOf(ConflictError);
+            expect(error).toMatchObject({
+                statusCode: 409,
+                message:
+                    'A project creation is already in progress for the organization',
+            });
+            expect(error.data).toEqual({});
             expect(
                 schedulerClient.createProjectWithCompile,
             ).not.toHaveBeenCalled();
@@ -806,9 +839,14 @@ describe('ProjectService', () => {
             await expect(
                 service.getActiveCreateProjectJob(projectCreator),
             ).resolves.toEqual(activeCreateJob);
+            expect(jobModel.findActiveCreateProjectJob).toHaveBeenCalledWith({
+                organizationUuid,
+                userUuid: projectCreator.userUuid,
+                createdAfter: expect.any(Date),
+            });
         });
 
-        test('returns null for recovery when no create job is active', async () => {
+        test("returns null for recovery when only another user's job is active", async () => {
             vi.mocked(
                 jobModel.findActiveCreateProjectJob,
             ).mockResolvedValueOnce(null);
@@ -816,6 +854,11 @@ describe('ProjectService', () => {
             await expect(
                 service.getActiveCreateProjectJob(projectCreator),
             ).resolves.toBeNull();
+            expect(jobModel.findActiveCreateProjectJob).toHaveBeenCalledWith({
+                organizationUuid,
+                userUuid: projectCreator.userUuid,
+                createdAfter: expect.any(Date),
+            });
         });
     });
     describe('organization warehouse credential authorization', () => {

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -1,5 +1,6 @@
 import { Ability } from '@casl/ability';
 import {
+    ConflictError,
     CustomDimensionType,
     CustomSqlQueryForbiddenError,
     DbtProjectType,
@@ -15,6 +16,7 @@ import {
     getCustomSqlFieldKey,
     JobStatusType,
     JobStepType,
+    JobType,
     MetricType,
     NotFoundError,
     OrganizationMemberRole,
@@ -32,6 +34,7 @@ import {
     type CreateWarehouseCredentials,
     type DownloadFile,
     type Explore,
+    type Job,
     type PossibleAbilities,
     type Project,
     type RegisteredAccount,
@@ -262,8 +265,12 @@ const savedChartModel = {
     })),
 };
 const jobModel = {
-    create: vi.fn(async () => undefined),
     get: vi.fn(async () => job),
+    findActiveCreateProjectJob: vi.fn<JobModel['findActiveCreateProjectJob']>(),
+    create: vi.fn<JobModel['create']>(async () => job),
+    createProjectJobIfNoActive: vi.fn<JobModel['createProjectJobIfNoActive']>(
+        async () => ({ isCreated: true, job }),
+    ),
     update: vi.fn(async () => undefined),
     updateJobStep: vi.fn(async () => undefined),
     setPendingJobsToSkipped: vi.fn(async () => undefined),
@@ -294,7 +301,8 @@ const schedulerClient = {
     backfillDefaultUserSpaces: vi.fn(async () => ({
         jobId: 'backfill-job-1',
     })),
-    createProjectWithCompile: vi.fn(async () => undefined),
+    createProjectWithCompile:
+        vi.fn<SchedulerClient['createProjectWithCompile']>(),
     deleteScheduledPreAggregateCronJobsForProject: vi.fn(async () => undefined),
     indexCatalog: vi.fn(async () => ({ jobId: 'catalog-job-1' })),
     materializePreAggregate: vi.fn(async () => ({ jobId: 'job-1' })),
@@ -611,6 +619,205 @@ describe('ProjectService', () => {
         });
     });
 
+    describe('active create project jobs', () => {
+        const organizationUuid = 'organization-uuid';
+        const projectCreator: SessionUser = {
+            ...user,
+            organizationUuid,
+            organizationName: 'Organization',
+            organizationCreatedAt: new Date('2026-08-03T08:00:00.000Z'),
+            ability: new Ability<PossibleAbilities>([
+                { subject: 'Project', action: 'create' },
+            ]),
+        };
+        const createProject: CreateProject = {
+            name: 'New project',
+            type: ProjectType.DEFAULT,
+            dbtConnection: { type: DbtProjectType.NONE },
+            dbtVersion: DbtVersionOptionLatest.LATEST,
+            warehouseConnection: warehouseClientMock.credentials,
+        };
+        const activeCreateJob: Job = {
+            ...job,
+            jobUuid: 'active-create-job-uuid',
+            projectUuid: undefined,
+            jobType: JobType.CREATE_PROJECT,
+            jobStatus: JobStatusType.RUNNING,
+            jobResults: undefined,
+        };
+
+        test('rejects a second non-preview create with the active job UUID', async () => {
+            vi.mocked(
+                jobModel.createProjectJobIfNoActive,
+            ).mockResolvedValueOnce({
+                isCreated: false,
+                activeJob: activeCreateJob,
+            });
+
+            const error = await service
+                .scheduleCreate(
+                    projectCreator,
+                    createProject,
+                    RequestMethod.WEB_APP,
+                )
+                .catch((caughtError) => caughtError);
+
+            expect(error).toBeInstanceOf(ConflictError);
+            expect(error).toMatchObject({
+                statusCode: 409,
+                data: { jobUuid: activeCreateJob.jobUuid },
+            });
+            expect(jobModel.create).not.toHaveBeenCalled();
+            expect(
+                schedulerClient.createProjectWithCompile,
+            ).not.toHaveBeenCalled();
+        });
+
+        test('allows a non-preview create when no active job exists', async () => {
+            await service.scheduleCreate(
+                projectCreator,
+                createProject,
+                RequestMethod.WEB_APP,
+            );
+
+            expect(jobModel.createProjectJobIfNoActive).toHaveBeenCalledWith({
+                job: expect.objectContaining({
+                    jobType: JobType.CREATE_PROJECT,
+                }),
+                organizationUuid,
+                createdAfter: expect.any(Date),
+            });
+            expect(
+                schedulerClient.createProjectWithCompile,
+            ).toHaveBeenCalledOnce();
+        });
+
+        test('allows a create when an active job is older than the cutoff', async () => {
+            const now = new Date('2026-08-03T09:00:00.000Z');
+            const oldJob: Job = {
+                ...activeCreateJob,
+                createdAt: new Date('2026-08-03T07:59:59.999Z'),
+            };
+            vi.useFakeTimers();
+            vi.setSystemTime(now);
+            vi.mocked(
+                jobModel.createProjectJobIfNoActive,
+            ).mockImplementationOnce(async ({ createdAfter }) =>
+                oldJob.createdAt >= createdAfter
+                    ? { isCreated: false, activeJob: oldJob }
+                    : { isCreated: true, job },
+            );
+
+            try {
+                await service.scheduleCreate(
+                    projectCreator,
+                    createProject,
+                    RequestMethod.WEB_APP,
+                );
+
+                expect(
+                    jobModel.createProjectJobIfNoActive,
+                ).toHaveBeenCalledWith({
+                    job: expect.objectContaining({
+                        jobType: JobType.CREATE_PROJECT,
+                    }),
+                    organizationUuid,
+                    createdAfter: new Date('2026-08-03T08:00:00.000Z'),
+                });
+                expect(
+                    schedulerClient.createProjectWithCompile,
+                ).toHaveBeenCalledOnce();
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        test('allows preview creates while a non-preview create is active', async () => {
+            await service.scheduleCreate(
+                projectCreator,
+                { ...createProject, type: ProjectType.PREVIEW },
+                RequestMethod.WEB_APP,
+            );
+
+            expect(jobModel.findActiveCreateProjectJob).not.toHaveBeenCalled();
+            expect(jobModel.createProjectJobIfNoActive).not.toHaveBeenCalled();
+            expect(jobModel.create).toHaveBeenCalledWith(
+                expect.objectContaining({ jobType: JobType.CREATE_PROJECT }),
+                true,
+            );
+        });
+
+        test('schedules exactly one job for two concurrent create attempts', async () => {
+            let createdJob: Job | null = null;
+            let simulatedInsertCount = 0;
+            vi.mocked(jobModel.createProjectJobIfNoActive).mockImplementation(
+                async ({ job: createJob }) => {
+                    if (createdJob) {
+                        return { isCreated: false, activeJob: createdJob };
+                    }
+                    createdJob = {
+                        ...activeCreateJob,
+                        jobUuid: createJob.jobUuid,
+                        userUuid: createJob.userUuid,
+                        jobStatus: createJob.jobStatus,
+                    };
+                    simulatedInsertCount += 1;
+                    return { isCreated: true, job: createdJob };
+                },
+            );
+
+            const results = await Promise.allSettled([
+                service.scheduleCreate(
+                    projectCreator,
+                    createProject,
+                    RequestMethod.WEB_APP,
+                ),
+                service.scheduleCreate(
+                    projectCreator,
+                    createProject,
+                    RequestMethod.WEB_APP,
+                ),
+            ]);
+
+            const fulfilledResults = results.filter(
+                (result) => result.status === 'fulfilled',
+            );
+            expect(fulfilledResults).toHaveLength(1);
+            const [rejection] = results.filter(
+                ({ status }) => status === 'rejected',
+            );
+            expect(rejection).toMatchObject({
+                reason: {
+                    statusCode: 409,
+                    data: { jobUuid: fulfilledResults[0].value.jobUuid },
+                },
+            });
+            expect(simulatedInsertCount).toBe(1);
+            expect(
+                schedulerClient.createProjectWithCompile,
+            ).toHaveBeenCalledOnce();
+        });
+
+        test('returns the active create job for recovery', async () => {
+            vi.mocked(
+                jobModel.findActiveCreateProjectJob,
+            ).mockResolvedValueOnce(activeCreateJob);
+
+            await expect(
+                service.getActiveCreateProjectJob(projectCreator),
+            ).resolves.toEqual(activeCreateJob);
+        });
+
+        test('returns null for recovery when no create job is active', async () => {
+            vi.mocked(
+                jobModel.findActiveCreateProjectJob,
+            ).mockResolvedValueOnce(null);
+
+            await expect(
+                service.getActiveCreateProjectJob(projectCreator),
+            ).resolves.toBeNull();
+        });
+    });
     describe('organization warehouse credential authorization', () => {
         const organizationWarehouseCredentialsUuid =
             'organization-warehouse-credentials-uuid';

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -267,6 +267,12 @@ const savedChartModel = {
 const jobModel = {
     get: vi.fn(async () => job),
     findActiveCreateProjectJob: vi.fn<JobModel['findActiveCreateProjectJob']>(),
+    findStaleCreateProjectJobUuids: vi.fn<
+        JobModel['findStaleCreateProjectJobUuids']
+    >(async () => []),
+    markCreateProjectJobsAsError: vi.fn<
+        JobModel['markCreateProjectJobsAsError']
+    >(async () => undefined),
     create: vi.fn<JobModel['create']>(async () => job),
     createProjectJobIfNoActive: vi.fn<JobModel['createProjectJobIfNoActive']>(
         async () => ({ isCreated: true, job }),
@@ -303,6 +309,9 @@ const schedulerClient = {
     })),
     createProjectWithCompile:
         vi.fn<SchedulerClient['createProjectWithCompile']>(),
+    hasCreateProjectWithCompileJob: vi.fn<
+        SchedulerClient['hasCreateProjectWithCompileJob']
+    >(async () => false),
     deleteScheduledPreAggregateCronJobsForProject: vi.fn(async () => undefined),
     indexCatalog: vi.fn(async () => ({ jobId: 'catalog-job-1' })),
     materializePreAggregate: vi.fn(async () => ({ jobId: 'job-1' })),
@@ -380,7 +389,9 @@ const getMockedProjectService = (
         tagsModel: tagsModel as unknown as TagsModel,
         catalogModel: catalogModel as unknown as CatalogModel,
         contentModel: {} as ContentModel,
-        encryptionUtil: {} as EncryptionUtil,
+        encryptionUtil: {
+            encrypt: vi.fn(() => Buffer.from('encrypted-project-data')),
+        } as unknown as EncryptionUtil,
         userModel: {} as UserModel,
         userOAuthGrantsModel: {} as UserOAuthGrantsModel,
         featureFlagModel: {
@@ -718,51 +729,36 @@ describe('ProjectService', () => {
                     jobType: JobType.CREATE_PROJECT,
                 }),
                 organizationUuid,
-                createdAfter: expect.any(Date),
             });
             expect(
                 schedulerClient.createProjectWithCompile,
             ).toHaveBeenCalledOnce();
         });
 
-        test('allows a create when an active job is older than the cutoff', async () => {
-            const now = new Date('2026-08-03T09:00:00.000Z');
+        test('rejects a create when the active job is older than an hour', async () => {
             const oldJob: Job = {
                 ...activeCreateJob,
                 createdAt: new Date('2026-08-03T07:59:59.999Z'),
             };
-            vi.useFakeTimers();
-            vi.setSystemTime(now);
             vi.mocked(
                 jobModel.createProjectJobIfNoActive,
-            ).mockImplementationOnce(async ({ createdAfter }) =>
-                oldJob.createdAt >= createdAfter
-                    ? { isCreated: false, activeJob: oldJob }
-                    : { isCreated: true, job },
-            );
+            ).mockResolvedValueOnce({ isCreated: false, activeJob: oldJob });
 
-            try {
-                await service.scheduleCreate(
+            const error = await service
+                .scheduleCreate(
                     projectCreator,
                     createProject,
                     RequestMethod.WEB_APP,
-                );
+                )
+                .catch((caughtError) => caughtError);
 
-                expect(
-                    jobModel.createProjectJobIfNoActive,
-                ).toHaveBeenCalledWith({
-                    job: expect.objectContaining({
-                        jobType: JobType.CREATE_PROJECT,
-                    }),
-                    organizationUuid,
-                    createdAfter: new Date('2026-08-03T08:00:00.000Z'),
-                });
-                expect(
-                    schedulerClient.createProjectWithCompile,
-                ).toHaveBeenCalledOnce();
-            } finally {
-                vi.useRealTimers();
-            }
+            expect(error).toMatchObject({
+                statusCode: 409,
+                data: { jobUuid: oldJob.jobUuid },
+            });
+            expect(
+                schedulerClient.createProjectWithCompile,
+            ).not.toHaveBeenCalled();
         });
 
         test('allows preview creates while a non-preview create is active', async () => {
@@ -842,7 +838,7 @@ describe('ProjectService', () => {
             expect(jobModel.findActiveCreateProjectJob).toHaveBeenCalledWith({
                 organizationUuid,
                 userUuid: projectCreator.userUuid,
-                createdAfter: expect.any(Date),
+                completedAfter: expect.any(Date),
             });
         });
 
@@ -857,7 +853,7 @@ describe('ProjectService', () => {
             expect(jobModel.findActiveCreateProjectJob).toHaveBeenCalledWith({
                 organizationUuid,
                 userUuid: projectCreator.userUuid,
-                createdAfter: expect.any(Date),
+                completedAfter: expect.any(Date),
             });
         });
     });

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -838,7 +838,6 @@ describe('ProjectService', () => {
             expect(jobModel.findActiveCreateProjectJob).toHaveBeenCalledWith({
                 organizationUuid,
                 userUuid: projectCreator.userUuid,
-                completedAfter: expect.any(Date),
             });
         });
 
@@ -853,7 +852,6 @@ describe('ProjectService', () => {
             expect(jobModel.findActiveCreateProjectJob).toHaveBeenCalledWith({
                 organizationUuid,
                 userUuid: projectCreator.userUuid,
-                completedAfter: expect.any(Date),
             });
         });
     });

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -450,7 +450,9 @@ const isValidDbtCloudWebhookSignature = (
 const WINDOW_CLAUSE_PATTERN = /\bover\s*\(/i;
 
 export class ProjectService extends BaseService {
-    static ACTIVE_CREATE_PROJECT_JOB_MAX_AGE_MS = 60 * 60 * 1000;
+    static RECENT_COMPLETED_CREATE_PROJECT_JOB_MAX_AGE_MS = 60 * 60 * 1000;
+
+    static CREATE_PROJECT_JOB_ENQUEUE_GRACE_MS = 15 * 60 * 1000;
 
     lightdashConfig: LightdashConfig;
 
@@ -2877,13 +2879,10 @@ export class ProjectService extends BaseService {
         if (data.type === ProjectType.PREVIEW) {
             await this.jobModel.create(job, true);
         } else {
+            await this.reapStaleCreateProjectJobs(user.organizationUuid);
             const result = await this.jobModel.createProjectJobIfNoActive({
                 job,
                 organizationUuid: user.organizationUuid,
-                createdAfter: new Date(
-                    Date.now() -
-                        ProjectService.ACTIVE_CREATE_PROJECT_JOB_MAX_AGE_MS,
-                ),
             });
             if (!result.isCreated) {
                 if (result.activeJob.userUuid !== user.userUuid) {
@@ -2897,18 +2896,45 @@ export class ProjectService extends BaseService {
                 );
             }
         }
-        // schedule job
-        await this.schedulerClient.createProjectWithCompile({
-            createdByUserUuid: user.userUuid,
-            isPreview: data.type === ProjectType.PREVIEW,
-            organizationUuid: user.organizationUuid,
-            requestMethod: method,
-            jobUuid: job.jobUuid,
-            data: encryptedData,
-            userUuid: user.userUuid,
-            projectUuid: undefined,
-        });
+        try {
+            await this.schedulerClient.createProjectWithCompile({
+                createdByUserUuid: user.userUuid,
+                isPreview: data.type === ProjectType.PREVIEW,
+                organizationUuid: user.organizationUuid,
+                requestMethod: method,
+                jobUuid: job.jobUuid,
+                data: encryptedData,
+                userUuid: user.userUuid,
+                projectUuid: undefined,
+            });
+        } catch (error) {
+            await this.jobModel.update(job.jobUuid, {
+                jobStatus: JobStatusType.ERROR,
+            });
+            throw error;
+        }
         return { jobUuid: job.jobUuid };
+    }
+
+    private async reapStaleCreateProjectJobs(
+        organizationUuid: string,
+    ): Promise<void> {
+        const staleJobUuids =
+            await this.jobModel.findStaleCreateProjectJobUuids({
+                organizationUuid,
+                updatedBefore: new Date(
+                    Date.now() -
+                        ProjectService.CREATE_PROJECT_JOB_ENQUEUE_GRACE_MS,
+                ),
+            });
+        const schedulerJobExists = await Promise.all(
+            staleJobUuids.map((jobUuid) =>
+                this.schedulerClient.hasCreateProjectWithCompileJob(jobUuid),
+            ),
+        );
+        await this.jobModel.markCreateProjectJobsAsError(
+            staleJobUuids.filter((_, index) => !schedulerJobExists[index]),
+        );
     }
 
     async getActiveCreateProjectJob(user: SessionUser): Promise<Job | null> {
@@ -2916,12 +2942,13 @@ export class ProjectService extends BaseService {
             throw new ForbiddenError('User is not part of an organization');
         }
 
+        await this.reapStaleCreateProjectJobs(user.organizationUuid);
         return this.jobModel.findActiveCreateProjectJob({
             organizationUuid: user.organizationUuid,
             userUuid: user.userUuid,
-            createdAfter: new Date(
+            completedAfter: new Date(
                 Date.now() -
-                    ProjectService.ACTIVE_CREATE_PROJECT_JOB_MAX_AGE_MS,
+                    ProjectService.RECENT_COMPLETED_CREATE_PROJECT_JOB_MAX_AGE_MS,
             ),
         });
     }

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2886,6 +2886,11 @@ export class ProjectService extends BaseService {
                 ),
             });
             if (!result.isCreated) {
+                if (result.activeJob.userUuid !== user.userUuid) {
+                    throw new ConflictError(
+                        'A project creation is already in progress for the organization',
+                    );
+                }
                 throw new ConflictError(
                     'A project creation is already in progress',
                     { jobUuid: result.activeJob.jobUuid },
@@ -2913,6 +2918,7 @@ export class ProjectService extends BaseService {
 
         return this.jobModel.findActiveCreateProjectJob({
             organizationUuid: user.organizationUuid,
+            userUuid: user.userUuid,
             createdAfter: new Date(
                 Date.now() -
                     ProjectService.ACTIVE_CREATE_PROJECT_JOB_MAX_AGE_MS,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -450,8 +450,6 @@ const isValidDbtCloudWebhookSignature = (
 const WINDOW_CLAUSE_PATTERN = /\bover\s*\(/i;
 
 export class ProjectService extends BaseService {
-    static RECENT_COMPLETED_CREATE_PROJECT_JOB_MAX_AGE_MS = 60 * 60 * 1000;
-
     static CREATE_PROJECT_JOB_ENQUEUE_GRACE_MS = 15 * 60 * 1000;
 
     lightdashConfig: LightdashConfig;
@@ -2946,10 +2944,6 @@ export class ProjectService extends BaseService {
         return this.jobModel.findActiveCreateProjectJob({
             organizationUuid: user.organizationUuid,
             userUuid: user.userUuid,
-            completedAfter: new Date(
-                Date.now() -
-                    ProjectService.RECENT_COMPLETED_CREATE_PROJECT_JOB_MAX_AGE_MS,
-            ),
         });
     }
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -32,6 +32,7 @@ import {
     combineManifestSources,
     CompilationSource,
     CompiledDimension,
+    ConflictError,
     ContentType,
     convertCustomMetricToDbt,
     convertExplores,
@@ -449,6 +450,8 @@ const isValidDbtCloudWebhookSignature = (
 const WINDOW_CLAUSE_PATTERN = /\bover\s*\(/i;
 
 export class ProjectService extends BaseService {
+    static ACTIVE_CREATE_PROJECT_JOB_MAX_AGE_MS = 60 * 60 * 1000;
+
     lightdashConfig: LightdashConfig;
 
     analytics: LightdashAnalytics;
@@ -2871,7 +2874,24 @@ export class ProjectService extends BaseService {
         };
 
         // create legacy job steps that UI expects
-        await this.jobModel.create(job);
+        if (data.type === ProjectType.PREVIEW) {
+            await this.jobModel.create(job, true);
+        } else {
+            const result = await this.jobModel.createProjectJobIfNoActive({
+                job,
+                organizationUuid: user.organizationUuid,
+                createdAfter: new Date(
+                    Date.now() -
+                        ProjectService.ACTIVE_CREATE_PROJECT_JOB_MAX_AGE_MS,
+                ),
+            });
+            if (!result.isCreated) {
+                throw new ConflictError(
+                    'A project creation is already in progress',
+                    { jobUuid: result.activeJob.jobUuid },
+                );
+            }
+        }
         // schedule job
         await this.schedulerClient.createProjectWithCompile({
             createdByUserUuid: user.userUuid,
@@ -2884,6 +2904,20 @@ export class ProjectService extends BaseService {
             projectUuid: undefined,
         });
         return { jobUuid: job.jobUuid };
+    }
+
+    async getActiveCreateProjectJob(user: SessionUser): Promise<Job | null> {
+        if (!isUserWithOrg(user)) {
+            throw new ForbiddenError('User is not part of an organization');
+        }
+
+        return this.jobModel.findActiveCreateProjectJob({
+            organizationUuid: user.organizationUuid,
+            createdAfter: new Date(
+                Date.now() -
+                    ProjectService.ACTIVE_CREATE_PROJECT_JOB_MAX_AGE_MS,
+            ),
+        });
     }
 
     static PREVIEW_PROJECT_FALLBACK_TTL_HOURS = 720;
@@ -3458,7 +3492,10 @@ export class ProjectService extends BaseService {
                 });
         }
 
-        await this.jobModel.create(job);
+        await this.jobModel.create(
+            job,
+            savedProject.type === ProjectType.PREVIEW,
+        );
 
         if (updatedProject.dbtConnection.type !== DbtProjectType.NONE) {
             await this.schedulerClient.testAndCompileProject({
@@ -8088,7 +8125,7 @@ export class ProjectService extends BaseService {
             steps: [{ stepType: JobStepType.COMPILING }],
         };
 
-        await this.jobModel.create(job);
+        await this.jobModel.create(job, type === ProjectType.PREVIEW);
 
         await this.schedulerClient.compileProject({
             createdByUserUuid: user.userUuid,

--- a/packages/backend/vitest.config.integration.ts
+++ b/packages/backend/vitest.config.integration.ts
@@ -6,8 +6,7 @@ export default defineConfig({
     test: {
         name: 'integration-tests',
         include: [
-            'src/ee/**/*integration.test.ts',
-            'src/controllers/authentication/**/*integration.test.ts',
+            'src/**/*integration.test.ts',
         ],
         exclude: [
             'node_modules',

--- a/packages/frontend/src/components/ProjectConnection/CreateProjectJobProgress.tsx
+++ b/packages/frontend/src/components/ProjectConnection/CreateProjectJobProgress.tsx
@@ -1,0 +1,110 @@
+import {
+    JobStatusType,
+    JobStepStatusType,
+    type Job,
+    type JobStep,
+} from '@lightdash/common';
+import {
+    Alert,
+    Group,
+    Loader,
+    Paper,
+    Progress,
+    Stack,
+    Text,
+} from '@mantine/core';
+import {
+    IconAlertTriangleFilled,
+    IconCircleCheckFilled,
+} from '@tabler/icons-react';
+import { type FC } from 'react';
+import { jobStatusLabel, runningStepsInfo } from '../../hooks/useRefreshServer';
+import MantineIcon from '../common/MantineIcon';
+
+const StepIcon: FC<{ step: JobStep }> = ({ step }) => {
+    switch (step.stepStatus) {
+        case JobStepStatusType.ERROR:
+            return <MantineIcon icon={IconAlertTriangleFilled} color="red" />;
+        case JobStepStatusType.DONE:
+            return <MantineIcon icon={IconCircleCheckFilled} color="green" />;
+        case JobStepStatusType.RUNNING:
+            return <Loader color="gray" size={16} />;
+        case JobStepStatusType.SKIPPED:
+        case JobStepStatusType.PENDING:
+            return <MantineIcon icon={IconCircleCheckFilled} color="gray.3" />;
+        default:
+            return null;
+    }
+};
+
+const CreateProjectJobProgress: FC<{ job: Job }> = ({ job }) => {
+    const hasFailed = job.jobStatus === JobStatusType.ERROR;
+    const isDone = job.jobStatus === JobStatusType.DONE;
+    const { completedStepsMessage, numberOfCompletedSteps, totalSteps } =
+        runningStepsInfo(job.steps);
+    const failedStep = job.steps.find(
+        (step) => step.stepStatus === JobStepStatusType.ERROR,
+    );
+
+    return (
+        <Paper withBorder radius="md" p="md">
+            <Stack gap="sm">
+                <Group gap="xs" wrap="nowrap">
+                    {!hasFailed && !isDone && <Loader color="gray" size="sm" />}
+                    {isDone && (
+                        <MantineIcon
+                            icon={IconCircleCheckFilled}
+                            color="green"
+                        />
+                    )}
+                    <Text fw={600}>
+                        {jobStatusLabel(job.jobStatus, job.jobType)}
+                    </Text>
+                </Group>
+
+                {totalSteps > 0 && (
+                    <Stack gap={4}>
+                        <Progress
+                            value={(numberOfCompletedSteps / totalSteps) * 100}
+                            color={hasFailed ? 'red' : undefined}
+                            size="sm"
+                        />
+                        <Text size="xs" c="dimmed">
+                            {`${completedStepsMessage} steps complete`}
+                        </Text>
+                    </Stack>
+                )}
+
+                <Stack gap="xs">
+                    {job.steps.map((step) => (
+                        <Group key={step.stepLabel} gap="xs" wrap="nowrap">
+                            <StepIcon step={step} />
+                            <Text
+                                size="sm"
+                                c={
+                                    step.stepStatus ===
+                                    JobStepStatusType.PENDING
+                                        ? 'dimmed'
+                                        : undefined
+                                }
+                            >
+                                {step.stepLabel}
+                            </Text>
+                        </Group>
+                    ))}
+                </Stack>
+
+                {hasFailed && (
+                    <Alert color="red" title="We couldn't create your project">
+                        <Text size="sm">
+                            {failedStep?.stepError ??
+                                'Check your connection details and try again.'}
+                        </Text>
+                    </Alert>
+                )}
+            </Stack>
+        </Paper>
+    );
+};
+
+export default CreateProjectJobProgress;

--- a/packages/frontend/src/components/ProjectConnection/CreateProjectconnection.test.tsx
+++ b/packages/frontend/src/components/ProjectConnection/CreateProjectconnection.test.tsx
@@ -1,0 +1,238 @@
+import {
+    JobStatusType,
+    JobStepStatusType,
+    JobStepType,
+    JobType,
+    WarehouseTypes,
+    type Job,
+} from '@lightdash/common';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+vi.mock('../../api', () => ({
+    lightdashApi: vi.fn(),
+}));
+
+import { lightdashApi } from '../../api';
+import ActiveJobProvider from '../../providers/ActiveJob/ActiveJobProvider';
+import { renderWithProviders } from '../../testing/testUtils';
+import CreateProjectConnection from './CreateProjectconnection';
+
+const mockApi = lightdashApi as unknown as Mock;
+
+const ACTIVE_JOB_URL = '/org/jobs/create-project/active';
+const CREATE_PROJECT_URL = '/org/projects/precompiled';
+
+const IN_FLIGHT_JOB_UUID = 'job-in-flight';
+
+const buildJob = (overrides: Partial<Job> = {}): Job =>
+    ({
+        jobUuid: IN_FLIGHT_JOB_UUID,
+        projectUuid: undefined,
+        userUuid: 'user-1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        jobStatus: JobStatusType.RUNNING,
+        jobType: JobType.CREATE_PROJECT,
+        steps: [
+            {
+                jobUuid: IN_FLIGHT_JOB_UUID,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+                stepStatus: JobStepStatusType.RUNNING,
+                stepType: JobStepType.TESTING_ADAPTOR,
+                stepLabel: 'Testing adaptor',
+                startedAt: new Date(),
+                stepError: undefined,
+                stepDbtLogs: undefined,
+            },
+            {
+                jobUuid: IN_FLIGHT_JOB_UUID,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+                stepStatus: JobStepStatusType.PENDING,
+                stepType: JobStepType.CREATING_PROJECT,
+                stepLabel: 'Creating project',
+                startedAt: undefined,
+                stepError: undefined,
+                stepDbtLogs: undefined,
+            },
+        ],
+        ...overrides,
+    }) as Job;
+
+type ApiCall = { url: string; method: string };
+
+const routeApi = (handlers: {
+    activeJob: () => unknown;
+    job?: () => unknown;
+    createProject?: () => unknown;
+}) => {
+    const calls: ApiCall[] = [];
+    mockApi.mockImplementation(({ url, method }: ApiCall) => {
+        calls.push({ url, method });
+        if (url === ACTIVE_JOB_URL) {
+            return Promise.resolve(handlers.activeJob());
+        }
+        if (url.startsWith('/jobs/')) {
+            return Promise.resolve(handlers.job?.() ?? buildJob());
+        }
+        if (url === CREATE_PROJECT_URL) {
+            return (
+                handlers.createProject?.() ??
+                Promise.resolve({ jobUuid: 'new-job' })
+            );
+        }
+        return Promise.resolve(null);
+    });
+    return calls;
+};
+
+const renderFlow = () =>
+    renderWithProviders(
+        <MemoryRouter initialEntries={['/onboarding/data-source/postgres']}>
+            <ActiveJobProvider>
+                <CreateProjectConnection
+                    isCreatingFirstProject
+                    selectedWarehouse={WarehouseTypes.POSTGRES}
+                    warehouseOnly
+                />
+            </ActiveJobProvider>
+        </MemoryRouter>,
+    );
+
+const fillConnectionForm = async () => {
+    const user = userEvent.setup();
+    await user.type(await screen.findByLabelText(/^Host/), 'localhost');
+    await user.type(screen.getByLabelText(/^User/), 'postgres');
+    await user.type(screen.getByLabelText(/^Password/), 'password');
+    await user.type(screen.getByLabelText(/^DB name/), 'postgres');
+    await user.type(screen.getByLabelText(/^Schema/), 'jaffle');
+    return user;
+};
+
+describe('CreateProjectConnection in-flight job recovery', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('resumes the creating state when a create-project job is already in flight', async () => {
+        routeApi({ activeJob: () => buildJob() });
+
+        renderFlow();
+
+        expect(
+            await screen.findByText('Creating your project'),
+        ).toBeInTheDocument();
+        expect(screen.getByText('Testing adaptor')).toBeInTheDocument();
+        expect(screen.getByText('Creating project')).toBeInTheDocument();
+        expect(screen.getByText('0/2 steps complete')).toBeInTheDocument();
+
+        expect(screen.queryByLabelText(/^Host/)).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: 'Test & save' }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('shows the connection form when no job is in flight', async () => {
+        const calls = routeApi({ activeJob: () => null });
+
+        renderFlow();
+
+        expect(await screen.findByLabelText(/^Host/)).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: 'Test & save' }),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText('Creating your project'),
+        ).not.toBeInTheDocument();
+        expect(calls.some(({ url }) => url.startsWith('/jobs/'))).toBe(false);
+    });
+
+    it('resumes polling the job carried by a 409 instead of failing the submit', async () => {
+        const calls = routeApi({
+            activeJob: () => null,
+            createProject: () =>
+                Promise.reject({
+                    status: 'error',
+                    error: {
+                        name: 'ConflictError',
+                        statusCode: 409,
+                        message: 'A project is already being created',
+                        data: { jobUuid: IN_FLIGHT_JOB_UUID },
+                    },
+                }),
+        });
+
+        renderFlow();
+
+        const user = await fillConnectionForm();
+        await user.click(screen.getByRole('button', { name: 'Test & save' }));
+
+        expect(
+            await screen.findByText('Creating your project'),
+        ).toBeInTheDocument();
+
+        await waitFor(() =>
+            expect(
+                calls.some(({ url }) => url === `/jobs/${IN_FLIGHT_JOB_UUID}`),
+            ).toBe(true),
+        );
+
+        expect(
+            calls.filter(({ url }) => url === CREATE_PROJECT_URL),
+        ).toHaveLength(1);
+    });
+
+    it('surfaces the failing step when the resumed job errors', async () => {
+        routeApi({
+            activeJob: () =>
+                buildJob({
+                    jobStatus: JobStatusType.ERROR,
+                    steps: [
+                        {
+                            jobUuid: IN_FLIGHT_JOB_UUID,
+                            createdAt: new Date(),
+                            updatedAt: new Date(),
+                            stepStatus: JobStepStatusType.ERROR,
+                            stepType: JobStepType.TESTING_ADAPTOR,
+                            stepLabel: 'Testing adaptor',
+                            startedAt: new Date(),
+                            stepError:
+                                'The server does not support SSL connections',
+                            stepDbtLogs: undefined,
+                        },
+                    ],
+                }),
+            job: () =>
+                buildJob({
+                    jobStatus: JobStatusType.ERROR,
+                    steps: [
+                        {
+                            jobUuid: IN_FLIGHT_JOB_UUID,
+                            createdAt: new Date(),
+                            updatedAt: new Date(),
+                            stepStatus: JobStepStatusType.ERROR,
+                            stepType: JobStepType.TESTING_ADAPTOR,
+                            stepLabel: 'Testing adaptor',
+                            startedAt: new Date(),
+                            stepError:
+                                'The server does not support SSL connections',
+                            stepDbtLogs: undefined,
+                        },
+                    ],
+                }),
+        });
+
+        renderFlow();
+
+        expect(
+            await screen.findByText(
+                'The server does not support SSL connections',
+            ),
+        ).toBeInTheDocument();
+        expect(await screen.findByLabelText(/^Host/)).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/components/ProjectConnection/CreateProjectconnection.test.tsx
+++ b/packages/frontend/src/components/ProjectConnection/CreateProjectconnection.test.tsx
@@ -160,7 +160,7 @@ describe('CreateProjectConnection in-flight job recovery', () => {
                     error: {
                         name: 'ConflictError',
                         statusCode: 409,
-                        message: 'A project is already being created',
+                        message: 'A project creation is already in progress',
                         data: { jobUuid: IN_FLIGHT_JOB_UUID },
                     },
                 }),

--- a/packages/frontend/src/components/ProjectConnection/CreateProjectconnection.test.tsx
+++ b/packages/frontend/src/components/ProjectConnection/CreateProjectconnection.test.tsx
@@ -103,6 +103,18 @@ const renderFlow = () =>
         </MemoryRouter>,
     );
 
+const renderProjectFlow = () =>
+    renderWithProviders(
+        <MemoryRouter initialEntries={['/projects/new']}>
+            <ActiveJobProvider>
+                <CreateProjectConnection
+                    isCreatingFirstProject={false}
+                    selectedWarehouse={WarehouseTypes.POSTGRES}
+                />
+            </ActiveJobProvider>
+        </MemoryRouter>,
+    );
+
 const fillConnectionForm = async () => {
     const user = userEvent.setup();
     await user.type(await screen.findByLabelText(/^Host/), 'localhost');
@@ -149,6 +161,27 @@ describe('CreateProjectConnection in-flight job recovery', () => {
             screen.queryByText('Creating your project'),
         ).not.toBeInTheDocument();
         expect(calls.some(({ url }) => url.startsWith('/jobs/'))).toBe(false);
+    });
+
+    it('keeps a fresh create form interactive when the recovered job is already done', async () => {
+        const completedJob = buildJob({
+            projectUuid: 'completed-project-uuid',
+            jobStatus: JobStatusType.DONE,
+        });
+        routeApi({
+            activeJob: () => completedJob,
+            job: () => completedJob,
+        });
+
+        renderProjectFlow();
+
+        expect(await screen.findByLabelText(/^Project name/)).toBeEnabled();
+        expect(
+            screen.getByRole('button', { name: 'Test & deploy project' }),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText('Creating your project'),
+        ).not.toBeInTheDocument();
     });
 
     it('resumes polling the job carried by a 409 instead of failing the submit', async () => {
@@ -223,24 +256,7 @@ describe('CreateProjectConnection in-flight job recovery', () => {
 
     it('surfaces the failing step when the resumed job errors', async () => {
         routeApi({
-            activeJob: () =>
-                buildJob({
-                    jobStatus: JobStatusType.ERROR,
-                    steps: [
-                        {
-                            jobUuid: IN_FLIGHT_JOB_UUID,
-                            createdAt: new Date(),
-                            updatedAt: new Date(),
-                            stepStatus: JobStepStatusType.ERROR,
-                            stepType: JobStepType.TESTING_ADAPTOR,
-                            stepLabel: 'Testing adaptor',
-                            startedAt: new Date(),
-                            stepError:
-                                'The server does not support SSL connections',
-                            stepDbtLogs: undefined,
-                        },
-                    ],
-                }),
+            activeJob: () => buildJob(),
             job: () =>
                 buildJob({
                     jobStatus: JobStatusType.ERROR,

--- a/packages/frontend/src/components/ProjectConnection/CreateProjectconnection.test.tsx
+++ b/packages/frontend/src/components/ProjectConnection/CreateProjectconnection.test.tsx
@@ -186,6 +186,41 @@ describe('CreateProjectConnection in-flight job recovery', () => {
         ).toHaveLength(1);
     });
 
+    it('shows an informational conflict without registering another active job', async () => {
+        const message =
+            'A project creation is already in progress for the organization';
+        const calls = routeApi({
+            activeJob: () => null,
+            createProject: () =>
+                Promise.reject({
+                    status: 'error',
+                    error: {
+                        name: 'ConflictError',
+                        statusCode: 409,
+                        message,
+                        data: {},
+                    },
+                }),
+        });
+
+        renderFlow();
+
+        const user = await fillConnectionForm();
+        await user.click(screen.getByRole('button', { name: 'Test & save' }));
+
+        expect(await screen.findByText(message)).toBeInTheDocument();
+        expect(
+            screen.queryByText('Failed to create project'),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByText('Creating your project'),
+        ).not.toBeInTheDocument();
+        expect(calls.some(({ url }) => url.startsWith('/jobs/'))).toBe(false);
+        expect(
+            calls.filter(({ url }) => url === CREATE_PROJECT_URL),
+        ).toHaveLength(1);
+    });
+
     it('surfaces the failing step when the resumed job errors', async () => {
         routeApi({
             activeJob: () =>

--- a/packages/frontend/src/components/ProjectConnection/CreateProjectconnection.tsx
+++ b/packages/frontend/src/components/ProjectConnection/CreateProjectconnection.tsx
@@ -85,7 +85,13 @@ const CreateProjectConnection: FC<CreateProjectConnectionProps> = ({
         useActiveCreateProjectJob();
 
     useEffect(() => {
-        if (!inFlightJob || createProjectJobId) {
+        if (
+            !inFlightJob ||
+            createProjectJobId ||
+            ![JobStatusType.STARTED, JobStatusType.RUNNING].includes(
+                inFlightJob.jobStatus,
+            )
+        ) {
             return;
         }
         resumeJob(inFlightJob.jobUuid);

--- a/packages/frontend/src/components/ProjectConnection/CreateProjectconnection.tsx
+++ b/packages/frontend/src/components/ProjectConnection/CreateProjectconnection.tsx
@@ -1,4 +1,5 @@
 import {
+    isApiError,
     isCreateProjectJob,
     JobStatusType,
     JobStepStatusType,
@@ -6,18 +7,27 @@ import {
     WarehouseTypes,
     type CreateWarehouseCredentials,
 } from '@lightdash/common';
-import { Button } from '@mantine/core';
-import { useQueryClient } from '@tanstack/react-query';
-import confetti from 'canvas-confetti';
-import { useEffect, useMemo, useRef, useState, type FC } from 'react';
-import { useLocation, useNavigate } from 'react-router';
-import { getProject, useCreateMutation } from '../../hooks/useProject';
-import { refetchFeatureFlags } from '../../hooks/useServerOrClientFeatureFlag';
+import { Button, Group, Loader } from '@mantine/core';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type FC,
+} from 'react';
+import { useLocation } from 'react-router';
+import {
+    getInFlightJobUuidFromError,
+    useActiveCreateProjectJob,
+} from '../../hooks/useActiveCreateProjectJob';
+import { useCreateMutation } from '../../hooks/useProject';
 import useActiveJob from '../../providers/ActiveJob/useActiveJob';
 import useApp from '../../providers/App/useApp';
 import useTracking from '../../providers/Tracking/useTracking';
 import { EventName } from '../../types/Events';
 import classes from './CreateProjectconnection.module.css';
+import CreateProjectJobProgress from './CreateProjectJobProgress';
 import { dbtDefaults, noneDefaultValues } from './DbtForms/defaultValues';
 import { dbtFormValidators } from './DbtForms/validators';
 import { FormContainer } from './FormContainer';
@@ -25,6 +35,7 @@ import { FormProvider, useForm } from './formContext';
 import { ProjectForm } from './ProjectForm';
 import { ProjectFormProvider } from './ProjectFormProvider';
 import { type ProjectConnectionForm } from './types';
+import { useCreateProjectSuccessRedirect } from './useCreateProjectSuccessRedirect';
 import { useOnProjectError } from './useOnProjectError';
 import { warehouseDefaultValues } from './WarehouseForms/defaultValues';
 import { createWarehouseValueValidators } from './WarehouseForms/validators';
@@ -45,23 +56,42 @@ const CreateProjectConnection: FC<CreateProjectConnectionProps> = ({
     successRedirect,
     celebrateOnSuccess = false,
 }) => {
-    const navigate = useNavigate();
     const { pathname } = useLocation();
     const onboardingFlow = pathname.startsWith('/onboarding/')
         ? 'new'
         : 'legacy';
-    const queryClient = useQueryClient();
     const { user, health } = useApp();
     const [createProjectJobId, setCreateProjectJobId] = useState<string>();
-    const { activeJob } = useActiveJob();
+    const { activeJob, setActiveJobId, setQuietActiveJobId } = useActiveJob();
     const { isLoading: isSaving, mutateAsync } = useCreateMutation({
         quietJobToast: warehouseOnly,
         warehouseOnly,
     });
     const onProjectError = useOnProjectError();
 
+    const resumeJob = useCallback(
+        (jobUuid: string) => {
+            setCreateProjectJobId(jobUuid);
+            if (warehouseOnly) {
+                setQuietActiveJobId(jobUuid);
+            } else {
+                setActiveJobId(jobUuid);
+            }
+        },
+        [warehouseOnly, setActiveJobId, setQuietActiveJobId],
+    );
+
+    const { data: inFlightJob, isInitialLoading: isCheckingInFlightJob } =
+        useActiveCreateProjectJob();
+
+    useEffect(() => {
+        if (!inFlightJob || createProjectJobId) {
+            return;
+        }
+        resumeJob(inFlightJob.jobUuid);
+    }, [inFlightJob, createProjectJobId, resumeJob]);
+
     const submitButtonRef = useRef<HTMLButtonElement>(null);
-    const hasFiredConfettiRef = useRef(false);
 
     const warehouseType = selectedWarehouse ?? WarehouseTypes.BIGQUERY;
     const dbtType = health.data?.defaultProject?.type ?? dbtDefaults.dbtType;
@@ -108,18 +138,27 @@ const CreateProjectConnection: FC<CreateProjectConnectionProps> = ({
             },
         });
         if (selectedWarehouse) {
-            const data = await mutateAsync({
-                name: name || user.data?.organizationName || 'My project',
-                type: ProjectType.DEFAULT,
-                dbtConnection,
-                dbtVersion,
-                organizationWarehouseCredentialsUuid,
-                warehouseConnection: {
-                    ...warehouseConnection,
-                    type: selectedWarehouse,
-                } as CreateWarehouseCredentials,
-            });
-            setCreateProjectJobId(data.jobUuid);
+            try {
+                const data = await mutateAsync({
+                    name: name || user.data?.organizationName || 'My project',
+                    type: ProjectType.DEFAULT,
+                    dbtConnection,
+                    dbtVersion,
+                    organizationWarehouseCredentialsUuid,
+                    warehouseConnection: {
+                        ...warehouseConnection,
+                        type: selectedWarehouse,
+                    } as CreateWarehouseCredentials,
+                });
+                setCreateProjectJobId(data.jobUuid);
+            } catch (error) {
+                const inFlightJobUuid = isApiError(error)
+                    ? getInFlightJobUuidFromError(error.error)
+                    : undefined;
+                if (inFlightJobUuid) {
+                    resumeJob(inFlightJobUuid);
+                }
+            }
         }
     };
 
@@ -127,86 +166,13 @@ const CreateProjectConnection: FC<CreateProjectConnectionProps> = ({
         onProjectError(errors);
     };
 
-    useEffect(() => {
-        if (
-            !createProjectJobId ||
-            createProjectJobId !== activeJob?.jobUuid ||
-            !isCreateProjectJob(activeJob) ||
-            !activeJob.jobResults?.projectUuid
-        ) {
-            return;
-        }
-        const { projectUuid } = activeJob.jobResults;
-        const redirectTo = successRedirect
-            ? successRedirect(projectUuid)
-            : `/createProjectSettings/${projectUuid}`;
-
-        if (!celebrateOnSuccess) {
-            void navigate({ pathname: redirectTo });
-            return;
-        }
-
-        // Celebrate path fires exactly once — the effect re-runs on every
-        // job-status poll, and the async closure below owns the navigation.
-        if (hasFiredConfettiRef.current) {
-            return;
-        }
-        hasFiredConfettiRef.current = true;
-
-        const rect = submitButtonRef.current?.getBoundingClientRect();
-        const origin = rect
-            ? {
-                  x: (rect.left + rect.width / 2) / window.innerWidth,
-                  y: (rect.top + rect.height / 2) / window.innerHeight,
-              }
-            : { x: 0.5, y: 0.7 };
-        // The canvas outlives the client-side navigation, so the burst carries
-        // over onto the page we land on.
-        void confetti({
-            disableForReducedMotion: true,
-            startVelocity: 35,
-            particleCount: 120,
-            spread: 100,
-            gravity: 0.7,
-            origin,
-        });
-
-        // Warm the caches the home reads before we land there, so it doesn't
-        // flash the stale "connect your warehouse" checklist (the projects/org
-        // lists still show no warehouse), the pre-homepage-builder home (the
-        // org's onboarding flags are only enabled once this first project
-        // exists) or a cold project spinner. The button stays busy meanwhile,
-        // so it reads as one smooth step. Navigate even if priming fails.
-        void (async () => {
-            try {
-                await Promise.all([
-                    queryClient.refetchQueries({
-                        queryKey: ['projects'],
-                        type: 'all',
-                    }),
-                    queryClient.refetchQueries({
-                        queryKey: ['organization'],
-                        type: 'all',
-                    }),
-                    refetchFeatureFlags(queryClient),
-                    queryClient.prefetchQuery({
-                        queryKey: ['project', projectUuid],
-                        queryFn: () => getProject(projectUuid),
-                    }),
-                ]);
-            } catch {
-                // Ignore — the destination will load normally on its own.
-            }
-            void navigate({ pathname: redirectTo });
-        })();
-    }, [
+    useCreateProjectSuccessRedirect({
         activeJob,
-        celebrateOnSuccess,
         createProjectJobId,
-        navigate,
-        queryClient,
         successRedirect,
-    ]);
+        celebrateOnSuccess,
+        submitButtonRef,
+    });
 
     // The warehouse adapter test runs inside the async create job, so
     // connection failures surface as the job's ERROR status, not via the
@@ -259,6 +225,23 @@ const CreateProjectConnection: FC<CreateProjectConnectionProps> = ({
         [isSaving, createProjectJobId, hasThisJobFailed],
     );
 
+    const thisJob =
+        createProjectJobId &&
+        createProjectJobId === activeJob?.jobUuid &&
+        isCreateProjectJob(activeJob)
+            ? activeJob
+            : undefined;
+
+    const hideForm = !!thisJob && thisJob.jobStatus !== JobStatusType.ERROR;
+
+    if (isCheckingInFlightJob) {
+        return (
+            <Group justify="center" p="xl">
+                <Loader color="gray" />
+            </Group>
+        );
+    }
+
     return (
         <FormProvider form={form}>
             <form
@@ -267,26 +250,35 @@ const CreateProjectConnection: FC<CreateProjectConnectionProps> = ({
             >
                 <FormContainer>
                     <ProjectFormProvider>
-                        <ProjectForm
-                            showGeneralSettings={
-                                !isCreatingFirstProject && !warehouseOnly
-                            }
-                            disabled={isSavingProject}
-                            defaultType={health.data?.defaultProject?.type}
-                            warehouseOnly={warehouseOnly}
-                        />
+                        {thisJob && <CreateProjectJobProgress job={thisJob} />}
 
-                        <Button
-                            ref={submitButtonRef}
-                            style={{ alignSelf: 'end' }}
-                            type="submit"
-                            loading={isSavingProject}
-                            disabled={!form.isValid()}
-                        >
-                            {warehouseOnly
-                                ? 'Test & save'
-                                : 'Test & deploy project'}
-                        </Button>
+                        {!hideForm && (
+                            <>
+                                <ProjectForm
+                                    showGeneralSettings={
+                                        !isCreatingFirstProject &&
+                                        !warehouseOnly
+                                    }
+                                    disabled={isSavingProject}
+                                    defaultType={
+                                        health.data?.defaultProject?.type
+                                    }
+                                    warehouseOnly={warehouseOnly}
+                                />
+
+                                <Button
+                                    ref={submitButtonRef}
+                                    style={{ alignSelf: 'end' }}
+                                    type="submit"
+                                    loading={isSavingProject}
+                                    disabled={!form.isValid()}
+                                >
+                                    {warehouseOnly
+                                        ? 'Test & save'
+                                        : 'Test & deploy project'}
+                                </Button>
+                            </>
+                        )}
                     </ProjectFormProvider>
                 </FormContainer>
             </form>

--- a/packages/frontend/src/components/ProjectConnection/useCreateProjectSuccessRedirect.ts
+++ b/packages/frontend/src/components/ProjectConnection/useCreateProjectSuccessRedirect.ts
@@ -1,0 +1,107 @@
+import { isCreateProjectJob, type Job } from '@lightdash/common';
+import { useQueryClient } from '@tanstack/react-query';
+import confetti from 'canvas-confetti';
+import { useEffect, useRef, type RefObject } from 'react';
+import { useNavigate } from 'react-router';
+import { getProject } from '../../hooks/useProject';
+import { refetchFeatureFlags } from '../../hooks/useServerOrClientFeatureFlag';
+
+export const useCreateProjectSuccessRedirect = ({
+    activeJob,
+    createProjectJobId,
+    successRedirect,
+    celebrateOnSuccess,
+    submitButtonRef,
+}: {
+    activeJob: Job | undefined;
+    createProjectJobId: string | undefined;
+    successRedirect: ((projectUuid: string) => string) | undefined;
+    celebrateOnSuccess: boolean;
+    submitButtonRef: RefObject<HTMLButtonElement | null>;
+}) => {
+    const navigate = useNavigate();
+    const queryClient = useQueryClient();
+    const hasFiredConfettiRef = useRef(false);
+
+    useEffect(() => {
+        if (
+            !createProjectJobId ||
+            createProjectJobId !== activeJob?.jobUuid ||
+            !isCreateProjectJob(activeJob) ||
+            !activeJob.jobResults?.projectUuid
+        ) {
+            return;
+        }
+        const { projectUuid } = activeJob.jobResults;
+        const redirectTo = successRedirect
+            ? successRedirect(projectUuid)
+            : `/createProjectSettings/${projectUuid}`;
+
+        if (!celebrateOnSuccess) {
+            void navigate({ pathname: redirectTo });
+            return;
+        }
+
+        // Celebrate path fires exactly once — the effect re-runs on every
+        // job-status poll, and the async closure below owns the navigation.
+        if (hasFiredConfettiRef.current) {
+            return;
+        }
+        hasFiredConfettiRef.current = true;
+
+        const rect = submitButtonRef.current?.getBoundingClientRect();
+        const origin = rect
+            ? {
+                  x: (rect.left + rect.width / 2) / window.innerWidth,
+                  y: (rect.top + rect.height / 2) / window.innerHeight,
+              }
+            : { x: 0.5, y: 0.7 };
+        // The canvas outlives the client-side navigation, so the burst carries
+        // over onto the page we land on.
+        void confetti({
+            disableForReducedMotion: true,
+            startVelocity: 35,
+            particleCount: 120,
+            spread: 100,
+            gravity: 0.7,
+            origin,
+        });
+
+        // Warm the caches the home reads before we land there, so it doesn't
+        // flash the stale "connect your warehouse" checklist (the projects/org
+        // lists still show no warehouse), the pre-homepage-builder home (the
+        // org's onboarding flags are only enabled once this first project
+        // exists) or a cold project spinner. The button stays busy meanwhile,
+        // so it reads as one smooth step. Navigate even if priming fails.
+        void (async () => {
+            try {
+                await Promise.all([
+                    queryClient.refetchQueries({
+                        queryKey: ['projects'],
+                        type: 'all',
+                    }),
+                    queryClient.refetchQueries({
+                        queryKey: ['organization'],
+                        type: 'all',
+                    }),
+                    refetchFeatureFlags(queryClient),
+                    queryClient.prefetchQuery({
+                        queryKey: ['project', projectUuid],
+                        queryFn: () => getProject(projectUuid),
+                    }),
+                ]);
+            } catch {
+                // Ignore — the destination will load normally on its own.
+            }
+            void navigate({ pathname: redirectTo });
+        })();
+    }, [
+        activeJob,
+        celebrateOnSuccess,
+        createProjectJobId,
+        navigate,
+        queryClient,
+        submitButtonRef,
+        successRedirect,
+    ]);
+};

--- a/packages/frontend/src/hooks/useActiveCreateProjectJob.ts
+++ b/packages/frontend/src/hooks/useActiveCreateProjectJob.ts
@@ -1,0 +1,38 @@
+import {
+    type ApiError,
+    type ApiErrorDetail,
+    type Job,
+} from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../api';
+
+const ACTIVE_CREATE_PROJECT_JOB_KEY = ['jobs', 'create-project', 'active'];
+
+const getActiveCreateProjectJob = async () =>
+    lightdashApi<Job | null>({
+        method: 'GET',
+        url: '/org/jobs/create-project/active',
+        body: undefined,
+    });
+
+export const useActiveCreateProjectJob = (enabled: boolean = true) =>
+    useQuery<Job | null, ApiError>({
+        queryKey: ACTIVE_CREATE_PROJECT_JOB_KEY,
+        queryFn: getActiveCreateProjectJob,
+        enabled,
+        retry: false,
+        staleTime: 0,
+        refetchOnWindowFocus: false,
+    });
+
+export const getInFlightJobUuidFromError = (
+    error: ApiErrorDetail,
+): string | undefined => {
+    if (error.statusCode !== 409) {
+        return undefined;
+    }
+    const jobUuid = error.data?.jobUuid;
+    return typeof jobUuid === 'string' && jobUuid.length > 0
+        ? jobUuid
+        : undefined;
+};

--- a/packages/frontend/src/hooks/useProject.ts
+++ b/packages/frontend/src/hooks/useProject.ts
@@ -136,7 +136,7 @@ export const useCreateMutation = (options?: {
     warehouseOnly?: boolean;
 }) => {
     const { setActiveJobId, setQuietActiveJobId } = useActiveJob();
-    const { showToastApiError } = useToaster();
+    const { showToastApiError, showToastInfo } = useToaster();
     const { track } = useTracking();
     const { pathname } = useLocation();
     const onboardingFlow = pathname.startsWith('/onboarding/')
@@ -147,7 +147,7 @@ export const useCreateMutation = (options?: {
         {
             mutationKey: ['project_create'],
             retry: (failureCount, { error }) =>
-                !getInFlightJobUuidFromError(error) && failureCount < 3,
+                error.statusCode !== 409 && failureCount < 3,
             onSuccess: (data) => {
                 if (options?.quietJobToast) {
                     setQuietActiveJobId(data.jobUuid);
@@ -163,6 +163,10 @@ export const useCreateMutation = (options?: {
                     } else {
                         setActiveJobId(inFlightJobUuid);
                     }
+                    return;
+                }
+                if (error.statusCode === 409) {
+                    showToastInfo({ title: error.message });
                     return;
                 }
                 track({

--- a/packages/frontend/src/hooks/useProject.ts
+++ b/packages/frontend/src/hooks/useProject.ts
@@ -27,6 +27,7 @@ import useActiveJob from '../providers/ActiveJob/useActiveJob';
 import useTracking from '../providers/Tracking/useTracking';
 import { EventName } from '../types/Events';
 import useToaster from './toaster/useToaster';
+import { getInFlightJobUuidFromError } from './useActiveCreateProjectJob';
 import useQueryError from './useQueryError';
 
 const createProject = async (data: CreateProject) =>
@@ -145,7 +146,8 @@ export const useCreateMutation = (options?: {
         (data) => createProject(data),
         {
             mutationKey: ['project_create'],
-            retry: 3,
+            retry: (failureCount, { error }) =>
+                !getInFlightJobUuidFromError(error) && failureCount < 3,
             onSuccess: (data) => {
                 if (options?.quietJobToast) {
                     setQuietActiveJobId(data.jobUuid);
@@ -154,6 +156,15 @@ export const useCreateMutation = (options?: {
                 }
             },
             onError: ({ error }, data) => {
+                const inFlightJobUuid = getInFlightJobUuidFromError(error);
+                if (inFlightJobUuid) {
+                    if (options?.quietJobToast) {
+                        setQuietActiveJobId(inFlightJobUuid);
+                    } else {
+                        setActiveJobId(inFlightJobUuid);
+                    }
+                    return;
+                }
                 track({
                     name: EventName.CREATE_PROJECT_FAILED,
                     properties: {


### PR DESCRIPTION
`POST /org/projects/precompiled` accepts a create unconditionally, so a second "Test & save" submitted while an earlier create job is still running produces a second, fully real project. Found from a production incident on a test account, where an org ended up with two identical `DEFAULT` projects, each with its own warehouse credentials.

Linear: SPK-786

## What actually happens

The submit button is genuinely disabled while a create job is in flight — `isSavingProject` covers the live job uuid, the button takes it as `loading`, and Mantine's Button applies `disabled: disabled || loading`. So a second submit is not reachable from a page that still holds the job.

What breaks that is anything which returns the client to a submittable state while the job is still running server-side. A page reload does it: the job uuid lives only in React state, so reloading wipes it, re-enables the form, and gives no indication that a create is in flight — the user submits again and gets a duplicate. A second tab does it too. **The server accepting the second create is the defect that holds regardless of how the client got there**, which is why the guard is the headline fix here; the client-side work removes the most likely way of getting into that state.

## What changed

**Backend — the fix**
- `POST /org/projects/precompiled` refuses a non-preview create while another create job for the same organization is in flight: 409 `ConflictError` carrying the active `jobUuid` in the error data. The check and the job insert are serialized inside one transaction holding an org-keyed `pg_advisory_xact_lock`, so two simultaneous requests cannot both pass the check. Jobs older than 1 hour are ignored so a stuck job can never block creates permanently.
- New `GET /org/jobs/create-project/active` returns **the caller's own** most recent in-flight (non-preview) create job, or `null` — the recovery handle a client needs after losing its job uuid. It is scoped to the requesting user, matching how `getJobStatus` already scopes project-less jobs, so it never exposes another member's job or its step errors.
- The 409 carries `jobUuid` only when the in-flight job belongs to the caller. When another organization member owns it the conflict is returned without a uuid and surfaced as information, since the caller could not poll that job anyway.
- New `is_preview` column on `jobs` (migration) so preview creates — a legitimate concurrent flow — are exempt from the guard and excluded from the lookup.

**Frontend — removes the main route into the bad state**
- The create-project flow queries the active-job endpoint on mount, so a reload returns to the "creating…" state and resumes polling instead of presenting a fresh, submittable form.
- A 409 naming the caller's own job is adopted rather than surfaced: the client resumes polling that job. A 409 without a job uuid (another member is creating) shows an informational message instead. Neither is retried.
- The bare button spinner is replaced with step-level progress (status label, progress bar, per-step state) and a clear error alert with the failing step's message. The observed job ran ~35s with no progress, timeout or result feedback, which is what prompted the reload in the first place.

## Reproduction

**API level — this is the one that proves the defect.** Log in, then `POST /api/v1/org/projects/precompiled` twice with the same body while the first job is still `RUNNING` (confirmed via `GET /api/v1/jobs/<uuid>`). Before the fix both requests return 200 with distinct job uuids, both jobs complete, and two identical `DEFAULT` projects exist in the org — no UI and no reload involved.

**UI level — how a real user reaches that second submit.** With the create job artificially slowed to ~30s to mirror the production timing: submit, then reload mid-job. The form comes back blank with no sign a create is in flight, while the orphaned job silently commits a project; a second submit then commits a duplicate.

## Verification after the fix

- Re-running the same double-POST script: the second request returns 409 with the first job's uuid in the error data, and exactly one project is created.
- In the browser: reload mid-job returns to the creating/progress state (form and submit unreachable), and the resumed job navigates to its project on completion. Submitting from a second tab while a job is in flight adopts the existing job's progress, with no second job row created.
- Backend: typecheck, lint, 105 vitest tests (guard allow/reject/preview/cutoff cases, atomic insert-or-return, lookup scoping). Frontend: typecheck, lint, unused-exports, full suite including tests verified to fail with the fix disabled (rehydration, null case, 409 resume with exactly one POST, resumed job error, uuid-less 409 registering no job).

## Follow-up from an adversarial review

An independent review found two real defects in the first version of this guard. Both were reproduced with a failing test before being fixed, and the same tests now pass.

**A failed scheduler enqueue stranded the job and locked the whole organization out.** The job row was committed inside the lock transaction and the enqueue ran afterwards with no compensation, so if it threw, the row sat in `STARTED` forever: every subsequent create got a 409, and the recovery endpoint kept handing that dead job to reloading clients, which polled it indefinitely. Red proof asserted the desired outcome and got `failedJobStatus: 'STARTED'`, `retryOutcome: 'failed'`, `retryStatusCode: 409`. The enqueue is now wrapped and marks the job errored on failure, and jobs whose backing scheduler work no longer exists are reaped.

**The one-hour age cutoff re-opened the very race this PR closes.** Because the guard ignored jobs older than an hour, a create still legitimately running after that — a large first dbt compile, exactly the case this protects — became invisible, so a reload showed a fresh form and a resubmit created a second project. The cutoff is gone; the check is now purely state-based, and dead jobs are handled by the reaper instead. The reaper decides by liveness, not age: it only errors a job when no backing scheduler job exists, and there is a test asserting a healthy long-running job is preserved.

**One review finding was attempted and then deliberately reverted.** The suggestion was to have recovery also return recently completed jobs, closing the window where a job finishes between the reload and the recovery query. Implemented, it caused a worse bug: the client adopts whatever recovery returns on mount, so anyone who had created a project in the previous hour and reopened the create form had the form replaced by the completed progress panel for their *previous* project — the form vanishing as they typed. E2E caught it (`createProjects.cy.ts` creates three projects in one session; the first passed, the next two failed with the name input matching and then disappearing), and it was confirmed against an unrelated PR where the same spec passes.

Recovery is therefore limited to jobs that are still in flight, which is correct and safe. The residual window is tracked as SPK-820 with the underlying design problem written up: an org-scoped server lookup genuinely cannot distinguish "I reloaded mid-create" from "I deliberately came back to create another", because the distinguishing signal is client-session state that the reload destroys.

## Real-Postgres integration coverage

The earlier note about the advisory-lock path only being covered against a mocked Knex no longer applies. There is now an integration suite running against real Postgres (`ProjectService.integration.test.ts`), including **two genuinely concurrent `scheduleCreate` calls on separate connections asserting exactly one job row**. That test passed before any of the fixes above, which is the honest confirmation that the original serialization claim held; the other five cover the defects described here. Running the non-EE integration tests required widening the integration config's `include` glob, which is part of this diff.

One finding from the review was **not** acted on. It claimed the 409 carve-out reduced `retry: 3` to two retries. `query-core@4.36.1` evaluates a numeric retry as `failureCount < retry` (`retryer.js:122`) with `failureCount++` after the check, so the predicate here is exactly equivalent and changing it would have introduced the off-by-one the finding was trying to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PYdraKeQMyKvSfcc7AZYr
