### PR TITLE
fix(charts): correct segment vs whole-column tooltips on stacked bars

### DIFF
--- a/packages/frontend/src/components/SimpleChart/index.tsx
+++ b/packages/frontend/src/components/SimpleChart/index.tsx
@@ -4,7 +4,11 @@ import {
     type PivotReference,
 } from '@lightdash/common';
 import { IconChartBarOff } from '@tabler/icons-react';
-import { type EChartsReactProps, type Opts } from 'echarts-for-react/lib/types';
+import {
+    type EChartsInstance,
+    type EChartsReactProps,
+    type Opts,
+} from 'echarts-for-react/lib/types';
 import { memo, useCallback, useEffect, useMemo, useRef, type FC } from 'react';
 import useEchartsCartesianConfig from '../../hooks/echarts/useEchartsCartesianConfig';
 import {
@@ -137,6 +141,55 @@ const resolveCssVariablesInOptions = <T,>(obj: T): T => {
         return result as T;
     }
     return obj;
+};
+
+// How far past the plot area a pointer still counts as hovering the axis
+const AXIS_LABEL_HOVER_BAND_PX = 40;
+
+type GridRect = { x: number; y: number; width: number; height: number };
+
+const isDimensionAxis = (axis: { type?: string } | undefined): boolean =>
+    axis?.type === 'category' || axis?.type === 'time';
+
+// Point inside the plot area that a pointer over the dimension axis labels maps
+// to, or null when the pointer isn't over them
+const getPlotPointForAxisHover = (
+    eCharts: EChartsInstance,
+    x: number,
+    y: number,
+): { x: number; y: number } | null => {
+    const grid: GridRect | undefined = eCharts
+        .getModel?.()
+        ?.getComponent?.('grid', 0)
+        ?.coordinateSystem?.getRect?.();
+    if (!grid) return null;
+
+    const isUnderXAxis =
+        x >= grid.x &&
+        x <= grid.x + grid.width &&
+        y > grid.y + grid.height &&
+        y <= grid.y + grid.height + AXIS_LABEL_HOVER_BAND_PX;
+    const isBesideYAxis =
+        y >= grid.y &&
+        y <= grid.y + grid.height &&
+        x < grid.x &&
+        x >= grid.x - AXIS_LABEL_HOVER_BAND_PX;
+    // getOption() clones the whole option, so only read it when it matters
+    if (!isUnderXAxis && !isBesideYAxis) return null;
+
+    const { xAxis, yAxis } = eCharts.getOption() as {
+        xAxis?: { type?: string }[];
+        yAxis?: { type?: string }[];
+    };
+
+    if (isUnderXAxis && isDimensionAxis(xAxis?.[0])) {
+        return { x, y: grid.y + grid.height / 2 };
+    }
+    if (isBesideYAxis && isDimensionAxis(yAxis?.[0])) {
+        return { x: grid.x + grid.width / 2, y };
+    }
+
+    return null;
 };
 
 const SimpleChart: FC<SimpleChartProps> = memo(
@@ -283,10 +336,10 @@ const SimpleChart: FC<SimpleChartProps> = memo(
         );
 
         const opts = useMemo<Opts>(() => {
-            const baseOpts: Opts & { useCoarsePointer?: boolean } = {
+            // `useCoarsePointer` is left at its default: its 44px hit-test halo
+            // makes white space near a bar register as a hover on that segment
+            const baseOpts: Opts = {
                 renderer: 'svg',
-                // Reduce mouseover hit-testing overhead on dashboard tiles
-                ...(props.isInDashboard && { useCoarsePointer: true }),
             };
 
             if (!eChartsOptions) {
@@ -300,7 +353,7 @@ const SimpleChart: FC<SimpleChartProps> = memo(
                 return { ...baseOpts, renderer: 'canvas' };
             }
             return baseOpts;
-        }, [eChartsOptions, props.isInDashboard]);
+        }, [eChartsOptions]);
 
         // When using canvas renderer, resolve CSS variables to computed values
         // since canvas doesn't have DOM access to resolve var(--...) strings.
@@ -331,10 +384,9 @@ const SimpleChart: FC<SimpleChartProps> = memo(
                     // Tooltip trigger 'item' does not work when symbol is not shown; reference: https://github.com/apache/echarts/issues/14563
                     const series = eCharts.getOption().series;
 
-                    const isGrouped = (series as any[]).some(
-                        (serie) => serie.pivotReference !== undefined,
-                    );
-                    if (Array.isArray(series) && !isGrouped) return null;
+                    // With a single series there is nothing to narrow down, so
+                    // leave the axis tooltip in place
+                    if (Array.isArray(series) && series.length < 2) return null;
 
                     if (
                         Array.isArray(series) &&
@@ -512,6 +564,61 @@ const SimpleChart: FC<SimpleChartProps> = memo(
             eChartsOptions?.tooltip,
             resolvedEChartsOptions?.tooltip,
         ]);
+
+        // ECharts only triggers the axis tooltip inside the plot area, so
+        // hovering the axis labels shows that category's whole column
+        useEffect(() => {
+            const eCharts = chartRef.current?.getEchartsInstance();
+            if (!eCharts) return;
+
+            const zRender = eCharts.getZr();
+            let isAxisTooltipShown = false;
+
+            const showTooltipOnAxisHover = ({
+                offsetX,
+                offsetY,
+            }: {
+                offsetX: number;
+                offsetY: number;
+            }) => {
+                // The hovered series owns the tooltip while in item mode
+                if (isItemTooltipActive.current) return;
+
+                const plotPoint = getPlotPointForAxisHover(
+                    eCharts,
+                    offsetX,
+                    offsetY,
+                );
+
+                if (plotPoint) {
+                    isAxisTooltipShown = true;
+                    // Trigger the tooltip as if hovering the plot area at the
+                    // same category, so ECharts builds it from the axis
+                    eCharts.dispatchAction({
+                        type: 'showTip',
+                        x: plotPoint.x,
+                        y: plotPoint.y,
+                    });
+                } else if (isAxisTooltipShown) {
+                    isAxisTooltipShown = false;
+                    // Inside the plot area ECharts drives the tooltip itself
+                    const isOverPlotArea = eCharts.containPixel(
+                        { gridIndex: 0 },
+                        [offsetX, offsetY],
+                    );
+                    if (!isOverPlotArea) {
+                        eCharts.dispatchAction({ type: 'hideTip' });
+                    }
+                }
+            };
+
+            zRender.on('mousemove', showTooltipOnAxisHover);
+            return () => {
+                if (!eCharts.isDisposed()) {
+                    zRender.off('mousemove', showTooltipOnAxisHover);
+                }
+            };
+        }, [chartRef, eChartsOptions]);
 
         // Memoize onEvents to prevent echarts-for-react from disposing and
         // re-creating the entire ECharts instance on every render. The library


### PR DESCRIPTION
Hovering a segment of a stacked bar should show that segment's value (`item` trigger); the whole column's breakdown comes from the axis tooltip, which ECharts only triggers in empty space inside the plot. Tall bars leave little or no such space, so the user gets stuck on the whole-column tooltip.

Three fixes:

- The per-segment tooltip only ever kicked in on pivoted charts — a stacked chart built from multiple metrics kept the axis tooltip, so hovering one segment listed every series. It now applies whenever there is more than one series (with a single series both tooltips say the same thing).
- Dashboard tiles set `useCoarsePointer`, whose 44px hit-test halo makes the white space *above* a bar register as a hover on its top segment (why this was easier to reproduce on a dashboard). It now stays at the ECharts default, so only touch devices get the halo.
- Bars that fill their column — 100% stacked ones always do — leave no white space at all, so hovering the dimension axis labels now shows that category's axis tooltip. Applies to the category/time axis only (bottom for vertical charts, left for flipped ones), not the value axis.

Verified the ECharts hit-testing and axis-hover behaviour in a standalone ECharts 5.6 harness (coarse pointer fires `mouseover` 12px above a bar, default pointer doesn't; axis-label hover shows the full column tooltip for the right category in both orientations), plus frontend lint and format. No running Lightdash app in this environment, so the preview deployment is the place to confirm the three hover cases.
