### PR TITLE
fix(data-apps): match chat input bottom padding to sides

### DIFF
--- a/packages/frontend/src/pages/AppGenerate.module.css
+++ b/packages/frontend/src/pages/AppGenerate.module.css
@@ -288,7 +288,7 @@
     min-height: 0;
     max-height: 46%;
     overflow-y: auto;
-    padding: var(--mantine-spacing-sm) var(--mantine-spacing-sm) 48px;
+    padding: var(--mantine-spacing-sm);
     border-top: 1px solid;
 
     @mixin light {


### PR DESCRIPTION
## Summary

The data-app chat input area (`.chatInputArea` in `AppGenerate.module.css`) had a hardcoded 48px bottom padding, leaving a large dead zone under the prompt box. This changes it to use the same `--mantine-spacing-sm` as the sides, so the padding is uniform (12px) all around.

Affects both places that use the class:
- the compose card ("Build a Data App" landing) — the card now hugs the prompt box
- the split sidebar view when iterating on an existing app

No element depends on the old 48px clearance (nothing floats over the bottom of the input area).


### Before
<img width="975" height="710" alt="before" src="https://github.com/user-attachments/assets/6f980ef7-d559-4dac-b2e0-0c6d5a21cc64" />

### After
<img width="975" height="710" alt="after" src="https://github.com/user-attachments/assets/3bf6f412-813f-4482-b74f-f11d4ba59fc1" />
