### PR TITLE
feat(autopilot): verified-content protection and scope settings UI

### DIFF
--- a/packages/backend/src/ee/models/ManagedAgentModel.ts
+++ b/packages/backend/src/ee/models/ManagedAgentModel.ts
@@ -536,6 +536,17 @@ export class ManagedAgentModel {
         );
     }
 
+    async isContentVerified(
+        contentType: 'chart' | 'dashboard',
+        contentUuid: string,
+    ): Promise<boolean> {
+        const row = await this.database('content_verification')
+            .where({ content_type: contentType, content_uuid: contentUuid })
+            .select('content_verification_uuid')
+            .first();
+        return row !== undefined;
+    }
+
     async getChartSpaceUuid(chartUuid: string): Promise<string | null> {
         const row = await this.database('saved_queries as sq')
             .leftJoin('spaces as s', 's.space_id', 'sq.space_id')

--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -478,6 +478,24 @@ export class ManagedAgentService extends BaseService {
             });
         }
 
+        // Verified content is protected by default: a human vouched for the
+        // definition, so Autopilot reports instead of rewriting.
+        const policy = await this.getPolicy(projectUuid);
+        if (policy.verifiedContent === 'protected') {
+            const isVerified = await this.managedAgentModel.isContentVerified(
+                entityType === ManagedAgentProtectedEntityType.CHART
+                    ? 'chart'
+                    : 'dashboard',
+                targetUuid,
+            );
+            if (isVerified) {
+                return JSON.stringify({
+                    error: `"${targetName}" is verified content and protected by project policy. You may report on it with log_insight, but do not flag, fix, or delete it.`,
+                    blocked: true,
+                });
+            }
+        }
+
         // Defense in depth: content living in an out-of-scope space cannot be
         // mutated even if a read tool leaked it.
         const spaceUuid =

--- a/packages/backend/src/ee/services/ManagedAgentService/config/agent.test.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/config/agent.test.ts
@@ -137,6 +137,19 @@ describe('renderManagedAgentConfig with policy', () => {
         expect(tools).toContain('flag_content');
     });
 
