### PR TITLE
feat(pre-aggregates): configure sort order

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/orders.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/orders.yml
@@ -19,7 +19,7 @@ models:
             time_dimension: order_date
             granularity: day
             sorts:
-              - field: order_date
+              - fieldId: orders_order_date_day
                 descending: true
           - name: orders_daily_avg_demo_2
             dimensions:

--- a/examples/full-jaffle-shop-demo/dbt/models/orders.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/orders.yml
@@ -18,6 +18,9 @@ models:
               - total_order_amount
             time_dimension: order_date
             granularity: day
+            sorts:
+              - field: order_date
+                descending: true
           - name: orders_daily_avg_demo_2
             dimensions:
               - status

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/PreAggregateMaterializationService.test.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/PreAggregateMaterializationService.test.ts
@@ -177,7 +177,7 @@ describe('PreAggregateMaterializationService', () => {
 
     test.each([
         {
-            name: 'applies legacy sorts to stored definitions without sort config',
+            name: 'applies automatic sorts to stored definitions without sort config',
             preAggregateDefinition:
                 baseStoredPreAggregateDefinition.preAggregateDefinition,
             expectedSorts: [

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/PreAggregateMaterializationService.test.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/PreAggregateMaterializationService.test.ts
@@ -99,7 +99,7 @@ describe('PreAggregateMaterializationService', () => {
         preAggregateModel.getPreAggregateDefinitionByUuid.mockResolvedValue({
             preAggregateDefinition: {
                 ...baseStoredPreAggregateDefinition.preAggregateDefinition,
-                sorts: [{ field: 'status', descending: false }],
+                sorts: [{ fieldId: 'orders_status', descending: false }],
             },
             preAggregateDefinitionUuid: 'def-1',
             materializationMetricQuery: {

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/PreAggregateMaterializationService.test.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/PreAggregateMaterializationService.test.ts
@@ -97,15 +97,18 @@ describe('PreAggregateMaterializationService', () => {
     test('runs query and promotes active materialization for valid definition', async () => {
         const queryUpdatedAt = new Date('2024-02-01T10:00:00.000Z');
         preAggregateModel.getPreAggregateDefinitionByUuid.mockResolvedValue({
-            ...baseStoredPreAggregateDefinition,
+            preAggregateDefinition: {
+                ...baseStoredPreAggregateDefinition.preAggregateDefinition,
+                sorts: [{ field: 'status', descending: false }],
+            },
             preAggregateDefinitionUuid: 'def-1',
             materializationMetricQuery: {
                 metricQuery: {
                     exploreName: 'orders',
-                    dimensions: [],
+                    dimensions: ['orders_status'],
                     metrics: [],
                     filters: {},
-                    sorts: [],
+                    sorts: [{ fieldId: 'orders_status', descending: false }],
                     limit: 100,
                     tableCalculations: [],
                 },
@@ -148,10 +151,10 @@ describe('PreAggregateMaterializationService', () => {
                 context: QueryExecutionContext.PRE_AGGREGATE_MATERIALIZATION,
                 metricQuery: {
                     exploreName: 'orders',
-                    dimensions: [],
+                    dimensions: ['orders_status'],
                     metrics: [],
                     filters: {},
-                    sorts: [],
+                    sorts: [{ fieldId: 'orders_status', descending: false }],
                     limit: 100,
                     tableCalculations: [],
                 },
@@ -172,10 +175,28 @@ describe('PreAggregateMaterializationService', () => {
         });
     });
 
-    test('sorts by dimensions with time dimension first and descending', async () => {
+    test.each([
+        {
+            name: 'applies legacy sorts to stored definitions without sort config',
+            preAggregateDefinition:
+                baseStoredPreAggregateDefinition.preAggregateDefinition,
+            expectedSorts: [
+                { fieldId: 'orders_order_date_day', descending: true },
+                { fieldId: 'orders_status', descending: false },
+            ],
+        },
+        {
+            name: 'preserves explicitly disabled materialization sorting',
+            preAggregateDefinition: {
+                ...baseStoredPreAggregateDefinition.preAggregateDefinition,
+                sorts: [],
+            },
+            expectedSorts: [],
+        },
+    ])('$name', async ({ preAggregateDefinition, expectedSorts }) => {
         const queryUpdatedAt = new Date('2024-02-01T10:00:00.000Z');
         preAggregateModel.getPreAggregateDefinitionByUuid.mockResolvedValue({
-            ...baseStoredPreAggregateDefinition,
+            preAggregateDefinition,
             preAggregateDefinitionUuid: 'def-1',
             materializationMetricQuery: {
                 metricQuery: {
@@ -218,10 +239,7 @@ describe('PreAggregateMaterializationService', () => {
         expect(asyncQueryService.executeAsyncMetricQuery).toHaveBeenCalledWith(
             expect.objectContaining({
                 metricQuery: expect.objectContaining({
-                    sorts: [
-                        { fieldId: 'orders_order_date_day', descending: true },
-                        { fieldId: 'orders_status', descending: false },
-                    ],
+                    sorts: expectedSorts,
                 }),
             }),
         );

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/PreAggregateMaterializationService.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/PreAggregateMaterializationService.ts
@@ -22,6 +22,7 @@ import { type AsyncQueryService } from '../../../services/AsyncQueryService/Asyn
 import { BaseService } from '../../../services/BaseService';
 import { traceSpan } from '../../../tracing/tracing';
 import { PreAggregateModel } from '../../models/PreAggregateModel';
+import { getDefaultMaterializationSorts } from './buildMaterializationMetricQuery';
 
 const QUERY_POLL_INTERVAL_MS = 1000;
 const QUERY_POLL_TIMEOUT_MS = 30 * 60 * 1000;
@@ -240,24 +241,18 @@ export class PreAggregateMaterializationService extends BaseService {
                         projectUuid: args.projectUuid,
                         context:
                             QueryExecutionContext.PRE_AGGREGATE_MATERIALIZATION,
-                        metricQuery: {
-                            ...materializationMetricQuery.metricQuery,
-                            sorts: materializationMetricQuery.metricQuery.dimensions
-                                .slice()
-                                .sort((a, b) => {
-                                    const timeDim =
-                                        materializationMetricQuery.timeDimensionFieldId;
-                                    if (a === timeDim) return -1;
-                                    if (b === timeDim) return 1;
-                                    return 0;
-                                })
-                                .map((fieldId) => ({
-                                    fieldId,
-                                    descending:
-                                        fieldId ===
-                                        materializationMetricQuery.timeDimensionFieldId,
-                                })),
-                        },
+                        metricQuery:
+                            definition.preAggregateDefinition.sorts ===
+                            undefined
+                                ? {
+                                      ...materializationMetricQuery.metricQuery,
+                                      sorts: getDefaultMaterializationSorts(
+                                          materializationMetricQuery.metricQuery
+                                              .dimensions,
+                                          materializationMetricQuery.timeDimensionFieldId,
+                                      ),
+                                  }
+                                : materializationMetricQuery.metricQuery,
                         ...(definition.preAggregateDefinition
                             .materializationRole
                             ? {

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.test.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.test.ts
@@ -4,6 +4,7 @@ import {
     FilterOperator,
     getParameterReferences,
     MetricType,
+    QueryExecutionContext,
     SupportedDbtAdapter,
     TimeFrames,
     UnitOfTime,
@@ -12,6 +13,8 @@ import {
     type Explore,
     type PreAggregateDef,
 } from '@lightdash/common';
+import { warehouseSqlBuilderFromType } from '@lightdash/warehouses';
+import { QueryComposer } from '../../../utils/QueryBuilder/QueryComposer';
 import { buildMaterializationMetricQuery } from './buildMaterializationMetricQuery';
 
 const makeDimension = ({
@@ -317,9 +320,10 @@ describe('buildMaterializationMetricQuery', () => {
         ]);
     });
 
-    it('disables materialization sorting with an explicit empty array', () => {
-        const result = buildMaterializationMetricQuery({
-            sourceExplore: getSourceExplore(),
+    it('compiles no ORDER BY when materialization sorting is explicitly disabled', () => {
+        const sourceExplore = getSourceExplore();
+        const { metricQuery } = buildMaterializationMetricQuery({
+            sourceExplore,
             preAggregateDef: {
                 name: 'orders_rollup',
                 dimensions: ['status'],
@@ -331,7 +335,19 @@ describe('buildMaterializationMetricQuery', () => {
             materializationConfig: { maxRows: null },
         });
 
-        expect(result.metricQuery.sorts).toEqual([]);
+        const sql = new QueryComposer(
+            { metricQuery },
+            {
+                explore: sourceExplore,
+                warehouseSqlBuilder: warehouseSqlBuilderFromType(
+                    SupportedDbtAdapter.POSTGRES,
+                ),
+                queryExecutionContext:
+                    QueryExecutionContext.PRE_AGGREGATE_MATERIALIZATION,
+            },
+        ).compile().query;
+
+        expect(sql).not.toContain('ORDER BY');
     });
 
     it('preserves configured canonical materialization sorts', () => {

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.test.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.test.ts
@@ -299,7 +299,7 @@ describe('buildMaterializationMetricQuery', () => {
         ]);
     });
 
-    it('applies ascending legacy sorts when there is no time dimension', () => {
+    it('sorts all dimensions ascending when there is no time dimension', () => {
         const result = buildMaterializationMetricQuery({
             sourceExplore: getSourceExplore(),
             preAggregateDef: {

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.test.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.test.ts
@@ -288,11 +288,149 @@ describe('buildMaterializationMetricQuery', () => {
             materializationConfig: { maxRows: null },
         });
 
-        expect(result.metricQuery.dimensions).toEqual(
-            expect.arrayContaining(['orders_status', 'orders_order_date_day']),
-        );
-        expect(result.metricQuery.dimensions).toHaveLength(2);
+        expect(result.metricQuery.dimensions).toEqual([
+            'orders_status',
+            'orders_order_date_day',
+        ]);
         expect(result.timeDimensionFieldId).toEqual('orders_order_date_day');
+        expect(result.metricQuery.sorts).toEqual([
+            { fieldId: 'orders_order_date_day', descending: true },
+            { fieldId: 'orders_status', descending: false },
+        ]);
+    });
+
+    it('applies ascending legacy sorts when there is no time dimension', () => {
+        const result = buildMaterializationMetricQuery({
+            sourceExplore: getSourceExplore(),
+            preAggregateDef: {
+                name: 'orders_rollup',
+                dimensions: ['status', 'customers.first_name'],
+                metrics: ['orders_order_count'],
+            },
+            materializationConfig: { maxRows: null },
+        });
+
+        expect(result.timeDimensionFieldId).toBeNull();
+        expect(result.metricQuery.sorts).toEqual([
+            { fieldId: 'orders_status', descending: false },
+            { fieldId: 'customers_first_name', descending: false },
+        ]);
+    });
+
+    it('disables materialization sorting with an explicit empty array', () => {
+        const result = buildMaterializationMetricQuery({
+            sourceExplore: getSourceExplore(),
+            preAggregateDef: {
+                name: 'orders_rollup',
+                dimensions: ['status'],
+                metrics: ['orders_order_count'],
+                timeDimension: 'order_date',
+                granularity: TimeFrames.DAY,
+                sorts: [],
+            },
+            materializationConfig: { maxRows: null },
+        });
+
+        expect(result.metricQuery.sorts).toEqual([]);
+    });
+
+    it('resolves configured materialization sorts and preserves order and direction', () => {
+        const result = buildMaterializationMetricQuery({
+            sourceExplore: getSourceExplore(),
+            preAggregateDef: {
+                name: 'orders_rollup',
+                dimensions: ['status', 'customers.first_name'],
+                metrics: ['orders_order_count'],
+                timeDimension: 'order_date',
+                granularity: TimeFrames.DAY,
+                sorts: [
+                    { field: 'status', descending: false },
+                    { field: 'order_date', descending: true },
+                ],
+            },
+            materializationConfig: { maxRows: null },
+        });
+
+        expect(result.metricQuery.sorts).toEqual([
+            { fieldId: 'orders_status', descending: false },
+            { fieldId: 'orders_order_date_day', descending: true },
+        ]);
+    });
+
+    it('rejects materialization sorts on dimensions outside the pre-aggregate', () => {
+        expect(() =>
+            buildMaterializationMetricQuery({
+                sourceExplore: getSourceExplore(),
+                preAggregateDef: {
+                    name: 'orders_rollup',
+                    dimensions: ['status'],
+                    metrics: ['orders_order_count'],
+                    sorts: [
+                        {
+                            field: 'customers.first_name',
+                            descending: false,
+                        },
+                    ],
+                },
+                materializationConfig: { maxRows: null },
+            }),
+        ).toThrow(
+            'Pre-aggregate "orders_rollup" sort references dimension "customers.first_name" which is not materialized in this pre-aggregate. Only dimensions included in the pre-aggregate (and its time dimension) can be sorted.',
+        );
+    });
+
+    it('rejects unknown dimensions in materialization sorts', () => {
+        expect(() =>
+            buildMaterializationMetricQuery({
+                sourceExplore: getSourceExplore(),
+                preAggregateDef: {
+                    name: 'orders_rollup',
+                    dimensions: ['status'],
+                    metrics: ['orders_order_count'],
+                    sorts: [{ field: 'unknown_dimension', descending: false }],
+                },
+                materializationConfig: { maxRows: null },
+            }),
+        ).toThrow(
+            'Pre-aggregate "orders_rollup" sort references unknown dimension "unknown_dimension". Only materialized dimensions can be sorted.',
+        );
+    });
+
+    it('rejects metrics in materialization sorts', () => {
+        expect(() =>
+            buildMaterializationMetricQuery({
+                sourceExplore: getSourceExplore(),
+                preAggregateDef: {
+                    name: 'orders_rollup',
+                    dimensions: ['status'],
+                    metrics: ['orders_order_count'],
+                    sorts: [{ field: 'order_count', descending: true }],
+                },
+                materializationConfig: { maxRows: null },
+            }),
+        ).toThrow(
+            'Pre-aggregate "orders_rollup" sort references metric "order_count". Only materialized dimensions can be sorted.',
+        );
+    });
+
+    it('rejects duplicate resolved materialization sort dimensions', () => {
+        expect(() =>
+            buildMaterializationMetricQuery({
+                sourceExplore: getSourceExplore(),
+                preAggregateDef: {
+                    name: 'orders_rollup',
+                    dimensions: ['status'],
+                    metrics: ['orders_order_count'],
+                    sorts: [
+                        { field: 'status', descending: false },
+                        { field: 'orders.status', descending: true },
+                    ],
+                },
+                materializationConfig: { maxRows: null },
+            }),
+        ).toThrow(
+            'Pre-aggregate "orders_rollup" has duplicate materialization sorts for dimension "orders.status" after resolving field references.',
+        );
     });
 
     it('does not duplicate the time dimension when it is already part of the definition', () => {

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.test.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.test.ts
@@ -334,7 +334,7 @@ describe('buildMaterializationMetricQuery', () => {
         expect(result.metricQuery.sorts).toEqual([]);
     });
 
-    it('resolves configured materialization sorts and preserves order and direction', () => {
+    it('preserves configured canonical materialization sorts', () => {
         const result = buildMaterializationMetricQuery({
             sourceExplore: getSourceExplore(),
             preAggregateDef: {
@@ -344,8 +344,11 @@ describe('buildMaterializationMetricQuery', () => {
                 timeDimension: 'order_date',
                 granularity: TimeFrames.DAY,
                 sorts: [
-                    { field: 'status', descending: false },
-                    { field: 'order_date', descending: true },
+                    { fieldId: 'orders_status', descending: false },
+                    {
+                        fieldId: 'orders_order_date_day',
+                        descending: true,
+                    },
                 ],
             },
             materializationConfig: { maxRows: null },
@@ -367,7 +370,7 @@ describe('buildMaterializationMetricQuery', () => {
                     metrics: ['orders_order_count'],
                     sorts: [
                         {
-                            field: 'customers.first_name',
+                            fieldId: 'customers_first_name',
                             descending: false,
                         },
                     ],
@@ -375,7 +378,48 @@ describe('buildMaterializationMetricQuery', () => {
                 materializationConfig: { maxRows: null },
             }),
         ).toThrow(
-            'Pre-aggregate "orders_rollup" sort references dimension "customers.first_name" which is not materialized in this pre-aggregate. Only dimensions included in the pre-aggregate (and its time dimension) can be sorted.',
+            'Pre-aggregate "orders_rollup" sort fieldId "customers_first_name" references a dimension which is not materialized in this pre-aggregate.',
+        );
+    });
+
+    it('suggests the granularity-specific fieldId for a base time dimension', () => {
+        expect(() =>
+            buildMaterializationMetricQuery({
+                sourceExplore: getSourceExplore(),
+                preAggregateDef: {
+                    name: 'orders_rollup',
+                    dimensions: ['status'],
+                    metrics: ['orders_order_count'],
+                    timeDimension: 'order_date',
+                    granularity: TimeFrames.DAY,
+                    sorts: [
+                        {
+                            fieldId: 'orders_order_date',
+                            descending: true,
+                        },
+                    ],
+                },
+                materializationConfig: { maxRows: null },
+            }),
+        ).toThrow(
+            'Use the granularity-specific fieldId "orders_order_date_day".',
+        );
+    });
+
+    it('suggests the compiled fieldId when a dimension reference is configured', () => {
+        expect(() =>
+            buildMaterializationMetricQuery({
+                sourceExplore: getSourceExplore(),
+                preAggregateDef: {
+                    name: 'orders_rollup',
+                    dimensions: ['status'],
+                    metrics: ['orders_order_count'],
+                    sorts: [{ fieldId: 'status', descending: false }],
+                },
+                materializationConfig: { maxRows: null },
+            }),
+        ).toThrow(
+            'sort fieldId "status" is a dimension reference, not a compiled field ID. Use "orders_status".',
         );
     });
 
@@ -387,12 +431,17 @@ describe('buildMaterializationMetricQuery', () => {
                     name: 'orders_rollup',
                     dimensions: ['status'],
                     metrics: ['orders_order_count'],
-                    sorts: [{ field: 'unknown_dimension', descending: false }],
+                    sorts: [
+                        {
+                            fieldId: 'orders_unknown_dimension',
+                            descending: false,
+                        },
+                    ],
                 },
                 materializationConfig: { maxRows: null },
             }),
         ).toThrow(
-            'Pre-aggregate "orders_rollup" sort references unknown dimension "unknown_dimension". Only materialized dimensions can be sorted.',
+            'Pre-aggregate "orders_rollup" sort references unknown dimension fieldId "orders_unknown_dimension". Only materialized dimensions can be sorted.',
         );
     });
 
@@ -404,16 +453,21 @@ describe('buildMaterializationMetricQuery', () => {
                     name: 'orders_rollup',
                     dimensions: ['status'],
                     metrics: ['orders_order_count'],
-                    sorts: [{ field: 'order_count', descending: true }],
+                    sorts: [
+                        {
+                            fieldId: 'orders_order_count',
+                            descending: true,
+                        },
+                    ],
                 },
                 materializationConfig: { maxRows: null },
             }),
         ).toThrow(
-            'Pre-aggregate "orders_rollup" sort references metric "order_count". Only materialized dimensions can be sorted.',
+            'Pre-aggregate "orders_rollup" sort references metric fieldId "orders_order_count". Only materialized dimensions can be sorted.',
         );
     });
 
-    it('rejects duplicate resolved materialization sort dimensions', () => {
+    it('rejects duplicate materialization sort fieldIds', () => {
         expect(() =>
             buildMaterializationMetricQuery({
                 sourceExplore: getSourceExplore(),
@@ -422,14 +476,14 @@ describe('buildMaterializationMetricQuery', () => {
                     dimensions: ['status'],
                     metrics: ['orders_order_count'],
                     sorts: [
-                        { field: 'status', descending: false },
-                        { field: 'orders.status', descending: true },
+                        { fieldId: 'orders_status', descending: false },
+                        { fieldId: 'orders_status', descending: true },
                     ],
                 },
                 materializationConfig: { maxRows: null },
             }),
         ).toThrow(
-            'Pre-aggregate "orders_rollup" has duplicate materialization sorts for dimension "orders.status" after resolving field references.',
+            'Pre-aggregate "orders_rollup" has duplicate materialization sorts for fieldId "orders_status".',
         );
     });
 

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.ts
@@ -217,46 +217,80 @@ export const buildMaterializationMetricQuery = ({
             : null;
 
     const materializedDimensionFieldIds = new Set(dimensions);
+    const allExploreDimensionFieldIds = new Set<FieldId>();
+    Object.values(sourceExplore.tables).forEach((table) => {
+        Object.values(table.dimensions).forEach((dimension) => {
+            allExploreDimensionFieldIds.add(getDimensionFieldId({ dimension }));
+        });
+    });
+
     const sortedDimensionFieldIds = new Set<FieldId>();
     const sorts =
         preAggregateDef.sorts === undefined
             ? getDefaultMaterializationSorts(dimensions, timeDimensionFieldId)
-            : preAggregateDef.sorts.map(({ field, descending }) => {
-                  const candidates = dimensionsByReference.get(field);
-                  if (!candidates || candidates.length === 0) {
-                      if (metricsByReference.has(field)) {
+            : preAggregateDef.sorts.map((sort) => {
+                  const { fieldId } = sort;
+
+                  if (!materializedDimensionFieldIds.has(fieldId)) {
+                      if (metricsByReference.has(fieldId)) {
                           throw new Error(
-                              `Pre-aggregate "${preAggregateDef.name}" sort references metric "${field}". Only materialized dimensions can be sorted.`,
+                              `Pre-aggregate "${preAggregateDef.name}" sort references metric fieldId "${fieldId}". Only materialized dimensions can be sorted.`,
+                          );
+                      }
+
+                      if (allExploreDimensionFieldIds.has(fieldId)) {
+                          const timeDimensionBaseFieldIds =
+                              preAggregateDef.timeDimension
+                                  ? (
+                                        dimensionsByReference.get(
+                                            preAggregateDef.timeDimension,
+                                        ) ?? []
+                                    ).map((dimension) =>
+                                        getDimensionFieldId({ dimension }),
+                                    )
+                                  : [];
+                          const timeDimensionHint =
+                              timeDimensionFieldId &&
+                              timeDimensionBaseFieldIds.includes(fieldId)
+                                  ? ` Use the granularity-specific fieldId "${timeDimensionFieldId}".`
+                                  : '';
+
+                          throw new Error(
+                              `Pre-aggregate "${preAggregateDef.name}" sort fieldId "${fieldId}" references a dimension which is not materialized in this pre-aggregate.${timeDimensionHint}`,
+                          );
+                      }
+
+                      const referenceCandidates =
+                          dimensionsByReference.get(fieldId);
+                      if (
+                          referenceCandidates &&
+                          referenceCandidates.length > 0
+                      ) {
+                          const suggestedFieldId = getDimensionFieldId({
+                              dimension: getSelectedDimension({
+                                  dimensionsByReference,
+                                  preAggregateDef,
+                                  dimensionReference: fieldId,
+                              }),
+                          });
+                          throw new Error(
+                              `Pre-aggregate "${preAggregateDef.name}" sort fieldId "${fieldId}" is a dimension reference, not a compiled field ID. Use "${suggestedFieldId}".`,
                           );
                       }
 
                       throw new Error(
-                          `Pre-aggregate "${preAggregateDef.name}" sort references unknown dimension "${field}". Only materialized dimensions can be sorted.`,
-                      );
-                  }
-
-                  const fieldId = getDimensionFieldId({
-                      dimension: getSelectedDimension({
-                          dimensionsByReference,
-                          preAggregateDef,
-                          dimensionReference: field,
-                      }),
-                  });
-
-                  if (!materializedDimensionFieldIds.has(fieldId)) {
-                      throw new Error(
-                          `Pre-aggregate "${preAggregateDef.name}" sort references dimension "${field}" which is not materialized in this pre-aggregate. Only dimensions included in the pre-aggregate (and its time dimension) can be sorted.`,
+                          `Pre-aggregate "${preAggregateDef.name}" sort references unknown dimension fieldId "${fieldId}". Only materialized dimensions can be sorted.`,
                       );
                   }
 
                   if (sortedDimensionFieldIds.has(fieldId)) {
                       throw new Error(
-                          `Pre-aggregate "${preAggregateDef.name}" has duplicate materialization sorts for dimension "${field}" after resolving field references.`,
+                          `Pre-aggregate "${preAggregateDef.name}" has duplicate materialization sorts for fieldId "${fieldId}".`,
                       );
                   }
                   sortedDimensionFieldIds.add(fieldId);
 
-                  return { fieldId, descending };
+                  return sort;
               });
 
     const selectedMetricFieldIds = new Set<FieldId>();

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.ts
@@ -16,6 +16,7 @@ import {
     type MaterializationMetricQueryPayload,
     type MetricQuery,
     type PreAggregateDef,
+    type SortField,
 } from '@lightdash/common';
 import { assertDimensionEligibleForDirectMaterialization } from '../../preAggregates/eligibility';
 import {
@@ -97,6 +98,18 @@ type MaterializationConfig = {
     maxRows: number | null;
 };
 
+export const getDefaultMaterializationSorts = (
+    dimensions: FieldId[],
+    timeDimensionFieldId: FieldId | null,
+): SortField[] => [
+    ...(timeDimensionFieldId
+        ? [{ fieldId: timeDimensionFieldId, descending: true }]
+        : []),
+    ...dimensions
+        .filter((fieldId) => fieldId !== timeDimensionFieldId)
+        .map((fieldId) => ({ fieldId, descending: false })),
+];
+
 const getPreAggregateDimensionFilters = ({
     sourceExplore,
     preAggregateDef,
@@ -142,10 +155,11 @@ export const buildMaterializationMetricQuery = ({
 }): MaterializationMetricQueryPayload => {
     const dimensionsByReference = getDimensionsByReference(sourceExplore);
     const dimensionReferences = [...preAggregateDef.dimensions];
-    const { materializedMetrics } = selectPreAggregateMetrics({
-        sourceExplore,
-        preAggregateDef,
-    });
+    const { materializedMetrics, metricsByReference } =
+        selectPreAggregateMetrics({
+            sourceExplore,
+            preAggregateDef,
+        });
 
     if (
         preAggregateDef.timeDimension &&
@@ -201,6 +215,49 @@ export const buildMaterializationMetricQuery = ({
                   ),
               })
             : null;
+
+    const materializedDimensionFieldIds = new Set(dimensions);
+    const sortedDimensionFieldIds = new Set<FieldId>();
+    const sorts =
+        preAggregateDef.sorts === undefined
+            ? getDefaultMaterializationSorts(dimensions, timeDimensionFieldId)
+            : preAggregateDef.sorts.map(({ field, descending }) => {
+                  const candidates = dimensionsByReference.get(field);
+                  if (!candidates || candidates.length === 0) {
+                      if (metricsByReference.has(field)) {
+                          throw new Error(
+                              `Pre-aggregate "${preAggregateDef.name}" sort references metric "${field}". Only materialized dimensions can be sorted.`,
+                          );
+                      }
+
+                      throw new Error(
+                          `Pre-aggregate "${preAggregateDef.name}" sort references unknown dimension "${field}". Only materialized dimensions can be sorted.`,
+                      );
+                  }
+
+                  const fieldId = getDimensionFieldId({
+                      dimension: getSelectedDimension({
+                          dimensionsByReference,
+                          preAggregateDef,
+                          dimensionReference: field,
+                      }),
+                  });
+
+                  if (!materializedDimensionFieldIds.has(fieldId)) {
+                      throw new Error(
+                          `Pre-aggregate "${preAggregateDef.name}" sort references dimension "${field}" which is not materialized in this pre-aggregate. Only dimensions included in the pre-aggregate (and its time dimension) can be sorted.`,
+                      );
+                  }
+
+                  if (sortedDimensionFieldIds.has(fieldId)) {
+                      throw new Error(
+                          `Pre-aggregate "${preAggregateDef.name}" has duplicate materialization sorts for dimension "${field}" after resolving field references.`,
+                      );
+                  }
+                  sortedDimensionFieldIds.add(fieldId);
+
+                  return { fieldId, descending };
+              });
 
     const selectedMetricFieldIds = new Set<FieldId>();
     const additionalMetrics: AdditionalMetric[] = [];
@@ -303,7 +360,7 @@ export const buildMaterializationMetricQuery = ({
         dimensions,
         metrics: metricFieldIds,
         filters: dimensionFilters ? { dimensions: dimensionFilters } : {},
-        sorts: [],
+        sorts,
         limit: resolvedMaxRows,
         tableCalculations: [],
         ...(additionalMetrics.length > 0 ? { additionalMetrics } : {}),

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -3604,6 +3604,7 @@ export class AsyncQueryService extends ProjectService {
         dataTimezone,
         sessionTimezone,
         applyDateZoomToFilters,
+        context,
         preloadedUserAccessControls,
         preloadedProjectParameters,
         preloadedProjectTimezone,
@@ -3641,6 +3642,7 @@ export class AsyncQueryService extends ProjectService {
         preloadedUserAccessControls?: UserAccessControls;
         preloadedProjectParameters?: DbProjectParameter[];
         preloadedProjectTimezone?: string;
+        context?: QueryExecutionContext;
     }): Promise<QueryComposer> {
         assertIsAccountWithOrg(account);
 
@@ -3717,6 +3719,7 @@ export class AsyncQueryService extends ProjectService {
                 rebaseRawTimestampFilters,
                 applyDateZoomToFilters,
                 displayTimezone,
+                queryExecutionContext: context,
             },
         );
     }
@@ -4576,6 +4579,7 @@ export class AsyncQueryService extends ProjectService {
             totalConfiguration,
             userAttributeOverrides,
             materializationRole,
+            context,
             ...(context === QueryExecutionContext.PRE_AGGREGATE_MATERIALIZATION
                 ? { skipModelRequiredFilters: true }
                 : {}),

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -57,6 +57,7 @@ import {
     parseAllReferences,
     parseTableCalculationFunctions,
     PivotConfiguration,
+    QueryExecutionContext,
     QueryWarning,
     quoteFieldReference,
     renderFilterRuleSqlFromField,
@@ -177,6 +178,7 @@ export type BuildQueryProps = {
      *  SELECT. Gated behind NaiveTimestampFilterRebase (the wrap defeats
      *  partition pruning). */
     rebaseRawTimestampFilters?: boolean;
+    queryExecutionContext?: QueryExecutionContext;
     /**
      * Turns this into a totals query: the builder collapses
      * `compiledMetricQuery` + `pivotConfiguration` to the requested grain (via
@@ -2359,7 +2361,11 @@ export class MetricQueryBuilder {
 
         // Apply default sort if no sorts are specified
         let effectiveSorts: SortField[] = sorts;
-        if (sorts.length === 0) {
+        if (
+            sorts.length === 0 &&
+            this.args.queryExecutionContext !==
+                QueryExecutionContext.PRE_AGGREGATE_MATERIALIZATION
+        ) {
             const defaultSort = this.getDefaultSort();
             effectiveSorts = defaultSort ? [defaultSort] : [];
         }

--- a/packages/backend/src/utils/QueryBuilder/QueryComposer.ts
+++ b/packages/backend/src/utils/QueryBuilder/QueryComposer.ts
@@ -12,6 +12,7 @@ import {
     type ParameterDefinitions,
     type ParametersValuesMap,
     type PivotConfiguration,
+    type QueryExecutionContext,
     type QueryWarning,
     type UserAccessControls,
     type UserAttributeValueMap,
@@ -66,6 +67,7 @@ export type QueryComposerContext = {
     dataTimezone?: string;
     rebaseRawTimestampFilters?: boolean;
     applyDateZoomToFilters?: boolean;
+    queryExecutionContext?: QueryExecutionContext;
     /**
      * Flag-gated timezone echoed to clients and persisted with the query.
      * Not a compile input — `timezone` drives SQL. SQL charts set it to null.
@@ -128,6 +130,7 @@ export class QueryComposer {
             dataTimezone,
             rebaseRawTimestampFilters,
             applyDateZoomToFilters,
+            queryExecutionContext,
         } = this.context;
 
         // Fold reserved definitions in so custom SQL referencing them compiles; a
@@ -191,6 +194,7 @@ export class QueryComposer {
             dataTimezone,
             rebaseRawTimestampFilters,
             totalConfiguration,
+            queryExecutionContext,
         });
         return this.queryBuilder;
     }

--- a/packages/common/src/dbt/validation.test.ts
+++ b/packages/common/src/dbt/validation.test.ts
@@ -1,5 +1,6 @@
 import { model } from '../compiler/translator.mock';
 import { DbtManifestVersion, type DbtRawModelNode } from '../types/dbt';
+import lightdashMetadataSchema from './schemas/lightdashMetadata.json';
 import { ManifestValidator } from './validation';
 
 const metadataSchemaId =
@@ -77,6 +78,15 @@ describe('DefaultTimeDimension metadata schema', () => {
                 interval: 'MONTH',
             }),
         ).toEqual([true, undefined]);
+    });
+});
+
+describe('pre-aggregate manifest validation boundary', () => {
+    test('keeps runtime parsing responsible while metadata schema omits pre-aggregates', () => {
+        expect(
+            lightdashMetadataSchema.definitions.LightdashModelMetadata
+                .properties,
+        ).not.toHaveProperty('pre_aggregates');
     });
 });
 

--- a/packages/common/src/preAggregates/definition.test.ts
+++ b/packages/common/src/preAggregates/definition.test.ts
@@ -10,6 +10,91 @@ describe('parseDbtPreAggregateDef', () => {
         metrics: ['order_count'],
     };
 
+    it('parses materialization sorts in order and defaults to ascending', () => {
+        expect(
+            parseDbtPreAggregateDef(
+                {
+                    ...basePreAggregate,
+                    sorts: [
+                        { field: ' order_date ', descending: true },
+                        { field: 'status' },
+                    ],
+                },
+                'orders',
+            ),
+        ).toEqual({
+            ...basePreAggregate,
+            sorts: [
+                { field: 'order_date', descending: true },
+                { field: 'status', descending: false },
+            ],
+        });
+    });
+
+    it('omits materialization sorts when they are not configured', () => {
+        expect(
+            parseDbtPreAggregateDef(basePreAggregate, 'orders'),
+        ).not.toHaveProperty('sorts');
+    });
+
+    it.each([
+        { name: 'false', sorts: false },
+        { name: 'an empty array', sorts: [] },
+    ])('normalizes $name to disabled materialization sorts', ({ sorts }) => {
+        expect(
+            parseDbtPreAggregateDef(
+                {
+                    ...basePreAggregate,
+                    sorts,
+                },
+                'orders',
+            ),
+        ).toHaveProperty('sorts', []);
+    });
+
+    it.each([
+        {
+            name: 'true',
+            sorts: true,
+            message: 'Expected an array of sort entries, or false / []',
+        },
+        {
+            name: 'null',
+            sorts: null,
+            message: 'Expected an array of sort entries, or false / []',
+        },
+        {
+            name: 'empty field',
+            sorts: [{ field: '' }],
+            message: '"field" must be a non-empty string',
+        },
+        {
+            name: 'invalid direction',
+            sorts: [{ field: 'order_date', descending: 'yes' }],
+            message: '"descending" must be a boolean',
+        },
+        {
+            name: 'unsupported field',
+            sorts: [{ field: 'order_date', nulls_first: true }],
+            message: 'has unsupported "sorts" fields: nulls_first',
+        },
+        {
+            name: 'duplicate field',
+            sorts: [{ field: 'order_date' }, { field: ' order_date ' }],
+            message: 'has duplicate "sorts" field "order_date"',
+        },
+    ])('rejects $name in materialization sorts', ({ sorts, message }) => {
+        expect(() =>
+            parseDbtPreAggregateDef(
+                {
+                    ...basePreAggregate,
+                    sorts,
+                },
+                'orders',
+            ),
+        ).toThrow(message);
+    });
+
     it('parses materialization_role and normalizes scalar attributes to arrays', () => {
         const result = parseDbtPreAggregateDef(
             {

--- a/packages/common/src/preAggregates/definition.test.ts
+++ b/packages/common/src/preAggregates/definition.test.ts
@@ -10,14 +10,17 @@ describe('parseDbtPreAggregateDef', () => {
         metrics: ['order_count'],
     };
 
-    it('parses materialization sorts in order and defaults to ascending', () => {
+    it('parses canonical materialization sorts in order', () => {
         expect(
             parseDbtPreAggregateDef(
                 {
                     ...basePreAggregate,
                     sorts: [
-                        { field: ' order_date ', descending: true },
-                        { field: 'status' },
+                        {
+                            fieldId: ' orders_order_date_day ',
+                            descending: true,
+                        },
+                        { fieldId: 'orders_status', descending: false },
                     ],
                 },
                 'orders',
@@ -25,8 +28,11 @@ describe('parseDbtPreAggregateDef', () => {
         ).toEqual({
             ...basePreAggregate,
             sorts: [
-                { field: 'order_date', descending: true },
-                { field: 'status', descending: false },
+                {
+                    fieldId: 'orders_order_date_day',
+                    descending: true,
+                },
+                { fieldId: 'orders_status', descending: false },
             ],
         });
     });
@@ -64,24 +70,69 @@ describe('parseDbtPreAggregateDef', () => {
             message: 'Expected an array of sort entries, or false / []',
         },
         {
-            name: 'empty field',
-            sorts: [{ field: '' }],
-            message: '"field" must be a non-empty string',
+            name: 'a non-object entry',
+            sorts: [null],
+            message: 'Expected an object',
         },
         {
-            name: 'invalid direction',
-            sorts: [{ field: 'order_date', descending: 'yes' }],
+            name: 'the old field key',
+            sorts: [{ field: 'order_date', descending: true }],
+            message: 'has unsupported "sorts" fields: field',
+        },
+        {
+            name: 'a missing fieldId',
+            sorts: [{ descending: false }],
+            message: '"fieldId" must be a non-empty string',
+        },
+        {
+            name: 'an empty fieldId',
+            sorts: [{ fieldId: '', descending: false }],
+            message: '"fieldId" must be a non-empty string',
+        },
+        {
+            name: 'a missing direction',
+            sorts: [{ fieldId: 'orders_order_date_day' }],
+            message: '"descending" is required',
+        },
+        {
+            name: 'an invalid direction',
+            sorts: [
+                {
+                    fieldId: 'orders_order_date_day',
+                    descending: 'yes',
+                },
+            ],
             message: '"descending" must be a boolean',
         },
         {
-            name: 'unsupported field',
-            sorts: [{ field: 'order_date', nulls_first: true }],
+            name: 'a misspelled direction',
+            sorts: [
+                {
+                    fieldId: 'orders_order_date_day',
+                    descending: true,
+                    desceding: false,
+                },
+            ],
+            message: 'has unsupported "sorts" fields: desceding',
+        },
+        {
+            name: 'unsupported null ordering',
+            sorts: [
+                {
+                    fieldId: 'orders_order_date_day',
+                    descending: true,
+                    nulls_first: true,
+                },
+            ],
             message: 'has unsupported "sorts" fields: nulls_first',
         },
         {
-            name: 'duplicate field',
-            sorts: [{ field: 'order_date' }, { field: ' order_date ' }],
-            message: 'has duplicate "sorts" field "order_date"',
+            name: 'a duplicate fieldId',
+            sorts: [
+                { fieldId: 'orders_status', descending: false },
+                { fieldId: ' orders_status ', descending: true },
+            ],
+            message: 'has duplicate "sorts" fieldId "orders_status"',
         },
     ])('rejects $name in materialization sorts', ({ sorts, message }) => {
         expect(() =>

--- a/packages/common/src/preAggregates/definition.ts
+++ b/packages/common/src/preAggregates/definition.ts
@@ -9,11 +9,15 @@ import { parseFilters } from '../types/filterGrammar';
 import type {
     PreAggregateDef,
     PreAggregateMaterializationRole,
+    PreAggregateSort,
 } from '../types/preAggregate';
 import { TimeFrames } from '../types/timeFrames';
 import type { UserAttributeValueMap } from '../types/userAttributes';
 
 const PRE_AGGREGATE_NAME_PATTERN = /^[a-zA-Z0-9_]+$/;
+
+const isUnknownRecord = (value: unknown): value is Record<string, unknown> =>
+    isPlainObject(value);
 
 const parsePreAggregateGranularity = (
     granularity: string,
@@ -48,6 +52,67 @@ const parsePreAggregateStringArray = (
             );
         }
         return item.trim();
+    });
+};
+
+const parsePreAggregateSorts = (
+    value: unknown,
+    modelName: string,
+    preAggregateName: string,
+): PreAggregateSort[] => {
+    if (value === false) {
+        return [];
+    }
+
+    if (!Array.isArray(value)) {
+        throw new ParseError(
+            `Pre-aggregate "${preAggregateName}" in model "${modelName}" has invalid "sorts". Expected an array of sort entries, or false / [] to disable materialization sorting, or remove "sorts" for automatic sorting.`,
+        );
+    }
+
+    const fields = new Set<string>();
+
+    return value.map((sort, index) => {
+        if (!isUnknownRecord(sort)) {
+            throw new ParseError(
+                `Pre-aggregate "${preAggregateName}" in model "${modelName}" has invalid "sorts" entry at index ${index}. Expected an object.`,
+            );
+        }
+
+        const { field, descending, ...unknownFields } = sort;
+        const unsupportedFields = keys(unknownFields);
+        if (!isEmpty(unsupportedFields)) {
+            throw new ParseError(
+                `Pre-aggregate "${preAggregateName}" in model "${modelName}" has unsupported "sorts" fields: ${unsupportedFields.join(
+                    ', ',
+                )}`,
+            );
+        }
+
+        if (typeof field !== 'string' || field.trim().length === 0) {
+            throw new ParseError(
+                `Pre-aggregate "${preAggregateName}" in model "${modelName}" has invalid "sorts" entry at index ${index}: "field" must be a non-empty string.`,
+            );
+        }
+        const normalizedField = field.trim();
+
+        if (fields.has(normalizedField)) {
+            throw new ParseError(
+                `Pre-aggregate "${preAggregateName}" in model "${modelName}" has duplicate "sorts" field "${normalizedField}".`,
+            );
+        }
+        fields.add(normalizedField);
+
+        if (descending !== undefined && typeof descending !== 'boolean') {
+            throw new ParseError(
+                `Pre-aggregate "${preAggregateName}" in model "${modelName}" has invalid "sorts" entry at index ${index}: "descending" must be a boolean.`,
+            );
+        }
+
+        return {
+            field: normalizedField,
+            descending: descending ?? false,
+        };
     });
 };
 
@@ -207,6 +272,11 @@ export const parseDbtPreAggregateDef = (
               )
             : undefined;
 
+    const sorts =
+        safePreAggregate?.sorts !== undefined
+            ? parsePreAggregateSorts(safePreAggregate.sorts, modelName, name)
+            : undefined;
+
     const filters = safePreAggregate?.filters
         ? parseFilters(safePreAggregate.filters)
         : undefined;
@@ -215,6 +285,7 @@ export const parseDbtPreAggregateDef = (
         name,
         dimensions,
         metrics,
+        ...(sorts !== undefined ? { sorts } : {}),
         ...(filters ? { filters } : {}),
         ...(timeDimension ? { timeDimension } : {}),
         ...(granularity ? { granularity } : {}),

--- a/packages/common/src/preAggregates/definition.ts
+++ b/packages/common/src/preAggregates/definition.ts
@@ -70,7 +70,7 @@ const parsePreAggregateSorts = (
         );
     }
 
-    const fields = new Set<string>();
+    const fieldIds = new Set<string>();
 
     return value.map((sort, index) => {
         if (!isUnknownRecord(sort)) {
@@ -79,9 +79,9 @@ const parsePreAggregateSorts = (
             );
         }
 
-        const { field, descending, ...unknownFields } = sort;
-        const unsupportedFields = keys(unknownFields);
-        if (!isEmpty(unsupportedFields)) {
+        const { fieldId, descending, ...unknownFields } = sort;
+        const unsupportedFields = Object.keys(unknownFields);
+        if (unsupportedFields.length > 0) {
             throw new ParseError(
                 `Pre-aggregate "${preAggregateName}" in model "${modelName}" has unsupported "sorts" fields: ${unsupportedFields.join(
                     ', ',
@@ -89,29 +89,34 @@ const parsePreAggregateSorts = (
             );
         }
 
-        if (typeof field !== 'string' || field.trim().length === 0) {
+        if (typeof fieldId !== 'string' || fieldId.trim().length === 0) {
             throw new ParseError(
-                `Pre-aggregate "${preAggregateName}" in model "${modelName}" has invalid "sorts" entry at index ${index}: "field" must be a non-empty string.`,
+                `Pre-aggregate "${preAggregateName}" in model "${modelName}" has invalid "sorts" entry at index ${index}: "fieldId" must be a non-empty string.`,
             );
         }
-        const normalizedField = field.trim();
+        const normalizedFieldId = fieldId.trim();
 
-        if (fields.has(normalizedField)) {
+        if (fieldIds.has(normalizedFieldId)) {
             throw new ParseError(
-                `Pre-aggregate "${preAggregateName}" in model "${modelName}" has duplicate "sorts" field "${normalizedField}".`,
+                `Pre-aggregate "${preAggregateName}" in model "${modelName}" has duplicate "sorts" fieldId "${normalizedFieldId}".`,
             );
         }
-        fields.add(normalizedField);
+        fieldIds.add(normalizedFieldId);
 
-        if (descending !== undefined && typeof descending !== 'boolean') {
+        if (descending === undefined) {
+            throw new ParseError(
+                `Pre-aggregate "${preAggregateName}" in model "${modelName}" has invalid "sorts" entry at index ${index}: "descending" is required.`,
+            );
+        }
+        if (typeof descending !== 'boolean') {
             throw new ParseError(
                 `Pre-aggregate "${preAggregateName}" in model "${modelName}" has invalid "sorts" entry at index ${index}: "descending" must be a boolean.`,
             );
         }
 
         return {
-            field: normalizedField,
-            descending: descending ?? false,
+            fieldId: normalizedFieldId,
+            descending,
         };
     });
 };

--- a/packages/common/src/preAggregates/schema.test.ts
+++ b/packages/common/src/preAggregates/schema.test.ts
@@ -1,0 +1,183 @@
+import Ajv from 'ajv';
+import AjvErrors from 'ajv-errors';
+import addFormats from 'ajv-formats';
+import lightdashDbtYamlSchema from '../schemas/json/lightdash-dbt-2.0.json';
+import modelAsCodeSchema from '../schemas/json/model-as-code-1.0.json';
+
+const dbtYamlAjv = new Ajv({
+    allErrors: true,
+    allowUnionTypes: true,
+    coerceTypes: true,
+});
+AjvErrors(dbtYamlAjv);
+
+const modelYamlAjv = new Ajv({
+    allErrors: true,
+    allowUnionTypes: true,
+    coerceTypes: true,
+    discriminator: true,
+});
+addFormats(modelYamlAjv);
+
+const validateDbtYaml = dbtYamlAjv.compile(lightdashDbtYamlSchema);
+const validateModelYaml = modelYamlAjv.compile(modelAsCodeSchema);
+
+const basePreAggregate = {
+    name: 'orders_rollup',
+    dimensions: ['status'],
+    metrics: ['order_count'],
+};
+
+const validateInBothSchemas = (
+    preAggregate: Record<string, unknown>,
+    expected: boolean,
+) => {
+    const dbtDocument = {
+        version: 2,
+        models: [
+            {
+                name: 'orders',
+                meta: { pre_aggregates: [preAggregate] },
+            },
+        ],
+    };
+    const modelDocument = {
+        type: 'model',
+        name: 'orders',
+        sql_from: 'analytics.orders',
+        dimensions: [
+            {
+                name: 'status',
+                type: 'string',
+                sql: '${TABLE}.status',
+            },
+        ],
+        pre_aggregates: [preAggregate],
+    };
+
+    expect(validateDbtYaml(dbtDocument)).toBe(expected);
+    expect(validateModelYaml(modelDocument)).toBe(expected);
+};
+
+describe('pre-aggregate sort schema parity', () => {
+    it('keeps the dbt and model-as-code sort contracts identical', () => {
+        const dbtSortSchema =
+            lightdashDbtYamlSchema.$defs.modelMeta.properties.pre_aggregates
+                .items.properties.sorts;
+        const modelSortSchema =
+            modelAsCodeSchema.definitions.BaseModel.properties.pre_aggregates
+                .items.properties.sorts;
+
+        expect(dbtSortSchema).toStrictEqual(modelSortSchema);
+    });
+
+    it.each([
+        {
+            name: 'canonical sorts',
+            preAggregate: {
+                ...basePreAggregate,
+                sorts: [
+                    { fieldId: 'orders_status', descending: false },
+                    {
+                        fieldId: 'orders_order_date_day',
+                        descending: true,
+                    },
+                ],
+            },
+            valid: true,
+        },
+        {
+            name: 'disabled sorts with false',
+            preAggregate: { ...basePreAggregate, sorts: false },
+            valid: true,
+        },
+        {
+            name: 'disabled sorts with an empty array',
+            preAggregate: { ...basePreAggregate, sorts: [] },
+            valid: true,
+        },
+        {
+            name: 'omitted sorts',
+            preAggregate: basePreAggregate,
+            valid: true,
+        },
+        {
+            name: 'a non-object entry',
+            preAggregate: {
+                ...basePreAggregate,
+                sorts: [null],
+            },
+            valid: false,
+        },
+        {
+            name: 'a missing fieldId',
+            preAggregate: {
+                ...basePreAggregate,
+                sorts: [{ descending: false }],
+            },
+            valid: false,
+        },
+        {
+            name: 'a missing descending value',
+            preAggregate: {
+                ...basePreAggregate,
+                sorts: [{ fieldId: 'orders_status' }],
+            },
+            valid: false,
+        },
+        {
+            name: 'a non-boolean descending value',
+            preAggregate: {
+                ...basePreAggregate,
+                sorts: [{ fieldId: 'orders_status', descending: 'yes' }],
+            },
+            valid: false,
+        },
+        {
+            name: 'a quoted boolean descending value',
+            preAggregate: {
+                ...basePreAggregate,
+                sorts: [{ fieldId: 'orders_status', descending: 'true' }],
+            },
+            valid: false,
+        },
+        {
+            name: 'the old field key',
+            preAggregate: {
+                ...basePreAggregate,
+                sorts: [{ field: 'status', descending: false }],
+            },
+            valid: false,
+        },
+        {
+            name: 'a misspelled desceding key',
+            preAggregate: {
+                ...basePreAggregate,
+                sorts: [
+                    {
+                        fieldId: 'orders_status',
+                        descending: false,
+                        desceding: true,
+                    },
+                ],
+            },
+            valid: false,
+        },
+        {
+            name: 'unsupported nulls_first',
+            preAggregate: {
+                ...basePreAggregate,
+                sorts: [
+                    {
+                        fieldId: 'orders_status',
+                        descending: false,
+                        nulls_first: true,
+                    },
+                ],
+            },
+            valid: false,
+        },
+    ])('$name is valid: $valid', ({ preAggregate, valid }) => {
+        validateInBothSchemas(preAggregate, valid);
+    });
+});

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -877,7 +877,7 @@
                                 }
                             },
                             "sorts": {
-                                "description": "Materialization sort order. When omitted, Lightdash automatically sorts the time dimension first and descending, then all remaining materialized dimensions ascending. Set to false or [] to disable sorting, or provide entries to sort only those materialized dimensions in the configured order. Sort order determines which rows are retained when max_rows truncates results.",
+                                "description": "Materialization sort order. When omitted, Lightdash automatically sorts the time dimension first and descending, then all remaining materialized dimensions ascending. Set to false or [] to disable sorting, or provide canonical query sort entries with a compiled Lightdash fieldId and explicit descending value. Compiled time-dimension IDs include granularity (for example, orders_order_date_day) and must be updated when granularity changes. Sort order determines which rows are retained when max_rows truncates results.",
                                 "oneOf": [
                                     {
                                         "const": false
@@ -887,16 +887,19 @@
                                         "items": {
                                             "type": "object",
                                             "properties": {
-                                                "field": {
+                                                "fieldId": {
                                                     "type": "string",
                                                     "minLength": 1
                                                 },
                                                 "descending": {
-                                                    "type": "boolean",
-                                                    "default": false
+                                                    "description": "Whether to sort descending. Must be an unquoted YAML boolean.",
+                                                    "enum": [true, false]
                                                 }
                                             },
-                                            "required": ["field"],
+                                            "required": [
+                                                "fieldId",
+                                                "descending"
+                                            ],
                                             "additionalProperties": false
                                         }
                                     }

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -876,6 +876,32 @@
                                     "type": "string"
                                 }
                             },
+                            "sorts": {
+                                "description": "Materialization sort order. When omitted, Lightdash automatically sorts the time dimension first and descending, then all remaining materialized dimensions ascending. Set to false or [] to disable sorting, or provide entries to sort only those materialized dimensions in the configured order. Sort order determines which rows are retained when max_rows truncates results.",
+                                "oneOf": [
+                                    {
+                                        "const": false
+                                    },
+                                    {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "field": {
+                                                    "type": "string",
+                                                    "minLength": 1
+                                                },
+                                                "descending": {
+                                                    "type": "boolean",
+                                                    "default": false
+                                                }
+                                            },
+                                            "required": ["field"],
+                                            "additionalProperties": false
+                                        }
+                                    }
+                                ]
+                            },
                             "filters": {
                                 "type": "array",
                                 "items": {

--- a/packages/common/src/schemas/json/model-as-code-1.0.json
+++ b/packages/common/src/schemas/json/model-as-code-1.0.json
@@ -96,7 +96,7 @@
                                 }
                             },
                             "sorts": {
-                                "description": "Materialization sort order. When omitted, Lightdash automatically sorts the time dimension first and descending, then all remaining materialized dimensions ascending. Set to false or [] to disable sorting, or provide entries to sort only those materialized dimensions in the configured order. Sort order determines which rows are retained when max_rows truncates results.",
+                                "description": "Materialization sort order. When omitted, Lightdash automatically sorts the time dimension first and descending, then all remaining materialized dimensions ascending. Set to false or [] to disable sorting, or provide canonical query sort entries with a compiled Lightdash fieldId and explicit descending value. Compiled time-dimension IDs include granularity (for example, orders_order_date_day) and must be updated when granularity changes. Sort order determines which rows are retained when max_rows truncates results.",
                                 "oneOf": [
                                     {
                                         "const": false
@@ -106,16 +106,19 @@
                                         "items": {
                                             "type": "object",
                                             "properties": {
-                                                "field": {
+                                                "fieldId": {
                                                     "type": "string",
                                                     "minLength": 1
                                                 },
                                                 "descending": {
-                                                    "type": "boolean",
-                                                    "default": false
+                                                    "description": "Whether to sort descending. Must be an unquoted YAML boolean.",
+                                                    "enum": [true, false]
                                                 }
                                             },
-                                            "required": ["field"],
+                                            "required": [
+                                                "fieldId",
+                                                "descending"
+                                            ],
                                             "additionalProperties": false
                                         }
                                     }

--- a/packages/common/src/schemas/json/model-as-code-1.0.json
+++ b/packages/common/src/schemas/json/model-as-code-1.0.json
@@ -95,6 +95,32 @@
                                     "type": "string"
                                 }
                             },
+                            "sorts": {
+                                "description": "Materialization sort order. When omitted, Lightdash automatically sorts the time dimension first and descending, then all remaining materialized dimensions ascending. Set to false or [] to disable sorting, or provide entries to sort only those materialized dimensions in the configured order. Sort order determines which rows are retained when max_rows truncates results.",
+                                "oneOf": [
+                                    {
+                                        "const": false
+                                    },
+                                    {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "field": {
+                                                    "type": "string",
+                                                    "minLength": 1
+                                                },
+                                                "descending": {
+                                                    "type": "boolean",
+                                                    "default": false
+                                                }
+                                            },
+                                            "required": ["field"],
+                                            "additionalProperties": false
+                                        }
+                                    }
+                                ]
+                            },
                             "filters": {
                                 "type": "array",
                                 "items": {

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -31,6 +31,7 @@ import {
 } from './field';
 import { parseFilters, type RequiredFilter } from './filterGrammar';
 import { type LightdashProjectConfig } from './lightdashProjectConfig';
+import { type PreAggregateSort } from './preAggregate';
 import { type OrderFieldsByStrategy, type TableBase } from './table';
 import { type DefaultTimeDimension, type TimeFrames } from './timeFrames';
 
@@ -136,14 +137,8 @@ export type DbtPreAggregateDef = {
     name: string;
     dimensions: string[];
     metrics: string[];
-    sorts?:
-        | false
-        | {
-              field?: string;
-              descending?: boolean;
-              [key: string]: unknown;
-          }[];
-    filters?: Record<string, AnyType>[];
+    sorts?: false | PreAggregateSort[];
+    filters?: Record<string, unknown>[];
     time_dimension?: string;
     granularity?: string;
     max_rows?: number;
@@ -151,9 +146,8 @@ export type DbtPreAggregateDef = {
         cron?: string;
     };
     materialization_role?: {
-        email?: string;
-        attributes?: Record<string, string | string[]>;
-        [key: string]: unknown;
+        email: string;
+        attributes: Record<string, string | string[]>;
     };
 };
 

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -136,6 +136,13 @@ export type DbtPreAggregateDef = {
     name: string;
     dimensions: string[];
     metrics: string[];
+    sorts?:
+        | false
+        | {
+              field?: string;
+              descending?: boolean;
+              [key: string]: unknown;
+          }[];
     filters?: Record<string, AnyType>[];
     time_dimension?: string;
     granularity?: string;

--- a/packages/common/src/types/preAggregate.ts
+++ b/packages/common/src/types/preAggregate.ts
@@ -1,7 +1,7 @@
 import { type FieldId, type MetricType } from './field';
 import { type MetricFilterRule } from './filter';
 import { type KnexPaginatedData } from './knex-paginate';
-import { type MetricQuery } from './metricQuery';
+import { type MetricQuery, type SortField } from './metricQuery';
 import { type ResultColumns } from './results';
 import { type PreAggregateMaterializationTrigger } from './scheduler';
 import { type TimeFrames } from './timeFrames';
@@ -40,16 +40,13 @@ export type PreAggregateMaterializationRole = {
     attributes: UserAttributeValueMap;
 };
 
-export type PreAggregateSort = {
-    field: string;
-    descending: boolean;
-};
+export type PreAggregateSort = Pick<SortField, 'fieldId' | 'descending'>;
 
 export type PreAggregateDef = {
     name: string;
     dimensions: string[];
     metrics: string[];
-    // Omitted sorts all dimensions automatically; [] disables sorting; non-empty configures explicit sorts.
+    // Omitted sorts all dimensions automatically; [] disables sorting; entries use canonical field IDs.
     sorts?: PreAggregateSort[];
     filters?: MetricFilterRule[];
     // Parser validation enforces that timeDimension and granularity are provided together

--- a/packages/common/src/types/preAggregate.ts
+++ b/packages/common/src/types/preAggregate.ts
@@ -40,10 +40,17 @@ export type PreAggregateMaterializationRole = {
     attributes: UserAttributeValueMap;
 };
 
+export type PreAggregateSort = {
+    field: string;
+    descending: boolean;
+};
+
 export type PreAggregateDef = {
     name: string;
     dimensions: string[];
     metrics: string[];
+    // Omitted uses legacy automatic sorting; [] disables sorting; non-empty configures explicit sorts.
+    sorts?: PreAggregateSort[];
     filters?: MetricFilterRule[];
     // Parser validation enforces that timeDimension and granularity are provided together
     timeDimension?: string;

--- a/packages/common/src/types/preAggregate.ts
+++ b/packages/common/src/types/preAggregate.ts
@@ -49,7 +49,7 @@ export type PreAggregateDef = {
     name: string;
     dimensions: string[];
     metrics: string[];
-    // Omitted uses legacy automatic sorting; [] disables sorting; non-empty configures explicit sorts.
+    // Omitted sorts all dimensions automatically; [] disables sorting; non-empty configures explicit sorts.
     sorts?: PreAggregateSort[];
     filters?: MetricFilterRule[];
     // Parser validation enforces that timeDimension and granularity are provided together


### PR DESCRIPTION
Closes: ZAP-767

Retains automatic all-dimension materialization sorting when `sorts` is omitted.
Adds explicit dimension subsets and `sorts: []` / `sorts: false` to disable sorting.
Covers parser, query builder, persisted payload compatibility, and service behavior.

Mintlify documentation remains a follow-up in the docs repository. It should recommend `sorts: false` when overriding sorts split across dbt `meta` and `config.meta`; the broader pre-existing lodash array-merge behavior needs separate evaluation.
