### PR TITLE
feat(cli)!: custom-dependency uploads default to No and fail closed in CI

### DIFF
--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -167,6 +167,7 @@ export type DownloadHandlerOptions = {
     includeApps?: boolean; // download: all of the project's apps, capped at --apps-limit; upload: all app folders on disk
     appsLimit?: string; // download only: cap for the --include-apps listing (default 50); raw string from commander
     createNew?: boolean; // upload only: always create a new app instead of updating the manifest's app
+    allowCustomDependencies?: boolean; // upload only: approve custom-dependency uploads without prompting
     force: boolean;
     path?: string; // New optional path parameter
     project?: string;
@@ -193,7 +194,7 @@ export type DownloadHandlerOptions = {
     includeVirtualViews: boolean;
     includeExternalConnections: boolean;
     includeAll: boolean;
-    appsOnly?: boolean; // download only: implies skipCharts + skipDashboards + skipSpaces
+    appsOnly?: boolean; // download: implies skipCharts + skipDashboards + skipSpaces; upload: apps-only filtered run
     stripPivotSeries: boolean; // Strip per-value pivot series config for portable chart YAML
     validate?: boolean; // Validate charts and dashboards after upload
     concurrency: number;
@@ -3539,7 +3540,23 @@ export const uploadHandler = async (
                                 GlobalState.log(line),
                             );
 
-                            if (process.stdin.isTTY && process.stdout.isTTY) {
+                            if (options.allowCustomDependencies !== true) {
+                                const canPrompt =
+                                    process.stdin.isTTY === true &&
+                                    process.stdout.isTTY === true &&
+                                    !GlobalState.isNonInteractive();
+                                if (!canPrompt) {
+                                    // Fail closed: installing packages in the
+                                    // build sandbox needs explicit approval.
+                                    GlobalState.log(
+                                        styles.error(
+                                            `Skipping "${subDir.name}": it declares custom dependencies, which need approval. Pass --allow-custom-dependencies to approve in non-interactive runs.`,
+                                        ),
+                                    );
+                                    appsFailed += 1;
+                                    // eslint-disable-next-line no-continue
+                                    continue;
+                                }
                                 // eslint-disable-next-line no-await-in-loop
                                 const { proceed } =
                                     await output.promptWhilePaused(() =>
@@ -3550,7 +3567,7 @@ export const uploadHandler = async (
                                                 type: 'confirm',
                                                 name: 'proceed',
                                                 message: `Upload "${subDir.name}" with custom dependencies?`,
-                                                default: true,
+                                                default: false,
                                             },
                                         ]),
                                     );
@@ -3563,7 +3580,6 @@ export const uploadHandler = async (
                                     continue;
                                 }
                             }
-                            // Non-TTY: proceed without prompting (upload is deliberate).
 
                             codeToUpload = attachDependenciesToCode(
                                 code,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1067,6 +1067,11 @@ const uploadCommand = program
         false,
     )
     .option(
+        '--allow-custom-dependencies',
+        'Approve uploading apps that declare custom dependencies without prompting. Required for non-interactive runs of such uploads.',
+        false,
+    )
+    .option(
         '--create-new',
         'Always create a new app from the uploaded code instead of updating the app referenced by lightdash-app.yml. The new app gets a fresh slug.',
         false,


### PR DESCRIPTION
Closes #26722

The confirmation for uploading apps with custom dependencies now defaults to **No** (matching the `apps create` posture), and non-interactive runs **fail** with an actionable error instead of proceeding silently. New `--allow-custom-dependencies` flag approves without prompting for CI/scripts.

⚠️ **Breaking:** CI pipelines uploading apps that declare custom dependencies must pass `--allow-custom-dependencies`. Needs a changelog callout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
