### PR TITLE
feat(apps): add viz render endpoints

### DIFF
--- a/packages/api-tests/tests/dataAppVizRender.test.ts
+++ b/packages/api-tests/tests/dataAppVizRender.test.ts
@@ -1,0 +1,115 @@
+import {
+    SEED_PROJECT,
+    type ApiError,
+    type ApiImportAppCodeResponse,
+    type DataAppCode,
+} from '@lightdash/common';
+import { randomUUID } from 'node:crypto';
+import { ApiClient } from '../helpers/api-client';
+import { login } from '../helpers/auth';
+
+const renderBaseUrl = (dataAppVizUuid: string) =>
+    `/api/v1/ee/projects/${SEED_PROJECT.project_uuid}/apps/visualizations/${dataAppVizUuid}`;
+
+const appsBaseUrl = `/api/v1/ee/projects/${SEED_PROJECT.project_uuid}/apps`;
+
+const createNonVisualizationDataApp = async (
+    client: ApiClient,
+): Promise<string> => {
+    const code: DataAppCode = {
+        manifest: {
+            codeVersion: 1,
+            projectUuid: SEED_PROJECT.project_uuid,
+            version: 1,
+            name: `Viz endpoint isolation ${randomUUID()}`,
+            description:
+                'Non-visualization data app used by API isolation tests',
+            template: null,
+            downloadedAt: new Date().toISOString(),
+        },
+        files: [
+            {
+                path: 'src/App.tsx',
+                contentBase64: Buffer.from(
+                    'export default function App() { return null; }',
+                ).toString('base64'),
+            },
+        ],
+    };
+    const response = await client.post<ApiImportAppCodeResponse>(
+        `${appsBaseUrl}/upload`,
+        { code, createNew: true },
+    );
+
+    expect(response.status).toBe(200);
+    return response.body.results.appUuid;
+};
+
+const deleteDataApp = (client: ApiClient, appUuid: string) =>
+    client.delete(`${appsBaseUrl}/${appUuid}`);
+
+describe('Data app visualization render endpoints', () => {
+    let admin: ApiClient;
+    let nonVisualizationDataAppUuid: string | null = null;
+
+    beforeAll(async () => {
+        admin = await login();
+        nonVisualizationDataAppUuid =
+            await createNonVisualizationDataApp(admin);
+    });
+
+    afterAll(async () => {
+        if (nonVisualizationDataAppUuid !== null) {
+            await deleteDataApp(admin, nonVisualizationDataAppUuid);
+        }
+    });
+
+    it.each(['render-metadata', 'versions/1/preview-token'])(
+        'returns a generic 404 for an unknown visualization on %s',
+        async (path) => {
+            const dataAppVizUuid = randomUUID();
+            const response = await admin.get<ApiError>(
+                `${renderBaseUrl(dataAppVizUuid)}/${path}`,
+                { failOnStatusCode: false },
+            );
+
+            expect(response.status).toBe(404);
+            expect(response.body.error.message).toBe(
+                'Data app visualization not found',
+            );
+            expect(response.body.error.message).not.toContain(dataAppVizUuid);
+        },
+    );
+
+    it.each(['render-metadata', 'versions/1/preview-token'])(
+        'returns a generic 404 for a non-visualization data app on %s',
+        async (path) => {
+            if (nonVisualizationDataAppUuid === null) {
+                throw new Error(
+                    'Expected a non-visualization data app fixture',
+                );
+            }
+            const response = await admin.get<ApiError>(
+                `${renderBaseUrl(nonVisualizationDataAppUuid)}/${path}`,
+                { failOnStatusCode: false },
+            );
+
+            expect(response.status).toBe(404);
+            expect(response.body.error.message).toBe(
+                'Data app visualization not found',
+            );
+            expect(response.body.error.message).not.toContain(
+                nonVisualizationDataAppUuid,
+            );
+        },
+    );
+
+    it('requires registered authentication', async () => {
+        const response = await new ApiClient().get(
+            `${renderBaseUrl(randomUUID())}/render-metadata`,
+            { failOnStatusCode: false },
+        );
+
+        expect(response.status).toBe(401);
+    });
+});

