### PR TITLE
feat(homepage): cta block with brand theming and custom colors

### DIFF
--- a/packages/common/src/ee/homepage/schema.test.ts
+++ b/packages/common/src/ee/homepage/schema.test.ts
@@ -86,6 +86,46 @@ describe('parseHomepageConfig', () => {
         expect(parseHomepageConfig(config)).toEqual(config);
     });
 
+    it('round-trips a cta block with every target shape', () => {
+        const config = {
+            version: 1 as const,
+            rows: [
+                {
+                    id: 'row-1',
+                    blocks: [
+                        {
+                            id: 'b1',
+                            type: 'cta' as const,
+                            config: {
+                                title: 'Explore your data',
+                                description: 'Answer your own question.',
+                                buttonLabel: 'Run a query',
+                                target: { type: 'run-query' as const },
+                                theme: 'custom' as const,
+                                customColor: '#ff5500',
+                                background: 'theme' as const,
+                                align: 'right' as const,
+                            },
+                        },
+                        {
+                            id: 'b2',
+                            type: 'cta' as const,
+                            config: {
+                                title: 'Data survey',
+                                buttonLabel: 'Take it',
+                                target: {
+                                    type: 'link' as const,
+                                    url: 'https://example.com/survey',
+                                },
+                            },
+                        },
+                    ],
+                },
+            ],
+        };
+        expect(parseHomepageConfig(config)).toEqual(config);
+    });
+
     it('strips unknown properties instead of persisting them', () => {
         const withExtras = {
             version: 1,

--- a/packages/common/src/ee/homepage/schema.ts
+++ b/packages/common/src/ee/homepage/schema.ts
@@ -110,6 +110,36 @@ const quickActionsBlockSchema = z.object({
     config: z.object({ actions: z.array(quickActionSchema) }),
 });
 
+const ctaTargetSchema = z.discriminatedUnion('type', [
+    z.object({ type: z.literal('ask-ai') }),
+    z.object({ type: z.literal('run-query') }),
+    z.object({ type: z.literal('browse-dashboards') }),
+    z.object({ type: z.literal('browse-spaces') }),
+    z.object({
+        type: z.literal('dashboard'),
+        dashboardUuid: z.string(),
+        label: z.string(),
+    }),
+    z.object({ type: z.literal('link'), url: z.string() }),
+]);
+
+const ctaBlockSchema = z.object({
+    id: z.string(),
+    type: z.literal('cta'),
+    config: z.object({
+        title: z.string().optional(),
+        description: z.string().optional(),
+        buttonLabel: z.string(),
+        target: ctaTargetSchema,
+        theme: z
+            .enum(['brand', 'accent', 'dark', 'neutral', 'custom'])
+            .optional(),
+        customColor: z.string().optional(),
+        background: z.enum(['none', 'card', 'theme']).optional(),
+        align: z.enum(['left', 'center', 'right']).optional(),
+    }),
+});
+
 const metricRefSchema = z.object({
     tableName: z.string(),
     metricName: z.string(),
@@ -142,6 +172,7 @@ export const homepageBlockSchema = z.discriminatedUnion('type', [
     resourcesBlockSchema,
     announcementsBlockSchema,
     quickActionsBlockSchema,
+    ctaBlockSchema,
     metricsBlockSchema,
     favoritesBlockSchema,
     recentBlockSchema,

--- a/packages/common/src/ee/homepage/types.ts
+++ b/packages/common/src/ee/homepage/types.ts
@@ -176,6 +176,48 @@ export type HomepageQuickActionsBlock = {
     config: { actions: HomepageQuickAction[] };
 };
 
+/** Where the CTA button leads: the quick-action vocabulary plus a free URL. */
+export type HomepageCtaTarget =
+    | HomepageQuickActionTarget
+    | { type: 'link'; url: string };
+
+/** Semantic theme tokens, resolved at render from the org's brand colors —
+ * a rebrand restyles every CTA without touching stored configs. `custom`
+ * reads the block's own `customColor`. */
+export type HomepageCtaTheme =
+    | 'brand'
+    | 'accent'
+    | 'dark'
+    | 'neutral'
+    | 'custom';
+
+/** The block's container: invisible (just the button on the page), a neutral
+ * card, or a surface painted with the theme (the button then inverts it). */
+export type HomepageCtaBackground = 'none' | 'card' | 'theme';
+
+/** Where a bare (title-less) CTA button sits in its row. */
+export type HomepageCtaAlign = 'left' | 'center' | 'right';
+
+export type HomepageCtaBlock = {
+    id: string;
+    type: 'cta';
+    config: {
+        /** Optional: without it the CTA is just its button. */
+        title?: string;
+        description?: string;
+        buttonLabel: string;
+        target: HomepageCtaTarget;
+        // Optional for back-compat: undefined renders as 'brand'.
+        theme?: HomepageCtaTheme;
+        /** Hex color used when `theme` is `custom`. */
+        customColor?: string;
+        // Optional: undefined renders as 'none' (chromeless).
+        background?: HomepageCtaBackground;
+        // Optional: undefined centres the bare button. Ignored with a title.
+        align?: HomepageCtaAlign;
+    };
+};
+
 export type HomepageMetricRef = {
     tableName: string;
     metricName: string;
@@ -242,6 +284,7 @@ export type HomepageBlock =
     | HomepageAnnouncementsBlock
     | HomepageMetricsBlock
     | HomepageQuickActionsBlock
+    | HomepageCtaBlock
     | HomepageFavoritesBlock
     | HomepageRecentBlock;
 

--- a/packages/frontend/src/ee/features/homepageBuilder/blockLayout.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blockLayout.ts
@@ -58,6 +58,15 @@ const blockLayoutTraits: Record<HomepageBlock['type'], BlockLayoutTrait> = {
         fullRowOnly: false,
         itemSpan: null,
     },
+    cta: {
+        // A banner is the page's one loud moment: it owns its row and joins
+        // the card-grid axis so its edges align with content around it.
+        widthTier: 'full',
+        columnWeight: 1,
+        rhythm: 'section',
+        fullRowOnly: true,
+        itemSpan: null,
+    },
     metrics: {
         widthTier: 'full',
         columnWeight: 2,

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/CtaBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/CtaBlock.tsx
@@ -1,0 +1,445 @@
+import {
+    assertUnreachable,
+    getContrastTextColor,
+    type HomepageCtaAlign,
+    type HomepageCtaBackground,
+    type HomepageCtaBlock,
+    type HomepageCtaTarget,
+    type HomepageCtaTheme,
+    type OrganizationBrandColor,
+} from '@lightdash/common';
+import {
+    ColorInput,
+    Group,
+    SegmentedControl,
+    Select,
+    Stack,
+    Text,
+    TextInput,
+    Tooltip,
+} from '@mantine-8/core';
+import { type CSSProperties, type FC } from 'react';
+import { Link } from 'react-router';
+import { useProjectColorPalette } from '../../../../hooks/appearance/useProjectColorPalette';
+import { useOrganizationBrand } from '../../../../hooks/organization/useOrganizationBrand';
+import useTracking from '../../../../providers/Tracking/useTracking';
+import { EventName } from '../../../../types/Events';
+import { useHomepageAiState } from '../hooks/useHomepageAiState';
+import { useReportRuntimeEmpty } from '../hooks/useRuntimeEmptyBlocks';
+import classes from './blockStyles.module.css';
+import { type BlockComponentProps, type BuildComponentProps } from './types';
+
+type CtaConfig = HomepageCtaBlock['config'];
+
+const targetUrl = (target: HomepageCtaTarget, projectUuid: string): string => {
+    switch (target.type) {
+        case 'ask-ai':
+            return `/projects/${projectUuid}/ai-agents`;
+        case 'run-query':
+            return `/projects/${projectUuid}/tables`;
+        case 'browse-dashboards':
+            return `/projects/${projectUuid}/dashboards`;
+        case 'browse-spaces':
+            return `/projects/${projectUuid}/spaces`;
+        case 'dashboard':
+            return `/projects/${projectUuid}/dashboards/${target.dashboardUuid}/view`;
+        case 'link':
+            return target.url;
+        default:
+            return assertUnreachable(target, 'Unknown CTA target');
+    }
+};
+
+const pickBrandHex = (
+    colors: OrganizationBrandColor[] | undefined,
+    kind: 'brand' | 'accent',
+): string | null => {
+    if (!colors || colors.length === 0) return null;
+    const preferred =
+        kind === 'brand'
+            ? ['brand', 'accent', 'dark']
+            : ['accent', 'brand', 'dark'];
+    for (const type of preferred) {
+        const match = colors.find(
+            (color) =>
+                color.type === type && /^#?[0-9a-f]{6}$/i.test(color.hex),
+        );
+        if (match)
+            return match.hex.startsWith('#') ? match.hex : `#${match.hex}`;
+    }
+    return null;
+};
+
+const DARK_SURFACE = '#101113';
+
+const isHex = (value: string | undefined): value is string =>
+    !!value && /^#[0-9a-f]{6}$/i.test(value.trim());
+
+/** What a theme token paints with, before deciding where it's applied. */
+type CtaPaint = { kind: 'neutral' } | { kind: 'solid'; hex: string };
+
+const resolveCtaPaint = (
+    theme: HomepageCtaTheme,
+    brandColors: OrganizationBrandColor[] | undefined,
+    customColor: string | undefined,
+): CtaPaint => {
+    switch (theme) {
+        case 'neutral':
+            return { kind: 'neutral' };
+        case 'dark':
+            return { kind: 'solid', hex: DARK_SURFACE };
+        case 'custom':
+            return {
+                kind: 'solid',
+                hex: isHex(customColor) ? customColor : DARK_SURFACE,
+            };
+        case 'brand':
+        case 'accent': {
+            const hex = pickBrandHex(brandColors, theme);
+            return { kind: 'solid', hex: hex ?? DARK_SURFACE };
+        }
+        default:
+            return assertUnreachable(theme, 'Unknown CTA theme');
+    }
+};
+
+const textOn = (hex: string): string =>
+    getContrastTextColor(hex) === 'black' ? '#1a1b1e' : '#ffffff';
+
+/** Inline paint vars for one surface (the banner or the button). */
+const paintStyle = (paint: CtaPaint, prefix: 'cta' | 'cta-btn') => {
+    if (paint.kind === 'neutral') return undefined;
+    return {
+        [`--${prefix}-bg`]: paint.hex,
+        [`--${prefix}-fg`]: textOn(paint.hex),
+    } as CSSProperties;
+};
+
+const CtaBanner: FC<{
+    config: CtaConfig;
+    projectUuid: string;
+    interactive: boolean;
+    onNavigate?: () => void;
+}> = ({ config, projectUuid, interactive, onNavigate }) => {
+    const { data: brand } = useOrganizationBrand();
+    const theme = config.theme ?? 'brand';
+    const background = config.background ?? 'none';
+    const align = config.align ?? 'center';
+    const paint = resolveCtaPaint(theme, brand?.colors, config.customColor);
+    // A themed background carries the paint and the button inverts it; any
+    // other background leaves the paint to the button itself.
+    const onBanner =
+        background === 'theme' ? paint : { kind: 'neutral' as const };
+    const onButton =
+        background !== 'theme' ? paint : { kind: 'neutral' as const };
+    const fill = background === 'theme' ? 'banner' : 'button';
+    const styleVars = {
+        ...paintStyle(onBanner, 'cta'),
+        ...paintStyle(onButton, 'cta-btn'),
+    } as CSSProperties;
+    const hasTitle = (config.title ?? '').trim() !== '';
+    const body = (
+        <>
+            {hasTitle ? (
+                <div className={classes.ctaBody}>
+                    <div className={classes.ctaTitle}>{config.title}</div>
+                    {config.description ? (
+                        <div className={classes.ctaDesc}>
+                            {config.description}
+                        </div>
+                    ) : null}
+                </div>
+            ) : null}
+            <span className={classes.ctaButton} data-fill={fill}>
+                {config.buttonLabel}
+            </span>
+        </>
+    );
+    const shared = {
+        className: interactive
+            ? `${classes.ctaBanner} ${classes.plainLink} ${classes.clickable}`
+            : classes.ctaBanner,
+        'data-theme': theme,
+        'data-bg': background,
+        'data-align': align,
+        'data-buttononly': !hasTitle,
+        style: styleVars,
+    };
+    if (!interactive) {
+        return <div {...shared}>{body}</div>;
+    }
+    const url = targetUrl(config.target, projectUuid);
+    return config.target.type === 'link' ? (
+        <a
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={onNavigate}
+            {...shared}
+        >
+            {body}
+        </a>
+    ) : (
+        <Link to={url} onClick={onNavigate} {...shared}>
+            {body}
+        </Link>
+    );
+};
+
+export const CtaBlockView: FC<BlockComponentProps> = ({
+    block,
+    projectUuid,
+}) => {
+    const { canAskAi } = useHomepageAiState(projectUuid);
+    const { track } = useTracking();
+    const config = block.type === 'cta' ? block.config : null;
+    // An ask-ai CTA is a dead button for viewers without AI — the page is
+    // told at runtime so the row collapses instead of leaving a gap.
+    const hidden = config?.target.type === 'ask-ai' && !canAskAi;
+    useReportRuntimeEmpty(block.id, hidden === true, false);
+    if (!config || hidden) return null;
+    return (
+        <CtaBanner
+            config={config}
+            projectUuid={projectUuid}
+            interactive
+            onNavigate={() =>
+                track({
+                    name: EventName.HOMEPAGE_QUICK_ACTION_CLICKED,
+                    properties: { actionType: `cta-${config.target.type}` },
+                })
+            }
+        />
+    );
+};
+
+const THEME_OPTIONS: {
+    value: Exclude<HomepageCtaTheme, 'custom'>;
+    label: string;
+}[] = [
+    { value: 'brand', label: 'Brand' },
+    { value: 'accent', label: 'Accent' },
+    { value: 'dark', label: 'Dark' },
+    { value: 'neutral', label: 'Neutral' },
+];
+
+const ThemeSwatches: FC<{
+    value: HomepageCtaTheme;
+    customColor: string | undefined;
+    paletteSwatches: string[];
+    onChange: (theme: HomepageCtaTheme, customColor?: string) => void;
+}> = ({ value, customColor, paletteSwatches, onChange }) => {
+    const { data: brand } = useOrganizationBrand();
+    return (
+        <Group gap={6} wrap="nowrap">
+            {THEME_OPTIONS.map((option) => {
+                const paint = resolveCtaPaint(
+                    option.value,
+                    brand?.colors,
+                    undefined,
+                );
+                const style = paintStyle(paint, 'cta');
+                return (
+                    <Tooltip
+                        key={option.value}
+                        label={option.label}
+                        openDelay={200}
+                    >
+                        <button
+                            type="button"
+                            aria-label={`${option.label} theme`}
+                            className={classes.ctaSwatch}
+                            data-selected={value === option.value}
+                            data-neutral={paint.kind === 'neutral'}
+                            style={style}
+                            onClick={() => onChange(option.value)}
+                        />
+                    </Tooltip>
+                );
+            })}
+            <ColorInput
+                size="xs"
+                w={130}
+                placeholder="Custom"
+                value={value === 'custom' ? (customColor ?? '') : ''}
+                swatches={paletteSwatches}
+                swatchesPerRow={paletteSwatches.length > 0 ? 10 : undefined}
+                onChangeEnd={(hex) => onChange('custom', hex)}
+            />
+        </Group>
+    );
+};
+
+type TargetChoice =
+    | 'run-query'
+    | 'ask-ai'
+    | 'browse-dashboards'
+    | 'browse-spaces'
+    | 'link';
+
+const TARGET_OPTIONS: { value: TargetChoice; label: string }[] = [
+    { value: 'run-query', label: 'Run a query' },
+    { value: 'ask-ai', label: 'Ask AI' },
+    { value: 'browse-dashboards', label: 'Browse dashboards' },
+    { value: 'browse-spaces', label: 'Browse spaces' },
+    { value: 'link', label: 'Custom link' },
+];
+
+export const CtaBlockBuild: FC<BuildComponentProps> = ({
+    block,
+    projectUuid,
+    onChange,
+}) => {
+    // Custom-color swatches come from the project's resolved chart palette,
+    // which already falls back to the org's active palette.
+    const { data: palette } = useProjectColorPalette(projectUuid);
+    if (block.type !== 'cta') return null;
+    const config = block.config;
+    const patch = (partial: Partial<CtaConfig>) =>
+        onChange({ ...block, config: { ...config, ...partial } });
+    // A stored dashboard target (config-as-code) keeps rendering; the picker
+    // covers the built-in destinations plus a free URL.
+    const targetChoice: TargetChoice =
+        config.target.type === 'dashboard' ? 'link' : config.target.type;
+    return (
+        <Stack gap="sm">
+            <CtaBanner
+                config={config}
+                projectUuid={projectUuid}
+                interactive={false}
+            />
+            <Group gap="xs" align="flex-end" wrap="nowrap">
+                <TextInput
+                    size="xs"
+                    label="Title"
+                    placeholder="Optional — leave empty for a button-only banner"
+                    fw={600}
+                    flex={1}
+                    value={config.title ?? ''}
+                    onChange={(e) =>
+                        patch({ title: e.currentTarget.value || undefined })
+                    }
+                />
+            </Group>
+            <TextInput
+                size="xs"
+                label="Supporting line"
+                placeholder="Optional"
+                value={config.description ?? ''}
+                onChange={(e) =>
+                    patch({ description: e.currentTarget.value || undefined })
+                }
+            />
+            <Group gap="xs" align="flex-end" wrap="nowrap">
+                <TextInput
+                    size="xs"
+                    label="Button label"
+                    w={180}
+                    value={config.buttonLabel}
+                    onChange={(e) =>
+                        patch({ buttonLabel: e.currentTarget.value })
+                    }
+                />
+                <Select
+                    size="xs"
+                    label="Button leads to"
+                    flex={1}
+                    data={TARGET_OPTIONS}
+                    value={targetChoice}
+                    allowDeselect={false}
+                    onChange={(next) => {
+                        if (!next) return;
+                        patch({
+                            target:
+                                next === 'link'
+                                    ? { type: 'link', url: '' }
+                                    : {
+                                          type: next as Exclude<
+                                              TargetChoice,
+                                              'link'
+                                          >,
+                                      },
+                        });
+                    }}
+                />
+            </Group>
+            {config.target.type === 'link' && (
+                <TextInput
+                    size="xs"
+                    label="URL"
+                    placeholder="https://…"
+                    value={config.target.url}
+                    onChange={(e) =>
+                        patch({
+                            target: {
+                                type: 'link',
+                                url: e.currentTarget.value,
+                            },
+                        })
+                    }
+                />
+            )}
+            <Group gap="lg" align="flex-end">
+                <Stack gap={4}>
+                    <Text size="xs" fw={500}>
+                        Theme
+                    </Text>
+                    <ThemeSwatches
+                        value={config.theme ?? 'brand'}
+                        customColor={config.customColor}
+                        paletteSwatches={palette?.colors ?? []}
+                        onChange={(theme, customColor) =>
+                            patch(
+                                theme === 'custom'
+                                    ? { theme, customColor }
+                                    : { theme },
+                            )
+                        }
+                    />
+                </Stack>
+                <Stack gap={4}>
+                    <Text size="xs" fw={500}>
+                        Background
+                    </Text>
+                    <SegmentedControl
+                        size="xs"
+                        value={config.background ?? 'none'}
+                        onChange={(next) =>
+                            patch({
+                                background: next as HomepageCtaBackground,
+                            })
+                        }
+                        data={[
+                            { value: 'none', label: 'None' },
+                            { value: 'card', label: 'Card' },
+                            { value: 'theme', label: 'Themed' },
+                        ]}
+                    />
+                </Stack>
+                {(config.title ?? '').trim() === '' && (
+                    <Stack gap={4}>
+                        <Text size="xs" fw={500}>
+                            Align
+                        </Text>
+                        <SegmentedControl
+                            size="xs"
+                            value={config.align ?? 'center'}
+                            onChange={(next) =>
+                                patch({ align: next as HomepageCtaAlign })
+                            }
+                            data={[
+                                { value: 'left', label: 'Left' },
+                                { value: 'center', label: 'Middle' },
+                                { value: 'right', label: 'Right' },
+                            ]}
+                        />
+                    </Stack>
+                )}
+            </Group>
+            <Text size="xs" c="dimmed">
+                Brand, Accent, and the gradients use your organization's brand
+                colors from Settings → Appearance.
+            </Text>
+        </Stack>
+    );
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -108,6 +108,177 @@ a .hoverCard:hover,
     overflow: hidden;
 }
 
+/* ---- CTA banner ----
+ * The page's one loud moment. Paint arrives as CSS vars resolved from the
+ * org's brand (see CtaBlock): solid hex or avatar-mesh gradient layers, on
+ * the banner or just the button. The [data-theme] attribute doubles as a
+ * specificity bump over the generic link/row helpers later in this file. */
+.ctaBanner[data-theme] {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: 24px;
+    padding: 24px 28px;
+    border-radius: 14px;
+    position: relative;
+    overflow: hidden;
+    background-color: var(--cta-bg, transparent);
+    color: var(--cta-fg, inherit);
+    box-shadow: var(--mantine-shadow-subtle);
+    transition: all 0.18s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* Sheen sits top-right, where the button lives. */
+.ctaBanner[data-theme]::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: radial-gradient(
+        120% 200% at 100% 0%,
+        rgb(255 255 255 / 12%),
+        transparent 55%
+    );
+}
+
+.ctaBanner[data-bg='card'] {
+    background-color: light-dark(#fff, var(--mantine-color-dark-6));
+    background-image: none;
+    color: light-dark(var(--mantine-color-ldGray-9), #fff);
+    border: 1px solid var(--mantine-color-ldGray-2);
+}
+
+.ctaBanner[data-bg='card']::after {
+    background: radial-gradient(
+        120% 200% at 100% 0%,
+        light-dark(rgb(0 0 0 / 3%), rgb(255 255 255 / 5%)),
+        transparent 55%
+    );
+}
+
+/* No background at all: the button (and any text) sits directly on the page.
+ * The container keeps only its row layout. */
+.ctaBanner[data-bg='none'] {
+    background: none;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+    overflow: visible;
+    padding: 4px 0;
+    color: light-dark(var(--mantine-color-ldGray-9), #fff);
+}
+
+.ctaBanner[data-bg='none']::after {
+    content: none;
+}
+
+/* A button-only CTA is a slimmer band; the admin picks where the button sits. */
+.ctaBanner[data-buttononly='true'] {
+    padding-top: 14px;
+    padding-bottom: 14px;
+}
+
+.ctaBanner[data-buttononly='true'][data-bg='none'] {
+    padding: 4px 0;
+}
+
+.ctaBanner[data-buttononly='true'][data-align='left'] {
+    justify-content: flex-start;
+}
+
+.ctaBanner[data-buttononly='true'][data-align='center'] {
+    justify-content: center;
+}
+
+.ctaBanner[data-buttononly='true'][data-align='right'] {
+    justify-content: flex-end;
+}
+
+.ctaBanner[data-theme].clickable:hover {
+    box-shadow: var(--mantine-shadow-heavy);
+    transform: translateY(-1px);
+    text-decoration: none;
+}
+
+.ctaBanner[data-bg='none'].clickable:hover {
+    box-shadow: none;
+    transform: none;
+}
+
+.ctaBody {
+    min-width: 0;
+    position: relative;
+}
+
+.ctaTitle {
+    font-size: 19px;
+    font-weight: 700;
+    letter-spacing: -0.2px;
+    line-height: 1.25;
+}
+
+.ctaDesc {
+    margin-top: 3px;
+    font-size: 13.5px;
+    opacity: 0.82;
+}
+
+/* The button is a styled span — the whole banner is the link. On a painted
+ * banner it inverts the banner's colors; with fill=button it carries the
+ * paint itself on a neutral banner. */
+.ctaButton {
+    position: relative;
+    flex-shrink: 0;
+    padding: 10px 20px;
+    border-radius: 10px;
+    font-size: 14px;
+    font-weight: 600;
+    background-color: var(
+        --cta-fg,
+        light-dark(var(--mantine-color-ldGray-9), #fff)
+    );
+    color: var(--cta-bg, light-dark(#fff, var(--mantine-color-ldGray-9)));
+    box-shadow: 0 1px 2px rgb(0 0 0 / 12%);
+    transition: transform 0.18s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.ctaButton[data-fill='button'] {
+    background-color: var(
+        --cta-btn-bg,
+        light-dark(var(--mantine-color-ldGray-9), #fff)
+    );
+    background-image: var(--cta-btn-bg-image, none);
+    background-blend-mode: var(--cta-btn-bg-blend, normal);
+    background-size: var(--cta-btn-bg-size, auto);
+    color: var(--cta-btn-fg, light-dark(#fff, var(--mantine-color-ldGray-9)));
+}
+
+.ctaBanner[data-theme].clickable:hover .ctaButton {
+    transform: scale(1.03);
+}
+
+/* Theme picker swatches in the build panel — same paint vars as the banner. */
+.ctaSwatch {
+    width: 26px;
+    height: 26px;
+    border-radius: 8px;
+    border: 1px solid var(--mantine-color-ldGray-3);
+    background-color: var(--cta-bg, transparent);
+    cursor: pointer;
+    padding: 0;
+    transition: all 0.12s ease-in-out;
+}
+
+.ctaSwatch[data-neutral='true'] {
+    background-color: light-dark(#fff, var(--mantine-color-dark-6));
+}
+
+.ctaSwatch[data-selected='true'] {
+    outline: 2px solid var(--mantine-color-blue-5);
+    outline-offset: 1px;
+}
+
 /* Compact mode's geometry resolves itself: as many tile columns as the
  * block's width affords, collapsing to a single column of rows when narrow.
  * The admin picks the density; the grid picks the arrangement. */

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/registry.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/registry.tsx
@@ -7,6 +7,7 @@ import {
     IconLayoutGrid,
     IconMarkdown,
     IconMessageChatbot,
+    IconRocket,
     IconSpeakerphone,
     IconStar,
     type Icon,
@@ -20,6 +21,7 @@ import {
 } from './AnnouncementsBlock';
 import { AskAiHeroBlockBuild, AskAiHeroBlockView } from './AskAiHeroBlock';
 import { CollectionBlockBuild, CollectionBlockView } from './CollectionBlock';
+import { CtaBlockBuild, CtaBlockView } from './CtaBlock';
 import { FavoritesBlockBuild, FavoritesBlockView } from './FavoritesBlock';
 import { GreetingBlockBuild, GreetingBlockView } from './GreetingBlock';
 import { MarkdownBlockBuild, MarkdownBlockView } from './MarkdownBlock';
@@ -91,6 +93,23 @@ export const blockLibrary: BlockDefinition[] = [
         }),
         View: QuickActionsBlockView,
         Build: QuickActionsBlockBuild,
+    },
+    {
+        type: 'cta',
+        label: 'Call to action',
+        description: 'One brand-themed banner with a single button.',
+        icon: IconRocket,
+        singleton: true,
+        create: () => ({
+            id: uuidv4(),
+            type: 'cta',
+            config: {
+                buttonLabel: 'Run a query',
+                target: { type: 'run-query' },
+            },
+        }),
+        View: CtaBlockView,
+        Build: CtaBlockBuild,
     },
     {
         type: 'metrics',

--- a/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.test.ts
@@ -59,6 +59,16 @@ const makeBlock = (
         case 'favorites':
         case 'recent':
             return { id, type, config: { title: 't' } };
+        case 'cta':
+            return {
+                id,
+                type,
+                config: {
+                    title: empty ? ' ' : 'Explore',
+                    buttonLabel: empty ? '' : 'Go',
+                    target: { type: 'run-query' },
+                },
+            };
         case 'greeting':
             return { id, type, config: { subtitle: 's' } };
         default:

--- a/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
@@ -165,6 +165,8 @@ const isConfigEmptyBlock = (block: HomepageBlock): boolean => {
             return (block.config.items?.length ?? 0) === 0;
         case 'quick-actions':
             return (block.config.actions?.length ?? 0) === 0;
+        case 'cta':
+            return (block.config.buttonLabel ?? '').trim() === '';
         case 'markdown':
             return (block.config.content ?? '').trim() === '';
         // Visibility depends on runtime data (viewer, AI availability, the
@@ -226,6 +228,7 @@ const hugUnitsFor = (block: HomepageBlock): ResolvedColumn['hugUnits'] => {
         case 'recent':
         case 'markdown':
         case 'quick-actions':
+        case 'cta':
         case 'ask-ai-hero':
         case 'greeting':
             return null;


### PR DESCRIPTION
Part of the Homepage v2 program.

## What

A new `cta` block — the homepage's one loud moment, and its first brand-aware surface. Where quick actions are quiet chrome ("where can I go?"), the CTA is a single element answering "what does the data team want you to do right now?" — the v2 answer to v1's landing-panel "Run a query" button.

**Config** (`{ title?, description?, buttonLabel, target, theme?, customColor?, background?, align? }`):
- **Bare button by default** — a new CTA is just a chromeless button (no box, no border) with **left / middle / right** alignment. Adding a title (and optional supporting line) switches to text-left / button-right.
- **`background`** picks the container: `none` (chromeless, default), `card` (neutral card chrome), or `theme` (the surface carries the paint and the button inverts it). With `none`/`card`, the paint goes to the button itself.
- **`theme`** is a semantic token: `brand` / `accent` resolve from `OrganizationBrand` colors at render (a rebrand restyles every CTA), plus `dark`, `neutral`, and `custom` — a color picker whose swatches come from the project's resolved chart palette (which already falls back to the org's active palette). Readable text via the existing `getContrastTextColor`.
- **`target`** reuses the quick-action vocabulary (ask-ai / run-query / browse dashboards / browse spaces / specific dashboard) plus a custom URL. The whole element is the link.

**Builder panel**: live preview, optional title/supporting inputs, button label + destination select (+ URL field for custom links), theme swatches with the real resolved colors, a `ColorInput` with palette swatches, Background (None/Card/Themed) control, and alignment control for bare buttons.

**Wiring**: zod schema + round-trip tests, layout traits (full-width, own row, section rhythm), config-empty rule (no button label = nothing to render), runtime-empty when the target is ask-ai and the viewer has no AI, singleton in the block library, click analytics via the existing quick-action event (`actionType: 'cta-<target>'`).

## Regression analysis

Purely additive: a new block type in the union — no existing block, schema field, or renderer changes. Old clients receiving a `cta` block drop it via the read-path sanitizer, and the empty-row hardening from #26732 keeps that safe.

## Testing

Common (3293) + homepageBuilder (242) suites green; typecheck + oxlint clean. Verified live in the builder: bare default (centred), aligned bare variants with custom colors, title+description on transparent/card/themed backgrounds, external-link target. Brand-color resolution falls back to the dark surface locally (dev has no `OrganizationBrand` row) — worth one look on an env with a real brand configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1fe2jShYJrNxZRXw5E6jx
