### PR TITLE
fix(auth): gate organization credential selection

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -25,6 +25,7 @@ import {
     SupportedDbtAdapter,
     WarehouseTypes,
     type ChartSummary,
+    type CreateProject,
     type CreateWarehouseCredentials,
     type DownloadFile,
     type Explore,
@@ -210,7 +211,14 @@ const projectModel = {
     createWithOptionalCredentials: vi.fn(
         async () => 'created-preview-project-uuid',
     ),
+    update: vi.fn(async () => undefined),
     delete: vi.fn(async () => undefined),
+};
+const organizationWarehouseCredentialsModel = {
+    getByUuidWithSensitiveData:
+        vi.fn<
+            OrganizationWarehouseCredentialsModel['getByUuidWithSensitiveData']
+        >(),
 };
 const preAggregateModel = {
     upsertPreAggregateDefinitions: vi.fn(),
@@ -236,6 +244,7 @@ const savedChartModel = {
     find: vi.fn(async () => [] as ChartSummary[]),
 };
 const jobModel = {
+    create: vi.fn(async () => undefined),
     get: vi.fn(async () => job),
     update: vi.fn(async () => undefined),
     updateJobStep: vi.fn(async () => undefined),
@@ -264,6 +273,7 @@ const emailModel = {
 };
 
 const schedulerClient = {
+    createProjectWithCompile: vi.fn(async () => undefined),
     deleteScheduledPreAggregateCronJobsForProject: vi.fn(async () => undefined),
     indexCatalog: vi.fn(async () => ({ jobId: 'catalog-job-1' })),
     materializePreAggregate: vi.fn(async () => ({ jobId: 'job-1' })),
@@ -304,6 +314,7 @@ const getMockedProjectService = (
             | 'provisionPlaygroundProject'
             | 'downloadFileModel'
             | 'getAiAgentService'
+            | 'organizationWarehouseCredentialsModel'
         >
     > = {},
 ) =>
@@ -361,7 +372,8 @@ const getMockedProjectService = (
             replace: vi.fn(async () => undefined),
         } as unknown as ProjectParametersModel,
         organizationWarehouseCredentialsModel:
-            {} as unknown as OrganizationWarehouseCredentialsModel,
+            overrides.organizationWarehouseCredentialsModel ??
+            (organizationWarehouseCredentialsModel as unknown as OrganizationWarehouseCredentialsModel),
         organizationModel: {} as unknown as OrganizationModel,
         projectCompileLogModel:
             projectCompileLogModel as unknown as ProjectCompileLogModel,
@@ -404,6 +416,176 @@ describe('ProjectService', () => {
 
     afterEach(() => {
         vi.clearAllMocks();
+    });
+
+    describe('organization warehouse credential authorization', () => {
+        const organizationWarehouseCredentialsUuid =
+            'organization-warehouse-credentials-uuid';
+        const warehouseConnection: CreateWarehouseCredentials = {
+            type: WarehouseTypes.SNOWFLAKE,
+            account: 'snowflake-account',
+            user: 'snowflake-user',
+            password: 'snowflake-password',
+            database: 'analytics',
+            warehouse: 'transforming',
+            schema: 'public',
+            authenticationType: SnowflakeAuthenticationType.PASSWORD,
+            organizationWarehouseCredentialsUuid,
+        };
+        const createProjectData: CreateProject = {
+            name: 'New project',
+            type: ProjectType.DEFAULT,
+            dbtConnection: { type: DbtProjectType.NONE },
+            dbtVersion: DefaultSupportedDbtVersion,
+            warehouseConnection: {
+                ...warehouseConnection,
+                organizationWarehouseCredentialsUuid: undefined,
+            },
+            organizationWarehouseCredentialsUuid,
+        };
+        const updateProjectData: UpdateProject = {
+            name: projectWithSensitiveFields.name,
+            dbtConnection: projectWithSensitiveFields.dbtConnection,
+            dbtVersion: projectWithSensitiveFields.dbtVersion,
+            warehouseConnection,
+        };
+        const projectCreationUser: SessionUser = {
+            ...user,
+            organizationUuid: projectWithSensitiveFields.organizationUuid,
+            ability: new Ability<PossibleAbilities>([
+                { subject: 'Project', action: 'create' },
+            ]),
+        };
+        const authorizedDeveloperAccount = {
+            ...developerAccount,
+            user: {
+                ...developerAccount.user,
+                role: OrganizationMemberRole.DEVELOPER,
+                ability: defineUserAbility(
+                    {
+                        userUuid: developerAccount.user.id,
+                        role: OrganizationMemberRole.DEVELOPER,
+                        organizationUuid:
+                            projectWithSensitiveFields.organizationUuid,
+                    },
+                    [],
+                ),
+            },
+        } as typeof developerAccount;
+        const organizationWarehouseCredentials = {
+            organizationWarehouseCredentialsUuid,
+            organizationUuid: projectWithSensitiveFields.organizationUuid,
+            name: 'Shared Snowflake',
+            description: null,
+            warehouseType: WarehouseTypes.SNOWFLAKE,
+            createdAt: new Date('2026-08-03T00:00:00.000Z'),
+            createdByUserUuid: account.user.id,
+            credentials: warehouseConnection,
+        };
+
+        beforeEach(() => {
+            organizationWarehouseCredentialsModel.getByUuidWithSensitiveData.mockResolvedValue(
+                organizationWarehouseCredentials,
+            );
+        });
+
+        test('rejects save-without-compile before resolving organization credentials', async () => {
+            await expect(
+                service.updateWarehouseCredentials(
+                    projectUuid,
+                    developerAccount,
+                    { warehouseConnection },
+                ),
+            ).rejects.toThrowError(ForbiddenError);
+            expect(
+                organizationWarehouseCredentialsModel.getByUuidWithSensitiveData,
+            ).not.toHaveBeenCalled();
+            expect(projectModel.update).not.toHaveBeenCalled();
+        });
+
+        test('rejects create-without-compile before resolving organization credentials', async () => {
+            await expect(
+                service.createWithoutCompile(
+                    projectCreationUser,
+                    createProjectData,
+                    RequestMethod.WEB_APP,
+                ),
+            ).rejects.toThrowError(ForbiddenError);
+            expect(
+                organizationWarehouseCredentialsModel.getByUuidWithSensitiveData,
+            ).not.toHaveBeenCalled();
+            expect(
+                projectModel.createWithOptionalCredentials,
+            ).not.toHaveBeenCalled();
+        });
+
+        test('rejects scheduled create before creating a job', async () => {
+            await expect(
+                service.scheduleCreate(
+                    projectCreationUser,
+                    createProjectData,
+                    RequestMethod.WEB_APP,
+                ),
+            ).rejects.toThrowError(ForbiddenError);
+            expect(
+                organizationWarehouseCredentialsModel.getByUuidWithSensitiveData,
+            ).not.toHaveBeenCalled();
+            expect(jobModel.create).not.toHaveBeenCalled();
+            expect(
+                schedulerClient.createProjectWithCompile,
+            ).not.toHaveBeenCalled();
+        });
+
+        test('rejects update-and-compile before resolving organization credentials', async () => {
+            await expect(
+                service.updateAndScheduleAsyncWork(
+                    projectUuid,
+                    developerAccount,
+                    updateProjectData,
+                    RequestMethod.WEB_APP,
+                ),
+            ).rejects.toThrowError(ForbiddenError);
+            expect(
+                organizationWarehouseCredentialsModel.getByUuidWithSensitiveData,
+            ).not.toHaveBeenCalled();
+            expect(jobModel.create).not.toHaveBeenCalled();
+            expect(projectModel.update).not.toHaveBeenCalled();
+        });
+
+        test('allows organization credentials for an organization developer', async () => {
+            await expect(
+                service.updateWarehouseCredentials(
+                    projectUuid,
+                    authorizedDeveloperAccount,
+                    { warehouseConnection },
+                ),
+            ).resolves.toBeUndefined();
+            expect(
+                organizationWarehouseCredentialsModel.getByUuidWithSensitiveData,
+            ).toHaveBeenCalledWith(organizationWarehouseCredentialsUuid);
+            expect(projectModel.update).toHaveBeenCalledOnce();
+        });
+
+        test('rejects organization credentials from another organization after lookup', async () => {
+            organizationWarehouseCredentialsModel.getByUuidWithSensitiveData.mockResolvedValueOnce(
+                {
+                    ...organizationWarehouseCredentials,
+                    organizationUuid: 'another-organization-uuid',
+                },
+            );
+
+            await expect(
+                service.updateWarehouseCredentials(
+                    projectUuid,
+                    authorizedDeveloperAccount,
+                    { warehouseConnection },
+                ),
+            ).rejects.toThrowError(ForbiddenError);
+            expect(
+                organizationWarehouseCredentialsModel.getByUuidWithSensitiveData,
+            ).toHaveBeenCalledWith(organizationWarehouseCredentialsUuid);
+            expect(projectModel.update).not.toHaveBeenCalled();
+        });
     });
 
     describe('ensurePlaygroundProject', () => {
@@ -490,6 +672,8 @@ describe('ProjectService', () => {
         ).mockResolvedValueOnce({
             ...projectWithSensitiveFields,
             warehouseConnection: warehouseClientMock.credentials,
+            organizationWarehouseCredentialsUuid:
+                'organization-warehouse-credentials-uuid',
         });
         const createWithoutCompileSpy = vi
             .spyOn(service, 'createWithoutCompile')
@@ -518,6 +702,9 @@ describe('ProjectService', () => {
 
         expect(projectModel.delete).toHaveBeenCalledWith(previewProjectUuid);
         expect(scheduleCompileProjectSpy).not.toHaveBeenCalled();
+        expect(createWithoutCompileSpy.mock.calls[0][1]).not.toHaveProperty(
+            'organizationWarehouseCredentialsUuid',
+        );
         createWithoutCompileSpy.mockRestore();
         scheduleCompileProjectSpy.mockRestore();
     });
@@ -530,6 +717,9 @@ describe('ProjectService', () => {
             organizationUuid: projectWithSensitiveFields.organizationUuid,
             organizationName: 'Test organization',
             organizationCreatedAt: new Date(),
+            ability: new Ability<PossibleAbilities>([
+                { subject: 'Project', action: 'create' },
+            ]),
         };
         const validateSpy = vi
             .spyOn(
@@ -552,6 +742,8 @@ describe('ProjectService', () => {
             .mockResolvedValueOnce({
                 ...projectWithSensitiveFields,
                 projectUuid: upstreamProjectUuid,
+                organizationWarehouseCredentialsUuid:
+                    'organization-warehouse-credentials-uuid',
             })
             .mockResolvedValueOnce({
                 ...projectWithSensitiveFields,
@@ -583,6 +775,18 @@ describe('ProjectService', () => {
                 accessCopyError: 'access copy failed',
                 contentCopyError: undefined,
             });
+            expect(
+                projectModel.createWithOptionalCredentials,
+            ).toHaveBeenCalledWith(
+                previewUser.userUuid,
+                previewUser.organizationUuid,
+                expect.objectContaining({
+                    organizationWarehouseCredentialsUuid:
+                        'organization-warehouse-credentials-uuid',
+                }),
+                null,
+                undefined,
+            );
         } finally {
             validateSpy.mockRestore();
             expirationSpy.mockRestore();

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1560,6 +1560,39 @@ export class ProjectService extends BaseService {
         return args;
     }
 
+    private assertCanUseOrganizationWarehouseCredentials(
+        accountOrUser: Account | SessionUser,
+        organizationUuid: string,
+        data: {
+            warehouseConnection?: CreateWarehouseCredentials;
+            organizationWarehouseCredentialsUuid?: string;
+        },
+    ): void {
+        const organizationWarehouseCredentialsUuid =
+            data.organizationWarehouseCredentialsUuid ||
+            (data.warehouseConnection?.type === WarehouseTypes.SNOWFLAKE
+                ? data.warehouseConnection.organizationWarehouseCredentialsUuid
+                : undefined);
+
+        if (!organizationWarehouseCredentialsUuid) {
+            return;
+        }
+
+        const auditedAbility = this.createAuditedAbility(accountOrUser);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('OrganizationWarehouseCredentials', {
+                    organizationUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'You do not have permission to use these organization warehouse credentials',
+            );
+        }
+    }
+
     // The project-update form sends masked oauthClientId / oauthClientSecret
     // (placeholder values), so merge them in from the saved project before
     // _resolveWarehouseClientCredentials runs the M2M token exchange. No-op for
@@ -2432,6 +2465,11 @@ export class ProjectService extends BaseService {
         );
 
         await this.validateProjectCreationPermissions(user, data);
+        this.assertCanUseOrganizationWarehouseCredentials(
+            user,
+            user.organizationUuid,
+            data,
+        );
 
         const newProjectData = data;
         ProjectService.validateDbtEnvironmentVariables(
@@ -2703,6 +2741,11 @@ export class ProjectService extends BaseService {
         );
 
         await this.validateProjectCreationPermissions(user, data);
+        this.assertCanUseOrganizationWarehouseCredentials(
+            user,
+            user.organizationUuid,
+            data,
+        );
         ProjectService.validateDbtEnvironmentVariables(data.dbtConnection);
 
         let encryptedData: string;
@@ -3249,6 +3292,11 @@ export class ProjectService extends BaseService {
         ) {
             throw new ForbiddenError();
         }
+        this.assertCanUseOrganizationWarehouseCredentials(
+            account,
+            savedProject.organizationUuid,
+            data,
+        );
 
         const job: CreateJob = {
             jobUuid: uuidv4(),
@@ -3398,6 +3446,11 @@ export class ProjectService extends BaseService {
         ) {
             throw new ForbiddenError();
         }
+        this.assertCanUseOrganizationWarehouseCredentials(
+            account,
+            savedProject.organizationUuid,
+            data,
+        );
 
         const updatedProjectData: UpdateProject = {
             name: savedProject.name,
@@ -8824,8 +8877,6 @@ export class ProjectService extends BaseService {
             ),
             upstreamProjectUuid: projectUuid,
             copyContent: data.copyContent,
-            organizationWarehouseCredentialsUuid:
-                project.organizationWarehouseCredentialsUuid,
             dbtVersion: project.dbtVersion,
         };
 


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8804/veria-79-privilege-escalation-via-unauthorized-cloning-of-snowflake

## What this fixes

Project create and update paths accepted an organization warehouse credential UUID after checking only project-level permissions. A project-only role could therefore resolve a shared credential it was not allowed to discover or select.

| Path | Before | After |
| --- | --- | --- |
| `createWithoutCompile` | Project create permission only | Also requires organization credential `view` for caller-supplied UUIDs |
| `scheduleCreate` | Project create permission only | Rejects before job creation or enqueue |
| `updateAndScheduleAsyncWork` | Project update permission only | Rejects before credential lookup, job creation, or persistence |
| `updateWarehouseCredentials` | Project update permission only | Rejects before sensitive credential lookup or persistence |

## How

`ProjectService.assertCanUseOrganizationWarehouseCredentials` extracts either supported UUID shape and runs an audited, organization-scoped `view:OrganizationWarehouseCredentials` check before any sensitive lookup.

```text
Caller-supplied UUID → project create/update check → org credential view check
                                                   ↓ allowed
                                      sensitive lookup → tenant check → persist

Trusted preview inheritance → derive UUID from authorized upstream project
                           → sensitive lookup → tenant check → persist
```

The resolver's existing same-organization check remains as defense in depth. `createPreview` lets `createWithoutCompile` derive the upstream UUID after the client-input guard, preserving trusted preview inheritance for project-only creators.

## Who's affected

| User class | Holds credential `view`? | Effect |
| --- | --- | --- |
| Organization admin/developer | Yes | No change; shared credential selection remains allowed |
| Organization editor | Yes, but cannot update project connections by default | No change |
| Organization viewer | No | No change; cannot reach project connection writes by default |
| Custom/project-only role with project create or update and credential `view` | Yes | No change |
| Custom/project-only role with project create or update but no credential `view` | No | Now receives 403 for caller-supplied organization credential UUIDs |
| Project-only preview creator inheriting from an upstream project | No | No change; server-derived inheritance remains allowed |

## Test plan

- [x] Full `ProjectService` unit file — 99 passed
- [x] Authorization scope and role parity — 24 passed, 1 intentional skip
- [x] Backend-wide unit suite — 5,555 passed, 1 intentional skip
- [x] `pnpm -F backend lint`
- [x] `pnpm -F backend format`
- [x] `pnpm backend-typecheck`
- [x] Denied every client-controlled create/update boundary before sensitive lookup or side effects
- [x] Allowed a real organization-developer ability
- [x] Rejected a cross-organization credential after lookup
- [x] Preserved project-only trusted preview inheritance