### PR TITLE
feat(cli): add --apps-only to lightdash upload

### DIFF
--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -3008,9 +3008,33 @@ export const uploadHandler = async (
             'Nothing to upload: --spaces-only cannot be combined with --skip-spaces.',
         );
     }
+    if (options.appsOnly && options.spacesOnly) {
+        throw new ParameterError(
+            '--apps-only cannot be combined with --spaces-only.',
+        );
+    }
+    if (
+        options.appsOnly &&
+        (options.charts.length > 0 || options.dashboards.length > 0)
+    ) {
+        throw new ParameterError(
+            '--apps-only cannot be combined with --charts or --dashboards.',
+        );
+    }
+    if (
+        options.appsOnly &&
+        options.apps === undefined &&
+        options.includeApps !== true
+    ) {
+        throw new ParameterError(
+            'Nothing to upload: --apps-only requires --apps <appReferences...> or --include-apps.',
+        );
+    }
 
     const isOrganizationUpload = options.organization === true;
-    const hasFilters = hasContentFilters(options);
+    // --apps-only rides the existing filter machinery: every non-app phase
+    // skips exactly as it does when only app refs are passed.
+    const hasFilters = hasContentFilters(options) || options.appsOnly === true;
     const shouldReconcileSpaces =
         !isOrganizationUpload && !options.skipSpaces && !hasFilters;
     let preflightSpaceFiles: SpaceCodeFile[] = [];

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1062,6 +1062,11 @@ const uploadCommand = program
         false,
     )
     .option(
+        '--apps-only',
+        'Upload only data apps, skipping charts, dashboards, and space reconciliation. Requires --apps <appReferences...> or --include-apps.',
+        false,
+    )
+    .option(
         '--create-new',
         'Always create a new app from the uploaded code instead of updating the app referenced by lightdash-app.yml. The new app gets a fresh slug.',
         false,


### PR DESCRIPTION
Closes #26717

`--include-apps` uploads every app folder but is not a content filter, so "push all apps and nothing else" had no expression. `--apps-only` rides the existing filter machinery (charts, dashboards, and space reconciliation skip exactly as in a filtered run) and requires `--apps` or `--include-apps`, mirroring download. Contradictory combos (`--spaces-only`, `--charts`, `--dashboards`) error out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
