### PR TITLE
feat(homepage): scheduled announcement publishing

### DIFF
--- a/packages/backend/src/ee/database/entities/projectHomepages.ts
+++ b/packages/backend/src/ee/database/entities/projectHomepages.ts
@@ -88,13 +88,19 @@ export type DbAnnouncement = {
     updated_at: Date;
     published_at: Date | null;
     pending_slack_channel_id: string | null;
+    scheduled_publish_at: Date | null;
 };
 
 export type DbAnnouncementIn = Pick<
     DbAnnouncement,
     'project_uuid' | 'title' | 'body' | 'created_by_user_uuid' | 'published_at'
 > &
-    Partial<Pick<DbAnnouncement, 'category' | 'pending_slack_channel_id'>>;
+    Partial<
+        Pick<
+            DbAnnouncement,
+            'category' | 'pending_slack_channel_id' | 'scheduled_publish_at'
+        >
+    >;
 
 export type DbAnnouncementUpdate = Partial<
     Pick<
@@ -106,6 +112,7 @@ export type DbAnnouncementUpdate = Partial<
         | 'updated_at'
         | 'published_at'
         | 'pending_slack_channel_id'
+        | 'scheduled_publish_at'
     >
 >;
 

--- a/packages/backend/src/ee/database/migrations/20260804150000_add_announcement_scheduled_publish.ts
+++ b/packages/backend/src/ee/database/migrations/20260804150000_add_announcement_scheduled_publish.ts
@@ -1,0 +1,21 @@
+import { Knex } from 'knex';
+
+const ANNOUNCEMENTS_TABLE = 'project_announcements';
+const DUE_INDEX = 'project_announcements_due_scheduled_idx';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(ANNOUNCEMENTS_TABLE, (table) => {
+        table.timestamp('scheduled_publish_at', { useTz: false }).nullable();
+    });
+    // The sweep scans for due unpublished rows; keep that scan indexed.
+    await knex.raw(
+        `CREATE INDEX ?? ON ?? (scheduled_publish_at) WHERE published_at IS NULL AND scheduled_publish_at IS NOT NULL`,
+        [DUE_INDEX, ANNOUNCEMENTS_TABLE],
+    );
+}
+
+export async function down(knex: Knex): Promise<void> {
+    // The column stays on rollback — dropping columns is a dangerous
+    // operation, and old code simply ignores it.
+    await knex.raw(`DROP INDEX IF EXISTS ??`, [DUE_INDEX]);
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -200,6 +200,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     slackAuthenticationModel:
                         models.getSlackAuthenticationModel(),
                     lightdashConfig: context.lightdashConfig,
+                    schedulerClient:
+                        clients.getSchedulerClient() as CommercialSchedulerClient,
                 }),
             homepageRecommendedActionSkipsService: ({ models }) =>
                 new HomepageRecommendedActionSkipsService({
@@ -1225,6 +1227,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 openIdIdentityModel: context.models.getOpenIdIdentityModel(),
                 mcpToolCallModel:
                     context.models.getMcpToolCallModel<McpToolCallModel>(),
+                projectHomepageService:
+                    context.serviceRepository.getProjectHomepageService<ProjectHomepageService>(),
                 prometheusMetrics: context.prometheusMetrics,
             }),
         clientProviders: {

--- a/packages/backend/src/ee/models/ProjectHomepageModel.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.ts
@@ -617,6 +617,7 @@ export class ProjectHomepageModel {
             published:
                 row.published_at !== null && row.published_at !== undefined,
             pendingSlackChannelId: row.pending_slack_channel_id ?? null,
+            scheduledPublishAt: row.scheduled_publish_at ?? null,
             createdByUserUuid: row.created_by_user_uuid,
             authorName: row.author_name?.trim() || null,
             createdAt: row.created_at,
@@ -693,6 +694,7 @@ export class ProjectHomepageModel {
         createdByUserUuid: string;
         pendingSlackChannelId: string | null;
         published: boolean;
+        scheduledPublishAt: Date | null;
     }): Promise<ProjectAnnouncement> {
         const [row] = await this.database(AnnouncementsTableName)
             .insert({
@@ -707,6 +709,9 @@ export class ProjectHomepageModel {
                 pending_slack_channel_id: data.published
                     ? null
                     : data.pendingSlackChannelId,
+                scheduled_publish_at: data.published
+                    ? null
+                    : data.scheduledPublishAt,
             })
             .returning('*');
         return ProjectHomepageModel.mapDbAnnouncement(row);
@@ -729,6 +734,9 @@ export class ProjectHomepageModel {
             const drafts = await trx(AnnouncementsTableName)
                 .where({ project_uuid: projectUuid })
                 .whereNull('published_at')
+                // Scheduled announcements are embargoed until their own
+                // instant — a homepage republish must not fire them early.
+                .whereNull('scheduled_publish_at')
                 .forUpdate()
                 .skipLocked()
                 .select('announcement_uuid', 'pending_slack_channel_id');
@@ -773,6 +781,69 @@ export class ProjectHomepageModel {
         });
     }
 
+    /**
+     * Publishes a single unpublished announcement (publish-now / scheduled
+     * job) or every due scheduled announcement across projects (sweep).
+     * Idempotent by construction: rows are locked with skipLocked and the
+     * update re-checks `published_at IS NULL`, so a job+sweep race publishes
+     * — and returns the Slack channel to notify — exactly once.
+     */
+    async publishPendingAnnouncements(options: {
+        announcementUuid?: string;
+        onlyDue: boolean;
+    }): Promise<
+        Array<{
+            announcement: ProjectAnnouncement;
+            slackChannelId: string | null;
+        }>
+    > {
+        return this.database.transaction(async (trx) => {
+            let query = trx(AnnouncementsTableName)
+                .whereNull('published_at')
+                .forUpdate()
+                .skipLocked()
+                .select('announcement_uuid', 'pending_slack_channel_id');
+            if (options.announcementUuid) {
+                query = query.where(
+                    'announcement_uuid',
+                    options.announcementUuid,
+                );
+            }
+            if (options.onlyDue) {
+                query = query
+                    .whereNotNull('scheduled_publish_at')
+                    .where('scheduled_publish_at', '<=', new Date());
+            }
+            const pending = await query;
+            if (pending.length === 0) return [];
+
+            const rows = await trx(AnnouncementsTableName)
+                .whereIn(
+                    'announcement_uuid',
+                    pending.map((row) => row.announcement_uuid),
+                )
+                .whereNull('published_at')
+                .update({
+                    published_at: new Date(),
+                    pending_slack_channel_id: null,
+                    scheduled_publish_at: null,
+                })
+                .returning('*');
+
+            const slackChannelByUuid = new Map(
+                pending.map((row) => [
+                    row.announcement_uuid,
+                    row.pending_slack_channel_id,
+                ]),
+            );
+            return rows.map((row) => ({
+                announcement: ProjectHomepageModel.mapDbAnnouncement(row),
+                slackChannelId:
+                    slackChannelByUuid.get(row.announcement_uuid) ?? null,
+            }));
+        });
+    }
+
     async updateAnnouncement(
         announcementUuid: string,
         update: UpdateAnnouncementRequest,
@@ -804,6 +875,9 @@ export class ProjectHomepageModel {
                     }),
                     ...(update.slackChannelId !== undefined && {
                         pending_slack_channel_id: update.slackChannelId,
+                    }),
+                    ...(update.scheduledPublishAt !== undefined && {
+                        scheduled_publish_at: update.scheduledPublishAt,
                     }),
                     updated_at: new Date(),
                 })

