### PR TITLE
fix(ai): show BYOK provider billing errors

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -2068,6 +2068,7 @@ export const streamAgentResponse = async ({
                 const userFacingMessage = getUserFacingErrorMessage(
                     error,
                     'Something went wrong while streaming the response. Please try again.',
+                    args.keyManagement,
                 );
 
                 await persistPrompt({
@@ -2099,6 +2100,7 @@ export const streamAgentResponse = async ({
         const userFacingMessage = getUserFacingErrorMessage(
             error,
             'Something went wrong while processing your request. Please try again.',
+            args.keyManagement,
         );
 
         await dependencies.updatePrompt({

--- a/packages/backend/src/ee/services/ai/utils/errorMessages.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/errorMessages.test.ts
@@ -3,6 +3,7 @@ import {
     AiAgentEmptyResponseError,
     EMPTY_RESPONSE_MESSAGE,
     getUserFacingErrorMessage,
+    PROVIDER_BILLING_MESSAGE,
 } from './errorMessages';
 
 const CONTEXT_LIMIT_MESSAGE =
@@ -46,9 +47,13 @@ describe('getUserFacingErrorMessage', () => {
             'The request exceeds the maximum context length for this model',
             "exceeds the model's maximum token limit",
         ])('detects context limit error: %s', (message) => {
-            expect(getUserFacingErrorMessage(new Error(message))).toBe(
-                CONTEXT_LIMIT_MESSAGE,
-            );
+            expect(
+                getUserFacingErrorMessage(
+                    new Error(message),
+                    undefined,
+                    'self-managed',
+                ),
+            ).toBe(CONTEXT_LIMIT_MESSAGE);
         });
 
         it('detects context limit from an Error object', () => {
@@ -73,9 +78,55 @@ describe('getUserFacingErrorMessage', () => {
             'You have exceeded your quota',
             'Request was throttled',
         ])('detects rate limit error: %s', (message) => {
-            expect(getUserFacingErrorMessage(new Error(message))).toBe(
-                RATE_LIMIT_MESSAGE,
-            );
+            expect(
+                getUserFacingErrorMessage(
+                    new Error(message),
+                    undefined,
+                    'self-managed',
+                ),
+            ).toBe(RATE_LIMIT_MESSAGE);
+        });
+    });
+
+    describe('provider billing errors', () => {
+        it.each([
+            'Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.',
+            'insufficient_quota',
+            'Provider billing is not enabled',
+            'Monthly spend limit reached',
+            'payment_required',
+            'HTTP 402 Payment Required',
+        ])(
+            'shows actionable billing guidance for self-managed keys: %s',
+            (message) => {
+                expect(
+                    getUserFacingErrorMessage(
+                        new Error(message),
+                        'Custom fallback',
+                        'self-managed',
+                    ),
+                ).toBe(PROVIDER_BILLING_MESSAGE);
+            },
+        );
+
+        it('does not expose provider billing errors for Lightdash-managed keys', () => {
+            expect(
+                getUserFacingErrorMessage(
+                    new Error('Your credit balance is too low'),
+                    'Custom fallback',
+                    'lightdash-managed',
+                ),
+            ).toBe('Custom fallback');
+        });
+
+        it('preserves the existing quota message for Lightdash-managed keys', () => {
+            expect(
+                getUserFacingErrorMessage(
+                    new Error('insufficient_quota'),
+                    'Custom fallback',
+                    'lightdash-managed',
+                ),
+            ).toBe(RATE_LIMIT_MESSAGE);
         });
     });
 
@@ -83,9 +134,13 @@ describe('getUserFacingErrorMessage', () => {
         it.each(['Request timeout', 'The operation timed out'])(
             'detects timeout error: %s',
             (message) => {
-                expect(getUserFacingErrorMessage(new Error(message))).toBe(
-                    TIMEOUT_MESSAGE,
-                );
+                expect(
+                    getUserFacingErrorMessage(
+                        new Error(message),
+                        undefined,
+                        'self-managed',
+                    ),
+                ).toBe(TIMEOUT_MESSAGE);
             },
         );
     });
@@ -99,6 +154,8 @@ describe('getUserFacingErrorMessage', () => {
                         'server-uuid',
                         'shared',
                     ),
+                    undefined,
+                    'self-managed',
                 ),
             ).toBe(
                 'MCP server "Shared Docs MCP" requires authorization before this agent can use it.',

--- a/packages/backend/src/ee/services/ai/utils/errorMessages.ts
+++ b/packages/backend/src/ee/services/ai/utils/errorMessages.ts
@@ -1,3 +1,4 @@
+import type { AiKeyManagement } from '../../../../analytics/aiUsage';
 import { McpAuthorizationRequiredError } from '../AiAgentMcpRuntimeClient';
 
 export const STEP_CAP_REACHED_MESSAGE =
@@ -15,6 +16,9 @@ export class AiAgentStepCapReachedError extends Error {
 
 export const EMPTY_RESPONSE_MESSAGE =
     'The agent finished without writing a response. Please try again — if it keeps happening, rephrase the question or start a new thread.';
+
+export const PROVIDER_BILLING_MESSAGE =
+    'The configured AI provider account has a billing or credit issue. Check its billing settings or add credits, then try again.';
 
 // A finished prompt must always carry either a response or an error message.
 // This error backs that invariant: the model stopped (under the step cap)
@@ -38,11 +42,13 @@ export class AiAgentEmptyResponseError extends Error {
  *
  * @param error - The error object or message
  * @param defaultMessage - Optional default message if no specific pattern matches
+ * @param keyManagement - Whether the request uses a Lightdash-managed or self-managed key
  * @returns A user-friendly error message
  */
 export const getUserFacingErrorMessage = (
     error: unknown,
     defaultMessage: string = 'Something went wrong while processing your request. Please try again.',
+    keyManagement?: AiKeyManagement,
 ): string => {
     if (error instanceof AiAgentStepCapReachedError) {
         return STEP_CAP_REACHED_MESSAGE;
@@ -74,6 +80,15 @@ export const getUserFacingErrorMessage = (
         }
 
         return 'We could not connect to the MCP server. Check that it is available and try again.';
+    }
+
+    if (
+        keyManagement === 'self-managed' &&
+        /credit balance|insufficient_quota|billing|spend limit|payment_required|http 402/i.test(
+            errorMessage,
+        )
+    ) {
+        return PROVIDER_BILLING_MESSAGE;
     }
 
     // Context/token limit errors


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/ZAP-763/as-a-user-with-a-byok-provider-key-i-want-ask-ai-to-show-billing

## Summary

Ask AI now tells users when their configured provider account needs billing attention or more credits instead of showing a generic streaming error. The actionable message is limited to self-managed keys, so Lightdash-managed provider failures keep their existing generic behavior.

## Root cause

The shared AI error mapper handled context limits, rate limits, timeouts, and MCP errors, but did not distinguish provider billing failures. Anthropic's insufficient-credit message missed every mapping, while `insufficient_quota` fell into the broad transient quota branch.

```ts
if (
    errorMessage.includes('rate limit') ||
    errorMessage.includes('quota') ||
    errorMessage.includes('throttl')
)
```

## Fix

The mapper classifies known provider billing and insufficient-credit signatures before the broad quota branch when the resolved key is `self-managed`. Both Ask AI streaming failure paths now pass the model's resolved key-management value into the mapper.

- `errorMessages.ts` — adds the BYOK-only provider billing mapping.
- `agentV2.ts` — threads resolved key ownership into in-stream and pre-stream error handling.
- `errorMessages.test.ts` — covers Anthropic, common billing signatures, managed-key isolation, and unchanged mappings.

## Before

- Self-managed provider credit error
  - `credit balance is too low` → generic streaming failure
  - `insufficient_quota` → transient high-demand message

## After

- Self-managed provider credit error → check the configured provider's billing settings or add credits
- Lightdash-managed provider credit error → existing generic behavior remains unchanged
- Context, rate-limit, timeout, MCP, and fallback errors → existing mappings remain unchanged

## Test plan

- [x] Exact Anthropic before/after mapper oracle for self-managed and Lightdash-managed keys
- [x] `errorMessages.test.ts` — 30 focused tests pass
- [x] Full backend suite — 386 files and 5,748 tests pass; 1 skipped
- [x] `pnpm -F backend typecheck`
- [x] `pnpm -F backend lint`
- [x] Restarted `ld3-api` and confirmed `/api/v1/health` is healthy