### PR TITLE
fix: guard MotherDuck locked configuration (SPK-819)

### DIFF
--- a/packages/backend/src/analytics/eventStream/UsageEventsCompactor.ts
+++ b/packages/backend/src/analytics/eventStream/UsageEventsCompactor.ts
@@ -284,6 +284,7 @@ export class UsageEventsCompactor extends S3BaseClient {
             {
                 resourceLimits: { memoryLimit: '256MB', threads: 1 },
                 logger: Logger,
+                enableQueryProfiling: true,
             },
         );
     }

--- a/packages/backend/src/clients/ResultsFileStorageClients/LocalParquetUploadStream.ts
+++ b/packages/backend/src/clients/ResultsFileStorageClients/LocalParquetUploadStream.ts
@@ -152,6 +152,7 @@ export const createLocalParquetUploadStream = ({
                                         threads: 1,
                                     },
                                     logger,
+                                    enableQueryProfiling: true,
                                     onQueryProfile:
                                         prometheusMetrics?.observeDuckdbQueryProfile,
                                 },

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.ts
@@ -119,6 +119,7 @@ export class PreAggregationDuckDbClient {
                             warehouseArgs.sharedResourceLimits,
                         instanceCacheKey: warehouseArgs.instanceCacheKey,
                         logger: Logger,
+                        enableQueryProfiling: true,
                         onQueryProfile:
                             this.prometheusMetrics?.observeDuckdbQueryProfile,
                     },

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
@@ -291,6 +291,114 @@ describe('DuckdbWarehouseClient', () => {
         expect(result.fields).toEqual({});
     });
 
