### PR TITLE
feat(filters): support multiple discrete dates for date "is" filter

### DIFF
--- a/packages/common/src/utils/filters.test.ts
+++ b/packages/common/src/utils/filters.test.ts
@@ -21,6 +21,7 @@ import {
     createFilterRuleFromField,
     createFilterRuleFromModelRequiredFilterRule,
     getDashboardFilterRulesForTileAndReferences,
+    getFilterRuleFromFieldWithDefaultValue,
     getUnmetFilterRequirements,
     isEmptyDashboardFilterRule,
     isFilterRuleInQuery,
@@ -391,6 +392,68 @@ describe('createFilterRuleFromField — time-interval DATE dims', () => {
             'Asia/Tokyo',
         );
         expect(rule.values).toEqual(['2024-11-01']);
+    });
+});
+
+describe('getFilterRuleFromFieldWithDefaultValue — multiple date values', () => {
+    const dayDim = {
+        ...dimension('order_date', 'orders'),
+        type: DimensionType.DATE,
+        timeInterval: TimeFrames.DAY,
+    } as const;
+    const timestampDim = {
+        ...dimension('created_at', 'orders'),
+        type: DimensionType.TIMESTAMP,
+    } as const;
+
+    const buildRule = (
+        operator: FilterOperator,
+        field: typeof dayDim | typeof timestampDim,
+        values: unknown[],
+    ) => {
+        const rule: FilterRule = {
+            id: 'id',
+            operator,
+            target: { fieldId: 'order_date' },
+        };
+        return getFilterRuleFromFieldWithDefaultValue(field, rule, values);
+    };
+
+    test.each([FilterOperator.EQUALS, FilterOperator.NOT_EQUALS])(
+        'keeps every date value for %s',
+        (operator) => {
+            expect(
+                buildRule(operator, dayDim, [
+                    '2024-11-01',
+                    '2024-11-07',
+                    '2024-12-24',
+                ]).values,
+            ).toEqual(['2024-11-01', '2024-11-07', '2024-12-24']);
+        },
+    );
+
+    test('keeps every timestamp value for equals', () => {
+        expect(
+            buildRule(FilterOperator.EQUALS, timestampDim, [
+                '2024-11-01T10:00:00Z',
+                '2024-11-07T10:00:00Z',
+            ]).values,
+        ).toHaveLength(2);
+    });
+
+    test('single-value operators still take only the first value', () => {
+        expect(
+            buildRule(FilterOperator.GREATER_THAN, dayDim, [
+                '2024-11-01',
+                '2024-11-07',
+            ]).values,
+        ).toEqual(['2024-11-01']);
+    });
+
+    test('existing single-value equals filters are unchanged', () => {
+        expect(
+            buildRule(FilterOperator.EQUALS, dayDim, ['2024-11-01']).values,
+        ).toEqual(['2024-11-01']);
     });
 });
 

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -255,6 +255,15 @@ export const getFilterRuleWithDefaultValue = <T extends FilterRule>(
             case FilterType.DATE: {
                 const value = values ? values[0] : undefined;
 
+                // equals/notEquals match any of the values (see
+                // renderDateOrTimestampFilterSql), so keep the whole list.
+                // Every other date operator takes a single value.
+                const keepsMultipleDateValues =
+                    !!values &&
+                    values.length > 1 &&
+                    (filterRule.operator === FilterOperator.EQUALS ||
+                        filterRule.operator === FilterOperator.NOT_EQUALS);
+
                 const isTimestamp =
                     !field ||
                     (isCustomSqlDimension(field)
@@ -281,48 +290,20 @@ export const getFilterRuleWithDefaultValue = <T extends FilterRule>(
                         completed: false,
                     } as DateFilterRule['settings'];
                 } else if (isTimestamp) {
-                    const valueIsDate =
-                        value !== undefined && typeof value !== 'number';
-
                     // NOTE: Using .format() makes this a standard ISO string
-                    const timestampValue = valueIsDate
-                        ? dayjs(value).format()
-                        : dayjs().format();
+                    const toTimestampValue = (rawValue: AnyType) =>
+                        rawValue !== undefined && typeof rawValue !== 'number'
+                            ? dayjs(rawValue).format()
+                            : dayjs().format();
 
-                    filterRuleDefaults.values = [timestampValue];
+                    filterRuleDefaults.values = keepsMultipleDateValues
+                        ? (values ?? []).map(toTimestampValue)
+                        : [toTimestampValue(value)];
                 } else {
-                    const valueIsDate =
-                        value !== undefined && typeof value !== 'number';
-
-                    const defaultTimeIntervalValues: Record<
-                        string,
-                        moment.Moment
-                    > = {
-                        [TimeFrames.DAY]: moment(),
-                        [TimeFrames.WEEK]: moment(
-                            valueIsDate ? value : undefined,
-                        ).startOf('week'),
-                        [TimeFrames.QUARTER]: moment(
-                            valueIsDate ? value : undefined,
-                        ).startOf('quarter'),
-                        [TimeFrames.MONTH]: moment(
-                            valueIsDate ? value : undefined,
-                        ).startOf('month'),
-                        [TimeFrames.YEAR]: moment(
-                            valueIsDate ? value : undefined,
-                        ).startOf('year'),
-                    };
-
                     const fieldTimeInterval =
                         isDimension(field) && field.timeInterval
                             ? field.timeInterval
                             : undefined;
-
-                    const defaultDate =
-                        fieldTimeInterval &&
-                        defaultTimeIntervalValues[fieldTimeInterval]
-                            ? defaultTimeIntervalValues[fieldTimeInterval]
-                            : moment();
 
                     // Shift TIMESTAMP-base time-interval dims into the project
                     // TZ before extracting the date. Plain DATE / DATE-base
@@ -331,21 +312,48 @@ export const getFilterRuleWithDefaultValue = <T extends FilterRule>(
                         ? timezone || 'UTC'
                         : 'UTC';
 
-                    const dateValue = valueIsDate
-                        ? formatDate(
-                              moment
-                                  .utc(value)
-                                  .tz(effectiveZone)
-                                  .format('YYYY-MM-DD'),
-                              // For QUARTER, we don't want to use the field's time interval(YYYY-[Q]Q) because the date is already in the correct format when generating the SQL
-                              fieldTimeInterval === TimeFrames.QUARTER
-                                  ? undefined
-                                  : fieldTimeInterval, // Use the field's time interval if it has one
-                              false,
-                          )
-                        : formatDate(defaultDate, undefined, false);
+                    const toDateValue = (rawValue: AnyType) => {
+                        const valueIsDate =
+                            rawValue !== undefined &&
+                            typeof rawValue !== 'number';
 
-                    filterRuleDefaults.values = [dateValue];
+                        if (valueIsDate) {
+                            return formatDate(
+                                moment
+                                    .utc(rawValue)
+                                    .tz(effectiveZone)
+                                    .format('YYYY-MM-DD'),
+                                // For QUARTER, we don't want to use the field's time interval(YYYY-[Q]Q) because the date is already in the correct format when generating the SQL
+                                fieldTimeInterval === TimeFrames.QUARTER
+                                    ? undefined
+                                    : fieldTimeInterval, // Use the field's time interval if it has one
+                                false,
+                            );
+                        }
+
+                        const defaultTimeIntervalValues: Record<
+                            string,
+                            moment.Moment
+                        > = {
+                            [TimeFrames.DAY]: moment(),
+                            [TimeFrames.WEEK]: moment().startOf('week'),
+                            [TimeFrames.QUARTER]: moment().startOf('quarter'),
+                            [TimeFrames.MONTH]: moment().startOf('month'),
+                            [TimeFrames.YEAR]: moment().startOf('year'),
+                        };
+
+                        const defaultDate =
+                            fieldTimeInterval &&
+                            defaultTimeIntervalValues[fieldTimeInterval]
+                                ? defaultTimeIntervalValues[fieldTimeInterval]
+                                : moment();
+
+                        return formatDate(defaultDate, undefined, false);
+                    };
+
+                    filterRuleDefaults.values = keepsMultipleDateValues
+                        ? (values ?? []).map(toDateValue)
+                        : [toDateValue(value)];
                 }
                 break;
             }

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -28,6 +28,11 @@ import FilterDateTimePicker from './FilterDateTimePicker';
 import FilterDateTimeRangePicker from './FilterDateTimeRangePicker';
 import FilterMonthAndYearPicker from './FilterMonthAndYearPicker';
 import FilterMultiDatePicker from './FilterMultiDatePicker';
+import {
+    getCoarseDateTimeFrame,
+    getStoredValueTimeFrame,
+    type MultiDateTimeFrame,
+} from './FilterMultiDatePicker.utils';
 import FilterPeriodToDateSelect from './FilterPeriodToDateSelect';
 import FilterQuarterPicker from './FilterQuarterPicker';
 import FilterUnitOfTimeAutoComplete from './FilterUnitOfTimeAutoComplete';
@@ -50,7 +55,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
     }
 
     const isFilterRuleDisabled = rule.disabled && !rule.values;
-    // Only the day-granularity equals/notEquals input takes several dates
+    // Only the equals/notEquals inputs take several values
     const placeholder = getPlaceholderByFilterTypeAndOperator({
         type: filterType,
         operator: rule.operator,
@@ -65,6 +70,41 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
     });
     const invalidDateFilterValue = getInvalidDateFilterValue(rule.values);
 
+    // equals/notEquals match any of the values, so they accept a list of
+    // discrete values at whatever grain the field is
+    const isMultiValueDateOperator =
+        rule.operator === FilterOperator.EQUALS ||
+        rule.operator === FilterOperator.NOT_EQUALS;
+
+    const renderMultiDatePicker = (timeFrame: MultiDateTimeFrame) => {
+        const storedTimeFrame = getStoredValueTimeFrame(timeFrame);
+
+        return (
+            <FilterMultiDatePicker
+                timeFrame={timeFrame}
+                disabled={disabled}
+                placeholder={multiDatePlaceholder}
+                firstDayOfWeek={getFirstDayOfWeek(startOfWeek)}
+                popoverProps={popoverProps}
+                data-autofocus
+                invalidValue={invalidDateFilterValue}
+                values={(rule.values ?? [])
+                    .map((value) =>
+                        parseFilterDateValue(value, storedTimeFrame),
+                    )
+                    .filter((value): value is Date => value !== null)}
+                onChange={(dates: Date[]) => {
+                    onChange({
+                        ...rule,
+                        values: dates.map((date) =>
+                            formatDate(date, storedTimeFrame),
+                        ),
+                    });
+                }}
+            />
+        );
+    };
+
     switch (rule.operator) {
         case FilterOperator.EQUALS:
         case FilterOperator.NOT_EQUALS:
@@ -73,6 +113,28 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
         case FilterOperator.LESS_THAN:
         case FilterOperator.LESS_THAN_OR_EQUAL:
             if (isDimension(field) && field.timeInterval) {
+                const coarseTimeFrame = getCoarseDateTimeFrame(
+                    field.timeInterval,
+                );
+
+                if (coarseTimeFrame && isMultiValueDateOperator) {
+                    return coarseTimeFrame === TimeFrames.WEEK ? (
+                        <Flex align="center" gap="xs" w="100%">
+                            <Text
+                                c="dimmed"
+                                style={{ whiteSpace: 'nowrap' }}
+                                size="xs"
+                            >
+                                week commencing
+                            </Text>
+
+                            {renderMultiDatePicker(coarseTimeFrame)}
+                        </Flex>
+                    ) : (
+                        renderMultiDatePicker(coarseTimeFrame)
+                    );
+                }
+
                 switch (field.timeInterval.toUpperCase()) {
                     case TimeFrames.WEEK:
                         return (
@@ -234,35 +296,8 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                 );
             }
 
-            // equals/notEquals match any of the values, so day-granularity date
-            // dimensions accept a list of discrete dates
-            if (
-                rule.operator === FilterOperator.EQUALS ||
-                rule.operator === FilterOperator.NOT_EQUALS
-            ) {
-                return (
-                    <FilterMultiDatePicker
-                        disabled={disabled}
-                        placeholder={multiDatePlaceholder}
-                        firstDayOfWeek={getFirstDayOfWeek(startOfWeek)}
-                        popoverProps={popoverProps}
-                        data-autofocus
-                        invalidValue={invalidDateFilterValue}
-                        values={(rule.values ?? [])
-                            .map((value) =>
-                                parseFilterDateValue(value, TimeFrames.DAY),
-                            )
-                            .filter((value): value is Date => value !== null)}
-                        onChange={(dates: Date[]) => {
-                            onChange({
-                                ...rule,
-                                values: dates.map((date) =>
-                                    formatDate(date, TimeFrames.DAY),
-                                ),
-                            });
-                        }}
-                    />
-                );
+            if (isMultiValueDateOperator) {
+                return renderMultiDatePicker(TimeFrames.DAY);
             }
 
             return (

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -27,6 +27,7 @@ import FilterDateRangePicker from './FilterDateRangePicker';
 import FilterDateTimePicker from './FilterDateTimePicker';
 import FilterDateTimeRangePicker from './FilterDateTimeRangePicker';
 import FilterMonthAndYearPicker from './FilterMonthAndYearPicker';
+import FilterMultiDatePicker from './FilterMultiDatePicker';
 import FilterPeriodToDateSelect from './FilterPeriodToDateSelect';
 import FilterQuarterPicker from './FilterQuarterPicker';
 import FilterUnitOfTimeAutoComplete from './FilterUnitOfTimeAutoComplete';
@@ -48,10 +49,19 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
         throw new Error('DateFilterInputs expects a FilterRule');
     }
 
+    const isFilterRuleDisabled = rule.disabled && !rule.values;
+    // Only the day-granularity equals/notEquals input takes several dates
     const placeholder = getPlaceholderByFilterTypeAndOperator({
         type: filterType,
         operator: rule.operator,
-        disabled: rule.disabled && !rule.values,
+        disabled: isFilterRuleDisabled,
+        singleValue: true,
+    });
+    const multiDatePlaceholder = getPlaceholderByFilterTypeAndOperator({
+        type: filterType,
+        operator: rule.operator,
+        disabled: isFilterRuleDisabled,
+        singleValue: false,
     });
     const invalidDateFilterValue = getInvalidDateFilterValue(rule.values);
 
@@ -218,6 +228,37 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                                 ...rule,
                                 // format as an ISO string, not for display
                                 values: v === null ? [] : [dayjs(v).format()],
+                            });
+                        }}
+                    />
+                );
+            }
+
+            // equals/notEquals match any of the values, so day-granularity date
+            // dimensions accept a list of discrete dates
+            if (
+                rule.operator === FilterOperator.EQUALS ||
+                rule.operator === FilterOperator.NOT_EQUALS
+            ) {
+                return (
+                    <FilterMultiDatePicker
+                        disabled={disabled}
+                        placeholder={multiDatePlaceholder}
+                        firstDayOfWeek={getFirstDayOfWeek(startOfWeek)}
+                        popoverProps={popoverProps}
+                        data-autofocus
+                        invalidValue={invalidDateFilterValue}
+                        values={(rule.values ?? [])
+                            .map((value) =>
+                                parseFilterDateValue(value, TimeFrames.DAY),
+                            )
+                            .filter((value): value is Date => value !== null)}
+                        onChange={(dates: Date[]) => {
+                            onChange({
+                                ...rule,
+                                values: dates.map((date) =>
+                                    formatDate(date, TimeFrames.DAY),
+                                ),
                             });
                         }}
                     />

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -70,12 +70,6 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
     });
     const invalidDateFilterValue = getInvalidDateFilterValue(rule.values);
 
