### PR TITLE
fix(cli): refer to data apps by slug in user-facing strings

### DIFF
--- a/packages/cli/src/handlers/apps/appsDownload.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.ts
@@ -182,12 +182,14 @@ export const computeLinkedAppSlugs = (args: {
  * Pre-context servers return a download payload without `context`.
  */
 export const ensureDownloadedAppContext = (
-    appUuid: string,
+    appRef: string,
     code: DataAppCodeDownload,
 ): DataAppCodeDownload => {
     if (code.context === undefined) {
         throw new Error(
-            `This Lightdash server does not support app context downloads (app ${appUuid}). Upgrade the server, or use a CLI version matching your server.`,
+            `This Lightdash server does not support app context downloads (app ${
+                code.manifest.slug ?? appRef
+            }). Upgrade the server, or use a CLI version matching your server.`,
         );
     }
     return code;

--- a/packages/cli/src/handlers/apps/preview.ts
+++ b/packages/cli/src/handlers/apps/preview.ts
@@ -82,7 +82,9 @@ export const assertScaffoldingSupportsPreviewProxy = async (
         .catch(() => '');
     if (!viteConfig.includes('LIGHTDASH_PREVIEW_PROXY_TARGET')) {
         throw new Error(
-            `This app's scaffolding predates the secure preview proxy. Re-download the app ('lightdash download --apps <appUuid>') to refresh vite.config.js, then run preview again.`,
+            `This app's scaffolding predates the secure preview proxy. Re-download the app ('lightdash download --apps ${path.basename(
+                appDir,
+            )}') to refresh vite.config.js, then run preview again.`,
         );
     }
 };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -927,7 +927,7 @@ const downloadCommand = program
     )
     .option(
         '--apps <appReferences...>',
-        'Download only the specified data apps, by UUID, slug, or app URL (enterprise). Works for apps not added to a space.',
+        'Download only the specified data apps, by slug, app URL, or UUID (enterprise). Works for apps not added to a space.',
     )
     .option(
         '--include-apps',
@@ -1054,7 +1054,7 @@ const uploadCommand = program
     .option('--gzip', 'Enable gzip compression for request bodies', false)
     .option(
         '--apps <appReferences...>',
-        'Upload only the specified data apps, by UUID, slug, or app URL (enterprise).',
+        'Upload only the specified data apps, by slug — the app folder name (enterprise).',
     )
     .option(
         '--include-apps',


### PR DESCRIPTION
Closes #26724

Slug-first user-facing strings across the apps CLI surface: the download/upload `--apps` help text, the preview re-download hint (now interpolates the app folder name so the command is copy-pasteable), and the app-context server-support error (prefers the manifest slug over the raw ref). No behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
