### PR TITLE
fix(ai): enforce source code access for agent writeback

### DIFF
--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -1,6 +1,8 @@
 import { Ability } from '@casl/ability';
 import {
     AiAgentReviewRemediation,
+    DbtProjectType,
+    ForbiddenError,
     JobStatusType,
     OrganizationMemberRole,
     PullRequestProvider,
@@ -8,7 +10,10 @@ import {
     type PossibleAbilities,
     type SessionUser,
 } from '@lightdash/common';
-import { getPullRequestComments } from '../../clients/github/Github';
+import {
+    getPullRequestComments,
+    getPullRequestDiffFiles,
+} from '../../clients/github/Github';
 import {
     AiAgentAdminService,
     getAiAgentReviewItemWritebackEligibility,
@@ -18,6 +23,7 @@ vi.mock('../../clients/github/Github', () => ({
     getInstallationToken: vi.fn(),
     getPullRequest: vi.fn(),
     getPullRequestComments: vi.fn(),
+    getPullRequestDiffFiles: vi.fn(),
 }));
 
 const NOW = new Date('2026-06-08T10:00:00.000Z');
@@ -140,8 +146,34 @@ const makeAdminUser = (): SessionUser => ({
             subject: 'OrganizationAiAgent',
             conditions: { organizationUuid: ORGANIZATION_UUID },
         },
+        {
+            action: 'view',
+            subject: 'SourceCode',
+            conditions: { organizationUuid: ORGANIZATION_UUID },
+        },
+        {
+            action: 'manage',
+            subject: 'SourceCode',
+            conditions: { organizationUuid: ORGANIZATION_UUID },
+        },
     ]),
     abilityRules: [],
+});
+
+const makeAiAdminWithoutSourceCodeUser = (): SessionUser => ({
+    ...makeAdminUser(),
+    ability: new Ability<PossibleAbilities>([
+        {
+            action: 'manage',
+            subject: 'AiAgent',
+            conditions: { organizationUuid: ORGANIZATION_UUID },
+        },
+        {
+            action: 'manage',
+            subject: 'OrganizationAiAgent',
+            conditions: { organizationUuid: ORGANIZATION_UUID },
+        },
+    ]),
 });
 
 const makeDeveloperUser = (): SessionUser => ({
@@ -156,6 +188,16 @@ const makeDeveloperUser = (): SessionUser => ({
         {
             action: 'manage',
             subject: 'OrganizationAiAgent',
+            conditions: { organizationUuid: ORGANIZATION_UUID },
+        },
+        {
+            action: 'view',
+            subject: 'SourceCode',
+            conditions: { organizationUuid: ORGANIZATION_UUID },
+        },
+        {
+            action: 'manage',
+            subject: 'SourceCode',
             conditions: { organizationUuid: ORGANIZATION_UUID },
         },
     ]),
@@ -472,6 +514,81 @@ describe('AiAgentAdminService review access', () => {
             'Insufficient permissions to access AI agent reviews',
         );
         expect(listReviewSignals).not.toHaveBeenCalled();
+    });
+
+    it('forbids starting writeback without manage:SourceCode', async () => {
+        const findExploresFromCache = vi.fn();
+        const aiAgentReviewWriteback = vi.fn();
+        const service = makeService({
+            aiAgentReviewClassifierModel: {
+                getReviewItem: vi.fn().mockResolvedValue(
+                    makeReviewItem({
+                        organizationUuid: ORGANIZATION_UUID,
+                        projectUuid: PROJECT_UUID,
+                        agentUuid: AGENT_UUID,
+                    }),
+                ),
+            },
+            projectModel: {
+                get: vi.fn().mockResolvedValue({
+                    organizationUuid: ORGANIZATION_UUID,
+                    dbtConnection: { type: DbtProjectType.GITHUB },
+                }),
+                findExploresFromCache,
+            },
+            githubAppInstallationsModel: {
+                findInstallationId: vi.fn().mockResolvedValue('installation-1'),
+            },
+            schedulerClient: { aiAgentReviewWriteback },
+        });
+
+        await expect(
+            service.createReviewItemWriteback(
+                makeAiAdminWithoutSourceCodeUser(),
+                'fingerprint-1',
+            ),
+        ).rejects.toThrow(ForbiddenError);
+        expect(findExploresFromCache).not.toHaveBeenCalled();
+        expect(aiAgentReviewWriteback).not.toHaveBeenCalled();
+    });
+
+    it('reports writeback as blocked without manage:SourceCode', async () => {
+        const reviewItem = makeReviewItem({
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PROJECT_UUID,
+            agentUuid: AGENT_UUID,
+        });
+        const service = makeService({
+            aiAgentReviewClassifierModel: {
+                getReviewItem: vi.fn().mockResolvedValue(reviewItem),
+                listReviewItems: vi.fn().mockResolvedValue([reviewItem]),
+            },
+            projectModel: {
+                get: vi.fn().mockResolvedValue({
+                    organizationUuid: ORGANIZATION_UUID,
+                    dbtConnection: { type: DbtProjectType.GITHUB },
+                }),
+            },
+            githubAppInstallationsModel: {
+                findInstallationId: vi.fn().mockResolvedValue('installation-1'),
+            },
+        });
+        const user = makeAiAdminWithoutSourceCodeUser();
+
+        const [listResult, detailResult] = await Promise.all([
+            service.listReviewItems(user),
+            service.getReviewItem(user, 'fingerprint-1'),
+        ]);
+
+        expect(listResult[0].writebackEligibility).toEqual({
+            eligible: false,
+            reason: 'insufficient_source_code_access',
+            strategy: 'semantic_layer',
+            provider: PullRequestProvider.GITHUB,
+        });
+        expect(detailResult.writebackEligibility).toEqual(
+            listResult[0].writebackEligibility,
+        );
     });
 });
 
