### PR TITLE
fix: await loginToOrganization so the multi-organization guard applies

### DIFF
--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -383,7 +383,9 @@ export class UserModel {
                 'organizations.organization_uuid',
                 'organizations.created_at',
                 'organizations.organization_name',
-            );
+            )
+            .orderBy('organizations.created_at', 'asc')
+            .orderBy('organizations.organization_id', 'asc');
 
         return organizations.map((organization) => ({
             organizationUuid: organization.organization_uuid,
@@ -457,6 +459,8 @@ export class UserModel {
             // this is already empty for them — the explicit guard documents
             // intent and survives any join refactor.
             .andWhere(`${UserTableName}.is_internal`, false)
+            .orderBy('organizations.created_at', 'asc')
+            .orderBy('organizations.organization_id', 'asc')
             .select<(DbUserDetails & { password_hash: string })[]>(
                 '*',
                 'organizations.created_at as organization_created_at',
@@ -1204,6 +1208,8 @@ export class UserModel {
     async findSessionUserByUUID(userUuid: string): Promise<SessionUser> {
         const [user] = await userDetailsQueryBuilder(this.database)
             .where('user_uuid', userUuid)
+            .orderBy('organizations.created_at', 'asc')
+            .orderBy('organizations.organization_id', 'asc')
             .select('*', 'organizations.created_at as organization_created_at');
         if (user === undefined) {
             throw new NotFoundError(`Cannot find user with uuid ${userUuid}`);
@@ -1278,6 +1284,8 @@ export class UserModel {
         const [user] = await userDetailsQueryBuilder(this.database)
             .where('email', email)
             .andWhere(`${UserTableName}.is_internal`, false)
+            .orderBy('organizations.created_at', 'asc')
+            .orderBy('organizations.organization_id', 'asc')
             .select('*', 'organizations.created_at as organization_created_at');
         return user
             ? mapDbUserDetailsToLightdashUser(

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -74,7 +74,12 @@ const userModel = {
     activateUser: vi.fn(async () => sessionUser),
     activateUserWithoutPassword: vi.fn(async () => sessionUser),
     addProjectMemberships: vi.fn(async () => undefined),
-    getOrganizationsForUser: vi.fn(async () => [sessionUser]),
+    getOrganizationsForUser: vi.fn<UserModel['getOrganizationsForUser']>(
+        async () => [sessionUser],
+    ),
+    getUserByPrimaryEmailAndPassword: vi.fn<
+        UserModel['getUserByPrimaryEmailAndPassword']
+    >(async () => userWithoutOrg),
     findUserByEmail: vi.fn<UserModel['findUserByEmail']>(async () => undefined),
     createPendingUser: vi.fn<UserModel['createPendingUser']>(
         async () => newUser,
@@ -255,6 +260,45 @@ describe('UserService', () => {
 
     afterEach(() => {
         vi.clearAllMocks();
+    });
+
+    describe('organization selection during login', () => {
+        const selectedOrganization = {
+            organizationUuid: 'selected-organization-uuid',
+            organizationName: 'Selected organization',
+            organizationCreatedAt: new Date('2025-01-01T00:00:00.000Z'),
+        };
+        const otherOrganization = {
+            organizationUuid: 'other-organization-uuid',
+            organizationName: 'Other organization',
+            organizationCreatedAt: new Date('2025-01-02T00:00:00.000Z'),
+        };
+
+        test('rejects password login for a user in multiple organizations', async () => {
+            userModel.getOrganizationsForUser.mockResolvedValueOnce([
+                selectedOrganization,
+                otherOrganization,
+            ]);
+
+            await expect(
+                userService.loginWithPassword('user@example.com', 'password'),
+            ).rejects.toThrow(
+                new ForbiddenError('User is part of multiple organizations'),
+            );
+        });
+
+        test('returns the resolved organization for a single-organization password login', async () => {
+            userModel.getOrganizationsForUser.mockResolvedValueOnce([
+                selectedOrganization,
+            ]);
+
+            await expect(
+                userService.loginWithPassword('user@example.com', 'password'),
+            ).resolves.toEqual({
+                ...userWithoutOrg,
+                ...selectedOrganization,
+            });
+        });
     });
 
     describe('OAuth grants', () => {
@@ -1069,7 +1113,7 @@ describe('UserService', () => {
 
                 await expect(
                     service.loginWithEmailOtp('EMAIL', '123456'),
-                ).resolves.toBe(sessionUser);
+                ).resolves.toEqual(sessionUser);
 
                 expect(
                     emailModel.getPrimaryEmailStatusByUserAndOtp,
@@ -1133,6 +1177,48 @@ describe('UserService', () => {
                         onboardingFlow: 'new',
                     },
                 });
+            });
+
+            test('rejects OTP login for a user in multiple organizations', async () => {
+                const service = createUserService(lightdashConfigMock, {
+                    featureFlagModel: createFeatureFlagModel(true),
+                });
+                const emailStatus = activeOtp();
+                userModel.findUserByEmail.mockResolvedValueOnce(sessionUser);
+                userModel.hasPassword.mockResolvedValueOnce(false);
+                userModel.hasOpenIdIdentity.mockResolvedValueOnce(false);
+                emailModel.getPrimaryEmailStatus.mockResolvedValueOnce(
+                    emailStatus,
+                );
+                emailModel.getPrimaryEmailStatusByUserAndOtp.mockResolvedValueOnce(
+                    emailStatus,
+                );
+                userModel.getOrganizationsForUser.mockResolvedValueOnce([
+                    {
+                        organizationUuid: 'first-organization-uuid',
+                        organizationName: 'First organization',
+                        organizationCreatedAt: new Date(
+                            '2025-01-01T00:00:00.000Z',
+                        ),
+                    },
+                    {
+                        organizationUuid: 'second-organization-uuid',
+                        organizationName: 'Second organization',
+                        organizationCreatedAt: new Date(
+                            '2025-01-02T00:00:00.000Z',
+                        ),
+                    },
+                ]);
+
+                await expect(
+                    service.loginWithEmailOtp('EMAIL', '123456'),
+                ).rejects.toThrow(
+                    new ForbiddenError(
+                        'User is part of multiple organizations',
+                    ),
+                );
+
+                expect(emailModel.deleteEmailOtp).not.toHaveBeenCalled();
             });
 
             test('rejects a sixth attempt without comparing the code', async () => {
@@ -1237,7 +1323,7 @@ describe('UserService', () => {
 
                 await expect(
                     service.loginWithEmailOtp('EMAIL', '123456'),
-                ).resolves.toBe(sessionUser);
+                ).resolves.toEqual(sessionUser);
             });
         });
 

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -62,7 +62,9 @@ const userModel = {
     hasPasswordByEmail: vi.fn<UserModel['hasPasswordByEmail']>(
         async () => false,
     ),
-    findSessionUserByOpenId: vi.fn(async () => undefined),
+    findSessionUserByOpenId: vi.fn<UserModel['findSessionUserByOpenId']>(
+        async () => undefined,
+    ),
     findSessionUserByUUID: vi.fn<UserModel['findSessionUserByUUID']>(
         async () => sessionUser,
     ),
@@ -273,6 +275,22 @@ describe('UserService', () => {
             organizationName: 'Other organization',
             organizationCreatedAt: new Date('2025-01-02T00:00:00.000Z'),
         };
+        const organizationlessSessionUser: SessionUser = { ...sessionUser };
+        delete organizationlessSessionUser.organizationUuid;
+        delete organizationlessSessionUser.organizationName;
+        delete organizationlessSessionUser.organizationCreatedAt;
+        delete organizationlessSessionUser.role;
+
+        test('allows password login for a user without an organization', async () => {
+            userModel.getOrganizationsForUser.mockResolvedValueOnce([]);
+
+            const result = await userService.loginWithPassword(
+                'user@example.com',
+                'password',
+            );
+
+            expect(result).not.toHaveProperty('organizationUuid');
+        });
 
         test('rejects password login for a user in multiple organizations', async () => {
             userModel.getOrganizationsForUser.mockResolvedValueOnce([
@@ -296,6 +314,53 @@ describe('UserService', () => {
                 userService.loginWithPassword('user@example.com', 'password'),
             ).resolves.toEqual({
                 ...userWithoutOrg,
+                ...selectedOrganization,
+            });
+        });
+
+        test('allows OpenID login for a user without an organization', async () => {
+            userModel.findSessionUserByOpenId.mockResolvedValueOnce(
+                organizationlessSessionUser,
+            );
+            userModel.getOrganizationsForUser.mockResolvedValueOnce([]);
+
+            const result = await userService.loginWithOpenId(
+                openIdUser,
+                undefined,
+                undefined,
+            );
+
+            expect(result).not.toHaveProperty('organizationUuid');
+        });
+
+        test('rejects OpenID login for a user in multiple organizations', async () => {
+            userModel.findSessionUserByOpenId.mockResolvedValueOnce(
+                organizationlessSessionUser,
+            );
+            userModel.getOrganizationsForUser.mockResolvedValueOnce([
+                selectedOrganization,
+                otherOrganization,
+            ]);
+
+            await expect(
+                userService.loginWithOpenId(openIdUser, undefined, undefined),
+            ).rejects.toThrow(
+                new ForbiddenError('User is part of multiple organizations'),
+            );
+        });
+
+        test('returns the resolved organization for a single-organization OpenID login', async () => {
+            userModel.findSessionUserByOpenId.mockResolvedValueOnce(
+                organizationlessSessionUser,
+            );
+            userModel.getOrganizationsForUser.mockResolvedValueOnce([
+                selectedOrganization,
+            ]);
+
+            await expect(
+                userService.loginWithOpenId(openIdUser, undefined, undefined),
+            ).resolves.toEqual({
+                ...organizationlessSessionUser,
                 ...selectedOrganization,
             });
         });

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -2591,16 +2591,15 @@ export class UserService extends BaseService {
         userUuid: string,
         loginMethod: LoginOptionTypes,
     ): Promise<
-        Pick<
-            LightdashUser,
-            'organizationUuid' | 'organizationCreatedAt' | 'organizationName'
-        >
+        | Pick<
+              LightdashUser,
+              'organizationUuid' | 'organizationCreatedAt' | 'organizationName'
+          >
+        | undefined
     > {
         const organizations =
             await this.userModel.getOrganizationsForUser(userUuid);
-        if (organizations.length === 0) {
-            throw new NotFoundError('User not part of any organization');
-        } else if (organizations.length > 1) {
+        if (organizations.length > 1) {
             throw new ForbiddenError('User is part of multiple organizations');
         }
         // TODO check valid login methods allowed in org

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -1051,7 +1051,7 @@ export class UserService extends BaseService {
                 throw new DeactivatedAccountError();
             }
 
-            const organization = this.loginToOrganization(
+            const organization = await this.loginToOrganization(
                 openIdSession?.userUuid,
                 openIdUser.openId.issuerType,
             );
@@ -1589,7 +1589,7 @@ export class UserService extends BaseService {
             if (!user.isActive) {
                 throw new DeactivatedAccountError();
             }
-            const userOrganization = this.loginToOrganization(
+            const userOrganization = await this.loginToOrganization(
                 user.userUuid,
                 LocalIssuerTypes.EMAIL,
             );
@@ -1614,7 +1614,7 @@ export class UserService extends BaseService {
                 metadata: { loginProvider: 'password' },
                 context,
             });
-            return user;
+            return userWithOrganization;
         } catch (e) {
             if (e instanceof NotFoundError) {
                 emitFailure('Email and password not recognized');
@@ -2017,7 +2017,7 @@ export class UserService extends BaseService {
                 'You do not have permission to login with personal access tokens',
             );
         }
-        const organization = this.loginToOrganization(
+        const organization = await this.loginToOrganization(
             user.userUuid,
             LocalIssuerTypes.API_TOKEN,
         );
@@ -2283,6 +2283,11 @@ export class UserService extends BaseService {
             }
             throw error;
         }
+        const organization = await this.loginToOrganization(
+            sessionUser.userUuid,
+            LocalIssuerTypes.EMAIL_OTP,
+        );
+        sessionUser = { ...sessionUser, ...organization };
         await this.tryVerifyUserEmail(sessionUser, emailStatus.email, 'otp');
         await this.emailModel.deleteEmailOtp(
             sessionUser.userUuid,


### PR DESCRIPTION
`UserService.loginToOrganization()` is `async`, but none of its call sites awaited it. The returned promise was spread into the session user, which contributes no properties, so the multi-organization guard inside it could never apply and the session organization came from an unordered join instead. Dormant since the code landed in March 2024.

Linear: SPK-788

## Reproduction

A user with two `organization_memberships` rows, ten consecutive password logins:

| | before | after |
|---|---|---|
| HTTP status | `200` on all 10 — login succeeds | `403` on all 10 — refused |
| guard | fires as an `unhandledRejection`, swallowed by Winston (`handleRejections: true`, `exitOnError: false`), logged on every login | thrown to the request handler as a handled `ForbiddenError` |
| session org | the unordered-join pick — **not** the organization the user created and owns | n/a, login refused |

The selected organization was **stable across all ten logins** in this environment, so this is reported as "arbitrary with respect to any user-meaningful ordering" rather than "flips between logins" — the row order simply is not something the query constrains, and the two-row plan happened to be consistent here.

Single-organization users were never affected: the ignored promise resolved and the join returned the one correct row. Verified after the fix that `demo@lightdash.com` still logs in normally with the right organization.

## What changed

- `await` at all three call sites — OpenID, password, and personal access token login.
- Password login now returns the user **with** the organization fields. It previously returned the pre-spread object, so this is the first time the resolved organization actually reaches the caller.
- Email OTP login gets the same guard. It never called `loginToOrganization` at all and went straight to a `@deprecated` lookup whose own comment warns against assuming a default organization.
- Deterministic ordering (`organizations.created_at`, then `organization_id`) on `getOrganizationsForUser` and on the `userDetailsQueryBuilder` consumers that take the first joined row, so any path still taking `[user]` picks the same organization every time rather than whatever the join happened to emit.

Tests cover the multi-org refusal on both the password and OTP paths, and a single-org login asserting the organization uuid is present on the returned session user — which is what fails if the promise is ever left un-awaited again.

Checked while here: `@typescript-eslint/no-floating-promises` is already enabled as an error, and a scan of the services directory reports zero violations. It did not catch this one because the promise was consumed by the spread rather than discarded.

## Follow-up from an adversarial review — organization-less users

The first version of this change had a serious side effect, caught in review, reproduced with a failing test, and fixed.

Adding the `await` revived the intended multi-organization refusal — but it also revived a second branch nobody meant to turn on: `loginToOrganization` threw `NotFoundError` when a user had **zero** organizations. Before this PR the un-awaited promise made that unreachable, so those users logged in fine with the organization fields simply absent. After it, they were rejected at authentication, and on the password path the `NotFoundError` was remapped to `AuthorizationError('Email and password not recognized')` — so a valid user was told their credentials were wrong.

That is a live regression rather than a theoretical one. A read-only production check found **no** multi-organization users at all, so reviving that half locks nobody out, but **33 active organization-less users, 32 of them single-sign-on accounts that are setup-complete and log in today**. It also breaks `/join-organization`, which is precisely the flow those users need — `PrivateRoute` routes anyone without an `organizationUuid` there, so blocking them at login removes the only way in.

The guard now refuses **multiple** organizations only. Zero organizations returns no organization fields, exactly as before, and the return type says so rather than being cast. Red proof, on both paths:

```
FAIL > allows password login for a user without an organization
  AuthorizationError: Email and password not recognized
FAIL > allows OpenID login for a user without an organization
  NotFoundError: User not part of any organization
```

Both pass after the fix, and the multi-organization and single-organization assertions stayed green throughout — they are the cover against the fix going too far in either direction.

## Scope of the guard — what this PR does and does not deliver

To be precise rather than claim more than is delivered: the refusal applies to the password, email OTP, personal access token, and existing-OpenID-session login paths. It does **not** cover the OpenID identity-linking and verified-email-linking branches, which return earlier and never call `loginToOrganization`. A multi-organization user presenting a *new* OpenID identity can therefore still log in through those paths. That is not a privilege escalation — they still authenticate a real identity — but the enforcement boundary is uneven, and extending it changes account-linking behaviour, so it belongs in its own change rather than being folded in here.

## Question for review — is refusing multi-org logins the behaviour we actually want?

This restores what the code has always *said* it does: a user in more than one organization is refused at login with `ForbiddenError('User is part of multiple organizations')`. That guard has been dead for over two years, so in practice such users have been logging in successfully all along and getting an arbitrary organization.

Turning it back on is the honest reading of the existing code. A read-only production check makes the blast radius concrete: there are currently **no multi-organization users at all**, so enabling the refusal locks nobody out today. It remains a real behaviour change for anyone who ends up in that state later, so it still wants a deliberate decision rather than my assumption:

- **Keep the refusal** (this PR) — multi-org membership stays unsupported, and anyone in that state is blocked at login until an admin resolves it.
- **Support multi-org instead** — drop the guard and choose the organization deterministically, with explicit selection at login or on a switcher. That is a larger piece of work and would want its own ticket; the deterministic ordering added here is a prerequisite either way.

I have not silently picked the product answer — the code's declared intent is implemented, and the alternative is flagged here. Happy to swap it for the second option if that is the direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PYdraKeQMyKvSfcc7AZYr
