### PR TITLE
feat(embed): bulk export all dashboard tiles as CSV/XLSX

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,5 +194,5 @@
             "pnpm -F formula run formatter"
         ]
     },
-    "packageManager": "pnpm@11.17.0+sha512.cca3cea332ad254bb84145f966d19f4879615210346fc92c79a047f23a0d7b3cca3c3792f0076ba1f1831d277efbcf0a9119b31a9a60eca7fb3d6231f331ef72"
+    "packageManager": "pnpm@11.20.0+sha512.9a6f330a95b66446ea088faf1521405a8a01f07fde7124cc9958dfed52d4bb436737e65b08f85f37b46fcba375092558ac51262b816844b22f63406ed166bfee"
 }

--- a/packages/backend/src/controllers/v2/DashboardController.ts
+++ b/packages/backend/src/controllers/v2/DashboardController.ts
@@ -54,18 +54,17 @@ export class DashboardControllerV2 extends BaseController {
         @Body() body: ExportContentRequest,
         @Request() req: express.Request,
     ): Promise<ApiJobScheduledResponse> {
-        assertRegisteredAccount(req.account);
+        // Intentionally not registered-only: embedded dashboards call this with
+        // a JWT account to bulk-export their tiles as a CSV/XLSX ZIP. The
+        // service enforces the required ability for both registered and JWT
+        // callers.
         this.setStatus(200);
 
         return {
             status: 'ok',
             results: await this.services
                 .getDashboardService()
-                .scheduleExportContent(
-                    toSessionUser(req.account),
-                    dashboardUuid,
-                    body,
-                ),
+                .scheduleExportContent(req.account!, dashboardUuid, body),
         };
     }
 

--- a/packages/backend/src/controllers/v2/DashboardController.ts
+++ b/packages/backend/src/controllers/v2/DashboardController.ts
@@ -54,10 +54,6 @@ export class DashboardControllerV2 extends BaseController {
         @Body() body: ExportContentRequest,
         @Request() req: express.Request,
     ): Promise<ApiJobScheduledResponse> {
-        // Intentionally not registered-only: embedded dashboards call this with
-        // a JWT account to bulk-export their tiles as a CSV/XLSX ZIP. The
-        // service enforces the required ability for both registered and JWT
-        // callers.
         this.setStatus(200);
 
         return {

--- a/packages/backend/src/ee/controllers/embedController.ts
+++ b/packages/backend/src/ee/controllers/embedController.ts
@@ -73,6 +73,7 @@ export type ApiEmbedDashboardResponse = {
         dashboardFiltersInteractivity?: CommonEmbedJwtContent['dashboardFiltersInteractivity'];
         parameterInteractivity?: CommonEmbedJwtContent['parameterInteractivity'];
         canExportCsv?: boolean;
+        canExportDashboardCsv?: boolean;
         canExportImages?: boolean;
         canExportPagePdf?: boolean;
         canDateZoom?: boolean;

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -5,6 +5,8 @@ import {
     isSchedulerTaskName,
     SCHEDULER_TASKS,
     SchedulerJobStatus,
+    type AnonymousAccount,
+    type ExportContentPayload,
 } from '@lightdash/common';
 import type { AddJobFunction } from 'graphile-worker';
 import Logger from '../../logging/logger';
@@ -937,6 +939,92 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                     },
                 );
             },
+            [SCHEDULER_TASKS.EXPORT_CONTENT]: async (payload, helpers) => {
+                await tryJobOrTimeout(
+                    SchedulerClient.processJob(
+                        SCHEDULER_TASKS.EXPORT_CONTENT,
+                        helpers.job.id,
+                        helpers.job.run_at,
+                        payload,
+                        async () => {
+                            const { encodedJwt } = payload;
+                            if (encodedJwt) {
+                                // Embed export: rebuild the anonymous account
+                                // from the JWT so the tile queries run under the
+                                // token's access instead of a DB user.
+                                const account =
+                                    await this.resolveEmbedExportAccount(
+                                        helpers.job.id,
+                                        helpers.job.run_at,
+                                        payload,
+                                        encodedJwt,
+                                    );
+                                await this.exportContent(
+                                    helpers.job.id,
+                                    helpers.job.run_at,
+                                    payload,
+                                    account,
+                                );
+                            } else {
+                                await this.exportContent(
+                                    helpers.job.id,
+                                    helpers.job.run_at,
+                                    payload,
+                                );
+                            }
+                        },
+                    ),
+                    helpers.job,
+                    this.lightdashConfig.scheduler.jobTimeout,
+                    async (job, e) => {
+                        await this.schedulerService.logSchedulerJob({
+                            task: SCHEDULER_TASKS.EXPORT_CONTENT,
+                            jobId: job.id,
+                            scheduledTime: job.run_at,
+                            status: SchedulerJobStatus.ERROR,
+                            details: {
+                                userUuid: payload.userUuid,
+                                projectUuid: payload.projectUuid,
+                                organizationUuid: payload.organizationUuid,
+                                error: getErrorMessage(e),
+                                createdByUserUuid: payload.userUuid,
+                            },
+                        });
+                    },
+                );
+            },
         };
+    }
+
+    // Resolves the embed account before exportContent's own logWrapper runs, so
+    // a rejected token (expired, revoked, no longer authorized) writes a job
+    // ERROR row instead of leaving the embed's poller on SCHEDULED forever —
+    // tryJobOrTimeout only handles timeouts.
+    private async resolveEmbedExportAccount(
+        jobId: string,
+        scheduledTime: Date,
+        payload: ExportContentPayload,
+        encodedJwt: string,
+    ): Promise<AnonymousAccount> {
+        try {
+            return await this.embedService.getAccountForDashboardExport(
+                payload,
+                encodedJwt,
+            );
+        } catch (e) {
+            await this.schedulerService.logSchedulerJob({
+                task: SCHEDULER_TASKS.EXPORT_CONTENT,
+                jobId,
+                scheduledTime,
+                status: SchedulerJobStatus.ERROR,
+                details: {
+                    createdByUserUuid: payload.userUuid,
+                    projectUuid: payload.projectUuid,
+                    organizationUuid: payload.organizationUuid,
+                    error: getErrorMessage(e),
+                },
+            });
+            throw e;
+        }
     }
 }

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -6,7 +6,6 @@ import {
     SCHEDULER_TASKS,
     SchedulerJobStatus,
     type AnonymousAccount,
-    type ExportContentPayload,
 } from '@lightdash/common';
 import type { AddJobFunction } from 'graphile-worker';
 import Logger from '../../logging/logger';
