### PR TITLE
refactor(cli): make the server's byte-compare the single unchanged-app authority

### DIFF
--- a/packages/cli/src/handlers/apps/appCodeFiles.test.ts
+++ b/packages/cli/src/handlers/apps/appCodeFiles.test.ts
@@ -1,20 +1,9 @@
-import {
-    type AnyType,
-    type DataAppCode,
-    type DataAppDependencies,
-} from '@lightdash/common';
-import {
-    promises as fs,
-    mkdirSync,
-    mkdtempSync,
-    utimesSync,
-    writeFileSync,
-} from 'fs';
+import { type DataAppCode, type DataAppDependencies } from '@lightdash/common';
+import { promises as fs } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import {
     appFolderName,
-    appFolderNeedsUpdating,
     applySdkMirrorToTemplateDeps,
     attachDependenciesToCode,
     buildDepsWarningLines,
@@ -587,90 +576,5 @@ describe('applySdkMirrorToTemplateDeps', () => {
         expect(applySdkMirrorToTemplateDeps(template, 'not-json')).toEqual(
             template,
         );
-    });
-});
-
-// ─── appFolderNeedsUpdating ────────────────────────────────────────────────────
-
-describe('appFolderNeedsUpdating', () => {
-    const DOWNLOADED_AT = '2026-07-30T12:00:00.000Z';
-    const manifest = { downloadedAt: DOWNLOADED_AT } as AnyType;
-
-    const buildFolder = () => {
-        const dir = mkdtempSync(path.join(os.tmpdir(), 'ld-app-folder-'));
-        mkdirSync(path.join(dir, 'src'), { recursive: true });
-        writeFileSync(path.join(dir, 'src', 'App.tsx'), 'x');
-        writeFileSync(path.join(dir, 'lightdash-app.yml'), 'slug: x');
-        mkdirSync(path.join(dir, '.lightdash', 'context'), {
-            recursive: true,
-        });
-        writeFileSync(
-            path.join(dir, '.lightdash', 'context', 'semantic-layer.yml'),
-            'models: []',
-        );
-        const at = new Date(DOWNLOADED_AT);
-        [
-            path.join(dir, 'src', 'App.tsx'),
-            path.join(dir, 'lightdash-app.yml'),
-            path.join(dir, '.lightdash', 'context', 'semantic-layer.yml'),
-        ].forEach((file) => utimesSync(file, at, at));
-        return dir;
-    };
-
-    it('is false for a freshly downloaded folder', async () => {
-        await expect(
-            appFolderNeedsUpdating(buildFolder(), manifest),
-        ).resolves.toBe(false);
-    });
-
-    it('is true when a src file was edited', async () => {
-        const dir = buildFolder();
-        const later = new Date('2026-07-30T13:00:00.000Z');
-        utimesSync(path.join(dir, 'src', 'App.tsx'), later, later);
-        await expect(appFolderNeedsUpdating(dir, manifest)).resolves.toBe(true);
-    });
-
-    it('is true when the manifest was edited', async () => {
-        const dir = buildFolder();
-        const later = new Date('2026-07-30T13:00:00.000Z');
-        utimesSync(path.join(dir, 'lightdash-app.yml'), later, later);
-        await expect(appFolderNeedsUpdating(dir, manifest)).resolves.toBe(true);
-    });
-
-    it('ignores regenerated context files', async () => {
-        const dir = buildFolder();
-        const later = new Date('2026-07-30T13:00:00.000Z');
-        utimesSync(
-            path.join(dir, '.lightdash', 'context', 'semantic-layer.yml'),
-            later,
-            later,
-        );
-        await expect(appFolderNeedsUpdating(dir, manifest)).resolves.toBe(
-            false,
-        );
-    });
-
-    it('is true when downloadedAt is missing', async () => {
-        await expect(
-            appFolderNeedsUpdating(buildFolder(), {} as AnyType),
-        ).resolves.toBe(true);
-    });
-
-    it('is true when downloadedAt is unparseable', async () => {
-        await expect(
-            appFolderNeedsUpdating(buildFolder(), {
-                downloadedAt: 'not-a-date',
-            } as AnyType),
-        ).resolves.toBe(true);
-    });
-
-    it('is true when a nested src file was edited', async () => {
-        const dir = buildFolder();
-        mkdirSync(path.join(dir, 'src', 'components'), { recursive: true });
-        const nested = path.join(dir, 'src', 'components', 'Chart.tsx');
-        writeFileSync(nested, 'x');
-        const later = new Date('2026-07-30T13:00:00.000Z');
-        utimesSync(nested, later, later);
-        await expect(appFolderNeedsUpdating(dir, manifest)).resolves.toBe(true);
     });
 });

