### PR TITLE
fix(scheduled-deliveries): wait for pivot totals before capture

### DIFF
--- a/packages/frontend/src/components/SimpleTable/index.screenshotReady.test.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.screenshotReady.test.tsx
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../testing/testUtils';
+
+const { mockContext } = vi.hoisted(() => ({
+    mockContext: {
+        current: {} as Record<string, unknown>,
+    },
+}));
+
+vi.mock('../common/PivotTable', () => ({
+    default: () => null,
+}));
+
+vi.mock('../LightdashVisualization/types', () => ({
+    isTableVisualizationConfig: () => true,
+}));
+
+vi.mock('../LightdashVisualization/useVisualizationContext', () => ({
+    useVisualizationContext: () => mockContext.current,
+}));
+
+// eslint-disable-next-line import/first
+import SimpleTable from './index';
+
+const totalLoadingFlags = [
+    'isCalculatingColumnTotals',
+    'isCalculatingRowTotals',
+    'isCalculatingRowSubtotals',
+    'isCalculatingGrandTotals',
+    'isCalculatingSubtotals',
+] as const;
+
+type TotalLoadingFlag = (typeof totalLoadingFlags)[number];
+
+const buildContext = (
+    chartConfigOverrides: Partial<Record<TotalLoadingFlag, boolean>> & {
+        columnTotalsError?: Error;
+    } = {},
+) => ({
+    columnOrder: [],
+    itemsMap: {},
+    visualizationConfig: {
+        chartConfig: {
+            columns: [],
+            pivotTableData: {
+                data: { rowsCount: 1 },
+                loading: false,
+                error: undefined,
+            },
+            isPivotTableEnabled: true,
+            isPivotResultStale: false,
+            showColumnCalculation: true,
+            showResultsTotal: false,
+            showSubtotals: false,
+            showSubtotalsExpanded: false,
+            showRowGrouping: false,
+            updateColumnProperty: vi.fn(),
+            getFieldLabel: vi.fn(),
+            getField: vi.fn(),
+            ...chartConfigOverrides,
+        },
+    },
+    resultsData: {
+        rows: [{}],
+        totalResults: 1,
+        hasFetchedAllRows: true,
+        setFetchAll: vi.fn(),
+    },
+    isLoading: false,
+    isEditMode: false,
+    parameters: undefined,
+    hasExplorerStore: false,
+});
+
+describe('SimpleTable screenshot readiness', () => {
+    beforeEach(() => {
+        mockContext.current = buildContext();
+    });
+
+    it.each(totalLoadingFlags)('waits while %s is true', (totalLoadingFlag) => {
+        mockContext.current = buildContext({ [totalLoadingFlag]: true });
+        const onScreenshotReady = vi.fn();
+
+        renderWithProviders(
+            <SimpleTable isDashboard onScreenshotReady={onScreenshotReady} />,
+        );
+
+        expect(onScreenshotReady).not.toHaveBeenCalled();
+    });
+
+    it('signals once after totals settle', () => {
+        mockContext.current = buildContext({
+            isCalculatingColumnTotals: true,
+        });
+        const onScreenshotReady = vi.fn();
+        const renderTable = () => (
+            <SimpleTable isDashboard onScreenshotReady={onScreenshotReady} />
+        );
+        const { rerender } = renderWithProviders(renderTable());
+
+        mockContext.current = buildContext();
+        rerender(renderTable());
+        rerender(renderTable());
+
+        expect(onScreenshotReady).toHaveBeenCalledOnce();
+    });
+
+    it('signals after a totals request settles with an error', () => {
+        mockContext.current = buildContext({
+            columnTotalsError: new Error('Totals failed'),
+        });
+        const onScreenshotReady = vi.fn();
+
+        renderWithProviders(
+            <SimpleTable isDashboard onScreenshotReady={onScreenshotReady} />,
+        );
+
+        expect(onScreenshotReady).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -106,8 +106,21 @@ const SimpleTable: FC<SimpleTableProps> = ({
         if (!onScreenshotReady && !onScreenshotError) return;
         if (!isTableVisualizationConfig(visualizationConfig)) return;
 
-        const { pivotTableData, isPivotTableEnabled } =
-            visualizationConfig.chartConfig;
+        const {
+            pivotTableData,
+            isPivotTableEnabled,
+            isCalculatingColumnTotals,
+            isCalculatingRowTotals,
+            isCalculatingRowSubtotals,
+            isCalculatingGrandTotals,
+            isCalculatingSubtotals,
+        } = visualizationConfig.chartConfig;
+        const isCalculatingAnyTotals =
+            isCalculatingColumnTotals ||
+            isCalculatingRowTotals ||
+            isCalculatingRowSubtotals ||
+            isCalculatingGrandTotals ||
+            isCalculatingSubtotals;
 
         if (pivotTableData.error) {
             onScreenshotError?.();
@@ -116,7 +129,11 @@ const SimpleTable: FC<SimpleTableProps> = ({
         }
 
         if (isPivotTableEnabled) {
-            if (pivotTableData.data && resultsData?.hasFetchedAllRows) {
+            if (
+                pivotTableData.data &&
+                resultsData?.hasFetchedAllRows &&
+                !isCalculatingAnyTotals
+            ) {
                 onScreenshotReady?.();
                 hasSignaledScreenshotReady.current = true;
             }


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9454/fix-loading-placeholders-in-scheduled-delivery-totals

## Summary

Scheduled dashboard deliveries could capture pivot tables while total cells still showed loading skeletons. Capture now waits for every enabled pivot total and subtotal request to settle.

## Root cause

Pivot data and the base query completed before the separately requested totals. `SimpleTable` signalled screenshot readiness from the base pivot state alone, so the headless browser could capture the dashboard while `PivotTable` still rendered total-cell skeletons.

```ts
if (pivotTableData.data && resultsData?.hasFetchedAllRows) {
    onScreenshotReady?.();
}
```

Async totals introduced a second loading phase after base results became ready, but the screenshot gate did not include that phase.

## Fix

Screenshot readiness now requires all five total and subtotal loading states to settle. Settled calculation errors remain exportable, so failed totals do not hang delivery capture.

- `packages/frontend/src/components/SimpleTable/index.tsx` — blocks pivot readiness while any totals request is fetching.
- `packages/frontend/src/components/SimpleTable/index.screenshotReady.test.tsx` — covers every loading flag, one-shot settlement, and settled errors.
- Totals query execution, skeleton rendering, non-pivot tables, and backend capture remain unchanged.

## Before

```text
Pivot rows ready ──> ready indicator ──> capture
       Totals still loading ──────────> skeletons in delivery
```

## After

```text
Pivot rows ready + totals settled ──> ready indicator ──> capture
                                      resolved values or error cells
```

## Test plan

- [x] `pnpm -F frontend typecheck`
- [x] `pnpm -F frontend exec vitest run src/components/SimpleTable/index.screenshotReady.test.tsx` — 7 tests pass
- [x] Targeted `oxlint` and `oxfmt --check`
- [x] Local Vite entrypoint and transformed `SimpleTable` serve successfully after frontend restart