### PR TITLE
fix(cli): resolve uuid and URL --apps refs on upload via the target project

### DIFF
--- a/packages/cli/src/handlers/apps/appsDownload.test.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.test.ts
@@ -23,6 +23,7 @@ import {
     preSlugServerHint,
     preSlugUploadHint,
     resolveAppsLimit,
+    resolveUploadFilterUuids,
     selectAppsToDownload,
     shouldAutoPushApp,
     shouldFallBackToSpaceScopedListing,
@@ -844,5 +845,32 @@ describe('shouldAutoPushApp', () => {
                 force: false,
             }),
         ).toBe(true);
+    });
+});
+
+describe('resolveUploadFilterUuids', () => {
+    const appUuid = 'd3afc44c-6f0f-4d9f-a267-fb739efa31dd';
+    const otherUuid = 'a1b2c3d4-0000-4000-8000-000000000000';
+
+    it('translates uuid refs the listing knows into slugs', () => {
+        const resolved = resolveUploadFilterUuids(new Set([appUuid]), [
+            { appUuid, slug: 'my-app' },
+        ]);
+        expect(resolved).toEqual(new Set(['my-app']));
+    });
+
+    it('keeps slug refs and unknown uuids untouched', () => {
+        const resolved = resolveUploadFilterUuids(
+            new Set(['my-app', otherUuid]),
+            [{ appUuid, slug: 'my-app' }],
+        );
+        expect(resolved).toEqual(new Set(['my-app', otherUuid]));
+    });
+
+    it('leaves uuid refs alone when the listing has no slugs (pre-slug server)', () => {
+        const resolved = resolveUploadFilterUuids(new Set([appUuid]), [
+            { appUuid },
+        ]);
+        expect(resolved).toEqual(new Set([appUuid]));
     });
 });

--- a/packages/cli/src/handlers/apps/appsDownload.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.ts
@@ -70,6 +70,31 @@ export const matchedUploadRefs = (
     );
 
 /**
+ * Slug-identity bundles carry no uuid, so a uuid/URL upload ref can't match
+ * a local folder directly. Translate refs the target project's app listing
+ * knows into their slugs; unknown refs keep their original form (and fall
+ * through to the unmatched warning).
+ */
+export const resolveUploadFilterUuids = (
+    filter: Set<string>,
+    listedApps: { appUuid: string; slug?: string }[],
+): Set<string> => {
+    const slugByUuid = new Map(
+        listedApps
+            .filter(
+                (app): app is { appUuid: string; slug: string } =>
+                    app.slug !== undefined,
+            )
+            .map((app) => [app.appUuid, app.slug]),
+    );
+    return new Set(
+        [...filter].map((ref) =>
+            isUuid(ref) ? (slugByUuid.get(ref) ?? ref) : ref,
+        ),
+    );
+};
+
+/**
  * Warning for --apps references that matched no local app folder. Uuid-shaped
  * refs (including refs parsed out of app URLs) get the slug-identity
  * explanation: id-free bundles can only be selected by slug.

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -55,6 +55,7 @@ import * as yaml from 'js-yaml';
 import groupBy from 'lodash/groupBy';
 import pLimit from 'p-limit';
 import * as path from 'path';
+import { validate as isUuid } from 'uuid';
 import { LightdashAnalytics } from '../analytics/analytics';
 import { getConfig, setAnswer } from '../config';
 import { CLI_VERSION } from '../env';
@@ -86,6 +87,7 @@ import {
     preSlugServerHint,
     preSlugUploadHint,
     resolveAppsLimit,
+    resolveUploadFilterUuids,
     selectAppsToDownload,
     shouldAutoPushApp,
     shouldFallBackToSpaceScopedListing,
@@ -3300,7 +3302,7 @@ export const uploadHandler = async (
             output.startItem('Data apps');
             // Explicit refs filter by slug/appUuid; --include-apps uploads all.
             // A pure auto-push run applies no filter — gated per folder below.
-            const uploadFilter = isExplicitAppSelection
+            let uploadFilter = isExplicitAppSelection
                 ? getDataAppUploadFilter(
                       explicitAppReferences,
                       options.includeApps === true,
@@ -3313,9 +3315,15 @@ export const uploadHandler = async (
                 kind: 'unknown',
                 targetProjectUuid: projectId,
             };
-            // Only the auto-push gate below (skipped entirely when explicit)
-            // reads presence, so an explicit run never needs the listing.
-            if (!isExplicitAppSelection && autoPushAppSlugs.length > 0) {
+            // The listing serves two consumers: the auto-push presence gate,
+            // and uuid/URL --apps refs, which resolve to slugs against the
+            // target so they can match slug-identity local folders.
+            const filterHasUuidRefs =
+                uploadFilter !== null && [...uploadFilter].some(isUuid);
+            if (
+                (!isExplicitAppSelection && autoPushAppSlugs.length > 0) ||
+                filterHasUuidRefs
+            ) {
                 try {
                     const projectApps = await lightdashApi<
                         ApiEmbedProjectAppsResponse['results']
@@ -3326,11 +3334,20 @@ export const uploadHandler = async (
                     });
                     // An older server answers without slugs; that is not an
                     // error, but it is not an answer either.
-                    if (projectApps.every((app) => app.slug !== undefined)) {
+                    if (
+                        !isExplicitAppSelection &&
+                        projectApps.every((app) => app.slug !== undefined)
+                    ) {
                         presence = {
                             kind: 'known',
                             slugs: new Set(projectApps.map((app) => app.slug)),
                         };
+                    }
+                    if (filterHasUuidRefs && uploadFilter !== null) {
+                        uploadFilter = resolveUploadFilterUuids(
+                            uploadFilter,
+                            projectApps,
+                        );
                     }
                 } catch (listErr) {
                     GlobalState.debug(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1054,7 +1054,7 @@ const uploadCommand = program
     .option('--gzip', 'Enable gzip compression for request bodies', false)
     .option(
         '--apps <appReferences...>',
-        'Upload only the specified data apps, by slug — the app folder name (enterprise).',
+        'Upload only the specified data apps, by slug (the app folder name), app URL, or UUID (enterprise). URL and UUID refs are resolved against the target project.',
     )
     .option(
         '--include-apps',


### PR DESCRIPTION
Closes #26720

`upload --apps` matched refs against local manifests only, so a pasted app URL or UUID silently matched nothing for slug-identity bundles (locally created apps carry no uuid). UUID-shaped refs now resolve to slugs against the target project's app listing before matching folders, mirroring download. Unknown refs and pre-slug servers keep today's behavior and warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
