### PR TITLE
fix(homepage): remove hero opening swap control, compact the opening-size control

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.tsx
@@ -1,7 +1,4 @@
-import {
-    type HomepageHeroDensity,
-    type HomepageOpening,
-} from '@lightdash/common';
+import { type HomepageHeroDensity } from '@lightdash/common';
 import {
     Box,
     SegmentedControl,
@@ -12,8 +9,6 @@ import {
 } from '@mantine-8/core';
 import { type FC } from 'react';
 import useApp from '../../../../providers/App/useApp';
-import useTracking from '../../../../providers/Tracking/useTracking';
-import { EventName } from '../../../../types/Events';
 import { DayOneAskInput } from '../DayOneAskInput';
 import { DEFAULT_GREETING_SUBTITLE, getGreeting } from '../greeting';
 import layout from '../homepageLayout.module.css';
@@ -98,6 +93,7 @@ export const HeroDensityControl: FC<{
         </Text>
         <SegmentedControl
             size="xs"
+            w="fit-content"
             value={value ?? 'auto'}
             onChange={(next) =>
                 onChange(
@@ -117,48 +113,6 @@ export const HeroDensityControl: FC<{
         </Text>
     </Stack>
 );
-
-// Shared by both hero-capable blocks: swaps the block type in place (id and
-// density survive), so switching the opening never touches the rows below.
-export const HeroOpeningControl: FC<{
-    projectUuid: string;
-    value: HomepageOpening;
-    onSwap: (opening: HomepageOpening) => void;
-}> = ({ projectUuid, value, onSwap }) => {
-    const { canAskAi } = useHomepageAiState(projectUuid);
-    const { track } = useTracking();
-    // Without a working composer there's no choice to offer.
-    if (!canAskAi) return null;
-    return (
-        <Stack gap={4}>
-            <Text size="xs" fw={500}>
-                Opening
-            </Text>
-            <SegmentedControl
-                size="xs"
-                value={value}
-                onChange={(next) => {
-                    if (next === value) return;
-                    track({
-                        name: EventName.HOMEPAGE_OPENING_SWAPPED,
-                        properties: {
-                            from: value,
-                            to: next as HomepageOpening,
-                        },
-                    });
-                    onSwap(next as HomepageOpening);
-                }}
-                data={[
-                    { value: 'ask-first', label: 'Ask AI' },
-                    { value: 'content-first', label: 'Greeting' },
-                ]}
-            />
-            <Text size="xs" c="dimmed">
-                Swaps just this opening block. Everything below stays put.
-            </Text>
-        </Stack>
-    );
-};
 
 export const AskAiHeroBlockView: FC<BlockComponentProps> = ({
     block,
@@ -213,20 +167,6 @@ export const AskAiHeroBlockBuild: FC<BuildComponentProps> = ({
                     block.config.showRecommendedActions === true
                 }
                 preview
-            />
-            <HeroOpeningControl
-                projectUuid={projectUuid}
-                value="ask-first"
-                onSwap={() =>
-                    onChange({
-                        id: block.id,
-                        type: 'greeting',
-                        config: {
-                            subtitle: DEFAULT_GREETING_SUBTITLE,
-                            density: block.config.density,
-                        },
-                    })
-                }
             />
             <Switch
                 label="Show greeting"

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/GreetingBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/GreetingBlock.tsx
@@ -1,6 +1,6 @@
 import { Stack, TextInput } from '@mantine-8/core';
 import { type FC } from 'react';
-import { HeroDensityControl, HeroOpeningControl } from './AskAiHeroBlock';
+import { HeroDensityControl } from './AskAiHeroBlock';
 import { GreetingHero } from './GreetingHero';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
@@ -11,27 +11,12 @@ export const GreetingBlockView: FC<BlockComponentProps> = ({ block }) => {
 
 export const GreetingBlockBuild: FC<BuildComponentProps> = ({
     block,
-    projectUuid,
     onChange,
 }) => {
     if (block.type !== 'greeting') return null;
     return (
         <Stack gap="sm">
             <GreetingHero subtitle={block.config.subtitle} />
-            <HeroOpeningControl
-                projectUuid={projectUuid}
-                value="content-first"
-                onSwap={() =>
-                    onChange({
-                        id: block.id,
-                        type: 'ask-ai-hero',
-                        config: {
-                            showGreeting: true,
-                            density: block.config.density,
-                        },
-                    })
-                }
-            />
             <TextInput
                 size="xs"
                 label="Line under the greeting"

--- a/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
@@ -17,8 +17,14 @@ const GRID_COLUMNS = 12;
 const LEADING_HERO_TYPES: HomepageBlock['type'][] = ['ask-ai-hero', 'greeting'];
 
 // Chrome-like rows that may sit above the composer without demoting it — they
-// join the hero composition instead (day-0 has its chips above the hero too).
-const HERO_COMPANION_TYPES: HomepageBlock['type'][] = ['quick-actions'];
+// join the hero composition instead. Day-0 has both above its hero: the
+// quick-action chips and the personal favorites strip. A hero demoted to a
+// body row silently loses its density control, so this list must cover every
+// block the starter layouts place above the composer.
+const HERO_COMPANION_TYPES: HomepageBlock['type'][] = [
+    'quick-actions',
+    'favorites',
+];
 
 // Gap before a row, as a token resolved to px in CSS. The first row of a
 // section has no gap (the section's own spacing separates it).


### PR DESCRIPTION
Part of PROD-9373 polish. Stacked on #26736.

## What

Hero build-panel cleanup from live QA:

- **Removed the "Opening" (Ask AI / Greeting) swap control** from both hero build panels (`AskAiHeroBlockBuild`, `GreetingBlockBuild`) and deleted the shared `HeroOpeningControl` component. The in-panel type swap wasn't discoverable or convincing in the builder, and the org-level opening choice (opt-in modal + `swapHeroBlocks`) already owns this decision; a stray per-block toggle competing with it was more confusing than useful. The `HOMEPAGE_OPENING_SWAPPED` analytics event stays defined (the opt-in flow still uses the opening concept) but this emitter is gone.
- **"Opening size" now actually works on pages with a favorites strip** — the resolver only granted hero treatment (and with it, the density setting) when the hero led the page, with only `quick-actions` allowed above it as companion chrome. Day-0 also places the personal favorites strip above the hero, so a page shaped exactly like day-0 silently lost its density control the moment favorites sat first. `favorites` is now a hero-companion type, so those rows join the hero composition and `Full screen`/`Compact` apply in Preview and on the published page.
- **"Opening size" control no longer stretches full width** — the segmented control is `w="fit-content"`, matching the visual weight of every other panel control. Its behaviour is unchanged: it sets the hero's stored `density`, which takes effect in Preview and on the published page (build canvas intentionally renders all rows full so nothing becomes un-editable).

## Regression analysis

Config shape untouched — removing the control removes a way to convert a block's type in place, nothing else. Existing `density` values keep working; blocks swapped previously stay as they are.

## Testing

homepageBuilder vitest suite (242) green; typecheck + oxlint clean; verified live in the builder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1fe2jShYJrNxZRXw5E6jx
