### PR TITLE
fix(auth): enforce the role delegation ceiling on invite links

### DIFF
--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1151,6 +1151,7 @@ export class ServiceRepository
                     projectModel: this.models.getProjectModel(),
                     featureFlagModel: this.models.getFeatureFlagModel(),
                     userAvatarModel: this.models.getUserAvatarModel(),
+                    rolesModel: this.models.getRolesModel(),
                 }),
         );
     }

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -35,12 +35,14 @@ import { OrganizationSettingsModel } from '../models/OrganizationSettingsModel';
 import { OrganizationSsoModel } from '../models/OrganizationSsoModel';
 import { PasswordResetLinkModel } from '../models/PasswordResetLinkModel';
 import { ProjectModel } from '../models/ProjectModel/ProjectModel';
+import { RolesModel } from '../models/RolesModel';
 import { SessionModel } from '../models/SessionModel';
 import { UserAvatarModel } from '../models/UserAvatarModel';
 import { UserModel } from '../models/UserModel';
 import { UserOAuthGrantsModel } from '../models/UserOAuthGrantsModel';
 import { UserWarehouseCredentialsModel } from '../models/UserWarehouseCredentials/UserWarehouseCredentialsModel';
 import { WarehouseAvailableTablesModel } from '../models/WarehouseAvailableTablesModel/WarehouseAvailableTablesModel';
+import { getOrganizationSystemRoleScopes } from '../utils/organizationRolePermissions';
 import { UserService } from './UserService';
 import {
     authenticatedUser,
@@ -196,6 +198,7 @@ type UserServiceTestOverrides = {
         PasswordResetLinkModel,
         'getByCode' | 'deleteByCode'
     >;
+    rolesModel?: Pick<RolesModel, 'getRoleWithScopesByUuid'>;
 };
 
 const createUserService = (
@@ -243,6 +246,7 @@ const createUserService = (
                 ),
             } as unknown as FeatureFlagModel),
         userAvatarModel: {} as UserAvatarModel,
+        rolesModel: (overrides.rolesModel as RolesModel) ?? ({} as RolesModel),
     });
 
 vi.spyOn(analyticsMock, 'track');
@@ -2906,6 +2910,7 @@ describe('UserService', () => {
                     })),
                 } as unknown as FeatureFlagModel,
                 userAvatarModel: {} as UserAvatarModel,
+                rolesModel: {} as RolesModel,
             });
 
             await expect(
@@ -2985,6 +2990,7 @@ describe('UserService', () => {
                     })),
                 } as unknown as FeatureFlagModel,
                 userAvatarModel: {} as UserAvatarModel,
+                rolesModel: {} as RolesModel,
             });
 
             await expect(
@@ -3107,6 +3113,107 @@ describe('UserService', () => {
             ).not.toHaveBeenCalled();
             expect(vi.mocked(inviteLinkModel.upsert)).not.toHaveBeenCalled();
         });
