### PR TITLE
feat(homepage): collection layouts (cards/compact) + content-type filter

### DIFF
--- a/packages/common/src/ee/homepage/schema.test.ts
+++ b/packages/common/src/ee/homepage/schema.test.ts
@@ -18,6 +18,8 @@ const validConfig: HomepageConfig = {
                         source: 'pinned',
                         verifiedOnly: true,
                         limit: 6,
+                        layout: 'list',
+                        contentTypes: ['dashboard', 'data_app'],
                     },
                 },
             ],

--- a/packages/common/src/ee/homepage/schema.ts
+++ b/packages/common/src/ee/homepage/schema.ts
@@ -37,6 +37,8 @@ const collectionItemRefSchema = z.object({
     uuid: z.string(),
 });
 
+const contentLayoutSchema = z.enum(['card', 'list']);
+
 const collectionBlockSchema = z.object({
     id: z.string(),
     type: z.literal('collection'),
@@ -55,6 +57,10 @@ const collectionBlockSchema = z.object({
             .optional(),
         verifiedOnly: z.boolean().optional(),
         limit: z.number().int().positive().optional(),
+        layout: contentLayoutSchema.optional(),
+        contentTypes: z
+            .array(z.enum(['chart', 'dashboard', 'space', 'data_app']))
+            .optional(),
     }),
 });
 
@@ -73,7 +79,7 @@ const resourcesBlockSchema = z.object({
     config: z.object({
         title: z.string(),
         items: z.array(resourceItemSchema),
-        layout: z.enum(['card', 'list']).optional(),
+        layout: contentLayoutSchema.optional(),
         showDescriptions: z.boolean().optional(),
     }),
 });

--- a/packages/common/src/ee/homepage/types.ts
+++ b/packages/common/src/ee/homepage/types.ts
@@ -84,6 +84,11 @@ export type HomepageCollectionBlock = {
         verifiedOnly?: boolean;
         /** How many items to show. Absent means DEFAULT_COLLECTION_LIMIT. */
         limit?: number;
+        // Optional for back-compat: undefined renders as 'card'.
+        layout?: HomepageContentLayout;
+        /** Narrows live sources to these content types. Ignored for `manual`
+         * (hand-picking is already the filter) and when absent or empty. */
+        contentTypes?: HomepageCollectionItemRef['contentType'][];
     };
 };
 
@@ -117,10 +122,12 @@ export type HomepageResourceItem = {
     appUuid?: string;
 };
 
