### PR TITLE
feat: reland opt-in MotherDuck instance caching (SPK-822)

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -11,6 +11,7 @@ import {
     UnexpectedServerError,
     UPLOAD_GSHEET_FROM_ROWS_MAX_BYTES,
 } from '@lightdash/common';
+import { MotherduckInstanceCache } from '@lightdash/warehouses';
 import { trace } from '@opentelemetry/api';
 import * as Sentry from '@sentry/node';
 import flash from 'connect-flash';
@@ -314,6 +315,12 @@ export default class App {
         this.featureFlagCheckFlushInterval.unref();
 
         this.prometheusMetrics.start();
+        MotherduckInstanceCache.configure(
+            this.lightdashConfig.motherduckInstanceCache,
+        );
+        MotherduckInstanceCache.setObserver((event) =>
+            this.prometheusMetrics.observeMotherduckCacheEvent(event),
+        );
         setGithubRateLimitObserver((rl) =>
             this.prometheusMetrics.observeGithubRateLimit(rl),
         );
@@ -1098,6 +1105,7 @@ export default class App {
             await this.eventStreamWriter.close();
             Logger.info('Flushed usage event stream writer');
         }
+        await MotherduckInstanceCache.closeAll('shutdown');
         await this.prometheusMetrics.stop();
         await shutdownOtelTracing();
         if (this.schedulerWorker && this.schedulerWorker.runner) {

--- a/packages/backend/src/NatsWorkerApp.ts
+++ b/packages/backend/src/NatsWorkerApp.ts
@@ -1,4 +1,5 @@
 import { createTerminus } from '@godaddy/terminus';
+import { MotherduckInstanceCache } from '@lightdash/warehouses';
 import * as Sentry from '@sentry/node';
 import express from 'express';
 import http from 'http';
@@ -181,6 +182,12 @@ export default class NatsWorkerApp {
     public async start() {
         registerOAuthRefreshStrategies();
         this.prometheusMetrics.start();
+        MotherduckInstanceCache.configure(
+            this.lightdashConfig.motherduckInstanceCache,
+        );
+        MotherduckInstanceCache.setObserver((event) =>
+            this.prometheusMetrics.observeMotherduckCacheEvent(event),
+        );
         this.prometheusMetrics.monitorDatabase(this.database);
         // @ts-ignore
         // eslint-disable-next-line no-extend-native, func-names
@@ -276,6 +283,7 @@ export default class NatsWorkerApp {
                     Logger.info('Flushing usage event stream writer');
                     await this.eventStreamWriter.close();
                 }
+                await MotherduckInstanceCache.closeAll('shutdown');
                 Logger.info('Stopping Prometheus metrics');
                 await this.prometheusMetrics.stop();
                 await shutdownOtelTracing();

--- a/packages/backend/src/SchedulerApp.ts
+++ b/packages/backend/src/SchedulerApp.ts
@@ -1,4 +1,5 @@
 import { createTerminus } from '@godaddy/terminus';
+import { MotherduckInstanceCache } from '@lightdash/warehouses';
 import * as Sentry from '@sentry/node';
 import { EventEmitter } from 'events';
 import express from 'express';
@@ -250,6 +251,12 @@ export default class SchedulerApp {
         registerOAuthRefreshStrategies();
 
         this.prometheusMetrics.start();
+        MotherduckInstanceCache.configure(
+            this.lightdashConfig.motherduckInstanceCache,
+        );
+        MotherduckInstanceCache.setObserver((event) =>
+            this.prometheusMetrics.observeMotherduckCacheEvent(event),
+        );
         setGithubRateLimitObserver((rl) =>
             this.prometheusMetrics.observeGithubRateLimit(rl),
         );
@@ -382,6 +389,7 @@ export default class SchedulerApp {
                     Logger.info('Flushing usage event stream writer');
                     await this.eventStreamWriter.close();
                 }
+                await MotherduckInstanceCache.closeAll('shutdown');
                 Logger.info('Stopping Prometheus metrics');
                 await this.prometheusMetrics.stop();
                 await shutdownOtelTracing();

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -380,6 +380,14 @@ export const lightdashConfigMock: LightdashConfig = {
             region: 'mock_region',
         },
     },
+    motherduckInstanceCache: {
+        enabled: false,
+        projectUuids: [],
+        idleTtlMs: 600000,
+        maxAgeMs: 3600000,
+        maxEntries: 8,
+        maxConsecutiveFailures: 3,
+    },
     usageEvents: {
         enabled: false,
         flushIntervalMs: 60000,

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -54,6 +54,72 @@ describe('Query phase metrics config', () => {
     });
 });
 
+describe('MotherDuck instance cache config', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('defaults to disabled with bounded cache defaults', () => {
+        expect(parseConfig().motherduckInstanceCache).toEqual({
+            enabled: false,
+            projectUuids: [],
+            idleTtlMs: 600000,
+            maxAgeMs: 3600000,
+            maxEntries: 8,
+            maxConsecutiveFailures: 3,
+        });
+    });
+
+    it('parses enablement, project allowlist, and resource bounds', () => {
+        process.env.MOTHERDUCK_INSTANCE_CACHE_ENABLED = 'true';
+        process.env.MOTHERDUCK_INSTANCE_CACHE_PROJECT_UUIDS =
+            'project-a, project-b';
+        process.env.MOTHERDUCK_INSTANCE_CACHE_IDLE_TTL_MS = '1000';
+        process.env.MOTHERDUCK_INSTANCE_CACHE_MAX_AGE_MS = '2000';
+        process.env.MOTHERDUCK_INSTANCE_CACHE_MAX_ENTRIES = '3';
+        process.env.MOTHERDUCK_INSTANCE_CACHE_MAX_CONSECUTIVE_FAILURES = '4';
+
+        expect(parseConfig().motherduckInstanceCache).toEqual({
+            enabled: true,
+            projectUuids: ['project-a', 'project-b'],
+            idleTtlMs: 1000,
+            maxAgeMs: 2000,
+            maxEntries: 3,
+            maxConsecutiveFailures: 4,
+        });
+    });
+
+    it.each([
+        {
+            deployment: 'Lightdash Cloud',
+            lightdashCloudInstance: 'cloud-instance',
+            warning:
+                'WARNING: MotherDuck instance cache is enabled with an empty project allowlist on a Lightdash Cloud deployment. No projects will use the cache.',
+        },
+        {
+            deployment: 'self-hosted',
+            lightdashCloudInstance: undefined,
+            warning:
+                'WARNING: MotherDuck instance cache is enabled with an empty project allowlist on a self-hosted deployment. All projects will use the cache.',
+        },
+    ])(
+        'warns how an empty allowlist resolves on $deployment',
+        ({ lightdashCloudInstance, warning }) => {
+            const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            process.env.MOTHERDUCK_INSTANCE_CACHE_ENABLED = 'true';
+            if (lightdashCloudInstance === undefined) {
+                delete process.env.LIGHTDASH_CLOUD_INSTANCE;
+            } else {
+                process.env.LIGHTDASH_CLOUD_INSTANCE = lightdashCloudInstance;
+            }
+
+            parseConfig();
+
+            expect(warn).toHaveBeenCalledWith(warning);
+        },
+    );
+});
+
 test('Should default results S3 config to S3 config', () => {
     process.env.S3_ACCESS_KEY = 'mock_access_key';
     process.env.S3_SECRET_KEY = 'mock_secret_key';

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1620,6 +1620,14 @@ export type LightdashConfig = {
         duckdbQueryMemoryLimit: string | null;
         s3?: Omit<S3Config, 'expirationTime'>;
     };
+    motherduckInstanceCache: {
+        enabled: boolean;
+        projectUuids: string[];
+        idleTtlMs: number;
+        maxAgeMs: number;
+        maxEntries: number;
+        maxConsecutiveFailures: number;
+    };
     usageEvents: {
         enabled: boolean;
         flushIntervalMs: number;
@@ -2452,6 +2460,40 @@ export const parseConfig = (): LightdashConfig => {
         getIntegerFromEnvironmentVariable('NATS_WORKER_CONCURRENCY') ?? 1;
     const natsWorkerQueueTimeoutMs =
         getIntegerFromEnvironmentVariable('NATS_QUEUE_TIMEOUT_MS') ?? 180000;
+    const lightdashCloudInstance = process.env.LIGHTDASH_CLOUD_INSTANCE;
+    const motherduckInstanceCache = {
+        enabled: process.env.MOTHERDUCK_INSTANCE_CACHE_ENABLED === 'true',
+        projectUuids: getArrayFromCommaSeparatedList(
+            'MOTHERDUCK_INSTANCE_CACHE_PROJECT_UUIDS',
+        ),
+        idleTtlMs:
+            getIntegerFromEnvironmentVariable(
+                'MOTHERDUCK_INSTANCE_CACHE_IDLE_TTL_MS',
+            ) ?? 10 * 60_000,
+        maxAgeMs:
+            getIntegerFromEnvironmentVariable(
+                'MOTHERDUCK_INSTANCE_CACHE_MAX_AGE_MS',
+            ) ?? 60 * 60_000,
+        maxEntries:
+            getIntegerFromEnvironmentVariable(
+                'MOTHERDUCK_INSTANCE_CACHE_MAX_ENTRIES',
+            ) ?? 8,
+        maxConsecutiveFailures:
+            getIntegerFromEnvironmentVariable(
+                'MOTHERDUCK_INSTANCE_CACHE_MAX_CONSECUTIVE_FAILURES',
+            ) ?? 3,
+    };
+
+    if (
+        motherduckInstanceCache.enabled &&
+        motherduckInstanceCache.projectUuids.length === 0
+    ) {
+        console.warn(
+            lightdashCloudInstance === undefined
+                ? 'WARNING: MotherDuck instance cache is enabled with an empty project allowlist on a self-hosted deployment. All projects will use the cache.'
+                : 'WARNING: MotherDuck instance cache is enabled with an empty project allowlist on a Lightdash Cloud deployment. No projects will use the cache.',
+        );
+    }
 
     if (preAggregatesEnabled && !preAggregatesS3) {
         throw new ParseError('Pre-aggregates require S3 configuration', {});
@@ -2718,7 +2760,7 @@ export const parseConfig = (): LightdashConfig => {
         helpMenuUrl: process.env.HELP_MENU_URL,
         staticIp: process.env.STATIC_IP || '',
         signupUrl: process.env.SIGNUP_URL,
-        lightdashCloudInstance: process.env.LIGHTDASH_CLOUD_INSTANCE,
+        lightdashCloudInstance,
         k8s: {
             nodeName: process.env.K8S_NODE_NAME,
             podName: process.env.K8S_POD_NAME,
@@ -3137,6 +3179,7 @@ export const parseConfig = (): LightdashConfig => {
                 process.env.PRE_AGGREGATE_DUCKDB_QUERY_MEMORY_LIMIT ?? null,
             s3: preAggregatesS3,
         },
+        motherduckInstanceCache,
         usageEvents: {
             enabled: usageEventsEnabled,
             flushIntervalMs:

--- a/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
@@ -5,6 +5,7 @@ import {
     CompiledMetric,
     CreateAthenaCredentials,
     CreateDatabricksCredentials,
+    CreateDuckdbMotherduckCredentials,
     CreatePostgresCredentials,
     CreateSnowflakeCredentials,
     DatabricksAuthenticationType,
@@ -12,6 +13,7 @@ import {
     DbtGithubProjectConfig,
     DbtProjectType,
     DimensionType,
+    DuckdbConnectionType,
     ExploreType,
     FieldType,
     MetricType,
@@ -23,6 +25,7 @@ import {
     SpaceMemberRole,
     WarehouseTypes,
 } from '@lightdash/common';
+import { MotherduckInstanceCache } from '@lightdash/warehouses';
 import knex from 'knex';
 import { getTracker, MockClient, RawQuery, Tracker } from 'knex-mock-client';
 import { FunctionQueryMatcher } from 'knex-mock-client/types/mock-client';
@@ -84,6 +87,7 @@ describe('ProjectModel', () => {
     });
     afterEach(() => {
         tracker.reset();
+        vi.restoreAllMocks();
     });
     test('should get project with no sensitive properties', async () => {
         tracker.on
@@ -121,6 +125,44 @@ describe('ProjectModel', () => {
         );
 
         expect(tracker.history.update).toHaveLength(1);
+    });
+
+    test('invalidates the previous MotherDuck connection after a credential update', async () => {
+        const previousCredentials: CreateDuckdbMotherduckCredentials = {
+            type: WarehouseTypes.DUCKDB,
+            connectionType: DuckdbConnectionType.MOTHERDUCK,
+            database: 'analytics',
+            schema: 'main',
+            token: 'previous-token',
+        };
+        const nextCredentials = {
+            ...previousCredentials,
+            token: 'next-token',
+        };
+        vi.spyOn(model, 'getWarehouseCredentialsForProject').mockResolvedValue(
+            previousCredentials,
+        );
+        const invalidate = vi
+            .spyOn(MotherduckInstanceCache, 'invalidateByConnectionString')
+            .mockImplementation(() => undefined);
+        tracker.on
+            .update(({ sql }) => sql.includes('projects'))
+            .response([{ project_id: 1 }]);
+        tracker.on
+            .insert(({ sql }) => sql.includes('warehouse_credentials'))
+            .response([]);
+
+        await model.update(projectUuid, {
+            name: expectedProject.name,
+            dbtConnection: expectedProject.dbtConnection,
+            dbtVersion: expectedProject.dbtVersion,
+            warehouseConnection: nextCredentials,
+        });
+
+        expect(invalidate).toHaveBeenCalledWith(
+            'md:analytics?motherduck_token=previous-token&saas_mode=true',
+            'credentials_updated',
+        );
     });
 
     test('checks project membership without requiring an email row', async () => {

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -58,6 +58,8 @@ import {
     type SummaryExplore,
 } from '@lightdash/common';
 import {
+    buildMotherduckConnectionString,
+    MotherduckInstanceCache,
     WarehouseCatalog,
     warehouseClientFromCredentials,
 } from '@lightdash/warehouses';
@@ -157,6 +159,14 @@ const warehouseCredentialsCache =
         : undefined;
 
 const INSERT_BATCH_SIZE = 1000;
+
+const getMotherduckConnectionString = (
+    credentials: CreateWarehouseCredentials,
+): string | undefined =>
+    credentials.type === WarehouseTypes.DUCKDB &&
+    credentials.connectionType === DuckdbConnectionType.MOTHERDUCK
+        ? buildMotherduckConnectionString(credentials)
+        : undefined;
 
 async function chunkedInsertReturning<T extends Record<string, unknown>>(
     trx: Transaction,
@@ -761,6 +771,13 @@ export class ProjectModel {
     }
 
     async update(projectUuid: string, data: UpdateProject): Promise<void> {
+        const previousConnectionString = getMotherduckConnectionString(
+            await this.getWarehouseCredentialsForProject(projectUuid),
+        );
+        const nextConnectionString = getMotherduckConnectionString(
+            data.warehouseConnection,
+        );
+
         // Invalidate warehouse credentials cache
         warehouseCredentialsCache?.del(projectUuid);
 
@@ -797,6 +814,16 @@ export class ProjectModel {
                 data.warehouseConnection,
             );
         });
+
+        if (
+            previousConnectionString &&
+            previousConnectionString !== nextConnectionString
+        ) {
+            MotherduckInstanceCache.invalidateByConnectionString(
+                previousConnectionString,
+                'credentials_updated',
+            );
+        }
     }
 
     async updateDetails(
@@ -3868,8 +3895,11 @@ export class ProjectModel {
 
     // Easier to mock in ProjectService
     // eslint-disable-next-line class-methods-use-this
-    getWarehouseClientFromCredentials(credentials: CreateWarehouseCredentials) {
-        return warehouseClientFromCredentials(credentials);
+    getWarehouseClientFromCredentials(
+        credentials: CreateWarehouseCredentials,
+        options?: Parameters<typeof warehouseClientFromCredentials>[1],
+    ) {
+        return warehouseClientFromCredentials(credentials, options);
     }
 
     async createVirtualView(

--- a/packages/backend/src/prometheus/PrometheusMetrics.test.ts
+++ b/packages/backend/src/prometheus/PrometheusMetrics.test.ts
@@ -150,3 +150,150 @@ describe('Project-attributed warehouse phase metrics', () => {
         });
     });
 });
+
+describe('MotherDuck instance cache metrics', () => {
+    beforeEach(() => {
+        prometheus.register.clear();
+    });
+
+    afterEach(() => {
+        prometheus.register.clear();
+    });
+
+    it('exposes enough project-scoped signals to evaluate a canary', async () => {
+        const metrics = new PrometheusMetrics(lightdashConfigMock.prometheus);
+        metrics.motherduckCacheAcquisitionCounter = new prometheus.Counter({
+            name: 'test_motherduck_cache_acquisitions_total',
+            help: 'test',
+            labelNames: ['result', 'project_uuid'],
+        });
+        metrics.motherduckCacheInstanceCreatedCounter = new prometheus.Counter({
+            name: 'test_motherduck_cache_instances_created_total',
+            help: 'test',
+            labelNames: ['project_uuid'],
+        });
+        metrics.motherduckCacheEvictionCounter = new prometheus.Counter({
+            name: 'test_motherduck_cache_evictions_total',
+            help: 'test',
+            labelNames: ['reason', 'project_uuid'],
+        });
+        metrics.motherduckCacheSizeGauge = new prometheus.Gauge({
+            name: 'test_motherduck_cache_entries',
+            help: 'test',
+        });
+        metrics.motherduckCacheRetryCounter = new prometheus.Counter({
+            name: 'test_motherduck_cache_retries_total',
+            help: 'test',
+            labelNames: ['outcome'],
+        });
+        metrics.motherduckCacheAcquireDurationHistogram =
+            new prometheus.Histogram({
+                name: 'test_motherduck_cache_acquire_duration_seconds',
+                help: 'test',
+                labelNames: ['result', 'project_uuid'],
+            });
+
+        metrics.observeMotherduckCacheEvent({
+            type: 'acquire',
+            result: 'miss',
+            entryId: 'entry-a',
+            projectUuid: 'project-a',
+            waitMs: 10,
+            instanceCreateMs: 20,
+            connectMs: 30,
+        });
+        metrics.observeMotherduckCacheEvent({
+            type: 'acquire',
+            result: 'hit',
+            entryId: 'entry-a',
+            projectUuid: 'project-a',
+            waitMs: 1,
+            instanceCreateMs: 0,
+            connectMs: 2,
+        });
+        metrics.observeMotherduckCacheEvent({
+            type: 'evict',
+            entryId: 'entry-a',
+            projectUuid: 'project-a',
+            reason: 'idle_ttl',
+            ageMs: 1000,
+        });
+        metrics.observeMotherduckCacheEvent({
+            type: 'retry',
+            entryId: 'entry-a',
+            outcome: 'recovered',
+        });
+        metrics.observeMotherduckCacheEvent({ type: 'size', entries: 2 });
+
+        await expect(
+            metrics.motherduckCacheAcquisitionCounter.get(),
+        ).resolves.toMatchObject({
+            values: expect.arrayContaining([
+                expect.objectContaining({
+                    labels: { result: 'miss', project_uuid: 'project-a' },
+                    value: 1,
+                }),
+                expect.objectContaining({
+                    labels: { result: 'hit', project_uuid: 'project-a' },
+                    value: 1,
+                }),
+            ]),
+        });
+        await expect(
+            metrics.motherduckCacheInstanceCreatedCounter.get(),
+        ).resolves.toMatchObject({
+            values: [
+                expect.objectContaining({
+                    labels: { project_uuid: 'project-a' },
+                    value: 1,
+                }),
+            ],
+        });
+        await expect(
+            metrics.motherduckCacheEvictionCounter.get(),
+        ).resolves.toMatchObject({
+            values: [
+                expect.objectContaining({
+                    labels: {
+                        reason: 'idle_ttl',
+                        project_uuid: 'project-a',
+                    },
+                    value: 1,
+                }),
+            ],
+        });
+        await expect(
+            metrics.motherduckCacheRetryCounter.get(),
+        ).resolves.toMatchObject({
+            values: [
+                expect.objectContaining({
+                    labels: { outcome: 'recovered' },
+                    value: 1,
+                }),
+            ],
+        });
+        await expect(
+            metrics.motherduckCacheSizeGauge.get(),
+        ).resolves.toMatchObject({
+            values: [expect.objectContaining({ value: 2 })],
+        });
+        await expect(
+            metrics.motherduckCacheAcquireDurationHistogram.get(),
+        ).resolves.toMatchObject({
+            values: expect.arrayContaining([
+                expect.objectContaining({
+                    metricName:
+                        'test_motherduck_cache_acquire_duration_seconds_sum',
+                    labels: { result: 'miss', project_uuid: 'project-a' },
+                    value: 0.06,
+                }),
+                expect.objectContaining({
+                    metricName:
+                        'test_motherduck_cache_acquire_duration_seconds_sum',
+                    labels: { result: 'hit', project_uuid: 'project-a' },
+                    value: 0.003,
+                }),
+            ]),
+        });
+    });
+});

--- a/packages/backend/src/prometheus/PrometheusMetrics.ts
+++ b/packages/backend/src/prometheus/PrometheusMetrics.ts
@@ -2,6 +2,7 @@ import {
     AI_AGENT_MEMORY_CONSOLIDATION_OPERATION_TYPES,
     AI_AGENT_MEMORY_CONSOLIDATION_REJECTION_REASONS,
     AnyType,
+    assertUnreachable,
     PreAggregateMissReason,
     QueryExecutionContext,
     QueryHistoryStatus,
@@ -9,6 +10,7 @@ import {
     type AiAgentMemoryConsolidationRejectionReason,
     type WarehousePhaseTimings,
 } from '@lightdash/common';
+import type { MotherduckCacheEvent } from '@lightdash/warehouses';
 import { EventEmitter } from 'events';
 import express from 'express';
 import * as fs from 'fs';
@@ -236,6 +238,26 @@ export default class PrometheusMetrics {
         null;
 
     public queryCacheHitCounter: prometheus.Counter<string> | null = null;
+
+    public motherduckCacheAcquisitionCounter: prometheus.Counter<
+        'result' | 'project_uuid'
+    > | null = null;
+
+    public motherduckCacheInstanceCreatedCounter: prometheus.Counter<'project_uuid'> | null =
+        null;
+
+    public motherduckCacheEvictionCounter: prometheus.Counter<
+        'reason' | 'project_uuid'
+    > | null = null;
+
+    public motherduckCacheSizeGauge: prometheus.Gauge | null = null;
+
+    public motherduckCacheRetryCounter: prometheus.Counter<'outcome'> | null =
+        null;
+
+    public motherduckCacheAcquireDurationHistogram: prometheus.Histogram<
+        'result' | 'project_uuid'
+    > | null = null;
 
     // Usage event stream writer metrics
     public usageEventsPushedCounter: prometheus.Counter | null = null;
@@ -1015,6 +1037,55 @@ export default class PrometheusMetrics {
                     ...rest,
                 });
 
+                this.motherduckCacheAcquisitionCounter = new prometheus.Counter(
+                    {
+                        name: 'lightdash_motherduck_instance_cache_acquisitions_total',
+                        help: 'Total MotherDuck instance cache acquisitions',
+                        labelNames: ['result', 'project_uuid'],
+                        ...rest,
+                    },
+                );
+
+                this.motherduckCacheInstanceCreatedCounter =
+                    new prometheus.Counter({
+                        name: 'lightdash_motherduck_instance_cache_instances_created_total',
+                        help: 'Total MotherDuck instances created by the cache',
+                        labelNames: ['project_uuid'],
+                        ...rest,
+                    });
+
+                this.motherduckCacheEvictionCounter = new prometheus.Counter({
+                    name: 'lightdash_motherduck_instance_cache_evictions_total',
+                    help: 'Total MotherDuck instance cache evictions',
+                    labelNames: ['reason', 'project_uuid'],
+                    ...rest,
+                });
+
+                this.motherduckCacheSizeGauge = new prometheus.Gauge({
+                    name: 'lightdash_motherduck_instance_cache_entries',
+                    help: 'Current MotherDuck instance cache entry count',
+                    ...rest,
+                });
+
+                this.motherduckCacheRetryCounter = new prometheus.Counter({
+                    name: 'lightdash_motherduck_instance_cache_retries_total',
+                    help: 'Total MotherDuck instance cache retries',
+                    labelNames: ['outcome'],
+                    ...rest,
+                });
+
+                this.motherduckCacheAcquireDurationHistogram =
+                    new prometheus.Histogram({
+                        name: 'lightdash_motherduck_instance_cache_acquire_duration_seconds',
+                        help: 'MotherDuck instance cache acquisition duration',
+                        labelNames: ['result', 'project_uuid'],
+                        buckets: [
+                            0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1,
+                            2.5, 5,
+                        ],
+                        ...rest,
+                    });
+
                 // Usage event stream writer metrics
                 this.usageEventsPushedCounter = new prometheus.Counter({
                     name: 'lightdash_usage_events_pushed_total',
@@ -1405,6 +1476,48 @@ export default class PrometheusMetrics {
             context,
             has_pre_aggregate_match: hasPreAggregateMatch ? 'true' : 'false',
         });
+    }
+
+    public observeMotherduckCacheEvent(event: MotherduckCacheEvent) {
+        switch (event.type) {
+            case 'acquire': {
+                const labels = {
+                    result: event.result,
+                    project_uuid: event.projectUuid ?? 'unknown',
+                };
+                this.motherduckCacheAcquisitionCounter?.inc(labels);
+                if (event.result === 'miss') {
+                    this.motherduckCacheInstanceCreatedCounter?.inc({
+                        project_uuid: event.projectUuid ?? 'unknown',
+                    });
+                }
+                this.motherduckCacheAcquireDurationHistogram?.observe(
+                    labels,
+                    (event.waitMs + event.instanceCreateMs + event.connectMs) /
+                        1000,
+                );
+                return;
+            }
+            case 'evict':
+                this.motherduckCacheEvictionCounter?.inc({
+                    reason: event.reason,
+                    project_uuid: event.projectUuid ?? 'unknown',
+                });
+                return;
+            case 'retry':
+                this.motherduckCacheRetryCounter?.inc({
+                    outcome: event.outcome,
+                });
+                return;
+            case 'size':
+                this.motherduckCacheSizeGauge?.set(event.entries);
+                return;
+            default:
+                assertUnreachable(
+                    event,
+                    'Unknown MotherDuck instance cache event',
+                );
+        }
     }
 
     public monitorPreAggregates(knex: Knex) {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -3188,7 +3188,11 @@ describe('AsyncQueryService', () => {
                 // THEN: Warehouse client created with tunneled credentials
                 expect(
                     mockProjectModel.getWarehouseClientFromCredentials,
-                ).toHaveBeenCalledWith(sshTunnelCredentials);
+                ).toHaveBeenCalledWith(sshTunnelCredentials, {
+                    enableInstanceCache: false,
+                    projectUuid: 'project uuid',
+                    logger: expect.anything(),
+                });
 
                 // THEN: Query executed through tunneled connection
                 expect(runQueryAndTransformRowsSpy).toHaveBeenCalledWith(

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -424,6 +424,128 @@ describe('ProjectService', () => {
     const { projectUuid } = defaultProject;
     const service = getMockedProjectService(lightdashConfigMock);
 
+    describe('MotherDuck instance cache enablement', () => {
+        test.each([
+            {
+                name: 'fails closed for a project on Lightdash Cloud when the allowlist is empty',
+                lightdashCloudInstance: 'cloud-instance',
+                projectUuids: [] as string[],
+                targetProjectUuid: projectUuid,
+                expected: false,
+            },
+            {
+                name: 'fails closed for every other project on Lightdash Cloud when the allowlist is empty',
+                lightdashCloudInstance: 'cloud-instance',
+                projectUuids: [] as string[],
+                targetProjectUuid: 'another-project',
+                expected: false,
+            },
+            {
+                name: 'enables a named project on Lightdash Cloud when the allowlist is populated',
+                lightdashCloudInstance: 'cloud-instance',
+                projectUuids: [projectUuid],
+                targetProjectUuid: projectUuid,
+                expected: true,
+            },
+            {
+                name: 'keeps an unnamed project disabled on Lightdash Cloud when the allowlist is populated',
+                lightdashCloudInstance: 'cloud-instance',
+                projectUuids: [projectUuid],
+                targetProjectUuid: 'another-project',
+                expected: false,
+            },
+            {
+                name: 'enables a project on self-hosted when the allowlist is empty',
+                lightdashCloudInstance: undefined,
+                projectUuids: [] as string[],
+                targetProjectUuid: projectUuid,
+                expected: true,
+            },
+            {
+                name: 'enables every other project on self-hosted when the allowlist is empty',
+                lightdashCloudInstance: undefined,
+                projectUuids: [] as string[],
+                targetProjectUuid: 'another-project',
+                expected: true,
+            },
+            {
+                name: 'enables a named project on self-hosted when the allowlist is populated',
+                lightdashCloudInstance: undefined,
+                projectUuids: [projectUuid],
+                targetProjectUuid: projectUuid,
+                expected: true,
+            },
+            {
+                name: 'keeps an unnamed project disabled on self-hosted when the allowlist is populated',
+                lightdashCloudInstance: undefined,
+                projectUuids: [projectUuid],
+                targetProjectUuid: 'another-project',
+                expected: false,
+            },
+        ])(
+            '$name',
+            async ({
+                lightdashCloudInstance,
+                projectUuids,
+                targetProjectUuid,
+                expected,
+            }) => {
+                const configuredService = getMockedProjectService({
+                    ...lightdashConfigMock,
+                    lightdashCloudInstance,
+                    motherduckInstanceCache: {
+                        ...lightdashConfigMock.motherduckInstanceCache,
+                        enabled: true,
+                        projectUuids,
+                    },
+                });
+                vi.mocked(
+                    projectModel.getWarehouseClientFromCredentials,
+                ).mockClear();
+
+                await configuredService._getWarehouseClient(
+                    targetProjectUuid,
+                    warehouseClientMock.credentials,
+                );
+
+                expect(
+                    vi.mocked(projectModel.getWarehouseClientFromCredentials),
+                ).toHaveBeenCalledWith(expect.anything(), {
+                    enableInstanceCache: expected,
+                    projectUuid: targetProjectUuid,
+                    logger: expect.anything(),
+                });
+            },
+        );
+
+        it('keeps the cache disabled when the feature flag is off', async () => {
+            const configuredService = getMockedProjectService({
+                ...lightdashConfigMock,
+                motherduckInstanceCache: {
+                    ...lightdashConfigMock.motherduckInstanceCache,
+                    enabled: false,
+                    projectUuids: [projectUuid],
+                },
+            });
+            vi.mocked(
+                projectModel.getWarehouseClientFromCredentials,
+            ).mockClear();
+
+            await configuredService._getWarehouseClient(
+                projectUuid,
+                warehouseClientMock.credentials,
+            );
+
+            expect(
+                vi.mocked(projectModel.getWarehouseClientFromCredentials),
+            ).toHaveBeenCalledWith(expect.anything(), {
+                enableInstanceCache: false,
+                projectUuid,
+                logger: expect.anything(),
+            });
+        });
+    });
+
     afterEach(() => {
         vi.clearAllMocks();
     });
@@ -1297,6 +1419,61 @@ describe('ProjectService', () => {
     });
 
     describe('user warehouse credentials override', () => {
+        test("should not let user credentials clear the project's requireUserCredentials setting", async () => {
+            service.warehouseClients = {};
+
+            vi.mocked(
+                projectModel.getWarehouseCredentialsForProject,
+            ).mockResolvedValueOnce({
+                type: WarehouseTypes.DUCKDB,
+                connectionType: DuckdbConnectionType.MOTHERDUCK,
+                database: 'analytics',
+                schema: 'main',
+                token: 'project-token',
+                requireUserCredentials: true,
+            });
+            const findForProjectWithSecretsMock = vi.fn(async () => ({
+                uuid: 'user-motherduck-creds-uuid',
+                credentials: {
+                    type: WarehouseTypes.DUCKDB,
+                    connectionType: DuckdbConnectionType.MOTHERDUCK,
+                    database: 'analytics',
+                    schema: 'main',
+                    token: 'user-token',
+                    requireUserCredentials: false,
+                },
+            }));
+            (
+                service as unknown as {
+                    userWarehouseCredentialsModel: {
+                        findForProjectWithSecrets: import('vitest').Mock;
+                    };
+                }
+            ).userWarehouseCredentialsModel.findForProjectWithSecrets =
+                findForProjectWithSecretsMock;
+
+            const mergedCredentials = await (
+                service as unknown as {
+                    getWarehouseCredentials: (args: {
+                        projectUuid: string;
+                        userId: string;
+                        isRegisteredUser: boolean;
+                    }) => Promise<CreateWarehouseCredentials>;
+                }
+            ).getWarehouseCredentials({
+                projectUuid,
+                userId: sessionAccount.user.id,
+                isRegisteredUser: true,
+            });
+
+            expect(mergedCredentials).toEqual(
+                expect.objectContaining({
+                    token: 'user-token',
+                    requireUserCredentials: true,
+                }),
+            );
+        });
+
         test('should use user Redshift IAM identity when requireUserCredentials is true', async () => {
             service.warehouseClients = {};
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1836,6 +1836,12 @@ export class ProjectService extends BaseService {
                 credentials = {
                     ...credentials,
                     ...userWarehouseCredentials.credentials,
+                    requireUserCredentials:
+                        credentials.requireUserCredentials ||
+                        ('requireUserCredentials' in
+                            userWarehouseCredentials.credentials &&
+                            userWarehouseCredentials.credentials
+                                .requireUserCredentials),
                 } as CreateWarehouseCredentials; // force type as typescript doesn't know the types match
 
                 this.logger.debug(
@@ -2020,8 +2026,18 @@ export class ProjectService extends BaseService {
                 );
         }
 
+        const { enabled, projectUuids } =
+            this.lightdashConfig.motherduckInstanceCache;
+        const emptyAllowlistEnablesAllProjects =
+            this.lightdashConfig.lightdashCloudInstance === undefined;
+        const enableInstanceCache =
+            enabled &&
+            (projectUuids.includes(projectUuid) ||
+                (projectUuids.length === 0 &&
+                    emptyAllowlistEnablesAllProjects));
         const client = this.projectModel.getWarehouseClientFromCredentials(
             credentialsWithOverrides,
+            { enableInstanceCache, projectUuid, logger: this.logger },
         );
         this.warehouseClients[cacheKey] = client;
         return { warehouseClient: client, sshTunnel, tunnelConnectMs };

--- a/packages/warehouses/src/index.ts
+++ b/packages/warehouses/src/index.ts
@@ -6,6 +6,8 @@ export * from './warehouseClients/AthenaWarehouseClient';
 export * from './warehouseClients/BigqueryWarehouseClient';
 export * from './warehouseClients/DatabricksWarehouseClient';
 export * from './warehouseClients/DuckdbWarehouseClient';
+export { MotherduckInstanceCache } from './warehouseClients/MotherduckInstanceCache';
+export type { MotherduckCacheEvent } from './warehouseClients/MotherduckInstanceCache';
 export * from './warehouseClients/PostgresWarehouseClient';
 export * from './warehouseClients/RedshiftWarehouseClient';
 export * from './warehouseClients/redshiftIamCredentials';

--- a/packages/warehouses/src/warehouseClientFromCredentials.ts
+++ b/packages/warehouses/src/warehouseClientFromCredentials.ts
@@ -9,7 +9,10 @@ import { AthenaWarehouseClient } from './warehouseClients/AthenaWarehouseClient'
 import { BigqueryWarehouseClient } from './warehouseClients/BigqueryWarehouseClient';
 import { ClickhouseWarehouseClient } from './warehouseClients/ClickhouseWarehouseClient';
 import { DatabricksWarehouseClient } from './warehouseClients/DatabricksWarehouseClient';
-import { DuckdbWarehouseClient } from './warehouseClients/DuckdbWarehouseClient';
+import {
+    DuckdbWarehouseClient,
+    type DuckdbWarehouseClientOptions,
+} from './warehouseClients/DuckdbWarehouseClient';
 import { PostgresWarehouseClient } from './warehouseClients/PostgresWarehouseClient';
 import { RedshiftWarehouseClient } from './warehouseClients/RedshiftWarehouseClient';
 import { SnowflakeWarehouseClient } from './warehouseClients/SnowflakeWarehouseClient';
@@ -17,6 +20,7 @@ import { TrinoWarehouseClient } from './warehouseClients/TrinoWarehouseClient';
 
 export const warehouseClientFromCredentials = (
     credentials: CreateWarehouseCredentials,
+    options?: DuckdbWarehouseClientOptions,
 ): WarehouseClient => {
     switch (credentials.type) {
         case WarehouseTypes.SNOWFLAKE:
@@ -36,7 +40,7 @@ export const warehouseClientFromCredentials = (
         case WarehouseTypes.ATHENA:
             return new AthenaWarehouseClient(credentials);
         case WarehouseTypes.DUCKDB:
-            return new DuckdbWarehouseClient(credentials);
+            return new DuckdbWarehouseClient(credentials, options);
         default:
             return assertUnreachable(
                 credentials,

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
@@ -7,6 +7,7 @@ import {
     WarehouseTypes,
     WeekDay,
 } from '@lightdash/common';
+import { createHash } from 'crypto';
 import fs from 'fs/promises';
 import type { Mock } from 'vitest';
 import {
@@ -14,6 +15,7 @@ import {
     mapFieldTypeFromTypeId,
     type DuckdbS3Credentials,
 } from './DuckdbWarehouseClient';
+import * as MotherduckInstanceCache from './MotherduckInstanceCache';
 
 const createInstanceMock = vi.fn();
 
@@ -204,6 +206,12 @@ describe('DuckdbWarehouseClient', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         DuckdbWarehouseClient.resetSharedDuckdbStateForTesting();
+        MotherduckInstanceCache.resetForTesting();
+        MotherduckInstanceCache.configure({
+            idleTtlMs: 60_000,
+            maxAgeMs: 60_000,
+            maxEntries: 8,
+        });
     });
 
     it('should return query rows and mapped fields', async () => {
@@ -362,6 +370,395 @@ describe('DuckdbWarehouseClient', () => {
                 /Europe\/London.*MotherDuck.*saas_mode.*server default zone.*configured zone/,
             ),
         );
+    });
+
+    describe('MotherDuck instance caching', () => {
+        const credentials = {
+            type: WarehouseTypes.DUCKDB,
+            connectionType: DuckdbConnectionType.MOTHERDUCK,
+            database: 'analytics',
+            schema: 'main',
+            token: 'token-a',
+        } as const;
+
+        it('reuses an instance without issuing SET or PRAGMA statements and reports connect timing', async () => {
+            const runMock = vi.fn();
+            const streamMock = vi.fn(async () =>
+                getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+            );
+            const onPhaseTiming = vi.fn();
+            const events: MotherduckInstanceCache.MotherduckCacheEvent[] = [];
+            MotherduckInstanceCache.setObserver((event) => events.push(event));
+            createInstanceMock.mockResolvedValue(
+                createMockConnection(streamMock, runMock),
+            );
+            const client = new DuckdbWarehouseClient(credentials, {
+                enableInstanceCache: true,
+                projectUuid: 'project-a',
+            });
+
+            await client.streamQuery('SELECT 1 AS val', vi.fn(), {
+                onPhaseTiming,
+            });
+            await client.streamQuery('SELECT 1 AS val', vi.fn(), {
+                onPhaseTiming,
+            });
+
+            expect(createInstanceMock).toHaveBeenCalledOnce();
+            expect(runMock).not.toHaveBeenCalledWith(
+                expect.stringMatching(/^(?:SET|PRAGMA)\b/i),
+            );
+            const acquisitions = events.filter(
+                (event) => event.type === 'acquire',
+            );
+            expect(acquisitions).toHaveLength(2);
+            acquisitions.forEach((event) => {
+                expect(onPhaseTiming).toHaveBeenCalledWith(
+                    'connect',
+                    event.waitMs + event.instanceCreateMs + event.connectMs,
+                );
+            });
+        });
+
+        it('reports instance creation and connection as direct connect timing', async () => {
+            const streamMock = vi.fn(async () =>
+                getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+            );
+            const onPhaseTiming = vi.fn();
+            const performanceNow = vi
+                .spyOn(performance, 'now')
+                .mockReturnValueOnce(0)
+                .mockReturnValueOnce(10)
+                .mockReturnValueOnce(30)
+                .mockReturnValueOnce(40)
+                .mockReturnValueOnce(45)
+                .mockReturnValue(45);
+            createInstanceMock.mockResolvedValue(
+                createMockConnection(streamMock),
+            );
+            const client = new DuckdbWarehouseClient(credentials);
+
+            try {
+                await client.streamQuery('SELECT 1 AS val', vi.fn(), {
+                    onPhaseTiming,
+                });
+            } finally {
+                performanceNow.mockRestore();
+            }
+
+            expect(onPhaseTiming).toHaveBeenCalledWith('connect', 25);
+        });
+
+        it('falls back to direct sessions when user credentials are required', async () => {
+            const streamMock = vi.fn(async () =>
+                getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+            );
+            createInstanceMock.mockImplementation(async () =>
+                createMockConnection(streamMock),
+            );
+            const client = new DuckdbWarehouseClient(
+                { ...credentials, requireUserCredentials: true },
+                { enableInstanceCache: true, projectUuid: 'project-a' },
+            );
+
+            await client.runQuery('SELECT 1 AS val');
+            await client.runQuery('SELECT 1 AS val');
+
+            expect(createInstanceMock).toHaveBeenCalledTimes(2);
+        });
+
+        it('retries one stale failure before rows are emitted and replaces only the failed entry', async () => {
+            const events: MotherduckInstanceCache.MotherduckCacheEvent[] = [];
+            MotherduckInstanceCache.setObserver((event) => events.push(event));
+            const staleError = new Error(
+                'Connection Error: Connection has already been closed',
+            );
+            const firstStream = vi.fn().mockRejectedValue(staleError);
+            const recoveredStream = vi.fn(async () =>
+                getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+            );
+            const firstInstance = createMockConnection(firstStream);
+            const recoveredInstance = createMockConnection(recoveredStream);
+            createInstanceMock
+                .mockResolvedValueOnce(firstInstance)
+                .mockResolvedValueOnce(recoveredInstance);
+            const client = new DuckdbWarehouseClient(credentials, {
+                enableInstanceCache: true,
+                projectUuid: 'project-a',
+            });
+
+            await expect(client.runQuery('SELECT 1 AS val')).resolves.toEqual(
+                expect.objectContaining({ rows: [{ val: 1 }] }),
+            );
+
+            expect(createInstanceMock).toHaveBeenCalledTimes(2);
+            expect(firstInstance.closeSync).toHaveBeenCalledOnce();
+            expect(events).toContainEqual(
+                expect.objectContaining({
+                    type: 'evict',
+                    reason: 'stale',
+                }),
+            );
+            expect(events).toContainEqual(
+                expect.objectContaining({
+                    type: 'retry',
+                    outcome: 'recovered',
+                }),
+            );
+        });
+
+        it('reports a failed retry and does not loop on a second stale failure', async () => {
+            const events: MotherduckInstanceCache.MotherduckCacheEvent[] = [];
+            MotherduckInstanceCache.setObserver((event) => events.push(event));
+            const staleError = new Error(
+                'Connection Error: Connection has already been closed',
+            );
+            const firstInstance = createMockConnection(
+                vi.fn().mockRejectedValue(staleError),
+            );
+            const secondInstance = createMockConnection(
+                vi.fn().mockRejectedValue(staleError),
+            );
+            createInstanceMock
+                .mockResolvedValueOnce(firstInstance)
+                .mockResolvedValueOnce(secondInstance);
+            const client = new DuckdbWarehouseClient(credentials, {
+                enableInstanceCache: true,
+                projectUuid: 'project-a',
+            });
+
+            await expect(client.runQuery('SELECT 1 AS val')).rejects.toThrow(
+                staleError,
+            );
+
+            expect(createInstanceMock).toHaveBeenCalledTimes(2);
+            expect(firstInstance.closeSync).toHaveBeenCalledOnce();
+            expect(secondInstance.closeSync).toHaveBeenCalledOnce();
+            expect(events).toContainEqual(
+                expect.objectContaining({
+                    type: 'retry',
+                    outcome: 'failed',
+                }),
+            );
+        });
+
+        it('does not retry a stale failure after rows reached the consumer', async () => {
+            const events: MotherduckInstanceCache.MotherduckCacheEvent[] = [];
+            MotherduckInstanceCache.setObserver((event) => events.push(event));
+            const staleError = new Error(
+                'Invalid Input Error: Cannot execute statement of closed connection',
+            );
+            const streamMock = vi.fn(async () => {
+                let hasYielded = false;
+                const iterator: AsyncIterableIterator<
+                    Record<string, unknown>[]
+                > = {
+                    next: async () => {
+                        if (!hasYielded) {
+                            hasYielded = true;
+                            return { done: false, value: [{ val: 1 }] };
+                        }
+                        throw staleError;
+                    },
+                    [Symbol.asyncIterator]() {
+                        return this;
+                    },
+                };
+                return {
+                    columnCount: 1,
+                    columnNames: () => ['val'],
+                    columnTypeId: () => DUCKDB_TYPE_IDS.INTEGER,
+                    yieldRowObjectJson: () => iterator,
+                };
+            });
+            const instance = createMockConnection(streamMock);
+            createInstanceMock.mockResolvedValue(instance);
+            const streamCallback = vi.fn();
+            const client = new DuckdbWarehouseClient(credentials, {
+                enableInstanceCache: true,
+                projectUuid: 'project-a',
+            });
+
+            await expect(
+                client.streamQuery('SELECT 1 AS val', streamCallback),
+            ).rejects.toThrow(staleError);
+            expect(streamCallback).toHaveBeenCalledOnce();
+            expect(createInstanceMock).toHaveBeenCalledOnce();
+            expect(instance.closeSync).toHaveBeenCalledOnce();
+            expect(events).toContainEqual(
+                expect.objectContaining({
+                    type: 'evict',
+                    reason: 'stale',
+                }),
+            );
+            expect(events).not.toContainEqual(
+                expect.objectContaining({ type: 'retry' }),
+            );
+        });
+
+        it('invalidates authentication failures without retrying', async () => {
+            const events: MotherduckInstanceCache.MotherduckCacheEvent[] = [];
+            MotherduckInstanceCache.setObserver((event) => events.push(event));
+            const authError = new Error(
+                'Invalid Input Error: MD Authentication Error: Invalid token',
+            );
+            const streamMock = vi.fn().mockRejectedValue(authError);
+            const instance = createMockConnection(streamMock);
+            createInstanceMock.mockResolvedValue(instance);
+            const client = new DuckdbWarehouseClient(credentials, {
+                enableInstanceCache: true,
+                projectUuid: 'project-a',
+            });
+
+            await expect(client.runQuery('SELECT 1 AS val')).rejects.toThrow(
+                authError,
+            );
+            expect(createInstanceMock).toHaveBeenCalledOnce();
+            expect(instance.closeSync).toHaveBeenCalledOnce();
+            expect(events).toContainEqual(
+                expect.objectContaining({
+                    type: 'evict',
+                    reason: 'auth',
+                }),
+            );
+            expect(events).not.toContainEqual(
+                expect.objectContaining({ type: 'retry' }),
+            );
+        });
+
+        it('never includes the cache digest in cached-instance log lines or metadata', async () => {
+            const streamMock = vi.fn(async () =>
+                getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+            );
+            const logger = { info: vi.fn() };
+            createInstanceMock.mockResolvedValue(
+                createMockConnection(streamMock),
+            );
+            const client = new DuckdbWarehouseClient(credentials, {
+                enableInstanceCache: true,
+                projectUuid: 'project-a',
+                logger,
+            });
+
+            await client.runQuery('SELECT 1 AS val');
+
+            const connectionString = createInstanceMock.mock.calls[0][0];
+            if (typeof connectionString !== 'string') {
+                throw new Error('Expected a MotherDuck connection string');
+            }
+            const digest = createHash('sha256')
+                .update(JSON.stringify({ connectionString, v: 1 }))
+                .digest('hex');
+            expect(JSON.stringify(logger.info.mock.calls)).not.toContain(
+                digest,
+            );
+        });
+    });
+
+    describe('session strategy routing', () => {
+        const createSuccessfulInstance = () =>
+            createMockConnection(
+                vi.fn(async () =>
+                    getMockStreamResult(
+                        [[{ val: 1 }]],
+                        [DUCKDB_TYPE_IDS.INTEGER],
+                    ),
+                ),
+                vi.fn(),
+            );
+
+        it('keeps embedded playground databases on direct read-only sessions', async () => {
+            createInstanceMock.mockResolvedValue(createSuccessfulInstance());
+            const onPhaseTiming = vi.fn();
+            const client = new DuckdbWarehouseClient({
+                type: WarehouseTypes.DUCKDB,
+                connectionType: DuckdbConnectionType.EMBEDDED,
+                dataset: 'jaffle_shop',
+            });
+
+            await client.streamQuery('SELECT 1 AS val', vi.fn(), {
+                onPhaseTiming,
+            });
+
+            expect(createInstanceMock).toHaveBeenCalledWith(
+                expect.stringContaining('jaffle_shop.duckdb'),
+                expect.objectContaining({ access_mode: 'READ_ONLY' }),
+            );
+            expect(onPhaseTiming).toHaveBeenCalledWith(
+                'connect',
+                expect.any(Number),
+            );
+        });
+
+        it('routes resource-limited in-memory clients to isolated sessions', async () => {
+            createInstanceMock.mockResolvedValue(createSuccessfulInstance());
+            const client = new DuckdbWarehouseClient(undefined, {
+                resourceLimits: { memoryLimit: '64MB', threads: 1 },
+            });
+
+            await client.runQuery('SELECT 1 AS val');
+            await client.runQuery('SELECT 1 AS val');
+
+            expect(createInstanceMock).toHaveBeenCalledTimes(2);
+            expect(createInstanceMock).toHaveBeenNthCalledWith(1, ':memory:');
+            expect(createInstanceMock).toHaveBeenNthCalledWith(2, ':memory:');
+        });
+
+        it('routes explicit cache keys to shared sessions', async () => {
+            createInstanceMock.mockResolvedValue(createSuccessfulInstance());
+            const client = new DuckdbWarehouseClient(undefined, {
+                instanceCacheKey: 'routing-shared-instance',
+            });
+
+            await client.runQuery('SELECT 1 AS val');
+            await client.runQuery('SELECT 1 AS val');
+
+            expect(createInstanceMock).toHaveBeenCalledExactlyOnceWith(
+                ':memory:',
+            );
+        });
+
+        it('keeps DuckLake on its existing shared session strategy', async () => {
+            createInstanceMock.mockResolvedValue(createSuccessfulInstance());
+            const client = new DuckdbWarehouseClient({
+                type: WarehouseTypes.DUCKDB,
+                connectionType: DuckdbConnectionType.DUCKLAKE,
+                schema: 'main',
+                catalogAlias: 'ducklake',
+                catalog: {
+                    type: DucklakeCatalogType.POSTGRES,
+                    host: 'pg.example.com',
+                    port: 5432,
+                    database: 'catalog',
+                    user: 'ducklake_user',
+                    password: 'password',
+                },
+                dataPath: {
+                    type: DucklakeDataPathType.S3,
+                    url: 's3://bucket/path/',
+                    region: 'us-east-1',
+                },
+            });
+
+            await client.runQuery('SELECT 1 AS val');
+            await client.runQuery('SELECT 1 AS val');
+
+            expect(createInstanceMock).toHaveBeenCalledExactlyOnceWith(
+                ':memory:',
+            );
+        });
+
+        it('keeps default in-memory clients on ephemeral sessions', async () => {
+            createInstanceMock.mockResolvedValue(createSuccessfulInstance());
+            const client = new DuckdbWarehouseClient();
+
+            await client.runQuery('SELECT 1 AS val');
+            await client.runQuery('SELECT 1 AS val');
+
+            expect(createInstanceMock).toHaveBeenCalledTimes(2);
+            expect(createInstanceMock).toHaveBeenNthCalledWith(1, ':memory:');
+            expect(createInstanceMock).toHaveBeenNthCalledWith(2, ':memory:');
+        });
     });
 
     it('sets timezone for in-memory and embedded DuckDB queries', async () => {

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -33,6 +33,8 @@ import fsSync from 'fs';
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
+import { classifyMotherduckError } from './MotherduckErrorClassifier';
+import * as MotherduckInstanceCache from './MotherduckInstanceCache';
 import WarehouseBaseClient from './WarehouseBaseClient';
 import WarehouseBaseSqlBuilder from './WarehouseBaseSqlBuilder';
 
@@ -148,6 +150,8 @@ export type DuckdbWarehouseClientOptions = {
     enableQueryProfiling?: boolean;
     onQueryProfile?: (profile: DuckdbQueryProfileMetrics) => void;
     embeddedQueryTimeoutMs?: number;
+    enableInstanceCache?: boolean;
+    projectUuid?: string;
 };
 
 export const mapFieldTypeFromTypeId = (typeId: number): DimensionType => {
@@ -330,7 +334,7 @@ const BLOCKED_USER_SQL_FILE_FUNCTION_PATTERN =
 
 const BLOCKED_USER_SQL_FILE_TABLE_PATTERN = /\b(?:from|join)\s+'[^']*'/i;
 
-const buildMotherduckConnectionString = ({
+export const buildMotherduckConnectionString = ({
     database,
     token,
 }: Pick<CreateDuckdbMotherduckCredentials, 'database' | 'token'>): string => {
@@ -450,6 +454,10 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
 
     private readonly embeddedQueryTimeoutMs: number;
 
+    private readonly enableInstanceCache: boolean;
+
+    private readonly projectUuid?: string;
+
     private allowsPreAggregateFileReads = false;
 
     private hasWarnedAboutMotherduckTimezone = false;
@@ -567,6 +575,8 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         this.onQueryProfile = options?.onQueryProfile;
         this.embeddedQueryTimeoutMs =
             options?.embeddedQueryTimeoutMs ?? EMBEDDED_QUERY_TIMEOUT_MS;
+        this.enableInstanceCache = options?.enableInstanceCache ?? false;
+        this.projectUuid = options?.projectUuid;
     }
 
     private static hashDucklakeConfig(
@@ -1490,19 +1500,39 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         );
     }
 
-    /**
-     * Dispatches to the appropriate session strategy:
-     * - Direct database (non-:memory: databasePath): connects to the MotherDuck path
-     * - Resource-limited: isolated ephemeral instance (e.g. parquet conversion)
-     * - Shared instance (has instanceCacheKey): warm cached instance for queries
-     * - Default: ephemeral query session
-     */
     private async withSession<T>(
         callback: (db: DuckdbConnection) => Promise<T>,
         organizationUuid?: string,
+        retryable: () => boolean = () => true,
+        onPhaseTiming?: (
+            phase: WarehouseQueryPhase,
+            durationMs: number,
+        ) => void,
     ): Promise<T> {
-        if (this.databasePath !== ':memory:') {
-            return this.withDirectSession(callback, organizationUuid);
+        if (this.embeddedConfig) {
+            return this.withDirectSession(
+                callback,
+                organizationUuid,
+                onPhaseTiming,
+            );
+        }
+
+        if (this.isMotherduck()) {
+            if (
+                this.enableInstanceCache &&
+                this.credentials.requireUserCredentials !== true
+            ) {
+                return this.withMotherduckCachedSession(
+                    callback,
+                    retryable,
+                    onPhaseTiming,
+                );
+            }
+            return this.withDirectSession(
+                callback,
+                organizationUuid,
+                onPhaseTiming,
+            );
         }
 
         if (this.hasResourceLimits()) {
@@ -1516,10 +1546,122 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         return this.withEphemeralQuerySession(callback);
     }
 
+    private async withMotherduckCachedSession<T>(
+        callback: (db: DuckdbConnection) => Promise<T>,
+        retryable: () => boolean,
+        onPhaseTiming?: (
+            phase: WarehouseQueryPhase,
+            durationMs: number,
+        ) => void,
+    ): Promise<T> {
+        let activeEntryId: string | undefined;
+
+        const runAttempt = () =>
+            MotherduckInstanceCache.withInstance(
+                this.databasePath,
+                { projectUuid: this.projectUuid },
+                async (instance, entryId, acquisitionTiming) => {
+                    activeEntryId = entryId;
+                    const sessionStart = performance.now();
+                    const connection = await instance.connect();
+                    const { connectMs } = acquisitionTiming;
+                    onPhaseTiming?.(
+                        'connect',
+                        acquisitionTiming.waitMs +
+                            acquisitionTiming.instanceCreateMs +
+                            connectMs,
+                    );
+
+                    try {
+                        const queryStart = performance.now();
+                        const result = await callback(connection);
+                        const queryMs = performance.now() - queryStart;
+                        const totalMs = performance.now() - sessionStart;
+                        this.logger?.info(
+                            `MotherDuck cached-instance session complete: entry_id=${entryId} connect=${formatMilliseconds(connectMs)}ms query=${formatMilliseconds(queryMs)}ms total=${formatMilliseconds(totalMs)}ms`,
+                            {
+                                entryId,
+                                projectUuid: this.projectUuid,
+                                connectMs,
+                                queryMs,
+                                totalMs,
+                            },
+                        );
+                        return result;
+                    } finally {
+                        connection.closeSync?.();
+                        connection.disconnectSync?.();
+                    }
+                },
+            );
+
+        try {
+            return await runAttempt();
+        } catch (error) {
+            const errorClass = classifyMotherduckError(error);
+            const failedEntryId = activeEntryId;
+            if (errorClass === 'auth') {
+                if (failedEntryId) {
+                    await MotherduckInstanceCache.invalidate(
+                        failedEntryId,
+                        'auth',
+                    );
+                }
+                throw error;
+            }
+            if (errorClass !== 'stale' || !failedEntryId) {
+                throw error;
+            }
+
+            await MotherduckInstanceCache.invalidate(failedEntryId, 'stale');
+            if (!retryable()) {
+                throw error;
+            }
+
+            activeEntryId = undefined;
+            try {
+                const result = await runAttempt();
+                MotherduckInstanceCache.recordRetry(failedEntryId, 'recovered');
+                this.logger?.info(
+                    'MotherDuck cached-instance session retry recovered',
+                    {
+                        entryId: failedEntryId,
+                        projectUuid: this.projectUuid,
+                    },
+                );
+                return result;
+            } catch (retryError) {
+                MotherduckInstanceCache.recordRetry(failedEntryId, 'failed');
+                const retryErrorClass = classifyMotherduckError(retryError);
+                if (
+                    activeEntryId &&
+                    (retryErrorClass === 'stale' || retryErrorClass === 'auth')
+                ) {
+                    await MotherduckInstanceCache.invalidate(
+                        activeEntryId,
+                        retryErrorClass,
+                    );
+                }
+                this.logger?.info(
+                    'MotherDuck cached-instance session retry failed',
+                    {
+                        entryId: failedEntryId,
+                        projectUuid: this.projectUuid,
+                    },
+                );
+                throw retryError;
+            }
+        }
+    }
+
     /** Direct connection to the configured MotherDuck database. */
     private async withDirectSession<T>(
         callback: (db: DuckdbConnection) => Promise<T>,
         organizationUuid?: string,
+        onPhaseTiming?: (
+            phase: WarehouseQueryPhase,
+            durationMs: number,
+        ) => void,
     ): Promise<T> {
         const sessionStart = performance.now();
 
@@ -1556,6 +1698,7 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
             const connectStart = performance.now();
             connection = await instance.connect();
             const connectMs = performance.now() - connectStart;
+            onPhaseTiming?.('connect', instanceCreateMs + connectMs);
 
             if (this.embeddedConfig) {
                 await DuckdbWarehouseClient.hardenInstance(connection);
@@ -1940,84 +2083,93 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         },
     ): Promise<void> {
         const reportPhase = options?.onPhaseTiming;
-        await this.withSession(async (db) => {
-            const sessionStart = performance.now();
-            if (options?.timezone) {
-                if (!this.isMotherduck()) {
-                    await db.run(
-                        `SET TimeZone = '${this.escapeString(
-                            options.timezone,
-                        )}';`,
-                    );
-                } else if (!this.hasWarnedAboutMotherduckTimezone) {
-                    this.hasWarnedAboutMotherduckTimezone = true;
-                    const message = `Requested timezone "${options.timezone}" cannot be applied because MotherDuck locks configuration under saas_mode; timestamps return in the server default zone instead of the configured zone.`;
-                    if (this.logger?.warn) {
-                        this.logger.warn(message);
-                    } else {
-                        this.logger?.info(message);
+        let hasEmittedRows = false;
+        await this.withSession(
+            async (db) => {
+                const sessionStart = performance.now();
+                if (options?.timezone) {
+                    if (!this.isMotherduck()) {
+                        await db.run(
+                            `SET TimeZone = '${this.escapeString(
+                                options.timezone,
+                            )}';`,
+                        );
+                    } else if (!this.hasWarnedAboutMotherduckTimezone) {
+                        this.hasWarnedAboutMotherduckTimezone = true;
+                        const message = `Requested timezone "${options.timezone}" cannot be applied because MotherDuck locks configuration under saas_mode; timestamps return in the server default zone instead of the configured zone.`;
+                        if (this.logger?.warn) {
+                            this.logger.warn(message);
+                        } else {
+                            this.logger?.info(message);
+                        }
                     }
                 }
-            }
 
-            const profilePath =
-                this.logger &&
-                this.enableQueryProfiling &&
-                !this.embeddedConfig &&
-                !this.isMotherduck()
-                    ? path.join(
-                          os.tmpdir(),
-                          `duckdb-profile-${Date.now()}-${Math.random().toString(36).slice(2)}.json`,
-                      )
-                    : undefined;
+                const profilePath =
+                    this.logger &&
+                    this.enableQueryProfiling &&
+                    !this.embeddedConfig &&
+                    !this.isMotherduck()
+                        ? path.join(
+                              os.tmpdir(),
+                              `duckdb-profile-${Date.now()}-${Math.random().toString(36).slice(2)}.json`,
+                          )
+                        : undefined;
 
-            if (profilePath) {
-                await db.run("PRAGMA enable_profiling='json';");
-                await db.run(`PRAGMA profiling_output='${profilePath}';`);
-            }
+                if (profilePath) {
+                    await db.run("PRAGMA enable_profiling='json';");
+                    await db.run(`PRAGMA profiling_output='${profilePath}';`);
+                }
 
-            if (this.embeddedConfig) {
-                await db.run("SET disabled_filesystems = 'LocalFileSystem';");
-            }
-            if (this.allowsPreAggregateFileReads) {
-                await this.validatePreAggregateSql(db, sql);
-            } else {
-                await this.validateUserSql(db, sql);
-            }
-            reportPhase?.('session', performance.now() - sessionStart);
+                if (this.embeddedConfig) {
+                    await db.run(
+                        "SET disabled_filesystems = 'LocalFileSystem';",
+                    );
+                }
+                if (this.allowsPreAggregateFileReads) {
+                    await this.validatePreAggregateSql(db, sql);
+                } else {
+                    await this.validateUserSql(db, sql);
+                }
+                reportPhase?.('session', performance.now() - sessionStart);
 
-            const queryStart = performance.now();
-            const result = await db.stream(
-                this.getSQLWithMetadata(sql, options?.tags),
-                this.getBindValues(options),
-            );
-            const fields =
-                DuckdbWarehouseClient.getFieldsFromStreamResult(result);
+                const queryStart = performance.now();
+                const result = await db.stream(
+                    this.getSQLWithMetadata(sql, options?.tags),
+                    this.getBindValues(options),
+                );
+                const fields =
+                    DuckdbWarehouseClient.getFieldsFromStreamResult(result);
 
-            let fetchStart: number | undefined;
-            // eslint-disable-next-line no-restricted-syntax
-            for await (const rows of result.yieldRowObjectJson()) {
+                let fetchStart: number | undefined;
+                // eslint-disable-next-line no-restricted-syntax
+                for await (const rows of result.yieldRowObjectJson()) {
+                    if (fetchStart === undefined) {
+                        reportPhase?.('query', performance.now() - queryStart);
+                        fetchStart = performance.now();
+                    }
+                    hasEmittedRows = true;
+                    await streamCallback({ fields, rows });
+                }
                 if (fetchStart === undefined) {
                     reportPhase?.('query', performance.now() - queryStart);
-                    fetchStart = performance.now();
+                    reportPhase?.('fetch', 0);
+                } else {
+                    reportPhase?.('fetch', performance.now() - fetchStart);
                 }
-                await streamCallback({ fields, rows });
-            }
-            if (fetchStart === undefined) {
-                reportPhase?.('query', performance.now() - queryStart);
-                reportPhase?.('fetch', 0);
-            } else {
-                reportPhase?.('fetch', performance.now() - fetchStart);
-            }
 
-            if (profilePath) {
-                await this.logQueryProfile(
-                    profilePath,
-                    this.logger!,
-                    options?.tags,
-                );
-            }
-        }, options?.tags?.organization_uuid);
+                if (profilePath) {
+                    await this.logQueryProfile(
+                        profilePath,
+                        this.logger!,
+                        options?.tags,
+                    );
+                }
+            },
+            options?.tags?.organization_uuid,
+            () => !hasEmittedRows,
+            reportPhase,
+        );
     }
 
     async executeAsyncQuery(

--- a/packages/warehouses/src/warehouseClients/MotherduckErrorClassifier.test.ts
+++ b/packages/warehouses/src/warehouseClients/MotherduckErrorClassifier.test.ts
@@ -1,0 +1,32 @@
+import { classifyMotherduckError } from './MotherduckErrorClassifier';
+
+describe('classifyMotherduckError', () => {
+    it.each([
+        'Connection Error: Connection has already been closed',
+        'Invalid Input Error: Cannot execute statement of closed connection',
+        'Catalog Error: Database analytics was detached',
+        'Invalid Input Error: database was invalidated because the instance was closed',
+    ])('classifies stale DuckDB handles: %s', (message) => {
+        expect(classifyMotherduckError(new Error(message))).toBe('stale');
+    });
+
+    it.each([
+        'MotherDuck Authentication failed: token rejected',
+        'Invalid Input Error: MD Authentication Error: Invalid token',
+        'Your request is not authenticated. Please check your MotherDuck token...',
+        'HTTP Error: Unauthorized',
+        "Could not connect to MotherDuck... (PERMISSION_DENIED, RPC 'CREATE_SLT')",
+        'RPC failed with PeRmIsSiOn_DeNiEd',
+        'COULD NOT CONNECT TO MOTHERDUCK',
+    ])('classifies MotherDuck authentication failures: %s', (message) => {
+        expect(classifyMotherduckError(new Error(message))).toBe('auth');
+    });
+
+    it.each([
+        'Binder Error: Referenced column missing_column not found',
+        'Catalog Error: Table with name missing_table does not exist',
+        'Invalid Input Error: configuration has been locked',
+    ])('leaves SQL and configuration errors untouched: %s', (message) => {
+        expect(classifyMotherduckError(new Error(message))).toBe('other');
+    });
+});

--- a/packages/warehouses/src/warehouseClients/MotherduckErrorClassifier.ts
+++ b/packages/warehouses/src/warehouseClients/MotherduckErrorClassifier.ts
@@ -1,0 +1,37 @@
+import { getErrorMessage } from '@lightdash/common';
+
+export type MotherduckErrorClass = 'auth' | 'stale' | 'other';
+
+const AUTH_ERROR_PATTERNS = [
+    /authentication failed/i,
+    /authentication error.*invalid token/i,
+    /invalid motherduck token/i,
+    /motherduck token.*(?:expired|invalid|rejected)/i,
+    /not authenticated/i,
+    /check your motherduck token/i,
+    /unauthorized/i,
+    /permission_denied/i,
+    /could not connect to motherduck/i,
+];
+
+const STALE_ERROR_PATTERNS = [
+    /connection.*(?:already )?closed/i,
+    /closed.*connection/i,
+    /database.*detached/i,
+    /detached.*database/i,
+    /instance.*closed/i,
+    /invalidated.*database/i,
+];
+
+export const classifyMotherduckError = (
+    error: unknown,
+): MotherduckErrorClass => {
+    const message = getErrorMessage(error);
+    if (AUTH_ERROR_PATTERNS.some((pattern) => pattern.test(message))) {
+        return 'auth';
+    }
+    if (STALE_ERROR_PATTERNS.some((pattern) => pattern.test(message))) {
+        return 'stale';
+    }
+    return 'other';
+};

--- a/packages/warehouses/src/warehouseClients/MotherduckInstanceCache.catalog.test.ts
+++ b/packages/warehouses/src/warehouseClients/MotherduckInstanceCache.catalog.test.ts
@@ -1,0 +1,76 @@
+import {
+    closeAll,
+    configure,
+    resetForTesting,
+    withInstance,
+} from './MotherduckInstanceCache';
+
+describe('MotherduckInstanceCache catalog freshness regression', () => {
+    beforeEach(() => {
+        resetForTesting();
+        configure({
+            idleTtlMs: 60_000,
+            maxAgeMs: 60_000,
+            maxEntries: 1,
+        });
+    });
+
+    afterEach(async () => {
+        await closeAll('shutdown');
+    });
+
+    it('serves a new table and column through both an already-warm connection and a fresh connection on the held instance', async () => {
+        let entryId = '';
+        await withInstance(
+            ':memory:',
+            {},
+            async (instance, acquiredEntryId) => {
+                entryId = acquiredEntryId;
+                const warmConnection = await instance.connect();
+                const ddlConnection = await instance.connect();
+                try {
+                    await warmConnection.run(
+                        'SELECT * FROM information_schema.columns',
+                    );
+                    await ddlConnection.run(
+                        'CREATE TABLE catalog_freshness (initial_column INTEGER)',
+                    );
+                    await ddlConnection.run(
+                        'ALTER TABLE catalog_freshness ADD COLUMN added_column VARCHAR',
+                    );
+
+                    const warmResult = await warmConnection.run(
+                        "SELECT column_name FROM information_schema.columns WHERE table_name = 'catalog_freshness' ORDER BY ordinal_position",
+                    );
+                    await expect(warmResult.getRowObjects()).resolves.toEqual([
+                        { column_name: 'initial_column' },
+                        { column_name: 'added_column' },
+                    ]);
+                } finally {
+                    ddlConnection.closeSync();
+                    warmConnection.closeSync();
+                }
+            },
+        );
+
+        await withInstance(
+            ':memory:',
+            {},
+            async (instance, acquiredEntryId) => {
+                expect(acquiredEntryId).toBe(entryId);
+                const freshConnection = await instance.connect();
+                try {
+                    const freshResult = await freshConnection.run(
+                        "SELECT column_name FROM information_schema.columns WHERE table_name = 'catalog_freshness' ORDER BY ordinal_position",
+                    );
+                    await expect(freshResult.getRowObjects()).resolves.toEqual([
+                        { column_name: 'initial_column' },
+                        { column_name: 'added_column' },
+                    ]);
+                } finally {
+                    freshConnection.closeSync();
+                }
+            },
+        );
+    });
+});

--- a/packages/warehouses/src/warehouseClients/MotherduckInstanceCache.integration.test.ts
+++ b/packages/warehouses/src/warehouseClients/MotherduckInstanceCache.integration.test.ts
@@ -1,0 +1,191 @@
+// Run: set -a; source .motherduck.env; set +a; pnpm -F warehouses exec vitest run src/warehouseClients/MotherduckInstanceCache.integration.test.ts
+
+import { DuckDBInstance } from '@duckdb/node-api';
+import { randomUUID } from 'crypto';
+import * as MotherduckInstanceCache from './MotherduckInstanceCache';
+
+type DuckdbInstance = Awaited<ReturnType<typeof DuckDBInstance.create>>;
+type DuckdbConnection = Awaited<ReturnType<DuckdbInstance['connect']>>;
+
+const motherduckToken = process.env.MOTHERDUCK_TOKEN?.trim();
+const database = 'jaffle_shop';
+const query = 'SELECT * FROM jaffle_shop.jaffle.orders LIMIT 10';
+const tablePrefix = 'ld_spk822_catalog_freshness_';
+const ownedTablePattern =
+    /^ld_spk822_catalog_freshness_[0-9a-f]{8}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{12}$/;
+
+const getConnectionString = () => {
+    if (!motherduckToken) {
+        throw new Error('MOTHERDUCK_TOKEN is required');
+    }
+    return `md:${database}?${new URLSearchParams({
+        motherduck_token: motherduckToken,
+        saas_mode: 'true',
+    }).toString()}`;
+};
+
+const closeConnection = (connection: DuckdbConnection) => {
+    connection.closeSync?.();
+    connection.disconnectSync?.();
+};
+
+const consumeQuery = async (connection: DuckdbConnection, sql: string) => {
+    const result = await connection.stream(sql);
+    const rows: Record<string, unknown>[] = [];
+    for await (const chunk of result.yieldRowObjectJson()) {
+        rows.push(...chunk);
+    }
+    return rows;
+};
+
+const withFreshInstance = async <T>(
+    callback: (connection: DuckdbConnection) => Promise<T>,
+) => {
+    const instance = await DuckDBInstance.create(getConnectionString());
+    const connection = await instance.connect();
+    try {
+        return await callback(connection);
+    } finally {
+        closeConnection(connection);
+        instance.closeSync?.();
+    }
+};
+
+const measureFreshInstance = async () => {
+    const startedAt = performance.now();
+    await withFreshInstance(async (connection) =>
+        consumeQuery(connection, query),
+    );
+    return performance.now() - startedAt;
+};
+
+const measureHeldInstance = async (instance: DuckdbInstance) => {
+    const startedAt = performance.now();
+    const connection = await instance.connect();
+    try {
+        await consumeQuery(connection, query);
+        return performance.now() - startedAt;
+    } finally {
+        closeConnection(connection);
+    }
+};
+
+const median = (values: number[]) => {
+    const sorted = [...values].sort((left, right) => left - right);
+    const middle = sorted[Math.floor(sorted.length / 2)];
+    if (middle === undefined) {
+        throw new Error('Cannot calculate the median of an empty set');
+    }
+    return middle;
+};
+
+describe.skipIf(!motherduckToken)(
+    'MotherDuck instance cache live integration',
+    () => {
+        let createdTableName: string | undefined;
+
+        beforeEach(() => {
+            MotherduckInstanceCache.resetForTesting();
+            MotherduckInstanceCache.configure({
+                idleTtlMs: 60_000,
+                maxAgeMs: 60_000,
+                maxEntries: 1,
+            });
+        });
+
+        afterEach(async () => {
+            await MotherduckInstanceCache.closeAll('shutdown');
+            if (createdTableName) {
+                if (!ownedTablePattern.test(createdTableName)) {
+                    throw new Error('Refusing to clean up an unowned table');
+                }
+                await withFreshInstance(async (connection) => {
+                    await connection.run(
+                        `DROP TABLE main."${createdTableName}"`,
+                    );
+                });
+                createdTableName = undefined;
+            }
+        });
+
+        it('keeps a held instance fresh for a table and column created after warmup', async () => {
+            const tableName = `${tablePrefix}${randomUUID().replaceAll('-', '_')}`;
+
+            await MotherduckInstanceCache.withInstance(
+                getConnectionString(),
+                {},
+                async (instance) => {
+                    const warmConnection = await instance.connect();
+                    try {
+                        await consumeQuery(
+                            warmConnection,
+                            'SELECT * FROM information_schema.columns LIMIT 1',
+                        );
+                        await withFreshInstance(async (connection) => {
+                            await connection.run(
+                                `CREATE TABLE main."${tableName}" (initial_column INTEGER)`,
+                            );
+                            createdTableName = tableName;
+                            await connection.run(
+                                `ALTER TABLE main."${tableName}" ADD COLUMN added_column VARCHAR`,
+                            );
+                        });
+
+                        const columnsSql = `SELECT column_name FROM information_schema.columns WHERE table_catalog = '${database}' AND table_schema = 'main' AND table_name = '${tableName}' ORDER BY ordinal_position`;
+                        const warmRows = await consumeQuery(
+                            warmConnection,
+                            columnsSql,
+                        );
+                        const freshConnection = await instance.connect();
+                        try {
+                            const freshRows = await consumeQuery(
+                                freshConnection,
+                                columnsSql,
+                            );
+                            expect(warmRows).toEqual([
+                                { column_name: 'initial_column' },
+                                { column_name: 'added_column' },
+                            ]);
+                            expect(freshRows).toEqual(warmRows);
+                        } finally {
+                            closeConnection(freshConnection);
+                        }
+                    } finally {
+                        closeConnection(warmConnection);
+                    }
+                },
+            );
+        }, 60_000);
+
+        it('keeps held-instance query cost several times below fresh-instance cost', async () => {
+            const freshInstanceMs: number[] = [];
+            const heldInstanceMs: number[] = [];
+
+            await MotherduckInstanceCache.withInstance(
+                getConnectionString(),
+                {},
+                async (instance) => {
+                    await measureHeldInstance(instance);
+                    const collectMeasurements = async (
+                        remaining: number,
+                    ): Promise<void> => {
+                        if (remaining === 0) {
+                            return;
+                        }
+                        freshInstanceMs.push(await measureFreshInstance());
+                        heldInstanceMs.push(
+                            await measureHeldInstance(instance),
+                        );
+                        await collectMeasurements(remaining - 1);
+                    };
+                    await collectMeasurements(3);
+                },
+            );
+
+            // A 3x threshold catches loss of instance reuse while leaving headroom for observed cross-run variance.
+            expect(
+                median(freshInstanceMs) / median(heldInstanceMs),
+            ).toBeGreaterThanOrEqual(3);
+        }, 60_000);
+    },
+);

--- a/packages/warehouses/src/warehouseClients/MotherduckInstanceCache.security.test.ts
+++ b/packages/warehouses/src/warehouseClients/MotherduckInstanceCache.security.test.ts
@@ -1,0 +1,229 @@
+import { DuckdbConnectionType, WarehouseTypes } from '@lightdash/common';
+import type { Mock } from 'vitest';
+import { DuckdbWarehouseClient } from './DuckdbWarehouseClient';
+import * as MotherduckInstanceCache from './MotherduckInstanceCache';
+
+const createInstanceMock = vi.fn();
+
+vi.mock('@duckdb/node-api', () => ({
+    DuckDBTypeId: { INTEGER: 4, VARCHAR: 17 },
+    DuckDBInstance: {
+        create: (...args: unknown[]) => createInstanceMock(...args),
+    },
+    version: () => 'v1.5.2',
+}));
+
+const getMockStreamResult = (marker: string) => ({
+    columnCount: 1,
+    columnNames: () => ['marker'],
+    columnTypeId: () => 17,
+    yieldRowObjectJson: async function* yieldRows() {
+        yield [{ marker }];
+    },
+});
+
+const createMockInstance = (streamMock: Mock) => ({
+    connect: async () => ({
+        run: vi.fn(),
+        stream: streamMock,
+        extractStatements: vi.fn(async () => ({
+            count: 1,
+            prepare: async () => ({
+                statementType: 1,
+                destroySync: vi.fn(),
+            }),
+        })),
+        interrupt: vi.fn(),
+        closeSync: vi.fn(),
+        disconnectSync: vi.fn(),
+    }),
+    closeSync: vi.fn(),
+});
+
+const motherduckCredentials = (database: string, token: string) =>
+    ({
+        type: WarehouseTypes.DUCKDB,
+        connectionType: DuckdbConnectionType.MOTHERDUCK,
+        database,
+        schema: 'main',
+        token,
+    }) as const;
+
+const cachedOptions = (projectUuid: string) => ({
+    enableInstanceCache: true,
+    projectUuid,
+});
+
+const successStream = (marker: string) =>
+    vi.fn(async () => getMockStreamResult(marker));
+
+describe('MotherDuck instance cache security boundaries', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.clearAllMocks();
+        MotherduckInstanceCache.resetForTesting();
+        MotherduckInstanceCache.configure({
+            idleTtlMs: 60_000,
+            maxAgeMs: 3_600_000,
+            maxEntries: 64,
+        });
+        DuckdbWarehouseClient.resetSharedDuckdbStateForTesting();
+    });
+
+    afterEach(async () => {
+        await MotherduckInstanceCache.closeAll('shutdown');
+        vi.useRealTimers();
+    });
+
+    it('isolates concurrent clients with different tokens for one database', async () => {
+        const streamA = successStream('token-a-rows');
+        const streamB = successStream('token-b-rows');
+        const instanceA = createMockInstance(streamA);
+        const instanceB = createMockInstance(streamB);
+        createInstanceMock.mockImplementation(async (connectionString) =>
+            String(connectionString).includes('token-a')
+                ? instanceA
+                : instanceB,
+        );
+        const clientA = new DuckdbWarehouseClient(
+            motherduckCredentials('analytics', 'token-a'),
+            cachedOptions('project-a'),
+        );
+        const clientB = new DuckdbWarehouseClient(
+            motherduckCredentials('analytics', 'token-b'),
+            cachedOptions('project-b'),
+        );
+
+        const [resultA, resultB] = await Promise.all([
+            clientA.runQuery('SELECT 1'),
+            clientB.runQuery('SELECT 1'),
+        ]);
+
+        expect(createInstanceMock).toHaveBeenCalledTimes(2);
+        expect(resultA.rows).toEqual([{ marker: 'token-a-rows' }]);
+        expect(resultB.rows).toEqual([{ marker: 'token-b-rows' }]);
+    });
+
+    it('isolates clients with one token across different databases', async () => {
+        createInstanceMock.mockImplementation(async (connectionString) =>
+            createMockInstance(
+                successStream(
+                    String(connectionString).startsWith('md:first')
+                        ? 'first-rows'
+                        : 'second-rows',
+                ),
+            ),
+        );
+        const firstClient = new DuckdbWarehouseClient(
+            motherduckCredentials('first', 'shared-token'),
+            cachedOptions('project-a'),
+        );
+        const secondClient = new DuckdbWarehouseClient(
+            motherduckCredentials('second', 'shared-token'),
+            cachedOptions('project-b'),
+        );
+
+        const [firstResult, secondResult] = await Promise.all([
+            firstClient.runQuery('SELECT 1'),
+            secondClient.runQuery('SELECT 1'),
+        ]);
+
+        expect(createInstanceMock).toHaveBeenCalledTimes(2);
+        expect(firstResult.rows).toEqual([{ marker: 'first-rows' }]);
+        expect(secondResult.rows).toEqual([{ marker: 'second-rows' }]);
+    });
+
+    it('never maps adversarial database names onto another credential entry', async () => {
+        const victimConnectionString = `md:analytics?${new URLSearchParams({
+            motherduck_token: 'victim-token',
+            saas_mode: 'true',
+        }).toString()}`;
+        const adversarialNames = [
+            'analytics?motherduck_token=victim-token',
+            'analytics?motherduck_token=victim-token&saas_mode=true',
+            'analytics&saas_mode=false',
+            'analytics%3Fmotherduck_token%3Dvictim-token',
+            'analytics/../analytics',
+            'analytics#',
+            'analytics/',
+            'analytics ',
+            'ANALYTICS',
+            'café',
+            'café',
+            'analytics%00',
+            '',
+            '�',
+        ];
+        createInstanceMock.mockImplementation(async () =>
+            createMockInstance(successStream('rows')),
+        );
+
+        await Promise.all(
+            adversarialNames.map((database, index) => {
+                const client = new DuckdbWarehouseClient(
+                    motherduckCredentials(database, 'attacker-token'),
+                    cachedOptions(`attacker-project-${index}`),
+                );
+                return client.runQuery('SELECT 1');
+            }),
+        );
+
+        const adversarialConnectionStrings = createInstanceMock.mock.calls.map(
+            ([connectionString]) => String(connectionString),
+        );
+        expect(adversarialConnectionStrings).not.toContain(
+            victimConnectionString,
+        );
+        expect(new Set(adversarialConnectionStrings).size).toBe(
+            adversarialNames.length,
+        );
+
+        const victimClient = new DuckdbWarehouseClient(
+            motherduckCredentials('analytics', 'victim-token'),
+            cachedOptions('victim-project'),
+        );
+        await victimClient.runQuery('SELECT 1');
+
+        expect(createInstanceMock).toHaveBeenLastCalledWith(
+            victimConnectionString,
+        );
+    });
+
+    it('does not close an in-flight instance when max age evicts it', async () => {
+        MotherduckInstanceCache.configure({
+            idleTtlMs: 60_000,
+            maxAgeMs: 1_000,
+            maxEntries: 8,
+        });
+        const instance = createMockInstance(successStream('rows'));
+        createInstanceMock
+            .mockResolvedValueOnce(instance)
+            .mockResolvedValue(createMockInstance(successStream('other')));
+        let releaseQuery: () => void = () => undefined;
+        const queryGate = new Promise<void>((resolve) => {
+            releaseQuery = resolve;
+        });
+        let entryId = '';
+        const inFlight = MotherduckInstanceCache.withInstance(
+            'md:analytics?motherduck_token=token-a',
+            {},
+            async (_instance, acquiredEntryId) => {
+                entryId = acquiredEntryId;
+                await queryGate;
+            },
+        );
+        await vi.waitFor(() => expect(entryId).not.toBe(''));
+
+        await vi.advanceTimersByTimeAsync(1_500);
+        await MotherduckInstanceCache.withInstance(
+            'md:other?motherduck_token=token-b',
+            {},
+            async () => undefined,
+        );
+
+        expect(instance.closeSync).not.toHaveBeenCalled();
+        releaseQuery();
+        await inFlight;
+        expect(instance.closeSync).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/warehouses/src/warehouseClients/MotherduckInstanceCache.test.ts
+++ b/packages/warehouses/src/warehouseClients/MotherduckInstanceCache.test.ts
@@ -1,0 +1,505 @@
+import { createHash } from 'crypto';
+import type { Mock } from 'vitest';
+import {
+    closeAll,
+    configure,
+    invalidate,
+    invalidateByConnectionString,
+    resetForTesting,
+    setObserver,
+    withInstance,
+    type MotherduckCacheEvent,
+} from './MotherduckInstanceCache';
+
+const createInstanceMock = vi.fn();
+
+vi.mock('@duckdb/node-api', () => ({
+    DuckDBInstance: {
+        create: (...args: unknown[]) => createInstanceMock(...args),
+    },
+}));
+
+const createInstance = (connect: Mock = vi.fn(async () => ({}))) => ({
+    connect,
+    closeSync: vi.fn(),
+});
+
+const configureForTesting = (
+    overrides: Partial<Parameters<typeof configure>[0]> = {},
+) =>
+    configure({
+        idleTtlMs: 1000,
+        maxAgeMs: 10_000,
+        maxEntries: 8,
+        ...overrides,
+    });
+
+describe('MotherduckInstanceCache', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.clearAllMocks();
+        resetForTesting();
+        configureForTesting();
+    });
+
+    afterEach(async () => {
+        await closeAll('shutdown');
+        vi.useRealTimers();
+    });
+
+    it('shares identical connection strings and separates different tokens', async () => {
+        createInstanceMock.mockImplementation(async () => createInstance());
+
+        const entryIds = await Promise.all([
+            withInstance(
+                'md:analytics?motherduck_token=token-a',
+                {},
+                async (_instance, entryId) => entryId,
+            ),
+            withInstance(
+                'md:analytics?motherduck_token=token-a',
+                {},
+                async (_instance, entryId) => entryId,
+            ),
+            withInstance(
+                'md:analytics?motherduck_token=token-b',
+                {},
+                async (_instance, entryId) => entryId,
+            ),
+        ]);
+
+        expect(createInstanceMock).toHaveBeenCalledTimes(2);
+        expect(entryIds[0]).toBe(entryIds[1]);
+        expect(entryIds[2]).not.toBe(entryIds[0]);
+    });
+
+    it('single-flights concurrent creation for an identical connection string', async () => {
+        let resolveCreation:
+            | ((instance: ReturnType<typeof createInstance>) => void)
+            | undefined;
+        createInstanceMock.mockImplementation(
+            () =>
+                new Promise((resolve) => {
+                    resolveCreation = resolve;
+                }),
+        );
+
+        const first = withInstance(
+            'md:analytics?motherduck_token=token-a',
+            {},
+            async (_instance, entryId) => entryId,
+        );
+        const second = withInstance(
+            'md:analytics?motherduck_token=token-a',
+            {},
+            async (_instance, entryId) => entryId,
+        );
+        await vi.waitFor(() =>
+            expect(createInstanceMock).toHaveBeenCalledOnce(),
+        );
+        resolveCreation?.(createInstance());
+
+        await expect(Promise.all([first, second])).resolves.toEqual([
+            expect.any(String),
+            expect.any(String),
+        ]);
+        expect(await first).toBe(await second);
+    });
+
+    it('keeps creation duration separate from acquisition wait', async () => {
+        const events: MotherduckCacheEvent[] = [];
+        let resolveCreation:
+            | ((instance: ReturnType<typeof createInstance>) => void)
+            | undefined;
+        setObserver((event) => events.push(event));
+        createInstanceMock.mockImplementation(
+            () =>
+                new Promise((resolve) => {
+                    resolveCreation = resolve;
+                }),
+        );
+
+        const acquisition = withInstance(
+            'md:analytics?motherduck_token=token-a',
+            {},
+            async () => undefined,
+        );
+        expect(createInstanceMock).toHaveBeenCalledOnce();
+        await vi.advanceTimersByTimeAsync(25);
+        resolveCreation?.(createInstance());
+        await acquisition;
+
+        expect(events).toContainEqual(
+            expect.objectContaining({
+                type: 'acquire',
+                result: 'miss',
+                waitMs: 0,
+                instanceCreateMs: 25,
+            }),
+        );
+    });
+
+    it('closes and replaces a creation that resolves after its connection string is invalidated', async () => {
+        const connectionString =
+            'md:analytics?motherduck_token=token-a&saas_mode=true';
+        const invalidatedInstance = createInstance();
+        const replacementInstance = createInstance();
+        let resolveInvalidatedCreation:
+            | ((instance: ReturnType<typeof createInstance>) => void)
+            | undefined;
+        createInstanceMock
+            .mockImplementationOnce(
+                () =>
+                    new Promise((resolve) => {
+                        resolveInvalidatedCreation = resolve;
+                    }),
+            )
+            .mockResolvedValueOnce(replacementInstance);
+
+        const first = withInstance(
+            connectionString,
+            {},
+            async (_instance, entryId) => entryId,
+        );
+        const waiting = withInstance(
+            connectionString,
+            {},
+            async (_instance, entryId) => entryId,
+        );
+        await vi.waitFor(() =>
+            expect(createInstanceMock).toHaveBeenCalledOnce(),
+        );
+
+        invalidateByConnectionString(connectionString, 'credentials_updated');
+        resolveInvalidatedCreation?.(invalidatedInstance);
+
+        await expect(Promise.all([first, waiting])).resolves.toEqual([
+            expect.any(String),
+            expect.any(String),
+        ]);
+        expect(await first).toBe(await waiting);
+        expect(createInstanceMock).toHaveBeenCalledTimes(2);
+        expect(invalidatedInstance.closeSync).toHaveBeenCalledOnce();
+        expect(replacementInstance.closeSync).not.toHaveBeenCalled();
+    });
+
+    it('invalidates a cached connection string with the requested reason', async () => {
+        const connectionString =
+            'md:analytics?motherduck_token=token-a&saas_mode=true';
+        const events: MotherduckCacheEvent[] = [];
+        const firstInstance = createInstance();
+        const secondInstance = createInstance();
+        setObserver((event) => events.push(event));
+        createInstanceMock
+            .mockResolvedValueOnce(firstInstance)
+            .mockResolvedValueOnce(secondInstance);
+
+        await withInstance(connectionString, {}, async () => undefined);
+        invalidateByConnectionString(connectionString, 'credentials_updated');
+        await withInstance(connectionString, {}, async () => undefined);
+
+        expect(events).toContainEqual(
+            expect.objectContaining({
+                type: 'evict',
+                reason: 'credentials_updated',
+            }),
+        );
+        expect(firstInstance.closeSync).toHaveBeenCalledOnce();
+        expect(createInstanceMock).toHaveBeenCalledTimes(2);
+    });
+
+    it.each([
+        {
+            bound: 'idle TTL',
+            options: { idleTtlMs: 10 },
+            elapsedMs: 11,
+            reason: 'idle_ttl',
+        },
+        {
+            bound: 'max age',
+            options: { maxAgeMs: 10 },
+            elapsedMs: 11,
+            reason: 'max_age',
+        },
+    ] as const)(
+        'evicts by $bound with the matching reason',
+        async ({ options, elapsedMs, reason }) => {
+            const events: MotherduckCacheEvent[] = [];
+            setObserver((event) => events.push(event));
+            createInstanceMock.mockImplementation(async () => createInstance());
+            configureForTesting(options);
+
+            await withInstance(
+                'md:analytics?motherduck_token=token-a',
+                {},
+                async () => undefined,
+            );
+            await vi.advanceTimersByTimeAsync(elapsedMs);
+
+            expect(events).toContainEqual(
+                expect.objectContaining({ type: 'evict', reason }),
+            );
+        },
+    );
+
+    it('evicts the least recently used entry at the configured cap', async () => {
+        const events: MotherduckCacheEvent[] = [];
+        setObserver((event) => events.push(event));
+        createInstanceMock.mockImplementation(async () => createInstance());
+        configureForTesting({ maxEntries: 2 });
+
+        await withInstance(
+            'md:a?motherduck_token=a',
+            {},
+            async () => undefined,
+        );
+        await vi.advanceTimersByTimeAsync(1);
+        await withInstance(
+            'md:b?motherduck_token=b',
+            {},
+            async () => undefined,
+        );
+        await vi.advanceTimersByTimeAsync(1);
+        await withInstance(
+            'md:a?motherduck_token=a',
+            {},
+            async () => undefined,
+        );
+        await vi.advanceTimersByTimeAsync(1);
+        await withInstance(
+            'md:c?motherduck_token=c',
+            {},
+            async () => undefined,
+        );
+
+        expect(events).toContainEqual(
+            expect.objectContaining({ type: 'evict', reason: 'lru' }),
+        );
+        await withInstance(
+            'md:b?motherduck_token=b',
+            {},
+            async () => undefined,
+        );
+        expect(createInstanceMock).toHaveBeenCalledTimes(4);
+    });
+
+    it('unlinks an in-flight entry immediately and closes it only after release', async () => {
+        const firstInstance = createInstance();
+        const secondInstance = createInstance();
+        createInstanceMock
+            .mockResolvedValueOnce(firstInstance)
+            .mockResolvedValueOnce(secondInstance);
+        let entryId = '';
+        let releaseQuery: () => void = () => undefined;
+        const queryGate = new Promise<void>((resolve) => {
+            releaseQuery = resolve;
+        });
+
+        const inFlight = withInstance(
+            'md:analytics?motherduck_token=token-a',
+            {},
+            async (_instance, acquiredEntryId) => {
+                entryId = acquiredEntryId;
+                await queryGate;
+            },
+        );
+        await vi.waitFor(() => expect(entryId).not.toBe(''));
+        const draining = invalidate(entryId, 'stale');
+        await withInstance(
+            'md:analytics?motherduck_token=token-a',
+            {},
+            async () => undefined,
+        );
+
+        expect(firstInstance.closeSync).not.toHaveBeenCalled();
+        expect(createInstanceMock).toHaveBeenCalledTimes(2);
+        releaseQuery();
+        await Promise.all([inFlight, draining]);
+        expect(firstInstance.closeSync).toHaveBeenCalledOnce();
+    });
+
+    it('evicts after three consecutive failures with the failures reason', async () => {
+        const events: MotherduckCacheEvent[] = [];
+        const instance = createInstance();
+        const failure = new Error('query failed');
+        setObserver((event) => events.push(event));
+        createInstanceMock.mockResolvedValue(instance);
+
+        const fail = () =>
+            withInstance(
+                'md:analytics?motherduck_token=token-a',
+                {},
+                async () => {
+                    throw failure;
+                },
+            );
+
+        await expect(fail()).rejects.toBe(failure);
+        await expect(fail()).rejects.toBe(failure);
+        expect(events).not.toContainEqual(
+            expect.objectContaining({ type: 'evict', reason: 'failures' }),
+        );
+
+        await expect(fail()).rejects.toBe(failure);
+        expect(events).toContainEqual(
+            expect.objectContaining({ type: 'evict', reason: 'failures' }),
+        );
+        expect(instance.closeSync).toHaveBeenCalledOnce();
+    });
+
+    it('resets consecutive failures after a successful callback', async () => {
+        const events: MotherduckCacheEvent[] = [];
+        const failure = new Error('query failed');
+        setObserver((event) => events.push(event));
+        createInstanceMock.mockResolvedValue(createInstance());
+        configureForTesting({ maxConsecutiveFailures: 2 });
+
+        const run = (shouldFail: boolean) =>
+            withInstance(
+                'md:analytics?motherduck_token=token-a',
+                {},
+                async () => {
+                    if (shouldFail) {
+                        throw failure;
+                    }
+                    return 'ok';
+                },
+            );
+
+        await expect(run(true)).rejects.toBe(failure);
+        await expect(run(false)).resolves.toBe('ok');
+        await expect(run(true)).rejects.toBe(failure);
+
+        expect(events).not.toContainEqual(
+            expect.objectContaining({ type: 'evict', reason: 'failures' }),
+        );
+        expect(createInstanceMock).toHaveBeenCalledOnce();
+    });
+
+    it('unlinks on failure without waiting for other in-flight references to drain', async () => {
+        const events: MotherduckCacheEvent[] = [];
+        const firstInstance = createInstance();
+        const secondInstance = createInstance();
+        const failure = new Error('query failed');
+        let blockingCallbackStarted = false;
+        let releaseBlockingCallback: () => void = () => undefined;
+        const blockingCallbackGate = new Promise<void>((resolve) => {
+            releaseBlockingCallback = resolve;
+        });
+        setObserver((event) => events.push(event));
+        createInstanceMock
+            .mockResolvedValueOnce(firstInstance)
+            .mockResolvedValueOnce(secondInstance);
+        configureForTesting({ maxConsecutiveFailures: 1 });
+
+        const blocking = withInstance(
+            'md:analytics?motherduck_token=token-a',
+            {},
+            async () => {
+                blockingCallbackStarted = true;
+                await blockingCallbackGate;
+            },
+        );
+        await vi.waitFor(() => expect(blockingCallbackStarted).toBe(true));
+
+        const failing = withInstance(
+            'md:analytics?motherduck_token=token-a',
+            {},
+            async () => {
+                throw failure;
+            },
+        );
+        await expect(failing).rejects.toBe(failure);
+        expect(firstInstance.closeSync).not.toHaveBeenCalled();
+        expect(events).toContainEqual(
+            expect.objectContaining({ type: 'evict', reason: 'failures' }),
+        );
+
+        await withInstance(
+            'md:analytics?motherduck_token=token-a',
+            {},
+            async () => undefined,
+        );
+        expect(createInstanceMock).toHaveBeenCalledTimes(2);
+
+        releaseBlockingCallback();
+        await blocking;
+        expect(firstInstance.closeSync).toHaveBeenCalledOnce();
+    });
+
+    it('reserves newly created entries before concurrent LRU eviction can drain them', async () => {
+        const firstInstance = createInstance();
+        const secondInstance = createInstance();
+        createInstanceMock
+            .mockResolvedValueOnce(firstInstance)
+            .mockResolvedValueOnce(secondInstance);
+        configureForTesting({ maxEntries: 1 });
+        let startedCallbacks = 0;
+        let releaseQueries: () => void = () => undefined;
+        const queryGate = new Promise<void>((resolve) => {
+            releaseQueries = resolve;
+        });
+
+        const first = withInstance(
+            'md:first?motherduck_token=first',
+            {},
+            async () => {
+                expect(firstInstance.closeSync).not.toHaveBeenCalled();
+                startedCallbacks += 1;
+                await queryGate;
+            },
+        );
+        const second = withInstance(
+            'md:second?motherduck_token=second',
+            {},
+            async () => {
+                expect(secondInstance.closeSync).not.toHaveBeenCalled();
+                startedCallbacks += 1;
+                await queryGate;
+            },
+        );
+
+        await vi.waitFor(() => expect(startedCallbacks).toBe(2));
+        expect(firstInstance.closeSync).not.toHaveBeenCalled();
+        releaseQueries();
+        await Promise.all([first, second]);
+        expect(firstInstance.closeSync).toHaveBeenCalledOnce();
+    });
+
+    it('never emits the credential-derived digest and isolates observer failures', async () => {
+        const connectionString =
+            'md:analytics?motherduck_token=token-a&saas_mode=true';
+        const digest = createHash('sha256')
+            .update(JSON.stringify({ connectionString, v: 1 }))
+            .digest('hex');
+        const events: MotherduckCacheEvent[] = [];
+        const observer = vi.fn((event: MotherduckCacheEvent) => {
+            events.push(event);
+            throw new Error('observer failure');
+        });
+        setObserver(observer);
+        createInstanceMock.mockResolvedValue(createInstance());
+
+        await expect(
+            withInstance(
+                connectionString,
+                { projectUuid: 'project-a' },
+                async () => 'ok',
+            ),
+        ).resolves.toBe('ok');
+        expect(JSON.stringify(events)).not.toContain(digest);
+        expect(JSON.stringify(events)).not.toContain('token-a');
+    });
+
+    it('uses an unrefed interval without keepalive queries', () => {
+        const setIntervalSpy = vi.spyOn(global, 'setInterval');
+        configureForTesting();
+
+        const timer = setIntervalSpy.mock.results.at(-1)?.value;
+        if (!timer || typeof timer === 'number') {
+            throw new Error('Expected a Node.js interval handle');
+        }
+        expect(timer.hasRef()).toBe(false);
+        expect(createInstanceMock).not.toHaveBeenCalled();
+    });
+});

--- a/packages/warehouses/src/warehouseClients/MotherduckInstanceCache.ts
+++ b/packages/warehouses/src/warehouseClients/MotherduckInstanceCache.ts
@@ -1,0 +1,479 @@
+import { DuckDBInstance } from '@duckdb/node-api';
+import { createHash, randomUUID } from 'crypto';
+
+export type DuckdbInstance = Awaited<ReturnType<typeof DuckDBInstance.create>>;
+
+export type EvictionReason =
+    | 'idle_ttl'
+    | 'max_age'
+    | 'lru'
+    | 'stale'
+    | 'auth'
+    | 'failures'
+    | 'credentials_updated'
+    | 'shutdown';
+
+export type MotherduckCacheEvent =
+    | {
+          type: 'acquire';
+          result: 'hit' | 'miss';
+          entryId: string;
+          projectUuid?: string;
+          waitMs: number;
+          instanceCreateMs: number;
+          connectMs: number;
+      }
+    | {
+          type: 'evict';
+          entryId: string;
+          projectUuid?: string;
+          reason: EvictionReason;
+          ageMs: number;
+      }
+    | {
+          type: 'retry';
+          entryId: string;
+          outcome: 'recovered' | 'failed';
+      }
+    | { type: 'size'; entries: number };
+
+type CacheOptions = {
+    idleTtlMs: number;
+    maxAgeMs: number;
+    maxEntries: number;
+    maxConsecutiveFailures?: number;
+};
+
+export type MotherduckCacheAcquisitionTiming = {
+    waitMs: number;
+    instanceCreateMs: number;
+    connectMs: number;
+};
+
+type ResolvedCacheOptions = CacheOptions & {
+    maxConsecutiveFailures: number;
+};
+
+type CacheEntry = {
+    instance: DuckdbInstance;
+    entryId: string;
+    projectUuid?: string;
+    createdAt: number;
+    lastUsedAt: number;
+    refCount: number;
+    consecutiveFailures: number;
+    draining: boolean;
+    closed: boolean;
+    closePromise: Promise<void>;
+    resolveClose: () => void;
+};
+
+type CacheAcquisition = {
+    entry: CacheEntry;
+    result: 'hit' | 'miss';
+    waitMs: number;
+    instanceCreateMs: number;
+};
+
+type CacheCreation = {
+    entry: CacheEntry;
+    instanceCreateMs: number;
+};
+
+type PendingCreation = {
+    generation: number;
+    invalidated: boolean;
+    promise: Promise<CacheCreation | undefined>;
+};
+
+const holdEntry = (entry: CacheEntry) => {
+    const heldEntry = entry;
+    heldEntry.refCount += 1;
+    heldEntry.lastUsedAt = performance.now();
+    return heldEntry;
+};
+
+const DEFAULT_OPTIONS: ResolvedCacheOptions = {
+    idleTtlMs: 10 * 60_000,
+    maxAgeMs: 60 * 60_000,
+    maxEntries: 8,
+    maxConsecutiveFailures: 3,
+};
+
+let options: ResolvedCacheOptions = DEFAULT_OPTIONS;
+let observer: (event: MotherduckCacheEvent) => void = () => undefined;
+let sweepTimer: ReturnType<typeof setInterval> | undefined;
+const entries = new Map<string, CacheEntry>();
+const pendingCreations = new Map<string, PendingCreation>();
+const creationGenerations = new Map<string, number>();
+
+const emit = (event: MotherduckCacheEvent) => {
+    try {
+        observer(event);
+    } catch {
+        return;
+    }
+};
+
+const cacheKeyFor = (connectionString: string) =>
+    createHash('sha256')
+        .update(JSON.stringify({ connectionString, v: 1 }))
+        .digest('hex');
+
+const closeInstance = (instance: DuckdbInstance) => {
+    try {
+        instance.closeSync?.();
+        return true;
+    } catch {
+        return false;
+    }
+};
+
+const closeEntry = (entry: CacheEntry) => {
+    if (entry.closed || entry.refCount > 0) {
+        return;
+    }
+
+    const closingEntry = entry;
+    closingEntry.closed = true;
+    closeInstance(closingEntry.instance);
+    closingEntry.resolveClose();
+};
+
+const unlinkEntry = (
+    key: string,
+    entry: CacheEntry,
+    reason: EvictionReason,
+) => {
+    if (entries.get(key) !== entry) {
+        return entry.closePromise;
+    }
+
+    entries.delete(key);
+    const drainingEntry = entry;
+    drainingEntry.draining = true;
+    emit({
+        type: 'evict',
+        entryId: entry.entryId,
+        projectUuid: entry.projectUuid,
+        reason,
+        ageMs: performance.now() - entry.createdAt,
+    });
+    emit({ type: 'size', entries: entries.size });
+    closeEntry(entry);
+    return entry.closePromise;
+};
+
+const sweep = () => {
+    const now = performance.now();
+
+    entries.forEach((entry, key) => {
+        const ageMs = now - entry.createdAt;
+        const idleMs = now - entry.lastUsedAt;
+        if (ageMs >= options.maxAgeMs) {
+            void unlinkEntry(key, entry, 'max_age');
+        } else if (entry.refCount === 0 && idleMs >= options.idleTtlMs) {
+            void unlinkEntry(key, entry, 'idle_ttl');
+        }
+    });
+};
+
+const scheduleSweep = () => {
+    if (sweepTimer) {
+        clearInterval(sweepTimer);
+    }
+
+    const intervalMs = Math.max(
+        1,
+        Math.min(options.idleTtlMs, options.maxAgeMs, 60_000),
+    );
+    sweepTimer = setInterval(() => {
+        sweep();
+    }, intervalMs);
+    sweepTimer.unref();
+};
+
+const createEntry = async (
+    key: string,
+    connectionString: string,
+    generation: number,
+    projectUuid?: string,
+): Promise<CacheCreation | undefined> => {
+    const createStart = performance.now();
+    // Deliberately bypass fromCache(): mixing its unbounded singleton with this cache would create conflicting lifecycles.
+    // Revisit on @duckdb/node-api upgrades if the binding cache gains eviction bounds.
+    const instance = await DuckDBInstance.create(connectionString);
+    const instanceCreateMs = performance.now() - createStart;
+    if ((creationGenerations.get(key) ?? 0) !== generation) {
+        closeInstance(instance);
+        return undefined;
+    }
+    let resolveClose: () => void = () => undefined;
+    const closePromise = new Promise<void>((resolve) => {
+        resolveClose = resolve;
+    });
+    const now = performance.now();
+    const entry: CacheEntry = {
+        instance,
+        entryId: randomUUID(),
+        projectUuid,
+        createdAt: now,
+        lastUsedAt: now,
+        refCount: 1,
+        consecutiveFailures: 0,
+        draining: false,
+        closed: false,
+        closePromise,
+        resolveClose,
+    };
+    entries.set(key, entry);
+    emit({ type: 'size', entries: entries.size });
+
+    if (entries.size > options.maxEntries) {
+        const lru = [...entries.entries()]
+            .filter(([, candidate]) => candidate !== entry)
+            .sort(([, left], [, right]) => left.lastUsedAt - right.lastUsedAt)
+            .at(0);
+        if (lru) {
+            void unlinkEntry(lru[0], lru[1], 'lru');
+        }
+    }
+
+    return { entry, instanceCreateMs };
+};
+
+const resolveCreation = async (
+    key: string,
+    pending: PendingCreation,
+    result: 'hit' | 'miss',
+    getWaitMs: () => number,
+    retry: () => Promise<CacheAcquisition>,
+): Promise<CacheAcquisition> => {
+    let created: CacheCreation | undefined;
+    try {
+        created = await pending.promise;
+    } finally {
+        if (pendingCreations.get(key) === pending) {
+            pendingCreations.delete(key);
+            if ((creationGenerations.get(key) ?? 0) === pending.generation) {
+                creationGenerations.delete(key);
+            }
+        }
+    }
+
+    if (!created || pending.invalidated) {
+        if (created && result === 'miss') {
+            created.entry.refCount -= 1;
+            closeEntry(created.entry);
+        }
+        return retry();
+    }
+
+    return {
+        entry: result === 'hit' ? holdEntry(created.entry) : created.entry,
+        result,
+        waitMs: getWaitMs(),
+        instanceCreateMs: result === 'miss' ? created.instanceCreateMs : 0,
+    };
+};
+
+const acquire = async (
+    connectionString: string,
+    projectUuid?: string,
+): Promise<CacheAcquisition> => {
+    const waitStart = performance.now();
+    sweep();
+    const key = cacheKeyFor(connectionString);
+    const existing = entries.get(key);
+    if (existing) {
+        return {
+            entry: holdEntry(existing),
+            result: 'hit',
+            waitMs: performance.now() - waitStart,
+            instanceCreateMs: 0,
+        };
+    }
+
+    const pending = pendingCreations.get(key);
+    if (pending) {
+        return resolveCreation(
+            key,
+            pending,
+            'hit',
+            () => performance.now() - waitStart,
+            () => acquire(connectionString, projectUuid),
+        );
+    }
+
+    const generation = creationGenerations.get(key) ?? 0;
+    const waitMs = performance.now() - waitStart;
+    const creation: PendingCreation = {
+        generation,
+        invalidated: false,
+        promise: createEntry(key, connectionString, generation, projectUuid),
+    };
+    pendingCreations.set(key, creation);
+    return resolveCreation(
+        key,
+        creation,
+        'miss',
+        () => waitMs,
+        () => acquire(connectionString, projectUuid),
+    );
+};
+
+export const configure = (nextOptions: CacheOptions): void => {
+    options = {
+        ...nextOptions,
+        maxConsecutiveFailures:
+            nextOptions.maxConsecutiveFailures ??
+            DEFAULT_OPTIONS.maxConsecutiveFailures,
+    };
+    scheduleSweep();
+};
+
+export const setObserver = (
+    nextObserver: (event: MotherduckCacheEvent) => void,
+): void => {
+    observer = nextObserver;
+    emit({ type: 'size', entries: entries.size });
+};
+
+export const withInstance = async <T>(
+    connectionString: string,
+    ctx: { projectUuid?: string },
+    fn: (
+        instance: DuckdbInstance,
+        entryId: string,
+        timing: MotherduckCacheAcquisitionTiming,
+    ) => Promise<T>,
+): Promise<T> => {
+    const acquisition = await acquire(connectionString, ctx.projectUuid);
+    const { entry } = acquisition;
+    const timing: MotherduckCacheAcquisitionTiming = {
+        waitMs: acquisition.waitMs,
+        instanceCreateMs: acquisition.instanceCreateMs,
+        connectMs: 0,
+    };
+    const observedInstance = new Proxy(entry.instance, {
+        get: (target, property) => {
+            if (property === 'connect') {
+                return async () => {
+                    const connectStart = performance.now();
+                    try {
+                        return await target.connect();
+                    } finally {
+                        timing.connectMs += performance.now() - connectStart;
+                    }
+                };
+            }
+            const value = Reflect.get(target, property, target);
+            return typeof value === 'function' ? value.bind(target) : value;
+        },
+    });
+
+    try {
+        const result = await fn(observedInstance, entry.entryId, timing);
+        entry.consecutiveFailures = 0;
+        return result;
+    } catch (error) {
+        entry.consecutiveFailures += 1;
+        if (
+            entry.consecutiveFailures >= options.maxConsecutiveFailures &&
+            !entry.draining
+        ) {
+            void unlinkEntry(cacheKeyFor(connectionString), entry, 'failures');
+        }
+        throw error;
+    } finally {
+        entry.refCount -= 1;
+        entry.lastUsedAt = performance.now();
+        emit({
+            type: 'acquire',
+            result: acquisition.result,
+            entryId: entry.entryId,
+            projectUuid: ctx.projectUuid,
+            waitMs: timing.waitMs,
+            instanceCreateMs: timing.instanceCreateMs,
+            connectMs: timing.connectMs,
+        });
+        if (entry.draining) {
+            closeEntry(entry);
+        }
+    }
+};
+
+export const invalidate = async (
+    entryId: string,
+    reason: EvictionReason,
+): Promise<void> => {
+    const match = [...entries.entries()].find(
+        ([, entry]) => entry.entryId === entryId,
+    );
+    if (match) {
+        await unlinkEntry(match[0], match[1], reason);
+    }
+};
+
+export const invalidateByConnectionString = (
+    connectionString: string,
+    reason: EvictionReason,
+): void => {
+    const key = cacheKeyFor(connectionString);
+    const pending = pendingCreations.get(key);
+    if (pending) {
+        pending.invalidated = true;
+        creationGenerations.set(key, (creationGenerations.get(key) ?? 0) + 1);
+    }
+    const entry = entries.get(key);
+    if (entry) {
+        void unlinkEntry(key, entry, reason);
+    }
+};
+
+export const closeAll = async (reason: EvictionReason): Promise<void> => {
+    await Promise.allSettled(
+        [...pendingCreations.values()].map(({ promise }) => promise),
+    );
+    const draining = [...entries.entries()].map(([key, entry]) =>
+        unlinkEntry(key, entry, reason),
+    );
+    await Promise.all(draining);
+};
+
+export const recordRetry = (
+    entryId: string,
+    outcome: 'recovered' | 'failed',
+): void => {
+    emit({ type: 'retry', entryId, outcome });
+};
+
+export const resetForTesting = (): void => {
+    if (sweepTimer) {
+        clearInterval(sweepTimer);
+    }
+    entries.forEach((entry) => {
+        const drainingEntry = entry;
+        drainingEntry.draining = true;
+        closeEntry(drainingEntry);
+    });
+    entries.clear();
+    pendingCreations.clear();
+    creationGenerations.clear();
+    options = DEFAULT_OPTIONS;
+    observer = () => undefined;
+    scheduleSweep();
+};
+
+export const MotherduckInstanceCache = {
+    configure,
+    setObserver,
+    withInstance,
+    invalidate,
+    invalidateByConnectionString,
+    recordRetry,
+    closeAll,
+    resetForTesting,
+};
+
+scheduleSweep();


### PR DESCRIPTION
## Summary

- Restore the opt-in MotherDuck instance cache implementation and its lifecycle, configuration, and observability coverage.
- Preserve the later per-project query-phase metrics configuration and tests while resolving the revert conflict.

## Why

This restores PR 26727, which was reverted in PR 26792. Production measurement since then showed cold-process connection setup remains the dominant cost at 11–12 seconds, while the SQL itself runs in about 250ms.

## Validation

- Targeted backend conflict tests: 160 passed
- Warehouses tests: 345 passed, 2 skipped
- Backend tests (sequential): 6,020 passed, 1 skipped
- `pnpm --filter warehouses typecheck`
- `pnpm --filter backend typecheck`
- Path-scoped backend and warehouses lint

Linear: SPK-822