### PR TITLE
feat: add deep research report navigation

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.module.css
@@ -13,13 +13,78 @@
 }
 
 .reportControls {
-    width: min(100%, 60rem);
+    width: min(100%, 74rem);
     margin-inline: auto;
-    padding-inline: clamp(1.25rem, 4vw, 3rem);
+    padding-inline: var(--mantine-spacing-lg);
 }
 
 .reportScroll {
     height: calc(100dvh - var(--navbar-height) - 3.75rem);
+}
+
+.reportLayout {
+    display: grid;
+    grid-template-columns: 14rem minmax(0, 1fr);
+    width: min(100%, 74rem);
+    min-height: 100%;
+    margin-inline: auto;
+}
+
+.contentsRail {
+    border-right: 1px solid var(--mantine-color-ldGray-2);
+}
+
+.contentsNav {
+    position: sticky;
+    top: 0;
+    display: grid;
+    gap: var(--mantine-spacing-sm);
+    padding: var(--mantine-spacing-xl) var(--mantine-spacing-md)
+        var(--mantine-spacing-3xl) var(--mantine-spacing-lg);
+}
+
+.contentsLabel {
+    padding-inline: var(--mantine-spacing-xs);
+    color: var(--mantine-color-dimmed);
+    font-size: 0.625rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    line-height: 1.4;
+    text-transform: uppercase;
+}
+
+.contentsList {
+    display: grid;
+    gap: 0.125rem;
+}
+
+.contentsControl {
+    min-width: 0;
+    padding: 0.375rem 0.625rem;
+    overflow: hidden;
+    color: var(--mantine-color-dimmed);
+    font-size: 0.75rem;
+    line-height: 1.35;
+    text-align: left;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    &[data-active='true'] {
+        color: var(--mantine-color-text);
+        background: var(--mantine-color-ldGray-1);
+        font-weight: 600;
+    }
+
+    &:focus-visible {
+        outline: 2px solid var(--mantine-color-indigo-outline);
+        outline-offset: 2px;
+    }
+}
+
+.sourceCount {
+    color: var(--mantine-color-dimmed);
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 0.6875rem;
 }
 
 .report {
@@ -43,6 +108,7 @@
 .reportHeader {
     display: grid;
     gap: var(--mantine-spacing-sm);
+    scroll-margin-top: var(--mantine-spacing-lg);
 }
 
 .introduction,
@@ -128,6 +194,7 @@
 .reportBody {
     h2 {
         margin-top: var(--mantine-spacing-3xl);
+        scroll-margin-top: var(--mantine-spacing-lg);
     }
 
     li + li {
@@ -236,6 +303,16 @@
     line-height: 1.45;
 }
 
+@media (max-width: 48em) {
+    .reportLayout {
+        display: block;
+    }
+
+    .contentsRail {
+        display: none;
+    }
+}
+
 @media (max-width: 36em) {
     .report {
         padding-inline: 1rem;
@@ -249,6 +326,15 @@
 @media print {
     .reportScroll {
         height: auto;
+    }
+
+    .reportLayout {
+        display: block;
+        width: 100%;
+    }
+
+    .contentsRail {
+        display: none;
     }
 
     .report {

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
@@ -108,6 +108,29 @@ describe('DeepResearchReport', () => {
         ).toBeInTheDocument();
     });
 
+    it('provides report section navigation', async () => {
+        renderReport(vi.fn(), {
+            ...deepResearchRunFixture,
+            sourceCount: null,
+        });
+
+        const contents = await screen.findByRole('navigation', {
+            name: 'Report contents',
+        });
+        await waitFor(() => {
+            expect(contents).toHaveTextContent('Summary');
+            expect(contents).toHaveTextContent('Conclusion');
+            expect(contents).toHaveTextContent('Sources1');
+        });
+
+        const summary = screen.getByRole('button', { name: 'Summary' });
+        const sources = screen.getByRole('button', { name: 'Sources' });
+
+        expect(summary).toHaveAttribute('aria-current', 'location');
+        expect(summary).toHaveAttribute('data-active', 'true');
+        expect(sources).not.toHaveAttribute('data-active');
+    });
+
     it('strips disallowed html from the report markdown', async () => {
         renderReport(vi.fn(), {
             ...deepResearchRunFixture,

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
@@ -5,11 +5,17 @@ import {
     Group,
     ScrollArea,
     Stack,
+    TableOfContents,
     Text,
     Title,
 } from '@mantine-8/core';
 import { IconArrowLeft } from '@tabler/icons-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { NAVBAR_HEIGHT } from '../../../../../components/common/Page/constants';
+import {
+    getDeepResearchReportHeadings,
+    getDeepResearchReportSourceCount,
+} from '../../deepResearch/reportDocument';
 import { type DeepResearchRunView } from '../../deepResearch/types';
 import { DeepResearchMarkdownReport } from './DeepResearchMarkdownReport';
 import styles from './DeepResearchReport.module.css';
@@ -21,9 +27,82 @@ type Props = {
 };
 
 export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
+    const reportRef = useRef<HTMLElement | null>(null);
+    const scrollViewportRef = useRef<HTMLDivElement | null>(null);
+    const reinitializeContents = useRef<() => void>(() => undefined);
+    const [activeSection, setActiveSection] = useState('report-summary');
+    const reportHeadings = useMemo(
+        () =>
+            run.resultMarkdown
+                ? getDeepResearchReportHeadings(run.resultMarkdown)
+                : [],
+        [run.resultMarkdown],
+    );
+    const contents = useMemo(
+        () => [
+            { id: 'report-summary', value: 'Summary', depth: 1 },
+            ...reportHeadings,
+        ],
+        [reportHeadings],
+    );
+    const updateActiveSection = useCallback(() => {
+        if (!reportRef.current || !scrollViewportRef.current) {
+            return;
+        }
+        const viewport = scrollViewportRef.current;
+        const viewportTop = viewport.getBoundingClientRect().top;
+        const headings = [
+            ...reportRef.current.querySelectorAll<HTMLElement>(
+                '[data-report-heading]',
+            ),
+        ];
+        const active = headings
+            .filter(
+                (heading) =>
+                    heading.getBoundingClientRect().top - viewportTop <= 48,
+            )
+            .at(-1);
+        const isAtEnd =
+            viewport.scrollHeight -
+                viewport.scrollTop -
+                viewport.clientHeight <=
+            2;
+
+        setActiveSection(
+            isAtEnd
+                ? (headings.at(-1)?.id ?? 'report-summary')
+                : (active?.id ?? 'report-summary'),
+        );
+    }, []);
+
+    useEffect(() => {
+        if (!opened) {
+            return undefined;
+        }
+        const frame = window.requestAnimationFrame(() => {
+            const headings =
+                reportRef.current?.querySelectorAll<HTMLElement>('h2') ?? [];
+            headings.forEach((heading, index) => {
+                const data = reportHeadings[index];
+                if (data) {
+                    heading.id = data.id;
+                    heading.dataset.reportHeading = '';
+                    heading.dataset.headingLabel = data.value;
+                }
+            });
+            reinitializeContents.current();
+        });
+        return () => window.cancelAnimationFrame(frame);
+    }, [opened, reportHeadings]);
+
     if (!run.resultMarkdown) {
         return null;
     }
+
+    const sourceCount =
+        run.sourceCount ??
+        getDeepResearchReportSourceCount(run.resultMarkdown) ??
+        '—';
 
     return (
         <Drawer
@@ -56,24 +135,103 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
             }}
             __vars={{ '--drawer-top-offset': `${NAVBAR_HEIGHT}px` }}
         >
-            <ScrollArea className={styles.reportScroll}>
-                <Box component="article" className={styles.report}>
-                    <Stack gap="xl">
-                        <Box component="header" className={styles.reportHeader}>
-                            <Text className={styles.eyebrow}>
-                                Deep research
+            <ScrollArea
+                className={styles.reportScroll}
+                viewportRef={scrollViewportRef}
+                onScrollPositionChange={updateActiveSection}
+            >
+                <Box className={styles.reportLayout}>
+                    <Box component="aside" className={styles.contentsRail}>
+                        <Box
+                            component="nav"
+                            className={styles.contentsNav}
+                            aria-label="Report contents"
+                        >
+                            <Text className={styles.contentsLabel}>
+                                Contents
                             </Text>
-                            <Title order={1} className={styles.reportTitle}>
-                                {run.question}
-                            </Title>
+                            <TableOfContents
+                                variant="light"
+                                color="gray"
+                                size="xs"
+                                radius="sm"
+                                initialData={contents}
+                                reinitializeRef={reinitializeContents}
+                                minDepthToOffset={1}
+                                classNames={{
+                                    root: styles.contentsList,
+                                    control: styles.contentsControl,
+                                }}
+                                scrollSpyOptions={{
+                                    selector:
+                                        '[data-deep-research-report] [data-report-heading]',
+                                    getDepth: () => 1,
+                                    getValue: (element) =>
+                                        element.dataset.headingLabel ?? '',
+                                }}
+                                getControlProps={({ data }) => ({
+                                    onClick: () => {
+                                        setActiveSection(data.id);
+                                        data.getNode().scrollIntoView({
+                                            block: 'start',
+                                        });
+                                    },
+                                    children:
+                                        data.value === 'Sources' ? (
+                                            <Group gap={5} wrap="nowrap">
+                                                <span>Sources</span>
+                                                <Text
+                                                    component="span"
+                                                    className={
+                                                        styles.sourceCount
+                                                    }
+                                                >
+                                                    {sourceCount}
+                                                </Text>
+                                            </Group>
+                                        ) : (
+                                            data.value
+                                        ),
+                                    title: data.value,
+                                    'data-active':
+                                        data.id === activeSection || undefined,
+                                    'aria-current':
+                                        data.id === activeSection
+                                            ? 'location'
+                                            : undefined,
+                                })}
+                            />
                         </Box>
-                        <DeepResearchMarkdownReport
-                            markdown={run.resultMarkdown}
-                            chartData={run.resultChartData}
-                            projectUuid={run.projectUuid}
-                            runUuid={run.uuid}
-                        />
-                    </Stack>
+                    </Box>
+                    <Box
+                        component="article"
+                        ref={reportRef}
+                        className={styles.report}
+                        data-deep-research-report
+                    >
+                        <Stack gap="xl">
+                            <Box
+                                component="header"
+                                id="report-summary"
+                                className={styles.reportHeader}
+                                data-report-heading
+                                data-heading-label="Summary"
+                            >
+                                <Text className={styles.eyebrow}>
+                                    Deep research
+                                </Text>
+                                <Title order={1} className={styles.reportTitle}>
+                                    {run.question}
+                                </Title>
+                            </Box>
+                            <DeepResearchMarkdownReport
+                                markdown={run.resultMarkdown}
+                                chartData={run.resultChartData}
+                                projectUuid={run.projectUuid}
+                                runUuid={run.uuid}
+                            />
+                        </Stack>
+                    </Box>
                 </Box>
             </ScrollArea>
         </Drawer>

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/reportDocument.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/reportDocument.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { getDeepResearchReportHeadings } from './reportDocument';
+
+describe('getDeepResearchReportHeadings', () => {
+    it('extracts rendered level-two headings from the Markdown AST', () => {
+        const markdown = `# Report title
+
+## **Baseline** ranking
+
+\`\`\`md
+## Not a section
+\`\`\`
+
+Temporary spikes
+----------------
+
+### Supporting detail`;
+
+        expect(getDeepResearchReportHeadings(markdown)).toEqual([
+            {
+                id: 'report-baseline-ranking-1',
+                value: 'Baseline ranking',
+                depth: 1,
+            },
+            {
+                id: 'report-temporary-spikes-2',
+                value: 'Temporary spikes',
+                depth: 1,
+            },
+        ]);
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/reportDocument.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/reportDocument.ts
@@ -1,0 +1,81 @@
+import remarkParse from 'remark-parse';
+import { unified } from 'unified';
+
+export type DeepResearchReportHeading = {
+    id: string;
+    value: string;
+    depth: number;
+};
+
+const markdownParser = unified().use(remarkParse);
+
+const getMarkdownNodeText = (node: unknown): string => {
+    if (!node || typeof node !== 'object') return '';
+
+    if (
+        'type' in node &&
+        (node.type === 'text' || node.type === 'inlineCode') &&
+        'value' in node &&
+        typeof node.value === 'string'
+    ) {
+        return node.value;
+    }
+
+    if (
+        'type' in node &&
+        node.type === 'image' &&
+        'alt' in node &&
+        typeof node.alt === 'string'
+    ) {
+        return node.alt;
+    }
+
+    if ('children' in node && Array.isArray(node.children)) {
+        return node.children.map(getMarkdownNodeText).join('');
+    }
+
+    return '';
+};
+
+const getDeepResearchReportHeadingId = (
+    title: string,
+    index: number,
+): string => {
+    const slug = title
+        .toLowerCase()
+        .normalize('NFKD')
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '')
+        .slice(0, 56);
+
+    return `report-${slug || 'section'}-${index + 1}`;
+};
+
+export const getDeepResearchReportHeadings = (
+    markdown: string,
+): DeepResearchReportHeading[] =>
+    markdownParser
+        .parse(markdown)
+        .children.filter((node) => node.type === 'heading' && node.depth === 2)
+        .map((heading, index) => {
+            const value = getMarkdownNodeText(heading).trim();
+
+            return {
+                id: getDeepResearchReportHeadingId(value, index),
+                value,
+                depth: 1,
+            };
+        });
+
+export const getDeepResearchReportSourceCount = (
+    markdown: string,
+): number | undefined => {
+    const sourcesSection = markdown.match(/^##\s+Sources\s*$([\s\S]*)/im)?.[1];
+    const sourceNumbers = [
+        ...(sourcesSection?.matchAll(/(?:^|\s)(?:\[(\d+)]|(\d+)[.)])\s+/gm) ??
+            []),
+    ].map((match) => match[1] ?? match[2]);
+    const count = new Set(sourceNumbers).size;
+
+    return count && count > 0 ? count : undefined;
+};


### PR DESCRIPTION
### Description
- add a sticky contents sidebar to completed deep research reports
- track the visible report section and support click-to-scroll navigation
- preserve the existing report rendering and hide navigation on smaller screens

### Testing
- pnpm --filter @lightdash/frontend test src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx src/ee/features/aiCopilot/components/DeepResearch/DeepResearchMarkdownReport.test.tsx
- pnpm --filter @lightdash/frontend typecheck
- focused oxlint and oxfmt checks
- validated the completed report in the local browser