### PR TITLE
fix(scheduler): run send-now deliveries as the caller

### DIFF
--- a/packages/backend/src/scheduler/SchedulerClient.test.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.test.ts
@@ -9,12 +9,17 @@ import { FeatureFlagModel } from '../models/FeatureFlagModel/FeatureFlagModel';
 import { SchedulerModel } from '../models/SchedulerModel';
 import { getOrgDeliveryQueueName, SchedulerClient } from './SchedulerClient';
 
+const { graphileAddJob } = vi.hoisted(() => ({
+    graphileAddJob: vi.fn().mockResolvedValue({ id: 'job-1' }),
+}));
+
 // The constructor eagerly calls makeWorkerUtils() to connect to graphile-worker;
 // stub it so we can construct the client without a database.
 vi.mock('graphile-worker', () => ({
-    makeWorkerUtils: vi
-        .fn()
-        .mockResolvedValue({ addJob: vi.fn(), withPgClient: vi.fn() }),
+    makeWorkerUtils: vi.fn().mockResolvedValue({
+        addJob: graphileAddJob,
+        withPgClient: vi.fn(),
+    }),
 }));
 
 const ORG_UUID = 'org-1';
@@ -53,7 +58,35 @@ const traceProperties: TraceTaskBase = {
 const startingDateTime = new Date(2023, 0, 1);
 
 describe('SchedulerClient per-org delivery queue', () => {
-    afterEach(() => vi.restoreAllMocks());
+    afterEach(() => {
+        vi.clearAllMocks();
+        vi.restoreAllMocks();
+    });
+
+    it('preserves the send-now execution user in the persisted job payload', async () => {
+        const client = makeClient(false, vi.fn());
+
+        await client.addScheduledDeliveryJob(
+            new Date('2026-08-03T10:00:00Z'),
+            {
+                ...scheduler,
+                ...traceProperties,
+                userUuid: 'triggering-user',
+                executionUserUuid: 'triggering-user',
+            },
+            scheduler.schedulerUuid,
+        );
+
+        expect(graphileAddJob).toHaveBeenCalledWith(
+            'handleScheduledDelivery',
+            expect.objectContaining({
+                schedulerUuid: scheduler.schedulerUuid,
+                userUuid: 'triggering-user',
+                executionUserUuid: 'triggering-user',
+            }),
+            expect.any(Object),
+        );
+    });
 
     it('routes recurring deliveries into a per-org queue when multi-org + flag are on', async () => {
         const get = vi.fn().mockResolvedValue({

--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -458,6 +458,10 @@ export class SchedulerClient {
             ? {
                   schedulerUuid,
                   ...traceProperties,
+                  ...('executionUserUuid' in scheduler &&
+                      scheduler.executionUserUuid && {
+                          executionUserUuid: scheduler.executionUserUuid,
+                      }),
               }
             : scheduler;
 

--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -17,6 +17,7 @@ import {
     type DeliveryCaptureManifest,
     type NotificationPayloadBase,
     type ScheduledDeliveryPayload,
+    type SchedulerAndTargets,
     type UploadGsheetPayload,
 } from '@lightdash/common';
 import ExecutionContext from 'node-execution-context';
@@ -747,6 +748,157 @@ const makeTaskWithDeps = (overrides: Partial<TaskDeps> = {}) =>
 
 const asDep = <K extends keyof TaskDeps>(value: unknown): TaskDeps[K] =>
     value as TaskDeps[K];
+
+describe('handleScheduledDelivery execution identity', () => {
+    const persistedScheduler = {
+        schedulerUuid: 'scheduler-1',
+        slug: 'scheduler',
+        name: 'scheduler',
+        createdAt: new Date('2026-08-03T09:00:00Z'),
+        updatedAt: new Date('2026-08-03T09:00:00Z'),
+        createdBy: 'scheduler-owner',
+        createdByName: 'Scheduler Owner',
+        format: SchedulerFormat.CSV,
+        cron: '0 9 * * *',
+        savedChartUuid: 'chart-1',
+        savedChartName: 'Chart',
+        dashboardUuid: null,
+        dashboardName: null,
+        savedSqlUuid: null,
+        savedSqlName: null,
+        appUuid: null,
+        appName: null,
+        options: { formatted: true, limit: 'table' },
+        enabled: true,
+        includeLinks: true,
+        targets: [],
+    } as SchedulerAndTargets;
+
+    const setup = () => {
+        const getSessionByUserUuid = vi.fn(async (userUuid: string) => ({
+            userUuid,
+        }));
+        const getAccountByUserUuid = vi.fn(async (userUuid: string) => ({
+            userUuid,
+        }));
+        const setSchedulerEnabled = vi.fn().mockResolvedValue(undefined);
+        const task = makeTaskWithDeps({
+            schedulerService: asDep<'schedulerService'>({
+                schedulerModel: {
+                    getSchedulerAndTargets: vi
+                        .fn()
+                        .mockResolvedValue(persistedScheduler),
+                },
+                logSchedulerJob: vi.fn().mockResolvedValue(undefined),
+                setSchedulerEnabled,
+            }),
+            userService: asDep<'userService'>({
+                getSessionByUserUuid,
+                getAccountByUserUuid,
+            }),
+            analytics: asDep<'analytics'>({ track: vi.fn() }),
+        });
+
+        const run = (executionUserUuid?: string) =>
+            (
+                task as unknown as {
+                    handleScheduledDelivery(
+                        jobId: string,
+                        scheduledTime: Date,
+                        payload: ScheduledDeliveryPayload,
+                        isFinalAttempt: boolean,
+                    ): Promise<void>;
+                }
+            ).handleScheduledDelivery(
+                'job-1',
+                new Date('2026-08-03T10:00:00Z'),
+                {
+                    schedulerUuid: persistedScheduler.schedulerUuid,
+                    organizationUuid: 'org-1',
+                    projectUuid: 'project-1',
+                    userUuid: 'job-actor',
+                    executionUserUuid,
+                },
+                true,
+            );
+
+        return {
+            task,
+            run,
+            getSessionByUserUuid,
+            getAccountByUserUuid,
+            setSchedulerEnabled,
+        };
+    };
+
+    it('uses the authenticated triggerer for a persisted send-now run', async () => {
+        const {
+            run,
+            getSessionByUserUuid,
+            getAccountByUserUuid,
+            setSchedulerEnabled,
+        } = setup();
+
+        await run('triggering-user');
+
+        expect(getSessionByUserUuid).toHaveBeenNthCalledWith(
+            1,
+            'triggering-user',
+        );
+        expect(getAccountByUserUuid).toHaveBeenCalledWith('triggering-user');
+        expect(setSchedulerEnabled).toHaveBeenCalledWith(
+            { userUuid: 'scheduler-owner' },
+            persistedScheduler.schedulerUuid,
+            false,
+        );
+    });
+
+    it('uses the persisted owner for a recurring run', async () => {
+        const { run, getSessionByUserUuid, getAccountByUserUuid } = setup();
+
+        await run();
+
+        expect(getSessionByUserUuid).toHaveBeenCalledTimes(1);
+        expect(getSessionByUserUuid).toHaveBeenCalledWith('scheduler-owner');
+        expect(getAccountByUserUuid).toHaveBeenCalledWith('scheduler-owner');
+    });
+
+    it('ignores an execution-user override on an inline client payload', async () => {
+        const { task, getSessionByUserUuid, getAccountByUserUuid } = setup();
+
+        await (
+            task as unknown as {
+                handleScheduledDelivery(
+                    jobId: string,
+                    scheduledTime: Date,
+                    payload: ScheduledDeliveryPayload,
+                    isFinalAttempt: boolean,
+                ): Promise<void>;
+            }
+        ).handleScheduledDelivery(
+            'job-1',
+            new Date('2026-08-03T10:00:00Z'),
+            {
+                ...persistedScheduler,
+                schedulerUuid: undefined,
+                createdBy: 'authenticated-caller',
+                organizationUuid: 'org-1',
+                projectUuid: 'project-1',
+                userUuid: 'authenticated-caller',
+                executionUserUuid: 'forged-user',
+            } as unknown as ScheduledDeliveryPayload,
+            true,
+        );
+
+        expect(getSessionByUserUuid).toHaveBeenCalledTimes(1);
+        expect(getSessionByUserUuid).toHaveBeenCalledWith(
+            'authenticated-caller',
+        );
+        expect(getAccountByUserUuid).toHaveBeenCalledWith(
+            'authenticated-caller',
+        );
+    });
+});
 
 const APP_ROW = {
     project_uuid: 'project-1',

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -4359,13 +4359,27 @@ export default class SchedulerTask {
         isFinalAttempt: boolean,
     ) {
         const schedulerUuid = getSchedulerUuid(schedulerPayload);
+        const isInlineScheduler = isCreateScheduler(schedulerPayload);
 
-        const scheduler: SchedulerAndTargets | CreateSchedulerAndTargets =
-            isCreateScheduler(schedulerPayload)
-                ? schedulerPayload
-                : await this.schedulerService.schedulerModel.getSchedulerAndTargets(
-                      schedulerPayload.schedulerUuid,
-                  );
+        const persistedOrInlineScheduler:
+            | SchedulerAndTargets
+            | CreateSchedulerAndTargets = isInlineScheduler
+            ? schedulerPayload
+            : await this.schedulerService.schedulerModel.getSchedulerAndTargets(
+                  schedulerPayload.schedulerUuid,
+              );
+
+        const schedulerOwnerUuid = persistedOrInlineScheduler.createdBy;
+        const executionUserUuid = isInlineScheduler
+            ? undefined
+            : schedulerPayload.executionUserUuid;
+        const userUuid = executionUserUuid ?? schedulerOwnerUuid;
+        const scheduler = executionUserUuid
+            ? {
+                  ...persistedOrInlineScheduler,
+                  createdBy: userUuid,
+              }
+            : persistedOrInlineScheduler;
 
         if (!scheduler.enabled) {
             await this.schedulerService.logSchedulerJob({
@@ -4386,7 +4400,6 @@ export default class SchedulerTask {
         }
 
         const {
-            createdBy: userUuid,
             savedChartUuid,
             dashboardUuid,
             thresholds,
@@ -4409,8 +4422,14 @@ export default class SchedulerTask {
 
             // Disable scheduler if it has no targets
             if (schedulerUuid) {
+                const schedulerOwner =
+                    userUuid === schedulerOwnerUuid
+                        ? sessionUser
+                        : await this.userService.getSessionByUserUuid(
+                              schedulerOwnerUuid,
+                          );
                 await this.schedulerService.setSchedulerEnabled(
-                    sessionUser,
+                    schedulerOwner,
                     schedulerUuid,
                     false,
                 );
@@ -4902,9 +4921,10 @@ export default class SchedulerTask {
 
             // Send failure notification email to scheduler creator
             try {
-                const user = await this.userService.getSessionByUserUuid(
-                    scheduler.createdBy,
-                );
+                const user =
+                    await this.userService.getSessionByUserUuid(
+                        schedulerOwnerUuid,
+                    );
                 if (user.email) {
                     const schedulerUrl =
                         scheduler.savedChartUuid || scheduler.dashboardUuid
@@ -4956,7 +4976,7 @@ export default class SchedulerTask {
                             try {
                                 const owner =
                                     await this.userService.getSessionByUserUuid(
-                                        scheduler.createdBy,
+                                        schedulerOwnerUuid,
                                     );
                                 const ownerName =
                                     `${owner.firstName} ${owner.lastName}`.trim();
@@ -5063,9 +5083,10 @@ export default class SchedulerTask {
                 Logger.warn(
                     `Disabling scheduler with non-retryable error: ${e}`,
                 );
-                const user = await this.userService.getSessionByUserUuid(
-                    scheduler.createdBy,
-                );
+                const user =
+                    await this.userService.getSessionByUserUuid(
+                        schedulerOwnerUuid,
+                    );
                 await this.schedulerService.setSchedulerEnabled(
                     user,
                     schedulerUuid!,

--- a/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
@@ -182,6 +182,11 @@ describe('SchedulerService', () => {
     });
 
     describe('sendSchedulerByUuid', () => {
+        const userWhoCanSendPersistedScheduler = buildUser([
+            { subject: 'ScheduledDeliveries', action: ['create'] },
+            { subject: 'SavedChart', action: ['view'] },
+        ]);
+
         test('should throw ForbiddenError when user cannot view the underlying resource', async () => {
             await expect(
                 service.sendSchedulerByUuid(
@@ -193,6 +198,25 @@ describe('SchedulerService', () => {
             expect(
                 schedulerClient.addScheduledDeliveryJob,
             ).not.toHaveBeenCalled();
+        });
+
+        test('executes send-now deliveries as the authenticated user', async () => {
+            await service.sendSchedulerByUuid(
+                userWhoCanSendPersistedScheduler,
+                chartSchedulerInPrivateSpace.schedulerUuid,
+            );
+
+            expect(
+                schedulerClient.addScheduledDeliveryJob,
+            ).toHaveBeenCalledWith(
+                expect.any(Date),
+                expect.objectContaining({
+                    executionUserUuid:
+                        userWhoCanSendPersistedScheduler.userUuid,
+                    userUuid: userWhoCanSendPersistedScheduler.userUuid,
+                }),
+                chartSchedulerInPrivateSpace.schedulerUuid,
+            );
         });
     });
 

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -1683,6 +1683,7 @@ export class SchedulerService extends BaseService {
             new Date(),
             {
                 ...scheduler,
+                executionUserUuid: user.userUuid,
                 organizationUuid,
                 projectUuid,
                 userUuid: user.userUuid,

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -628,7 +628,12 @@ export type QueueTraceProperties = {
 
 // Scheduler task types
 export type ScheduledDeliveryPayload = TraceTaskBase &
-    (CreateSchedulerAndTargets | Pick<Scheduler, 'schedulerUuid'>);
+    (
+        | CreateSchedulerAndTargets
+        | (Pick<Scheduler, 'schedulerUuid'> & {
+              executionUserUuid?: string;
+          })
+    );
 
 export const isCreateScheduler = (
     data: ScheduledDeliveryPayload,


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8755/veria-51-privilege-escalation-via-scheduler-ownership-reassignment

## What this fixes

An authorized user can reassign a scheduled delivery to a more privileged member and then trigger send-now. The worker reloads the scheduler and previously executed as its new owner, which allowed the caller to borrow that member's row-level security and user-attribute context.

```text
Before: caller ──send now──> persisted scheduler ──execute as──> owner
After:  caller ──send now──> persisted scheduler ──execute as──> caller
        cron   ──scheduled─> persisted scheduler ──execute as──> owner
```

| Path | Before | After |
| --- | --- | --- |
| `SchedulerService.sendSchedulerByUuid()` | Authorized the caller but did not preserve an execution identity | Adds a server-owned caller identity to persisted send-now jobs |
| `SchedulerClient.addScheduledDeliveryJob()` | Reduced persisted jobs to scheduler UUID and trace fields | Preserves the explicit execution identity through queue serialization |
| `SchedulerTask.handleScheduledDelivery()` | Reloaded and executed every persisted job as the stored owner | Uses the caller for send-now and the stored owner for recurring jobs |

## How

Persisted send-now jobs carry an optional `executionUserUuid` that is set from the authenticated session. The scheduler client keeps it when constructing the compact Graphile payload, and the worker applies it to query, render, export, and AI execution without changing persistent ownership.

Recurring jobs omit the field and retain owner-based execution. Owner contacts and owner-authorized maintenance also retain the stored owner. Inline client-supplied sends ignore the field even if it appears in the untyped request body, so it cannot become a new identity-injection path.

## Who's affected

| User class | Affected? |
| --- | --- |
| Admin triggering send-now | No access lost; the run now uses the admin's own context |
| Editor/custom role with `create:ScheduledDeliveries` and resource view | **Yes** — can still trigger send-now, but only with their own permissions and user attributes |
| Viewer/custom role without delivery-create or resource-view access | No; existing authorization still rejects the request |
| Stored scheduler owner during recurring delivery | No; recurring runs continue to use the owner |
| New owner after reassignment | No consent or configuration change; their identity is no longer borrowed by another user's send-now request |

## Test plan

- [x] Reproduced the pre-fix queue identity mismatch with a failing service regression test.
- [x] Verified service construction, Graphile payload serialization, worker execution identity, recurring owner fallback, owner-only maintenance, and rejection of a forged inline override — 92/92 affected tests pass.
- [x] `pnpm -F common typecheck` and `pnpm -F backend typecheck` pass.
- [x] Targeted common/backend lint and format checks pass for all changed files.
- [x] Full backend unit suite passes: 376 files, 5,554 tests passed and 1 skipped.