### PR TITLE
fix(unfurl): pass session budget timeout to browserless to outlast the ready-wait

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.test.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.test.ts
@@ -482,6 +482,7 @@ describe('UnfurlService', () => {
                 headlessBrowser: {
                     host: 'headless-browser',
                     browserEndpoint: 'ws://headless-browser:3000',
+                    screenshotTimeoutMs: 180_000,
                 },
             });
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -538,6 +539,26 @@ describe('UnfurlService', () => {
             );
             expect(browser.newPage).toHaveBeenCalledWith(
                 expect.objectContaining({ serviceWorkers: 'block' }),
+            );
+        });
+
+        // The browserless session budget has to outlast the ready-wait, or the
+        // container's own TIMEOUT kills the session mid-capture.
+        it('asks browserless for a session budget covering the ready-wait', async () => {
+            const { service, page } = setup();
+            page.evaluate.mockResolvedValue(validManifest);
+
+            await service.captureAppDeliveryManifest({
+                url: APP_URL,
+                authUserUuid: 'user-uuid-1',
+            });
+
+            const [endpoint] =
+                playwrightMocks.connectOverCDP.mock.calls[
+                    playwrightMocks.connectOverCDP.mock.calls.length - 1
+                ];
+            expect(new URL(endpoint).searchParams.get('timeout')).toBe(
+                '210000',
             );
         });
 

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -249,14 +249,22 @@ const getBackoffDelay = (retryCount: number, baseDelayMs: number): number => {
     return Math.round(exponentialDelay + jitter);
 };
 
+// Headroom over the screenshot timeout for goto + evaluate around the wait, so
+// the requested session budget always outlives the work.
+const BROWSERLESS_SESSION_BUFFER_MS = 30_000;
+
 // Browserless honours the window size only through launch args, not the
-// Playwright viewport, and app iframes size themselves to the window.
+// Playwright viewport, and app iframes size themselves to the window. The
+// explicit `timeout` overrides the container's TIMEOUT config, which otherwise
+// can kill the session before the app's ready indicator appears.
 const getAppBrowserEndpoint = (
     browserEndpoint: string,
     size: { width: number; height: number },
+    timeoutMs: number,
     internalHost?: string,
 ): string => {
     const endpoint = new URL(browserEndpoint);
+    endpoint.searchParams.set('timeout', String(timeoutMs));
     const args = [`--window-size=${size.width},${size.height}`];
     // App bundles call secure-context APIs (crypto.randomUUID in the SDK
     // transport), which a plain-http internal host silently breaks.
@@ -1354,6 +1362,8 @@ export class UnfurlService extends BaseService {
                             ? getAppBrowserEndpoint(
                                   browserEndpoint,
                                   initialViewport,
+                                  this.screenshotTimeoutMs +
+                                      BROWSERLESS_SESSION_BUFFER_MS,
                                   this.lightdashConfig.headlessBrowser
                                       .internalLightdashHost,
                               )
@@ -2429,6 +2439,7 @@ export class UnfurlService extends BaseService {
                 getAppBrowserEndpoint(
                     this.lightdashConfig.headlessBrowser.browserEndpoint,
                     appViewport,
+                    this.screenshotTimeoutMs + BROWSERLESS_SESSION_BUFFER_MS,
                     this.lightdashConfig.headlessBrowser.internalLightdashHost,
                 ),
                 { timeout: 1000 * 60 * 30 },


### PR DESCRIPTION
Closes:

### Description:

When capturing app screenshots via Browserless, the container's own `TIMEOUT` setting could kill the session before the app's ready indicator appeared, causing mid-capture failures. This fix passes an explicit `timeout` query parameter to the Browserless endpoint, calculated as the screenshot timeout plus a 30-second buffer (`BROWSERLESS_SESSION_BUFFER_MS`). This ensures the requested session budget always outlasts the full capture lifecycle, including the `goto` and `evaluate` calls around the ready-wait.

A test has been added to verify that the `timeout` parameter passed to Browserless correctly reflects the screenshot timeout plus the buffer (e.g. `180000 + 30000 = 210000`).

Relates: PROD-9383
