### PR TITLE
feat(embed): add viz render endpoints

### DIFF
--- a/packages/api-tests/tests/dataAppVizRender.test.ts
+++ b/packages/api-tests/tests/dataAppVizRender.test.ts
@@ -2,11 +2,16 @@ import {
     SEED_PROJECT,
     type ApiError,
     type ApiImportAppCodeResponse,
+    type CreateEmbedJwt,
     type DataAppCode,
+    type DecodedEmbed,
+    type UpdateEmbed,
 } from '@lightdash/common';
 import { randomUUID } from 'node:crypto';
-import { ApiClient } from '../helpers/api-client';
+import { ApiClient, type Body } from '../helpers/api-client';
 import { login } from '../helpers/auth';
+
+const embedApiPrefix = `/api/v1/embed/${SEED_PROJECT.project_uuid}`;
 
 const renderBaseUrl = (dataAppVizUuid: string) =>
     `/api/v1/ee/projects/${SEED_PROJECT.project_uuid}/apps/visualizations/${dataAppVizUuid}`;
@@ -47,6 +52,20 @@ const createNonVisualizationDataApp = async (
 
 const deleteDataApp = (client: ApiClient, appUuid: string) =>
     client.delete(`${appsBaseUrl}/${appUuid}`);
+
+const embedRenderBaseUrl = (savedChartUuid: string, dataAppVizUuid: string) =>
+    `${embedApiPrefix}/chart/${savedChartUuid}/visualizations/${dataAppVizUuid}`;
+
+const getEmbedConfig = (client: ApiClient) =>
+    client.get<Body<DecodedEmbed>>(`${embedApiPrefix}/config`, {
+        failOnStatusCode: false,
+    });
+
+const updateEmbedConfig = (client: ApiClient, body: UpdateEmbed) =>
+    client.patch<Body<unknown>>(`${embedApiPrefix}/config`, body);
+
+const getEmbedUrl = (client: ApiClient, body: CreateEmbedJwt) =>
+    client.post<Body<{ url: string }>>(`${embedApiPrefix}/get-embed-url`, body);
 
 describe('Data app visualization render endpoints', () => {
     let admin: ApiClient;
@@ -111,5 +130,144 @@ describe('Data app visualization render endpoints', () => {
         );
 
         expect(response.status).toBe(401);
+    });
+});
+
+describe('Embedded data app visualization render endpoints', () => {
+    let admin: ApiClient;
+    let embedEnabled = true;
+    let originalConfig: DecodedEmbed;
+    let savedChartUuid: string;
+    let embedToken: string;
+    let nonVisualizationDataAppUuid: string | null = null;
+
+    beforeAll(async () => {
+        admin = await login();
+
+        const configResponse = await getEmbedConfig(admin);
+        if (configResponse.status === 403) {
+            embedEnabled = false;
+            return;
+        }
+
+        expect(configResponse.status).toBe(200);
+        originalConfig = configResponse.body.results;
+        nonVisualizationDataAppUuid =
+            await createNonVisualizationDataApp(admin);
+
+        const chartsResponse = await admin.get<Body<Array<{ uuid: string }>>>(
+            `/api/v1/projects/${SEED_PROJECT.project_uuid}/charts`,
+        );
+        expect(chartsResponse.status).toBe(200);
+        const [savedChart] = chartsResponse.body.results;
+        if (!savedChart) {
+            throw new Error('Expected the seed project to contain a chart');
+        }
+        savedChartUuid = savedChart.uuid;
+
+        await updateEmbedConfig(admin, {
+            dashboardUuids: originalConfig.dashboardUuids,
+            allowAllDashboards: originalConfig.allowAllDashboards,
+            chartUuids: [
+                ...new Set([...originalConfig.chartUuids, savedChartUuid]),
+            ],
+            allowAllCharts: false,
+        });
+
+        const embedUrlResponse = await getEmbedUrl(admin, {
+            user: {
+                externalId: 'data-app-viz-render-api-test',
+                email: 'data-app-viz-render-api-test@lightdash.com',
+            },
+            content: {
+                type: 'chart',
+                contentId: savedChartUuid,
+                scopes: ['view:Chart'],
+                canExportCsv: false,
+                canExportImages: false,
+                canViewUnderlyingData: false,
+                projectUuid: SEED_PROJECT.project_uuid,
+            },
+            expiresIn: '1h',
+        });
+        expect(embedUrlResponse.status).toBe(200);
+        const [, token] = embedUrlResponse.body.results.url.split('#');
+        if (!token) throw new Error('Embed URL did not contain a token');
+        embedToken = token;
+    });
+
+    beforeEach((context) => {
+        if (!embedEnabled) context.skip();
+    });
+
+    afterAll(async () => {
+        if (!embedEnabled) return;
+        await updateEmbedConfig(admin, {
+            dashboardUuids: originalConfig.dashboardUuids,
+            allowAllDashboards: originalConfig.allowAllDashboards,
+            chartUuids: originalConfig.chartUuids,
+            allowAllCharts: originalConfig.allowAllCharts,
+        });
+        if (nonVisualizationDataAppUuid !== null) {
+            await deleteDataApp(admin, nonVisualizationDataAppUuid);
+        }
+    });
+
+    it.each(['render-metadata', 'versions/1/preview-token'])(
+        'returns a generic 404 for an unknown visualization on %s',
+        async (path) => {
+            const dataAppVizUuid = randomUUID();
+            const response = await new ApiClient().get<ApiError>(
+                `${embedRenderBaseUrl(savedChartUuid, dataAppVizUuid)}/${path}`,
+                {
+                    headers: { 'lightdash-embed-token': embedToken },
+                    failOnStatusCode: false,
+                },
+            );
+
+            expect(response.status).toBe(404);
+            expect(response.body.error.message).toBe(
+                'Data app visualization not found',
+            );
+            expect(response.body.error.message).not.toContain(dataAppVizUuid);
+        },
+    );
+
+    it.each(['render-metadata', 'versions/1/preview-token'])(
+        'returns a generic 404 for a non-visualization data app on %s',
+        async (path) => {
+            if (nonVisualizationDataAppUuid === null) {
+                throw new Error(
+                    'Expected a non-visualization data app fixture',
+                );
+            }
+            const response = await new ApiClient().get<ApiError>(
+                `${embedRenderBaseUrl(
+                    savedChartUuid,
+                    nonVisualizationDataAppUuid,
+                )}/${path}`,
+                {
+                    headers: { 'lightdash-embed-token': embedToken },
+                    failOnStatusCode: false,
+                },
+            );
+
+            expect(response.status).toBe(404);
+            expect(response.body.error.message).toBe(
+                'Data app visualization not found',
+            );
+            expect(response.body.error.message).not.toContain(
+                nonVisualizationDataAppUuid,
+            );
+        },
+    );
+
+    it('rejects requests without embed authentication', async () => {
+        const response = await new ApiClient().get(
+            `${embedRenderBaseUrl(savedChartUuid, randomUUID())}/render-metadata`,
+            { failOnStatusCode: false },
+        );
+
+        expect(response.status).toBe(403);
     });
 });