--- a/packages/backend/src/ee/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerClient.ts
@@ -17,6 +17,7 @@ import {
     EmbedArtifactVersionJobPayload,
     GenerateArtifactQuestionJobPayload,
     JobPriority,
+    PublishAnnouncementPayload,
     SlackPromptJobPayload,
 } from '@lightdash/common';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
@@ -42,6 +43,40 @@ export const aiAgentReviewRunAt = (
         : now;
 
 export class CommercialSchedulerClient extends SchedulerClient {
+    /**
+     * One pending publish per announcement: the stable jobKey (default
+     * jobKeyMode `replace`) makes rescheduling an in-place move of `runAt`.
+     * maxAttempts 1 — the due-announcements sweep is the retry mechanism.
+     */
+    async schedulePublishAnnouncement(
+        payload: PublishAnnouncementPayload,
+        runAt: Date,
+    ) {
+        const graphileClient = await this.graphileUtils;
+        const { id: jobId } = await graphileClient.addJob(
+            EE_SCHEDULER_TASKS.PUBLISH_ANNOUNCEMENT,
+            payload,
+            {
+                runAt,
+                maxAttempts: 1,
+                jobKey: `announcement-publish:${payload.announcementUuid}`,
+                priority: JobPriority.LOW,
+            },
+        );
+        return { jobId };
+    }
+
+    async cancelPublishAnnouncement(announcementUuid: string): Promise<void> {
+        const graphileClient = await this.graphileUtils;
+        await graphileClient.withPgClient(async (pgClient) => {
+            await pgClient.query(
+                `DELETE FROM graphile_worker.jobs
+                 WHERE locked_by IS NULL AND key = $1`,
+                [`announcement-publish:${announcementUuid}`],
+            );
+        });
+    }
+
     async aiAgentMemoryDistill(payload: AiAgentMemoryDistillJobPayload) {
         const graphileClient = await this.graphileUtils;
         const { id: jobId } = await graphileClient.addJob(

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -34,6 +34,7 @@ import type { EmbedService } from '../services/EmbedService/EmbedService';
 import { ManagedAgentService } from '../services/ManagedAgentService/ManagedAgentService';
 import { type OnboardingAgentService } from '../services/OnboardingAgentService/OnboardingAgentService';
 import { ProjectContextService } from '../services/ProjectContextService/ProjectContextService';
+import type { ProjectHomepageService } from '../services/ProjectHomepageService';
 import { sendReviewNotification } from './tasks/sendReviewNotification';
 
 const MCP_TOOL_CALL_RETENTION_DAYS = 90;
@@ -115,6 +116,10 @@ type CommercialSchedulerWorkerArguments = SchedulerWorkerArguments & {
     projectModel: ProjectModel;
     openIdIdentityModel: OpenIdIdentityModel;
     mcpToolCallModel: McpToolCallModel;
+    projectHomepageService: Pick<
+        ProjectHomepageService,
+        'publishScheduledAnnouncement' | 'sweepDueAnnouncements'
+    >;
 };
 
 export class CommercialSchedulerWorker extends SchedulerWorker {
@@ -152,6 +157,8 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
 
     protected readonly mcpToolCallModel: McpToolCallModel;
 
+    protected readonly projectHomepageService: CommercialSchedulerWorkerArguments['projectHomepageService'];
+
     private readonly cleanupMetrics: PrometheusMetrics | null;
 
     constructor(args: CommercialSchedulerWorkerArguments) {
@@ -176,6 +183,7 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
         this.projectModel = args.projectModel;
         this.openIdIdentityModel = args.openIdIdentityModel;
         this.mcpToolCallModel = args.mcpToolCallModel;
+        this.projectHomepageService = args.projectHomepageService;
         this.cleanupMetrics = args.prometheusMetrics ?? null;
     }
 
@@ -187,6 +195,16 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                 pattern: '*/2 * * * *', // Every 2 minutes
                 options: {
                     backfillPeriod: 5 * 60 * 1000, // 5 min
+                    maxAttempts: 1,
+                },
+            },
+            {
+                // Backstop for scheduled announcement publishes whose one-shot
+                // job was lost (deploy, crash): late, never lost.
+                task: EE_SCHEDULER_TASKS.SWEEP_DUE_ANNOUNCEMENTS,
+                pattern: '*/10 * * * *', // Every 10 minutes
+                options: {
+                    backfillPeriod: 10 * 60 * 1000, // 10 min
                     maxAttempts: 1,
                 },
             },
@@ -699,6 +717,14 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
             },
             [EE_SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS]: async () => {
                 await this.appGenerateService.sweepStaleLocks();
+            },
+            [EE_SCHEDULER_TASKS.PUBLISH_ANNOUNCEMENT]: async (payload) => {
+                await this.projectHomepageService.publishScheduledAnnouncement(
+                    payload,
+                );
+            },
+            [EE_SCHEDULER_TASKS.SWEEP_DUE_ANNOUNCEMENTS]: async () => {
+                await this.projectHomepageService.sweepDueAnnouncements();
             },
             [EE_SCHEDULER_TASKS.SWEEP_STALE_AI_WRITEBACK_RUNS]: async () => {
                 const swept = await this.aiWritebackService.sweepStaleRuns();

--- a/packages/backend/src/ee/services/ProjectHomepageService.test.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.test.ts
@@ -118,6 +118,7 @@ const makeService = ({
     persistentDownloadFileService = {},
     slackClient = {},
     slackInstalled = true,
+    schedulerClient = {},
 }: {
     flagEnabled?: boolean;
     projectHomepageModel?: Partial<
@@ -133,6 +134,9 @@ const makeService = ({
     >;
     slackClient?: Partial<ProjectHomepageServiceArguments['slackClient']>;
     slackInstalled?: boolean;
+    schedulerClient?: Partial<
+        ProjectHomepageServiceArguments['schedulerClient']
+    >;
 } = {}) =>
     new ProjectHomepageService({
         analytics: { track: vi.fn() },
@@ -164,6 +168,7 @@ const makeService = ({
             updateAnnouncement: vi.fn(),
             deleteAnnouncement: vi.fn().mockResolvedValue(undefined),
             publishProjectDraftAnnouncements: vi.fn().mockResolvedValue([]),
+            publishPendingAnnouncements: vi.fn().mockResolvedValue([]),
             findOrgHomepageSettings: vi.fn().mockResolvedValue(null),
             upsertOrgHomepageSettings: vi.fn(),
             swapHeroBlocks: vi.fn().mockResolvedValue(undefined),
@@ -205,6 +210,13 @@ const makeService = ({
         lightdashConfig: {
             siteUrl: 'http://localhost:3000',
         } as ProjectHomepageServiceArguments['lightdashConfig'],
+        schedulerClient: {
+            schedulePublishAnnouncement: vi
+                .fn()
+                .mockResolvedValue({ jobId: 'job-1' }),
+            cancelPublishAnnouncement: vi.fn().mockResolvedValue(undefined),
+            ...schedulerClient,
+        },
     });
 
 describe('ProjectHomepageService', () => {
@@ -734,6 +746,7 @@ describe('ProjectHomepageService', () => {
             category: null,
             pinned: false,
             published: false,
+            scheduledPublishAt: null,
             createdByUserUuid: 'user-1',
             authorName: 'Ana',
             createdAt: new Date(),
@@ -842,6 +855,259 @@ describe('ProjectHomepageService', () => {
                 expect.objectContaining({ published: true }),
             );
             expect(postMessage).not.toHaveBeenCalled();
+        });
+
+        it('createAnnouncement with scheduledPublishAt stores it and enqueues the one-shot job', async () => {
+            const future = new Date(Date.now() + 60 * 60 * 1000);
+            const createAnnouncement = vi.fn().mockResolvedValue({
+                ...madeAnnouncement,
+                scheduledPublishAt: future,
+            });
+            const schedulePublishAnnouncement = vi
+                .fn()
+                .mockResolvedValue({ jobId: 'job-1' });
+            const service = makeService({
+                projectHomepageModel: { createAnnouncement },
+                schedulerClient: { schedulePublishAnnouncement },
+            });
+            await service.createAnnouncement(makeAdminUser(), PROJECT_UUID, {
+                title: 'Launch',
+                body: null,
+                category: null,
+                scheduledPublishAt: future,
+            });
+            expect(createAnnouncement).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    published: false,
+                    scheduledPublishAt: future,
+                }),
+            );
+            expect(schedulePublishAnnouncement).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    announcementUuid: madeAnnouncement.announcementUuid,
+                    projectUuid: PROJECT_UUID,
+                }),
+                future,
+            );
+        });
+
+        it('createAnnouncement rejects a past scheduledPublishAt', async () => {
+            const service = makeService();
+            await expect(
+                service.createAnnouncement(makeAdminUser(), PROJECT_UUID, {
+                    title: 'Launch',
+                    body: null,
+                    category: null,
+                    scheduledPublishAt: new Date(Date.now() - 1000),
+                }),
+            ).rejects.toThrow(ParameterError);
+        });
+
+        it('createAnnouncement rejects publishNow combined with scheduledPublishAt', async () => {
+            const service = makeService();
+            await expect(
+                service.createAnnouncement(makeAdminUser(), PROJECT_UUID, {
+                    title: 'Launch',
+                    body: null,
+                    category: null,
+                    publishNow: true,
+                    scheduledPublishAt: new Date(Date.now() + 60_000),
+                }),
+            ).rejects.toThrow(ParameterError);
+        });
+
+        it('updateAnnouncement reschedules the job when scheduledPublishAt changes', async () => {
+            const future = new Date(Date.now() + 60 * 60 * 1000);
+            const schedulePublishAnnouncement = vi
+                .fn()
+                .mockResolvedValue({ jobId: 'job-1' });
+            const service = makeService({
+                projectHomepageModel: {
+                    getAnnouncement: vi
+                        .fn()
+                        .mockResolvedValue(madeAnnouncement),
+                    updateAnnouncement: vi.fn().mockResolvedValue({
+                        ...madeAnnouncement,
+                        scheduledPublishAt: future,
+                    }),
+                },
+                schedulerClient: { schedulePublishAnnouncement },
+            });
+            await service.updateAnnouncement(
+                makeAdminUser(),
+                PROJECT_UUID,
+                'ann-9',
+                { scheduledPublishAt: future },
+            );
+            expect(schedulePublishAnnouncement).toHaveBeenCalledWith(
+                expect.objectContaining({ announcementUuid: 'ann-9' }),
+                future,
+            );
+        });
+
+        it('updateAnnouncement unschedules back to draft and cancels the job', async () => {
+            const cancelPublishAnnouncement = vi
+                .fn()
+                .mockResolvedValue(undefined);
+            const updateAnnouncement = vi
+                .fn()
+                .mockResolvedValue(madeAnnouncement);
+            const service = makeService({
+                projectHomepageModel: {
+                    getAnnouncement: vi.fn().mockResolvedValue({
+                        ...madeAnnouncement,
+                        scheduledPublishAt: new Date(Date.now() + 60_000),
+                    }),
+                    updateAnnouncement,
+                },
+                schedulerClient: { cancelPublishAnnouncement },
+            });
+            await service.updateAnnouncement(
+                makeAdminUser(),
+                PROJECT_UUID,
+                'ann-9',
+                { scheduledPublishAt: null },
+            );
+            expect(updateAnnouncement).toHaveBeenCalledWith(
+                'ann-9',
+                expect.objectContaining({ scheduledPublishAt: null }),
+            );
+            expect(cancelPublishAnnouncement).toHaveBeenCalledWith('ann-9');
+        });
+
+        it('updateAnnouncement publishNow publishes once, notifies Slack, and cancels the job', async () => {
+            const postMessage = vi.fn().mockResolvedValue(undefined);
+            const cancelPublishAnnouncement = vi
+                .fn()
+                .mockResolvedValue(undefined);
+            const publishPendingAnnouncements = vi.fn().mockResolvedValue([
+                {
+                    announcement: { ...madeAnnouncement, published: true },
+                    slackChannelId: 'C123',
+                },
+            ]);
+            const service = makeService({
+                projectHomepageModel: {
+                    getAnnouncement: vi
+                        .fn()
+                        .mockResolvedValue(madeAnnouncement),
+                    publishPendingAnnouncements,
+                },
+                schedulerClient: { cancelPublishAnnouncement },
+                slackClient: { postMessage },
+            });
+            const result = await service.updateAnnouncement(
+                makeAdminUser(),
+                PROJECT_UUID,
+                'ann-9',
+                { publishNow: true },
+            );
+            expect(publishPendingAnnouncements).toHaveBeenCalledWith({
+                announcementUuid: 'ann-9',
+                onlyDue: false,
+            });
+            expect(cancelPublishAnnouncement).toHaveBeenCalledWith('ann-9');
+            expect(postMessage).toHaveBeenCalledWith(
+                expect.objectContaining({ channel: 'C123' }),
+            );
+            expect(result.published).toBe(true);
+        });
+
+        it('updateAnnouncement rejects scheduling a published announcement', async () => {
+            const service = makeService({
+                projectHomepageModel: {
+                    getAnnouncement: vi.fn().mockResolvedValue({
+                        ...madeAnnouncement,
+                        published: true,
+                    }),
+                },
+            });
+            await expect(
+                service.updateAnnouncement(
+                    makeAdminUser(),
+                    PROJECT_UUID,
+                    'ann-9',
+                    { scheduledPublishAt: new Date(Date.now() + 60_000) },
+                ),
+            ).rejects.toThrow(ParameterError);
+        });
+
+        it('deleteAnnouncement cancels any pending publish job', async () => {
+            const cancelPublishAnnouncement = vi
+                .fn()
+                .mockResolvedValue(undefined);
+            const service = makeService({
+                projectHomepageModel: {
+                    getAnnouncement: vi
+                        .fn()
+                        .mockResolvedValue(madeAnnouncement),
+                },
+                schedulerClient: { cancelPublishAnnouncement },
+            });
+            await service.deleteAnnouncement(
+                makeAdminUser(),
+                PROJECT_UUID,
+                madeAnnouncement.announcementUuid,
+            );
+            expect(cancelPublishAnnouncement).toHaveBeenCalledWith(
+                madeAnnouncement.announcementUuid,
+            );
+        });
+
+        it('publishScheduledAnnouncement no-ops when the payload project does not own the row', async () => {
+            const publishPendingAnnouncements = vi.fn();
+            const service = makeService({
+                projectHomepageModel: {
+                    getAnnouncement: vi.fn().mockResolvedValue({
+                        ...madeAnnouncement,
+                        projectUuid: 'other-project',
+                    }),
+                    publishPendingAnnouncements,
+                },
+            });
+            await service.publishScheduledAnnouncement({
+                organizationUuid: ORGANIZATION_UUID,
+                projectUuid: PROJECT_UUID,
+                userUuid: 'user-1',
+                announcementUuid: madeAnnouncement.announcementUuid,
+            });
+            expect(publishPendingAnnouncements).not.toHaveBeenCalled();
+        });
+
+        it('sweepDueAnnouncements publishes due rows and notifies Slack via the project org', async () => {
+            const postMessage = vi.fn().mockResolvedValue(undefined);
+            const getSummary = vi
+                .fn()
+                .mockResolvedValue({ organizationUuid: ORGANIZATION_UUID });
+            const service = makeService({
+                projectHomepageModel: {
+                    publishPendingAnnouncements: vi.fn().mockResolvedValue([
+                        {
+                            announcement: {
+                                ...madeAnnouncement,
+                                published: true,
+                            },
+                            slackChannelId: 'C123',
+                        },
+                        {
+                            announcement: {
+                                ...madeAnnouncement,
+                                announcementUuid: 'ann-10',
+                                published: true,
+                            },
+                            slackChannelId: null,
+                        },
+                    ]),
+                },
+                projectModel: { getSummary },
+                slackClient: { postMessage },
+            });
+            const count = await service.sweepDueAnnouncements();
+            expect(count).toBe(2);
+            expect(postMessage).toHaveBeenCalledTimes(1);
+            expect(postMessage).toHaveBeenCalledWith(
+                expect.objectContaining({ channel: 'C123' }),
+            );
         });
 
         it('createAnnouncement without publishNow stays a draft', async () => {

--- a/packages/backend/src/ee/services/ProjectHomepageService.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.ts
@@ -23,6 +23,7 @@ import {
     type ProjectAnnouncement,
     type ProjectHomepage,
     type ProjectMemberRole,
+    type PublishAnnouncementPayload,
     type ResolvedHomepage,
     type SessionUser,
     type UpdateAnnouncementRequest,
@@ -45,6 +46,7 @@ import { type FeatureFlagService } from '../../services/FeatureFlag/FeatureFlagS
 import { type PersistentDownloadFileService } from '../../services/PersistentDownloadFileService/PersistentDownloadFileService';
 import { secureFetch } from '../../utils/secureFetch/secureFetch';
 import { type ProjectHomepageModel } from '../models/ProjectHomepageModel';
+import { type CommercialSchedulerClient } from '../scheduler/SchedulerClient';
 import {
     classifyResourceUrl,
     parseOpenGraph,
@@ -184,6 +186,7 @@ export type ProjectHomepageServiceArguments = {
         | 'updateAnnouncement'
         | 'deleteAnnouncement'
         | 'publishProjectDraftAnnouncements'
+        | 'publishPendingAnnouncements'
         | 'findOrgHomepageSettings'
         | 'upsertOrgHomepageSettings'
         | 'swapHeroBlocks'
@@ -200,6 +203,10 @@ export type ProjectHomepageServiceArguments = {
         'getInstallationFromOrganizationUuid'
     >;
     lightdashConfig: Pick<LightdashConfig, 'siteUrl'>;
+    schedulerClient: Pick<
+        CommercialSchedulerClient,
+        'schedulePublishAnnouncement' | 'cancelPublishAnnouncement'
+    >;
 };
 
 export class ProjectHomepageService extends BaseService {
@@ -223,6 +230,8 @@ export class ProjectHomepageService extends BaseService {
 
     private readonly lightdashConfig: ProjectHomepageServiceArguments['lightdashConfig'];
 
+    private readonly schedulerClient: ProjectHomepageServiceArguments['schedulerClient'];
+
     constructor(args: ProjectHomepageServiceArguments) {
         super();
         this.projectHomepageModel = args.projectHomepageModel;
@@ -235,6 +244,7 @@ export class ProjectHomepageService extends BaseService {
         this.slackClient = args.slackClient;
         this.slackAuthenticationModel = args.slackAuthenticationModel;
         this.lightdashConfig = args.lightdashConfig;
+        this.schedulerClient = args.schedulerClient;
     }
 
     // Homepage v2 is on when the org opted in via settings OR the commercial
@@ -914,6 +924,16 @@ export class ProjectHomepageService extends BaseService {
         await this.assertCanManage(user, projectUuid);
         ProjectHomepageService.validateAnnouncementTitle(data.title);
         ProjectHomepageService.validateAnnouncementBody(data.body);
+        if (data.publishNow && data.scheduledPublishAt) {
+            throw new ParameterError(
+                'An announcement cannot both publish now and be scheduled',
+            );
+        }
+        if (data.scheduledPublishAt) {
+            ProjectHomepageService.validateScheduledPublishAt(
+                data.scheduledPublishAt,
+            );
+        }
         if (data.slackChannelId) {
             if (!user.organizationUuid) throw new ForbiddenError();
             await this.assertSlackInstalled(user.organizationUuid);
@@ -921,7 +941,8 @@ export class ProjectHomepageService extends BaseService {
         // Default path creates a draft — invisible on the live homepage, its
         // Slack notification (if any) deferred until the homepage is
         // published, see `publishHomepage`. With `publishNow` (posting from
-        // the published homepage) it goes live and notifies immediately.
+        // the published homepage) it goes live and notifies immediately; with
+        // `scheduledPublishAt` it goes live at that instant.
         const announcement = await this.projectHomepageModel.createAnnouncement(
             {
                 projectUuid,
@@ -931,6 +952,7 @@ export class ProjectHomepageService extends BaseService {
                 createdByUserUuid: user.userUuid,
                 pendingSlackChannelId: data.slackChannelId ?? null,
                 published: data.publishNow === true,
+                scheduledPublishAt: data.scheduledPublishAt ?? null,
             },
         );
         if (data.publishNow && data.slackChannelId && user.organizationUuid) {
@@ -939,6 +961,20 @@ export class ProjectHomepageService extends BaseService {
                 projectUuid,
                 announcement,
                 data.slackChannelId,
+            );
+        }
+        if (announcement.scheduledPublishAt) {
+            // assertCanManage guarantees an org; throw rather than silently
+            // leaving the row to the sweep if that invariant ever breaks.
+            if (!user.organizationUuid) throw new ForbiddenError();
+            await this.schedulerClient.schedulePublishAnnouncement(
+                {
+                    organizationUuid: user.organizationUuid,
+                    projectUuid,
+                    userUuid: user.userUuid,
+                    announcementUuid: announcement.announcementUuid,
+                },
+                announcement.scheduledPublishAt,
             );
         }
         return announcement;
@@ -975,10 +1011,75 @@ export class ProjectHomepageService extends BaseService {
                 await this.assertSlackInstalled(user.organizationUuid);
             }
         }
-        return this.projectHomepageModel.updateAnnouncement(announcementUuid, {
-            ...update,
-            ...(update.title !== undefined && { title: update.title.trim() }),
-        });
+        const { publishNow, scheduledPublishAt, ...contentUpdate } = update;
+        if (publishNow && scheduledPublishAt) {
+            throw new ParameterError(
+                'An announcement cannot both publish now and be scheduled',
+            );
+        }
+        if (
+            announcement.published &&
+            (publishNow || scheduledPublishAt !== undefined)
+        ) {
+            throw new ParameterError('Announcement is already published');
+        }
+        if (scheduledPublishAt) {
+            ProjectHomepageService.validateScheduledPublishAt(
+                scheduledPublishAt,
+            );
+        }
+
+        // Content edits (and any schedule change) land first so a publish-now
+        // publishes what the admin just wrote, with the current Slack target.
+        const hasModelUpdate =
+            Object.keys(contentUpdate).length > 0 ||
+            scheduledPublishAt !== undefined;
+        const updated = hasModelUpdate
+            ? await this.projectHomepageModel.updateAnnouncement(
+                  announcementUuid,
+                  {
+                      ...contentUpdate,
+                      ...(update.title !== undefined && {
+                          title: update.title.trim(),
+                      }),
+                      ...(scheduledPublishAt !== undefined && {
+                          scheduledPublishAt,
+                      }),
+                  },
+              )
+            : announcement;
+
+        if (publishNow) {
+            const published =
+                await this.projectHomepageModel.publishPendingAnnouncements({
+                    announcementUuid,
+                    onlyDue: false,
+                });
+            await this.schedulerClient.cancelPublishAnnouncement(
+                announcementUuid,
+            );
+            await this.notifyPublishedAnnouncements(published);
+            return published[0]?.announcement ?? updated;
+        }
+        if (scheduledPublishAt) {
+            // assertCanManage guarantees an org; throw rather than silently
+            // leaving the row to the sweep if that invariant ever breaks.
+            if (!user.organizationUuid) throw new ForbiddenError();
+            await this.schedulerClient.schedulePublishAnnouncement(
+                {
+                    organizationUuid: user.organizationUuid,
+                    projectUuid,
+                    userUuid: user.userUuid,
+                    announcementUuid,
+                },
+                scheduledPublishAt,
+            );
+        } else if (scheduledPublishAt === null) {
+            await this.schedulerClient.cancelPublishAnnouncement(
+                announcementUuid,
+            );
+        }
+        return updated;
     }
 
     // Best-effort: uploaded images are only reachable through the body, so
@@ -1023,7 +1124,83 @@ export class ProjectHomepageService extends BaseService {
             announcementUuid,
         );
         await this.projectHomepageModel.deleteAnnouncement(announcementUuid);
+        await this.schedulerClient.cancelPublishAnnouncement(announcementUuid);
         await this.deleteAnnouncementImages(projectUuid, announcement.body);
+    }
+
+    private static validateScheduledPublishAt(scheduledPublishAt: Date): void {
+        if (
+            Number.isNaN(scheduledPublishAt.getTime()) ||
+            scheduledPublishAt.getTime() <= Date.now()
+        ) {
+            throw new ParameterError(
+                'Scheduled publish time must be in the future',
+            );
+        }
+    }
+
+    /** Slack for announcements published by the worker: org resolved from the
+     * project row at publish time, never from a stale job payload. */
+    private async notifyPublishedAnnouncements(
+        published: Array<{
+            announcement: ProjectAnnouncement;
+            slackChannelId: string | null;
+        }>,
+    ): Promise<void> {
+        await Promise.all(
+            published.map(async ({ announcement, slackChannelId }) => {
+                if (!slackChannelId) return;
+                try {
+                    const { organizationUuid } =
+                        await this.projectModel.getSummary(
+                            announcement.projectUuid,
+                        );
+                    await this.notifyAnnouncementToSlack(
+                        organizationUuid,
+                        announcement.projectUuid,
+                        announcement,
+                        slackChannelId,
+                    );
+                } catch (error) {
+                    this.logger.error(
+                        `Failed to notify Slack for announcement ${
+                            announcement.announcementUuid
+                        }: ${getErrorMessage(error)}`,
+                    );
+                }
+            }),
+        );
+    }
+
+    /** Worker entrypoint for the one-shot publish job. */
+    async publishScheduledAnnouncement(
+        payload: PublishAnnouncementPayload,
+    ): Promise<void> {
+        const announcement = await this.projectHomepageModel.getAnnouncement(
+            payload.announcementUuid,
+        );
+        // Stale or forged payloads publish nothing: the row must still exist,
+        // belong to the payload's project, and actually be due.
+        if (!announcement || announcement.projectUuid !== payload.projectUuid) {
+            return;
+        }
+        const published =
+            await this.projectHomepageModel.publishPendingAnnouncements({
+                announcementUuid: payload.announcementUuid,
+                onlyDue: true,
+            });
+        await this.notifyPublishedAnnouncements(published);
+    }
+
+    /** Worker entrypoint for the backstop sweep: publishes anything due whose
+     * job was lost (deploy, crash). Returns how many were published. */
+    async sweepDueAnnouncements(): Promise<number> {
+        const published =
+            await this.projectHomepageModel.publishPendingAnnouncements({
+                onlyDue: true,
+            });
+        await this.notifyPublishedAnnouncements(published);
+        return published.length;
     }
 
     private static async bufferAnnouncementImageUpload(

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -255,6 +255,13 @@ const getTagsForTask: {
         'user.uuid': payload.userUuid,
         'project.uuid': payload.projectUuid,
     }),
+    [SCHEDULER_TASKS.PUBLISH_ANNOUNCEMENT]: (payload) => ({
+        'organization.uuid': payload.organizationUuid,
+        'user.uuid': payload.userUuid,
+        'project.uuid': payload.projectUuid,
+        'announcement.uuid': payload.announcementUuid,
+    }),
+    [SCHEDULER_TASKS.SWEEP_DUE_ANNOUNCEMENTS]: () => ({}),
     [SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS]: () => ({}),
     [SCHEDULER_TASKS.SWEEP_STALE_AI_WRITEBACK_RUNS]: () => ({}),
     [SCHEDULER_TASKS.SWEEP_STALE_AI_DEEP_RESEARCH_RUNS]: () => ({}),

--- a/packages/common/src/ee/homepage/types.ts
+++ b/packages/common/src/ee/homepage/types.ts
@@ -489,6 +489,11 @@ export type ProjectAnnouncement = {
      * are only visible to users who can manage announcements.
      */
     pendingSlackChannelId: string | null;
+    /**
+     * When set (and unpublished), the announcement publishes automatically at
+     * this UTC instant. Null once published or for plain drafts.
+     */
+    scheduledPublishAt: Date | null;
     createdByUserUuid: string | null;
     authorName: string | null;
     createdAt: Date;
@@ -513,8 +518,14 @@ export type CreateAnnouncementRequest = {
      * When true the announcement goes live immediately and its Slack
      * notification (if any) fires now, instead of waiting for the next
      * homepage publish. Used when posting from the published homepage.
+     * Mutually exclusive with `scheduledPublishAt`.
      */
     publishNow?: boolean;
+    /**
+     * Future UTC instant at which the announcement publishes automatically
+     * (Slack notification fires then). Mutually exclusive with `publishNow`.
+     */
+    scheduledPublishAt?: Date;
 };
 
 /** PATCH semantics: omitted fields are left unchanged */
@@ -525,6 +536,17 @@ export type UpdateAnnouncementRequest = {
     pinned?: boolean;
     /** Only drafts: set to retarget the Slack notification, null to cancel it */
     slackChannelId?: string | null;
+    /**
+     * Unpublished only: set a future UTC instant to schedule (or reschedule)
+     * automatic publishing, null to unschedule back to a plain draft.
+     */
+    scheduledPublishAt?: Date | null;
+    /**
+     * Unpublished only: publish immediately (fires the pending Slack
+     * notification, cancels any schedule). Cannot combine with
+     * `scheduledPublishAt`.
+     */
+    publishNow?: boolean;
 };
 
 /** Slack's markdown block rejects ~12k chars; cap bodies well under it */

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -612,6 +612,10 @@ export type TraceTaskBase = {
     schedulerUuid?: string;
 };
 
+export type PublishAnnouncementPayload = TraceTaskBase & {
+    announcementUuid: string;
+};
+
 export type ManagedAgentHeartbeatTriggeredBy = 'cron' | 'manual' | 'on_enable';
 
 export type ManagedAgentHeartbeatPayload = TraceTaskBase & {

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -36,6 +36,7 @@ import {
     type MaterializePreAggregatePayload,
     type MsTeamsBatchNotificationPayload,
     type MsTeamsNotificationPayload,
+    type PublishAnnouncementPayload,
     type ReplaceCustomFieldsPayload,
     type ScheduledDeliveryPayload,
     type SchedulerCreateProjectWithCompilePayload,
@@ -162,6 +163,8 @@ export const EE_SCHEDULER_TASKS = {
     CONSOLIDATE_AI_AGENT_MEMORY_PARTITION: 'consolidateAiAgentMemoryPartition',
     CLEAN_MCP_TOOL_CALLS: 'cleanMcpToolCalls',
     CLEAN_AI_DEEP_RESEARCH_REPORTS: 'cleanAiDeepResearchReports',
+    PUBLISH_ANNOUNCEMENT: 'publishAnnouncement',
+    SWEEP_DUE_ANNOUNCEMENTS: 'sweepDueAnnouncements',
 } as const;
 
 export const SCHEDULER_TASKS = {
@@ -270,6 +273,8 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.CONSOLIDATE_AI_AGENT_MEMORY_PARTITION]: AiAgentMemoryConsolidatePartitionJobPayload;
     [SCHEDULER_TASKS.CLEAN_MCP_TOOL_CALLS]: TraceTaskBase;
     [SCHEDULER_TASKS.CLEAN_AI_DEEP_RESEARCH_REPORTS]: TraceTaskBase;
+    [SCHEDULER_TASKS.PUBLISH_ANNOUNCEMENT]: PublishAnnouncementPayload;
+    [SCHEDULER_TASKS.SWEEP_DUE_ANNOUNCEMENTS]: TraceTaskBase;
     [SCHEDULER_TASKS.AI_WRITEBACK_PIPELINE]: AiWritebackPipelineJobPayload;
     [SCHEDULER_TASKS.AI_DEEP_RESEARCH]: AiDeepResearchPipelineJobPayload;
     [SCHEDULER_TASKS.AGENT_ONBOARDING_RUN]: AgentOnboardingPipelineJobPayload;
@@ -298,6 +303,8 @@ export interface EETaskPayloadMap {
     [EE_SCHEDULER_TASKS.CONSOLIDATE_AI_AGENT_MEMORY_PARTITION]: AiAgentMemoryConsolidatePartitionJobPayload;
     [EE_SCHEDULER_TASKS.CLEAN_MCP_TOOL_CALLS]: TraceTaskBase;
     [EE_SCHEDULER_TASKS.CLEAN_AI_DEEP_RESEARCH_REPORTS]: TraceTaskBase;
+    [EE_SCHEDULER_TASKS.PUBLISH_ANNOUNCEMENT]: PublishAnnouncementPayload;
+    [EE_SCHEDULER_TASKS.SWEEP_DUE_ANNOUNCEMENTS]: TraceTaskBase;
     [EE_SCHEDULER_TASKS.AI_WRITEBACK_PIPELINE]: AiWritebackPipelineJobPayload;
     [EE_SCHEDULER_TASKS.AI_DEEP_RESEARCH]: AiDeepResearchPipelineJobPayload;
     [EE_SCHEDULER_TASKS.AGENT_ONBOARDING_RUN]: AgentOnboardingPipelineJobPayload;

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AnnouncementsBlock.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AnnouncementsBlock.test.tsx
@@ -43,6 +43,7 @@ const announcement: ProjectAnnouncement = {
     pinned: false,
     published: true,
     pendingSlackChannelId: null,
+    scheduledPublishAt: null,
     createdByUserUuid: 'u1',
     authorName: 'Ana',
     createdAt: new Date(),

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AnnouncementsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AnnouncementsBlock.tsx
@@ -13,17 +13,21 @@ import {
     Select,
     Skeleton,
     Stack,
+    Switch,
     Text,
     TextInput,
     Tooltip,
 } from '@mantine-8/core';
+import { TimeInput } from '@mantine-8/dates';
 import {
     IconChevronDown,
     IconChevronRight,
+    IconClock,
     IconPencil,
     IconPin,
     IconPinnedOff,
     IconPlus,
+    IconSend,
     IconSpeakerphone,
     IconTrash,
 } from '@tabler/icons-react';
@@ -36,6 +40,7 @@ import {
     type ReactNode,
 } from 'react';
 import { CategoryBadge } from '../../../../components/common/CategoryBadge/CategoryBadge';
+import CalendarPickerInput from '../../../../components/common/DatePickers/CalendarPickerInput';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import MantineModal from '../../../../components/common/MantineModal';
 import { SlackChannelSelect } from '../../../../components/common/SlackChannelSelect';
@@ -155,9 +160,23 @@ const AnnouncementCard: FC<{
         {(announcement.pinned || !announcement.published) && (
             <div className={classes.cardHeader}>
                 <span className={classes.headerTags}>
-                    {!announcement.published && (
-                        <span className={classes.draftTag}>Draft</span>
-                    )}
+                    {!announcement.published &&
+                        (announcement.scheduledPublishAt ? (
+                            <span className={classes.draftTag}>
+                                <MantineIcon icon={IconClock} size="sm" />
+                                Scheduled ·{' '}
+                                {new Date(
+                                    announcement.scheduledPublishAt,
+                                ).toLocaleString(undefined, {
+                                    month: 'short',
+                                    day: 'numeric',
+                                    hour: 'numeric',
+                                    minute: '2-digit',
+                                })}
+                            </span>
+                        ) : (
+                            <span className={classes.draftTag}>Draft</span>
+                        ))}
                     {announcement.pinned && (
                         <span className={classes.pinnedTag}>
                             <MantineIcon icon={IconPin} size="sm" />
@@ -354,9 +373,57 @@ const AnnouncementItemActions: FC<{
     onEdit: (announcement: ProjectAnnouncement) => void;
     onDelete: (announcement: ProjectAnnouncement) => void;
 }> = ({ projectUuid, announcement, onEdit, onDelete }) => {
-    const { mutate: update } = useUpdateAnnouncement(projectUuid);
+    const [confirmingPublish, setConfirmingPublish] = useState(false);
+    const { mutate: update, isLoading: updating } =
+        useUpdateAnnouncement(projectUuid);
     return (
         <>
+            {!announcement.published && (
+                <Tooltip label="Publish now">
+                    <ActionIcon
+                        variant="subtle"
+                        color="ldGray.6"
+                        size="sm"
+                        aria-label="Publish announcement now"
+                        onClick={() => setConfirmingPublish(true)}
+                    >
+                        <MantineIcon icon={IconSend} />
+                    </ActionIcon>
+                </Tooltip>
+            )}
+            {confirmingPublish && (
+                <MantineModal
+                    opened
+                    onClose={() => !updating && setConfirmingPublish(false)}
+                    title="Publish announcement"
+                    icon={IconSend}
+                    confirmLabel="Publish now"
+                    confirmLoading={updating}
+                    onConfirm={() =>
+                        update(
+                            {
+                                announcementUuid: announcement.announcementUuid,
+                                publishNow: true,
+                            },
+                            {
+                                onSuccess: () => setConfirmingPublish(false),
+                            },
+                        )
+                    }
+                >
+                    <Text size="sm">
+                        “{announcement.title}” goes live on the homepage
+                        immediately
+                        {announcement.pendingSlackChannelId
+                            ? ' and notifies Slack'
+                            : ''}
+                        {announcement.scheduledPublishAt
+                            ? ', replacing its schedule'
+                            : ''}
+                        .
+                    </Text>
+                </MantineModal>
+            )}
             <Tooltip label={announcement.pinned ? 'Unpin' : 'Pin to top'}>
                 <ActionIcon
                     variant="subtle"
@@ -557,6 +624,9 @@ const AnnouncementFormModal: FC<{
     // Slack can only be retargeted while the announcement is still a draft.
     const slackEditable = slackInstalled && !announcement?.published;
     const initialSlackChannelId = announcement?.pendingSlackChannelId ?? null;
+    const initialSchedule = announcement?.scheduledPublishAt
+        ? new Date(announcement.scheduledPublishAt)
+        : null;
     const [title, setTitle] = useState(announcement?.title ?? '');
     const [body, setBody] = useState(announcement?.body ?? '');
     const [category, setCategory] = useState<AnnouncementCategory | null>(
@@ -565,6 +635,29 @@ const AnnouncementFormModal: FC<{
     const [slackChannelId, setSlackChannelId] = useState<string | null>(
         initialSlackChannelId,
     );
+    const [scheduleEnabled, setScheduleEnabled] = useState(
+        initialSchedule !== null,
+    );
+    const [scheduleDate, setScheduleDate] = useState<Date | null>(
+        initialSchedule,
+    );
+    const [scheduleTime, setScheduleTime] = useState(
+        initialSchedule
+            ? `${String(initialSchedule.getHours()).padStart(2, '0')}:${String(
+                  initialSchedule.getMinutes(),
+              ).padStart(2, '0')}`
+            : '09:00',
+    );
+    // Wall-clock date+time in the admin's local timezone → a UTC instant.
+    const scheduledAt = useMemo(() => {
+        if (!scheduleEnabled || !scheduleDate) return null;
+        const [hours, minutes] = scheduleTime.split(':').map(Number);
+        const combined = new Date(scheduleDate);
+        combined.setHours(hours || 0, minutes || 0, 0, 0);
+        return combined;
+    }, [scheduleEnabled, scheduleDate, scheduleTime]);
+    const scheduleInPast =
+        scheduledAt !== null && scheduledAt.getTime() <= Date.now();
     const { mutate: create, isLoading: creating } =
         useCreateAnnouncement(projectUuid);
     const { mutate: update, isLoading: updating } =
@@ -589,6 +682,13 @@ const AnnouncementFormModal: FC<{
                     slackChannelId !== initialSlackChannelId
                         ? { slackChannelId }
                         : {}),
+                    ...(scheduledAt &&
+                    scheduledAt.getTime() !== initialSchedule?.getTime()
+                        ? { scheduledPublishAt: scheduledAt }
+                        : {}),
+                    ...(!scheduleEnabled && initialSchedule
+                        ? { scheduledPublishAt: null }
+                        : {}),
                 },
                 { onSuccess: onClose },
             );
@@ -599,7 +699,11 @@ const AnnouncementFormModal: FC<{
                     body: bodyValue,
                     category,
                     slackChannelId,
-                    ...(publishNow ? { publishNow: true } : {}),
+                    ...(scheduledAt
+                        ? { scheduledPublishAt: scheduledAt }
+                        : publishNow
+                          ? { publishNow: true }
+                          : {}),
                 },
                 { onSuccess: onClose },
             );
@@ -608,6 +712,8 @@ const AnnouncementFormModal: FC<{
 
     let saveLabel = 'Create draft';
     if (isEdit) saveLabel = 'Save';
+    else if (scheduledAt)
+        saveLabel = slackChannelId ? 'Schedule & queue Slack' : 'Schedule';
     else if (publishNow)
         saveLabel = slackChannelId ? 'Post & send to Slack' : 'Post';
     else if (slackChannelId) saveLabel = 'Create draft & queue Slack';
@@ -621,7 +727,11 @@ const AnnouncementFormModal: FC<{
             size="lg"
             onConfirm={handleSave}
             confirmLabel={saveLabel}
-            confirmDisabled={title.trim().length === 0 || bodyTooLong}
+            confirmDisabled={
+                title.trim().length === 0 ||
+                bodyTooLong ||
+                (scheduleEnabled && (!scheduledAt || scheduleInPast))
+            }
             confirmLoading={isLoading}
         >
             <Stack gap="md">
@@ -670,6 +780,41 @@ const AnnouncementFormModal: FC<{
                         />
                     )}
                 </Group>
+                {!announcement?.published && (
+                    <Stack gap="xs">
+                        <Switch
+                            size="xs"
+                            label="Schedule publish"
+                            checked={scheduleEnabled}
+                            onChange={(event) =>
+                                setScheduleEnabled(event.currentTarget.checked)
+                            }
+                        />
+                        {scheduleEnabled && (
+                            <Group grow align="flex-start" wrap="nowrap">
+                                <CalendarPickerInput
+                                    label="Date"
+                                    size="sm"
+                                    radius="md"
+                                    value={scheduleDate}
+                                    onChange={setScheduleDate}
+                                    minDate={new Date()}
+                                />
+                                <TimeInput
+                                    label="Time"
+                                    size="sm"
+                                    radius="md"
+                                    value={scheduleTime}
+                                    onChange={(event) =>
+                                        setScheduleTime(
+                                            event.currentTarget.value,
+                                        )
+                                    }
+                                />
+                            </Group>
+                        )}
+                    </Stack>
+                )}
                 {bodyTooLong && (
                     <Text size="xs" c="red">
                         Body is {body.trim().length.toLocaleString()} characters
@@ -678,7 +823,24 @@ const AnnouncementFormModal: FC<{
                         fewer.
                     </Text>
                 )}
-                {!isEdit && publishNow ? (
+                {scheduleEnabled && scheduleInPast ? (
+                    <Text size="xs" c="red">
+                        Pick a publish time in the future.
+                    </Text>
+                ) : scheduleEnabled && scheduledAt ? (
+                    <Text size="xs" c="dimmed">
+                        Publishes automatically on{' '}
+                        {scheduledAt.toLocaleString(undefined, {
+                            weekday: 'short',
+                            month: 'short',
+                            day: 'numeric',
+                            hour: 'numeric',
+                            minute: '2-digit',
+                        })}{' '}
+                        (your local time)
+                        {slackChannelId ? ' and notifies Slack then' : ''}.
+                    </Text>
+                ) : !isEdit && publishNow ? (
                     <Text size="xs" c="dimmed">
                         Goes live on the homepage immediately
                         {slackChannelId ? ' and notifies Slack' : ''}.


### PR DESCRIPTION
Closes ZAP-699

Stacked on #26788.

## What

Data announcements can now be scheduled to publish at a future time. The Slack notification (if a channel is set) fires at publish time. Admins schedule from the composer (builder or published homepage), and scheduled cards show a "Scheduled · date" tag with reschedule / unschedule / publish-now available from the existing admin actions.

## Design

**The row is the source of truth; the Graphile job is just an alarm clock.** A lost job (deploy, worker crash) delays a publish until the sweep catches it — it can never lose or duplicate one.

- New `scheduled_publish_at` column (UTC) + partial index on due unpublished rows. States: draft → scheduled → published.
- One-shot Graphile job per announcement: `jobKey announcement-publish:<uuid>`, `maxAttempts 1`, default `jobKeyMode: replace` so rescheduling moves `runAt` in place. Cancel uses the `locked_by IS NULL` delete idiom (announcement delete, unschedule, publish-now).
- `publishPendingAnnouncements` model method: `FOR UPDATE SKIP LOCKED` + `WHERE published_at IS NULL` re-check, so a job+sweep race (or an impatient publish-now) publishes and notifies Slack exactly once.
- Backstop sweep (`sweepDueAnnouncements`, every 10 min, EE cron item modelled on the stale-locks sweeps) publishes any due row whose job was lost, resolving each row's org from the projects table — never from a stale payload.
- **`publishProjectDraftAnnouncements` now excludes scheduled rows**, so republishing the homepage layout cannot fire an embargoed announcement early.
- Worker handler re-fetches the row and verifies it belongs to the payload's project before publishing.
- Registered through the full EE ceremony: `EE_SCHEDULER_TASKS`, payload maps, tracer attributes, EE worker task list + cron item, DI in `ee/index.ts`.

## Frontend

- Composer gains a "Schedule publish" switch with date (`CalendarPickerInput`) + time (`TimeInput`) in the admin's local time, with the resolved instant echoed in the footer. Deliberately not the cron builder — this is one-shot. Confirm label becomes "Schedule" / "Schedule & queue Slack".
- Unpublished cards get a publish-now hover action with a confirm modal; scheduled cards show the "Scheduled · date" tag instead of "Draft".
- Times are entered in the admin's local timezone (labelled as such); a project-timezone picker is a possible follow-up.

## Regression analysis

- Plain drafts and the homepage-publish flow are unchanged (`scheduled_publish_at` null everywhere existing paths run; covered by tests).
- `updateAnnouncement` splits `publishNow`/`scheduledPublishAt` from content edits and applies content first, so publish-now publishes what was just written; published announcements reject both fields.
- Past timestamps are rejected at the API (and the composer disables the confirm).

## Testing

- 10 new service unit tests: schedule on create/update, past-time and conflicting-flags rejection, unschedule cancels the job, publish-now exactly-once + Slack, wrong-project payload no-op, sweep with mixed Slack/non-Slack rows.
- Live end-to-end in the dev app: scheduled an announcement 2 minutes out → "Scheduled · 4 Aug, 15:23" tag + Graphile job row created; republished the homepage layout mid-wait → row stayed embargoed; the job fired and the announcement published at 14:23:00.128 UTC (128 ms after its instant), schedule and job cleared, card rendering as a normal published announcement.