### PR TITLE
fix(data-apps): show query name instead of timestamped filename in CSV delivery notifications

### DIFF
--- a/packages/backend/src/clients/EmailClient/EmailClient.test.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.test.ts
@@ -217,6 +217,57 @@ describe('EmailClient', () => {
             ]);
         });
 
+        test('should show the query name rather than the download filename when present', async () => {
+            const client = new EmailClient({
+                lightdashConfig: lightdashConfigWithBasicSMTP,
+            });
+
+            await client.sendDashboardCsvNotificationEmail(
+                'recipient@example.com',
+                'subject',
+                'title',
+                'description',
+                undefined,
+                'date',
+                'frequency',
+                [
+                    {
+                        path: 'https://example.com/revenue.csv',
+                        filename: 'csv-Revenue by region-2026-08-04.csv',
+                        chartName: 'Revenue by region',
+                        localPath: '',
+                        truncated: false,
+                    },
+                    {
+                        path: 'https://example.com/plain.csv',
+                        filename: 'plain.csv',
+                        localPath: '',
+                        truncated: false,
+                    },
+                ],
+                'https://example.com/app',
+                'https://example.com/scheduler',
+                true,
+            );
+
+            const sentContext = (
+                vi.mocked(client.transporter!.sendMail).mock
+                    .calls[0][0] as unknown as {
+                    context: {
+                        csvUrls: { displayName: string; filename: string }[];
+                    };
+                }
+            ).context;
+
+            expect(sentContext.csvUrls.map((file) => file.displayName)).toEqual(
+                ['Revenue by region', 'plain.csv'],
+            );
+            // The download name itself is untouched.
+            expect(sentContext.csvUrls[0].filename).toBe(
+                'csv-Revenue by region-2026-08-04.csv',
+            );
+        });
+
         test('should headline app deliveries with queries rather than dashboard charts', async () => {
             const client = new EmailClient({
                 lightdashConfig: lightdashConfigWithBasicSMTP,

--- a/packages/backend/src/clients/EmailClient/EmailClient.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.ts
@@ -78,6 +78,8 @@ export const SMTP_CONNECTION_CONFIG = {
 export type AttachmentUrl = {
     path: string;
     filename: string;
+    /** Clean label shown to recipients (app deliveries); filename stays the download name. */
+    chartName?: string;
     localPath: string;
     truncated: boolean;
 };
@@ -869,13 +871,20 @@ export default class EmailClient {
         sender?: EmailSenderIdentity | null,
         isApp: boolean = false,
     ) {
-        const csvUrls = attachments.filter(
-            (attachment) => !attachment.truncated,
-        );
+        // App deliveries carry the query label; dashboards fall back to the
+        // (timestamped) download filename.
+        const withDisplayName = (attachment: AttachmentUrl) => ({
+            ...attachment,
+            displayName: attachment.chartName ?? attachment.filename,
+        });
 
-        const truncatedCsvUrls = attachments.filter(
-            (attachment) => attachment.truncated,
-        );
+        const csvUrls = attachments
+            .filter((attachment) => !attachment.truncated)
+            .map(withDisplayName);
+
+        const truncatedCsvUrls = attachments
+            .filter((attachment) => attachment.truncated)
+            .map(withDisplayName);
 
         const emailAttachments = asAttachment
             ? csvUrls

--- a/packages/backend/src/clients/EmailClient/templates/dashboardCsvNotification.html
+++ b/packages/backend/src/clients/EmailClient/templates/dashboardCsvNotification.html
@@ -1095,7 +1095,7 @@
                                                                                                                                 mso-text-raise: 6px;
                                                                                                                             "
                                                                                                                             target="_blank"
-                                                                                                                            >{{filename}}</a
+                                                                                                                            >{{displayName}}</a
                                                                                                                         >
                                                                                                                     </td>
                                                                                                                 </tr>
@@ -1465,7 +1465,7 @@
                                                                                                                                 mso-text-raise: 6px;
                                                                                                                             "
                                                                                                                             target="_blank"
-                                                                                                                            >{{filename}}</a
+                                                                                                                            >{{displayName}}</a
                                                                                                                         >
                                                                                                                     </td>
                                                                                                                 </tr>

--- a/packages/backend/src/clients/Slack/SlackMessageBlocks.test.ts
+++ b/packages/backend/src/clients/Slack/SlackMessageBlocks.test.ts
@@ -478,6 +478,47 @@ describe('SlackMessageBlocks', () => {
             },
         ];
 
+        // Recipients see the query label; the timestamped filename is only the
+        // download name.
+        it('labels app delivery downloads with the query name when present', () => {
+            const blocks = getDashboardCsvResultsBlocks({
+                title: 'App delivery',
+                name: 'App delivery',
+                description: 'desc',
+                ctaUrl: 'https://app.lightdash.com/apps/abc',
+                csvUrls: [
+                    {
+                        filename: 'csv-Revenue by region-2026-08-04.csv',
+                        chartName: 'Revenue by region',
+                        path: 'https://s3.example.com/exports/revenue.csv',
+                        localPath: '/tmp/revenue.csv',
+                        truncated: false,
+                    },
+                ],
+            });
+
+            const text = findBlocks(blocks, 'section')
+                .map((s) => s.text?.text ?? '')
+                .join('\n');
+            expect(text).toContain('Revenue by region');
+            expect(text).not.toContain('csv-Revenue by region-2026-08-04.csv');
+        });
+
+        it('falls back to the filename when a download has no query name', () => {
+            const blocks = getDashboardCsvResultsBlocks({
+                title: 'Dashboard delivery',
+                name: 'Dashboard delivery',
+                description: 'desc',
+                ctaUrl: 'https://app.lightdash.com/dashboard/abc',
+                csvUrls,
+            });
+
+            const text = findBlocks(blocks, 'section')
+                .map((s) => s.text?.text ?? '')
+                .join('\n');
+            expect(text).toContain('chart-0.csv');
+        });
+
         it('renders an APP_QUERY failure as "label: error" and pluralizes the headline as a query', () => {
             const failures: PartialFailure[] = [
                 {

--- a/packages/backend/src/clients/Slack/SlackMessageBlocks.ts
+++ b/packages/backend/src/clients/Slack/SlackMessageBlocks.ts
@@ -624,6 +624,11 @@ export const getDashboardCsvResultsBlocks = ({
     const safeCtaUrl = safeUrl(ctaUrl);
     const headerText = sanitizeHeaderText(title);
 
+    // App deliveries carry the query label; dashboards fall back to the
+    // (timestamped) download filename.
+    const displayName = (csvUrl: AttachmentUrl): string =>
+        csvUrl.chartName ?? csvUrl.filename;
+
     const perChartBlock = (
         csvUrl: AttachmentUrl,
         index: number,
@@ -644,7 +649,9 @@ export const getDashboardCsvResultsBlocks = ({
                 text: {
                     type: 'mrkdwn',
                     text: truncateText(
-                        `:black_small_square: ${sanitizeText(csvUrl.filename)}`,
+                        `:black_small_square: ${sanitizeText(
+                            displayName(csvUrl),
+                        )}`,
                         SLACK_LIMITS.SECTION_TEXT,
                     ),
                 },
@@ -666,7 +673,7 @@ export const getDashboardCsvResultsBlocks = ({
                 type: 'mrkdwn',
                 text: truncateText(
                     `:warning: ${sanitizeText(
-                        csvUrl.filename,
+                        displayName(csvUrl),
                     )} — download unavailable. Open in Lightdash to access this result.`,
                     SLACK_LIMITS.SECTION_TEXT,
                 ),
@@ -684,11 +691,11 @@ export const getDashboardCsvResultsBlocks = ({
     // malformed mrkdwn and re-trigger invalid_blocks).
     const COLLAPSE_TEXT_BUDGET = SLACK_LIMITS.SECTION_TEXT - 200;
     const buildCsvRow = (u: AttachmentUrl): string => {
-        const filename = sanitizeText(u.filename);
+        const label = sanitizeText(displayName(u));
         const downloadUrl = safeUrl(u.path);
         return downloadUrl
-            ? `:black_small_square: <${downloadUrl}|${filename}>`
-            : `:warning: ${filename} — download unavailable`;
+            ? `:black_small_square: <${downloadUrl}|${label}>`
+            : `:warning: ${label} — download unavailable`;
     };
     const buildCollapsedSection = (): KnownBlock => {
         const lines: string[] = [];

--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -2082,7 +2082,9 @@ describe('app delivery target senders', () => {
 
         expect(postMessage).toHaveBeenCalledTimes(1);
         const blocks = JSON.stringify(postMessage.mock.calls[0][0].blocks);
-        expect(blocks).toContain('csv-Revenue-2026-07-30.csv');
+        // Recipients see the query label, not the timestamped download name.
+        expect(blocks).toContain(':black_small_square: Revenue');
+        expect(blocks).not.toContain('csv-Revenue-2026-07-30.csv');
         expect(blocks).toContain(
             'Sessions reached its query limit; additional rows may exist (5000 rows delivered)',
         );


### PR DESCRIPTION
Closes:

### Description:

When sending CSV delivery notifications (both Slack and email), links and labels previously showed the raw timestamped download filename (e.g. `csv-Revenue by region-2026-08-04.csv`). For app deliveries, the query name is now used as the display label shown to recipients, while the underlying download filename remains unchanged. Dashboard deliveries without a query name continue to fall back to the filename as before.

A `chartName` field has been added to `AttachmentUrl` to carry the human-readable query label through to the notification templates. Both the Slack message blocks and the email HTML template now render this `displayName` (resolved as `chartName ?? filename`) in place of the raw filename.

Relates: PROD-9383