--- a/packages/backend/src/ee/controllers/embedController.ts
+++ b/packages/backend/src/ee/controllers/embedController.ts
@@ -4,6 +4,8 @@ import {
     AnyType,
     ApiCalculateSubtotalsResponse,
     ApiCalculateTotalResponse,
+    ApiDataAppVizPreviewTokenResponse,
+    ApiDataAppVizRenderMetadataResponse,
     ApiErrorPayload,
     ApiExecuteAsyncDashboardChartQueryResults,
     ApiExecuteAsyncDashboardSqlChartQueryResults,
@@ -751,6 +753,64 @@ export class EmbedController extends BaseController {
         return {
             status: 'ok',
             results,
+        };
+    }
+
+    /**
+     * @summary Get embedded data app visualization render metadata
+     */
+    @SuccessResponse('200', 'Success')
+    @Get(
+        '/chart/{savedChartUuid}/visualizations/{dataAppVizUuid}/render-metadata',
+    )
+    @OperationId('getEmbedDataAppVizRenderMetadata')
+    async getEmbedDataAppVizRenderMetadata(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() savedChartUuid: string,
+        @Path() dataAppVizUuid: string,
+    ): Promise<ApiDataAppVizRenderMetadataResponse> {
+        assertEmbeddedAuth(req.account);
+        const results =
+            await this.getEmbedService().getEmbedDataAppVizRenderMetadata(
+                req.account,
+                projectUuid,
+                savedChartUuid,
+                dataAppVizUuid,
+            );
+        return {
+            status: 'ok',
+            results,
+        };
+    }
+
+    /**
+     * @summary Get an embedded data app visualization preview token
+     */
+    @SuccessResponse('200', 'Success')
+    @Get(
+        '/chart/{savedChartUuid}/visualizations/{dataAppVizUuid}/versions/{version}/preview-token',
+    )
+    @OperationId('getEmbedDataAppVizPreviewToken')
+    async getEmbedDataAppVizPreviewToken(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() savedChartUuid: string,
+        @Path() dataAppVizUuid: string,
+        @Path() version: number,
+    ): Promise<ApiDataAppVizPreviewTokenResponse> {
+        assertEmbeddedAuth(req.account);
+        const token =
+            await this.getEmbedService().getEmbedDataAppVizPreviewToken(
+                req.account,
+                projectUuid,
+                savedChartUuid,
+                dataAppVizUuid,
+                version,
+            );
+        return {
+            status: 'ok',
+            results: { token },
         };
     }
 

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -383,6 +383,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     asyncQueryService: repository.getAsyncQueryService(),
                     permissionsService: repository.getPermissionsService(),
                     dashboardModel: models.getDashboardModel(),
+                    appModel: models.getAppModel(),
                     embedModel: models.getEmbedModel(),
                     projectModel: models.getProjectModel(),
                     savedChartModel: models.getSavedChartModel(),

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -217,6 +217,11 @@ import {
     describeDashboardBlueprint,
 } from './dashboardBlueprint';
 import {
+    resolveDataAppVisualizationForRender,
+    resolveDataAppVizRenderMetadata,
+    resolveRenderableDataAppVizVersion,
+} from './dataAppVizRender';
+import {
     assertDependenciesHaveNoKnownMalware,
     assertDependenciesMeetMinReleaseAge,
 } from './dependencyGuards';
@@ -7670,13 +7675,11 @@ export class AppGenerateService extends BaseService {
         projectUuid: string,
         dataAppVizUuid: string,
     ) {
-        const dataAppViz = await this.appModel.findVisualizationApp(
-            dataAppVizUuid,
+        const dataAppViz = await resolveDataAppVisualizationForRender(
+            this.appModel,
             projectUuid,
+            dataAppVizUuid,
         );
-        if (!dataAppViz) {
-            throw new NotFoundError('Data app visualization not found');
-        }
 
         await this.assertDataAppsEnabled(user);
         await this.assertCanViewApp(user, {
@@ -7699,39 +7702,10 @@ export class AppGenerateService extends BaseService {
             projectUuid,
             dataAppVizUuid,
         );
-        const [latestVersion, latestRenderableVersion] = await Promise.all([
-            this.appModel.getLatestVersion(dataAppViz.app_id),
-            this.appModel.getLatestRenderableDataAppVizVersion(
-                dataAppViz.app_id,
-            ),
-        ]);
-        const latestBuildInProgress =
-            latestVersion !== null &&
-            isAppVersionInProgress(latestVersion.status);
-
-        if (
-            latestRenderableVersion !== null &&
-            latestRenderableVersion.viz_schema !== null
-        ) {
-            return {
-                state: 'ready',
-                version: latestRenderableVersion.version,
-                schema: latestRenderableVersion.viz_schema,
-                latestBuildInProgress,
-            };
-        }
-
-        if (latestBuildInProgress) {
-            return {
-                state: 'building',
-                latestBuildInProgress: true,
-            };
-        }
-
-        return {
-            state: 'failed',
-            latestBuildInProgress: false,
-        };
+        return resolveDataAppVizRenderMetadata(
+            this.appModel,
+            dataAppViz.app_id,
+        );
     }
 
     async getDataAppVizPreviewToken(
@@ -7746,23 +7720,11 @@ export class AppGenerateService extends BaseService {
             dataAppVizUuid,
         );
 
-        if (!Number.isInteger(version) || version < 1) {
-            throw new ParameterError('Version must be a positive integer');
-        }
-
-        const appVersion = await this.appModel.getVersion(
+        await resolveRenderableDataAppVizVersion(
+            this.appModel,
             dataAppViz.app_id,
             version,
         );
-        if (
-            appVersion === null ||
-            appVersion.status !== 'ready' ||
-            appVersion.viz_schema === null
-        ) {
-            throw new NotFoundError(
-                'Renderable data app visualization version not found',
-            );
-        }
 
         return mintPreviewToken(
             this.lightdashConfig.lightdashSecret,

--- a/packages/backend/src/ee/services/AppGenerateService/dataAppVizRender.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/dataAppVizRender.ts
@@ -1,0 +1,85 @@
+import {
+    isAppVersionInProgress,
+    NotFoundError,
+    ParameterError,
+    type DataAppVizRenderMetadata,
+} from '@lightdash/common';
+import { type DbAppVersion } from '../../../database/entities/apps';
+import { type AppModel } from '../../../models/AppModel';
+
+export type DataAppVisualizationForRender = NonNullable<
+    Awaited<ReturnType<AppModel['findVisualizationApp']>>
+>;
+
+export const resolveDataAppVisualizationForRender = async (
+    appModel: AppModel,
+    projectUuid: string,
+    dataAppVizUuid: string,
+): Promise<DataAppVisualizationForRender> => {
+    const dataAppViz = await appModel.findVisualizationApp(
+        dataAppVizUuid,
+        projectUuid,
+    );
+    if (!dataAppViz) {
+        throw new NotFoundError('Data app visualization not found');
+    }
+    return dataAppViz;
+};
+
+export const resolveDataAppVizRenderMetadata = async (
+    appModel: AppModel,
+    appUuid: string,
+): Promise<DataAppVizRenderMetadata> => {
+    const [latestVersion, latestRenderableVersion] = await Promise.all([
+        appModel.getLatestVersion(appUuid),
+        appModel.getLatestRenderableDataAppVizVersion(appUuid),
+    ]);
+    const latestBuildInProgress =
+        latestVersion !== null && isAppVersionInProgress(latestVersion.status);
+
+    if (
+        latestRenderableVersion !== null &&
+        latestRenderableVersion.viz_schema !== null
+    ) {
+        return {
+            state: 'ready',
+            version: latestRenderableVersion.version,
+            schema: latestRenderableVersion.viz_schema,
+            latestBuildInProgress,
+        };
+    }
+
+    if (latestBuildInProgress) {
+        return {
+            state: 'building',
+            latestBuildInProgress: true,
+        };
+    }
+
+    return {
+        state: 'failed',
+        latestBuildInProgress: false,
+    };
+};
+
+export const resolveRenderableDataAppVizVersion = async (
+    appModel: AppModel,
+    appUuid: string,
+    version: number,
+): Promise<DbAppVersion> => {
+    if (!Number.isInteger(version) || version < 1) {
+        throw new ParameterError('Version must be a positive integer');
+    }
+
+    const appVersion = await appModel.getVersion(appUuid, version);
+    if (
+        appVersion === null ||
+        appVersion.status !== 'ready' ||
+        appVersion.viz_schema === null
+    ) {
+        throw new NotFoundError(
+            'Renderable data app visualization version not found',
+        );
+    }
+    return appVersion;
+};

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.dataAppVizRender.test.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.dataAppVizRender.test.ts
@@ -1,0 +1,416 @@
+import {
+    ChartType,
+    DashboardTileTypes,
+    ForbiddenError,
+    NotFoundError,
+    type AnonymousAccount,
+    type DataAppVizSchema,
+    type EmbedContent,
+} from '@lightdash/common';
+import { verifyPreviewToken } from '../../../routers/appPreviewToken';
+import { EmbedService } from './EmbedService';
+import { EmbedServiceArgumentsMock } from './EmbedService.mock';
+
+const PROJECT_UUID = 'project-1';
+const ORGANIZATION_UUID = 'org-1';
+const DATA_APP_VIZ_UUID = 'data-app-viz-1';
+const SAVED_CHART_UUID = 'saved-chart-1';
+
+const vizSchema: DataAppVizSchema = {
+    fields: [],
+    configOptions: [],
+    colorPalette: null,
+};
+
+const makeDataAppVizRow = () => ({
+    app_id: DATA_APP_VIZ_UUID,
+    project_uuid: PROJECT_UUID,
+    organization_uuid: ORGANIZATION_UUID,
+    space_uuid: null,
+    created_by_user_uuid: 'author-1',
+});
+
+const makeVersion = (overrides: Record<string, unknown> = {}) => ({
+    app_version_id: 'app-version-1',
+    app_id: DATA_APP_VIZ_UUID,
+    version: 1,
+    prompt: 'build a chart',
+    status: 'ready',
+    error: null,
+    status_message: null,
+    status_history: [],
+    status_updated_at: new Date('2026-06-30'),
+    resources: null,
+    dependencies: null,
+    viz_schema: vizSchema,
+    generation_usage: null,
+    created_at: new Date('2026-06-30'),
+    created_by_user_uuid: 'author-1',
+    ...overrides,
+});
+
+const makeSavedChart = (overrides: Record<string, unknown> = {}) => ({
+    uuid: SAVED_CHART_UUID,
+    projectUuid: PROJECT_UUID,
+    tableName: 'orders',
+    metricQuery: {},
+    chartConfig: {
+        type: ChartType.DATA_APP_VIZ,
+        config: {
+            dataAppVizUuid: DATA_APP_VIZ_UUID,
+            fieldMapping: {},
+        },
+    },
+    ...overrides,
+});
+
+const makeAccount = (
+    content: Partial<EmbedContent> & Pick<EmbedContent, 'type'>,
+): AnonymousAccount =>
+    ({
+        authentication: { type: 'jwt', source: 'embed-token' },
+        user: { id: 'embed-user-1' },
+        organization: { organizationUuid: ORGANIZATION_UUID },
+        access: {
+            content: {
+                chartUuids: [],
+                explores: [],
+                ...content,
+            },
+        },
+        embed: { projectUuid: PROJECT_UUID },
+        isJwtUser: vi.fn().mockReturnValue(true),
+    }) as unknown as AnonymousAccount;
+
+const chartAccount = () =>
+    makeAccount({ type: 'chart', chartUuids: [SAVED_CHART_UUID] });
+
+const dashboardAccount = () =>
+    makeAccount({ type: 'dashboard', dashboardUuid: 'dashboard-1' });
+
+const buildService = ({
+    appModel = {},
+    savedChartModel = {},
+    dashboardModel = {},
+    featureFlagModel = {
+        get: vi.fn().mockResolvedValue({ enabled: true }),
+    },
+}: {
+    appModel?: Record<string, unknown>;
+    savedChartModel?: Record<string, unknown>;
+    dashboardModel?: Record<string, unknown>;
+    featureFlagModel?: Record<string, unknown>;
+}) =>
+    new EmbedService({
+        ...EmbedServiceArgumentsMock,
+        lightdashConfig: {
+            ...EmbedServiceArgumentsMock.lightdashConfig,
+            lightdashSecret: 'test-secret',
+        },
+        appModel,
+        savedChartModel,
+        dashboardModel,
+        featureFlagModel,
+    } as never);
+
+describe('EmbedService data app viz rendering', () => {
+    it('resolves the template-filtered viz before the feature flag or chart authorization', async () => {
+        const featureFlagModel = { get: vi.fn() };
+        const savedChartModel = { get: vi.fn() };
+        const service = buildService({
+            appModel: {
+                findVisualizationApp: vi.fn().mockResolvedValue(undefined),
+            },
+            featureFlagModel,
+            savedChartModel,
+        });
+
+        await expect(
+            service.getEmbedDataAppVizRenderMetadata(
+                chartAccount(),
+                PROJECT_UUID,
+                SAVED_CHART_UUID,
+                'non-visualization-data-app',
+            ),
+        ).rejects.toThrow(NotFoundError);
+
+        expect(featureFlagModel.get).not.toHaveBeenCalled();
+        expect(savedChartModel.get).not.toHaveBeenCalled();
+    });
+
+    it('serves metadata to the standalone chart named by the JWT', async () => {
+        const savedChartModel = {
+            get: vi.fn().mockResolvedValue(makeSavedChart()),
+        };
+        const service = buildService({
+            appModel: {
+                findVisualizationApp: vi
+                    .fn()
+                    .mockResolvedValue(makeDataAppVizRow()),
+                getLatestVersion: vi
+                    .fn()
+                    .mockResolvedValue(
+                        makeVersion({ version: 2, status: 'building' }),
+                    ),
+                getLatestRenderableDataAppVizVersion: vi
+                    .fn()
+                    .mockResolvedValue(makeVersion()),
+            },
+            savedChartModel,
+        });
+
+        await expect(
+            service.getEmbedDataAppVizRenderMetadata(
+                chartAccount(),
+                PROJECT_UUID,
+                SAVED_CHART_UUID,
+                DATA_APP_VIZ_UUID,
+            ),
+        ).resolves.toEqual({
+            state: 'ready',
+            version: 1,
+            schema: vizSchema,
+            latestBuildInProgress: true,
+        });
+        expect(savedChartModel.get).toHaveBeenCalledWith(SAVED_CHART_UUID);
+    });
+
+    it('rejects a different chart than the standalone chart named by the JWT', async () => {
+        const savedChartModel = { get: vi.fn() };
+        const service = buildService({
+            appModel: {
+                findVisualizationApp: vi
+                    .fn()
+                    .mockResolvedValue(makeDataAppVizRow()),
+            },
+            savedChartModel,
+        });
+
+        await expect(
+            service.getEmbedDataAppVizRenderMetadata(
+                chartAccount(),
+                PROJECT_UUID,
+                'another-chart',
+                DATA_APP_VIZ_UUID,
+            ),
+        ).rejects.toThrow(ForbiddenError);
+        expect(savedChartModel.get).not.toHaveBeenCalled();
+    });
+
+    it('serves metadata when the saved chart is a tile on the authorized dashboard', async () => {
+        const dashboardModel = {
+            getByIdOrSlug: vi.fn().mockResolvedValue({
+                uuid: 'dashboard-1',
+                tiles: [
+                    {
+                        uuid: 'tile-1',
+                        type: DashboardTileTypes.SAVED_CHART,
+                        properties: { savedChartUuid: SAVED_CHART_UUID },
+                    },
+                ],
+            }),
+        };
+        const savedChartModel = {
+            get: vi.fn().mockResolvedValue(makeSavedChart()),
+        };
+        const service = buildService({
+            appModel: {
+                findVisualizationApp: vi
+                    .fn()
+                    .mockResolvedValue(makeDataAppVizRow()),
+                getLatestVersion: vi.fn().mockResolvedValue(makeVersion()),
+                getLatestRenderableDataAppVizVersion: vi
+                    .fn()
+                    .mockResolvedValue(makeVersion()),
+            },
+            dashboardModel,
+            savedChartModel,
+        });
+
+        await expect(
+            service.getEmbedDataAppVizRenderMetadata(
+                dashboardAccount(),
+                PROJECT_UUID,
+                SAVED_CHART_UUID,
+                DATA_APP_VIZ_UUID,
+            ),
+        ).resolves.toMatchObject({ state: 'ready', version: 1 });
+        expect(dashboardModel.getByIdOrSlug).toHaveBeenCalledWith(
+            'dashboard-1',
+            { projectUuid: PROJECT_UUID },
+        );
+    });
+
+    it('rejects a saved chart that is not a tile on the authorized dashboard', async () => {
+        const savedChartModel = { get: vi.fn() };
+        const service = buildService({
+            appModel: {
+                findVisualizationApp: vi
+                    .fn()
+                    .mockResolvedValue(makeDataAppVizRow()),
+            },
+            dashboardModel: {
+                getByIdOrSlug: vi.fn().mockResolvedValue({
+                    uuid: 'dashboard-1',
+                    tiles: [],
+                }),
+            },
+            savedChartModel,
+        });
+
+        await expect(
+            service.getEmbedDataAppVizRenderMetadata(
+                dashboardAccount(),
+                PROJECT_UUID,
+                SAVED_CHART_UUID,
+                DATA_APP_VIZ_UUID,
+            ),
+        ).rejects.toThrow('Tile for saved chart');
+        expect(savedChartModel.get).not.toHaveBeenCalled();
+    });
+
+    it('rejects a saved chart that does not reference the requested viz', async () => {
+        const service = buildService({
+            appModel: {
+                findVisualizationApp: vi
+                    .fn()
+                    .mockResolvedValue(makeDataAppVizRow()),
+            },
+            savedChartModel: {
+                get: vi.fn().mockResolvedValue(
+                    makeSavedChart({
+                        chartConfig: {
+                            type: ChartType.DATA_APP_VIZ,
+                            config: {
+                                dataAppVizUuid: 'another-viz',
+                                fieldMapping: {},
+                            },
+                        },
+                    }),
+                ),
+            },
+        });
+
+        await expect(
+            service.getEmbedDataAppVizRenderMetadata(
+                chartAccount(),
+                PROJECT_UUID,
+                SAVED_CHART_UUID,
+                DATA_APP_VIZ_UUID,
+            ),
+        ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('rejects a saved chart that is not a data app visualization', async () => {
+        const service = buildService({
+            appModel: {
+                findVisualizationApp: vi
+                    .fn()
+                    .mockResolvedValue(makeDataAppVizRow()),
+            },
+            savedChartModel: {
+                get: vi.fn().mockResolvedValue(
+                    makeSavedChart({
+                        chartConfig: {
+                            type: ChartType.TABLE,
+                        },
+                    }),
+                ),
+            },
+        });
+
+        await expect(
+            service.getEmbedDataAppVizRenderMetadata(
+                chartAccount(),
+                PROJECT_UUID,
+                SAVED_CHART_UUID,
+                DATA_APP_VIZ_UUID,
+            ),
+        ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('checks EnableDataApps before loading the authorized saved chart', async () => {
+        const savedChartModel = { get: vi.fn() };
+        const service = buildService({
+            appModel: {
+                findVisualizationApp: vi
+                    .fn()
+                    .mockResolvedValue(makeDataAppVizRow()),
+            },
+            featureFlagModel: {
+                get: vi.fn().mockResolvedValue({ enabled: false }),
+            },
+            savedChartModel,
+        });
+
+        await expect(
+            service.getEmbedDataAppVizRenderMetadata(
+                chartAccount(),
+                PROJECT_UUID,
+                SAVED_CHART_UUID,
+                DATA_APP_VIZ_UUID,
+            ),
+        ).rejects.toThrow(ForbiddenError);
+        expect(savedChartModel.get).not.toHaveBeenCalled();
+    });
+
+    it.each(['dataApp', 'aiAgent', 'metricsCatalog', 'apiAccess'] as const)(
+        'rejects %s embed JWTs',
+        async (type) => {
+            const savedChartModel = { get: vi.fn() };
+            const service = buildService({
+                appModel: {
+                    findVisualizationApp: vi
+                        .fn()
+                        .mockResolvedValue(makeDataAppVizRow()),
+                },
+                savedChartModel,
+            });
+
+            await expect(
+                service.getEmbedDataAppVizRenderMetadata(
+                    makeAccount({ type }),
+                    PROJECT_UUID,
+                    SAVED_CHART_UUID,
+                    DATA_APP_VIZ_UUID,
+                ),
+            ).rejects.toThrow(ForbiddenError);
+            expect(savedChartModel.get).not.toHaveBeenCalled();
+        },
+    );
+
+    it('mints a token only for the exact requested renderable version', async () => {
+        const appModel = {
+            findVisualizationApp: vi
+                .fn()
+                .mockResolvedValue(makeDataAppVizRow()),
+            getVersion: vi.fn().mockResolvedValue(makeVersion({ version: 2 })),
+        };
+        const service = buildService({
+            appModel,
+            savedChartModel: {
+                get: vi.fn().mockResolvedValue(makeSavedChart()),
+            },
+        });
+
+        const token = await service.getEmbedDataAppVizPreviewToken(
+            chartAccount(),
+            PROJECT_UUID,
+            SAVED_CHART_UUID,
+            DATA_APP_VIZ_UUID,
+            2,
+        );
+
+        expect(appModel.getVersion).toHaveBeenCalledWith(DATA_APP_VIZ_UUID, 2);
+        expect(
+            verifyPreviewToken(token, 'test-secret', DATA_APP_VIZ_UUID, 2),
+        ).toMatchObject({
+            ok: true,
+            payload: {
+                userUuid: 'embed-user-1',
+                organizationUuid: ORGANIZATION_UUID,
+                projectUuid: PROJECT_UUID,
+            },
+        });
+    });
+});

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.mock.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.mock.ts
@@ -6,6 +6,7 @@ import {
 } from '@lightdash/common';
 import { LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
 import { lightdashConfigMock } from '../../../config/lightdashConfig.mock';
+import { AppModel } from '../../../models/AppModel';
 import { DashboardModel } from '../../../models/DashboardModel/DashboardModel';
 import { FeatureFlagModel } from '../../../models/FeatureFlagModel/FeatureFlagModel';
 import { OrganizationModel } from '../../../models/OrganizationModel';
@@ -112,6 +113,7 @@ export const EmbedServiceArgumentsMock: ConstructorParameters<
     analytics: {} as LightdashAnalytics,
     encryptionUtil: {} as EncryptionUtil,
     embedModel: embedModelMock,
+    appModel: {} as AppModel,
     dashboardModel: {} as DashboardModel,
     savedChartModel: {} as SavedChartModel,
     savedSqlModel: {} as SavedSqlModel,

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -9,6 +9,7 @@ import {
     assertUnreachable,
     CalculateSubtotalsFromQuery,
     CalculateTotalFromQuery,
+    ChartType,
     CommercialFeatureFlags,
     CompiledDimension,
     CreateEmbedJwt,
@@ -27,6 +28,7 @@ import {
     ExecuteAsyncDashboardChartRequestParams,
     Explore,
     ExploreError,
+    FeatureFlags,
     FieldValueSearchResult,
     FilterableDimension,
     ForbiddenError,
@@ -68,6 +70,7 @@ import {
     UpdateEmbed,
     UserAccessControls,
     UserAttributeValueMap,
+    type DataAppVizRenderMetadata,
     type ParameterDefinitions,
     type ParametersValuesMap,
     type SessionUser,
@@ -81,6 +84,7 @@ import {
     encodeLightdashJwt,
 } from '../../../auth/lightdashJwt';
 import { LightdashConfig } from '../../../config/parseConfig';
+import { AppModel } from '../../../models/AppModel';
 import { DashboardModel } from '../../../models/DashboardModel/DashboardModel';
 import { FeatureFlagModel } from '../../../models/FeatureFlagModel/FeatureFlagModel';
 import { OrganizationModel } from '../../../models/OrganizationModel';
@@ -89,6 +93,7 @@ import { SavedChartModel } from '../../../models/SavedChartModel';
 import { SavedSqlModel } from '../../../models/SavedSqlModel';
 import { UserAttributesModel } from '../../../models/UserAttributesModel';
 import { UserModel } from '../../../models/UserModel';
+import { mintPreviewToken } from '../../../routers/appPreviewToken';
 import { AsyncQueryService } from '../../../services/AsyncQueryService/AsyncQueryService';
 import { BaseService } from '../../../services/BaseService';
 import { PermissionsService } from '../../../services/PermissionsService/PermissionsService';
@@ -105,6 +110,11 @@ import { QueryComposer } from '../../../utils/QueryBuilder/QueryComposer';
 import { SubtotalsCalculator } from '../../../utils/SubtotalsCalculator';
 import { EmbedDashboardViewed, EmbedQueryViewed } from '../../analytics';
 import { EmbedModel } from '../../models/EmbedModel';
+import {
+    resolveDataAppVisualizationForRender,
+    resolveDataAppVizRenderMetadata,
+    resolveRenderableDataAppVizVersion,
+} from '../AppGenerateService/dataAppVizRender';
 
 const escapeEmbedJwtUserAttributeValue = (value: string): string =>
     value.replaceAll("'", "''");
@@ -114,6 +124,7 @@ type Dependencies = {
     analytics: LightdashAnalytics;
     encryptionUtil: EncryptionUtil;
     embedModel: EmbedModel;
+    appModel: AppModel;
     dashboardModel: DashboardModel;
     savedChartModel: SavedChartModel;
     savedSqlModel: SavedSqlModel;
@@ -136,6 +147,8 @@ export class EmbedService extends BaseService {
     private readonly encryptionUtil: EncryptionUtil;
 
     private readonly embedModel: EmbedModel;
+
+    private readonly appModel: AppModel;
 
     private readonly dashboardModel: DashboardModel;
 
@@ -167,6 +180,7 @@ export class EmbedService extends BaseService {
         this.permissionsService = dependencies.permissionsService;
         this.analytics = dependencies.analytics;
         this.embedModel = dependencies.embedModel;
+        this.appModel = dependencies.appModel;
         this.dashboardModel = dependencies.dashboardModel;
         this.savedChartModel = dependencies.savedChartModel;
         this.savedSqlModel = dependencies.savedSqlModel;
@@ -1675,22 +1689,15 @@ export class EmbedService extends BaseService {
         };
     }
 
-    /**
-     * Common setup logic for saved chart calculations in embed context.
-     * Supports both chart embeds (direct chart access) and dashboard embeds (chart via tile).
-     */
-    private async _prepareSavedChartForCalculation(
+    private async getAuthorizedSavedChartForEmbed(
         account: AnonymousAccount,
         projectUuid: string,
         savedChartUuid: string,
-        dashboardFilters?: DashboardFilters,
     ) {
         const { type, dashboardUuid, chartUuids } = account.access.content;
 
         switch (type) {
-            // Handle chart embeds (direct chart access)
             case 'chart': {
-                // Validate that the requested chart matches the embedded chart
                 if (!chartUuids.includes(savedChartUuid)) {
                     throw new ForbiddenError(
                         `Not authorized to access chart ${savedChartUuid}`,
@@ -1705,27 +1712,14 @@ export class EmbedService extends BaseService {
                     );
                 }
 
-                const explore = await this.projectModel.getExploreFromCache(
-                    projectUuid,
-                    chart.tableName,
-                );
-
-                if (isExploreError(explore)) {
-                    throw new ForbiddenError(
-                        `Explore ${chart.tableName} on project ${projectUuid} has errors : ${explore.errors}`,
-                    );
-                }
-
                 return {
                     dashboardUuid: undefined,
+                    dashboard: undefined,
+                    tileUuid: undefined,
                     chart,
-                    explore,
-                    metricQuery: chart.metricQuery,
                 };
             }
             case 'dataApp':
-                // Data app JWTs have no saved-chart grants; reject explicitly
-                // rather than falling into the dashboard-tile path.
                 throw new ForbiddenError(
                     'Data app embeds cannot access saved charts',
                 );
@@ -1749,8 +1743,6 @@ export class EmbedService extends BaseService {
                     `Unknown embed content type: ${type}`,
                 );
         }
-
-        // Handle dashboard embeds (chart via tile)
 
         if (!dashboardUuid) {
             throw new ParameterError(
@@ -1787,6 +1779,123 @@ export class EmbedService extends BaseService {
             tile.uuid,
         );
 
+        return {
+            dashboardUuid,
+            dashboard,
+            tileUuid: tile.uuid,
+            chart,
+        };
+    }
+
+    private async getAuthorizedDataAppVizForEmbed(
+        account: AnonymousAccount,
+        projectUuid: string,
+        savedChartUuid: string,
+        dataAppVizUuid: string,
+    ) {
+        const dataAppViz = await resolveDataAppVisualizationForRender(
+            this.appModel,
+            projectUuid,
+            dataAppVizUuid,
+        );
+
+        if (projectUuid !== account.embed.projectUuid) {
+            throw new ForbiddenError(
+                'Project mismatch between URL and embed token',
+            );
+        }
+
+        const { enabled } = await this.featureFlagModel.get({
+            user: {
+                userUuid: account.user.id,
+                organizationUuid: dataAppViz.organization_uuid,
+            },
+            featureFlagId: FeatureFlags.EnableDataApps,
+        });
+        if (!enabled) {
+            throw new ForbiddenError('Data apps are not enabled');
+        }
+
+        const { chart } = await this.getAuthorizedSavedChartForEmbed(
+            account,
+            projectUuid,
+            savedChartUuid,
+        );
+        if (
+            chart.chartConfig.type !== ChartType.DATA_APP_VIZ ||
+            chart.chartConfig.config?.dataAppVizUuid !== dataAppVizUuid
+        ) {
+            throw new ForbiddenError(
+                'Saved chart does not render this data app visualization',
+            );
+        }
+
+        return dataAppViz;
+    }
+
+    async getEmbedDataAppVizRenderMetadata(
+        account: AnonymousAccount,
+        projectUuid: string,
+        savedChartUuid: string,
+        dataAppVizUuid: string,
+    ): Promise<DataAppVizRenderMetadata> {
+        const dataAppViz = await this.getAuthorizedDataAppVizForEmbed(
+            account,
+            projectUuid,
+            savedChartUuid,
+            dataAppVizUuid,
+        );
+        return resolveDataAppVizRenderMetadata(
+            this.appModel,
+            dataAppViz.app_id,
+        );
+    }
+
+    async getEmbedDataAppVizPreviewToken(
+        account: AnonymousAccount,
+        projectUuid: string,
+        savedChartUuid: string,
+        dataAppVizUuid: string,
+        version: number,
+    ): Promise<string> {
+        const dataAppViz = await this.getAuthorizedDataAppVizForEmbed(
+            account,
+            projectUuid,
+            savedChartUuid,
+            dataAppVizUuid,
+        );
+        await resolveRenderableDataAppVizVersion(
+            this.appModel,
+            dataAppViz.app_id,
+            version,
+        );
+        return mintPreviewToken(
+            this.lightdashConfig.lightdashSecret,
+            dataAppViz.app_id,
+            version,
+            account.user.id,
+            dataAppViz.organization_uuid,
+            projectUuid,
+        );
+    }
+
+    /**
+     * Common setup logic for saved chart calculations in embed context.
+     * Supports both chart embeds (direct chart access) and dashboard embeds (chart via tile).
+     */
+    private async _prepareSavedChartForCalculation(
+        account: AnonymousAccount,
+        projectUuid: string,
+        savedChartUuid: string,
+        dashboardFilters?: DashboardFilters,
+    ) {
+        const { dashboardUuid, dashboard, tileUuid, chart } =
+            await this.getAuthorizedSavedChartForEmbed(
+                account,
+                projectUuid,
+                savedChartUuid,
+            );
+
         const explore = await this.projectModel.getExploreFromCache(
             projectUuid,
             chart.tableName,
@@ -1798,11 +1907,25 @@ export class EmbedService extends BaseService {
             );
         }
 
+        if (!dashboard) {
+            return {
+                dashboardUuid: undefined,
+                chart,
+                explore,
+                metricQuery: chart.metricQuery,
+            };
+        }
+        if (!tileUuid) {
+            throw new ParameterError(
+                `Tile for saved chart ${savedChartUuid} not found`,
+            );
+        }
+
         const appliedDashboardFilters = await this._getAppliedDashboardFilters(
             account,
             explore,
             dashboard,
-            tile.uuid,
+            tileUuid,
             dashboardFilters,
         );
         const metricQuery = appliedDashboardFilters


### PR DESCRIPTION
Part 2 of the GLITCH-645 stack. Builds on #26780.

Adds the equivalent viz render endpoints for embed JWTs. Requests are bound to the saved chart authorized by the chart or dashboard embed and must reference the exact data app visualization being rendered.

Tests cover chart and dashboard embeds, unsupported JWT content types, feature flags, isolation, and exact-version token minting.

Next: #26782

Linear: https://linear.app/lightdash/issue/GLITCH-645