--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -11,6 +11,8 @@ import {
     type ApiClarifyAppResponse,
     type ApiCreateAppSchedulerResponse,
     type ApiDataAppActivityResponse,
+    type ApiDataAppVizPreviewTokenResponse,
+    type ApiDataAppVizRenderMetadataResponse,
     type ApiDeleteAppResponse,
     type ApiDuplicateAppResponse,
     type ApiEmbedProjectAppsResponse,
@@ -179,6 +181,58 @@ export class AppGenerateController extends BaseController {
         return {
             status: 'ok',
             results: result,
+        };
+    }
+
+    /**
+     * @summary Get data app visualization render metadata
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/visualizations/{dataAppVizUuid}/render-metadata')
+    @OperationId('getDataAppVizRenderMetadata')
+    async getDataAppVizRenderMetadata(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() dataAppVizUuid: string,
+    ): Promise<ApiDataAppVizRenderMetadataResponse> {
+        assertRegisteredAccount(req.account);
+        const result =
+            await this.getAppGenerateService().getDataAppVizRenderMetadata(
+                toSessionUser(req.account),
+                projectUuid,
+                dataAppVizUuid,
+            );
+        return {
+            status: 'ok',
+            results: result,
+        };
+    }
+
+    /**
+     * @summary Get a data app visualization preview token
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/visualizations/{dataAppVizUuid}/versions/{version}/preview-token')
+    @OperationId('getDataAppVizPreviewToken')
+    async getDataAppVizPreviewToken(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() dataAppVizUuid: string,
+        @Path() version: number,
+    ): Promise<ApiDataAppVizPreviewTokenResponse> {
+        assertRegisteredAccount(req.account);
+        const token =
+            await this.getAppGenerateService().getDataAppVizPreviewToken(
+                toSessionUser(req.account),
+                projectUuid,
+                dataAppVizUuid,
+                version,
+            );
+        return {
+            status: 'ok',
+            results: { token },
         };
     }
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
@@ -7,6 +7,7 @@ import {
     OrganizationMemberRole,
     type DataAppVizSchema,
 } from '@lightdash/common';
+import { verifyPreviewToken } from '../../../routers/appPreviewToken';
 import { AppGenerateService } from './AppGenerateService';
 
 vi.mock('e2b', () => ({
@@ -57,7 +58,7 @@ const makeDataAppVizRow = (overrides: Record<string, unknown> = {}) => ({
 
 function buildService(appModel: unknown) {
     const service = new AppGenerateService({
-        lightdashConfig: {} as never,
+        lightdashConfig: { lightdashSecret: 'test-secret' } as never,
         analytics: {} as never,
         analyticsModel: {} as never,
         catalogModel: {} as never,
@@ -274,6 +275,231 @@ describe('AppGenerateService data app vizs', () => {
                 'not-a-data-app-viz',
             ),
         ).rejects.toThrow(NotFoundError);
+    });
+
+    describe('viz-only render metadata', () => {
+        const makeVersion = (overrides: Record<string, unknown> = {}) => ({
+            app_version_id: 'app-version-1',
+            app_id: 'data-app-viz-1',
+            version: 1,
+            prompt: 'build a chart',
+            status: 'ready',
+            error: null,
+            status_message: null,
+            status_history: [],
+            status_updated_at: new Date('2026-06-30'),
+            resources: null,
+            dependencies: null,
+            viz_schema: vizSchema,
+            generation_usage: null,
+            created_at: new Date('2026-06-30'),
+            created_by_user_uuid: 'user-1',
+            ...overrides,
+        });
+
+        it('resolves the template-filtered viz before checking the feature flag', async () => {
+            const appModel = {
+                findVisualizationApp: vi.fn().mockResolvedValue(undefined),
+            };
+            const service = buildService(appModel);
+            const dataAppsEnabledFor = vi.spyOn(service, 'dataAppsEnabledFor');
+
+            await expect(
+                service.getDataAppVizRenderMetadata(
+                    USER,
+                    'project-1',
+                    'non-visualization-data-app',
+                ),
+            ).rejects.toMatchObject({
+                message: 'Data app visualization not found',
+            });
+
+            expect(dataAppsEnabledFor).not.toHaveBeenCalled();
+        });
+
+        it('resolves the template-filtered viz before validating a token version', async () => {
+            const appModel = {
+                findVisualizationApp: vi.fn().mockResolvedValue(undefined),
+            };
+            const service = buildService(appModel);
+            const dataAppsEnabledFor = vi.spyOn(service, 'dataAppsEnabledFor');
+
+            await expect(
+                service.getDataAppVizPreviewToken(
+                    USER,
+                    'project-1',
+                    'non-visualization-data-app',
+                    0,
+                ),
+            ).rejects.toThrow(NotFoundError);
+
+            expect(dataAppsEnabledFor).not.toHaveBeenCalled();
+        });
+
+        it('rejects a real viz when data apps are disabled', async () => {
+            const appModel = {
+                findVisualizationApp: vi
+                    .fn()
+                    .mockResolvedValue(makeDataAppVizRow()),
+            };
+            const service = buildService(appModel);
+            vi.spyOn(service, 'dataAppsEnabledFor').mockResolvedValue(false);
+
+            await expect(
+                service.getDataAppVizRenderMetadata(
+                    USER,
+                    'project-1',
+                    'data-app-viz-1',
+                ),
+            ).rejects.toThrow(ForbiddenError);
+        });
+
+        it('serves the last renderable version while the latest build is in progress', async () => {
+            const appModel = {
+                findVisualizationApp: vi
+                    .fn()
+                    .mockResolvedValue(makeDataAppVizRow()),
+                getLatestVersion: vi
+                    .fn()
+                    .mockResolvedValue(
+                        makeVersion({ version: 3, status: 'building' }),
+                    ),
+                getLatestRenderableDataAppVizVersion: vi
+                    .fn()
+                    .mockResolvedValue(makeVersion({ version: 2 })),
+            };
+            const service = buildService(appModel);
+
+            await expect(
+                service.getDataAppVizRenderMetadata(
+                    USER,
+                    'project-1',
+                    'data-app-viz-1',
+                ),
+            ).resolves.toEqual({
+                state: 'ready',
+                version: 2,
+                schema: vizSchema,
+                latestBuildInProgress: true,
+            });
+        });
+
+        it('returns building when no renderable version exists and the latest build is in progress', async () => {
+            const appModel = {
+                findVisualizationApp: vi
+                    .fn()
+                    .mockResolvedValue(makeDataAppVizRow()),
+                getLatestVersion: vi
+                    .fn()
+                    .mockResolvedValue(makeVersion({ status: 'generating' })),
+                getLatestRenderableDataAppVizVersion: vi
+                    .fn()
+                    .mockResolvedValue(null),
+            };
+            const service = buildService(appModel);
+
+            await expect(
+                service.getDataAppVizRenderMetadata(
+                    USER,
+                    'project-1',
+                    'data-app-viz-1',
+                ),
+            ).resolves.toEqual({
+                state: 'building',
+                latestBuildInProgress: true,
+            });
+        });
+
+        it.each([
+            makeVersion({ status: 'error', viz_schema: null }),
+            makeVersion({ status: 'ready', viz_schema: null }),
+            null,
+        ])(
+            'returns failed when no renderable version or active build exists',
+            async (latestVersion) => {
+                const appModel = {
+                    findVisualizationApp: vi
+                        .fn()
+                        .mockResolvedValue(makeDataAppVizRow()),
+                    getLatestVersion: vi.fn().mockResolvedValue(latestVersion),
+                    getLatestRenderableDataAppVizVersion: vi
+                        .fn()
+                        .mockResolvedValue(null),
+                };
+                const service = buildService(appModel);
+
+                await expect(
+                    service.getDataAppVizRenderMetadata(
+                        USER,
+                        'project-1',
+                        'data-app-viz-1',
+                    ),
+                ).resolves.toEqual({
+                    state: 'failed',
+                    latestBuildInProgress: false,
+                });
+            },
+        );
+
+        it('mints a token for the exact requested renderable version', async () => {
+            const appModel = {
+                findVisualizationApp: vi
+                    .fn()
+                    .mockResolvedValue(makeDataAppVizRow()),
+                getVersion: vi
+                    .fn()
+                    .mockResolvedValue(makeVersion({ version: 2 })),
+            };
+            const service = buildService(appModel);
+
+            const token = await service.getDataAppVizPreviewToken(
+                USER,
+                'project-1',
+                'data-app-viz-1',
+                2,
+            );
+
+            expect(appModel.getVersion).toHaveBeenCalledWith(
+                'data-app-viz-1',
+                2,
+            );
+            expect(
+                verifyPreviewToken(token, 'test-secret', 'data-app-viz-1', 2),
+            ).toMatchObject({
+                ok: true,
+                payload: {
+                    appUuid: 'data-app-viz-1',
+                    version: 2,
+                    organizationUuid: 'org-1',
+                    projectUuid: 'project-1',
+                },
+            });
+        });
+
+        it.each([
+            null,
+            makeVersion({ status: 'building' }),
+            makeVersion({ viz_schema: null }),
+        ])('rejects a non-renderable requested version', async (appVersion) => {
+            const appModel = {
+                findVisualizationApp: vi
+                    .fn()
+                    .mockResolvedValue(makeDataAppVizRow()),
+                getVersion: vi.fn().mockResolvedValue(appVersion),
+            };
+            const service = buildService(appModel);
+
+            await expect(
+                service.getDataAppVizPreviewToken(
+                    USER,
+                    'project-1',
+                    'data-app-viz-1',
+                    2,
+                ),
+            ).rejects.toMatchObject({
+                message: 'Renderable data app visualization version not found',
+            });
+        });
     });
 
     it('surfaces viz_schema per version as resources.vizSchema', async () => {

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -79,6 +79,7 @@ import {
     type DataAppManifestExternalConnection,
     type DataAppTemplate,
     type DataAppViz,
+    type DataAppVizRenderMetadata,
     type DataAppVizSchema,
     type EmbedProjectApp,
     type Explore,
@@ -7662,6 +7663,115 @@ export class AppGenerateService extends BaseService {
             created_by_user_uuid: dataAppViz.created_by_user_uuid,
         });
         return AppGenerateService.mapDataAppViz(dataAppViz);
+    }
+
+    private async getAuthorizedDataAppVisualization(
+        user: SessionUser,
+        projectUuid: string,
+        dataAppVizUuid: string,
+    ) {
+        const dataAppViz = await this.appModel.findVisualizationApp(
+            dataAppVizUuid,
+            projectUuid,
+        );
+        if (!dataAppViz) {
+            throw new NotFoundError('Data app visualization not found');
+        }
+
+        await this.assertDataAppsEnabled(user);
+        await this.assertCanViewApp(user, {
+            project_uuid: dataAppViz.project_uuid,
+            space_uuid: dataAppViz.space_uuid,
+            organization_uuid: dataAppViz.organization_uuid,
+            created_by_user_uuid: dataAppViz.created_by_user_uuid,
+        });
+
+        return dataAppViz;
+    }
+
+    async getDataAppVizRenderMetadata(
+        user: SessionUser,
+        projectUuid: string,
+        dataAppVizUuid: string,
+    ): Promise<DataAppVizRenderMetadata> {
+        const dataAppViz = await this.getAuthorizedDataAppVisualization(
+            user,
+            projectUuid,
+            dataAppVizUuid,
+        );
+        const [latestVersion, latestRenderableVersion] = await Promise.all([
+            this.appModel.getLatestVersion(dataAppViz.app_id),
+            this.appModel.getLatestRenderableDataAppVizVersion(
+                dataAppViz.app_id,
+            ),
+        ]);
+        const latestBuildInProgress =
+            latestVersion !== null &&
+            isAppVersionInProgress(latestVersion.status);
+
+        if (
+            latestRenderableVersion !== null &&
+            latestRenderableVersion.viz_schema !== null
+        ) {
+            return {
+                state: 'ready',
+                version: latestRenderableVersion.version,
+                schema: latestRenderableVersion.viz_schema,
+                latestBuildInProgress,
+            };
+        }
+
+        if (latestBuildInProgress) {
+            return {
+                state: 'building',
+                latestBuildInProgress: true,
+            };
+        }
+
+        return {
+            state: 'failed',
+            latestBuildInProgress: false,
+        };
+    }
+
+    async getDataAppVizPreviewToken(
+        user: SessionUser,
+        projectUuid: string,
+        dataAppVizUuid: string,
+        version: number,
+    ): Promise<string> {
+        const dataAppViz = await this.getAuthorizedDataAppVisualization(
+            user,
+            projectUuid,
+            dataAppVizUuid,
+        );
+
+        if (!Number.isInteger(version) || version < 1) {
+            throw new ParameterError('Version must be a positive integer');
+        }
+
+        const appVersion = await this.appModel.getVersion(
+            dataAppViz.app_id,
+            version,
+        );
+        if (
+            appVersion === null ||
+            appVersion.status !== 'ready' ||
+            appVersion.viz_schema === null
+        ) {
+            throw new NotFoundError(
+                'Renderable data app visualization version not found',
+            );
+        }
+
+        return mintPreviewToken(
+            this.lightdashConfig.lightdashSecret,
+            dataAppViz.app_id,
+            version,
+            user.userUuid,
+            dataAppViz.organization_uuid,
+            projectUuid,
+        );
     }
 
     async listMyApps(

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -581,6 +581,17 @@ export class AppModel {
         return row ?? null;
     }
 
+    async getLatestRenderableDataAppVizVersion(
+        appId: string,
+    ): Promise<DbAppVersion | null> {
+        const row = await this.database(AppVersionsTableName)
+            .where({ app_id: appId, status: 'ready' })
+            .whereNotNull('viz_schema')
+            .orderBy('version', 'desc')
+            .first();
+        return row ?? null;
+    }
+
     /**
      * Whether any version between the latest ready version and `beforeVersion`
      * (both exclusive) was cancelled by the user. The persistent Claude session

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -976,6 +976,29 @@ export type ApiListDataAppVizsResponse = ApiSuccess<
 >;
 export type ApiGetDataAppVizResponse = ApiSuccess<DataAppViz>;
 
+export type DataAppVizRenderMetadata =
+    | {
+          state: 'ready';
+          version: number;
+          schema: DataAppVizSchema;
+          latestBuildInProgress: boolean;
+      }
+    | {
+          state: 'building';
+          latestBuildInProgress: true;
+      }
+    | {
+          state: 'failed';
+          latestBuildInProgress: false;
+      };
+
+export type ApiDataAppVizRenderMetadataResponse =
+    ApiSuccess<DataAppVizRenderMetadata>;
+
+export type ApiDataAppVizPreviewTokenResponse = ApiSuccess<{
+    token: string;
+}>;
+
 // postMessage type the host uses to push render context into the sandboxed
 // iframe over the existing app SDK bridge (no new transport).
 export const APP_SDK_DATA_APP_VIZ_CONTEXT_MESSAGE =


### PR DESCRIPTION
Part 1 of the GLITCH-645 stack.

Adds dedicated visualization render-metadata and version-specific preview-token endpoints for registered users. Viz lookups are template-filtered before feature flags and authorization, and metadata keeps the last renderable version available while a newer build runs.

Tests cover endpoint isolation, build-state selection, feature-flag behavior, and exact-version token minting.

Next: #26781

Linear: https://linear.app/lightdash/issue/GLITCH-645
