### PR TITLE
fix: gracefully finish max-step agent runs

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
@@ -11,6 +11,7 @@ import {
     getAgentTools,
     getDeepResearchBudgetInstruction,
     getPromptMcpServers,
+    getStepBudgetOverride,
     normalizeToolOutput,
     recordAgentStepUsage,
     storeInvalidAgentToolCall,
@@ -211,6 +212,71 @@ describe('buildForcedFirstStep', () => {
             },
         });
         expect(prepareStep?.({ stepNumber: 1 })).toEqual({});
+    });
+});
+
+describe('getStepBudgetOverride', () => {
+    it('steers standard agents through the final five steps', () => {
+        const execution = { mode: 'standard', maxSteps: 10 } as const;
+
+        expect(getStepBudgetOverride(execution, 4)).toBeUndefined();
+        expect(getStepBudgetOverride(execution, 5)).toMatchObject({
+            message: expect.stringContaining('finish with the best answer'),
+        });
+        expect(getStepBudgetOverride(execution, 8)).not.toHaveProperty(
+            'activeTools',
+        );
+    });
+
+    it('reserves the final standard-agent step for a response', () => {
+        expect(
+            getStepBudgetOverride({ mode: 'standard', maxSteps: 10 }, 9),
+        ).toEqual({
+            message: expect.stringContaining('Respond to the user now'),
+            activeTools: [],
+            toolChoice: 'none',
+        });
+    });
+
+    it('steers every step when the standard-agent budget is five', () => {
+        expect(
+            getStepBudgetOverride({ mode: 'standard', maxSteps: 5 }, 0),
+        ).toMatchObject({
+            message: expect.stringContaining('finish with the best answer'),
+        });
+        expect(
+            getStepBudgetOverride({ mode: 'standard', maxSteps: 5 }, 4),
+        ).toMatchObject({
+            activeTools: [],
+            toolChoice: 'none',
+        });
+    });
+
+    it('does not alter deep-research steps', () => {
+        expect(
+            getStepBudgetOverride(
+                {
+                    mode: 'deep_research',
+                    runUuid: 'run-1',
+                    phase: 'investigating',
+                    maxSteps: 10,
+                    budget: {
+                        maxTokens: 10_000,
+                        maxToolCalls: 20,
+                        maxWarehouseQueries: 10,
+                        maxResultRows: 1_000,
+                        maxHypotheses: 2,
+                    },
+                    initialTokenUsage: 0,
+                    research: {
+                        role: 'planner',
+                        maxHypotheses: 2,
+                        onHypotheses: vi.fn(),
+                    },
+                },
+                9,
+            ),
+        ).toBeUndefined();
     });
 });
 

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -136,6 +136,14 @@ export const recordAgentStepUsage = async ({
 
 export const DEFAULT_AGENT_MAX_STEPS = 40;
 
+export const AGENT_WRAP_UP_STEPS = 5;
+
+export const AGENT_WRAP_UP_INSTRUCTION =
+    'You are running out of steps. Stop expanding the scope. Use tools only if essential, then finish with the best answer you can. If you cannot fully complete the request, explain what you found and what prevented completion.';
+
+export const AGENT_FINAL_STEP_INSTRUCTION =
+    'This is your final step. Do not call any tools. Respond to the user now with the best answer you can, including any limitations or reasons the request could not be fully completed.';
+
 const PERSIST_TIMEOUT_MS = 10_000;
 
 /**
@@ -478,6 +486,28 @@ export const buildForcedFirstStep = (args: AiAgentArgs, tools: ToolSet) => {
             : {};
 };
 
+export const getStepBudgetOverride = (
+    execution: AiAgentArgs['execution'],
+    stepNumber: number,
+) => {
+    if (
+        execution.mode !== 'standard' ||
+        stepNumber < Math.max(0, execution.maxSteps - AGENT_WRAP_UP_STEPS)
+    ) {
+        return undefined;
+    }
+
+    if (stepNumber >= execution.maxSteps - 1) {
+        return {
+            message: AGENT_FINAL_STEP_INSTRUCTION,
+            activeTools: [] as string[],
+            toolChoice: 'none' as const,
+        };
+    }
+
+    return { message: AGENT_WRAP_UP_INSTRUCTION };
+};
+
 const buildPrepareStep = ({
     args,
     dependencies,
@@ -506,6 +536,10 @@ const buildPrepareStep = ({
         messages: ModelMessage[];
     }) => {
         const forced = forcedFirstStep?.({ stepNumber }) ?? {};
+        const stepBudgetOverride = getStepBudgetOverride(
+            args.execution,
+            stepNumber,
+        );
 
         const extraMessages: ModelMessage[] = [];
         let activeTools = getMcpActiveTools(
@@ -574,13 +608,31 @@ const buildPrepareStep = ({
             });
         }
 
-        if (extraMessages.length === 0 && activeTools === undefined) {
+        if (stepBudgetOverride) {
+            extraMessages.push({
+                role: 'user',
+                content: stepBudgetOverride.message,
+            });
+        }
+
+        if (
+            extraMessages.length === 0 &&
+            activeTools === undefined &&
+            stepBudgetOverride === undefined
+        ) {
             return forced;
         }
 
+        const stepActiveTools = stepBudgetOverride?.activeTools ?? activeTools;
+
         return {
             ...forced,
-            ...(activeTools !== undefined ? { activeTools } : {}),
+            ...(stepActiveTools !== undefined
+                ? { activeTools: stepActiveTools }
+                : {}),
+            ...(stepBudgetOverride?.toolChoice !== undefined
+                ? { toolChoice: stepBudgetOverride.toolChoice }
+                : {}),
             messages: [...messages, ...extraMessages],
         };
     };

--- a/packages/backend/src/ee/services/ai/utils/errorMessages.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/errorMessages.test.ts
@@ -1,9 +1,11 @@
 import { McpAuthorizationRequiredError } from '../AiAgentMcpRuntimeClient';
 import {
     AiAgentEmptyResponseError,
+    AiAgentStepCapReachedError,
     EMPTY_RESPONSE_MESSAGE,
     getUserFacingErrorMessage,
     PROVIDER_BILLING_MESSAGE,
+    STEP_CAP_REACHED_MESSAGE,
 } from './errorMessages';
 
 const CONTEXT_LIMIT_MESSAGE =
@@ -16,6 +18,14 @@ const TIMEOUT_MESSAGE =
     'This request took too long to process. Try breaking it into smaller questions or start a new thread.';
 
 describe('getUserFacingErrorMessage', () => {
+    it('describes the step cap as a work limit with next actions', () => {
+        expect(
+            getUserFacingErrorMessage(new AiAgentStepCapReachedError(40)),
+        ).toBe(STEP_CAP_REACHED_MESSAGE);
+        expect(STEP_CAP_REACHED_MESSAGE).toContain('work limit');
+        expect(STEP_CAP_REACHED_MESSAGE).toContain('split your request');
+    });
+
     describe('empty response invariant', () => {
         it('maps AiAgentEmptyResponseError to the user-facing empty-response message', () => {
             const error = new AiAgentEmptyResponseError('stop', 3);

--- a/packages/backend/src/ee/services/ai/utils/errorMessages.ts
+++ b/packages/backend/src/ee/services/ai/utils/errorMessages.ts
@@ -2,7 +2,7 @@ import type { AiKeyManagement } from '../../../../analytics/aiUsage';
 import { McpAuthorizationRequiredError } from '../AiAgentMcpRuntimeClient';
 
 export const STEP_CAP_REACHED_MESSAGE =
-    'The agent reached its maximum number of steps before finishing. Please try asking for fewer things at once, or split your question into smaller parts.';
+    'The agent reached its work limit before it could write a response. Try asking for fewer things at once, or split your request into smaller parts.';
 
 export class AiAgentStepCapReachedError extends Error {
     readonly stepsCount: number;


### PR DESCRIPTION
## Summary

- Steer standard agents to finish during their final five allowed steps.
- Disable tools on the final step so the agent must respond.
- Improve fallback guidance when a response is still empty.
- Keep deep-research execution unchanged.

## Validation

- 49 focused backend tests
- Backend TypeScript check
- Oxlint, Oxfmt, and git diff check
- Browser: Claude Sonnet 5 and GPT-5.4 with 10 allowed steps; each used 6 steps and returned a useful partial response without an error

Closes: https://linear.app/lightdash/issue/ZAP-740/as-a-user-i-want-a-clearer-max-steps-reached-error-message