### PR TITLE
fix(databricks): restrict dynamic OAuth hosts

### DIFF
--- a/packages/backend/src/controllers/authentication/strategies/databricksStrategy.test.ts
+++ b/packages/backend/src/controllers/authentication/strategies/databricksStrategy.test.ts
@@ -1,0 +1,46 @@
+import { ParameterError } from '@lightdash/common';
+import {
+    getDatabricksOidcEndpointsFromHost,
+    normalizeDatabricksHostLenient,
+} from './databricksStrategy';
+
+describe('getDatabricksOidcEndpointsFromHost', () => {
+    it.each([
+        'dbc-123.cloud.databricks.com',
+        'dbc-123.dev.databricks.com',
+        '123.gcp.databricks.com',
+        'adb-123.4.azuredatabricks.net',
+        'adb-123.databricks.azure.cn',
+        'adb-123.databricks.azure.us',
+        'dbc-123.cloud.databricks.us',
+        'dbc-123.cloud.databricks.mil',
+    ])('constructs OAuth endpoints for %s', (serverHostName) => {
+        expect(getDatabricksOidcEndpointsFromHost(serverHostName)).toEqual({
+            host: serverHostName,
+            issuer: `https://${serverHostName}`,
+            authorizationURL: `https://${serverHostName}/oidc/v1/authorize`,
+            tokenURL: `https://${serverHostName}/oidc/v1/token`,
+        });
+    });
+
+    it.each([
+        'attacker.example.com',
+        'localhost:4443',
+        'cloud.databricks.com',
+        'fakecloud.databricks.com',
+        'dbc-123.cloud.databricks.com.attacker.example',
+        'dbc-123.cloud.databricks.com:8443',
+    ])('rejects a non-workspace OAuth endpoint at %s', (serverHostName) => {
+        expect(() =>
+            getDatabricksOidcEndpointsFromHost(serverHostName),
+        ).toThrow(ParameterError);
+    });
+});
+
+describe('normalizeDatabricksHostLenient', () => {
+    it('keeps URL and bare-host representations equivalent', () => {
+        expect(
+            normalizeDatabricksHostLenient('https://workspace.example.com'),
+        ).toBe(normalizeDatabricksHostLenient('workspace.example.com'));
+    });
+});

--- a/packages/backend/src/controllers/authentication/strategies/databricksStrategy.ts
+++ b/packages/backend/src/controllers/authentication/strategies/databricksStrategy.ts
@@ -20,6 +20,22 @@ type DatabricksStrategyConfig = {
     clientSecret?: string;
 };
 
+const VALID_DATABRICKS_DOMAIN_SUFFIXES = [
+    '.cloud.databricks.com',
+    '.dev.databricks.com',
+    '.gcp.databricks.com',
+    '.azuredatabricks.net',
+    '.databricks.azure.cn',
+    '.databricks.azure.us',
+    '.cloud.databricks.us',
+    '.cloud.databricks.mil',
+];
+
+const isValidDatabricksHost = (host: string): boolean =>
+    VALID_DATABRICKS_DOMAIN_SUFFIXES.some((domainSuffix) =>
+        host.toLowerCase().endsWith(domainSuffix),
+    );
+
 export const normalizeDatabricksHost = (serverHostName: string): string => {
     const trimmed = serverHostName.trim();
     const parsed = new URL(
@@ -57,6 +73,11 @@ export const normalizeDatabricksHostLenient = (
 
 export const getDatabricksOidcEndpointsFromHost = (serverHostName: string) => {
     const host = normalizeDatabricksHost(serverHostName);
+    if (!isValidDatabricksHost(host)) {
+        throw new ParameterError(
+            'Databricks serverHostName must use a valid Databricks domain',
+        );
+    }
     const issuer = `https://${host}`;
     return {
         host,


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9034/veria-89-server-wide-databricks-oauth-client-secret-exfiltration-via

## Summary

Databricks OAuth now rejects dynamic workspace hosts outside Databricks-controlled domains before constructing authorization or token endpoints. This prevents a logged-in user from retargeting server-configured OAuth credentials to an arbitrary origin.

## Root cause

The dynamic OAuth resolver accepted `serverHostName` or the callback `iss` host, selected the applicable OAuth client, and passed the host into endpoint construction with syntax-only validation.

```ts
const host = normalizeDatabricksHost(serverHostName);
const tokenURL = `https://${host}/oidc/v1/token`;
```

Both the project and instance-wide paths therefore trusted the caller's destination before Passport performed the authorization-code exchange.

## Fix

The endpoint constructor now accepts only canonical Databricks-owned domain suffixes before returning an issuer or token URL.

- `databricksStrategy.ts` — validates AWS, Azure, GCP, China, US Government, DoD, and internal Databricks workspace domains at the OAuth trust boundary.
- `databricksStrategy.test.ts` — covers every permitted suffix, the reported arbitrary-host path, SSRF/lookalike/port bypass shapes, and unchanged lenient destination normalization.
- Public-preview custom `<name>.databricks.com` URLs remain out of scope because trusting the broad parent suffix requires a separate product decision.

## Before

```text
user host ──> dynamic token URL ──> OAuth code exchange
                                          │
                              configured client secret
```

## After

```text
user host ──> Databricks domain check ──┬─> fixed HTTPS OAuth endpoints
                                       └─> reject non-workspace host
```

## Test plan

- [x] `pnpm -F backend exec vitest run --config vitest.config.ts src/controllers/authentication/strategies/databricksStrategy.test.ts src/utils/credentialDestination.test.ts` — 47 passed.
- [x] `pnpm -F backend test:dev:nowatch` — 399 passed, 1 skipped.
- [x] Full backend unit suite — 5,628 passed, 1 skipped.
- [x] `pnpm -F backend typecheck && pnpm -F backend lint`.
- [x] Before/after regression: arbitrary and loopback hosts fail before the fix and throw `ParameterError` after it.
- [x] Verified unaffected behavior: all eight supported domain families and lenient URL/bare-host destination comparison remain stable.