### PR TITLE
feat(charts): add 'treat as category' option for numeric x-axes

### DIFF
--- a/packages/common/src/schemas/json/chart-as-code-1.0.json
+++ b/packages/common/src/schemas/json/chart-as-code-1.0.json
@@ -3386,6 +3386,10 @@
                         "sortType": {
                             "$ref": "#/$defs/XAxisSortType",
                             "description": "How to sort the X axis"
+                        },
+                        "treatAsCategory": {
+                            "description": "Render a numeric X axis as discrete categories instead of a continuous scale",
+                            "type": "boolean"
                         }
                     },
                     "type": "object"

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -710,6 +710,8 @@ export type XAxis = Axis & {
     dataZoomAnchor?: 'start' | 'end';
     /** Number of items visible at once in the data-zoom window */
     dataZoomItemCount?: number;
+    /** Render a numeric X axis as discrete categories instead of a continuous scale */
+    treatAsCategory?: boolean;
 };
 
 export enum XAxisSortType {

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
@@ -90,6 +90,7 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
         setXAxisSort,
         setXAxisLabelRotation,
         setScrollableChart,
+        setXAxisTreatAsCategory,
         setDataZoomAnchor,
         setDataZoomItemCount,
         dirtyChartType,
@@ -123,9 +124,18 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
         [false, false],
     );
 
+    // A numeric x-axis can be rendered as discrete categories, so bars get band
+    // spacing instead of overlapping the y-axis at the ends of the range.
+    const canTreatXAxisAsCategory =
+        isNumericItem(xAxisField) && !dirtyLayout?.flipAxes;
+    const treatXAxisAsCategory =
+        canTreatXAxisAsCategory &&
+        !!dirtyEchartsConfig?.xAxis?.[0]?.treatAsCategory;
+    const isXAxisCategory =
+        getAxisTypeFromField(xAxisField) === 'category' || treatXAxisAsCategory;
+
     const canSortByBarTotals =
