### PR TITLE
feat(homepage): onboarding provisioner respects the org opening preset

### DIFF
--- a/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.test.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.test.ts
@@ -99,6 +99,11 @@ const buildArguments = () => {
         >();
     const track =
         vi.fn<ProvisionOnboardingHomepageArguments['analytics']['track']>();
+    const findOrgHomepageSettings = vi
+        .fn<
+            ProvisionOnboardingHomepageArguments['projectHomepageModel']['findOrgHomepageSettings']
+        >()
+        .mockResolvedValue(null);
 
     const featureFlagService = {
         get: getFeatureFlag,
@@ -109,6 +114,7 @@ const buildArguments = () => {
         list: listHomepages,
         create: createHomepage,
         publish: publishHomepage,
+        findOrgHomepageSettings,
     };
     const analytics = { track };
 
@@ -142,6 +148,7 @@ const buildArguments = () => {
         listHomepages: vi.mocked(listHomepages),
         createHomepage: vi.mocked(createHomepage),
         publishHomepage: vi.mocked(publishHomepage),
+        findOrgHomepageSettings: vi.mocked(findOrgHomepageSettings),
         track: vi.mocked(track),
     };
 };
@@ -435,6 +442,24 @@ describe('provisionOnboardingHomepage', () => {
                 homepageBuilderEnablement: 'enabled',
                 codingAgentOnboardingEnablement: 'enabled',
             },
+        });
+    });
+
+    it('provisions the content-first homepage when the org chose that opening', async () => {
+        const mocks = buildArguments();
+        mocks.findOrgHomepageSettings.mockResolvedValue({
+            organizationUuid: ORGANIZATION_UUID,
+            enabled: true,
+            opening: 'content-first',
+        });
+
+        await provisionOnboardingHomepage(mocks.args);
+
+        expect(mocks.createHomepage).toHaveBeenCalledWith({
+            projectUuid: PROJECT_UUID,
+            name: 'Getting started',
+            draftConfig: buildOnboardingHomepageConfig('content-first'),
+            createdByUserUuid: USER_UUID,
         });
     });
 

--- a/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.ts
@@ -30,7 +30,7 @@ export type ProvisionOnboardingHomepageArguments = {
     projectModel: Pick<ProjectModel, 'getAllByOrganizationUuid'>;
     projectHomepageModel: Pick<
         ProjectHomepageModel,
-        'list' | 'create' | 'publish'
+        'list' | 'create' | 'publish' | 'findOrgHomepageSettings'
     >;
     analytics: Pick<LightdashAnalytics, 'track'>;
 };
@@ -139,10 +139,20 @@ export const provisionOnboardingHomepage = async ({
             return;
         }
 
+        // An org that already chose a content-first opening shouldn't get an
+        // AI-first homepage minted for its new projects.
+        const orgHomepageSettings =
+            await projectHomepageModel.findOrgHomepageSettings(
+                organizationUuid,
+            );
         const homepage = await projectHomepageModel.create({
             projectUuid,
             name: 'Getting started',
-            draftConfig: buildOnboardingHomepageConfig(),
+            draftConfig: buildOnboardingHomepageConfig(
+                orgHomepageSettings?.opening === 'content-first'
+                    ? 'content-first'
+                    : 'ask-first',
+            ),
             createdByUserUuid: user.userUuid,
         });
         await projectHomepageModel.publish(homepage.homepageUuid, {

--- a/packages/common/src/ee/homepage/onboardingHomepage.ts
+++ b/packages/common/src/ee/homepage/onboardingHomepage.ts
@@ -1,37 +1,75 @@
+import { type HomepageOpening } from './orgSettings';
 import { type HomepageConfig } from './types';
 
-export const buildOnboardingHomepageConfig = (): HomepageConfig => ({
+export const buildOnboardingHomepageConfig = (
+    opening: HomepageOpening = 'ask-first',
+): HomepageConfig => ({
     version: 1,
-    rows: [
-        {
-            id: 'onboarding-row-ask-ai-hero',
-            blocks: [
-                {
-                    id: 'onboarding-block-ask-ai-hero',
-                    type: 'ask-ai-hero',
-                    config: {
-                        showGreeting: true,
-                        showRecommendedActions: true,
-                    },
-                },
-            ],
-        },
-        {
-            id: 'onboarding-row-quick-actions',
-            blocks: [
-                {
-                    id: 'onboarding-block-quick-actions',
-                    type: 'quick-actions',
-                    config: {
-                        actions: [
-                            { type: 'ask-ai' },
-                            { type: 'run-query' },
-                            { type: 'browse-dashboards' },
-                            { type: 'browse-spaces' },
-                        ],
-                    },
-                },
-            ],
-        },
-    ],
+    rows:
+        opening === 'ask-first'
+            ? [
+                  {
+                      id: 'onboarding-row-ask-ai-hero',
+                      blocks: [
+                          {
+                              id: 'onboarding-block-ask-ai-hero',
+                              type: 'ask-ai-hero',
+                              config: {
+                                  showGreeting: true,
+                                  showRecommendedActions: true,
+                              },
+                          },
+                      ],
+                  },
+                  {
+                      id: 'onboarding-row-quick-actions',
+                      blocks: [
+                          {
+                              id: 'onboarding-block-quick-actions',
+                              type: 'quick-actions',
+                              config: {
+                                  actions: [
+                                      { type: 'ask-ai' },
+                                      { type: 'run-query' },
+                                      { type: 'browse-dashboards' },
+                                      { type: 'browse-spaces' },
+                                  ],
+                              },
+                          },
+                      ],
+                  },
+              ]
+            : [
+                  {
+                      id: 'onboarding-row-greeting',
+                      blocks: [
+                          {
+                              id: 'onboarding-block-greeting',
+                              type: 'greeting',
+                              config: {
+                                  subtitle:
+                                      'Pick up where you left off, or start something new.',
+                              },
+                          },
+                      ],
+                  },
+                  {
+                      id: 'onboarding-row-quick-actions',
+                      blocks: [
+                          {
+                              id: 'onboarding-block-quick-actions',
+                              type: 'quick-actions',
+                              config: {
+                                  // Ask AI stays reachable, just not the opening.
+                                  actions: [
+                                      { type: 'run-query' },
+                                      { type: 'browse-dashboards' },
+                                      { type: 'browse-spaces' },
+                                      { type: 'ask-ai' },
+                                  ],
+                              },
+                          },
+                      ],
+                  },
+              ],
 });


### PR DESCRIPTION
## Onboarding provisioner respects the org opening preset (3/3)

Part of [ZAP-749](https://linear.app/lightdash/issue/ZAP-749) under [ZAP-747](https://linear.app/lightdash/issue/ZAP-747).

### What
- `buildOnboardingHomepageConfig(opening)` gains a content-first variant: greeting hero + quick actions, with Ask AI demoted to a quick action instead of the opening.
- `provisionOnboardingHomepage` reads the org homepage settings before minting the "Getting started" homepage, so an org that chose content-first doesn't get an AI-first homepage on new projects.

### Regression analysis
- Default stays `ask-first` when no settings row or no explicit content-first choice exists — the exact config provisioned today, byte for byte (test asserts `buildOnboardingHomepageConfig()` equality).
- Known trade-off: the recommended-actions checklist only exists on the AI hero block, so content-first onboarding homepages don't show it. Called out in ZAP-749.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1fe2jShYJrNxZRXw5E6jx