### PR TITLE
fix(dashboards): map date filters across explores

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -15,6 +15,7 @@ import {
     CreateEmbedRequestBody,
     DashboardAvailableFilters,
     DashboardDAO,
+    DashboardFieldTarget,
     DashboardFilters,
     DateGranularity,
     DateZoom,
@@ -33,9 +34,11 @@ import {
     formatRows,
     getAvailableFilterFieldIds,
     getColumnTimezone,
+    getDashboardFieldTarget,
     getDashboardFiltersForTileAndTables,
     getDimensionMapFromTables,
     getDimensions,
+    getExploreDefaultTimeDimension,
     getFilterInteractivityValue,
     getItemId,
     InteractivityOptions,
@@ -695,19 +698,14 @@ export class EmbedService extends BaseService {
         const { dashboardUuids, allowAllDashboards } =
             await this.embedModel.get(projectUuid);
 
-        if (!isFilterInteractivityEnabled(account.access.filtering)) {
-            // If dashboard filters interactivity is not enabled, we return an empty list
-            return {
-                savedQueryFilters: {},
-                allFilterableFields: [],
-                allFilterableMetrics: [],
-                savedQueryMetricFilters: {},
-            };
-        }
+        const hasFilterInteractivity = isFilterInteractivityEnabled(
+            account.access.filtering,
+        );
 
         let allFilters: {
             uuid: string;
             filters: CompiledDimension[];
+            defaultTimeDimension?: DashboardFieldTarget;
         }[] = [];
 
         const savedQueryUuids = savedChartUuidsAndTileUuids.map(
@@ -804,13 +802,22 @@ export class EmbedService extends BaseService {
 
         const filterPromises = savedCharts.map(async (savedChart) => {
             const explore = exploreCache[savedChart.tableName];
-            if (isExploreError(explore))
+            if (isExploreError(explore)) {
                 return { uuid: savedChart.uuid, filters: [] };
+            }
             const filters = getDimensions(explore).filter(
                 (field) => isFilterableDimension(field) && !field.hidden,
             );
+            const defaultTimeDimension =
+                getExploreDefaultTimeDimension(explore);
 
-            return { uuid: savedChart.uuid, filters };
+            return {
+                uuid: savedChart.uuid,
+                filters,
+                defaultTimeDimension: defaultTimeDimension
+                    ? getDashboardFieldTarget(defaultTimeDimension)
+                    : undefined,
+            };
         });
 
         allFilters = await Promise.all(filterPromises);
@@ -846,11 +853,30 @@ export class EmbedService extends BaseService {
             };
         }, {});
 
+        const defaultTimeDimensions = savedChartUuidsAndTileUuids.reduce<
+            DashboardAvailableFilters['defaultTimeDimensions']
+        >((acc, savedChartUuidAndTileUuid) => {
+            const filterResult = allFilters.find(
+                (result) =>
+                    result.uuid === savedChartUuidAndTileUuid.savedChartUuid,
+            );
+            return filterResult?.defaultTimeDimension
+                ? {
+                      ...acc,
+                      [savedChartUuidAndTileUuid.tileUuid]:
+                          filterResult.defaultTimeDimension,
+                  }
+                : acc;
+        }, {});
+
         return {
-            savedQueryFilters,
-            allFilterableFields,
+            savedQueryFilters: hasFilterInteractivity ? savedQueryFilters : {},
+            allFilterableFields: hasFilterInteractivity
+                ? allFilterableFields
+                : [],
             allFilterableMetrics: [],
             savedQueryMetricFilters: {},
+            defaultTimeDimensions,
         };
     }
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -47,6 +47,7 @@ import {
     CustomSqlQueryForbiddenError,
     DashboardAvailableFilters,
     DashboardBasicDetails,
+    DashboardFieldTarget,
     DashboardFilters,
     DatabricksAuthenticationType,
     DatabricksTokenError,
@@ -78,10 +79,12 @@ import {
     getAvailableFilterFieldIds,
     getAvailableParametersFromTables,
     getColumnTimezone,
+    getDashboardFieldTarget,
     getDashboardFilterRulesForTables,
     getDbtEnvironmentVariableKeyError,
     getDimensions,
     getErrorMessage,
+    getExploreDefaultTimeDimension,
     getFieldFormatOverrideProps,
     getFields,
     getIntrinsicUserAttributes,
@@ -7944,6 +7947,7 @@ export class ProjectService extends BaseService {
             uuid: string;
             filters: CompiledDimension[];
             metricFilters: Metric[];
+            defaultTimeDimension?: DashboardFieldTarget;
         };
 
         let allFilters: ChartFilters[] = [];
@@ -8010,6 +8014,7 @@ export class ProjectService extends BaseService {
                             uuid: savedChart.uuid,
                             filters: [],
                             metricFilters: [],
+                            defaultTimeDimension: undefined,
                         };
                     }
 
@@ -8026,11 +8031,18 @@ export class ProjectService extends BaseService {
                             (field) => !field.hidden,
                         );
                     }
+                    const defaultTimeDimension =
+                        explore && !isExploreError(explore)
+                            ? getExploreDefaultTimeDimension(explore)
+                            : undefined;
 
                     return {
                         uuid: savedChart.uuid,
                         filters,
                         metricFilters,
+                        defaultTimeDimension: defaultTimeDimension
+                            ? getDashboardFieldTarget(defaultTimeDimension)
+                            : undefined,
                     };
                 });
             },