+
+        describe('delegation ceiling', () => {
+            // Manages members, but its own scopes stop at organization member
+            // level — so it may invite a member and must not mint an admin.
+            const limitedManagerRole = {
+                roleUuid: 'limited-org-manager-role',
+                organizationUuid: sessionUser.organizationUuid,
+                level: 'organization',
+                scopes: [
+                    'manage:Organization',
+                    'manage:OrganizationMemberProfile',
+                    'create:InviteLink',
+                    ...getOrganizationSystemRoleScopes(
+                        OrganizationMemberRole.MEMBER,
+                    ),
+                ],
+            };
+            const limitedManagerUser = {
+                ...sessionUser,
+                role: OrganizationMemberRole.MEMBER,
+                roleUuid: limitedManagerRole.roleUuid,
+                ability: defineUserAbility(
+                    {
+                        userUuid: sessionUser.userUuid,
+                        role: OrganizationMemberRole.ADMIN,
+                        organizationUuid: sessionUser.organizationUuid,
+                        roleUuid: undefined,
+                    },
+                    [],
+                ),
+            };
+            const buildLimitedManagerService = () =>
+                createUserService(lightdashConfigMock, {
+                    rolesModel: {
+                        getRoleWithScopesByUuid: vi
+                            .fn()
+                            .mockResolvedValue(limitedManagerRole),
+                    } as unknown as RolesModel,
+                });
+
+            test('rejects an invite whose role exceeds the caller permissions', async () => {
+                await expect(
+                    buildLimitedManagerService().createPendingUserAndInviteLink(
+                        limitedManagerUser,
+                        {
+                            ...inviteUser,
+                            role: OrganizationMemberRole.ADMIN,
+                        },
+                    ),
+                ).rejects.toBeInstanceOf(ForbiddenError);
+
+                expect(
+                    vi.mocked(userModel.createPendingUser),
+                ).not.toHaveBeenCalled();
+                expect(vi.mocked(userModel.joinOrg)).not.toHaveBeenCalled();
+                expect(
+                    vi.mocked(inviteLinkModel.upsert),
+                ).not.toHaveBeenCalled();
+            });
+
+            test('rejects a setup invite from a caller that is not admin-equivalent', async () => {
+                await expect(
+                    buildLimitedManagerService().createPendingUserAndInviteLink(
+                        limitedManagerUser,
+                        {
+                            ...inviteUser,
+                            purpose: InviteLinkPurpose.Setup,
+                        },
+                    ),
+                ).rejects.toBeInstanceOf(ForbiddenError);
+
+                expect(
+                    vi.mocked(userModel.createPendingUser),
+                ).not.toHaveBeenCalled();
+                expect(
+                    vi.mocked(inviteLinkModel.upsert),
+                ).not.toHaveBeenCalled();
+            });
+
+            test('allows an invite the caller permissions already cover', async () => {
+                await buildLimitedManagerService().createPendingUserAndInviteLink(
+                    limitedManagerUser,
+                    { ...inviteUser, role: OrganizationMemberRole.MEMBER },
+                );
+
+                expect(
+                    vi.mocked(userModel.createPendingUser),
+                ).toHaveBeenCalledWith(
+                    sessionUser.organizationUuid,
+                    {
+                        email: inviteUser.email,
+                        firstName: '',
+                        lastName: '',
+                        role: OrganizationMemberRole.MEMBER,
+                    },
+                    true,
+                    undefined,
+                );
+            });
+        });
+
         test('should send invite when email belongs to user without org', async () => {
             (
                 userModel.findUserByEmail as import('vitest').Mock

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -6,6 +6,7 @@ import {
     ExpiredError,
     FeatureFlags,
     ForbiddenError,
+    getUserAbilityBuilder,
     InviteLinkPurpose,
     LightdashUser,
     NotFoundError,
@@ -3115,48 +3116,73 @@ describe('UserService', () => {
         });
 
         describe('delegation ceiling', () => {
-            // Manages members, but its own scopes stop at organization member
-            // level — so it may invite a member and must not mint an admin.
+            // Manages members and invites, but its own scopes stop at
+            // organization member level — so it may invite a member and must
+            // not mint an admin.
             const limitedManagerRole = {
                 roleUuid: 'limited-org-manager-role',
                 organizationUuid: sessionUser.organizationUuid,
                 level: 'organization',
                 scopes: [
-                    'manage:Organization',
                     'manage:OrganizationMemberProfile',
-                    'create:InviteLink',
+                    'manage:InviteLink',
                     ...getOrganizationSystemRoleScopes(
                         OrganizationMemberRole.MEMBER,
                     ),
                 ],
             };
-            const limitedManagerUser = {
+
+            const patConfig = (enabled: boolean) => ({
+                enabled,
+                allowedOrgRoles: Object.values(OrganizationMemberRole),
+                maxExpirationTimeInDays: undefined,
+            });
+
+            // Built the way production builds it: from the role's scopes, so
+            // the PAT scope is granted by config rather than by the role.
+            const limitedManagerUser = (patEnabled: boolean): SessionUser => ({
                 ...sessionUser,
                 role: OrganizationMemberRole.MEMBER,
                 roleUuid: limitedManagerRole.roleUuid,
-                ability: defineUserAbility(
-                    {
+                ability: getUserAbilityBuilder({
+                    user: {
                         userUuid: sessionUser.userUuid,
-                        role: OrganizationMemberRole.ADMIN,
+                        role: OrganizationMemberRole.MEMBER,
                         organizationUuid: sessionUser.organizationUuid,
-                        roleUuid: undefined,
+                        roleUuid: limitedManagerRole.roleUuid,
                     },
-                    [],
-                ),
-            };
-            const buildLimitedManagerService = () =>
-                createUserService(lightdashConfigMock, {
-                    rolesModel: {
-                        getRoleWithScopesByUuid: vi
-                            .fn()
-                            .mockResolvedValue(limitedManagerRole),
-                    } as unknown as RolesModel,
-                });
+                    projectProfiles: [],
+                    permissionsConfig: { pat: patConfig(patEnabled) },
+                    customRoleScopes: {
+                        [limitedManagerRole.roleUuid]:
+                            limitedManagerRole.scopes,
+                    },
+                    customRolesEnabled: true,
+                }).builder.build(),
+            });
+
+            const buildLimitedManagerService = (patEnabled: boolean = false) =>
+                createUserService(
+                    {
+                        ...lightdashConfigMock,
+                        auth: {
+                            ...lightdashConfigMock.auth,
+                            pat: patConfig(patEnabled),
+                        },
+                    },
+                    {
+                        rolesModel: {
+                            getRoleWithScopesByUuid: vi
+                                .fn()
+                                .mockResolvedValue(limitedManagerRole),
+                        } as unknown as RolesModel,
+                    },
+                );
 
             test('rejects an invite whose role exceeds the caller permissions', async () => {
                 await expect(
                     buildLimitedManagerService().createPendingUserAndInviteLink(
-                        limitedManagerUser,
+                        limitedManagerUser(false),
                         {
                             ...inviteUser,
                             role: OrganizationMemberRole.ADMIN,
@@ -3176,7 +3202,7 @@ describe('UserService', () => {
             test('rejects a setup invite from a caller that is not admin-equivalent', async () => {
                 await expect(
                     buildLimitedManagerService().createPendingUserAndInviteLink(
-                        limitedManagerUser,
+                        limitedManagerUser(false),
                         {
                             ...inviteUser,
                             purpose: InviteLinkPurpose.Setup,
@@ -3194,7 +3220,7 @@ describe('UserService', () => {
 
             test('allows an invite the caller permissions already cover', async () => {
                 await buildLimitedManagerService().createPendingUserAndInviteLink(
-                    limitedManagerUser,
+                    limitedManagerUser(false),
                     { ...inviteUser, role: OrganizationMemberRole.MEMBER },
                 );
 
@@ -3211,6 +3237,89 @@ describe('UserService', () => {
                     true,
                     undefined,
                 );
+            });
+
+            // The invited role carries manage:PersonalAccessToken from the PAT
+            // config, and so does the caller — a custom role never lists that
+            // scope, so comparing against its stored scopes alone would deny
+            // every invite.
+            test('allows a covered invite when personal access tokens are enabled', async () => {
+                await buildLimitedManagerService(
+                    true,
+                ).createPendingUserAndInviteLink(limitedManagerUser(true), {
+                    ...inviteUser,
+                    role: OrganizationMemberRole.MEMBER,
+                });
+
+                expect(
+                    vi.mocked(userModel.createPendingUser),
+                ).toHaveBeenCalledWith(
+                    sessionUser.organizationUuid,
+                    {
+                        email: inviteUser.email,
+                        firstName: '',
+                        lastName: '',
+                        role: OrganizationMemberRole.MEMBER,
+                    },
+                    true,
+                    undefined,
+                );
+            });
+
+            // rolesModel is left unstubbed here: a system-role caller must be
+            // measured from its own role, without a custom-role lookup.
+            test('allows an organization admin to invite an admin', async () => {
+                const adminUser = {
+                    ...sessionUser,
+                    ability: defineUserAbility(
+                        {
+                            userUuid: sessionUser.userUuid,
+                            role: OrganizationMemberRole.ADMIN,
+                            organizationUuid: sessionUser.organizationUuid,
+                            roleUuid: undefined,
+                        },
+                        [],
+                    ),
+                };
+
+                await createUserService(
+                    lightdashConfigMock,
+                ).createPendingUserAndInviteLink(adminUser, {
+                    ...inviteUser,
+                    role: OrganizationMemberRole.ADMIN,
+                });
+
+                expect(
+                    vi.mocked(userModel.createPendingUser),
+                ).toHaveBeenCalledWith(
+                    sessionUser.organizationUuid,
+                    {
+                        email: inviteUser.email,
+                        firstName: '',
+                        lastName: '',
+                        role: OrganizationMemberRole.ADMIN,
+                    },
+                    true,
+                    undefined,
+                );
+            });
+
+            test('still rejects an admin invite when personal access tokens are enabled', async () => {
+                await expect(
+                    buildLimitedManagerService(
+                        true,
+                    ).createPendingUserAndInviteLink(limitedManagerUser(true), {
+                        ...inviteUser,
+                        role: OrganizationMemberRole.ADMIN,
+                    }),
+                ).rejects.toBeInstanceOf(ForbiddenError);
+
+                expect(
+                    vi.mocked(userModel.createPendingUser),
+                ).not.toHaveBeenCalled();
+                expect(
+                    vi.mocked(inviteLinkModel.upsert),
+                ).not.toHaveBeenCalled();
             });
         });
 

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -110,6 +110,7 @@ import { OrganizationSettingsModel } from '../models/OrganizationSettingsModel';
 import { OrganizationSsoModel } from '../models/OrganizationSsoModel';
 import { PasswordResetLinkModel } from '../models/PasswordResetLinkModel';
 import { ProjectModel } from '../models/ProjectModel/ProjectModel';
+import { RolesModel } from '../models/RolesModel';
 import { SessionModel } from '../models/SessionModel';
 import { UserAvatarModel } from '../models/UserAvatarModel';
 import { CreatePasswordlessUserArgs, UserModel } from '../models/UserModel';
@@ -117,6 +118,10 @@ import { UserOAuthGrantsModel } from '../models/UserOAuthGrantsModel';
 import { UserWarehouseCredentialsModel } from '../models/UserWarehouseCredentials/UserWarehouseCredentialsModel';
 import { WarehouseAvailableTablesModel } from '../models/WarehouseAvailableTablesModel/WarehouseAvailableTablesModel';
 import { wrapSentryTransaction } from '../utils';
+import {
+    getOrganizationSystemRoleScopes,
+    validateOrganizationScopesCanBeGranted,
+} from '../utils/organizationRolePermissions';
 import { processAvatarImage } from '../utils/processAvatarImage';
 import { BaseService } from './BaseService';
 import { getOrganizationSettingsInstanceDefaults } from './OrganizationSettingsService/getInstanceDefaults';
@@ -156,6 +161,7 @@ type UserServiceArguments = {
     projectModel: ProjectModel;
     featureFlagModel: FeatureFlagModel;
     userAvatarModel: UserAvatarModel;
+    rolesModel: RolesModel;
 };
 
 function isSameMinute(a: Date | null, b: Date): boolean {
@@ -277,6 +283,8 @@ export class UserService extends BaseService {
 
     private readonly featureFlagModel: FeatureFlagModel;
 
+    private readonly rolesModel: RolesModel;
+
     private readonly emailOneTimePasscodeExpirySeconds = 60 * 15;
 
     private readonly emailOneTimePasscodeMaxAttempts = 5;
@@ -306,6 +314,7 @@ export class UserService extends BaseService {
         projectModel,
         featureFlagModel,
         userAvatarModel,
+        rolesModel,
     }: UserServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -331,6 +340,7 @@ export class UserService extends BaseService {
         this.projectModel = projectModel;
         this.featureFlagModel = featureFlagModel;
         this.userAvatarModel = userAvatarModel;
+        this.rolesModel = rolesModel;
     }
 
     private identifyUser(
@@ -741,6 +751,23 @@ export class UserService extends BaseService {
                     `Unknown invite link purpose: ${purpose}`,
                 );
         }
+
+        // Before any user row is written or joined: an invite must not grant a
+        // role the caller could not grant directly. There is no compensating
+        // delete on this path.
+        await validateOrganizationScopesCanBeGranted({
+            user,
+            organizationUuid,
+            grantedScopes: getOrganizationSystemRoleScopes(userRole, {
+                includePersonalAccessToken:
+                    this.lightdashConfig.auth?.pat?.enabled === true &&
+                    this.lightdashConfig.auth.pat.allowedOrgRoles.includes(
+                        userRole,
+                    ),
+            }),
+            rolesModel: this.rolesModel,
+        });
+
         if (!existingUserWithEmail) {
             const onboardingFlow = await this.getOnboardingFlow(user);
             const pendingUser = await this.userModel.createPendingUser(

--- a/packages/backend/src/utils/organizationRolePermissions.ts
+++ b/packages/backend/src/utils/organizationRolePermissions.ts
@@ -29,12 +29,16 @@ const getCallerOrganizationScopes = async (
         throw new ForbiddenError('You do not have permission');
     }
 
+    // Custom roles never list this scope, but the ability builder still grants
+    // it from the PAT config, so it is part of the caller's real footprint.
+    const canManagePersonalAccessToken = user.ability.can(
+        'manage',
+        'PersonalAccessToken',
+    );
+
     if (!user.roleUuid) {
         return getOrganizationSystemRoleScopes(user.role, {
-            includePersonalAccessToken: user.ability.can(
-                'manage',
-                'PersonalAccessToken',
-            ),
+            includePersonalAccessToken: canManagePersonalAccessToken,
         });
     }
 
@@ -45,7 +49,9 @@ const getCallerOrganizationScopes = async (
         throw new ForbiddenError('You do not have permission');
     }
 
-    return role.scopes;
+    return canManagePersonalAccessToken
+        ? [...role.scopes, 'manage:PersonalAccessToken']
+        : role.scopes;
 };
 
 export const validateOrganizationScopesCanBeGranted = async ({


### PR DESCRIPTION
Closes [PROD-9483](https://linear.app/lightdash/issue/PROD-9483/invite-links-bypass-the-organization-role-delegation-ceiling).

Stacks on **#26771** (`spk-535`), which introduces the shared delegation guard this PR reuses. Base retargets to `main` when that merges.

## What this fixes

Creating an invite gated the requested organization role behind a single `can('manage', OrganizationMemberProfile)` check. That answers "may this caller edit member profiles at all" — a capability question, not a delegation question. Once true, the caller's own role never constrained the requested role, so a limited organization manager could invite an address they control as `admin` and escalate.

| Path | Today | After this PR |
| --- | --- | --- |
| `UserService.createPendingUserAndInviteLink()`, `purpose: member` | Accepts any `role` in the body once the caller can manage member profiles | Requested role's scopes must be covered by the caller's own |
| `UserService.createPendingUserAndInviteLink()`, `purpose: setup` | Hard-codes `ADMIN` behind that same single check | Caller must itself be admin-equivalent |
| `getCallerOrganizationScopes()` (custom-role callers) | Returns the role's stored scopes verbatim | Also counts `manage:PersonalAccessToken`, which the ability builder grants from config |

## How

`validateOrganizationScopesCanBeGranted` runs immediately after `userRole` is resolved and before anything is written. Placement is load-bearing: this path has no compensating delete, so a denial added later would leave a half-created user behind.

```
  resolve userRole (member | setup -> admin)
            |
            v
  [ validateOrganizationScopesCanBeGranted ]  <-- denial happens here
            |            throws ForbiddenError
            v
  +---------+---------+---------+
  |         |                   |
  v         v                   v
createPendingUser  joinOrg  updateOrganizationMember   <-- no rollback past this line
  |         |                   |
  +---------+---------+---------+
            v
      inviteLinkModel.upsert
```

`UserService` takes `rolesModel` through `ServiceRepository` so the guard can resolve a custom-role caller's scopes.

### The PAT scope, counted on both sides

The guard adds `manage:PersonalAccessToken` to the *granted* scopes when the invited role is PAT-eligible. A custom role never stores that scope — `scopeAbilityBuilder.handlePatConfigApplication` grants it at runtime from `auth.pat` — so measuring a custom-role caller by its stored scopes alone under-counted it by exactly that one scope, and every invite failed.

`auth.pat.enabled` defaults to `true` (`DISABLE_PAT !== 'true'`) with `allowedOrgRoles` defaulting to every role, so this was the default-configuration path, not an edge case. `getCallerOrganizationScopes` now counts the scope on the caller side too, matching what the system-role branch already did.

## Who's affected

| User class | Covered by its own scopes? | Affected? |
| --- | --- | --- |
| Organization admin (system role) | Yes | No |
| Developer / Editor / Viewer (system roles) | No `manage:OrganizationMemberProfile` | No — could not set a role before either |
| Custom role: member-level scopes + `manage:InviteLink` + `manage:OrganizationMemberProfile` | Yes for `member` | No for `member`; **yes for `admin`** — *this is the bypass we are closing* |
| Custom role: `manage:InviteLink` only, no member-level `view:*` | No | **Yes** — see below |
| Service accounts | Unchanged | No — separate path, already gated by #26771 |

### Behavior change worth a release note

`manage:X` covers `view:X`, but the `member` role confers `view:JobStatus` and `view:PinnedItems`. A narrow custom role holding only `manage:InviteLink` + `manage:OrganizationMemberProfile` will now be denied even a plain `member` invite until those two scopes are added to it. This is the same ceiling #26771 applies to direct role assignment, so the two surfaces stay consistent.

## Test plan

- [x] `pnpm -F backend typecheck` — clean
- [x] `pnpm -F backend lint` — clean
- [x] `pnpm -F backend exec vitest run src/services/UserService.test.ts` — 119 pass, 6 new delegation-ceiling cases
- [x] `vitest run src/services/RolesService src/services/OrganizationService src/ee/services/ServiceAccountService src/utils` — 871 pass across the changed helper's other consumers
- [x] Negative oracle: removing the guard fails 3 of the new tests; removing the PAT fix fails 1
- [x] Manual, against a real org custom-role session on a local instance:

```
                                                        before      after
  limited manager invites role=admin                      201    ->   403
    ... and the admin membership row it created           yes    ->   none
  limited manager requests purpose=setup                  201    ->   403
  limited manager invites role=member (legitimate)        201    ->   201
  organization admin invites role=admin                   201    ->   201
```

The `before` column is a real reproduction, not inspection: the escalated invite returned `201` and `organization_memberships` held an `admin` row for the invited address.
