### PR TITLE
fix(ai): restrict writeback sandbox permissions

### DIFF
--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
@@ -38,14 +38,17 @@ import {
     workstreamLockKey,
 } from './AiWritebackService';
 import {
+    ALLOWED_TOOLS,
     COMPILE_WRAPPER_PATH,
     GENERAL_ALLOWED_TOOLS,
     GENERAL_DISALLOWED_TOOLS,
     MAX_CONCURRENT_WORKSTREAM_TURNS_PER_THREAD,
     PR_DESCRIPTION_CLOSE,
     PR_DESCRIPTION_OPEN,
+    PR_DESCRIPTION_PATH,
     PR_TITLE_CLOSE,
     PR_TITLE_OPEN,
+    PR_TITLE_PATH,
 } from './constants';
 import { DeniedPathError } from './deniedPaths';
 import {
@@ -2184,6 +2187,22 @@ describe('auditReasonForError', () => {
 
     it('falls back to unknown for unrecognised errors', () => {
         expect(auditReasonForError(new Error('boom'))).toBe('unknown');
+    });
+});
+
+describe('ALLOWED_TOOLS', () => {
+    const tools = ALLOWED_TOOLS.split(',');
+
+    it('only grants explicit PR metadata writes directly under /tmp', () => {
+        expect(tools).toContain(`Write(/${PR_TITLE_PATH})`);
+        expect(tools).toContain(`Write(/${PR_DESCRIPTION_PATH})`);
+        expect(tools).not.toContain('Write(//tmp/**)');
+    });
+
+    it('only grants Bash access to the secret-stripping compile wrapper', () => {
+        expect(tools.filter((tool) => tool.startsWith('Bash('))).toEqual([
+            `Bash(${COMPILE_WRAPPER_PATH}:*)`,
+        ]);
     });
 });
 

--- a/packages/backend/src/ee/services/AiWritebackService/constants.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/constants.ts
@@ -126,8 +126,7 @@ export const COMPILE_STRIPPED_ENV_VARS = [
 //   - read/edit/write/glob/grep over the cloned repo at CWD
 //   - read/write/edit under TMP_PROFILES_DIR (the patched profiles copy)
 //   - write to the two PR metadata files the host reads after the run
-//   - bash scoped to the compile wrapper (COMPILE_WRAPPER_PATH) and the file
-//     ops needed to set up the temporary profiles dir
+//   - bash scoped to the compile wrapper (COMPILE_WRAPPER_PATH)
 export const ALLOWED_TOOLS = [
     `Read(/${CWD}/**)`,
     `Glob(/${CWD}/**)`,
@@ -146,17 +145,14 @@ export const ALLOWED_TOOLS = [
     // outside the cwd workspace so it must also be passed via `--add-dir`.
     'Skill',
     `Read(/${CLAUDE_SKILLS_DIR}/**)`,
-    // PR metadata files live directly in /tmp. This permission alone is not
-    // enough: Claude Code also confines Write/Edit to the cwd workspace, so
-    // /tmp must additionally be passed via `--add-dir /tmp` (see
-    // runAgentInSandbox). Without that the agent's /tmp write is refused and it
-    // falls back to the repo root, where the host has to scrub it.
-    `Write(//tmp/**)`,
+    // PR metadata files live directly in /tmp, which is also passed via
+    // `--add-dir /tmp`. Keep these paths explicit: the compile wrapper is an
+    // executable in /tmp and must never be writable by the agent.
+    `Write(/${PR_TITLE_PATH})`,
+    `Write(/${PR_DESCRIPTION_PATH})`,
     // Compile only via the secret-stripping wrapper, never raw
     // `lightdash compile` — see COMPILE_WRAPPER_PATH.
     `Bash(${COMPILE_WRAPPER_PATH}:*)`,
-    'Bash(mkdir:*)',
-    'Bash(cp:*)',
 ].join(',');
 
 // Anthropic model used for the writeback agent. Pinned to a specific Sonnet


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-530/veria-46-credential-exposure-via-ai-sandbox-policy-bypass-in-writeback

## Summary

Restricts the dbt writeback agent to explicit PR metadata files under `/tmp` and removes unrestricted filesystem Bash commands. This prevents the agent from replacing the secret-stripping compile wrapper while preserving existing repo, profile, skill, and compile access.

## Root cause

The writeback Claude process inherits `ANTHROPIC_API_KEY`. Its sandbox policy also allowed arbitrary writes under `/tmp`, including the executable compile wrapper that protects child processes by stripping secrets. Raw `cp` and `mkdir` commands added further filesystem mutation paths.

```ts
`Write(//tmp/**)`,
'Bash(mkdir:*)',
'Bash(cp:*)',
```

Broad `/tmp` access was introduced when exact metadata writes failed outside the working directory. The sandbox now passes `/tmp` through `--add-dir`, so exact absolute file rules work without exposing sibling executables.

## Fix

- `constants.ts` grants writes only to `PR_TITLE_PATH` and `PR_DESCRIPTION_PATH` directly under `/tmp`.
- The secret-stripping compile wrapper is now the only Bash command available to the dbt writeback agent.
- Regression tests pin both invariants. Removing `ANTHROPIC_API_KEY` from the agent process remains outside this focused fix.

## Before

```text
Agent ── Write(//tmp/**) ──> PR metadata
                           └─> executable compile wrapper
Agent ── Bash(cp/mkdir) ───> arbitrary temporary filesystem changes
```

## After

```text
Agent ── Write ──> /tmp/pr_title.txt
              └─> /tmp/pr_description.md
Agent ── Bash ───> host-written secret-stripping compile wrapper only
Host  ── stages ─> credential-free /tmp/ld-profiles
```

## Test plan

- [x] Regression test fails before the fix on both unsafe policy invariants.
- [x] Full backend unit suite: 386 files passed; 5,742 tests passed; 1 skipped.
- [x] `pnpm -F backend lint`
- [x] `pnpm -F backend typecheck`
- [x] Focused final test: 1 file passed; 8 matching tests passed; 116 skipped.
- [ ] Human security review before merge, as required by the linked finding.

Live credential extraction was intentionally not exercised; the before/after oracle asserts the policy passed to Claude Code directly.