### PR TITLE
fix(backend): reject SQL injection via metric query sort field ids

### DIFF
--- a/packages/backend/src/queryCompiler.test.ts
+++ b/packages/backend/src/queryCompiler.test.ts
@@ -1454,3 +1454,72 @@ describe('compilePostCalculationMetric', () => {
         );
     });
 });
+
+describe('compileMetricQuery rejects injected sort field ids (PROD-9482)', () => {
+    const injectedFieldIds = [
+        'table1_dim_1" DESC --', // double-quote break-out
+        'table1_dim_1` DESC --', // backtick break-out (BigQuery/Databricks)
+        'table1_dim_1\\', // trailing backslash (BigQuery escape break-out)
+    ];
+
+    it.each(injectedFieldIds)(
+        'throws a CompileError for sort field id %j',
+        (fieldId) => {
+            expect(() =>
+                compileMetricQuery({
+                    explore: EXPLORE,
+                    metricQuery: {
+                        ...METRIC_QUERY_NO_CALCS,
+                        sorts: [{ fieldId, descending: false }],
+                    },
+                    warehouseSqlBuilder: warehouseClientMock,
+                    availableParameters: [],
+                }),
+            ).toThrow(/quote or backslash/);
+        },
+    );
+
+    it('rejects an injected sort before compiling a running-total table calculation that consumes it', () => {
+        expect(() =>
+            compileMetricQuery({
+                explore: EXPLORE,
+                metricQuery: {
+                    ...METRIC_QUERY_NO_CALCS,
+                    sorts: [
+                        { fieldId: 'table1_dim_1" DESC --', descending: false },
+                    ],
+                    tableCalculations: [
+                        {
+                            name: 'running_total',
+                            displayName: 'Running total',
+                            template: {
+                                type: TableCalculationTemplateType.RUNNING_TOTAL,
+                                fieldId: 'table_3_metric_1',
+                            },
+                        },
+                    ],
+                },
+                warehouseSqlBuilder: warehouseClientMock,
+                availableParameters: [],
+            }),
+        ).toThrow(/quote or backslash/);
+    });
+
+    it('preserves valid dimension, metric, and table-calculation sorts', () => {
+        expect(() =>
+            compileMetricQuery({
+                explore: EXPLORE,
+                metricQuery: {
+                    ...METRIC_QUERY_VALID_REFERENCES,
+                    sorts: [
+                        { fieldId: 'table1_dim_1', descending: false },
+                        { fieldId: 'table_3_metric_1', descending: true },
+                        { fieldId: 'calc2', descending: false },
+                    ],
+                },
+                warehouseSqlBuilder: warehouseClientMock,
+                availableParameters: [],
+            }),
+        ).not.toThrow();
+    });
+});

--- a/packages/backend/src/queryCompiler.ts
+++ b/packages/backend/src/queryCompiler.ts
@@ -400,12 +400,28 @@ type CompileMetricQueryArgs = {
     warehouseSqlBuilder: WarehouseSqlBuilder;
     availableParameters: string[];
 };
