### PR TITLE
feat(cli): add --app-space to place created data apps in a space

### DIFF
--- a/packages/cli/src/handlers/apps/appsDownload.test.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.test.ts
@@ -23,6 +23,7 @@ import {
     preSlugServerHint,
     preSlugUploadHint,
     resolveAppsLimit,
+    resolveAppSpaceUuid,
     resolveUploadFilterUuids,
     selectAppsToDownload,
     shouldFallBackToSpaceScopedListing,
@@ -765,5 +766,29 @@ describe('resolveUploadFilterUuids', () => {
             { appUuid },
         ]);
         expect(resolved).toEqual(new Set([appUuid]));
+    });
+});
+
+describe('resolveAppSpaceUuid', () => {
+    const spaces = [
+        { uuid: 'space-1', slug: 'marketing' },
+        { uuid: 'space-2', slug: 'finance' },
+        { uuid: 'space-3', slug: 'finance' },
+    ];
+
+    it('resolves a unique slug to its uuid', () => {
+        expect(resolveAppSpaceUuid('marketing', spaces)).toBe('space-1');
+    });
+
+    it('fails loudly when no space matches the slug', () => {
+        expect(() => resolveAppSpaceUuid('missing', spaces)).toThrow(
+            /no space with slug "missing"/,
+        );
+    });
+
+    it('fails loudly when the slug is ambiguous', () => {
+        expect(() => resolveAppSpaceUuid('finance', spaces)).toThrow(
+            /multiple spaces match/,
+        );
     });
 });

--- a/packages/cli/src/handlers/apps/appsDownload.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.ts
@@ -70,6 +70,27 @@ export const matchedUploadRefs = (
     );
 
 /**
+ * Resolves a --app-space slug ref against the target project's spaces.
+ * UUID refs skip this (no listing needed); slug misses and ambiguity fail
+ * loudly — a space choice is explicit, so never guess.
+ */
+export const resolveAppSpaceUuid = (
+    ref: string,
+    spaces: { uuid: string; slug: string }[],
+): string => {
+    const matches = spaces.filter((space) => space.slug === ref);
+    if (matches.length === 1) return matches[0].uuid;
+    if (matches.length === 0) {
+        throw new ParameterError(
+            `--app-space: no space with slug "${ref}" in the target project. Create it first or pass the space UUID.`,
+        );
+    }
+    throw new ParameterError(
+        `--app-space: multiple spaces match slug "${ref}" — pass the space UUID instead.`,
+    );
+};
+
+/**
  * Slug-identity bundles carry no uuid, so a uuid/URL upload ref can't match
  * a local folder directly. Translate refs the target project's app listing
  * knows into their slugs; unknown refs keep their original form (and fall

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -21,6 +21,7 @@ import {
     ApiImportAppCodeResponse,
     ApiScheduledDeliveryAsCodeListResponse,
     ApiScheduledDeliveryAsCodeUpsertResponse,
+    ApiSpaceSummaryListResponse,
     ApiSqlChartAsCodeListResponse,
     ApiVirtualViewAsCodeListResponse,
     ApiVirtualViewAsCodeUpsertResponse,
@@ -86,6 +87,7 @@ import {
     preSlugServerHint,
     preSlugUploadHint,
     resolveAppsLimit,
+    resolveAppSpaceUuid,
     resolveUploadFilterUuids,
     selectAppsToDownload,
     shouldFallBackToSpaceScopedListing,
@@ -165,6 +167,7 @@ export type DownloadHandlerOptions = {
     appsLimit?: string; // download only: cap for the --include-apps listing (default 50); raw string from commander
     createNew?: boolean; // upload only: always create a new app instead of updating the manifest's app
     allowCustomDependencies?: boolean; // upload only: approve custom-dependency uploads without prompting
+    appSpace?: string; // upload only: space (slug or uuid) for data apps this run creates
     force: boolean;
     path?: string; // New optional path parameter
     project?: string;
@@ -3355,6 +3358,27 @@ export const uploadHandler = async (
                 }
             }
 
+            // The server applies the space on creates only; existing apps
+            // keep their space.
+            let appSpaceUuid: string | undefined;
+            if (options.appSpace !== undefined) {
+                if (isUuid(options.appSpace)) {
+                    appSpaceUuid = options.appSpace;
+                } else {
+                    const spaces = await lightdashApi<
+                        ApiSpaceSummaryListResponse['results']
+                    >({
+                        method: 'GET',
+                        url: `/api/v1/projects/${projectId}/spaces`,
+                        body: undefined,
+                    });
+                    appSpaceUuid = resolveAppSpaceUuid(
+                        options.appSpace,
+                        spaces,
+                    );
+                }
+            }
+
             const baseDir = getDownloadFolder(options.path);
             const appsDir = path.join(baseDir, 'apps');
 
@@ -3552,6 +3576,7 @@ export const uploadHandler = async (
                     }
 
                     const body = buildImportBody(codeToUpload, projectId, {
+                        space: appSpaceUuid,
                         createNew: options.createNew === true,
                         force: options.force,
                     });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1072,6 +1072,10 @@ const uploadCommand = program
         false,
     )
     .option(
+        '--app-space <spaceRef>',
+        'Space (slug or UUID) for data apps this upload creates. Existing apps keep their space.',
+    )
+    .option(
         '--create-new',
         'Always create a new app from the uploaded code instead of updating the app referenced by lightdash-app.yml. The new app gets a fresh slug.',
         false,


### PR DESCRIPTION
GLITCH-582

The import API already accepts `spaceUuid` on creates (with space permission checks server-side); the CLI just never sent it. `--app-space` takes a space slug or UUID — slugs resolve against the target project's spaces and fail loudly on a miss or ambiguity. Applies to creates only; existing apps keep their space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
