### PR TITLE
feat: attribute saved charts to the data app viz they render

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -806,6 +806,15 @@ export type CreateSavedChartVersionEvent = BaseTrack & {
             size: number;
             type: string;
         };
+        // The viz a chart renders with. `dataAppVizUuid` is the only join key
+        // between a saved chart and the data app that backs it — no other chart
+        // event carries it, so without this the analytics side can count viz
+        // charts but never attribute them to a viz.
+        dataAppViz?: {
+            dataAppVizUuid: string;
+            mappedFieldCount: number;
+            changedOptionCount: number;
+        };
         numFixedWidthBinCustomDimensions: number;
         numFixedBinsBinCustomDimensions: number;
         numCustomRangeBinCustomDimensions: number;

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -806,10 +806,7 @@ export type CreateSavedChartVersionEvent = BaseTrack & {
             size: number;
             type: string;
         };
-        // The viz a chart renders with. `dataAppVizUuid` is the only join key
-        // between a saved chart and the data app that backs it — no other chart
-        // event carries it, so without this the analytics side can count viz
-        // charts but never attribute them to a viz.
+        // Join key linking a saved chart to its data app viz
         dataAppViz?: {
             dataAppVizUuid: string;
             mappedFieldCount: number;

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.dataAppVizEvent.test.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.dataAppVizEvent.test.ts
@@ -1,0 +1,89 @@
+import {
+    ChartType,
+    type MetricQuery,
+    type SavedChartDAO,
+} from '@lightdash/common';
+import { SavedChartService } from './SavedChartService';
+
+const metricQuery: MetricQuery = {
+    exploreName: 'orders',
+    dimensions: ['orders_status'],
+    metrics: ['orders_count'],
+    filters: {},
+    sorts: [],
+    limit: 500,
+    tableCalculations: [],
+};
+
+const chartWithConfig = (
+    chartConfig: SavedChartDAO['chartConfig'],
+): SavedChartDAO =>
+    ({
+        uuid: 'chart-uuid',
+        projectUuid: 'project-uuid',
+        name: 'Revenue by status',
+        description: undefined,
+        metricQuery,
+        chartConfig,
+        parameters: {},
+    }) as SavedChartDAO;
+
+describe('SavedChartService.getCreateEventProperties data app viz attribution', () => {
+    it('carries the viz uuid and config shape for a data app viz chart', () => {
+        const properties = SavedChartService.getCreateEventProperties(
+            chartWithConfig({
+                type: ChartType.DATA_APP_VIZ,
+                config: {
+                    dataAppVizUuid: 'viz-uuid',
+                    fieldMapping: {
+                        category: 'orders_status',
+                        value: 'orders_count',
+                    },
+                    optionValues: { showLegend: false },
+                },
+            }),
+        );
+
+        expect(properties.chartType).toBe(ChartType.DATA_APP_VIZ);
+        expect(properties.dataAppViz).toEqual({
+            dataAppVizUuid: 'viz-uuid',
+            mappedFieldCount: 2,
+            changedOptionCount: 1,
+        });
+    });
+
+    it('reports zero changed options when the user kept every default', () => {
+        const properties = SavedChartService.getCreateEventProperties(
+            chartWithConfig({
+                type: ChartType.DATA_APP_VIZ,
+                config: {
+                    dataAppVizUuid: 'viz-uuid',
+                    fieldMapping: { category: 'orders_status' },
+                },
+            }),
+        );
+
+        expect(properties.dataAppViz).toEqual({
+            dataAppVizUuid: 'viz-uuid',
+            mappedFieldCount: 1,
+            changedOptionCount: 0,
+        });
+    });
+
+    it('omits the block for a viz chart saved before a viz was picked', () => {
+        const properties = SavedChartService.getCreateEventProperties(
+            chartWithConfig({ type: ChartType.DATA_APP_VIZ }),
+        );
+
+        expect(properties.chartType).toBe(ChartType.DATA_APP_VIZ);
+        expect(properties.dataAppViz).toBeUndefined();
+    });
+
+    it('omits the block for every other chart type', () => {
+        const properties = SavedChartService.getCreateEventProperties(
+            chartWithConfig({ type: ChartType.TABLE, config: {} }),
+        );
+
+        expect(properties.dataAppViz).toBeUndefined();
+    });
+});

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -399,6 +399,20 @@ export class SavedChartService
                                   : `${savedChart.chartConfig.config?.spec?.mark}`,
                       }
                     : undefined,
+            dataAppViz:
+                savedChart.chartConfig.type === ChartType.DATA_APP_VIZ &&
+                savedChart.chartConfig.config
+                    ? {
+                          dataAppVizUuid:
+                              savedChart.chartConfig.config.dataAppVizUuid,
+                          mappedFieldCount: Object.keys(
+                              savedChart.chartConfig.config.fieldMapping || {},
+                          ).length,
+                          changedOptionCount: Object.keys(
+                              savedChart.chartConfig.config.optionValues || {},
+                          ).length,
+                      }
+                    : undefined,
             parametersCount: Object.keys(savedChart.parameters || {}).length,
             ...countCustomDimensionsInMetricQuery(savedChart.metricQuery),
             ...SavedChartService.getChartConfigEventProperties(savedChart),


### PR DESCRIPTION
Closes the last gap for [GLITCH-650](https://linear.app/lightdash/issue/GLITCH-650/preparation-gather-usage-metrics-and-candidates-for-testing).

## The gap

`saved_chart_version.created` already carries a per-chart-type detail object for `cartesian`, `pie`, `table`, `bigValue`, `treemap`, `funnel` and `custom`. `data_app_viz` was the only chart type without one, so the event recorded that a chart used a viz but never which viz.

That uuid lives only in `DataAppVizChartConfig.config`, and the analytics project ingests events only with no Lightdash database replica, so it cannot be recovered downstream. Without it, viz adoption can be counted per project but never attributed to an individual viz, which is what separates a load-bearing viz from an abandoned one.

## What changed

A `dataAppViz` detail object on `CreateSavedChartVersionEvent`, populated in `SavedChartService.getCreateEventProperties` exactly like the ones next to it:

- `dataAppVizUuid`, the join key
- `mappedFieldCount` and `changedOptionCount`, the config-shape counts, mirroring how `custom` reports `size` and `type`

No field mappings, option values or other user content are sent. Charts saved before a viz was picked have no config and are simply omitted from the block, same as every other chart type.

## Notes

Data starts from deploy. The corresponding analytics models land in lightdash/analytics#114, which for now counts viz charts in aggregate on `chart_usage`; a per-viz chart count goes on `data_app_vizs` once this has been live long enough to be worth reading.

## Testing

Four unit tests on `getCreateEventProperties` covering a fully configured viz, one with only defaults, a viz chart with no config, and a non-viz chart. Backend lint passes, and typecheck is clean apart from the pre-existing `split2` module error on main.