### PR TITLE
fix(homepage): builder drop affordances match the row width envelope

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.module.css
@@ -244,6 +244,15 @@
     opacity: 1;
 }
 
+/* Drop affordances live outside the tiered row containers, so they carry the
+ * same width envelope themselves — a drop slot wider than its siblings reads
+ * as a different column system. Build rows all resolve to the full tier. */
+.dropEnvelope {
+    composes: tierFull from './homepageLayout.module.css';
+    width: 100%;
+    margin-inline: auto;
+}
+
 .rowDropZone {
     height: 12px;
     display: flex;

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
@@ -242,7 +242,7 @@ const RowGap: FC<{
     return (
         <div
             ref={setNodeRef}
-            className={classes.rowDropZone}
+            className={`${classes.rowDropZone} ${classes.dropEnvelope}`}
             data-drag-active={isDragActive}
             data-menu-open={menuOpened}
         >
@@ -289,7 +289,10 @@ const RowGap: FC<{
 const EndDropZone: FC<{ isEmpty: boolean }> = ({ isEmpty }) => {
     const { setNodeRef } = useDroppable({ id: END_ZONE_ID });
     return (
-        <div ref={setNodeRef} className={classes.endZone}>
+        <div
+            ref={setNodeRef}
+            className={`${classes.endZone} ${classes.dropEnvelope}`}
+        >
             <MantineIcon
                 icon={IconPlus}
                 size={15}
@@ -377,7 +380,7 @@ const ColIndicator: FC<{ active: boolean }> = ({ active }) => (
 // A translucent preview of the block, shown in the layout exactly where the
 // drop will land — held until release.
 const GhostBlock: FC<{ definition: BlockDefinition }> = ({ definition }) => (
-    <div className={classes.ghostBlock}>
+    <div className={`${classes.ghostBlock} ${classes.dropEnvelope}`}>
         <IconSquare icon={definition.icon} />
         <span className={classes.ghostBlockLabel}>{definition.label}</span>
     </div>


### PR DESCRIPTION
Part of PROD-9373. Stacked on #26733.

## What

Builder polish from live QA:

- **Drop affordances match the row width envelope** — the between-row drop zones, the blue dashed drop ghost, and the "Drag a block here" end zone rendered outside the tiered row containers, so they spanned the full canvas while block rows cap at the full tier (1000px). A shared `dropEnvelope` class (composing `tierFull`) puts all three on the same column system as their siblings.
- **Empty-row crash fix landed downstack** (in #26732): a stored row whose blocks the read-path sanitizer dropped (e.g. a config value from an unreleased build) crashed both builder and view. The resolver now resolves empty rows benignly on the build surface (kept 1:1 for editability), the view surface drops them, and `migrateHomepageConfig` removes ghost rows at the editor boundary — with a regression test.
- **Paste row harmonised** (in #26732): the resource paste input, add button, and "Add data app" button were three mismatched controls; they're now a single `radius="md"` input with both actions (add link / add data app) as tooltipped icons in the right section, and one hint line.

## Testing

- homepageBuilder vitest suite green incl. the new empty-row resolver test; typecheck + oxlint clean.
- Verified live in the builder: drop zones flush with card edges, paste row single control, real draft (previously crashing) loads and edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1fe2jShYJrNxZRXw5E6jx
