### PR TITLE
feat(homepage): org-level homepage settings with opening preset

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -488,6 +488,10 @@ import {
     McpToolCallTableName,
 } from '../ee/database/entities/mcpToolCall';
 import {
+    OrganizationHomepageSettingsTable,
+    OrganizationHomepageSettingsTableName,
+} from '../ee/database/entities/organizationHomepageSettings';
+import {
     PreAggregateDailyStatsTable,
     PreAggregateDailyStatsTableName,
 } from '../ee/database/entities/preAggregateDailyStats';
@@ -649,6 +653,7 @@ declare module 'knex/types/tables' {
         [AiAgentUserPreferencesTableName]: AiAgentUserPreferencesTable;
         [HomepagesTableName]: ProjectHomepagesTable;
         [HomepageAssignmentsTableName]: HomepageAssignmentsTable;
+        [OrganizationHomepageSettingsTableName]: OrganizationHomepageSettingsTable;
         [AnnouncementsTableName]: AnnouncementsTable;
         [AiAgentReasoningTableName]: AiAgentReasoningTable;
         [AiAgentToolCallTableName]: AiAgentToolCallTable;

--- a/packages/backend/src/ee/controllers/organizationHomepageSettingsController.ts
+++ b/packages/backend/src/ee/controllers/organizationHomepageSettingsController.ts
@@ -1,0 +1,76 @@
+import {
+    assertRegisteredAccount,
+    type ApiErrorPayload,
+    type ApiOrganizationHomepageSettingsResponse,
+    type UpdateOrganizationHomepageSettings,
+} from '@lightdash/common';
+import {
+    Body,
+    Get,
+    Middlewares,
+    OperationId,
+    Patch,
+    Request,
+    Response,
+    Route,
+    SuccessResponse,
+    Tags,
+} from '@tsoa/runtime';
+import express from 'express';
+import { toSessionUser } from '../../auth/account/account';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    unauthorisedInDemo,
+} from '../../controllers/authentication';
+import { BaseController } from '../../controllers/baseController';
+import { type ProjectHomepageService } from '../services/ProjectHomepageService';
+
+@Route('/api/v1/org/homepage-settings')
+@Response<ApiErrorPayload>('default', 'Error')
+@Tags('Homepage')
+export class OrganizationHomepageSettingsController extends BaseController {
+    private getHomepageService(): ProjectHomepageService {
+        return this.services.getProjectHomepageService<ProjectHomepageService>();
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/')
+    @OperationId('getOrganizationHomepageSettings')
+    async getSettings(
+        @Request() req: express.Request,
+    ): Promise<ApiOrganizationHomepageSettingsResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getHomepageService().getOrgHomepageSettings(
+                toSessionUser(req.account),
+            ),
+        };
+    }
+
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Patch('/')
+    @OperationId('updateOrganizationHomepageSettings')
+    async updateSettings(
+        @Request() req: express.Request,
+        @Body() body: UpdateOrganizationHomepageSettings,
+    ): Promise<ApiOrganizationHomepageSettingsResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getHomepageService().updateOrgHomepageSettings(
+                toSessionUser(req.account),
+                body,
+            ),
+        };
+    }
+}

