### PR TITLE
feat(data-apps): track app delivery capture metrics on `scheduler_job.completed`

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1557,6 +1557,14 @@ export type SchedulerJobEvent = BaseTrack & {
         sendNow?: boolean;
         isThresholdAlert?: boolean;
         error?: string;
+        // App csv/xlsx deliveries only: shape of what the capture render
+        // produced and how much of it reached recipients.
+        capturedQueryCount?: number;
+        deliveredFileCount?: number;
+        renderFailureCount?: number;
+        downloadFailureCount?: number;
+        noticeCount?: number;
+        captureOverflow?: boolean;
     };
 };
 

--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -26,6 +26,7 @@ import {
     type UploadGsheetPayload,
 } from '@lightdash/common';
 import ExecutionContext from 'node-execution-context';
+import type { Mock } from 'vitest';
 import type { ExecutionContextInfo } from '../logging/winston';
 import SchedulerTask, {
     buildItemMapFromColumns,
@@ -1705,11 +1706,16 @@ describe('captureAppDeliveryQueries', () => {
 });
 
 describe('handleScheduledDelivery — app delivery capture', () => {
-    const setup = () => {
-        const captureAppDeliveryManifest = vi
-            .fn()
-            .mockResolvedValue(manifestOf([readyItem()]));
+    const setup = ({
+        manifest = manifestOf([readyItem()]),
+        page,
+    }: {
+        manifest?: DeliveryCaptureManifest;
+        page?: Partial<PageData>;
+    } = {}) => {
+        const captureAppDeliveryManifest = vi.fn().mockResolvedValue(manifest);
         const generateJobsForSchedulerTargets = vi.fn().mockResolvedValue([]);
+        const track = vi.fn();
         const task = makeTaskWithDeps({
             lightdashConfig: asDep<'lightdashConfig'>({
                 siteUrl: 'https://lightdash.example.com',
@@ -1740,7 +1746,7 @@ describe('handleScheduledDelivery — app delivery capture', () => {
                     organization: { organizationUuid: 'org-1' },
                 }),
             }),
-            analytics: asDep<'analytics'>({ track: vi.fn() }),
+            analytics: asDep<'analytics'>({ track }),
             schedulerClient: asDep<'schedulerClient'>({
                 generateJobsForSchedulerTargets,
             }),
@@ -1754,6 +1760,7 @@ describe('handleScheduledDelivery — app delivery capture', () => {
             pageType: 'app',
             organizationUuid: 'org-1',
             csvUrls: [],
+            ...page,
         });
         (task as unknown as Record<string, unknown>).getNotificationPageData =
             getNotificationPageData;
@@ -1762,6 +1769,7 @@ describe('handleScheduledDelivery — app delivery capture', () => {
             captureAppDeliveryManifest,
             getNotificationPageData,
             generateJobsForSchedulerTargets,
+            track,
         };
     };
 
@@ -1908,6 +1916,86 @@ describe('handleScheduledDelivery — app delivery capture', () => {
         );
 
         expect(captureAppDeliveryManifest).not.toHaveBeenCalled();
+    });
+
+    const completedEvent = (track: Mock) =>
+        track.mock.calls
+            .map(([event]) => event)
+            .find(
+                (event: { event: string }) =>
+                    event.event === 'scheduler_job.completed',
+            );
+
+    it('describes the app delivery payload on the completed event', async () => {
+        const { task, track } = setup({
+            manifest: manifestOf(
+                [readyItem(), readyItem({ order: 1 }), errorItem()],
+                2,
+            ),
+            page: {
+                csvUrls: [
+                    {
+                        filename: 'csv-Revenue.csv',
+                        path: 'https://files.example.com/revenue.csv',
+                        localPath: 'https://files.example.com/revenue.csv',
+                        chartName: 'Revenue',
+                        truncated: false,
+                    },
+                ],
+                failures: [
+                    {
+                        type: PartialFailureType.APP_QUERY,
+                        stage: 'render',
+                        captureKey: 'v1:key-err',
+                        label: 'Broken query',
+                        error: 'Query timed out',
+                    },
+                    {
+                        type: PartialFailureType.APP_QUERY,
+                        stage: 'download',
+                        captureKey: 'v1:key-1',
+                        label: 'Orders',
+                        error: 'storage unavailable',
+                    },
+                ],
+                notices: [
+                    {
+                        type: 'limit_reached',
+                        label: 'Sessions',
+                        rowCount: 5000,
+                    },
+                ],
+            },
+        });
+
+        await run(task, appScheduler({ targets: [{ recipient: 'a@b.com' }] }));
+
+        expect(completedEvent(track).properties).toMatchObject({
+            capturedQueryCount: 3,
+            deliveredFileCount: 1,
+            renderFailureCount: 1,
+            downloadFailureCount: 1,
+            noticeCount: 1,
+            captureOverflow: true,
+        });
+    });
+
+    it('omits the app delivery counts for a non-app delivery', async () => {
+        const { task, track } = setup();
+
+        await run(
+            task,
+            appScheduler({
+                appUuid: null,
+                appName: null,
+                dashboardUuid: 'dashboard-1',
+                targets: [{ recipient: 'a@b.com' }],
+            }),
+        );
+
+        expect(completedEvent(track).properties).not.toHaveProperty(
+            'capturedQueryCount',
+        );
     });
 });
 

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -4616,6 +4616,7 @@ export default class SchedulerTask {
 
             let page: NotificationPayloadBase['page'] | undefined;
             let deliveryQueries: SchedulerDeliveryQuery[] | undefined;
+            let appCaptureManifest: DeliveryCaptureManifest | undefined;
             let perChannelPages:
                 | {
                       email?: NotificationPayloadBase['page'];
@@ -4692,7 +4693,7 @@ export default class SchedulerTask {
 
                 // Captured once: the fan-out builds a page per distinct expiry,
                 // and a second render would hand recipients different data.
-                const appCaptureManifest =
+                appCaptureManifest =
                     isAppCreateScheduler(scheduler) &&
                     (scheduler.format === SchedulerFormat.CSV ||
                         scheduler.format === SchedulerFormat.XLSX)
@@ -4869,6 +4870,24 @@ export default class SchedulerTask {
                     },
                 });
 
+                // App deliveries: how much of the captured render actually shipped.
+                const appQueryFailures = (stage: 'render' | 'download') =>
+                    partialFailures.filter(
+                        (failure) =>
+                            failure.type === PartialFailureType.APP_QUERY &&
+                            failure.stage === stage,
+                    ).length;
+                const appDeliveryProperties = appCaptureManifest
+                    ? {
+                          capturedQueryCount: appCaptureManifest.items.length,
+                          deliveredFileCount: page?.csvUrls?.length ?? 0,
+                          renderFailureCount: appQueryFailures('render'),
+                          downloadFailureCount: appQueryFailures('download'),
+                          noticeCount: page?.notices?.length ?? 0,
+                          captureOverflow: appCaptureManifest.overflowCount > 0,
+                      }
+                    : {};
+
                 this.analytics.track({
                     event: 'scheduler_job.completed',
                     anonymousId: LightdashAnalytics.anonymousId,
@@ -4883,6 +4902,7 @@ export default class SchedulerTask {
                         hasPartialFailures:
                             partialFailures && partialFailures.length > 0,
                         partialFailuresCount: partialFailures?.length ?? 0,
+                        ...appDeliveryProperties,
                     },
                 });
             } catch (tailError) {


### PR DESCRIPTION
Closes:

### Description:

When a `scheduler_job.completed` analytics event is emitted for an app CSV/XLSX delivery, additional properties are now included to describe the shape of the capture render and how much of it reached recipients:

- `capturedQueryCount` — total number of queries in the capture manifest
- `deliveredFileCount` — number of files successfully delivered
- `renderFailureCount` — number of queries that failed during the render stage
- `downloadFailureCount` — number of queries that failed during the download stage
- `noticeCount` — number of notices (e.g. row limit warnings) attached to the delivery
- `captureOverflow` — whether the capture manifest had overflow items

These properties are only included for app deliveries; non-app deliveries leave them absent from the event. Tests cover both cases.

Relates: PROD-9383
