### PR TITLE
fix(mcp): enforce OAuth scopes at the MCP endpoint

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.authorization.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.authorization.test.ts
@@ -1,0 +1,58 @@
+import type { Account } from '@lightdash/common';
+import { McpService } from './McpService';
+
+const createService = () =>
+    Object.assign(Object.create(McpService.prototype), {
+        lightdashConfig: { mcp: { enabled: true } },
+    }) as McpService;
+
+const createAccount = ({
+    isOauthUser,
+    scopes = [],
+}: {
+    isOauthUser: boolean;
+    scopes?: string[];
+}) =>
+    ({
+        authentication: {
+            type: isOauthUser ? 'oauth' : 'pat',
+            scopes,
+        },
+        isOauthUser: () => isOauthUser,
+    }) as unknown as Account;
+
+describe('McpService MCP scope authorization', () => {
+    it.each([
+        { scopes: [] },
+        { scopes: ['read'] },
+        { scopes: ['write'] },
+        { scopes: ['read', 'write'] },
+    ])('rejects OAuth clients without an MCP scope: %j', ({ scopes }) => {
+        const service = createService();
+
+        expect(() =>
+            service.canAccessMcp(createAccount({ isOauthUser: true, scopes })),
+        ).toThrow('You are not allowed to access MCP');
+    });
+
+    it.each([['mcp:read'], ['mcp:write']])(
+        'allows OAuth clients with the %s scope',
+        (scope) => {
+            const service = createService();
+
+            expect(
+                service.canAccessMcp(
+                    createAccount({ isOauthUser: true, scopes: [scope] }),
+                ),
+            ).toBe(true);
+        },
+    );
+
+    it('does not require OAuth scopes for other account types', () => {
+        const service = createService();
+
+        expect(
+            service.canAccessMcp(createAccount({ isOauthUser: false })),
+        ).toBe(true);
+    });
+});

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -57,7 +57,6 @@ import {
     McpGetTaskResult,
     mcpListProjectsToolDefinition,
     MetricQuery,
-    MissingConfigError,
     NotFoundError,
     OauthAccount,
     ParameterError,
@@ -122,6 +121,7 @@ import { CatalogService } from '../../../services/CatalogService/CatalogService'
 import { ContentVerificationService } from '../../../services/ContentVerificationService';
 import { CsvService } from '../../../services/CsvService/CsvService';
 import { FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
+import { OAuthScope } from '../../../services/OAuthService/OAuthService';
 import { ProjectService } from '../../../services/ProjectService/ProjectService';
 import { ShareService } from '../../../services/ShareService/ShareService';
 import { SpaceService } from '../../../services/SpaceService/SpaceService';
@@ -3742,29 +3742,15 @@ export class McpService extends BaseService {
         return { user, account, organizationUuid: user.organizationUuid };
     }
 
-    public canAccessMcp(context: McpProtocolContext): boolean {
-        if (!context.authInfo) {
-            throw new ForbiddenError('Invalid authInfo context');
-        }
-
-        const user = context.authInfo.extra?.user;
-        const account = context.authInfo.extra?.account;
-
-        // TODO replace with CASL ability check
-        // Do not enforce client scopes for now until more MCP clients support this
-        /*
-        //const { scopes } = account.authentication;
-
-        if (
-            !scopes.includes(OAuthScope.MCP_READ) &&
-            !scopes.includes(OAuthScope.MCP_WRITE)
-        ) {
-            throw new ForbiddenError('You are not allowed to access MCP');
-        }
-        */
-
-        if (!this.lightdashConfig.mcp.enabled) {
-            throw new MissingConfigError('MCP is not enabled');
+    public canAccessMcp(account: Account): boolean {
+        if (account.authentication.type === 'oauth') {
+            const { scopes } = account.authentication;
+            if (
+                !scopes.includes(OAuthScope.MCP_READ) &&
+                !scopes.includes(OAuthScope.MCP_WRITE)
+            ) {
+                throw new ForbiddenError('You are not allowed to access MCP');
+            }
         }
 
         return true;
@@ -3884,7 +3870,8 @@ export class McpService extends BaseService {
     }
 
     public getLightdashVersion(context: McpProtocolContext): string {
-        this.canAccessMcp(context);
+        const { account } = McpService.getAccount(context);
+        this.canAccessMcp(account);
         return VERSION;
     }
 

--- a/packages/backend/src/routers/mcpRouter.authorization.test.ts
+++ b/packages/backend/src/routers/mcpRouter.authorization.test.ts
@@ -1,0 +1,161 @@
+import type { Account } from '@lightdash/common';
+import type { NextFunction, Request, Response } from 'express';
+import express from 'express';
+import { request as httpRequest, type Server } from 'http';
+import type { AddressInfo } from 'net';
+import { McpService } from '../ee/services/McpService/McpService';
+import mcpRouter from './mcpRouter';
+
+vi.mock('../controllers/authentication', () => ({
+    allowApiKeyAuthentication: (
+        _request: Request,
+        _response: Response,
+        next: NextFunction,
+    ) => next(),
+}));
+
+vi.mock('../logging/logger', () => ({
+    default: {
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+    },
+}));
+
+type TestAuthentication =
+    | { type: 'oauth'; scopes: string[] }
+    | { type: 'pat' }
+    | { type: 'service-account' };
+
+const createAccount = (authentication: TestAuthentication) =>
+    ({
+        authentication,
+        isAuthenticated: () => true,
+    }) as unknown as Account;
+
+const createMcpService = () =>
+    Object.assign(Object.create(McpService.prototype), {
+        isEnabled: vi.fn().mockResolvedValue(true),
+    }) as McpService;
+
+const servers: Server[] = [];
+
+const sendHttpRequest = ({
+    method,
+    port,
+}: {
+    method: 'DELETE' | 'GET' | 'POST';
+    port: number;
+}) =>
+    new Promise<{ body: string; status: number }>((resolve, reject) => {
+        const request = httpRequest(
+            {
+                headers: { authorization: 'Bearer test-token' },
+                hostname: '127.0.0.1',
+                method,
+                path: '/api/v1/mcp',
+                port,
+            },
+            (response) => {
+                const chunks: Buffer[] = [];
+                response.on('data', (chunk: Buffer) => chunks.push(chunk));
+                response.on('end', () =>
+                    resolve({
+                        body: Buffer.concat(chunks).toString('utf8'),
+                        status: response.statusCode ?? 0,
+                    }),
+                );
+            },
+        );
+        request.on('error', reject);
+        request.end();
+    });
+
+const requestMcp = async ({
+    account,
+    method,
+}: {
+    account: Account;
+    method: 'DELETE' | 'GET' | 'POST';
+}) => {
+    const app = express();
+    const mcpService = createMcpService();
+    app.use((request, _response, next) => {
+        request.account = account;
+        request.user = {
+            email: 'test@lightdash.com',
+            userUuid: 'user-uuid',
+            organizationUuid: 'organization-uuid',
+        } as Express.User;
+        request.services = {
+            getMcpService: () => mcpService,
+        } as Express.Request['services'];
+        next();
+    });
+    app.use('/api/v1/mcp', mcpRouter);
+
+    const server = app.listen(0);
+    servers.push(server);
+    const address = server.address() as AddressInfo;
+    const response = await sendHttpRequest({ method, port: address.port });
+
+    return { response, mcpService };
+};
+
+afterEach(async () => {
+    await Promise.all(
+        servers.splice(0).map(
+            (server) =>
+                new Promise<void>((resolve, reject) => {
+                    server.close((error) => {
+                        if (error) {
+                            reject(error);
+                            return;
+                        }
+                        resolve();
+                    });
+                }),
+        ),
+    );
+});
+
+describe('MCP router OAuth scope authorization', () => {
+    it.each(['GET', 'POST'] as const)(
+        'rejects %s requests without an MCP scope',
+        async (method) => {
+            const { response, mcpService } = await requestMcp({
+                account: createAccount({ type: 'oauth', scopes: ['read'] }),
+                method,
+            });
+
+            expect(response).toEqual({
+                body: '{"error":"You are not allowed to access MCP"}',
+                status: 403,
+            });
+            expect(mcpService.isEnabled).not.toHaveBeenCalled();
+        },
+    );
+
+    const authorizedCases: Array<{ authentication: TestAuthentication }> = [
+        { authentication: { type: 'oauth', scopes: ['mcp:read'] } },
+        { authentication: { type: 'oauth', scopes: ['mcp:write'] } },
+        { authentication: { type: 'pat' } },
+        { authentication: { type: 'service-account' } },
+    ];
+
+    it.each(authorizedCases)(
+        'continues for authorized authentication: $authentication.type',
+        async ({ authentication }) => {
+            const { response, mcpService } = await requestMcp({
+                account: createAccount(authentication),
+                method: 'DELETE',
+            });
+
+            expect(response).toEqual({
+                body: '{"error":"Method not allowed"}',
+                status: 405,
+            });
+            expect(mcpService.isEnabled).toHaveBeenCalledOnce();
+        },
+    );
+});

--- a/packages/backend/src/routers/mcpRouter.ts
+++ b/packages/backend/src/routers/mcpRouter.ts
@@ -210,6 +210,11 @@ mcpRouter.all(
             );
 
             const mcpService = getMcpService(req);
+            const { account } = req;
+            if (!account) {
+                throw new ForbiddenError('MCP request is missing an account');
+            }
+            mcpService.canAccessMcp(account);
 
             // Check if MCP is enabled (either via config or AI Copilot flag)
             const isEnabled = await mcpService.isEnabled(req.user!);


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8812/veria-78-authorization-bypass-in-mcp-endpoints-via-unenforced-oauth

## Summary

OAuth tokens without an MCP scope could access `/api/v1/mcp`. This PR requires `mcp:read` or `mcp:write` at the route boundary, before transport or tool work. PATs and service accounts are unchanged; per-tool CASL/project checks remain in place.

## Why it was disabled

[PR #16088](https://github.com/lightdash/lightdash/pull/16088) added the scope guard and CASL TODO on August 1, 2025. [PR #16161](https://github.com/lightdash/lightdash/pull/16161) commented it out a week later because Claude Code omitted scopes. Javier Rengel Jiménez authored both changes. That temporary compatibility workaround remained as MCP access expanded.

## MCP client compatibility

| Client | Published scope support | Result |
| --- | --- | --- |
| [ChatGPT](https://developers.openai.com/plugins/build/auth#oauth-flow) | Scope-based OAuth consent | Compatible; reconnect stale grants |
| [Claude Code](https://code.claude.com/docs/en/mcp#restrict-oauth-scopes) | Discovers or pins OAuth scopes | Compatible on current versions |
| [Codex](https://learn.chatgpt.com/docs/extend/mcp) | Prefers server `scopes_supported` | Compatible |
| [Cursor](https://cursor.com/changelog/page/10) | Documents MCP OAuth scopes/state | Expected compatible; upgrade older clients |

This reflects current published behavior, not end-to-end smoke tests in every harness. Existing tokens issued without an MCP scope must re-authenticate. Clients that still omit scopes now fail closed with 403.

## Test plan

- [x] Focused Vitest: 2 files, 13 tests
- [x] Backend typecheck, lint, and format
- [x] OAuth scope matrix: empty/`read`/`write` rejected; `mcp:read`/`mcp:write` accepted
- [x] PAT and service-account access unchanged
- [x] Temporary OAuth test tokens removed
