### PR TITLE
fix(backend): prevent credential reuse after endpoint changes

### DIFF
--- a/packages/backend/src/dbt/DbtMetadataApiClient.ts
+++ b/packages/backend/src/dbt/DbtMetadataApiClient.ts
@@ -10,6 +10,7 @@ import {
 } from '@lightdash/common';
 import { gql, GraphQLClient } from 'graphql-request';
 import { DbtClient } from '../types';
+import { DEFAULT_DBT_CLOUD_DISCOVERY_ENDPOINT } from '../utils/credentialDestination';
 
 const quoteChars: Record<SupportedDbtAdapter, string> = {
     bigquery: '`',
@@ -150,8 +151,7 @@ const dbtCloudEnvironmentQuery = gql`
 `;
 
 export class DbtMetadataApiClient implements DbtClient {
-    private readonly domain: string =
-        'https://metadata.cloud.getdbt.com/graphql';
+    private readonly domain: string = DEFAULT_DBT_CLOUD_DISCOVERY_ENDPOINT;
 
     private readonly bearerToken: string;
 

--- a/packages/backend/src/ee/models/ExternalConnectionModel.test.ts
+++ b/packages/backend/src/ee/models/ExternalConnectionModel.test.ts
@@ -407,6 +407,36 @@ describe('ExternalConnectionModel', () => {
             );
             expect(wroteEncrypted).toBe(true);
         });
+
+        it('deletes the stored secret when the origin changes without a replacement', async () => {
+            tracker.on
+                .select(ExternalConnectionsTableName)
+                .response([makeDbConnection()]);
+            tracker.on.update(ExternalConnectionsTableName).response(1);
+            tracker.on.delete(ExternalConnectionSecretsTableName).response(1);
+
+            await model.update(CONNECTION_UUID, USER_UUID, {
+                origin: 'https://attacker.example.com',
+            });
+
+            expect(tracker.history.delete).toHaveLength(1);
+            expect(tracker.history.delete[0].sql).toContain(
+                ExternalConnectionSecretsTableName,
+            );
+        });
+
+        it('keeps the stored secret for a normalized-equivalent origin', async () => {
+            tracker.on
+                .select(ExternalConnectionsTableName)
+                .response([makeDbConnection()]);
+            tracker.on.update(ExternalConnectionsTableName).response(1);
+
+            await model.update(CONNECTION_UUID, USER_UUID, {
+                origin: 'https://API.ACME.COM./',
+            });
+
+            expect(tracker.history.delete).toHaveLength(0);
+        });
     });
 
     describe('rotateSecret', () => {

--- a/packages/backend/src/ee/models/ExternalConnectionModel.ts
+++ b/packages/backend/src/ee/models/ExternalConnectionModel.ts
@@ -11,6 +11,7 @@ import {
 } from '@lightdash/common';
 import { type Knex } from 'knex';
 import { AppsTableName } from '../../database/entities/apps';
+import { normalizeCredentialUrlOrigin } from '../../utils/credentialDestination';
 import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
 import {
     AppExternalConnectionsTableName,
@@ -532,17 +533,19 @@ export class ExternalConnectionModel {
                 .update(updatePayload);
 
             // Secret tri-state: `null` clears it, a non-empty string sets it,
-            // and undefined/blank leaves it unchanged. Switching to type
-            // 'none', or changing the auth type without supplying a new secret,
-            // also clears any stored secret so an old credential can never be
-            // reused by (or leaked through) the new auth method.
+            // and undefined/blank leaves it unchanged unless the credential's
+            // auth type or origin changes.
             const resultingType = data.type ?? existing.type;
             const typeChanged =
                 data.type !== undefined && data.type !== existing.type;
+            const originChanged =
+                data.origin !== undefined &&
+                normalizeCredentialUrlOrigin(data.origin) !==
+                    normalizeCredentialUrlOrigin(existing.origin);
             if (
                 resultingType === 'none' ||
                 data.secret === null ||
-                (typeChanged && !data.secret)
+                ((typeChanged || originChanged) && !data.secret)
             ) {
                 await ExternalConnectionModel.deleteSecret(trx, uuid);
             } else if (data.secret) {

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
@@ -352,6 +352,29 @@ describe('ExternalConnectionService.update type switches', () => {
             }),
         );
     });
+
+    it('rejects changing the origin without a new secret', async () => {
+        const { service, model } = buildService({});
+        mockAbility(service, true);
+
+        await expect(
+            service.update(adminAccount, projectUuid, connectionUuid, {
+                origin: 'https://attacker.example.com',
+            }),
+        ).rejects.toThrow(ParameterError);
+        expect(model.update).not.toHaveBeenCalled();
+    });
+
+    it('keeps the stored secret for a normalized-equivalent origin', async () => {
+        const { service, model } = buildService({});
+        mockAbility(service, true);
+
+        await service.update(adminAccount, projectUuid, connectionUuid, {
+            origin: 'https://API.EXAMPLE.COM./',
+        });
+
+        expect(model.update).toHaveBeenCalled();
+    });
 });
 
 // -------------------------------------------------------------------

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
@@ -25,6 +25,7 @@ import { LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
 import { type AppModel } from '../../../models/AppModel';
 import { BaseService } from '../../../services/BaseService';
 import type { SpacePermissionService } from '../../../services/SpaceService/SpacePermissionService';
+import { normalizeCredentialUrlOrigin } from '../../../utils/credentialDestination';
 import {
     secureFetch,
     SecureFetchError,
@@ -300,19 +301,21 @@ export class ExternalConnectionService extends BaseService {
         const resultingType = data.type ?? existing.type;
         const typeChanged =
             data.type !== undefined && data.type !== existing.type;
+        const originChanged =
+            data.origin !== undefined &&
+            normalizeCredentialUrlOrigin(data.origin) !==
+                normalizeCredentialUrlOrigin(existing.origin);
 
-        // A blank secret keeps the stored one ONLY when the type is unchanged.
-        // On a type change the stored secret belongs to the old auth method, so
-        // it is dropped and the caller must supply a new one (validation then
-        // requires it). This prevents e.g. a stored service-account keyfile from
-        // being reused — and leaked — as a bearer token when switching types.
+        // A stored secret is valid only for its current auth type and origin.
+        // Changing either requires the caller to supply a new one.
         let hasSecretAfter: boolean;
         if (data.secret === null) {
             hasSecretAfter = false;
         } else if (data.secret) {
             hasSecretAfter = true;
         } else {
-            hasSecretAfter = !typeChanged && existing.hasSecret;
+            hasSecretAfter =
+                !typeChanged && !originChanged && existing.hasSecret;
         }
 
         // Resolve a field that belongs only to the resulting auth type: use the

--- a/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
@@ -6,7 +6,11 @@ import {
     CreateAthenaCredentials,
     CreateDatabricksCredentials,
     CreatePostgresCredentials,
+    CreateSnowflakeCredentials,
     DatabricksAuthenticationType,
+    DbtCloudIDEProjectConfig,
+    DbtGithubProjectConfig,
+    DbtProjectType,
     DimensionType,
     ExploreType,
     FieldType,
@@ -319,6 +323,50 @@ describe('ProjectModel', () => {
             expect(result.password).toEqual('new_password');
         });
 
+        test('should NOT merge Postgres secrets when the host changes', () => {
+            const incompleteConfig = {
+                ...CompletePostgresCredentials,
+                host: 'attacker.example.com',
+                user: undefined,
+                password: undefined,
+            } as unknown as CreatePostgresCredentials;
+
+            const result = ProjectModel.mergeMissingWarehouseSecrets(
+                incompleteConfig,
+                CompletePostgresCredentials,
+            );
+
+            expect(result.user).toBeUndefined();
+            expect(result.password).toBeUndefined();
+        });
+
+        test('should NOT merge Snowflake secrets when the access URL changes', () => {
+            const completeConfig: CreateSnowflakeCredentials = {
+                type: WarehouseTypes.SNOWFLAKE,
+                account: 'account',
+                user: 'saved-user',
+                password: 'saved-password',
+                database: 'database',
+                warehouse: 'warehouse',
+                schema: 'schema',
+                accessUrl: 'https://account.snowflakecomputing.com',
+            };
+            const incompleteConfig = {
+                ...completeConfig,
+                user: undefined,
+                password: undefined,
+                accessUrl: 'https://attacker.example.com',
+            } as unknown as CreateSnowflakeCredentials;
+
+            const result = ProjectModel.mergeMissingWarehouseSecrets(
+                incompleteConfig,
+                completeConfig,
+            );
+
+            expect(result.user).toBeUndefined();
+            expect(result.password).toBeUndefined();
+        });
+
         test('should NOT merge Athena access keys when authenticationType is iam_role', async () => {
             const incompleteAthenaCredentials: CreateAthenaCredentials = {
                 type: WarehouseTypes.ATHENA,
@@ -400,6 +448,88 @@ describe('ProjectModel', () => {
 
             expect(result.oauthClientId).toEqual('client-id');
             expect(result.oauthClientSecret).toEqual('client-secret');
+        });
+    });
+
+    describe('mergeMissingDbtConfigSecrets', () => {
+        test('should NOT merge the dbt Cloud API key when the discovery endpoint changes', () => {
+            const completeConfig: DbtCloudIDEProjectConfig = {
+                type: DbtProjectType.DBT_CLOUD_IDE,
+                api_key: 'saved-api-key',
+                environment_id: 'environment-id',
+                discovery_api_endpoint: 'https://metadata.cloud.getdbt.com',
+            };
+            const incompleteConfig = {
+                ...completeConfig,
+                api_key: undefined,
+                discovery_api_endpoint: 'https://attacker.example.com',
+            } as unknown as DbtCloudIDEProjectConfig;
+
+            const result = ProjectModel.mergeMissingDbtConfigSecrets(
+                incompleteConfig,
+                completeConfig,
+            );
+
+            if (result.type !== DbtProjectType.DBT_CLOUD_IDE) {
+                throw new Error('Expected a dbt Cloud IDE config');
+            }
+            expect(result.api_key).toBeUndefined();
+        });
+
+        test('should NOT merge a GitHub token when the host domain changes', () => {
+            const completeConfig: DbtGithubProjectConfig = {
+                type: DbtProjectType.GITHUB,
+                authorization_method: 'personal_access_token',
+                personal_access_token: 'saved-token',
+                installation_id: undefined,
+                repository: 'lightdash/lightdash',
+                branch: 'main',
+                project_sub_path: '/',
+                host_domain: 'github.com',
+            };
+            const incompleteConfig = {
+                ...completeConfig,
+                personal_access_token: undefined,
+                host_domain: 'attacker.example.com',
+            };
+
+            const result = ProjectModel.mergeMissingDbtConfigSecrets(
+                incompleteConfig,
+                completeConfig,
+            );
+
+            if (result.type !== DbtProjectType.GITHUB) {
+                throw new Error('Expected a GitHub config');
+            }
+            expect(result.personal_access_token).toBeUndefined();
+        });
+
+        test('should merge a GitHub token for a normalized-equivalent host domain', () => {
+            const completeConfig: DbtGithubProjectConfig = {
+                type: DbtProjectType.GITHUB,
+                authorization_method: 'personal_access_token',
+                personal_access_token: 'saved-token',
+                installation_id: undefined,
+                repository: 'lightdash/lightdash',
+                branch: 'main',
+                project_sub_path: '/',
+                host_domain: 'github.com',
+            };
+            const incompleteConfig = {
+                ...completeConfig,
+                personal_access_token: undefined,
+                host_domain: 'GITHUB.COM.',
+            };
+
+            const result = ProjectModel.mergeMissingDbtConfigSecrets(
+                incompleteConfig,
+                completeConfig,
+            );
+
+            if (result.type !== DbtProjectType.GITHUB) {
+                throw new Error('Expected a GitHub config');
+            }
+            expect(result.personal_access_token).toEqual('saved-token');
         });
     });
 

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -65,7 +65,6 @@ import NodeCache from 'node-cache';
 import { DatabaseError } from 'pg';
 import { v4 as uuidv4 } from 'uuid';
 import { LightdashConfig } from '../../config/parseConfig';
-import { normalizeDatabricksHostLenient } from '../../controllers/authentication/strategies/databricksStrategy';
 import {
     DashboardsTableName,
     DashboardTabsTableName,
@@ -126,6 +125,10 @@ import {
 import { ServiceAccountsTableName } from '../../ee/database/entities/serviceAccounts';
 import Logger from '../../logging/logger';
 import { wrapSentryTransaction, wrapSentryTransactionSync } from '../../utils';
+import {
+    hasSameDbtCredentialDestination,
+    hasSameWarehouseCredentialDestination,
+} from '../../utils/credentialDestination';
 import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
 import {
     acquireProjectSlugLock,
@@ -206,7 +209,9 @@ export class ProjectModel {
         incompleteConfig: DbtProjectConfig,
         completeConfig: DbtProjectConfig,
     ): DbtProjectConfig {
-        if (incompleteConfig.type !== completeConfig.type) {
+        if (
+            !hasSameDbtCredentialDestination(incompleteConfig, completeConfig)
+        ) {
             return incompleteConfig;
         }
         return {
@@ -231,7 +236,10 @@ export class ProjectModel {
         T extends CreateWarehouseCredentials = CreateWarehouseCredentials,
     >(incompleteConfig: T, completeConfig: CreateWarehouseCredentials): T {
         if (
-            incompleteConfig.type !== completeConfig.type ||
+            !hasSameWarehouseCredentialDestination(
+                incompleteConfig,
+                completeConfig,
+            ) ||
             // BigQuery ADC authentication does not require credentials to be set
             (incompleteConfig.type === WarehouseTypes.BIGQUERY &&
                 incompleteConfig.authenticationType ===
@@ -240,16 +248,6 @@ export class ProjectModel {
             (incompleteConfig.type === WarehouseTypes.ATHENA &&
                 incompleteConfig.authenticationType ===
                     AthenaAuthenticationType.IAM_ROLE)
-        ) {
-            return incompleteConfig;
-        }
-        // Databricks secrets are only valid for the host they were entered
-        // for, so a host change requires re-entering them instead of merging
-        if (
-            incompleteConfig.type === WarehouseTypes.DATABRICKS &&
-            completeConfig.type === WarehouseTypes.DATABRICKS &&
-            normalizeDatabricksHostLenient(incompleteConfig.serverHostName) !==
-                normalizeDatabricksHostLenient(completeConfig.serverHostName)
         ) {
             return incompleteConfig;
         }

--- a/packages/backend/src/projectAdapters/dbtBitBucketProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtBitBucketProjectAdapter.ts
@@ -6,9 +6,8 @@ import {
 import { WarehouseClient } from '@lightdash/warehouses';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import { CachedWarehouse } from '../types';
+import { DEFAULT_BITBUCKET_HOST_DOMAIN } from '../utils/credentialDestination';
 import { DbtGitProjectAdapter } from './dbtGitProjectAdapter';
-
-const DEFAULT_HOST_DOMAIN = 'bitbucket.org';
 
 type Args = {
     warehouseClient: WarehouseClient;
@@ -45,7 +44,7 @@ export class DbtBitBucketProjectAdapter extends DbtGitProjectAdapter {
         selector,
     }: Args) {
         const remoteRepositoryUrl = `https://${username}:${personalAccessToken}@${
-            hostDomain || DEFAULT_HOST_DOMAIN
+            hostDomain || DEFAULT_BITBUCKET_HOST_DOMAIN
         }/${repository}.git`;
         super({
             analytics,

--- a/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGithubProjectAdapter.ts
@@ -7,9 +7,8 @@ import {
 import { WarehouseClient } from '@lightdash/warehouses';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import { CachedWarehouse } from '../types';
+import { DEFAULT_GITHUB_HOST_DOMAIN } from '../utils/credentialDestination';
 import { DbtGitProjectAdapter } from './dbtGitProjectAdapter';
-
-const DEFAULT_GITHUB_HOST_DOMAIN = 'github.com';
 
 type DbtGithubProjectAdapterArgs = {
     warehouseClient: WarehouseClient;

--- a/packages/backend/src/projectAdapters/dbtGitlabProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtGitlabProjectAdapter.ts
@@ -6,9 +6,8 @@ import {
 import { WarehouseClient } from '@lightdash/warehouses';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import { CachedWarehouse } from '../types';
+import { DEFAULT_GITLAB_HOST_DOMAIN } from '../utils/credentialDestination';
 import { DbtGitProjectAdapter } from './dbtGitProjectAdapter';
-
-const DEFAULT_GITLAB_HOST_DOMAIN = 'gitlab.com';
 
 type DbtGitlabProjectAdapterArgs = {
     warehouseClient: WarehouseClient;

--- a/packages/backend/src/utils/credentialDestination.test.ts
+++ b/packages/backend/src/utils/credentialDestination.test.ts
@@ -1,0 +1,552 @@
+import {
+    DbtProjectType,
+    DuckdbConnectionType,
+    DucklakeCatalogType,
+    DucklakeDataPathType,
+    WarehouseTypes,
+    type CreateWarehouseCredentials,
+    type DbtProjectConfig,
+} from '@lightdash/common';
+import {
+    hasSameDbtCredentialDestination,
+    hasSameWarehouseCredentialDestination,
+    normalizeCredentialUrlOrigin,
+} from './credentialDestination';
+
+const postgres: CreateWarehouseCredentials = {
+    type: WarehouseTypes.POSTGRES,
+    host: 'db.example.com',
+    port: 5432,
+    user: 'user',
+    password: 'password',
+    dbname: 'database',
+    schema: 'public',
+};
+
+const redshift: CreateWarehouseCredentials = {
+    type: WarehouseTypes.REDSHIFT,
+    host: 'cluster.example.com',
+    port: 5439,
+    user: 'user',
+    password: 'password',
+    dbname: 'database',
+    schema: 'public',
+};
+
+const bigquery: CreateWarehouseCredentials = {
+    type: WarehouseTypes.BIGQUERY,
+    project: 'project',
+    dataset: 'dataset',
+    keyfileContents: { private_key: 'secret' },
+    timeoutSeconds: 30,
+    priority: 'interactive',
+    retries: 3,
+    location: 'US',
+    maximumBytesBilled: undefined,
+    accessUrl: 'https://bigquery.example.com/api',
+};
+
+const snowflake: CreateWarehouseCredentials = {
+    type: WarehouseTypes.SNOWFLAKE,
+    account: 'account',
+    user: 'user',
+    password: 'password',
+    database: 'database',
+    warehouse: 'warehouse',
+    schema: 'schema',
+    accessUrl: 'https://snowflake.example.com/api',
+};
+
+const databricks: CreateWarehouseCredentials = {
+    type: WarehouseTypes.DATABRICKS,
+    database: 'database',
+    serverHostName: 'workspace.example.com',
+    httpPath: '/sql/warehouse',
+    personalAccessToken: 'token',
+};
+
+const trino: CreateWarehouseCredentials = {
+    type: WarehouseTypes.TRINO,
+    host: 'trino.example.com',
+    port: 8443,
+    user: 'user',
+    password: 'password',
+    dbname: 'database',
+    schema: 'schema',
+    http_scheme: 'https',
+};
+
+const clickhouse: CreateWarehouseCredentials = {
+    type: WarehouseTypes.CLICKHOUSE,
+    host: 'clickhouse.example.com',
+    port: 8443,
+    user: 'user',
+    password: 'password',
+    schema: 'schema',
+    secure: true,
+};
+
+const athena: CreateWarehouseCredentials = {
+    type: WarehouseTypes.ATHENA,
+    region: 'eu-west-1',
+    database: 'database',
+    schema: 'schema',
+    s3StagingDir: 's3://results',
+    accessKeyId: 'key',
+    secretAccessKey: 'secret',
+};
+
+const motherduck: CreateWarehouseCredentials = {
+    type: WarehouseTypes.DUCKDB,
+    connectionType: DuckdbConnectionType.MOTHERDUCK,
+    database: 'database',
+    schema: 'schema',
+    token: 'token',
+};
+
+const ducklake: CreateWarehouseCredentials = {
+    type: WarehouseTypes.DUCKDB,
+    connectionType: DuckdbConnectionType.DUCKLAKE,
+    catalog: {
+        type: DucklakeCatalogType.POSTGRES,
+        host: 'catalog.example.com',
+        port: 5432,
+        database: 'catalog',
+        user: 'user',
+        password: 'password',
+    },
+    dataPath: {
+        type: DucklakeDataPathType.S3,
+        url: 's3://bucket/Private',
+        endpoint: 'https://storage.example.com/api',
+        region: 'eu-west-1',
+        accessKeyId: 'key',
+        secretAccessKey: 'secret',
+        forcePathStyle: false,
+        useSsl: true,
+    },
+    schema: 'schema',
+};
+
+const warehouseDestinationChanges: Array<{
+    name: string;
+    before: CreateWarehouseCredentials;
+    after: CreateWarehouseCredentials;
+}> = [
+    {
+        name: 'BigQuery access URL path',
+        before: bigquery,
+        after: { ...bigquery, accessUrl: 'https://bigquery.example.com/other' },
+    },
+    {
+        name: 'Postgres host',
+        before: postgres,
+        after: { ...postgres, host: 'attacker.example.com' },
+    },
+    {
+        name: 'Postgres port',
+        before: postgres,
+        after: { ...postgres, port: 6432 },
+    },
+    {
+        name: 'Redshift host',
+        before: redshift,
+        after: { ...redshift, host: 'attacker.example.com' },
+    },
+    {
+        name: 'SSH tunnel activation',
+        before: {
+            ...postgres,
+            useSshTunnel: false,
+            sshTunnelHost: 'tunnel.example.com',
+            sshTunnelPrivateKey: 'key',
+        },
+        after: {
+            ...postgres,
+            useSshTunnel: true,
+            sshTunnelHost: 'tunnel.example.com',
+            sshTunnelPrivateKey: undefined,
+        },
+    },
+    {
+        name: 'Snowflake account',
+        before: snowflake,
+        after: { ...snowflake, account: 'other-account' },
+    },
+    {
+        name: 'Snowflake access URL path',
+        before: snowflake,
+        after: {
+            ...snowflake,
+            accessUrl: 'https://snowflake.example.com/other',
+        },
+    },
+    {
+        name: 'Databricks host',
+        before: databricks,
+        after: { ...databricks, serverHostName: 'attacker.example.com' },
+    },
+    {
+        name: 'Trino scheme',
+        before: trino,
+        after: { ...trino, http_scheme: 'http' },
+    },
+    {
+        name: 'ClickHouse transport security',
+        before: clickhouse,
+        after: { ...clickhouse, secure: false },
+    },
+    {
+        name: 'Athena region',
+        before: athena,
+        after: { ...athena, region: 'us-east-1' },
+    },
+    {
+        name: 'DuckDB connection type',
+        before: motherduck,
+        after: ducklake,
+    },
+    {
+        name: 'DuckLake catalog host',
+        before: ducklake,
+        after: {
+            ...ducklake,
+            catalog: { ...ducklake.catalog, host: 'attacker.example.com' },
+        } as CreateWarehouseCredentials,
+    },
+    {
+        name: 'DuckLake S3 path case',
+        before: ducklake,
+        after: {
+            ...ducklake,
+            dataPath: { ...ducklake.dataPath, url: 's3://bucket/private' },
+        } as CreateWarehouseCredentials,
+    },
+    {
+        name: 'DuckLake S3 endpoint path',
+        before: ducklake,
+        after: {
+            ...ducklake,
+            dataPath: {
+                ...ducklake.dataPath,
+                endpoint: 'https://storage.example.com/other',
+            },
+        } as CreateWarehouseCredentials,
+    },
+    {
+        name: 'DuckLake S3 URL style',
+        before: ducklake,
+        after: {
+            ...ducklake,
+            dataPath: { ...ducklake.dataPath, forcePathStyle: true },
+        } as CreateWarehouseCredentials,
+    },
+    {
+        name: 'DuckLake S3 transport security',
+        before: ducklake,
+        after: {
+            ...ducklake,
+            dataPath: { ...ducklake.dataPath, useSsl: false },
+        } as CreateWarehouseCredentials,
+    },
+    {
+        name: 'DuckLake GCS path case',
+        before: {
+            ...ducklake,
+            dataPath: {
+                type: DucklakeDataPathType.GCS,
+                url: 'gs://bucket/Private',
+                hmacKeyId: 'key',
+                hmacSecret: 'secret',
+            },
+        } as CreateWarehouseCredentials,
+        after: {
+            ...ducklake,
+            dataPath: {
+                type: DucklakeDataPathType.GCS,
+                url: 'gs://bucket/private',
+            },
+        } as CreateWarehouseCredentials,
+    },
+    {
+        name: 'DuckLake Azure path case',
+        before: {
+            ...ducklake,
+            dataPath: {
+                type: DucklakeDataPathType.AZURE,
+                url: 'az://container/Private',
+                accountName: 'account',
+                accountKey: 'secret',
+            },
+        } as CreateWarehouseCredentials,
+        after: {
+            ...ducklake,
+            dataPath: {
+                type: DucklakeDataPathType.AZURE,
+                url: 'az://container/private',
+                accountName: 'account',
+            },
+        } as CreateWarehouseCredentials,
+    },
+];
+
+const dbtCloud: DbtProjectConfig = {
+    type: DbtProjectType.DBT_CLOUD_IDE,
+    environment_id: 'environment',
+    api_key: 'key',
+    discovery_api_endpoint: 'https://metadata.cloud.getdbt.com/graphql',
+};
+
+const github: DbtProjectConfig = {
+    type: DbtProjectType.GITHUB,
+    authorization_method: 'personal_access_token',
+    personal_access_token: 'token',
+    repository: 'lightdash/lightdash',
+    branch: 'main',
+    project_sub_path: '/',
+    host_domain: 'github.com',
+};
+
+const gitlab: DbtProjectConfig = {
+    type: DbtProjectType.GITLAB,
+    personal_access_token: 'token',
+    repository: 'lightdash/lightdash',
+    branch: 'main',
+    project_sub_path: '/',
+    host_domain: 'gitlab.com',
+};
+
+const bitbucket: DbtProjectConfig = {
+    type: DbtProjectType.BITBUCKET,
+    username: 'user',
+    personal_access_token: 'token',
+    repository: 'lightdash/lightdash',
+    branch: 'main',
+    project_sub_path: '/',
+    host_domain: 'bitbucket.org',
+};
+
+describe('credential destinations', () => {
+    test.each(warehouseDestinationChanges)(
+        'detects a changed $name',
+        ({ before, after }) => {
+            expect(hasSameWarehouseCredentialDestination(after, before)).toBe(
+                false,
+            );
+        },
+    );
+
+    test('ignores dormant SSH field edits while the tunnel is disabled', () => {
+        expect(
+            hasSameWarehouseCredentialDestination(
+                {
+                    ...postgres,
+                    useSshTunnel: false,
+                    sshTunnelHost: 'new-tunnel.example.com',
+                },
+                {
+                    ...postgres,
+                    useSshTunnel: false,
+                    sshTunnelHost: 'old-tunnel.example.com',
+                    sshTunnelPrivateKey: 'key',
+                },
+            ),
+        ).toBe(true);
+    });
+
+    test('treats the implicit and explicit SSH port 22 as equivalent', () => {
+        expect(
+            hasSameWarehouseCredentialDestination(
+                {
+                    ...postgres,
+                    useSshTunnel: true,
+                    sshTunnelHost: 'tunnel.example.com',
+                    sshTunnelPort: 22,
+                },
+                {
+                    ...postgres,
+                    useSshTunnel: true,
+                    sshTunnelHost: 'tunnel.example.com',
+                    sshTunnelPort: undefined,
+                },
+            ),
+        ).toBe(true);
+    });
+
+    test('normalizes URL hostname case and a trailing DNS dot without dropping the path', () => {
+        expect(
+            hasSameWarehouseCredentialDestination(
+                {
+                    ...bigquery,
+                    accessUrl: 'https://BIGQUERY.EXAMPLE.COM./api',
+                },
+                bigquery,
+            ),
+        ).toBe(true);
+        expect(normalizeCredentialUrlOrigin('https://API.EXAMPLE.COM./')).toBe(
+            'https://api.example.com',
+        );
+    });
+
+    test('ignores DuckDB destinations that do not receive stored credentials', () => {
+        expect(
+            hasSameWarehouseCredentialDestination(
+                { ...motherduck, database: 'other-database' },
+                motherduck,
+            ),
+        ).toBe(true);
+        expect(
+            hasSameWarehouseCredentialDestination(
+                {
+                    type: WarehouseTypes.DUCKDB,
+                    connectionType: DuckdbConnectionType.EMBEDDED,
+                    dataset: 'other.csv',
+                },
+                {
+                    type: WarehouseTypes.DUCKDB,
+                    connectionType: DuckdbConnectionType.EMBEDDED,
+                    dataset: 'data.csv',
+                },
+            ),
+        ).toBe(true);
+        expect(
+            hasSameWarehouseCredentialDestination(
+                {
+                    ...ducklake,
+                    catalog: {
+                        type: DucklakeCatalogType.SQLITE,
+                        path: 'other.sqlite',
+                    },
+                } as CreateWarehouseCredentials,
+                {
+                    ...ducklake,
+                    catalog: {
+                        type: DucklakeCatalogType.SQLITE,
+                        path: 'catalog.sqlite',
+                    },
+                } as CreateWarehouseCredentials,
+            ),
+        ).toBe(true);
+        expect(
+            hasSameWarehouseCredentialDestination(
+                {
+                    ...ducklake,
+                    catalog: {
+                        type: DucklakeCatalogType.DUCKDB,
+                        path: 'other.duckdb',
+                    },
+                } as CreateWarehouseCredentials,
+                {
+                    ...ducklake,
+                    catalog: {
+                        type: DucklakeCatalogType.DUCKDB,
+                        path: 'catalog.duckdb',
+                    },
+                } as CreateWarehouseCredentials,
+            ),
+        ).toBe(true);
+        expect(
+            hasSameWarehouseCredentialDestination(
+                {
+                    ...ducklake,
+                    dataPath: {
+                        type: DucklakeDataPathType.LOCAL,
+                        path: '/other',
+                    },
+                } as CreateWarehouseCredentials,
+                {
+                    ...ducklake,
+                    dataPath: {
+                        type: DucklakeDataPathType.LOCAL,
+                        path: '/data',
+                    },
+                } as CreateWarehouseCredentials,
+            ),
+        ).toBe(true);
+    });
+
+    test.each([
+        {
+            name: 'dbt Cloud origin',
+            before: dbtCloud,
+            after: {
+                ...dbtCloud,
+                discovery_api_endpoint: 'https://attacker.example.com/graphql',
+            } as DbtProjectConfig,
+        },
+        {
+            name: 'GitHub host',
+            before: github,
+            after: {
+                ...github,
+                host_domain: 'attacker.example.com',
+            } as DbtProjectConfig,
+        },
+        {
+            name: 'GitLab host',
+            before: gitlab,
+            after: {
+                ...gitlab,
+                host_domain: 'attacker.example.com',
+            } as DbtProjectConfig,
+        },
+        {
+            name: 'Bitbucket host',
+            before: bitbucket,
+            after: {
+                ...bitbucket,
+                host_domain: 'attacker.example.com',
+            } as DbtProjectConfig,
+        },
+    ])('detects a changed $name', ({ before, after }) => {
+        expect(hasSameDbtCredentialDestination(after, before)).toBe(false);
+    });
+
+    test('uses effective dbt defaults and normalized hosts', () => {
+        expect(
+            hasSameDbtCredentialDestination(
+                {
+                    ...github,
+                    host_domain: 'GITHUB.COM.',
+                } as DbtProjectConfig,
+                { ...github, host_domain: undefined } as DbtProjectConfig,
+            ),
+        ).toBe(true);
+        expect(
+            hasSameDbtCredentialDestination(
+                {
+                    ...dbtCloud,
+                    discovery_api_endpoint:
+                        'https://METADATA.CLOUD.GETDBT.COM./ignored',
+                } as DbtProjectConfig,
+                { ...dbtCloud, discovery_api_endpoint: undefined },
+            ),
+        ).toBe(true);
+    });
+
+    test.each<DbtProjectConfig>([
+        {
+            type: DbtProjectType.DBT,
+            project_dir: '/dbt',
+        },
+        {
+            type: DbtProjectType.AZURE_DEVOPS,
+            personal_access_token: 'token',
+            organization: 'organization',
+            project: 'project',
+            repository: 'repository',
+            branch: 'main',
+            project_sub_path: '/',
+        },
+        {
+            type: DbtProjectType.NONE,
+        },
+        {
+            type: DbtProjectType.MANIFEST,
+            manifest: '{}',
+            hideRefreshButton: false,
+        },
+    ])('keeps secrets for non-retargetable dbt type $type', (config) => {
+        expect(hasSameDbtCredentialDestination(config, config)).toBe(true);
+    });
+});

--- a/packages/backend/src/utils/credentialDestination.ts
+++ b/packages/backend/src/utils/credentialDestination.ts
@@ -1,0 +1,223 @@
+import {
+    assertUnreachable,
+    DbtProjectType,
+    DuckdbConnectionType,
+    DucklakeCatalogType,
+    DucklakeDataPathType,
+    WarehouseTypes,
+    type CreateWarehouseCredentials,
+    type DbtProjectConfig,
+} from '@lightdash/common';
+import isEqual from 'lodash/isEqual';
+import { normalizeDatabricksHostLenient } from '../controllers/authentication/strategies/databricksStrategy';
+
+export const DEFAULT_DBT_CLOUD_DISCOVERY_ENDPOINT =
+    'https://metadata.cloud.getdbt.com/graphql';
+export const DEFAULT_GITHUB_HOST_DOMAIN = 'github.com';
+export const DEFAULT_GITLAB_HOST_DOMAIN = 'gitlab.com';
+export const DEFAULT_BITBUCKET_HOST_DOMAIN = 'bitbucket.org';
+
+export const normalizeCredentialHost = (host: string | undefined): string =>
+    host?.trim().toLowerCase().replace(/\.$/, '') ?? '';
+
+const normalizeUrl = (value: string): URL | undefined => {
+    try {
+        const url = new URL(value);
+        url.hostname = normalizeCredentialHost(url.hostname);
+        return url;
+    } catch {
+        return undefined;
+    }
+};
+
+export const normalizeCredentialUrlOrigin = (value: string): string =>
+    normalizeUrl(value)?.origin.toLowerCase() ?? value.trim().toLowerCase();
+
+const normalizeCredentialBaseUrl = (value: string | undefined): string => {
+    if (!value?.trim()) {
+        return '';
+    }
+    return normalizeUrl(value)?.href ?? value.trim();
+};
+
+const normalizeStorageUri = (value: string): string =>
+    normalizeUrl(value)?.href ?? value.trim();
+
+const getDbtCredentialDestination = (config: DbtProjectConfig): unknown[] => {
+    switch (config.type) {
+        case DbtProjectType.DBT_CLOUD_IDE:
+            return [
+                normalizeCredentialUrlOrigin(
+                    config.discovery_api_endpoint ||
+                        DEFAULT_DBT_CLOUD_DISCOVERY_ENDPOINT,
+                ),
+            ];
+        case DbtProjectType.GITHUB:
+            return [
+                normalizeCredentialHost(
+                    config.host_domain || DEFAULT_GITHUB_HOST_DOMAIN,
+                ),
+            ];
+        case DbtProjectType.GITLAB:
+            return [
+                normalizeCredentialHost(
+                    config.host_domain || DEFAULT_GITLAB_HOST_DOMAIN,
+                ),
+            ];
+        case DbtProjectType.BITBUCKET:
+            return [
+                normalizeCredentialHost(
+                    config.host_domain || DEFAULT_BITBUCKET_HOST_DOMAIN,
+                ),
+            ];
+        case DbtProjectType.AZURE_DEVOPS:
+        case DbtProjectType.DBT:
+        case DbtProjectType.NONE:
+        case DbtProjectType.MANIFEST:
+            return [];
+        default:
+            return assertUnreachable(config, 'Unknown dbt project type');
+    }
+};
+
+export const hasSameDbtCredentialDestination = (
+    incompleteConfig: DbtProjectConfig,
+    completeConfig: DbtProjectConfig,
+): boolean =>
+    incompleteConfig.type === completeConfig.type &&
+    isEqual(
+        getDbtCredentialDestination(incompleteConfig),
+        getDbtCredentialDestination(completeConfig),
+    );
+
+const getSshTunnelDestination = (credentials: {
+    useSshTunnel?: boolean;
+    sshTunnelHost?: string;
+    sshTunnelPort?: number;
+}): unknown[] =>
+    credentials.useSshTunnel
+        ? [
+              true,
+              normalizeCredentialHost(credentials.sshTunnelHost),
+              credentials.sshTunnelPort ?? 22,
+          ]
+        : [false];
+
+const getDucklakeCatalogDestination = (
+    credentials: Extract<
+        CreateWarehouseCredentials,
+        { type: WarehouseTypes.DUCKDB }
+    > & { connectionType: DuckdbConnectionType.DUCKLAKE },
+): unknown[] => {
+    switch (credentials.catalog.type) {
+        case DucklakeCatalogType.POSTGRES:
+            return [
+                credentials.catalog.type,
+                normalizeCredentialHost(credentials.catalog.host),
+                credentials.catalog.port,
+            ];
+        case DucklakeCatalogType.SQLITE:
+        case DucklakeCatalogType.DUCKDB:
+            return [credentials.catalog.type];
+        default:
+            return assertUnreachable(
+                credentials.catalog,
+                'Unknown DuckLake catalog type',
+            );
+    }
+};
+
+const getDucklakeDataPathDestination = (
+    credentials: Extract<
+        CreateWarehouseCredentials,
+        { type: WarehouseTypes.DUCKDB }
+    > & { connectionType: DuckdbConnectionType.DUCKLAKE },
+): unknown[] => {
+    switch (credentials.dataPath.type) {
+        case DucklakeDataPathType.S3:
+            return [
+                credentials.dataPath.type,
+                normalizeStorageUri(credentials.dataPath.url),
+                normalizeCredentialBaseUrl(credentials.dataPath.endpoint),
+                normalizeCredentialHost(credentials.dataPath.region),
+                credentials.dataPath.forcePathStyle,
+                credentials.dataPath.useSsl,
+            ];
+        case DucklakeDataPathType.GCS:
+            return [
+                credentials.dataPath.type,
+                normalizeStorageUri(credentials.dataPath.url),
+            ];
+        case DucklakeDataPathType.AZURE:
+            return [
+                credentials.dataPath.type,
+                normalizeStorageUri(credentials.dataPath.url),
+                normalizeCredentialHost(credentials.dataPath.accountName),
+            ];
+        case DucklakeDataPathType.LOCAL:
+            return [credentials.dataPath.type];
+        default:
+            return assertUnreachable(
+                credentials.dataPath,
+                'Unknown DuckLake data path type',
+            );
+    }
+};
+
+const getWarehouseCredentialDestination = (
+    config: CreateWarehouseCredentials,
+): unknown[] => {
+    switch (config.type) {
+        case WarehouseTypes.BIGQUERY:
+            return [normalizeCredentialBaseUrl(config.accessUrl)];
+        case WarehouseTypes.POSTGRES:
+        case WarehouseTypes.REDSHIFT:
+            return [
+                normalizeCredentialHost(config.host),
+                config.port,
+                ...getSshTunnelDestination(config),
+            ];
+        case WarehouseTypes.SNOWFLAKE:
+            return [
+                normalizeCredentialHost(config.account),
+                normalizeCredentialBaseUrl(config.accessUrl),
+            ];
+        case WarehouseTypes.DATABRICKS:
+            return [normalizeDatabricksHostLenient(config.serverHostName)];
+        case WarehouseTypes.TRINO:
+            return [
+                normalizeCredentialHost(config.host),
+                config.port,
+                config.http_scheme.toLowerCase(),
+            ];
+        case WarehouseTypes.CLICKHOUSE:
+            return [
+                normalizeCredentialHost(config.host),
+                config.port,
+                config.secure ?? false,
+            ];
+        case WarehouseTypes.ATHENA:
+            return [normalizeCredentialHost(config.region)];
+        case WarehouseTypes.DUCKDB:
+            if (config.connectionType === DuckdbConnectionType.DUCKLAKE) {
+                return [
+                    config.connectionType,
+                    getDucklakeCatalogDestination(config),
+                    getDucklakeDataPathDestination(config),
+                ];
+            }
+            return [config.connectionType];
+        default:
+            return assertUnreachable(config, 'Unknown warehouse type');
+    }
+};
+
+export const hasSameWarehouseCredentialDestination = (
+    incompleteConfig: CreateWarehouseCredentials,
+    completeConfig: CreateWarehouseCredentials,
+): boolean =>
+    incompleteConfig.type === completeConfig.type &&
+    isEqual(
+        getWarehouseCredentialDestination(incompleteConfig),
+        getWarehouseCredentialDestination(completeConfig),
+    );


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8757/veria-52-credential-exfiltration-via-connection-endpoint-retargeting

## Summary

Prevents stored connection credentials from following an edited external, dbt, or warehouse destination when the write-only secret is omitted. Non-routing edits and normalized-equivalent destinations keep the existing masked-secret editing behavior.

## Root cause

Connection edit payloads omit masked secrets, so the backend restores missing credential fields from encrypted storage. The merge checked only the broad connection or authentication type and did not bind reuse to the destination that receives the credential.

```ts
isSecretMissingInNewConfig && isSecretPresentInSavedConfig
    ? savedSecret
    : newSecret;
```

This let a same-type edit change fields such as `origin`, `host`, `accessUrl`, `host_domain`, or `discovery_api_endpoint`, then send the preserved credential to the new route during a later connection request.

## Fix

Derives an exhaustive normalized credential-destination identity for every dbt and warehouse variant, and restores omitted secrets only while that identity is unchanged. External connections require a replacement secret before an authenticated origin change, with model-level deletion as defense in depth.

- `credentialDestination.ts` centralizes routing fields, URL/storage normalization, SSH/DuckLake effective settings, and provider defaults.
- Project secret merging uses the shared identity before restoring masked fields.
- External service/model updates reject or clear credentials when the origin changes.
- Table-driven regressions cover every dbt/warehouse branch plus full URL paths, case-sensitive storage paths, SSH defaults, and normalized equivalents.

## Before

```text
stored secret + changed destination + omitted secret
                         │
                         └── preserve secret ──> request to new destination
```

## After

```text
stored secret + changed destination + omitted secret
                         │
                         └── destination mismatch ──> require new credential

stored secret + unchanged/equivalent destination + omitted secret
                         │
                         └── destination match ─────> preserve edit UX
```

## Test plan

- [x] `pnpm -F backend typecheck`
- [x] `pnpm -F backend lint`
- [x] `pnpm -F backend format` — 1,919 files checked
- [x] Five affected Vitest files — 149 passed, 1 pre-existing skipped
- [x] Focused destination-policy suite — 32 passed
- [x] `git diff --check`
- [x] No-network shared-default smoke — GitHub, GitLab, Bitbucket, and dbt metadata defaults
