### PR TITLE
fix(homepage-builder): give data app cards a filled fallback band

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
@@ -94,10 +94,9 @@ const isDefaultFavicon = (img: HTMLImageElement) => img.naturalWidth < 32;
 // --- Thumbnails -------------------------------------------------------------
 
 // The media slot for a data app card: its screenshot when there is one,
-// otherwise the neutral icon square native content uses (see ContentCard) —
-// never a full-size coloured placeholder. A fallback should be quieter than
-// the real thing, not louder. Kind stays legible in text on the card body.
-// Shared by the published card and the editor canvas so they can't drift.
+// otherwise the same neutral wash tile a link with no favicon falls back to —
+// a filled band, but no kind tint (internal content takes no colour). Shared
+// by the published card and the editor canvas so they can't drift.
 const DataAppThumb: FC<{
     item: HomepageResourceItem;
     projectUuid: string;
@@ -110,10 +109,11 @@ const DataAppThumb: FC<{
     );
     const thumbnailUrl = failed ? undefined : data?.thumbnailUrl;
     if (!thumbnailUrl) {
-        // Same neutral square a link with no favicon falls back to — no kind tint.
         return (
-            <div className={classes.mediaIcon}>
-                <IconSquare icon={IconAppWindow} />
+            <div className={classes.resThumbTile}>
+                <div className={classes.resGlyphTile}>
+                    <MantineIcon icon={IconAppWindow} size={22} />
+                </div>
             </div>
         );
     }

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -773,8 +773,6 @@ a .hoverCard:hover,
     color: light-dark(#b0453a, #dd8a80);
 }
 
-/* Data apps use the brand orange, tinted into a quiet backdrop for the
- * icon fallback when an app has no thumbnail. */
 /* External-link affordance: quiet corner mark, revealed on hover. */
 .resExternal {
     position: absolute;
@@ -788,15 +786,6 @@ a .hoverCard:hover,
 
 .mediaCard:hover .resExternal {
     opacity: 1;
-}
-
-.mediaIcon {
-    /* Stands in for the image band, so an icon-only card is exactly as tall as
-     * one with a screenshot and a mixed grid keeps a single baseline. */
-    flex: 1;
-    min-height: 56px;
-    display: grid;
-    place-items: center;
 }
 
 .mediaBody {


### PR DESCRIPTION
## What

In the Resources block's card layout, every resource kind renders a filled media band — a screenshot, a favicon on a kind-tinted wash, or a neutral wash — except a data app with no screenshot, which rendered a bare icon floating on the card's white body. On a mixed row that one card read as unfinished.

This gives the data app fallback the same **neutral wash tile** a link with no favicon falls back to (`resThumbTile` + centred glyph), so every card in the grid has a filled band.

| Before | After |
|---|---|
| Bare icon on white card body | Neutral gray wash band with the app-window glyph |

This is a partial revisit of #26446, which removed the old full-orange placeholder because it was louder than the real thumbnails. The rule that PR settled — *internal content takes no kind tint* — still holds: the new band is the untinted neutral wash, not a colour. What changes is only that the band is filled instead of empty.

## Regression analysis

- **Shared media slot**: `DataAppThumb` is dispatched by `CardThumb`, used by both the published `ResourceCard` and the editor `BuildCard`, so builder and viewer can't drift — one edit covers both.
- **Grid baseline holds**: `.resThumbTile` has the same `flex: 1; min-height: 56px` geometry the removed `.mediaIcon` stand-in had, so icon-only cards stay exactly as tall as screenshot cards and mixed rows keep a single baseline.
- **Screenshot path untouched**: apps with a thumbnail render it exactly as before; the load-failure path (`onError`) lands on the same new fallback as "no thumbnail at all" — one visual outcome for both.
- **List layout untouched**: the compact tile row keeps its glyph-square language.
- **Dead code removed, not orphaned**: `.mediaIcon` had no remaining users after the swap and is deleted, along with a stray comment left over from the deleted orange gradient.
- **No stored config or type changes** — purely presentational.

## Verification

- oxlint clean; all 14 `ResourcesBlock` tests pass (the fallback tests assert no `img` element renders, which still holds — the fallback is still icon-based, just on a filled band).
- Verified in the live app in light and dark by publishing a resources block with two data apps and stubbing the thumbnail endpoint to null to exercise the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nyStYDNXQ81vMbiC7jKgK