@@ -8098,11 +8110,28 @@ export class ProjectService extends BaseService {
             };
         }, {});
 
+        const defaultTimeDimensions = savedChartUuidsAndTileUuids.reduce<
+            DashboardAvailableFilters['defaultTimeDimensions']
+        >((acc, savedChartUuidAndTileUuid) => {
+            const filterResult = allFilters.find(
+                (result) =>
+                    result.uuid === savedChartUuidAndTileUuid.savedChartUuid,
+            );
+            return filterResult?.defaultTimeDimension
+                ? {
+                      ...acc,
+                      [savedChartUuidAndTileUuid.tileUuid]:
+                          filterResult.defaultTimeDimension,
+                  }
+                : acc;
+        }, {});
+
         return {
             savedQueryFilters,
             allFilterableFields,
             allFilterableMetrics,
             savedQueryMetricFilters,
+            defaultTimeDimensions,
         };
     }
 

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -1,6 +1,6 @@
 import { type ContentVerificationInfo } from './contentVerification';
 import { type FilterableDimension, type Metric } from './field';
-import { type DashboardFilters } from './filter';
+import { type DashboardFieldTarget, type DashboardFilters } from './filter';
 import { type KnexPaginatedData } from './knex-paginate';
 import { type DashboardParameters } from './parameters';
 import {
@@ -353,6 +353,7 @@ export type DashboardAvailableFilters = {
     allFilterableFields: FilterableDimension[];
     allFilterableMetrics: Metric[];
     savedQueryMetricFilters: Record<string, number[]>;
+    defaultTimeDimensions: Record<string, DashboardFieldTarget>;
 };
 
 export type SavedChartsInfoForDashboardAvailableFilters = {

--- a/packages/common/src/utils/filters.test.ts
+++ b/packages/common/src/utils/filters.test.ts
@@ -17,6 +17,7 @@ import {
     addDashboardFiltersToMetricQuery,
     addFilterRule,
     applyDashboardFiltersForTile,
+    applyDefaultTimeDimensionTileTargets,
     createFilterRuleFromField,
     createFilterRuleFromModelRequiredFilterRule,
     getDashboardFilterRulesForTileAndReferences,
@@ -1358,6 +1359,54 @@ describe('applyDashboardFiltersForTile', () => {
         ).toEqual([]);
     });
 
+    test('maps an unmapped date filter to the explore default time dimension', () => {
+        const exploreWithDefaultTimeDimension = {
+            ...mockExplore,
+            tables: {
+                ...mockExplore.tables,
+                orders: {
+                    ...mockExplore.tables.orders,
+                    defaultTimeDimension: {
+                        field: 'order_date',
+                        interval: TimeFrames.DAY,
+                    },
+                },
+            },
+        };
+        const crossExploreDateRule: DashboardFilterRule = {
+            id: 'f-cross-explore-date',
+            target: {
+                fieldId: 'events_created_at',
+                tableName: 'events',
+                fallbackType: DimensionType.DATE,
+            },
+            operator: FilterOperator.EQUALS,
+            values: ['2026-08-01'],
+            label: 'Date',
+        };
+
+        const { metricQuery, appliedDashboardFilters } =
+            applyDashboardFiltersForTile({
+                tileUuid: 't-1',
+                metricQuery: baseMetricQuery,
+                dashboardFilters: {
+                    dimensions: [crossExploreDateRule],
+                    metrics: [],
+                    tableCalculations: [],
+                },
+                explore: exploreWithDefaultTimeDimension,
+            });
+
+        expect(appliedDashboardFilters.dimensions).toHaveLength(1);
+        expect(appliedDashboardFilters.dimensions[0].target).toMatchObject({
+            fieldId: 'orders_order_date',
+            tableName: 'orders',
+        });
+        expect(
+            (metricQuery.filters.dimensions as AndFilterGroup).and[0],
+        ).toMatchObject({ target: { fieldId: 'orders_order_date' } });
+    });
+
     test('drops rules whose tileTargets disable them for this tile', () => {
         const disabledRule: DashboardFilterRule = {
             ...statusRule,
@@ -1404,6 +1453,129 @@ describe('applyDashboardFiltersForTile', () => {
             target: { fieldId: 'orders_status' },
             values: [true],
         });
+    });
+});
+
+describe('applyDefaultTimeDimensionTileTargets', () => {
+    const sourceDateDimension = {
+        ...mockExplore.tables.orders.dimensions.order_date,
+        name: 'created_at',
+        table: 'events',
+        tableLabel: 'Events',
+    };
+    const defaultTimeDimension =
+        mockExplore.tables.orders.dimensions.order_date;
+
+    test('maps a date filter to each tile default without overriding explicit targets', () => {
+        const filters: DashboardFilters = {
+            dimensions: [
+                {
+                    id: 'date-filter',
+                    target: {
+                        fieldId: 'events_created_at',
+                        tableName: 'events',
+                    },
+                    operator: FilterOperator.EQUALS,
+                    values: ['2026-08-01'],
+                    label: 'Date',
+                    tileTargets: {
+                        excluded: false,
+                        explicit: {
+                            fieldId: 'custom_date',
+                            tableName: 'custom',
+                            fallbackType: DimensionType.DATE,
+                        },
+                    },
+                },
+            ],
+            metrics: [],
+            tableCalculations: [],
+        };
+
+        const result = applyDefaultTimeDimensionTileTargets(
+            filters,
+            {
+                source: [sourceDateDimension],
+                target: [defaultTimeDimension],
+                excluded: [defaultTimeDimension],
+                explicit: [defaultTimeDimension],
+            },
+            {
+                source: {
+                    fieldId: 'events_created_at',
+                    tableName: 'events',
+                    fallbackType: DimensionType.DATE,
+                },
+                target: {
+                    fieldId: 'orders_order_date',
+                    tableName: 'orders',
+                    fallbackType: DimensionType.DATE,
+                },
+                excluded: {
+                    fieldId: 'orders_order_date',
+                    tableName: 'orders',
+                    fallbackType: DimensionType.DATE,
+                },
+                explicit: {
+                    fieldId: 'orders_order_date',
+                    tableName: 'orders',
+                    fallbackType: DimensionType.DATE,
+                },
+            },
+        );
+
+        expect(result.dimensions[0].target.fallbackType).toBe(
+            DimensionType.DATE,
+        );
+        expect(result.dimensions[0].tileTargets).toEqual({
+            excluded: false,
+            explicit: {
+                fieldId: 'custom_date',
+                tableName: 'custom',
+                fallbackType: DimensionType.DATE,
+            },
+            target: {
+                fieldId: 'orders_order_date',
+                tableName: 'orders',
+                fallbackType: DimensionType.DATE,
+            },
+        });
+        expect(result.dimensions[0].tileTargets).not.toHaveProperty('source');
+    });
+
+    test('does not map non-date filters', () => {
+        const filters: DashboardFilters = {
+            dimensions: [
+                {
+                    id: 'status-filter',
+                    target: {
+                        fieldId: 'orders_status',
+                        tableName: 'orders',
+                        fallbackType: DimensionType.STRING,
+                    },
+                    operator: FilterOperator.EQUALS,
+                    values: ['completed'],
+                    label: 'Status',
+                    tileTargets: {},
+                },
+            ],
+            metrics: [],
+            tableCalculations: [],
+        };
+
+        expect(
+            applyDefaultTimeDimensionTileTargets(
+                filters,
+                { target: [defaultTimeDimension] },
+                {
+                    target: {
+                        fieldId: 'orders_order_date',
+                        tableName: 'orders',
+                        fallbackType: DimensionType.DATE,
+                    },
+                },
+            ),
+        ).toEqual(filters);
     });
 });
 

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -16,6 +16,7 @@ import {
     TableCalculationType,
     type CompiledField,
     type CustomSqlDimension,
+    type DashboardFilterableField,
     type Dimension,
     type Field,
     type FilterableDimension,
@@ -440,6 +441,9 @@ const getDefaultTileTargets = (
             [tileUuid]: {
                 fieldId: getItemId(filterableField),
                 tableName: filterableField.table,
+                ...(isDimension(filterableField)
+                    ? { fallbackType: filterableField.type }
+                    : {}),
             },
         };
     }, {});
