### PR TITLE
feat(metrics): attribute warehouse query phases per project

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -102,6 +102,9 @@ export const lightdashConfigMock: LightdashConfig = {
         extendedMetricsEnabled: false,
         httpMetricsEnabled: false,
     },
+    queryPhaseMetrics: {
+        projectUuids: [],
+    },
     dashboard: {
         maxTilesPerTab: 50,
         maxTabsPerDashboard: 20,

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -39,6 +39,21 @@ beforeEach(() => {
     };
 });
 
+describe('Query phase metrics config', () => {
+    it('defaults to an empty project allowlist', () => {
+        expect(parseConfig().queryPhaseMetrics).toEqual({ projectUuids: [] });
+    });
+
+    it('parses a trimmed project allowlist and drops empty entries', () => {
+        process.env.QUERY_PHASE_METRICS_PROJECT_UUIDS =
+            ' project-a, ,project-b, ';
+
+        expect(parseConfig().queryPhaseMetrics).toEqual({
+            projectUuids: ['project-a', 'project-b'],
+        });
+    });
+});
+
 test('Should default results S3 config to S3 config', () => {
     process.env.S3_ACCESS_KEY = 'mock_access_key';
     process.env.S3_SECRET_KEY = 'mock_secret_key';

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1356,6 +1356,9 @@ export type LightdashConfig = {
         extendedMetricsEnabled: boolean;
         httpMetricsEnabled: boolean;
     };
+    queryPhaseMetrics: {
+        projectUuids: string[];
+    };
     database: {
         connectionUri: string | undefined;
         maxConnections: number | undefined;
@@ -2753,6 +2756,11 @@ export const parseConfig = (): LightdashConfig => {
             httpMetricsEnabled:
                 process.env.LIGHTDASH_PROMETHEUS_HTTP_METRICS_ENABLED ===
                 'true', // defaults to false
+        },
+        queryPhaseMetrics: {
+            projectUuids: getArrayFromCommaSeparatedList(
+                'QUERY_PHASE_METRICS_PROJECT_UUIDS',
+            ),
         },
         allowMultiOrgs: process.env.ALLOW_MULTIPLE_ORGS === 'true',
         maxPayloadSize: process.env.LIGHTDASH_MAX_PAYLOAD || '5mb',

--- a/packages/backend/src/prometheus/PrometheusMetrics.test.ts
+++ b/packages/backend/src/prometheus/PrometheusMetrics.test.ts
@@ -1,5 +1,7 @@
 import express from 'express';
-import { getHttpUriLabel } from './PrometheusMetrics';
+import prometheus from 'prom-client';
+import { lightdashConfigMock } from '../config/lightdashConfig.mock';
+import PrometheusMetrics, { getHttpUriLabel } from './PrometheusMetrics';
 
 type PartialRequest = Partial<express.Request>;
 
@@ -89,6 +91,62 @@ describe('getHttpUriLabel', () => {
                 path: '/assets/main-abc123.js',
             });
             expect(getHttpUriLabel(req)).toBe('/assets/*');
+        });
+    });
+});
+
+describe('Project-attributed warehouse phase metrics', () => {
+    beforeEach(() => {
+        prometheus.register.clear();
+    });
+
+    afterEach(() => {
+        prometheus.register.clear();
+    });
+
+    it('observes phase durations with the bounded project dimension', async () => {
+        const metrics = new PrometheusMetrics(lightdashConfigMock.prometheus);
+        const histogram = new prometheus.Histogram({
+            name: 'test_query_warehouse_phase_duration_by_project_seconds',
+            help: 'test',
+            labelNames: ['project_uuid', 'phase', 'warehouse_type', 'context'],
+        });
+        Object.assign(metrics, {
+            projectQueryPhaseDurationHistogram: histogram,
+        });
+
+        metrics.observeProjectQueryPhaseDurations(
+            'project-a',
+            { connect: 100, query: 200 },
+            'postgres',
+            'explore',
+        );
+
+        await expect(histogram.get()).resolves.toMatchObject({
+            values: expect.arrayContaining([
+                expect.objectContaining({
+                    metricName:
+                        'test_query_warehouse_phase_duration_by_project_seconds_sum',
+                    labels: {
+                        project_uuid: 'project-a',
+                        phase: 'connect',
+                        warehouse_type: 'postgres',
+                        context: 'interactive',
+                    },
+                    value: 0.1,
+                }),
+                expect.objectContaining({
+                    metricName:
+                        'test_query_warehouse_phase_duration_by_project_seconds_sum',
+                    labels: {
+                        project_uuid: 'project-a',
+                        phase: 'query',
+                        warehouse_type: 'postgres',
+                        context: 'interactive',
+                    },
+                    value: 0.2,
+                }),
+            ]),
         });
     });
 });

