### PR TITLE
refactor(frontend): use viz render endpoints

### DIFF
--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -59,6 +59,8 @@ import type {
     ApiCloneAiAgentThreadShareResponse,
     ApiCreateEvaluationResponse,
     ApiDataAppActivityResponse,
+    ApiDataAppVizPreviewTokenResponse,
+    ApiDataAppVizRenderMetadataResponse,
     ApiExternalConnectionAsCodeListResponse,
     ApiExternalConnectionAsCodeUpsertResponse,
     ApiGenerateAppResponse,
@@ -1331,6 +1333,8 @@ type ApiResults =
     | ApiGetAppResponse['results']
     | ApiListDataAppVizsResponse['results']
     | ApiGetDataAppVizResponse['results']
+    | ApiDataAppVizRenderMetadataResponse['results']
+    | ApiDataAppVizPreviewTokenResponse['results']
     | ApiMyAppsResponse['results']
     | ApiDataAppActivityResponse['results']
     | ApiPromoteAppResponse['results']

--- a/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
@@ -1,10 +1,14 @@
+import { MantineProvider } from '@mantine-8/core';
 import { render } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
-    dataAppViz: {
+    metadata: {
         current: undefined as
             | {
+                  state: 'ready';
+                  version: number;
+                  latestBuildInProgress: boolean;
                   schema: {
                       fields: Array<never>;
                       configOptions: Array<{
@@ -13,32 +17,37 @@ const mocks = vi.hoisted(() => ({
                           label: string;
                           default: string;
                       }>;
+                      colorPalette: null;
                   };
               }
             | undefined,
     },
+    token: { current: 'preview-token' as string | undefined },
+    embedToken: { current: undefined as string | undefined },
     iframePreview: vi.fn(() => null),
+    renderMetadataHook: vi.fn(),
+    previewTokenHook: vi.fn(),
     setFetchAll: vi.fn(),
 }));
 
 vi.mock('react-router', () => ({
     useParams: () => ({ projectUuid: 'project-uuid' }),
 }));
+vi.mock('../../ee/providers/Embed/useEmbed', () => ({
+    default: () => ({ embedToken: mocks.embedToken.current }),
+}));
 vi.mock('../../features/apps/AppIframePreview', () => ({
     default: mocks.iframePreview,
 }));
-vi.mock('../../features/apps/hooks/useAppPreviewToken', () => ({
-    useAppPreviewToken: () => ({ data: 'preview-token' }),
-}));
-vi.mock('../../features/apps/hooks/useDataAppVisualization', () => ({
-    useDataAppVisualization: () => ({ data: mocks.dataAppViz.current }),
-}));
-vi.mock('../../features/apps/hooks/useGetApp', () => ({
-    useGetApp: () => ({
-        data: {
-            pages: [{ versions: [{ status: 'ready', version: 1 }] }],
-        },
-    }),
+vi.mock('../../features/apps/hooks/useDataAppVizRender', () => ({
+    useDataAppVizRenderMetadata: (...args: unknown[]) => {
+        mocks.renderMetadataHook(...args);
+        return { data: mocks.metadata.current };
+    },
+    useDataAppVizPreviewToken: (...args: unknown[]) => {
+        mocks.previewTokenHook(...args);
+        return { data: mocks.token.current };
+    },
 }));
 vi.mock('../../features/apps/previewOrigin', () => ({
     usePreviewOrigin: () => 'https://preview.example.com',
@@ -57,6 +66,7 @@ vi.mock('../LightdashVisualization/useVisualizationContext', () => ({
                 },
             },
         },
+        savedChartUuid: 'saved-chart-uuid',
         resultsData: {
             rows: [{ 'orders.category': { value: { raw: 'Hardware' } } }],
             setFetchAll: mocks.setFetchAll,
@@ -67,35 +77,52 @@ vi.mock('../LightdashVisualization/useVisualizationContext', () => ({
 
 import DataAppVizRenderer from './index';
 
-describe('DataAppVizRenderer option delivery', () => {
+const renderRenderer = () =>
+    render(
+        <MantineProvider>
+            <DataAppVizRenderer />
+        </MantineProvider>,
+    );
+
+const readyMetadata = () => ({
+    state: 'ready' as const,
+    version: 7,
+    latestBuildInProgress: false,
+    schema: {
+        fields: [],
+        configOptions: [
+            {
+                type: 'text' as const,
+                name: 'title',
+                label: 'Title',
+                default: 'Sales',
+            },
+        ],
+        colorPalette: null,
+    },
+});
+
+describe('DataAppVizRenderer', () => {
     beforeEach(() => {
-        mocks.dataAppViz.current = undefined;
+        mocks.metadata.current = readyMetadata();
+        mocks.token.current = 'preview-token';
+        mocks.embedToken.current = undefined;
         mocks.iframePreview.mockClear();
+        mocks.renderMetadataHook.mockClear();
+        mocks.previewTokenHook.mockClear();
         mocks.setFetchAll.mockClear();
     });
 
-    it('does not push stale stored options before the declaration resolves', () => {
-        const { rerender } = render(<DataAppVizRenderer />);
+    it('waits for render metadata before mounting the iframe', () => {
+        mocks.metadata.current = undefined;
 
-        expect(mocks.iframePreview).toHaveBeenLastCalledWith(
-            expect.objectContaining({ dataAppVizContext: undefined }),
-            undefined,
-        );
+        renderRenderer();
 
-        mocks.dataAppViz.current = {
-            schema: {
-                fields: [],
-                configOptions: [
-                    {
-                        type: 'text',
-                        name: 'title',
-                        label: 'Title',
-                        default: 'Sales',
-                    },
-                ],
-            },
-        };
-        rerender(<DataAppVizRenderer />);
+        expect(mocks.iframePreview).not.toHaveBeenCalled();
+    });
+
+    it('uses the metadata schema to deliver effective options', () => {
+        renderRenderer();
 
         expect(mocks.iframePreview).toHaveBeenLastCalledWith(
             expect.objectContaining({
@@ -105,6 +132,41 @@ describe('DataAppVizRenderer option delivery', () => {
                 }),
             }),
             undefined,
+        );
+    });
+
+    it('requests and renders the exact version selected by metadata', () => {
+        renderRenderer();
+
+        expect(mocks.previewTokenHook).toHaveBeenCalledWith(
+            'project-uuid',
+            'viz-uuid',
+            7,
+            {
+                isEmbedded: false,
+                savedChartUuid: 'saved-chart-uuid',
+            },
+        );
+        expect(mocks.iframePreview).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                src: 'https://preview.example.com/api/apps/viz-uuid/versions/7/t/preview-token/?r=0#transport=postMessage&projectUuid=project-uuid',
+            }),
+            undefined,
+        );
+    });
+
+    it('selects the embed route target when an embed JWT is present', () => {
+        mocks.embedToken.current = 'embed-token';
+
+        renderRenderer();
+
+        expect(mocks.renderMetadataHook).toHaveBeenCalledWith(
+            'project-uuid',
+            'viz-uuid',
+            {
+                isEmbedded: true,
+                savedChartUuid: 'saved-chart-uuid',
+            },
         );
     });
 });

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -6,10 +6,12 @@ import { Stack, Text } from '@mantine-8/core';
 import { IconPuzzle } from '@tabler/icons-react';
 import { useEffect, useMemo, useRef, type FC } from 'react';
 import { useParams } from 'react-router';
+import useEmbed from '../../ee/providers/Embed/useEmbed';
 import AppIframePreview from '../../features/apps/AppIframePreview';
-import { useAppPreviewToken } from '../../features/apps/hooks/useAppPreviewToken';
-import { useDataAppVisualization } from '../../features/apps/hooks/useDataAppVisualization';
-import { useGetApp } from '../../features/apps/hooks/useGetApp';
+import {
+    useDataAppVizPreviewToken,
+    useDataAppVizRenderMetadata,
+} from '../../features/apps/hooks/useDataAppVizRender';
 import { usePreviewOrigin } from '../../features/apps/previewOrigin';
 import { reconcileDataAppVizFieldMapping } from '../../features/apps/utils/autoMapDataAppVizFields';
 import MantineIcon from '../common/MantineIcon';
@@ -32,8 +34,14 @@ const DataAppVizPlaceholder: FC<{ message: string }> = ({ message }) => (
 
 const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
-    const { visualizationConfig, resultsData, colorPalette, itemsMap } =
-        useVisualizationContext();
+    const {
+        visualizationConfig,
+        resultsData,
+        colorPalette,
+        itemsMap,
+        savedChartUuid,
+    } = useVisualizationContext();
+    const { embedToken } = useEmbed();
     const previewOrigin = usePreviewOrigin();
     const hasSignaledScreenshotReady = useRef(false);
 
@@ -59,34 +67,25 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
     const optionValues = config?.optionValues;
     const rows = resultsData?.rows;
 
-    // Hooks run unconditionally; the queries are `enabled`-gated on their args.
-    const { data: appData } = useGetApp(
+    const renderTarget = useMemo(
+        () => ({ isEmbedded: !!embedToken, savedChartUuid }),
+        [embedToken, savedChartUuid],
+    );
+    const { data: renderMetadata } = useDataAppVizRenderMetadata(
         projectUuid,
         dataAppVizUuid || undefined,
+        renderTarget,
     );
-
-    // The declaration is the only source of option defaults, so the renderer
-    // fetches it to resolve effective values.
-    const { data: dataAppViz } = useDataAppVisualization(
+    const readyMetadata =
+        renderMetadata?.state === 'ready' ? renderMetadata : undefined;
+    const { data: token } = useDataAppVizPreviewToken(
         projectUuid,
         dataAppVizUuid || undefined,
+        readyMetadata?.version,
+        renderTarget,
     );
-    const configOptions = dataAppViz?.schema?.configOptions;
-    const fields = dataAppViz?.schema?.fields;
-
-    // Latest READY version of the chosen data app viz drives the preview.
-    const readyVersion = useMemo(() => {
-        const versions = appData?.pages.flatMap((page) => page.versions) ?? [];
-        const ready = versions.filter((v) => v.status === 'ready');
-        if (ready.length === 0) return undefined;
-        return ready.reduce((max, v) => Math.max(max, v.version), 0);
-    }, [appData]);
-
-    const { data: token } = useAppPreviewToken(
-        projectUuid,
-        dataAppVizUuid || undefined,
-        readyVersion,
-    );
+    const configOptions = readyMetadata?.schema.configOptions;
+    const fields = readyMetadata?.schema.fields;
 
     const dataAppVizContext = useMemo<DataAppVizContext | undefined>(() => {
         if (!rows || !configOptions || !fields) return undefined;
@@ -124,13 +123,13 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
         );
     }
 
-    if (readyVersion === undefined || !token) {
+    if (!readyMetadata || !token) {
         return (
             <DataAppVizPlaceholder message="Data app visualization is still generating…" />
         );
     }
 
-    const previewUrl = `${previewOrigin}/api/apps/${dataAppVizUuid}/versions/${readyVersion}/t/${token}/?r=0#transport=postMessage&projectUuid=${projectUuid}`;
+    const previewUrl = `${previewOrigin}/api/apps/${dataAppVizUuid}/versions/${readyMetadata.version}/t/${token}/?r=0#transport=postMessage&projectUuid=${projectUuid}`;
 
     return (
         <AppIframePreview

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -361,6 +361,7 @@ const VisualizationProvider: FC<
         getGroupColor,
         getSeriesColor,
         chartConfig,
+        savedChartUuid,
         parameters,
         containerWidth,
         containerHeight,

--- a/packages/frontend/src/components/LightdashVisualization/context.ts
+++ b/packages/frontend/src/components/LightdashVisualization/context.ts
@@ -48,6 +48,7 @@ type VisualizationContext = {
     getGroupColor: (groupPrefix: string, groupName: string) => string;
     colorPalette: string[];
     chartConfig: ChartConfig;
+    savedChartUuid?: string;
     apiErrorDetail?: ApiErrorDetail | null;
     parameters?: ParametersValuesMap;
     // Container dimensions for responsive visualizations

--- a/packages/frontend/src/features/apps/hooks/useDataAppVizRender.test.tsx
+++ b/packages/frontend/src/features/apps/hooks/useDataAppVizRender.test.tsx
@@ -1,0 +1,110 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    useDataAppVizPreviewToken,
+    useDataAppVizRenderMetadata,
+} from './useDataAppVizRender';
+
+const mocks = vi.hoisted(() => ({
+    lightdashApi: vi.fn(),
+    useQuery: vi.fn(),
+}));
+
+vi.mock('../../../api', () => ({ lightdashApi: mocks.lightdashApi }));
+vi.mock('@tanstack/react-query', () => ({ useQuery: mocks.useQuery }));
+
+type CapturedQuery = {
+    queryKey: unknown[];
+    queryFn: () => Promise<unknown>;
+    enabled: boolean;
+    refetchInterval?: (data: unknown) => number | false;
+};
+
+describe('useDataAppVizRender', () => {
+    beforeEach(() => {
+        mocks.lightdashApi.mockReset();
+        mocks.useQuery.mockReset();
+        mocks.useQuery.mockImplementation((options) => options);
+    });
+
+    it('uses registered viz-only routes and polls only while a build is active', async () => {
+        const { result } = renderHook(() =>
+            useDataAppVizRenderMetadata('project-1', 'viz-1', {
+                isEmbedded: false,
+                savedChartUuid: 'chart-1',
+            }),
+        );
+        const query = result.current as unknown as CapturedQuery;
+
+        expect(query.queryKey).toEqual([
+            'data-app-viz-render-metadata',
+            'project-1',
+            'viz-1',
+            'registered',
+            'chart-1',
+        ]);
+        expect(query.enabled).toBe(true);
+        await query.queryFn();
+        expect(mocks.lightdashApi).toHaveBeenCalledWith({
+            method: 'GET',
+            url: '/ee/projects/project-1/apps/visualizations/viz-1/render-metadata',
+        });
+        expect(query.refetchInterval?.({ latestBuildInProgress: true })).toBe(
+            3000,
+        );
+        expect(query.refetchInterval?.({ latestBuildInProgress: false })).toBe(
+            false,
+        );
+    });
+
+    it('uses the saved-chart-bound embed routes for metadata and exact-version tokens', async () => {
+        const target = {
+            isEmbedded: true,
+            savedChartUuid: 'chart-1',
+        };
+        const { result: metadataResult } = renderHook(() =>
+            useDataAppVizRenderMetadata('project-1', 'viz-1', target),
+        );
+        const metadataQuery =
+            metadataResult.current as unknown as CapturedQuery;
+
+        await metadataQuery.queryFn();
+        expect(mocks.lightdashApi).toHaveBeenLastCalledWith({
+            method: 'GET',
+            url: '/embed/project-1/chart/chart-1/visualizations/viz-1/render-metadata',
+        });
+
+        mocks.lightdashApi.mockResolvedValue({ token: 'token-7' });
+        const { result: tokenResult } = renderHook(() =>
+            useDataAppVizPreviewToken('project-1', 'viz-1', 7, target),
+        );
+        const tokenQuery = tokenResult.current as unknown as CapturedQuery;
+
+        await expect(tokenQuery.queryFn()).resolves.toBe('token-7');
+        expect(tokenQuery.queryKey).toEqual([
+            'data-app-viz-preview-token',
+            'project-1',
+            'viz-1',
+            7,
+            'embed',
+            'chart-1',
+        ]);
+        expect(mocks.lightdashApi).toHaveBeenLastCalledWith({
+            method: 'GET',
+            url: '/embed/project-1/chart/chart-1/visualizations/viz-1/versions/7/preview-token',
+        });
+    });
+
+    it('does not call an embed route without a saved chart UUID', () => {
+        const { result } = renderHook(() =>
+            useDataAppVizRenderMetadata('project-1', 'viz-1', {
+                isEmbedded: true,
+                savedChartUuid: undefined,
+            }),
+        );
+
+        expect((result.current as unknown as CapturedQuery).enabled).toBe(
+            false,
+        );
+    });
+});

--- a/packages/frontend/src/features/apps/hooks/useDataAppVizRender.ts
+++ b/packages/frontend/src/features/apps/hooks/useDataAppVizRender.ts
@@ -1,0 +1,96 @@
+import {
+    type ApiDataAppVizPreviewTokenResponse,
+    type ApiDataAppVizRenderMetadataResponse,
+    type ApiError,
+    type DataAppVizRenderMetadata,
+} from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../../../api';
+
+const DATA_APP_VIZ_RENDER_POLL_INTERVAL_MS = 3000;
+
+type DataAppVizRenderTarget = {
+    isEmbedded: boolean;
+    savedChartUuid: string | undefined;
+};
+
+const getRenderBaseUrl = (
+    projectUuid: string,
+    dataAppVizUuid: string,
+    { isEmbedded, savedChartUuid }: DataAppVizRenderTarget,
+): string =>
+    isEmbedded
+        ? `/embed/${projectUuid}/chart/${savedChartUuid}/visualizations/${dataAppVizUuid}`
+        : `/ee/projects/${projectUuid}/apps/visualizations/${dataAppVizUuid}`;
+
+const isTargetReady = (
+    projectUuid: string | undefined,
+    dataAppVizUuid: string | undefined,
+    target: DataAppVizRenderTarget,
+): boolean =>
+    !!projectUuid &&
+    !!dataAppVizUuid &&
+    (!target.isEmbedded || !!target.savedChartUuid);
+
+export const useDataAppVizRenderMetadata = (
+    projectUuid: string | undefined,
+    dataAppVizUuid: string | undefined,
+    target: DataAppVizRenderTarget,
+) =>
+    useQuery<DataAppVizRenderMetadata, ApiError>({
+        queryKey: [
+            'data-app-viz-render-metadata',
+            projectUuid,
+            dataAppVizUuid,
+            target.isEmbedded ? 'embed' : 'registered',
+            target.savedChartUuid,
+        ],
+        queryFn: () =>
+            lightdashApi<ApiDataAppVizRenderMetadataResponse['results']>({
+                method: 'GET',
+                url: `${getRenderBaseUrl(
+                    projectUuid!,
+                    dataAppVizUuid!,
+                    target,
+                )}/render-metadata`,
+            }),
+        enabled: isTargetReady(projectUuid, dataAppVizUuid, target),
+        refetchInterval: (metadata) =>
+            metadata?.latestBuildInProgress
+                ? DATA_APP_VIZ_RENDER_POLL_INTERVAL_MS
+                : false,
+    });
+
+export const useDataAppVizPreviewToken = (
+    projectUuid: string | undefined,
+    dataAppVizUuid: string | undefined,
+    version: number | undefined,
+    target: DataAppVizRenderTarget,
+) =>
+    useQuery<string, ApiError>({
+        queryKey: [
+            'data-app-viz-preview-token',
+            projectUuid,
+            dataAppVizUuid,
+            version,
+            target.isEmbedded ? 'embed' : 'registered',
+            target.savedChartUuid,
+        ],
+        queryFn: async () => {
+            const { token } = await lightdashApi<
+                ApiDataAppVizPreviewTokenResponse['results']
+            >({
+                method: 'GET',
+                url: `${getRenderBaseUrl(
+                    projectUuid!,
+                    dataAppVizUuid!,
+                    target,
+                )}/versions/${version}/preview-token`,
+            });
+            return token;
+        },
+        enabled:
+            isTargetReady(projectUuid, dataAppVizUuid, target) &&
+            version !== undefined &&
+            version > 0,
+    });


### PR DESCRIPTION
Part 3 of the GLITCH-645 stack. Builds on #26781.

Moves the frontend renderer from generic data-app calls to the new viz-only metadata and preview-token endpoints. Registered and embedded renders use the exact version selected by metadata, and metadata polls only while a build is active.

Tests cover registered and embed route selection, version consistency, rendering context, and conditional polling.

## Embed flow

```mermaid
sequenceDiagram
    autonumber
    participant UI as Embedded DataAppVizRenderer
    participant EC as EmbedController
    participant ES as EmbedService
    participant Models as App / Chart / Dashboard models
    participant Mint as mintPreviewToken
    participant Preview as App preview server

    UI->>EC: GET render-metadata with embed JWT
    EC->>EC: assertEmbeddedAuth
    EC->>ES: getEmbedDataAppVizRenderMetadata(P, C, V)

    ES->>Models: Find visualization V in project P<br/>Require data_app_viz template
    ES->>ES: Confirm P matches embed JWT project

    alt Direct chart embed
        ES->>Models: Load chart C
        ES->>ES: Require C in JWT chartUuids
    else Dashboard embed
        ES->>Models: Load JWT-authorized dashboard
        ES->>ES: Require dashboard tile referencing C
    end

    ES->>ES: Require chart C is DATA_APP_VIZ<br/>and chart.dataAppVizUuid equals V
    ES->>Models: Find latest renderable version
    ES-->>UI: Metadata with version N and schema

    UI->>EC: GET versions/N/preview-token with embed JWT
    EC->>ES: getEmbedDataAppVizPreviewToken(P, C, V, N)
    ES->>ES: Repeat project, content, and viz authorization
    ES->>Models: Require version N is ready and renderable
    ES->>Mint: mintPreviewToken(secret, V, N, embedUser, org, P)
    Note over ES,Mint: App preview token is minted here
    Mint-->>UI: App preview JWT

    UI->>Preview: GET /api/apps/V/versions/N/t/previewToken/
    Preview->>Preview: Verify signature, app V, and exact version N
    Preview-->>UI: Serve iframe HTML and assets
```

## Signed-in chart flow

```mermaid
sequenceDiagram
    autonumber
    participant UI as Signed-in DataAppVizRenderer
    participant AC as AppGenerateController
    participant AS as AppGenerateService
    participant Models as AppModel
    participant Mint as mintPreviewToken
    participant Preview as App preview server

    UI->>AC: GET render-metadata with session or API key
    AC->>AC: assertRegisteredAccount
    AC->>AS: getDataAppVizRenderMetadata(user, P, V)

    AS->>Models: Find visualization V in project P<br/>Require data_app_viz template
    AS->>AS: Require EnableDataApps and app view permission
    AS->>Models: Find latest renderable version
    AS-->>UI: Metadata with version N and schema

    UI->>AC: GET versions/N/preview-token
    AC->>AS: getDataAppVizPreviewToken(user, P, V, N)
    AS->>AS: Repeat feature and app authorization
    AS->>Models: Require version N is ready and renderable
    AS->>Mint: mintPreviewToken(secret, V, N, userUuid, org, P)
    Note over AS,Mint: App preview token is minted here
    Mint-->>UI: App preview JWT

    UI->>Preview: GET /api/apps/V/versions/N/t/previewToken/
    Preview->>Preview: Verify signature, app V, and exact version N
    Preview-->>UI: Serve iframe HTML and assets
```

Linear: https://linear.app/lightdash/issue/GLITCH-645
