### PR TITLE
fix(ai): detect typed provider billing errors

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
@@ -1,13 +1,15 @@
-import type { ModelMessage } from 'ai';
+import { APICallError, generateText, type ModelMessage } from 'ai';
 import {
     registerAiUsageTracker,
     type AiUsageEvent,
 } from '../../../../analytics/aiUsage';
 import type { AiAgentArgs, AiAgentDependencies } from '../types/aiAgent';
+import { PROVIDER_BILLING_MESSAGE } from '../utils/errorMessages';
 import {
     buildAgentMessages,
     buildDeepResearchExecutionContextSnapshot,
     buildForcedFirstStep,
+    generateAgentResponse,
     getAgentTools,
     getDeepResearchBudgetInstruction,
     getPromptMcpServers,
@@ -17,6 +19,107 @@ import {
     withEarlyToolProgress,
     type AgentMcpToolSetup,
 } from './agentV2';
+
+vi.mock('ai', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('ai')>()),
+    generateText: vi.fn(),
+}));
+
+describe('generateAgentResponse error persistence', () => {
+    it('persists provider billing guidance for a self-managed key', async () => {
+        const updatePrompt = vi.fn().mockResolvedValue(undefined);
+        const dependencies = new Proxy(
+            {
+                listExplores: vi.fn().mockResolvedValue([]),
+                updatePrompt,
+            },
+            {
+                get: (target, property: string) =>
+                    target[property as keyof typeof target] ?? vi.fn(),
+            },
+        ) as unknown as AiAgentDependencies;
+        const args = {
+            agentSettings: {
+                uuid: 'agent-1',
+                name: 'Test agent',
+                projectUuid: 'project-1',
+            },
+            aiAgentMemoryEnabled: false,
+            availableSkills: [],
+            callOptions: {},
+            canManageAgent: false,
+            canRunSql: true,
+            compactionSummary: null,
+            debugLoggingEnabled: false,
+            deepResearchRuns: [],
+            enableAiWriteback: false,
+            enableCodingAgent: false,
+            enableContentTools: false,
+            enableDataAccess: false,
+            enableEditProjectContext: false,
+            enableGrepFields: false,
+            enablePreviewDeploySetup: false,
+            enableRepoDiscovery: false,
+            execution: { mode: 'standard', maxSteps: 10 },
+            findExploresFieldSearchSize: 10,
+            findFieldsPageSize: 10,
+            forceToolHints: false,
+            getDashboardChartsPageSize: 10,
+            keyManagement: 'self-managed',
+            knowledgeDocuments: [],
+            mcpServers: [],
+            messageHistory: [{ role: 'user', content: 'Question' }],
+            model: {},
+            organizationId: 'organization-1',
+            projectContext: [],
+            projectContextEnabled: false,
+            promptUuid: 'prompt-1',
+            providerOptions: {},
+            repoFsRoot: null,
+            repoFsSupportsCodeSearch: false,
+            requestingUser: null,
+            runSqlMaxLimit: 5000,
+            siteUrl: 'http://localhost',
+            telemetryEnabled: false,
+            threadUuid: 'thread-1',
+            toolDescriptionMaxChars: 1000,
+            toolHints: [],
+            userId: 'user-1',
+            writebackAttribution: null,
+        } as unknown as AiAgentArgs;
+        const providerError = new APICallError({
+            message: 'Provider request failed',
+            url: 'https://api.anthropic.com/v1/messages',
+            requestBodyValues: {},
+            statusCode: 400,
+            data: {
+                type: 'error',
+                error: {
+                    type: 'billing_error',
+                    message: 'Provider request failed',
+                },
+            },
+        });
+        vi.mocked(generateText).mockRejectedValueOnce(providerError);
+
+        await expect(
+            generateAgentResponse({
+                args,
+                dependencies,
+                mcpToolSetup: {
+                    tools: {},
+                    mcpToolNameToServerUuid: {},
+                    unavailableMcpServers: [],
+                    closeMcpClients: vi.fn().mockResolvedValue(undefined),
+                },
+            }),
+        ).rejects.toBe(providerError);
+        expect(updatePrompt).toHaveBeenCalledWith({
+            promptUuid: 'prompt-1',
+            errorMessage: PROVIDER_BILLING_MESSAGE,
+        });
+    });
+});
 
 describe('recordAgentStepUsage', () => {
     const usage = {

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -1604,6 +1604,7 @@ export const generateAgentResponse = async ({
         const userFacingMessage = getUserFacingErrorMessage(
             error,
             'Something went wrong while generating the response. Please try again.',
+            args.keyManagement,
         );
 
         if (args.execution.mode !== 'deep_research') {

--- a/packages/backend/src/ee/services/ai/utils/errorMessages.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/errorMessages.test.ts
@@ -1,3 +1,4 @@
+import { APICallError, RetryError } from 'ai';
 import { McpAuthorizationRequiredError } from '../AiAgentMcpRuntimeClient';
 import {
     AiAgentEmptyResponseError,
@@ -89,19 +90,73 @@ describe('getUserFacingErrorMessage', () => {
     });
 
     describe('provider billing errors', () => {
+        const apiCallError = ({
+            statusCode = 400,
+            data,
+        }: {
+            statusCode?: number;
+            data?: unknown;
+        }) =>
+            new APICallError({
+                message: 'Provider request failed',
+                url: 'https://provider.example.com/v1/messages',
+                requestBodyValues: {},
+                statusCode,
+                data,
+            });
+
         it.each([
-            'Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.',
-            'insufficient_quota',
-            'Provider billing is not enabled',
-            'Monthly spend limit reached',
-            'payment_required',
-            'HTTP 402 Payment Required',
+            [
+                'Anthropic billing code',
+                apiCallError({
+                    data: {
+                        type: 'error',
+                        error: {
+                            type: 'billing_error',
+                            message: 'Provider request failed',
+                        },
+                    },
+                }),
+            ],
+            [
+                'OpenAI insufficient quota code',
+                apiCallError({
+                    statusCode: 429,
+                    data: {
+                        error: {
+                            type: 'insufficient_quota',
+                            code: 'insufficient_quota',
+                            message: 'Provider request failed',
+                        },
+                    },
+                }),
+            ],
+            [
+                'OpenAI insufficient quota after retries',
+                new RetryError({
+                    message: 'Failed after 3 attempts',
+                    reason: 'maxRetriesExceeded',
+                    errors: [
+                        apiCallError({
+                            statusCode: 429,
+                            data: {
+                                error: {
+                                    type: 'insufficient_quota',
+                                    code: 'insufficient_quota',
+                                    message: 'Provider request failed',
+                                },
+                            },
+                        }),
+                    ],
+                }),
+            ],
+            ['HTTP 402', apiCallError({ statusCode: 402 })],
         ])(
             'shows actionable billing guidance for self-managed keys: %s',
-            (message) => {
+            (_name, error) => {
                 expect(
                     getUserFacingErrorMessage(
-                        new Error(message),
+                        error,
                         'Custom fallback',
                         'self-managed',
                     ),
@@ -112,7 +167,15 @@ describe('getUserFacingErrorMessage', () => {
         it('does not expose provider billing errors for Lightdash-managed keys', () => {
             expect(
                 getUserFacingErrorMessage(
-                    new Error('Your credit balance is too low'),
+                    apiCallError({
+                        data: {
+                            type: 'error',
+                            error: {
+                                type: 'billing_error',
+                                message: 'Provider request failed',
+                            },
+                        },
+                    }),
                     'Custom fallback',
                     'lightdash-managed',
                 ),

--- a/packages/backend/src/ee/services/ai/utils/errorMessages.ts
+++ b/packages/backend/src/ee/services/ai/utils/errorMessages.ts
@@ -1,3 +1,5 @@
+import { APICallError, RetryError } from 'ai';
+import { get, isPlainObject } from 'lodash';
 import type { AiKeyManagement } from '../../../../analytics/aiUsage';
 import { McpAuthorizationRequiredError } from '../AiAgentMcpRuntimeClient';
 
@@ -19,6 +21,44 @@ export const EMPTY_RESPONSE_MESSAGE =
 
 export const PROVIDER_BILLING_MESSAGE =
     'The configured AI provider account has a billing or credit issue. Check its billing settings or add credits, then try again.';
+
+const PROVIDER_BILLING_ERROR_CODES = new Set([
+    'billing_error',
+    'insufficient_credit',
+    'insufficient_credits',
+    'insufficient_quota',
+    'payment_required',
+]);
+
+const getApiCallError = (error: unknown): APICallError | undefined => {
+    if (APICallError.isInstance(error)) return error;
+    if (
+        RetryError.isInstance(error) &&
+        APICallError.isInstance(error.lastError)
+    ) {
+        return error.lastError;
+    }
+    return undefined;
+};
+
+const isProviderBillingError = (error: unknown): boolean => {
+    const apiCallError = getApiCallError(error);
+    if (!apiCallError) return false;
+    if (apiCallError.statusCode === 402) return true;
+
+    const data = isPlainObject(apiCallError.data)
+        ? apiCallError.data
+        : undefined;
+    return [
+        get(data, 'type'),
+        get(data, 'code'),
+        get(data, 'error.type'),
+        get(data, 'error.code'),
+    ].some(
+        (code) =>
+            typeof code === 'string' && PROVIDER_BILLING_ERROR_CODES.has(code),
+    );
+};
 
 // A finished prompt must always carry either a response or an error message.
 // This error backs that invariant: the model stopped (under the step cap)
@@ -82,12 +122,7 @@ export const getUserFacingErrorMessage = (
         return 'We could not connect to the MCP server. Check that it is available and try again.';
     }
 
-    if (
-        keyManagement === 'self-managed' &&
-        /credit balance|insufficient_quota|billing|spend limit|payment_required|http 402/i.test(
-            errorMessage,
-        )
-    ) {
+    if (keyManagement === 'self-managed' && isProviderBillingError(error)) {
         return PROVIDER_BILLING_MESSAGE;
     }
 


### PR DESCRIPTION
### Description

- Replace provider billing message regexes with structured AI SDK error codes and HTTP 402.
- Handle Anthropic billing errors and OpenAI insufficient quota errors, including retry-wrapped API failures.
- Preserve self-managed key gating and pass key management through streaming and non-streaming persistence paths.
- Add mapper and persistence-boundary regression coverage.

### Validation

- 51 focused backend tests passed.
- Backend TypeScript check passed.
- Targeted lint and formatting passed.
- Pre-commit secrets, lint, formatting, and unused-export checks passed.
- Final independent review found no issues.

Closes: [ZAP-763](https://linear.app/lightdash/issue/ZAP-763/as-a-user-with-a-byok-provider-key-i-want-ask-ai-to-show-billing)