### PR TITLE
fix(scheduler): prevent stale pivot Google Sheets sync failures

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -1,4 +1,6 @@
 import {
+    ChartType,
+    DashboardTileTypes,
     DimensionType,
     DownloadFileType,
     FieldReferenceError,
@@ -12,10 +14,13 @@ import {
     PartialFailureType,
     SchedulerFormat,
     ThresholdOperator,
+    VizAggregationOptions,
+    VizIndexType,
     type CapturedQuery,
     type CreateSchedulerAndTargets,
     type DeliveryCaptureManifest,
     type NotificationPayloadBase,
+    type ReadyQueryResultsPage,
     type ScheduledDeliveryPayload,
     type SchedulerAndTargets,
     type UploadGsheetPayload,
@@ -748,6 +753,247 @@ const makeTaskWithDeps = (overrides: Partial<TaskDeps> = {}) =>
 
 const asDep = <K extends keyof TaskDeps>(value: unknown): TaskDeps[K] =>
     value as TaskDeps[K];
+
+describe('uploadGsheets — pivot routing', () => {
+    const validPivotDetails: NonNullable<
+        ReadyQueryResultsPage['pivotDetails']
+    > = {
+        totalColumnCount: 1,
+        indexColumn: [
+            {
+                reference: 'orders_order_date',
+                type: VizIndexType.TIME,
+            },
+        ],
+        valuesColumns: [
+            {
+                referenceField: 'orders_count',
+                pivotColumnName: 'orders_count_any_complete',
+                aggregation: VizAggregationOptions.ANY,
+                pivotValues: [
+                    {
+                        referenceField: 'orders_status',
+                        value: 'complete',
+                    },
+                ],
+            },
+        ],
+        groupByColumns: [{ reference: 'orders_status' }],
+        sortBy: [],
+        originalColumns: {},
+    };
+    const itemMap = buildItemMapFromColumns([
+        { key: 'orders_order_date', type: 'date' },
+        { key: 'orders_status', type: 'string' },
+        { key: 'orders_count', type: 'number' },
+    ]);
+    const flatRows = [{ orders_order_date: '2026-08-04' }];
+    const pivotedRows = [
+        {
+            orders_order_date: '2026-08-04',
+            orders_count_any_complete: 42,
+        },
+    ];
+
+    const makeChart = (hasPivotConfig: boolean) => ({
+        uuid: 'chart-1',
+        projectUuid: 'project-1',
+        chartConfig: {
+            type: ChartType.TABLE,
+            config: {},
+        },
+        metricQuery: {
+            dimensions: ['orders_order_date', 'orders_status'],
+            metrics: ['orders_count'],
+            filters: {},
+            sorts: [],
+            limit: 500,
+            tableCalculations: [],
+            additionalMetrics: [],
+        },
+        pivotConfig: hasPivotConfig
+            ? { columns: ['orders_status'] }
+            : undefined,
+        tableConfig: {
+            columnOrder: ['orders_order_date', 'orders_status', 'orders_count'],
+        },
+    });
+
+    const setup = ({
+        source,
+        hasPivotConfig,
+        pivotDetails,
+    }: {
+        source: 'saved-chart' | 'dashboard';
+        hasPivotConfig: boolean;
+        pivotDetails: ReadyQueryResultsPage['pivotDetails'];
+    }) => {
+        const appendToSheet = vi.fn().mockResolvedValue(undefined);
+        const appendCsvToSheet = vi.fn().mockResolvedValue(undefined);
+        const logSchedulerJob = vi.fn().mockResolvedValue(undefined);
+        const chart = makeChart(hasPivotConfig);
+        const dashboardUuid = source === 'dashboard' ? 'dashboard-1' : null;
+        const scheduler = {
+            schedulerUuid: 'scheduler-1',
+            name: 'Daily sync',
+            createdBy: 'user-1',
+            format: SchedulerFormat.GSHEETS,
+            savedChartUuid: source === 'saved-chart' ? chart.uuid : null,
+            dashboardUuid,
+            savedSqlUuid: null,
+            cron: '0 7 * * *',
+            timezone: 'UTC',
+            options: { gdriveId: 'sheet-1' },
+            thresholds: undefined,
+            filters: undefined,
+        };
+        const task = makeTaskWithDeps({
+            googleDriveClient: asDep<'googleDriveClient'>({
+                isEnabled: true,
+                uploadMetadata: vi.fn().mockResolvedValue(undefined),
+                createNewTab: vi.fn().mockResolvedValue('Chart'),
+                appendToSheet,
+                appendCsvToSheet,
+            }),
+            schedulerService: asDep<'schedulerService'>({
+                schedulerModel: {
+                    getSchedulerAndTargets: vi
+                        .fn()
+                        .mockResolvedValue(scheduler),
+                },
+                savedChartModel: {
+                    get: vi.fn().mockResolvedValue(chart),
+                },
+                getSchedulerDefaultTimezone: vi.fn().mockResolvedValue('UTC'),
+                logSchedulerJob,
+            }),
+            userService: asDep<'userService'>({
+                getSessionByUserUuid: vi.fn().mockResolvedValue({}),
+                getAccountByUserUuid: vi.fn().mockResolvedValue({
+                    user: { email: 'demo@lightdash.com' },
+                    organization: { organizationUuid: 'org-1' },
+                }),
+                getRefreshToken: vi.fn().mockResolvedValue('refresh-token'),
+            }),
+            asyncQueryService: asDep<'asyncQueryService'>({
+                executeSavedChartQueryAndGetResults: vi.fn().mockResolvedValue({
+                    rows: pivotDetails ? pivotedRows : flatRows,
+                    fields: itemMap,
+                    pivotDetails,
+                    displayTimezone: null,
+                }),
+                executeDashboardChartQueryAndGetResults: vi
+                    .fn()
+                    .mockResolvedValue({
+                        rows: pivotDetails ? pivotedRows : flatRows,
+                        fields: itemMap,
+                        pivotDetails,
+                        displayTimezone: null,
+                    }),
+            }),
+            dashboardService: asDep<'dashboardService'>({
+                getByIdOrSlug: vi.fn().mockResolvedValue({
+                    uuid: dashboardUuid,
+                    projectUuid: 'project-1',
+                    filters: {
+                        dimensions: [],
+                        metrics: [],
+                        tableCalculations: [],
+                    },
+                    tiles: [
+                        {
+                            uuid: 'tile-1',
+                            type: DashboardTileTypes.SAVED_CHART,
+                            properties: {
+                                title: 'Chart',
+                                savedChartUuid: chart.uuid,
+                            },
+                        },
+                    ],
+                    displayTimezone: null,
+                }),
+            }),
+            analytics: asDep<'analytics'>({ track: vi.fn() }),
+            lightdashConfig: asDep<'lightdashConfig'>({
+                siteUrl: 'http://localhost:8090',
+            }),
+        });
+
+        const run = () =>
+            (
+                task as unknown as {
+                    uploadGsheets(
+                        jobId: string,
+                        notification: {
+                            schedulerUuid: string;
+                            scheduledTime: Date;
+                            jobGroup: string;
+                            userUuid: string;
+                            organizationUuid: string;
+                            projectUuid: string;
+                        },
+                    ): Promise<void>;
+                }
+            ).uploadGsheets('job-1', {
+                schedulerUuid: scheduler.schedulerUuid,
+                scheduledTime: new Date('2026-08-04T07:00:00Z'),
+                jobGroup: 'scheduled_delivery',
+                userUuid: 'user-1',
+                organizationUuid: 'org-1',
+                projectUuid: 'project-1',
+            });
+
+        return { appendToSheet, appendCsvToSheet, logSchedulerJob, run };
+    };
+
+    it.each(['saved-chart', 'dashboard'] as const)(
+        'exports flat %s results when stale pivot config has no SQL pivot details',
+        async (source) => {
+            const result = setup({
+                source,
+                hasPivotConfig: true,
+                pivotDetails: null,
+            });
+
+            await result.run();
+
+            expect(result.appendToSheet).toHaveBeenCalledOnce();
+            expect(result.appendCsvToSheet).not.toHaveBeenCalled();
+        },
+    );
+
+    it.each(['saved-chart', 'dashboard'] as const)(
+        'exports pivoted %s results when SQL pivot details exist',
+        async (source) => {
+            const result = setup({
+                source,
+                hasPivotConfig: true,
+                pivotDetails: validPivotDetails,
+            });
+
+            await result.run();
+
+            expect(result.appendCsvToSheet).toHaveBeenCalledOnce();
+            expect(result.appendToSheet).not.toHaveBeenCalled();
+        },
+    );
+
+    it('keeps non-pivoted saved-chart results on the flat writer', async () => {
+        const result = setup({
+            source: 'saved-chart',
+            hasPivotConfig: false,
+            pivotDetails: null,
+        });
+
+        await result.run();
+
+        expect(result.appendToSheet).toHaveBeenCalledOnce();
+        expect(result.appendCsvToSheet).not.toHaveBeenCalled();
+        expect(result.logSchedulerJob).toHaveBeenLastCalledWith(
+            expect.objectContaining({ status: 'completed' }),
+        );
+    });
+});
 
 describe('handleScheduledDelivery execution identity', () => {
     const persistedScheduler = {

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -3844,13 +3844,9 @@ export default class SchedulerTask {
                 const pivotConfig = getPivotConfig(chart);
                 if (
                     pivotConfig &&
+                    pivotDetails &&
                     isTableChartConfig(chart.chartConfig.config)
                 ) {
-                    if (!pivotDetails) {
-                        throw new Error(
-                            'Cannot export pivoted results without SQL pivot details',
-                        );
-                    }
                     // pivotResultsAsCsv expects a formatted ResultRow[] type, so we need to convert it first
                     const formattedRows = formatRows(
                         rows,
@@ -4011,13 +4007,9 @@ export default class SchedulerTask {
                         const pivotConfig = getPivotConfig(chart);
                         if (
                             pivotConfig &&
+                            pivotDetails &&
                             isTableChartConfig(chart.chartConfig.config)
                         ) {
-                            if (!pivotDetails) {
-                                throw new Error(
-                                    'Cannot export pivoted results without SQL pivot details',
-                                );
-                            }
                             // pivotResultsAsCsv expects a formatted ResultRow[] type, so we need to convert it first
                             const formattedRows = formatRows(
                                 rows,


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9466/google-sheets-sync-sync-fails-with-cannot-export-pivoted-results

## Summary

Google Sheets scheduled deliveries no longer fail when a chart retains stale pivot configuration after its pivot value is removed. Saved-chart and dashboard syncs fall back to the flat result shape when the executed query has no SQL pivot details.

## Root cause

The scheduler treated UI pivot configuration as proof that query results were pivoted. A chart edit could leave pivot columns behind without a metric or table calculation, so SQL pivot derivation produced no `pivotDetails` and the delivery threw before writing results.

```text
Before: stale pivot config -> pivot writer -> missing SQL details -> error
After:  stale pivot config + no SQL details -> flat writer -> sync completes
        valid pivot config + SQL details    -> pivot writer -> sync completes
```

The direct CSV/XLSX path already treats stored SQL pivot details as authoritative; the scheduled Google Sheets path still enforced the older mismatch as an error.

## Fix

Saved-chart and dashboard Google Sheets deliveries now enter pivot formatting only when stored SQL pivot details exist. Valid pivots keep their current formatting, and non-pivoted results continue through the existing flat writer.

- `packages/backend/src/scheduler/SchedulerTask.ts` — use query pivot details as the scheduled-delivery pivot signal.
- `packages/backend/src/scheduler/SchedulerTask.test.ts` — cover stale, valid, and absent pivot states for saved charts and dashboards.
- Ad-hoc Google Sheets exports, chart persistence cleanup, and direct CSV/XLSX downloads remain unchanged.

## Before

The focused regression test failed with `Cannot export pivoted results without SQL pivot details`.

## After

The five-case routing matrix passes for stale, valid, and absent pivot state across saved-chart and dashboard deliveries.

## Test plan

- [x] Full `SchedulerTask.test.ts` — 70/70 passed.
- [x] Backend typecheck.
- [x] Touched-file Oxlint and Oxfmt checks.
- [x] `git diff --check`.