+    it('skips MotherDuck timezone and profiling configuration, warns once, and runs every query', async () => {
+        const runMock = vi.fn();
+        const streamMock = vi.fn(async () =>
+            getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+        );
+        const logger = { info: vi.fn(), warn: vi.fn() };
+
+        createInstanceMock.mockResolvedValue(
+            createMockConnection(streamMock, runMock),
+        );
+
+        const client = new DuckdbWarehouseClient(
+            {
+                type: WarehouseTypes.DUCKDB,
+                connectionType: DuckdbConnectionType.MOTHERDUCK,
+                database: 'analytics',
+                schema: 'main',
+                token: 'motherduck_token',
+            },
+            { logger, enableQueryProfiling: true },
+        );
+
+        await client.runQuery('SELECT 1 AS val', undefined, 'Europe/London');
+        await client.runQuery('SELECT 2 AS val', undefined, 'Europe/London');
+
+        expect(streamMock).toHaveBeenCalledTimes(2);
+        expect(runMock).not.toHaveBeenCalledWith(
+            "SET TimeZone = 'Europe/London';",
+        );
+        expect(runMock).not.toHaveBeenCalledWith(
+            "PRAGMA enable_profiling='json';",
+        );
+        expect(logger.warn).toHaveBeenCalledExactlyOnceWith(
+            expect.stringMatching(
+                /Europe\/London.*MotherDuck.*saas_mode.*server default zone.*configured zone/,
+            ),
+        );
+        expect(logger.info).not.toHaveBeenCalledWith(
+            expect.stringContaining('Requested timezone'),
+        );
+    });
+
+    it('falls back to info for the MotherDuck timezone warning', async () => {
+        const runMock = vi.fn();
+        const streamMock = vi.fn(async () =>
+            getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+        );
+        const logger = { info: vi.fn() };
+
+        createInstanceMock.mockResolvedValue(
+            createMockConnection(streamMock, runMock),
+        );
+
+        const client = new DuckdbWarehouseClient(
+            {
+                type: WarehouseTypes.DUCKDB,
+                connectionType: DuckdbConnectionType.MOTHERDUCK,
+                database: 'analytics',
+                schema: 'main',
+                token: 'motherduck_token',
+            },
+            { logger },
+        );
+
+        await client.runQuery('SELECT 1 AS val', undefined, 'Europe/London');
+
+        expect(logger.info).toHaveBeenCalledWith(
+            expect.stringMatching(
+                /Europe\/London.*MotherDuck.*saas_mode.*server default zone.*configured zone/,
+            ),
+        );
+    });
+
+    it('sets timezone for in-memory and embedded DuckDB queries', async () => {
+        const runMock = vi.fn();
+        const streamMock = vi.fn(async () =>
+            getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+        );
+
+        createInstanceMock.mockResolvedValue(
+            createMockConnection(streamMock, runMock),
+        );
+
+        const inMemoryClient = new DuckdbWarehouseClient();
+        await inMemoryClient.runQuery(
+            'SELECT 1 AS val',
+            undefined,
+            'Europe/London',
+        );
+        expect(runMock).toHaveBeenCalledWith("SET TimeZone = 'Europe/London';");
+
+        runMock.mockClear();
+
+        const embeddedClient = new DuckdbWarehouseClient({
+            type: WarehouseTypes.DUCKDB,
+            connectionType: DuckdbConnectionType.EMBEDDED,
+            dataset: 'jaffle_shop',
+        });
+        await embeddedClient.runQuery(
+            'SELECT 2 AS val',
+            undefined,
+            'America/New_York',
+        );
+        expect(runMock).toHaveBeenCalledWith(
+            "SET TimeZone = 'America/New_York';",
+        );
+    });
+
     it('should set timezone, S3 config, and shared resource limits before streaming', async () => {
         const runMock = vi.fn();
         const streamMock = vi.fn(async () =>
@@ -763,6 +871,7 @@ describe('DuckdbWarehouseClient', () => {
 
         const client = new DuckdbWarehouseClient(undefined, {
             logger,
+            enableQueryProfiling: true,
             onQueryProfile,
         });
         await client.runQuery('SELECT 1 AS val', {
@@ -801,6 +910,30 @@ describe('DuckdbWarehouseClient', () => {
         expect(runMock).not.toHaveBeenCalledWith(
             "SET disabled_filesystems = 'LocalFileSystem';",
         );
+        expect(runMock).toHaveBeenCalledWith("PRAGMA enable_profiling='json';");
+    });
+
+    it('does not enable query profiling for a logger without the opt-in flag', async () => {
+        const runMock = vi.fn();
+        const streamMock = vi.fn(async () =>
+            getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+        );
+        const logger = { info: vi.fn() };
+
+        createInstanceMock.mockResolvedValue(
+            createMockConnection(streamMock, runMock),
+        );
+
+        const client = new DuckdbWarehouseClient(undefined, { logger });
+        await client.runQuery('SELECT 1 AS val');
+
+        expect(runMock).not.toHaveBeenCalledWith(
+            "PRAGMA enable_profiling='json';",
+        );
+        expect(logger.info).not.toHaveBeenCalledWith(
+            expect.stringContaining('DuckDB query profile:'),
+            expect.anything(),
+        );
     });
 
     it('logs raw profile timings when DuckDB reports cpu above latency', async () => {
@@ -828,7 +961,10 @@ describe('DuckdbWarehouseClient', () => {
             createMockConnection(streamMock, runMock),
         );
 
-        const client = new DuckdbWarehouseClient(undefined, { logger });
+        const client = new DuckdbWarehouseClient(undefined, {
+            logger,
+            enableQueryProfiling: true,
+        });
         await client.runQuery('SELECT 1 AS val');
 
         expect(logger.info).toHaveBeenCalledWith(

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -111,6 +111,7 @@ export type DuckdbResourceLimits = {
 
 export type DuckdbLogger = {
     info: (message: string, metadata?: Record<string, unknown>) => void;
+    warn?: (message: string, metadata?: Record<string, unknown>) => void;
 };
 
 export type DuckdbQueryProfileMetrics = {
@@ -144,6 +145,7 @@ export type DuckdbWarehouseClientOptions = {
      */
     instanceCacheKey?: string;
     logger?: DuckdbLogger;
+    enableQueryProfiling?: boolean;
     onQueryProfile?: (profile: DuckdbQueryProfileMetrics) => void;
     embeddedQueryTimeoutMs?: number;
 };
@@ -440,6 +442,8 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
 
     private readonly logger?: DuckdbLogger;
 
+    private readonly enableQueryProfiling: boolean;
+
     private readonly onQueryProfile?: (
         profile: DuckdbQueryProfileMetrics,
     ) => void;
@@ -447,6 +451,8 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
     private readonly embeddedQueryTimeoutMs: number;
 
     private allowsPreAggregateFileReads = false;
+
+    private hasWarnedAboutMotherduckTimezone = false;
 
     constructor(
         credentials?: CreateDuckdbCredentials | DuckdbConnectionCredentials,
@@ -557,6 +563,7 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         this.instanceCacheKey =
             options?.instanceCacheKey ?? ducklakeAutoCacheKey;
         this.logger = options?.logger;
+        this.enableQueryProfiling = options?.enableQueryProfiling ?? false;
         this.onQueryProfile = options?.onQueryProfile;
         this.embeddedQueryTimeoutMs =
             options?.embeddedQueryTimeoutMs ?? EMBEDDED_QUERY_TIMEOUT_MS;
@@ -1475,6 +1482,14 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         );
     }
 
+    private isMotherduck(): boolean {
+        return (
+            !this.embeddedConfig &&
+            !this.ducklakeConfig &&
+            this.databasePath.startsWith('md:')
+        );
+    }
+
     /**
      * Dispatches to the appropriate session strategy:
      * - Direct database (non-:memory: databasePath): connects to the MotherDuck path
@@ -1928,13 +1943,28 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         await this.withSession(async (db) => {
             const sessionStart = performance.now();
             if (options?.timezone) {
-                await db.run(
-                    `SET TimeZone = '${this.escapeString(options.timezone)}';`,
-                );
+                if (!this.isMotherduck()) {
+                    await db.run(
+                        `SET TimeZone = '${this.escapeString(
+                            options.timezone,
+                        )}';`,
+                    );
+                } else if (!this.hasWarnedAboutMotherduckTimezone) {
+                    this.hasWarnedAboutMotherduckTimezone = true;
+                    const message = `Requested timezone "${options.timezone}" cannot be applied because MotherDuck locks configuration under saas_mode; timestamps return in the server default zone instead of the configured zone.`;
+                    if (this.logger?.warn) {
+                        this.logger.warn(message);
+                    } else {
+                        this.logger?.info(message);
+                    }
+                }
             }
 
             const profilePath =
-                this.logger && !this.embeddedConfig
+                this.logger &&
+                this.enableQueryProfiling &&
+                !this.embeddedConfig &&
+                !this.isMotherduck()
                     ? path.join(
                           os.tmpdir(),
                           `duckdb-profile-${Date.now()}-${Math.random().toString(36).slice(2)}.json`,


### PR DESCRIPTION
## Summary

Fix two MotherDuck `saas_mode` locked-configuration failures identified during an investigation into MotherDuck query latency.

Any MotherDuck project with a configured data timezone currently fails every query. There is no supported way to set `TimeZone` on a MotherDuck `saas_mode` connection: `SET`, `SET SESSION`, `SET GLOBAL`, and `PRAGMA` all return the locked-configuration error; `SET LOCAL` is not implemented; and connection-string parameters are silently ignored. This was verified empirically against a live MotherDuck account, including an invalid-zone control that was accepted, proving that the parameters are ignored rather than honoured.

This change skips the configured timezone for MotherDuck connections, so timestamps return in the server default zone, and emits a once-per-client warning. It also makes query profiling explicit rather than implicitly enabled by logger presence, which allows DuckDB logging to be wired up without taking MotherDuck queries down.

## Validation

- `pnpm -F warehouses typecheck`
- `pnpm -F backend typecheck`
- `pnpm -F warehouses test`
- Touched-path linters for warehouses and backend

Fixes SPK-819

Supersedes #26713

test-timezone
