### PR TITLE
fix(data-apps): use "queries in this app" headline for app CSV email deliveries

### DIFF
--- a/packages/backend/src/clients/EmailClient/EmailClient.test.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.test.ts
@@ -217,6 +217,69 @@ describe('EmailClient', () => {
             ]);
         });
 
+        test('should headline app deliveries with queries rather than dashboard charts', async () => {
+            const client = new EmailClient({
+                lightdashConfig: lightdashConfigWithBasicSMTP,
+            });
+            const attachments = [
+                {
+                    path: 'https://example.com/file.csv',
+                    filename: 'file.csv',
+                    localPath: '',
+                    truncated: false,
+                },
+            ];
+            const headlineOf = (callIndex: number) =>
+                (
+                    vi.mocked(client.transporter!.sendMail).mock.calls[
+                        callIndex
+                    ][0] as unknown as {
+                        context: { resultsHeadline: string };
+                    }
+                ).context.resultsHeadline;
+
+            await client.sendDashboardCsvNotificationEmail(
+                'recipient@example.com',
+                'subject',
+                'title',
+                'description',
+                undefined,
+                'date',
+                'frequency',
+                attachments,
+                'https://example.com/app',
+                'https://example.com/scheduler',
+                true,
+                7,
+                false,
+                SchedulerFormat.CSV,
+                undefined,
+                undefined,
+                undefined,
+                true,
+            );
+            await client.sendDashboardCsvNotificationEmail(
+                'recipient@example.com',
+                'subject',
+                'title',
+                'description',
+                undefined,
+                'date',
+                'frequency',
+                attachments,
+                'https://example.com/dashboard',
+                'https://example.com/scheduler',
+                true,
+            );
+
+            expect(headlineOf(0)).toBe(
+                'The latest results for the queries in this app are ready to download!',
+            );
+            expect(headlineOf(1)).toBe(
+                'The latest results for the charts in this dashboard are ready to download!',
+            );
+        });
+
         test('should not flag notices when an app delivery had none', async () => {
             const client = new EmailClient({
                 lightdashConfig: lightdashConfigWithBasicSMTP,

--- a/packages/backend/src/clients/EmailClient/EmailClient.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.ts
@@ -867,6 +867,7 @@ export default class EmailClient {
         failures?: PartialFailure[],
         notices?: DeliveryNotice[],
         sender?: EmailSenderIdentity | null,
+        isApp: boolean = false,
     ) {
         const csvUrls = attachments.filter(
             (attachment) => !attachment.truncated,
@@ -899,6 +900,9 @@ export default class EmailClient {
             context: {
                 title,
                 description,
+                resultsHeadline: isApp
+                    ? 'The latest results for the queries in this app are ready to download!'
+                    : 'The latest results for the charts in this dashboard are ready to download!',
                 hasMessage: !!message,
                 message: message && sanitizeHtml(marked(message)),
                 date,

--- a/packages/backend/src/clients/EmailClient/templates/dashboardCsvNotification.html
+++ b/packages/backend/src/clients/EmailClient/templates/dashboardCsvNotification.html
@@ -1010,19 +1010,7 @@
                                                                                                                                 mso-text-raise: 1px;
                                                                                                                             "
                                                                                                                         >
-                                                                                                                            The
-                                                                                                                            latest
-                                                                                                                            results
-                                                                                                                            for
-                                                                                                                            the
-                                                                                                                            charts
-                                                                                                                            in
-                                                                                                                            this
-                                                                                                                            dashboard
-                                                                                                                            are
-                                                                                                                            ready
-                                                                                                                            to
-                                                                                                                            download!
+                                                                                                                            {{resultsHeadline}}
                                                                                                                         </h1>
                                                                                                                     </td>
                                                                                                                 </tr>

--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -2124,6 +2124,8 @@ describe('app delivery target senders', () => {
         expect(args[7]).toEqual(page.csvUrls);
         expect(args[14]).toEqual(page.failures);
         expect(args[15]).toEqual(page.notices);
+        // isApp — drives the app-aware headline in the template.
+        expect(args[17]).toBe(true);
     });
 
     it('posts an app xlsx delivery to the MS Teams webhook', async () => {

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -3491,6 +3491,7 @@ export default class SchedulerTask {
                     failures,
                     notices,
                     senderIdentity,
+                    !!appUuid,
                 );
             } else {
                 throw new Error('Not implemented');


### PR DESCRIPTION
Closes:

### Description:

When sending dashboard CSV notification emails for **app deliveries**, the headline in the email template previously always read *"The latest results for the charts in this dashboard are ready to download!"* — even when the delivery originated from an app (which contains queries, not dashboard charts).

This change introduces an `isApp` flag to `sendDashboardCsvNotificationEmail` that controls a `resultsHeadline` template variable, allowing the email to display context-appropriate copy:

- **App deliveries:** *"The latest results for the queries in this app are ready to download!"*
- **Dashboard deliveries:** *"The latest results for the charts in this dashboard are ready to download!"*

The flag is derived from the presence of `appUuid` in the scheduler task and is passed through to the email client accordingly.

Relates: PROD-9383