@@ -948,30 +947,47 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                         payload,
                         async () => {
                             const { encodedJwt } = payload;
-                            if (encodedJwt) {
-                                // Embed export: rebuild the anonymous account
-                                // from the JWT so the tile queries run under the
-                                // token's access instead of a DB user.
-                                const account =
-                                    await this.resolveEmbedExportAccount(
-                                        helpers.job.id,
-                                        helpers.job.run_at,
+                            if (!encodedJwt) {
+                                await this.exportContent(
+                                    helpers.job.id,
+                                    helpers.job.run_at,
+                                    payload,
+                                );
+                                return;
+                            }
+                            // Embed export: run tile queries under the
+                            // JWT's access instead of a DB user.
+                            let account: AnonymousAccount;
+                            try {
+                                account =
+                                    await this.embedService.getAccountForDashboardExport(
                                         payload,
                                         encodedJwt,
                                     );
-                                await this.exportContent(
-                                    helpers.job.id,
-                                    helpers.job.run_at,
-                                    payload,
-                                    account,
-                                );
-                            } else {
-                                await this.exportContent(
-                                    helpers.job.id,
-                                    helpers.job.run_at,
-                                    payload,
-                                );
+                            } catch (e) {
+                                // Log before exportContent's logWrapper so a
+                                // rejected token writes a job ERROR row.
+                                await this.schedulerService.logSchedulerJob({
+                                    task: SCHEDULER_TASKS.EXPORT_CONTENT,
+                                    jobId: helpers.job.id,
+                                    scheduledTime: helpers.job.run_at,
+                                    status: SchedulerJobStatus.ERROR,
+                                    details: {
+                                        createdByUserUuid: payload.userUuid,
+                                        projectUuid: payload.projectUuid,
+                                        organizationUuid:
+                                            payload.organizationUuid,
+                                        error: getErrorMessage(e),
+                                    },
+                                });
+                                throw e;
                             }
+                            await this.exportContent(
+                                helpers.job.id,
+                                helpers.job.run_at,
+                                payload,
+                                account,
+                            );
                         },
                     ),
                     helpers.job,
@@ -994,37 +1010,5 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                 );
             },
         };
-    }
-
-    // Resolves the embed account before exportContent's own logWrapper runs, so
-    // a rejected token (expired, revoked, no longer authorized) writes a job
-    // ERROR row instead of leaving the embed's poller on SCHEDULED forever —
-    // tryJobOrTimeout only handles timeouts.
-    private async resolveEmbedExportAccount(
-        jobId: string,
-        scheduledTime: Date,
-        payload: ExportContentPayload,
-        encodedJwt: string,
-    ): Promise<AnonymousAccount> {
-        try {
-            return await this.embedService.getAccountForDashboardExport(
-                payload,
-                encodedJwt,
-            );
-        } catch (e) {
-            await this.schedulerService.logSchedulerJob({
-                task: SCHEDULER_TASKS.EXPORT_CONTENT,
-                jobId,
-                scheduledTime,
-                status: SchedulerJobStatus.ERROR,
-                details: {
-                    createdByUserUuid: payload.userUuid,
-                    projectUuid: payload.projectUuid,
-                    organizationUuid: payload.organizationUuid,
-                    error: getErrorMessage(e),
-                },
-            });
-            throw e;
-        }
     }
 }

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
@@ -1,5 +1,6 @@
 import { Ability } from '@casl/ability';
 import {
+    buildAccountHelpers,
     ForbiddenError,
     type AnonymousAccount,
     type CreateEmbedJwt,
@@ -274,6 +275,63 @@ describe('EmbedService', () => {
                 type: 'metricsCatalog',
                 explores: [],
             });
+        });
+    });
+
+    describe('getAccountForDashboardExport', () => {
+        const exportPayload = {
+            projectUuid: mockProjectUuid,
+            organizationUuid: mockOrganizationUuid,
+            resourceUuid: 'dashboard-1',
+        };
+
+        const accountWithExportAbility = (dashboardUuid: string) => {
+            const account = {
+                organization: { organizationUuid: mockOrganizationUuid },
+                authentication: { type: 'jwt', source: 'encoded-jwt' },
+                user: {
+                    id: 'external::user-1',
+                    type: 'anonymous',
+                    ability: new Ability<PossibleAbilities>([
+                        {
+                            subject: 'ExportCsv',
+                            action: 'manage',
+                            conditions: {
+                                'metadata.dashboardUuid': dashboardUuid,
+                            },
+                        },
+                    ]),
+                },
+            } as unknown as AnonymousAccount;
+            return {
+                ...account,
+                ...buildAccountHelpers(account),
+            } as AnonymousAccount;
+        };
+
+        test('returns the rebuilt account when the token can export the job dashboard', async () => {
+            const account = accountWithExportAbility('dashboard-1');
+            vi.spyOn(service, 'getAccountFromJwt').mockResolvedValue(account);
+
+            await expect(
+                service.getAccountForDashboardExport(
+                    exportPayload,
+                    'encoded-jwt',
+                ),
+            ).resolves.toBe(account);
+        });
+
+        test('rejects when the token is scoped to a different dashboard', async () => {
+            vi.spyOn(service, 'getAccountFromJwt').mockResolvedValue(
+                accountWithExportAbility('dashboard-2'),
+            );
+
+            await expect(
+                service.getAccountForDashboardExport(
+                    exportPayload,
+                    'encoded-jwt',
+                ),
+            ).rejects.toThrowError(ForbiddenError);
         });
     });
 

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
@@ -1,6 +1,5 @@
 import { Ability } from '@casl/ability';
 import {
-    buildAccountHelpers,
     ForbiddenError,
     type AnonymousAccount,
     type CreateEmbedJwt,
@@ -275,63 +274,6 @@ describe('EmbedService', () => {
                 type: 'metricsCatalog',
                 explores: [],
             });
-        });
-    });
-
-    describe('getAccountForDashboardExport', () => {
-        const exportPayload = {
-            projectUuid: mockProjectUuid,
-            organizationUuid: mockOrganizationUuid,
-            resourceUuid: 'dashboard-1',
-        };
-
-        const accountWithExportAbility = (dashboardUuid: string) => {
-            const account = {
-                organization: { organizationUuid: mockOrganizationUuid },
-                authentication: { type: 'jwt', source: 'encoded-jwt' },
-                user: {
-                    id: 'external::user-1',
-                    type: 'anonymous',
-                    ability: new Ability<PossibleAbilities>([
-                        {
-                            subject: 'ExportCsv',
-                            action: 'manage',
-                            conditions: {
-                                'metadata.dashboardUuid': dashboardUuid,
-                            },
-                        },
-                    ]),
-                },
-            } as unknown as AnonymousAccount;
-            return {
-                ...account,
-                ...buildAccountHelpers(account),
-            } as AnonymousAccount;
-        };
-
-        test('returns the rebuilt account when the token can export the job dashboard', async () => {
-            const account = accountWithExportAbility('dashboard-1');
-            vi.spyOn(service, 'getAccountFromJwt').mockResolvedValue(account);
-
-            await expect(
-                service.getAccountForDashboardExport(
-                    exportPayload,
-                    'encoded-jwt',
-                ),
-            ).resolves.toBe(account);
-        });
-
-        test('rejects when the token is scoped to a different dashboard', async () => {
-            vi.spyOn(service, 'getAccountFromJwt').mockResolvedValue(
-                accountWithExportAbility('dashboard-2'),
-            );
-
-            await expect(
-                service.getAccountForDashboardExport(
-                    exportPayload,
-                    'encoded-jwt',
-                ),
-            ).rejects.toThrowError(ForbiddenError);
         });
     });
 

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -2573,11 +2573,8 @@ export class EmbedService extends BaseService {
         );
     }
 