--- a/packages/backend/src/prometheus/PrometheusMetrics.ts
+++ b/packages/backend/src/prometheus/PrometheusMetrics.ts
@@ -307,6 +307,9 @@ export default class PrometheusMetrics {
 
     private warehousePhaseDurationHistogram: prometheus.Histogram | null = null;
 
+    private projectQueryPhaseDurationHistogram: prometheus.Histogram | null =
+        null;
+
     private overheadDurationHistogram: prometheus.Histogram | null = null;
 
     private httpServerRequestsDurationSeconds: prometheus.Histogram<
@@ -410,6 +413,22 @@ export default class PrometheusMetrics {
                         ...rest,
                     },
                 );
+
+                this.projectQueryPhaseDurationHistogram =
+                    new prometheus.Histogram({
+                        name: 'lightdash_query_warehouse_phase_duration_by_project_seconds',
+                        help: 'Warehouse query duration by phase, attributed per project for allowlisted projects',
+                        labelNames: [
+                            'project_uuid',
+                            'phase',
+                            'warehouse_type',
+                            'context',
+                        ],
+                        buckets: [
+                            0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120,
+                        ],
+                        ...rest,
+                    });
 
                 this.overheadDurationHistogram = new prometheus.Histogram({
                     name: 'lightdash_query_overhead_duration_seconds',
@@ -1481,6 +1500,26 @@ export default class PrometheusMetrics {
         Object.entries(phaseTimings).forEach(([phase, durationMs]) => {
             this.warehousePhaseDurationHistogram?.observe(
                 {
+                    phase,
+                    warehouse_type: warehouseType,
+                    context: contextLabel,
+                },
+                durationMs / 1000,
+            );
+        });
+    }
+
+    public observeProjectQueryPhaseDurations(
+        projectUuid: string,
+        phaseTimings: WarehousePhaseTimings,
+        warehouseType: string,
+        context: string,
+    ) {
+        const contextLabel = getQueryContextLabel(context);
+        Object.entries(phaseTimings).forEach(([phase, durationMs]) => {
+            this.projectQueryPhaseDurationHistogram?.observe(
+                {
+                    project_uuid: projectUuid,
                     phase,
                     warehouse_type: warehouseType,
                     context: contextLabel,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2827,6 +2827,19 @@ export class AsyncQueryService extends ProjectService {
                 queryTags.query_context,
             );
 
+            if (
+                this.lightdashConfig.queryPhaseMetrics.projectUuids.includes(
+                    projectUuid,
+                )
+            ) {
+                this.prometheusMetrics?.observeProjectQueryPhaseDurations(
+                    projectUuid,
+                    warehousePhaseTimings,
+                    warehouseCredentialsType,
+                    queryTags.query_context,
+                );
+            }
+
             this.analytics.track({
                 ...analyticsIdentity,
                 event: 'query.ready',


### PR DESCRIPTION
Linear: SPK-841

## Why

Warehouse phase timings — `connect`, `session`, `query`, `fetch` — are recorded with only `warehouse_type` and `context`. On a multi-tenant deployment that means they cannot be read for a single project: every figure is blended across all tenants using that warehouse type.

That blocks a specific, concrete question. When a project's queries are slow, the phase split is what says where the time goes and therefore what would fix it — time in `query` points at the warehouse, time in `fetch` points at result streaming on our side, time in `session` points at per-session setup. Those lead to completely different work. Today the split can only be read as an aggregate across tenants, so it cannot settle the question for any one of them.

## What

Adds `lightdash_query_warehouse_phase_duration_by_project_seconds` — the existing phase timings with a `project_uuid` label, alongside `phase`, `warehouse_type` and `context`.

## Cardinality

`project_uuid` is deliberately **not** added to the existing shared histograms. On a multi-tenant deployment that is unbounded label cardinality growing with tenant count, which is a real cost and a real risk.

Instead this histogram is emitted only for projects named in a standalone allowlist, `QUERY_PHASE_METRICS_PROJECT_UUIDS`, which **defaults to empty**. An empty allowlist emits nothing at all. So the label set is bounded by configuration rather than by tenant count, it fails closed, and the metric self-retires when the list is cleared.

The allowlist is intentionally its own config rather than reusing an existing one, so this stands alone and is not coupled to any other feature's lifecycle.

## Scope note

This PR previously also instrumented the MotherDuck instance cache — hit/coalesced accounting, creation-failure counters, an in-flight gauge and a depth-at-acquire histogram. That cache is being reverted (#26792), so all of it has been dropped. What remains is the part that never depended on the cache existing.

## Testing

`pnpm -F backend typecheck` clean; 160 tests pass across the config and prometheus suites, covering the allowlist parsing (including empty-default and whitespace handling) and that the histogram is emitted only for allowlisted projects. Touched-path linter clean.