### PR TITLE
feat(charts): show granularity in default date axis labels

### DIFF
--- a/packages/common/src/index.test.ts
+++ b/packages/common/src/index.test.ts
@@ -3,9 +3,12 @@ import {
     DimensionType,
     formatRawValue,
     getDateGroupLabel,
+    getDateGroupLabelWithGranularity,
     getFilterRuleFromFieldWithDefaultValue,
     getPasswordSchema,
     isValidEmailAddress,
+    TimeFrames,
+    type Dimension,
 } from '.';
 import {
     dateDayDimension,
@@ -177,6 +180,47 @@ describe('getDateGroupLabel', () => {
                 label: 'day date (day)',
             }),
         ).toEqual('Day date day'); // doesn't recognize (day) as a valid time frame
+    });
+});
+
+describe('getDateGroupLabelWithGranularity', () => {
+    test('appends the standard granularity to the base field label', () => {
+        expect(
+            getDateGroupLabelWithGranularity({
+                ...dateDayDimensionWithGroup,
+                timeIntervalBaseDimensionName: 'date',
+            } as Dimension),
+        ).toEqual('date (Day)');
+    });
+
+    test('preserves a project granularity label override', () => {
+        expect(
+            getDateGroupLabelWithGranularity({
+                ...dateDayDimensionWithGroup,
+                label: 'date Week starting Monday',
+                timeInterval: TimeFrames.WEEK,
+                timeIntervalLabel: 'Week starting Monday',
+                timeIntervalBaseDimensionName: 'date',
+            } as Dimension),
+        ).toEqual('date (Week starting Monday)');
+    });
+
+    test('uses the base field group for a custom granularity', () => {
+        expect(
+            getDateGroupLabelWithGranularity({
+                ...dateDayDimensionWithGroup,
+                label: 'Fiscal quarter',
+                timeInterval: undefined,
+                customTimeInterval: 'fiscal_quarter',
+                timeIntervalBaseDimensionName: 'date',
+            } as Dimension),
+        ).toEqual('date group (Fiscal quarter)');
+    });
+
+    test('returns undefined for a non-date-granularity field', () => {
+        expect(
+            getDateGroupLabelWithGranularity(stringDimension),
+        ).toBeUndefined();
     });
 });
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -39,6 +39,7 @@ import { getFields } from './utils/fields';
 import { formatItemValue } from './utils/formatting';
 import { getItemId, getItemLabelWithoutTableName } from './utils/item';
 import { getOrganizationNameSchema } from './utils/organization';
+import { timeFrameConfigs } from './utils/timeFrames';
 import type { PivotValuesColumn } from './visualizations/types';
 
 dayjs.extend(utc);
