### PR TITLE
fix(cli): validate login, project, and slug before apps create prompts

### DIFF
--- a/packages/cli/src/handlers/apps/createApp.test.ts
+++ b/packages/cli/src/handlers/apps/createApp.test.ts
@@ -293,7 +293,9 @@ describe('createAppHandler', () => {
                 verbose: false,
             }),
         ).rejects.toThrow('Data app creation cancelled');
-        expect(lightdashApi).not.toHaveBeenCalled();
+        // Preflight (auth, project, slug availability) runs before the
+        // prompts, so the context call has already happened by then.
+        expect(lightdashApi).toHaveBeenCalledTimes(1);
         await expect(
             fs.access(path.join(root, 'apps', 'revenue-explorer')),
         ).rejects.toThrow();
@@ -313,7 +315,34 @@ describe('createAppHandler', () => {
         expect(GlobalState.log).not.toHaveBeenCalledWith(
             expect.stringContaining('react@19.2.5'),
         );
-        expect(lightdashApi).not.toHaveBeenCalled();
+    });
+
+    it('asks for no approvals when the server rejects the slug', async () => {
+        const root = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-create-app-'));
+        vi.mocked(lightdashApi).mockRejectedValueOnce(
+            new Error('Slug already in use'),
+        );
+
+        await expect(
+            createAppHandler('Revenue Explorer', {
+                path: root,
+                verbose: false,
+            }),
+        ).rejects.toThrow('Slug already in use');
+        expect(promptMock).not.toHaveBeenCalled();
+    });
+
+    it('asks for no approvals when not logged in', async () => {
+        const root = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-create-app-'));
+        vi.mocked(getConfig).mockResolvedValueOnce({} as never);
+
+        await expect(
+            createAppHandler('Revenue Explorer', {
+                path: root,
+                verbose: false,
+            }),
+        ).rejects.toThrow('Not logged in');
+        expect(promptMock).not.toHaveBeenCalled();
     });
 
     it('requires explicit approval in non-interactive mode', async () => {

--- a/packages/cli/src/handlers/apps/createApp.ts
+++ b/packages/cli/src/handlers/apps/createApp.ts
@@ -271,17 +271,9 @@ export const createAppHandler = async (
         const appDir = path.join(getDownloadFolder(options.path), 'apps', slug);
         await assertAppDirectoryAvailable(appDir);
         await assertNpmAvailable();
-        await confirmLocalPackageTooling(options.assumeYes ?? false);
 
-        const staticFiles = buildStaticAuthoringFiles({
-            appName: name,
-            sdkVersion: CLI_VERSION,
-        });
-        await confirmDependencyInstall(
-            parseDirectPackages(staticFiles),
-            options.assumeYes ?? false,
-        );
-
+        // Validate auth, project, and slug availability before asking the
+        // user to approve any local package installation.
         await checkLightdashVersion();
         const config = await getConfig();
         if (!config.context?.apiKey || !config.context.serverUrl) {
@@ -308,6 +300,17 @@ export const createAppHandler = async (
             url: `/api/v1/ee/projects/${projectUuid}/apps/authoring-context?slug=${encodeURIComponent(slug)}`,
             body: undefined,
         });
+
+        await confirmLocalPackageTooling(options.assumeYes ?? false);
+
+        const staticFiles = buildStaticAuthoringFiles({
+            appName: name,
+            sdkVersion: CLI_VERSION,
+        });
+        await confirmDependencyInstall(
+            parseDirectPackages(staticFiles),
+            options.assumeYes ?? false,
+        );
         const manifest = buildLocalAppManifest({
             name,
             description: options.description ?? '',


### PR DESCRIPTION
Closes #26716

`lightdash apps create` now validates auth, project selection, and slug availability **before** the two install-approval prompts — previously you could carefully approve the npm install and then hit "Not logged in" or a taken slug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
