### PR TITLE
feat: add org/project IDs to webapp onboarding events

### DIFF
--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectSuccess.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectSuccess.tsx
@@ -3,6 +3,7 @@ import { IconCheck } from '@tabler/icons-react';
 import confetti from 'canvas-confetti';
 import { type FC } from 'react';
 import { Link } from 'react-router';
+import { useOrganization } from '../../../hooks/organization/useOrganization';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import MantineIcon from '../../common/MantineIcon';
@@ -17,6 +18,7 @@ interface ConnectSuccessProps {
 
 const ConnectSuccess: FC<ConnectSuccessProps> = ({ projectUuid }) => {
     const { track } = useTracking();
+    const { data: organization } = useOrganization();
 
     return (
         <OnboardingWrapper>
@@ -69,6 +71,8 @@ const ConnectSuccess: FC<ConnectSuccessProps> = ({ projectUuid }) => {
                             track({
                                 name: EventName.ONBOARDING_PROJECT_READY_START_EXPLORING_CLICKED,
                                 properties: {
+                                    organizationId:
+                                        organization?.organizationUuid ?? null,
                                     projectId: projectUuid,
                                     onboardingFlow: 'legacy',
                                 },

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SelectWarehouse.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SelectWarehouse.tsx
@@ -82,7 +82,7 @@ const SelectWarehouse: FC<SelectWarehouseProps> = ({
                                                   properties: {
                                                       organizationId:
                                                           organization?.organizationUuid ??
-                                                          '',
+                                                          null,
                                                       warehouse: item.key,
                                                       tier:
                                                           item.key ===

--- a/packages/frontend/src/pages/OnboardingDataSource.tsx
+++ b/packages/frontend/src/pages/OnboardingDataSource.tsx
@@ -132,7 +132,7 @@ const DataSourcePicker: FC = () => {
         track({
             name: EventName.ONBOARDING_WAREHOUSE_SELECTED,
             properties: {
-                organizationId: organization?.organizationUuid ?? '',
+                organizationId: organization?.organizationUuid ?? null,
                 warehouse: String(key),
                 tier,
                 onboardingFlow: 'new',

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -733,7 +733,7 @@ type OrganizationBrandDetectedEvent = {
 type OnboardingWarehouseSelectedEvent = {
     name: EventName.ONBOARDING_WAREHOUSE_SELECTED;
     properties: {
-        organizationId: string;
+        organizationId: string | null;
         warehouse: string;
         tier: 'popular' | 'all' | 'other';
         onboardingFlow: 'legacy' | 'new';
@@ -765,6 +765,7 @@ type SnowflakeCliSsoConnectCompletedEvent = {
 type OnboardingProjectReadyStartExploringClickedEvent = {
     name: EventName.ONBOARDING_PROJECT_READY_START_EXPLORING_CLICKED;
     properties: {
+        organizationId: string | null;
         projectId: string;
         onboardingFlow: 'legacy' | 'new';
     };


### PR DESCRIPTION
## What changed

Attribution properties on the webapp onboarding events:

- `onboarding_warehouse.selected` (both the legacy and new onboarding emit sites): `organizationId` now falls back to explicit `null` instead of `''` when the org hasn't loaded, so empty strings can't pollute attribution queries.
- `onboarding_project_ready.start_exploring_clicked`: now also carries `organizationId` alongside the existing `projectId`.
- Tracking types widened to `string | null` to match.

## Pre-account stitch — verified working, no code change needed

`signup_form.submitted` fires before the user has an account, so it cannot carry org/project IDs by construction. Runtime verification (local dev instance, events captured to a local RudderStack sink) shows the anonymous half of the funnel already stitches to the server half:

- The RudderStack browser SDK keeps a stable `anonymousId` across the whole flow (persisted client-side).
- `identify(userUuid)` fires at account creation (`Register.tsx`, also `LoginLanding.tsx` / `Invite.tsx`), aliasing that same `anonymousId` to the `userId`.
- Server-side `onboarding.step_completed` events carry `userId` and `organizationId`.

Join path: webapp event `anonymous_id` → identify alias (`anonymous_id` ↔ `user_id`) → server event `user_id` → `organizationId`.

Captured payloads from one end-to-end local signup (IDs are from a synthetic local org):

| Event | anonymousId | userId | properties |
| --- | --- | --- | --- |
| `lightdash_webapp.signup_form.submitted` | `ec2ee9d6-…` | `""` | `variant: password`, `onboardingFlow: legacy` |
| `identify` (account creation) | `ec2ee9d6-…` | `e7ef51c8-…` | — |
| `lightdash_webapp.onboarding_warehouse.selected` | `ec2ee9d6-…` | — | `organizationId: 75ca7a3a-…`, `warehouse: postgres`, `tier: all`, `onboardingFlow: legacy` |
| `lightdash_webapp.onboarding_project_ready.start_exploring_clicked` | `ec2ee9d6-…` | — | `organizationId: 75ca7a3a-…`, `projectId: 2e68ccaa-…`, `onboardingFlow: legacy` |
| `lightdash_server.onboarding.step_completed` (step `org_created`) | — | `e7ef51c8-…` | `organizationId: 75ca7a3a-…` |

One caveat found while verifying: the browser SDK (`rudder-sdk-js` 2.9.1) strips null-valued properties before sending, so explicit nulls are a type-level contract only — on the wire and in the warehouse an unset property reads as null either way. The server-side Node SDK does preserve explicit nulls.

Linear: SPK-826