@@ -1859,6 +1976,66 @@ describe('AiAgentAdminService project-scoped read access', () => {
         ).rejects.toThrow(
             'Insufficient permissions to access AI agent features',
         );
+    });
+
+    it('forbids reading a linked pull request diff without view:SourceCode', async () => {
+        const aiAgentReviewClassifierModel = {
+            getReviewItem: vi.fn().mockResolvedValue(
+                makeReviewItem({
+                    organizationUuid: ORGANIZATION_UUID,
+                    projectUuid: PROJECT_UUID,
+                    linkedPrUrl: PR_URL,
+                }),
+            ),
+        };
+        const service = makeService({
+            aiAgentReviewClassifierModel,
+            projectModel,
+        });
+        (getPullRequestDiffFiles as import('vitest').Mock).mockResolvedValue({
+            files: [],
+            additions: 0,
+            deletions: 0,
+        });
+
+        await expect(
+            service.getReviewItemPrDiff(
+                makeAiAdminWithoutSourceCodeUser(),
+                'fingerprint-1',
+            ),
+        ).rejects.toThrow(ForbiddenError);
+        expect(getPullRequestDiffFiles).not.toHaveBeenCalled();
+    });
+
+    it('reads a linked pull request diff with view:SourceCode', async () => {
+        const aiAgentReviewClassifierModel = {
+            getReviewItem: vi.fn().mockResolvedValue(
+                makeReviewItem({
+                    organizationUuid: ORGANIZATION_UUID,
+                    projectUuid: PROJECT_UUID,
+                    linkedPrUrl: PR_URL,
+                }),
+            ),
+        };
+        const service = makeService({
+            aiAgentReviewClassifierModel,
+            projectModel,
+        });
+        (getPullRequestDiffFiles as import('vitest').Mock).mockResolvedValue({
+            files: [],
+            additions: 0,
+            deletions: 0,
+        });
+
+        await expect(
+            service.getReviewItemPrDiff(makeAdminUser(), 'fingerprint-1'),
+        ).resolves.toEqual({
+            prUrl: PR_URL,
+            files: [],
+            additions: 0,
+            deletions: 0,
+        });
+        expect(getPullRequestDiffFiles).toHaveBeenCalledTimes(1);
     });
 });
 

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -149,6 +149,8 @@ type ProjectWritebackAccess =
 
 type ProjectWritebackAccessEntry = [string, ProjectWritebackAccess];
 
