### PR TITLE
feat(autopilot): protections table and mutation choke point

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -476,6 +476,8 @@ import {
 import {
     ManagedAgentActionsTable,
     ManagedAgentActionsTableName,
+    ManagedAgentProtectionsTable,
+    ManagedAgentProtectionsTableName,
     ManagedAgentRunsTable,
     ManagedAgentRunsTableName,
     ManagedAgentSettingsTable,
@@ -698,6 +700,7 @@ declare module 'knex/types/tables' {
         [ManagedAgentSettingsTableName]: ManagedAgentSettingsTable;
         [ManagedAgentActionsTableName]: ManagedAgentActionsTable;
         [ManagedAgentRunsTableName]: ManagedAgentRunsTable;
+        [ManagedAgentProtectionsTableName]: ManagedAgentProtectionsTable;
         [UserFavoritesTableName]: UserFavoritesTable;
         [ContentVerificationTableName]: ContentVerificationTable;
         [AppsTableName]: AppsTable;

--- a/packages/backend/src/ee/database/entities/managedAgent.ts
+++ b/packages/backend/src/ee/database/entities/managedAgent.ts
@@ -3,6 +3,27 @@ import { type Knex } from 'knex';
 export const ManagedAgentSettingsTableName = 'managed_agent_settings';
 export const ManagedAgentActionsTableName = 'managed_agent_actions';
 export const ManagedAgentRunsTableName = 'managed_agent_runs';
+export const ManagedAgentProtectionsTableName = 'managed_agent_protections';
+
+export type DbManagedAgentProtection = {
+    project_uuid: string;
+    entity_type: string;
+    entity_uuid: string;
+    level: string;
+    created_by_user_uuid: string | null;
+    created_at: Date;
+};
+
+export type DbManagedAgentProtectionCreate = Omit<
+    DbManagedAgentProtection,
+    'created_at'
+>;
+
+export type ManagedAgentProtectionsTable = Knex.CompositeTableType<
+    DbManagedAgentProtection,
+    DbManagedAgentProtectionCreate,
+    Partial<Pick<DbManagedAgentProtection, 'level' | 'created_by_user_uuid'>>
+>;
 
 export type DbManagedAgentSettings = {
     project_uuid: string;

--- a/packages/backend/src/ee/database/migrations/20260804113000_create_managed_agent_protections.ts
+++ b/packages/backend/src/ee/database/migrations/20260804113000_create_managed_agent_protections.ts
@@ -1,0 +1,32 @@
+import { Knex } from 'knex';
+
+const ManagedAgentProtectionsTableName = 'managed_agent_protections';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(ManagedAgentProtectionsTableName, (table) => {
+        table
+            .uuid('project_uuid')
+            .notNullable()
+            .references('project_uuid')
+            .inTable('projects')
+            .onDelete('CASCADE');
+        table.text('entity_type').notNullable();
+        table.uuid('entity_uuid').notNullable();
+        table.text('level').notNullable();
+        table
+            .uuid('created_by_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable('users')
+            .onDelete('SET NULL');
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table.primary(['project_uuid', 'entity_type', 'entity_uuid']);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(ManagedAgentProtectionsTableName);
+}

--- a/packages/backend/src/ee/models/ManagedAgentModel.ts
+++ b/packages/backend/src/ee/models/ManagedAgentModel.ts
@@ -7,6 +7,9 @@ import {
     type CreateManagedAgentAction,
     type ManagedAgentAction,
     type ManagedAgentActionFilters,
+    type ManagedAgentProtectedEntityType,
+    type ManagedAgentProtection,
+    type ManagedAgentProtectionLevel,
     type ManagedAgentRun,
     type ManagedAgentRunTriggeredBy,
     type ManagedAgentSettings,
@@ -16,9 +19,11 @@ import { type Knex } from 'knex';
 import type { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
 import {
     ManagedAgentActionsTableName,
+    ManagedAgentProtectionsTableName,
     ManagedAgentRunsTableName,
     ManagedAgentSettingsTableName,
     type DbManagedAgentActionWithReverser,
+    type DbManagedAgentProtection,
     type DbManagedAgentRun,
     type DbManagedAgentSettings,
 } from '../database/entities/managedAgent';
@@ -197,6 +202,78 @@ export class ManagedAgentModel {
             enabled: true,
         });
         return rows.map(ManagedAgentModel.mapDbSettings);
+    }
+
+    // --- Protections ---
+
+    static mapDbProtection(
+        row: DbManagedAgentProtection,
+    ): ManagedAgentProtection {
+        return {
+            projectUuid: row.project_uuid,
+            entityType: row.entity_type as ManagedAgentProtectedEntityType,
+            entityUuid: row.entity_uuid,
+            level: row.level as ManagedAgentProtectionLevel,
+            createdByUserUuid: row.created_by_user_uuid,
+            createdAt: row.created_at,
+        };
+    }
+
+    async listProtections(
+        projectUuid: string,
+    ): Promise<ManagedAgentProtection[]> {
+        const rows = await this.database(ManagedAgentProtectionsTableName)
+            .where({ project_uuid: projectUuid })
+            .orderBy('created_at', 'asc');
+        return rows.map(ManagedAgentModel.mapDbProtection);
+    }
+
+    async findProtectionLevel(
+        projectUuid: string,
+        entityType: ManagedAgentProtectedEntityType,
+        entityUuid: string,
+    ): Promise<ManagedAgentProtectionLevel | null> {
+        const row = await this.database(ManagedAgentProtectionsTableName)
+            .where({
+                project_uuid: projectUuid,
+                entity_type: entityType,
+                entity_uuid: entityUuid,
+            })
+            .select('level')
+            .first();
+        return row ? (row.level as ManagedAgentProtectionLevel) : null;
+    }
+
+    async upsertProtection(
+        protection: Omit<ManagedAgentProtection, 'createdAt'>,
+    ): Promise<void> {
+        await this.database(ManagedAgentProtectionsTableName)
+            .insert({
+                project_uuid: protection.projectUuid,
+                entity_type: protection.entityType,
+                entity_uuid: protection.entityUuid,
+                level: protection.level,
+                created_by_user_uuid: protection.createdByUserUuid,
+            })
+            .onConflict(['project_uuid', 'entity_type', 'entity_uuid'])
+            .merge({
+                level: protection.level,
+                created_by_user_uuid: protection.createdByUserUuid,
+            });
+    }
+
+    async deleteProtection(
+        projectUuid: string,
+        entityType: ManagedAgentProtectedEntityType,
+        entityUuid: string,
+    ): Promise<void> {
+        await this.database(ManagedAgentProtectionsTableName)
+            .where({
+                project_uuid: projectUuid,
+                entity_type: entityType,
+                entity_uuid: entityUuid,
+            })
+            .delete();
     }
 
     // --- Actions ---

--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    assertUnreachable,
     DEFAULT_MANAGED_AGENT_POLICY,
     FeatureFlags,
     ForbiddenError,
@@ -7,6 +8,7 @@ import {
     getManagedAgentActionCategory,
     getManagedAgentScheduleCron,
     ManagedAgentActionType,
+    ManagedAgentProtectedEntityType,
     ManagedAgentRunStatus,
     ManagedAgentTargetType,
     NotFoundError,
@@ -408,6 +410,47 @@ export class ManagedAgentService extends BaseService {
     private async getPolicy(projectUuid: string): Promise<ManagedAgentPolicy> {
         const settings = await this.managedAgentModel.getSettings(projectUuid);
         return settings?.policy ?? DEFAULT_MANAGED_AGENT_POLICY;
+    }
+
+    // Single choke point for admin-configured protections. Returns a blocked
+    // tool result when the target may not be mutated, null when allowed.
+    private async checkTargetProtectionGuard(
+        projectUuid: string,
+        targetType: ManagedAgentTargetType,
+        targetUuid: string,
+        targetName: string,
+    ): Promise<string | null> {
+        let entityType: ManagedAgentProtectedEntityType;
+        switch (targetType) {
+            case ManagedAgentTargetType.CHART:
+                entityType = ManagedAgentProtectedEntityType.CHART;
+                break;
+            case ManagedAgentTargetType.DASHBOARD:
+                entityType = ManagedAgentProtectedEntityType.DASHBOARD;
+                break;
+            case ManagedAgentTargetType.SPACE:
+            case ManagedAgentTargetType.PROJECT:
+                return null;
+            default:
+                return assertUnreachable(
+                    targetType,
+                    `Unknown target type: ${targetType}`,
+                );
+        }
+        const level = await this.managedAgentModel.findProtectionLevel(
+            projectUuid,
+            entityType,
+            targetUuid,
+        );
+        if (!level) {
+            return null;
+        }
+        return JSON.stringify({
+            error: `"${targetName}" is ${level} from Autopilot by a project admin. Do not flag, fix, or delete it${
+                level === 'excluded' ? ', and do not report on it' : ''
+            }.`,
+            blocked: true,
+        });
     }
 
     private async syncProjectAgentConfig(projectUuid: string): Promise<void> {
@@ -2179,6 +2222,16 @@ chartConfig:
             input.chart_config,
         );
 
+        const fixProtectionBlock = await this.checkTargetProtectionGuard(
+            projectUuid,
+            ManagedAgentTargetType.CHART,
+            chartUuid,
+            chartName,
+        );
+        if (fixProtectionBlock) {
+            return fixProtectionBlock;
+        }
+
         // Get the current chart and verify it belongs to this project
         const chart = await this.savedChartModel.get(chartUuid);
         ManagedAgentService.assertProjectOwnership(
@@ -2483,6 +2536,15 @@ chartConfig:
             ManagedAgentTargetType,
             'target_type',
         );
+        const flagProtectionBlock = await this.checkTargetProtectionGuard(
+            projectUuid,
+            targetType,
+            targetUuid,
+            targetName,
+        );
+        if (flagProtectionBlock) {
+            return flagProtectionBlock;
+        }
         if (
             !(await this.canActorViewTarget(
                 actor,
@@ -2609,6 +2671,16 @@ chartConfig:
                 error: `Soft-delete is disabled by project policy (cleanup mode: ${policy.aggression}). Flag or log an insight instead.`,
                 blocked: true,
             });
+        }
+
+        const deleteProtectionBlock = await this.checkTargetProtectionGuard(
+            projectUuid,
+            targetType,
+            targetUuid,
+            targetName,
+        );
+        if (deleteProtectionBlock) {
+            return deleteProtectionBlock;
         }
 
         const protectCutoff = new Date();

--- a/packages/common/src/ee/types/managedAgent.ts
+++ b/packages/common/src/ee/types/managedAgent.ts
@@ -57,6 +57,25 @@ export const getManagedAgentScheduleOption = (
     return match ? match[0] : ManagedAgentScheduleOption.DAILY;
 };
 
+export enum ManagedAgentProtectedEntityType {
+    CHART = 'chart',
+    DASHBOARD = 'dashboard',
+    SPACE = 'space',
+}
+
+// 'protected': Autopilot may see and report the entity but never mutate it.
+// 'excluded': Autopilot does not see the entity at all.
+export type ManagedAgentProtectionLevel = 'protected' | 'excluded';
+
+export type ManagedAgentProtection = {
+    projectUuid: string;
+    entityType: ManagedAgentProtectedEntityType;
+    entityUuid: string;
+    level: ManagedAgentProtectionLevel;
+    createdByUserUuid: string | null;
+    createdAt: Date;
+};
+
 export type ManagedAgentAggression = 'observe' | 'flag' | 'cleanup';
 
 export type ManagedAgentAudience = 'admins' | 'everyone';


### PR DESCRIPTION
## Summary

First PR of the Autopilot scope & protection model (Linear: PROD-7796, PROD-7373, PROD-9305; stacked on #26775). Spec agreed 2026-08-04.

Adds the mechanism with no behavior change:

- New table `managed_agent_protections` (PK project + entity_type + entity_uuid) with two levels: `protected` (Autopilot may see and report the entity but never mutate it) and `excluded` (Autopilot does not see it at all). Cascades with project deletion; polymorphic entity_uuid supports charts, dashboards, and spaces.
- Model methods: list, find level, upsert, delete.
- One choke point in the service, `checkTargetProtectionGuard`, consulted by `flag_content`, `soft_delete_content`, and `fix_broken_chart` before any mutation. Blocked attempts return the established `{blocked, error}` tool-result shape.

Nothing writes to the table yet. Space scope (allowlist/denylist with subtree inheritance, filtering every read tool) and verified-content protection land in the next PRs on this stack; item-level exclusion UI is the fast-follow that closes PROD-7796.

## Regression analysis

None expected: the table is empty until later PRs add writers, so the guard always returns null today. The guard runs before mutation-side effects in all three handlers, and space/project targets pass through untouched.

## Testing

- Full backend suite green (5,719 tests)
- Migration applied and verified against a dev database

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UgXBzcYYEeoMUUShzL7DsU