--- a/packages/backend/src/ee/database/entities/organizationHomepageSettings.ts
+++ b/packages/backend/src/ee/database/entities/organizationHomepageSettings.ts
@@ -1,0 +1,25 @@
+import { type HomepageOpening } from '@lightdash/common';
+import { type Knex } from 'knex';
+
+export const OrganizationHomepageSettingsTableName =
+    'organization_homepage_settings';
+
+export type DbOrganizationHomepageSettings = {
+    organization_uuid: string;
+    enabled: boolean;
+    opening: HomepageOpening | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type OrganizationHomepageSettingsTable = Knex.CompositeTableType<
+    DbOrganizationHomepageSettings,
+    Pick<
+        DbOrganizationHomepageSettings,
+        'organization_uuid' | 'enabled' | 'opening'
+    >,
+    Partial<
+        Pick<DbOrganizationHomepageSettings, 'enabled' | 'opening'> &
+            Pick<DbOrganizationHomepageSettings, 'updated_at'>
+    >
+>;

--- a/packages/backend/src/ee/database/migrations/20260803110000_create_organization_homepage_settings.ts
+++ b/packages/backend/src/ee/database/migrations/20260803110000_create_organization_homepage_settings.ts
@@ -1,0 +1,31 @@
+import { Knex } from 'knex';
+
+const OrganizationHomepageSettingsTableName = 'organization_homepage_settings';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(
+        OrganizationHomepageSettingsTableName,
+        (table) => {
+            table
+                .uuid('organization_uuid')
+                .primary()
+                .references('organization_uuid')
+                .inTable('organizations')
+                .onDelete('CASCADE');
+            table.boolean('enabled').notNullable().defaultTo(false);
+            table.text('opening').nullable();
+            table
+                .timestamp('created_at')
+                .notNullable()
+                .defaultTo(knex.fn.now());
+            table
+                .timestamp('updated_at')
+                .notNullable()
+                .defaultTo(knex.fn.now());
+        },
+    );
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(OrganizationHomepageSettingsTableName);
+}

--- a/packages/backend/src/ee/database/migrations/20260803160000_backfill_org_homepage_settings_from_flag.ts
+++ b/packages/backend/src/ee/database/migrations/20260803160000_backfill_org_homepage_settings_from_flag.ts
@@ -1,0 +1,38 @@
+import { Knex } from 'knex';
+
+const OrganizationHomepageSettingsTableName = 'organization_homepage_settings';
+const FeatureFlagOverridesTableName = 'feature_flag_overrides';
+
+/**
+ * Orgs enabled via the homepage-builder flag override get an explicit
+ * settings row, so their enablement survives the flag's eventual removal and
+ * the in-product switch-back control works for them. `opening` stays NULL
+ * (auto), which is exactly the behaviour they already have. Additive and
+ * idempotent: existing settings rows are never touched.
+ */
+export async function up(knex: Knex): Promise<void> {
+    const hasSettings = await knex.schema.hasTable(
+        OrganizationHomepageSettingsTableName,
+    );
+    const hasOverrides = await knex.schema.hasTable(
+        FeatureFlagOverridesTableName,
+    );
+    if (!hasSettings || !hasOverrides) return;
+
+    await knex.raw(`
+        INSERT INTO ${OrganizationHomepageSettingsTableName} (organization_uuid, enabled, opening)
+        SELECT DISTINCT ffo.organization_uuid, true, NULL
+        FROM ${FeatureFlagOverridesTableName} ffo
+        JOIN organizations o ON o.organization_uuid = ffo.organization_uuid
+        WHERE ffo.flag_id = 'homepage-builder'
+          AND ffo.enabled = true
+          AND ffo.organization_uuid IS NOT NULL
+        ON CONFLICT (organization_uuid) DO NOTHING
+    `);
+}
+
+export async function down(): Promise<void> {
+    // Backfilled rows are indistinguishable from explicit opt-ins by the time
+    // a rollback would run, and deleting them would turn the homepage off for
+    // real orgs. The flag override still enables those orgs either way.
+}

--- a/packages/backend/src/ee/models/ProjectHomepageModel.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.ts
@@ -1,22 +1,28 @@
 import {
     AnnouncementCategory,
     ConflictError,
+    HOMEPAGE_DEFAULT_GREETING_SUBTITLE,
     NotFoundError,
     ParameterError,
     sanitizeHomepageConfig,
     type AnnouncementsPage,
     type HomepageAssignment,
     type HomepageAudience,
+    type HomepageBlock,
     type HomepageConfig,
+    type HomepageOpening,
     type HomepageRecentlyViewedItem,
+    type OrganizationHomepageSettings,
     type ProjectAnnouncement,
     type ProjectHomepage,
     type ProjectMemberRole,
     type PublishedProjectHomepage,
     type ResolvedPublishedHomepage,
     type UpdateAnnouncementRequest,
+    type UpdateOrganizationHomepageSettings,
 } from '@lightdash/common';
 import { type Knex } from 'knex';
