### PR TITLE
feat(homepage): post announcements from the published homepage

### DIFF
--- a/packages/backend/src/ee/models/ProjectHomepageModel.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.ts
@@ -692,6 +692,7 @@ export class ProjectHomepageModel {
         category: AnnouncementCategory | null;
         createdByUserUuid: string;
         pendingSlackChannelId: string | null;
+        published: boolean;
     }): Promise<ProjectAnnouncement> {
         const [row] = await this.database(AnnouncementsTableName)
             .insert({
@@ -700,8 +701,12 @@ export class ProjectHomepageModel {
                 body: data.body,
                 category: data.category,
                 created_by_user_uuid: data.createdByUserUuid,
-                published_at: null,
-                pending_slack_channel_id: data.pendingSlackChannelId,
+                published_at: data.published ? new Date() : null,
+                // A published announcement has no deferred notification —
+                // the caller fires Slack immediately instead.
+                pending_slack_channel_id: data.published
+                    ? null
+                    : data.pendingSlackChannelId,
             })
             .returning('*');
         return ProjectHomepageModel.mapDbAnnouncement(row);

--- a/packages/backend/src/ee/services/ProjectHomepageService.test.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.test.ts
@@ -799,6 +799,68 @@ describe('ProjectHomepageService', () => {
             );
         });
 
+        it('createAnnouncement with publishNow creates it published and notifies Slack immediately', async () => {
+            const postMessage = vi.fn().mockResolvedValue(undefined);
+            const createAnnouncement = vi
+                .fn()
+                .mockResolvedValue({ ...madeAnnouncement, published: true });
+            const service = makeService({
+                projectHomepageModel: { createAnnouncement },
+                slackClient: { postMessage },
+            });
+            await service.createAnnouncement(makeAdminUser(), PROJECT_UUID, {
+                title: 'Launch',
+                body: null,
+                category: null,
+                slackChannelId: 'C123',
+                publishNow: true,
+            });
+            expect(createAnnouncement).toHaveBeenCalledWith(
+                expect.objectContaining({ published: true }),
+            );
+            expect(postMessage).toHaveBeenCalledWith(
+                expect.objectContaining({ channel: 'C123' }),
+            );
+        });
+
+        it('createAnnouncement with publishNow and no channel publishes without Slack', async () => {
+            const postMessage = vi.fn().mockResolvedValue(undefined);
+            const createAnnouncement = vi
+                .fn()
+                .mockResolvedValue({ ...madeAnnouncement, published: true });
+            const service = makeService({
+                projectHomepageModel: { createAnnouncement },
+                slackClient: { postMessage },
+            });
+            await service.createAnnouncement(makeAdminUser(), PROJECT_UUID, {
+                title: 'Launch',
+                body: null,
+                category: null,
+                publishNow: true,
+            });
+            expect(createAnnouncement).toHaveBeenCalledWith(
+                expect.objectContaining({ published: true }),
+            );
+            expect(postMessage).not.toHaveBeenCalled();
+        });
+
+        it('createAnnouncement without publishNow stays a draft', async () => {
+            const createAnnouncement = vi
+                .fn()
+                .mockResolvedValue(madeAnnouncement);
+            const service = makeService({
+                projectHomepageModel: { createAnnouncement },
+            });
+            await service.createAnnouncement(makeAdminUser(), PROJECT_UUID, {
+                title: 'Launch',
+                body: null,
+                category: null,
+            });
+            expect(createAnnouncement).toHaveBeenCalledWith(
+                expect.objectContaining({ published: false }),
+            );
+        });
+
         it('updateAnnouncement passes pinned through for an owned announcement', async () => {
             const announcement = {
                 announcementUuid: 'ann-1',

--- a/packages/backend/src/ee/services/ProjectHomepageService.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.ts
@@ -918,17 +918,30 @@ export class ProjectHomepageService extends BaseService {
             if (!user.organizationUuid) throw new ForbiddenError();
             await this.assertSlackInstalled(user.organizationUuid);
         }
-        // Created as a draft — it stays invisible on the live homepage and its
-        // Slack notification (if any) is deferred until the homepage is
-        // published, see `publishHomepage`.
-        return this.projectHomepageModel.createAnnouncement({
-            projectUuid,
-            title: data.title.trim(),
-            body: data.body,
-            category: data.category,
-            createdByUserUuid: user.userUuid,
-            pendingSlackChannelId: data.slackChannelId ?? null,
-        });
+        // Default path creates a draft — invisible on the live homepage, its
+        // Slack notification (if any) deferred until the homepage is
+        // published, see `publishHomepage`. With `publishNow` (posting from
+        // the published homepage) it goes live and notifies immediately.
+        const announcement = await this.projectHomepageModel.createAnnouncement(
+            {
+                projectUuid,
+                title: data.title.trim(),
+                body: data.body,
+                category: data.category,
+                createdByUserUuid: user.userUuid,
+                pendingSlackChannelId: data.slackChannelId ?? null,
+                published: data.publishNow === true,
+            },
+        );
+        if (data.publishNow && data.slackChannelId && user.organizationUuid) {
+            await this.notifyAnnouncementToSlack(
+                user.organizationUuid,
+                projectUuid,
+                announcement,
+                data.slackChannelId,
+            );
+        }
+        return announcement;
     }
 
     async updateAnnouncement(

--- a/packages/common/src/ee/homepage/types.ts
+++ b/packages/common/src/ee/homepage/types.ts
@@ -509,6 +509,12 @@ export type CreateAnnouncementRequest = {
      * this Slack channel. Requires the org to have Slack installed.
      */
     slackChannelId?: string | null;
+    /**
+     * When true the announcement goes live immediately and its Slack
+     * notification (if any) fires now, instead of waiting for the next
+     * homepage publish. Used when posting from the published homepage.
+     */
+    publishNow?: boolean;
 };
 
 /** PATCH semantics: omitted fields are left unchanged */

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AnnouncementsBlock.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AnnouncementsBlock.test.tsx
@@ -1,0 +1,112 @@
+import {
+    type HomepageBlock,
+    type ProjectAnnouncement,
+} from '@lightdash/common';
+import { MantineProvider } from '@mantine-8/core';
+import { render, screen } from '@testing-library/react';
+import { AnnouncementsBlockView } from './AnnouncementsBlock';
+
+const mockCan = vi.fn();
+vi.mock('../../../../providers/App/useApp', () => ({
+    default: () => ({
+        user: {
+            data: { organizationUuid: 'org-1', ability: { can: mockCan } },
+        },
+    }),
+}));
+
+const mockUseAnnouncements = vi.fn();
+vi.mock('../hooks/useAnnouncements', () => ({
+    useAnnouncements: (...args: unknown[]) => mockUseAnnouncements(...args),
+    useCreateAnnouncement: () => ({ mutate: vi.fn(), isLoading: false }),
+    useUpdateAnnouncement: () => ({ mutate: vi.fn(), isLoading: false }),
+    useDeleteAnnouncement: () => ({ mutate: vi.fn(), isLoading: false }),
+    useUploadAnnouncementImage: () => ({ mutateAsync: vi.fn() }),
+}));
+
+vi.mock('../../../../hooks/slack/useSlack', () => ({
+    useGetSlack: () => ({ data: undefined }),
+}));
+
+const block: HomepageBlock = {
+    id: 'b1',
+    type: 'announcements',
+    config: { title: 'From the data team' },
+};
+
+const announcement: ProjectAnnouncement = {
+    announcementUuid: 'ann-1',
+    projectUuid: 'p1',
+    title: 'Orders explore refreshed',
+    body: null,
+    category: null,
+    pinned: false,
+    published: true,
+    pendingSlackChannelId: null,
+    createdByUserUuid: 'u1',
+    authorName: 'Ana',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+};
+
+const feed = (items: ProjectAnnouncement[]) => ({
+    data: { items, totalCount: items.length },
+    isInitialLoading: false,
+    isError: false,
+});
+
+const renderView = () =>
+    render(
+        <MantineProvider env="test">
+            <AnnouncementsBlockView
+                block={block}
+                projectUuid="p1"
+                itemSpan={null}
+                standalone
+            />
+        </MantineProvider>,
+    );
+
+it('renders nothing for a viewer when the feed is empty', () => {
+    mockCan.mockReturnValue(false);
+    mockUseAnnouncements.mockReturnValue(feed([]));
+    renderView();
+    expect(screen.queryByText('From the data team')).not.toBeInTheDocument();
+    expect(screen.queryByText('New announcement')).not.toBeInTheDocument();
+});
+
+it('shows the feed without admin actions for a viewer', () => {
+    mockCan.mockReturnValue(false);
+    mockUseAnnouncements.mockReturnValue(feed([announcement]));
+    renderView();
+    expect(screen.getByText('Orders explore refreshed')).toBeInTheDocument();
+    expect(screen.queryByText('New announcement')).not.toBeInTheDocument();
+    expect(
+        screen.queryByLabelText('Edit announcement'),
+    ).not.toBeInTheDocument();
+    expect(mockUseAnnouncements).toHaveBeenCalledWith(
+        'p1',
+        expect.objectContaining({ includeUnpublished: false }),
+    );
+});
+
+it('keeps the create entry point for a manager on an empty feed', () => {
+    mockCan.mockReturnValue(true);
+    mockUseAnnouncements.mockReturnValue(feed([]));
+    renderView();
+    expect(screen.getByText('New announcement')).toBeInTheDocument();
+    expect(screen.getByText(/share your first update/)).toBeInTheDocument();
+});
+
+it('shows admin actions and drafts for a manager', () => {
+    mockCan.mockReturnValue(true);
+    mockUseAnnouncements.mockReturnValue(feed([announcement]));
+    renderView();
+    expect(screen.getByText('New announcement')).toBeInTheDocument();
+    expect(screen.getByLabelText('Edit announcement')).toBeInTheDocument();
+    expect(screen.getByLabelText('Delete announcement')).toBeInTheDocument();
+    expect(mockUseAnnouncements).toHaveBeenCalledWith(
+        'p1',
+        expect.objectContaining({ includeUnpublished: true }),
+    );
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AnnouncementsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AnnouncementsBlock.tsx
@@ -1,3 +1,4 @@
+import { subject } from '@casl/ability';
 import {
     ANNOUNCEMENT_BODY_MAX_LENGTH,
     ANNOUNCEMENT_CATEGORY_META,
@@ -40,6 +41,7 @@ import MantineModal from '../../../../components/common/MantineModal';
 import { SlackChannelSelect } from '../../../../components/common/SlackChannelSelect';
 import { useGetSlack } from '../../../../hooks/slack/useSlack';
 import { useTimeAgo } from '../../../../hooks/useTimeAgo';
+import useApp from '../../../../providers/App/useApp';
 import {
     useAnnouncements,
     useCreateAnnouncement,
@@ -346,22 +348,192 @@ const FeedError: FC = () => (
     </div>
 );
 
+const AnnouncementItemActions: FC<{
+    projectUuid: string;
+    announcement: ProjectAnnouncement;
+    onEdit: (announcement: ProjectAnnouncement) => void;
+    onDelete: (announcement: ProjectAnnouncement) => void;
+}> = ({ projectUuid, announcement, onEdit, onDelete }) => {
+    const { mutate: update } = useUpdateAnnouncement(projectUuid);
+    return (
+        <>
+            <Tooltip label={announcement.pinned ? 'Unpin' : 'Pin to top'}>
+                <ActionIcon
+                    variant="subtle"
+                    color="ldGray.6"
+                    size="sm"
+                    aria-label={announcement.pinned ? 'Unpin' : 'Pin'}
+                    onClick={() =>
+                        update({
+                            announcementUuid: announcement.announcementUuid,
+                            pinned: !announcement.pinned,
+                        })
+                    }
+                >
+                    <MantineIcon
+                        icon={announcement.pinned ? IconPinnedOff : IconPin}
+                    />
+                </ActionIcon>
+            </Tooltip>
+            <Tooltip label="Edit">
+                <ActionIcon
+                    variant="subtle"
+                    color="ldGray.6"
+                    size="sm"
+                    aria-label="Edit announcement"
+                    onClick={() => onEdit(announcement)}
+                >
+                    <MantineIcon icon={IconPencil} />
+                </ActionIcon>
+            </Tooltip>
+            <Tooltip label="Delete">
+                <ActionIcon
+                    variant="subtle"
+                    color="red"
+                    size="sm"
+                    aria-label="Delete announcement"
+                    onClick={() => onDelete(announcement)}
+                >
+                    <MantineIcon icon={IconTrash} />
+                </ActionIcon>
+            </Tooltip>
+        </>
+    );
+};
+
+const DeleteAnnouncementModal: FC<{
+    projectUuid: string;
+    announcement: ProjectAnnouncement;
+    onClose: () => void;
+}> = ({ projectUuid, announcement, onClose }) => {
+    const { mutate: remove, isLoading: removing } =
+        useDeleteAnnouncement(projectUuid);
+    return (
+        <MantineModal
+            opened
+            onClose={() => !removing && onClose()}
+            title="Delete announcement"
+            variant="delete"
+            resourceType="announcement"
+            resourceLabel={announcement.title}
+            cancelDisabled={removing}
+            confirmLoading={removing}
+            onConfirm={() =>
+                remove(announcement.announcementUuid, { onSuccess: onClose })
+            }
+        />
+    );
+};
+
+/** Form modal wrapper mounted only while open, so plain homepage viewers
+ * never pay for the Slack settings fetch the picker needs. */
+const AnnouncementComposer: FC<{
+    projectUuid: string;
+    announcement: ProjectAnnouncement | null;
+    publishNow: boolean;
+    onClose: () => void;
+}> = ({ projectUuid, announcement, publishNow, onClose }) => {
+    const { data: slack } = useGetSlack();
+    return (
+        <AnnouncementFormModal
+            projectUuid={projectUuid}
+            announcement={announcement}
+            slackInstalled={!!slack?.organizationUuid}
+            publishNow={publishNow}
+            onClose={onClose}
+        />
+    );
+};
+
 export const AnnouncementsBlockView: FC<BlockComponentProps> = ({
     block,
     projectUuid,
 }) => {
-    const { announcements, isLoading, isError } =
-        useAnnouncementFeed(projectUuid);
+    const { user } = useApp();
+    const canManage =
+        user.data?.ability?.can(
+            'manage',
+            subject('ProjectHomepage', {
+                organizationUuid: user.data?.organizationUuid,
+                projectUuid,
+            }),
+        ) ?? false;
+    // Managers see drafts inline (tagged) so they can edit or delete them
+    // from here; viewers only ever get published announcements.
+    const { announcements, isLoading, isError } = useAnnouncementFeed(
+        projectUuid,
+        canManage,
+    );
+    const [creating, setCreating] = useState(false);
+    const [editing, setEditing] = useState<ProjectAnnouncement | null>(null);
+    const [deleting, setDeleting] = useState<ProjectAnnouncement | null>(null);
     if (block.type !== 'announcements') return null;
-    // Read mode stays invisible until there is something real to show.
-    if (isLoading || isError || announcements.length === 0) return null;
+    // Read mode stays invisible until there is something real to show —
+    // except for managers, who keep the entry point on an empty feed.
+    if (isLoading || isError) return null;
+    if (announcements.length === 0 && !canManage) return null;
     return (
         <Stack gap="sm" className={classes.feedBand}>
-            <BlockHeader icon={IconSpeakerphone} title={block.config.title} />
-            <AnnouncementFeed
-                projectUuid={projectUuid}
-                announcements={announcements}
+            <BlockHeader
+                icon={IconSpeakerphone}
+                title={block.config.title}
+                actions={
+                    canManage ? (
+                        <Button
+                            variant="subtle"
+                            color="ldGray.7"
+                            size="compact-xs"
+                            leftSection={
+                                <MantineIcon icon={IconPlus} size="sm" />
+                            }
+                            onClick={() => setCreating(true)}
+                        >
+                            New announcement
+                        </Button>
+                    ) : undefined
+                }
             />
+            {announcements.length === 0 ? (
+                <div className={classes.emptyHint}>
+                    No announcements yet — share your first update. Viewers
+                    don’t see this block while it’s empty.
+                </div>
+            ) : (
+                <AnnouncementFeed
+                    projectUuid={projectUuid}
+                    announcements={announcements}
+                    renderActions={
+                        canManage
+                            ? (announcement) => (
+                                  <AnnouncementItemActions
+                                      projectUuid={projectUuid}
+                                      announcement={announcement}
+                                      onEdit={setEditing}
+                                      onDelete={setDeleting}
+                                  />
+                              )
+                            : undefined
+                    }
+                />
+            )}
+            {(creating || editing !== null) && (
+                <AnnouncementComposer
+                    projectUuid={projectUuid}
+                    announcement={editing}
+                    publishNow={creating}
+                    onClose={() => {
+                        setCreating(false);
+                        setEditing(null);
+                    }}
+                />
+            )}
+            {deleting !== null && (
+                <DeleteAnnouncementModal
+                    projectUuid={projectUuid}
+                    announcement={deleting}
+                    onClose={() => setDeleting(null)}
+                />
+            )}
         </Stack>
     );
 };
@@ -370,8 +542,17 @@ const AnnouncementFormModal: FC<{
     projectUuid: string;
     announcement: ProjectAnnouncement | null;
     slackInstalled: boolean;
+    /** Publish immediately on create (posting from the live homepage)
+     * instead of the builder's draft-until-homepage-publish flow. */
+    publishNow?: boolean;
     onClose: () => void;
-}> = ({ projectUuid, announcement, slackInstalled, onClose }) => {
+}> = ({
+    projectUuid,
+    announcement,
+    slackInstalled,
+    publishNow = false,
+    onClose,
+}) => {
     const isEdit = announcement !== null;
     // Slack can only be retargeted while the announcement is still a draft.
     const slackEditable = slackInstalled && !announcement?.published;
@@ -418,6 +599,7 @@ const AnnouncementFormModal: FC<{
                     body: bodyValue,
                     category,
                     slackChannelId,
+                    ...(publishNow ? { publishNow: true } : {}),
                 },
                 { onSuccess: onClose },
             );
@@ -426,6 +608,8 @@ const AnnouncementFormModal: FC<{
 
     let saveLabel = 'Create draft';
     if (isEdit) saveLabel = 'Save';
+    else if (publishNow)
+        saveLabel = slackChannelId ? 'Post & send to Slack' : 'Post';
     else if (slackChannelId) saveLabel = 'Create draft & queue Slack';
 
     return (
@@ -494,14 +678,21 @@ const AnnouncementFormModal: FC<{
                         fewer.
                     </Text>
                 )}
-                {!announcement?.published && (
+                {!isEdit && publishNow ? (
                     <Text size="xs" c="dimmed">
-                        Saved as a draft. It
-                        {slackChannelId
-                            ? ' and its Slack notification'
-                            : ''}{' '}
-                        goes live when you publish the homepage.
+                        Goes live on the homepage immediately
+                        {slackChannelId ? ' and notifies Slack' : ''}.
                     </Text>
+                ) : (
+                    !announcement?.published && (
+                        <Text size="xs" c="dimmed">
+                            Saved as a draft. It
+                            {slackChannelId
+                                ? ' and its Slack notification'
+                                : ''}{' '}
+                            goes live when you publish the homepage.
+                        </Text>
+                    )
                 )}
             </Stack>
         </MantineModal>
@@ -524,54 +715,15 @@ export const AnnouncementsBlockBuild: FC<BuildComponentProps> = ({
     // Warmed here so the Slack picker is ready the instant the modal opens.
     const { data: slack } = useGetSlack();
     const slackInstalled = !!slack?.organizationUuid;
-    const { mutate: update } = useUpdateAnnouncement(projectUuid);
-    const { mutate: remove, isLoading: removing } =
-        useDeleteAnnouncement(projectUuid);
     if (block.type !== 'announcements') return null;
 
     const itemActions = (announcement: ProjectAnnouncement) => (
-        <>
-            <Tooltip label={announcement.pinned ? 'Unpin' : 'Pin to top'}>
-                <ActionIcon
-                    variant="subtle"
-                    color="ldGray.6"
-                    size="sm"
-                    aria-label={announcement.pinned ? 'Unpin' : 'Pin'}
-                    onClick={() =>
-                        update({
-                            announcementUuid: announcement.announcementUuid,
-                            pinned: !announcement.pinned,
-                        })
-                    }
-                >
-                    <MantineIcon
-                        icon={announcement.pinned ? IconPinnedOff : IconPin}
-                    />
-                </ActionIcon>
-            </Tooltip>
-            <Tooltip label="Edit">
-                <ActionIcon
-                    variant="subtle"
-                    color="ldGray.6"
-                    size="sm"
-                    aria-label="Edit announcement"
-                    onClick={() => setEditing(announcement)}
-                >
-                    <MantineIcon icon={IconPencil} />
-                </ActionIcon>
-            </Tooltip>
-            <Tooltip label="Delete">
-                <ActionIcon
-                    variant="subtle"
-                    color="red"
-                    size="sm"
-                    aria-label="Delete announcement"
-                    onClick={() => setDeleting(announcement)}
-                >
-                    <MantineIcon icon={IconTrash} />
-                </ActionIcon>
-            </Tooltip>
-        </>
+        <AnnouncementItemActions
+            projectUuid={projectUuid}
+            announcement={announcement}
+            onEdit={setEditing}
+            onDelete={setDeleting}
+        />
     );
 
     return (
@@ -615,20 +767,10 @@ export const AnnouncementsBlockBuild: FC<BuildComponentProps> = ({
                 />
             )}
             {deleting !== null && (
-                <MantineModal
-                    opened
-                    onClose={() => !removing && setDeleting(null)}
-                    title="Delete announcement"
-                    variant="delete"
-                    resourceType="announcement"
-                    resourceLabel={deleting.title}
-                    cancelDisabled={removing}
-                    confirmLoading={removing}
-                    onConfirm={() =>
-                        remove(deleting.announcementUuid, {
-                            onSuccess: () => setDeleting(null),
-                        })
-                    }
+                <DeleteAnnouncementModal
+                    projectUuid={projectUuid}
+                    announcement={deleting}
+                    onClose={() => setDeleting(null)}
                 />
             )}
         </Stack>

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/BlockShell.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/BlockShell.tsx
@@ -1,6 +1,6 @@
 import { Box } from '@mantine-8/core';
 import { type Icon } from '@tabler/icons-react';
-import { type FC, type PropsWithChildren } from 'react';
+import { type FC, type PropsWithChildren, type ReactNode } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import classes from './blockStyles.module.css';
 
@@ -15,6 +15,8 @@ type BlockHeaderProps = {
     /** Centre the header — used when the block's content is centred too, so
      * header and content read as one unit. */
     centered?: boolean;
+    /** Right-aligned header controls (e.g. an admin-only action). */
+    actions?: ReactNode;
 };
 
 export const BlockHeader: FC<BlockHeaderProps> = ({
@@ -22,6 +24,7 @@ export const BlockHeader: FC<BlockHeaderProps> = ({
     title,
     pill,
     centered = false,
+    actions,
 }) => (
     <Box
         className={`${classes.sectionHeader}${
@@ -32,6 +35,9 @@ export const BlockHeader: FC<BlockHeaderProps> = ({
         <MantineIcon icon={icon} size={14} color="ldGray.6" />
         <span className={classes.sectionTitle}>{title}</span>
         {pill ? <MiniPill>{pill}</MiniPill> : null}
+        {actions ? (
+            <span className={classes.sectionHeaderActions}>{actions}</span>
+        ) : null}
     </Box>
 );
 

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -8,6 +8,10 @@
     justify-content: center;
 }
 
+.sectionHeaderActions {
+    margin-left: auto;
+}
+
 .sectionTitle {
     font-size: 13px;
     font-weight: 500;


### PR DESCRIPTION
Closes ZAP-689

## What

Admins (anyone with `manage` on `ProjectHomepage`) can now post data announcements directly from the published homepage, without entering the builder and republishing the layout.

- The announcements block on the published homepage shows a **New announcement** header action, pin/edit/delete on each card, and drafts inline (tagged) — for managers only. Viewers see exactly what they saw before.
- The composer opens in a live mode: **Post** publishes immediately and fires the Slack notification (if a channel is selected) right away, instead of the builder's draft-until-homepage-publish flow.
- Managers also keep an entry point when the feed is empty (viewers still don't see the empty block).

## How

- `CreateAnnouncementRequest` gains an optional `publishNow` flag. The service creates the row with `published_at` set and calls the same `notifyAnnouncementToSlack` used by `publishHomepage`; no pending Slack channel is stored for live posts.
- Permissions are unchanged: `createAnnouncement` already enforces `assertCanManage`, so the live path is covered server-side. The frontend gates the UI with the same CASL subject the builder page uses.
- The builder's item actions and delete modal were extracted into shared components (`AnnouncementItemActions`, `DeleteAnnouncementModal`) reused by the published view; `BlockHeader` gains an optional right-aligned `actions` slot.
- The Slack settings fetch for the composer is mounted only while the modal is open, so plain viewers never pay for it.

## Regression analysis

- Draft flow untouched: without `publishNow` the model stores `published_at: null` and the pending channel exactly as before (covered by existing + new unit tests).
- Viewer rendering unchanged: the published block still renders nothing while loading/on error/empty for non-managers, and the feed query stays `includeUnpublished=false` for them (separate query key, no cache collision).
- `BlockHeader` change is additive (optional prop, no layout change when absent).

## Testing

- New service tests: publishNow publishes + notifies Slack immediately; publishNow without a channel publishes silently; default path stays a draft.
- Verified end-to-end in the dev app: posted from the published homepage, card appeared immediately with `published_at` set in the DB and admin actions on hover.