### PR TITLE
feat(embed): create and edit charts in the embedded dashboard builder

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -453,6 +453,13 @@ export class EmbedService extends BaseService {
         }
 
         const { contentId } = decodedToken.content;
+
+        if (!contentId) {
+            throw new ParameterError(
+                'JWT content of type chart requires a `contentId` with the saved chart uuid or slug.',
+            );
+        }
+
         const chart = await this.savedChartModel.get(contentId);
 
         if (chart.projectUuid !== projectUuid) {

--- a/packages/backend/src/routers/savedChartRouter.ts
+++ b/packages/backend/src/routers/savedChartRouter.ts
@@ -149,7 +149,7 @@ savedChartRouter.post(
         req.services
             .getSavedChartService()
             .createVersion(
-                req.user!,
+                req.account!,
                 getObjectValue(req.params, 'savedQueryUuid'),
                 req.body,
             )

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.contentVerification.test.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.contentVerification.test.ts
@@ -301,7 +301,7 @@ describe('SavedChartService - Content Verification', () => {
     describe('Preserve verification on edit', () => {
         it('should preserve chart verification when admin edits content via createVersion', async () => {
             const result = await service.createVersion(
-                adminUser,
+                fromSession(adminUser, 'session-cookie'),
                 'chart-uuid',
                 {
                     tableName: 'test_table',
@@ -324,21 +324,25 @@ describe('SavedChartService - Content Verification', () => {
         });
 
         it('should auto-unverify chart when content is edited with preserveVerification=false', async () => {
-            await service.createVersion(adminUser, 'chart-uuid', {
-                tableName: 'test_table',
-                metricQuery: {
-                    exploreName: 'test',
-                    dimensions: [],
-                    metrics: [],
-                    filters: {},
-                    sorts: [],
-                    limit: 500,
-                    tableCalculations: [],
+            await service.createVersion(
+                fromSession(adminUser, 'session-cookie'),
+                'chart-uuid',
+                {
+                    tableName: 'test_table',
+                    metricQuery: {
+                        exploreName: 'test',
+                        dimensions: [],
+                        metrics: [],
+                        filters: {},
+                        sorts: [],
+                        limit: 500,
+                        tableCalculations: [],
+                    },
+                    chartConfig: { type: ChartType.CARTESIAN },
+                    tableConfig: { columnOrder: [] },
+                    preserveVerification: false,
                 },
-                chartConfig: { type: ChartType.CARTESIAN },
-                tableConfig: { columnOrder: [] },
-                preserveVerification: false,
-            });
+            );
 
             expect(contentVerificationModel.unverify).toHaveBeenCalledWith(
                 ContentType.CHART,

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -610,10 +610,12 @@ export class SavedChartService
     }
 
     async createVersion(
-        user: SessionUser,
+        account: Account,
         savedChartUuid: string,
         data: CreateSavedChartVersion,
     ): Promise<SavedChart> {
+        // Embed writes run as the write actor and only inside the write space
+        const { user, embedWriteActions } = getAccountWriteContext(account);
         const { preserveVerification, ...chartVersion } = data;
         const {
             organizationUuid,
@@ -626,6 +628,12 @@ export class SavedChartService
                 tableCalculations: oldTableCalculations,
             },
         } = await this.savedChartModel.get(savedChartUuid);
+
+        if (embedWriteActions && spaceUuid !== embedWriteActions.spaceUuid) {
+            throw new ForbiddenError(
+                'Embed token does not allow updating charts outside the write space',
+            );
+        }
 
         const { inheritsFromOrgOrProject, access } =
             await this.spacePermissionService.getSpaceAccessContext(

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -108,6 +108,14 @@ export enum FeatureFlags {
     EnableDataApps = 'enable-data-apps',
 
     /**
+     * Let embedded dashboard builders create and edit charts in place ("New
+     * chart" in the add-tile menu and "Edit chart" on tiles). Resolved with
+     * the embed write actor and organization, surfaced via embedWriteContext.
+     * Disabled by default.
+     */
+    EmbedChartBuilder = 'embed-chart-builder',
+
+    /**
      * Per-organization gate for declaring custom npm dependencies in data
      * apps. Disabled by default; self-hosted instances can enable it globally
      * via LIGHTDASH_ENABLE_FEATURE_FLAGS.

--- a/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
+++ b/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
@@ -43,6 +43,9 @@ type Props = {
     allowedTileTypes?: DashboardTileTypes[];
     spaceUuid?: string;
     maxSelectedValues?: number;
+    // Overrides the default "New chart" navigation (which leaves for the
+    // project's table picker). Embeds use this to build the chart in place.
+    onNewChart?: () => void;
 } & Pick<ButtonProps, 'disabled' | 'radius'>;
 
 const AddTileButton: FC<Props> = ({
@@ -55,6 +58,7 @@ const AddTileButton: FC<Props> = ({
     allowedTileTypes,
     spaceUuid,
     maxSelectedValues,
+    onNewChart,
 }) => {
     const [addTileType, setAddTileType] = useState<DashboardTileTypes>();
     const [isAddChartTilesModalOpen, setIsAddChartTilesModalOpen] =
@@ -76,7 +80,7 @@ const AddTileButton: FC<Props> = ({
         [allowedTileTypes],
     );
     const showSavedCharts = isTileTypeAllowed(DashboardTileTypes.SAVED_CHART);
-    const showNewChart = !allowedTileTypes;
+    const showNewChart = onNewChart !== undefined || !allowedTileTypes;
     const showDataApps =
         dataAppsEnabled && isTileTypeAllowed(DashboardTileTypes.DATA_APP);
     const showMarkdown = isTileTypeAllowed(DashboardTileTypes.MARKDOWN);
@@ -161,6 +165,10 @@ const AddTileButton: FC<Props> = ({
                         {showNewChart && (
                             <Menu.Item
                                 onClick={() => {
+                                    if (onNewChart) {
+                                        onNewChart();
+                                        return;
+                                    }
                                     storeDashboard(
                                         dashboardTiles,
                                         dashboardFilters,
@@ -179,7 +187,13 @@ const AddTileButton: FC<Props> = ({
                             >
                                 <Group gap="xxs">
                                     <Text fz="sm">New chart</Text>
-                                    <Tooltip label="Charts generated from here are exclusive to this dashboard">
+                                    <Tooltip
+                                        label={
+                                            onNewChart
+                                                ? 'Build a new chart and add it to this dashboard'
+                                                : 'Charts generated from here are exclusive to this dashboard'
+                                        }
+                                    >
                                         <MantineIcon
                                             icon={IconInfoCircle}
                                             color="ldGray.6"

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -53,6 +53,7 @@ import {
     IconAlertCircle,
     IconAlertTriangle,
     IconCopy,
+    IconFilePencil,
     IconFilter,
     IconFolders,
     IconRefreshDot,
@@ -593,6 +594,8 @@ interface DashboardChartTileMainProps extends Pick<
     canDateZoom?: boolean;
     canViewExplore?: boolean;
     onExplore?: (options: { chart: SavedChart }) => void;
+    // Embed dashboard builder: opens the chart in the in-place editor
+    onEditChart?: (chart: SavedChart) => void;
     colorPaletteOverride?: string[];
     darkColorPaletteOverride?: string[] | null;
 }
@@ -1888,6 +1891,7 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
         canExportImages,
         canViewExplore: canViewExploreOverride,
         onExplore,
+        onEditChart,
         colorPaletteOverride,
         darkColorPaletteOverride,
     } = props;
@@ -2028,8 +2032,19 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
                     canExportCsv ||
                     (canExportImages &&
                         !isTableChartConfig(chart.chartConfig.config)) ||
-                    isEmbeddedExploreEnabled ? (
+                    isEmbeddedExploreEnabled ||
+                    (onEditChart && props.isEditMode) ? (
                         <>
+                            {onEditChart && props.isEditMode && (
+                                <Menu.Item
+                                    leftSection={
+                                        <MantineIcon icon={IconFilePencil} />
+                                    }
+                                    onClick={() => onEditChart(chart)}
+                                >
+                                    Edit chart
+                                </Menu.Item>
+                            )}
                             {isEmbeddedExploreEnabled && (
                                 <Menu.Item
                                     leftSection={

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/BasePanel.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/BasePanel.tsx
@@ -32,7 +32,13 @@ const getPreAggregateName = (explore: SummaryExplore) =>
 const exploreHasGroups = (explore: SummaryExplore): boolean =>
     !!(explore.groups && explore.groups.length > 0) || !!explore.groupLabel;
 
-const BasePanel = () => {
+type Props = {
+    // Overrides the default navigation to the project's explore page. Embeds
+    // use this to keep the selected table inside the embed route.
+    onExploreClick?: (explore: SummaryExplore) => void;
+};
+
+const BasePanel = ({ onExploreClick }: Props) => {
     const navigate = useNavigate();
     const location = useLocation();
     const projectUuid = useProjectUuid();
@@ -130,13 +136,23 @@ const BasePanel = () => {
     const handleExploreClick = useCallback(
         (explore: SummaryExplore) => {
             startTransition(() => {
+                if (onExploreClick) {
+                    onExploreClick(explore);
+                    return;
+                }
                 void navigate({
                     pathname: `/projects/${projectUuid}/tables/${explore.name}`,
                     search: location.search,
                 });
             });
         },
-        [navigate, projectUuid, location.search, startTransition],
+        [
+            navigate,
+            projectUuid,
+            location.search,
+            startTransition,
+            onExploreClick,
+        ],
     );
 
     if (exploresResult.status === 'loading') {

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
@@ -1,4 +1,5 @@
 import { subject } from '@casl/ability';
+import { type SummaryExplore } from '@lightdash/common';
 import { useQueryClient } from '@tanstack/react-query';
 import {
     lazy,
@@ -26,7 +27,14 @@ import LoadingSkeleton from '../ExploreTree/LoadingSkeleton';
 const LazyExplorePanel = lazy(() => import('../ExplorePanel'));
 const LazyBasePanel = lazy(() => import('./BasePanel'));
 
-const ExploreSideBar = memo(() => {
+type Props = {
+    // Embeds override table navigation and the back-to-tables action so both
+    // stay inside the embed route.
+    onExploreClick?: (explore: SummaryExplore) => void;
+    onBackToTables?: () => void;
+};
+
+const ExploreSideBar = memo(({ onExploreClick, onBackToTables }: Props) => {
     const projectUuid = useProjectUuid();
 
     const tableName = useExplorerSelector(selectTableName);
@@ -56,8 +64,12 @@ const ExploreSideBar = memo(() => {
     );
     const handleBack = useCallback(() => {
         void clearExplore();
+        if (onBackToTables) {
+            onBackToTables();
+            return;
+        }
         void navigate(`/projects/${projectUuid}/tables`);
-    }, [clearExplore, navigate, projectUuid]);
+    }, [clearExplore, navigate, projectUuid, onBackToTables]);
 
     // When transitioning back to tables it's relatively fast so we don't show any skeleton
     const isTransitioningToExplore = useMemo(
@@ -71,12 +83,16 @@ const ExploreSideBar = memo(() => {
                 <LoadingSkeleton />
             ) : !tableName ? (
                 <Suspense fallback={<LoadingSkeleton />}>
-                    <LazyBasePanel />
+                    <LazyBasePanel onExploreClick={onExploreClick} />
                 </Suspense>
             ) : (
                 <Suspense fallback={<LoadingSkeleton />}>
                     <LazyExplorePanel
-                        onBack={canManageExplore ? handleBack : undefined}
+                        onBack={
+                            onBackToTables || canManageExplore
+                                ? handleBack
+                                : undefined
+                        }
                     />
                 </Suspense>
             )}

--- a/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
@@ -179,7 +179,7 @@ const ExplorerHeader: FC = memo(() => {
 
                 {/* For saved charts the main app saves from SavedChartsHeader;
                     embeds edit saved charts here, so keep the button ("Save changes") */}
-                {(!savedChart || (isEmbedded && canCreateEmbedSavedChart)) &&
+                {(!savedChart || isEmbedded) &&
                     (!isEmbedded || canCreateEmbedSavedChart) && (
                         <Tooltip
                             disabled={buttonDisabledMessage === null}

--- a/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/index.tsx
@@ -177,20 +177,23 @@ const ExplorerHeader: FC = memo(() => {
 
                 <RefreshButton size="xs" />
 
-                {!savedChart && (!isEmbedded || canCreateEmbedSavedChart) && (
-                    <Tooltip
-                        disabled={buttonDisabledMessage === null}
-                        withinPortal
-                        position="bottom"
-                        label={buttonDisabledMessage}
-                    >
-                        <div>
-                            <SaveChartButton
-                                disabled={buttonDisabledMessage !== null}
-                            />
-                        </div>
-                    </Tooltip>
-                )}
+                {/* For saved charts the main app saves from SavedChartsHeader;
+                    embeds edit saved charts here, so keep the button ("Save changes") */}
+                {(!savedChart || (isEmbedded && canCreateEmbedSavedChart)) &&
+                    (!isEmbedded || canCreateEmbedSavedChart) && (
+                        <Tooltip
+                            disabled={buttonDisabledMessage === null}
+                            withinPortal
+                            position="bottom"
+                            label={buttonDisabledMessage}
+                        >
+                            <div>
+                                <SaveChartButton
+                                    disabled={buttonDisabledMessage !== null}
+                                />
+                            </div>
+                        </Tooltip>
+                    )}
                 <Can
                     I="update"
                     this={subject('Explore', {

--- a/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
+++ b/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
@@ -85,7 +85,7 @@ const SaveChartButton: FC<{
         setIsQueryModalOpen(true);
     };
 
-    const update = useAddVersionMutation();
+    const update = useAddVersionMutation({ redirectOnSuccess: !isEmbedded });
     const updateMetadata = useUpdateMutation(
         savedChart?.dashboardUuid ?? undefined,
         savedChart?.uuid,
@@ -107,13 +107,20 @@ const SaveChartButton: FC<{
             });
         }
         if (hasVersionChanges) {
-            update.mutate({
-                uuid: savedChart.uuid,
-                payload: {
-                    ...unsavedChartVersionForSave,
-                    ...verificationUpdate,
+            update.mutate(
+                {
+                    uuid: savedChart.uuid,
+                    payload: {
+                        ...unsavedChartVersionForSave,
+                        ...verificationUpdate,
+                    },
                 },
-            });
+                {
+                    // Lets the embed dashboard builder react to the update
+                    // (e.g. close its chart editor modal)
+                    onSuccess: (data) => embed.onChartSaved?.(data),
+                },
+            );
         }
     };
     const { data: explore } = useExplore(unsavedChartVersion.tableName);
@@ -174,7 +181,9 @@ const SaveChartButton: FC<{
     const showSaveAsMenu = !!savedChart;
     const isSaveAsDisabled =
         !unsavedChartVersion.tableName ||
-        !hasUnsavedChanges ||
+        // Embeds may duplicate a chart as-is (there is no other way to copy
+        // one there); the main app keeps requiring changes
+        (!hasUnsavedChanges && !isEmbedded) ||
         foundCustomMetricWithDuplicateId ||
         !!missingRequiredParameters?.length;
 
@@ -262,9 +271,10 @@ const SaveChartButton: FC<{
                         setIsQueryModalOpen(false);
                         setIsSaveAsModal(false);
                     }}
-                    onConfirm={() => {
+                    onConfirm={(saved) => {
                         setIsQueryModalOpen(false);
                         setIsSaveAsModal(false);
+                        embed.onChartSaved?.(saved);
                     }}
                     defaultSpaceUuid={spaceUuid ?? undefined}
                     chartMetadata={generatedMetadata ?? undefined}

--- a/packages/frontend/src/components/common/Page/Page.module.css
+++ b/packages/frontend/src/components/common/Page/Page.module.css
@@ -28,6 +28,11 @@
     overflow-y: visible;
 }
 
+/* Hosted in a modal (or any non-viewport container): fill the parent, not 100vh */
+.root[data-container-height='true'] {
+    --page-height: 100%;
+}
+
 .root[data-full-page-scroll='true'] {
     height: auto;
     max-height: none;

--- a/packages/frontend/src/components/common/Page/Page.tsx
+++ b/packages/frontend/src/components/common/Page/Page.tsx
@@ -23,6 +23,9 @@ type StyleProps = {
     withFixedContent?: boolean;
     withFooter?: boolean;
     withFullHeight?: boolean;
+    // Size to the parent container instead of the viewport. Use when the page
+    // renders inside a modal or another host that is not viewport-height.
+    withContainerHeight?: boolean;
     withHeader?: boolean;
     withNavbar?: boolean;
     withPaddedContent?: boolean;
@@ -74,6 +77,7 @@ const Page: FC<React.PropsWithChildren<Props>> = ({
     withXLargePaddedContent = false,
     withFooter = false,
     withFullHeight = false,
+    withContainerHeight = false,
     withNavbar = true,
     withPaddedContent = false,
     withSidebarFooter = false,
@@ -117,6 +121,7 @@ const Page: FC<React.PropsWithChildren<Props>> = ({
                 data-has-banner={hasBanner}
                 data-full-page-scroll={fullPageScroll}
                 data-full-height={withFullHeight}
+                data-container-height={withContainerHeight}
                 data-with-sidebar={withSidebar}
                 data-sidebar-resizing={isSidebarResizing}
                 data-centered-root={withCenteredRoot}

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/index.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/index.tsx
@@ -1,4 +1,7 @@
-import { type CreateSavedChartVersion } from '@lightdash/common';
+import {
+    type CreateSavedChartVersion,
+    type SavedChart,
+} from '@lightdash/common';
 import { IconChartBar } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { useParams } from 'react-router';
@@ -14,7 +17,7 @@ interface ChartCreateModalProps extends Pick<
 > {
     savedData: CreateSavedChartVersion;
     defaultSpaceUuid?: string;
-    onConfirm: (savedData: CreateSavedChartVersion) => void;
+    onConfirm: (savedChart: SavedChart) => void;
     chartMetadata?: ChartMetadata;
     /**
      * When true, ignore the editing-dashboard context and let the user choose a

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
@@ -1,15 +1,21 @@
 import {
+    ChartType,
     DashboardTileTypes,
+    FeatureFlags,
     QueryExecutionContext,
     assertUnreachable,
+    getDefaultChartTileSize,
+    isDashboardContent,
     type DashboardTile,
     type EmbedDashboard as EmbedDashboardType,
+    type SavedChart,
 } from '@lightdash/common';
 import { Box, Button, Group, Tabs, TextInput } from '@mantine-8/core';
 import { IconCheck, IconPencil, IconUnlink, IconX } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { Responsive, WidthProvider, type Layout } from 'react-grid-layout';
 import { useLocation, useNavigate } from 'react-router';
+import { v4 as uuid4 } from 'uuid';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import SuboptimalState from '../../../../../components/common/SuboptimalState/SuboptimalState';
 import AddTileButton from '../../../../../components/DashboardTiles/AddTileButton';
@@ -32,10 +38,12 @@ import {
     appendNewTilesToBottom,
     useUpdateDashboard,
 } from '../../../../../hooks/dashboard/useDashboard';
+import { useServerFeatureFlag } from '../../../../../hooks/useServerOrClientFeatureFlag';
 import useDashboardContext from '../../../../../providers/Dashboard/useDashboardContext';
 import useEmbed from '../../../../providers/Embed/useEmbed';
 import { embedContractClass } from '../../styles/embedClassContract';
 import { useEmbedDashboard } from '../hooks';
+import EmbedDashboardChartEditorModal from './EmbedDashboardChartEditorModal';
 import EmbedDashboardChartTile from './EmbedDashboardChartTile';
 import EmbedDashboardHeader from './EmbedDashboardHeader';
 import EmbedDataAppTile from './EmbedDataAppTile';
@@ -66,6 +74,7 @@ const EmbedDashboardGrid: FC<{
     onBreakpointChange: (cols: number) => void;
     onDeleteTile: (tile: DashboardTile) => void;
     onEditTile: (tile: DashboardTile) => void;
+    onEditChart?: (chart: SavedChart) => void;
     useDashboardEditorTileQueries: boolean;
 }> = ({
     filteredTiles,
@@ -82,6 +91,7 @@ const EmbedDashboardGrid: FC<{
     onBreakpointChange,
     onDeleteTile,
     onEditTile,
+    onEditChart,
     useDashboardEditorTileQueries,
 }) => (
     <Group grow pt="sm" px="xs">
@@ -135,6 +145,7 @@ const EmbedDashboardGrid: FC<{
                                         isEditMode={isEditMode}
                                         onDelete={() => onDeleteTile(tile)}
                                         onEdit={onEditTile}
+                                        onEditChart={onEditChart}
                                         canExportCsv={dashboard.canExportCsv}
                                         canExportImages={
                                             dashboard.canExportImages
@@ -258,7 +269,14 @@ const EmbedDashboard: FC<{
     const setHaveTabsChanged = useDashboardContext((c) => c.setHaveTabsChanged);
     const haveTabsChanged = useDashboardContext((c) => c.haveTabsChanged);
 
-    const { embedToken, mode, paletteUuid, writeActions } = useEmbed();
+    const {
+        content,
+        embedToken,
+        embedWriteContext,
+        mode,
+        paletteUuid,
+        writeActions,
+    } = useEmbed();
     const navigate = useNavigate();
     const { pathname, search } = useLocation();
     const [localDashboard, setLocalDashboard] = useState<
@@ -443,6 +461,21 @@ const EmbedDashboard: FC<{
 
     const canWriteDashboard =
         !!writeActions && dashboard?.spaceUuid === writeActions.spaceUuid;
+    // Creating/editing charts in the builder is flag-gated and needs the
+    // token to allow ad-hoc exploring (canExplore) plus a write actor that
+    // can create charts in the write space.
+    const chartBuilderFlag = useServerFeatureFlag(
+        FeatureFlags.EmbedChartBuilder,
+    );
+    const canAddNewChart =
+        chartBuilderFlag.data?.enabled === true &&
+        canWriteDashboard &&
+        embedWriteContext?.canCreateSavedChart === true &&
+        content !== undefined &&
+        isDashboardContent(content) &&
+        content.canExplore === true;
+    const [isNewChartOpen, setIsNewChartOpen] = useState(false);
+    const [chartToEdit, setChartToEdit] = useState<SavedChart>();
     const hasDashboardNameChanged =
         !!dashboard && draftDashboardName.trim() !== dashboard.name;
     const hasDashboardChanged =
@@ -507,6 +540,39 @@ const EmbedDashboard: FC<{
             setDashboardTiles,
             setHaveTilesChanged,
         ],
+    );
+
+    const handleChartEditorSaved = useCallback(
+        (chart: SavedChart) => {
+            // "Save changes" on an existing tile's chart: the tile already
+            // references it and its query cache is reset by the update
+            // mutation, so it refreshes on its own. A different uuid means a
+            // brand-new chart ("New chart" or "Save as new chart") that still
+            // needs a tile.
+            const isNewChart = chart.uuid !== chartToEdit?.uuid;
+            if (isNewChart) {
+                handleAddTiles([
+                    {
+                        uuid: uuid4(),
+                        type: DashboardTileTypes.SAVED_CHART,
+                        properties: {
+                            savedChartUuid: chart.uuid,
+                            chartName: chart.name,
+                            // BigNumber charts default to hidden title for cleaner appearance
+                            hideTitle:
+                                chart.chartConfig.type === ChartType.BIG_NUMBER
+                                    ? true
+                                    : undefined,
+                        },
+                        tabUuid: undefined,
+                        ...getDefaultChartTileSize(chart.chartConfig.type),
+                    },
+                ]);
+            }
+            setChartToEdit(undefined);
+            setIsNewChartOpen(false);
+        },
+        [chartToEdit, handleAddTiles],
     );
 
     const handleDeleteTile = useCallback(
@@ -683,6 +749,11 @@ const EmbedDashboard: FC<{
                     spaceUuid={writeActions?.spaceUuid}
                     maxSelectedValues={1}
                     disabled={isSaving}
+                    onNewChart={
+                        canAddNewChart
+                            ? () => setIsNewChartOpen(true)
+                            : undefined
+                    }
                 />
                 <Button
                     size="xs"
@@ -760,6 +831,7 @@ const EmbedDashboard: FC<{
                 onBreakpointChange={setCurrentCols}
                 onDeleteTile={handleDeleteTile}
                 onEditTile={handleEditTile}
+                onEditChart={canAddNewChart ? setChartToEdit : undefined}
                 useDashboardEditorTileQueries={canWriteDashboard}
             />
         </>
@@ -830,6 +902,17 @@ const EmbedDashboard: FC<{
                     {renderDashboardEditToolbar()}
                     {renderGridWithGuidedSetup()}
                 </>
+            )}
+            {canAddNewChart && (
+                <EmbedDashboardChartEditorModal
+                    opened={isNewChartOpen || chartToEdit !== undefined}
+                    onClose={() => {
+                        setIsNewChartOpen(false);
+                        setChartToEdit(undefined);
+                    }}
+                    onChartSaved={handleChartEditorSaved}
+                    editChart={chartToEdit}
+                />
             )}
         </div>
     );

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardChartEditorModal.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardChartEditorModal.tsx
@@ -1,0 +1,82 @@
+import { type SavedChart } from '@lightdash/common';
+import { IconChartBar } from '@tabler/icons-react';
+import { useMemo, useState, type FC } from 'react';
+import MantineModal from '../../../../../components/common/MantineModal';
+import EmbedProviderContext from '../../../../providers/Embed/context';
+import useEmbed from '../../../../providers/Embed/useEmbed';
+import EmbedExplore from '../../EmbedExplore/components/EmbedExplore';
+
+type Props = {
+    opened: boolean;
+    onClose: () => void;
+    onChartSaved: (chart: SavedChart) => void;
+    // When set, the editor opens this chart and saving creates a new version
+    // of it; when absent, it starts from the table picker and creates a chart.
+    editChart?: SavedChart;
+};
+
+/**
+ * Chart editor for the embedded dashboard builder: a full-screen modal hosting
+ * an Explore. "New chart" starts on the table picker; "Edit chart" opens an
+ * existing tile's chart. Saving goes through the regular embed write-actions
+ * path and hands the chart back via `onChartSaved`.
+ */
+const EmbedDashboardChartEditorModal: FC<Props> = ({
+    opened,
+    onClose,
+    onChartSaved,
+    editChart,
+}) => {
+    const embedContext = useEmbed();
+    const [pickedExploreId, setPickedExploreId] = useState<string>();
+    const exploreId = editChart ? editChart.tableName : pickedExploreId;
+
+    const handleClose = () => {
+        setPickedExploreId(undefined);
+        onClose();
+    };
+
+    // The explorer renders over the dashboard, not instead of it: suppress the
+    // header's "Back to Dashboard" button (closing the modal is the way back)
+    // and capture the chart created/updated by the save flow.
+    const overriddenContext = useMemo(
+        () => ({
+            ...embedContext,
+            onBackToDashboard: undefined,
+            savedChart: undefined,
+            savedQueryUuid: undefined,
+            onChartSaved,
+        }),
+        [embedContext, onChartSaved],
+    );
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={handleClose}
+            title={editChart ? 'Edit chart' : 'New chart'}
+            icon={IconChartBar}
+            fullScreen
+            cancelLabel={false}
+            modalBodyProps={{ px: 0, py: 0 }}
+        >
+            <EmbedProviderContext.Provider value={overriddenContext}>
+                <EmbedExplore
+                    containerStyles={{ height: '100%', overflow: 'hidden' }}
+                    exploreId={exploreId ?? ''}
+                    savedChart={editChart}
+                    allowChartUpdate={editChart !== undefined}
+                    onExploreSelect={editChart ? undefined : setPickedExploreId}
+                    onBackToTables={
+                        editChart
+                            ? undefined
+                            : () => setPickedExploreId(undefined)
+                    }
+                    fitContainerHeight
+                />
+            </EmbedProviderContext.Provider>
+        </MantineModal>
+    );
+};
+
+export default EmbedDashboardChartEditorModal;

--- a/packages/frontend/src/ee/features/embed/EmbedExplore/components/EmbedExplore.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedExplore/components/EmbedExplore.tsx
@@ -19,7 +19,12 @@ import { useExplorerQueryEffects } from '../../../../../hooks/useExplorerQueryEf
 import { ExplorerSection } from '../../../../../providers/Explorer/types';
 import useEmbed from '../../../../providers/Embed/useEmbed';
 
-const EmbedExploreView: FC<{ exploreId: string }> = ({ exploreId }) => {
+const EmbedExploreView: FC<{
+    exploreId: string;
+    onExploreSelect?: (exploreName: string) => void;
+    onBackToTables?: () => void;
+    fitContainerHeight?: boolean;
+}> = ({ exploreId, onExploreSelect, onBackToTables, fitContainerHeight }) => {
     const { data } = useExplore(exploreId);
 
     // Run the query effects hook
@@ -27,8 +32,18 @@ const EmbedExploreView: FC<{ exploreId: string }> = ({ exploreId }) => {
 
     return (
         <Page
+            withContainerHeight={fitContainerHeight}
             title={data ? data?.label : 'Tables'}
-            sidebar={<ExploreSideBar />}
+            sidebar={
+                <ExploreSideBar
+                    onExploreClick={
+                        onExploreSelect
+                            ? (explore) => onExploreSelect(explore.name)
+                            : undefined
+                    }
+                    onBackToTables={onBackToTables}
+                />
+            }
             withFullHeight
             withPaddedContent
         >
@@ -39,8 +54,19 @@ const EmbedExploreView: FC<{ exploreId: string }> = ({ exploreId }) => {
 
 const EmbedExploreContent: FC<{
     exploreId: string;
-    savedChart: SavedChart | CreateSavedChartVersion;
-}> = ({ exploreId, savedChart }) => {
+    savedChart?: SavedChart | CreateSavedChartVersion;
+    onExploreSelect?: (exploreName: string) => void;
+    onBackToTables?: () => void;
+    fitContainerHeight?: boolean;
+    allowChartUpdate?: boolean;
+}> = ({
+    exploreId,
+    savedChart,
+    onExploreSelect,
+    onBackToTables,
+    fitContainerHeight,
+    allowChartUpdate,
+}) => {
     // Create store with embed-specific state
     // Using useState - store is created once when component mounts
     // Parent key prop ensures component remounts when exploring different tables
@@ -53,6 +79,12 @@ const EmbedExploreContent: FC<{
                 ExplorerSection.RESULTS,
             ],
             initialState: {
+                // With a full SavedChart in the store the save flow becomes
+                // "Save changes" (new version) instead of create
+                savedChart:
+                    allowChartUpdate && savedChart && 'uuid' in savedChart
+                        ? savedChart
+                        : undefined,
                 unsavedChartVersion: {
                     tableName: exploreId,
                     metricQuery: savedChart?.metricQuery || {
@@ -94,21 +126,38 @@ const EmbedExploreContent: FC<{
 
     return (
         <Provider store={store}>
-            <EmbedExploreView exploreId={exploreId} />
+            <EmbedExploreView
+                exploreId={exploreId}
+                onExploreSelect={onExploreSelect}
+                onBackToTables={onBackToTables}
+                fitContainerHeight={fitContainerHeight}
+            />
         </Provider>
     );
 };
 
 type Props = {
     containerStyles?: React.CSSProperties;
+    // Empty when no table is selected yet — the sidebar then shows the table picker
     exploreId: string;
-    savedChart: SavedChart | CreateSavedChartVersion;
+    savedChart?: SavedChart | CreateSavedChartVersion;
+    onExploreSelect?: (exploreName: string) => void;
+    onBackToTables?: () => void;
+    // Size the explore to its container instead of the viewport (modal hosts)
+    fitContainerHeight?: boolean;
+    // Treat a full SavedChart as editable: saving creates a new version of it
+    // instead of a new chart
+    allowChartUpdate?: boolean;
 };
 
 const EmbedExplore: FC<Props> = ({
     containerStyles,
     exploreId,
     savedChart,
+    onExploreSelect,
+    onBackToTables,
+    fitContainerHeight,
+    allowChartUpdate,
 }) => {
     const { projectUuid } = useEmbed();
     const { error: exploreError } = useExplore(exploreId);
@@ -140,9 +189,15 @@ const EmbedExplore: FC<Props> = ({
     return (
         <div style={containerStyles ?? { height: '100vh', overflowY: 'auto' }}>
             <EmbedExploreContent
-                key={`embed-${exploreId}`}
+                key={`embed-${exploreId}-${
+                    savedChart && 'uuid' in savedChart ? savedChart.uuid : ''
+                }`}
                 exploreId={exploreId}
                 savedChart={savedChart}
+                onExploreSelect={onExploreSelect}
+                onBackToTables={onBackToTables}
+                fitContainerHeight={fitContainerHeight}
+                allowChartUpdate={allowChartUpdate}
             />
         </div>
     );

--- a/packages/frontend/src/ee/features/embed/EmbedExplore/components/EmbedExplore.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedExplore/components/EmbedExplore.tsx
@@ -67,9 +67,7 @@ const EmbedExploreContent: FC<{
     fitContainerHeight,
     allowChartUpdate,
 }) => {
-    // Create store with embed-specific state
-    // Using useState - store is created once when component mounts
-    // Parent key prop ensures component remounts when exploring different tables
+    // The store initializes once; the parent key remounts it when inputs change.
     const [store] = useState(() => {
         const initialState = buildInitialExplorerState({
             isEditMode: true,
@@ -191,7 +189,7 @@ const EmbedExplore: FC<Props> = ({
             <EmbedExploreContent
                 key={`embed-${exploreId}-${
                     savedChart && 'uuid' in savedChart ? savedChart.uuid : ''
-                }`}
+                }-${allowChartUpdate ? 'update' : 'create'}`}
                 exploreId={exploreId}
                 savedChart={savedChart}
                 onExploreSelect={onExploreSelect}

--- a/packages/frontend/src/ee/providers/Embed/types.ts
+++ b/packages/frontend/src/ee/providers/Embed/types.ts
@@ -43,6 +43,9 @@ export interface EmbedContext {
     t: (input: string) => string | undefined;
     // The function to call when the user clicks "Back to dashboard" from an Explore
     onBackToDashboard?: () => void;
+    // Called after a chart is created from an embedded Explore. The dashboard
+    // builder's "New chart" flow uses this to turn the chart into a tile.
+    onChartSaved?: (chart: SavedChart) => void;
     // The chart that the user is exploring
     savedChart?: EmbedExploreChart;
     // The UUID of the saved query being viewed in an embedded Chart

--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -497,7 +497,12 @@ export const useDuplicateChartMutation = (
     );
 };
 
-export const useAddVersionMutation = () => {
+export const useAddVersionMutation = (options?: {
+    // Embeds save in place (e.g. the dashboard builder's chart editor); the
+    // chart view route doesn't exist there and would hit the auth guard.
+    redirectOnSuccess?: boolean;
+}) => {
+    const redirectOnSuccess = options?.redirectOnSuccess ?? true;
     const navigate = useNavigate();
     const queryClient = useQueryClient();
     const dashboardUuid = useSearchParams('fromDashboard');
@@ -559,9 +564,11 @@ export const useAddVersionMutation = () => {
                 showToastSuccess({
                     title: `Success! Chart was updated.`,
                 });
-                void navigate(
-                    `/projects/${data.projectUuid}/saved/${data.uuid}/view`,
-                );
+                if (redirectOnSuccess) {
+                    void navigate(
+                        `/projects/${data.projectUuid}/saved/${data.uuid}/view`,
+                    );
+                }
             }
         },
         onError: ({ error }) => {

--- a/scripts/dev-fast-start.sh
+++ b/scripts/dev-fast-start.sh
@@ -136,6 +136,27 @@ else
     echo "OK: venv ready"
 fi
 
+# The seed deploys the demo project with the backend's default dbt version
+# (currently v1.11, which needs Python >=3.10), so a dbt1.11 binary must be on
+# PATH alongside dbt1.7. Build it in its own shared venv (one dbt-core version
+# per venv) and shim it into the shared venv's bin.
+SHARED_VENV_111="${HOME}/.lightdash/dev-venv-1.11"
+if ! test -x venv/bin/dbt1.11; then
+    if ! test -f "$SHARED_VENV_111/bin/dbt"; then
+        PY310=""
+        for p in python3.13 python3.12 python3.11 python3.10; do
+            command -v "$p" >/dev/null 2>&1 && PY310="$p" && break
+        done
+        [ -n "$PY310" ] || fail "venv" "dbt 1.11 needs Python >=3.10 but none found (install e.g. brew install python@3.12)"
+        "$PY310" -m venv "$SHARED_VENV_111" || fail "venv" "$PY310 -m venv (dbt 1.11 cache) failed"
+        "$SHARED_VENV_111/bin/pip" install 'dbt-core~=1.11.0' dbt-postgres >/dev/null 2>&1 \
+            || fail "venv" "pip install dbt 1.11 into shared cache failed"
+    fi
+    ln -sf "$SHARED_VENV_111/bin/dbt" "$SHARED_VENV/bin/dbt1.11" 2>/dev/null || ln -sf "$SHARED_VENV_111/bin/dbt" venv/bin/dbt1.11
+    test -x venv/bin/dbt1.11 || fail "venv" "dbt1.11 shim is broken"
+    echo "OK: dbt1.11 available ($SHARED_VENV_111)"
+fi
+
 # ---------------------------------------------------------------------------
 step "Ensure .env.development.local"
 ENV_PORTS_CHANGED=0


### PR DESCRIPTION
Closes [PROD-9141](https://linear.app/lightdash/issue/PROD-9141)

## What

Adds in-place chart authoring to the **embedded dashboard builder**, behind the `embed-chart-builder` feature flag. With a `dashboard` embed token carrying `canExplore: true` and `writeActions`, the builder's edit mode gains:

- **New chart** in the "Add tile" menu: opens a full-screen editor starting from the table picker; the saved chart is created in the `writeActions` space (as the write actor) and appended to the dashboard as a tile.
- **Edit chart** on chart tiles: opens the same editor pre-loaded with the chart in update mode ("Save changes" creates a new version of the same chart); the tile refreshes automatically.
- **Save as new chart** while editing: duplicates the chart (enabled even without query changes, since embeds have no other way to copy a chart) and adds the copy as a tile.

The editor is a full-screen modal rather than a route so it works identically in iframe and SDK modes and never unmounts the builder (no draft-persistence machinery needed). Tokens mint exactly as before; no new JWT content type or permission grants.

## Rollout

`embed-chart-builder` is disabled by default. Enable per instance via `LIGHTDASH_ENABLE_FEATURE_FLAGS=embed-chart-builder` or the flag's DB default. Note: embed pages resolve flags without user/org context, so per-organization overrides do not apply to embedded users — flag on/off is effectively instance-wide for this surface.

## How to test

1. Enable the `embed-chart-builder` flag and mint a dashboard embed token with `canExplore: true` and `writeActions: { userUuid | serviceAccountUserUuid, spaceUuid }` for a dashboard in that space (`examples/api/embedding.http`).
2. Open the embed → **Edit** → **Add tile → New chart** → pick a table, build a query, save → tile appears; **Save** the dashboard.
3. Hover a chart tile → **⋯ → Edit chart** → modify → **Save changes** → editor closes, tile refreshes. Try the **+** split button for "Save as new chart".
4. With the flag off (or without `writeActions`/`canExplore`), none of the new options render and the builder behaves as before.

Verified end-to-end in a browser (both flag states) plus unit suites for jwt abilities, EmbedService, and SavedChartService.


https://github.com/user-attachments/assets/d415c018-4dd0-47f5-a5be-e192e92f1e98

