### PR TITLE
feat(search): slim down the navbar search target

### DIFF
--- a/packages/e2e/cypress/e2e/app/globalSearch.cy.ts
+++ b/packages/e2e/cypress/e2e/app/globalSearch.cy.ts
@@ -28,7 +28,9 @@ describe('Global search', () => {
         }
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/home`);
 
-        cy.contains('Search Jaffle shop').should('be.visible');
+        cy.findByRole('search')
+            .should('be.visible')
+            .and('contain.text', 'Search');
         // search and select space
         search('jaffle');
         cy.findByRole('dialog')

--- a/packages/frontend/src/features/omnibar/components/Omnibar.tsx
+++ b/packages/frontend/src/features/omnibar/components/Omnibar.tsx
@@ -336,9 +336,7 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
             >
                 {(style) => (
                     <OmnibarTarget
-                        placeholder={`Search ${
-                            projectData?.name ?? 'your project'
-                        }`}
+                        placeholder="Search"
                         style={style}
                         onOpen={handleOmnibarOpenInputClick}
                     />

--- a/packages/frontend/src/features/omnibar/components/OmnibarTarget.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarTarget.tsx
@@ -25,11 +25,11 @@ const OmnibarTarget: FC<Props> = ({ placeholder, style, onOpen }) => {
             style={style}
             wrap="nowrap"
             w={{
-                xs: 150,
-                sm: 200,
-                md: 250,
-                lg: 300,
-                xl: 350,
+                xs: 110,
+                sm: 130,
+                md: 150,
+                lg: 170,
+                xl: 190,
             }}
             className={classes.container}
         >


### PR DESCRIPTION
## What

Makes the collapsed global-search box in the navbar take up less horizontal space.

- Reduces the `OmnibarTarget` width at every breakpoint (`xs` 150→110, `sm` 200→130, `md` 250→150, `lg` 300→170, `xl` 350→190).
- Shortens the placeholder from `Search <project name>` to just `Search`, since the project name no longer fits the narrower target.

Only the collapsed target changes. The expanded omnibar, its search behaviour, and the project name shown inside the open panel are all untouched.

## Test plan

- `pnpm -F frontend typecheck` — clean (exit 0, 0 errors)
- `pnpm -F frontend lint` — 0 warnings, 0 errors
- `oxfmt --check` on both changed files — correctly formatted
- Pre-commit hooks (linter, formatter, git-secrets, `ts-unused-exports`) all pass

Not yet exercised in a running browser — this is a pure CSS-width and static-string change, so reviewers may want to eyeball the navbar at a narrow breakpoint.

## Notes

No Linear ticket for this one (confirmed by the author).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012s797ZWj6wUZrMcK4GP4qb