+// Sort field ids are rendered verbatim inside quoted identifiers in ORDER BY, so
+// a field quote character (" or `) or a backslash can only be an attempt to break
+// out and inject SQL. Rejected across every dialect's quote char, not just the
+// current one, because compiled queries are persisted and replayed elsewhere.
+const forbiddenSortFieldIdChars = /["`\\]/;
+
+const assertSafeSortFieldId = (fieldId: string): void => {
+    if (forbiddenSortFieldIdChars.test(fieldId)) {
+        throw new CompileError(
+            `Invalid sort field "${fieldId}": field ids cannot contain quote or backslash characters.`,
+        );
+    }
+};
+
 export const compileMetricQuery = ({
     explore,
     metricQuery,
     warehouseSqlBuilder,
     availableParameters,
 }: CompileMetricQueryArgs): CompiledMetricQuery => {
+    metricQuery.sorts.forEach((sort) => assertSafeSortFieldId(sort.fieldId));
+
     const fieldQuoteChar = warehouseSqlBuilder.getFieldQuoteChar();
 
     // Reserved parameters are always referenceable in custom SQL; include them once here.


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9482

## Summary

Any user who can run a metric query could inject SQL through `MetricQuery.sorts[].fieldId`. The field id was rendered verbatim between the warehouse dialect's field-quote characters in `ORDER BY`, so a payload like `payments_payment_method" DESC --` broke out of the quoted identifier — flipping the sort despite `descending: false` and commenting out the `LIMIT`. Reachable from `POST /api/v2/projects/{uuid}/query/metric-query` and `POST /api/v1/projects/{uuid}/explores/{exploreName}/compileQuery`.

## Root cause

`compileMetricQuery` passes caller-supplied `sorts` straight to the query builder, which wraps each `fieldId` in quote chars without escaping or validating it:

```ts
// MetricQueryBuilder.getSortSQL
let fieldSort = `${fieldQuoteChar}${sort.fieldId}${fieldQuoteChar}${sort.descending ? ' DESC' : ''}...`;
```

The same raw interpolation exists in all four `ORDER BY` sinks: the standard sort, the custom-bin `_order` variant, the window `ORDER BY` (`buildWindowOrderByClause`), and the running-total table-calculation template. Legitimate field ids are always snake_case identifiers, so no valid sort ever contains a quote or backslash — those characters can only be a break-out attempt.

## Fix

Validate `sorts` at the single `compileMetricQuery` chokepoint — every builder path funnels through it — and reject any `fieldId` containing `"`, `` ` ``, or `\` with a `CompileError` (400) **before any SQL is rendered**. The forbidden set is dialect-independent (it covers every warehouse's field-quote char plus the BigQuery/Databricks/ClickHouse backslash escape), so a query compiled under one dialect can't carry a break-out char that becomes live under another.

- `packages/backend/src/queryCompiler.ts` — add `assertSafeSortFieldId`; run it over every `sorts[].fieldId` at the top of `compileMetricQuery`. Covers all four `ORDER BY` sinks at once.
- `packages/backend/src/queryCompiler.test.ts` — regression tests: rejects `"`, `` ` ``, and `\` break-outs (incl. through the running-total sink); leaves valid dimension/metric/table-calculation sorts untouched.

Chose rejection over per-dialect escaping (the ticket's suggested mechanism): rejection needs no dialect-specific escape semantics and is verifiable locally, matching the house pattern of reject-before-render (#26710, #26764); the escape-only attempt on the sibling pivot bug (#24046) was closed unmerged.

**Out of scope** (follow-ups, not this vector): other identifier positions on the same endpoints — `customDimensions[].id`, `tableCalculations[].template` refs, `additionalMetrics[].name` — tracked in PROD-9485. Pivot `sortBy` identifiers remain in PROD-9481 / SPK-615.

## Before

Injected sort compiled straight through (`descending: false`), and executed on Postgres — order reversed, `LIMIT` commented out:

```
Payload: sorts[].fieldId = payments_payment_method" DESC --   (descending: false)

Compiled:  ORDER BY "payments_payment_method" DESC --"
           LIMIT 10
Executed:  gift_card -> credit_card -> coupon -> bank_transfer   (reverse — injected DESC ran)
```

## After

```
compileQuery / metric-query   →  HTTP 400 CompileError
  "Invalid sort field "payments_payment_method" DESC --": field ids cannot
   contain quote or backslash characters."
backtick payload (BigQuery)   →  HTTP 400
valid sort (descending:false) →  bank_transfer -> coupon -> credit_card -> gift_card   (unchanged)
valid sort (descending:true)  →  gift_card -> credit_card -> coupon -> bank_transfer   (legitimate reverse)
```

## Test plan

- [x] `pnpm -F backend typecheck` && `pnpm -F backend lint` — clean
- [x] `npx vitest run src/queryCompiler.test.ts` — 50 pass (added the PROD-9482 regression suite; verified it fails against the pre-fix compiler)
- [x] `npx vitest run` over the four sink suites + snapshots (queryCompiler, tableCalculationTemplateQueryCompiler, MetricQueryBuilder, QueryComposer, TotalQueryBuilder, utils, dashboardSorts) — 415 pass, no snapshot churn (valid SQL byte-unchanged)
- [x] Manual: exploit from the ticket → 400 on both endpoints (`"` and `` ` `` payloads); valid asc/desc sorts execute correctly on the live dev instance

**Known edge (accepted):** a virtual-view column or Postgres-wire alias whose name literally contains `"`, `` ` ``, or `\` (derived from raw warehouse column names, not snake-cased) is now rejected when sorted on — rare, and fail-closed is the right default for a security fix. PROD-9485 covers validating those references at their source.