### PR TITLE
fix(groups): resolve the groups feature flag from the account organization

### DIFF
--- a/packages/backend/src/services/GroupService.test.ts
+++ b/packages/backend/src/services/GroupService.test.ts
@@ -1,10 +1,12 @@
 import { Ability } from '@casl/ability';
 import {
+    FeatureFlags,
     PromotionAction,
     type Account,
     type GroupAsCode,
     type PossibleAbilities,
 } from '@lightdash/common';
+import { type FeatureFlagService } from './FeatureFlag/FeatureFlagService';
 import { GroupsService } from './GroupService';
 
 const createAuthentication = (
@@ -70,7 +72,7 @@ describe('GroupsService groups as code', () => {
         upsertGroupAsCode: vi.fn(),
     };
     const featureFlagService = {
-        get: vi.fn().mockResolvedValue({ enabled: true }),
+        get: vi.fn<FeatureFlagService['get']>(),
     };
     const service = new GroupsService({
         analytics: analytics as never,
@@ -87,7 +89,10 @@ describe('GroupsService groups as code', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
-        featureFlagService.get.mockResolvedValue({ enabled: true });
+        featureFlagService.get.mockResolvedValue({
+            id: FeatureFlags.UserGroupsEnabled,
+            enabled: true,
+        });
         groupsModel.upsertGroupAsCode.mockResolvedValue({
             action: PromotionAction.NO_CHANGES,
             groupUuid: 'group-uuid',
@@ -118,6 +123,30 @@ describe('GroupsService groups as code', () => {
                 members: ['a@example.com', 'z@example.com'],
             },
         ]);
+    });
+
+    it('uses the account organization when resolving the groups feature flag', async () => {
+        vi.mocked(featureFlagService.get).mockImplementationOnce(
+            async ({ user, featureFlagId }) => ({
+                id: featureFlagId,
+                enabled:
+                    user?.organizationUuid === 'organization-uuid' &&
+                    featureFlagId === FeatureFlags.UserGroupsEnabled,
+            }),
+        );
+        groupsModel.find.mockResolvedValue({ data: [] });
+        groupsModel.findGroupMembers.mockResolvedValue({ data: [] });
+
+        await expect(
+            service.getGroupsAsCode(createAccount('pat'), 'organization-uuid'),
+        ).resolves.toStrictEqual([]);
+        expect(featureFlagService.get).toHaveBeenCalledWith({
+            user: {
+                userUuid: 'actor-user-uuid',
+                organizationUuid: 'organization-uuid',
+            },
+            featureFlagId: FeatureFlags.UserGroupsEnabled,
+        });
     });
 
     it.each(['pat', 'service-account'] as const)(
@@ -191,7 +220,10 @@ describe('GroupsService groups as code', () => {
     });
 
     it('respects the existing groups feature flag', async () => {
-        featureFlagService.get.mockResolvedValueOnce({ enabled: false });
+        featureFlagService.get.mockResolvedValueOnce({
+            id: FeatureFlags.UserGroupsEnabled,
+            enabled: false,
+        });
 
         await expect(
             service.upsertGroupAsCode(

--- a/packages/backend/src/services/GroupService.ts
+++ b/packages/backend/src/services/GroupService.ts
@@ -10,7 +10,7 @@ import {
     GroupMember,
     GroupMembership,
     GroupWithMembers,
-    LightdashUser,
+    isAccount,
     ParameterError,
     ProjectGroupAccess,
     ProjectMemberRole,
@@ -133,7 +133,7 @@ export class GroupsService extends BaseService {
         organizationUuid: string,
     ): Promise<GroupAsCode[]> {
         this.validateGroupsAsCodeAccess(account, organizationUuid);
-        if (!(await this.isGroupServiceEnabled(account.user))) {
+        if (!(await this.isGroupServiceEnabled(account))) {
             throw new ForbiddenError('Group service is not enabled');
         }
 
@@ -169,7 +169,7 @@ export class GroupsService extends BaseService {
         groupInput: GroupAsCode,
     ): Promise<ApiGroupAsCodeUpsertResponse['results']> {
         this.validateGroupsAsCodeAccess(account, organizationUuid);
-        if (!(await this.isGroupServiceEnabled(account.user))) {
+        if (!(await this.isGroupServiceEnabled(account))) {
             throw new ForbiddenError('Group service is not enabled');
         }
 
@@ -203,8 +203,14 @@ export class GroupsService extends BaseService {
     }
 
     private async isGroupServiceEnabled(
-        user: Pick<LightdashUser, 'userUuid' | 'organizationUuid'>,
+        accountOrUser: RegisteredAccount | SessionUser,
     ): Promise<boolean> {
+        const user = isAccount(accountOrUser)
+            ? {
+                  userUuid: accountOrUser.user.userUuid,
+                  organizationUuid: accountOrUser.organization.organizationUuid,
+              }
+            : accountOrUser;
         const featureFlag = await this.featureFlagService.get({
             user,
             featureFlagId: FeatureFlags.UserGroupsEnabled,


### PR DESCRIPTION
Fixes #26747
Linear: PROD-9471

## Problem

The groups content-as-code endpoints (`GET`/`POST /api/v2/orgs/{orgUuid}/code/groups`) returned HTTP 403 `Group service is not enabled` even when `user-groups-enabled` had an **enabled organization-level override**. The Groups UI worked normally for the same organization, so only groups-as-code was broken.

## Cause

`extractOrganizationFromUser()` in `packages/backend/src/auth/account/account.ts` destructures `organizationUuid`, `organizationName` and `organizationCreatedAt` **out** of the `SessionUser` and moves them onto `account.organization`. What remains becomes `account.user`, so `account.user.organizationUuid` is `undefined` at runtime — `toSessionUser()` exists precisely to reattach those fields.

`getGroupsAsCode()` and `upsertGroupAsCode()` passed `account.user` into `isGroupServiceEnabled()`, which forwards it to `FeatureFlagService.get({ user })`. `FeatureFlagModel.getOverrideFromDatabase()` guards the organization-override lookup with `if (args.user?.organizationUuid)`, so with that field undefined the **org-override query was skipped entirely**. Resolution fell through to the flag default and `user-groups-enabled` resolved `false`.

It compiled cleanly because `LightdashUser.organizationUuid` is optional, so the missing property was not a type error.

Every other `isGroupServiceEnabled()` call site receives a full `SessionUser`, which does carry `organizationUuid` — that is why only the content-as-code path was affected.

## Fix

`isGroupServiceEnabled()` now accepts `RegisteredAccount | SessionUser` and builds the feature-flag user from `account.organization.organizationUuid` when given an account, using the existing `isAccount()` helper. `validateGroupsAsCodeAccess()` already asserts `account.organization.organizationUuid === organizationUuid` and narrows to `RegisteredAccount` before the flag check, so the account's organization is provably the same one the request targets.

## Impact

Organizations whose groups feature is enabled via an organization-level override can use groups-as-code again. Note the two CLI paths failed differently: `download --organization` catches this specific 403 and reports `service unavailable`, so groups were **silently missing** from downloaded content, while `upload --organization` has no such catch and failed outright.

## Verification

- New regression test in `GroupService.test.ts` asserting the flag is resolved with the account's organization UUID. Confirmed **red before the fix** (`ForbiddenError: Group service is not enabled`) and green after.
- `pnpm -F backend exec vitest run src/services/GroupService.test.ts` — 7/7 pass.
- `pnpm -F backend typecheck` — clean.
- `pnpm --filter backend run linter` on touched paths — clean.

### End-to-end runtime verification

Reproduced against a local instance with a real PAT (the CLI's auth path) and real Postgres, with a single organization-level override row (`user_uuid` NULL, `enabled` true) and the flag's `default_enabled` NULL — the state an organization has when groups are enabled per-org.

Note that `.env.development` sets `GROUPS_ENABLED=true`, which `LEGACY_ENABLE_ENV_VARS` maps into the feature-flag enable-allowlist. That short-circuits `resolve()` before it reaches the database and hides this bug entirely, so the reproduction requires `GROUPS_ENABLED=false`.

Both endpoints were exercised over HTTP.

`GET /api/v2/orgs/{orgUuid}/code/groups` (download):

| Code | Org override | Result |
| --- | --- | --- |
| Before | `true` | 403 `Group service is not enabled` |
| Before | `false` | 403 (override never read) |
| After | `true` | 200, groups returned |
| After | `false` | 403 (override correctly honored) |

`POST /api/v2/orgs/{orgUuid}/code/groups` (upload):

| Code | Org override | Operation | Result |
| --- | --- | --- | --- |
| Before | `true` | create | 403 |
| Before | `true` | update | 403 |
| After | `true` | create | 200 `{"action":"create"}`, group and membership persisted |
| After | `true` | update | 200 `{"action":"update"}`, membership updated |
| After | `false` | create | 403, and no row written |

The `false` rows are the control: the fix makes the organization override authoritative in both directions rather than simply opening the gate, and the disabled case still blocks before any write.
