### PR TITLE
feat(ai): allow API authentication for Deep Research runs

### DIFF
--- a/packages/backend/src/ee/controllers/AiDeepResearchController.test.ts
+++ b/packages/backend/src/ee/controllers/AiDeepResearchController.test.ts
@@ -1,0 +1,111 @@
+import {
+    ForbiddenError,
+    type Account,
+    type AiDeepResearchRequestBody,
+    type AiDeepResearchRun,
+} from '@lightdash/common';
+import type { Request } from 'express';
+import {
+    fromApiKey,
+    fromOauth,
+    fromServiceAccount,
+    fromSession,
+} from '../../auth/account/account';
+import {
+    buildAccount,
+    defaultSessionUser,
+} from '../../auth/account/account.mock';
+import type { ServiceRepository } from '../../services/ServiceRepository';
+import type { AiDeepResearchService } from '../services/AiDeepResearchService/AiDeepResearchService';
+import { AiDeepResearchController } from './AiDeepResearchController';
+
+const projectUuid = 'project-uuid';
+const requestBody: AiDeepResearchRequestBody = {
+    prompt: 'Investigate conversion performance',
+    agentUuid: 'agent-uuid',
+    threadUuid: 'thread-uuid',
+    promptUuid: 'prompt-uuid',
+    entryPoint: 'ask_ai',
+};
+const run = {
+    aiDeepResearchRunUuid: 'run-uuid',
+} as AiDeepResearchRun;
+
+const buildController = () => {
+    const createRun = vi.fn<AiDeepResearchService['createRun']>(
+        async () => run,
+    );
+    const services = {
+        getAiDeepResearchService: () => ({ createRun }),
+    } as unknown as ServiceRepository;
+
+    return {
+        controller: new AiDeepResearchController(services),
+        createRun,
+    };
+};
+
+const buildRequest = (account: Account): Request => ({ account }) as Request;
+
+describe('AiDeepResearchController.createRun', () => {
+    it.each([
+        ['session', fromSession(defaultSessionUser, 'session-cookie')],
+        ['personal access token', fromApiKey(defaultSessionUser, 'pat-token')],
+        [
+            'service account',
+            fromServiceAccount(
+                {
+                    ...defaultSessionUser,
+                    serviceAccount: {
+                        uuid: 'service-account-uuid',
+                        description: 'Service account',
+                    },
+                },
+                'service-account-token',
+            ),
+        ],
+        [
+            'OAuth',
+            fromOauth(defaultSessionUser, {
+                accessToken: 'oauth-token',
+                client: { id: 'oauth-client' },
+            }),
+        ],
+    ])('allows %s authentication', async (_name, account) => {
+        const { controller, createRun } = buildController();
+
+        const response = await controller.createRun(
+            buildRequest(account),
+            projectUuid,
+            requestBody,
+        );
+
+        expect(controller.getStatus()).toBe(202);
+        expect(createRun).toHaveBeenCalledWith({
+            user: expect.objectContaining({
+                userUuid: defaultSessionUser.userUuid,
+                organizationUuid: defaultSessionUser.organizationUuid,
+            }),
+            projectUuid,
+            prompt: requestBody.prompt,
+            agentUuid: requestBody.agentUuid,
+            aiThreadUuid: requestBody.threadUuid,
+            promptUuid: requestBody.promptUuid,
+            entryPoint: requestBody.entryPoint,
+        });
+        expect(response).toEqual({ status: 'ok', results: run });
+    });
+
+    it('rejects embedded JWT authentication', async () => {
+        const { controller, createRun } = buildController();
+
+        await expect(
+            controller.createRun(
+                buildRequest(buildAccount({ accountType: 'jwt' })),
+                projectUuid,
+                requestBody,
+            ),
+        ).rejects.toThrow(ForbiddenError);
+        expect(createRun).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/ee/controllers/AiDeepResearchController.ts
+++ b/packages/backend/src/ee/controllers/AiDeepResearchController.ts
@@ -1,6 +1,5 @@
 import {
     assertRegisteredAccount,
-    ForbiddenError,
     type AiDeepResearchRequestBody,
     type ApiAiAgentThreadMessageVizQueryResponse,
     type ApiAiDeepResearchChartResponse,
@@ -55,11 +54,6 @@ export class AiDeepResearchController extends BaseController {
         @Body() body: AiDeepResearchRequestBody,
     ): Promise<ApiAiDeepResearchRunResponse> {
         assertRegisteredAccount(req.account);
-        if (req.account.authentication.type !== 'session') {
-            throw new ForbiddenError(
-                'Deep Research must be started from a signed-in browser session',
-            );
-        }
         this.setStatus(202);
         return {
             status: 'ok',

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.test.ts
@@ -3,6 +3,7 @@ import {
     type AiDeepResearchHypothesis,
     type AiDeepResearchInvestigationReport,
     type AnyType,
+    type RegisteredAccount,
     type SessionUser,
 } from '@lightdash/common';
 import { type DbAiDeepResearchRun } from '../../database/entities/aiDeepResearch';
@@ -199,6 +200,28 @@ const reportSubmission = (toolCallId = 'report-1', input = report) =>
         result: JSON.stringify({ submitted: true }),
     });
 
+const registeredAccount = ({
+    authentication = { type: 'session' as const, source: '' },
+    isActive = true,
+}: {
+    authentication?: RegisteredAccount['authentication'];
+    isActive?: boolean;
+} = {}): RegisteredAccount =>
+    ({
+        authentication,
+        organization: {
+            organizationUuid: 'org-1',
+            name: 'Acme',
+            createdAt: new Date('2026-01-01'),
+        },
+        user: {
+            userUuid: 'user-1',
+            id: 'user-1',
+            type: 'registered',
+            isActive,
+        },
+    }) as RegisteredAccount;
+
 const researchRole = (options: AnyType) => options.execution.research?.role;
 
 /**
@@ -243,11 +266,6 @@ const buildExecutor = ({
     provenance?: AnyType[];
     childProvenance?: AnyType[];
 } = {}) => {
-    const session = {
-        userUuid: 'user-1',
-        organizationUuid: 'org-1',
-        isActive: true,
-    } as SessionUser;
     const aiDeepResearchRunModel = {
         accumulateTokenUsage: vi.fn().mockResolvedValue(true),
         appendProgressEvent: vi.fn().mockResolvedValue(true),
@@ -264,7 +282,9 @@ const buildExecutor = ({
         ),
     };
     const userService = {
-        getSessionByUserUuidAndOrg: vi.fn().mockResolvedValue(session),
+        getAccountByUserUuidAndOrg: vi
+            .fn()
+            .mockResolvedValue(registeredAccount()),
     };
     const executor = new AiDeepResearchExecutor({
         aiAgentService: {
@@ -326,11 +346,9 @@ describe('AiDeepResearchExecutor', () => {
     it('does not start a run created by an inactive user', async () => {
         const { executor, userService, generateAgentThreadResponse } =
             buildExecutor();
-        userService.getSessionByUserUuidAndOrg.mockResolvedValue({
-            userUuid: 'user-1',
-            organizationUuid: 'org-1',
-            isActive: false,
-        });
+        userService.getAccountByUserUuidAndOrg.mockResolvedValue(
+            registeredAccount({ isActive: false }),
+        );
 
         await expect(
             executor.execute(run(), {
@@ -343,6 +361,28 @@ describe('AiDeepResearchExecutor', () => {
             terminalReason: 'permission_revoked',
         });
         expect(generateAgentThreadResponse).not.toHaveBeenCalled();
+    });
+
+    it('starts a run created by an inactive service-account user', async () => {
+        const { executor, userService, generateAgentThreadResponse } =
+            buildExecutor();
+        userService.getAccountByUserUuidAndOrg.mockResolvedValue(
+            registeredAccount({
+                authentication: {
+                    type: 'service-account',
+                    source: '',
+                    serviceAccountUuid: 'service-account-1',
+                    serviceAccountDescription: 'CI',
+                },
+                isActive: false,
+            }),
+        );
+
+        await executor.execute(run(), {
+            signal: new AbortController().signal,
+        });
+
+        expect(generateAgentThreadResponse).toHaveBeenCalled();
     });
 
     it('does not start an already cancelled run', async () => {

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.ts
@@ -11,6 +11,7 @@ import {
     type AiDeepResearchSubmittedReport,
     type SessionUser,
 } from '@lightdash/common';
+import { toSessionUser } from '../../../auth/account';
 import Logger from '../../../logging/logger';
 import type { UserService } from '../../../services/UserService';
 import type { DbAiDeepResearchRun } from '../../database/entities/aiDeepResearch';
@@ -63,7 +64,7 @@ type Dependencies = {
         | 'touch'
         | 'updateExecutionContextSnapshot'
     >;
-    userService: Pick<UserService, 'getSessionByUserUuidAndOrg'>;
+    userService: Pick<UserService, 'getAccountByUserUuidAndOrg'>;
 };
 
 const parseJson = (value: string): unknown => {
@@ -210,10 +211,11 @@ export class AiDeepResearchExecutor {
             }
             authorizationCheckInFlight = true;
             pendingAuthorizationCheck = this.dependencies.userService
-                .getSessionByUserUuidAndOrg(
+                .getAccountByUserUuidAndOrg(
                     run.created_by_user_uuid,
                     run.organization_uuid,
                 )
+                .then(toSessionUser)
                 .then((currentUser) =>
                     this.dependencies.aiAgentService.assertDeepResearchAccess(
                         currentUser,
@@ -277,12 +279,13 @@ export class AiDeepResearchExecutor {
             };
         }
 
-        const user: SessionUser =
-            await this.dependencies.userService.getSessionByUserUuidAndOrg(
+        const account =
+            await this.dependencies.userService.getAccountByUserUuidAndOrg(
                 run.created_by_user_uuid,
                 run.organization_uuid,
             );
-        if (!user.isActive) {
+        const user: SessionUser = toSessionUser(account);
+        if (!user.isActive && !user.serviceAccount) {
             return {
                 status: 'failed',
                 errorMessage:

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
@@ -675,39 +675,39 @@ describe('AiDeepResearchService', () => {
             expect(model.create).not.toHaveBeenCalled();
         });
 
-        it.each([
-            {
-                principal: 'service account',
+        it('allows background execution for a service account', async () => {
+            const { service, model } = buildService();
+
+            const run = await service.createRun({
+                ...validCreateRunArgs(),
                 user: {
                     ...userWithProjectAccess(),
                     serviceAccount: { uuid: 'service-account-1' },
                 },
-            },
-            {
-                principal: 'impersonated user',
-                user: {
-                    ...userWithProjectAccess(),
-                    impersonation: {
-                        adminId: 'admin-1',
-                        adminEmail: 'admin@example.com',
-                        adminRole: 'admin',
-                    },
-                },
-            },
-        ])(
-            'rejects background execution for a $principal',
-            async ({ user }) => {
-                const { service, model } = buildService();
+            });
 
-                await expect(
-                    service.createRun({
-                        ...validCreateRunArgs(),
-                        user,
-                    }),
-                ).rejects.toBeInstanceOf(ForbiddenError);
-                expect(model.create).not.toHaveBeenCalled();
-            },
-        );
+            expect(run.status).toBe('queued');
+            expect(model.create).toHaveBeenCalled();
+        });
+
+        it('rejects background execution for an impersonated user', async () => {
+            const { service, model } = buildService();
+
+            await expect(
+                service.createRun({
+                    ...validCreateRunArgs(),
+                    user: {
+                        ...userWithProjectAccess(),
+                        impersonation: {
+                            adminId: 'admin-1',
+                            adminEmail: 'admin@example.com',
+                            adminRole: 'admin',
+                        },
+                    },
+                }),
+            ).rejects.toBeInstanceOf(ForbiddenError);
+            expect(model.create).not.toHaveBeenCalled();
+        });
 
         it('rejects run creation when Deep Research is disabled', async () => {
             const { service, model } = buildService({

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
@@ -580,7 +580,7 @@ export class AiDeepResearchService extends BaseService {
         if (!isUserWithOrg(args.user)) {
             throw new ForbiddenError('User is not part of an organization');
         }
-        if (args.user.serviceAccount || args.user.impersonation) {
+        if (args.user.impersonation) {
             throw new ForbiddenError(
                 'Deep Research must be started by a signed-in user',
             );

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -66,6 +66,9 @@ const userModel = {
     findSessionUserByUUID: vi.fn<UserModel['findSessionUserByUUID']>(
         async () => sessionUser,
     ),
+    findSessionUserAndOrgByUuid: vi.fn<
+        UserModel['findSessionUserAndOrgByUuid']
+    >(async () => sessionUser),
     getSessionUserFromCacheOrDB: vi.fn(async () => ({
         sessionUser,
         cacheHit: false,
@@ -320,7 +323,7 @@ describe('UserService', () => {
                 uuid: 'service-account-uuid',
                 description: 'CI preview',
                 scopes: ['system:developer'],
-                organizationUuid: sessionUser.organizationUuid,
+                organizationUuid: organisation.organizationUuid,
             });
 
             const account = await service.getAccountByUserUuid('userUuid');
@@ -332,6 +335,51 @@ describe('UserService', () => {
                 serviceAccountDescription: 'CI preview',
             });
             expect(account.user.id).toBe('userUuid');
+        });
+    });
+
+    describe('getAccountByUserUuidAndOrg', () => {
+        test('should preserve the requested organization for normal users', async () => {
+            const account = await userService.getAccountByUserUuidAndOrg(
+                'userUuid',
+                'organizationUuid',
+            );
+
+            expect(userModel.findSessionUserAndOrgByUuid).toHaveBeenCalledWith(
+                'userUuid',
+                'organizationUuid',
+            );
+            expect(account.isSessionUser()).toBe(true);
+            expect(account.isServiceAccount()).toBe(false);
+        });
+
+        test('should preserve service-account authentication', async () => {
+            const service = createUserService({
+                ...lightdashConfigMock,
+                serviceAccount: {
+                    enabled: true,
+                },
+            });
+            (
+                userModel.findServiceAccountByUserUuid as import('vitest').Mock
+            ).mockResolvedValueOnce({
+                uuid: 'service-account-uuid',
+                description: 'CI preview',
+                scopes: ['system:developer'],
+                organizationUuid: organisation.organizationUuid,
+            });
+
+            const account = await service.getAccountByUserUuidAndOrg(
+                'userUuid',
+                organisation.organizationUuid,
+            );
+
+            expect(account.isServiceAccount()).toBe(true);
+            expect(account.authentication).toMatchObject({
+                type: 'service-account',
+                serviceAccountUuid: 'service-account-uuid',
+                serviceAccountDescription: 'CI preview',
+            });
         });
     });
 

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -2060,15 +2060,17 @@ export class UserService extends BaseService {
         );
     }
 
-    async getAccountByUserUuid(userUuid: string): Promise<RegisteredAccount> {
-        const sessionUser = await this.getSessionByUserUuid(userUuid);
-
+    private async getAccountForSessionUser(
+        sessionUser: SessionUser,
+    ): Promise<RegisteredAccount> {
         if (!this.lightdashConfig.serviceAccount.enabled) {
             return AccountFactory.fromSession(sessionUser);
         }
 
         const serviceAccount =
-            await this.userModel.findServiceAccountByUserUuid(userUuid);
+            await this.userModel.findServiceAccountByUserUuid(
+                sessionUser.userUuid,
+            );
 
         if (serviceAccount) {
             return AccountFactory.fromServiceAccount(
@@ -2084,6 +2086,24 @@ export class UserService extends BaseService {
         }
 
         return AccountFactory.fromSession(sessionUser);
+    }
+
+    async getAccountByUserUuid(userUuid: string): Promise<RegisteredAccount> {
+        const sessionUser = await this.getSessionByUserUuid(userUuid);
+
+        return this.getAccountForSessionUser(sessionUser);
+    }
+
+    async getAccountByUserUuidAndOrg(
+        userUuid: string,
+        organizationUuid: string,
+    ): Promise<RegisteredAccount> {
+        const sessionUser = await this.getSessionByUserUuidAndOrg(
+            userUuid,
+            organizationUuid,
+        );
+
+        return this.getAccountForSessionUser(sessionUser);
     }
 
     private otpExpirationDate(createdAt: Date) {


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9486/allow-api-authenticated-users-to-start-deep-research-runs

## Description:

Allows registered users to start Deep Research runs through session, personal access token, service-account, or OAuth authentication. The existing Deep Research permission, project access, thread ownership, prompt integrity, and impersonation checks remain unchanged.

Before:
  Browser session → authorization and ownership checks → queued run
  API authentication → session-only 403

After:
  Registered account → authorization and ownership checks → queued run
  Embedded JWT → registered-account 403

The background worker now rehydrates the registered account in the run's organization so service-account identity survives queue execution. Deleted service accounts and deactivated human users still fail the runtime access check.

Verified with backend typecheck, lint, API generation, 197 focused tests, and a local PAT request that returned HTTP 202 and queued a run.
