### PR TITLE
fix(data-apps): give app deliveries a retry budget and swallow post-enqueue bookkeeping errors

### DIFF
--- a/packages/backend/src/scheduler/SchedulerClient.test.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.test.ts
@@ -88,6 +88,28 @@ describe('SchedulerClient per-org delivery queue', () => {
         );
     });
 
+    // App deliveries render through the headless browser (capture render), so
+    // they need the same retry budget as dashboard image jobs.
+    it('gives app deliveries a retry budget', async () => {
+        const client = makeClient(false, vi.fn());
+
+        await client.addScheduledDeliveryJob(
+            new Date('2026-08-03T10:00:00Z'),
+            {
+                ...scheduler,
+                ...traceProperties,
+                appUuid: 'app-1',
+            },
+            scheduler.schedulerUuid,
+        );
+
+        expect(graphileAddJob).toHaveBeenCalledWith(
+            'handleScheduledDelivery',
+            expect.any(Object),
+            expect.objectContaining({ maxAttempts: 2 }),
+        );
+    });
+
     it('routes recurring deliveries into a per-org queue when multi-org + flag are on', async () => {
         const get = vi.fn().mockResolvedValue({
             id: FeatureFlags.ScheduledDeliveryPerOrgQueue,

--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -12,6 +12,7 @@ import {
     GoogleChatNotificationPayload,
     GsheetsNotificationPayload,
     hasSchedulerUuid,
+    isAppCreateScheduler,
     isCreateScheduler,
     isCreateSchedulerGoogleChatTarget,
     isCreateSchedulerMsTeamsTarget,
@@ -465,11 +466,15 @@ export class SchedulerClient {
               }
             : scheduler;
 
+        // Dashboard images and every app delivery (including csv/xlsx, which
+        // capture their queries from a headless render) are retried once more:
+        // the headless browser fails transiently.
         let maxAttempts = SCHEDULED_JOB_MAX_ATTEMPTS;
         if (
             isCreateScheduler(scheduler) &&
-            scheduler.format === SchedulerFormat.IMAGE &&
-            !!scheduler.dashboardUuid
+            ((scheduler.format === SchedulerFormat.IMAGE &&
+                !!scheduler.dashboardUuid) ||
+                isAppCreateScheduler(scheduler))
         ) {
             maxAttempts = SCHEDULED_JOB_MAX_ATTEMPTS + 1;
         }

--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -1787,6 +1787,76 @@ describe('handleScheduledDelivery — app delivery capture', () => {
             true,
         );
 
+    // Bookkeeping runs after the notification jobs are queued, so a throw
+    // there must not fail the job — with maxAttempts > 1 the retry would queue
+    // a second set of them and recipients would get the delivery twice.
+    it('completes without rethrowing when post-enqueue bookkeeping fails', async () => {
+        const generateJobsForSchedulerTargets = vi
+            .fn()
+            .mockResolvedValue([
+                { target: 'a@b.com', jobId: 'target-job-1', type: 'email' },
+            ]);
+        const track = vi.fn();
+        const logSchedulerJob = vi
+            .fn()
+            .mockResolvedValueOnce(undefined) // STARTED
+            .mockRejectedValue(new Error('scheduler log write failed'));
+        const task = makeTaskWithDeps({
+            lightdashConfig: asDep<'lightdashConfig'>({
+                siteUrl: 'https://lightdash.example.com',
+                headlessBrowser: {
+                    internalLightdashHost: 'http://lightdash-dev:3000',
+                },
+                persistentDownloadUrls: { expirationSeconds: 3600 },
+            }),
+            schedulerService: asDep<'schedulerService'>({
+                logSchedulerJob,
+                appModel: {
+                    findAppByUuid: vi.fn().mockResolvedValue(APP_ROW),
+                },
+            }),
+            organizationSettingsModel: asDep<'organizationSettingsModel'>({
+                get: vi.fn().mockResolvedValue({}),
+            }),
+            userService: asDep<'userService'>({
+                getSessionByUserUuid: vi.fn().mockResolvedValue({}),
+                getAccountByUserUuid: vi.fn().mockResolvedValue({
+                    user: { id: 'user-id-1' },
+                    organization: { organizationUuid: 'org-1' },
+                }),
+            }),
+            analytics: asDep<'analytics'>({ track }),
+            schedulerClient: asDep<'schedulerClient'>({
+                generateJobsForSchedulerTargets,
+            }),
+            unfurlService: asDep<'unfurlService'>({
+                captureAppDeliveryManifest: vi
+                    .fn()
+                    .mockResolvedValue(manifestOf([readyItem()])),
+            }),
+        });
+        (task as unknown as Record<string, unknown>).getNotificationPageData =
+            vi.fn().mockResolvedValue({
+                url: 'https://lightdash.example.com/app',
+                details: { name: 'Sales App', description: undefined },
+                pageType: 'app',
+                organizationUuid: 'org-1',
+                csvUrls: [],
+            });
+
+        await expect(
+            run(task, appScheduler({ targets: [{ recipient: 'a@b.com' }] })),
+        ).resolves.toBeUndefined();
+
+        // The retry budget must only cover the pre-enqueue phase.
+        expect(generateJobsForSchedulerTargets).toHaveBeenCalledTimes(1);
+        expect(
+            track.mock.calls.some(
+                ([event]) => event.event === 'scheduler_job.failed',
+            ),
+        ).toBe(false);
+    });
+
     it('captures the app render exactly once across two expiration groups', async () => {
         const { task, captureAppDeliveryManifest, getNotificationPageData } =
             setup();

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -4820,64 +4820,78 @@ export default class SchedulerTask {
                     perChannelPages,
                 );
 
-            // Create scheduled jobs for targets
-            await Promise.all(
-                scheduledJobs.map(({ target, jobId: targetJobId }) => {
-                    if (!target) {
-                        return Promise.resolve();
-                    }
+            // The notification jobs are now queued: nothing below may
+            // rethrow, or the retry budget (maxAttempts > 1) would re-run the
+            // whole body and queue a SECOND set of them — duplicate sends.
+            // A partial enqueue inside generateJobsForSchedulerTargets remains
+            // a narrow pre-existing window, shared with dashboard image jobs.
+            try {
+                // Create scheduled jobs for targets
+                await Promise.all(
+                    scheduledJobs.map(({ target, jobId: targetJobId }) => {
+                        if (!target) {
+                            return Promise.resolve();
+                        }
 
-                    return this.logScheduledTarget(
-                        scheduler.format,
-                        target,
-                        targetJobId,
-                        schedulerUuid,
-                        jobId,
-                        scheduledTime,
-                        {
-                            projectUuid: schedulerPayload.projectUuid,
-                            organizationUuid: schedulerPayload.organizationUuid,
-                            createdByUserUuid: schedulerPayload.userUuid,
-                        },
-                    );
-                }),
-            );
+                        return this.logScheduledTarget(
+                            scheduler.format,
+                            target,
+                            targetJobId,
+                            schedulerUuid,
+                            jobId,
+                            scheduledTime,
+                            {
+                                projectUuid: schedulerPayload.projectUuid,
+                                organizationUuid:
+                                    schedulerPayload.organizationUuid,
+                                createdByUserUuid: schedulerPayload.userUuid,
+                            },
+                        );
+                    }),
+                );
 
-            // Page render failures; any AI-augmentation failure was already
-            // appended to the page above.
-            const partialFailures = page?.failures ?? [];
+                // Page render failures; any AI-augmentation failure was already
+                // appended to the page above.
+                const partialFailures = page?.failures ?? [];
 
-            await this.schedulerService.logSchedulerJob({
-                task: SCHEDULER_TASKS.HANDLE_SCHEDULED_DELIVERY,
-                schedulerUuid,
-                jobId,
-                jobGroup: jobId,
-                scheduledTime,
-                status: SchedulerJobStatus.COMPLETED,
-                details: {
-                    projectUuid: schedulerPayload.projectUuid,
-                    organizationUuid: schedulerPayload.organizationUuid,
-                    createdByUserUuid: schedulerPayload.userUuid,
-                    ...(partialFailures.length > 0 && { partialFailures }),
-                },
-            });
-
-            this.analytics.track({
-                event: 'scheduler_job.completed',
-                anonymousId: LightdashAnalytics.anonymousId,
-                userId: schedulerPayload.userUuid,
-                properties: {
+                await this.schedulerService.logSchedulerJob({
+                    task: SCHEDULER_TASKS.HANDLE_SCHEDULED_DELIVERY,
+                    schedulerUuid,
                     jobId,
-                    organizationId: schedulerPayload.organizationUuid,
-                    projectId: schedulerPayload.projectUuid,
-                    schedulerId: schedulerUuid,
-                    groupId: jobId,
-                    isThresholdAlert: scheduler.thresholds !== undefined,
-                    hasPartialFailures:
-                        partialFailures && partialFailures.length > 0,
-                    partialFailuresCount: partialFailures?.length ?? 0,
-                },
-            });
+                    jobGroup: jobId,
+                    scheduledTime,
+                    status: SchedulerJobStatus.COMPLETED,
+                    details: {
+                        projectUuid: schedulerPayload.projectUuid,
+                        organizationUuid: schedulerPayload.organizationUuid,
+                        createdByUserUuid: schedulerPayload.userUuid,
+                        ...(partialFailures.length > 0 && { partialFailures }),
+                    },
+                });
+
+                this.analytics.track({
+                    event: 'scheduler_job.completed',
+                    anonymousId: LightdashAnalytics.anonymousId,
+                    userId: schedulerPayload.userUuid,
+                    properties: {
+                        jobId,
+                        organizationId: schedulerPayload.organizationUuid,
+                        projectId: schedulerPayload.projectUuid,
+                        schedulerId: schedulerUuid,
+                        groupId: jobId,
+                        isThresholdAlert: scheduler.thresholds !== undefined,
+                        hasPartialFailures:
+                            partialFailures && partialFailures.length > 0,
+                        partialFailuresCount: partialFailures?.length ?? 0,
+                    },
+                });
+            } catch (tailError) {
+                Logger.error(
+                    `Scheduled delivery ${jobId} was delivered but its completion bookkeeping failed: ${getErrorMessage(
+                        tailError,
+                    )}`,
+                );
+            }
         } catch (e) {
             this.analytics.track({
                 event: 'scheduler_job.failed',


### PR DESCRIPTION
Closes:

### Description:

App deliveries render through the headless browser (similar to dashboard image jobs), so they now receive the same increased retry budget (`maxAttempts + 1`) to handle transient headless browser failures.

To prevent the retry budget from causing duplicate deliveries, the post-enqueue bookkeeping phase (logging scheduled targets, writing the completion status, and firing the `scheduler_job.completed` analytics event) is now wrapped in a `try/catch`. If any of those steps fail after notification jobs have already been queued, the error is logged but not rethrown — ensuring the retry mechanism cannot trigger a second round of sends.

Relates: PROD-9383