@@ -492,6 +496,7 @@ export const createDashboardFilterRuleFromField = ({
                 fieldId: getItemId(field),
                 tableName: field.table,
                 fieldName: field.name,
+                ...(isDimension(field) ? { fallbackType: field.type } : {}),
             },
             tileTargets: getDefaultTileTargets(field, availableTileFilters),
             disabled: !isTemporary,
@@ -1364,6 +1369,85 @@ export const getAvailableFilterFieldIds = (explore: Explore): string[] => [
         .map(([fieldId]) => fieldId),
 ];
 
+export const getExploreDefaultTimeDimension = (
+    explore: Explore,
+): FilterableDimension | undefined => {
+    const baseTable = explore.tables[explore.baseTable];
+    const defaultTimeDimension = baseTable?.defaultTimeDimension;
+    if (!baseTable || !defaultTimeDimension) {
+        return undefined;
+    }
+
+    const fieldId = convertFieldRefToFieldId(
+        defaultTimeDimension.field,
+        baseTable.name,
+    );
+    const dimension = getDimensionMapFromTables(explore.tables)[fieldId];
+    return dimension && isFilterableDimension(dimension)
+        ? dimension
+        : undefined;
+};
+
+export const getDashboardFieldTarget = (
+    field: FilterableDimension,
+): DashboardFieldTarget => ({
+    fieldId: getItemId(field),
+    tableName: field.table,
+    fallbackType: field.type,
+});
+
+const isDateDimensionType = (type: DimensionType | undefined): boolean =>
+    type === DimensionType.DATE || type === DimensionType.TIMESTAMP;
+
+export const applyDefaultTimeDimensionTileTargets = (
+    dashboardFilters: DashboardFilters,
+    filterableFieldsByTileUuid: Record<string, DashboardFilterableField[]>,
+    defaultTimeDimensions: Record<string, DashboardFieldTarget>,
+): DashboardFilters => ({
+    ...dashboardFilters,
+    dimensions: dashboardFilters.dimensions.map((filter) => {
+        const sourceField = Object.values(filterableFieldsByTileUuid)
+            .flat()
+            .find((field) => getItemId(field) === filter.target.fieldId);
+        const filterType =
+            filter.target.fallbackType ??
+            (sourceField && isDimension(sourceField)
+                ? sourceField.type
+                : undefined);
+        if (!isDateDimensionType(filterType)) {
+            return filter;
+        }
+
+        const tileTargets = Object.entries(defaultTimeDimensions).reduce(
+            (targets, [tileUuid, defaultTimeDimensionTarget]) => {
+                if (targets[tileUuid] !== undefined) {
+                    return targets;
+                }
+                const tileHasSourceField = filterableFieldsByTileUuid[
+                    tileUuid
+                ]?.some((field) => getItemId(field) === filter.target.fieldId);
+                if (tileHasSourceField) {
+                    return targets;
+                }
+                return {
+                    ...targets,
+                    [tileUuid]: defaultTimeDimensionTarget,
+                };
+            },
+            { ...filter.tileTargets },
+        );
+
+        return {
+            ...filter,
+            target: {
+                ...filter.target,
+                fallbackType: filterType,
+            },
+            tileTargets,
+        };
+    }),
+});
+
 export const applyDashboardFiltersForTile = ({
     tileUuid,
     metricQuery,
@@ -1378,10 +1462,29 @@ export const applyDashboardFiltersForTile = ({
     metricQuery: MetricQuery;
     appliedDashboardFilters: DashboardFilters;
 } => {
+    const availableFieldIds = getAvailableFilterFieldIds(explore);
+    const defaultTimeDimension = getExploreDefaultTimeDimension(explore);
+    const dimensionFilters = dashboardFilters.dimensions.map((filter) => {
+        const tileTarget = filter.tileTargets?.[tileUuid];
+        if (
+            tileTarget !== undefined ||
+            availableFieldIds.includes(filter.target.fieldId) ||
+            !isDateDimensionType(filter.target.fallbackType) ||
+            !defaultTimeDimension
+        ) {
+            return filter;
+        }
+        return {
+            ...filter,
+            target: {
+                ...getDashboardFieldTarget(defaultTimeDimension),
+            },
+        };
+    });
     const appliedDashboardFilters = getDashboardFiltersForTileAndTables(
         tileUuid,
-        getAvailableFilterFieldIds(explore),
-        dashboardFilters,
+        availableFieldIds,
+        { ...dashboardFilters, dimensions: dimensionFilters },
     );
     return {
         metricQuery: addDashboardFiltersToMetricQuery(

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -1,5 +1,6 @@
 import {
     applyDimensionOverrides,
+    applyDefaultTimeDimensionTileTargets,
     applyMetricOverrides,
     compressDashboardFiltersToParam,
     convertDashboardFiltersParamToDashboardFilters,
@@ -1337,7 +1338,7 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
     }, [dashboardAvailableFiltersData]);
 
     const allFilters = useMemo(() => {
-        return {
+        const filters = {
             dimensions: [
                 ...dashboardFilters.dimensions,
                 ...safeTemporaryFilters?.dimensions,
@@ -1351,7 +1352,19 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
                 ...safeTemporaryFilters?.tableCalculations,
             ],
         };
-    }, [dashboardFilters, safeTemporaryFilters]);
+        return filterableFieldsByTileUuid && dashboardAvailableFiltersData
+            ? applyDefaultTimeDimensionTileTargets(
+                  filters,
+                  filterableFieldsByTileUuid,
+                  dashboardAvailableFiltersData.defaultTimeDimensions,
+              )
+            : filters;
+    }, [
+        dashboardFilters,
+        safeTemporaryFilters,
+        filterableFieldsByTileUuid,
+        dashboardAvailableFiltersData,
+    ]);
 
     // Watch for filter changes and emit events (skip initial render)
     useEffect(() => {


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9427/dashboard-date-filter-should-auto-apply-across-explores-without-manual

## Summary

Dashboard date filters now target each tile's model-level default time dimension when the source field does not exist in that tile's explore. Explicit per-tile targets and exclusions still take precedence, and generated mappings remain runtime-only.

## Root cause

The available-filters response exposed each tile's fields but not its explore's configured default time dimension. The frontend therefore had no canonical target for another explore, and the common query path discarded the unresolved source field.

```ts
const field = filterableFields.find(({ id }) => id === filterRule.target.fieldId);
// No matching field meant the rule could not be applied to this tile.
```

## Fix

The backend resolves a compact default-time target for every saved-chart tile. The dashboard provider derives missing date-filter mappings at runtime, and the common filter path provides the same typed fallback for callers outside the provider.

- `packages/common` resolves default time dimensions, derives safe targets, and preserves explicit mappings.
- `packages/backend` adds compact defaults to authenticated and embedded available-filter responses without exposing the full catalog to noninteractive embeds.
- `packages/frontend` applies generated mappings to saved and temporary filters without persisting them.
- Broader arbitrary-field equivalence across explores remains out of scope for PROD-9427.

## Behavior

```text
Before: dashboard date filter -> field missing in another explore -> filter dropped
After:  dashboard date filter -> field missing in another explore -> model default time dimension
```

## Test plan

- [x] Focused common filter suite — 77/77 tests pass, including the retained regression.
- [x] Common, backend, and frontend typechecks.
- [x] Focused lint for every hand-edited source file.
- [x] TSOA route and Swagger regeneration.
- [x] Local available-filters API returns distinct compact defaults for Orders and Visit Analytics.
- [x] Chrome DevTools MCP applies an Events date filter and triggers all 15 dashboard chart queries.
- [x] Orders and Visit Analytics requests have no manual target, then return and compile their respective default time dimensions.

## Evidence

- Before: the retained regression expected one applied dimension filter but received none.
- After: the available-filters response resolved two Orders tiles to `orders_order_date` and two Visit Analytics tiles to `visit_analytics_visit_date`.
- Browser: applying `Events Date = 2025-07-01` triggered all 15 chart queries; Orders and Visit Analytics requests had no explicit tile target, then returned and compiled their respective default time dimensions.
