### PR TITLE
feat(homepage): render paths respect the org opening preset

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.test.tsx
@@ -26,8 +26,12 @@ vi.mock('./hooks/useRecentContents', () => ({
     }),
 }));
 
-vi.mock('./hooks/useHomepageAiState', () => ({
-    useHomepageAiState: () => ({ isLoading: false, ...aiState.current }),
+vi.mock('./hooks/useOrgHomepageSettings', () => ({
+    useHomepageOpening: () => ({
+        isLoading: false,
+        canAskAi: aiState.current.canAskAi,
+        opening: aiState.current.canAskAi ? 'ask-first' : 'content-first',
+    }),
 }));
 
 vi.mock('../../../providers/App/useApp', () => ({
@@ -54,6 +58,14 @@ vi.mock('./blocks/ContentCard', () => ({
 
 vi.mock('./hooks/useCollectionContent', () => ({
     useCollectionContent: () => ({ data: [{ uuid: 'pinned-1' }] }),
+}));
+
+vi.mock('./hooks/useCollectionSourceContent', () => ({
+    useCollectionSourceContent: () => ({
+        items: [],
+        isLoading: false,
+        source: 'most-viewed',
+    }),
 }));
 
 vi.mock('./blocks/RecentBlock', () => ({

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.tsx
@@ -1,22 +1,23 @@
 import { type PinnedItems } from '@lightdash/common';
-import { Box, Stack, Text } from '@mantine-8/core';
-import { IconClock, IconPin } from '@tabler/icons-react';
+import { Box, Stack } from '@mantine-8/core';
+import { IconClock, IconFlame, IconPin } from '@tabler/icons-react';
 import { type FC } from 'react';
-import useApp from '../../../providers/App/useApp';
 import { AskAiHero } from './blocks/AskAiHeroBlock';
 import { BlockHeader } from './blocks/BlockShell';
 import { ContentCard } from './blocks/ContentCard';
 import { PersonalFavoritesBar } from './blocks/FavoritesBlock';
+import { GreetingHero } from './blocks/GreetingHero';
 import { KeySpaces } from './blocks/KeySpaces';
 import { getDefaultQuickActions } from './blocks/quickActionDefaults';
 import { QuickActionCards } from './blocks/QuickActionsBlock';
 import { RecentList } from './blocks/RecentBlock';
 import classes from './DayOneHomepage.module.css';
-import { getGreeting } from './greeting';
+import { DEFAULT_GREETING_SUBTITLE } from './greeting';
 import layout from './homepageLayout.module.css';
 import { useCollectionContent } from './hooks/useCollectionContent';
-import { useHomepageAiState } from './hooks/useHomepageAiState';
+import { useCollectionSourceContent } from './hooks/useCollectionSourceContent';
 import { useKeySpaces } from './hooks/useKeySpaces';
+import { useHomepageOpening } from './hooks/useOrgHomepageSettings';
 import { useRecentContents } from './hooks/useRecentContents';
 
 type Props = {
@@ -51,13 +52,40 @@ const PinnedCollection: FC<{
     );
 };
 
+/** The project's most viewed content, resolved through the same live source
+ * the Collection block offers — day-0 shows what the org actually uses. */
+const MostPopularSection: FC<{ projectUuid: string }> = ({ projectUuid }) => {
+    const { items } = useCollectionSourceContent(projectUuid, {
+        title: 'Most popular',
+        source: 'most-viewed',
+        items: [],
+        limit: 4,
+    });
+
+    if (items.length === 0) return null;
+
+    return (
+        <Box>
+            <BlockHeader icon={IconFlame} title="Most popular" />
+            <Stack gap={8}>
+                {items.map((content) => (
+                    <ContentCard
+                        key={content.uuid}
+                        content={content}
+                        projectUuid={projectUuid}
+                    />
+                ))}
+            </Stack>
+        </Box>
+    );
+};
+
 // Four fits one grid row at the page's 3-column span, which is the point: a
 // starting set, not a directory.
 const MAX_KEY_SPACES = 4;
 
 export const DayOneHomepage: FC<Props> = ({ projectUuid, pinnedItems }) => {
-    const { user } = useApp();
-    const { canAskAi } = useHomepageAiState(projectUuid);
+    const { opening } = useHomepageOpening(projectUuid);
     const { spaces: keySpaces } = useKeySpaces(projectUuid, MAX_KEY_SPACES);
     const recent = useRecentContents(projectUuid);
     // Keep the header while loading so the section doesn't pop in under the
@@ -77,7 +105,7 @@ export const DayOneHomepage: FC<Props> = ({ projectUuid, pinnedItems }) => {
                 data-presentation="shared"
                 data-density="compact"
             >
-                {canAskAi ? (
+                {opening === 'ask-first' ? (
                     <div className={layout.hero}>
                         <AskAiHero
                             projectUuid={projectUuid}
@@ -88,24 +116,14 @@ export const DayOneHomepage: FC<Props> = ({ projectUuid, pinnedItems }) => {
                 ) : (
                     // Same hero shell and type scale as the Ask AI variant, so
                     // both day-0 openings sit identically in the fold
-                    <Stack className={layout.hero} gap={16} align="center">
-                        <Box ta="center">
-                            <Text
-                                component="h1"
-                                className={layout.heroGreeting}
-                            >
-                                {getGreeting(user.data?.firstName)}
-                            </Text>
-                            <Text className={layout.heroGreetingSub}>
-                                Pick up where you left off, or start something
-                                new.
-                            </Text>
-                        </Box>
-                        <QuickActionCards
-                            actions={getDefaultQuickActions()}
-                            projectUuid={projectUuid}
-                        />
-                    </Stack>
+                    <div className={layout.hero}>
+                        <GreetingHero subtitle={DEFAULT_GREETING_SUBTITLE}>
+                            <QuickActionCards
+                                actions={getDefaultQuickActions()}
+                                projectUuid={projectUuid}
+                            />
+                        </GreetingHero>
+                    </div>
                 )}
             </div>
 
@@ -130,6 +148,7 @@ export const DayOneHomepage: FC<Props> = ({ projectUuid, pinnedItems }) => {
                             <RecentList projectUuid={projectUuid} />
                         </Box>
                     )}
+                    <MostPopularSection projectUuid={projectUuid} />
                     <PinnedCollection
                         projectUuid={projectUuid}
                         pinnedItems={pinnedItems}

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageBuilderPage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageBuilderPage.tsx
@@ -11,8 +11,8 @@ import { useProject } from '../../../hooks/useProject';
 import useApp from '../../../providers/App/useApp';
 import { CreateHomepageModal } from './CreateHomepageModal';
 import { HomepageEditor } from './HomepageEditor';
-import { useHomepageAiState } from './hooks/useHomepageAiState';
 import { useKeySpaces } from './hooks/useKeySpaces';
+import { useHomepageOpening } from './hooks/useOrgHomepageSettings';
 import {
     useCreateHomepageWithDraft,
     useHomepageBuilderFlag,
@@ -38,8 +38,8 @@ export const HomepageBuilderPage: FC = () => {
     const { user } = useApp();
     const { isEnabled: isFlagEnabled, isLoading: isFlagLoading } =
         useHomepageBuilderFlag();
-    const { canAskAi, isLoading: isAiStateLoading } =
-        useHomepageAiState(projectUuid);
+    const { opening, isLoading: isAiStateLoading } =
+        useHomepageOpening(projectUuid);
     // The starter homepage mirrors day-0: the project's pins and the same key
     // spaces day-0 leads its body with.
     const { data: project } = useProject(projectUuid);
@@ -95,7 +95,7 @@ export const HomepageBuilderPage: FC = () => {
             {
                 name: 'Homepage',
                 draftConfig: buildStarterHomepage(
-                    canAskAi,
+                    opening,
                     (pinnedItems ?? []).map((item) => ({
                         contentType: item.type,
                         uuid: item.data.uuid,
@@ -109,7 +109,7 @@ export const HomepageBuilderPage: FC = () => {
         shouldAutoCreate,
         createFirstHomepage,
         openHomepage,
-        canAskAi,
+        opening,
         pinnedItems,
         keySpaces,
     ]);

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
@@ -4,10 +4,11 @@ import {
     type HomepageConfig,
 } from '@lightdash/common';
 import { Box, Paper, Text } from '@mantine-8/core';
-import { type FC, type ReactNode } from 'react';
+import { useMemo, type FC, type ReactNode } from 'react';
 import { TIER_CLASS } from './blockLayout';
 import { getBlockDefinition } from './blocks/registry';
 import layout from './homepageLayout.module.css';
+import { HomepageConfigFactsContext } from './hooks/useHomepageConfigFacts';
 import { useRuntimeEmptyBlocks } from './hooks/useRuntimeEmptyBlocks';
 import {
     resolveHomepageLayout,
@@ -112,56 +113,67 @@ export const PublishedHomepage: FC<Props> = ({
     personalPlaceholders = false,
     topBar = null,
 }) => {
-    const { hero, rows } = resolveHomepageLayout(migrateHomepageConfig(config));
+    const migrated = migrateHomepageConfig(config);
+    const { hero, rows } = resolveHomepageLayout(migrated);
+    const configFacts = useMemo(
+        () => ({
+            hasQuickActionsBlock: config.rows.some((row) =>
+                row.blocks.some((block) => block.type === 'quick-actions'),
+            ),
+        }),
+        [config],
+    );
 
     return (
-        <RuntimeEmptyBlocksProvider>
-            <div className={layout.page}>
-                {topBar}
-                {hero && (
-                    <div
-                        className={layout.heroSection}
-                        data-presentation={hero.presentation}
-                        data-density={hero.density}
-                    >
-                        {hero.companions.length > 0 && (
-                            <div className={layout.heroCompanions}>
-                                {hero.companions.map((row) => (
-                                    <RowRenderer
-                                        key={row.id}
-                                        row={row}
-                                        projectUuid={projectUuid}
-                                        personalPlaceholders={
-                                            personalPlaceholders
-                                        }
-                                    />
-                                ))}
+        <HomepageConfigFactsContext.Provider value={configFacts}>
+            <RuntimeEmptyBlocksProvider>
+                <div className={layout.page}>
+                    {topBar}
+                    {hero && (
+                        <div
+                            className={layout.heroSection}
+                            data-presentation={hero.presentation}
+                            data-density={hero.density}
+                        >
+                            {hero.companions.length > 0 && (
+                                <div className={layout.heroCompanions}>
+                                    {hero.companions.map((row) => (
+                                        <RowRenderer
+                                            key={row.id}
+                                            row={row}
+                                            projectUuid={projectUuid}
+                                            personalPlaceholders={
+                                                personalPlaceholders
+                                            }
+                                        />
+                                    ))}
+                                </div>
+                            )}
+                            <div className={layout.hero}>
+                                <BlockRenderer
+                                    block={hero.row.columns[0].block}
+                                    projectUuid={projectUuid}
+                                    personalPlaceholders={personalPlaceholders}
+                                    itemSpan={hero.row.columns[0].itemSpan}
+                                    standalone={hero.row.columns.length === 1}
+                                />
                             </div>
-                        )}
-                        <div className={layout.hero}>
-                            <BlockRenderer
-                                block={hero.row.columns[0].block}
-                                projectUuid={projectUuid}
-                                personalPlaceholders={personalPlaceholders}
-                                itemSpan={hero.row.columns[0].itemSpan}
-                                standalone={hero.row.columns.length === 1}
-                            />
                         </div>
-                    </div>
-                )}
-                {rows.length > 0 && (
-                    <div className={layout.secondary}>
-                        {rows.map((row) => (
-                            <RowRenderer
-                                key={row.id}
-                                row={row}
-                                projectUuid={projectUuid}
-                                personalPlaceholders={personalPlaceholders}
-                            />
-                        ))}
-                    </div>
-                )}
-            </div>
-        </RuntimeEmptyBlocksProvider>
+                    )}
+                    {rows.length > 0 && (
+                        <div className={layout.secondary}>
+                            {rows.map((row) => (
+                                <RowRenderer
+                                    key={row.id}
+                                    row={row}
+                                    projectUuid={projectUuid}
+                                    personalPlaceholders={personalPlaceholders}
+                                />
+                            ))}
+                        </div>
+                    )}
+                </div>
+            </RuntimeEmptyBlocksProvider>
+        </HomepageConfigFactsContext.Provider>
     );
 };

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.test.tsx
@@ -6,16 +6,24 @@ import { AskAiHeroBlockBuild, AskAiHeroBlockView } from './AskAiHeroBlock';
 vi.mock('../DayOneAskInput', () => ({
     DayOneAskInput: () => <div data-testid="ask-input" />,
 }));
-vi.mock('../../aiCopilot/hooks/useAiAgentsButtonVisibility', () => ({
-    useAiAgentButtonVisibility: () => true,
-}));
 vi.mock('../../../../providers/App/useApp', () => ({
     default: () => ({ user: { data: { firstName: 'Test' } } }),
+}));
+vi.mock('./QuickActionsBlock', () => ({
+    QuickActionCards: () => <div data-testid="quick-actions" />,
 }));
 const state = vi.hoisted(() => ({
     isLoading: false,
     isWarehouseConnected: true,
     hasPendingActions: false,
+    canAskAi: true,
+}));
+
+vi.mock('../hooks/useHomepageAiState', () => ({
+    useHomepageAiState: () => ({
+        canAskAi: state.canAskAi,
+        isLoading: false,
+    }),
 }));
 
 vi.mock('./useRecommendedActions', () => ({
@@ -57,6 +65,23 @@ describe('AskAiHeroBlockView', () => {
         state.isLoading = false;
         state.isWarehouseConnected = true;
         state.hasPendingActions = false;
+        state.canAskAi = true;
+    });
+
+    it('renders the greeting hero with quick actions when AI is unavailable', () => {
+        state.canAskAi = false;
+        wrap(
+            <AskAiHeroBlockView
+                itemSpan={null}
+                block={block}
+                projectUuid="p1"
+            />,
+        );
+        expect(screen.queryByTestId('ask-input')).toBeNull();
+        expect(screen.getByText(/Good \w+, Test/)).toBeInTheDocument();
+        // The full content-first hero: quick actions directly under the
+        // greeting, matching day-0 and the opt-in preview.
+        expect(screen.getByTestId('quick-actions')).toBeInTheDocument();
     });
 
     it('greets in the hero slot', () => {

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.tsx
@@ -1,4 +1,7 @@
-import { type HomepageHeroDensity } from '@lightdash/common';
+import {
+    type HomepageHeroDensity,
+    type HomepageOpening,
+} from '@lightdash/common';
 import {
     Box,
     SegmentedControl,
@@ -9,10 +12,14 @@ import {
 } from '@mantine-8/core';
 import { type FC } from 'react';
 import useApp from '../../../../providers/App/useApp';
-import { useAiAgentButtonVisibility } from '../../aiCopilot/hooks/useAiAgentsButtonVisibility';
 import { DayOneAskInput } from '../DayOneAskInput';
-import { getGreeting } from '../greeting';
+import { DEFAULT_GREETING_SUBTITLE, getGreeting } from '../greeting';
 import layout from '../homepageLayout.module.css';
+import { useHomepageAiState } from '../hooks/useHomepageAiState';
+import { useHomepageConfigFacts } from '../hooks/useHomepageConfigFacts';
+import { GreetingHero } from './GreetingHero';
+import { getDefaultQuickActions } from './quickActionDefaults';
+import { QuickActionCards } from './QuickActionsBlock';
 import {
     RecommendedActionsChecklist,
     RecommendedActionsChecklistPlaceholder,
@@ -109,12 +116,64 @@ export const HeroDensityControl: FC<{
     </Stack>
 );
 
+// Shared by both hero-capable blocks: swaps the block type in place (id and
+// density survive), so switching the opening never touches the rows below.
+export const HeroOpeningControl: FC<{
+    projectUuid: string;
+    value: HomepageOpening;
+    onSwap: (opening: HomepageOpening) => void;
+}> = ({ projectUuid, value, onSwap }) => {
+    const { canAskAi } = useHomepageAiState(projectUuid);
+    // Without a working composer there's no choice to offer.
+    if (!canAskAi) return null;
+    return (
+        <Stack gap={4}>
+            <Text size="xs" fw={500}>
+                Opening
+            </Text>
+            <SegmentedControl
+                size="xs"
+                value={value}
+                onChange={(next) => {
+                    if (next !== value) onSwap(next as HomepageOpening);
+                }}
+                data={[
+                    { value: 'ask-first', label: 'Ask AI' },
+                    { value: 'content-first', label: 'Greeting' },
+                ]}
+            />
+            <Text size="xs" c="dimmed">
+                Swaps just this opening block. Everything below stays put.
+            </Text>
+        </Stack>
+    );
+};
+
 export const AskAiHeroBlockView: FC<BlockComponentProps> = ({
     block,
     projectUuid,
 }) => {
-    const isAiEnabled = useAiAgentButtonVisibility();
-    if (block.type !== 'ask-ai-hero' || !isAiEnabled) return null;
+    // Stored configs are rewritten when an org chooses content-first, so a
+    // surviving ask-ai-hero block only degrades when AI can't answer: the
+    // hero slot becomes the greeting opening instead of a hole in the page.
+    const { canAskAi } = useHomepageAiState(projectUuid);
+    const { hasQuickActionsBlock } = useHomepageConfigFacts();
+    if (block.type !== 'ask-ai-hero') return null;
+    if (!canAskAi) {
+        // The full content-first hero, matching day-0: quick actions belong
+        // right under the greeting, unless the page already has its own
+        // quick-actions block (which would duplicate them).
+        return (
+            <GreetingHero subtitle={DEFAULT_GREETING_SUBTITLE}>
+                {!hasQuickActionsBlock && (
+                    <QuickActionCards
+                        actions={getDefaultQuickActions()}
+                        projectUuid={projectUuid}
+                    />
+                )}
+            </GreetingHero>
+        );
+    }
     // The greeting follows its toggle regardless of the block's position; it
     // still renders inline mid-page rather than only in the hero slot.
     return (
@@ -143,6 +202,20 @@ export const AskAiHeroBlockBuild: FC<BuildComponentProps> = ({
                     block.config.showRecommendedActions === true
                 }
                 preview
+            />
+            <HeroOpeningControl
+                projectUuid={projectUuid}
+                value="ask-first"
+                onSwap={() =>
+                    onChange({
+                        id: block.id,
+                        type: 'greeting',
+                        config: {
+                            subtitle: DEFAULT_GREETING_SUBTITLE,
+                            density: block.config.density,
+                        },
+                    })
+                }
             />
             <Switch
                 label="Show greeting"

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/GreetingBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/GreetingBlock.tsx
@@ -1,40 +1,37 @@
-import { Box, Stack, Text, TextInput } from '@mantine-8/core';
+import { Stack, TextInput } from '@mantine-8/core';
 import { type FC } from 'react';
-import useApp from '../../../../providers/App/useApp';
-import { getGreeting } from '../greeting';
-import layout from '../homepageLayout.module.css';
-import { HeroDensityControl } from './AskAiHeroBlock';
+import { HeroDensityControl, HeroOpeningControl } from './AskAiHeroBlock';
+import { GreetingHero } from './GreetingHero';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
-
-// Same type scale as the day-0 opening, so a greeting-led homepage and day-0
-// read identically.
-const Greeting: FC<{ subtitle: string }> = ({ subtitle }) => {
-    const { user } = useApp();
-    return (
-        <Box ta="center">
-            <Text component="h1" className={layout.heroGreeting}>
-                {getGreeting(user.data?.firstName)}
-            </Text>
-            {subtitle.trim() ? (
-                <Text className={layout.heroGreetingSub}>{subtitle}</Text>
-            ) : null}
-        </Box>
-    );
-};
 
 export const GreetingBlockView: FC<BlockComponentProps> = ({ block }) => {
     if (block.type !== 'greeting') return null;
-    return <Greeting subtitle={block.config.subtitle} />;
+    return <GreetingHero subtitle={block.config.subtitle} />;
 };
 
 export const GreetingBlockBuild: FC<BuildComponentProps> = ({
     block,
+    projectUuid,
     onChange,
 }) => {
     if (block.type !== 'greeting') return null;
     return (
         <Stack gap="sm">
-            <Greeting subtitle={block.config.subtitle} />
+            <GreetingHero subtitle={block.config.subtitle} />
+            <HeroOpeningControl
+                projectUuid={projectUuid}
+                value="content-first"
+                onSwap={() =>
+                    onChange({
+                        id: block.id,
+                        type: 'ask-ai-hero',
+                        config: {
+                            showGreeting: true,
+                            density: block.config.density,
+                        },
+                    })
+                }
+            />
             <TextInput
                 size="xs"
                 label="Line under the greeting"

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/GreetingHero.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/GreetingHero.tsx
@@ -1,0 +1,28 @@
+import { Box, Stack, Text } from '@mantine-8/core';
+import { type FC, type PropsWithChildren } from 'react';
+import useApp from '../../../../providers/App/useApp';
+import { getGreeting } from '../greeting';
+import layout from '../homepageLayout.module.css';
+
+/** The greeting opening, shared by day-0, the greeting block, and the AI
+ * hero's no-AI degrade so all three read identically. Children render under
+ * the greeting (e.g. quick actions). */
+export const GreetingHero: FC<PropsWithChildren<{ subtitle: string }>> = ({
+    subtitle,
+    children,
+}) => {
+    const { user } = useApp();
+    return (
+        <Stack gap={16} align="center">
+            <Box ta="center">
+                <Text component="h1" className={layout.heroGreeting}>
+                    {getGreeting(user.data?.firstName)}
+                </Text>
+                {subtitle.trim() ? (
+                    <Text className={layout.heroGreetingSub}>{subtitle}</Text>
+                ) : null}
+            </Box>
+            {children}
+        </Stack>
+    );
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/greeting.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/greeting.ts
@@ -1,4 +1,7 @@
+import { HOMEPAGE_DEFAULT_GREETING_SUBTITLE } from '@lightdash/common';
 import { dayPart } from './blocks/dayPart';
+
+export const DEFAULT_GREETING_SUBTITLE = HOMEPAGE_DEFAULT_GREETING_SUBTITLE;
 
 export const getGreeting = (firstName: string | undefined): string => {
     const name = firstName?.trim();

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useHomepageConfigFacts.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useHomepageConfigFacts.ts
@@ -1,0 +1,18 @@
+import { createContext, useContext } from 'react';
+
+type HomepageConfigFacts = {
+    /** Whether any block in the page config is a quick-actions block. The AI
+     * hero's content-first degrade uses it to avoid injecting a second set of
+     * quick actions. */
+    hasQuickActionsBlock: boolean;
+};
+
+/** Facts derived from the whole page config that individual blocks need but
+ * cannot see on their own (a block only knows itself). The defaults are the
+ * safe values for surfaces without a stored config (day-0, previews). */
+export const HomepageConfigFactsContext = createContext<HomepageConfigFacts>({
+    hasQuickActionsBlock: false,
+});
+
+export const useHomepageConfigFacts = () =>
+    useContext(HomepageConfigFactsContext);

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useOrgHomepageSettings.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useOrgHomepageSettings.ts
@@ -1,0 +1,48 @@
+import {
+    type ApiError,
+    type HomepageOpening,
+    type OrganizationHomepageSettings,
+} from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../../../../api';
+import { useHomepageAiState } from './useHomepageAiState';
+
+const ORG_HOMEPAGE_SETTINGS_QUERY_KEY = 'org_homepage_settings';
+
+const getOrgHomepageSettingsApi = async () =>
+    lightdashApi<OrganizationHomepageSettings>({
+        url: `/org/homepage-settings`,
+        method: 'GET',
+        body: undefined,
+    });
+
+export const useOrgHomepageSettings = () =>
+    useQuery<OrganizationHomepageSettings, ApiError>({
+        queryKey: [ORG_HOMEPAGE_SETTINGS_QUERY_KEY],
+        queryFn: getOrgHomepageSettingsApi,
+    });
+
+/**
+ * The opening the homepage should render, resolved from the org's choice and
+ * AI availability. The org preset wins; `null` (never chosen) falls back to
+ * the legacy rule where AI availability decides. Ask-first always requires a
+ * working composer, so without AI it clamps to content-first rather than
+ * opening on a hero that can't answer anything.
+ */
+export const useHomepageOpening = (projectUuid: string | undefined) => {
+    const settings = useOrgHomepageSettings();
+    const { canAskAi, isLoading: isAiStateLoading } =
+        useHomepageAiState(projectUuid);
+
+    const preferred = settings.data?.opening ?? null;
+    const opening: HomepageOpening =
+        preferred === 'content-first' || !canAskAi
+            ? 'content-first'
+            : 'ask-first';
+
+    return {
+        opening,
+        canAskAi,
+        isLoading: isAiStateLoading || settings.isInitialLoading,
+    };
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useProjectHomepage.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useProjectHomepage.ts
@@ -17,6 +17,7 @@ import useToaster from '../../../../hooks/toaster/useToaster';
 import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
 import { IS_MOBILE } from '../../../../utils/isMobile';
 import { ANNOUNCEMENTS_QUERY_KEY } from './useAnnouncements';
+import { useOrgHomepageSettings } from './useOrgHomepageSettings';
 
 const PROJECT_HOMEPAGE_QUERY_KEY = 'project_homepage';
 
@@ -125,12 +126,20 @@ const updateGroupPrioritiesApi = async (
     });
 
 export const useHomepageBuilderFlag = () => {
-    const { data: flag, isLoading } = useServerFeatureFlag(
+    const { data: flag, isLoading: isFlagLoading } = useServerFeatureFlag(
         CommercialFeatureFlags.HomepageBuilder,
     );
+    // Homepage v2 is on when the org opted in via settings OR the commercial
+    // flag is set — the flag remains as the legacy path/kill-switch while the
+    // opt-in flow rolls out. Must match the backend rule in
+    // ProjectHomepageService.isHomepageEnabled.
+    const settings = useOrgHomepageSettings();
     // The homepage builder / new onboarding surfaces are desktop-only for now,
     // so fall back to the classic homepage on mobile.
-    return { isEnabled: !IS_MOBILE && !!flag?.enabled, isLoading };
+    return {
+        isEnabled: !IS_MOBILE && (!!flag?.enabled || !!settings.data?.enabled),
+        isLoading: isFlagLoading || settings.isInitialLoading,
+    };
 };
 
 export const useResolvedHomepage = (

--- a/packages/frontend/src/ee/features/homepageBuilder/starterHomepage.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/starterHomepage.test.ts
@@ -1,44 +1,77 @@
+import { type HomepageOpening } from '@lightdash/common';
 import { describe, expect, it } from 'vitest';
 import { buildStarterHomepage } from './starterHomepage';
 
 const types = (
-    canAskAi: boolean,
+    opening: HomepageOpening,
     pins: { contentType: 'chart'; uuid: string }[] = [],
 ) =>
-    buildStarterHomepage(canAskAi, pins).rows.flatMap((row) =>
+    buildStarterHomepage(opening, pins).rows.flatMap((row) =>
         row.blocks.map((block) => block.type),
     );
 
 describe('buildStarterHomepage', () => {
     // The first homepage must reproduce day-0 block for block, in order, so
     // publishing it doesn't change the page out from under viewers.
-    it('mirrors the non-AI day-0 page', () => {
-        expect(types(false)).toEqual([
+    it('mirrors the content-first day-0 page', () => {
+        expect(types('content-first')).toEqual([
             'favorites',
             'greeting',
             'quick-actions',
             'recent',
+            'collection',
         ]);
     });
 
-    it('leads with the Ask AI hero when the project has an agent', () => {
-        expect(types(true)).toEqual(['favorites', 'ask-ai-hero']);
+    it('leads with the Ask AI hero for the ask-first opening', () => {
+        expect(types('ask-first')).toEqual([
+            'favorites',
+            'ask-ai-hero',
+            'recent',
+            'collection',
+        ]);
+    });
+
+    it('includes a live most-popular collection, mirroring day-0', () => {
+        const config = buildStarterHomepage('content-first', []);
+        const collections = config.rows
+            .flatMap((row) => row.blocks)
+            .filter((block) => block.type === 'collection');
+
+        expect(collections).toHaveLength(1);
+        expect(collections[0]).toMatchObject({
+            config: {
+                title: 'Most popular',
+                source: 'most-viewed',
+                items: [],
+            },
+        });
     });
 
     it('tracks the live pin list rather than copying it', () => {
         const pins = [{ contentType: 'chart' as const, uuid: 'chart-1' }];
-        const config = buildStarterHomepage(false, pins);
-        const collection = config.rows
+        const config = buildStarterHomepage('content-first', pins);
+        const pinnedCollection = config.rows
             .flatMap((row) => row.blocks)
-            .find((block) => block.type === 'collection');
+            .find(
+                (block) =>
+                    block.type === 'collection' &&
+                    block.config.title === 'Pinned',
+            );
 
         // A frozen copy would stop following pins after publish.
-        expect(collection).toMatchObject({
+        expect(pinnedCollection).toMatchObject({
             config: { title: 'Pinned', source: 'pinned', items: [] },
         });
     });
 
     it('leaves out the pinned collection when nothing is pinned', () => {
-        expect(types(false)).not.toContain('collection');
+        const config = buildStarterHomepage('content-first', []);
+        const titles = config.rows
+            .flatMap((row) => row.blocks)
+            .filter((block) => block.type === 'collection')
+            .map((block) => block.config.title);
+
+        expect(titles).not.toContain('Pinned');
     });
 });

--- a/packages/frontend/src/ee/features/homepageBuilder/starterHomepage.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/starterHomepage.ts
@@ -2,9 +2,11 @@ import {
     type HomepageBlock,
     type HomepageCollectionItemRef,
     type HomepageConfig,
+    type HomepageOpening,
 } from '@lightdash/common';
 import { v4 as uuidv4 } from 'uuid';
 import { getDefaultQuickActions } from './blocks/quickActionDefaults';
+import { DEFAULT_GREETING_SUBTITLE } from './greeting';
 
 /**
  * The layout a brand-new homepage starts from — a block-for-block copy of what
@@ -13,7 +15,7 @@ import { getDefaultQuickActions } from './blocks/quickActionDefaults';
  * people were already looking at, not drop them onto a different one.
  */
 export const buildStarterHomepage = (
-    canAskAi: boolean,
+    opening: HomepageOpening,
     pinnedItems: HomepageCollectionItemRef[],
     keySpaceUuids: string[] = [],
 ): HomepageConfig => {
@@ -25,7 +27,7 @@ export const buildStarterHomepage = (
             type: 'favorites',
             config: { title: 'My favorites' },
         }),
-        canAskAi
+        opening === 'ask-first'
             ? row({
                   id: uuidv4(),
                   type: 'ask-ai-hero',
@@ -34,12 +36,21 @@ export const buildStarterHomepage = (
             : row({
                   id: uuidv4(),
                   type: 'greeting',
-                  config: {
-                      subtitle:
-                          'Pick up where you left off, or start something new.',
-                  },
+                  config: { subtitle: DEFAULT_GREETING_SUBTITLE },
               }),
     ];
+
+    // Day-0 pairs the greeting with quick actions, directly under it — the
+    // AI hero stands alone.
+    if (opening === 'content-first') {
+        rows.push(
+            row({
+                id: uuidv4(),
+                type: 'quick-actions',
+                config: { actions: getDefaultQuickActions() },
+            }),
+        );
+    }
 
     // The same spaces day-0 leads its body with, so the first draft opens on
     // the page people were already looking at.
@@ -59,21 +70,29 @@ export const buildStarterHomepage = (
         );
     }
 
-    // Day-0 pairs the greeting with quick actions; the AI hero stands alone.
-    if (!canAskAi) {
-        rows.push(
-            row({
-                id: uuidv4(),
-                type: 'quick-actions',
-                config: { actions: getDefaultQuickActions() },
-            }),
-            row({
-                id: uuidv4(),
-                type: 'recent',
-                config: { title: 'Recently viewed' },
-            }),
-        );
-    }
+    // Day-0 shows Recently viewed for both openings, so the first draft must
+    // keep it too.
+    rows.push(
+        row({
+            id: uuidv4(),
+            type: 'recent',
+            config: { title: 'Recently viewed' },
+        }),
+    );
+
+    // Live most-viewed source, mirroring day-0: the block keeps tracking what
+    // the org actually uses rather than freezing a snapshot.
+    rows.push(
+        row({
+            id: uuidv4(),
+            type: 'collection',
+            config: {
+                title: 'Most popular',
+                source: 'most-viewed',
+                items: [],
+            },
+        }),
+    );
 
     if (pinnedItems.length > 0) {
         rows.push(


### PR DESCRIPTION
## Render paths respect the org opening preset (2/4)

Part of [ZAP-749](https://linear.app/lightdash/issue/ZAP-749) under [ZAP-747](https://linear.app/lightdash/issue/ZAP-747). The hero degrade also resolves [ZAP-724](https://linear.app/lightdash/issue/ZAP-724).

### What
- `useOrgHomepageSettings` + `useHomepageOpening`: the org preset decides the opening, clamped to content-first when AI can't answer.
- Day-0 and `buildStarterHomepage` branch on the resolved opening; quick actions sit directly under the greeting, above Start here.
- **Day-0 gains a Most popular section** backed by the live `most-viewed` collection source; the starter mirrors it with a live collection block.
- `AskAiHeroBlockView` degrades to the greeting hero (with quick actions, deduped via a page-level `HomepageConfigFacts` context) instead of rendering `null` when AI is unavailable.
- New shared `GreetingHero` consolidates the three previously duplicated greeting openings (day-0, greeting block, degrade).
- One-click opening swap (`HeroOpeningControl`) in both hero build panels.
- `useHomepageBuilderFlag` mirrors the backend rule: enabled = settings OR flag.

### Regression analysis
- Orgs with no settings row resolve exactly as before (AI availability decides).
- The degrade changes behaviour only where a stored ask hero previously rendered a blank slot (AI off / no agents).
- 267 tests pass on this branch standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1fe2jShYJrNxZRXw5E6jx