### PR TITLE
fix(totals): calculate totals with joined-view dimensions

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -1746,6 +1746,46 @@ LIMIT 10`;
     });
 
     describe('Query builder with deduplication', () => {
+        test('column totals keep joins required by source group dimensions', () => {
+            const result = buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: {
+                    ...METRIC_QUERY_TWO_TABLES,
+                    dimensions: ['table1_dim1', 'table2_dim2'],
+                    metrics: ['table1_metric1'],
+                    sorts: [],
+                    filters: {
+                        metrics: {
+                            id: 'root',
+                            and: [
+                                {
+                                    id: 'metric-filter',
+                                    target: { fieldId: 'table1_metric1' },
+                                    operator: FilterOperator.GREATER_THAN,
+                                    values: [0],
+                                },
+                            ],
+                        },
+                    },
+                    tableCalculations: [],
+                    compiledTableCalculations: [],
+                },
+                warehouseSqlBuilder: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: QUERY_BUILDER_UTC_TIMEZONE,
+                totalConfiguration: {
+                    kind: 'columnTotal',
+                    subtotalDimensions: undefined,
+                },
+            });
+
+            expect(
+                result.query.match(
+                    /JOIN "db"\."schema"\."table2" AS "table2"/g,
+                ),
+            ).toHaveLength(2);
+        });
+
         test('Should build query with CTEs for metrics to prevent inflation', () => {
             // Use the imported explore mock with MANY_TO_ONE relationship to trigger metric inflation
             const result = buildQuery({

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -4873,6 +4873,7 @@ export class MetricQueryBuilder {
               leadingCtes: string[];
               binCtes: string[];
               joins: string[];
+              tables: string[];
               aggregations: SourceQueryAggregations | undefined;
               aggregationFields: ItemsMap;
               warnings: QueryWarning[];
@@ -4914,14 +4915,14 @@ export class MetricQueryBuilder {
         const binJoinDimensions = compiledCustomDimensions
             .filter(isCustomBinDimension)
             .filter((cd) => allJoinDimensions.has(cd.id));
-        const binExprs =
-            getCustomBinDimensionSql({
-                warehouseSqlBuilder,
-                explore,
-                customDimensions: binJoinDimensions,
-                intrinsicUserAttributes,
-                userAttributes,
-            })?.exprs ?? {};
+        const binJoinDimensionSql = getCustomBinDimensionSql({
+            warehouseSqlBuilder,
+            explore,
+            customDimensions: binJoinDimensions,
+            intrinsicUserAttributes,
+            userAttributes,
+        });
+        const binExprs = binJoinDimensionSql?.exprs ?? {};
         const unselectedBinSql = getCustomBinDimensionSql({
             warehouseSqlBuilder,
             explore,
@@ -4931,6 +4932,31 @@ export class MetricQueryBuilder {
             intrinsicUserAttributes,
             userAttributes,
         });
+        const customDimensionIds = new Set(
+            compiledCustomDimensions.map((dimension) => dimension.id),
+        );
+        const tables = [
+            ...[...allJoinDimensions]
+                .filter((dimensionId) => !customDimensionIds.has(dimensionId))
+                .flatMap((dimensionId) => {
+                    const dimension = getDimensionFromId({
+                        dimId: dimensionId,
+                        dimensions: this.exploreDimensions,
+                        dimensionsWithoutAccess:
+                            this.exploreDimensionsWithoutAccess,
+                        adapterType,
+                        startOfWeek,
+                        timezone: this.timezoneForDateTrunc,
+                        columnTimezone: this.columnTimezone,
+                    });
+                    return dimension.tablesReferences || [dimension.table];
+                }),
+            ...compiledCustomDimensions
+                .filter(isCompiledCustomSqlDimension)
+                .filter((dimension) => allJoinDimensions.has(dimension.id))
+                .flatMap((dimension) => dimension.tablesReferences),
+            ...(binJoinDimensionSql?.tables ?? []),
+        ];
 
         const getJoinDimensionExpr = (dimId: string): string => {
             const customDimension = compiledCustomDimensions.find(
@@ -5085,6 +5111,7 @@ export class MetricQueryBuilder {
             leadingCtes,
             binCtes: unselectedBinSql?.ctes ?? [],
             joins,
+            tables,
             aggregations,
             aggregationFields,
             warnings,
@@ -5114,11 +5141,6 @@ export class MetricQueryBuilder {
         const dimensionsSQL = this.getDimensionsSQL();
         const metricsSQL = this.getMetricsSQL();
 
-        const joins = this.getJoinsSQL({
-            tablesReferencedInDimensions: dimensionsSQL.tables,
-            tablesReferencedInMetrics: metricsSQL.tables,
-        });
-
         // Mutates dimensionsSQL before any consumer reads it, so the
         // source-query restriction joins reach every raw scan (main select,
         // fan-out, distinct-metric, nested-aggregate and totals CTEs).
@@ -5127,8 +5149,14 @@ export class MetricQueryBuilder {
             dimensionsSQL.ctes.unshift(...sourceQuerySQL.leadingCtes);
             dimensionsSQL.ctes.push(...sourceQuerySQL.binCtes);
             dimensionsSQL.joins.push(...sourceQuerySQL.joins);
+            dimensionsSQL.tables.push(...sourceQuerySQL.tables);
             Object.assign(fields, sourceQuerySQL.aggregationFields);
         }
+
+        const joins = this.getJoinsSQL({
+            tablesReferencedInDimensions: dimensionsSQL.tables,
+            tablesReferencedInMetrics: metricsSQL.tables,
+        });
 
         const sqlSelect = `SELECT\n${[
             ...Object.values(dimensionsSQL.selects),


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9465/semantic-layer-column-totals-fail-with-relation-does-not-exist-when-a

## Summary

Column totals now calculate when a table combines metric filters with dimensions from joined views. Previously, the totals warehouse query could fail because it referenced a joined-view alias that was not present in the outer query.

## Root cause

Metric filters preserve the source query's passing dimension groups before totals re-aggregate the raw rows. The totals query collapsed those dimensions before planning its outer warehouse joins, but the source-group predicate still used each dimension's raw SQL expression.

```sql
FROM base_view
INNER JOIN source_dimension_groups
    ON joined_view.dimension = source_dimension_groups.joined_dimension
-- joined_view was not joined in this outer query
```

The joined view existed inside `source_rows`, so the row query worked, but it was out of scope when the outer totals predicate ran.

## Fix

`MetricQueryBuilder` now carries table dependencies from source-group dimensions into outer join planning without re-selecting the collapsed dimensions or changing the totals grain.

- `MetricQueryBuilder.ts` resolves table references for explore, custom SQL, and bin dimensions before compiling outer joins.
- `MetricQueryBuilder.test.ts` adds a regression for metric-filtered column totals with a many-to-one joined-view dimension.

## Before

```text
source_rows (base + joined view)
        │
        ▼
source_dimension_groups
        │
        ▼
totals scan (base only) ── predicate uses joined_view.dimension ── ERROR
```

## After

```text
source_rows (base + joined view)
        │
        ▼
source_dimension_groups
        │
        ▼
totals scan (base + joined view) ── predicate uses joined_view.dimension ── OK
```

## Test plan

- [x] Focused regression fails before the fix and passes after it.
- [x] `pnpm -F backend exec vitest run --config vitest.config.ts src/utils/QueryBuilder` — 20 files and 605 tests pass.
- [x] `pnpm -F backend typecheck`
- [x] `pnpm -F backend lint`
- [x] `pnpm -F backend format`
- [x] Existing QueryBuilder snapshots remain unchanged.
- [x] Read-only production query history confirms the missing-relation SQL shape without copying customer data into this PR.