### PR TITLE
fix(mcp): send WWW-Authenticate header on 401

### DIFF
--- a/packages/backend/src/routers/mcpRouter.ts
+++ b/packages/backend/src/routers/mcpRouter.ts
@@ -14,7 +14,7 @@ import { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 // eslint-disable-next-line import/extensions
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { randomUUID } from 'crypto';
-import express, { type Router } from 'express';
+import express, { type RequestHandler, type Router } from 'express';
 import { IncomingMessage } from 'http';
 import { validate as isValidUuid } from 'uuid';
 import { allowApiKeyAuthentication } from '../controllers/authentication';
@@ -199,6 +199,15 @@ const returnHeaderIfUnauthenticated = (
     }
 };
 
+// Passport 401s credential-less requests itself, hiding the WWW-Authenticate header OAuth discovery needs
+const authenticateOnlyWithCredentials: RequestHandler = (req, res, next) => {
+    if (!req.headers.authorization && !req.isAuthenticated()) {
+        next();
+        return;
+    }
+    allowApiKeyAuthentication(req, res, next);
+};
+
 // MCP endpoint - supports Streamable HTTP
 // Keep the MCP router as raw Express because:
 // - MCP protocol requirements don't align with REST/TSOA patterns
@@ -207,7 +216,7 @@ const returnHeaderIfUnauthenticated = (
 mcpRouter.all(
     ['/', '/projects/:projectUuid'],
     aliasMcpBearerPersonalAccessToken,
-    allowApiKeyAuthentication,
+    authenticateOnlyWithCredentials,
     returnHeaderIfUnauthenticated,
     async (req, res) => {
         try {


### PR DESCRIPTION
MCP clients that support OAuth (ChatGPT apps, Claude, MCP Inspector) discover our authorization server by probing the MCP endpoint without credentials and reading the \`WWW-Authenticate: Bearer resource_metadata="..."\` header off the 401, as required by the MCP auth spec and RFC 9728 §5.1. That header was never sent: \`allowApiKeyAuthentication\` falls through to passport's \`headerapikey\` strategy, which terminates credential-less requests itself with a bare-text 401 before \`returnHeaderIfUnauthenticated\` — the middleware that sets the header — ever runs. OpenAI's platform reads that response as "MCP server does not implement OAuth" and refuses to register the server.

The fix wraps the auth middleware in \`authenticateOnlyWithCredentials\`: when a request carries no \`Authorization\` header and no session, it skips authentication entirely and falls through to \`returnHeaderIfUnauthenticated\`, which emits the 401 with the discovery header. Requests with credentials (OAuth bearer, PAT, service account, session cookie) go through the exact same chain as before, so the only observable change is the shape of the credential-less 401 — same status code, now with the spec-required header and a JSON body. Verified end to end locally: OpenAI's tunnel now completes discovery, dynamic client registration, token exchange, and tool calls against a local instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)