### PR TITLE
feat(data-apps): round-trip the app's space through lightdash-app.yml

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -350,6 +350,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     savedChartService: repository.getSavedChartService(),
                     spacePermissionService:
                         repository.getSpacePermissionService(),
+                    coderService: repository.getCoderService(),
                     dashboardService: repository.getDashboardService(),
                     projectService: repository.getProjectService(),
                     promoteService: repository.getPromoteService(),

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
@@ -132,6 +132,14 @@ function buildService(
         getLatestVersion: vi.fn().mockResolvedValue(null),
         countInProgressVersionsForProject: vi.fn().mockResolvedValue(0),
         updateApp: vi.fn().mockResolvedValue({}),
+        moveToSpace: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const coderService = {
+        getOrCreateSpace: vi.fn().mockResolvedValue({
+            space: { uuid: 'resolved-space-uuid' },
+            created: false,
+        }),
     };
 
     const schedulerClient = {
@@ -194,6 +202,7 @@ function buildService(
         schedulerClient: schedulerClient as never,
         savedChartService: {} as never,
         spacePermissionService: spacePermissionService as never,
+        coderService: coderService as never,
         dashboardService: {} as never,
         projectService: {} as never,
         promoteService: {} as never,
@@ -242,6 +251,7 @@ function buildService(
         schedulerClient,
         analytics,
         externalConnectionModel,
+        coderService,
     };
 }
 
@@ -362,6 +372,126 @@ describe('AppGenerateService.importAppCode', () => {
         expect(schedulerClient.appBuildFromSource).not.toHaveBeenCalledWith(
             expect.objectContaining({ organizationUuid: USER_ORG_UUID }),
         );
+    });
+
+    it('create mode: places the app in the manifest spaceSlug space', async () => {
+        const { service, appModel, coderService } = buildService();
+        appModel.findApp.mockResolvedValue(undefined);
+
+        await service.importAppCode(makeUser(), PROJECT_UUID, {
+            code: makeCode(undefined, { spaceSlug: 'sales/q3-reports' }),
+        } as ImportAppCodeRequestBody);
+
+        expect(coderService.getOrCreateSpace).toHaveBeenCalledWith(
+            PROJECT_UUID,
+            'sales/q3-reports',
+            expect.anything(),
+            undefined,
+            undefined,
+            undefined,
+            true,
+        );
+        expect(appModel.createWithVersion).toHaveBeenCalledWith(
+            expect.objectContaining({ space_uuid: 'resolved-space-uuid' }),
+            expect.anything(),
+            'pending',
+            expect.any(Object),
+            undefined,
+            undefined,
+            { forceSlug: true },
+        );
+    });
+
+    it('create mode: an explicit body spaceUuid wins over the manifest spaceSlug', async () => {
+        const { service, appModel, coderService } = buildService();
+        appModel.findApp.mockResolvedValue(undefined);
+
+        await service.importAppCode(makeUser(), PROJECT_UUID, {
+            code: makeCode(undefined, { spaceSlug: 'sales/q3-reports' }),
+            spaceUuid: 'explicit-space-uuid',
+        } as ImportAppCodeRequestBody);
+
+        expect(coderService.getOrCreateSpace).not.toHaveBeenCalled();
+        expect(appModel.createWithVersion).toHaveBeenCalledWith(
+            expect.objectContaining({ space_uuid: 'explicit-space-uuid' }),
+            expect.anything(),
+            'pending',
+            expect.any(Object),
+            undefined,
+            undefined,
+            { forceSlug: true },
+        );
+    });
+
+    it('append mode: moves the app when the manifest spaceSlug resolves elsewhere', async () => {
+        const { service, appModel } = buildService();
+        appModel.findApp.mockResolvedValue({
+            app_id: EXISTING_APP_UUID,
+            project_uuid: PROJECT_UUID,
+            space_uuid: 'old-space-uuid',
+            created_by_user_uuid: USER_UUID,
+            organization_uuid: PROJECT_ORG_UUID,
+            name: 'Test App',
+            description: 'A test app',
+            slug: EXISTING_APP_SLUG,
+        });
+        appModel.getLatestVersion.mockResolvedValue({ version: 4 });
+
+        await service.importAppCode(makeUser(), PROJECT_UUID, {
+            code: makeCode(undefined, { spaceSlug: 'sales/q3-reports' }),
+            targetAppUuid: EXISTING_APP_UUID,
+        } as ImportAppCodeRequestBody);
+
+        expect(appModel.moveToSpace).toHaveBeenCalledWith({
+            appId: EXISTING_APP_UUID,
+            projectUuid: PROJECT_UUID,
+            targetSpaceUuid: 'resolved-space-uuid',
+        });
+    });
+
+    it('append mode: no move when the manifest spaceSlug resolves to the current space', async () => {
+        const { service, appModel } = buildService();
+        appModel.findApp.mockResolvedValue({
+            app_id: EXISTING_APP_UUID,
+            project_uuid: PROJECT_UUID,
+            space_uuid: 'resolved-space-uuid',
+            created_by_user_uuid: USER_UUID,
+            organization_uuid: PROJECT_ORG_UUID,
+            name: 'Test App',
+            description: 'A test app',
+            slug: EXISTING_APP_SLUG,
+        });
+        appModel.getLatestVersion.mockResolvedValue({ version: 4 });
+
+        await service.importAppCode(makeUser(), PROJECT_UUID, {
+            code: makeCode(undefined, { spaceSlug: 'sales/q3-reports' }),
+            targetAppUuid: EXISTING_APP_UUID,
+        } as ImportAppCodeRequestBody);
+
+        expect(appModel.moveToSpace).not.toHaveBeenCalled();
+    });
+
+    it('append mode: leaves placement untouched when the manifest has no spaceSlug', async () => {
+        const { service, appModel, coderService } = buildService();
+        appModel.findApp.mockResolvedValue({
+            app_id: EXISTING_APP_UUID,
+            project_uuid: PROJECT_UUID,
+            space_uuid: 'old-space-uuid',
+            created_by_user_uuid: USER_UUID,
+            organization_uuid: PROJECT_ORG_UUID,
+            name: 'Test App',
+            description: 'A test app',
+            slug: EXISTING_APP_SLUG,
+        });
+        appModel.getLatestVersion.mockResolvedValue({ version: 4 });
+
+        await service.importAppCode(makeUser(), PROJECT_UUID, {
+            code: makeCode(),
+            targetAppUuid: EXISTING_APP_UUID,
+        } as ImportAppCodeRequestBody);
+
+        expect(coderService.getOrCreateSpace).not.toHaveBeenCalled();
+        expect(appModel.moveToSpace).not.toHaveBeenCalled();
     });
 
     it('throws ParameterError when targetAppUuid is given but app is not found', async () => {

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.buildFromSource.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.buildFromSource.test.ts
@@ -106,6 +106,7 @@ function buildService(
         schedulerClient: {} as never,
         savedChartService: {} as never,
         spacePermissionService: {} as never,
+        coderService: {} as never,
         dashboardService: {} as never,
         projectService: {} as never,
         promoteService: {} as never,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.clarifyApp.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.clarifyApp.test.ts
@@ -88,6 +88,7 @@ function buildService() {
             }),
         } as never,
         spacePermissionService: {} as never,
+        coderService: {} as never,
         dashboardService: {} as never,
         projectService: {} as never,
         promoteService: {} as never,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizGeneration.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizGeneration.test.ts
@@ -70,6 +70,7 @@ function buildService(
         schedulerClient: schedulerClient as never,
         savedChartService: {} as never,
         spacePermissionService: {} as never,
+        coderService: {} as never,
         dashboardService: {} as never,
         projectService: {} as never,
         promoteService: {} as never,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
@@ -78,6 +78,7 @@ function buildService(appModel: unknown) {
         schedulerClient: {} as never,
         savedChartService: {} as never,
         spacePermissionService: {} as never,
+        coderService: {} as never,
         dashboardService: {} as never,
         projectService: {} as never,
         promoteService: {} as never,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.externalSamples.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.externalSamples.test.ts
@@ -73,6 +73,7 @@ function buildService() {
             schedulerClient: {} as never,
             savedChartService: {} as never,
             spacePermissionService: {} as never,
+            coderService: {} as never,
             dashboardService: {} as never,
             projectService: {} as never,
             promoteService: {} as never,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.getAppCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.getAppCode.test.ts
@@ -158,6 +158,7 @@ function buildService(overrides: {
     projectParametersModel?: Record<string, unknown>;
     organizationDesignModel?: Record<string, unknown>;
     externalConnectionModel?: Record<string, unknown>;
+    spaceModel?: Record<string, unknown>;
 }): AppGenerateService {
     const {
         appModel = {},
@@ -166,6 +167,7 @@ function buildService(overrides: {
         projectParametersModel = {},
         organizationDesignModel = {},
         externalConnectionModel = {},
+        spaceModel = {},
     } = overrides;
 
     // Default mocks for context-assembly methods so existing tests don't break
@@ -216,10 +218,11 @@ function buildService(overrides: {
         pinnedListModel: {} as never,
         projectModel: fullProjectModel as never,
         projectParametersModel: fullProjectParametersModel as never,
-        spaceModel: {} as never,
+        spaceModel: spaceModel as never,
         schedulerClient: {} as never,
         savedChartService: {} as never,
         spacePermissionService: spacePermissionService as never,
+        coderService: {} as never,
         dashboardService: {} as never,
         projectService: {} as never,
         promoteService: {} as never,
@@ -283,6 +286,8 @@ describe('AppGenerateService.getAppCode', () => {
         expect(result.manifest.codeVersion).toBe(1);
         // No links → the key is omitted so link-less manifests stay unchanged
         expect(result.manifest).not.toHaveProperty('externalConnections');
+        // Personal app → no spaceSlug key
+        expect(result.manifest).not.toHaveProperty('spaceSlug');
 
         // files — exactly the two source entries
         expect(result.files).toHaveLength(2);
@@ -315,6 +320,32 @@ describe('AppGenerateService.getAppCode', () => {
                 hasCustomDependencies: false,
             }),
         });
+    });
+
+    it('emits spaceSlug as a content-as-code path for an in-space app', async () => {
+        const fakeS3 = makeFakeS3(sourceTarBuffer);
+        const appModel = {
+            getAppByUuidOrSlug: vi
+                .fn()
+                .mockResolvedValue({ ...fakeApp, space_uuid: 'space-uuid-1' }),
+            getLatestReadyVersion: vi.fn().mockResolvedValue(fakeAppVersion),
+        };
+        const spaceModel = {
+            getSpaceSummary: vi
+                .fn()
+                .mockResolvedValue({ path: 'sales.q3_reports' }),
+        };
+
+        const svc = buildService({
+            appModel,
+            spaceModel,
+            s3ClientOverride: fakeS3,
+        });
+
+        const result = await svc.getAppCode(fakeUser, PROJECT_UUID, APP_UUID);
+
+        expect(spaceModel.getSpaceSummary).toHaveBeenCalledWith('space-uuid-1');
+        expect(result.manifest.spaceSlug).toBe('sales/q3-reports');
     });
 
     it('resolves the app via the uuid-or-slug lookup when given a slug', async () => {

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -28,6 +28,7 @@ import {
     FilterOperator,
     ForbiddenError,
     formatPromptWithClarifications,
+    getContentAsCodePathFromLtreePath,
     getEffectiveFieldAiHints,
     getErrorMessage,
     getVisibleDataAppClaudeModels,
@@ -140,6 +141,7 @@ import { ProjectParametersModel } from '../../../models/ProjectParametersModel';
 import { SpaceModel } from '../../../models/SpaceModel';
 import { mintPreviewToken } from '../../../routers/appPreviewToken';
 import { BaseService } from '../../../services/BaseService';
+import type { CoderService } from '../../../services/CoderService/CoderService';
 import type { DashboardService } from '../../../services/DashboardService/DashboardService';
 import type { ProjectService } from '../../../services/ProjectService/ProjectService';
 import type { PromoteService } from '../../../services/PromoteService/PromoteService';
@@ -284,6 +286,7 @@ type AppGenerateServiceDeps = {
     schedulerClient: CommercialSchedulerClient;
     savedChartService: SavedChartService;
     spacePermissionService: SpacePermissionService;
+    coderService: CoderService;
     dashboardService: DashboardService;
     projectService: ProjectService;
     promoteService: PromoteService;
@@ -447,6 +450,8 @@ export class AppGenerateService extends BaseService {
 
     private readonly spacePermissionService: SpacePermissionService;
 
+    private readonly coderService: CoderService;
+
     private readonly dashboardService: DashboardService;
 
     private readonly projectService: ProjectService;
@@ -477,6 +482,7 @@ export class AppGenerateService extends BaseService {
         schedulerClient,
         savedChartService,
         spacePermissionService,
+        coderService,
         dashboardService,
         projectService,
         promoteService,
@@ -499,6 +505,7 @@ export class AppGenerateService extends BaseService {
         this.schedulerClient = schedulerClient;
         this.savedChartService = savedChartService;
         this.spacePermissionService = spacePermissionService;
+        this.coderService = coderService;
         this.dashboardService = dashboardService;
         this.projectService = projectService;
         this.promoteService = promoteService;
@@ -9211,6 +9218,30 @@ export class AppGenerateService extends BaseService {
         });
     }
 
+    /**
+     * Manifest spaceSlug → space uuid in the target project, creating the
+     * space if missing (same machinery as dashboards-as-code). Returns
+     * undefined when the manifest has no placement (personal apps and
+     * pre-field bundles), which callers treat as "leave untouched".
+     */
+    private async resolveManifestSpace(
+        user: SessionUser,
+        projectUuid: string,
+        spaceSlug: string | undefined,
+    ): Promise<string | undefined> {
+        if (spaceSlug === undefined) return undefined;
+        const { space } = await this.coderService.getOrCreateSpace(
+            projectUuid,
+            spaceSlug,
+            user,
+            undefined,
+            undefined,
+            undefined,
+            true,
+        );
+        return space.uuid;
+    }
+
     async getAppCode(
         user: SessionUser,
         projectUuid: string,
@@ -9283,6 +9314,12 @@ export class AppGenerateService extends BaseService {
             app.app_id,
         );
 
+        // In-space apps emit the space as a content-as-code path so uploads
+        // can recreate placement; personal apps omit the key.
+        const appSpace = app.space_uuid
+            ? await this.spaceModel.getSpaceSummary(app.space_uuid)
+            : null;
+
         const manifest = buildManifest({
             slug: app.slug,
             version: resolvedVersion,
@@ -9300,6 +9337,13 @@ export class AppGenerateService extends BaseService {
                           alias: link.alias,
                           connectionSlug: link.connection.slug,
                       })),
+                  }
+                : {}),
+            ...(appSpace
+                ? {
+                      spaceSlug: getContentAsCodePathFromLtreePath(
+                          appSpace.path,
+                      ),
                   }
                 : {}),
             downloadedAt: new Date().toISOString(),
@@ -9984,6 +10028,36 @@ export class AppGenerateService extends BaseService {
                 code.manifest,
                 projectUuid,
             );
+            // spaceSlug present → reconcile placement; absent → untouched
+            // (mirrors the externalConnections manifest semantics).
+            const manifestSpaceUuid = await this.resolveManifestSpace(
+                user,
+                projectUuid,
+                code.manifest.spaceSlug,
+            );
+            if (
+                manifestSpaceUuid !== undefined &&
+                manifestSpaceUuid !== existingApp.space_uuid
+            ) {
+                const spaceContext =
+                    await this.spacePermissionService.getSpaceAccessContext(
+                        user.userUuid,
+                        manifestSpaceUuid,
+                    );
+                this.assertDataAppAbility(
+                    user,
+                    'manage',
+                    organizationUuid,
+                    projectUuid,
+                    'Insufficient permissions to move this data app into the manifest space',
+                    spaceContext,
+                );
+                await this.appModel.moveToSpace({
+                    appId: existingApp.app_id,
+                    projectUuid,
+                    targetSpaceUuid: manifestSpaceUuid,
+                });
+            }
             newAppUuid = existingApp.app_id;
             newAppSlug = existingApp.slug;
             const latestVersion = await this.appModel.getLatestVersion(
@@ -10010,11 +10084,21 @@ export class AppGenerateService extends BaseService {
                 projectUuid,
                 'Insufficient permissions to create data apps',
             );
-            if (body.spaceUuid) {
+            // Explicit --app-space wins over the manifest's spaceSlug; both
+            // absent → personal app.
+            const targetSpaceUuid =
+                body.spaceUuid ??
+                (await this.resolveManifestSpace(
+                    user,
+                    projectUuid,
+                    code.manifest.spaceSlug,
+                )) ??
+                null;
+            if (targetSpaceUuid) {
                 const spaceContext =
                     await this.spacePermissionService.getSpaceAccessContext(
                         user.userUuid,
-                        body.spaceUuid,
+                        targetSpaceUuid,
                     );
                 this.assertDataAppAbility(
                     user,
@@ -10033,7 +10117,7 @@ export class AppGenerateService extends BaseService {
                     name: code.manifest.name,
                     description: code.manifest.description,
                     template: code.manifest.template,
-                    space_uuid: body.spaceUuid ?? null,
+                    space_uuid: targetSpaceUuid,
                     // Round-trip the manifest slug exactly; createNew and
                     // pre-slug bundles let the model generate a unique one.
                     ...(manifestSlug !== undefined && !body.createNew

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.upgrade.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.upgrade.test.ts
@@ -82,6 +82,7 @@ function buildService(opts: { canManage?: boolean } = {}) {
         schedulerClient: schedulerClient as never,
         savedChartService: {} as never,
         spacePermissionService: spacePermissionService as never,
+        coderService: {} as never,
         dashboardService: {} as never,
         projectService: {} as never,
         promoteService: {} as never,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.vizSchemaCopy.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.vizSchemaCopy.test.ts
@@ -144,6 +144,7 @@ function buildService() {
         spacePermissionService: {
             getSpaceAccessContext: vi.fn().mockResolvedValue({}),
         } as never,
+        coderService: {} as never,
         dashboardService: {} as never,
         projectService: {} as never,
         promoteService: {} as never,

--- a/packages/backend/src/ee/services/AppGenerateService/appCode.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/appCode.ts
@@ -19,6 +19,7 @@ export const buildManifest = (args: {
     template: DataAppManifest['template'];
     vizSchema?: DataAppManifest['vizSchema'];
     externalConnections?: DataAppManifest['externalConnections'];
+    spaceSlug?: DataAppManifest['spaceSlug'];
     downloadedAt: string;
 }): DataAppManifest => ({ codeVersion: 1, ...args });
 

--- a/packages/common/src/ee/apps/code.ts
+++ b/packages/common/src/ee/apps/code.ts
@@ -45,6 +45,11 @@ export type DataAppManifest = {
     // reconciled to match exactly; absent → existing links are left untouched
     // (bundles downloaded before this field, or apps with no links).
     externalConnections?: DataAppManifestExternalConnection[];
+    // Content-as-code path of the space the app lives in (same encoding as
+    // DashboardAsCode.spaceSlug). Present → upload reconciles placement,
+    // creating the space if missing; absent → personal app on download,
+    // placement left untouched on upload (also covers pre-field bundles).
+    spaceSlug?: string;
     downloadedAt: string; // ISO
     scaffoldingVersion?: string; // CLI/SDK version the vendored scaffolding came from (Phase 2)
 };


### PR DESCRIPTION
Closes #26725

Download emits `spaceSlug` (a content-as-code path, same encoding as dashboards) for in-space apps. Upload reconciles placement: creates land in that space (created if missing via the dashboards-as-code space machinery; an explicit `--app-space` still wins), and appends move the app when the resolved space differs. Absent `spaceSlug` — personal apps and pre-field bundles — leaves placement untouched, mirroring the `externalConnections` manifest semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
