### PR TITLE
fix(sql-runner): preserve Y-axis series order

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -2202,6 +2202,104 @@ describe('AsyncQueryService', () => {
 
             // THEN: Test completed successfully - all critical behaviors verified
         });
+
+        test('returns SQL Runner value columns in configured y-axis order after JSONB persistence', async () => {
+            const valuesColumns = [
+                {
+                    reference: 'b_actual_new',
+                    aggregation: VizAggregationOptions.COUNT,
+                },
+                {
+                    reference: 'c_actual',
+                    aggregation: VizAggregationOptions.COUNT,
+                },
+                {
+                    reference: 'a_forecast',
+                    aggregation: VizAggregationOptions.COUNT,
+                },
+            ];
+            const makePivotValueColumn = (referenceField: string) => ({
+                referenceField,
+                pivotColumnName: `${referenceField}_count`,
+                aggregation: VizAggregationOptions.COUNT,
+                pivotValues: [],
+            });
+            const mockQueryHistory: QueryHistory = {
+                createdAt: new Date(),
+                organizationUuid: sessionAccount.organization.organizationUuid!,
+                createdByUserUuid: sessionAccount.user.id,
+                createdBy: sessionAccount.user.id,
+                createdByAccount: null,
+                createdByActorType: 'session',
+                queryUuid: 'test-query-uuid',
+                projectUuid,
+                status: QueryHistoryStatus.READY,
+                error: null,
+                erroredAt: null,
+                metricQuery: metricQueryMock,
+                context: QueryExecutionContext.SQL_RUNNER,
+                fields: validExplore.tables.a.dimensions,
+                compiledSql: 'SELECT * FROM test.table',
+                warehouseQueryId: 'test-warehouse-query-id',
+                warehouseQueryMetadata: null,
+                requestParameters: {} as ExecuteAsyncQueryRequestParams,
+                totalRowCount: 1,
+                warehouseExecutionTimeMs: 1,
+                defaultPageSize: 10,
+                cacheKey: 'test-cache-key',
+                pivotConfiguration: {
+                    indexColumn: {
+                        reference: 'x',
+                        type: VizIndexType.CATEGORY,
+                    },
+                    valuesColumns,
+                    groupByColumns: undefined,
+                    sortBy: [],
+                },
+                pivotTotalColumnCount: 3,
+                // PostgreSQL JSONB does not preserve insertion order. This is
+                // the order returned for the ticket's c/a/b column names.
+                pivotValuesColumns: {
+                    c_actual_count: makePivotValueColumn('c_actual'),
+                    a_forecast_count: makePivotValueColumn('a_forecast'),
+                    b_actual_new_count: makePivotValueColumn('b_actual_new'),
+                },
+                resultsFileName: 'results-file-name.json',
+                resultsCreatedAt: new Date(),
+                resultsUpdatedAt: new Date(),
+                resultsExpiresAt: new Date(Date.now() + 60_000),
+                columns: expectedColumns,
+                originalColumns: {},
+                preAggregateCompiledSql: null,
+                processingStartedAt: null,
+            };
+
+            serviceWithCache.queryHistoryModel.get = vi
+                .fn()
+                .mockResolvedValue(mockQueryHistory);
+            serviceWithCache.getResultsPageFromS3 = vi.fn().mockResolvedValue({
+                rows: [expectedFormattedRow],
+            });
+            serviceWithCache.getExplore = vi
+                .fn()
+                .mockResolvedValue(validExplore);
+
+            const result = await serviceWithCache.getAsyncQueryResults({
+                account: sessionAccount,
+                projectUuid,
+                queryUuid: 'test-query-uuid',
+                page: 1,
+                pageSize: 10,
+            });
+
+            expect(result).toMatchObject({
+                pivotDetails: {
+                    valuesColumns: valuesColumns.map(({ reference }) =>
+                        makePivotValueColumn(reference),
+                    ),
+                },
+            });
+        });
     });
 
     describe('download pivot routing', () => {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -867,13 +867,26 @@ export class AsyncQueryService extends ProjectService {
             return null;
         }
 
+        const valueColumnOrder = new Map(
+            pivotConfiguration.valuesColumns.map((column, index) => [
+                PivotQueryBuilder.getValueColumnFieldName(
+                    column.reference,
+                    column.aggregation,
+                ),
+                index,
+            ]),
+        );
+        const getValueColumnOrder = (column: PivotValuesColumn) =>
+            valueColumnOrder.get(
+                PivotQueryBuilder.getValueColumnFieldName(
+                    column.referenceField,
+                    column.aggregation,
+                ),
+            ) ?? Number.MAX_SAFE_INTEGER;
         const sortedValuesColumns = Object.values(pivotValuesColumns).sort(
-            (a, b) => {
-                if (a.columnIndex && b.columnIndex) {
-                    return a.columnIndex - b.columnIndex;
-                }
-                return 0;
-            },
+            (a, b) =>
+                (a.columnIndex ?? 0) - (b.columnIndex ?? 0) ||
+                getValueColumnOrder(a) - getValueColumnOrder(b),
         );
 
         return {


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9341/sql-runner-bar-chart-series-order-is-unpredictable-doesnt-follow

## Summary

SQL Runner bar charts now render multi-metric series in the order configured on the Y-axis. SELECT column order remains independent from chart-series order.

## Root cause

The async query stored pivot value columns in a PostgreSQL JSONB object, which does not preserve insertion order. The result reader sorted only by pivot-group `columnIndex`, so ungrouped metrics and metrics within one group retained JSONB storage order instead of the configured Y-axis order.

```ts
Object.values(pivotValuesColumns).sort((a, b) =>
    a.columnIndex && b.columnIndex ? a.columnIndex - b.columnIndex : 0,
);
```

#26134 did not introduce the lost ordering, but unmasked it by making the final series-array position control mixed-chart paint order.

## Fix

The result reader now sorts by pivot-group rank first and configured value-column rank second. The persisted pivot configuration repairs existing query histories without a schema migration.

- `packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts` — restores group-then-Y-axis order when reconstructing pivot details.
- `packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts` — covers a three-series JSONB round trip whose storage order differs from configured order.
- Series-reorder UI remains out of scope because deterministic Y-axis add order satisfies this bug.

## Before

```text
Configured Y-axis: b_actual_new → c_actual → a_forecast
Returned series:   c_actual → a_forecast → b_actual_new
```

## After

```text
Configured Y-axis: b_actual_new → c_actual → a_forecast
Returned series:   b_actual_new → c_actual → a_forecast
```

## Test plan

- [x] `pnpm -F backend typecheck`
- [x] Targeted backend lint and formatter checks
- [x] `AsyncQueryService.test.ts` — 60 tests pass, including the failing-then-passing JSONB regression
- [x] Complete backend unit suite — 384 files, 5,689 tests pass, one pre-existing skip
- [x] Runtime edge cases — pivot-group rank stays primary, configured metric rank breaks ties, unknown columns remain available, and non-pivot history remains unchanged
- [x] Manual SQL Runner bar chart — SELECT `c, b, a`, Y-axis `c, a, b`, API and rendered legend both `c, a, b`