### PR TITLE
fix(backend): hide dbt environment variables from viewers

### DIFF
--- a/packages/backend/src/services/ProjectDbtSourcesService.test.ts
+++ b/packages/backend/src/services/ProjectDbtSourcesService.test.ts
@@ -22,6 +22,15 @@ const adminSessionUser: SessionUser = {
     ]),
 };
 const adminAccount = fromSession(adminSessionUser, 'session-cookie');
+const viewerAccount = fromSession(
+    {
+        ...adminSessionUser,
+        ability: new Ability<PossibleAbilities>([
+            { subject: 'Project', action: 'view' },
+        ]),
+    },
+    'session-cookie',
+);
 
 // buildAccount() defaults to a developer-level ability: `update`/`view` on
 // Project but NOT `manage` — additional dbt source mutations require `manage`.
@@ -303,6 +312,28 @@ describe('ProjectDbtSourcesService', () => {
     });
 
     describe('getProjectDbtSource (credential stripping)', () => {
+        const sourceWithEnvironment = {
+            projectDbtSourceUuid: sourceUuid,
+            projectUuid,
+            name: 'jaffle-2',
+            isPrimary: false,
+            precedence: 1,
+            dbtConnection: {
+                type: DbtProjectType.GITHUB,
+                authorization_method: 'installation_id',
+                installation_id: '123',
+                repository: 'acme/jaffle-2',
+                branch: 'main',
+                project_sub_path: '/dbt',
+                environment: [
+                    {
+                        key: 'DBT_ENV_SECRET_PASSWORD',
+                        value: 'super-secret',
+                    },
+                ],
+            },
+        } as never;
+
         it('strips sensitive credential fields from the returned connection', async () => {
             projectDbtSourcesModel.getSource.mockResolvedValue({
                 projectDbtSourceUuid: sourceUuid,
@@ -333,6 +364,38 @@ describe('ProjectDbtSourcesService', () => {
             expect(result.dbtConnection).toMatchObject({
                 repository: 'acme/jaffle-2',
             });
+        });
+
+        it('does not expose dbt environment variables to project viewers', async () => {
+            projectDbtSourcesModel.getSource.mockResolvedValue(
+                sourceWithEnvironment,
+            );
+            const service = getService();
+
+            const result = await service.getProjectDbtSource(
+                viewerAccount,
+                projectUuid,
+                sourceUuid,
+            );
+
+            expect(result.dbtConnection).not.toHaveProperty('environment');
+        });
+
+        it('returns dbt environment variables to users who can manage the project', async () => {
+            projectDbtSourcesModel.getSource.mockResolvedValue(
+                sourceWithEnvironment,
+            );
+            const service = getService();
+
+            const result = await service.getProjectDbtSource(
+                adminAccount,
+                projectUuid,
+                sourceUuid,
+            );
+
+            expect(result.dbtConnection).toHaveProperty('environment', [
+                { key: 'DBT_ENV_SECRET_PASSWORD', value: 'super-secret' },
+            ]);
         });
 
         it('fails clearly, naming the source, when its credentials cannot be decrypted', async () => {

--- a/packages/backend/src/services/ProjectDbtSourcesService.ts
+++ b/packages/backend/src/services/ProjectDbtSourcesService.ts
@@ -18,6 +18,7 @@ import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../config/parseConfig';
 import { ProjectDbtSourcesModel } from '../models/ProjectDbtSourcesModel';
 import { ProjectModel } from '../models/ProjectModel/ProjectModel';
+import { omitDbtEnvironment } from '../utils/dbtProjectConfig';
 import { BaseService } from './BaseService';
 
 type ProjectDbtSourcesServiceArguments = {
@@ -221,7 +222,15 @@ export class ProjectDbtSourcesService extends BaseService {
         projectUuid: string,
         projectDbtSourceUuid: string,
     ): Promise<ProjectDbtSourceWithConnection> {
-        await this.checkProjectAccess(account, projectUuid, 'view');
+        const organizationUuid = await this.checkProjectAccess(
+            account,
+            projectUuid,
+            'view',
+        );
+        const canManageProject = this.createAuditedAbility(account).can(
+            'manage',
+            subject('Project', { organizationUuid, projectUuid }),
+        );
         const source =
             await this.projectDbtSourcesModel.getSource(projectDbtSourceUuid);
         if (source.projectUuid !== projectUuid) {
@@ -238,11 +247,15 @@ export class ProjectDbtSourcesService extends BaseService {
                 `Could not load credentials for dbt source "${source.name}" — remove it and add it again with a fresh connection.`,
             );
         }
+        const dbtConnection = ProjectDbtSourcesService.stripDbtSecrets(
+            source.dbtConnection,
+        );
         return {
             ...ProjectDbtSourcesService.toSummary(source),
-            dbtConnection: ProjectDbtSourcesService.stripDbtSecrets(
-                source.dbtConnection,
-            ),
+            dbtConnection:
+                canManageProject || !dbtConnection
+                    ? dbtConnection
+                    : omitDbtEnvironment(dbtConnection),
         };
     }
 

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -30,6 +30,7 @@ import {
     type DownloadFile,
     type Explore,
     type PossibleAbilities,
+    type Project,
     type RegisteredAccount,
     type UpdateProject,
 } from '@lightdash/common';
@@ -409,6 +410,15 @@ const developerAccount = {
         ]),
     },
 } as typeof account;
+const viewerAccount = {
+    ...account,
+    user: {
+        ...account.user,
+        ability: new Ability<PossibleAbilities>([
+            { subject: 'Project', action: 'view' },
+        ]),
+    },
+} as typeof account;
 
 describe('ProjectService', () => {
     const { projectUuid } = defaultProject;
@@ -416,6 +426,39 @@ describe('ProjectService', () => {
 
     afterEach(() => {
         vi.clearAllMocks();
+    });
+
+    describe('getProject', () => {
+        const projectWithEnvironment: Project = {
+            ...projectWithSensitiveFields,
+            dbtConnection: {
+                type: DbtProjectType.DBT,
+                environment: [
+                    { key: 'DBT_ENV_SECRET_PASSWORD', value: 'super-secret' },
+                ],
+            },
+        };
+
+        test('does not expose dbt environment variables to project viewers', async () => {
+            projectModel.get.mockResolvedValueOnce(projectWithEnvironment);
+
+            const result = await service.getProject(projectUuid, viewerAccount);
+
+            expect(result.dbtConnection).not.toHaveProperty('environment');
+        });
+
+        test('returns dbt environment variables to users who can update the project', async () => {
+            projectModel.get.mockResolvedValueOnce(projectWithEnvironment);
+
+            const result = await service.getProject(
+                projectUuid,
+                developerAccount,
+            );
+
+            expect(result.dbtConnection).toHaveProperty('environment', [
+                { key: 'DBT_ENV_SECRET_PASSWORD', value: 'super-secret' },
+            ]);
+        });
     });
 
     describe('organization warehouse credential authorization', () => {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -280,6 +280,7 @@ import { CachedWarehouse, ProjectAdapter } from '../../types';
 import { runWorkerThread, wrapSentryTransaction } from '../../utils';
 import { buildCacheHash, getCacheUserUuid } from '../../utils/cacheUtils';
 import { metricQueryWithLimit as applyMetricQueryLimit } from '../../utils/csvLimitUtils';
+import { omitDbtEnvironment } from '../../utils/dbtProjectConfig';
 import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
 import { PivotQueryBuilder } from '../../utils/QueryBuilder/PivotQueryBuilder';
 import { QueryComposer } from '../../utils/QueryBuilder/QueryComposer';
@@ -2365,17 +2366,21 @@ export class ProjectService extends BaseService {
     async getProject(projectUuid: string, account: Account): Promise<Project> {
         const project = await this.projectModel.get(projectUuid);
         const auditedAbility = this.createAuditedAbility(account);
-        if (
-            auditedAbility.cannot(
-                'view',
-                subject('Project', {
-                    organizationUuid: project.organizationUuid,
-                    projectUuid,
-                }),
-            )
-        ) {
+        const projectSubject = subject('Project', {
+            organizationUuid: project.organizationUuid,
+            projectUuid,
+        });
+        if (auditedAbility.cannot('view', projectSubject)) {
             throw new ForbiddenError();
         }
+
+        if (auditedAbility.cannot('update', projectSubject)) {
+            return {
+                ...project,
+                dbtConnection: omitDbtEnvironment(project.dbtConnection),
+            };
+        }
+
         return project;
     }
 

--- a/packages/backend/src/utils/dbtProjectConfig.ts
+++ b/packages/backend/src/utils/dbtProjectConfig.ts
@@ -1,0 +1,13 @@
+import { type DbtProjectConfig } from '@lightdash/common';
+
+export const omitDbtEnvironment = (
+    dbtConnection: DbtProjectConfig,
+): DbtProjectConfig => {
+    if (!('environment' in dbtConnection)) {
+        return dbtConnection;
+    }
+
+    const { environment: _environment, ...connectionWithoutEnvironment } =
+        dbtConnection;
+    return connectionWithoutEnvironment as DbtProjectConfig;
+};


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-527/veria-43-exposure-of-sensitive-dbt-environment-variables-to-project

## What this fixes

Project read APIs currently return every dbt environment variable to anyone with project view access. This exposes credentials and tokens stored in those values to users who cannot edit the connection.

| Path | Before | After |
| --- | --- | --- |
| `ProjectService.getProject()` | `view:Project` receives environment values | Values require `update:Project` |
| `ProjectDbtSourcesService.getProjectDbtSource()` | `view:Project` receives environment values | Values require `manage:Project` |

## How

A shared `omitDbtEnvironment` projection removes the optional `environment` field without mutating the stored connection. Primary project reads apply it after the existing view check. Additional-source reads apply it after the existing top-level credential stripping.

The response omits the field instead of returning masks or empty values, so clients cannot accidentally persist a placeholder or clear the stored configuration.

## Who's affected

| User class | Primary connection | Additional dbt sources |
| --- | --- | --- |
| Admin | Unchanged | Unchanged |
| Developer | Unchanged (`update:Project`) | Environment omitted without `manage:Project` |
| Editor / Viewer | Environment omitted | Environment omitted |
| Custom roles / service accounts | Preserved with `update:Project` | Preserved with `manage:Project` |

Other project and connection metadata remains unchanged for every role.

## Test plan

- [x] Backend unit suite: 389 files, 5,772 passed, 1 existing skip
- [x] Backend typecheck
- [x] Targeted backend lint and formatting
- [x] Regression tests fail before the fix and pass after it for both services
- [x] Runtime API: Admin retains the environment on both endpoints
- [x] Runtime API: Viewer receives no environment on either endpoint
- [x] Runtime cleanup verified: original encrypted config and role restored; temporary source removed