@@ -689,13 +690,19 @@ export const getDateGroupLabel = (axisItem: ItemsMap[string]) => {
         axisItem.timeInterval
     ) {
         const timeFrame =
-            TimeFrames[axisItem.timeInterval]?.toLowerCase() || '';
+            axisItem.timeIntervalLabel ??
+            TimeFrames[axisItem.timeInterval]?.toLowerCase() ??
+            '';
 
-        if (timeFrame && axisItem.label.endsWith(` ${timeFrame}`)) {
+        const timeFrameSuffix = ` ${timeFrame}`;
+        if (
+            timeFrame &&
+            axisItem.label.toLowerCase().endsWith(timeFrameSuffix.toLowerCase())
+        ) {
             // Remove the time frame from the end of the label - e.g. from 'Order created day' to 'Order created'.
-            return getItemLabelWithoutTableName(axisItem).replace(
-                new RegExp(`\\s+${timeFrame}$`),
-                '',
+            return getItemLabelWithoutTableName(axisItem).slice(
+                0,
+                -timeFrameSuffix.length,
             );
         }
 
@@ -703,6 +710,33 @@ export const getDateGroupLabel = (axisItem: ItemsMap[string]) => {
     }
 
     return undefined;
+};
+
+export const getDateGroupLabelWithGranularity = (
+    axisItem: ItemsMap[string],
+): string | undefined => {
+    if (!isDimension(axisItem) || !axisItem.timeIntervalBaseDimensionName) {
+        return undefined;
+    }
+
+    if (axisItem.customTimeInterval) {
+        const fieldLabel = axisItem.groups?.at(-1);
+        return fieldLabel ? `${fieldLabel} (${axisItem.label})` : undefined;
+    }
+
+    if (!axisItem.timeInterval) {
+        return undefined;
+    }
+
+    const fieldLabel = getDateGroupLabel(axisItem);
+    if (!fieldLabel) {
+        return undefined;
+    }
+
+    const granularityLabel =
+        axisItem.timeIntervalLabel ??
+        timeFrameConfigs[axisItem.timeInterval].getLabel();
+    return `${fieldLabel} (${granularityLabel})`;
 };
 
 export const getAxisName = ({

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
@@ -2,6 +2,7 @@ import {
     CartesianSeriesType,
     getAxisName,
     getDateGroupLabel,
+    getDateGroupLabelWithGranularity,
     getGranularityMapFromItems,
     getItemLabelWithoutTableName,
     getXAxisSort,
@@ -204,7 +205,8 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                         value={dirtyEchartsConfig?.xAxis?.[0]?.name ?? ''}
                         placeholder={
                             (xAxisField &&
-                                (getDateGroupLabel(xAxisField) ||
+                                (getDateGroupLabelWithGranularity(xAxisField) ||
+                                    getDateGroupLabel(xAxisField) ||
                                     getItemLabelWithoutTableName(
                                         xAxisField,
                                     ))) ||

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -26,6 +26,7 @@ import {
     getBarTotalLabelStyle,
     getCustomFormatFromLegacy,
     getDateGroupLabel,
+    getDateGroupLabelWithGranularity,
     getFormatExpressionLocale,
     getFormattedValue,
     getFormatterTimezone,
@@ -2579,7 +2580,10 @@ const getEchartAxes = ({
                                 })
                               : xAxisConfiguration?.[0]?.name ||
                                 (xAxisItem
-                                    ? getDateGroupLabel(xAxisItem) ||
+                                    ? getDateGroupLabelWithGranularity(
+                                          xAxisItem,
+                                      ) ||
+                                      getDateGroupLabel(xAxisItem) ||
                                       getItemLabelWithoutTableName(xAxisItem)
                                     : undefined),
                           nameLocation: 'center',
@@ -2683,7 +2687,10 @@ const getEchartAxes = ({
                           name: validCartesianConfig.layout.flipAxes
                               ? yAxisConfiguration?.[0]?.name ||
                                 (yAxisItem
-                                    ? getDateGroupLabel(yAxisItem) ||
+                                    ? getDateGroupLabelWithGranularity(
+                                          yAxisItem,
+                                      ) ||
+                                      getDateGroupLabel(yAxisItem) ||
                                       getItemLabelWithoutTableName(yAxisItem)
                                     : undefined)
                               : getAxisName({


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-1203/dynamic-x-axis-label-based-on-date-granularity

## Description

Date-backed Cartesian X axes now include the effective granularity in their computed title. This makes the displayed grain clear while preserving the field identity and any explicitly configured title.

Before: `Visit date`
After: `Visit date (Month)`
Date Zoom: `Visit date (Month)` → `Visit date (Week)`
Custom title: `Orders over time` → `Orders over time`

The chart and axis editor derive the default from the same field metadata. Standard grains, custom granularities, and project granularity-label overrides use their effective display label. Non-date axes keep their existing fallback.

## Test plan

- [x] Verify monthly and quarterly default titles in the local chart UI.
- [x] Verify the computed title on a flipped horizontal chart.
- [x] Verify the axis editor displays the same computed placeholder.
- [x] Verify an unsaved explicit custom title overrides the computed title.
- [x] Run focused common, Date Zoom, and Cartesian frontend tests.
- [x] Run common/frontend typechecks, linters, format checks, and `git diff --check`.