### PR TITLE
fix(cli): explain the pnpm lockfile requirement in custom-dependency errors

### DIFF
--- a/packages/cli/src/handlers/apps/appCodeFiles.test.ts
+++ b/packages/cli/src/handlers/apps/appCodeFiles.test.ts
@@ -459,6 +459,7 @@ describe('readDependenciesFromDir', () => {
         expect(result).not.toBeNull();
         expect(result?.packageJson).toBe(makePackageJson());
         expect(result?.lockfile).toBe(LOCKFILE_CONTENT);
+        expect(result?.hasNpmLockfile).toBe(false);
     });
 
     // The download scaffold always writes package.json but never a lockfile,
@@ -477,6 +478,14 @@ describe('readDependenciesFromDir', () => {
         await expect(readDependenciesFromDir(dir)).rejects.toThrow(
             /package\.json/,
         );
+    });
+
+    it('flags a stray package-lock.json when the pnpm lockfile is absent', async () => {
+        await fs.writeFile(path.join(dir, 'package.json'), makePackageJson());
+        await fs.writeFile(path.join(dir, 'package-lock.json'), '{}');
+        const result = await readDependenciesFromDir(dir);
+        expect(result?.lockfile).toBeNull();
+        expect(result?.hasNpmLockfile).toBe(true);
     });
 });
 

--- a/packages/cli/src/handlers/apps/appCodeFiles.ts
+++ b/packages/cli/src/handlers/apps/appCodeFiles.ts
@@ -217,6 +217,10 @@ export type LocalAppDependencies = {
     // freshly downloaded folder; it only becomes an error if the declared
     // set differs from the template baseline (the caller decides).
     lockfile: string | null;
+    // A stray package-lock.json — custom deps require pnpm's lockfile, so
+    // the caller can give a targeted hint when this is set and lockfile
+    // is null.
+    hasNpmLockfile: boolean;
 };
 
 /**
@@ -230,17 +234,23 @@ export const readDependenciesFromDir = async (
 ): Promise<LocalAppDependencies | null> => {
     const pkgJsonPath = path.join(dir, 'package.json');
     const lockfilePath = path.join(dir, 'pnpm-lock.yaml');
+    const npmLockfilePath = path.join(dir, 'package-lock.json');
 
-    const [pkgJsonExists, lockfileExists] = await Promise.all([
-        fs
-            .stat(pkgJsonPath)
-            .then(() => true)
-            .catch(() => false),
-        fs
-            .stat(lockfilePath)
-            .then(() => true)
-            .catch(() => false),
-    ]);
+    const [pkgJsonExists, lockfileExists, npmLockfileExists] =
+        await Promise.all([
+            fs
+                .stat(pkgJsonPath)
+                .then(() => true)
+                .catch(() => false),
+            fs
+                .stat(lockfilePath)
+                .then(() => true)
+                .catch(() => false),
+            fs
+                .stat(npmLockfilePath)
+                .then(() => true)
+                .catch(() => false),
+        ]);
 
     if (!pkgJsonExists && !lockfileExists) return null;
 
@@ -255,7 +265,7 @@ export const readDependenciesFromDir = async (
         lockfileExists ? fs.readFile(lockfilePath, 'utf-8') : null,
     ]);
 
-    return { packageJson, lockfile };
+    return { packageJson, lockfile, hasNpmLockfile: npmLockfileExists };
 };
 
 /**

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -3476,7 +3476,9 @@ export const uploadHandler = async (
                             if (rawDeps.lockfile === null) {
                                 GlobalState.log(
                                     styles.error(
-                                        `Skipping "${subDir.name}": it declares custom dependencies but has no pnpm-lock.yaml. Run 'pnpm install' in the app folder to generate one, then upload again.`,
+                                        rawDeps.hasNpmLockfile
+                                            ? `Skipping "${subDir.name}": custom dependencies require a pnpm lockfile — the server builds with pnpm, so package-lock.json is not used. Run 'pnpm install' in the app folder to generate pnpm-lock.yaml, then upload again.`
+                                            : `Skipping "${subDir.name}": it declares custom dependencies but has no pnpm-lock.yaml (the server builds with pnpm). Run 'pnpm install' in the app folder to generate one, then upload again.`,
                                     ),
                                 );
                                 appsFailed += 1;

--- a/packages/common/src/ee/apps/code.ts
+++ b/packages/common/src/ee/apps/code.ts
@@ -420,7 +420,7 @@ export function validateDataAppDependencies(
     for (const name of Object.keys(customDeps)) {
         if (!d.lockfile.includes(name)) {
             throw new Error(
-                `Invalid dependencies: "${name}" is declared in package.json but not found in pnpm-lock.yaml. Run 'pnpm install --lockfile-only' to update the lockfile, then upload again`,
+                `Invalid dependencies: "${name}" is declared in package.json but not found in pnpm-lock.yaml. The build sandbox installs with pnpm — run 'pnpm install --lockfile-only' to update the lockfile, then upload again`,
             );
         }
     }


### PR DESCRIPTION
Closes #26721

Default app flows stay npm-first; pnpm now appears only in custom-dependency messages, which explain why it's required (the server builds with pnpm). A stray `package-lock.json` next to declared custom deps gets a targeted hint instead of the generic missing-lockfile error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