+    it('states verified-content protection in the prompt', () => {
+        const protectedConfig = renderManagedAgentConfig(baseArgs);
+        expect(protectedConfig.system).toContain('Verified content: protected');
+        const optedOut = renderManagedAgentConfig({
+            ...baseArgs,
+            policy: {
+                ...DEFAULT_MANAGED_AGENT_POLICY,
+                verifiedContent: 'none',
+            },
+        });
+        expect(optedOut.system).toContain('treated like any other content');
+    });
+
     it('changes the config hash when policy changes', () => {
         const a = getManagedAgentConfigHash(renderManagedAgentConfig(baseArgs));
         const b = getManagedAgentConfigHash(

--- a/packages/backend/src/ee/services/ManagedAgentService/config/agent.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/config/agent.ts
@@ -20,6 +20,7 @@ export const buildManagedAgentSystemPrompt = (
         escalationHours,
         aggression,
         audience,
+        verifiedContent,
     } = policy;
 
     const aggressionRules = (() => {
@@ -99,6 +100,7 @@ This project's admin has configured the following policy. It is enforced by your
 - Slow queries: ${slowQueryThresholdMs}+ ms warehouse execution time
 - Cleanup mode: ${aggression}
 - Audience: ${audience === 'admins' ? 'admin-only (your suggestions space is restricted to admins)' : 'everyone (your suggestions are visible to all project users)'}
+- Verified content: ${verifiedContent === 'protected' ? 'protected. You may report on it with log_insight but NEVER flag, fix, or delete it' : 'treated like any other content'}
 
 ## Rules
 - ALWAYS explain WHY you're taking an action in the description field

--- a/packages/common/src/ee/types/managedAgent.ts
+++ b/packages/common/src/ee/types/managedAgent.ts
@@ -153,6 +153,7 @@ export type ManagedAgentPolicy = {
     aggression: ManagedAgentAggression;
     audience: ManagedAgentAudience;
     spaceScopeMode: ManagedAgentSpaceScopeMode;
+    verifiedContent: 'protected' | 'none';
 };
 
 export type UpdateManagedAgentPolicy = Partial<ManagedAgentPolicy>;
@@ -189,6 +190,10 @@ const managedAgentPolicySchema = z.object({
         .enum(['all-except', 'only'])
         .default('all-except')
         .catch('all-except'),
+    verifiedContent: z
+        .enum(['protected', 'none'])
+        .default('protected')
+        .catch('protected'),
 });
 
 export const DEFAULT_MANAGED_AGENT_POLICY: ManagedAgentPolicy =

--- a/packages/common/src/ee/types/managedAgentPolicy.test.ts
+++ b/packages/common/src/ee/types/managedAgentPolicy.test.ts
@@ -18,6 +18,7 @@ describe('resolveManagedAgentPolicy', () => {
             aggression: 'cleanup',
             audience: 'everyone',
             spaceScopeMode: 'all-except',
+            verifiedContent: 'protected',
         });
     });
 

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -14,6 +14,7 @@ import {
     ManagedAgentRunStatus,
     ManagedAgentScheduleOption,
     type UpdateManagedAgentPolicy,
+    type UpdateManagedAgentSpaceScope,
     type Project,
     type SavedChart,
     type UpdatedByUser,
@@ -26,6 +27,7 @@ import {
     Group,
     Loader,
     Menu,
+    MultiSelect,
     Select,
     Stack,
     Switch,
@@ -86,6 +88,7 @@ import { useGetSlack } from '../../../hooks/slack/useSlack';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { useProject } from '../../../hooks/useProject';
 import { useChartVersion, useSavedQuery } from '../../../hooks/useSavedQuery';
+import { useSpaceSummaries } from '../../../hooks/useSpaces';
 import useApp from '../../../providers/App/useApp';
 import { useManagedAgentActions } from './hooks/useManagedAgentActions';
 import { useManagedAgentLatestRun } from './hooks/useManagedAgentLatestRun';
@@ -112,6 +115,7 @@ const updateSettings = async (
         slackChannelId?: string | null;
         toolSettings?: Record<string, boolean>;
         policy?: UpdateManagedAgentPolicy;
+        spaceScope?: UpdateManagedAgentSpaceScope;
     },
 ) =>
     lightdashApi({
@@ -1216,6 +1220,7 @@ const SettingsSidebar: FC<{
     slackChannelId: string | null;
     toolSettings: Record<string, boolean>;
     policy: ManagedAgentPolicy;
+    scopedSpaceUuids: string[];
     isLoading: boolean;
     onClose: () => void;
 }> = ({
@@ -1225,11 +1230,13 @@ const SettingsSidebar: FC<{
     slackChannelId,
     toolSettings,
     policy,
+    scopedSpaceUuids,
     isLoading,
     onClose,
 }) => {
     const queryClient = useQueryClient();
     const { data: slackInstallation } = useGetSlack();
+    const { data: spaceSummaries } = useSpaceSummaries(projectUuid, true);
     const organizationHasSlack = !!slackInstallation?.organizationUuid;
     const [slackNotificationsEnabled, setSlackNotificationsEnabled] =
         useState(!!slackChannelId);
@@ -1238,12 +1245,19 @@ const SettingsSidebar: FC<{
         setSlackNotificationsEnabled(!!slackChannelId);
     }, [slackChannelId]);
 
+    const { showToastApiError: showSettingsApiError } = useToaster();
     const mutation = useMutation({
         mutationFn: (body: Parameters<typeof updateSettings>[1]) =>
             updateSettings(projectUuid, body),
         onSuccess: () => {
             void queryClient.invalidateQueries({
                 queryKey: ['managed-agent-settings', projectUuid],
+            });
+        },
+        onError: ({ error }: ApiError) => {
+            showSettingsApiError({
+                title: 'Failed to update Autopilot settings',
+                apiError: error,
             });
         },
     });
@@ -1295,6 +1309,40 @@ const SettingsSidebar: FC<{
         },
         [mutation],
     );
+
+    // Scope edits are drafted locally and saved with one PATCH on Apply
+    const [selectedSpaces, setSelectedSpaces] =
+        useState<string[]>(scopedSpaceUuids);
+    const [draftScopeMode, setDraftScopeMode] = useState(policy.spaceScopeMode);
+
+    const isScopeDirty =
+        draftScopeMode !== policy.spaceScopeMode ||
+        selectedSpaces.length !== scopedSpaceUuids.length ||
+        selectedSpaces.some((uuid) => !scopedSpaceUuids.includes(uuid));
+
+    const handleApplySpaceScope = useCallback(() => {
+        const scope: UpdateManagedAgentSpaceScope = {
+            mode: draftScopeMode,
+            spaceUuids: selectedSpaces,
+        };
+        mutation.mutate({ spaceScope: scope });
+    }, [mutation, draftScopeMode, selectedSpaces]);
+
+    const handleResetSpaceScope = useCallback(() => {
+        setDraftScopeMode(policy.spaceScopeMode);
+        setSelectedSpaces(scopedSpaceUuids);
+    }, [policy.spaceScopeMode, scopedSpaceUuids]);
+
+    // The caption reflects what is saved, not the draft being composed
+    const spaceScopeSummary = (() => {
+        const count = scopedSpaceUuids.length;
+        if (policy.spaceScopeMode === 'only') {
+            return `Monitoring ${count} selected ${count === 1 ? 'space' : 'spaces'}.`;
+        }
+        return count === 0
+            ? 'Monitoring all spaces.'
+            : `Monitoring all spaces except ${count} excluded.`;
+    })();
 
     return (
         <Stack gap={0} h="100%" className={classes.sidebar}>
@@ -1510,6 +1558,82 @@ const SettingsSidebar: FC<{
                                         )}
                                     </Group>
                                 ))}
+                                <Stack
+                                    gap={6}
+                                    className={classes.toolToggleRow}
+                                >
+                                    <Text fz="xs" fw={500}>
+                                        Space scope
+                                    </Text>
+                                    <Stack gap={4}>
+                                        <Select
+                                            data={[
+                                                {
+                                                    value: 'all-except',
+                                                    label: 'Monitor all spaces except…',
+                                                },
+                                                {
+                                                    value: 'only',
+                                                    label: 'Monitor only these spaces…',
+                                                },
+                                            ]}
+                                            value={draftScopeMode}
+                                            onChange={(value) => {
+                                                if (value) {
+                                                    setDraftScopeMode(
+                                                        value as ManagedAgentPolicy['spaceScopeMode'],
+                                                    );
+                                                }
+                                            }}
+                                            size="sm"
+                                            disabled={mutation.isLoading}
+                                        />
+                                        <MultiSelect
+                                            data={(spaceSummaries ?? []).map(
+                                                (space) => ({
+                                                    value: space.uuid,
+                                                    label: space.name,
+                                                }),
+                                            )}
+                                            value={selectedSpaces}
+                                            onChange={setSelectedSpaces}
+                                            placeholder={
+                                                selectedSpaces.length === 0
+                                                    ? 'Search spaces...'
+                                                    : undefined
+                                            }
+                                            searchable
+                                            clearable
+                                            size="sm"
+                                            disabled={mutation.isLoading}
+                                        />
+                                    </Stack>
+                                    {isScopeDirty && (
+                                        <Group gap="xs">
+                                            <Button
+                                                size="xs"
+                                                onClick={handleApplySpaceScope}
+                                                loading={mutation.isLoading}
+                                            >
+                                                Apply scope
+                                            </Button>
+                                            <Button
+                                                size="xs"
+                                                variant="subtle"
+                                                onClick={handleResetSpaceScope}
+                                                disabled={mutation.isLoading}
+                                            >
+                                                Cancel
+                                            </Button>
+                                        </Group>
+                                    )}
+                                    <Text fz={11} c="dimmed">
+                                        {spaceScopeSummary}{' '}
+                                        {policy.spaceScopeMode === 'only'
+                                            ? 'New spaces are not monitored until added here. Selections include child spaces.'
+                                            : 'Excluded spaces and their child spaces are invisible to Autopilot.'}
+                                    </Text>
+                                </Stack>
                             </Stack>
                         </Stack>
 
@@ -1669,6 +1793,39 @@ const SettingsSidebar: FC<{
                                             audience: e.currentTarget.checked
                                                 ? 'admins'
                                                 : 'everyone',
+                                        })
+                                    }
+                                    disabled={mutation.isLoading}
+                                    size="xs"
+                                    color="ldDark"
+                                />
+                            </Group>
+
+                            <Group
+                                justify="space-between"
+                                align="flex-start"
+                                wrap="nowrap"
+                            >
+                                <Stack gap={3}>
+                                    <Text fz="xs" fw={500}>
+                                        Protect verified content
+                                    </Text>
+                                    <Text fz={11} c="dimmed">
+                                        Autopilot can report on verified charts
+                                        and dashboards but never changes or
+                                        deletes them.
+                                    </Text>
+                                </Stack>
+                                <Switch
+                                    checked={
+                                        policy.verifiedContent === 'protected'
+                                    }
+                                    onChange={(e) =>
+                                        handlePolicyChange({
+                                            verifiedContent: e.currentTarget
+                                                .checked
+                                                ? 'protected'
+                                                : 'none',
                                         })
                                     }
                                     disabled={mutation.isLoading}
@@ -2428,6 +2585,9 @@ export const ManagedAgentActivityPage: FC = () => {
                                     policy={
                                         settings?.policy ??
                                         DEFAULT_MANAGED_AGENT_POLICY
+                                    }
+                                    scopedSpaceUuids={
+                                        settings?.scopedSpaceUuids ?? []
                                     }
                                     isLoading={settingsLoading}
                                     onClose={() => setSettingsOpen(false)}

--- a/packages/frontend/src/ee/features/managedAgent/hooks/useManagedAgentSettings.ts
+++ b/packages/frontend/src/ee/features/managedAgent/hooks/useManagedAgentSettings.ts
@@ -14,6 +14,7 @@ type ManagedAgentSettings = {
     slackChannelId: string | null;
     toolSettings: Record<string, boolean>;
     policy: ManagedAgentPolicy;
+    scopedSpaceUuids: string[];
     createdAt: string;
     updatedAt: string;
 };


### PR DESCRIPTION
## Summary

Third PR of the Autopilot scope & protection model (Linear: PROD-9305, PROD-7373; stacked on #26790).

**Verified-content protection (PROD-9305):**
- New policy field `verifiedContent`: `protected` (default) or `none`.
- When protected, the mutation choke point blocks flag, fix, and delete on verified charts and dashboards. Autopilot can still see and report on them; a broken verified chart is high-value signal, but a human vouched for the definition so Autopilot reports instead of rewriting.
- The active stance is rendered into the agent prompt.

**Settings UI:**
- New Space scope section: mode select (all spaces except excluded / only selected spaces), searchable space picker with per-mode labels, a live summary line ("Monitoring all spaces except 2 excluded."), and the agreed note that new spaces are not monitored in allowlist mode.
- New "Protect verified content" toggle in the Policy section.

## Regression analysis

One intentional behavior change, called out on the Linear ticket: with the default policy, Autopilot no longer auto-fixes broken verified charts (it reports instead). `verifiedContent: 'none'` restores the old behavior per project. Projects with no verified content are unaffected. Everything else is additive UI; the sidebar renders correctly against a backend without these fields via resolver defaults.

## Testing

- New render test for the verified-content prompt statement (both stances)
- Full common (3,304) and backend (5,720) suites green; frontend typecheck and lint green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UgXBzcYYEeoMUUShzL7DsU