+import { OrganizationHomepageSettingsTableName } from '../database/entities/organizationHomepageSettings';
 import {
     AnnouncementsTableName,
     HomepageAssignmentsTableName,
@@ -50,6 +56,131 @@ export class ProjectHomepageModel {
             createdAt: row.created_at,
             updatedAt: row.updated_at,
         };
+    }
+
+    async findOrgHomepageSettings(
+        organizationUuid: string,
+    ): Promise<OrganizationHomepageSettings | null> {
+        const row = await this.database(OrganizationHomepageSettingsTableName)
+            .where('organization_uuid', organizationUuid)
+            .first();
+        if (!row) return null;
+        return {
+            organizationUuid: row.organization_uuid,
+            enabled: row.enabled,
+            opening: row.opening,
+        };
+    }
+
+    async upsertOrgHomepageSettings(
+        organizationUuid: string,
+        update: UpdateOrganizationHomepageSettings,
+    ): Promise<OrganizationHomepageSettings> {
+        const [row] = await this.database(OrganizationHomepageSettingsTableName)
+            .insert({
+                organization_uuid: organizationUuid,
+                enabled: update.enabled,
+                opening: update.opening,
+            })
+            .onConflict('organization_uuid')
+            .merge({
+                enabled: update.enabled,
+                opening: update.opening,
+                updated_at: new Date(),
+            })
+            .returning('*');
+        return {
+            organizationUuid: row.organization_uuid,
+            enabled: row.enabled,
+            opening: row.opening,
+        };
+    }
+
+    /**
+     * Rewrites stored hero blocks across every homepage in the organization
+     * (drafts and published) to match the opening the admin just chose:
+     * content-first turns ask heroes into greetings, ask-first turns greetings
+     * into ask heroes. Block ids and density survive; a page-level exception
+     * is one swap away in the builder.
+     */
+    async swapHeroBlocks(
+        organizationUuid: string,
+        opening: HomepageOpening,
+    ): Promise<void> {
+        const rows: DbProjectHomepage[] = await this.database(
+            HomepagesTableName,
+        )
+            .join(
+                'projects',
+                'projects.project_uuid',
+                `${HomepagesTableName}.project_uuid`,
+            )
+            .join(
+                'organizations',
+                'organizations.organization_id',
+                'projects.organization_id',
+            )
+            .where('organizations.organization_uuid', organizationUuid)
+            .select<DbProjectHomepage[]>(`${HomepagesTableName}.*`);
+
+        const sourceType =
+            opening === 'content-first' ? 'ask-ai-hero' : 'greeting';
+        const swapBlock = (block: HomepageBlock): HomepageBlock => {
+            if (opening === 'content-first' && block.type === 'ask-ai-hero') {
+                return {
+                    id: block.id,
+                    type: 'greeting',
+                    config: {
+                        subtitle: HOMEPAGE_DEFAULT_GREETING_SUBTITLE,
+                        density: block.config.density,
+                    },
+                };
+            }
+            if (opening === 'ask-first' && block.type === 'greeting') {
+                return {
+                    id: block.id,
+                    type: 'ask-ai-hero',
+                    config: {
+                        showGreeting: true,
+                        density: block.config.density,
+                    },
+                };
+            }
+            return block;
+        };
+
+        const swapConfig = (config: HomepageConfig): HomepageConfig => ({
+            ...config,
+            rows: config.rows.map((row) => ({
+                ...row,
+                blocks: row.blocks.map(swapBlock),
+            })),
+        });
+
+        const hasSourceHero = (config: HomepageConfig | null): boolean =>
+            config?.rows.some((row) =>
+                row.blocks.some((block) => block.type === sourceType),
+            ) ?? false;
+
+        const affected = rows.filter(
+            (row) =>
+                hasSourceHero(row.draft_config) ||
+                hasSourceHero(row.published_config),
+        );
+        await Promise.all(
+            affected.map((row) =>
+                this.database(HomepagesTableName)
+                    .where('homepage_uuid', row.homepage_uuid)
+                    .update({
+                        draft_config: swapConfig(row.draft_config),
+                        published_config:
+                            row.published_config === null
+                                ? null
+                                : swapConfig(row.published_config),
+                        updated_at: new Date(),
+                    }),
+            ),
+        );
     }
 
     async getDefault(

--- a/packages/backend/src/ee/services/ProjectHomepageService.test.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.test.ts
@@ -163,6 +163,9 @@ const makeService = ({
             updateAnnouncement: vi.fn(),
             deleteAnnouncement: vi.fn().mockResolvedValue(undefined),
             publishProjectDraftAnnouncements: vi.fn().mockResolvedValue([]),
+            findOrgHomepageSettings: vi.fn().mockResolvedValue(null),
+            upsertOrgHomepageSettings: vi.fn(),
+            swapHeroBlocks: vi.fn().mockResolvedValue(undefined),
             ...projectHomepageModel,
         },
         groupsModel: {
@@ -214,6 +217,93 @@ describe('ProjectHomepageService', () => {
         await expect(
             service.getResolvedHomepage(makeAdminUser(), PROJECT_UUID),
         ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('org settings opt-in enables the homepage even when the flag is off', async () => {
+        const service = makeService({
+            flagEnabled: false,
+            projectHomepageModel: {
+                findOrgHomepageSettings: vi.fn().mockResolvedValue({
+                    organizationUuid: ORGANIZATION_UUID,
+                    enabled: true,
+                    opening: 'content-first',
+                }),
+            },
+        });
+
+        await expect(
+            service.getResolvedHomepage(makeAdminUser(), PROJECT_UUID),
+        ).resolves.toBeNull();
+    });
+
+    it('getOrgHomepageSettings returns defaults when the org never opted in', async () => {
+        const service = makeService();
+
+        await expect(
+            service.getOrgHomepageSettings(makeViewerUser()),
+        ).resolves.toEqual({
+            organizationUuid: ORGANIZATION_UUID,
+            enabled: false,
+            opening: null,
+        });
+    });
+
+    it('updateOrgHomepageSettings requires org-admin ability', async () => {
+        const upsert = vi.fn();
+        const service = makeService({
+            projectHomepageModel: { upsertOrgHomepageSettings: upsert },
+        });
+
+        await expect(
+            service.updateOrgHomepageSettings(makeViewerUser(), {
+                enabled: true,
+                opening: 'ask-first',
+            }),
+        ).rejects.toThrow(ForbiddenError);
+        expect(upsert).not.toHaveBeenCalled();
+    });
+
+    it('updateOrgHomepageSettings upserts for org admins', async () => {
+        const settings = {
+            organizationUuid: ORGANIZATION_UUID,
+            enabled: true,
+            opening: 'content-first' as const,
+        };
+        const upsert = vi.fn().mockResolvedValue(settings);
+        const swapHeroes = vi.fn().mockResolvedValue(undefined);
+        const service = makeService({
+            projectHomepageModel: {
+                upsertOrgHomepageSettings: upsert,
+                swapHeroBlocks: swapHeroes,
+            },
+        });
+        const orgAdmin: SessionUser = {
+            ...baseUser(),
+            ability: new Ability<PossibleAbilities>([
+                {
+                    action: 'manage',
+                    subject: 'Organization',
+                    conditions: { organizationUuid: ORGANIZATION_UUID },
+                },
+            ]),
+        };
+
+        await expect(
+            service.updateOrgHomepageSettings(orgAdmin, {
+                enabled: true,
+                opening: 'content-first',
+            }),
+        ).resolves.toEqual(settings);
+        expect(upsert).toHaveBeenCalledWith(ORGANIZATION_UUID, {
+            enabled: true,
+            opening: 'content-first',
+        });
+        // The chosen opening rewrites stored heroes so the builder and the
+        // rendered pages agree with it, in both directions.
+        expect(swapHeroes).toHaveBeenCalledWith(
+            ORGANIZATION_UUID,
+            'content-first',
+        );
     });
 
     it('getPublishedHomepage returns null when nothing is published', async () => {

--- a/packages/backend/src/ee/services/ProjectHomepageService.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.ts
@@ -19,12 +19,14 @@ import {
     type HomepageRecentlyViewedItem,
     type HomepageViewAsResult,
     type HomepageViewAsTarget,
+    type OrganizationHomepageSettings,
     type ProjectAnnouncement,
     type ProjectHomepage,
     type ProjectMemberRole,
     type ResolvedHomepage,
     type SessionUser,
     type UpdateAnnouncementRequest,
+    type UpdateOrganizationHomepageSettings,
     type UpdateProjectHomepageDraftRequest,
 } from '@lightdash/common';
 import { type KnownBlock } from '@slack/web-api';
@@ -181,6 +183,9 @@ export type ProjectHomepageServiceArguments = {
         | 'updateAnnouncement'
         | 'deleteAnnouncement'
         | 'publishProjectDraftAnnouncements'
+        | 'findOrgHomepageSettings'
+        | 'upsertOrgHomepageSettings'
+        | 'swapHeroBlocks'
     >;
     featureFlagService: Pick<FeatureFlagService, 'get'>;
     groupsModel: Pick<GroupsModel, 'findUserGroups'>;
@@ -227,14 +232,84 @@ export class ProjectHomepageService extends BaseService {
         this.lightdashConfig = args.lightdashConfig;
     }
 
-    private async assertFlagEnabled(user: SessionUser): Promise<void> {
+    // Homepage v2 is on when the org opted in via settings OR the commercial
+    // flag is set — the flag remains as the legacy enablement path and
+    // kill-switch while the opt-in flow rolls out.
+    private async isHomepageEnabled(user: SessionUser): Promise<boolean> {
+        if (user.organizationUuid) {
+            const settings =
+                await this.projectHomepageModel.findOrgHomepageSettings(
+                    user.organizationUuid,
+                );
+            if (settings?.enabled) return true;
+        }
         const flag = await this.featureFlagService.get({
             user,
             featureFlagId: CommercialFeatureFlags.HomepageBuilder,
         });
-        if (!flag.enabled) {
+        return flag.enabled;
+    }
+
+    private async assertFlagEnabled(user: SessionUser): Promise<void> {
+        if (!(await this.isHomepageEnabled(user))) {
             throw new ForbiddenError('Homepage builder is not enabled');
         }
+    }
+
+    async getOrgHomepageSettings(
+        user: SessionUser,
+    ): Promise<OrganizationHomepageSettings> {
+        if (!user.organizationUuid) {
+            throw new ForbiddenError();
+        }
+        const settings =
+            await this.projectHomepageModel.findOrgHomepageSettings(
+                user.organizationUuid,
+            );
+        return (
+            settings ?? {
+                organizationUuid: user.organizationUuid,
+                enabled: false,
+                opening: null,
+            }
+        );
+    }
+
+    async updateOrgHomepageSettings(
+        user: SessionUser,
+        update: UpdateOrganizationHomepageSettings,
+    ): Promise<OrganizationHomepageSettings> {
+        if (!user.organizationUuid) {
+            throw new ForbiddenError();
+        }
+        const ability = this.createAuditedAbility(user);
+        if (
+            ability.cannot(
+                'manage',
+                subject('Organization', {
+                    organizationUuid: user.organizationUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'Only organization admins can change homepage settings',
+            );
+        }
+        const settings =
+            await this.projectHomepageModel.upsertOrgHomepageSettings(
+                user.organizationUuid,
+                update,
+            );
+        // Choosing an opening is an explicit layout decision: rewrite stored
+        // hero blocks in both directions so the builder, drafts, and
+        // published pages all agree with it (block ids and density survive).
+        if (update.opening !== null) {
+            await this.projectHomepageModel.swapHeroBlocks(
+                user.organizationUuid,
+                update.opening,
+            );
+        }
+        return settings;
     }
 
     private async assertCanView(

--- a/packages/common/src/ee/homepage/orgSettings.ts
+++ b/packages/common/src/ee/homepage/orgSettings.ts
@@ -1,0 +1,37 @@
+import { type ApiSuccess } from '../../types/api/success';
+
+/** Which hero opens the homepage: the Ask AI composer or greeting + quick
+ * actions. An admin's layout decision, independent of whether AI is licensed. */
+export type HomepageOpening = 'ask-first' | 'content-first';
+
+export const HOMEPAGE_OPENINGS: HomepageOpening[] = [
+    'ask-first',
+    'content-first',
+];
+
+export const isHomepageOpening = (value: unknown): value is HomepageOpening =>
+    typeof value === 'string' &&
+    HOMEPAGE_OPENINGS.includes(value as HomepageOpening);
+
+/** Org-wide homepage v2 state. `enabled` turns the new homepage on for every
+ * project in the organization; the commercial flag remains as a kill-switch.
+ * `opening: null` means "auto" — AI availability decides, which is the legacy
+ * behaviour for orgs enabled via the flag before this setting existed. */
+export type OrganizationHomepageSettings = {
+    organizationUuid: string;
+    enabled: boolean;
+    opening: HomepageOpening | null;
+};
+
+export type UpdateOrganizationHomepageSettings = {
+    enabled: boolean;
+    opening: HomepageOpening | null;
+};
+
+/** Subtitle a greeting hero starts with, shared by the starter homepage and
+ * the opt-in swap of stored ask heroes to greetings. */
+export const HOMEPAGE_DEFAULT_GREETING_SUBTITLE =
+    'Pick up where you left off, or start something new.';
+
+export type ApiOrganizationHomepageSettingsResponse =
+    ApiSuccess<OrganizationHomepageSettings>;

--- a/packages/common/src/ee/index.ts
+++ b/packages/common/src/ee/index.ts
@@ -20,6 +20,7 @@ export * from './commercialFeatureFlags';
 export * from './designs/types';
 export * from './embed';
 export * from './homepage/onboardingHomepage';
+export * from './homepage/orgSettings';
 export * from './homepage/schema';
 export * from './homepage/types';
 export * from './preAggregates';

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -79,6 +79,7 @@ import type {
     ApiOrganizationDesignFileResponse,
     ApiOrganizationDesignResponse,
     ApiOrganizationDesignsResponse,
+    ApiOrganizationHomepageSettingsResponse,
     ApiPreviewTokenResponse,
     ApiProjectHomepageOrNullResponse,
     ApiProjectHomepageResponse,
@@ -1342,6 +1343,7 @@ type ApiResults =
     | ApiOrganizationDesignFileResponse['results']
     | ApiProjectHomepageResponse['results']
     | ApiProjectHomepageOrNullResponse['results']
+    | ApiOrganizationHomepageSettingsResponse['results']
     | ApiResolvedHomepageResponse['results']
     | ApiAnnouncementsResponse['results']
     | ApiAnnouncementResponse['results']


### PR DESCRIPTION
## Org-level homepage settings with opening preset (1/4)

Part of [ZAP-749](https://linear.app/lightdash/issue/ZAP-749) under [ZAP-747](https://linear.app/lightdash/issue/ZAP-747). Implements [PROD-9327](https://linear.app/lightdash/issue/PROD-9327) / #26440 at org scope.

### What
- New EE table `organization_homepage_settings` (`enabled`, `opening: ask-first | content-first | null`, org uuid PK). Org-wide by design: opting in propagates to all projects.
- `GET/PATCH /api/v1/org/homepage-settings` (read: any member; write: org admins).
- Enablement rule: homepage v2 is on when **settings OR the commercial flag** — the flag becomes the legacy path/kill-switch.
- **Choosing an opening rewrites stored hero blocks symmetrically** (`swapHeroBlocks`: content-first turns ask heroes into greetings and vice versa, ids/density survive) so the builder, drafts, and published pages always agree with the admin's explicit choice.
- **Backfill migration**: orgs enabled via the flag override get an explicit settings row (`opening NULL` = auto, zero behaviour change), so enablement survives eventual flag removal.

### Regression analysis
- No settings row + flag off: unchanged (disabled). Flag-enabled orgs: unchanged behaviour, now with an explicit row.
- `swapHeroBlocks` only runs on an explicit admin PATCH with an opening; it never fires from reads or migrations. Concurrent draft saves are protected by the existing `updatedAt` compare-and-set.
- Backfill verified via rollback/re-migrate cycle locally; additive with `ON CONFLICT DO NOTHING`, no-op `down`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1fe2jShYJrNxZRXw5E6jx