### PR TITLE
fix(unfurl): use the configurable screenshot timeout for app renders

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.test.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.test.ts
@@ -87,6 +87,7 @@ function createService(
             siteUrl: 'https://app.lightdash.cloud',
             headlessBrowser: {
                 internalLightdashHost: 'http://headless-browser:8080',
+                screenshotTimeoutMs: 45_000,
                 ...(overrides.headlessBrowser ?? {}),
             },
         } as unknown as LightdashConfig,
@@ -508,7 +509,7 @@ describe('UnfurlService', () => {
             );
             expect(page.waitForSelector).toHaveBeenCalledWith(
                 SCREENSHOT_SELECTORS.READY_INDICATOR,
-                { state: 'attached', timeout: 60_000 },
+                { state: 'attached', timeout: 45_000 },
             );
             expect(page.evaluate).toHaveBeenCalledWith(
                 expect.any(Function),

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -222,7 +222,6 @@ const appViewport = {
 const APP_SCREENSHOT_MIN_HEIGHT = 600;
 
 // How long we wait for `MinimalApp` to mount the ready indicator.
-const APP_READY_TIMEOUT_MS = 60_000;
 
 const bigNumberViewport = {
     width: 768,
@@ -1796,7 +1795,7 @@ export class UnfurlService extends BaseService {
                         // chart entrance animations can finish.
                         const APP_ANIMATION_BUFFER_MS = 5_000;
                         this.logger.info(
-                            `Waiting for app screenshot ready indicator (timeout ${APP_READY_TIMEOUT_MS}ms) - unfurlId: ${imageId}`,
+                            `Waiting for app screenshot ready indicator (timeout ${this.screenshotTimeoutMs}ms) - unfurlId: ${imageId}`,
                         );
                         const waitStart = Date.now();
                         try {
@@ -1804,7 +1803,7 @@ export class UnfurlService extends BaseService {
                                 SCREENSHOT_SELECTORS.READY_INDICATOR,
                                 {
                                     state: 'attached',
-                                    timeout: APP_READY_TIMEOUT_MS,
+                                    timeout: this.screenshotTimeoutMs,
                                 },
                             );
                             this.logger.info(
@@ -1825,7 +1824,7 @@ export class UnfurlService extends BaseService {
                             // screenshot still happens for apps that never
                             // signal (older bundles, or pathological cases).
                             this.logger.warn(
-                                `App ready indicator not detected within ${APP_READY_TIMEOUT_MS}ms; proceeding with animation buffer only - unfurlId: ${imageId}`,
+                                `App ready indicator not detected within ${this.screenshotTimeoutMs}ms; proceeding with animation buffer only - unfurlId: ${imageId}`,
                             );
                             this.analytics.track({
                                 event: 'headless_browser.app_ready_wait',
@@ -2480,13 +2479,13 @@ export class UnfurlService extends BaseService {
             try {
                 await page.waitForSelector(
                     SCREENSHOT_SELECTORS.READY_INDICATOR,
-                    { state: 'attached', timeout: APP_READY_TIMEOUT_MS },
+                    { state: 'attached', timeout: this.screenshotTimeoutMs },
                 );
             } catch (waitError) {
                 // Fail-closed: unlike the screenshot path there is no partial
                 // result worth shipping, so the timeout propagates.
                 this.logger.error(
-                    `App delivery capture ready indicator not detected within ${APP_READY_TIMEOUT_MS}ms - contextId: ${contextId}`,
+                    `App delivery capture ready indicator not detected within ${this.screenshotTimeoutMs}ms - contextId: ${contextId}`,
                 );
                 throw waitError;
             }


### PR DESCRIPTION
## Summary

App headless renders waited on a hardcoded **60s** ready-indicator timeout, while dashboard/chart renders use the configurable `screenshotTimeoutMs` (default **180s**, `HEADLESS_BROWSER_SCREENSHOT_TIMEOUT_MS`). Any data app whose warehouse queries take longer than 60s therefore shipped spinner screenshots on every scheduled image delivery — and the same ceiling applies to the app data-delivery capture path, where it fails the delivery closed.

Production telemetry (`headless_browser.app_ready_wait`) confirms the mechanism: every failed app render rides the exact 60s ceiling (60,002–60,004ms) while successful renders settle at p50 ~6s / p95 ~16s — the timeouts are apps that need more than 60s, not slow-but-healthy renders being clipped.

Fix: both app wait sites (screenshot render and delivery capture) now use `this.screenshotTimeoutMs`, consistent with dashboards. Self-hosters who bump `HEADLESS_BROWSER_SCREENSHOT_TIMEOUT_MS` now cover apps too.

## Testing

- `UnfurlService.test.ts` 28/28 — config stub sets a distinctive `screenshotTimeoutMs` and asserts it flows into the app wait (proves configurability rather than another constant)
- backend typecheck clean

Closes: PROD-9424
Closes: #26632