### PR TITLE
feat: polish deep research run cards

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.module.css
@@ -1,17 +1,84 @@
 .card {
-    border: 1px solid var(--mantine-color-ldGray-3);
+    border: 1px solid
+        light-dark(var(--mantine-color-ldGray-3), var(--mantine-color-ldDark-4));
 }
 
-.statusBadge {
+.header {
+    min-width: 0;
+}
+
+.headingGroup {
+    min-width: 0;
+}
+
+.eyebrow {
+    letter-spacing: 0.08em;
+    color: light-dark(
+        var(--mantine-color-ldGray-7),
+        var(--mantine-color-ldGray-1)
+    );
+}
+
+.runMeta {
+    row-gap: var(--mantine-spacing-xxs);
+}
+
+.statusMeta {
+    min-width: 0;
+    flex-shrink: 1;
+}
+
+.metaSeparator {
+    flex-shrink: 0;
+    border-radius: var(--mantine-radius-xl);
+}
+
+.metaSeparator {
+    width: 3px;
+    height: 3px;
+    background-color: light-dark(
+        var(--mantine-color-ldGray-4),
+        var(--mantine-color-ldGray-2)
+    );
+}
+
+.metaText {
+    color: light-dark(
+        var(--mantine-color-ldGray-7),
+        var(--mantine-color-ldGray-1)
+    );
+}
+
+.stopButton {
     flex-shrink: 0;
 }
 
-.answer {
-    border-left: 3px solid var(--mantine-color-indigo-outline);
-    background: light-dark(
-        var(--mantine-color-ldGray-0),
-        var(--mantine-color-ldDark-6)
+.phase {
+    min-width: 0;
+}
+
+.phaseDot {
+    width: 7px;
+    height: 7px;
+    flex: none;
+    border-radius: var(--mantine-radius-xl);
+    background-color: light-dark(
+        var(--mantine-color-ldGray-6),
+        var(--mantine-color-ldGray-1)
     );
+}
+
+.metrics {
+    color: light-dark(
+        var(--mantine-color-ldGray-8),
+        var(--mantine-color-ldGray-1)
+    );
+}
+
+.answer {
+    border: 1px solid
+        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-ldDark-4));
+    background: var(--mantine-color-body);
 }
 
 .answerPreview {
@@ -20,6 +87,105 @@
     overflow: hidden;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 5;
+}
+
+.activitySection {
+    min-width: 0;
+}
+
+.activitySection[data-active='true'] {
+    padding-top: var(--mantine-spacing-md);
+    border-top: 1px solid
+        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-ldDark-4));
+}
+
+.activityButton {
+    color: light-dark(
+        var(--mantine-color-ldGray-7),
+        var(--mantine-color-ldGray-1)
+    );
+}
+
+.activityChevron {
+    transition: transform 160ms ease;
+}
+
+.activityChevron[data-open='true'] {
+    transform: rotate(180deg);
+}
+
+.timeline {
+    position: relative;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.timeline::before {
+    position: absolute;
+    top: 0.5rem;
+    bottom: 0.5rem;
+    left: calc(4.75rem + var(--mantine-spacing-sm) + 0.25rem);
+    width: 1px;
+    background: light-dark(
+        var(--mantine-color-ldGray-2),
+        var(--mantine-color-ldDark-4)
+    );
+    content: '';
+}
+
+.timelineItem {
+    display: grid;
+    grid-template-columns: 4.75rem 0.5rem minmax(0, 1fr);
+    column-gap: var(--mantine-spacing-sm);
+    align-items: start;
+    padding-bottom: var(--mantine-spacing-md);
+}
+
+.timelineItem:last-child {
+    padding-bottom: 0;
+}
+
+.eventTime {
+    color: light-dark(
+        var(--mantine-color-ldGray-6),
+        var(--mantine-color-ldGray-2)
+    );
+    font: 400 var(--mantine-font-size-xs) / 1.5
+        var(--mantine-font-family-monospace);
+    font-variant-numeric: tabular-nums;
+    text-align: right;
+    white-space: nowrap;
+}
+
+.timelineNode {
+    z-index: 1;
+    width: 0.5rem;
+    height: 0.5rem;
+    margin-top: 0.3rem;
+    border: 1px solid
+        light-dark(var(--mantine-color-ldGray-3), var(--mantine-color-ldDark-3));
+    border-radius: 50%;
+    background: var(--mantine-color-body);
+}
+
+.timelineItem[data-current='true'] .timelineNode {
+    border-color: light-dark(
+        var(--mantine-color-ldGray-8),
+        var(--mantine-color-ldGray-1)
+    );
+    background: light-dark(
+        var(--mantine-color-ldGray-8),
+        var(--mantine-color-ldGray-1)
+    );
+}
+
+.eventLabel {
+    min-width: 0;
+    color: var(--mantine-color-text);
+    font-size: var(--mantine-font-size-xs);
+    font-weight: 500;
+    line-height: 1.5;
 }
 
 .liveRegion {
@@ -32,4 +198,18 @@
     clip: rect(0, 0, 0, 0);
     white-space: nowrap;
     border: 0;
+}
+
+@media (max-width: 36em) {
+    .header {
+        flex-wrap: wrap;
+    }
+
+    .headingGroup {
+        flex-basis: 100%;
+    }
+
+    .stopButton {
+        margin-left: var(--mantine-spacing-lg);
+    }
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.test.tsx
@@ -51,7 +51,6 @@ describe('DeepResearchRunCard', () => {
             expect(
                 screen.getByRole('button', { name: 'Stop research' }),
             ).toBeInTheDocument();
-            expect(screen.getAllByRole('separator')).toHaveLength(2);
         },
     );
 
@@ -94,6 +93,9 @@ describe('DeepResearchRunCard', () => {
 
         await user.click(screen.getByRole('button', { name: 'View activity' }));
         expect(
+            await screen.findByRole('list', { name: 'Research activity' }),
+        ).toBeInTheDocument();
+        expect(
             screen.getByText('Executed a warehouse query'),
         ).toBeInTheDocument();
 
@@ -102,9 +104,9 @@ describe('DeepResearchRunCard', () => {
     });
 
     it.each([
-        ['completed', 'Completed'],
-        ['cancelled', 'Cancelled'],
-        ['failed', 'Failed'],
+        ['completed', /^Completed in/],
+        ['cancelled', 'Stopped'],
+        ['failed', 'Couldn’t complete'],
     ] as const)(
         'renders the %s terminal state without a stop action',
         (status, label) => {
@@ -131,8 +133,20 @@ describe('DeepResearchRunCard', () => {
                 screen.queryByRole('button', { name: 'Stop research' }),
             ).not.toBeInTheDocument();
             expect(
-                screen.getByText('This run is saved in this thread.'),
-            ).toBeInTheDocument();
+                screen.queryByText('Saved in this thread.'),
+            ).not.toBeInTheDocument();
+
+            if (status === 'completed') {
+                expect(
+                    screen.getByText(
+                        'Completed in 18m · 7 queries · 2 findings',
+                    ),
+                ).toBeInTheDocument();
+                expect(screen.queryByText('Sources')).not.toBeInTheDocument();
+                expect(
+                    screen.queryByText(deepResearchRunFixture.question),
+                ).not.toBeInTheDocument();
+            }
         },
     );
 
@@ -150,12 +164,12 @@ describe('DeepResearchRunCard', () => {
         expect(screen.getByText('Partially completed')).toBeInTheDocument();
         expect(
             screen.getByText(
-                /findings and completed queries have been preserved/i,
+                /completed queries and available findings are saved below/i,
             ),
         ).toBeInTheDocument();
-        expect(screen.getByText('Executive answer')).toBeInTheDocument();
+        expect(screen.getByText('Research summary')).toBeInTheDocument();
         expect(
-            screen.getByRole('button', { name: 'Open full report' }),
+            screen.getByRole('button', { name: 'View full report' }),
         ).toBeInTheDocument();
     });
 
@@ -179,16 +193,21 @@ describe('DeepResearchRunCard', () => {
         );
 
         expect(
+            screen.getByText('This report is no longer available.'),
+        ).toBeInTheDocument();
+        expect(
             screen.getByText(
-                'This Deep research report expired after 30 days.',
+                'Deep Research reports are available for 30 days.',
             ),
         ).toBeInTheDocument();
         expect(
-            screen.getAllByText(deepResearchRunFixture.question),
-        ).toHaveLength(2);
-        expect(screen.queryByText('Executive answer')).not.toBeInTheDocument();
+            screen.getByText(deepResearchRunFixture.question),
+        ).toBeInTheDocument();
+        expect(screen.queryByText('Research summary')).not.toBeInTheDocument();
 
-        await user.click(screen.getByRole('button', { name: 'Run again' }));
+        await user.click(
+            screen.getByRole('button', { name: 'Run research again' }),
+        );
         expect(onRunAgain).toHaveBeenCalledOnce();
     });
 
@@ -202,7 +221,7 @@ describe('DeepResearchRunCard', () => {
         );
 
         await user.click(
-            screen.getByRole('button', { name: 'Open full report' }),
+            screen.getByRole('button', { name: 'View full report' }),
         );
 
         expect(trackReportEngagement).toHaveBeenCalledWith('opened', {
@@ -216,7 +235,7 @@ describe('DeepResearchRunCard', () => {
         });
     });
 
-    it('renders the executive answer as Markdown', () => {
+    it('renders the research summary as Markdown', () => {
         renderWithProviders(
             <DeepResearchRunCard
                 run={{
@@ -315,10 +334,32 @@ The full report continues here.`,
             />,
         );
 
-        expect(screen.getByText('Executive answer')).toBeInTheDocument();
+        expect(screen.getByText('Research summary')).toBeInTheDocument();
         await user.click(
             screen.getByRole('button', { name: 'Review permissions' }),
         );
         expect(onReviewPermissions).toHaveBeenCalledOnce();
+    });
+
+    it('offers to run failed research again when the thread is idle', async () => {
+        const user = userEvent.setup();
+        const onRunAgain = vi.fn();
+        renderWithProviders(
+            <DeepResearchRunCard
+                run={{
+                    ...deepResearchRunFixture,
+                    status: 'failed',
+                    resultMarkdown: null,
+                }}
+                projectUuid="project-1"
+                canRunAgain
+                onRunAgain={onRunAgain}
+            />,
+        );
+
+        await user.click(
+            screen.getByRole('button', { name: 'Run research again' }),
+        );
+        expect(onRunAgain).toHaveBeenCalledOnce();
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
@@ -1,28 +1,24 @@
 import {
     Alert,
-    Badge,
+    Box,
     Button,
     Collapse,
-    Divider,
     Group,
     Paper,
-    SimpleGrid,
     Stack,
     Text,
-    ThemeIcon,
-    Timeline,
 } from '@mantine-8/core';
 import {
     IconAlertCircle,
     IconCheck,
-    IconClock,
-    IconFileSearch,
+    IconChevronDown,
     IconPlayerStop,
     IconPlugConnected,
     IconTelescope,
 } from '@tabler/icons-react';
 import {
     useEffect,
+    useId,
     useState,
     type AnchorHTMLAttributes,
     type FC,
@@ -53,25 +49,21 @@ const PREVIEW_MARKDOWN_COMPONENTS: StreamdownProps['components'] = {
     >['a'],
 };
 
-const STATUS_CONFIG: Record<
-    DeepResearchRunView['status'],
-    { label: string; color: string }
-> = {
-    queued: { label: 'Queued', color: 'gray' },
-    running: { label: 'Running', color: 'indigo' },
-    waiting_for_permission: {
-        label: 'Waiting for permission',
-        color: 'yellow',
-    },
-    waiting_for_reconnection: {
-        label: 'Waiting for reconnection',
-        color: 'yellow',
-    },
-    completed: { label: 'Completed', color: 'green' },
-    partially_completed: { label: 'Partially completed', color: 'yellow' },
-    failed: { label: 'Failed', color: 'red' },
-    cancelled: { label: 'Cancelled', color: 'gray' },
-};
+const STATUS_CONFIG: Record<DeepResearchRunView['status'], { label: string }> =
+    {
+        queued: { label: 'Queued' },
+        running: { label: 'Running' },
+        waiting_for_permission: {
+            label: 'Permission required',
+        },
+        waiting_for_reconnection: {
+            label: 'Reconnect required',
+        },
+        completed: { label: 'Completed' },
+        partially_completed: { label: 'Partially completed' },
+        failed: { label: 'Couldn’t complete' },
+        cancelled: { label: 'Stopped' },
+    };
 
 const getElapsedLabel = (elapsedMs: number) => {
     const elapsedSeconds = Math.floor(Math.max(0, elapsedMs) / 1_000);
@@ -118,6 +110,61 @@ const useElapsedMs = (run: DeepResearchRunView, isTerminal: boolean) => {
     return elapsed.elapsedMs;
 };
 
+export const DeepResearchRunHeading = ({
+    statusLabel,
+    elapsedLabel,
+    action,
+}: {
+    statusLabel: string;
+    elapsedLabel?: string;
+    action?: ReactNode;
+}) => (
+    <Group
+        className={styles.header}
+        justify="space-between"
+        align="center"
+        wrap="nowrap"
+    >
+        <Stack className={styles.headingGroup}>
+            <Group className={styles.runMeta} gap="xs" wrap="wrap">
+                <MantineIcon
+                    icon={IconTelescope}
+                    size={16}
+                    stroke={1.8}
+                    color="currentColor"
+                    className={styles.metaText}
+                />
+                <Text
+                    size="xs"
+                    fw={700}
+                    ff="monospace"
+                    tt="uppercase"
+                    className={styles.eyebrow}
+                >
+                    Deep research
+                </Text>
+                <Box className={styles.metaSeparator} />
+                <Group className={styles.statusMeta} gap={6} wrap="nowrap">
+                    <Text size="xs" className={styles.metaText}>
+                        {statusLabel}
+                    </Text>
+                    {elapsedLabel && (
+                        <>
+                            <Text size="xs" className={styles.metaText}>
+                                ·
+                            </Text>
+                            <Text size="xs" className={styles.metaText}>
+                                {elapsedLabel}
+                            </Text>
+                        </>
+                    )}
+                </Group>
+            </Group>
+        </Stack>
+        {action}
+    </Group>
+);
+
 type Props = {
     run: DeepResearchRunView;
     projectUuid: string;
@@ -139,6 +186,7 @@ export const DeepResearchRunCard = ({
     const cancelMutation = useCancelDeepResearchMutation(projectUuid, run.uuid);
     const [isActivityOpen, setIsActivityOpen] = useState(false);
     const [isReportOpen, setIsReportOpen] = useState(false);
+    const activityId = useId();
     const trackReportEngagement = useTrackDeepResearchReportEngagement();
     const [announcedStatus, setAnnouncedStatus] = useState(run.status);
 
@@ -157,6 +205,9 @@ export const DeepResearchRunCard = ({
         isActionRequired &&
         !!run.actionRequired &&
         !!(onReconnect || onContinueWithoutSource);
+    const elapsedLabel = getElapsedLabel(elapsedMs);
+    const isCompleted = run.status === 'completed';
+    const completedStatusLabel = `${status.label} in ${elapsedLabel} · ${run.queryCount} ${run.queryCount === 1 ? 'query' : 'queries'} · ${run.findingCount} ${run.findingCount === 1 ? 'finding' : 'findings'}`;
 
     return (
         <Paper
@@ -166,88 +217,73 @@ export const DeepResearchRunCard = ({
             aria-label="Deep research run"
         >
             <Stack gap="md">
-                <Group justify="space-between" align="flex-start" wrap="nowrap">
-                    <Group align="flex-start" wrap="nowrap">
-                        <ThemeIcon color="indigo" variant="light" radius="md">
-                            <MantineIcon icon={IconTelescope} size={18} />
-                        </ThemeIcon>
-                        <Stack gap={3}>
-                            <Group gap="xs">
-                                <Text
-                                    size="xs"
-                                    c="indigo"
-                                    fw={700}
-                                    tt="uppercase"
-                                >
-                                    Deep research
-                                </Text>
-                            </Group>
-                            <Text fw={600}>{run.question}</Text>
-                        </Stack>
-                    </Group>
-                    <Badge
-                        className={styles.statusBadge}
-                        color={status.color}
-                        variant="light"
-                    >
-                        {status.label}
-                    </Badge>
-                </Group>
+                <DeepResearchRunHeading
+                    statusLabel={
+                        isCompleted ? completedStatusLabel : status.label
+                    }
+                    elapsedLabel={
+                        run.status === 'queued' || isCompleted
+                            ? undefined
+                            : elapsedLabel
+                    }
+                    action={
+                        !isTerminal ? (
+                            <Button
+                                className={styles.stopButton}
+                                variant="subtle"
+                                color="gray"
+                                size="sm"
+                                leftSection={<IconPlayerStop size={14} />}
+                                loading={cancelMutation.isLoading}
+                                onClick={() => cancelMutation.mutate()}
+                            >
+                                Stop research
+                            </Button>
+                        ) : undefined
+                    }
+                />
 
                 <Text className={styles.liveRegion} aria-live="polite">
                     Research status changed to {status.label}
                 </Text>
 
-                <Divider />
-
                 {run.phase && !isTerminal && (
-                    <Group gap="xs" wrap="nowrap">
-                        <ThemeIcon size="sm" color="indigo" variant="light">
-                            <MantineIcon icon={IconFileSearch} size={13} />
-                        </ThemeIcon>
-                        <Text size="sm" fw={600}>
+                    <Group gap="xs" wrap="nowrap" className={styles.phase}>
+                        <Box className={styles.phaseDot} />
+                        <Text size="sm" fw={500}>
                             {run.phase}
                         </Text>
                     </Group>
                 )}
 
-                <SimpleGrid cols={{ base: 2, sm: 4 }} spacing="sm">
-                    <Stack gap={2}>
-                        <Text size="xs" c="dimmed">
-                            Elapsed
-                        </Text>
-                        <Group gap={5}>
-                            <IconClock size={13} />
-                            <Text size="sm" ff="monospace">
-                                {getElapsedLabel(elapsedMs)}
+                {!isCompleted && (
+                    <Group className={styles.metrics} gap="md" wrap="wrap">
+                        <Group gap={5} wrap="nowrap">
+                            <Text size="xs">Queries</Text>
+                            <Text size="sm" fw={600} ff="monospace">
+                                {run.queryCount}
                             </Text>
                         </Group>
-                    </Stack>
-                    <Stack gap={2}>
-                        <Text size="xs" c="dimmed">
-                            Sources
-                        </Text>
-                        <Text size="sm" fw={600}>
-                            {run.sourceCount ?? '—'}
-                        </Text>
-                    </Stack>
-                    <Stack gap={2}>
-                        <Text size="xs" c="dimmed">
-                            Queries
-                        </Text>
-                        <Text size="sm" fw={600}>
-                            {run.queryCount}
-                        </Text>
-                    </Stack>
-                    <Stack gap={2}>
-                        <Text size="xs" c="dimmed">
-                            Findings
-                        </Text>
-                        <Text size="sm" fw={600}>
-                            {run.findingCount}
-                        </Text>
-                    </Stack>
-                </SimpleGrid>
+                        <Group gap={5} wrap="nowrap">
+                            <Text size="xs">Sources</Text>
+                            <Text size="sm" fw={600} ff="monospace">
+                                {run.sourceCount ?? '—'}
+                            </Text>
+                        </Group>
+                        <Group gap={5} wrap="nowrap">
+                            <Text size="xs">Findings</Text>
+                            <Text size="sm" fw={600} ff="monospace">
+                                {run.findingCount}
+                            </Text>
+                        </Group>
+                    </Group>
+                )}
+
+                {!isTerminal && (
+                    <Text size="xs" c="dimmed">
+                        Research continues if you leave this page.
+                    </Text>
+                )}
 
                 {canShowActionRequired && run.actionRequired && (
                     <Alert
@@ -296,22 +332,33 @@ export const DeepResearchRunCard = ({
 
                 {run.status === 'failed' && (
                     <Alert color="red" icon={<IconAlertCircle size={16} />}>
-                        <Text size="sm">
-                            {run.errorMessage ??
-                                'The investigation stopped before a report could be completed.'}
-                        </Text>
-                        <Text size="sm" mt="xs">
-                            Completed queries and partial findings remain
-                            available below. You can rerun the question after
-                            resolving the issue.
-                        </Text>
+                        <Stack gap="sm">
+                            <Text size="sm">
+                                {run.errorMessage ??
+                                    'Research stopped before the report was ready.'}
+                            </Text>
+                            <Text size="sm">
+                                Any completed queries and findings are saved
+                                below.
+                            </Text>
+                            {canRunAgain && onRunAgain && (
+                                <Button
+                                    size="xs"
+                                    variant="default"
+                                    w="fit-content"
+                                    onClick={onRunAgain}
+                                >
+                                    Run research again
+                                </Button>
+                            )}
+                        </Stack>
                     </Alert>
                 )}
 
                 {run.status === 'partially_completed' && !isReportExpired && (
                     <Alert color="yellow" icon={<IconAlertCircle size={16} />}>
-                        The report is incomplete, but all validated findings and
-                        completed queries have been preserved.
+                        This report is incomplete. Completed queries and
+                        available findings are saved below.
                     </Alert>
                 )}
 
@@ -319,7 +366,10 @@ export const DeepResearchRunCard = ({
                     <Paper variant="dotted" p="md" radius="sm">
                         <Stack gap="xs">
                             <Text size="sm" fw={600}>
-                                This Deep research report expired after 30 days.
+                                This report is no longer available.
+                            </Text>
+                            <Text size="sm" c="dimmed">
+                                Deep Research reports are available for 30 days.
                             </Text>
                             <Text size="sm">{run.question}</Text>
                             {run.completedAt && (
@@ -336,23 +386,23 @@ export const DeepResearchRunCard = ({
                                 disabled={!canRunAgain || !onRunAgain}
                                 onClick={onRunAgain}
                             >
-                                Run again
+                                Run research again
                             </Button>
                         </Stack>
                     </Paper>
                 )}
 
                 {hasReport && (
-                    <Paper className={styles.answer} p="md" radius="sm">
-                        <Stack gap="xs">
+                    <Paper className={styles.answer} p="lg" radius="sm">
+                        <Stack gap="md">
                             <Group gap="xs">
                                 <MantineIcon
                                     icon={IconCheck}
                                     size={16}
-                                    color="green.6"
+                                    color="ldGray.6"
                                 />
                                 <Text size="sm" fw={700}>
-                                    Executive answer
+                                    Research summary
                                 </Text>
                             </Group>
                             {run.resultMarkdown && (
@@ -366,7 +416,7 @@ export const DeepResearchRunCard = ({
                                 </AiMarkdown>
                             )}
                             <Button
-                                variant="light"
+                                color="ldDark"
                                 size="xs"
                                 w="fit-content"
                                 onClick={() => {
@@ -389,31 +439,56 @@ export const DeepResearchRunCard = ({
                                     setIsReportOpen(true);
                                 }}
                             >
-                                Open full report
+                                View full report
                             </Button>
                         </Stack>
                     </Paper>
                 )}
 
                 {run.latestEvents.length > 0 && (
-                    <>
+                    <Stack
+                        gap="md"
+                        className={styles.activitySection}
+                        data-active={!isTerminal}
+                    >
                         <Button
-                            variant="subtle"
+                            className={styles.activityButton}
+                            variant="transparent"
+                            color="gray"
                             size="xs"
                             w="fit-content"
+                            px={0}
+                            rightSection={
+                                <MantineIcon
+                                    icon={IconChevronDown}
+                                    size={13}
+                                    className={styles.activityChevron}
+                                    data-open={isActivityOpen}
+                                />
+                            }
                             onClick={() => setIsActivityOpen((open) => !open)}
                             aria-expanded={isActivityOpen}
+                            aria-controls={activityId}
                         >
                             {isActivityOpen ? 'Hide activity' : 'View activity'}
                         </Button>
-                        <Collapse in={isActivityOpen}>
-                            <Timeline bulletSize={16} lineWidth={1}>
-                                {run.latestEvents.map((event) => (
-                                    <Timeline.Item
+                        <Collapse id={activityId} in={isActivityOpen}>
+                            <Box
+                                component="ul"
+                                className={styles.timeline}
+                                aria-label="Research activity"
+                            >
+                                {run.latestEvents.map((event, index) => (
+                                    <Box
+                                        component="li"
                                         key={event.uuid}
-                                        title={event.label}
+                                        className={styles.timelineItem}
+                                        data-current={
+                                            (isTerminal && index === 0) ||
+                                            undefined
+                                        }
                                     >
-                                        <Text size="xs" c="dimmed">
+                                        <Text className={styles.eventTime}>
                                             {new Date(
                                                 event.createdAt,
                                             ).toLocaleTimeString([], {
@@ -421,34 +496,16 @@ export const DeepResearchRunCard = ({
                                                 minute: '2-digit',
                                             })}
                                         </Text>
-                                    </Timeline.Item>
+                                        <Box className={styles.timelineNode} />
+                                        <Text className={styles.eventLabel}>
+                                            {event.label}
+                                        </Text>
+                                    </Box>
                                 ))}
-                            </Timeline>
+                            </Box>
                         </Collapse>
-                    </>
+                    </Stack>
                 )}
-
-                <Divider />
-
-                <Group justify="space-between" align="center">
-                    <Text size="xs" c="dimmed">
-                        {isTerminal
-                            ? 'This run is saved in this thread.'
-                            : 'You can leave this page while research continues.'}
-                    </Text>
-                    {!isTerminal && (
-                        <Button
-                            variant="subtle"
-                            color="red"
-                            size="xs"
-                            leftSection={<IconPlayerStop size={14} />}
-                            loading={cancelMutation.isLoading}
-                            onClick={() => cancelMutation.mutate()}
-                        >
-                            Stop research
-                        </Button>
-                    )}
-                </Group>
             </Stack>
 
             <DeepResearchReport

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchThreadRuns.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchThreadRuns.test.tsx
@@ -21,6 +21,9 @@ vi.mock('../../hooks/useDeepResearch', () => ({
 
 vi.mock('./DeepResearchRunCard', () => ({
     DeepResearchRunCard: () => <div>Saved deep research result</div>,
+    DeepResearchRunHeading: ({ statusLabel }: { statusLabel: string }) => (
+        <div>{statusLabel}</div>
+    ),
 }));
 
 describe('DeepResearchThreadRuns', () => {
@@ -84,7 +87,7 @@ describe('DeepResearchThreadRuns', () => {
                 screen.getByText('Saved deep research result'),
             ).toBeInTheDocument();
             expect(
-                screen.queryByText('Could not refresh this run'),
+                screen.queryByText('Couldn’t load the latest activity'),
             ).not.toBeInTheDocument();
         },
     );
@@ -94,7 +97,7 @@ describe('DeepResearchThreadRuns', () => {
         renderThreadRuns();
 
         expect(
-            screen.getByText('Could not refresh this run'),
+            screen.getByText('Couldn’t load the latest activity'),
         ).toBeInTheDocument();
         expect(
             screen.queryByText('Saved deep research result'),
@@ -111,7 +114,9 @@ describe('DeepResearchThreadRuns', () => {
             />,
         );
 
-        const retryButton = screen.getByRole('button', { name: 'Try again' });
+        const retryButton = screen.getByRole('button', {
+            name: 'Try starting again',
+        });
         expect(retryButton).toBeDisabled();
         await user.click(retryButton);
         expect(continueDeepResearchMock).not.toHaveBeenCalled();
@@ -126,7 +131,9 @@ describe('DeepResearchThreadRuns', () => {
                 canRetry
             />,
         );
-        await user.click(screen.getByRole('button', { name: 'Try again' }));
+        await user.click(
+            screen.getByRole('button', { name: 'Try starting again' }),
+        );
 
         expect(continueDeepResearchMock).toHaveBeenCalledWith({
             question: registration.question,

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchThreadRuns.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchThreadRuns.tsx
@@ -4,7 +4,11 @@ import {
     useContinueDeepResearchMutation,
     useDeepResearchRun,
 } from '../../hooks/useDeepResearch';
-import { DeepResearchRunCard } from './DeepResearchRunCard';
+import {
+    DeepResearchRunCard,
+    DeepResearchRunHeading,
+} from './DeepResearchRunCard';
+import styles from './DeepResearchRunCard.module.css';
 
 const DeepResearchThreadRun = ({
     registration,
@@ -25,21 +29,25 @@ const DeepResearchThreadRun = ({
     if (registration.state !== 'started') {
         const failed = registration.state === 'start_failed';
         return (
-            <Paper p="lg" radius="md" withBorder aria-label="Deep research run">
-                <Stack gap="xs">
-                    <Text size="xs" c="indigo" fw={700} tt="uppercase">
-                        Deep research
-                    </Text>
-                    <Text fw={600}>{registration.question}</Text>
+            <Paper
+                className={styles.card}
+                p="lg"
+                radius="md"
+                aria-label="Deep research run"
+            >
+                <Stack gap="md">
+                    <DeepResearchRunHeading
+                        statusLabel={failed ? 'Could not start' : 'Queued'}
+                    />
                     {failed ? (
-                        <Alert color="red" title="Research did not start">
+                        <Alert color="red">
                             {registration.errorMessage ??
-                                'The run could not be created. Your question is preserved in this thread; try again when the service is available.'}
+                                'Research didn’t start. Your question is saved in this thread.'}
                         </Alert>
                     ) : (
                         <Text size="sm" c="dimmed" aria-live="polite">
-                            Starting research… The run card is saved in this
-                            thread.
+                            Starting research… You can leave this page while it
+                            runs.
                         </Text>
                     )}
                     {failed && (
@@ -58,7 +66,7 @@ const DeepResearchThreadRun = ({
                                 });
                             }}
                         >
-                            Try again
+                            Try starting again
                         </Button>
                     )}
                 </Stack>
@@ -66,19 +74,24 @@ const DeepResearchThreadRun = ({
         );
     }
     if (runQuery.isLoading) {
-        return <Skeleton h={190} radius="md" />;
+        return <Skeleton h={160} radius="md" />;
     }
     if (runQuery.isError && !runQuery.data) {
         return (
-            <Paper p="lg" radius="md" withBorder aria-label="Deep research run">
+            <Paper
+                className={styles.card}
+                p="lg"
+                radius="md"
+                aria-label="Deep research run"
+            >
                 <Stack gap="sm">
-                    <Text size="xs" c="indigo" fw={700} tt="uppercase">
-                        Deep research
-                    </Text>
-                    <Text fw={600}>{registration.question}</Text>
-                    <Alert color="yellow" title="Could not refresh this run">
-                        The durable run is still saved. Check your connection
-                        and try loading its latest state again.
+                    <DeepResearchRunHeading statusLabel="Updates unavailable" />
+                    <Alert
+                        color="yellow"
+                        title="Couldn’t load the latest activity"
+                    >
+                        Your research is still saved. Check your connection,
+                        then refresh the activity.
                     </Alert>
                     <Button
                         size="xs"
@@ -89,7 +102,7 @@ const DeepResearchThreadRun = ({
                             void runQuery.eventsQuery.refetch();
                         }}
                     >
-                        Try again
+                        Refresh activity
                     </Button>
                 </Stack>
             </Paper>

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/runProgress.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/runProgress.ts
@@ -68,6 +68,28 @@ const getPhaseLabel = (
     }
 };
 
+const getLatestEvents = (events: AiDeepResearchEvent[]) => {
+    const labels = new Set<string>();
+    return events.reduceRight<DeepResearchRunView['latestEvents']>(
+        (latestEvents, event) => {
+            const label = getEventLabel(event);
+            if (latestEvents.length === 4 || labels.has(label)) {
+                return latestEvents;
+            }
+
+            labels.add(label);
+            latestEvents.push({
+                uuid: event.aiDeepResearchEventUuid,
+                type: event.eventType,
+                label,
+                createdAt: event.createdAt,
+            });
+            return latestEvents;
+        },
+        [],
+    );
+};
+
 export const isDeepResearchRunTerminal = (
     status: DeepResearchRunStatus,
 ): boolean =>
@@ -147,15 +169,7 @@ export const adaptDeepResearchRun = ({
             ? countDeepResearchFindings(run.resultMarkdown)
             : 0,
         actionRequired: null,
-        latestEvents: events
-            .slice(-4)
-            .reverse()
-            .map((event) => ({
-                uuid: event.aiDeepResearchEventUuid,
-                type: event.eventType,
-                label: getEventLabel(event),
-                createdAt: event.createdAt,
-            })),
+        latestEvents: getLatestEvents(events),
         resultMarkdown: run.resultMarkdown,
         resultChartData: run.resultChartData,
         reportExpiresAt: run.reportExpiresAt,

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.test.tsx
@@ -440,6 +440,9 @@ describe('useDeepResearchRun', () => {
 
         await waitFor(() => expect(result.current.data?.queryCount).toBe(1));
         expect(
+            result.current.data?.latestEvents.map((event) => event.label),
+        ).toEqual(['Executed a warehouse query', 'Research running']);
+        expect(
             lightdashApiMock.mock.calls.filter(([args]) =>
                 (args as { url: string }).url.includes('/events'),
             ),


### PR DESCRIPTION
### Summary
- refine Deep Research queued, running, and completed card hierarchy
- clarify status, recovery, summary, report, and saved-state copy
- move completed run totals into the header and tighten spacing to the supplied reference
- deduplicate repeated activity events while preserving newest-first chronology
- improve responsive layout, dark-mode contrast, and accessibility

### Test plan
- pnpm vitest: DeepResearchRunCard, DeepResearchThreadRuns, and useDeepResearch (29 tests)
- frontend oxlint on changed files
- frontend TypeScript check
- frontend format check
- git diff --check
- Impeccable detector
- browser validation with real Deep Research data at desktop and 390x844