### PR TITLE
feat(homepage): Try-the-new-Homepage promo card + org-wide opt-in modal

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/AdminHomepageControls.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/AdminHomepageControls.test.tsx
@@ -1,6 +1,7 @@
+import { MantineProvider } from '@mantine-8/core';
 import { render, screen } from '@testing-library/react';
 import { type PropsWithChildren } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AdminHomepageControls } from './AdminHomepageControls';
 
 vi.mock('react-router', () => ({
@@ -11,14 +12,40 @@ vi.mock('../../../providers/Ability', () => ({
     Can: ({ children }: PropsWithChildren) => children,
 }));
 
-describe('AdminHomepageControls', () => {
-    it('only renders homepage curation controls', () => {
-        const { container } = render(
+const { settings } = vi.hoisted(() => ({
+    settings: {
+        current: { enabled: false, opening: null } as {
+            enabled: boolean;
+            opening: 'ask-first' | 'content-first' | null;
+        },
+    },
+}));
+
+vi.mock('./hooks/useOrgHomepageSettings', () => ({
+    useOrgHomepageSettings: () => ({ data: settings.current }),
+    useUpdateOrgHomepageSettings: () => ({
+        mutate: vi.fn(),
+        isLoading: false,
+    }),
+}));
+
+const renderControls = () =>
+    render(
+        <MantineProvider>
             <AdminHomepageControls
                 projectUuid="project-1"
                 organizationUuid="organization-1"
-            />,
-        );
+            />
+        </MantineProvider>,
+    );
+
+describe('AdminHomepageControls', () => {
+    beforeEach(() => {
+        settings.current = { enabled: false, opening: null };
+    });
+
+    it('only renders homepage curation controls', () => {
+        const { container } = renderControls();
 
         const customizeButton = screen.getByRole('button', {
             name: 'Customize homepage',
@@ -29,5 +56,26 @@ describe('AdminHomepageControls', () => {
         expect(
             container.querySelector('[data-deep-research-control-target]'),
         ).not.toBeInTheDocument();
+    });
+
+    it('hides the switch-back control for flag-enabled orgs (no opt-in row)', () => {
+        renderControls();
+
+        expect(
+            screen.queryByRole('button', {
+                name: 'Switch back to classic homepage',
+            }),
+        ).toBeNull();
+    });
+
+    it('offers switch-back when the org opted in via settings', () => {
+        settings.current = { enabled: true, opening: 'content-first' };
+        renderControls();
+
+        expect(
+            screen.getByRole('button', {
+                name: 'Switch back to classic homepage',
+            }),
+        ).toBeInTheDocument();
     });
 });

--- a/packages/frontend/src/ee/features/homepageBuilder/AdminHomepageControls.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/AdminHomepageControls.tsx
@@ -1,15 +1,72 @@
 import { subject } from '@casl/ability';
-import { IconEdit, IconPlus } from '@tabler/icons-react';
-import { type FC } from 'react';
+import { Text } from '@mantine-8/core';
+import { IconArrowBackUp, IconEdit, IconPlus } from '@tabler/icons-react';
+import { useState, type FC } from 'react';
 import { useNavigate } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
+import MantineModal from '../../../components/common/MantineModal';
 import { Can } from '../../../providers/Ability';
 import classes from './adminHomepageControls.module.css';
+import {
+    useOrgHomepageSettings,
+    useUpdateOrgHomepageSettings,
+} from './hooks/useOrgHomepageSettings';
 
 type Props = {
     projectUuid: string;
     organizationUuid: string | undefined;
     showNewHomepage?: boolean;
+};
+
+// Quiet escape hatch for the opt-in flow: only offered when the org enabled
+// homepage v2 via settings (flag-enabled orgs have no settings row to unset).
+const SwitchBackButton: FC<{ organizationUuid: string | undefined }> = ({
+    organizationUuid,
+}) => {
+    const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+    const settings = useOrgHomepageSettings();
+    const updateSettings = useUpdateOrgHomepageSettings();
+
+    if (!settings.data?.enabled) return null;
+
+    return (
+        <Can I="manage" this={subject('Organization', { organizationUuid })}>
+            <button
+                type="button"
+                className={classes.tbBtn}
+                aria-label="Switch back to classic homepage"
+                onClick={() => setIsConfirmOpen(true)}
+            >
+                <MantineIcon icon={IconArrowBackUp} size={15} />
+                <span className={classes.tbBtnLabel} aria-hidden="true">
+                    Classic homepage
+                </span>
+            </button>
+            <MantineModal
+                opened={isConfirmOpen}
+                onClose={() => setIsConfirmOpen(false)}
+                role="alertdialog"
+                title="Switch back to the classic homepage?"
+                confirmLabel="Switch back"
+                confirmLoading={updateSettings.isLoading}
+                onConfirm={() =>
+                    updateSettings.mutate(
+                        {
+                            enabled: false,
+                            opening: settings.data?.opening ?? null,
+                        },
+                        { onSuccess: () => setIsConfirmOpen(false) },
+                    )
+                }
+            >
+                <Text size="sm">
+                    This turns the new homepage off for every project in your
+                    organization. Published homepages are kept, and everything
+                    comes back exactly as it was if you turn it on again.
+                </Text>
+            </MantineModal>
+        </Can>
+    );
 };
 
 // Pinned top-right, just below the navbar, for anyone who can manage the
@@ -22,6 +79,7 @@ export const AdminHomepageControls: FC<Props> = ({
     const navigate = useNavigate();
     return (
         <div className={classes.corner}>
+            <SwitchBackButton organizationUuid={organizationUuid} />
             <Can
                 I="manage"
                 this={subject('ProjectHomepage', {

--- a/packages/frontend/src/ee/features/homepageBuilder/TryNewHomepagePromo.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/TryNewHomepagePromo.module.css
@@ -1,0 +1,248 @@
+/* ---- Promo card on the classic homepage ---- */
+
+.promoCard {
+    position: relative;
+    background: var(--mantine-color-body);
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: 12px;
+    padding: 14px 16px;
+    box-shadow: var(--mantine-shadow-subtle);
+}
+
+.promoInner {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+}
+
+.promoIcon {
+    display: grid;
+    place-items: center;
+    width: 34px;
+    height: 34px;
+    flex-shrink: 0;
+    border-radius: 10px;
+    background: var(--mantine-color-ldGray-0);
+    border: 1px solid var(--mantine-color-ldGray-2);
+    color: var(--mantine-color-ldGray-6);
+}
+
+.promoCopy {
+    flex: 1;
+    min-width: 0;
+}
+
+/* ---- Modal hero: quiet dot-grid panel ---- */
+
+.hero {
+    padding: 20px 24px 18px;
+    background-color: var(--mantine-color-ldGray-1);
+    background-image: radial-gradient(
+        var(--mantine-color-ldGray-3) 1px,
+        transparent 1px
+    );
+    background-size: 14px 14px;
+    border-bottom: 1px solid var(--mantine-color-ldGray-2);
+}
+
+.heroCards {
+    display: flex;
+    gap: 16px;
+    justify-content: center;
+    align-items: stretch;
+}
+
+/* ---- Preset preview cards: gradient header band, meta on white ---- */
+
+.presetCard {
+    flex: 1;
+    max-width: 320px;
+    display: flex;
+    flex-direction: column;
+    text-align: left;
+    padding: 0;
+    border: 2px solid var(--mantine-color-ldGray-2);
+    border-radius: 16px;
+    background: var(--mantine-color-body);
+    box-shadow: var(--mantine-shadow-heavy);
+    cursor: pointer;
+    overflow: hidden;
+    transition: border-color 120ms ease;
+}
+
+.presetCard[data-selected='true'] {
+    border-color: var(--mantine-color-ldDark-9);
+}
+
+.presetCard[data-static='true'] {
+    cursor: default;
+}
+
+/* Header band: the mini day-0 mock on a quiet neutral panel */
+.presetMock {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 9px;
+    min-height: 128px;
+    padding: 20px 18px;
+    background: var(--mantine-color-ldGray-0);
+    border-bottom: 1px solid var(--mantine-color-ldGray-1);
+}
+
+.mockGreeting {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--mantine-color-ldDark-9);
+}
+
+.mockSub {
+    font-size: 10px;
+    color: var(--mantine-color-ldGray-5);
+    margin-top: -6px;
+}
+
+/* Floating composer pill, echoing the real day-0 hero */
+.mockComposer {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 9px 12px;
+    border-radius: 999px;
+    background: var(--mantine-color-body);
+    border: 1px solid var(--mantine-color-ldGray-2);
+    box-shadow: var(--mantine-shadow-subtle);
+    font-size: 11px;
+    color: var(--mantine-color-ldGray-5);
+}
+
+.mockComposerArrow {
+    margin-left: auto;
+    display: grid;
+    place-items: center;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--mantine-color-ldGray-2);
+    color: var(--mantine-color-ldGray-6);
+    font-size: 10px;
+    line-height: 1;
+}
+
+.mockChips {
+    display: flex;
+    gap: 6px;
+}
+
+.mockChip {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    padding: 5px 9px;
+    border-radius: 8px;
+    background: var(--mantine-color-body);
+    border: 1px solid var(--mantine-color-ldGray-2);
+    box-shadow: var(--mantine-shadow-subtle);
+    font-size: 10px;
+    font-weight: 500;
+    color: var(--mantine-color-ldDark-9);
+}
+
+.mockChipDot {
+    width: 6px;
+    height: 6px;
+    border-radius: 2px;
+    background: var(--mantine-color-teal-5);
+}
+
+.mockCards {
+    display: flex;
+    gap: 6px;
+    width: 100%;
+}
+
+.mockCard {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 6px 7px;
+    border-radius: 7px;
+    background: var(--mantine-color-body);
+    border: 1px solid var(--mantine-color-ldGray-2);
+    box-shadow: var(--mantine-shadow-subtle);
+}
+
+.mockCardIcon {
+    width: 8px;
+    height: 8px;
+    border-radius: 3px;
+    background: var(--mantine-color-ldGray-3);
+}
+
+.mockCardLine {
+    height: 4px;
+    border-radius: 2px;
+    background: var(--mantine-color-ldGray-2);
+}
+
+.mockCardLine[data-short='true'] {
+    width: 60%;
+}
+
+/* ---- Feature highlights below the preview panel ---- */
+
+.features {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px 20px;
+    padding: 16px 28px 14px;
+}
+
+.featureItem {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+}
+
+.featureIcon {
+    display: grid;
+    place-items: center;
+    width: 28px;
+    height: 28px;
+    flex-shrink: 0;
+    margin-top: 2px;
+    border-radius: 8px;
+    background: var(--mantine-color-ldGray-0);
+    border: 1px solid var(--mantine-color-ldGray-2);
+    color: var(--mantine-color-ldGray-6);
+}
+
+.presetMeta {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 12px 16px 14px;
+}
+
+.presetCheck {
+    display: grid;
+    place-items: center;
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+    border-radius: 50%;
+    border: 1px solid var(--mantine-color-ldGray-3);
+    color: transparent;
+}
+
+.presetCard[data-selected='true'] .presetCheck {
+    border-color: var(--mantine-color-ldDark-9);
+    background: var(--mantine-color-ldDark-9);
+    /* ldDark-9 flips light in the dark scheme, so the tick flips dark */
+    color: light-dark(var(--mantine-color-white), var(--mantine-color-black));
+}

--- a/packages/frontend/src/ee/features/homepageBuilder/TryNewHomepagePromo.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/TryNewHomepagePromo.test.tsx
@@ -1,0 +1,146 @@
+import { Ability } from '@casl/ability';
+import { MantineProvider } from '@mantine-8/core';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TryNewHomepageCard, TryNewHomepageModal } from './TryNewHomepagePromo';
+
+vi.mock('react-router', () => ({
+    useNavigate: () => vi.fn(),
+}));
+
+const { aiState, mutateSettings, abilityRules, license } = vi.hoisted(() => ({
+    aiState: { current: { canAskAi: true } },
+    mutateSettings: vi.fn(),
+    abilityRules: {
+        current: [{ action: 'manage', subject: 'Organization' }],
+    },
+    license: { current: true },
+}));
+
+vi.mock('./hooks/useHomepageAiState', () => ({
+    useHomepageAiState: () => ({ isLoading: false, ...aiState.current }),
+}));
+
+vi.mock('./hooks/useOrgHomepageSettings', () => ({
+    useOrgHomepageSettings: () => ({
+        data: { enabled: false, opening: null },
+    }),
+    useUpdateOrgHomepageSettings: () => ({
+        mutate: mutateSettings,
+        isLoading: false,
+    }),
+}));
+
+vi.mock('../../../providers/App/useApp', () => ({
+    default: () => ({
+        user: {
+            data: {
+                userUuid: 'user-1',
+                firstName: 'Ada',
+                ability: new Ability(abilityRules.current),
+            },
+        },
+        health: {
+            data: {
+                license: {
+                    hasLicenseKey: license.current,
+                    valid: license.current,
+                },
+            },
+        },
+    }),
+}));
+
+const renderCard = (onTryNow = vi.fn()) =>
+    render(
+        <MantineProvider>
+            <TryNewHomepageCard organizationUuid="org-1" onTryNow={onTryNow} />
+        </MantineProvider>,
+    );
+
+const renderModal = () =>
+    render(
+        <MantineProvider>
+            <TryNewHomepageModal
+                opened
+                onClose={vi.fn()}
+                projectUuid="project-1"
+            />
+        </MantineProvider>,
+    );
+
+describe('TryNewHomepageCard', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        mutateSettings.mockClear();
+        aiState.current = { canAskAi: true };
+        abilityRules.current = [{ action: 'manage', subject: 'Organization' }];
+        license.current = true;
+    });
+
+    it('shows the invitation to org admins', () => {
+        renderCard();
+        expect(screen.getByText('A new Homepage is here')).toBeInTheDocument();
+    });
+
+    it('hides the invitation from non-admins', () => {
+        abilityRules.current = [];
+        renderCard();
+        expect(screen.queryByText('A new Homepage is here')).toBeNull();
+    });
+
+    it('hides the invitation on unlicensed instances', () => {
+        license.current = false;
+        renderCard();
+        expect(screen.queryByText('A new Homepage is here')).toBeNull();
+    });
+
+    it('stays dismissed after the close button', () => {
+        const { unmount } = renderCard();
+        fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+        expect(screen.queryByText('A new Homepage is here')).toBeNull();
+
+        unmount();
+        renderCard();
+        expect(screen.queryByText('A new Homepage is here')).toBeNull();
+    });
+});
+
+describe('TryNewHomepageModal', () => {
+    beforeEach(() => {
+        mutateSettings.mockClear();
+        aiState.current = { canAskAi: true };
+    });
+
+    it('offers both openings and turns on the selected one org-wide', () => {
+        renderModal();
+
+        expect(screen.getByText('Ask first')).toBeInTheDocument();
+        expect(screen.getByText('Content first')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByText('Ask first'));
+        fireEvent.click(
+            screen.getByRole('button', { name: 'Turn on for all projects' }),
+        );
+
+        expect(mutateSettings).toHaveBeenCalledWith(
+            { enabled: true, opening: 'ask-first' },
+            expect.anything(),
+        );
+    });
+
+    it('skips the fork and goes content-first when AI is unavailable', () => {
+        aiState.current = { canAskAi: false };
+        renderModal();
+
+        expect(screen.queryByText('Ask first')).toBeNull();
+        fireEvent.click(
+            screen.getByRole('button', { name: 'Turn on for all projects' }),
+        );
+
+        expect(mutateSettings).toHaveBeenCalledWith(
+            { enabled: true, opening: 'content-first' },
+            expect.anything(),
+        );
+    });
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/TryNewHomepagePromo.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/TryNewHomepagePromo.tsx
@@ -1,0 +1,346 @@
+import { subject } from '@casl/ability';
+import { type HomepageOpening } from '@lightdash/common';
+import {
+    Badge,
+    Box,
+    Button,
+    CloseButton,
+    Group,
+    Stack,
+    Text,
+} from '@mantine-8/core';
+import {
+    IconCheck,
+    IconHome,
+    IconLayoutGrid,
+    IconLink,
+    IconSpeakerphone,
+    IconUsersGroup,
+} from '@tabler/icons-react';
+import { useState, type FC } from 'react';
+import { useNavigate } from 'react-router';
+import { useLocalStorage } from 'react-use';
+import MantineIcon from '../../../components/common/MantineIcon';
+import MantineModal from '../../../components/common/MantineModal';
+import useApp from '../../../providers/App/useApp';
+import { IS_MOBILE } from '../../../utils/isMobile';
+import { DEFAULT_GREETING_SUBTITLE, getGreeting } from './greeting';
+import { useHomepageAiState } from './hooks/useHomepageAiState';
+import { useUpdateOrgHomepageSettings } from './hooks/useOrgHomepageSettings';
+import classes from './TryNewHomepagePromo.module.css';
+
+/** Miniature of the page each opening produces, in the gallery-card language:
+ * mock content above, name below. The choice step doubles as the gallery. */
+const PresetCard: FC<{
+    opening: HomepageOpening;
+    greeting: string;
+    // Without AI there is no alternative, so the single preview renders as a
+    // plain illustration rather than a pressable "choice".
+    selectable: boolean;
+    selected: boolean;
+    onSelect: () => void;
+}> = ({ opening, greeting, selectable, selected, onSelect }) => (
+    <button
+        type="button"
+        className={classes.presetCard}
+        data-selected={selectable && selected}
+        data-static={!selectable}
+        onClick={selectable ? onSelect : undefined}
+        aria-pressed={selectable ? selected : undefined}
+    >
+        <div className={classes.presetMock}>
+            <span className={classes.mockGreeting}>{greeting}</span>
+            {opening === 'ask-first' ? (
+                <>
+                    <span className={classes.mockSub}>
+                        What do you want to know?
+                    </span>
+                    <span className={classes.mockComposer}>
+                        Ask anything about your data…
+                        <span className={classes.mockComposerArrow}>↑</span>
+                    </span>
+                </>
+            ) : (
+                <>
+                    <span className={classes.mockSub}>
+                        {DEFAULT_GREETING_SUBTITLE}
+                    </span>
+                    <span className={classes.mockChips}>
+                        <span className={classes.mockChip}>
+                            <span className={classes.mockChipDot} />
+                            Run a query
+                        </span>
+                        <span className={classes.mockChip}>
+                            <span className={classes.mockChipDot} />
+                            Dashboards
+                        </span>
+                        <span className={classes.mockChip}>
+                            <span className={classes.mockChipDot} />
+                            Spaces
+                        </span>
+                    </span>
+                </>
+            )}
+            <span className={classes.mockCards}>
+                {[0, 1, 2].map((i) => (
+                    <span key={i} className={classes.mockCard}>
+                        <span className={classes.mockCardIcon} />
+                        <span className={classes.mockCardLine} />
+                        <span
+                            className={classes.mockCardLine}
+                            data-short="true"
+                        />
+                    </span>
+                ))}
+            </span>
+        </div>
+        <div className={classes.presetMeta}>
+            <Box>
+                <Text size="sm" fw={600}>
+                    {opening === 'ask-first'
+                        ? 'Ask first'
+                        : selectable
+                          ? 'Content first'
+                          : 'Your homepage'}
+                </Text>
+                <Text size="xs" c="dimmed">
+                    {opening === 'ask-first'
+                        ? 'Opens on the Ask AI composer, curated content below.'
+                        : selectable
+                          ? 'Opens on your content; Ask AI stays a quick action.'
+                          : 'Opens on your content: quick actions, spaces, and recent items.'}
+                </Text>
+            </Box>
+            {selectable && (
+                <span className={classes.presetCheck}>
+                    <MantineIcon icon={IconCheck} size={12} />
+                </span>
+            )}
+        </div>
+    </button>
+);
+
+// The sell: what admins can actually build, not just how the page opens.
+const FEATURE_HIGHLIGHTS = [
+    {
+        icon: IconLayoutGrid,
+        label: 'Collections',
+        description:
+            'Curate charts, dashboards, and spaces, or keep them live from most viewed and pinned.',
+    },
+    {
+        icon: IconSpeakerphone,
+        label: 'Data announcements',
+        description:
+            'Post releases, incidents, and schema changes right on the front page.',
+    },
+    {
+        icon: IconLink,
+        label: 'Resources',
+        description:
+            'Link runbooks, videos, docs, and tools from anywhere on the web.',
+    },
+    {
+        icon: IconUsersGroup,
+        label: 'Audiences',
+        description:
+            'Publish different homepages to different groups and roles.',
+    },
+];
+
+export const TryNewHomepageModal: FC<{
+    opened: boolean;
+    onClose: () => void;
+    projectUuid: string;
+}> = ({ opened, onClose, projectUuid }) => {
+    const navigate = useNavigate();
+    const { user } = useApp();
+    const { canAskAi } = useHomepageAiState(projectUuid);
+    const [opening, setOpening] = useState<HomepageOpening>('ask-first');
+    const [isLive, setIsLive] = useState(false);
+    // Applying on success flips the homepage immediately, so the success
+    // screen shows over the page it is describing. This modal must therefore
+    // be mounted at page level (outside the homepage branch), or the flip
+    // would unmount it mid-flow.
+    const updateSettings = useUpdateOrgHomepageSettings();
+
+    const greeting = getGreeting(user.data?.firstName);
+    // Without a working composer there's no fork to offer — content-first is
+    // simply what the homepage is, not a degraded choice.
+    const showChoice = canAskAi;
+
+    const handleTurnOn = () => {
+        updateSettings.mutate(
+            { enabled: true, opening: showChoice ? opening : 'content-first' },
+            { onSuccess: () => setIsLive(true) },
+        );
+    };
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            size={720}
+            title={
+                isLive ? 'Your new homepage is live' : 'Meet the new Homepage'
+            }
+            subtitle={
+                isLive
+                    ? 'Everyone in your organization now lands on it.'
+                    : 'Composable blocks, curated collections, and announcements, published to your whole team.'
+            }
+            icon={IconHome}
+            modalBodyProps={{ px: 0, py: 0 }}
+            cancelLabel={isLive ? 'Done' : 'Not now'}
+            confirmLabel={isLive ? 'Customize it' : 'Turn on for all projects'}
+            confirmLoading={updateSettings.isLoading}
+            onConfirm={
+                isLive
+                    ? () =>
+                          navigate(`/projects/${projectUuid}/homepage-builder`)
+                    : handleTurnOn
+            }
+        >
+            <div className={classes.hero}>
+                {isLive ? (
+                    <Stack align="center" gap={14}>
+                        <Text fw={600}>This is what your team sees now.</Text>
+                        <div className={classes.heroCards}>
+                            <PresetCard
+                                opening={showChoice ? opening : 'content-first'}
+                                greeting={greeting}
+                                selectable={false}
+                                selected={false}
+                                onSelect={() => {}}
+                            />
+                        </div>
+                        <Text size="sm" c="dimmed" ta="center" maw={420}>
+                            Every project now opens{' '}
+                            {opening === 'ask-first' && showChoice
+                                ? 'on the Ask AI composer'
+                                : 'on its content'}
+                            . You can customize each project's homepage, or swap
+                            its opening, from the builder.
+                        </Text>
+                    </Stack>
+                ) : (
+                    <Stack gap={14}>
+                        <Text size="sm" fw={500} ta="center">
+                            {showChoice
+                                ? 'Pick how it opens. This is what it could look like'
+                                : 'This is what it could look like'}
+                        </Text>
+                        <div className={classes.heroCards}>
+                            {showChoice && (
+                                <PresetCard
+                                    opening="ask-first"
+                                    greeting={greeting}
+                                    selectable
+                                    selected={opening === 'ask-first'}
+                                    onSelect={() => setOpening('ask-first')}
+                                />
+                            )}
+                            <PresetCard
+                                opening="content-first"
+                                greeting={greeting}
+                                selectable={showChoice}
+                                selected={opening === 'content-first'}
+                                onSelect={() => setOpening('content-first')}
+                            />
+                        </div>
+                        <Text size="xs" c="dimmed" ta="center">
+                            Turns on the new homepage for{' '}
+                            <Text span size="xs" fw={600}>
+                                all projects in your organization
+                            </Text>
+                            . You can switch back any time.
+                        </Text>
+                    </Stack>
+                )}
+            </div>
+            {!isLive && (
+                <div className={classes.features}>
+                    {FEATURE_HIGHLIGHTS.map((feature) => (
+                        <div
+                            key={feature.label}
+                            className={classes.featureItem}
+                        >
+                            <span className={classes.featureIcon}>
+                                <MantineIcon icon={feature.icon} size={15} />
+                            </span>
+                            <Box>
+                                <Text size="sm" fw={600}>
+                                    {feature.label}
+                                </Text>
+                                <Text size="xs" c="dimmed">
+                                    {feature.description}
+                                </Text>
+                            </Box>
+                        </div>
+                    ))}
+                </div>
+            )}
+        </MantineModal>
+    );
+};
+
+/** Dismissible invitation on the classic homepage, shown only to org admins —
+ * the one role that can complete the org-wide opt-in. The modal itself lives
+ * at page level (it must survive the homepage flip), so opening it is the
+ * parent's job. */
+export const TryNewHomepageCard: FC<{
+    organizationUuid: string | undefined;
+    onTryNow: () => void;
+}> = ({ organizationUuid, onTryNow }) => {
+    const { user, health } = useApp();
+    const [dismissed, setDismissed] = useLocalStorage(
+        `homepage-v2-promo-dismissed-${user.data?.userUuid ?? 'anon'}`,
+        false,
+    );
+
+    const isOrgAdmin =
+        user.data?.ability?.can(
+            'manage',
+            subject('Organization', { organizationUuid }),
+        ) ?? false;
+
+    // The homepage builder is an enterprise feature: unlicensed self-hosted
+    // instances have no backing service, so never invite them to try it.
+    const hasValidLicense = !!health.data?.license?.valid;
+
+    // The new homepage has no mobile experience yet, so don't invite mobile
+    // users into it.
+    if (IS_MOBILE || dismissed || !isOrgAdmin || !hasValidLicense) return null;
+
+    return (
+        <div className={classes.promoCard}>
+            <div className={classes.promoInner}>
+                <span className={classes.promoIcon}>
+                    <MantineIcon icon={IconHome} size={18} />
+                </span>
+                <div className={classes.promoCopy}>
+                    <Group gap={6}>
+                        <Text size="sm" fw={600}>
+                            A new Homepage is here
+                        </Text>
+                        <Badge size="xs" variant="filled" color="dark">
+                            New
+                        </Badge>
+                    </Group>
+                    <Text size="xs" c="dimmed">
+                        A curated start page for your whole team, with blocks,
+                        collections, and announcements you compose.
+                    </Text>
+                </div>
+                <Button variant="default" size="xs" onClick={onTryNow}>
+                    Try it now!
+                </Button>
+                <CloseButton
+                    size="sm"
+                    aria-label="Dismiss"
+                    onClick={() => setDismissed(true)}
+                />
+            </div>
+        </div>
+    );
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useOrgHomepageSettings.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useOrgHomepageSettings.ts
@@ -2,9 +2,11 @@ import {
     type ApiError,
     type HomepageOpening,
     type OrganizationHomepageSettings,
+    type UpdateOrganizationHomepageSettings,
 } from '@lightdash/common';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { lightdashApi } from '../../../../api';
+import useToaster from '../../../../hooks/toaster/useToaster';
 import { useHomepageAiState } from './useHomepageAiState';
 
 const ORG_HOMEPAGE_SETTINGS_QUERY_KEY = 'org_homepage_settings';
@@ -21,6 +23,43 @@ export const useOrgHomepageSettings = () =>
         queryKey: [ORG_HOMEPAGE_SETTINGS_QUERY_KEY],
         queryFn: getOrgHomepageSettingsApi,
     });
+
+const updateOrgHomepageSettingsApi = async (
+    data: UpdateOrganizationHomepageSettings,
+) =>
+    lightdashApi<OrganizationHomepageSettings>({
+        url: `/org/homepage-settings`,
+        method: 'PATCH',
+        body: JSON.stringify(data),
+    });
+
+export const useUpdateOrgHomepageSettings = () => {
+    const { showToastApiError } = useToaster();
+    const queryClient = useQueryClient();
+    return useMutation<
+        OrganizationHomepageSettings,
+        ApiError,
+        UpdateOrganizationHomepageSettings
+    >(updateOrgHomepageSettingsApi, {
+        mutationKey: ['update_org_homepage_settings'],
+        onSuccess: async (settings) => {
+            // Seed the cache directly so the homepage flips without a refetch
+            // round-trip; homepage configs may have been rewritten server-side
+            // (content-first swaps stored ask heroes), so refetch those.
+            queryClient.setQueryData(
+                [ORG_HOMEPAGE_SETTINGS_QUERY_KEY],
+                settings,
+            );
+            await queryClient.invalidateQueries(['project_homepage']);
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to update homepage settings',
+                apiError: error,
+            });
+        },
+    });
+};
 
 /**
  * The opening the homepage should render, resolved from the org's choice and

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import { DbtProjectType, ProjectType } from '@lightdash/common';
 import { Stack } from '@mantine-8/core';
-import { type FC } from 'react';
+import { useState, type FC, type ReactNode } from 'react';
 import { useParams } from 'react-router';
 import { useUnmount } from 'react-use';
 import ErrorState from '../components/common/ErrorState';
@@ -22,6 +22,10 @@ import {
     useResolvedHomepage,
 } from '../ee/features/homepageBuilder/hooks/useProjectHomepage';
 import { PublishedHomepage } from '../ee/features/homepageBuilder/PublishedHomepage';
+import {
+    TryNewHomepageCard,
+    TryNewHomepageModal,
+} from '../ee/features/homepageBuilder/TryNewHomepagePromo';
 import { ManagedAgentHomeCard } from '../ee/features/managedAgent/ManagedAgentHomeCard';
 import { useFavorites } from '../hooks/favorites/useFavorites';
 import { usePinnedItems } from '../hooks/pinning/usePinnedItems';
@@ -36,6 +40,7 @@ import { PinnedItemsProvider } from '../providers/PinnedItems/PinnedItemsProvide
 
 const Home: FC = () => {
     const params = useParams<{ projectUuid: string }>();
+    const [isTryNewHomepageOpen, setIsTryNewHomepageOpen] = useState(false);
     const selectedProjectUuid = params.projectUuid;
     const project = useProject(selectedProjectUuid);
     const onboarding = useOnboardingStatus();
@@ -74,8 +79,24 @@ const Home: FC = () => {
 
     useUnmount(() => onboarding.remove());
 
+    // Rendered in the loading state too: opting in triggers the resolved
+    // homepage's first fetch, which sends Home through this spinner — the
+    // modal must survive that or its success screen is lost mid-flow.
+    const tryNewHomepageModal = selectedProjectUuid ? (
+        <TryNewHomepageModal
+            opened={isTryNewHomepageOpen}
+            onClose={() => setIsTryNewHomepageOpen(false)}
+            projectUuid={selectedProjectUuid}
+        />
+    ) : null;
+
     if (isLoading) {
-        return <PageSpinner />;
+        return (
+            <>
+                <PageSpinner />
+                {tryNewHomepageModal}
+            </>
+        );
     }
 
     if (error) {
@@ -94,6 +115,7 @@ const Home: FC = () => {
         project.data.type !== ProjectType.PREVIEW &&
         project.data.dbtConnection.type === DbtProjectType.GITHUB;
 
+    let body: ReactNode;
     if (
         isHomepageBuilderEnabled &&
         resolvedHomepage.data?.type === 'homepage'
@@ -102,7 +124,7 @@ const Home: FC = () => {
         const hasFavoritesBlock = homepage.config.rows.some((row) =>
             row.blocks.some((block) => block.type === 'favorites'),
         );
-        return (
+        body = (
             <Page withFooter noContentPadding>
                 <AdminHomepageControls
                     projectUuid={project.data.projectUuid}
@@ -122,14 +144,12 @@ const Home: FC = () => {
                 />
             </Page>
         );
-    }
-
-    if (
+    } else if (
         isHomepageBuilderEnabled &&
         resolvedHomepage.data === null &&
         onboarding.data.ranQuery
     ) {
-        return (
+        body = (
             <Page withFooter noContentPadding>
                 <AdminHomepageControls
                     projectUuid={project.data.projectUuid}
@@ -150,58 +170,83 @@ const Home: FC = () => {
                 </FavoritesProvider>
             </Page>
         );
+    } else {
+        body = (
+            <Page withFixedContent withPaddedContent withFooter>
+                <Stack gap="xl">
+                    {!onboarding.data.ranQuery ? (
+                        <OnboardingPanel
+                            projectUuid={project.data.projectUuid}
+                            userName={user.data?.firstName}
+                        />
+                    ) : (
+                        <FavoritesProvider
+                            projectUuid={project.data.projectUuid}
+                        >
+                            <LandingPanel
+                                userName={user.data?.firstName}
+                                projectUuid={project.data.projectUuid}
+                            />
+                            {/* Below the greeting on purpose: an admin-only promo
+                            shouldn't outrank the page's own hero */}
+                            {!isHomepageBuilderEnabled && (
+                                <TryNewHomepageCard
+                                    organizationUuid={
+                                        project.data.organizationUuid
+                                    }
+                                    onTryNow={() =>
+                                        setIsTryNewHomepageOpen(true)
+                                    }
+                                />
+                            )}
+                            {project.data.type !== ProjectType.PREVIEW && (
+                                <ManagedAgentHomeCard
+                                    projectUuid={project.data.projectUuid}
+                                />
+                            )}
+                            {isAiAgentsEnabled && (
+                                <AiSearchBox
+                                    projectUuid={project.data.projectUuid}
+                                    showAiReviewsPromo={isGitHubProject}
+                                />
+                            )}
+                            <PinnedItemsProvider
+                                organizationUuid={project.data.organizationUuid}
+                                projectUuid={project.data.projectUuid}
+                                pinnedListUuid={
+                                    project.data.pinnedListUuid || ''
+                                }
+                                allowDelete={false}
+                            >
+                                <PinnedAndFavoritesSection
+                                    pinnedItems={pinnedItems.data ?? []}
+                                    favoriteItems={favorites.data ?? []}
+                                    pinnedIsEnabled={Boolean(
+                                        mostPopularAndRecentlyUpdated
+                                            ?.mostPopular.length ||
+                                        mostPopularAndRecentlyUpdated
+                                            ?.recentlyUpdated.length,
+                                    )}
+                                />
+                            </PinnedItemsProvider>
+                            <HomepageContentPanel
+                                data={mostPopularAndRecentlyUpdated}
+                                projectUuid={project.data.projectUuid}
+                            />
+                        </FavoritesProvider>
+                    )}
+                </Stack>
+            </Page>
+        );
     }
 
     return (
-        <Page withFixedContent withPaddedContent withFooter>
-            <Stack gap="xl">
-                {!onboarding.data.ranQuery ? (
-                    <OnboardingPanel
-                        projectUuid={project.data.projectUuid}
-                        userName={user.data?.firstName}
-                    />
-                ) : (
-                    <FavoritesProvider projectUuid={project.data.projectUuid}>
-                        <LandingPanel
-                            userName={user.data?.firstName}
-                            projectUuid={project.data.projectUuid}
-                        />
-                        {project.data.type !== ProjectType.PREVIEW && (
-                            <ManagedAgentHomeCard
-                                projectUuid={project.data.projectUuid}
-                            />
-                        )}
-                        {isAiAgentsEnabled && (
-                            <AiSearchBox
-                                projectUuid={project.data.projectUuid}
-                                showAiReviewsPromo={isGitHubProject}
-                            />
-                        )}
-                        <PinnedItemsProvider
-                            organizationUuid={project.data.organizationUuid}
-                            projectUuid={project.data.projectUuid}
-                            pinnedListUuid={project.data.pinnedListUuid || ''}
-                            allowDelete={false}
-                        >
-                            <PinnedAndFavoritesSection
-                                pinnedItems={pinnedItems.data ?? []}
-                                favoriteItems={favorites.data ?? []}
-                                pinnedIsEnabled={Boolean(
-                                    mostPopularAndRecentlyUpdated?.mostPopular
-                                        .length ||
-                                    mostPopularAndRecentlyUpdated
-                                        ?.recentlyUpdated.length,
-                                )}
-                            />
-                        </PinnedItemsProvider>
-                        <HomepageContentPanel
-                            data={mostPopularAndRecentlyUpdated}
-                            projectUuid={project.data.projectUuid}
-                        />
-                    </FavoritesProvider>
-                )}
-            </Stack>
-        </Page>
+        <>
+            {body}
+            {/* Page-level so it survives the org-wide flip: the success
+                screen then shows over the new homepage it is describing */}
+            {tryNewHomepageModal}
+        </>
     );
 };
 


### PR DESCRIPTION
## "Try the new Homepage" promo card + org-wide opt-in modal (4/4)

Implements [ZAP-748](https://linear.app/lightdash/issue/ZAP-748) under [ZAP-747](https://linear.app/lightdash/issue/ZAP-747). Single squashed commit on top of the ZAP-749 stack (#26690 → #26691 → #26692).

### What
- **Promo card** below the greeting on the classic homepage: org admins only, **valid EE license required** (unlicensed self-hosted instances never see it), dismissible per user (localStorage), hidden on mobile. Home icon + New badge, "A new Homepage is here" / "Try it now!".
- **Modal**: ask-first vs content-first as preset preview mini-cards (ask-first pre-selected; without AI a single non-selectable preview with AI-free copy), a what-you-can-build grid (collections, announcements, resources, audiences), and explicit org-wide scope copy.
- **Success screen** shows the chosen preset card over the newly live homepage — the modal is mounted at Home page level so the org-wide flip renders behind it instead of unmounting it.
- **Switch back**: confirmed org-wide revert in `AdminHomepageControls`, only for orgs enabled via settings.
- `useUpdateOrgHomepageSettings` seeds the settings cache and invalidates homepage queries (configs may have been rewritten server-side by the hero swap).

### Verified live
Full loop exercised repeatedly in the dev app: card → modal → opt-in (both openings) → success over the new homepage → customize → switch back → re-opt-in. Also verified the no-AI variant and the license gate (unit test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1fe2jShYJrNxZRXw5E6jx