### PR TITLE
feat(cli): offer to install dependencies in apps preview

### DIFF
--- a/packages/cli/src/handlers/apps/preview.test.ts
+++ b/packages/cli/src/handlers/apps/preview.test.ts
@@ -1,18 +1,26 @@
 import { type DataAppCode } from '@lightdash/common';
+import execa from 'execa';
 import { promises as fs } from 'fs';
+import inquirer from 'inquirer';
 import * as os from 'os';
 import * as path from 'path';
+import type { Mock } from 'vitest';
+import GlobalState from '../../globalState';
 import { getAuthHeader } from '../utils';
 import { writeBundleToDir } from './appCodeFiles';
 import {
     assertNodeModulesPresent,
     assertScaffoldingSupportsPreviewProxy,
     buildPreviewChildEnv,
+    ensureNodeModules,
     preflightPreviewRequest,
     projectNotFoundMessage,
     removeLegacyPreviewCredential,
     resolvePreviewTarget,
 } from './preview';
+
+vi.mock('execa');
+vi.mock('inquirer', () => ({ default: { prompt: vi.fn() } }));
 
 const previewBundle: DataAppCode = {
     manifest: {
@@ -146,8 +154,75 @@ describe('assertNodeModulesPresent', () => {
     it('errors telling the user to npm install, without installing', async () => {
         const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-prev-'));
         await expect(assertNodeModulesPresent(dir)).rejects.toThrow(
-            /Run 'npm install' in .* \(preview does not auto-install\)/,
+            /Run 'npm install' in .*, or rerun with --assume-yes/,
         );
+    });
+});
+
+describe('ensureNodeModules', () => {
+    const promptMock = inquirer.prompt as unknown as Mock;
+    let dir: string;
+
+    beforeEach(async () => {
+        dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-prev-'));
+        vi.mocked(execa).mockReset();
+        promptMock.mockReset();
+        vi.spyOn(GlobalState, 'log').mockImplementation(() => {});
+        vi.spyOn(GlobalState, 'isNonInteractive').mockReturnValue(false);
+    });
+
+    afterEach(async () => {
+        vi.restoreAllMocks();
+        await fs.rm(dir, { recursive: true, force: true });
+    });
+
+    it('does nothing when node_modules exists', async () => {
+        await fs.mkdir(path.join(dir, 'node_modules'));
+        await ensureNodeModules({ appDir: dir, assumeYes: false });
+        expect(execa).not.toHaveBeenCalled();
+        expect(promptMock).not.toHaveBeenCalled();
+    });
+
+    it('fails fast without installing when not interactive', async () => {
+        vi.spyOn(GlobalState, 'isNonInteractive').mockReturnValue(true);
+        await expect(
+            ensureNodeModules({ appDir: dir, assumeYes: false }),
+        ).rejects.toThrow(/Run 'npm install'/);
+        expect(execa).not.toHaveBeenCalled();
+        expect(promptMock).not.toHaveBeenCalled();
+    });
+
+    it('installs without prompting with --assume-yes', async () => {
+        await ensureNodeModules({ appDir: dir, assumeYes: true });
+        expect(promptMock).not.toHaveBeenCalled();
+        expect(execa).toHaveBeenCalledWith(
+            'npm',
+            [
+                'install',
+                '--include=dev',
+                '--ignore-scripts',
+                '--no-package-lock',
+            ],
+            expect.objectContaining({ cwd: dir }),
+        );
+    });
+
+    it('cancels without installing when the warning prompt is declined', async () => {
+        const stdinTty = process.stdin.isTTY;
+        const stdoutTty = process.stdout.isTTY;
+        process.stdin.isTTY = true;
+        process.stdout.isTTY = true;
+        promptMock.mockResolvedValueOnce({ confirmed: false });
+        try {
+            await expect(
+                ensureNodeModules({ appDir: dir, assumeYes: false }),
+            ).rejects.toThrow('Preview cancelled.');
+        } finally {
+            process.stdin.isTTY = stdinTty;
+            process.stdout.isTTY = stdoutTty;
+        }
+        expect(promptMock).toHaveBeenCalledTimes(1);
+        expect(execa).not.toHaveBeenCalled();
     });
 });
 

--- a/packages/cli/src/handlers/apps/preview.ts
+++ b/packages/cli/src/handlers/apps/preview.ts
@@ -2,6 +2,7 @@ import { AuthorizationError, type DataAppManifest } from '@lightdash/common';
 import { randomBytes } from 'crypto';
 import execa from 'execa';
 import { promises as fs } from 'fs';
+import inquirer from 'inquirer';
 import * as path from 'path';
 import { getConfig } from '../../config';
 import GlobalState from '../../globalState';
@@ -116,18 +117,124 @@ export const resolvePreviewTarget = async (args: {
     };
 };
 
-export const assertNodeModulesPresent = async (
-    appDir: string,
-): Promise<void> => {
-    const isDir = await fs
+const hasNodeModules = async (appDir: string): Promise<boolean> =>
+    fs
         .stat(path.join(appDir, 'node_modules'))
         .then((s) => s.isDirectory())
         .catch(() => false);
-    if (!isDir) {
+
+export const assertNodeModulesPresent = async (
+    appDir: string,
+): Promise<void> => {
+    if (!(await hasNodeModules(appDir))) {
         throw new Error(
-            `Dependencies are not installed. Run 'npm install' in ${appDir} first (preview does not auto-install).`,
+            `Dependencies are not installed. Run 'npm install' in ${appDir} first, or rerun with --assume-yes to approve the install.`,
         );
     }
+};
+
+const readDirectPackages = async (appDir: string): Promise<string[]> => {
+    let raw: string;
+    try {
+        raw = await fs.readFile(path.join(appDir, 'package.json'), 'utf-8');
+    } catch {
+        return [];
+    }
+    try {
+        const parsed = JSON.parse(raw) as {
+            dependencies?: Record<string, string>;
+            devDependencies?: Record<string, string>;
+        };
+        return Object.entries({
+            ...parsed.dependencies,
+            ...parsed.devDependencies,
+        })
+            .map(([packageName, version]) => `${packageName}@${version}`)
+            .sort();
+    } catch {
+        return [];
+    }
+};
+
+/**
+ * Preview needs the app's packages on disk. Mirrors the `apps create`
+ * approval posture: a strong warning plus a two-step confirm (both
+ * defaulting to No) before anything is downloaded to this machine.
+ */
+export const ensureNodeModules = async (args: {
+    appDir: string;
+    assumeYes: boolean;
+}): Promise<void> => {
+    if (await hasNodeModules(args.appDir)) return;
+
+    const interactive =
+        !GlobalState.isNonInteractive() &&
+        process.stdin.isTTY === true &&
+        process.stdout.isTTY === true;
+    if (!args.assumeYes && !interactive) {
+        await assertNodeModulesPresent(args.appDir);
+        return;
+    }
+
+    GlobalState.log(
+        styles.warning(
+            [
+                '⚠ Local package installation',
+                'Previewing this app requires its npm packages, which are not installed yet. Continuing downloads third-party packages through npm into the app folder.',
+                'Dependency lifecycle scripts are disabled, but npm will access the network and write files on this machine.',
+                'Only continue if you trust the packages this app declares.',
+            ].join('\n'),
+        ),
+    );
+    if (!args.assumeYes) {
+        const { confirmed } = await inquirer.prompt<{ confirmed: boolean }>([
+            {
+                type: 'confirm',
+                name: 'confirmed',
+                message: 'Continue and review the packages to be installed?',
+                default: false,
+            },
+        ]);
+        if (!confirmed) {
+            throw new Error('Preview cancelled.');
+        }
+    }
+
+    const directPackages = await readDirectPackages(args.appDir);
+    GlobalState.log(
+        [
+            'Previewing this data app will install these direct npm packages:',
+            ...directPackages.map((packageSpec) => `  - ${packageSpec}`),
+            '\nDependency lifecycle scripts will be disabled.',
+        ].join('\n'),
+    );
+    if (!args.assumeYes) {
+        const { confirmed } = await inquirer.prompt<{ confirmed: boolean }>([
+            {
+                type: 'confirm',
+                name: 'confirmed',
+                message: 'Install these packages and start the preview?',
+                default: false,
+            },
+        ]);
+        if (!confirmed) {
+            throw new Error('Preview cancelled.');
+        }
+    }
+
+    await execa(
+        'npm',
+        ['install', '--include=dev', '--ignore-scripts', '--no-package-lock'],
+        {
+            cwd: args.appDir,
+            env: {
+                ...process.env,
+                npm_config_ignore_scripts: 'true',
+                npm_config_package_lock: 'false',
+            },
+            stdio: 'inherit',
+        },
+    );
 };
 
 /**
@@ -215,6 +322,7 @@ type AppsPreviewOptions = {
     project?: string;
     url?: string;
     token?: string;
+    assumeYes: boolean;
     verbose: boolean;
 };
 
@@ -251,7 +359,10 @@ export const appsPreviewHandler = async (
         projectFlag: options.project,
         cwd: process.cwd(),
     });
-    await assertNodeModulesPresent(target.appDir);
+    await ensureNodeModules({
+        appDir: target.appDir,
+        assumeYes: options.assumeYes,
+    });
 
     await assertScaffoldingSupportsPreviewProxy(target.appDir);
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1124,6 +1124,11 @@ appsProgram
         '--token <token>',
         'API key / personal access token (default: your login config)',
     )
+    .option(
+        '-y, --assume-yes',
+        'assume yes to the dependency install prompts when node_modules is missing',
+        false,
+    )
     .option('--verbose', undefined, false)
     .action(appsPreviewHandler);
 


### PR DESCRIPTION
Closes #26718

`lightdash apps preview` offers to run the dependency install when `node_modules` is missing, instead of dead-ending after `download → preview`. Same strong warning + two-step approval as `apps create` (both defaulting to No); `-y` approves both; non-interactive runs keep the fail-fast error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
