### PR TITLE
fix: decide the onboarding redirect only on confirmed organization state

### DIFF
--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -388,7 +388,9 @@ export class UserModel {
                 'organizations.organization_uuid',
                 'organizations.created_at',
                 'organizations.organization_name',
-            );
+            )
+            .orderBy('organizations.created_at', 'asc')
+            .orderBy('organizations.organization_id', 'asc');
 
         return organizations.map((organization) => ({
             organizationUuid: organization.organization_uuid,
@@ -1276,6 +1278,8 @@ export class UserModel {
     async findSessionUserByUUID(userUuid: string): Promise<SessionUser> {
         const [user] = await userDetailsQueryBuilder(this.database)
             .where('user_uuid', userUuid)
+            .orderBy('organizations.created_at', 'asc')
+            .orderBy('organizations.organization_id', 'asc')
             .select('*', 'organizations.created_at as organization_created_at');
         if (user === undefined) {
             throw new NotFoundError(`Cannot find user with uuid ${userUuid}`);
@@ -1350,6 +1354,8 @@ export class UserModel {
         const [user] = await userDetailsQueryBuilder(this.database)
             .where('email', email)
             .andWhere(`${UserTableName}.is_internal`, false)
+            .orderBy('organizations.created_at', 'asc')
+            .orderBy('organizations.organization_id', 'asc')
             .select('*', 'organizations.created_at as organization_created_at');
         return user
             ? mapDbUserDetailsToLightdashUser(

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -69,7 +69,9 @@ const userModel = {
     hasPasswordByEmail: vi.fn<UserModel['hasPasswordByEmail']>(
         async () => false,
     ),
-    findSessionUserByOpenId: vi.fn(async () => undefined),
+    findSessionUserByOpenId: vi.fn<UserModel['findSessionUserByOpenId']>(
+        async () => undefined,
+    ),
     findSessionUserByUUID: vi.fn<UserModel['findSessionUserByUUID']>(
         async () => sessionUser,
     ),
@@ -85,7 +87,12 @@ const userModel = {
     activateUser: vi.fn(async () => sessionUser),
     activateUserWithoutPassword: vi.fn(async () => sessionUser),
     addProjectMemberships: vi.fn(async () => undefined),
-    getOrganizationsForUser: vi.fn(async () => [sessionUser]),
+    getOrganizationsForUser: vi.fn<UserModel['getOrganizationsForUser']>(
+        async () => [sessionUser],
+    ),
+    getUserByPrimaryEmailAndPassword: vi.fn<
+        UserModel['getUserByPrimaryEmailAndPassword']
+    >(async () => userWithoutOrg),
     findUserByEmail: vi.fn<UserModel['findUserByEmail']>(async () => undefined),
     createPendingUser: vi.fn<UserModel['createPendingUser']>(
         async () => newUser,
@@ -281,6 +288,108 @@ describe('UserService', () => {
 
     afterEach(() => {
         vi.clearAllMocks();
+    });
+
+    describe('organization selection during login', () => {
+        const selectedOrganization = {
+            organizationUuid: 'selected-organization-uuid',
+            organizationName: 'Selected organization',
+            organizationCreatedAt: new Date('2025-01-01T00:00:00.000Z'),
+        };
+        const otherOrganization = {
+            organizationUuid: 'other-organization-uuid',
+            organizationName: 'Other organization',
+            organizationCreatedAt: new Date('2025-01-02T00:00:00.000Z'),
+        };
+        const organizationlessSessionUser: SessionUser = { ...sessionUser };
+        delete organizationlessSessionUser.organizationUuid;
+        delete organizationlessSessionUser.organizationName;
+        delete organizationlessSessionUser.organizationCreatedAt;
+        delete organizationlessSessionUser.role;
+
+        test('allows password login for a user without an organization', async () => {
+            userModel.getOrganizationsForUser.mockResolvedValueOnce([]);
+
+            const result = await userService.loginWithPassword(
+                'user@example.com',
+                'password',
+            );
+
+            expect(result).not.toHaveProperty('organizationUuid');
+        });
+
+        test('rejects password login for a user in multiple organizations', async () => {
+            userModel.getOrganizationsForUser.mockResolvedValueOnce([
+                selectedOrganization,
+                otherOrganization,
+            ]);
+
+            await expect(
+                userService.loginWithPassword('user@example.com', 'password'),
+            ).rejects.toThrow(
+                new ForbiddenError('User is part of multiple organizations'),
+            );
+        });
+
+        test('returns the resolved organization for a single-organization password login', async () => {
+            userModel.getOrganizationsForUser.mockResolvedValueOnce([
+                selectedOrganization,
+            ]);
+
+            await expect(
+                userService.loginWithPassword('user@example.com', 'password'),
+            ).resolves.toEqual({
+                ...userWithoutOrg,
+                ...selectedOrganization,
+            });
+        });
+
+        test('allows OpenID login for a user without an organization', async () => {
+            userModel.findSessionUserByOpenId.mockResolvedValueOnce(
+                organizationlessSessionUser,
+            );
+            userModel.getOrganizationsForUser.mockResolvedValueOnce([]);
+
+            const result = await userService.loginWithOpenId(
+                openIdUser,
+                undefined,
+                undefined,
+            );
+
+            expect(result).not.toHaveProperty('organizationUuid');
+        });
+
+        test('rejects OpenID login for a user in multiple organizations', async () => {
+            userModel.findSessionUserByOpenId.mockResolvedValueOnce(
+                organizationlessSessionUser,
+            );
+            userModel.getOrganizationsForUser.mockResolvedValueOnce([
+                selectedOrganization,
+                otherOrganization,
+            ]);
+
+            await expect(
+                userService.loginWithOpenId(openIdUser, undefined, undefined),
+            ).rejects.toThrow(
+                new ForbiddenError('User is part of multiple organizations'),
+            );
+        });
+
+        test('returns the resolved organization for a single-organization OpenID login', async () => {
+            userModel.findSessionUserByOpenId.mockResolvedValueOnce(
+                organizationlessSessionUser,
+            );
+            userModel.getOrganizationsForUser.mockResolvedValueOnce([
+                selectedOrganization,
+            ]);
+
+            await expect(
+                userService.loginWithOpenId(openIdUser, undefined, undefined),
+            ).resolves.toEqual({
+                ...organizationlessSessionUser,
+                ...selectedOrganization,
+            });
+        });
     });
 
     describe('OAuth grants', () => {
@@ -1170,7 +1279,7 @@ describe('UserService', () => {
 
                 await expect(
                     service.loginWithEmailOtp('EMAIL', '123456'),
-                ).resolves.toBe(sessionUser);
+                ).resolves.toEqual(sessionUser);
 
                 expect(
                     emailModel.getPrimaryEmailStatusByUserAndOtp,
@@ -1234,6 +1343,48 @@ describe('UserService', () => {
                         onboardingFlow: 'new',
                     },
                 });
+            });
+
+            test('rejects OTP login for a user in multiple organizations', async () => {
+                const service = createUserService(lightdashConfigMock, {
+                    featureFlagModel: createFeatureFlagModel(true),
+                });
+                const emailStatus = activeOtp();
+                userModel.findUserByEmail.mockResolvedValueOnce(sessionUser);
+                userModel.hasPassword.mockResolvedValueOnce(false);
+                userModel.hasOpenIdIdentity.mockResolvedValueOnce(false);
+                emailModel.getPrimaryEmailStatus.mockResolvedValueOnce(
+                    emailStatus,
+                );
+                emailModel.getPrimaryEmailStatusByUserAndOtp.mockResolvedValueOnce(
+                    emailStatus,
+                );
+                userModel.getOrganizationsForUser.mockResolvedValueOnce([
+                    {
+                        organizationUuid: 'first-organization-uuid',
+                        organizationName: 'First organization',
+                        organizationCreatedAt: new Date(
+                            '2025-01-01T00:00:00.000Z',
+                        ),
+                    },
+                    {
+                        organizationUuid: 'second-organization-uuid',
+                        organizationName: 'Second organization',
+                        organizationCreatedAt: new Date(
+                            '2025-01-02T00:00:00.000Z',
+                        ),
+                    },
+                ]);
+
+                await expect(
+                    service.loginWithEmailOtp('EMAIL', '123456'),
+                ).rejects.toThrow(
+                    new ForbiddenError(
+                        'User is part of multiple organizations',
+                    ),
+                );
+
+                expect(emailModel.deleteEmailOtp).not.toHaveBeenCalled();
             });
 
             test('rejects a sixth attempt without comparing the code', async () => {
@@ -1338,7 +1489,7 @@ describe('UserService', () => {
 
                 await expect(
                     service.loginWithEmailOtp('EMAIL', '123456'),
-                ).resolves.toBe(sessionUser);
+                ).resolves.toEqual(sessionUser);
             });
         });
 

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -1096,7 +1096,7 @@ export class UserService extends BaseService {
                 throw new DeactivatedAccountError();
             }
 
-            const organization = this.loginToOrganization(
+            const organization = await this.loginToOrganization(
                 openIdSession?.userUuid,
                 openIdUser.openId.issuerType,
             );
@@ -1634,7 +1634,7 @@ export class UserService extends BaseService {
             if (!user.isActive) {
                 throw new DeactivatedAccountError();
             }
-            const userOrganization = this.loginToOrganization(
+            const userOrganization = await this.loginToOrganization(
                 user.userUuid,
                 LocalIssuerTypes.EMAIL,
             );
@@ -1659,7 +1659,7 @@ export class UserService extends BaseService {
                 metadata: { loginProvider: 'password' },
                 context,
             });
-            return user;
+            return userWithOrganization;
         } catch (e) {
             if (e instanceof NotFoundError) {
                 emitFailure('Email and password not recognized');
@@ -2106,7 +2106,7 @@ export class UserService extends BaseService {
                 'You do not have permission to login with personal access tokens',
             );
         }
-        const organization = this.loginToOrganization(
+        const organization = await this.loginToOrganization(
             user.userUuid,
             LocalIssuerTypes.API_TOKEN,
         );
@@ -2392,6 +2392,11 @@ export class UserService extends BaseService {
             }
             throw error;
         }
+        const organization = await this.loginToOrganization(
+            sessionUser.userUuid,
+            LocalIssuerTypes.EMAIL_OTP,
+        );
+        sessionUser = { ...sessionUser, ...organization };
         await this.tryVerifyUserEmail(sessionUser, emailStatus.email, 'otp');
         await this.emailModel.deleteEmailOtp(
             sessionUser.userUuid,
@@ -2695,16 +2700,15 @@ export class UserService extends BaseService {
         userUuid: string,
         loginMethod: LoginOptionTypes,
     ): Promise<
-        Pick<
-            LightdashUser,
-            'organizationUuid' | 'organizationCreatedAt' | 'organizationName'
-        >
+        | Pick<
+              LightdashUser,
+              'organizationUuid' | 'organizationCreatedAt' | 'organizationName'
+          >
+        | undefined
     > {
         const organizations =
             await this.userModel.getOrganizationsForUser(userUuid);
-        if (organizations.length === 0) {
-            throw new NotFoundError('User not part of any organization');
-        } else if (organizations.length > 1) {
+        if (organizations.length > 1) {
             throw new ForbiddenError('User is part of multiple organizations');
         }
         // TODO check valid login methods allowed in org

--- a/packages/frontend/src/components/AppRoute.organizationFreshness.test.tsx
+++ b/packages/frontend/src/components/AppRoute.organizationFreshness.test.tsx
@@ -1,0 +1,211 @@
+import { Ability } from '@casl/ability';
+import { CommercialFeatureFlags, FeatureFlags } from '@lightdash/common';
+import { MantineProvider } from '@mantine/core';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type FC, type PropsWithChildren } from 'react';
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+vi.mock('../api', () => ({
+    lightdashApi: vi.fn(),
+}));
+
+vi.mock('../providers/App/useApp', () => ({
+    default: () => ({
+        health: { isInitialLoading: false, error: null, data: {} },
+        user: {
+            isInitialLoading: false,
+            data: {
+                organizationUuid: 'org-1',
+                ability: new Ability([
+                    {
+                        action: 'create',
+                        subject: 'Project',
+                        conditions: { organizationUuid: 'org-1' },
+                    },
+                ]),
+            },
+        },
+    }),
+}));
+
+import { lightdashApi } from '../api';
+import { createQueryClient } from '../providers/ReactQuery/createQueryClient';
+import AppRoute from './AppRoute';
+
+const mockApi = lightdashApi as unknown as Mock;
+
+const ORG_URL = '/org';
+const PROJECT_ROUTE = '/projects/project-1/home';
+
+const organization = (needsProject: boolean) => ({
+    organizationUuid: 'org-1',
+    name: 'Jaffle Shop',
+    needsProject,
+});
+
+const NavigateButton: FC = () => {
+    const navigate = useNavigate();
+    return (
+        <button type="button" onClick={() => void navigate(PROJECT_ROUTE)}>
+            go to project
+        </button>
+    );
+};
+
+const Providers: FC<
+    PropsWithChildren<{ queryClient: ReturnType<typeof createQueryClient> }>
+> = ({ queryClient, children }) => (
+    <QueryClientProvider client={queryClient}>
+        <MantineProvider env="test">{children}</MantineProvider>
+    </QueryClientProvider>
+);
+
+const setup = ({
+    cachedNeedsProject,
+    serverNeedsProject,
+    cacheAgeMs = 0,
+    primeFlagCache = false,
+}: {
+    cachedNeedsProject: boolean;
+    serverNeedsProject: boolean;
+    cacheAgeMs?: number;
+    primeFlagCache?: boolean;
+}) => {
+    const calls: string[] = [];
+    mockApi.mockImplementation(({ url }: { url: string }) => {
+        calls.push(url);
+        if (url === ORG_URL) {
+            return Promise.resolve(organization(serverNeedsProject));
+        }
+        if (url === `/feature-flag/${FeatureFlags.NewOnboarding}`) {
+            return Promise.resolve({
+                id: FeatureFlags.NewOnboarding,
+                enabled: true,
+            });
+        }
+        if (url === `/feature-flag/${CommercialFeatureFlags.HomepageBuilder}`) {
+            return Promise.resolve({
+                id: CommercialFeatureFlags.HomepageBuilder,
+                enabled: false,
+            });
+        }
+        return Promise.resolve(null);
+    });
+
+    const queryClient = createQueryClient({ queries: { retry: false } });
+    queryClient.setQueryData(
+        ['organization'],
+        organization(cachedNeedsProject),
+        { updatedAt: Date.now() - cacheAgeMs },
+    );
+    if (primeFlagCache) {
+        queryClient.setQueryData(
+            ['feature-flag', CommercialFeatureFlags.HomepageBuilder],
+            { id: CommercialFeatureFlags.HomepageBuilder, enabled: false },
+        );
+        queryClient.setQueryData(['feature-flag', FeatureFlags.NewOnboarding], {
+            id: FeatureFlags.NewOnboarding,
+            enabled: true,
+        });
+    }
+
+    render(
+        <Providers queryClient={queryClient}>
+            <MemoryRouter initialEntries={['/start']}>
+                <Routes>
+                    <Route path="/start" element={<NavigateButton />} />
+                    <Route
+                        path="/projects/:projectUuid/home"
+                        element={
+                            <AppRoute>
+                                <div>PROJECT PAGE</div>
+                            </AppRoute>
+                        }
+                    />
+                    <Route
+                        path="/onboarding/data-source"
+                        element={<div>ONBOARDING PAGE</div>}
+                    />
+                    <Route
+                        path="/createProject"
+                        element={<div>LEGACY CREATE PROJECT</div>}
+                    />
+                    <Route
+                        path="/get-started"
+                        element={<div>GET STARTED PAGE</div>}
+                    />
+                </Routes>
+            </MemoryRouter>
+        </Providers>,
+    );
+
+    return { calls };
+};
+
+const navigateToProject = async () => {
+    const user = userEvent.setup();
+    await user.click(
+        await screen.findByRole('button', { name: 'go to project' }),
+    );
+};
+
+describe('AppRoute onboarding gate freshness', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders the project from cache without a spinner or a revalidation when the organization already has projects', async () => {
+        const { calls } = setup({
+            cachedNeedsProject: false,
+            serverNeedsProject: false,
+            primeFlagCache: true,
+        });
+
+        await navigateToProject();
+
+        expect(await screen.findByText('PROJECT PAGE')).toBeInTheDocument();
+        expect(screen.queryByTestId('page-spinner')).not.toBeInTheDocument();
+        expect(calls.filter((url) => url === ORG_URL)).toHaveLength(0);
+    });
+
+    it('sends the user to onboarding when the organization genuinely has no projects', async () => {
+        setup({ cachedNeedsProject: true, serverNeedsProject: true });
+
+        await navigateToProject();
+
+        expect(await screen.findByText('ONBOARDING PAGE')).toBeInTheDocument();
+    });
+
+    it('does not strand the user on onboarding when a fresh cached needsProject is already false on the server', async () => {
+        const { calls } = setup({
+            cachedNeedsProject: true,
+            serverNeedsProject: false,
+            primeFlagCache: true,
+        });
+
+        await navigateToProject();
+
+        expect(await screen.findByText('PROJECT PAGE')).toBeInTheDocument();
+        expect(screen.queryByText('ONBOARDING PAGE')).not.toBeInTheDocument();
+        expect(calls.filter((url) => url === ORG_URL).length).toBeGreaterThan(
+            0,
+        );
+    });
+
+    it('does not strand the user on onboarding when a stale cached needsProject is already false on the server', async () => {
+        setup({
+            cachedNeedsProject: true,
+            serverNeedsProject: false,
+            cacheAgeMs: 60_000,
+            primeFlagCache: true,
+        });
+
+        await navigateToProject();
+
+        expect(await screen.findByText('PROJECT PAGE')).toBeInTheDocument();
+        expect(screen.queryByText('ONBOARDING PAGE')).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/components/AppRoute.test.tsx
+++ b/packages/frontend/src/components/AppRoute.test.tsx
@@ -1,5 +1,6 @@
 import { Ability } from '@casl/ability';
 import { MantineProvider } from '@mantine/core';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import AppRoute from './AppRoute';
@@ -40,6 +41,7 @@ vi.mock('../hooks/organization/useOrganization', () => ({
     useOrganization: () => ({
         data: { needsProject: state.needsProject },
         isInitialLoading: false,
+        isFetchedAfterMount: true,
         error: null,
     }),
 }));
@@ -60,32 +62,34 @@ vi.mock('../ee/features/homepageBuilder/hooks/useProjectHomepage', () => ({
 
 const renderAppRoute = () =>
     render(
-        <MantineProvider env="test">
-            <MemoryRouter initialEntries={['/']}>
-                <Routes>
-                    <Route
-                        path="/"
-                        element={
-                            <AppRoute>
-                                <div>app</div>
-                            </AppRoute>
-                        }
-                    />
-                    <Route
-                        path="/get-started"
-                        element={<div>get started</div>}
-                    />
-                    <Route
-                        path="/createProject"
-                        element={<div>create project</div>}
-                    />
-                    <Route
-                        path="/onboarding/data-source"
-                        element={<div>data source</div>}
-                    />
-                </Routes>
-            </MemoryRouter>
-        </MantineProvider>,
+        <QueryClientProvider client={new QueryClient()}>
+            <MantineProvider env="test">
+                <MemoryRouter initialEntries={['/']}>
+                    <Routes>
+                        <Route
+                            path="/"
+                            element={
+                                <AppRoute>
+                                    <div>app</div>
+                                </AppRoute>
+                            }
+                        />
+                        <Route
+                            path="/get-started"
+                            element={<div>get started</div>}
+                        />
+                        <Route
+                            path="/createProject"
+                            element={<div>create project</div>}
+                        />
+                        <Route
+                            path="/onboarding/data-source"
+                            element={<div>data source</div>}
+                        />
+                    </Routes>
+                </MemoryRouter>
+            </MantineProvider>
+        </QueryClientProvider>,
     );
 
 describe('AppRoute', () => {

--- a/packages/frontend/src/components/AppRoute.tsx
+++ b/packages/frontend/src/components/AppRoute.tsx
@@ -1,6 +1,11 @@
 import { subject } from '@casl/ability';
-import { FeatureFlags, ProjectType } from '@lightdash/common';
-import { type FC } from 'react';
+import {
+    FeatureFlags,
+    type Organization,
+    ProjectType,
+} from '@lightdash/common';
+import { useQueryClient } from '@tanstack/react-query';
+import { useRef, type FC } from 'react';
 import { Navigate, useLocation } from 'react-router';
 import { useHomepageBuilderFlag } from '../ee/features/homepageBuilder/hooks/useProjectHomepage';
 import { useOrganization } from '../hooks/organization/useOrganization';
@@ -12,7 +17,20 @@ import PageSpinner from './PageSpinner';
 const AppRoute: FC<React.PropsWithChildren> = ({ children }) => {
     const { health, user } = useApp();
     const location = useLocation();
-    const orgRequest = useOrganization();
+    const queryClient = useQueryClient();
+
+    const mustConfirmNoProjectRef = useRef<boolean | undefined>(undefined);
+    if (mustConfirmNoProjectRef.current === undefined) {
+        mustConfirmNoProjectRef.current =
+            queryClient.getQueryData<Organization>(['organization'])
+                ?.needsProject === true;
+    }
+
+    const orgRequest = useOrganization(
+        mustConfirmNoProjectRef.current
+            ? { refetchOnMount: 'always' }
+            : undefined,
+    );
     const homepageBuilderFlag = useHomepageBuilderFlag();
     const orgSetupPageFlag = useServerFeatureFlag(FeatureFlags.NewOnboarding);
 


### PR DESCRIPTION
`AppRoute` could send a user who already has a project into the "connect your warehouse" onboarding flow, based on a cached `needsProject` value that was no longer true.

Linear: SPK-787

This was filed as an unconfirmed code-reading finding. **It reproduces**, and the real behaviour is worse than the ticket describes — see below.

## Reproduction

Two failing cases, both with the server reporting `needsProject: false` (the org does have a project) while the client's `['organization']` cache still holds `true`, entered by client-side navigation:

| org cache state | `GET /org` refetches | result |
|---|---|---|
| fresh (< 30s `staleTime`) | **0** | redirected to onboarding |
| stale (> 30s) | 1 | redirected to onboarding |

Two corrections to the ticket's account:

- **The fresh case issues no request at all.** There is no race to lose — the global `staleTime: 30000` means the cached value is served without revalidation, so the gate decides on data that is simply wrong.
- **Neither case self-heals.** `<Navigate>` renders from the stale value immediately and the subtree unmounts, so nothing re-evaluates the gate when fresh data lands. The user is stranded on `/onboarding/data-source`, not briefly flashed.

Worth noting for triage: an early measurement appeared to show the stale case recovering. That was an artefact of the feature-flag queries being uncached — their `isLoading` spinner delays the redirect long enough for the refetch to land. With the flag cache primed (the normal state after the first navigation) that accidental shield disappears. The bug's visibility therefore depends on session warmth, which likely explains why it went unnoticed.

## The fix

The redirect decision is now gated asymmetrically on freshness:

- **Redirecting into onboarding requires data fetched after mount.** If the cached value says `needsProject`, the gate forces a revalidation and holds the spinner until it resolves.
- **Passing through does not.** An organization known to have projects renders straight from cache — no forced request, no spinner — so the common path is unchanged.

This replaces the per-call-site workaround pattern (`CreateProjectconnection` already had to `refetchQueries(['organization'])` before navigating, with a comment naming this exact symptom); any path into `/projects/*` is now covered by the gate itself.

## Tests

`AppRoute.organizationFreshness.test.tsx` — 4 tests: the two reproductions above, a genuine-no-projects case (onboarding still fires), and a fast-path case asserting **zero** `GET /org` requests and no spinner. Reverting the component changes turns both reproduction tests red while the fast-path test stays green; the fast-path test also guards against a future fix that force-revalidates unconditionally.

`AppRoute.test.tsx` (pre-existing, tracked) needed two mechanical updates to keep passing: a `QueryClientProvider` wrapper, since the component now reads the query cache, and `isFetchedAfterMount: true` on its `useOrganization` mock. Its five assertions are unchanged — the mock now expresses "the org state is decided", which each of its cases already assumed. Most of its 56-line diff is re-indentation from the added wrapper.

Full battery green: typecheck, lint on touched paths, unused-exports, 256 files / 2022 tests.

## Separate finding, deliberately not fixed here

`useServerFeatureFlag` sets `retry: false`, so a failed or 403 flag request settles at `isLoading: false, data: undefined`; the `?? false` at the flag check then reads that transport failure as a deliberate "off" and routes the user to the legacy `/createProject` with no spinner and no error. Measured and confirmed, but left unchanged — deciding whether a failed flag fetch should surface an error, retry, or keep defaulting to legacy is a product call, not a drive-by.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PYdraKeQMyKvSfcc7AZYr
