### PR TITLE
feat(autopilot): typed per-project policy on managed agent settings

### DIFF
--- a/packages/backend/src/ee/database/entities/managedAgent.ts
+++ b/packages/backend/src/ee/database/entities/managedAgent.ts
@@ -18,6 +18,7 @@ export type DbManagedAgentSettings = {
     anthropic_vault_config_hash: string | null;
     slack_channel_id: string | null;
     tool_settings: Record<string, boolean>;
+    policy: Record<string, unknown>;
     created_at: Date;
     updated_at: Date;
 };
@@ -41,6 +42,7 @@ export type DbManagedAgentSettingsCreate = Pick<
             | 'anthropic_vault_config_hash'
             | 'slack_channel_id'
             | 'tool_settings'
+            | 'policy'
             | 'updated_at'
         >
     >;
@@ -60,6 +62,7 @@ export type DbManagedAgentSettingsUpdate = Partial<
         | 'anthropic_vault_config_hash'
         | 'slack_channel_id'
         | 'tool_settings'
+        | 'policy'
         | 'updated_at'
     >
 >;

--- a/packages/backend/src/ee/database/migrations/20260803120000_add_managed_agent_policy.ts
+++ b/packages/backend/src/ee/database/migrations/20260803120000_add_managed_agent_policy.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex';
+
+const ManagedAgentSettingsTableName = 'managed_agent_settings';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(ManagedAgentSettingsTableName, (table) => {
+        table.jsonb('policy').notNullable().defaultTo('{}');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(ManagedAgentSettingsTableName, (table) => {
+        table.dropColumn('policy');
+    });
+}

--- a/packages/backend/src/ee/models/ManagedAgentModel.ts
+++ b/packages/backend/src/ee/models/ManagedAgentModel.ts
@@ -2,6 +2,7 @@ import {
     getManagedAgentScheduleCron,
     getManagedAgentScheduleOption,
     ManagedAgentRunStatus,
+    resolveManagedAgentPolicy,
     type CreateManagedAgentAction,
     type ManagedAgentAction,
     type ManagedAgentActionFilters,
@@ -47,6 +48,7 @@ export class ManagedAgentModel {
             enabledByUserUuid: row.enabled_by_user_uuid,
             slackChannelId: row.slack_channel_id,
             toolSettings: row.tool_settings ?? {},
+            policy: resolveManagedAgentPolicy(row.policy),
             createdAt: row.created_at,
             updatedAt: row.updated_at,
         };
@@ -146,6 +148,16 @@ export class ManagedAgentModel {
         userUuid: string,
         update: UpdateManagedAgentSettings,
     ): Promise<ManagedAgentSettings> {
+        // Policy is stored as sparse overrides; merge the partial update into
+        // the stored overrides so unset fields keep tracking defaults.
+        let mergedPolicy: Record<string, unknown> | undefined;
+        if (update.policy !== undefined) {
+            const existing = await this.database(ManagedAgentSettingsTableName)
+                .where({ project_uuid: projectUuid })
+                .select('policy')
+                .first();
+            mergedPolicy = { ...(existing?.policy ?? {}), ...update.policy };
+        }
         const [row] = await this.database(ManagedAgentSettingsTableName)
             .insert({
                 project_uuid: projectUuid,
@@ -154,6 +166,7 @@ export class ManagedAgentModel {
                 enabled_by_user_uuid: update.enabled ? userUuid : null,
                 slack_channel_id: update.slackChannelId ?? null,
                 tool_settings: update.toolSettings ?? {},
+                policy: mergedPolicy ?? {},
                 updated_at: new Date(),
             })
             .onConflict('project_uuid')
@@ -167,6 +180,9 @@ export class ManagedAgentModel {
                 }),
                 ...(update.toolSettings !== undefined && {
                     tool_settings: update.toolSettings,
+                }),
+                ...(mergedPolicy !== undefined && {
+                    policy: mergedPolicy,
                 }),
                 enabled_by_user_uuid: update.enabled ? userUuid : undefined,
                 updated_at: new Date(),

--- a/packages/common/src/ee/types/managedAgent.ts
+++ b/packages/common/src/ee/types/managedAgent.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import { type ApiSuccess } from '../../types/api/success';
 
 export enum ManagedAgentActionType {
@@ -56,6 +57,63 @@ export const getManagedAgentScheduleOption = (
     return match ? match[0] : ManagedAgentScheduleOption.DAILY;
 };
 
+export type ManagedAgentAggression = 'observe' | 'flag' | 'cleanup';
+
+export type ManagedAgentAudience = 'admins' | 'everyone';
+
+export type ManagedAgentPolicy = {
+    stalenessChartDays: number;
+    stalenessDashboardDays: number;
+    previewProjectDays: number;
+    slowQueryThresholdMs: number;
+    protectRecentDays: number;
+    escalationHours: number;
+    aggression: ManagedAgentAggression;
+    audience: ManagedAgentAudience;
+};
+
+export type UpdateManagedAgentPolicy = Partial<ManagedAgentPolicy>;
+
+// Per-field .catch() keeps one bad stored value from discarding the rest
+const managedAgentPolicySchema = z.object({
+    stalenessChartDays: z.number().int().min(7).max(3650).default(90).catch(90),
+    stalenessDashboardDays: z
+        .number()
+        .int()
+        .min(7)
+        .max(3650)
+        .default(90)
+        .catch(90),
+    previewProjectDays: z.number().int().min(7).max(3650).default(90).catch(90),
+    slowQueryThresholdMs: z
+        .number()
+        .int()
+        .min(100)
+        .max(600_000)
+        .default(2000)
+        .catch(2000),
+    protectRecentDays: z.number().int().min(0).max(365).default(30).catch(30),
+    escalationHours: z.number().int().min(0).max(720).default(24).catch(24),
+    aggression: z
+        .enum(['observe', 'flag', 'cleanup'])
+        .default('cleanup')
+        .catch('cleanup'),
+    audience: z
+        .enum(['admins', 'everyone'])
+        .default('everyone')
+        .catch('everyone'),
+});
+
+export const DEFAULT_MANAGED_AGENT_POLICY: ManagedAgentPolicy =
+    managedAgentPolicySchema.parse({});
+
+export const resolveManagedAgentPolicy = (
+    input: unknown,
+): ManagedAgentPolicy => {
+    const result = managedAgentPolicySchema.safeParse(input ?? {});
+    return result.success ? result.data : DEFAULT_MANAGED_AGENT_POLICY;
+};
+
 export type ManagedAgentSettings = {
     projectUuid: string;
     enabled: boolean;
@@ -63,6 +121,7 @@ export type ManagedAgentSettings = {
     enabledByUserUuid: string | null;
     slackChannelId: string | null;
     toolSettings: Record<string, boolean>;
+    policy: ManagedAgentPolicy;
     createdAt: Date;
     updatedAt: Date;
 };
@@ -120,6 +179,7 @@ export type UpdateManagedAgentSettings = {
     schedule?: ManagedAgentScheduleOption;
     slackChannelId?: string | null;
     toolSettings?: Record<string, boolean>;
+    policy?: UpdateManagedAgentPolicy;
 };
 
 export type CreateManagedAgentAction = {

--- a/packages/common/src/ee/types/managedAgentPolicy.test.ts
+++ b/packages/common/src/ee/types/managedAgentPolicy.test.ts
@@ -1,0 +1,67 @@
+import {
+    DEFAULT_MANAGED_AGENT_POLICY,
+    resolveManagedAgentPolicy,
+} from './managedAgent';
+
+describe('resolveManagedAgentPolicy', () => {
+    it('returns defaults for empty overrides', () => {
+        expect(resolveManagedAgentPolicy({})).toEqual(
+            DEFAULT_MANAGED_AGENT_POLICY,
+        );
+        expect(DEFAULT_MANAGED_AGENT_POLICY).toEqual({
+            stalenessChartDays: 90,
+            stalenessDashboardDays: 90,
+            previewProjectDays: 90,
+            slowQueryThresholdMs: 2000,
+            protectRecentDays: 30,
+            escalationHours: 24,
+            aggression: 'cleanup',
+            audience: 'everyone',
+        });
+    });
+
+    it('returns defaults for null, undefined, and non-object input', () => {
+        expect(resolveManagedAgentPolicy(null)).toEqual(
+            DEFAULT_MANAGED_AGENT_POLICY,
+        );
+        expect(resolveManagedAgentPolicy(undefined)).toEqual(
+            DEFAULT_MANAGED_AGENT_POLICY,
+        );
+        expect(resolveManagedAgentPolicy('not-an-object')).toEqual(
+            DEFAULT_MANAGED_AGENT_POLICY,
+        );
+    });
+
+    it('applies valid overrides on top of defaults', () => {
+        expect(
+            resolveManagedAgentPolicy({
+                stalenessChartDays: 180,
+                aggression: 'flag',
+            }),
+        ).toEqual({
+            ...DEFAULT_MANAGED_AGENT_POLICY,
+            stalenessChartDays: 180,
+            aggression: 'flag',
+        });
+    });
+
+    it('falls back per-field on invalid values without discarding valid ones', () => {
+        expect(
+            resolveManagedAgentPolicy({
+                stalenessChartDays: -5,
+                slowQueryThresholdMs: 'fast',
+                aggression: 'nuke-everything',
+                escalationHours: 48,
+            }),
+        ).toEqual({
+            ...DEFAULT_MANAGED_AGENT_POLICY,
+            escalationHours: 48,
+        });
+    });
+
+    it('ignores unknown keys', () => {
+        expect(resolveManagedAgentPolicy({ someFutureKey: true })).toEqual(
+            DEFAULT_MANAGED_AGENT_POLICY,
+        );
+    });
+});


### PR DESCRIPTION
## Summary

First slice of the Autopilot policy layer (Linear: PROD-9410, PROD-9418, PROD-9419, PROD-9420; sets up https://github.com/lightdash/lightdash/issues/26345).

Adds a typed `ManagedAgentPolicy` object to managed-agent settings: staleness windows per content type, preview-project age, slow-query threshold, new-content protection window, escalation hours, aggression level (`observe | flag | cleanup`), and audience (`admins | everyone`).

- Storage: sparse jsonb overrides in `managed_agent_settings.policy`. Only admin-changed fields are stored, so untouched projects keep tracking default changes.
- Resolution: zod resolver in common with per-field `.catch()` fallbacks. One corrupt stored value falls back alone instead of discarding the whole policy.
- API: `PATCH /managed-agent/settings` accepts a partial policy, merged server-side into stored overrides.

This PR is plumbing only. Nothing reads the policy yet: enforcement (SQL, guards, prompt) is the next PR in the stack, UI is the one after.

## Regression analysis

No behavior change. The migration adds a `NOT NULL DEFAULT '{}'` jsonb column to a small table; existing rows resolve to defaults that exactly reproduce current hardcoded behavior. Services reading settings before the migration runs see `undefined`, and the resolver returns defaults. GET settings gains an additive `policy` field; old clients ignore it.

## Testing

- 5 new resolver unit tests (defaults, per-field fallback, unknown keys, non-object input)
- `common`/`backend` typecheck and full backend suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UgXBzcYYEeoMUUShzL7DsU