### PR TITLE
fix(parameters): reject invalid shapes before SQL rendering

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/parameters.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/parameters.test.ts
@@ -1,4 +1,4 @@
-import type { ParametersValuesMap } from '@lightdash/common';
+import { CompileError, type ParametersValuesMap } from '@lightdash/common';
 import { warehouseClientMock } from './MetricQueryBuilder.mock';
 import {
     safeReplaceParameters,
@@ -106,6 +106,34 @@ describe('replaceParameters', () => {
 });
 
 describe('safeReplaceParametersWithSqlBuilder', () => {
+    it('should reject nested array parameters before replacing SQL', () => {
+        const sql = 'SELECT ${lightdash.parameters.inj} FROM sensitive_table';
+        const parameters = {
+            inj: [["coupon') OR TRUE --"]],
+        } as unknown as ParametersValuesMap;
+
+        expect(() =>
+            safeReplaceParametersWithSqlBuilder(
+                sql,
+                parameters,
+                mockSqlBuilder,
+            ),
+        ).toThrowError(CompileError);
+    });
+
+    it('should preserve mixed primitive arrays for typed parameter validation', () => {
+        const sql =
+            'SELECT ${lightdash.parameters.values} FROM sensitive_table';
+        const parameters = {
+            values: ['coupon', 2],
+        } as unknown as ParametersValuesMap;
+
+        expect(
+            safeReplaceParametersWithSqlBuilder(sql, parameters, mockSqlBuilder)
+                .replacedSql,
+        ).toBe("SELECT 'coupon', 2 FROM sensitive_table");
+    });
+
     it('should escape single quote in string parameter to prevent SQL injection', () => {
         const sql =
             'SELECT * FROM users WHERE name = ${lightdash.parameters.name}';
@@ -162,6 +190,22 @@ describe('unsafeReplaceParametersAsRaw', () => {
 });
 
 describe('safeReplaceParametersWithTypes', () => {
+    it('should reject nested Liquid parameter arrays before rendering SQL', () => {
+        const sql =
+            '{% if ld.parameters.inj %}{{ ld.parameters.inj }}{% endif %}';
+        const parameters = {
+            inj: [["coupon') OR TRUE --"]],
+        } as unknown as ParametersValuesMap;
+
+        expect(() =>
+            safeReplaceParametersWithTypes({
+                sql,
+                parameterValuesMap: parameters,
+                sqlBuilder: mockSqlBuilder,
+            }),
+        ).toThrowError(CompileError);
+    });
+
     it('should not wrap number parameters in quotes', () => {
         const sql =
             'SELECT * FROM users WHERE id = ${lightdash.parameters.user_id}';

--- a/packages/backend/src/utils/QueryBuilder/parameters.ts
+++ b/packages/backend/src/utils/QueryBuilder/parameters.ts
@@ -1,9 +1,11 @@
 import {
+    escapeParameterValue,
     getParameterReferences,
     isReservedParameterName,
     parameterRegex,
     renderLiquidSql,
     UnexpectedServerError,
+    type EscapedParameterValue,
     type FieldsContext,
     type ParameterDefinitions,
     type ParametersValuesMap,
@@ -63,21 +65,14 @@ const validateAndSanitizeDate = (value: unknown): string => {
 const escapeParameterValues = (
     parameters: ParametersValuesMap,
     escapeString: (value: string) => string,
-): ParametersValuesMap => {
-    const escapedParameters: ParametersValuesMap = {};
+): Record<string, EscapedParameterValue> => {
+    const escapedParameters: Record<string, EscapedParameterValue> = {};
 
     Object.entries(parameters).forEach(([key, value]) => {
-        if (Array.isArray(value)) {
-            // Handle array of strings or numbers
-            const escapedArray = value.map((item) =>
-                typeof item === 'number' ? item : escapeString(item),
-            );
-            escapedParameters[key] = escapedArray as string[] | number[];
-        } else {
-            // Handle single string or number
-            escapedParameters[key] =
-                typeof value === 'number' ? value : escapeString(value);
-        }
+        escapedParameters[key] = escapeParameterValue(value, {
+            escapeString,
+            allowMixedArrayValues: true,
+        });
     });
 
     return escapedParameters;

--- a/packages/backend/src/utils/QueryBuilder/utils.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.ts
@@ -43,6 +43,7 @@ import {
     TableCalculationType,
     UserAttributeValueMap,
     WeekDay,
+    type EscapedParameterValue,
     type WarehouseSqlBuilder,
 } from '@lightdash/common';
 import { intersection, isArray } from 'lodash';
@@ -203,7 +204,7 @@ const getWrapChars = (wrapChar: string): [string, string] => {
 export const replaceLightdashValues = (
     regex: RegExp,
     sql: string,
-    valuesMap: Record<string, string | number | string[] | number[]>,
+    valuesMap: Record<string, EscapedParameterValue>,
     quoteChar: string | '',
     wrapChar: string | '',
     {

--- a/packages/common/src/templating/liquidSql.test.ts
+++ b/packages/common/src/templating/liquidSql.test.ts
@@ -1,3 +1,4 @@
+import { CompileError } from '../types/errors';
 import {
     buildLiquidContext,
     renderLiquidSql,
@@ -100,6 +101,57 @@ describe('buildLiquidContext', () => {
                 query: { fields: [], filters: [] },
             },
         });
+    });
+
+    it('should escape string arrays and preserve number arrays', () => {
+        const context = buildLiquidContext(
+            {
+                strings: ["coupon'", 'card'],
+                numbers: [1, 2],
+            },
+            undefined,
+            (value) => value.replaceAll("'", "''"),
+        );
+
+        expect(context.ld.parameters).toEqual({
+            strings: ["coupon''", 'card'],
+            numbers: [1, 2],
+        });
+    });
+
+    it.each([
+        ['mixed primitives', ['coupon', 1]],
+        ['object values', [{ value: 'coupon' }]],
+    ])('should reject %s in parameter arrays', (_name, value) => {
+        const parameters = {
+            invalid: value,
+        } as unknown as Parameters<typeof buildLiquidContext>[0];
+
+        expect(() => buildLiquidContext(parameters)).toThrowError(
+            expect.objectContaining({
+                statusCode: 400,
+                message:
+                    'Parameter arrays must contain only strings or only numbers',
+            }),
+        );
+    });
+
+    it.each([
+        ['object', { value: 'coupon' }],
+        ['null', null],
+        ['boolean', true],
+    ])('should reject a scalar %s parameter', (_name, value) => {
+        const parameters = {
+            invalid: value,
+        } as unknown as Parameters<typeof buildLiquidContext>[0];
+
+        expect(() => buildLiquidContext(parameters)).toThrowError(
+            expect.objectContaining({
+                statusCode: 400,
+                message:
+                    'Parameters must be strings, numbers, or arrays of strings or numbers',
+            }),
+        );
     });
 
     it('should derive query.fields and query.filters from fieldsContext', () => {
@@ -281,6 +333,20 @@ describe('renderLiquidSql', () => {
                 (value) => value.replaceAll("'", "''"),
             ).trim(),
         ).toBe("coupon'') OR TRUE --");
+    });
+
+    it('should reject nested array parameters before rendering SQL', () => {
+        const sql =
+            '{% if ld.parameters.inj %}{{ ld.parameters.inj }}{% endif %}';
+        const parameters = {
+            inj: [["coupon') OR TRUE --"]],
+        } as unknown as Parameters<typeof renderLiquidSql>[1];
+
+        expect(() =>
+            renderLiquidSql(sql, parameters, undefined, (value) =>
+                value.replaceAll("'", "''"),
+            ),
+        ).toThrowError(CompileError);
     });
 
     it('should handle SQL with mixed content around Liquid blocks', () => {

--- a/packages/common/src/templating/liquidSql.ts
+++ b/packages/common/src/templating/liquidSql.ts
@@ -1,4 +1,6 @@
 import { Liquid } from 'liquidjs';
+import { CompileError } from '../types/errors';
+import { escapeParameterValue, type ParameterValue } from '../types/parameters';
 
 /**
  * Liquid template engine for SQL rendering.
@@ -24,8 +26,6 @@ const liquidSqlEngine = new Liquid({
 const LIGHTDASH_LIQUID_PATTERN =
     /\{%[^%]*(?:ld|lightdash)\.(?:parameters|query)\b/;
 
-type ParameterValue = string | number | string[] | number[];
-
 const UNSAFE_PARAMETER_KEY_PARTS = new Set([
     '__proto__',
     'constructor',
@@ -34,27 +34,6 @@ const UNSAFE_PARAMETER_KEY_PARTS = new Set([
 
 const isSafeParameterKey = (key: string) =>
     !key.split('.').some((part) => UNSAFE_PARAMETER_KEY_PARTS.has(part));
-
-const escapeLiquidParameterValue = (
-    value: ParameterValue,
-    escapeString?: (value: string) => string,
-): ParameterValue => {
-    if (!escapeString) {
-        return value;
-    }
-
-    if (typeof value === 'string') {
-        return escapeString(value);
-    }
-
-    if (Array.isArray(value)) {
-        return value.every((item): item is string => typeof item === 'string')
-            ? value.map(escapeString)
-            : value;
-    }
-
-    return value;
-};
 
 /**
  * Query-time field introspection for a single field.
@@ -107,10 +86,7 @@ export const buildLiquidContext = (
 
     for (const [key, value] of Object.entries(parameterValuesMap)) {
         if (isSafeParameterKey(key)) {
-            const escapedValue = escapeLiquidParameterValue(
-                value,
-                escapeString,
-            );
+            const escapedValue = escapeParameterValue(value, { escapeString });
 
             parameters[key] = escapedValue;
 
@@ -206,7 +182,11 @@ export const renderLiquidSql = (
             escapeString,
         );
         return liquidSqlEngine.parseAndRenderSync(sql, context);
-    } catch {
+    } catch (error) {
+        if (error instanceof CompileError) {
+            throw error;
+        }
+
         // If Liquid parsing fails (e.g., malformed syntax or unrelated {% in SQL),
         // fall back to the original SQL so we don't break existing queries
         return sql;

--- a/packages/common/src/types/parameters.ts
+++ b/packages/common/src/types/parameters.ts
@@ -1,10 +1,80 @@
+import { CompileError } from './errors';
 import type { LightdashProjectParameter } from './lightdashProjectConfig';
 
 // Base type for parameter values - can be extended later for new types (dates, booleans, etc.)
 export type ParameterValue = string | number | string[] | number[];
+export type EscapedParameterValue = string | number | Array<string | number>;
 
 // Used anywhere we have parameters
 export type ParametersValuesMap = Record<string, ParameterValue>;
+
+type EscapeParameterValueOptions = {
+    escapeString?: (value: string) => string;
+    allowMixedArrayValues?: false;
+};
+
+type EscapeMixedParameterValueOptions = {
+    escapeString?: (value: string) => string;
+    allowMixedArrayValues: true;
+};
+
+export function escapeParameterValue(
+    value: unknown,
+    options: EscapeMixedParameterValueOptions,
+): EscapedParameterValue;
+export function escapeParameterValue(
+    value: unknown,
+    options?: EscapeParameterValueOptions,
+): ParameterValue;
+export function escapeParameterValue(
+    value: unknown,
+    options:
+        | EscapeParameterValueOptions
+        | EscapeMixedParameterValueOptions = {},
+): EscapedParameterValue {
+    const { escapeString, allowMixedArrayValues = false } = options;
+
+    if (typeof value === 'string') {
+        return escapeString ? escapeString(value) : value;
+    }
+
+    if (typeof value === 'number') {
+        return value;
+    }
+
+    if (Array.isArray(value)) {
+        const hasOnlyStrings = value.every(
+            (item): item is string => typeof item === 'string',
+        );
+        const hasOnlyNumbers = value.every(
+            (item): item is number => typeof item === 'number',
+        );
+        const hasOnlyPrimitiveValues = value.every(
+            (item) => typeof item === 'string' || typeof item === 'number',
+        );
+
+        if (
+            hasOnlyPrimitiveValues &&
+            (allowMixedArrayValues || hasOnlyStrings || hasOnlyNumbers)
+        ) {
+            return value.map((item) =>
+                typeof item === 'string' && escapeString
+                    ? escapeString(item)
+                    : item,
+            );
+        }
+
+        throw new CompileError(
+            allowMixedArrayValues
+                ? 'Parameter arrays must contain only strings and numbers'
+                : 'Parameter arrays must contain only strings or only numbers',
+        );
+    }
+
+    throw new CompileError(
+        'Parameters must be strings, numbers, or arrays of strings or numbers',
+    );
+}
 
 export type ParameterDefinitions = Record<string, LightdashProjectParameter>;
 


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-536/veria-42-sql-injection-in-filter-and-templating-logic-via-type

## Summary

Rejects malformed parameter shapes before Liquid or standard parameter rendering so nested arrays cannot bypass warehouse string escaping.

This covers both parameter syntaxes while preserving valid strings, numbers, homogeneous arrays, and the existing typed-number handling for mixed primitive arrays.

## Root cause

Runtime API payloads could reach query compilation with shapes outside the declared `ParameterValue` union. Liquid returned arrays unchanged unless every item was a string, while standard replacement passed nested values to string escaping through implicit coercion.

```ts
return value.every((item) => typeof item === 'string')
    ? value.map(escapeString)
    : value;
```

The filter-side nested-array path was already closed by #26710. The remaining parameter paths did not share the same fail-closed validation.

## Fix

- `packages/common/src/types/parameters.ts` validates runtime parameter shapes and escapes supported values at one shared boundary.
- Liquid rendering requires homogeneous string or number arrays and propagates validation errors instead of treating them as malformed template syntax.
- Standard `${ld.parameters.*}` replacement rejects nested and object values while retaining safely escaped mixed primitives for typed parameter validation.

## Before

```text
nested request value
        |
        v
Liquid / ${...} replacement
        |
        v
implicit array coercion
        |
        v
unescaped text reaches compiled SQL
```

## After

```text
nested request value
        |
        v
shared parameter validation
        |
        v
CompileError (HTTP 400)
        |
        v
SQL rendering stops
```

## Test plan

- [x] `pnpm -F common test` — 124 files, 3301 passed, 1 skipped
- [x] `pnpm -F backend test src/utils/QueryBuilder/parameters.test.ts` — 27 passed
- [x] `pnpm -F common typecheck && pnpm -F backend typecheck`
- [x] `pnpm -F common lint && pnpm -F backend lint`
- [x] `pnpm -F common format && pnpm -F backend format`
- [x] Regression coverage for nested arrays in Liquid and standard parameter syntax
- [x] Compatibility coverage for escaped string arrays, numeric arrays, mixed typed primitives, malformed Liquid syntax, and invalid scalar values