### PR TITLE
feat(virtual-views): expand date columns into time interval dimensions

### DIFF
--- a/packages/backend/src/services/CoderService/CoderService.virtualViews.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.virtualViews.test.ts
@@ -6,6 +6,7 @@ import {
     OrganizationMemberRole,
     PossibleAbilities,
     PromotionAction,
+    TimeFrames,
     type Explore,
     type SessionUser,
     type VirtualViewAsCode,
@@ -127,6 +128,39 @@ describe('CoderService virtual views as code', () => {
             skipped: [],
             missingSlugs: [],
         });
+    });
+
+    test('excludes generated time interval dimensions from the exported columns', async () => {
+        const withIntervals = {
+            ...virtualView,
+            tables: {
+                orders_by_customer: {
+                    ...virtualView.tables.orders_by_customer,
+                    dimensions: {
+                        ...virtualView.tables.orders_by_customer.dimensions,
+                        order_date: {
+                            name: 'order_date',
+                            type: DimensionType.DATE,
+                            isIntervalBase: true,
+                        },
+                        order_date_month: {
+                            name: 'order_date_month',
+                            type: DimensionType.DATE,
+                            timeInterval: TimeFrames.MONTH,
+                            timeIntervalBaseDimensionName: 'order_date',
+                        },
+                    },
+                },
+            },
+        } as unknown as Explore;
+        const { service } = buildService(withIntervals);
+
+        const result = await service.getVirtualViews(user, projectUuid);
+
+        expect(result.virtualViews[0].columns).toEqual([
+            { reference: 'customer_id', type: DimensionType.NUMBER },
+            { reference: 'order_date', type: DimensionType.DATE },
+        ]);
     });
 
     test('returns no changes for an identical second apply', async () => {

--- a/packages/backend/src/services/CoderService/handlers/VirtualViewCoder.ts
+++ b/packages/backend/src/services/CoderService/handlers/VirtualViewCoder.ts
@@ -41,7 +41,12 @@ export class VirtualViewCoder extends BaseService {
 
     private static transform(virtualView: Explore): VirtualViewAsCode | null {
         const table = virtualView.tables[virtualView.baseTable];
-        const dimensions = table ? Object.values(table.dimensions) : [];
+        // Generated time interval dimensions aren't real SQL columns
+        const dimensions = table
+            ? Object.values(table.dimensions).filter(
+                  ({ timeInterval }) => timeInterval === undefined,
+              )
+            : [];
         const dimensionNames = dimensions.map(({ name }) => name);
         if (
             !virtualView.name?.trim() ||

--- a/packages/backend/src/utils/QueryBuilder/SqlQueryComposer.ts
+++ b/packages/backend/src/utils/QueryBuilder/SqlQueryComposer.ts
@@ -126,9 +126,13 @@ export class SqlQueryComposer extends QueryComposer {
             warehouseClient,
         );
 
+        // Only the columns the SQL actually selects — the virtual view also
+        // holds the generated time interval dimensions
         const dimensions = Object.values(
             virtualView.tables[virtualView.baseTable].dimensions,
-        ).map((d) => convertFieldRefToFieldId(d.name, virtualView.name));
+        )
+            .filter((d) => d.timeInterval === undefined)
+            .map((d) => convertFieldRefToFieldId(d.name, virtualView.name));
 
         const fieldQuoteChar = warehouseClient.getFieldQuoteChar();
         const adapterType = warehouseClient.getAdapterType();

--- a/packages/common/src/utils/virtualView.test.ts
+++ b/packages/common/src/utils/virtualView.test.ts
@@ -3,6 +3,7 @@ import { ExploreType } from '../types/explore';
 import { DimensionType } from '../types/field';
 import type { ParametersValuesMap } from '../types/parameters';
 import { WarehouseTypes } from '../types/projects';
+import { TimeFrames } from '../types/timeFrames';
 import type { WarehouseClient } from '../types/warehouse';
 import type { VizColumn } from '../visualizations/types';
 import { WeekDay } from './timeFrames';
@@ -143,5 +144,94 @@ describe('createVirtualView', () => {
         expect(result.tables.my_view.dimensions['total"revenue'].sql).toBe(
             '"total""revenue"',
         );
+    });
+    test('should not create interval dimensions for non-date columns', () => {
+        const result = createVirtualView(
+            'my_view',
+            'SELECT order_id, status FROM orders',
+            columns,
+            fakeWarehouseClient,
+        );
+
+        expect(
+            Object.keys(result.tables.my_view.dimensions).sort(),
+        ).toStrictEqual(['order_id', 'status']);
+        expect(result.tables.my_view.dimensions.order_id.isIntervalBase).toBe(
+            false,
+        );
+    });
+
+    test('should expand a date column into interval dimensions', () => {
+        const result = createVirtualView(
+            'my_view',
+            'SELECT order_date FROM orders',
+            [{ reference: 'order_date', type: DimensionType.DATE }],
+            fakeWarehouseClient,
+        );
+
+        const { dimensions } = result.tables.my_view;
+
+        expect(Object.keys(dimensions).sort()).toStrictEqual([
+            'order_date',
+            'order_date_day',
+            'order_date_month',
+            'order_date_quarter',
+            'order_date_week',
+            'order_date_year',
+        ]);
+        expect(dimensions.order_date.isIntervalBase).toBe(true);
+        expect(dimensions.order_date_month).toMatchObject({
+            label: 'Order date month',
+            type: DimensionType.DATE,
+            timeInterval: TimeFrames.MONTH,
+            timeIntervalBaseDimensionName: 'order_date',
+            timeIntervalBaseDimensionType: DimensionType.DATE,
+            groups: ['Order date'],
+            isIntervalBase: false,
+        });
+        expect(
+            result.tables.my_view.dimensions.order_date_month.compiledSql,
+        ).toBe(`DATE_TRUNC('MONTH', "order_date")`);
+    });
+
+    test('should include a raw dimension for timestamp columns', () => {
+        const result = createVirtualView(
+            'my_view',
+            'SELECT created_at FROM orders',
+            [{ reference: 'created_at', type: DimensionType.TIMESTAMP }],
+            fakeWarehouseClient,
+        );
+
+        const { dimensions } = result.tables.my_view;
+
+        expect(Object.keys(dimensions).sort()).toStrictEqual([
+            'created_at',
+            'created_at_day',
+            'created_at_month',
+            'created_at_quarter',
+            'created_at_raw',
+            'created_at_week',
+            'created_at_year',
+        ]);
+        expect(dimensions.created_at_raw.type).toBe(DimensionType.TIMESTAMP);
+        expect(dimensions.created_at_day.type).toBe(DimensionType.DATE);
+    });
+
+    test('should not overwrite a real column that collides with an interval name', () => {
+        const result = createVirtualView(
+            'my_view',
+            'SELECT order_date, order_date_week FROM orders',
+            [
+                { reference: 'order_date', type: DimensionType.DATE },
+                { reference: 'order_date_week', type: DimensionType.STRING },
+            ],
+            fakeWarehouseClient,
+        );
+
+        const collidingDimension =
+            result.tables.my_view.dimensions.order_date_week;
+
+        expect(collidingDimension.type).toBe(DimensionType.STRING);
+        expect(collidingDimension.timeInterval).toBeUndefined();
     });
 });

--- a/packages/common/src/utils/virtualView.ts
+++ b/packages/common/src/utils/virtualView.ts
@@ -14,8 +14,11 @@ import {
     type WarehouseClient,
 } from '../types/warehouse';
 import { type VizColumn } from '../visualizations/types';
-import { WeekDay } from './timeFrames';
+import { getDefaultTimeFrames, timeFrameConfigs, WeekDay } from './timeFrames';
 import { defaultNullSafeEqualSql, quoteFieldReference } from './warehouse';
+
+const isIntervalColumnType = (type: DimensionType): boolean =>
+    type === DimensionType.DATE || type === DimensionType.TIMESTAMP;
 
 export const createVirtualView = (
     virtualViewName: string,
@@ -28,23 +31,73 @@ export const createVirtualView = (
     const exploreCompiler = new ExploreCompiler(warehouseClient);
 
     const fieldQuoteChar = warehouseClient.getFieldQuoteChar();
+    const adapterType = warehouseClient.getAdapterType();
+    const startOfWeek = warehouseClient.getStartOfWeek();
+    const tableLabel = friendlyName(virtualViewName);
+    const columnReferences = new Set(columns.map(({ reference }) => reference));
 
     const dimensions = columns.reduce<Record<string, Dimension>>(
         (acc, column) => {
+            const type = column.type ?? DimensionType.STRING;
+            const columnLabel = friendlyName(column.reference);
+            const columnSql = quoteFieldReference(
+                column.reference,
+                fieldQuoteChar,
+                adapterType,
+            );
+            const isIntervalBase = isIntervalColumnType(type);
+
             acc[column.reference] = {
                 name: column.reference,
-                label: friendlyName(column.reference),
-                type: column.type ?? DimensionType.STRING,
+                label: columnLabel,
+                type,
                 table: virtualViewName,
                 fieldType: FieldType.DIMENSION,
-                sql: quoteFieldReference(
-                    column.reference,
-                    fieldQuoteChar,
-                    warehouseClient.getAdapterType(),
-                ),
-                tableLabel: friendlyName(virtualViewName),
+                sql: columnSql,
+                tableLabel,
                 hidden: false,
+                isIntervalBase,
             };
+
+            // Virtual views have no meta layer to override intervals, so
+            // date/timestamp columns always get the default set
+            if (isIntervalBase) {
+                getDefaultTimeFrames(type).forEach((timeInterval) => {
+                    const intervalName = `${
+                        column.reference
+                    }_${timeInterval.toLowerCase()}`;
+                    // A real column of the same name always wins
+                    if (columnReferences.has(intervalName)) {
+                        return;
+                    }
+                    const intervalConfig = timeFrameConfigs[timeInterval];
+
+                    acc[intervalName] = {
+                        name: intervalName,
+                        label: `${columnLabel} ${intervalConfig
+                            .getLabel()
+                            .toLowerCase()}`,
+                        type: intervalConfig.getDimensionType(type),
+                        table: virtualViewName,
+                        fieldType: FieldType.DIMENSION,
+                        sql: intervalConfig.getSql(
+                            adapterType,
+                            timeInterval,
+                            columnSql,
+                            type,
+                            startOfWeek,
+                        ),
+                        tableLabel,
+                        hidden: false,
+                        timeInterval,
+                        timeIntervalBaseDimensionName: column.reference,
+                        timeIntervalBaseDimensionType: type,
+                        groups: [columnLabel],
+                        isIntervalBase: false,
+                    };
+                });
+            }
+
             return acc;
         },
         {},


### PR DESCRIPTION
Closes: lightdash/lightdash#26784

### Description:

Virtual views mapped every SQL column to a flat dimension, so DATE/TIMESTAMP columns never got the Day/Week/Month/Quarter/Year siblings that dbt-sourced date dimensions get — which is what drives the granularity picker and date filter grouping in the frontend.

`createVirtualView` now marks date/timestamp columns as `isIntervalBase` and generates the default interval dimensions for them using the same warehouse-aware `timeFrameConfigs[...].getSql()` generator the dbt path uses (virtual views have no meta layer, so there's no per-column override — always the defaults). A real column whose name collides with a generated interval name wins.

Two consumers that treated "every virtual view dimension" as "a column the SQL selects" now skip the generated ones: the mock metric query in `SqlQueryComposer` (SQL charts) and the columns exported by `VirtualViewCoder` (virtual views as code).

Note: virtual view explores are persisted in `cached_explores` and only regenerated on save, so existing virtual views pick up the interval dimensions the next time they're edited/saved (or re-applied as code).