### PR TITLE
fix(ai): fail interrupted agent turns during shutdown

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -179,6 +179,7 @@ export type AppArguments = {
     pgWireServerFactory?: (
         serviceRepository: ServiceRepository,
     ) => PgWireServerInstance;
+    beforeShutdown?: (serviceRepository: ServiceRepository) => Promise<void>;
 };
 
 export default class App {
@@ -198,6 +199,10 @@ export default class App {
 
     private readonly pgWireServerFactory:
         | ((serviceRepository: ServiceRepository) => PgWireServerInstance)
+        | undefined;
+
+    private readonly beforeShutdown:
+        | ((serviceRepository: ServiceRepository) => Promise<void>)
         | undefined;
 
     private readonly clients: ClientRepository;
@@ -292,6 +297,7 @@ export default class App {
             args.schedulerWorkerFactory || schedulerWorkerFactory;
         this.customExpressMiddlewares = args.customExpressMiddlewares || [];
         this.pgWireServerFactory = args.pgWireServerFactory;
+        this.beforeShutdown = args.beforeShutdown;
     }
 
     async start() {
@@ -1065,6 +1071,12 @@ export default class App {
     }
 
     async stop() {
+        try {
+            await this.beforeShutdown?.(this.serviceRepository);
+        } catch (error) {
+            Logger.error('Error running pre-shutdown hook', error);
+        }
+
         if (this.featureFlagCheckFlushInterval) {
             clearInterval(this.featureFlagCheckFlushInterval);
             this.featureFlagCheckFlushInterval = undefined;

--- a/packages/backend/src/ee/aiAgentShutdown.test.ts
+++ b/packages/backend/src/ee/aiAgentShutdown.test.ts
@@ -1,0 +1,29 @@
+import { failInFlightAiAgentStreams } from './aiAgentShutdown';
+
+describe('failInFlightAiAgentStreams', () => {
+    it('shuts down an initialized AI agent service', async () => {
+        const failInFlightStreamedPrompts = vi
+            .fn()
+            .mockResolvedValue(undefined);
+        const getInitializedAiAgentService = vi.fn().mockReturnValue({
+            failInFlightStreamedPrompts,
+        });
+
+        await failInFlightAiAgentStreams({
+            getInitializedAiAgentService,
+        } as never);
+
+        expect(getInitializedAiAgentService).toHaveBeenCalledOnce();
+        expect(failInFlightStreamedPrompts).toHaveBeenCalledOnce();
+    });
+
+    it('does not construct an unused AI agent service during shutdown', async () => {
+        const getInitializedAiAgentService = vi.fn().mockReturnValue(undefined);
+
+        await failInFlightAiAgentStreams({
+            getInitializedAiAgentService,
+        } as never);
+
+        expect(getInitializedAiAgentService).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/backend/src/ee/aiAgentShutdown.ts
+++ b/packages/backend/src/ee/aiAgentShutdown.ts
@@ -1,0 +1,13 @@
+import type { ServiceRepository } from '../services/ServiceRepository';
+
+type StreamShutdownService = {
+    failInFlightStreamedPrompts: () => Promise<void>;
+};
+
+export const failInFlightAiAgentStreams = async (
+    repository: Pick<ServiceRepository, 'getInitializedAiAgentService'>,
+): Promise<void> => {
+    await repository
+        .getInitializedAiAgentService<StreamShutdownService>()
+        ?.failInFlightStreamedPrompts();
+};

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -22,6 +22,7 @@ import { OrganizationService } from '../services/OrganizationService/Organizatio
 import { ProjectService } from '../services/ProjectService/ProjectService';
 import { RolesService } from '../services/RolesService/RolesService';
 import { EncryptionUtil } from '../utils/EncryptionUtil/EncryptionUtil';
+import { failInFlightAiAgentStreams } from './aiAgentShutdown';
 import { AiModelCatalog } from './clients/Ai/AiModelCatalog';
 import LicenseClient from './clients/License/LicenseClient';
 import { ManagedAgentClient } from './clients/ManagedAgentClient';
@@ -112,6 +113,7 @@ type EnterpriseAppArguments = Pick<
     | 'modelProviders'
     | 'customExpressMiddlewares'
     | 'pgWireServerFactory'
+    | 'beforeShutdown'
 >;
 
 // Shared instance so the per-key model list cache is shared across resolvers
@@ -140,6 +142,9 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
     registerPreAggregateStream();
 
     return {
+        beforeShutdown: async (repository) => {
+            await failInFlightAiAgentStreams(repository);
+        },
         serviceProviders: {
             licenseService: () =>
                 new EnterpriseLicenseService({

--- a/packages/backend/src/ee/models/AiAgentModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.integration.test.ts
@@ -64,6 +64,140 @@ describe('AiAgentModel prompt activity', () => {
         );
     });
 
+    it('fails only prompts that are still pending during shutdown', async () => {
+        const threadUuid = await createWebAppThread();
+        const [pendingPromptUuid, completedPromptUuid, failedPromptUuid] =
+            await Promise.all(
+                ['pending', 'completed', 'failed'].map((state) =>
+                    model.createWebAppPrompt({
+                        threadUuid,
+                        createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                        prompt: `${state} prompt`,
+                    }),
+                ),
+            );
+
+        await Promise.all([
+            model.updateModelResponse({
+                promptUuid: completedPromptUuid,
+                response: 'Completed response',
+            }),
+            model.updateModelResponse({
+                promptUuid: failedPromptUuid,
+                errorMessage: 'Existing failure',
+            }),
+        ]);
+
+        const promptStates = (await database(AiPromptTableName)
+            .select(['ai_prompt_uuid', 'response', 'error_message'])
+            .select(database.raw('responded_at::text as responded_at'))
+            .whereIn('ai_prompt_uuid', [
+                pendingPromptUuid,
+                completedPromptUuid,
+                failedPromptUuid,
+            ])) as unknown as Array<{
+            ai_prompt_uuid: string;
+            responded_at: string | null;
+            response: string | null;
+            error_message: string | null;
+        }>;
+        const initialStatesByUuid = new Map(
+            promptStates.map((prompt) => [prompt.ai_prompt_uuid, prompt]),
+        );
+        const pendingState = initialStatesByUuid.get(pendingPromptUuid)!;
+        const failedState = initialStatesByUuid.get(failedPromptUuid)!;
+
+        const updatedPromptUuids = await model.failPendingPrompts(
+            [pendingPromptUuid, completedPromptUuid, failedPromptUuid],
+            'Server restarted',
+        );
+        const prompts = await database(AiPromptTableName)
+            .select([
+                'ai_prompt_uuid',
+                'response',
+                'responded_at',
+                'error_message',
+            ])
+            .whereIn('ai_prompt_uuid', [
+                pendingPromptUuid,
+                completedPromptUuid,
+                failedPromptUuid,
+            ]);
+        const promptsByUuid = new Map(
+            prompts.map((prompt) => [prompt.ai_prompt_uuid, prompt]),
+        );
+
+        expect(updatedPromptUuids).toEqual([pendingPromptUuid]);
+        expect(promptsByUuid.get(pendingPromptUuid)).toMatchObject({
+            response: null,
+            error_message: 'Server restarted',
+        });
+        expect(
+            promptsByUuid.get(pendingPromptUuid)?.responded_at,
+        ).not.toBeNull();
+
+        await model.updateModelResponse(
+            {
+                promptUuid: pendingPromptUuid,
+                response: 'Late response',
+            },
+            {
+                onlyIfPending: true,
+            },
+        );
+        const shutdownFailedPrompt = await database(AiPromptTableName)
+            .select(['response', 'error_message'])
+            .where('ai_prompt_uuid', pendingPromptUuid)
+            .first();
+
+        expect(shutdownFailedPrompt).toMatchObject({
+            response: null,
+            error_message: 'Server restarted',
+        });
+        expect(promptsByUuid.get(completedPromptUuid)).toMatchObject({
+            response: 'Completed response',
+            error_message: null,
+        });
+        expect(promptsByUuid.get(failedPromptUuid)).toMatchObject({
+            response: null,
+            error_message: 'Existing failure',
+        });
+
+        const retryStarted = await model.resetPromptResponseForRetry(
+            failedPromptUuid,
+            {
+                respondedAt: failedState.responded_at,
+                response: failedState.response,
+                errorMessage: failedState.error_message,
+            },
+        );
+        expect(retryStarted).toBe(true);
+
+        const retriedPromptUuids = await model.failPendingPrompts(
+            [failedPromptUuid],
+            'Server restarted during retry',
+        );
+        expect(retriedPromptUuids).toEqual([failedPromptUuid]);
+
+        await model.updateModelResponse(
+            {
+                promptUuid: failedPromptUuid,
+                response: 'Late retry response',
+            },
+            {
+                onlyIfPending: true,
+            },
+        );
+        const shutdownFailedRetry = await database(AiPromptTableName)
+            .select(['response', 'error_message'])
+            .where('ai_prompt_uuid', failedPromptUuid)
+            .first();
+        expect(shutdownFailedRetry).toMatchObject({
+            response: null,
+            error_message: 'Server restarted during retry',
+        });
+    });
+
     it('keeps reused tool call ids scoped to their prompts', async () => {
         const threadUuid = await createWebAppThread();
         const expectedResults = ['first prompt result', 'second prompt result'];

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -193,6 +193,33 @@ import {
 import { type SqlApprovalDecision } from '../services/ai/tools/sqlApprovals';
 import { AiAgentReviewClassifierModel } from './AiAgentReviewClassifierModel';
 
+export type AiPromptResponseState = {
+    respondedAt: string | null;
+    response: string | null;
+    errorMessage: string | null;
+};
+
+const wherePromptResponseState = (
+    query: Knex.QueryBuilder,
+    state: AiPromptResponseState,
+): void => {
+    if (state.respondedAt === null) {
+        query.whereNull('responded_at');
+    } else {
+        query.where('responded_at', state.respondedAt);
+    }
+    if (state.response === null) {
+        query.whereNull('response');
+    } else {
+        query.where('response', state.response);
+    }
+    if (state.errorMessage === null) {
+        query.whereNull('error_message');
+    } else {
+        query.where('error_message', state.errorMessage);
+    }
+};
+
 type Dependencies = {
     database: Knex;
     lightdashConfig: LightdashConfig;
@@ -4832,6 +4859,7 @@ export class AiAgentModel {
 
     async updateModelResponse(
         data: UpdateSlackResponse | UpdateWebAppResponse,
+        { onlyIfPending = false }: { onlyIfPending?: boolean } = {},
     ) {
         // A new response supersedes any previous error for this prompt
         const outcome: {
@@ -4849,7 +4877,7 @@ export class AiAgentModel {
                           : {}),
                   };
 
-        await this.database(AiPromptTableName)
+        const query = this.database(AiPromptTableName)
             .update({
                 responded_at: this.database.fn.now(),
                 ...outcome,
@@ -4862,8 +4890,54 @@ export class AiAgentModel {
             })
             .where({
                 ai_prompt_uuid: data.promptUuid,
+            });
+
+        if (onlyIfPending) {
+            query
+                .whereNull('responded_at')
+                .whereNull('response')
+                .whereNull('error_message');
+        }
+
+        await query.returning('ai_prompt_uuid');
+    }
+
+    async resetPromptResponseForRetry(
+        promptUuid: string,
+        previousState: AiPromptResponseState,
+    ): Promise<boolean> {
+        const rows = await this.database(AiPromptTableName)
+            .update({
+                responded_at: this.database.raw('NULL'),
+                error_message: null,
             })
-            .returning('ai_prompt_uuid');
+            .where('ai_prompt_uuid', promptUuid)
+            .modify((query) => wherePromptResponseState(query, previousState))
+            .returning<{ ai_prompt_uuid: string }[]>('ai_prompt_uuid');
+
+        return rows.length > 0;
+    }
+
+    async failPendingPrompts(
+        promptUuids: string[],
+        errorMessage: string,
+    ): Promise<string[]> {
+        if (promptUuids.length === 0) {
+            return [];
+        }
+
+        const rows = await this.database(AiPromptTableName)
+            .update({
+                responded_at: this.database.fn.now(),
+                error_message: errorMessage,
+            })
+            .whereIn('ai_prompt_uuid', promptUuids)
+            .whereNull('responded_at')
+            .whereNull('response')
+            .whereNull('error_message')
+            .returning<{ ai_prompt_uuid: string }[]>('ai_prompt_uuid');
+
+        return rows.map(({ ai_prompt_uuid }) => ai_prompt_uuid);
     }
 
     async createAiPromptInterrupt(data: {
@@ -5517,7 +5591,7 @@ export class AiAgentModel {
 
     async findWebAppPrompt(
         promptUuid: string,
-    ): Promise<AiWebAppPrompt | undefined> {
+    ): Promise<(AiWebAppPrompt & AiPromptResponseState) | undefined> {
         return this.database(AiPromptTableName)
             .join(
                 AiWebAppPromptTableName,
@@ -5546,7 +5620,9 @@ export class AiAgentModel {
                 createdAt: `${AiPromptTableName}.created_at`,
                 response: `${AiPromptTableName}.response`,
                 errorMessage: `${AiPromptTableName}.error_message`,
-                respondedAt: `${AiPromptTableName}.responded_at`,
+                respondedAt: this.database.raw('??::text', [
+                    `${AiPromptTableName}.responded_at`,
+                ]),
                 humanScore: `${AiPromptTableName}.human_score`,
                 humanFeedback: `${AiPromptTableName}.human_feedback`,
                 filtersOutput: `${AiPromptTableName}.filters_output`,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.shutdown.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.shutdown.test.ts
@@ -1,0 +1,241 @@
+import { ParameterError } from '@lightdash/common';
+import type {
+    AiAgentModel,
+    AiPromptResponseState,
+} from '../../models/AiAgentModel';
+import { AiAgentService } from './AiAgentService';
+
+vi.mock('../ai/AiAgentMcpRuntimeClient', async (importOriginal) => ({
+    ...(await importOriginal()),
+    AiAgentMcpRuntimeClient: vi
+        .fn()
+        // eslint-disable-next-line prefer-arrow-callback
+        .mockImplementation(function MockAiAgentMcpRuntimeClient() {
+            return {};
+        }),
+}));
+
+type ShutdownHarness = {
+    beginStreamPreparation: () => void;
+    endStreamPreparation: () => void;
+    trackStreamPrompt: (
+        promptUuid: string,
+        responseState: AiPromptResponseState,
+    ) => void;
+    persistTrackedPromptUpdate: (
+        update: Parameters<AiAgentModel['updateModelResponse']>[0],
+    ) => Promise<void> | undefined;
+    failInFlightStreamedPrompts: () => Promise<void>;
+};
+
+type PromptResolutionOptions = {
+    resetErrorForStreamRetry: boolean;
+    onPromptResolved: (
+        promptUuid: string,
+        state: AiPromptResponseState,
+    ) => void;
+};
+
+type PrivateService = {
+    prepareAgentThreadResponse: (
+        user: unknown,
+        options: PromptResolutionOptions,
+    ) => Promise<unknown>;
+    generateOrStreamAgentResponse: (...args: unknown[]) => Promise<unknown>;
+};
+
+const pendingState: AiPromptResponseState = {
+    respondedAt: null,
+    response: null,
+    errorMessage: null,
+};
+
+const createDeferred = () => {
+    let resolve!: () => void;
+    const promise = new Promise<void>((resolvePromise) => {
+        resolve = resolvePromise;
+    });
+    return { promise, resolve };
+};
+
+const buildService = () => {
+    const updateModelResponse = vi.fn().mockResolvedValue(undefined);
+    const failPendingPrompts = vi
+        .fn()
+        .mockImplementation(async (promptUuids: string[]) => promptUuids);
+    const service = new AiAgentService({
+        aiAgentModel: {
+            updateModelResponse,
+            failPendingPrompts,
+        },
+    } as unknown as ConstructorParameters<typeof AiAgentService>[0]);
+
+    return {
+        instance: service,
+        service: service as unknown as ShutdownHarness,
+        updateModelResponse,
+        failPendingPrompts,
+    };
+};
+
+describe('AiAgentService streamed prompt shutdown', () => {
+    it('wires prompt resolution into shutdown through the public stream flow', async () => {
+        const { instance, service, failPendingPrompts } = buildService();
+        const privateService = instance as unknown as PrivateService;
+        const preparation = createDeferred();
+        const generateResponse = vi
+            .spyOn(privateService, 'generateOrStreamAgentResponse')
+            .mockResolvedValue({});
+        vi.spyOn(
+            privateService,
+            'prepareAgentThreadResponse',
+        ).mockImplementation(async (_user, options) => {
+            expect(options.resetErrorForStreamRetry).toBe(true);
+            options.onPromptResolved('prompt-uuid', pendingState);
+            await preparation.promise;
+            return {
+                user: { organizationUuid: 'organization-uuid' },
+                chatHistoryMessages: [],
+                prompt: { promptUuid: 'prompt-uuid', response: null },
+                compaction: null,
+            };
+        });
+
+        const stream = instance.streamAgentThreadResponse(
+            { organizationUuid: 'organization-uuid' } as never,
+            {
+                agentUuid: 'agent-uuid',
+                threadUuid: 'thread-uuid',
+                enableSqlMode: false,
+                toolHints: [],
+            },
+        );
+        await Promise.resolve();
+        await service.failInFlightStreamedPrompts();
+        preparation.resolve();
+
+        await expect(stream).rejects.toThrow(
+            'Something went wrong while processing your request. Please try again.',
+        );
+        expect(failPendingPrompts).toHaveBeenCalledWith(
+            ['prompt-uuid'],
+            'The server restarted while generating this response. Please try again.',
+        );
+        expect(generateResponse).not.toHaveBeenCalled();
+    });
+
+    it('persists a post-resolution preparation failure', async () => {
+        const { instance, updateModelResponse } = buildService();
+        const privateService = instance as unknown as PrivateService;
+        vi.spyOn(
+            privateService,
+            'prepareAgentThreadResponse',
+        ).mockImplementation(async (_user, options) => {
+            options.onPromptResolved('prompt-uuid', pendingState);
+            throw new Error('Preparation failed');
+        });
+
+        await expect(
+            instance.streamAgentThreadResponse(
+                { organizationUuid: 'organization-uuid' } as never,
+                {
+                    agentUuid: 'agent-uuid',
+                    threadUuid: 'thread-uuid',
+                    enableSqlMode: false,
+                    toolHints: [],
+                },
+            ),
+        ).rejects.toThrow(
+            'Something went wrong while processing your request. Please try again.',
+        );
+
+        expect(updateModelResponse).toHaveBeenCalledWith(
+            {
+                promptUuid: 'prompt-uuid',
+                errorMessage:
+                    'Something went wrong while processing your request. Please try again.',
+            },
+            { onlyIfPending: true },
+        );
+    });
+
+    it('closes admission and waits for an admitted prompt before failing it', async () => {
+        const { service, failPendingPrompts } = buildService();
+        service.beginStreamPreparation();
+
+        const shutdown = service.failInFlightStreamedPrompts();
+        await Promise.resolve();
+
+        expect(() => service.beginStreamPreparation()).toThrow(ParameterError);
+        expect(failPendingPrompts).not.toHaveBeenCalled();
+
+        service.trackStreamPrompt('prompt-uuid', pendingState);
+        service.endStreamPreparation();
+        await shutdown;
+
+        expect(failPendingPrompts).toHaveBeenCalledWith(
+            ['prompt-uuid'],
+            'The server restarted while generating this response. Please try again.',
+        );
+    });
+
+    it('lets a terminal write that started first win the shutdown race', async () => {
+        const { service, updateModelResponse, failPendingPrompts } =
+            buildService();
+        const terminalWrite = createDeferred();
+        updateModelResponse.mockReturnValueOnce(terminalWrite.promise);
+        service.trackStreamPrompt('prompt-uuid', pendingState);
+
+        const update = service.persistTrackedPromptUpdate({
+            promptUuid: 'prompt-uuid',
+            response: 'Completed response',
+        });
+        const shutdown = service.failInFlightStreamedPrompts();
+        expect(failPendingPrompts).not.toHaveBeenCalled();
+
+        terminalWrite.resolve();
+        await Promise.all([update, shutdown]);
+
+        expect(updateModelResponse).toHaveBeenCalledWith(
+            {
+                promptUuid: 'prompt-uuid',
+                response: 'Completed response',
+            },
+            { onlyIfPending: true },
+        );
+        expect(failPendingPrompts).not.toHaveBeenCalled();
+    });
+
+    it('ignores a terminal callback after shutdown wins', async () => {
+        const { service, updateModelResponse } = buildService();
+        const retryState: AiPromptResponseState = {
+            respondedAt: '2026-08-04 08:00:00+00',
+            response: null,
+            errorMessage: 'Previous failure',
+        };
+        service.trackStreamPrompt('retry-prompt-uuid', retryState);
+
+        await service.failInFlightStreamedPrompts();
+        const lateUpdate = service.persistTrackedPromptUpdate({
+            promptUuid: 'retry-prompt-uuid',
+            response: 'Late response',
+        });
+
+        expect(lateUpdate).toBeUndefined();
+        expect(updateModelResponse).not.toHaveBeenCalled();
+    });
+
+    it('bounds the preparation barrier during shutdown', async () => {
+        vi.useFakeTimers();
+        const { service, failPendingPrompts } = buildService();
+        service.beginStreamPreparation();
+
+        const shutdown = service.failInFlightStreamedPrompts();
+        await vi.advanceTimersByTimeAsync(5_000);
+        await shutdown;
+
+        expect(failPendingPrompts).not.toHaveBeenCalled();
+        service.endStreamPreparation();
+        vi.useRealTimers();
+    });
+});

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -232,6 +232,7 @@ import {
     type AiAgentMcpServerToolPermissionSettingUpdate,
     type AiMcpCredential,
     type AiMcpServerWithSensitiveData,
+    type AiPromptResponseState,
 } from '../../models/AiAgentModel';
 import { AiAgentReviewClassifierModel } from '../../models/AiAgentReviewClassifierModel';
 import { AiAgentReviewNotificationModel } from '../../models/AiAgentReviewNotificationModel';
@@ -392,6 +393,10 @@ type AgentResponseStream = {
 };
 
 const MAX_AI_PROMPT_CONTEXT_ITEMS = 10;
+const AI_AGENT_SHUTDOWN_ERROR_MESSAGE =
+    'The server restarted while generating this response. Please try again.';
+const AI_AGENT_SHUTDOWN_PERSIST_TIMEOUT_MS = 5_000;
+const AI_AGENT_SHUTDOWN_PERSIST_ATTEMPTS = 2;
 const EXPLICIT_SLACK_CHANNEL_LINKING_REQUIRED_REASON =
     'explicit_slack_channel_linking_required';
 const AGENT_AVATAR_MAX_BYTES = 5 * 1024 * 1024;
@@ -692,6 +697,23 @@ function validateGeneratedSuggestion(
 
 export class AiAgentService extends BaseService {
     private readonly aiAgentModel: AiAgentModel;
+
+    private readonly inFlightStreamPrompts = new Map<
+        string,
+        AiPromptResponseState
+    >();
+
+    private readonly shutdownFailedPromptUuids = new Set<string>();
+
+    private readonly terminalStreamUpdates = new Map<string, Promise<void>>();
+
+    private activeStreamPreparations = 0;
+
+    private readonly streamPreparationWaiters = new Set<() => void>();
+
+    private isShuttingDown = false;
+
+    private shutdownPromise: Promise<void> | undefined;
 
     private readonly aiAgentMemoryModel: AiAgentMemoryModel;
 
@@ -4742,11 +4764,18 @@ export class AiAgentService extends BaseService {
             threadUuid,
             promptUuid,
             retrieveRelevantArtifacts = true,
+            onPromptResolved,
+            resetErrorForStreamRetry = false,
         }: {
             agentUuid: string;
             threadUuid: string;
             promptUuid?: string;
             retrieveRelevantArtifacts?: boolean;
+            onPromptResolved?: (
+                promptUuid: string,
+                responseState: AiPromptResponseState,
+            ) => void;
+            resetErrorForStreamRetry?: boolean;
         },
     ) {
         if (!user.organizationUuid) {
@@ -4810,6 +4839,36 @@ export class AiAgentService extends BaseService {
         ) {
             throw new NotFoundError(`Prompt not found: ${targetPromptUuid}`);
         }
+        if (
+            resetErrorForStreamRetry &&
+            prompt.response === null &&
+            prompt.errorMessage !== null
+        ) {
+            const retryStarted =
+                await this.aiAgentModel.resetPromptResponseForRetry(
+                    prompt.promptUuid,
+                    {
+                        respondedAt: prompt.respondedAt,
+                        response: prompt.response,
+                        errorMessage: prompt.errorMessage,
+                    },
+                );
+            if (!retryStarted) {
+                throw new ParameterError(
+                    'This response changed while the retry was starting. Please try again.',
+                );
+            }
+            prompt.respondedAt = null;
+            prompt.errorMessage = null;
+        }
+        if (prompt.response === null) {
+            onPromptResolved?.(prompt.promptUuid, {
+                respondedAt: prompt.respondedAt,
+                response: prompt.response,
+                errorMessage: prompt.errorMessage,
+            });
+        }
+
         const targetThreadMessages = threadMessages.slice(
             0,
             targetPromptIndex + 1,
@@ -4855,6 +4914,100 @@ export class AiAgentService extends BaseService {
         };
     }
 
+    private beginStreamPreparation(): void {
+        if (this.isShuttingDown) {
+            throw new ParameterError(
+                'The server is restarting. Please try again shortly.',
+            );
+        }
+        this.activeStreamPreparations += 1;
+    }
+
+    private endStreamPreparation(): void {
+        this.activeStreamPreparations -= 1;
+        if (this.activeStreamPreparations === 0) {
+            this.streamPreparationWaiters.forEach((resolve) => resolve());
+            this.streamPreparationWaiters.clear();
+        }
+    }
+
+    private async waitForStreamPreparations(): Promise<void> {
+        if (this.activeStreamPreparations === 0) {
+            return;
+        }
+        await new Promise<void>((resolve) => {
+            this.streamPreparationWaiters.add(resolve);
+        });
+    }
+
+    private async withShutdownTimeout<T>(operation: Promise<T>): Promise<T> {
+        let timer: NodeJS.Timeout | undefined;
+        try {
+            return await Promise.race([
+                operation,
+                new Promise<never>((_resolve, reject) => {
+                    timer = setTimeout(
+                        () => reject(new Error('AI agent shutdown timed out')),
+                        AI_AGENT_SHUTDOWN_PERSIST_TIMEOUT_MS,
+                    );
+                }),
+            ]);
+        } finally {
+            clearTimeout(timer);
+        }
+    }
+
+    private trackStreamPrompt(
+        promptUuid: string,
+        responseState: AiPromptResponseState,
+    ): void {
+        this.inFlightStreamPrompts.set(promptUuid, responseState);
+    }
+
+    private persistTrackedPromptUpdate(
+        update: UpdateSlackResponse | UpdateWebAppResponse,
+    ): Promise<void> | undefined {
+        if (
+            this.shutdownFailedPromptUuids.has(update.promptUuid) ||
+            (this.isShuttingDown &&
+                this.inFlightStreamPrompts.has(update.promptUuid))
+        ) {
+            return undefined;
+        }
+
+        const isTerminalStreamUpdate =
+            this.inFlightStreamPrompts.has(update.promptUuid) &&
+            (update.response !== undefined ||
+                update.errorMessage !== undefined);
+        const modelUpdatePromise = this.aiAgentModel.updateModelResponse(
+            update,
+            {
+                onlyIfPending: isTerminalStreamUpdate,
+            },
+        );
+        if (!isTerminalStreamUpdate) {
+            return modelUpdatePromise;
+        }
+
+        const terminalUpdatePromise = modelUpdatePromise
+            .then(() => {
+                this.inFlightStreamPrompts.delete(update.promptUuid);
+            })
+            .finally(() => {
+                if (
+                    this.terminalStreamUpdates.get(update.promptUuid) ===
+                    terminalUpdatePromise
+                ) {
+                    this.terminalStreamUpdates.delete(update.promptUuid);
+                }
+            });
+        this.terminalStreamUpdates.set(
+            update.promptUuid,
+            terminalUpdatePromise,
+        );
+        return terminalUpdatePromise;
+    }
+
     async streamAgentThreadResponse(
         user: SessionUser,
         {
@@ -4873,7 +5026,18 @@ export class AiAgentService extends BaseService {
             runtimeOptions?: EmbedAiAgentRuntimeOptions;
         },
     ): Promise<AgentResponseStream> {
+        let isPreparing = false;
+        let trackedPromptUuid: string | undefined;
+        const finishPreparation = () => {
+            if (isPreparing) {
+                isPreparing = false;
+                this.endStreamPreparation();
+            }
+        };
+
         try {
+            this.beginStreamPreparation();
+            isPreparing = true;
             const {
                 user: validatedUser,
                 chatHistoryMessages,
@@ -4882,7 +5046,20 @@ export class AiAgentService extends BaseService {
             } = await this.prepareAgentThreadResponse(user, {
                 agentUuid,
                 threadUuid,
+                resetErrorForStreamRetry: true,
+                onPromptResolved: (promptUuid, responseState) => {
+                    trackedPromptUuid = promptUuid;
+                    this.trackStreamPrompt(promptUuid, responseState);
+                    finishPreparation();
+                },
             });
+            finishPreparation();
+
+            if (this.isShuttingDown) {
+                throw new ParameterError(
+                    'The server is restarting. Please try again shortly.',
+                );
+            }
 
             // Re-running an answered prompt would stamp an error onto a good
             // response (chat history already ends with its assistant answer)
@@ -4921,25 +5098,129 @@ export class AiAgentService extends BaseService {
                 });
             }
 
-            return await this.generateOrStreamAgentResponse(
-                validatedUser,
-                {
-                    messageHistory: chatHistoryMessages,
-                    compactionSummary: compaction?.summary ?? null,
-                },
-                {
-                    prompt,
-                    stream: true,
-                    canManageAgent,
-                    enableSqlMode,
-                    autoApproveSql,
-                    toolHints,
-                    runtimeOptions,
-                },
-            );
+            try {
+                return await this.generateOrStreamAgentResponse(
+                    validatedUser,
+                    {
+                        messageHistory: chatHistoryMessages,
+                        compactionSummary: compaction?.summary ?? null,
+                    },
+                    {
+                        prompt,
+                        stream: true,
+                        canManageAgent,
+                        enableSqlMode,
+                        autoApproveSql,
+                        toolHints,
+                        runtimeOptions,
+                    },
+                );
+            } catch (error) {
+                if (!this.isShuttingDown) {
+                    this.inFlightStreamPrompts.delete(prompt.promptUuid);
+                }
+                throw error;
+            }
         } catch (e) {
+            finishPreparation();
+            if (
+                trackedPromptUuid &&
+                !this.isShuttingDown &&
+                this.inFlightStreamPrompts.has(trackedPromptUuid)
+            ) {
+                try {
+                    await this.persistTrackedPromptUpdate({
+                        promptUuid: trackedPromptUuid,
+                        errorMessage: getUserFacingErrorMessage(e),
+                    });
+                } catch (persistError) {
+                    this.inFlightStreamPrompts.delete(trackedPromptUuid);
+                    Logger.error(
+                        'Failed to persist agent stream preparation error:',
+                        persistError,
+                    );
+                }
+            }
             Logger.error('Failed to generate agent thread response:', e);
             throw new ParameterError(getUserFacingErrorMessage(e));
+        }
+    }
+
+    async failInFlightStreamedPrompts(): Promise<void> {
+        if (!this.shutdownPromise) {
+            this.isShuttingDown = true;
+            this.shutdownPromise = this.persistInFlightStreamFailures();
+        }
+        await this.shutdownPromise;
+    }
+
+    private async persistInFlightStreamFailures(): Promise<void> {
+        try {
+            await this.withShutdownTimeout(this.waitForStreamPreparations());
+        } catch {
+            Logger.warn(
+                '[AiAgent][Shutdown] Timed out waiting for stream preparations',
+            );
+        }
+
+        const terminalUpdates = [...this.terminalStreamUpdates.values()];
+        if (terminalUpdates.length > 0) {
+            try {
+                await this.withShutdownTimeout(
+                    Promise.allSettled(terminalUpdates),
+                );
+            } catch {
+                Logger.warn(
+                    '[AiAgent][Shutdown] Timed out waiting for terminal prompt updates',
+                );
+            }
+        }
+
+        const promptUuids = [...this.inFlightStreamPrompts.keys()];
+        if (promptUuids.length === 0) {
+            return;
+        }
+
+        promptUuids.forEach((promptUuid) =>
+            this.shutdownFailedPromptUuids.add(promptUuid),
+        );
+
+        const persistFailures = async (attempt: number): Promise<string[]> => {
+            try {
+                return await this.withShutdownTimeout(
+                    this.aiAgentModel.failPendingPrompts(
+                        promptUuids,
+                        AI_AGENT_SHUTDOWN_ERROR_MESSAGE,
+                    ),
+                );
+            } catch (error) {
+                Logger.warn(
+                    `[AiAgent][Shutdown] Failed to persist prompt failures (attempt ${attempt}/${AI_AGENT_SHUTDOWN_PERSIST_ATTEMPTS})`,
+                );
+                if (attempt < AI_AGENT_SHUTDOWN_PERSIST_ATTEMPTS) {
+                    return persistFailures(attempt + 1);
+                }
+                throw error;
+            }
+        };
+
+        try {
+            const failedPromptUuids = await persistFailures(1);
+            Logger.info(
+                `[AiAgent][Shutdown] Marked ${failedPromptUuids.length} in-flight prompt(s) as failed`,
+            );
+        } catch (error) {
+            promptUuids.forEach((promptUuid) =>
+                this.shutdownFailedPromptUuids.delete(promptUuid),
+            );
+            Logger.error(
+                '[AiAgent][Shutdown] Failed to mark in-flight prompts as failed',
+                error,
+            );
+            Sentry.captureException(error, {
+                tags: { errorType: 'AiAgentShutdownPersistenceError' },
+            });
+            throw error;
         }
     }
 
@@ -9327,8 +9608,10 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             updatePrompt: (
                 update: UpdateSlackResponse | UpdateWebAppResponse,
             ) => {
-                const updatePromise =
-                    this.aiAgentModel.updateModelResponse(update);
+                const updatePromise = this.persistTrackedPromptUpdate(update);
+                if (!updatePromise) {
+                    return Promise.resolve();
+                }
                 const updateWithCitationTelemetryPromise =
                     aiAgentMemoryEnabled &&
                     update.response !== undefined &&

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1470,6 +1470,14 @@ export class ServiceRepository
         return this.getService('aiAgentService');
     }
 
+    public getInitializedAiAgentService<AiAgentServiceImplT>():
+        | AiAgentServiceImplT
+        | undefined {
+        return this.serviceInstances.aiAgentService as
+            | AiAgentServiceImplT
+            | undefined;
+    }
+
     public getAiAgentToolsService<
         AiAgentToolsServiceImplT,
     >(): AiAgentToolsServiceImplT {


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8981/ai-agent-turns-die-silently-when-the-backend-pod-is-terminated-mid

## Summary

Agent turns interrupted by a backend pod shutdown now become retryable errors immediately instead of appearing to load forever and later failing without an explanation. This covers web and embedded streamed turns owned by the terminating process.

## Root cause

SIGTERM awaited the application's existing cleanup and then exited the process, but no lifecycle step owned active AI streams. A prompt interrupted after tool execution could therefore keep `response`, `responded_at`, and `error_message` null.

```ts
process.on('SIGTERM', async () => {
    await app.stop();
    process.exit(0);
});
```

Normal stream callbacks persist terminal responses, but pod termination can stop the process before those callbacks run.

## Fix

Shutdown closes stream admission, waits for admitted prompts to resolve, drains terminal writes, and conditionally marks remaining prompts with a retry error before normal cleanup continues. Pending-row updates decide shutdown/completion races atomically, and a streamed retry claims the exact prior error state before starting a new attempt.

- `App` and the enterprise shutdown seam invoke only an already-initialized AI service and keep core cleanup isolated from hook failures.
- `AiAgentService` tracks streamed prompts, bounds preparation and persistence waits, and suppresses late callbacks after shutdown wins.
- `AiAgentModel` batches pending failures and protects retry/reset transitions with conditional updates.
- Non-stream, title-generation, evaluation, Slack, and scheduler flows remain out of scope.

```text
Before: SIGTERM -> cleanup -> process exit -> prompt remains pending
After:  SIGTERM -> close admission -> persist retry error -> cleanup -> exit
                              \-> normal terminal write may win first
```

## Before

After the stale timeout, the interrupted thread returned:

```json
{"status":"error","message":null,"errorMessage":null}
```

## After

The interrupted thread returns immediately:

```json
{"status":"error","message":null,"errorMessage":"The server restarted while generating this response. Please try again."}
```

Retrying the same prompt UUID replaces that error in place with a successful response.

## Test plan

- [x] `pnpm -F backend typecheck && pnpm -F backend lint`
- [x] Focused shutdown unit tests — 8/8 passed
- [x] `AiAgentModel.integration.test.ts` — 5/5 passed
- [x] Broader backend unit suite — 5,721 passed, 1 skipped
- [x] Manual: two concurrent real streams plus duplicate SIGTERM persist the retry error before PM2 restart
- [x] Manual: retry the exact interrupted prompt to `status: idle` with a successful response and no additional prompt row
- [x] Manual: normal completion and client-disconnect stream consumption remain successful