-/** How a resources block presents its items: media-rich cards, or a compact
- * mode whose geometry (tile columns vs single-column rows) resolves from the
- * block's width rather than being a third admin choice. */
-export type HomepageResourcesLayout = 'card' | 'list';
+/** Shared display vocabulary for content-listing blocks: media-rich cards, or
+ * a compact mode whose geometry (tile columns vs single-column rows) resolves
+ * from the block's width rather than being a third admin choice. */
+export type HomepageContentLayout = 'card' | 'list';
+
+export type HomepageResourcesLayout = HomepageContentLayout;
 
 export type HomepageResourcesBlock = {
     id: string;

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
@@ -24,12 +24,14 @@ import {
     type HomepageCollectionBlock,
     type HomepageCollectionItemRef,
     type HomepageCollectionSource,
+    type HomepageContentLayout,
     type SummaryContent,
 } from '@lightdash/common';
 import {
     Box,
     Button,
     Checkbox,
+    Chip,
     Divider,
     Group,
     SegmentedControl,
@@ -70,6 +72,7 @@ import { useReportRuntimeEmpty } from '../hooks/useRuntimeEmptyBlocks';
 import { BlockHeader } from './BlockShell';
 import classes from './blockStyles.module.css';
 import { ContentCard } from './ContentCard';
+import { ContentLayoutControl } from './ContentLayoutControl';
 import { PageGrid, PageGridItem } from './PageGrid';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
@@ -522,6 +525,53 @@ const EMPTY_CONFIG: HomepageCollectionBlock['config'] = {
     items: [],
 };
 
+const collectionLayoutOf = (
+    config: HomepageCollectionBlock['config'],
+): HomepageContentLayout => config.layout ?? 'card';
+
+/** The one place a resolved collection turns into pixels — view, dynamic
+ * preview, and skeletons all agree on what each layout looks like. Compact
+ * mode's geometry (tile columns vs rows) resolves from the block's width. */
+const CollectionContentGrid: FC<{
+    layout: HomepageContentLayout;
+    itemSpan: number | null;
+    contents: SummaryContent[];
+    projectUuid: string;
+    starFor?: (
+        content: SummaryContent,
+    ) => { isFavorite: boolean; onToggle: () => void } | undefined;
+}> = ({ layout, itemSpan, contents, projectUuid, starFor }) => {
+    if (layout === 'list') {
+        return (
+            <div className={classes.resTileGrid}>
+                {contents.map((content) => (
+                    <ContentCard
+                        key={content.uuid}
+                        content={content}
+                        projectUuid={projectUuid}
+                        variant="compact"
+                        star={starFor?.(content)}
+                    />
+                ))}
+            </div>
+        );
+    }
+    return (
+        <PageGrid itemSpan={itemSpan} elastic>
+            {contents.map((content) => (
+                <PageGridItem key={content.uuid}>
+                    <ContentCard
+                        content={content}
+                        projectUuid={projectUuid}
+                        variant="tile"
+                        star={starFor?.(content)}
+                    />
+                </PageGridItem>
+            ))}
+        </PageGrid>
+    );
+};
+
 const SkeletonGrid: FC<{ itemSpan: number | null }> = ({ itemSpan }) => (
     <PageGrid itemSpan={itemSpan} elastic>
         {[0, 1, 2].map((i) => (
@@ -561,36 +611,25 @@ export const CollectionBlockView: FC<BlockComponentProps> = ({
             {isLoading ? (
                 <SkeletonGrid itemSpan={itemSpan ?? null} />
             ) : (
-                <PageGrid itemSpan={itemSpan ?? null} elastic>
-                    {contents.map((content) => {
+                <CollectionContentGrid
+                    layout={collectionLayoutOf(config)}
+                    itemSpan={itemSpan ?? null}
+                    contents={contents}
+                    projectUuid={projectUuid}
+                    starFor={(content) => {
                         const favoriteType = toFavoriteType(content);
-                        return (
-                            <PageGridItem key={content.uuid}>
-                                <ContentCard
-                                    content={content}
-                                    projectUuid={projectUuid}
-                                    variant="tile"
-                                    star={
-                                        favoriteType
-                                            ? {
-                                                  isFavorite: favoriteUuids.has(
-                                                      content.uuid,
-                                                  ),
-                                                  onToggle: () =>
-                                                      toggleFavorite({
-                                                          contentType:
-                                                              favoriteType,
-                                                          contentUuid:
-                                                              content.uuid,
-                                                      }),
-                                              }
-                                            : undefined
-                                    }
-                                />
-                            </PageGridItem>
-                        );
-                    })}
-                </PageGrid>
+                        return favoriteType
+                            ? {
+                                  isFavorite: favoriteUuids.has(content.uuid),
+                                  onToggle: () =>
+                                      toggleFavorite({
+                                          contentType: favoriteType,
+                                          contentUuid: content.uuid,
+                                      }),
+                              }
+                            : undefined;
+                    }}
+                />
             )}
         </Stack>
     );
@@ -601,8 +640,9 @@ export const CollectionBlockView: FC<BlockComponentProps> = ({
 const SortableTile: FC<{
     content: SummaryContent;
     projectUuid: string;
+    layout: HomepageContentLayout;
     onRemove: () => void;
-}> = ({ content, projectUuid, onRemove }) => {
+}> = ({ content, projectUuid, layout, onRemove }) => {
     const {
         attributes,
         listeners,
@@ -611,10 +651,14 @@ const SortableTile: FC<{
         transition,
         isDragging,
     } = useSortable({ id: content.uuid });
+    const wrapperClass =
+        layout === 'list'
+            ? classes.sortableTile
+            : `${classes.sortableTile} ${layoutClasses.pageGridItem}`;
     return (
         <div
             ref={setNodeRef}
-            className={`${classes.sortableTile} ${layoutClasses.pageGridItem}`}
+            className={wrapperClass}
             data-dragging={isDragging}
             style={{
                 transform: CSS.Translate.toString(transform),
@@ -626,7 +670,7 @@ const SortableTile: FC<{
             <ContentCard
                 content={content}
                 projectUuid={projectUuid}
-                variant="tile"
+                variant={layout === 'list' ? 'compact' : 'tile'}
                 onRemove={onRemove}
             />
         </div>
@@ -670,6 +714,16 @@ const SOURCE_OPTIONS: {
     },
 ];
 
+const CONTENT_TYPE_OPTIONS: {
+    value: HomepageCollectionItemRef['contentType'];
+    label: string;
+}[] = [
+    { value: 'dashboard', label: 'Dashboards' },
+    { value: 'chart', label: 'Charts' },
+    { value: 'data_app', label: 'Apps' },
+    { value: 'space', label: 'Spaces' },
+];
+
 const CollectionSourceControls: FC<{
     config: HomepageCollectionBlock['config'];
     onChange: (config: HomepageCollectionBlock['config']) => void;
@@ -678,49 +732,80 @@ const CollectionSourceControls: FC<{
     const hint = SOURCE_OPTIONS.find((o) => o.value === source)?.hint;
     return (
         <Stack gap={6}>
-            <Select
-                size="xs"
-                label="Items"
-                data={SOURCE_OPTIONS.map(({ value, label }) => ({
-                    value,
-                    label,
-                }))}
-                value={source}
-                allowDeselect={false}
-                onChange={(next) =>
-                    next &&
-                    onChange({
-                        ...config,
-                        source: next as HomepageCollectionSource,
-                    })
-                }
-            />
-            {hint && (
-                <Text size="xs" c="dimmed">
-                    {hint}
-                </Text>
-            )}
-            <Group gap="sm" align="flex-end">
+            <Group gap="xs" align="flex-end" wrap="nowrap">
+                <Select
+                    size="xs"
+                    label="Items"
+                    flex={1}
+                    data={SOURCE_OPTIONS.map(({ value, label }) => ({
+                        value,
+                        label,
+                    }))}
+                    value={source}
+                    allowDeselect={false}
+                    onChange={(next) =>
+                        next &&
+                        onChange({
+                            ...config,
+                            source: next as HomepageCollectionSource,
+                        })
+                    }
+                />
                 <NumberInput
                     size="xs"
                     label="Show at most"
-                    w={120}
+                    w={110}
                     min={1}
                     max={MAX_COLLECTION_LIMIT}
                     value={collectionLimitOf(config)}
                     onNumberChange={(limit) => onChange({ ...config, limit })}
                 />
-                <Checkbox
+            </Group>
+            {hint && (
+                <Text size="xs" c="dimmed">
+                    {hint}
+                </Text>
+            )}
+            <Group gap={6}>
+                {source !== 'manual' && (
+                    <Chip.Group
+                        multiple
+                        value={config.contentTypes ?? []}
+                        onChange={(next) =>
+                            onChange({
+                                ...config,
+                                contentTypes: next.length
+                                    ? (next as HomepageCollectionItemRef['contentType'][])
+                                    : undefined,
+                            })
+                        }
+                    >
+                        {CONTENT_TYPE_OPTIONS.map(({ value, label }) => (
+                            <Chip
+                                key={value}
+                                value={value}
+                                size="xs"
+                                variant="light"
+                            >
+                                {label}
+                            </Chip>
+                        ))}
+                    </Chip.Group>
+                )}
+                {source !== 'manual' && (
+                    <Divider orientation="vertical" mx={2} />
+                )}
+                <Chip
                     size="xs"
-                    label="Verified only"
+                    variant="light"
+                    color="green"
                     checked={config.verifiedOnly === true}
-                    onChange={(e) =>
-                        onChange({
-                            ...config,
-                            verifiedOnly: e.currentTarget.checked,
-                        })
+                    onChange={(checked) =>
+                        onChange({ ...config, verifiedOnly: checked })
                     }
-                />
+                >
+                    Verified only
+                </Chip>
             </Group>
         </Stack>
     );
@@ -750,17 +835,12 @@ const DynamicSourcePreview: FC<{
                     it does.
                 </div>
             ) : (
-                <PageGrid itemSpan={itemSpan} elastic>
-                    {items.map((content) => (
-                        <PageGridItem key={content.uuid}>
-                            <ContentCard
-                                content={content}
-                                projectUuid={projectUuid}
-                                variant="tile"
-                            />
-                        </PageGridItem>
-                    ))}
-                </PageGrid>
+                <CollectionContentGrid
+                    layout={collectionLayoutOf(config)}
+                    itemSpan={itemSpan}
+                    contents={items}
+                    projectUuid={projectUuid}
+                />
             )}
             <div className={classes.buildHint}>
                 {isPersonal
@@ -793,6 +873,7 @@ export const CollectionBlockBuild: FC<BuildComponentProps> = ({
     );
     if (block.type !== 'collection') return null;
     const source = collectionSourceOf(block.config);
+    const layout = collectionLayoutOf(block.config);
 
     const importablePins = (pinnedItems ?? []).map(
         (item): HomepageCollectionItemRef => ({
@@ -801,23 +882,44 @@ export const CollectionBlockBuild: FC<BuildComponentProps> = ({
         }),
     );
 
+    const removeItem = (uuid: string) =>
+        onChange({
+            ...block,
+            config: {
+                ...block.config,
+                items: block.config.items.filter((item) => item.uuid !== uuid),
+            },
+        });
+
     return (
         <Stack gap="xs">
-            <TextInput
-                label="Title"
-                size="xs"
-                fw={600}
-                value={block.config.title}
-                onChange={(e) =>
-                    onChange({
-                        ...block,
-                        config: {
-                            ...block.config,
-                            title: e.currentTarget.value,
-                        },
-                    })
-                }
-            />
+            <Group gap="xs" align="flex-end" wrap="nowrap">
+                <TextInput
+                    label="Title"
+                    size="xs"
+                    fw={600}
+                    flex={1}
+                    value={block.config.title}
+                    onChange={(e) =>
+                        onChange({
+                            ...block,
+                            config: {
+                                ...block.config,
+                                title: e.currentTarget.value,
+                            },
+                        })
+                    }
+                />
+                <ContentLayoutControl
+                    value={layout}
+                    onChange={(nextLayout) =>
+                        onChange({
+                            ...block,
+                            config: { ...block.config, layout: nextLayout },
+                        })
+                    }
+                />
+            </Group>
             <CollectionSourceControls
                 config={block.config}
                 onChange={(config) => onChange({ ...block, config })}
@@ -852,28 +954,19 @@ export const CollectionBlockBuild: FC<BuildComponentProps> = ({
                         items={(contents ?? []).map((content) => content.uuid)}
                         strategy={rectSortingStrategy}
                     >
-                        <PageGrid itemSpan={itemSpan ?? null} elastic>
-                            {(contents ?? []).map((content) => (
-                                <SortableTile
-                                    key={content.uuid}
-                                    content={content}
-                                    projectUuid={projectUuid}
-                                    onRemove={() =>
-                                        onChange({
-                                            ...block,
-                                            config: {
-                                                ...block.config,
-                                                items: block.config.items.filter(
-                                                    (item) =>
-                                                        item.uuid !==
-                                                        content.uuid,
-                                                ),
-                                            },
-                                        })
-                                    }
-                                />
-                            ))}
-                            <PageGridItem>
+                        {layout === 'list' ? (
+                            <div className={classes.resTileGrid}>
+                                {(contents ?? []).map((content) => (
+                                    <SortableTile
+                                        key={content.uuid}
+                                        content={content}
+                                        projectUuid={projectUuid}
+                                        layout={layout}
+                                        onRemove={() =>
+                                            removeItem(content.uuid)
+                                        }
+                                    />
+                                ))}
                                 <button
                                     type="button"
                                     className={classes.addContentTile}
@@ -882,8 +975,35 @@ export const CollectionBlockBuild: FC<BuildComponentProps> = ({
                                     <MantineIcon icon={IconPlus} size={14} />
                                     Add content
                                 </button>
-                            </PageGridItem>
-                        </PageGrid>
+                            </div>
+                        ) : (
+                            <PageGrid itemSpan={itemSpan ?? null} elastic>
+                                {(contents ?? []).map((content) => (
+                                    <SortableTile
+                                        key={content.uuid}
+                                        content={content}
+                                        projectUuid={projectUuid}
+                                        layout={layout}
+                                        onRemove={() =>
+                                            removeItem(content.uuid)
+                                        }
+                                    />
+                                ))}
+                                <PageGridItem>
+                                    <button
+                                        type="button"
+                                        className={classes.addContentTile}
+                                        onClick={() => setIsPickerOpen(true)}
+                                    >
+                                        <MantineIcon
+                                            icon={IconPlus}
+                                            size={14}
+                                        />
+                                        Add content
+                                    </button>
+                                </PageGridItem>
+                            </PageGrid>
+                        )}
                     </SortableContext>
                 </DndContext>
             )}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
@@ -1,4 +1,5 @@
 import {
+    ContentType,
     contentToResourceViewItem,
     type SummaryContent,
 } from '@lightdash/common';
@@ -23,7 +24,9 @@ type Props = {
     projectUuid: string;
     onRemove?: () => void;
     star?: { isFavorite: boolean; onToggle: () => void };
-    variant?: 'row' | 'tile';
+    /** `row`/`tile` are card-chrome variants; `compact` is a slim
+     * single-line tile for dense grids. */
+    variant?: 'row' | 'tile' | 'compact';
 };
 
 const VerifiedBadge: FC<{ content: SummaryContent }> = ({ content }) =>
@@ -55,10 +58,17 @@ const TileExtra: FC<{ content: SummaryContent }> = ({ content }) => {
     );
 };
 
+const CONTENT_KIND_LABEL: Record<SummaryContent['contentType'], string> = {
+    [ContentType.CHART]: 'Chart',
+    [ContentType.DASHBOARD]: 'Dashboard',
+    [ContentType.SPACE]: 'Space',
+    [ContentType.DATA_APP]: 'App',
+};
+
 const KindAndViews: FC<{ content: SummaryContent }> = ({ content }) => (
     <Group gap={5} wrap="nowrap" className={classes.rowMeta}>
-        <Text size="xs" c="dimmed" tt="capitalize" span>
-            {content.contentType}
+        <Text size="xs" c="dimmed" span>
+            {CONTENT_KIND_LABEL[content.contentType]}
         </Text>
         <Text size="xs" c="dimmed" span>
             ·
@@ -135,6 +145,37 @@ export const ContentCard: FC<Props> = ({
         ? null
         : getResourceUrl(projectUuid, contentToResourceViewItem(content));
     const cardClass = `${classes.hoverCard}${to ? ` ${classes.clickable}` : ''}`;
+
+    // A single dense line — visibly lighter than the two-line card variant.
+    if (variant === 'compact') {
+        return (
+            <MaybeLink
+                to={to}
+                className={`${classes.resTile}${to ? ` ${classes.clickable}` : ''}`}
+            >
+                <ResourceIcon item={contentToResourceViewItem(content)} />
+                <Group gap={5} wrap="nowrap" className={classes.resTileBody}>
+                    <Text size="sm" fw={600} truncate>
+                        {content.name}
+                    </Text>
+                    <VerifiedBadge content={content} />
+                </Group>
+                <Group gap={4} wrap="nowrap">
+                    <MantineIcon icon={IconEye} size={12} color="ldGray.6" />
+                    <Text size="xs" c="dimmed" span>
+                        {content.views}
+                    </Text>
+                </Group>
+                <Box className={classes.tileActions}>
+                    <CardActions
+                        content={content}
+                        onRemove={onRemove}
+                        star={star}
+                    />
+                </Box>
+            </MaybeLink>
+        );
+    }
 
     if (variant === 'tile') {
         // Horizontal at half a card unit: two content tiles stack to exactly

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentLayoutControl.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentLayoutControl.tsx
@@ -1,0 +1,34 @@
+import { type HomepageContentLayout } from '@lightdash/common';
+import { Box, SegmentedControl, Tooltip } from '@mantine-8/core';
+import { IconLayoutGrid, IconLayoutList } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../../components/common/MantineIcon';
+
+const OPTIONS = [
+    { value: 'card', label: 'Cards', icon: IconLayoutGrid },
+    { value: 'list', label: 'Compact', icon: IconLayoutList },
+] as const;
+
+/** The one layout switcher every content-listing block uses, so the options
+ * always carry the same icons and names. Compact's arrangement (tile columns
+ * vs rows) resolves from the block's width — geometry is not an admin choice. */
+export const ContentLayoutControl: FC<{
+    value: HomepageContentLayout;
+    onChange: (layout: HomepageContentLayout) => void;
+}> = ({ value, onChange }) => (
+    <SegmentedControl
+        size="xs"
+        value={value}
+        onChange={(next) => onChange(next as HomepageContentLayout)}
+        data={OPTIONS.map((option) => ({
+            value: option.value,
+            label: (
+                <Tooltip label={option.label} openDelay={200}>
+                    <Box component="span" lh={0} display="inline-block">
+                        <MantineIcon icon={option.icon} />
+                    </Box>
+                </Tooltip>
+            ),
+        }))}
+    />
+);

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
@@ -5,9 +5,7 @@ import {
 } from '@lightdash/common';
 import {
     ActionIcon,
-    Box,
     Group,
-    SegmentedControl,
     Select,
     Stack,
     Switch,
@@ -20,8 +18,6 @@ import {
     IconBook,
     IconBrandYoutube,
     IconExternalLink,
-    IconLayoutGrid,
-    IconLayoutList,
     IconLink,
     IconPlus,
     IconSparkles,
@@ -41,6 +37,7 @@ import MantineIcon from '../../../../components/common/MantineIcon';
 import { useAppThumbnailUrl } from '../../../../features/apps/hooks/useAppThumbnail';
 import { BlockHeader, IconSquare, MiniPill } from './BlockShell';
 import classes from './blockStyles.module.css';
+import { ContentLayoutControl } from './ContentLayoutControl';
 import { DataAppPickerModal } from './DataAppPickerModal';
 import { PageGrid, PageGridItem } from './PageGrid';
 import {
@@ -646,42 +643,11 @@ export const ResourcesBlockBuild: FC<BuildComponentProps> = ({
                         patchConfig({ title: e.currentTarget.value })
                     }
                 />
-                <SegmentedControl
-                    size="xs"
+                <ContentLayoutControl
                     value={layout}
-                    onChange={(v) =>
-                        patchConfig({ layout: v as HomepageResourcesLayout })
+                    onChange={(nextLayout) =>
+                        patchConfig({ layout: nextLayout })
                     }
-                    data={[
-                        {
-                            value: 'card',
-                            label: (
-                                <Tooltip label="Cards" openDelay={200}>
-                                    <Box
-                                        component="span"
-                                        lh={0}
-                                        display="inline-block"
-                                    >
-                                        <MantineIcon icon={IconLayoutGrid} />
-                                    </Box>
-                                </Tooltip>
-                            ),
-                        },
-                        {
-                            value: 'list',
-                            label: (
-                                <Tooltip label="Compact" openDelay={200}>
-                                    <Box
-                                        component="span"
-                                        lh={0}
-                                        display="inline-block"
-                                    >
-                                        <MantineIcon icon={IconLayoutList} />
-                                    </Box>
-                                </Tooltip>
-                            ),
-                        },
-                    ]}
                 />
             </Group>
             <Switch

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useCollectionSourceContent.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useCollectionSourceContent.ts
@@ -99,11 +99,20 @@ export const useCollectionSourceContent = (
     }, [source, manual.data, recent.contents, derived.data]);
 
     const items = useMemo(() => {
-        const filtered = config.verifiedOnly
-            ? resolved.filter(isVerified)
+        // Manual collections are already hand-filtered by picking; the type
+        // filter only narrows live rules.
+        const typeFilter =
+            source !== 'manual' && (config.contentTypes?.length ?? 0) > 0
+                ? new Set<string>(config.contentTypes)
+                : null;
+        const byType = typeFilter
+            ? resolved.filter((content) => typeFilter.has(content.contentType))
             : resolved;
+        const filtered = config.verifiedOnly
+            ? byType.filter(isVerified)
+            : byType;
         return filtered.slice(0, limit);
-    }, [resolved, config.verifiedOnly, limit]);
+    }, [resolved, source, config.contentTypes, config.verifiedOnly, limit]);
 
     const isLoading =
         source === 'manual'


### PR DESCRIPTION
Part of PROD-9373. Stacked on #26732.

## What

Extends the two-mode display vocabulary from Resources (#26732) to the Collection block, which was locked to one presentation (the ContentCard grid):

- **`layout: card | list`** on collection config, switched via a shared `ContentLayoutControl` (same icons, names, and tooltips as Resources — Cards / Compact). `card` is the existing grid; Compact renders single-line tiles (icon + name + view count) whose geometry resolves from the block's width: tile columns when wide, a single column of rows when narrow. Geometry is never an admin choice.
- **`contentTypes` filter for live sources** — narrows `most-viewed` / `pinned` / `favorites` / etc. to chosen types via chips in the build panel (Dashboards / Charts / Apps / Spaces). Unlocks blocks like "Most popular apps" as live rules. Ignored for `manual` (hand-picking already is the filter) and when no chip is selected.
- **Build panel harmonised** — Items source + limit share one aligned row; all filters (type chips + Verified only) are one pill row; hints collapse to a single line. `ContentCard` kind labels fixed (`App`, not `Data_app`).
- One shared renderer (`CollectionContentGrid`) drives view, dynamic-source preview, and the manual build canvas; manual collections stay drag-sortable in both modes. Favorite stars work in both.

## Regression analysis

- Stored configs have neither field: `layout` defaults to `'card'` (byte-identical rendering) and an absent/empty `contentTypes` applies no filter.
- The filter is applied client-side on already-access-filtered results, before `limit` — it never widens what a viewer can see.
- `ContentCard` gains a `compact` variant; existing `row`/`tile` variants are untouched.

## Testing

- Schema round-trip test covers `layout` + `contentTypes` (common: 3292 passed); frontend typecheck, oxlint, and homepageBuilder vitest suite (241) green.
- Verified live: wide vs narrow compact collections adapt automatically; chip filter narrows a most-viewed block in real time; tooltips on the layout switcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1fe2jShYJrNxZRXw5E6jx
