### PR TITLE
fix(cli): bare --apps-only means all apps

### DIFF
--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -1724,6 +1724,16 @@ export const downloadHandler = async (
 
     const isOrganizationDownload = options.organization === true;
 
+    // Bare --apps-only means "all apps": imply --include-apps.
+    if (
+        options.appsOnly &&
+        options.apps === undefined &&
+        options.includeApps !== true &&
+        options.includeAll !== true
+    ) {
+        options.includeApps = true;
+    }
+
     const includeAll = options.includeAll === true;
     const includeApps =
         !options.spacesOnly && (options.includeApps === true || includeAll);
@@ -3022,14 +3032,13 @@ export const uploadHandler = async (
             '--apps-only cannot be combined with --charts or --dashboards.',
         );
     }
+    // Bare --apps-only means "all apps": imply --include-apps.
     if (
         options.appsOnly &&
         options.apps === undefined &&
         options.includeApps !== true
     ) {
-        throw new ParameterError(
-            'Nothing to upload: --apps-only requires --apps <appReferences...> or --include-apps.',
-        );
+        options.includeApps = true;
     }
 
     const isOrganizationUpload = options.organization === true;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -941,7 +941,7 @@ const downloadCommand = program
     )
     .option(
         '--apps-only',
-        'Download only data apps (implies --skip-charts --skip-dashboards --skip-spaces). Requires --apps <appReferences...>, --include-apps, or --include-all.',
+        "Download only data apps (implies --skip-charts --skip-dashboards --skip-spaces). Bare --apps-only downloads all the project's apps; pass --apps <appReferences...> to select.",
         false,
     )
     .option(
@@ -1063,7 +1063,7 @@ const uploadCommand = program
     )
     .option(
         '--apps-only',
-        'Upload only data apps, skipping charts, dashboards, and space reconciliation. Requires --apps <appReferences...> or --include-apps.',
+        'Upload only data apps, skipping charts, dashboards, and space reconciliation. Bare --apps-only uploads every app folder; pass --apps <appReferences...> to select.',
         false,
     )
     .option(


### PR DESCRIPTION
Refs #26717 (follow-up to #26754)

Requiring `--include-apps` alongside `--apps-only` was pointless friction — asking for apps only obviously means including apps. Bare `--apps-only` now implies `--include-apps` on both download and upload; explicit `--apps` refs still narrow the selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)