### PR TITLE
fix(headless-browser): validate browser destinations

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.test.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.test.ts
@@ -2,11 +2,14 @@ import {
     DELIVERY_CAPTURE_GLOBAL,
     DownloadFileType,
     LightdashPage,
+    LightdashRequestMethodHeader,
     NotFoundError,
+    RequestMethod,
     SCREENSHOT_SELECTORS,
     UnexpectedServerError,
     type DeliveryCaptureManifest,
 } from '@lightdash/common';
+import type { Route, WebSocketRoute } from 'playwright';
 import { type LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { type FileStorageClient } from '../../clients/FileStorage/FileStorageClient';
 import { type SlackClient } from '../../clients/Slack/SlackClient';
@@ -27,9 +30,22 @@ const playwrightMocks = vi.hoisted(() => ({
     connectOverCDP: vi.fn(),
 }));
 
-vi.mock('playwright', () => ({
-    default: { chromium: { connectOverCDP: playwrightMocks.connectOverCDP } },
-    chromium: { connectOverCDP: playwrightMocks.connectOverCDP },
+const ssrfMocks = vi.hoisted(() => ({
+    validatePublicHttpUrl: vi.fn(),
+}));
+
+vi.mock('playwright', () => {
+    const chromium = { connectOverCDP: playwrightMocks.connectOverCDP };
+    const errors = { TimeoutError: class extends Error {} };
+    return {
+        default: { chromium, errors },
+        chromium,
+        errors,
+    };
+});
+
+vi.mock('../../utils/ssrfProtection', () => ({
+    validatePublicHttpUrl: ssrfMocks.validatePublicHttpUrl,
 }));
 
 const mockFileStorageClient = {
@@ -396,11 +412,12 @@ describe('UnfurlService', () => {
             const pageContext = {
                 addCookies: vi.fn().mockResolvedValue(undefined),
                 newCDPSession: vi.fn().mockResolvedValue(cdpSession),
+                route: vi.fn().mockResolvedValue(undefined),
+                routeWebSocket: vi.fn().mockResolvedValue(undefined),
             };
             return {
                 cdpSession,
                 pageContext,
-                route: vi.fn().mockResolvedValue(undefined),
                 addInitScript: vi.fn().mockResolvedValue(undefined),
                 context: vi.fn().mockReturnValue(pageContext),
                 on: vi.fn(),
@@ -410,6 +427,48 @@ describe('UnfurlService', () => {
                 screenshot: vi.fn().mockResolvedValue(Buffer.from('nope')),
                 close: vi.fn().mockResolvedValue(undefined),
             };
+        };
+
+        type MockPage = ReturnType<typeof createMockPage>;
+
+        const getRequestRouteHandler = (
+            page: MockPage,
+        ): ((route: Route) => Promise<void>) => {
+            const registration = page.pageContext.route.mock.calls.find(
+                ([pattern]) => pattern === '**',
+            );
+            expect(registration).toBeDefined();
+            if (!registration) {
+                throw new Error('Expected a catch-all browser route');
+            }
+            return registration[1] as (route: Route) => Promise<void>;
+        };
+
+        const createMockRoute = (
+            url: string,
+            headers: Record<string, string> = {},
+        ) => ({
+            request: vi.fn().mockReturnValue({
+                url: vi.fn().mockReturnValue(url),
+                headers: vi.fn().mockReturnValue(headers),
+            }),
+            abort: vi.fn().mockResolvedValue(undefined),
+            continue: vi.fn().mockResolvedValue(undefined),
+            fallback: vi.fn().mockResolvedValue(undefined),
+        });
+
+        const getWebSocketRouteHandler = (
+            page: MockPage,
+        ): ((route: WebSocketRoute) => Promise<void>) => {
+            const registration =
+                page.pageContext.routeWebSocket.mock.calls.find(
+                    ([pattern]) => pattern === '**',
+                );
+            expect(registration).toBeDefined();
+            if (!registration) {
+                throw new Error('Expected a catch-all websocket route');
+            }
+            return registration[1] as (route: WebSocketRoute) => Promise<void>;
         };
 
         const setup = () => {
@@ -461,7 +520,7 @@ describe('UnfurlService', () => {
         });
 
         it('renders with the same window geometry as the app screenshot path', async () => {
-            const { service, page } = setup();
+            const { service, browser, page } = setup();
             page.evaluate.mockResolvedValue(validManifest);
 
             await service.captureAppDeliveryManifest({
@@ -477,6 +536,247 @@ describe('UnfurlService', () => {
                 'Emulation.setDeviceMetricsOverride',
                 expect.objectContaining({ width: 1400, height: 4000 }),
             );
+            expect(browser.newPage).toHaveBeenCalledWith(
+                expect.objectContaining({ serviceWorkers: 'block' }),
+            );
+        });
+
+        it('guards dashboard and chart screenshots and preserves internal request headers', async () => {
+            const { service, browser, page } = setup();
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            vi.spyOn(service as any, 'unfurlDetails').mockResolvedValue(
+                undefined,
+            );
+            page.addInitScript.mockRejectedValueOnce(
+                new Error('stop after route registration'),
+            );
+
+            await expect(
+                service.unfurlImage({
+                    url: APP_URL,
+                    imageId: 'image-1',
+                    authUserUuid: 'user-uuid-1',
+                    context: 'export_dashboard' as never,
+                    selectedTabs: null,
+                }),
+            ).rejects.toThrow('stop after route registration');
+
+            expect(browser.newPage).toHaveBeenCalledWith(
+                expect.objectContaining({ serviceWorkers: 'block' }),
+            );
+            expect(page.pageContext.route).toHaveBeenCalledWith(
+                '**',
+                expect.any(Function),
+            );
+            expect(page.pageContext.routeWebSocket).toHaveBeenCalledWith(
+                '**',
+                expect.any(Function),
+            );
+
+            const handler = getRequestRouteHandler(page);
+            const route = createMockRoute(
+                'http://headless-browser:8080/api/v1/health',
+                {
+                    authorization: 'Bearer internal-token',
+                    cookie: 'connect.sid=session-value',
+                },
+            );
+
+            await handler(route as unknown as Route);
+
+            expect(ssrfMocks.validatePublicHttpUrl).not.toHaveBeenCalled();
+            expect(route.continue).toHaveBeenCalledWith({
+                headers: {
+                    authorization: 'Bearer internal-token',
+                    cookie: 'connect.sid=session-value',
+                    [LightdashRequestMethodHeader]:
+                        RequestMethod.HEADLESS_BROWSER,
+                    'Lightdash-Headless-Browser-Context': 'export_dashboard',
+                    'Lightdash-Headless-Browser-Context-Id': 'undefined',
+                },
+            });
+        });
+
+        it('blocks outbound browser requests to non-public destinations', async () => {
+            const { service, page } = setup();
+            page.evaluate.mockResolvedValue(validManifest);
+            ssrfMocks.validatePublicHttpUrl.mockRejectedValueOnce(
+                new Error('non-public destination'),
+            );
+
+            await service.captureAppDeliveryManifest({
+                url: APP_URL,
+                authUserUuid: 'user-uuid-1',
+            });
+
+            const handler = getRequestRouteHandler(page);
+            const route = createMockRoute('http://127.0.0.1/private');
+
+            await handler(route as unknown as Route);
+
+            expect(route.abort).toHaveBeenCalledWith('accessdenied');
+            expect(route.continue).not.toHaveBeenCalled();
+        });
+
+        it('continues public browser requests without internal headers', async () => {
+            const { service, page } = setup();
+            page.evaluate.mockResolvedValue(validManifest);
+            ssrfMocks.validatePublicHttpUrl.mockResolvedValueOnce(
+                new URL('https://cdn.example.com/image.png'),
+            );
+
+            await service.captureAppDeliveryManifest({
+                url: APP_URL,
+                authUserUuid: 'user-uuid-1',
+            });
+
+            const handler = getRequestRouteHandler(page);
+            const route = createMockRoute('https://cdn.example.com/image.png');
+
+            await handler(route as unknown as Route);
+
+            expect(ssrfMocks.validatePublicHttpUrl).toHaveBeenCalledWith(
+                'https://cdn.example.com/image.png',
+                { allowedProtocols: ['http:', 'https:'] },
+            );
+            expect(route.continue).toHaveBeenCalledWith();
+            expect(route.abort).not.toHaveBeenCalled();
+        });
+
+        it('continues Lightdash requests with headless-browser headers', async () => {
+            const { service, page } = setup();
+            page.evaluate.mockResolvedValue(validManifest);
+
+            await service.captureAppDeliveryManifest({
+                url: APP_URL,
+                authUserUuid: 'user-uuid-1',
+                contextId: 'job-1',
+            });
+
+            const handler = getRequestRouteHandler(page);
+            const route = createMockRoute(
+                'http://headless-browser:8080/api/v1/health',
+                { accept: '*/*' },
+            );
+
+            await handler(route as unknown as Route);
+
+            expect(ssrfMocks.validatePublicHttpUrl).not.toHaveBeenCalled();
+            expect(route.continue).toHaveBeenCalledWith({
+                headers: expect.objectContaining({
+                    accept: '*/*',
+                    'Lightdash-Headless-Browser-Context': 'scheduled_delivery',
+                    'Lightdash-Headless-Browser-Context-Id': 'job-1',
+                }),
+            });
+        });
+
+        it.each([
+            'https://headless-browser:8080/api/v1/health',
+            'http://headless-browser:8081/api/v1/health',
+        ])('validates internal-origin near miss %s', async (url) => {
+            const { service, page } = setup();
+            page.evaluate.mockResolvedValue(validManifest);
+            ssrfMocks.validatePublicHttpUrl.mockResolvedValueOnce(new URL(url));
+
+            await service.captureAppDeliveryManifest({
+                url: APP_URL,
+                authUserUuid: 'user-uuid-1',
+            });
+
+            const handler = getRequestRouteHandler(page);
+            const route = createMockRoute(url, {
+                authorization: 'Bearer internal-token',
+            });
+
+            await handler(route as unknown as Route);
+
+            expect(ssrfMocks.validatePublicHttpUrl).toHaveBeenCalledWith(url, {
+                allowedProtocols: ['http:', 'https:'],
+            });
+            expect(route.continue).toHaveBeenCalledWith();
+        });
+
+        it('blocks websocket connections to non-public destinations', async () => {
+            const { service, page } = setup();
+            page.evaluate.mockResolvedValue(validManifest);
+            ssrfMocks.validatePublicHttpUrl.mockRejectedValueOnce(
+                new Error('non-public destination'),
+            );
+
+            await service.captureAppDeliveryManifest({
+                url: APP_URL,
+                authUserUuid: 'user-uuid-1',
+            });
+
+            const handler = getWebSocketRouteHandler(page);
+            const webSocketRoute = {
+                url: vi.fn().mockReturnValue('ws://127.0.0.1/private'),
+                close: vi.fn().mockResolvedValue(undefined),
+                connectToServer: vi.fn(),
+            };
+
+            await handler(webSocketRoute as unknown as WebSocketRoute);
+
+            expect(webSocketRoute.close).toHaveBeenCalledWith({
+                code: 1008,
+                reason: 'Destination is not permitted',
+            });
+            expect(webSocketRoute.connectToServer).not.toHaveBeenCalled();
+        });
+
+        it('connects websocket requests to public destinations', async () => {
+            const { service, page } = setup();
+            page.evaluate.mockResolvedValue(validManifest);
+            ssrfMocks.validatePublicHttpUrl.mockResolvedValueOnce(
+                new URL('wss://stream.example.com/socket'),
+            );
+
+            await service.captureAppDeliveryManifest({
+                url: APP_URL,
+                authUserUuid: 'user-uuid-1',
+            });
+
+            const handler = getWebSocketRouteHandler(page);
+            const webSocketRoute = {
+                url: vi.fn().mockReturnValue('wss://stream.example.com/socket'),
+                close: vi.fn().mockResolvedValue(undefined),
+                connectToServer: vi.fn(),
+            };
+
+            await handler(webSocketRoute as unknown as WebSocketRoute);
+
+            expect(ssrfMocks.validatePublicHttpUrl).toHaveBeenCalledWith(
+                'wss://stream.example.com/socket',
+                { allowedProtocols: ['ws:', 'wss:'] },
+            );
+            expect(webSocketRoute.connectToServer).toHaveBeenCalled();
+            expect(webSocketRoute.close).not.toHaveBeenCalled();
+        });
+
+        it('connects internal websocket requests without public validation', async () => {
+            const { service, page } = setup();
+            page.evaluate.mockResolvedValue(validManifest);
+
+            await service.captureAppDeliveryManifest({
+                url: APP_URL,
+                authUserUuid: 'user-uuid-1',
+            });
+
+            const handler = getWebSocketRouteHandler(page);
+            const webSocketRoute = {
+                url: vi
+                    .fn()
+                    .mockReturnValue('ws://headless-browser:8080/socket'),
+                close: vi.fn().mockResolvedValue(undefined),
+                connectToServer: vi.fn(),
+            };
+
+            await handler(webSocketRoute as unknown as WebSocketRoute);
+
+            expect(ssrfMocks.validatePublicHttpUrl).not.toHaveBeenCalled();
+            expect(webSocketRoute.connectToServer).toHaveBeenCalled();
+            expect(webSocketRoute.close).not.toHaveBeenCalled();
         });
 
         it('throws when the window global is missing', async () => {

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -74,6 +74,7 @@ import { SlackAuthenticationModel } from '../../models/SlackAuthenticationModel'
 import { SlackUnfurlImageModel } from '../../models/SlackUnfurlImageModel';
 import { getAuthenticationToken } from '../../routers/headlessBrowser';
 import { traceSpan } from '../../tracing/tracing';
+import { validatePublicHttpUrl } from '../../utils/ssrfProtection';
 import { BaseService } from '../BaseService';
 import type { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 import { countPdfPages } from './countPdfPages';
@@ -1135,6 +1136,102 @@ export class UnfurlService extends BaseService {
         }
     }
 
+    private async registerHeadlessBrowserRoutes({
+        browserContext,
+        context,
+        contextId,
+    }: {
+        browserContext: playwright.BrowserContext;
+        context: ScreenshotContext;
+        contextId?: unknown;
+    }): Promise<void> {
+        const internalLightdashUrl = new URL(
+            this.lightdashConfig.headlessBrowser.internalLightdashHost,
+        );
+        const isInternalLightdashUrl = (url: URL): boolean => {
+            const getHttpProtocol = (): string => {
+                if (url.protocol === 'ws:') {
+                    return 'http:';
+                }
+                if (url.protocol === 'wss:') {
+                    return 'https:';
+                }
+                return url.protocol;
+            };
+
+            return (
+                getHttpProtocol() === internalLightdashUrl.protocol &&
+                url.host === internalLightdashUrl.host
+            );
+        };
+        const isAllowedDestination = async (
+            url: URL,
+            allowedProtocols: string[],
+        ): Promise<boolean> => {
+            if (isInternalLightdashUrl(url)) {
+                return true;
+            }
+
+            try {
+                await validatePublicHttpUrl(url.toString(), {
+                    allowedProtocols,
+                });
+                return true;
+            } catch {
+                this.logger.warn(
+                    `Blocked headless browser request to non-public origin: ${url.origin}`,
+                );
+                return false;
+            }
+        };
+
+        await Promise.all([
+            browserContext.route('**', async (route) => {
+                const requestUrl = new URL(route.request().url());
+
+                if (isInternalLightdashUrl(requestUrl)) {
+                    try {
+                        await route.continue({
+                            headers: {
+                                ...route.request().headers(),
+                                [LightdashRequestMethodHeader]:
+                                    RequestMethod.HEADLESS_BROWSER,
+                                'Lightdash-Headless-Browser-Context': context,
+                                'Lightdash-Headless-Browser-Context-Id': String(
+                                    contextId ?? 'undefined',
+                                ),
+                            },
+                        });
+                    } catch {
+                        await route.continue().catch(() => {});
+                    }
+                    return;
+                }
+
+                if (
+                    await isAllowedDestination(requestUrl, ['http:', 'https:'])
+                ) {
+                    await route.continue().catch(() => {});
+                    return;
+                }
+
+                await route.abort('accessdenied').catch(() => {});
+            }),
+            browserContext.routeWebSocket('**', async (webSocketRoute) => {
+                const requestUrl = new URL(webSocketRoute.url());
+                if (await isAllowedDestination(requestUrl, ['ws:', 'wss:'])) {
+                    webSocketRoute.connectToServer();
+                    return;
+                }
+
+                await webSocketRoute.close({
+                    code: 1008,
+                    reason: 'Destination is not permitted',
+                });
+            }),
+        ]);
+    }
+
     private async saveScreenshot({
         imageId,
         cookie,
@@ -1292,6 +1389,7 @@ export class UnfurlService extends BaseService {
 
                     page = await browser.newPage({
                         viewport: initialViewport,
+                        serviceWorkers: 'block',
                         // Allow self-signed / untrusted certs when the
                         // internal Lightdash host is reached through an
                         // HTTPS ingress whose cert isn't in the browserless
@@ -1310,31 +1408,10 @@ export class UnfurlService extends BaseService {
                         );
                     }
 
-                    // Scope custom headers to internal requests only — setting them
-                    // on every request (e.g. Google Fonts) triggers CORS preflight failures.
-                    const internalHost =
-                        this.lightdashConfig.headlessBrowser.internalLightdashHost.replace(
-                            /\/+$/,
-                            '',
-                        );
-                    await page.route(`${internalHost}/**`, async (route) => {
-                        try {
-                            await route.continue({
-                                headers: {
-                                    ...route.request().headers(),
-                                    [LightdashRequestMethodHeader]:
-                                        RequestMethod.HEADLESS_BROWSER,
-                                    'Lightdash-Headless-Browser-Context':
-                                        context,
-                                    'Lightdash-Headless-Browser-Context-Id':
-                                        contextId
-                                            ? contextId.toString()
-                                            : 'undefined',
-                                },
-                            });
-                        } catch {
-                            await route.fallback().catch(() => {});
-                        }
+                    await this.registerHeadlessBrowserRoutes({
+                        browserContext: page.context(),
+                        context,
+                        contextId,
                     });
 
                     // Polyfill crypto.randomUUID (needed for Loom iframes)
@@ -2358,6 +2435,7 @@ export class UnfurlService extends BaseService {
             );
             page = await browser.newPage({
                 viewport: appViewport,
+                serviceWorkers: 'block',
                 ignoreHTTPSErrors:
                     this.lightdashConfig.headlessBrowser
                         .internalLightdashHostIgnoreHttpsErrors,
@@ -2370,35 +2448,10 @@ export class UnfurlService extends BaseService {
                 `contextId: ${contextId}`,
             );
 
-            // Scope custom headers to internal requests only — setting them on
-            // every request (e.g. Google Fonts) triggers CORS preflight failures.
-            const internalHost =
-                this.lightdashConfig.headlessBrowser.internalLightdashHost.replace(
-                    /\/+$/,
-                    '',
-                );
-            await page.route(`${internalHost}/**`, async (route) => {
-                try {
-                    await route.continue({
-                        headers: {
-                            ...route.request().headers(),
-                            [LightdashRequestMethodHeader]:
-                                RequestMethod.HEADLESS_BROWSER,
-                            'Lightdash-Headless-Browser-Context':
-                                ScreenshotContext.SCHEDULED_DELIVERY,
-                            // String(): a non-string jobId (graphile ids can
-                            // surface as bigint) throws in route.continue.
-                            'Lightdash-Headless-Browser-Context-Id': String(
-                                contextId ?? 'undefined',
-                            ),
-                        },
-                    });
-                } catch {
-                    // Best effort only: a failed continue({headers}) pollutes
-                    // the request's fallback overrides, so no retry can resume
-                    // it — the String() above is the real safeguard.
-                    await route.continue().catch(() => {});
-                }
+            await this.registerHeadlessBrowserRoutes({
+                browserContext: page.context(),
+                context: ScreenshotContext.SCHEDULED_DELIVERY,
+                contextId,
             });
 
             const cookieMatch = cookie.match(/connect\.sid=([^;]+)/);

--- a/packages/backend/src/utils/ssrfProtection.test.ts
+++ b/packages/backend/src/utils/ssrfProtection.test.ts
@@ -71,6 +71,22 @@ describe('validatePublicHttpUrl', () => {
         ).rejects.toThrow(privateUrlError);
     });
 
+    it.each([
+        'http://198.18.0.1',
+        'http://[64:ff9b:1::7f00:1]',
+        'http://[100:0:0:1::1]',
+        'http://[2001:2::1]',
+        'http://[400::1]',
+        'http://[2001:5::1]',
+        'http://[3fff::1]',
+    ])('rejects non-public unicast target %s', async (url) => {
+        await expect(
+            validatePublicHttpUrl(url, {
+                allowedProtocols: ['http:', 'https:'],
+            }),
+        ).rejects.toThrow(privateUrlError);
+    });
+
     it('rejects public hostnames that resolve to private addresses', async () => {
         mockedLookup.mockResolvedValueOnce([
             { address: '10.0.0.10', family: 4 },
@@ -101,6 +117,22 @@ describe('validatePublicHttpUrl', () => {
         ).resolves.toMatchObject({
             hostname: 'example.com',
             protocol: 'https:',
+        });
+    });
+
+    it('accepts public IPv6 literals in global unicast space', async () => {
+        mockedLookup.mockResolvedValueOnce([
+            { address: '2606:4700:4700::1111', family: 6 },
+        ]);
+
+        await expect(
+            validatePublicHttpUrl('https://[2606:4700:4700::1111]/mcp'),
+        ).resolves.toMatchObject({
+            hostname: '[2606:4700:4700::1111]',
+            protocol: 'https:',
+        });
+        expect(mockedLookup).toHaveBeenCalledWith('2606:4700:4700::1111', {
+            all: true,
         });
     });
 });

--- a/packages/backend/src/utils/ssrfProtection.ts
+++ b/packages/backend/src/utils/ssrfProtection.ts
@@ -17,6 +17,42 @@ const HOSTNAME_LOOKUP_ERROR_MESSAGE =
 const normalizeHostname = (hostname: string): string =>
     hostname.replace(/^\[/, '').replace(/\]$/, '').toLowerCase();
 
+// ipaddr.js classifies reserved and special-use ranges as unicast even though
+// they are not safe public destinations.
+const NON_PUBLIC_IPV4_UNICAST_RANGES = [
+    '192.0.0.0/24',
+    '192.88.99.0/24',
+    '198.18.0.0/15',
+].map((cidr) => ipaddr.parseCIDR(cidr)) as [ipaddr.IPv4, number][];
+
+const ASSIGNABLE_IPV6_GLOBAL_UNICAST_RANGE = ipaddr.parseCIDR('2000::/3') as [
+    ipaddr.IPv6,
+    number,
+];
+
+const NON_PUBLIC_IPV6_UNICAST_RANGES = [
+    '2001::/23',
+    '2001:db8::/32',
+    '2002::/16',
+    '3fff::/20',
+].map((cidr) => ipaddr.parseCIDR(cidr)) as [ipaddr.IPv6, number][];
+
+const isNonPublicUnicastAddress = (
+    address: ipaddr.IPv4 | ipaddr.IPv6,
+): boolean => {
+    if (address.kind() === 'ipv4') {
+        return NON_PUBLIC_IPV4_UNICAST_RANGES.some((range) =>
+            (address as ipaddr.IPv4).match(range),
+        );
+    }
+
+    const ipv6Address = address as ipaddr.IPv6;
+    return (
+        !ipv6Address.match(ASSIGNABLE_IPV6_GLOBAL_UNICAST_RANGE) ||
+        NON_PUBLIC_IPV6_UNICAST_RANGES.some((range) => ipv6Address.match(range))
+    );
+};
+
 export const isPrivateAddress = (address: string): boolean => {
     const normalizedAddress = normalizeHostname(address);
 
@@ -28,7 +64,11 @@ export const isPrivateAddress = (address: string): boolean => {
         return false;
     }
 
-    return ipaddr.process(normalizedAddress).range() !== 'unicast';
+    const parsedAddress = ipaddr.process(normalizedAddress);
+    return (
+        parsedAddress.range() !== 'unicast' ||
+        isNonPublicUnicastAddress(parsedAddress)
+    );
 };
 
 export const validatePublicHttpUrl = async (
@@ -59,13 +99,14 @@ export const validatePublicHttpUrl = async (
         return parsedUrl;
     }
 
-    if (isPrivateAddress(parsedUrl.hostname)) {
+    const hostname = normalizeHostname(parsedUrl.hostname);
+    if (isPrivateAddress(hostname)) {
         throw new ParameterError(PRIVATE_ADDRESS_ERROR_MESSAGE);
     }
 
     let addresses: { address: string }[];
     try {
-        addresses = await lookup(parsedUrl.hostname, { all: true });
+        addresses = await lookup(hostname, { all: true });
     } catch {
         throw new ParameterError(HOSTNAME_LOOKUP_ERROR_MESSAGE);
     }


### PR DESCRIPTION
Related: https://linear.app/lightdash/issue/PROD-9307

## Summary

Adds a product-only defense-in-depth check for destinations opened by Browserless screenshot sessions. The change adds no proxy, deployment component, Helm value, or other infrastructure.

## Root cause

Browserless inherits its container's network access. Lightdash attached internal request headers during screenshot capture, but did not validate the other HTTP or WebSocket destinations initiated by rendered content.

```ts
await route.continue({ headers: headlessBrowserHeaders });
```

That allowed untrusted page content to ask Chromium to connect to private or special-purpose addresses reachable from the Browserless network.

## Fix

Registers one destination policy on the Playwright browser context and uses it from both screenshot paths.

```text
Browser page
  ├─ exact Lightdash origin ──────────────► continue with internal headers
  └─ other HTTP(S) / WebSocket request ──► validate DNS + IP destination
                                               ├─ public ─────► continue
                                               └─ non-public ─X abort / close
```

- Preserves request headers and adds headless-browser headers only for the exact configured Lightdash origin, including protocol and port.
- Validates other HTTP(S) and WebSocket destinations with the shared SSRF guard.
- Blocks service workers in both browser capture contexts.
- Tightens IPv4/IPv6 special-use classification, including bracketed IPv6 literals.

## Evidence

Before:
  A real Browserless session reached a private Docker fixture with HTTP 200.

After:
  The same Playwright routing seam returned HTTP 200 for public HTTPS and blocked the private fixture with `ERR_ACCESS_DENIED`.

## Scope

This is an application-layer mitigation, not a complete browser network sandbox. DNS rebinding between Node validation and Chromium connection, dedicated/shared-worker WebSockets, WebRTC/ICE, and other socket-level paths remain outside this PR. PROD-9307 stays open for any full network-containment work.

## Test plan

- [x] Focused backend Vitest suites: 46 tests pass.
- [x] `pnpm --dir packages/backend typecheck`
- [x] `pnpm --dir packages/backend lint`
- [x] `pnpm --dir packages/backend format`
- [x] Real Browserless/Playwright probe: public HTTPS returns 200 and the private fixture is denied.
- [x] Five-lens review approves the final diff with no unresolved findings.
