### PR TITLE
perf(homepage): make recently-viewed use the viewer's own history index

### DIFF
--- a/packages/backend/src/database/migrations/20260804101500_add_user_uuid_indexes_to_analytics_views.ts
+++ b/packages/backend/src/database/migrations/20260804101500_add_user_uuid_indexes_to_analytics_views.ts
@@ -1,0 +1,56 @@
+import { Knex } from 'knex';
+
+// CREATE INDEX CONCURRENTLY cannot run inside a transaction. Each statement
+// runs in its own implicit transaction; the migration is idempotent so a
+// partial run can be safely resumed by re-running.
+export const config = { transaction: false };
+
+const INDEXES: ReadonlyArray<{ table: string; index: string }> = [
+    {
+        table: 'analytics_chart_views',
+        index: 'analytics_chart_views_user_uuid_timestamp_index',
+    },
+    {
+        table: 'analytics_dashboard_views',
+        index: 'analytics_dashboard_views_user_uuid_timestamp_index',
+    },
+];
+
+export async function up(knex: Knex): Promise<void> {
+    // Index builds on these tables can run for minutes; a configured
+    // statement_timeout would abort the build and leave the migration lock held.
+    await knex.raw(`SET statement_timeout = 0`);
+    try {
+        for (const { table, index } of INDEXES) {
+            // A crashed CONCURRENTLY build leaves an INVALID index behind, and
+            // IF NOT EXISTS matches by name only — drop it before rebuilding.
+            // eslint-disable-next-line no-await-in-loop
+            const invalid = await knex.raw<{ rowCount: number }>(
+                `SELECT 1 FROM pg_class c
+                 JOIN pg_index i ON i.indexrelid = c.oid
+                 WHERE c.relname = ? AND NOT i.indisvalid`,
+                [index],
+            );
+            if ((invalid.rowCount ?? 0) > 0) {
+                // eslint-disable-next-line no-await-in-loop
+                await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS ??`, [index]);
+            }
+            // eslint-disable-next-line no-console
+            console.log(`Building ${index} (concurrently)`);
+            // eslint-disable-next-line no-await-in-loop
+            await knex.raw(
+                `CREATE INDEX CONCURRENTLY IF NOT EXISTS ?? ON ?? (user_uuid, "timestamp" DESC)`,
+                [index, table],
+            );
+        }
+    } finally {
+        await knex.raw(`RESET statement_timeout`);
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    for (const { index } of INDEXES) {
+        // eslint-disable-next-line no-await-in-loop
+        await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS ??`, [index]);
+    }
+}

--- a/packages/backend/src/ee/models/ProjectHomepageModel.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.ts
@@ -326,19 +326,16 @@ export class ProjectHomepageModel {
             }>;
         }>(
             `
-            SELECT content_type, content_uuid, max(viewed_at) AS viewed_at
-            FROM (
+            -- Read the viewer's own history first, off the
+            -- (user_uuid, timestamp) indexes, and only then filter by project.
+            -- Joining the content tables up front makes Postgres drive from
+            -- saved_queries and re-scan every chart's whole view history.
+            WITH raw_views AS MATERIALIZED (
                 SELECT 'chart' AS content_type,
                        acv.chart_uuid AS content_uuid,
                        acv.timestamp AS viewed_at
                 FROM analytics_chart_views acv
-                JOIN saved_queries sq ON sq.saved_query_uuid = acv.chart_uuid
-                JOIN spaces s ON s.space_id = sq.space_id
-                JOIN projects p ON p.project_id = s.project_id
                 WHERE acv.user_uuid = :userUuid
-                  AND p.project_uuid = :projectUuid
-                  AND sq.deleted_at IS NULL
-                  AND s.deleted_at IS NULL
                   -- Opening a dashboard records a view for every tile on it,
                   -- which would bury the dashboard the user actually opened.
                   -- Tiles are tagged where we can, but several code paths
@@ -349,24 +346,55 @@ export class ProjectHomepageModel {
                       SELECT 1
                       FROM analytics_dashboard_views tile_dv
                       WHERE tile_dv.user_uuid = acv.user_uuid
-                        AND acv.timestamp BETWEEN tile_dv.timestamp - interval '2 seconds'
-                                              AND tile_dv.timestamp + interval '15 seconds'
+                        -- Keep tile_dv.timestamp on the left: this is the same
+                        -- window as acv BETWEEN tile_dv - 2s AND tile_dv + 15s,
+                        -- but only this orientation is an indexable range.
+                        -- The other way round Postgres builds the full
+                        -- chart-views x dashboard-views cross product.
+                        AND tile_dv.timestamp BETWEEN acv.timestamp - interval '15 seconds'
+                                                  AND acv.timestamp + interval '2 seconds'
                   )
                 UNION ALL
                 SELECT 'dashboard' AS content_type,
                        adv.dashboard_uuid AS content_uuid,
                        adv.timestamp AS viewed_at
                 FROM analytics_dashboard_views adv
-                JOIN dashboards d ON d.dashboard_uuid = adv.dashboard_uuid
-                JOIN spaces s ON s.space_id = d.space_id
-                JOIN projects p ON p.project_id = s.project_id
                 WHERE adv.user_uuid = :userUuid
-                  AND p.project_uuid = :projectUuid
-                  AND d.deleted_at IS NULL
-                  AND s.deleted_at IS NULL
-            ) views
-            GROUP BY content_type, content_uuid
-            ORDER BY viewed_at DESC
+            ),
+            recent AS MATERIALIZED (
+                SELECT content_type, content_uuid, max(viewed_at) AS viewed_at
+                FROM raw_views
+                GROUP BY content_type, content_uuid
+            )
+            SELECT r.content_type, r.content_uuid, r.viewed_at
+            FROM recent r
+            WHERE (
+                    r.content_type = 'chart'
+                    AND EXISTS (
+                        SELECT 1
+                        FROM saved_queries sq
+                        JOIN spaces s ON s.space_id = sq.space_id
+                        JOIN projects p ON p.project_id = s.project_id
+                        WHERE sq.saved_query_uuid = r.content_uuid
+                          AND p.project_uuid = :projectUuid
+                          AND sq.deleted_at IS NULL
+                          AND s.deleted_at IS NULL
+                    )
+                  )
+               OR (
+                    r.content_type = 'dashboard'
+                    AND EXISTS (
+                        SELECT 1
+                        FROM dashboards d
+                        JOIN spaces s ON s.space_id = d.space_id
+                        JOIN projects p ON p.project_id = s.project_id
+                        WHERE d.dashboard_uuid = r.content_uuid
+                          AND p.project_uuid = :projectUuid
+                          AND d.deleted_at IS NULL
+                          AND s.deleted_at IS NULL
+                    )
+                  )
+            ORDER BY r.viewed_at DESC
             LIMIT :limit
             `,
             { userUuid, projectUuid, limit },


### PR DESCRIPTION
## Problem

`GET /projects/:uuid/homepage/recently-viewed` backs the day-0 homepage and the recently-viewed collection block, so it runs on homepage load. The query had two problems:

1. **No index on `user_uuid`.** `analytics_chart_views` and `analytics_dashboard_views` are indexed on `chart_uuid` / `dashboard_uuid` and the primary key only, but the query filters on `user_uuid`.
2. **The tile-suppression `NOT EXISTS` was not indexable.** It was written as `acv.timestamp BETWEEN tile_dv.timestamp - interval '2 seconds' AND tile_dv.timestamp + interval '15 seconds'` — outer column on the left, so Postgres cannot turn it into a range scan and builds the full chart-views × dashboard-views cross product for that viewer.

The second one dominates, and it is **quadratic in a single user's history** rather than linear in table size — the heaviest users hurt worst.

## Measurements

Seeded 3M chart views / 500k dashboard views over 44 users, warm runs:

| Variant | Time |
|---|---|
| Before | **~60,000 ms** |
| Index on `(user_uuid, timestamp)` only | ~63,000 ms |
| Index + query restructure (this PR) | **~675 ms** |

The index alone is worth nothing — the plan showed `Nested Loop Anti Join … Rows Removed by Join Filter: 500,201,729`. Both parts are needed.

## Changes

- Migration adding `(user_uuid, timestamp DESC)` to both analytics view tables, built `CONCURRENTLY` with `transaction: false`, idempotent (drops a leftover `INVALID` index before rebuilding) and `statement_timeout = 0` so a configured timeout can't abort the build holding the migration lock. Verified up / rollback / re-apply.
- Read the viewer's history off those indexes first and apply the project filter afterwards. Joining the content tables up front made Postgres drive from `saved_queries` and re-scan every chart's entire view history.
- Flipped the suppression `BETWEEN` to the equivalent indexable orientation, with a comment so it doesn't get flipped back.

## Behaviour

Unchanged — no time window, no product change. Verified by differential testing old vs new across 8 rounds of randomised data covering the suppression window boundaries (offsets at -3s/-2s/-1s/0s/+14s/+15s/+16s around every dashboard view), soft-deleted charts, dashboards and spaces, cross-project content, and null/tagged/untagged contexts: 0 mismatches. The harness was mutation-tested — deliberately breaking the suppression window and the soft-delete filter produced 38 and 8 mismatches respectively, so it does detect divergence.

Also verified identical output on the 3M-row dataset.

## Follow-up (not in this PR)

The query still aggregates the viewer's entire lifetime history before `LIMIT`, so cost grows with account age. Bounding it to a 90-day window measured at ~120 ms, a further ~6×, but that is a user-visible change so it's left as a separate decision.

Relates: ZAP-621

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011QVjNt4KFNYVZKM7xSSpdq