### PR TITLE
fix(query-sdk): fall back to local id generation when `crypto.randomUUID` is unavailable

### DIFF
--- a/packages/query-sdk/src/postMessageTransport.test.ts
+++ b/packages/query-sdk/src/postMessageTransport.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createRequestId } from './postMessageTransport';
+
+describe('createRequestId', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('uses crypto.randomUUID when available', () => {
+        vi.stubGlobal('crypto', { randomUUID: () => 'uuid-from-crypto' });
+
+        expect(createRequestId()).toBe('uuid-from-crypto');
+    });
+
+    // Apps served from a plain-http origin (self-hosted, headless capture) have
+    // no secure context, so `crypto.randomUUID` is undefined there.
+    it('falls back to a locally generated id when randomUUID is missing', () => {
+        vi.stubGlobal('crypto', {});
+
+        const first = createRequestId();
+        const second = createRequestId();
+
+        expect(first).toEqual(expect.any(String));
+        expect(first.length).toBeGreaterThan(0);
+        expect(second).not.toBe(first);
+    });
+
+    it('falls back when crypto itself is undefined', () => {
+        vi.stubGlobal('crypto', undefined);
+
+        expect(createRequestId()).toEqual(expect.any(String));
+    });
+});

--- a/packages/query-sdk/src/postMessageTransport.ts
+++ b/packages/query-sdk/src/postMessageTransport.ts
@@ -143,6 +143,15 @@ const DEFAULT_TIMEOUT_MS = 120_000;
 const READY_TIMEOUT_MS = 10_000;
 
 /**
+ * `crypto.randomUUID` is secure-context only, so it's missing when the app is
+ * served over plain http. Ids only need to be unique within one page session.
+ */
+export const createRequestId = (): string =>
+    typeof crypto !== 'undefined' && 'randomUUID' in crypto
+        ? crypto.randomUUID()
+        : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+/**
  * Creates a FetchAdapter that sends HTTP requests to the parent window
  * via postMessage and waits for responses.
  */
@@ -201,7 +210,7 @@ function createPostMessageFetchAdapter(config: {
     ): Promise<T> => {
         await readyPromise;
 
-        const id = crypto.randomUUID();
+        const id = createRequestId();
 
         return new Promise<T>((resolve, reject) => {
             const timer = setTimeout(() => {
@@ -309,7 +318,7 @@ function createPostMessageExternalFetch(config: {
     ): Promise<ExternalFetchResult> => {
         await readyPromise;
 
-        const id = crypto.randomUUID();
+        const id = createRequestId();
 
         return new Promise<ExternalFetchResult>((resolve, reject) => {
             const timer = setTimeout(() => {


### PR DESCRIPTION
Closes:

### Description:

`crypto.randomUUID` is only available in secure contexts (HTTPS), meaning it is `undefined` when the app is served over plain HTTP (e.g. self-hosted or headless capture environments). This caused a runtime error when generating request IDs in the postMessage transport.

A `createRequestId` helper has been introduced that falls back to a locally generated ID using `Date.now()` and `Math.random()` when `crypto.randomUUID` is unavailable or when `crypto` itself is undefined. Since IDs only need to be unique within a single page session, this fallback is sufficient.

Tests cover all three cases: `crypto.randomUUID` available, `crypto` present but without `randomUUID`, and `crypto` entirely undefined.

Relates: PROD-9383