--- a/packages/cli/src/handlers/apps/appCodeFiles.ts
+++ b/packages/cli/src/handlers/apps/appCodeFiles.ts
@@ -323,57 +323,6 @@ export const attachDependenciesToCode = (
 ): DataAppCode =>
     Object.keys(customDeps).length > 0 ? { ...code, dependencies: deps } : code;
 
-const CHANGE_TOLERANCE_MS = 30_000;
-
-const collectMtimes = async (dir: string): Promise<number[]> => {
-    const entries = await fs.readdir(dir, { withFileTypes: true });
-    const nested = await Promise.all(
-        entries.map(async (entry) => {
-            const entryPath = path.join(dir, entry.name);
-            if (entry.isDirectory()) return collectMtimes(entryPath);
-            const stats = await fs.stat(entryPath);
-            return [stats.mtime.getTime()];
-        }),
-    );
-    return nested.flat();
-};
-
-const statMtime = async (file: string): Promise<number[]> =>
-    fs
-        .stat(file)
-        .then((stats) => [stats.mtime.getTime()])
-        .catch(() => []);
-
-/**
- * Mirrors the chart/dashboard rule: changed when a file that actually gets
- * uploaded has drifted more than 30s from the manifest's downloadedAt.
- */
-export const appFolderNeedsUpdating = async (
-    dir: string,
-    manifest: DataAppManifest,
-): Promise<boolean> => {
-    if (!manifest.downloadedAt) return true;
-    const downloadedAt = new Date(manifest.downloadedAt).getTime();
-    if (Number.isNaN(downloadedAt)) return true;
-
-    const srcDir = path.join(dir, 'src');
-    const srcExists = await fs
-        .stat(srcDir)
-        .then((s) => s.isDirectory())
-        .catch(() => false);
-
-    const mtimes = [
-        ...(srcExists ? await collectMtimes(srcDir) : []),
-        ...(await statMtime(path.join(dir, 'package.json'))),
-        ...(await statMtime(path.join(dir, 'pnpm-lock.yaml'))),
-        ...(await statMtime(path.join(dir, MANIFEST_FILENAME))),
-    ];
-
-    return mtimes.some(
-        (mtime) => Math.abs(mtime - downloadedAt) > CHANGE_TOLERANCE_MS,
-    );
-};
-
 export const readManifestFromDir = async (
     dir: string,
 ): Promise<DataAppManifest> => {

--- a/packages/cli/src/handlers/apps/appsDownload.test.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.test.ts
@@ -25,7 +25,6 @@ import {
     resolveAppsLimit,
     resolveUploadFilterUuids,
     selectAppsToDownload,
-    shouldAutoPushApp,
     shouldFallBackToSpaceScopedListing,
     shouldWarnAllSkipped,
     unmatchedUploadRefsWarning,
@@ -739,112 +738,6 @@ describe('downloadAppsToDir', () => {
 
         expect(outcome.skippedNotBuiltCount).toBe(1);
         expect(outcome.failures).toEqual([]);
-    });
-});
-
-describe('shouldAutoPushApp', () => {
-    const manifest = {
-        slug: 'revenue-explorer',
-        projectUuid: 'source-project',
-    };
-    const known = (...slugs: string[]): AnyType => ({
-        kind: 'known',
-        slugs: new Set(slugs),
-    });
-
-    it('pushes when the target project does not have the app', () => {
-        expect(
-            shouldAutoPushApp({
-                manifest,
-                presence: known(),
-                folderChanged: false,
-                force: false,
-            }),
-        ).toBe(true);
-    });
-
-    it('pushes when the app exists and the folder changed', () => {
-        expect(
-            shouldAutoPushApp({
-                manifest,
-                presence: known('revenue-explorer'),
-                folderChanged: true,
-                force: false,
-            }),
-        ).toBe(true);
-    });
-
-    it('skips when the app exists and nothing changed', () => {
-        expect(
-            shouldAutoPushApp({
-                manifest,
-                presence: known('revenue-explorer'),
-                folderChanged: false,
-                force: false,
-            }),
-        ).toBe(false);
-    });
-
-    it('pushes an unchanged existing app under --force', () => {
-        expect(
-            shouldAutoPushApp({
-                manifest,
-                presence: known('revenue-explorer'),
-                folderChanged: false,
-                force: true,
-            }),
-        ).toBe(true);
-    });
-
-    it('falls back to the project comparison when presence is unknown', () => {
-        expect(
-            shouldAutoPushApp({
-                manifest,
-                presence: {
-                    kind: 'unknown',
-                    targetProjectUuid: 'other-project',
-                },
-                folderChanged: false,
-                force: false,
-            }),
-        ).toBe(true);
-
-        expect(
-            shouldAutoPushApp({
-                manifest,
-                presence: {
-                    kind: 'unknown',
-                    targetProjectUuid: 'source-project',
-                },
-                folderChanged: false,
-                force: false,
-            }),
-        ).toBe(false);
-    });
-
-    it('pushes a slug-less manifest so a pre-slug bundle still lands', () => {
-        expect(
-            shouldAutoPushApp({
-                manifest: { slug: undefined, projectUuid: 'source-project' },
-                presence: known('revenue-explorer'),
-                folderChanged: false,
-                force: false,
-            }),
-        ).toBe(true);
-    });
-
-    it('pushes a slug-less manifest against an older server with unknown presence', () => {
-        expect(
-            shouldAutoPushApp({
-                manifest: { slug: undefined, projectUuid: 'source-project' },
-                presence: {
-                    kind: 'unknown',
-                    targetProjectUuid: 'source-project',
-                },
-                folderChanged: false,
-                force: false,
-            }),
-        ).toBe(true);
     });
 });
 