+type SourceCodeAction = 'view' | 'manage';
+
 /**
  * Read-access scope for the org-wide AI admin surfaces (threads, agents,
  * reviews). `all` = org principal with `view:OrganizationAiAgent`; `projects`
@@ -454,6 +456,49 @@ export class AiAgentAdminService extends BaseService {
                 'Insufficient permissions to access AI agent reviews',
             );
         }
+    }
+
+    private assertSourceCodeAccess(
+        user: SessionUser,
+        organizationUuid: string,
+        projectUuid: string,
+        action: SourceCodeAction,
+    ): void {
+        const sourceCodeSubject = subject('SourceCode', {
+            organizationUuid,
+            projectUuid,
+            ...(action === 'manage' ? { isProtectedBranch: false } : {}),
+        });
+        if (this.createAuditedAbility(user).cannot(action, sourceCodeSubject)) {
+            throw new ForbiddenError();
+        }
+    }
+
+    private getWritebackEligibility(
+        user: SessionUser,
+        args: Parameters<typeof getAiAgentReviewItemWritebackEligibility>[0],
+    ): AiAgentReviewItemWritebackEligibility {
+        const eligibility = getAiAgentReviewItemWritebackEligibility(args);
+        if (
+            !eligibility.eligible ||
+            !args.item.projectUuid ||
+            this.createAuditedAbility(user).can(
+                'manage',
+                subject('SourceCode', {
+                    organizationUuid: args.item.organizationUuid,
+                    projectUuid: args.item.projectUuid,
+                    isProtectedBranch: false,
+                }),
+            )
+        ) {
+            return eligibility;
+        }
+
+        return unavailableWritebackEligibility(
+            'insufficient_source_code_access',
+            eligibility.strategy,
+            eligibility.provider,
+        );
     }
 
     /**
@@ -839,24 +884,21 @@ export class AiAgentAdminService extends BaseService {
         const reconciled = items.map((item) => {
             const override = overrides.get(item.fingerprint);
             const reconciledItem = { ...item, ...(override ?? {}) };
-            const writebackEligibility =
-                getAiAgentReviewItemWritebackEligibility({
-                    item: reconciledItem,
-                    reviewsEnabled,
-                    projectContextEnabled,
-                    projectAccess: reconciledItem.projectUuid
-                        ? (projectAccessByUuid.get(
-                              reconciledItem.projectUuid,
-                          ) ?? null)
-                        : null,
-                    hasSemanticWritebackConfig:
-                        this.hasSemanticWritebackConfig(),
-                    sourceThreadHasWritebackPr:
-                        !!reconciledItem.latestFinding?.threadUuid &&
-                        (writebackPrByThread.get(
-                            reconciledItem.latestFinding.threadUuid,
-                        )?.length ?? 0) > 0,
-                });
+            const writebackEligibility = this.getWritebackEligibility(user, {
+                item: reconciledItem,
+                reviewsEnabled,
+                projectContextEnabled,
+                projectAccess: reconciledItem.projectUuid
+                    ? (projectAccessByUuid.get(reconciledItem.projectUuid) ??
+                      null)
+                    : null,
+                hasSemanticWritebackConfig: this.hasSemanticWritebackConfig(),
+                sourceThreadHasWritebackPr:
+                    !!reconciledItem.latestFinding?.threadUuid &&
+                    (writebackPrByThread.get(
+                        reconciledItem.latestFinding.threadUuid,
+                    )?.length ?? 0) > 0,
+            });
 
             return {
                 ...reconciledItem,
@@ -1109,6 +1151,10 @@ export class AiAgentAdminService extends BaseService {
             case 'project_context_disabled':
                 throw new ParameterError(
                     'Project context writeback is not enabled',
+                );
+            case 'insufficient_source_code_access':
+                throw new ForbiddenError(
+                    'Insufficient permissions to manage source code',
                 );
             case 'unsupported_source_control':
                 throw new ParameterError(
@@ -1677,7 +1723,7 @@ export class AiAgentAdminService extends BaseService {
         const sourceThreadHasWritebackPr =
             finding !== null &&
             (writebackPrByThread.get(finding.threadUuid)?.length ?? 0) > 0;
-        const writebackEligibility = getAiAgentReviewItemWritebackEligibility({
+        const writebackEligibility = this.getWritebackEligibility(user, {
             item: reviewItem,
             reviewsEnabled,
             projectContextEnabled,
@@ -1701,6 +1747,12 @@ export class AiAgentAdminService extends BaseService {
         }
         const { projectUuid } = scope;
         const { agentUuid } = scope;
+        this.assertSourceCodeAccess(
+            user,
+            organizationUuid,
+            projectUuid,
+            'manage',
+        );
 
         // Plan the writeback up front: for semantic_layer we seed a real
         // Build-fix thread with the writeback prompt so the workspace can show
@@ -1970,6 +2022,7 @@ export class AiAgentAdminService extends BaseService {
                     : null;
                 const writeback =
                     await this.projectContextService.writebackEntry({
+                        user,
                         projectUuid,
                         entry: plan.entry,
                         branchTimestamp: Date.now(),
@@ -2823,6 +2876,15 @@ export class AiAgentAdminService extends BaseService {
                 'No pull request is linked to this review item',
             );
         }
+        if (!reviewItem.projectUuid) {
+            throw new ForbiddenError();
+        }
+        this.assertSourceCodeAccess(
+            user,
+            organizationUuid,
+            reviewItem.projectUuid,
+            'view',
+        );
         const parsed = parsePullRequestUrl(reviewItem.linkedPrUrl);
         if (!parsed) {
             throw new NotFoundError(
@@ -2911,7 +2973,7 @@ export class AiAgentAdminService extends BaseService {
                   )
               ).get(reviewItem.latestFinding.threadUuid)?.length ?? 0) > 0
             : false;
-        const writebackEligibility = getAiAgentReviewItemWritebackEligibility({
+        const writebackEligibility = this.getWritebackEligibility(user, {
             item: reviewItem,
             reviewsEnabled,
             projectContextEnabled,
@@ -2988,6 +3050,7 @@ export class AiAgentAdminService extends BaseService {
         }
 
         const preview = await this.projectContextService.previewWriteback({
+            user,
             projectUuid: reviewItem.projectUuid,
             entry: plan.entry,
         });

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -8411,6 +8411,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                   }
                 : null;
             const writeback = await this.projectContextService.writebackEntry({
+                user,
                 projectUuid,
                 entry,
                 branchTimestamp: Date.now(),

--- a/packages/backend/src/ee/services/ProjectContextService/ProjectContextService.test.ts
+++ b/packages/backend/src/ee/services/ProjectContextService/ProjectContextService.test.ts
@@ -65,12 +65,33 @@ const existingEntries = (): ProjectContextEntry[] => [
     },
 ];
 
-const userWithIngestAccess = (canManage: boolean = true): SessionUser => {
+const userWithProjectContextAccess = ({
+    canCompile = true,
+    canViewSourceCode = true,
+    canManageSourceCode = true,
+}: {
+    canCompile?: boolean;
+    canViewSourceCode?: boolean;
+    canManageSourceCode?: boolean;
+} = {}): SessionUser => {
     const { build, can, rules } = new AbilityBuilder<MemberAbility>(Ability);
-    if (canManage) {
+    if (canCompile) {
         can('manage', 'CompileProject', {
             organizationUuid: ORG_UUID,
             projectUuid: PROJECT_UUID,
+        });
+    }
+    if (canViewSourceCode) {
+        can('view', 'SourceCode', {
+            organizationUuid: ORG_UUID,
+            projectUuid: PROJECT_UUID,
+        });
+    }
+    if (canManageSourceCode) {
+        can('manage', 'SourceCode', {
+            organizationUuid: ORG_UUID,
+            projectUuid: PROJECT_UUID,
+            isProtectedBranch: false,
         });
     }
 
@@ -148,10 +169,26 @@ describe('ProjectContextService.ingestProjectContext', () => {
 
         await expect(
             service.ingestProjectContext(
-                userWithIngestAccess(false),
+                userWithProjectContextAccess({ canCompile: false }),
                 PROJECT_UUID,
             ),
         ).rejects.toThrow(ForbiddenError);
+        expect(getCachedEntries()).toEqual(existingEntries());
+    });
+
+    test('requires view source-code access', async () => {
+        const { service, getCachedEntries } = makeService({});
+
+        await expect(
+            service.ingestProjectContext(
+                userWithProjectContextAccess({
+                    canViewSourceCode: false,
+                    canManageSourceCode: false,
+                }),
+                PROJECT_UUID,
+            ),
+        ).rejects.toThrow(ForbiddenError);
+        expect(mockGetInstallationToken).not.toHaveBeenCalled();
         expect(getCachedEntries()).toEqual(existingEntries());
     });
 
@@ -163,7 +200,7 @@ describe('ProjectContextService.ingestProjectContext', () => {
             },
         });
         const result = await service.ingestProjectContext(
-            userWithIngestAccess(),
+            userWithProjectContextAccess(),
             PROJECT_UUID,
         );
         expect(result).toEqual({
@@ -178,7 +215,7 @@ describe('ProjectContextService.ingestProjectContext', () => {
             installationId: undefined,
         });
         const result = await service.ingestProjectContext(
-            userWithIngestAccess(),
+            userWithProjectContextAccess(),
             PROJECT_UUID,
         );
         expect(result).toEqual({
@@ -192,7 +229,7 @@ describe('ProjectContextService.ingestProjectContext', () => {
         mockGetFileContent.mockRejectedValue(new NotFoundError('missing'));
         const { service, getCachedEntries } = makeService({});
         const result = await service.ingestProjectContext(
-            userWithIngestAccess(),
+            userWithProjectContextAccess(),
             PROJECT_UUID,
         );
         expect(result).toEqual({ ingested: true, entryCount: 0 });
@@ -211,7 +248,7 @@ describe('ProjectContextService.ingestProjectContext', () => {
         });
         const { service, getCachedEntries } = makeService({});
         const result = await service.ingestProjectContext(
-            userWithIngestAccess(),
+            userWithProjectContextAccess(),
             PROJECT_UUID,
         );
         expect(result).toEqual({ ingested: true, entryCount: 1 });
@@ -230,9 +267,40 @@ describe('ProjectContextService.ingestProjectContext', () => {
         mockGetFileContent.mockRejectedValue(new Error('500 from GitHub'));
         const { service, getCachedEntries } = makeService({});
         await expect(
-            service.ingestProjectContext(userWithIngestAccess(), PROJECT_UUID),
+            service.ingestProjectContext(
+                userWithProjectContextAccess(),
+                PROJECT_UUID,
+            ),
         ).rejects.toThrow('500 from GitHub');
         expect(getCachedEntries()).toEqual(existingEntries());
+    });
+});
+
+describe('ProjectContextService.previewWriteback', () => {
+    const judgeEntry = {
+        op: 'create' as const,
+        id: null,
+        kind: 'definition' as const,
+        content: '"HR" = high-risk cohort.',
+        terms: ['HR'],
+        objects: [],
+    };
+
+    test('requires view source-code access before reading the file', async () => {
+        const { service } = makeService({});
+
+        await expect(
+            service.previewWriteback({
+                user: userWithProjectContextAccess({
+                    canViewSourceCode: false,
+                    canManageSourceCode: false,
+                }),
+                projectUuid: PROJECT_UUID,
+                entry: judgeEntry,
+            }),
+        ).rejects.toThrow(ForbiddenError);
+        expect(mockGetInstallationToken).not.toHaveBeenCalled();
+        expect(mockGetFileContent).not.toHaveBeenCalled();
     });
 });
 
@@ -264,6 +332,7 @@ describe('ProjectContextService.writebackEntry', () => {
         const { service } = makeService({});
 
         const result = await service.writebackEntry({
+            user: userWithProjectContextAccess(),
             projectUuid: PROJECT_UUID,
             entry: { ...judgeEntry, objects: ['orders'] },
             branchTimestamp: 1000,
@@ -285,6 +354,7 @@ describe('ProjectContextService.writebackEntry', () => {
 
         const error = await service
             .writebackEntry({
+                user: userWithProjectContextAccess(),
                 projectUuid: PROJECT_UUID,
                 entry: { ...judgeEntry, op: 'update' as const, id: null },
                 branchTimestamp: 1000,
@@ -301,6 +371,7 @@ describe('ProjectContextService.writebackEntry', () => {
         const { service } = makeService({});
 
         const result = await service.writebackEntry({
+            user: userWithProjectContextAccess(),
             projectUuid: PROJECT_UUID,
             entry: judgeEntry,
             branchTimestamp: 1000,
@@ -345,6 +416,7 @@ describe('ProjectContextService.writebackEntry', () => {
         const { service } = makeService({});
 
         const result = await service.writebackEntry({
+            user: userWithProjectContextAccess(),
             projectUuid: PROJECT_UUID,
             entry: { ...judgeEntry, op: 'update', id: 'hr' },
             branchTimestamp: 2000,
@@ -367,6 +439,7 @@ describe('ProjectContextService.writebackEntry', () => {
         const { service } = makeService({ installationId: undefined });
         await expect(
             service.writebackEntry({
+                user: userWithProjectContextAccess(),
                 projectUuid: PROJECT_UUID,
                 entry: judgeEntry,
                 branchTimestamp: 1,
@@ -380,6 +453,7 @@ describe('ProjectContextService.writebackEntry', () => {
         const { service } = makeService({});
 
         await service.writebackEntry({
+            user: userWithProjectContextAccess(),
             projectUuid: PROJECT_UUID,
             entry: judgeEntry,
             branchTimestamp: 1000,
@@ -396,5 +470,23 @@ describe('ProjectContextService.writebackEntry', () => {
             'https://app.lightdash.com/projects/p/ai-agents/a/threads/t',
         );
         expect(body).toContain('prompt-123');
+    });
+
+    test('requires manage source-code access before creating a branch', async () => {
+        const { service } = makeService({});
+
+        await expect(
+            service.writebackEntry({
+                user: userWithProjectContextAccess({
+                    canManageSourceCode: false,
+                }),
+                projectUuid: PROJECT_UUID,
+                entry: judgeEntry,
+                branchTimestamp: 1000,
+                sourceThread: null,
+            }),
+        ).rejects.toThrow(ForbiddenError);
+        expect(mockGetInstallationToken).not.toHaveBeenCalled();
+        expect(mockCreateBranch).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/ee/services/ProjectContextService/ProjectContextService.ts
+++ b/packages/backend/src/ee/services/ProjectContextService/ProjectContextService.ts
@@ -63,6 +63,8 @@ type GithubAccess = {
     token: string;
 };
 
+type SourceCodeAction = 'view' | 'manage';
+
 type ProjectContextServiceDeps = {
     projectModel: ProjectModel;
     githubAppInstallationsModel: GithubAppInstallationsModel;
@@ -115,12 +117,22 @@ export class ProjectContextService extends BaseService {
         };
     }
 
-    // Resolves the project's GitHub repo + an installation token, or null when
-    // the project isn't GitHub-backed / the org hasn't installed the app.
     private async resolveGithubAccess(
+        user: SessionUser,
         projectUuid: string,
+        action: SourceCodeAction,
     ): Promise<GithubAccess | null> {
         const project = await this.projectModel.get(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
+        const sourceCodeSubject = subject('SourceCode', {
+            organizationUuid: project.organizationUuid,
+            projectUuid,
+            ...(action === 'manage' ? { isProtectedBranch: false } : {}),
+        });
+        if (auditedAbility.cannot(action, sourceCodeSubject)) {
+            throw new ForbiddenError();
+        }
+
         const connection = ProjectContextService.resolveGithubConnection(
             project.dbtConnection,
         );
@@ -173,7 +185,11 @@ export class ProjectContextService extends BaseService {
     ): Promise<ProjectContextIngestResult> {
         await this.assertCanIngestProjectContext(user, projectUuid);
 
-        const access = await this.resolveGithubAccess(projectUuid);
+        const access = await this.resolveGithubAccess(
+            user,
+            projectUuid,
+            'view',
+        );
         if (!access) {
             return { ingested: false, reason: 'no_github_access' };
         }
@@ -222,6 +238,7 @@ export class ProjectContextService extends BaseService {
      * caller can show a before/after diff before committing to the PR.
      */
     async previewWriteback(args: {
+        user: SessionUser;
         projectUuid: string;
         entry: AiAgentJudgeProjectContextEntry;
     }): Promise<{
@@ -233,7 +250,11 @@ export class ProjectContextService extends BaseService {
         upgradesFileToV2: boolean;
     }> {
         const entry = parseWritebackEntry(args.entry);
-        const access = await this.resolveGithubAccess(args.projectUuid);
+        const access = await this.resolveGithubAccess(
+            args.user,
+            args.projectUuid,
+            'view',
+        );
         if (!access) {
             throw new NotFoundError(
                 'Project is not connected to GitHub or the GitHub App is not installed',
@@ -268,6 +289,7 @@ export class ProjectContextService extends BaseService {
     }
 
     async writebackEntry(args: {
+        user: SessionUser;
         projectUuid: string;
         entry: AiAgentJudgeProjectContextEntry;
         branchTimestamp: number;
@@ -280,7 +302,11 @@ export class ProjectContextService extends BaseService {
         } | null;
     }): Promise<ProjectContextWritebackResult> {
         const entry = parseWritebackEntry(args.entry);
-        const access = await this.resolveGithubAccess(args.projectUuid);
+        const access = await this.resolveGithubAccess(
+            args.user,
+            args.projectUuid,
+            'manage',
+        );
         if (!access) {
             throw new NotFoundError(
                 'Project is not connected to GitHub or the GitHub App is not installed',

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -379,6 +379,7 @@ export type AiAgentReviewItemWritebackBlockedReason =
     | 'missing_agent'
     | 'missing_project_context_entry'
     | 'project_context_disabled'
+    | 'insufficient_source_code_access'
     | 'unsupported_source_control'
     | 'git_app_not_installed'
     | 'missing_writeback_config'

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.ts
@@ -65,6 +65,8 @@ export const writebackBlockedReasonLabels: Record<
     missing_agent: 'No agent is linked to this issue',
     missing_project_context_entry: 'No project context entry was generated',
     project_context_disabled: 'Project context is not enabled',
+    insufficient_source_code_access:
+        'You do not have permission to modify source code',
     unsupported_source_control: 'Project is not connected to GitHub or GitLab',
     git_app_not_installed: 'Git app is not installed',
     missing_writeback_config: 'Writeback runtime is not configured',
@@ -91,6 +93,8 @@ export const writebackBlockedReasonDescriptions: Partial<
         'Install the Lightdash app on your repository so it can open pull requests.',
     project_context_disabled:
         'Enable project context so Lightdash can propose updates to your project knowledge.',
+    insufficient_source_code_access:
+        'Ask a project admin for permission to manage source code before creating a pull request.',
     missing_writeback_config:
         'Ask an admin to configure the writeback runtime to enable automatic fixes.',
 };


### PR DESCRIPTION
Closes: [PROD-8809](https://linear.app/lightdash/issue/PROD-8809/veria-67-authorization-bypass-in-ai-agent-services-enables)

## What this fixes

AI-agent managers could use review diffs and project-context writeback through the privileged GitHub App without holding the separate Source Code permission. This change requires `view:SourceCode` for repository reads and `manage:SourceCode` for branch, commit, and pull-request operations.

| Path | Before | After |
| --- | --- | --- |
| Review PR diff | AI review access reached the GitHub diff client | Also requires project-scoped `view:SourceCode` |
| Project-context ingest/preview | Compile or AI review access reached repository files | Also requires project-scoped `view:SourceCode` before token issuance |
| Review and remediation writeback | AI review/thread access could queue or open a PR | Also requires project-scoped `manage:SourceCode` with `isProtectedBranch: false` |

```text
Before: AI management ───────────────▶ GitHub App token ─▶ repo read/write
After:  AI management ─▶ SourceCode ─▶ GitHub App token ─▶ repo read/write
                         view / manage
```

## How

`ProjectContextService` now requires the initiating `SessionUser` for previews and writebacks, and authorizes the project before resolving the GitHub App token. AI-admin diff and enqueue paths enforce the same boundary before client calls, threads, persistence, or scheduler jobs; the worker rechecks the reconstructed user so revoked access cannot complete a queued write.

Writeback eligibility now includes `manage:SourceCode`. Restricted users see a disabled Create PR action with an `insufficient_source_code_access` explanation instead of an action that ends in a 403.

The separate cross-project repository-selection and managed-agent credential findings remain out of scope.

## Who's affected

| User class | Source Code access | Impact |
| --- | --- | --- |
| Organization/project Admin or Developer | View + manage | None; authorized reads and writeback are unchanged |
| Editor or Viewer without AI management | None | None; these users cannot reach AI review administration |
| Custom AI manager with `view:SourceCode` only | View | Diffs/previews remain available; Create PR is disabled |
| Custom AI manager without Source Code scopes | None | Repository reads return 403 and Create PR is disabled; this closes the bypass |
| Custom AI manager with `manage:SourceCode` | Manage | None; writeback remains available |

## Test plan

- [x] Backend authorization/service suites — 86 tests pass
- [x] Frontend writeback action/detail suites — 8 tests pass
- [x] Common and backend typechecks pass
- [x] Changed frontend permission mapping passes standalone TypeScript check
- [x] Common, backend, and frontend lint pass
- [x] Touched-file formatting and `git diff --check` pass
- [x] API/schema generation passes; generated artifacts are intentionally not committed
- [ ] Manual live-GitHub check with a custom restricted role (external repository state is mocked in automated coverage)