-    /**
-     * Rebuilds the anonymous account for a queued dashboard export job,
-     * re-verifying the token (signature and expiry) and re-asserting the export
-     * ability against the job's dashboard so the worker never trusts the queue.
-     */
+    // Re-verifies the token and re-asserts the export ability against the
+    // job's dashboard, so the worker never trusts the queue.
     async getAccountForDashboardExport(
         payload: Pick<
             ExportContentPayload,

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -28,6 +28,7 @@ import {
     ExecuteAsyncDashboardChartRequestParams,
     Explore,
     ExploreError,
+    ExportContentPayload,
     FeatureFlags,
     FieldValueSearchResult,
     FilterableDimension,
@@ -617,6 +618,7 @@ export class EmbedService extends BaseService {
         const {
             isPreview,
             canExportCsv,
+            canExportDashboardCsv,
             canExportImages,
             canExportPagePdf,
             canDateZoom,
@@ -691,6 +693,7 @@ export class EmbedService extends BaseService {
             dashboardFiltersInteractivity: account.access.filtering,
             parameterInteractivity: account.access.parameters,
             canExportCsv,
+            canExportDashboardCsv,
             canExportImages,
             canExportPagePdf: canExportPagePdf ?? true, // enabled by default for backwards compatibility
             canDateZoom,
@@ -2568,6 +2571,41 @@ export class EmbedService extends BaseService {
                 });
             },
         );
+    }
+
+    /**
+     * Rebuilds the anonymous account for a queued dashboard export job,
+     * re-verifying the token (signature and expiry) and re-asserting the export
+     * ability against the job's dashboard so the worker never trusts the queue.
+     */
+    async getAccountForDashboardExport(
+        payload: Pick<
+            ExportContentPayload,
+            'projectUuid' | 'organizationUuid' | 'resourceUuid'
+        >,
+        encodedJwt: string,
+    ): Promise<AnonymousAccount> {
+        const account = await this.getAccountFromJwt(
+            payload.projectUuid,
+            encodedJwt,
+        );
+
+        if (
+            this.createAuditedAbility(account).cannot(
+                'manage',
+                subject('ExportCsv', {
+                    organizationUuid: payload.organizationUuid,
+                    projectUuid: payload.projectUuid,
+                    metadata: { dashboardUuid: payload.resourceUuid },
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'Embed token is not authorized to export this dashboard',
+            );
+        }
+
+        return account;
     }
 
     private async getEmbedWriteContext(

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -665,6 +665,9 @@ export default class SchedulerTask {
         // Captured once per job by captureAppDeliveryQueries — never rendered here,
         // so the per-channel fan-out can't trigger a second app render.
         appCaptureManifest?: DeliveryCaptureManifest,
+        // Embed/JWT exports pass a pre-resolved anonymous account (no DB user),
+        // used for CSV/XLSX tile queries in place of getAccountByUserUuid.
+        overrideAccount?: AccountType,
     ): Promise<
         NotificationPayloadBase['page'] & {
             deliveryQueries?: SchedulerDeliveryQuery[];
@@ -946,7 +949,8 @@ export default class SchedulerTask {
             case SchedulerFormat.CSV:
             case SchedulerFormat.XLSX:
                 const account =
-                    await this.userService.getAccountByUserUuid(userUuid);
+                    overrideAccount ??
+                    (await this.userService.getAccountByUserUuid(userUuid));
                 const csvOptions = isSchedulerCsvOptions(options)
                     ? options
                     : undefined;
@@ -5161,7 +5165,7 @@ export default class SchedulerTask {
         zipNameBase: string;
         organizationUuid: string;
         projectUuid: string;
-        createdByUserUuid: string;
+        createdByUserUuid: string | null;
         logContext?: string;
     }) {
         if (!this.fileStorageClient.isEnabled()) {
@@ -5396,6 +5400,9 @@ export default class SchedulerTask {
         jobId: string,
         scheduledTime: Date,
         payload: ExportContentPayload,
+        // Embed/JWT exports pass a pre-resolved anonymous account so the tile
+        // queries run under the token's access instead of a DB user.
+        overrideAccount?: AccountType,
     ) {
         await this.logWrapper<string | number>(
             {
@@ -5451,6 +5458,8 @@ export default class SchedulerTask {
                         dateZoomGranularity: payload.dateZoomGranularity,
                         parameters: payload.parameters,
                     },
+                    undefined,
+                    overrideAccount,
                 );
 
                 if (payload.format === SchedulerFormat.IMAGE) {
@@ -5506,7 +5515,10 @@ export default class SchedulerTask {
                         zipNameBase: page.details.name,
                         organizationUuid: payload.organizationUuid,
                         projectUuid: payload.projectUuid,
-                        createdByUserUuid: payload.userUuid,
+                        // JWT/embed callers have no DB user row to reference.
+                        createdByUserUuid: overrideAccount
+                            ? null
+                            : payload.userUuid,
                     });
 
                     return {

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -2,6 +2,7 @@ import { subject } from '@casl/ability';
 import {
     Account,
     AnyType,
+    assertRegisteredAccount,
     DashboardFilters,
     DateGranularity,
     DownloadFileType,
@@ -574,6 +575,10 @@ export class CsvService extends BaseService {
         selectedTabs: string[] | null,
         dateZoomGranularity?: DateGranularity | string,
     ) {
+        // Registered-only: this legacy payload cannot carry an embed JWT, so a
+        // JWT-scheduled job would fail at the worker. Embeds use the v2
+        // dashboard exports endpoint instead.
+        assertRegisteredAccount(account);
         const dashboard =
             await this.dashboardModel.getByIdOrSlug(dashboardUuid);
         const auditedAbility = this.createAuditedAbility(account);

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -20,6 +20,7 @@ import {
     type UpdateDashboard,
 } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
+import { fromSession } from '../../auth/account/account';
 import { SlackClient } from '../../clients/Slack/SlackClient';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import { AnalyticsModel } from '../../models/AnalyticsModel';
@@ -245,7 +246,7 @@ describe('DashboardService', () => {
     });
 
     test('should forward the applied parameter values when exporting content', async () => {
-        await service.scheduleExportContent(user, dashboard.uuid, {
+        await service.scheduleExportContent(fromSession(user), dashboard.uuid, {
             format: SchedulerFormat.IMAGE,
             parameters: { region: 'APAC' },
         });
@@ -254,6 +255,61 @@ describe('DashboardService', () => {
             SCHEDULER_TASKS.EXPORT_CONTENT,
             expect.objectContaining({ parameters: { region: 'APAC' } }),
         );
+    });
+
+    const embedExportAccount = () => {
+        const sessionAccount = fromSession(user);
+        return {
+            ...sessionAccount,
+            isJwtUser: () => true,
+            authentication: { type: 'jwt', source: 'encoded-jwt' },
+            user: {
+                ...sessionAccount.user,
+                type: 'anonymous',
+                id: 'external::user-1',
+                // Mirrors the grant embed JWTs get from canExportDashboardCsv:
+                // manage ExportCsv scoped to the token's dashboard.
+                ability: new Ability<PossibleAbilities>([
+                    {
+                        subject: 'ExportCsv',
+                        action: 'manage',
+                        conditions: {
+                            'metadata.dashboardUuid': dashboard.uuid,
+                        },
+                    },
+                ]),
+            },
+        } as unknown as Account;
+    };
+
+    test('should carry the encoded JWT when an embed token exports content', async () => {
+        await service.scheduleExportContent(
+            embedExportAccount(),
+            dashboard.uuid,
+            {
+                format: SchedulerFormat.CSV,
+            },
+        );
+
+        expect(schedulerClient.scheduleTask).toHaveBeenCalledWith(
+            SCHEDULER_TASKS.EXPORT_CONTENT,
+            expect.objectContaining({
+                encodedJwt: 'encoded-jwt',
+                userUuid: 'external::user-1',
+            }),
+        );
+    });
+
+    test('should reject an embed token exporting content as an image', async () => {
+        await expect(
+            service.scheduleExportContent(
+                embedExportAccount(),
+                dashboard.uuid,
+                {
+                    format: SchedulerFormat.IMAGE,
+                },
+            ),
+        ).rejects.toThrowError(ForbiddenError);
     });
 
     test('throws when an embed write token saves a SQL chart from outside the write space', async () => {

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -1,6 +1,7 @@
 import { subject } from '@casl/ability';
 import {
     AbilityAction,
+    assertRegisteredAccount,
     BulkActionable,
     ContentType,
     CreateDashboard,
@@ -23,6 +24,7 @@ import {
     isDashboardScheduler,
     isDashboardUnversionedFields,
     isDashboardVersionedFields,
+    isJwtUser,
     isUserWithOrg,
     isValidFrequency,
     isValidTimezone,
@@ -162,7 +164,7 @@ export class DashboardService
     contentVerificationModel: ContentVerificationModel;
 
     async scheduleExportContent(
-        user: SessionUser,
+        account: Account,
         dashboardUuidOrSlug: UuidOrSlug,
         data: ExportContentRequest,
     ) {
@@ -179,11 +181,14 @@ export class DashboardService
             throw new ParameterError('Unsupported export format');
         }
 
-        const auditedAbility = this.createAuditedAbility(user);
+        const auditedAbility = this.createAuditedAbility(account);
         if (data.format === SchedulerFormat.IMAGE) {
+            // Image export renders the dashboard in a headless browser using a
+            // real session, so it is not available to embed/JWT callers.
+            assertRegisteredAccount(account);
             const { inheritsFromOrgOrProject, access } =
                 await this.spacePermissionService.getSpaceAccessContext(
-                    user.userUuid,
+                    account.user.userUuid,
                     dashboard.spaceUuid,
                 );
 
@@ -220,6 +225,13 @@ export class DashboardService
             throw new ForbiddenError();
         }
 
+        // Embed/JWT callers have no DB user; carry the encoded token so the
+        // scheduler worker can rebuild the anonymous account to run the tile
+        // queries under the same access it was granted.
+        const encodedJwt = isJwtUser(account)
+            ? account.authentication.source
+            : undefined;
+
         const payload: ExportContentPayload = {
             resourceType: SchedulerResourceType.DASHBOARD,
             resourceUuid: dashboard.uuid,
@@ -232,7 +244,8 @@ export class DashboardService
             parameters: data.parameters,
             organizationUuid: dashboard.organizationUuid,
             projectUuid: dashboard.projectUuid,
-            userUuid: user.userUuid,
+            userUuid: account.user.id,
+            encodedJwt,
             schedulerUuid: undefined,
         };
 

--- a/packages/common/src/authorization/jwtAbility.test.ts
+++ b/packages/common/src/authorization/jwtAbility.test.ts
@@ -236,6 +236,91 @@ describe('Embedded dashboard abilities', () => {
             });
         });
 
+        describe('Dashboard-level CSV/XLSX export (Export all)', () => {
+            it('should allow managing ExportCsv for the bound dashboard when canExportDashboardCsv is true', () => {
+                const embedUser = createEmbedJwt({
+                    content: { canExportDashboardCsv: true },
+                });
+                const ability = defineAbilityForEmbedUser(
+                    embedUser,
+                    dashboardUuid,
+                );
+
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('ExportCsv', {
+                            organizationUuid: organization.organizationUuid,
+                            projectUuid: embed.projectUuid,
+                            metadata: {
+                                dashboardUuid,
+                                dashboardName: 'Dashboard 1',
+                            },
+                        }),
+                    ),
+                ).toBe(true);
+
+                expect(
+                    ability.can(
+                        'view',
+                        subject('JobStatus', {
+                            organizationUuid: organization.organizationUuid,
+                            projectUuid: embed.projectUuid,
+                            createdByUserUuid: 'external-id-1',
+                        }),
+                    ),
+                ).toBe(true);
+            });
+
+            it('should not allow managing ExportCsv for a different dashboard', () => {
+                const embedUser = createEmbedJwt({
+                    content: { canExportDashboardCsv: true },
+                });
+                const ability = defineAbilityForEmbedUser(
+                    embedUser,
+                    dashboardUuid,
+                );
+
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('ExportCsv', {
+                            organizationUuid: organization.organizationUuid,
+                            projectUuid: embed.projectUuid,
+                            metadata: {
+                                dashboardUuid: 'some-other-dashboard',
+                                dashboardName: 'Other dashboard',
+                            },
+                        }),
+                    ),
+                ).toBe(false);
+            });
+
+            it('should not allow managing ExportCsv when canExportDashboardCsv is false', () => {
+                const embedUser = createEmbedJwt({
+                    content: { canExportDashboardCsv: false },
+                });
+                const ability = defineAbilityForEmbedUser(
+                    embedUser,
+                    dashboardUuid,
+                );
+
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('ExportCsv', {
+                            organizationUuid: organization.organizationUuid,
+                            projectUuid: embed.projectUuid,
+                            metadata: {
+                                dashboardUuid,
+                                dashboardName: 'Dashboard 1',
+                            },
+                        }),
+                    ),
+                ).toBe(false);
+            });
+        });
+
         describe('PDF export', () => {
             it('should allow PDF export when canExportPagePdf is true', () => {
                 const embedUser = createEmbedJwt({

--- a/packages/common/src/authorization/jwtAbility.ts
+++ b/packages/common/src/authorization/jwtAbility.ts
@@ -289,6 +289,24 @@ const exportAbilities: EmbeddedAbilityBuilder = ({
                 type: 'pdf',
             });
         }
+
+        // Dashboard-level "Export all" (bundles every tile into a CSV/XLSX ZIP).
+        // Scoped to this dashboard via metadata.dashboardUuid so the shared
+        // `manage ExportCsv` check in DashboardService.scheduleExportContent
+        // passes only for the embedded dashboard. The accompanying JobStatus
+        // grant lets the embed poll the async export job it created.
+        if (embedUser.content.canExportDashboardCsv) {
+            can('manage', 'ExportCsv', {
+                organizationUuid: organization.organizationUuid,
+                projectUuid: embed.projectUuid,
+                'metadata.dashboardUuid': content.dashboardUuid,
+            });
+            can('view', 'JobStatus', {
+                organizationUuid: organization.organizationUuid,
+                projectUuid: embed.projectUuid,
+                createdByUserUuid: externalId,
+            });
+        }
     }
 
     return { embedUser, content, embed, externalId, builder };

--- a/packages/common/src/authorization/jwtAbility.ts
+++ b/packages/common/src/authorization/jwtAbility.ts
@@ -290,11 +290,8 @@ const exportAbilities: EmbeddedAbilityBuilder = ({
             });
         }
 
-        // Dashboard-level "Export all" (bundles every tile into a CSV/XLSX ZIP).
-        // Scoped to this dashboard via metadata.dashboardUuid so the shared
-        // `manage ExportCsv` check in DashboardService.scheduleExportContent
-        // passes only for the embedded dashboard. The accompanying JobStatus
-        // grant lets the embed poll the async export job it created.
+        // Dashboard-level "Export all", scoped to the token's dashboard; the
+        // JobStatus grant lets the embed poll the async export job it created.
         if (embedUser.content.canExportDashboardCsv) {
             can('manage', 'ExportCsv', {
                 organizationUuid: organization.organizationUuid,

--- a/packages/common/src/ee/embed/index.ts
+++ b/packages/common/src/ee/embed/index.ts
@@ -73,6 +73,11 @@ export const InteractivityOptionsSchema = z.object({
         DashboardFilterInteractivityOptionsSchema.optional(),
     parameterInteractivity: ParameterInteractivityOptionsSchema.optional(),
     canExportCsv: z.boolean().optional(),
+    // Authorizes a dashboard-level "Export all" that bundles every chart tile
+    // into a single CSV/XLSX ZIP. Off by default — independent from the
+    // per-tile canExportCsv so operators can enable bulk export without the
+    // per-tile buttons, or vice versa.
+    canExportDashboardCsv: z.boolean().optional(),
     canExportImages: z.boolean().optional(),
     canExportPagePdf: z.boolean().optional(),
     canDateZoom: z.boolean().optional(),
@@ -219,6 +224,7 @@ export type CommonEmbedJwtContent = {
         enabled: boolean;
     };
     canExportCsv?: boolean;
+    canExportDashboardCsv?: boolean;
     canExportImages?: boolean;
     canDateZoom?: boolean;
     canExportPagePdf?: boolean;

--- a/packages/common/src/ee/embed/index.ts
+++ b/packages/common/src/ee/embed/index.ts
@@ -73,10 +73,8 @@ export const InteractivityOptionsSchema = z.object({
         DashboardFilterInteractivityOptionsSchema.optional(),
     parameterInteractivity: ParameterInteractivityOptionsSchema.optional(),
     canExportCsv: z.boolean().optional(),
-    // Authorizes a dashboard-level "Export all" that bundles every chart tile
-    // into a single CSV/XLSX ZIP. Off by default — independent from the
-    // per-tile canExportCsv so operators can enable bulk export without the
-    // per-tile buttons, or vice versa.
+    // Dashboard-level "Export all" (CSV/XLSX ZIP of every tile). Off by
+    // default and independent from the per-tile canExportCsv.
     canExportDashboardCsv: z.boolean().optional(),
     canExportImages: z.boolean().optional(),
     canExportPagePdf: z.boolean().optional(),

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -870,6 +870,9 @@ export type ExportContentPayload = TraceTaskBase & {
     customViewportWidth?: number;
     selectedTabs?: string[] | null;
     parameters?: ParametersValuesMap;
+    // Set for embed/JWT exports so the scheduler worker can rebuild the
+    // anonymous account (no DB user) and run each tile query under it.
+    encodedJwt?: string;
 };
 
 export type ExportContentRequest = {

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardExportAll.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardExportAll.tsx
@@ -1,0 +1,109 @@
+import {
+    SchedulerFormat,
+    type Dashboard,
+    type InteractivityOptions,
+    type SchedulerCsvOptions,
+} from '@lightdash/common';
+import { ActionIcon, Menu, Tooltip } from '@mantine-8/core';
+import { IconCsv, IconFileTypeXls, IconTableExport } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { useExportDashboardContent } from '../../../../../hooks/dashboard/useDashboard';
+import useDashboardContext from '../../../../../providers/Dashboard/useDashboardContext';
+import { type EventData } from '../../../../../providers/Tracking/types';
+import useTracking from '../../../../../providers/Tracking/useTracking';
+import { embedContractClass } from '../../styles/embedClassContract';
+
+type Props = {
+    dashboard: Dashboard & InteractivityOptions;
+    projectUuid: string;
+};
+
+// Bundles every chart tile into a single CSV/XLSX ZIP. Uses the same defaults as
+// the non-embedded export modal (formatted values, table row limit) so embed
+// viewers get a one-click "download everything" without extra configuration.
+const EmbedDashboardExportAll: FC<Props> = ({ dashboard, projectUuid }) => {
+    const { track } = useTracking();
+    const exportDashboardContentMutation = useExportDashboardContent();
+    const dashboardFilters = useDashboardContext((c) => c.allFilters);
+    const dateZoomGranularity = useDashboardContext(
+        (c) => c.dateZoomGranularity,
+    );
+    const parameterValues = useDashboardContext((c) => c.parameterValues);
+
+    if (!dashboard.canExportDashboardCsv) {
+        return null;
+    }
+
+    const handleExport = (
+        format: SchedulerFormat.CSV | SchedulerFormat.XLSX,
+    ) => {
+        const options: SchedulerCsvOptions = {
+            formatted: true,
+            limit: 'table',
+            asAttachment: false,
+            exportPivotedData: true,
+            xlsxFileLayout: format === SchedulerFormat.XLSX ? 'zip' : undefined,
+        };
+
+        const event = {
+            name: 'embedding_export_all.clicked',
+            properties: {
+                projectUuid,
+                dashboardUuid: dashboard.uuid,
+                format,
+            },
+        };
+        track(event as EventData);
+
+        exportDashboardContentMutation.mutate({
+            dashboard,
+            format,
+            options,
+            dashboardFilters,
+            dateZoomGranularity,
+            parameters: parameterValues,
+            selectedTabs: null,
+        });
+    };
+
+    return (
+        <Menu position="bottom-end" withinPortal>
+            <Menu.Target>
+                <Tooltip
+                    label="Export all tiles"
+                    withinPortal
+                    position="bottom"
+                >
+                    <ActionIcon
+                        className={embedContractClass(
+                            'ld-dashboard-export-all',
+                        )}
+                        variant="default"
+                        size="lg"
+                        radius="md"
+                        loading={exportDashboardContentMutation.isLoading}
+                    >
+                        <MantineIcon icon={IconTableExport} />
+                    </ActionIcon>
+                </Tooltip>
+            </Menu.Target>
+            <Menu.Dropdown>
+                <Menu.Item
+                    leftSection={<MantineIcon icon={IconCsv} />}
+                    onClick={() => handleExport(SchedulerFormat.CSV)}
+                >
+                    Export all as .csv (.zip)
+                </Menu.Item>
+                <Menu.Item
+                    leftSection={<MantineIcon icon={IconFileTypeXls} />}
+                    onClick={() => handleExport(SchedulerFormat.XLSX)}
+                >
+                    Export all as .xlsx (.zip)
+                </Menu.Item>
+            </Menu.Dropdown>
+        </Menu>
+    );
+};
+
+export default EmbedDashboardExportAll;

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardHeader.module.css
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardHeader.module.css
@@ -22,6 +22,7 @@
 .actions {
     display: flex;
     align-items: center;
+    gap: var(--mantine-spacing-xs);
     padding-right: var(--mantine-spacing-lg);
     padding-left: var(--mantine-spacing-sm);
 }

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardHeader.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardHeader.tsx
@@ -7,6 +7,7 @@ import {
 import { Box } from '@mantine-8/core';
 import { type FC, type ReactNode } from 'react';
 import { embedContractClass } from '../../styles/embedClassContract';
+import EmbedDashboardExportAll from './EmbedDashboardExportAll';
 import EmbedDashboardExportPdf from './EmbedDashboardExportPdf';
 import EmbedDashboardFilterBar from './EmbedDashboardFilterBar';
 import styles from './EmbedDashboardHeader.module.css';
@@ -24,7 +25,11 @@ const EmbedDashboardHeader: FC<Props> = ({ dashboard, projectUuid, tabs }) => {
         isParameterInteractivityEnabled(dashboard.parameterInteractivity) ||
         isFilterInteractivityEnabled(dashboard.dashboardFiltersInteractivity);
 
-    if (!hasFilterBar && !tabs && !dashboard.canExportPagePdf) {
+    const hasHeaderActions = Boolean(
+        dashboard.canExportPagePdf || dashboard.canExportDashboardCsv,
+    );
+
+    if (!hasFilterBar && !tabs && !hasHeaderActions) {
         return null;
     }
 
@@ -53,8 +58,12 @@ const EmbedDashboardHeader: FC<Props> = ({ dashboard, projectUuid, tabs }) => {
             data-has-tabs={Boolean(tabs)}
         >
             <Box className={styles.primary}>{tabs ?? filterBar}</Box>
-            {dashboard.canExportPagePdf && (
+            {hasHeaderActions && (
                 <Box className={styles.actions}>
+                    <EmbedDashboardExportAll
+                        dashboard={dashboard}
+                        projectUuid={projectUuid}
+                    />
                     <EmbedDashboardExportPdf
                         dashboard={dashboard}
                         projectUuid={projectUuid}

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewDashboardForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewDashboardForm.tsx
@@ -81,6 +81,7 @@ type FormValues = {
     dashboardFiltersInteractivity: DashboardFilterInteractivityOptions;
     parameterInteractivity: ParameterInteractivityOptions;
     canExportCsv?: boolean;
+    canExportDashboardCsv?: boolean;
     canExportImages?: boolean;
     externalId?: string;
     canExportPagePdf?: boolean;
@@ -131,6 +132,7 @@ const EmbedPreviewDashboardForm: FC<{
                 enabled: false,
             },
             canExportCsv: false,
+            canExportDashboardCsv: false,
             canExportImages: false,
             canDateZoom: false,
             canExportPagePdf: true,
@@ -176,6 +178,7 @@ const EmbedPreviewDashboardForm: FC<{
                     },
                     parameterInteractivity: values.parameterInteractivity,
                     canExportCsv: values.canExportCsv,
+                    canExportDashboardCsv: values.canExportDashboardCsv,
                     canExportImages: values.canExportImages,
                     isPreview,
                     canDateZoom: values.canDateZoom,
@@ -407,7 +410,16 @@ const EmbedPreviewDashboardForm: FC<{
                                     {...form.getInputProps('canExportCsv', {
                                         type: 'checkbox',
                                     })}
-                                    label="Export CSV"
+                                    label="Export CSV (per tile)"
+                                />
+                                <Switch
+                                    {...form.getInputProps(
+                                        'canExportDashboardCsv',
+                                        {
+                                            type: 'checkbox',
+                                        },
+                                    )}
+                                    label="Export all tiles (CSV/XLSX ZIP)"
                                 />
                                 <Switch
                                     {...form.getInputProps('canExportImages', {

--- a/packages/frontend/src/ee/features/embed/styles/embedClassContract.test.ts
+++ b/packages/frontend/src/ee/features/embed/styles/embedClassContract.test.ts
@@ -30,6 +30,7 @@ describe('embed class contract', () => {
             'ld-dashboard-date-zoom-dropdown',
             'ld-dashboard-parameter-dropdown',
             'ld-dashboard-guided-setup',
+            'ld-dashboard-export-all',
         ]);
     });
 

--- a/packages/frontend/src/ee/features/embed/styles/embedClassContract.ts
+++ b/packages/frontend/src/ee/features/embed/styles/embedClassContract.ts
@@ -31,6 +31,7 @@ export const EMBED_CLASS_CONTRACT = [
     'ld-dashboard-date-zoom-dropdown', // portalled
     'ld-dashboard-parameter-dropdown', // portalled
     'ld-dashboard-guided-setup', // modal shown while filter rules are unmet (portalled)
+    'ld-dashboard-export-all', // dashboard-level "Export all" (CSV/XLSX ZIP) button
 ] as const satisfies readonly `ld-${EmbedSurface}-${string}`[];
 
 export type EmbedContractClassName = (typeof EMBED_CLASS_CONTRACT)[number];

--- a/packages/frontend/src/features/scheduler/hooks/useScheduler.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useScheduler.ts
@@ -195,9 +195,14 @@ export const getSchedulerJobStatus = async <
     T = ApiJobStatusResponse['results'],
 >(
     jobId: string,
+    // Embedded callers must pass this: the JWT auth middleware resolves the embed
+    // secret from a project in the path or query, and this route has neither.
+    projectUuid?: string,
 ) =>
     lightdashApi<T extends ApiJobStatusResponse['results'] ? T : never>({
-        url: `/schedulers/job/${jobId}/status`,
+        url: `/schedulers/job/${jobId}/status${
+            projectUuid ? `?projectUuid=${projectUuid}` : ''
+        }`,
         method: 'GET',
         body: undefined,
     });
@@ -477,8 +482,9 @@ const getJobStatus = async (
     jobId: string,
     onComplete: (response: Record<string, AnyType> | null) => void,
     onError: (error: Error) => void,
+    projectUuid?: string,
 ) => {
-    getSchedulerJobStatus(jobId)
+    getSchedulerJobStatus(jobId, projectUuid)
         .then((data) => {
             if (data.status === SchedulerJobStatus.COMPLETED) {
                 return onComplete(data.details);
@@ -486,7 +492,7 @@ const getJobStatus = async (
                 onError(new Error(data.details?.error || 'Job failed'));
             } else {
                 setTimeout(
-                    () => getJobStatus(jobId, onComplete, onError),
+                    () => getJobStatus(jobId, onComplete, onError, projectUuid),
                     2000,
                 );
             }
@@ -496,7 +502,7 @@ const getJobStatus = async (
         });
 };
 
-export const pollJobStatus = async (jobId: string) => {
+export const pollJobStatus = async (jobId: string, projectUuid?: string) => {
     if (!jobId) {
         throw new Error('Cannot poll job status: jobId is required');
     }
@@ -505,6 +511,7 @@ export const pollJobStatus = async (jobId: string) => {
             jobId,
             (details) => resolve(details),
             (error) => reject(error),
+            projectUuid,
         ),
     );
 };

--- a/packages/frontend/src/hooks/dashboard/useDashboard.test.tsx
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.test.tsx
@@ -49,6 +49,7 @@ const mockPollJobStatus = pollJobStatus as unknown as Mock;
 const dashboard = {
     uuid: 'dashboard-uuid',
     name: 'My dashboard',
+    projectUuid: 'project-uuid',
 } as Dashboard;
 
 function createWrapper() {
@@ -91,7 +92,7 @@ describe('useExportDashboardContentPreview', () => {
         expect(url).toBe('https://example.com/preview.png');
         expect(mockApi).toHaveBeenCalledWith(
             expect.objectContaining({
-                url: `/dashboards/${dashboard.uuid}/exports`,
+                url: `/dashboards/${dashboard.uuid}/exports?projectUuid=${dashboard.projectUuid}`,
                 version: 'v2',
                 method: 'POST',
             }),
@@ -104,7 +105,10 @@ describe('useExportDashboardContentPreview', () => {
                 selectedTabs: ['tab-1'],
             }),
         );
-        expect(mockPollJobStatus).toHaveBeenCalledWith('job-1');
+        expect(mockPollJobStatus).toHaveBeenCalledWith(
+            'job-1',
+            dashboard.projectUuid,
+        );
     });
 
     it('rejects when the job completes without a url', async () => {

--- a/packages/frontend/src/hooks/dashboard/useDashboard.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.ts
@@ -387,6 +387,7 @@ export const useExportDashboardContentPreview = () => {
             );
             const details = (await pollJobStatus(
                 job.jobId,
+                data.dashboard.projectUuid,
             )) as DashboardContentExportDetails | null;
             if (!details?.url) {
                 throw new Error('Preview generation returned no image');

--- a/packages/frontend/src/hooks/dashboard/useDashboard.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.ts
@@ -210,8 +210,12 @@ export const useDashboardVersionRefresh = (
     });
 };
 
+// projectUuid is passed as a query param, not because the endpoint needs it, but
+// because the JWT auth middleware resolves the embed secret from it — embedded
+// dashboards can't authenticate on a route without a project in the path.
 const exportDashboardContent = async (
     id: string,
+    projectUuid: string,
     data: {
         format: ExportContentFormat;
         options?: SchedulerCsvOptions | SchedulerImageOptions;
@@ -223,7 +227,7 @@ const exportDashboardContent = async (
     },
 ) =>
     lightdashApi<ApiJobScheduledResponse['results']>({
-        url: `/dashboards/${id}/exports`,
+        url: `/dashboards/${id}/exports?projectUuid=${projectUuid}`,
         version: 'v2',
         method: 'POST',
         body: JSON.stringify(data),
@@ -259,15 +263,19 @@ export const useExportDashboardContent = () => {
         }
     >(
         (data) =>
-            exportDashboardContent(data.dashboard.uuid, {
-                format: data.format,
-                options: data.options,
-                dashboardFilters: data.dashboardFilters,
-                dateZoomGranularity: data.dateZoomGranularity,
-                customViewportWidth: data.customViewportWidth,
-                selectedTabs: data.selectedTabs,
-                parameters: data.parameters,
-            }),
+            exportDashboardContent(
+                data.dashboard.uuid,
+                data.dashboard.projectUuid,
+                {
+                    format: data.format,
+                    options: data.options,
+                    dashboardFilters: data.dashboardFilters,
+                    dateZoomGranularity: data.dateZoomGranularity,
+                    customViewportWidth: data.customViewportWidth,
+                    selectedTabs: data.selectedTabs,
+                    parameters: data.parameters,
+                },
+            ),
         {
             mutationKey: ['export_dashboard_content'],
             onMutate: (data) => {
@@ -279,7 +287,7 @@ export const useExportDashboardContent = () => {
                 });
             },
             onSuccess: async (job, data) => {
-                pollJobStatus(job.jobId)
+                pollJobStatus(job.jobId, data.dashboard.projectUuid)
                     .then((rawDetails) => {
                         const details =
                             rawDetails as DashboardContentExportDetails | null;
@@ -364,15 +372,19 @@ export const useExportDashboardContentPreview = () => {
         }
     >(
         async (data) => {
-            const job = await exportDashboardContent(data.dashboard.uuid, {
-                format: SchedulerFormat.IMAGE,
-                options: {},
-                dashboardFilters: data.dashboardFilters,
-                dateZoomGranularity: data.dateZoomGranularity,
-                customViewportWidth: data.customViewportWidth,
-                selectedTabs: data.selectedTabs,
-                parameters: data.parameters,
-            });
+            const job = await exportDashboardContent(
+                data.dashboard.uuid,
+                data.dashboard.projectUuid,
+                {
+                    format: SchedulerFormat.IMAGE,
+                    options: {},
+                    dashboardFilters: data.dashboardFilters,
+                    dateZoomGranularity: data.dateZoomGranularity,
+                    customViewportWidth: data.customViewportWidth,
+                    selectedTabs: data.selectedTabs,
+                    parameters: data.parameters,
+                },
+            );
             const details = (await pollJobStatus(
                 job.jobId,
             )) as DashboardContentExportDetails | null;


### PR DESCRIPTION
Closes: #24702

### Description:

Embedded dashboards only support per-tile CSV export, so viewers have to download each tile one at a time. This adds a dashboard-level **"Export all"** to the embedded dashboard header that bundles every chart tile into a single CSV or XLSX ZIP — the equivalent of the non-embedded `DashboardExportModal` — gated behind a new embed-JWT flag `canExportDashboardCsv`.

Following the embed guidance (no new `/embed` endpoint), the existing async export endpoint `POST /api/v2/dashboards/{uuid}/exports` is made JWT-compatible instead:

- **`canExportDashboardCsv`** grants `manage:ExportCsv` scoped to the token's dashboard (`metadata.dashboardUuid`) plus `view:JobStatus`, so the *existing* `DashboardService.scheduleExportContent` permission check passes only for the embedded dashboard — no service-side auth branching.
- `scheduleExportContent` now takes an `Account` (was `SessionUser`) and threads the encoded JWT into the export job payload. Image export stays registered-only (the headless render needs a session).
- The EE worker rebuilds the anonymous account from the JWT and re-asserts the export ability against the job's dashboard before running tile queries, mirroring the shipped `DOWNLOAD_ASYNC_QUERY_RESULTS` pattern. A rejected token (expired/revoked) writes a job ERROR row so the embed poller doesn't hang on `SCHEDULED`.
- Both the export POST and the job-status poll now carry `?projectUuid=`, since the JWT middleware resolves the embed secret from a project in the path or query and neither route has one.
- The legacy v1 `exportCsv` path is now explicitly registered-only: it shares the same `manage:ExportCsv` check the new grant satisfies, but its payload can't carry a JWT, so a JWT-scheduled job would crash at the worker. v2 is the single embed export path.

### Notes for reviewers

- Reuses `manage:ExportCsv` rather than introducing a new CASL subject/scope, so no `scoped_roles` migration is needed (embed JWT auth is separate from custom roles).
- Persistent/presigned download URLs are created with a `null` creator for JWT callers, since there's no DB user row to reference.
- Docs for the new flag live in the docs repo and need a follow-up.
- Not exercised end-to-end against a running embed — worth a functional pass before merge.



### Demo

<img width="1756" height="1040" alt="CleanShot 2026-08-04 at 15 04 20@2x" src="https://github.com/user-attachments/assets/11000de0-96b1-43b3-b289-bd0bee75567f" />

<img width="576" height="274" alt="CleanShot 2026-08-04 at 15 04 34@2x" src="https://github.com/user-attachments/assets/77496c05-553a-4a68-a65d-e5158d5d3ae2" />