-        dirtyChartType === CartesianSeriesType.BAR &&
-        getAxisTypeFromField(xAxisField) === 'category';
+        dirtyChartType === CartesianSeriesType.BAR && isXAxisCategory;
 
     const xAxisSortOptions = [
         { value: XAxisSort.DEFAULT, label: 'Default', icon: IconMinus },
@@ -204,7 +214,22 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                         onChange={(value) => setXAxisName(value)}
                     />
 
-                    {isNumericItem(xAxisField) && (
+                    {canTreatXAxisAsCategory && (
+                        <Switch
+                            size="xs"
+                            classNames={{
+                                label: compactStyles.compactCheckboxLabel,
+                            }}
+                            label="Treat as category"
+                            description="Space values evenly instead of on a continuous scale"
+                            checked={treatXAxisAsCategory}
+                            onChange={(e) =>
+                                setXAxisTreatAsCategory(e.currentTarget.checked)
+                            }
+                        />
+                    )}
+
+                    {isNumericItem(xAxisField) && !treatXAxisAsCategory && (
                         <AxisMinMax
                             label={`Auto ${dirtyLayout?.flipAxes ? 'y' : 'x'}-axis range`}
                             min={dirtyEchartsConfig?.xAxis?.[0]?.min}
@@ -214,7 +239,7 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                         />
                     )}
 
-                    {isNumericItem(xAxisField) && (
+                    {isNumericItem(xAxisField) && !treatXAxisAsCategory && (
                         <AxisMinInterval
                             label="Min tick interval"
                             value={dirtyEchartsConfig?.xAxis?.[0]?.minInterval}
@@ -224,7 +249,7 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                         />
                     )}
 
-                    {isNumericItem(xAxisField) && !dirtyLayout?.flipAxes && (
+                    {canTreatXAxisAsCategory && !treatXAxisAsCategory && (
                         <>
                             <Switch
                                 size="xs"
@@ -302,7 +327,7 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                         )}
                     </Group>
 
-                    {getAxisTypeFromField(xAxisField) === 'category' && (
+                    {isXAxisCategory && (
                         <Stack gap="xs">
                             <Checkbox
                                 size="xs"

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -702,6 +702,15 @@ const useCartesianChartConfig = ({
             };
         });
     }, []);
+    const setXAxisTreatAsCategory = useCallback((treatAsCategory: boolean) => {
+        setDirtyEchartsConfig((prevState) => {
+            const [firstAxis, ...axes] = prevState?.xAxis || [];
+            return {
+                ...prevState,
+                xAxis: [{ ...firstAxis, treatAsCategory }, ...axes],
+            };
+        });
+    }, []);
     const setDataZoomAnchor = useCallback((dataZoomAnchor: 'start' | 'end') => {
         setDirtyEchartsConfig((prevState) => {
             const [firstAxis, ...axes] = prevState?.xAxis || [];
@@ -1537,6 +1546,7 @@ const useCartesianChartConfig = ({
         setXAxisSort,
         setXAxisLabelRotation,
         setScrollableChart,
+        setXAxisTreatAsCategory,
         setDataZoomAnchor,
         setDataZoomItemCount,
         updateSeries,

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
@@ -8,6 +8,7 @@ import {
     FilterOperator,
     TimeFrames,
     transformToPercentageStacking,
+    type CartesianChart,
     type Dimension,
     type EChartsSeries,
     type Field,
@@ -25,6 +26,7 @@ import {
     filterSeriesWithNoData,
     getAxisDefaultMaxValue,
     getAxisDefaultMinValue,
+    getAxisType,
     getCartesianLabelLayout,
     getCategoryDateAxisConfig,
     getLongestLabelsForAxis,
@@ -771,6 +773,97 @@ describe('getPinnedDayTickFormatter', () => {
         expect(f(Date.UTC(2025, 5, 30, 22))).toBe('30');
         expect(f(Date.UTC(2025, 6, 1, 22))).toBe('{bold|Jul}');
         expect(f(Date.UTC(2025, 6, 2, 22))).toBe('2');
+    });
+});
+
+describe('getAxisType with treatAsCategory', () => {
+    const xFieldId = 'orders_year_number';
+    const yFieldId = 'orders_count';
+
+    const numericField = {
+        fieldType: FieldType.DIMENSION,
+        type: DimensionType.NUMBER,
+        name: 'year_number',
+        table: 'orders',
+    } as unknown as Field;
+
+    const itemsMap = {
+        [xFieldId]: numericField,
+        [yFieldId]: numericField,
+    } as ItemsMap;
+
+    const createConfig = ({
+        treatAsCategory,
+        flipAxes,
+    }: {
+        treatAsCategory?: boolean;
+        flipAxes?: boolean;
+    }): CartesianChart => ({
+        layout: { xField: xFieldId, yField: [yFieldId], flipAxes },
+        eChartsConfig: {
+            xAxis: [{ treatAsCategory }],
+            series: [
+                {
+                    type: CartesianSeriesType.BAR,
+                    yAxisIndex: 0,
+                    encode: {
+                        xRef: { field: xFieldId },
+                        yRef: { field: yFieldId },
+                    },
+                },
+            ],
+        },
+    });
+
+    const getBottomAxisType = (config: CartesianChart) =>
+        getAxisType({
+            validCartesianConfig: config,
+            itemsMap,
+            bottomAxisXId: xFieldId,
+            leftAxisYId: yFieldId,
+        }).bottomAxisType;
+
+    test('numeric x-axis stays a value axis by default', () => {
+        expect(getBottomAxisType(createConfig({}))).toBe('value');
+        expect(
+            getBottomAxisType(createConfig({ treatAsCategory: false })),
+        ).toBe('value');
+    });
+
+    test('numeric x-axis becomes a category axis when treatAsCategory is on', () => {
+        expect(getBottomAxisType(createConfig({ treatAsCategory: true }))).toBe(
+            'category',
+        );
+    });
+
+    test('treatAsCategory is ignored when axes are flipped', () => {
+        expect(
+            getBottomAxisType(
+                createConfig({ treatAsCategory: true, flipAxes: true }),
+            ),
+        ).toBe('value');
+    });
+
+    test('treatAsCategory does not override a time axis', () => {
+        const dateFieldId = 'orders_created_at';
+        const config = createConfig({ treatAsCategory: true });
+        expect(
+            getAxisType({
+                validCartesianConfig: config,
+                itemsMap: {
+                    [dateFieldId]: {
+                        fieldType: FieldType.DIMENSION,
+                        type: DimensionType.DATE,
+                        name: 'created_at',
+                        table: 'orders',
+                        timeInterval: TimeFrames.DAY,
+                    },
+                    [yFieldId]: numericField,
+                } as unknown as ItemsMap,
+                bottomAxisXId: dateFieldId,
+                leftAxisYId: yFieldId,
+            }).bottomAxisType,
+        ).toBe('time');
     });
 });
 

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -238,7 +238,7 @@ type GetAxisTypeArg = {
     rightAxisYId?: string;
     leftAxisYId?: string;
 };
-const getAxisType = ({
+export const getAxisType = ({
     validCartesianConfig,
     itemsMap,
     topAxisXId,
@@ -276,11 +276,20 @@ const getAxisType = ({
         return shouldUseCategory ? 'category' : axisType;
     };
 
+    // Opt-in: render a numeric dimension axis as discrete categories so bars get
+    // band spacing instead of being centred on their value at the grid edges.
+    const treatXAxisAsCategory =
+        !validCartesianConfig.layout.flipAxes &&
+        !!validCartesianConfig.eChartsConfig.xAxis?.[0]?.treatAsCategory;
+
     const topAxisType = inferAxisType(topAxisXId, true);
+    const inferredBottomAxisType = inferAxisType(bottomAxisXId, true);
     const bottomAxisType =
         bottomAxisXId === EMPTY_X_AXIS
             ? 'category'
-            : inferAxisType(bottomAxisXId, true);
+            : treatXAxisAsCategory && inferredBottomAxisType === 'value'
+              ? 'category'
+              : inferredBottomAxisType;
 
     // horizontal bar chart needs the type 'category' in the left/right axis
     const defaultRightAxisType = inferAxisType(rightAxisYId, false);


### PR DESCRIPTION
Closes: lightdash/lightdash#26698

### Description:

A numeric field on the x-axis resolves to a continuous ECharts `value` axis, which centres each bar on its numeric position — so the bars at the data min and max spill half a bar width past the grid, overlapping the left y-axis and clipping at the right edge.

Adds an opt-in `treatAsCategory` x-axis setting (Axes tab, shown only when the x-axis field is numeric and axes aren't flipped). When enabled, `getAxisType` sends the dimension axis to ECharts as `category`, so bars render in discrete bands with boundary padding. Nothing about the field changes: it stays numeric in the query, sorts numerically in SQL, and keeps its number formatting for labels — unlike the string table-calculation workaround.

Side effects of the axis becoming a category axis, which come for free from existing type-gated logic: "Enable scrollable chart" and bar-totals sorting become available, and the value-axis-only controls (auto range, min tick interval, truncate) are hidden while it's on.

Horizontal bars already force a category axis for numeric dimensions, so this is unchanged for flipped charts. Existing charts are unaffected — the setting defaults to off.

Not verified in a running app (no dev server in this environment); covered by unit tests on `getAxisType` for the on/off, flipped, and time-field cases.

https://github.com/user-attachments/assets/1c3f1b7d-01a7-4aa3-93ab-9a16bbbbda1e