### PR TITLE
fix(pre-aggregates): honor required filters

### DIFF
--- a/packages/backend/src/ee/preAggregates/matcher.test.ts
+++ b/packages/backend/src/ee/preAggregates/matcher.test.ts
@@ -1132,6 +1132,80 @@ describe('findMatch', () => {
             }
         });
 
+        it.each([
+            { queryDays: 9, expectedHit: true },
+            { queryDays: 10, expectedHit: true },
+            { queryDays: 11, expectedHit: false },
+        ])(
+            'matches a required 10-day materialization against a past-$queryDays-days query',
+            ({ queryDays, expectedHit }) => {
+                const explore = getExploreWithRequiredFilters({
+                    requiredFilters: [
+                        {
+                            id: 'required-order-date-filter',
+                            target: { fieldRef: 'order_date_day' },
+                            operator: FilterOperator.IN_THE_PAST,
+                            values: [10],
+                            settings: { unitOfTime: UnitOfTime.days },
+                            required: true,
+                        },
+                    ],
+                    preAggregates: [
+                        {
+                            name: 'orders_daily',
+                            dimensions: ['order_date'],
+                            metrics: ['order_count'],
+                            timeDimension: 'order_date',
+                            granularity: TimeFrames.DAY,
+                        },
+                    ],
+                });
+
+                const result = preAggregateUtils.findMatch(
+                    makeMetricQuery({
+                        dimensions: [],
+                        metrics: ['orders_order_count'],
+                        filters: {
+                            dimensions: {
+                                id: 'query-filters',
+                                and: [
+                                    {
+                                        id: 'query-date-filter',
+                                        target: {
+                                            fieldId: 'orders_order_date_day',
+                                        },
+                                        operator: FilterOperator.IN_THE_PAST,
+                                        values: [queryDays],
+                                        settings: {
+                                            unitOfTime: UnitOfTime.days,
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    }),
+                    explore,
+                );
+
+                expect(result).toStrictEqual(
+                    expectedHit
+                        ? {
+                              hit: true,
+                              preAggregateName: 'orders_daily',
+                              miss: null,
+                          }
+                        : {
+                              hit: false,
+                              preAggregateName: null,
+                              miss: {
+                                  reason: PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED,
+                                  fieldId: 'orders_order_date_day',
+                              },
+                          },
+                );
+            },
+        );
+
         it('misses when a sibling time filter suppresses but cannot satisfy the required fallback', () => {
             const explore = getExploreWithRequiredFilters({
                 requiredFilters: [

--- a/packages/backend/src/ee/preAggregates/matcher.test.ts
+++ b/packages/backend/src/ee/preAggregates/matcher.test.ts
@@ -15,7 +15,11 @@ import {
     type CompiledDimension,
     type CompiledMetric,
     type Explore,
+    type FilterGroup,
+    type FilterRule,
     type MetricQuery,
+    type ModelRequiredFilterRule,
+    type PreAggregateDef,
 } from '@lightdash/common';
 
 const makeDimension = ({
@@ -175,6 +179,35 @@ const makeMetricQuery = (
     ...(partial.customDimensions
         ? { customDimensions: partial.customDimensions }
         : {}),
+});
+
+const getExploreWithRequiredFilters = ({
+    requiredFilters,
+    preAggregates,
+}: {
+    requiredFilters: ModelRequiredFilterRule[];
+    preAggregates: PreAggregateDef[];
+}): Explore => {
+    const explore = baseExplore();
+
+    return {
+        ...explore,
+        tables: {
+            ...explore.tables,
+            orders: {
+                ...explore.tables.orders,
+                requiredFilters,
+            },
+        },
+        preAggregates,
+    };
+};
+
+const makeStatusFilterRule = (values: string[]): FilterRule => ({
+    id: 'query-status-filter',
+    operator: FilterOperator.EQUALS,
+    target: { fieldId: 'orders_status' },
+    values,
 });
 
 const makeCustomBinDimension = (binType: BinType) => {
@@ -948,6 +981,328 @@ describe('findMatch', () => {
         expect(result.miss).toStrictEqual({
             reason: PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED,
             fieldId: 'orders_status',
+        });
+    });
+
+    describe('model required filter coverage', () => {
+        const makeRequiredStatusFilter = (
+            values: string[],
+            required = true,
+        ): ModelRequiredFilterRule => ({
+            id: 'required-status-filter',
+            target: { fieldRef: 'status' },
+            operator: FilterOperator.EQUALS,
+            values,
+            required,
+        });
+
+        const statusRollup: PreAggregateDef = {
+            name: 'orders_status_rollup',
+            dimensions: ['status'],
+            metrics: ['order_count'],
+        };
+
+        const makeAndFilterGroup = (...rules: FilterRule[]): FilterGroup => ({
+            id: 'query-filters',
+            and: rules,
+        });
+
+        const findStatusMatch = ({
+            requiredValues,
+            required,
+            dimensionFilters,
+        }: {
+            requiredValues: string[];
+            required: boolean;
+            dimensionFilters: FilterGroup;
+        }) =>
+            preAggregateUtils.findMatch(
+                makeMetricQuery({
+                    dimensions: ['orders_status'],
+                    metrics: ['orders_order_count'],
+                    filters: { dimensions: dimensionFilters },
+                }),
+                getExploreWithRequiredFilters({
+                    requiredFilters: [
+                        makeRequiredStatusFilter(requiredValues, required),
+                    ],
+                    preAggregates: [statusRollup],
+                }),
+            );
+
+        it('matches a filterless query when the same required fallback restricts materialization', () => {
+            const explore = getExploreWithRequiredFilters({
+                requiredFilters: [makeRequiredStatusFilter(['completed'])],
+                preAggregates: [
+                    {
+                        name: 'orders_rollup',
+                        dimensions: [],
+                        metrics: ['order_count'],
+                    },
+                ],
+            });
+
+            const result = preAggregateUtils.findMatch(
+                makeMetricQuery({
+                    dimensions: [],
+                    metrics: ['orders_order_count'],
+                }),
+                explore,
+            );
+
+            expect(result).toStrictEqual({
+                hit: true,
+                preAggregateName: 'orders_rollup',
+                miss: null,
+            });
+        });
+
+        it.each([
+            {
+                description: 'equivalent explicit query filter',
+                requiredValues: ['completed', 'shipped'],
+                required: true,
+                dimensionFilters: makeAndFilterGroup(
+                    makeStatusFilterRule(['completed', 'shipped']),
+                ),
+                expectedHit: true,
+            },
+            {
+                description: 'narrower explicit query filter',
+                requiredValues: ['completed', 'shipped'],
+                required: true,
+                dimensionFilters: makeAndFilterGroup(
+                    makeStatusFilterRule(['completed']),
+                ),
+                expectedHit: true,
+            },
+            {
+                description: 'broader same-field query filter',
+                requiredValues: ['completed'],
+                required: true,
+                dimensionFilters: makeAndFilterGroup(
+                    makeStatusFilterRule(['completed', 'shipped']),
+                ),
+                expectedHit: false,
+            },
+            {
+                description: 'required:false model filter',
+                requiredValues: ['completed'],
+                required: false,
+                dimensionFilters: makeAndFilterGroup(
+                    makeStatusFilterRule(['completed', 'shipped']),
+                ),
+                expectedHit: true,
+            },
+            {
+                description: 'disabled same-target query filter',
+                requiredValues: ['completed'],
+                required: true,
+                dimensionFilters: makeAndFilterGroup({
+                    ...makeStatusFilterRule(['completed']),
+                    disabled: true,
+                }),
+                expectedHit: false,
+            },
+            {
+                description: 'OR branch that broadens the query',
+                requiredValues: ['completed'],
+                required: true,
+                dimensionFilters: {
+                    id: 'query-filters',
+                    or: [
+                        makeStatusFilterRule(['completed']),
+                        {
+                            ...makeStatusFilterRule(['shipped']),
+                            id: 'query-shipped-filter',
+                        },
+                    ],
+                },
+                expectedHit: false,
+            },
+        ])('$description', (testCase) => {
+            const result = findStatusMatch(testCase);
+
+            expect(result.hit).toBe(testCase.expectedHit);
+            if (!testCase.expectedHit) {
+                expect(result.miss).toStrictEqual({
+                    reason: PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED,
+                    fieldId: 'orders_status',
+                });
+            }
+        });
+
+        it('misses when a sibling time filter suppresses but cannot satisfy the required fallback', () => {
+            const explore = getExploreWithRequiredFilters({
+                requiredFilters: [
+                    {
+                        id: 'required-order-date-filter',
+                        target: { fieldRef: 'order_date_day' },
+                        operator: FilterOperator.IN_THE_PAST,
+                        values: [3],
+                        settings: { unitOfTime: UnitOfTime.days },
+                        required: true,
+                    },
+                ],
+                preAggregates: [
+                    {
+                        name: 'orders_daily',
+                        dimensions: ['order_date'],
+                        metrics: ['order_count'],
+                        timeDimension: 'order_date',
+                        granularity: TimeFrames.DAY,
+                    },
+                ],
+            });
+
+            const result = preAggregateUtils.findMatch(
+                makeMetricQuery({
+                    dimensions: ['orders_order_date_month'],
+                    metrics: ['orders_order_count'],
+                    filters: {
+                        dimensions: {
+                            id: 'query-filters',
+                            and: [
+                                {
+                                    id: 'query-date-filter',
+                                    target: {
+                                        fieldId: 'orders_order_date_month',
+                                    },
+                                    operator: FilterOperator.IN_THE_PAST,
+                                    values: [7],
+                                    settings: {
+                                        unitOfTime: UnitOfTime.days,
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                }),
+                explore,
+            );
+
+            expect(result.miss).toStrictEqual({
+                reason: PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED,
+                fieldId: 'orders_order_date_day',
+            });
+        });
+
+        it('matches identical joined-table required fallbacks', () => {
+            const explore = getExploreWithRequiredFilters({
+                requiredFilters: [
+                    {
+                        id: 'required-customer-filter',
+                        target: {
+                            fieldRef: 'customers.first_name',
+                            tableName: 'customers',
+                        },
+                        operator: FilterOperator.EQUALS,
+                        values: ['Alice'],
+                        required: true,
+                    },
+                ],
+                preAggregates: [
+                    {
+                        name: 'orders_rollup',
+                        dimensions: [],
+                        metrics: ['order_count'],
+                    },
+                ],
+            });
+
+            const result = preAggregateUtils.findMatch(
+                makeMetricQuery({
+                    dimensions: [],
+                    metrics: ['orders_order_count'],
+                }),
+                explore,
+            );
+
+            expect(result).toStrictEqual({
+                hit: true,
+                preAggregateName: 'orders_rollup',
+                miss: null,
+            });
+        });
+
+        it('does not let a query fallback satisfy an explicit pre-aggregate filter', () => {
+            const explore = getExploreWithRequiredFilters({
+                requiredFilters: [makeRequiredStatusFilter(['completed'])],
+                preAggregates: [
+                    {
+                        name: 'orders_status_rollup',
+                        dimensions: [],
+                        metrics: ['order_count'],
+                        filters: [
+                            {
+                                id: 'rollup-status-filter',
+                                target: { fieldRef: 'status' },
+                                operator: FilterOperator.EQUALS,
+                                values: ['completed', 'shipped'],
+                            },
+                        ],
+                    },
+                ],
+            });
+
+            const result = preAggregateUtils.findMatch(
+                makeMetricQuery({
+                    dimensions: [],
+                    metrics: ['orders_order_count'],
+                }),
+                explore,
+            );
+
+            expect(result.miss).toStrictEqual({
+                reason: PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED,
+                fieldId: 'orders_status',
+            });
+        });
+
+        it('rejects an unsafe same-shape candidate before the selection tie-break', () => {
+            const explore = getExploreWithRequiredFilters({
+                requiredFilters: [makeRequiredStatusFilter(['completed'])],
+                preAggregates: [
+                    {
+                        name: 'unsafe_required_rollup',
+                        dimensions: ['status'],
+                        metrics: ['order_count'],
+                    },
+                    {
+                        name: 'safe_explicit_rollup',
+                        dimensions: ['status'],
+                        metrics: ['order_count'],
+                        filters: [
+                            {
+                                id: 'rollup-status-filter',
+                                target: { fieldRef: 'status' },
+                                operator: FilterOperator.EQUALS,
+                                values: ['completed', 'shipped'],
+                            },
+                        ],
+                    },
+                ],
+            });
+
+            const result = preAggregateUtils.findMatch(
+                makeMetricQuery({
+                    dimensions: ['orders_status'],
+                    metrics: ['orders_order_count'],
+                    filters: {
+                        dimensions: {
+                            id: 'query-filters',
+                            and: [makeStatusFilterRule(['shipped'])],
+                        },
+                    },
+                }),
+                explore,
+            );
+
+            expect(result).toStrictEqual({
+                hit: true,
+                preAggregateName: 'safe_explicit_rollup',
+                miss: null,
+            });
         });
     });
 

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.test.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.test.ts
@@ -12,6 +12,13 @@ import {
     type Explore,
     type PreAggregateDef,
 } from '@lightdash/common';
+import { compileMetricQuery } from '../../../queryCompiler';
+import { MetricQueryBuilder } from '../../../utils/QueryBuilder/MetricQueryBuilder';
+import {
+    INTRINSIC_USER_ATTRIBUTES,
+    QUERY_BUILDER_UTC_TIMEZONE,
+    warehouseClientMock,
+} from '../../../utils/QueryBuilder/MetricQueryBuilder.mock';
 import { buildMaterializationMetricQuery } from './buildMaterializationMetricQuery';
 
 const makeDimension = ({
@@ -272,6 +279,44 @@ const getSourceExplore = (): Explore =>
         },
     }) as Explore;
 
+const buildFilterlessMaterializationSql = (required: boolean): string => {
+    const sourceExplore = getSourceExplore();
+    sourceExplore.tables.orders.requiredFilters = [
+        {
+            id: 'model-status-filter',
+            target: { fieldRef: 'status' },
+            operator: FilterOperator.EQUALS,
+            values: ['completed'],
+            required,
+        },
+    ];
+
+    const { metricQuery } = buildMaterializationMetricQuery({
+        sourceExplore,
+        preAggregateDef: {
+            name: 'orders_rollup',
+            dimensions: ['status'],
+            metrics: ['order_count'],
+        },
+        materializationConfig: { maxRows: null },
+    });
+    const compiledMetricQuery = compileMetricQuery({
+        explore: sourceExplore,
+        metricQuery,
+        warehouseSqlBuilder: warehouseClientMock,
+        availableParameters: [],
+    });
+
+    return new MetricQueryBuilder({
+        explore: sourceExplore,
+        compiledMetricQuery,
+        warehouseSqlBuilder: warehouseClientMock,
+        parameterDefinitions: {},
+        intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+        timezone: QUERY_BUILDER_UTC_TIMEZONE,
+    }).compileQuery().query;
+};
+
 describe('buildMaterializationMetricQuery', () => {
     it('includes the time dimension with the configured granularity when omitted from dimensions', () => {
         const preAggregateDef: PreAggregateDef = {
@@ -414,6 +459,18 @@ describe('buildMaterializationMetricQuery', () => {
         });
         expect(result.timeDimensionFieldId).toBeNull();
     });
+
+    it.each([
+        { required: true, restrictsMaterialization: true },
+        { required: false, restrictsMaterialization: false },
+    ])(
+        'required:$required model filter restricts materialization: $restrictsMaterialization',
+        ({ required, restrictsMaterialization }) => {
+            const sql = buildFilterlessMaterializationSql(required);
+
+            expect(sql.includes("'completed'")).toBe(restrictsMaterialization);
+        },
+    );
 
     it('emits pre-aggregate filters into materialization dimension filters', () => {
         const preAggregateDef: PreAggregateDef = {

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.ts
@@ -1,6 +1,5 @@
 import {
     assertUnreachable,
-    convertFieldRefToFieldId,
     getItemId,
     getPreAggregateMetricComponentColumnName,
     MetricType,
@@ -11,7 +10,6 @@ import {
     type CompiledMetric,
     type Explore,
     type FieldId,
-    type FilterRule,
     type MaterializationMetricComponent,
     type MaterializationMetricQueryPayload,
     type MetricQuery,
@@ -95,40 +93,6 @@ const hasTimeDimensionReference = ({
 
 type MaterializationConfig = {
     maxRows: number | null;
-};
-
-const getPreAggregateDimensionFilters = ({
-    sourceExplore,
-    preAggregateDef,
-}: {
-    sourceExplore: Explore;
-    preAggregateDef: PreAggregateDef;
-}): MetricQuery['filters']['dimensions'] | undefined => {
-    if (!preAggregateDef.filters || preAggregateDef.filters.length === 0) {
-        return undefined;
-    }
-
-    return {
-        id: 'pre-aggregate-filters',
-        and: preAggregateDef.filters.map<FilterRule>((filter) => ({
-            id: filter.id,
-            target: {
-                fieldId: convertFieldRefToFieldId(
-                    filter.target.fieldRef,
-                    sourceExplore.baseTable,
-                ),
-            },
-            operator: filter.operator,
-            values: filter.values,
-            ...(filter.settings ? { settings: filter.settings } : {}),
-            ...(filter.required !== undefined
-                ? { required: filter.required }
-                : {}),
-            ...(filter.disabled !== undefined
-                ? { disabled: filter.disabled }
-                : {}),
-        })),
-    };
 };
 
 export const buildMaterializationMetricQuery = ({
@@ -293,9 +257,9 @@ export const buildMaterializationMetricQuery = ({
         preAggregateDef.maxRows ??
         materializationConfig.maxRows ??
         SYSTEM_MAX_ROWS;
-    const dimensionFilters = getPreAggregateDimensionFilters({
-        sourceExplore,
-        preAggregateDef,
+    const dimensionFilters = preAggregateUtils.getPreAggregateDimensionFilters({
+        filters: preAggregateDef.filters,
+        baseTable: sourceExplore.baseTable,
     });
 
     const metricQuery: MetricQuery = {

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -4,10 +4,8 @@ import {
     CompiledDimension,
     CompiledMetric,
     CompiledMetricQuery,
-    CompiledTable,
     CompiledTableCalculation,
     CompileError,
-    createFilterRuleFromModelRequiredFilterRule,
     dateTruncTimezoneConversions,
     DEFAULT_FILTER_CASE_SENSITIVE,
     DimensionType,
@@ -42,7 +40,6 @@ import {
     isCustomBinDimension,
     isDimension,
     isFilterGroup,
-    isFilterRuleInQuery,
     isJoinModelRequiredFilter,
     isNonAggregateMetric,
     isPeriodOverPeriodAdditionalMetric,
@@ -59,6 +56,7 @@ import {
     PivotConfiguration,
     QueryWarning,
     quoteFieldReference,
+    reduceRequiredDimensionFiltersToFilterRules,
     renderFilterRuleSqlFromField,
     renderTableCalculationFilterRuleSql,
     resolveTimestampFilterContext,
@@ -1331,7 +1329,6 @@ export class MetricQueryBuilder {
 
         const requiredDimensionFilterSql =
             this.getNestedDimensionFilterSQLFromModelFilters(
-                explore.tables[explore.baseTable],
                 dimensionsFilterGroup,
             );
         const tableCompiledSqlWhere =
@@ -2009,65 +2006,32 @@ export class MetricQueryBuilder {
     }
 
     private getNestedDimensionFilterSQLFromModelFilters(
-        table: CompiledTable,
         dimensionsFilterGroup: FilterGroup | undefined,
     ): string | undefined {
         const { explore } = this.args;
         // We only force required filters that are not explicitly set to false
         // requiredFilters with required:false will be added on the UI, but not enforced on the backend
-        const modelFilterRules: MetricFilterRule[] | undefined =
-            table.requiredFilters?.filter(
-                (filter) => filter.required !== false,
-            );
+        const modelFilterRules = explore.tables[
+            explore.baseTable
+        ].requiredFilters?.filter((filter) => filter.required !== false);
 
         if (!modelFilterRules) return undefined;
 
-        const reducedRules: string[] = modelFilterRules.reduce<string[]>(
-            (acc, filter) => {
-                let dimension: CompiledDimension | undefined;
-
-                // This function already takes care of falling back to the base table if the fieldRef doesn't have 2 parts (falls back to base table name)
-                const filterRule = createFilterRuleFromModelRequiredFilterRule(
-                    filter,
-                    table.name,
-                );
-
-                if (isJoinModelRequiredFilter(filter)) {
-                    const joinedTable = explore.tables[filter.target.tableName];
-
-                    if (joinedTable) {
-                        dimension = Object.values(joinedTable.dimensions).find(
-                            (d) => getItemId(d) === filterRule.target.fieldId,
-                        );
-                    }
-                } else {
-                    dimension = Object.values(table.dimensions).find(
-                        (tc) => getItemId(tc) === filterRule.target.fieldId,
-                    );
-                }
-
-                if (!dimension) return acc;
-
-                if (
-                    isFilterRuleInQuery(
-                        dimension,
+        // The pre-aggregate matcher relies on this exact reduction to decide
+        // physical coverage, so both must go through the shared helper.
+        return reduceRequiredDimensionFiltersToFilterRules(
+            modelFilterRules,
+            dimensionsFilterGroup,
+            explore,
+        )
+            .map(
+                (filterRule) =>
+                    `( ${this.getFilterRuleSQL(
                         filterRule,
-                        dimensionsFilterGroup,
-                        explore,
-                    )
-                )
-                    return acc;
-
-                const filterString = `( ${this.getFilterRuleSQL(
-                    filterRule,
-                    FieldType.DIMENSION,
-                )} )`;
-                return [...acc, filterString];
-            },
-            [],
-        );
-
-        return reducedRules.join(' AND ');
+                        FieldType.DIMENSION,
+                    )} )`,
+            )
+            .join(' AND ');
     }
 
     private getNestedFilterSQLFromGroup(

--- a/packages/common/src/ee/preAggregates/filters.ts
+++ b/packages/common/src/ee/preAggregates/filters.ts
@@ -1,0 +1,47 @@
+import { convertFieldRefToFieldId } from '../../types/field';
+import type {
+    FilterGroup,
+    FilterOperator,
+    FilterRule,
+} from '../../types/filter';
+
+type PreAggregateFilterRule = FilterRule<
+    FilterOperator,
+    { fieldRef: string },
+    unknown,
+    unknown
+>;
+
+export const getPreAggregateDimensionFilters = ({
+    filters,
+    baseTable,
+}: {
+    filters: PreAggregateFilterRule[] | undefined;
+    baseTable: string;
+}): FilterGroup | undefined => {
+    if (!filters || filters.length === 0) {
+        return undefined;
+    }
+
+    return {
+        id: 'pre-aggregate-filters',
+        and: filters.map<FilterRule>((filter) => ({
+            id: filter.id,
+            target: {
+                fieldId: convertFieldRefToFieldId(
+                    filter.target.fieldRef,
+                    baseTable,
+                ),
+            },
+            operator: filter.operator,
+            values: filter.values,
+            ...(filter.settings ? { settings: filter.settings } : {}),
+            ...(filter.required !== undefined
+                ? { required: filter.required }
+                : {}),
+            ...(filter.disabled !== undefined
+                ? { disabled: filter.disabled }
+                : {}),
+        })),
+    };
+};

--- a/packages/common/src/ee/preAggregates/matcher.ts
+++ b/packages/common/src/ee/preAggregates/matcher.ts
@@ -18,6 +18,7 @@ import {
     type FilterGroupItem,
     type FilterRule,
     type MetricFilterRule,
+    type ModelRequiredFilterRule,
 } from '../../types/filter';
 import type { MetricQuery } from '../../types/metricQuery';
 import {
@@ -26,15 +27,24 @@ import {
     type PreAggregateMatchMiss,
 } from '../../types/preAggregate';
 import type { TimeFrames } from '../../types/timeFrames';
+import assertUnreachable from '../../utils/assertUnreachable';
 import { getMetricsMapFromTables } from '../../utils/fields';
+import { reduceRequiredDimensionFiltersToFilterRules } from '../../utils/filters';
 import { getItemId } from '../../utils/item';
 import { timeFrameOrder } from '../../utils/timeFrames';
 import { isCompatible } from './additivity';
+import { getPreAggregateDimensionFilters } from './filters';
 import { getDimensionReferences, getMetricReferences } from './references';
 
 export type PreAggregateMatchResult =
     | { hit: true; preAggregateName: string; miss: null }
     | { hit: false; preAggregateName: null; miss: PreAggregateMatchMiss };
+
+type MaterializationFilter =
+    | { source: 'pre_aggregate'; filter: MetricFilterRule }
+    | { source: 'model_required'; filter: FilterRule };
+
+type MaterializationFilterRule = MaterializationFilter['filter'];
 
 const isGranularityCoarserOrEqual = (
     queryGranularity: TimeFrames,
@@ -118,14 +128,14 @@ const getPreAggregateFilterTargetReferences = (
               ],
     );
 
-const matchesPreAggregateFilterTarget = ({
+const matchesMaterializationFilterTarget = ({
     queryFilterRule,
-    preAggregateFilter,
+    materializationFilter,
     explore,
     dimensionsByFieldId,
 }: {
     queryFilterRule: FilterRule;
-    preAggregateFilter: MetricFilterRule;
+    materializationFilter: MaterializationFilter;
     explore: Explore;
     dimensionsByFieldId: Map<
         FieldId,
@@ -138,15 +148,27 @@ const matchesPreAggregateFilterTarget = ({
         return false;
     }
 
-    const preAggregateReferences = getPreAggregateFilterTargetReferences(
-        preAggregateFilter,
-        explore.baseTable,
-    );
+    switch (materializationFilter.source) {
+        case 'pre_aggregate': {
+            const preAggregateReferences =
+                getPreAggregateFilterTargetReferences(
+                    materializationFilter.filter,
+                    explore.baseTable,
+                );
 
-    return getDimensionReferences({
-        dimension: queryDimension,
-        baseTable: explore.baseTable,
-    }).some((reference) => preAggregateReferences.has(reference));
+            return getDimensionReferences({
+                dimension: queryDimension,
+                baseTable: explore.baseTable,
+            }).some((reference) => preAggregateReferences.has(reference));
+        }
+        case 'model_required':
+            return queryFieldId === materializationFilter.filter.target.fieldId;
+        default:
+            return assertUnreachable(
+                materializationFilter,
+                'Unknown materialization filter source',
+            );
+    }
 };
 
 const isValueSubset = (
@@ -317,7 +339,7 @@ const isCompletedDateFilter = (
 
 const isRelativeDateFilterEquivalentOrNarrower = (
     queryFilterRule: FilterRule,
-    preAggregateFilter: MetricFilterRule,
+    preAggregateFilter: MaterializationFilterRule,
 ): boolean => {
     if (queryFilterRule.operator !== preAggregateFilter.operator) {
         return false;
@@ -374,7 +396,7 @@ const isRelativeDateFilterEquivalentOrNarrower = (
 
 const isStringFilterEquivalentOrNarrower = (
     queryFilterRule: FilterRule,
-    preAggregateFilter: MetricFilterRule,
+    preAggregateFilter: MaterializationFilterRule,
 ): boolean => {
     const preAggregateValue = String(preAggregateFilter.values?.[0] ?? '');
 
@@ -450,7 +472,7 @@ const isStringFilterEquivalentOrNarrower = (
 
 const isNumberFilterEquivalentOrNarrower = (
     queryFilterRule: FilterRule,
-    preAggregateFilter: MetricFilterRule,
+    preAggregateFilter: MaterializationFilterRule,
 ): boolean => {
     if (preAggregateFilter.operator === FilterOperator.EQUALS) {
         return (
@@ -510,7 +532,7 @@ const isNumberFilterEquivalentOrNarrower = (
 
 const isDateFilterEquivalentOrNarrower = (
     queryFilterRule: FilterRule,
-    preAggregateFilter: MetricFilterRule,
+    preAggregateFilter: MaterializationFilterRule,
 ): boolean => {
     if (
         preAggregateFilter.operator === FilterOperator.IN_THE_PAST ||
@@ -586,7 +608,7 @@ const isDateFilterEquivalentOrNarrower = (
 
 const isBooleanFilterEquivalentOrNarrower = (
     queryFilterRule: FilterRule,
-    preAggregateFilter: MetricFilterRule,
+    preAggregateFilter: MaterializationFilterRule,
 ): boolean => {
     if (
         preAggregateFilter.operator === FilterOperator.NULL ||
@@ -603,12 +625,12 @@ const isBooleanFilterEquivalentOrNarrower = (
 
 const isFilterRuleEquivalentOrNarrower = ({
     queryFilterRule,
-    preAggregateFilter,
+    materializationFilter,
     explore,
     dimensionsByFieldId,
 }: {
     queryFilterRule: FilterRule;
-    preAggregateFilter: MetricFilterRule;
+    materializationFilter: MaterializationFilter;
     explore: Explore;
     dimensionsByFieldId: Map<
         FieldId,
@@ -619,9 +641,9 @@ const isFilterRuleEquivalentOrNarrower = ({
         return false;
     }
     if (
-        !matchesPreAggregateFilterTarget({
+        !matchesMaterializationFilterTarget({
             queryFilterRule,
-            preAggregateFilter,
+            materializationFilter,
             explore,
             dimensionsByFieldId,
         })
@@ -636,41 +658,42 @@ const isFilterRuleEquivalentOrNarrower = ({
         return false;
     }
 
+    const materializationFilterRule = materializationFilter.filter;
     switch (queryDimension.type) {
         case 'string':
             return isStringFilterEquivalentOrNarrower(
                 queryFilterRule,
-                preAggregateFilter,
+                materializationFilterRule,
             );
         case 'number':
             return isNumberFilterEquivalentOrNarrower(
                 queryFilterRule,
-                preAggregateFilter,
+                materializationFilterRule,
             );
         case 'date':
         case 'timestamp':
             return isDateFilterEquivalentOrNarrower(
                 queryFilterRule,
-                preAggregateFilter,
+                materializationFilterRule,
             );
         case 'boolean':
             return isBooleanFilterEquivalentOrNarrower(
                 queryFilterRule,
-                preAggregateFilter,
+                materializationFilterRule,
             );
         default:
             return false;
     }
 };
 
-const filterGroupImpliesPreAggregateFilter = ({
+const filterGroupImpliesMaterializationFilter = ({
     filterGroup,
-    preAggregateFilter,
+    materializationFilter,
     explore,
     dimensionsByFieldId,
 }: {
     filterGroup: FilterGroup | undefined;
-    preAggregateFilter: MetricFilterRule;
+    materializationFilter: MaterializationFilter;
     explore: Explore;
     dimensionsByFieldId: Map<
         FieldId,
@@ -692,15 +715,15 @@ const filterGroupImpliesPreAggregateFilter = ({
     if (isAndFilterGroup(filterGroup)) {
         return groupItems.some((item) =>
             isFilterGroup(item)
-                ? filterGroupImpliesPreAggregateFilter({
+                ? filterGroupImpliesMaterializationFilter({
                       filterGroup: item,
-                      preAggregateFilter,
+                      materializationFilter,
                       explore,
                       dimensionsByFieldId,
                   })
                 : isFilterRuleEquivalentOrNarrower({
                       queryFilterRule: item,
-                      preAggregateFilter,
+                      materializationFilter,
                       explore,
                       dimensionsByFieldId,
                   }),
@@ -709,20 +732,25 @@ const filterGroupImpliesPreAggregateFilter = ({
 
     return groupItems.every((item) =>
         isFilterGroup(item)
-            ? filterGroupImpliesPreAggregateFilter({
+            ? filterGroupImpliesMaterializationFilter({
                   filterGroup: item,
-                  preAggregateFilter,
+                  materializationFilter,
                   explore,
                   dimensionsByFieldId,
               })
             : isFilterRuleEquivalentOrNarrower({
                   queryFilterRule: item,
-                  preAggregateFilter,
+                  materializationFilter,
                   explore,
                   dimensionsByFieldId,
               }),
     );
 };
+
+type UnsatisfiedMaterializationFilterMiss = Extract<
+    PreAggregateMatchMiss,
+    { reason: PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED }
+>;
 
 const getUnsatisfiedPreAggregateFilterMiss = ({
     metricQuery,
@@ -737,16 +765,16 @@ const getUnsatisfiedPreAggregateFilterMiss = ({
         FieldId,
         Explore['tables'][string]['dimensions'][string]
     >;
-}): Extract<
-    PreAggregateMatchMiss,
-    { reason: PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED }
-> | null => {
+}): UnsatisfiedMaterializationFilterMiss | null => {
     const preAggregateFilters = preAggregateDef.filters || [];
     const unsatisfiedFilter = preAggregateFilters.find(
         (preAggregateFilter) =>
-            !filterGroupImpliesPreAggregateFilter({
+            !filterGroupImpliesMaterializationFilter({
                 filterGroup: metricQuery.filters.dimensions,
-                preAggregateFilter,
+                materializationFilter: {
+                    source: 'pre_aggregate',
+                    filter: preAggregateFilter,
+                },
                 explore,
                 dimensionsByFieldId,
             }),
@@ -762,6 +790,58 @@ const getUnsatisfiedPreAggregateFilterMiss = ({
             unsatisfiedFilter.target.fieldRef,
             explore.baseTable,
         ),
+    };
+};
+
+const getUnsatisfiedRequiredModelFilterMiss = ({
+    metricQuery,
+    explore,
+    preAggregateDef,
+    dimensionsByFieldId,
+    requiredModelFilters,
+    queryRequiredFallbackIds,
+}: {
+    metricQuery: MetricQuery;
+    explore: Explore;
+    preAggregateDef: PreAggregateDef;
+    dimensionsByFieldId: Map<
+        FieldId,
+        Explore['tables'][string]['dimensions'][string]
+    >;
+    requiredModelFilters: ModelRequiredFilterRule[];
+    queryRequiredFallbackIds: ReadonlySet<string>;
+}): UnsatisfiedMaterializationFilterMiss | null => {
+    const preAggregateDimensionFilters = getPreAggregateDimensionFilters({
+        filters: preAggregateDef.filters,
+        baseTable: explore.baseTable,
+    });
+    const materializationRequiredFilters =
+        reduceRequiredDimensionFiltersToFilterRules(
+            requiredModelFilters,
+            preAggregateDimensionFilters,
+            explore,
+        );
+    const unsatisfiedFilter = materializationRequiredFilters.find(
+        (requiredFilter) =>
+            !queryRequiredFallbackIds.has(requiredFilter.id) &&
+            !filterGroupImpliesMaterializationFilter({
+                filterGroup: metricQuery.filters.dimensions,
+                materializationFilter: {
+                    source: 'model_required',
+                    filter: requiredFilter,
+                },
+                explore,
+                dimensionsByFieldId,
+            }),
+    );
+
+    if (!unsatisfiedFilter) {
+        return null;
+    }
+
+    return {
+        reason: PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED,
+        fieldId: unsatisfiedFilter.target.fieldId,
     };
 };
 
@@ -816,6 +896,8 @@ const getMissForDef = ({
     preAggregateDef,
     dimensionsByFieldId,
     metricsByFieldId,
+    requiredModelFilters,
+    queryRequiredFallbackIds,
 }: {
     metricQuery: MetricQuery;
     explore: Explore;
@@ -825,6 +907,8 @@ const getMissForDef = ({
         Explore['tables'][string]['dimensions'][string]
     >;
     metricsByFieldId: ReturnType<typeof getMetricsMapFromTables>;
+    requiredModelFilters: ModelRequiredFilterRule[];
+    queryRequiredFallbackIds: ReadonlySet<string>;
 }): PreAggregateMatchMiss | null => {
     const defMetrics = new Set(preAggregateDef.metrics);
     for (const metricFieldId of metricQuery.metrics) {
@@ -946,6 +1030,19 @@ const getMissForDef = ({
         return unsatisfiedPreAggregateFilterMiss;
     }
 
+    const unsatisfiedRequiredModelFilterMiss =
+        getUnsatisfiedRequiredModelFilterMiss({
+            metricQuery,
+            explore,
+            preAggregateDef,
+            dimensionsByFieldId,
+            requiredModelFilters,
+            queryRequiredFallbackIds,
+        });
+    if (unsatisfiedRequiredModelFilterMiss) {
+        return unsatisfiedRequiredModelFilterMiss;
+    }
+
     const granularityMiss = getGranularityMissForDef(
         metricQuery,
         explore,
@@ -1001,6 +1098,17 @@ export const findMatch = (
 
     const dimensionsByFieldId = getDimensionsByFieldId(explore);
     const metricsByFieldId = getMetricsMapFromTables(explore.tables);
+    const requiredModelFilters =
+        explore.tables[explore.baseTable].requiredFilters?.filter(
+            (filter) => filter.required !== false,
+        ) ?? [];
+    const queryRequiredFallbackIds = new Set(
+        reduceRequiredDimensionFiltersToFilterRules(
+            requiredModelFilters,
+            metricQuery.filters.dimensions,
+            explore,
+        ).map((filter) => filter.id),
+    );
 
     const matchedDefs: PreAggregateDef[] = [];
     let firstMiss: PreAggregateMatchMiss | null = null;
@@ -1012,6 +1120,8 @@ export const findMatch = (
             preAggregateDef,
             dimensionsByFieldId,
             metricsByFieldId,
+            requiredModelFilters,
+            queryRequiredFallbackIds,
         });
 
         if (!miss) {

--- a/packages/common/src/ee/preAggregates/utils.ts
+++ b/packages/common/src/ee/preAggregates/utils.ts
@@ -14,6 +14,7 @@ export {
     PreAggregateNumberMetricDependencyIneligibilityReason,
     type PreAggregateNumberMetricDependencies,
 } from './numberMetricDependencies';
+export { getPreAggregateDimensionFilters } from './filters';
 export { applyUserBypass, findMatch } from './matcher';
 export {
     getMetricRepresentation,


### PR DESCRIPTION
Closes: ZAP-769

Pre-aggregate matching now accounts for required model filters applied during materialization, preventing broader queries from reading incomplete rollups.
Matcher and SQL generation now share the same required-filter reduction logic.

Adds regression coverage for fallback, explicit, sibling-time, OR, joined-filter, tie-break, date-bound, and SQL-generation cases.
