### PR TITLE
feat(homepage): opt-in funnel and customisation analytics

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -904,6 +904,30 @@ type OnboardingHomepageProvisionedEvent = BaseTrack & {
     };
 };
 
+type OrganizationHomepageSettingsUpdatedEvent = BaseTrack & {
+    event: 'organization_homepage_settings.updated';
+    userId: string;
+    properties: {
+        organizationId: string;
+        enabled: boolean;
+        opening: 'ask-first' | 'content-first' | null;
+        previouslyEnabled: boolean;
+    };
+};
+
+type HomepagePublishedEvent = BaseTrack & {
+    event: 'homepage.published';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        homepageUuid: string;
+        audienceType: 'everyone' | 'groups' | 'roles';
+        blockTypeCounts: Record<string, number>;
+        openingBlockType: string | null;
+    };
+};
+
 export type OnboardingHomepageSkippedReason =
     | 'new_onboarding_flag_disabled'
     | 'homepage_builder_flag_disabled'
@@ -3207,6 +3231,8 @@ type TypedEvent =
     | OnboardingHomepageProvisionedEvent
     | OnboardingHomepageSkippedEvent
     | OnboardingHomepageFailedEvent
+    | OrganizationHomepageSettingsUpdatedEvent
+    | HomepagePublishedEvent
     | OnboardingOrgFlagsProvisionedEvent
     | PlaygroundProjectProvisionedEvent
     | PlaygroundProjectSkippedEvent

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -184,6 +184,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 new ProjectHomepageService({
                     projectHomepageModel:
                         models.getProjectHomepageModel<ProjectHomepageModel>(),
+                    analytics: context.lightdashAnalytics,
                     featureFlagService: repository.getFeatureFlagService(),
                     groupsModel: models.getGroupsModel(),
                     projectModel: models.getProjectModel(),

--- a/packages/backend/src/ee/services/ProjectHomepageService.test.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.test.ts
@@ -135,6 +135,7 @@ const makeService = ({
     slackInstalled?: boolean;
 } = {}) =>
     new ProjectHomepageService({
+        analytics: { track: vi.fn() },
         featureFlagService: {
             get: vi.fn().mockResolvedValue({
                 id: 'homepage-builder',

--- a/packages/backend/src/ee/services/ProjectHomepageService.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.ts
@@ -33,6 +33,7 @@ import { type KnownBlock } from '@slack/web-api';
 import { createCanvas, loadImage } from 'canvas';
 import { randomUUID } from 'crypto';
 import { type Readable } from 'stream';
+import { type LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { type FileStorageClient } from '../../clients/FileStorage/FileStorageClient';
 import { type SlackClient } from '../../clients/Slack/SlackClient';
 import { type LightdashConfig } from '../../config/parseConfig';
@@ -187,6 +188,7 @@ export type ProjectHomepageServiceArguments = {
         | 'upsertOrgHomepageSettings'
         | 'swapHeroBlocks'
     >;
+    analytics: Pick<LightdashAnalytics, 'track'>;
     featureFlagService: Pick<FeatureFlagService, 'get'>;
     groupsModel: Pick<GroupsModel, 'findUserGroups'>;
     projectModel: Pick<ProjectModel, 'getProjectMemberAccess' | 'getSummary'>;
@@ -202,6 +204,8 @@ export type ProjectHomepageServiceArguments = {
 
 export class ProjectHomepageService extends BaseService {
     private readonly projectHomepageModel: ProjectHomepageServiceArguments['projectHomepageModel'];
+
+    private readonly analytics: ProjectHomepageServiceArguments['analytics'];
 
     private readonly featureFlagService: ProjectHomepageServiceArguments['featureFlagService'];
 
@@ -222,6 +226,7 @@ export class ProjectHomepageService extends BaseService {
     constructor(args: ProjectHomepageServiceArguments) {
         super();
         this.projectHomepageModel = args.projectHomepageModel;
+        this.analytics = args.analytics;
         this.featureFlagService = args.featureFlagService;
         this.groupsModel = args.groupsModel;
         this.projectModel = args.projectModel;
@@ -295,6 +300,10 @@ export class ProjectHomepageService extends BaseService {
                 'Only organization admins can change homepage settings',
             );
         }
+        const previous =
+            await this.projectHomepageModel.findOrgHomepageSettings(
+                user.organizationUuid,
+            );
         const settings =
             await this.projectHomepageModel.upsertOrgHomepageSettings(
                 user.organizationUuid,
@@ -309,6 +318,16 @@ export class ProjectHomepageService extends BaseService {
                 update.opening,
             );
         }
+        this.analytics.track({
+            event: 'organization_homepage_settings.updated',
+            userId: user.userUuid,
+            properties: {
+                organizationId: user.organizationUuid,
+                enabled: settings.enabled,
+                opening: settings.opening,
+                previouslyEnabled: previous?.enabled ?? false,
+            },
+        });
         return settings;
     }
 
@@ -607,6 +626,32 @@ export class ProjectHomepageService extends BaseService {
             homepageUuid,
             audience,
         );
+        const publishedBlocks = (published.publishedConfig?.rows ?? []).flatMap(
+            (row) => row.blocks,
+        );
+        this.analytics.track({
+            event: 'homepage.published',
+            userId: user.userUuid,
+            properties: {
+                organizationId: user.organizationUuid ?? '',
+                projectId: projectUuid,
+                homepageUuid,
+                audienceType: audience.type,
+                blockTypeCounts: publishedBlocks.reduce<Record<string, number>>(
+                    (counts, block) => ({
+                        ...counts,
+                        [block.type]: (counts[block.type] ?? 0) + 1,
+                    }),
+                    {},
+                ),
+                openingBlockType:
+                    publishedBlocks.find(
+                        (block) =>
+                            block.type === 'ask-ai-hero' ||
+                            block.type === 'greeting',
+                    )?.type ?? null,
+            },
+        });
         const { organizationUuid } = user;
         if (organizationUuid) {
             const publishedDrafts =

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
@@ -60,6 +60,8 @@ import { Fragment, useEffect, useMemo, useRef, useState, type FC } from 'react';
 import { useNavigate } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
 import MantineModal from '../../../components/common/MantineModal';
+import useTracking from '../../../providers/Tracking/useTracking';
+import { EventName } from '../../../types/Events';
 import { TIER_CLASS, traitFor } from './blockLayout';
 import { IconSquare } from './blocks/BlockShell';
 import {
@@ -547,6 +549,7 @@ export const HomepageEditor: FC<Props> = ({
     // Admins of an agent-less project can still *see* AI, so gate the AI
     // blocks on an agent actually existing.
     const { canAskAi } = useHomepageAiState(projectUuid);
+    const { track } = useTracking();
 
     const [draft, setDraft] = useState<HomepageConfig>(() =>
         migrateHomepageConfig(homepage.draftConfig),
@@ -721,6 +724,10 @@ export const HomepageEditor: FC<Props> = ({
         if (!target) return;
         if (source.kind === 'new') {
             const block = source.definition.create();
+            track({
+                name: EventName.HOMEPAGE_BLOCK_ADDED,
+                properties: { blockType: block.type },
+            });
             setDraft((prev) => dropNewBlock(prev, block, target));
             setJustPlacedId(block.id);
             return;
@@ -954,18 +961,27 @@ export const HomepageEditor: FC<Props> = ({
                                                     rowIndex,
                                                 )}
                                                 blocks={availableBlocks}
-                                                onQuickAdd={(definition) =>
+                                                onQuickAdd={(definition) => {
+                                                    const block =
+                                                        definition.create();
+                                                    track({
+                                                        name: EventName.HOMEPAGE_BLOCK_ADDED,
+                                                        properties: {
+                                                            blockType:
+                                                                block.type,
+                                                        },
+                                                    });
                                                     setDraft((prev) =>
                                                         dropNewBlock(
                                                             prev,
-                                                            definition.create(),
+                                                            block,
                                                             {
                                                                 kind: 'row',
                                                                 rowIndex,
                                                             },
                                                         ),
-                                                    )
-                                                }
+                                                    );
+                                                }}
                                             />
                                             {activeDrag &&
                                                 rowIndicatorActive(
@@ -1125,7 +1141,17 @@ export const HomepageEditor: FC<Props> = ({
                                                                                         ),
                                                                                 )
                                                                             }
-                                                                            onRemove={() =>
+                                                                            onRemove={() => {
+                                                                                track(
+                                                                                    {
+                                                                                        name: EventName.HOMEPAGE_BLOCK_REMOVED,
+                                                                                        properties:
+                                                                                            {
+                                                                                                blockType:
+                                                                                                    block.type,
+                                                                                            },
+                                                                                    },
+                                                                                );
                                                                                 setDraft(
                                                                                     (
                                                                                         prev,
@@ -1134,8 +1160,8 @@ export const HomepageEditor: FC<Props> = ({
                                                                                             prev,
                                                                                             block.id,
                                                                                         ),
-                                                                                )
-                                                                            }
+                                                                                );
+                                                                            }}
                                                                             onChange={(
                                                                                 updated,
                                                                             ) =>
@@ -1177,12 +1203,22 @@ export const HomepageEditor: FC<Props> = ({
                                                             blocks={
                                                                 columnBlocks
                                                             }
-                                                            onAdd={(def) =>
+                                                            onAdd={(def) => {
+                                                                const newBlock =
+                                                                    def.create();
+                                                                track({
+                                                                    name: EventName.HOMEPAGE_BLOCK_ADDED,
+                                                                    properties:
+                                                                        {
+                                                                            blockType:
+                                                                                newBlock.type,
+                                                                        },
+                                                                });
                                                                 setDraft(
                                                                     (prev) =>
                                                                         dropNewBlock(
                                                                             prev,
-                                                                            def.create(),
+                                                                            newBlock,
                                                                             {
                                                                                 kind: 'cell',
                                                                                 rowIndex,
@@ -1192,8 +1228,8 @@ export const HomepageEditor: FC<Props> = ({
                                                                                         .length,
                                                                             },
                                                                         ),
-                                                                )
-                                                            }
+                                                                );
+                                                            }}
                                                         />
                                                     ) : (
                                                         activeDrag && (

--- a/packages/frontend/src/ee/features/homepageBuilder/TryNewHomepagePromo.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/TryNewHomepagePromo.test.tsx
@@ -8,6 +8,10 @@ vi.mock('react-router', () => ({
     useNavigate: () => vi.fn(),
 }));
 
+vi.mock('../../../providers/Tracking/useTracking', () => ({
+    default: () => ({ track: vi.fn() }),
+}));
+
 const { aiState, mutateSettings, abilityRules, license } = vi.hoisted(() => ({
     aiState: { current: { canAskAi: true } },
     mutateSettings: vi.fn(),

--- a/packages/frontend/src/ee/features/homepageBuilder/TryNewHomepagePromo.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/TryNewHomepagePromo.tsx
@@ -17,12 +17,14 @@ import {
     IconSpeakerphone,
     IconUsersGroup,
 } from '@tabler/icons-react';
-import { useState, type FC } from 'react';
+import { useEffect, useRef, useState, type FC } from 'react';
 import { useNavigate } from 'react-router';
 import { useLocalStorage } from 'react-use';
 import MantineIcon from '../../../components/common/MantineIcon';
 import MantineModal from '../../../components/common/MantineModal';
 import useApp from '../../../providers/App/useApp';
+import useTracking from '../../../providers/Tracking/useTracking';
+import { EventName } from '../../../types/Events';
 import { IS_MOBILE } from '../../../utils/isMobile';
 import { DEFAULT_GREETING_SUBTITLE, getGreeting } from './greeting';
 import { useHomepageAiState } from './hooks/useHomepageAiState';
@@ -156,6 +158,7 @@ export const TryNewHomepageModal: FC<{
     const navigate = useNavigate();
     const { user } = useApp();
     const { canAskAi } = useHomepageAiState(projectUuid);
+    const { track } = useTracking();
     const [opening, setOpening] = useState<HomepageOpening>('ask-first');
     const [isLive, setIsLive] = useState(false);
     // Applying on success flips the homepage immediately, so the success
@@ -170,9 +173,22 @@ export const TryNewHomepageModal: FC<{
     const showChoice = canAskAi;
 
     const handleTurnOn = () => {
+        const chosenOpening = showChoice ? opening : 'content-first';
         updateSettings.mutate(
-            { enabled: true, opening: showChoice ? opening : 'content-first' },
-            { onSuccess: () => setIsLive(true) },
+            { enabled: true, opening: chosenOpening },
+            {
+                onSuccess: (settings) => {
+                    setIsLive(true);
+                    track({
+                        name: EventName.HOMEPAGE_V2_OPTED_IN,
+                        properties: {
+                            organizationUuid: settings.organizationUuid,
+                            opening: chosenOpening,
+                            canAskAi,
+                        },
+                    });
+                },
+            },
         );
     };
 
@@ -293,6 +309,7 @@ export const TryNewHomepageCard: FC<{
     onTryNow: () => void;
 }> = ({ organizationUuid, onTryNow }) => {
     const { user, health } = useApp();
+    const { track } = useTracking();
     const [dismissed, setDismissed] = useLocalStorage(
         `homepage-v2-promo-dismissed-${user.data?.userUuid ?? 'anon'}`,
         false,
@@ -308,9 +325,23 @@ export const TryNewHomepageCard: FC<{
     // instances have no backing service, so never invite them to try it.
     const hasValidLicense = !!health.data?.license?.valid;
 
+    const isVisible = !IS_MOBILE && !dismissed && isOrgAdmin && hasValidLicense;
+
+    // Once per mount, not per render: seeing the card is the top of the
+    // opt-in funnel.
+    const hasTrackedView = useRef(false);
+    useEffect(() => {
+        if (!isVisible || hasTrackedView.current || !organizationUuid) return;
+        hasTrackedView.current = true;
+        track({
+            name: EventName.HOMEPAGE_V2_PROMO_VIEWED,
+            properties: { organizationUuid },
+        });
+    }, [isVisible, organizationUuid, track]);
+
     // The new homepage has no mobile experience yet, so don't invite mobile
     // users into it.
-    if (IS_MOBILE || dismissed || !isOrgAdmin || !hasValidLicense) return null;
+    if (!isVisible) return null;
 
     return (
         <div className={classes.promoCard}>
@@ -338,7 +369,15 @@ export const TryNewHomepageCard: FC<{
                 <CloseButton
                     size="sm"
                     aria-label="Dismiss"
-                    onClick={() => setDismissed(true)}
+                    onClick={() => {
+                        setDismissed(true);
+                        if (organizationUuid) {
+                            track({
+                                name: EventName.HOMEPAGE_V2_PROMO_DISMISSED,
+                                properties: { organizationUuid },
+                            });
+                        }
+                    }}
                 />
             </div>
         </div>

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.test.tsx
@@ -9,6 +9,9 @@ vi.mock('../DayOneAskInput', () => ({
 vi.mock('../../../../providers/App/useApp', () => ({
     default: () => ({ user: { data: { firstName: 'Test' } } }),
 }));
+vi.mock('../../../../providers/Tracking/useTracking', () => ({
+    default: () => ({ track: vi.fn() }),
+}));
 vi.mock('./QuickActionsBlock', () => ({
     QuickActionCards: () => <div data-testid="quick-actions" />,
 }));

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.tsx
@@ -12,6 +12,8 @@ import {
 } from '@mantine-8/core';
 import { type FC } from 'react';
 import useApp from '../../../../providers/App/useApp';
+import useTracking from '../../../../providers/Tracking/useTracking';
+import { EventName } from '../../../../types/Events';
 import { DayOneAskInput } from '../DayOneAskInput';
 import { DEFAULT_GREETING_SUBTITLE, getGreeting } from '../greeting';
 import layout from '../homepageLayout.module.css';
@@ -124,6 +126,7 @@ export const HeroOpeningControl: FC<{
     onSwap: (opening: HomepageOpening) => void;
 }> = ({ projectUuid, value, onSwap }) => {
     const { canAskAi } = useHomepageAiState(projectUuid);
+    const { track } = useTracking();
     // Without a working composer there's no choice to offer.
     if (!canAskAi) return null;
     return (
@@ -135,7 +138,15 @@ export const HeroOpeningControl: FC<{
                 size="xs"
                 value={value}
                 onChange={(next) => {
-                    if (next !== value) onSwap(next as HomepageOpening);
+                    if (next === value) return;
+                    track({
+                        name: EventName.HOMEPAGE_OPENING_SWAPPED,
+                        properties: {
+                            from: value,
+                            to: next as HomepageOpening,
+                        },
+                    });
+                    onSwap(next as HomepageOpening);
                 }}
                 data={[
                     { value: 'ask-first', label: 'Ask AI' },

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -144,6 +144,51 @@ export type HomepageQuickActionClickedEvent = {
     };
 };
 
+export type HomepageV2PromoViewedEvent = {
+    name: EventName.HOMEPAGE_V2_PROMO_VIEWED;
+    properties: {
+        organizationUuid: string;
+    };
+};
+
+export type HomepageV2PromoDismissedEvent = {
+    name: EventName.HOMEPAGE_V2_PROMO_DISMISSED;
+    properties: {
+        organizationUuid: string;
+    };
+};
+
+export type HomepageV2OptedInEvent = {
+    name: EventName.HOMEPAGE_V2_OPTED_IN;
+    properties: {
+        organizationUuid: string;
+        opening: 'ask-first' | 'content-first';
+        canAskAi: boolean;
+    };
+};
+
+export type HomepageBlockAddedEvent = {
+    name: EventName.HOMEPAGE_BLOCK_ADDED;
+    properties: {
+        blockType: string;
+    };
+};
+
+export type HomepageBlockRemovedEvent = {
+    name: EventName.HOMEPAGE_BLOCK_REMOVED;
+    properties: {
+        blockType: string;
+    };
+};
+
+export type HomepageOpeningSwappedEvent = {
+    name: EventName.HOMEPAGE_OPENING_SWAPPED;
+    properties: {
+        from: 'ask-first' | 'content-first';
+        to: 'ask-first' | 'content-first';
+    };
+};
+
 export type HomepageRecommendedActionClickedEvent = {
     name: EventName.HOMEPAGE_RECOMMENDED_ACTION_CLICKED;
     properties: {
@@ -826,6 +871,12 @@ export type EventData =
     | HomepageStarsMediaCardClickedEvent
     | CreateProjectColumnsDefinedButtonClickedEvent
     | HomepageQuickActionClickedEvent
+    | HomepageV2PromoViewedEvent
+    | HomepageV2PromoDismissedEvent
+    | HomepageV2OptedInEvent
+    | HomepageBlockAddedEvent
+    | HomepageBlockRemovedEvent
+    | HomepageOpeningSwappedEvent
     | HomepageRecommendedActionClickedEvent
     | HomepageRecommendedActionSkippedEvent
     | SetupStepClickedEvent

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -82,6 +82,12 @@ export enum SectionName {
 
 export enum EventName {
     HOMEPAGE_QUICK_ACTION_CLICKED = 'homepage_quick_action.clicked',
+    HOMEPAGE_V2_PROMO_VIEWED = 'homepage_v2_promo.viewed',
+    HOMEPAGE_V2_PROMO_DISMISSED = 'homepage_v2_promo.dismissed',
+    HOMEPAGE_V2_OPTED_IN = 'homepage_v2.opted_in',
+    HOMEPAGE_BLOCK_ADDED = 'homepage_block.added',
+    HOMEPAGE_BLOCK_REMOVED = 'homepage_block.removed',
+    HOMEPAGE_OPENING_SWAPPED = 'homepage_opening.swapped',
     HOMEPAGE_RECOMMENDED_ACTION_CLICKED = 'homepage_recommended_action.clicked',
     HOMEPAGE_RECOMMENDED_ACTION_SKIPPED = 'homepage_recommended_action.skipped',
     REVOKE_INVITES_BUTTON_CLICKED = 'revoke_invites_button.clicked',


### PR DESCRIPTION
## Opt-in funnel + customisation analytics (5/5)

Implements [ZAP-750](https://linear.app/lightdash/issue/ZAP-750) under [ZAP-747](https://linear.app/lightdash/issue/ZAP-747). Stacked on #26704.

### Server-side (rudderstack via LightdashAnalytics, ad-block-proof)
- `organization_homepage_settings.updated` — `{enabled, opening, previouslyEnabled}`: the opt-in/opt-out signal, fired where the mutation lands.
- `homepage.published` — `{audienceType, blockTypeCounts, openingBlockType}`: which blocks earn their place on real published pages.

### Client-side (useTracking)
- `homepage_v2_promo.viewed` / `.dismissed` — top of the funnel (viewed fires once per mount).
- `homepage_v2.opted_in` — `{opening, canAskAi}`: **content-first chosen despite AI being available** is the PROD-9327 signal that should drive the eventual global default.
- `homepage_block.added` / `.removed` — all three builder add paths (drag from rail, row quick-add, cell add) plus remove.
- `homepage_opening.swapped` — the per-page hero swap in the builder.

### Notes
- The saved query/dashboard over these events (opt-in rate, ask-vs-content split, opt-out rate) is deliberately left for once events flow in prod.
- Stack was also rebased onto latest main in this push: the Deploy Preview failures were the preview DB snapshot containing main's AI-memory migrations that our older base image lacked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1fe2jShYJrNxZRXw5E6jx