--- a/packages/cli/src/handlers/apps/appsDownload.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.ts
@@ -234,33 +234,6 @@ export const preSlugUploadHint = (args: {
             : ''
     }. Uploads keep working via uuid matching meanwhile.`;
 
-export type AppPresence =
-    // Slugs the target project already has. Authoritative.
-    | { kind: 'known'; slugs: Set<string> }
-    // Listing unavailable or slug-less (older server): fall back to comparing
-    // the manifest's source project against the upload target.
-    | { kind: 'unknown'; targetProjectUuid: string };
-
-/**
- * Auto-pushed apps normally upload only when the folder changed, because every
- * upload triggers a sandbox rebuild. The exception is an app the target project
- * does not have yet — without it a dashboard moved to a new project or instance
- * lands with its tile skipped.
- */
-export const shouldAutoPushApp = (args: {
-    manifest: Pick<DataAppManifest, 'slug' | 'projectUuid'>;
-    presence: AppPresence;
-    folderChanged: boolean;
-    force: boolean;
-}): boolean => {
-    if (args.force || args.folderChanged) return true;
-    if (args.manifest.slug === undefined) return true;
-    if (args.presence.kind === 'known') {
-        return !args.presence.slugs.has(args.manifest.slug);
-    }
-    return args.manifest.projectUuid !== args.presence.targetProjectUuid;
-};
-
 export type AppDownloadFailure = { appRef: string; message: string };
 
 export type AppDownloadErrorOutcome =

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -68,7 +68,6 @@ import {
     type ContentAsCodeOutputVariant,
 } from '../terminal/contentAsCodeOutput';
 import {
-    appFolderNeedsUpdating,
     applySdkMirrorToTemplateDeps,
     attachDependenciesToCode,
     buildDepsWarningLines,
@@ -89,11 +88,9 @@ import {
     resolveAppsLimit,
     resolveUploadFilterUuids,
     selectAppsToDownload,
-    shouldAutoPushApp,
     shouldFallBackToSpaceScopedListing,
     unmatchedUploadRefsWarning,
     uploadFilterMatches,
-    type AppPresence,
 } from './apps/appsDownload';
 import { loadTemplateDependencies } from './apps/scaffolding';
 import {
@@ -3334,21 +3331,11 @@ export const uploadHandler = async (
                   )
                 : null;
 
-            // The manifest always names the source project, so comparing it
-            // to the target would re-push every run — list the target instead.
-            let presence: AppPresence = {
-                kind: 'unknown',
-                targetProjectUuid: projectId,
-            };
-            // The listing serves two consumers: the auto-push presence gate,
-            // and uuid/URL --apps refs, which resolve to slugs against the
-            // target so they can match slug-identity local folders.
+            // uuid/URL --apps refs resolve to slugs against the target
+            // project's listing so they can match slug-identity local folders.
             const filterHasUuidRefs =
                 uploadFilter !== null && [...uploadFilter].some(isUuid);
-            if (
-                (!isExplicitAppSelection && autoPushAppSlugs.length > 0) ||
-                filterHasUuidRefs
-            ) {
+            if (filterHasUuidRefs && uploadFilter !== null) {
                 try {
                     const projectApps = await lightdashApi<
                         ApiEmbedProjectAppsResponse['results']
@@ -3357,23 +3344,10 @@ export const uploadHandler = async (
                         url: `/api/v1/ee/projects/${projectId}/apps`,
                         body: undefined,
                     });
-                    // An older server answers without slugs; that is not an
-                    // error, but it is not an answer either.
-                    if (
-                        !isExplicitAppSelection &&
-                        projectApps.every((app) => app.slug !== undefined)
-                    ) {
-                        presence = {
-                            kind: 'known',
-                            slugs: new Set(projectApps.map((app) => app.slug)),
-                        };
-                    }
-                    if (filterHasUuidRefs && uploadFilter !== null) {
-                        uploadFilter = resolveUploadFilterUuids(
-                            uploadFilter,
-                            projectApps,
-                        );
-                    }
+                    uploadFilter = resolveUploadFilterUuids(
+                        uploadFilter,
+                        projectApps,
+                    );
                 } catch (listErr) {
                     GlobalState.debug(
                         `Could not list target project apps: ${getErrorMessage(listErr)}`,
@@ -3449,26 +3423,10 @@ export const uploadHandler = async (
                             // eslint-disable-next-line no-continue
                             continue;
                         }
-                        // eslint-disable-next-line no-await-in-loop
-                        const folderChanged = await appFolderNeedsUpdating(
-                            folderPath,
-                            code.manifest,
-                        );
-                        if (
-                            !shouldAutoPushApp({
-                                manifest: code.manifest,
-                                presence,
-                                folderChanged,
-                                force: options.force === true,
-                            })
-                        ) {
-                            GlobalState.debug(
-                                `Skipping app "${subDir.name}" — unchanged and already in the target project`,
-                            );
-                            appsSkipped += 1;
-                            // eslint-disable-next-line no-continue
-                            continue;
-                        }
+                        // Auto-push candidates always POST: the server's
+                        // byte-compare skip is the single unchanged authority,
+                        // and it runs before the build cap, so identical apps
+                        // cost no build slots.
                     }
 
                     // Read declared dependencies from the app folder (optional).


### PR DESCRIPTION
Closes #26723

Dashboard auto-push no longer gates on local mtimes (touching a file re-pushed; editing within 30s of download could silently not push). Referenced apps always POST, and the server's identical-version skip — which runs before the build cap, so unchanged apps cost no build slots — is the single authority deciding created/updated/unchanged. Deletes `shouldAutoPushApp`, `AppPresence`, and `appFolderNeedsUpdating` (~330 lines). Note: servers predating the identical-version skip will rebuild on every dashboard push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