-    // equals/notEquals match any of the values, so they accept a list of
-    // discrete values at whatever grain the field is
-    const isMultiValueDateOperator =
-        rule.operator === FilterOperator.EQUALS ||
-        rule.operator === FilterOperator.NOT_EQUALS;
-
     const renderMultiDatePicker = (timeFrame: MultiDateTimeFrame) => {
         const storedTimeFrame = getStoredValueTimeFrame(timeFrame);
 
@@ -105,19 +99,47 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
         );
     };
 
+    const renderTimestampPicker = () => {
+        const value =
+            rule.values && rule.values[0] && !invalidDateFilterValue
+                ? dayjs(rule?.values?.[0]).toDate()
+                : dayjs().toDate();
+
+        return (
+            <FilterDateTimePicker
+                disabled={disabled}
+                placeholder={placeholder}
+                data-autofocus
+                withSeconds
+                // FIXME: mantine v7
+                // mantine does not set the first day of the week based on the locale
+                // so we need to do it manually and always pass it as a prop
+                firstDayOfWeek={getFirstDayOfWeek(startOfWeek)}
+                popoverProps={popoverProps}
+                invalidValue={invalidDateFilterValue}
+                value={value}
+                onChange={(v: Date | null) => {
+                    onChange({
+                        ...rule,
+                        // format as an ISO string, not for display
+                        values: v === null ? [] : [dayjs(v).format()],
+                    });
+                }}
+            />
+        );
+    };
+
     switch (rule.operator) {
+        // equals/notEquals match any of the values, so they accept a list of
+        // discrete values at whatever grain the field is
         case FilterOperator.EQUALS:
-        case FilterOperator.NOT_EQUALS:
-        case FilterOperator.GREATER_THAN:
-        case FilterOperator.GREATER_THAN_OR_EQUAL:
-        case FilterOperator.LESS_THAN:
-        case FilterOperator.LESS_THAN_OR_EQUAL:
+        case FilterOperator.NOT_EQUALS: {
             if (isDimension(field) && field.timeInterval) {
                 const coarseTimeFrame = getCoarseDateTimeFrame(
                     field.timeInterval,
                 );
 
-                if (coarseTimeFrame && isMultiValueDateOperator) {
+                if (coarseTimeFrame) {
                     return coarseTimeFrame === TimeFrames.WEEK ? (
                         <Flex align="center" gap="xs" w="100%">
                             <Text
@@ -134,7 +156,21 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                         renderMultiDatePicker(coarseTimeFrame)
                     );
                 }
+                // day-grain intervals get the day picker below; hour-grain
+                // and raw intervals are timestamp-typed
+            }
 
+            if (isTimestamp) {
+                return renderTimestampPicker();
+            }
+
+            return renderMultiDatePicker(TimeFrames.DAY);
+        }
+        case FilterOperator.GREATER_THAN:
+        case FilterOperator.GREATER_THAN_OR_EQUAL:
+        case FilterOperator.LESS_THAN:
+        case FilterOperator.LESS_THAN_OR_EQUAL:
+            if (isDimension(field) && field.timeInterval) {
                 switch (field.timeInterval.toUpperCase()) {
                     case TimeFrames.WEEK:
                         return (
@@ -267,37 +303,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
             }
 
             if (isTimestamp) {
-                const value =
-                    rule.values && rule.values[0] && !invalidDateFilterValue
-                        ? dayjs(rule?.values?.[0]).toDate()
-                        : dayjs().toDate();
-
-                return (
-                    <FilterDateTimePicker
-                        disabled={disabled}
-                        placeholder={placeholder}
-                        data-autofocus
-                        withSeconds
-                        // FIXME: mantine v7
-                        // mantine does not set the first day of the week based on the locale
-                        // so we need to do it manually and always pass it as a prop
-                        firstDayOfWeek={getFirstDayOfWeek(startOfWeek)}
-                        popoverProps={popoverProps}
-                        invalidValue={invalidDateFilterValue}
-                        value={value}
-                        onChange={(v: Date | null) => {
-                            onChange({
-                                ...rule,
-                                // format as an ISO string, not for display
-                                values: v === null ? [] : [dayjs(v).format()],
-                            });
-                        }}
-                    />
-                );
-            }
-
-            if (isMultiValueDateOperator) {
-                return renderMultiDatePicker(TimeFrames.DAY);
+                return renderTimestampPicker();
             }
 
             return (

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiDateCalendar.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiDateCalendar.tsx
@@ -1,0 +1,223 @@
+import { assertUnreachable, TimeFrames } from '@lightdash/common';
+import {
+    DatePicker,
+    MonthPicker,
+    YearPicker,
+    type DayOfWeek,
+} from '@mantine/dates';
+import dayjs from 'dayjs';
+import { useState, type FC } from 'react';
+import {
+    endOfWeek,
+    isInWeekRange,
+    startOfWeek,
+} from '../utils/filterDateUtils';
+import {
+    toggleTimeFrameValue,
+    type MultiDateTimeFrame,
+} from './FilterMultiDatePicker.utils';
+import quarterClasses from './FilterQuarterPicker.module.css';
+import { formatMantineDate, parseMantineDate } from './mantineDateAdapter';
+
+type Props = {
+    timeFrame: MultiDateTimeFrame;
+    values: Date[];
+    firstDayOfWeek: DayOfWeek;
+    onChange: (values: Date[]) => void;
+};
+
+const QUARTER_MONTHS = [
+    [0, 1, 2],
+    [3, 4, 5],
+    [6, 7, 8],
+    [9, 10, 11],
+];
+
+const getQuarterMonths = (month: number): number[] =>
+    QUARTER_MONTHS.find((months) => months.includes(month)) ??
+    QUARTER_MONTHS[0];
+
+/**
+ * Weeks have no multi-select calendar of their own, so days are selected one at
+ * a time and snapped to the week they belong to.
+ */
+const MultiWeekCalendar: FC<Omit<Props, 'timeFrame'>> = ({
+    values,
+    firstDayOfWeek,
+    onChange,
+}) => {
+    const [hoveredDate, setHoveredDate] = useState<Date | null>(null);
+
+    const getDayProps = (mantineValue: string) => {
+        const date = parseMantineDate(mantineValue);
+        if (!date) return {};
+
+        const isSelected = values.some((value) =>
+            isInWeekRange(date, value, firstDayOfWeek),
+        );
+        const isInRange =
+            isSelected || isInWeekRange(date, hoveredDate, firstDayOfWeek);
+
+        return {
+            onMouseEnter: () => setHoveredDate(date),
+            onMouseLeave: () => setHoveredDate(null),
+            inRange: isInRange,
+            firstInRange: isInRange
+                ? dayjs(startOfWeek(date, firstDayOfWeek)).isSame(date)
+                : false,
+            lastInRange: isInRange
+                ? dayjs(endOfWeek(date, firstDayOfWeek)).isSame(date)
+                : false,
+            selected: isSelected,
+        };
+    };
+
+    return (
+        <DatePicker
+            firstDayOfWeek={firstDayOfWeek}
+            defaultDate={formatMantineDate(values[0] ?? null) ?? undefined}
+            value={null}
+            getDayProps={getDayProps}
+            onChange={(mantineValue) => {
+                const date = parseMantineDate(mantineValue);
+                if (!date) return;
+                onChange(
+                    toggleTimeFrameValue(
+                        values,
+                        date,
+                        TimeFrames.WEEK,
+                        firstDayOfWeek,
+                    ),
+                );
+            }}
+        />
+    );
+};
+
+/**
+ * Quarters are picked from a month calendar where every month of a quarter
+ * highlights and toggles together.
+ */
+const MultiQuarterCalendar: FC<Omit<Props, 'timeFrame'>> = ({
+    values,
+    firstDayOfWeek,
+    onChange,
+}) => {
+    const [hoveredMonth, setHoveredMonth] = useState<Date | null>(null);
+
+    const getMonthControlProps = (mantineValue: string) => {
+        const date = parseMantineDate(mantineValue);
+        if (!date) return {};
+
+        const isSelected = values.some(
+            (value) =>
+                value.getFullYear() === date.getFullYear() &&
+                getQuarterMonths(value.getMonth()).includes(date.getMonth()),
+        );
+        const isHovered =
+            !isSelected &&
+            hoveredMonth !== null &&
+            hoveredMonth.getFullYear() === date.getFullYear() &&
+            getQuarterMonths(hoveredMonth.getMonth()).includes(date.getMonth());
+
+        return {
+            className: quarterClasses.monthControl,
+            'data-quarter-selected': isSelected || undefined,
+            'data-quarter-hovered': isHovered || undefined,
+            onMouseEnter: () => setHoveredMonth(date),
+            onMouseLeave: () => setHoveredMonth(null),
+        };
+    };
+
+    return (
+        <MonthPicker
+            defaultDate={formatMantineDate(values[0] ?? null) ?? undefined}
+            value={null}
+            getMonthControlProps={getMonthControlProps}
+            onMouseLeave={() => setHoveredMonth(null)}
+            onChange={(mantineValue) => {
+                const date = parseMantineDate(mantineValue);
+                if (!date) return;
+                onChange(
+                    toggleTimeFrameValue(
+                        values,
+                        date,
+                        TimeFrames.QUARTER,
+                        firstDayOfWeek,
+                    ),
+                );
+            }}
+        />
+    );
+};
+
+const FilterMultiDateCalendar: FC<Props> = ({
+    timeFrame,
+    values,
+    firstDayOfWeek,
+    onChange,
+}) => {
+    const mantineValues = values
+        .map(formatMantineDate)
+        .filter((value): value is string => value !== null);
+
+    const handleChange = (nextValues: string[]) => {
+        onChange(
+            nextValues
+                .map(parseMantineDate)
+                .filter((date): date is Date => date !== null),
+        );
+    };
+
+    switch (timeFrame) {
+        case TimeFrames.DAY:
+            return (
+                <DatePicker
+                    type="multiple"
+                    firstDayOfWeek={firstDayOfWeek}
+                    // open on the earliest selected date rather than today
+                    defaultDate={mantineValues[0]}
+                    value={mantineValues}
+                    onChange={handleChange}
+                />
+            );
+        case TimeFrames.WEEK:
+            return (
+                <MultiWeekCalendar
+                    values={values}
+                    firstDayOfWeek={firstDayOfWeek}
+                    onChange={onChange}
+                />
+            );
+        case TimeFrames.MONTH:
+            return (
+                <MonthPicker
+                    type="multiple"
+                    defaultDate={mantineValues[0]}
+                    value={mantineValues}
+                    onChange={handleChange}
+                />
+            );
+        case TimeFrames.QUARTER:
+            return (
+                <MultiQuarterCalendar
+                    values={values}
+                    firstDayOfWeek={firstDayOfWeek}
+                    onChange={onChange}
+                />
+            );
+        case TimeFrames.YEAR:
+            return (
+                <YearPicker
+                    type="multiple"
+                    defaultDate={mantineValues[0]}
+                    value={mantineValues}
+                    onChange={handleChange}
+                />
+            );
+        default:
+            return assertUnreachable(timeFrame, 'Unknown date filter grain');
+    }
+};
+
+export default FilterMultiDateCalendar;

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiDatePicker.module.css
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiDatePicker.module.css
@@ -1,0 +1,4 @@
+.pillsInput {
+    max-height: 350px;
+    overflow-y: auto;
+}

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiDatePicker.test.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiDatePicker.test.tsx
@@ -43,9 +43,9 @@ describe('FilterMultiDatePicker', () => {
         );
 
         expect(getSelectedDates()).toEqual([
-            '2024-12-24',
-            '2024-11-01',
-            '2024-11-07',
+            'December 24, 2024',
+            'November 1, 2024',
+            'November 7, 2024',
         ]);
     });
 
@@ -56,7 +56,10 @@ describe('FilterMultiDatePicker', () => {
 
         await userEvent.type(screen.getByRole('textbox'), '2024-11-07{Enter}');
 
-        expect(getSelectedDates()).toEqual(['2024-11-01', '2024-11-07']);
+        expect(getSelectedDates()).toEqual([
+            'November 1, 2024',
+            'November 7, 2024',
+        ]);
     });
 
     it('ignores an unparseable typed value', async () => {
@@ -82,10 +85,13 @@ describe('FilterMultiDatePicker', () => {
             screen.findByRole('button', { name: '7 November 2024' });
 
         await userEvent.click(await getDayCell());
-        expect(getSelectedDates()).toEqual(['2024-11-01', '2024-11-07']);
+        expect(getSelectedDates()).toEqual([
+            'November 1, 2024',
+            'November 7, 2024',
+        ]);
 
         await userEvent.click(await getDayCell());
-        expect(getSelectedDates()).toEqual(['2024-11-01']);
+        expect(getSelectedDates()).toEqual(['November 1, 2024']);
     });
 
     it('removes a single date without dropping the others', async () => {
@@ -96,9 +102,9 @@ describe('FilterMultiDatePicker', () => {
         );
 
         await userEvent.click(
-            screen.getByRole('button', { name: 'Remove 2024-11-01' }),
+            screen.getByRole('button', { name: 'Remove November 1, 2024' }),
         );
 
-        expect(getSelectedDates()).toEqual(['2024-11-07']);
+        expect(getSelectedDates()).toEqual(['November 7, 2024']);
     });
 });

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiDatePicker.test.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiDatePicker.test.tsx
@@ -1,8 +1,8 @@
 import { TimeFrames } from '@lightdash/common';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../../testing/testUtils';
 import FilterMultiDatePicker from './FilterMultiDatePicker';
 import { type MultiDateTimeFrame } from './FilterMultiDatePicker.utils';
@@ -97,6 +97,30 @@ describe('FilterMultiDatePicker', () => {
 
         await userEvent.click(await getDayCell());
         expect(getSelectedDates()).toEqual(['November 1, 2024']);
+    });
+
+    it('closes the calendar when clicking outside', async () => {
+        const onClose = vi.fn();
+        renderWithProviders(
+            <FilterMultiDatePicker
+                timeFrame={TimeFrames.DAY}
+                placeholder={PLACEHOLDER}
+                firstDayOfWeek={1}
+                values={[]}
+                onChange={vi.fn()}
+                popoverProps={{ onClose }}
+            />,
+        );
+
+        await userEvent.click(screen.getByRole('textbox'));
+        expect(screen.getByRole('dialog')).toBeVisible();
+
+        await userEvent.click(document.body);
+
+        await waitFor(() =>
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument(),
+        );
+        expect(onClose).toHaveBeenCalledOnce();
     });
 
     it('removes a single date without dropping the others', async () => {

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiDatePicker.test.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiDatePicker.test.tsx
@@ -1,20 +1,25 @@
+import { TimeFrames } from '@lightdash/common';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
 import { describe, expect, it } from 'vitest';
 import { renderWithProviders } from '../../../../testing/testUtils';
 import FilterMultiDatePicker from './FilterMultiDatePicker';
+import { type MultiDateTimeFrame } from './FilterMultiDatePicker.utils';
 
 const PLACEHOLDER = 'Select dates';
 
 const ControlledPicker = ({
     initialValues = [],
+    timeFrame = TimeFrames.DAY,
 }: {
     initialValues?: Date[];
+    timeFrame?: MultiDateTimeFrame;
 }) => {
     const [values, setValues] = useState<Date[]>(initialValues);
     return (
         <FilterMultiDatePicker
+            timeFrame={timeFrame}
             placeholder={PLACEHOLDER}
             firstDayOfWeek={1}
             values={values}
@@ -43,9 +48,9 @@ describe('FilterMultiDatePicker', () => {
         );
 
         expect(getSelectedDates()).toEqual([
-            'December 24, 2024',
             'November 1, 2024',
             'November 7, 2024',
+            'December 24, 2024',
         ]);
     });
 
@@ -106,5 +111,172 @@ describe('FilterMultiDatePicker', () => {
         );
 
         expect(getSelectedDates()).toEqual(['November 7, 2024']);
+    });
+
+    describe('week grain', () => {
+        it('snaps selected days to the start of their week', async () => {
+            renderWithProviders(
+                <ControlledPicker
+                    timeFrame={TimeFrames.WEEK}
+                    initialValues={[new Date(2024, 10, 18)]}
+                />,
+            );
+
+            await userEvent.click(screen.getByRole('textbox'));
+            await userEvent.click(
+                await screen.findByRole('button', { name: '7 November 2024' }),
+            );
+
+            // firstDayOfWeek is Monday, so Thursday 7 Nov snaps to Monday 4 Nov
+            expect(getSelectedDates()).toEqual([
+                'November 4, 2024',
+                'November 18, 2024',
+            ]);
+        });
+
+        it('deselects a week when any of its days is clicked again', async () => {
+            renderWithProviders(
+                <ControlledPicker
+                    timeFrame={TimeFrames.WEEK}
+                    initialValues={[new Date(2024, 10, 4)]}
+                />,
+            );
+
+            await userEvent.click(screen.getByRole('textbox'));
+            await userEvent.click(
+                await screen.findByRole('button', { name: '6 November 2024' }),
+            );
+
+            expect(getSelectedDates()).toEqual([]);
+        });
+    });
+
+    describe('month grain', () => {
+        it('labels values as month and year', () => {
+            renderWithProviders(
+                <ControlledPicker
+                    timeFrame={TimeFrames.MONTH}
+                    initialValues={[
+                        new Date(2024, 10, 12),
+                        new Date(2024, 0, 1),
+                    ]}
+                />,
+            );
+
+            expect(getSelectedDates()).toEqual([
+                'January 2024',
+                'November 2024',
+            ]);
+        });
+
+        it('toggles months in the calendar popover', async () => {
+            renderWithProviders(
+                <ControlledPicker
+                    timeFrame={TimeFrames.MONTH}
+                    initialValues={[new Date(2024, 0, 1)]}
+                />,
+            );
+
+            await userEvent.click(screen.getByRole('textbox'));
+            await userEvent.click(
+                await screen.findByRole('button', { name: 'Mar' }),
+            );
+
+            expect(getSelectedDates()).toEqual(['January 2024', 'March 2024']);
+        });
+
+        it('adds a typed month on Enter', async () => {
+            renderWithProviders(
+                <ControlledPicker timeFrame={TimeFrames.MONTH} />,
+            );
+
+            await userEvent.type(
+                screen.getByPlaceholderText(PLACEHOLDER),
+                '2024-11{Enter}',
+            );
+
+            expect(getSelectedDates()).toEqual(['November 2024']);
+        });
+    });
+
+    describe('quarter grain', () => {
+        it('snaps values to the start of their quarter', () => {
+            renderWithProviders(
+                <ControlledPicker
+                    timeFrame={TimeFrames.QUARTER}
+                    initialValues={[
+                        new Date(2024, 10, 12),
+                        new Date(2024, 1, 3),
+                    ]}
+                />,
+            );
+
+            expect(getSelectedDates()).toEqual(['2024-Q1', '2024-Q4']);
+        });
+
+        it('toggles a whole quarter from any of its months', async () => {
+            renderWithProviders(
+                <ControlledPicker
+                    timeFrame={TimeFrames.QUARTER}
+                    initialValues={[new Date(2024, 0, 1)]}
+                />,
+            );
+
+            await userEvent.click(screen.getByRole('textbox'));
+            await userEvent.click(
+                await screen.findByRole('button', { name: 'Aug' }),
+            );
+            expect(getSelectedDates()).toEqual(['2024-Q1', '2024-Q3']);
+
+            // a different month of the same quarter removes it again
+            await userEvent.click(screen.getByRole('button', { name: 'Sep' }));
+            expect(getSelectedDates()).toEqual(['2024-Q1']);
+        });
+
+        it('dedupes values that fall in the same quarter', () => {
+            renderWithProviders(
+                <ControlledPicker
+                    timeFrame={TimeFrames.QUARTER}
+                    initialValues={[
+                        new Date(2024, 9, 1),
+                        new Date(2024, 11, 31),
+                    ]}
+                />,
+            );
+
+            expect(getSelectedDates()).toEqual(['2024-Q4']);
+        });
+    });
+
+    describe('year grain', () => {
+        it('labels values as the year alone', () => {
+            renderWithProviders(
+                <ControlledPicker
+                    timeFrame={TimeFrames.YEAR}
+                    initialValues={[
+                        new Date(2025, 5, 2),
+                        new Date(2024, 10, 12),
+                    ]}
+                />,
+            );
+
+            expect(getSelectedDates()).toEqual(['2024', '2025']);
+        });
+
+        it('toggles years in the calendar popover', async () => {
+            renderWithProviders(
+                <ControlledPicker
+                    timeFrame={TimeFrames.YEAR}
+                    initialValues={[new Date(2024, 0, 1)]}
+                />,
+            );
+
+            await userEvent.click(screen.getByRole('textbox'));
+            await userEvent.click(
+                await screen.findByRole('button', { name: '2026' }),
+            );
+
+            expect(getSelectedDates()).toEqual(['2024', '2026']);
+        });
     });
 });

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiDatePicker.test.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiDatePicker.test.tsx
@@ -1,0 +1,104 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../../../testing/testUtils';
+import FilterMultiDatePicker from './FilterMultiDatePicker';
+
+const PLACEHOLDER = 'Select dates';
+
+const ControlledPicker = ({
+    initialValues = [],
+}: {
+    initialValues?: Date[];
+}) => {
+    const [values, setValues] = useState<Date[]>(initialValues);
+    return (
+        <FilterMultiDatePicker
+            placeholder={PLACEHOLDER}
+            firstDayOfWeek={1}
+            values={values}
+            onChange={setValues}
+        />
+    );
+};
+
+const getSelectedDates = () =>
+    screen
+        .queryAllByRole('button', { name: /^Remove/ })
+        .map((button) =>
+            button.getAttribute('aria-label')?.replace('Remove ', ''),
+        );
+
+describe('FilterMultiDatePicker', () => {
+    it('renders a pill per selected date, sorted ascending', () => {
+        renderWithProviders(
+            <ControlledPicker
+                initialValues={[
+                    new Date(2024, 11, 24),
+                    new Date(2024, 10, 1),
+                    new Date(2024, 10, 7),
+                ]}
+            />,
+        );
+
+        expect(getSelectedDates()).toEqual([
+            '2024-12-24',
+            '2024-11-01',
+            '2024-11-07',
+        ]);
+    });
+
+    it('adds a typed date on Enter and keeps existing values', async () => {
+        renderWithProviders(
+            <ControlledPicker initialValues={[new Date(2024, 10, 1)]} />,
+        );
+
+        await userEvent.type(screen.getByRole('textbox'), '2024-11-07{Enter}');
+
+        expect(getSelectedDates()).toEqual(['2024-11-01', '2024-11-07']);
+    });
+
+    it('ignores an unparseable typed value', async () => {
+        renderWithProviders(<ControlledPicker />);
+
+        await userEvent.type(
+            screen.getByPlaceholderText(PLACEHOLDER),
+            'not a date{Enter}',
+        );
+
+        expect(getSelectedDates()).toEqual([]);
+    });
+
+    it('toggles dates in the calendar popover', async () => {
+        renderWithProviders(
+            <ControlledPicker initialValues={[new Date(2024, 10, 1)]} />,
+        );
+
+        await userEvent.click(screen.getByRole('textbox'));
+
+        // the calendar opens on the month of the selected date, not today
+        const getDayCell = () =>
+            screen.findByRole('button', { name: '7 November 2024' });
+
+        await userEvent.click(await getDayCell());
+        expect(getSelectedDates()).toEqual(['2024-11-01', '2024-11-07']);
+
+        await userEvent.click(await getDayCell());
+        expect(getSelectedDates()).toEqual(['2024-11-01']);
+    });
+
+    it('removes a single date without dropping the others', async () => {
+        renderWithProviders(
+            <ControlledPicker
+                initialValues={[new Date(2024, 10, 1), new Date(2024, 10, 7)]}
+            />,
+        );
+
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Remove 2024-11-01' }),
+        );
+
+        expect(getSelectedDates()).toEqual(['2024-11-07']);
+    });
+});

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiDatePicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiDatePicker.tsx
@@ -2,6 +2,7 @@ import { TimeFrames } from '@lightdash/common';
 import { Pill, PillsInput, Popover } from '@mantine-8/core';
 import { DatePicker, type DayOfWeek } from '@mantine-8/dates';
 import { useDisclosure } from '@mantine-8/hooks';
+import dayjs from 'dayjs';
 import {
     useCallback,
     useMemo,
@@ -28,6 +29,12 @@ type Props = {
 
 const sortAscending = (dates: Date[]): Date[] =>
     [...dates].sort((a, b) => a.getTime() - b.getTime());
+
+// matches the single date input, which uses Mantine's default value format
+const DISPLAY_FORMAT = 'MMMM D, YYYY';
+
+const formatDisplayDate = (value: string): string =>
+    dayjs(value).format(DISPLAY_FORMAT);
 
 /**
  * Multi-value date picker for the "is" / "is not" operators, which match any of
@@ -165,11 +172,13 @@ const FilterMultiDatePicker: FC<Props> = ({
                                 disabled={disabled}
                                 onRemove={() => handleRemove(value)}
                                 removeButtonProps={{
-                                    'aria-label': `Remove ${value}`,
+                                    'aria-label': `Remove ${formatDisplayDate(
+                                        value,
+                                    )}`,
                                     'aria-hidden': false,
                                 }}
                             >
-                                {value}
+                                {formatDisplayDate(value)}
                             </Pill>
                         ))}
                         <PillsInput.Field

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiDatePicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiDatePicker.tsx
@@ -1,7 +1,7 @@
 import { TimeFrames } from '@lightdash/common';
-import { Pill, PillsInput, Popover } from '@mantine-8/core';
-import { DatePicker, type DayOfWeek } from '@mantine-8/dates';
-import { useDisclosure } from '@mantine-8/hooks';
+import { Pill, PillsInput, Popover } from '@mantine/core';
+import { DatePicker, type DayOfWeek } from '@mantine/dates';
+import { useDisclosure } from '@mantine/hooks';
 import dayjs from 'dayjs';
 import {
     useCallback,

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiDatePicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiDatePicker.tsx
@@ -1,0 +1,208 @@
+import { TimeFrames } from '@lightdash/common';
+import { Pill, PillsInput, Popover } from '@mantine-8/core';
+import { DatePicker, type DayOfWeek } from '@mantine-8/dates';
+import { useDisclosure } from '@mantine-8/hooks';
+import {
+    useCallback,
+    useMemo,
+    useState,
+    type FC,
+    type KeyboardEvent,
+} from 'react';
+import { type FilterPopoverProps } from '../context';
+import { parseFilterDateValue } from './DateFilterInputs.utils';
+import classes from './FilterMultiDatePicker.module.css';
+import InvalidDateInput from './InvalidDateInput';
+import { formatMantineDate, parseMantineDate } from './mantineDateAdapter';
+
+type Props = {
+    values: Date[];
+    onChange: (values: Date[]) => void;
+    firstDayOfWeek: DayOfWeek;
+    placeholder?: string;
+    disabled?: boolean;
+    invalidValue?: string;
+    popoverProps?: FilterPopoverProps;
+    'data-autofocus'?: boolean;
+};
+
+const sortAscending = (dates: Date[]): Date[] =>
+    [...dates].sort((a, b) => a.getTime() - b.getTime());
+
+/**
+ * Multi-value date picker for the "is" / "is not" operators, which match any of
+ * the selected dates. Dates can be toggled in the calendar or typed into the
+ * field.
+ */
+const FilterMultiDatePicker: FC<Props> = ({
+    values,
+    onChange,
+    firstDayOfWeek,
+    placeholder,
+    disabled,
+    invalidValue,
+    popoverProps,
+    'data-autofocus': dataAutofocus,
+}) => {
+    const [opened, { open, close }] = useDisclosure(false);
+    const [search, setSearch] = useState('');
+
+    const mantineValues = useMemo(
+        () =>
+            values
+                .map(formatMantineDate)
+                .filter((value): value is string => value !== null),
+        [values],
+    );
+
+    const openPopover = useCallback(() => {
+        if (disabled || opened) return;
+        popoverProps?.onOpen?.();
+        open();
+    }, [disabled, opened, open, popoverProps]);
+
+    const closePopover = useCallback(() => {
+        popoverProps?.onClose?.();
+        close();
+    }, [close, popoverProps]);
+
+    const handleCalendarChange = useCallback(
+        (nextValues: string[]) => {
+            onChange(
+                sortAscending(
+                    nextValues
+                        .map(parseMantineDate)
+                        .filter((date): date is Date => date !== null),
+                ),
+            );
+        },
+        [onChange],
+    );
+
+    const handleRemove = useCallback(
+        (valueToRemove: string) => {
+            handleCalendarChange(
+                mantineValues.filter((value) => value !== valueToRemove),
+            );
+        },
+        [handleCalendarChange, mantineValues],
+    );
+
+    const commitSearch = useCallback(() => {
+        if (search.trim() === '') return;
+        const parsed = parseFilterDateValue(search.trim(), TimeFrames.DAY);
+        setSearch('');
+        const formatted = parsed && formatMantineDate(parsed);
+        if (!formatted || mantineValues.includes(formatted)) return;
+        handleCalendarChange([...mantineValues, formatted]);
+    }, [handleCalendarChange, mantineValues, search]);
+
+    const handleKeyDown = useCallback(
+        (event: KeyboardEvent<HTMLInputElement>) => {
+            if (event.key === 'Enter') {
+                event.preventDefault();
+                commitSearch();
+                return;
+            }
+            if (
+                event.key === 'Backspace' &&
+                search === '' &&
+                mantineValues.length > 0
+            ) {
+                event.preventDefault();
+                handleRemove(mantineValues[mantineValues.length - 1]);
+            }
+        },
+        [commitSearch, handleRemove, mantineValues, search],
+    );
+
+    // A value we cannot parse means the rule holds something that is not a date
+    // (e.g. hand-authored YAML) — surface it instead of silently dropping it.
+    if (invalidValue) {
+        return (
+            <InvalidDateInput
+                value={invalidValue}
+                disabled={disabled}
+                popoverProps={popoverProps}
+                autoFocus={dataAutofocus}
+            >
+                {({ close: closeInvalid }) => (
+                    <DatePicker
+                        type="multiple"
+                        firstDayOfWeek={firstDayOfWeek}
+                        value={[]}
+                        onChange={(nextValues) => {
+                            handleCalendarChange(nextValues);
+                            closeInvalid();
+                        }}
+                    />
+                )}
+            </InvalidDateInput>
+        );
+    }
+
+    return (
+        <Popover
+            shadow="sm"
+            withinPortal
+            {...popoverProps}
+            opened={opened}
+            onClose={closePopover}
+        >
+            <Popover.Target>
+                <PillsInput
+                    w="100%"
+                    size="xs"
+                    disabled={disabled}
+                    classNames={{ input: classes.pillsInput }}
+                    onClick={openPopover}
+                >
+                    <Pill.Group>
+                        {mantineValues.map((value) => (
+                            <Pill
+                                key={value}
+                                withRemoveButton={!disabled}
+                                disabled={disabled}
+                                onRemove={() => handleRemove(value)}
+                                removeButtonProps={{
+                                    'aria-label': `Remove ${value}`,
+                                    'aria-hidden': false,
+                                }}
+                            >
+                                {value}
+                            </Pill>
+                        ))}
+                        <PillsInput.Field
+                            data-autofocus={dataAutofocus}
+                            value={search}
+                            disabled={disabled}
+                            placeholder={
+                                mantineValues.length > 0
+                                    ? undefined
+                                    : placeholder
+                            }
+                            onChange={(event) =>
+                                setSearch(event.currentTarget.value)
+                            }
+                            onFocus={openPopover}
+                            onBlur={commitSearch}
+                            onKeyDown={handleKeyDown}
+                        />
+                    </Pill.Group>
+                </PillsInput>
+            </Popover.Target>
+            <Popover.Dropdown>
+                <DatePicker
+                    type="multiple"
+                    firstDayOfWeek={firstDayOfWeek}
+                    // open on the earliest selected date rather than today
+                    defaultDate={mantineValues[0]}
+                    value={mantineValues}
+                    onChange={handleCalendarChange}
+                />
+            </Popover.Dropdown>
+        </Popover>
+    );
+};
+
+export default FilterMultiDatePicker;

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiDatePicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiDatePicker.tsx
@@ -1,8 +1,6 @@
-import { TimeFrames } from '@lightdash/common';
 import { Pill, PillsInput, Popover } from '@mantine/core';
-import { DatePicker, type DayOfWeek } from '@mantine/dates';
+import { type DayOfWeek } from '@mantine/dates';
 import { useDisclosure } from '@mantine/hooks';
-import dayjs from 'dayjs';
 import {
     useCallback,
     useMemo,
@@ -11,12 +9,18 @@ import {
     type KeyboardEvent,
 } from 'react';
 import { type FilterPopoverProps } from '../context';
-import { parseFilterDateValue } from './DateFilterInputs.utils';
+import FilterMultiDateCalendar from './FilterMultiDateCalendar';
 import classes from './FilterMultiDatePicker.module.css';
+import {
+    formatTimeFrameLabel,
+    normalizeTimeFrameValues,
+    parseTypedTimeFrameValue,
+    type MultiDateTimeFrame,
+} from './FilterMultiDatePicker.utils';
 import InvalidDateInput from './InvalidDateInput';
-import { formatMantineDate, parseMantineDate } from './mantineDateAdapter';
 
 type Props = {
+    timeFrame: MultiDateTimeFrame;
     values: Date[];
     onChange: (values: Date[]) => void;
     firstDayOfWeek: DayOfWeek;
@@ -27,21 +31,13 @@ type Props = {
     'data-autofocus'?: boolean;
 };
 
-const sortAscending = (dates: Date[]): Date[] =>
-    [...dates].sort((a, b) => a.getTime() - b.getTime());
-
-// matches the single date input, which uses Mantine's default value format
-const DISPLAY_FORMAT = 'MMMM D, YYYY';
-
-const formatDisplayDate = (value: string): string =>
-    dayjs(value).format(DISPLAY_FORMAT);
-
 /**
  * Multi-value date picker for the "is" / "is not" operators, which match any of
- * the selected dates. Dates can be toggled in the calendar or typed into the
- * field.
+ * the selected values. Values are toggled in the calendar of the field's grain —
+ * days, weeks, months, quarters or years — or typed into the field.
  */
 const FilterMultiDatePicker: FC<Props> = ({
+    timeFrame,
     values,
     onChange,
     firstDayOfWeek,
@@ -54,12 +50,9 @@ const FilterMultiDatePicker: FC<Props> = ({
     const [opened, { open, close }] = useDisclosure(false);
     const [search, setSearch] = useState('');
 
-    const mantineValues = useMemo(
-        () =>
-            values
-                .map(formatMantineDate)
-                .filter((value): value is string => value !== null),
-        [values],
+    const selectedValues = useMemo(
+        () => normalizeTimeFrameValues(values, timeFrame, firstDayOfWeek),
+        [values, timeFrame, firstDayOfWeek],
     );
 
     const openPopover = useCallback(() => {
@@ -73,36 +66,33 @@ const FilterMultiDatePicker: FC<Props> = ({
         close();
     }, [close, popoverProps]);
 
-    const handleCalendarChange = useCallback(
-        (nextValues: string[]) => {
+    const handleChange = useCallback(
+        (nextValues: Date[]) => {
             onChange(
-                sortAscending(
-                    nextValues
-                        .map(parseMantineDate)
-                        .filter((date): date is Date => date !== null),
-                ),
+                normalizeTimeFrameValues(nextValues, timeFrame, firstDayOfWeek),
             );
         },
-        [onChange],
+        [onChange, timeFrame, firstDayOfWeek],
     );
 
     const handleRemove = useCallback(
-        (valueToRemove: string) => {
-            handleCalendarChange(
-                mantineValues.filter((value) => value !== valueToRemove),
+        (valueToRemove: Date) => {
+            handleChange(
+                selectedValues.filter(
+                    (value) => value.getTime() !== valueToRemove.getTime(),
+                ),
             );
         },
-        [handleCalendarChange, mantineValues],
+        [handleChange, selectedValues],
     );
 
     const commitSearch = useCallback(() => {
         if (search.trim() === '') return;
-        const parsed = parseFilterDateValue(search.trim(), TimeFrames.DAY);
+        const parsed = parseTypedTimeFrameValue(search.trim(), timeFrame);
         setSearch('');
-        const formatted = parsed && formatMantineDate(parsed);
-        if (!formatted || mantineValues.includes(formatted)) return;
-        handleCalendarChange([...mantineValues, formatted]);
-    }, [handleCalendarChange, mantineValues, search]);
+        if (!parsed) return;
+        handleChange([...selectedValues, parsed]);
+    }, [handleChange, selectedValues, search, timeFrame]);
 
     const handleKeyDown = useCallback(
         (event: KeyboardEvent<HTMLInputElement>) => {
@@ -114,13 +104,13 @@ const FilterMultiDatePicker: FC<Props> = ({
             if (
                 event.key === 'Backspace' &&
                 search === '' &&
-                mantineValues.length > 0
+                selectedValues.length > 0
             ) {
                 event.preventDefault();
-                handleRemove(mantineValues[mantineValues.length - 1]);
+                handleRemove(selectedValues[selectedValues.length - 1]);
             }
         },
-        [commitSearch, handleRemove, mantineValues, search],
+        [commitSearch, handleRemove, selectedValues, search],
     );
 
     // A value we cannot parse means the rule holds something that is not a date
@@ -134,12 +124,12 @@ const FilterMultiDatePicker: FC<Props> = ({
                 autoFocus={dataAutofocus}
             >
                 {({ close: closeInvalid }) => (
-                    <DatePicker
-                        type="multiple"
+                    <FilterMultiDateCalendar
+                        timeFrame={timeFrame}
                         firstDayOfWeek={firstDayOfWeek}
-                        value={[]}
+                        values={[]}
                         onChange={(nextValues) => {
-                            handleCalendarChange(nextValues);
+                            handleChange(nextValues);
                             closeInvalid();
                         }}
                     />
@@ -165,28 +155,32 @@ const FilterMultiDatePicker: FC<Props> = ({
                     onClick={openPopover}
                 >
                     <Pill.Group>
-                        {mantineValues.map((value) => (
-                            <Pill
-                                key={value}
-                                withRemoveButton={!disabled}
-                                disabled={disabled}
-                                onRemove={() => handleRemove(value)}
-                                removeButtonProps={{
-                                    'aria-label': `Remove ${formatDisplayDate(
-                                        value,
-                                    )}`,
-                                    'aria-hidden': false,
-                                }}
-                            >
-                                {formatDisplayDate(value)}
-                            </Pill>
-                        ))}
+                        {selectedValues.map((value) => {
+                            const label = formatTimeFrameLabel(
+                                value,
+                                timeFrame,
+                            );
+                            return (
+                                <Pill
+                                    key={value.getTime()}
+                                    withRemoveButton={!disabled}
+                                    disabled={disabled}
+                                    onRemove={() => handleRemove(value)}
+                                    removeButtonProps={{
+                                        'aria-label': `Remove ${label}`,
+                                        'aria-hidden': false,
+                                    }}
+                                >
+                                    {label}
+                                </Pill>
+                            );
+                        })}
                         <PillsInput.Field
                             data-autofocus={dataAutofocus}
                             value={search}
                             disabled={disabled}
                             placeholder={
-                                mantineValues.length > 0
+                                selectedValues.length > 0
                                     ? undefined
                                     : placeholder
                             }
@@ -201,13 +195,11 @@ const FilterMultiDatePicker: FC<Props> = ({
                 </PillsInput>
             </Popover.Target>
             <Popover.Dropdown>
-                <DatePicker
-                    type="multiple"
+                <FilterMultiDateCalendar
+                    timeFrame={timeFrame}
                     firstDayOfWeek={firstDayOfWeek}
-                    // open on the earliest selected date rather than today
-                    defaultDate={mantineValues[0]}
-                    value={mantineValues}
-                    onChange={handleCalendarChange}
+                    values={selectedValues}
+                    onChange={handleChange}
                 />
             </Popover.Dropdown>
         </Popover>

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiDatePicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiDatePicker.tsx
@@ -57,14 +57,19 @@ const FilterMultiDatePicker: FC<Props> = ({
 
     const openPopover = useCallback(() => {
         if (disabled || opened) return;
-        popoverProps?.onOpen?.();
         open();
-    }, [disabled, opened, open, popoverProps]);
+    }, [disabled, opened, open]);
 
-    const closePopover = useCallback(() => {
-        popoverProps?.onClose?.();
-        close();
-    }, [close, popoverProps]);
+    const handlePopoverChange = useCallback(
+        (nextOpened: boolean) => {
+            if (nextOpened) {
+                open();
+            } else {
+                close();
+            }
+        },
+        [close, open],
+    );
 
     const handleChange = useCallback(
         (nextValues: Date[]) => {
@@ -144,7 +149,7 @@ const FilterMultiDatePicker: FC<Props> = ({
             withinPortal
             {...popoverProps}
             opened={opened}
-            onClose={closePopover}
+            onChange={handlePopoverChange}
         >
             <Popover.Target>
                 <PillsInput

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiDatePicker.utils.test.ts
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiDatePicker.utils.test.ts
@@ -1,0 +1,75 @@
+import { TimeFrames } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import {
+    getCoarseDateTimeFrame,
+    getStoredValueTimeFrame,
+    startOfTimeFrame,
+} from './FilterMultiDatePicker.utils';
+
+describe('getCoarseDateTimeFrame', () => {
+    it('maps calendar intervals to their grain', () => {
+        expect(getCoarseDateTimeFrame(TimeFrames.WEEK)).toBe(TimeFrames.WEEK);
+        expect(getCoarseDateTimeFrame(TimeFrames.MONTH)).toBe(TimeFrames.MONTH);
+        expect(getCoarseDateTimeFrame(TimeFrames.QUARTER)).toBe(
+            TimeFrames.QUARTER,
+        );
+        expect(getCoarseDateTimeFrame(TimeFrames.YEAR)).toBe(TimeFrames.YEAR);
+    });
+
+    it('accepts lowercase intervals', () => {
+        expect(getCoarseDateTimeFrame('month' as unknown as TimeFrames)).toBe(
+            TimeFrames.MONTH,
+        );
+    });
+
+    it('returns null for intervals without a calendar picker', () => {
+        expect(getCoarseDateTimeFrame(TimeFrames.DAY)).toBeNull();
+        expect(getCoarseDateTimeFrame(TimeFrames.HOUR)).toBeNull();
+        expect(getCoarseDateTimeFrame(TimeFrames.RAW)).toBeNull();
+    });
+});
+
+describe('getStoredValueTimeFrame', () => {
+    it('stores quarters as the first day of the quarter', () => {
+        expect(getStoredValueTimeFrame(TimeFrames.QUARTER)).toBe(
+            TimeFrames.DAY,
+        );
+    });
+
+    it('stores every other grain in its own format', () => {
+        expect(getStoredValueTimeFrame(TimeFrames.WEEK)).toBe(TimeFrames.WEEK);
+        expect(getStoredValueTimeFrame(TimeFrames.MONTH)).toBe(
+            TimeFrames.MONTH,
+        );
+        expect(getStoredValueTimeFrame(TimeFrames.YEAR)).toBe(TimeFrames.YEAR);
+    });
+});
+
+describe('startOfTimeFrame', () => {
+    const date = new Date(2024, 10, 7, 13, 45);
+
+    it('snaps to the start of the period', () => {
+        expect(startOfTimeFrame(date, TimeFrames.DAY, 1)).toEqual(
+            new Date(2024, 10, 7),
+        );
+        // Monday of the week containing Thursday 7 November
+        expect(startOfTimeFrame(date, TimeFrames.WEEK, 1)).toEqual(
+            new Date(2024, 10, 4),
+        );
+        expect(startOfTimeFrame(date, TimeFrames.MONTH, 1)).toEqual(
+            new Date(2024, 10, 1),
+        );
+        expect(startOfTimeFrame(date, TimeFrames.QUARTER, 1)).toEqual(
+            new Date(2024, 9, 1),
+        );
+        expect(startOfTimeFrame(date, TimeFrames.YEAR, 1)).toEqual(
+            new Date(2024, 0, 1),
+        );
+    });
+
+    it('follows the first day of the week for weeks', () => {
+        expect(startOfTimeFrame(date, TimeFrames.WEEK, 0)).toEqual(
+            new Date(2024, 10, 3),
+        );
+    });
+});

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiDatePicker.utils.ts
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiDatePicker.utils.ts
@@ -1,0 +1,134 @@
+import { assertUnreachable, formatDate, TimeFrames } from '@lightdash/common';
+import { type DayOfWeek } from '@mantine/dates';
+import dayjs from 'dayjs';
+import quarterOfYear from 'dayjs/plugin/quarterOfYear';
+import { startOfWeek } from '../utils/filterDateUtils';
+import { parseFilterDateValue } from './DateFilterInputs.utils';
+
+dayjs.extend(quarterOfYear);
+
+/** Calendar grains that can hold a list of discrete values. */
+export type MultiDateTimeFrame =
+    | TimeFrames.DAY
+    | TimeFrames.WEEK
+    | TimeFrames.MONTH
+    | TimeFrames.QUARTER
+    | TimeFrames.YEAR;
+
+/** Grains with a dedicated picker of their own, i.e. anything but day. */
+export type CoarseDateTimeFrame = Exclude<MultiDateTimeFrame, TimeFrames.DAY>;
+
+/**
+ * Resolves a dimension's time interval to its calendar grain. Returns null for
+ * intervals without a calendar picker (raw, hour, minute, ...).
+ */
+export const getCoarseDateTimeFrame = (
+    timeInterval: TimeFrames,
+): CoarseDateTimeFrame | null => {
+    switch (timeInterval.toUpperCase()) {
+        case TimeFrames.WEEK:
+            return TimeFrames.WEEK;
+        case TimeFrames.MONTH:
+            return TimeFrames.MONTH;
+        case TimeFrames.QUARTER:
+            return TimeFrames.QUARTER;
+        case TimeFrames.YEAR:
+            return TimeFrames.YEAR;
+        default:
+            return null;
+    }
+};
+
+/**
+ * Format the rule values are stored in. Quarters are stored as the first day of
+ * the quarter rather than `YYYY-[Q]Q`, matching the single-value picker.
+ */
+export const getStoredValueTimeFrame = (
+    timeFrame: MultiDateTimeFrame,
+): TimeFrames =>
+    timeFrame === TimeFrames.QUARTER ? TimeFrames.DAY : timeFrame;
+
+export const startOfTimeFrame = (
+    date: Date,
+    timeFrame: MultiDateTimeFrame,
+    firstDayOfWeek: DayOfWeek,
+): Date => {
+    switch (timeFrame) {
+        case TimeFrames.DAY:
+            return dayjs(date).startOf('day').toDate();
+        case TimeFrames.WEEK:
+            return startOfWeek(date, firstDayOfWeek);
+        case TimeFrames.MONTH:
+            return dayjs(date).startOf('month').toDate();
+        case TimeFrames.QUARTER:
+            return dayjs(date).startOf('quarter').toDate();
+        case TimeFrames.YEAR:
+            return dayjs(date).startOf('year').toDate();
+        default:
+            return assertUnreachable(timeFrame, 'Unknown date filter grain');
+    }
+};
+
+/** Long, region-unambiguous labels for the selected values. */
+export const formatTimeFrameLabel = (
+    date: Date,
+    timeFrame: MultiDateTimeFrame,
+): string => {
+    switch (timeFrame) {
+        case TimeFrames.DAY:
+        case TimeFrames.WEEK:
+            return dayjs(date).format('MMMM D, YYYY');
+        case TimeFrames.MONTH:
+            return dayjs(date).format('MMMM YYYY');
+        case TimeFrames.QUARTER:
+            return formatDate(date, TimeFrames.QUARTER);
+        case TimeFrames.YEAR:
+            return dayjs(date).format('YYYY');
+        default:
+            return assertUnreachable(timeFrame, 'Unknown date filter grain');
+    }
+};
+
+/** Snaps every value to the start of its period, then dedupes and sorts. */
+export const normalizeTimeFrameValues = (
+    dates: Date[],
+    timeFrame: MultiDateTimeFrame,
+    firstDayOfWeek: DayOfWeek,
+): Date[] => {
+    const starts = dates.map((date) =>
+        startOfTimeFrame(date, timeFrame, firstDayOfWeek),
+    );
+    const byTime = new Map(starts.map((date) => [date.getTime(), date]));
+    return [...byTime.values()].sort((a, b) => a.getTime() - b.getTime());
+};
+
+export const toggleTimeFrameValue = (
+    dates: Date[],
+    date: Date,
+    timeFrame: MultiDateTimeFrame,
+    firstDayOfWeek: DayOfWeek,
+): Date[] => {
+    const start = startOfTimeFrame(date, timeFrame, firstDayOfWeek);
+    const isSelected = dates.some(
+        (value) =>
+            startOfTimeFrame(value, timeFrame, firstDayOfWeek).getTime() ===
+            start.getTime(),
+    );
+
+    return isSelected
+        ? dates.filter(
+              (value) =>
+                  startOfTimeFrame(
+                      value,
+                      timeFrame,
+                      firstDayOfWeek,
+                  ).getTime() !== start.getTime(),
+          )
+        : [...dates, start];
+};
+
+export const parseTypedTimeFrameValue = (
+    input: string,
+    timeFrame: MultiDateTimeFrame,
+): Date | null =>
+    parseFilterDateValue(input, getStoredValueTimeFrame(timeFrame));

--- a/packages/frontend/src/components/common/Filters/utils/getPlaceholderByFilterTypeAndOperator.ts
+++ b/packages/frontend/src/components/common/Filters/utils/getPlaceholderByFilterTypeAndOperator.ts
@@ -93,6 +93,7 @@ export const getPlaceholderByFilterTypeAndOperator = ({
             switch (operator) {
                 case FilterOperator.EQUALS:
                 case FilterOperator.NOT_EQUALS:
+                    return singleValue ? 'Select a date' : 'Select date(s)';
                 case FilterOperator.LESS_THAN:
                 case FilterOperator.LESS_THAN_OR_EQUAL:
                 case FilterOperator.GREATER_THAN:


### PR DESCRIPTION
Closes: lightdash/lightdash#26793

### Description:

A date filter using `is` / `is not` can now hold several discrete values, matching any of them. This works on dashboards (including for viewers, from the filter bar) and in Explore.

The SQL compiler already renders multi-value date equals as `IN (...)` / `NOT IN (...)` — [`renderDateOrTimestampFilterSql`](<>) — so this fills in the two gaps that made it unreachable:

* **New** `FilterMultiDatePicker` — a pills input backed by a multi-select calendar. Values can be toggled in the calendar, typed in and committed with Enter, or removed via the pill's × / Backspace. They are kept sorted and deduped, and the calendar opens on the earliest selected value rather than today.
* `getFilterRuleWithDefaultValue` no longer truncates a date filter's `values` to `values[0]` when the operator is `equals` / `notEquals`. Single-value filters and every other date operator are unchanged.

The picker adapts to the field's grain rather than being limited to days, so it also covers week, month, quarter and year dimensions — and any custom dimension, since the grain is read from the field's time interval:

<!-- linear:table-colwidths:266,266,266 -->
| Grain | Calendar | Pill label |
| -- | -- | -- |
| Day | multi-select day picker | `August 4, 2026` |
| Week | day picker, snapping each click to the week it belongs to | `August 3, 2026` (prefixed "week commencing") |
| Month | multi-select month picker | `August 2026` |
| Quarter | month picker where a quarter's months highlight and toggle together | `2026-Q3` |
| Year | multi-select year picker | `2026` |

Labels use the long, region-unambiguous form (avoiding DD/MM vs MM/DD), and each grain stores values in exactly the format its single-value picker already used, so existing filters keep working. Timestamp fields and the comparison operators (`is before`, `is after`, …) keep their single-value pickers.

**Verification:** unit tests cover the value-preservation logic in `common`, the grain helpers, and the picker's add/remove/sort/typed-entry/calendar-toggle behaviour at every grain (22 tests). Frontend build, typecheck and lint are clean. I could not drive the running app in this environment, so a manual pass on the dashboard filter bar is worth doing before merge.

### Demo

<img src="https://github.com/user-attachments/assets/1f4a88c8-465a-4747-b1ed-dad7cb7f7e4d " alt="CleanShot 2026-08-07 at 10 57 20@2x" width="4290" data-linear-height="2832" />