### PR TITLE
fix(data-apps): surface limit-reached notices in Teams and Google Chat webhook deliveries

### DIFF
--- a/packages/backend/src/clients/GoogleChat/GoogleChatClient.test.ts
+++ b/packages/backend/src/clients/GoogleChat/GoogleChatClient.test.ts
@@ -50,6 +50,69 @@ describe('postCsvsWithWebhook app failure lines', () => {
         }
     };
 
+    const widgetTexts = async (
+        args: Parameters<GoogleChatClient['postCsvsWithWebhook']>[0],
+    ): Promise<string[]> => {
+        const fetchMock = vi
+            .spyOn(globalThis, 'fetch')
+            .mockResolvedValue({ ok: true, status: 200 } as Response);
+        try {
+            await client.postCsvsWithWebhook(args);
+            const [, init] = fetchMock.mock.calls[0];
+            const payload = JSON.parse(init?.body as string);
+            return payload.cardsV2[0].card.sections[0].widgets.map(
+                (widget: { textParagraph?: { text: string } }) =>
+                    widget.textParagraph?.text ?? '',
+            );
+        } finally {
+            fetchMock.mockRestore();
+        }
+    };
+
+    // Limit notices reached email and Slack but were silently dropped here.
+    it('renders limit-reached notices, stripping markup from the label', async () => {
+        const texts = await widgetTexts({
+            webhookUrl: 'https://chat.googleapis.com/v1/spaces/abc',
+            title: 'App delivery',
+            name: 'App delivery',
+            description: 'desc',
+            ctaUrl: 'https://app.lightdash.com/apps/abc',
+            csvUrls: [csvUrl],
+            footer: 'footer',
+            notices: [
+                {
+                    type: 'limit_reached',
+                    label: HOSTILE_LABEL,
+                    rowCount: 5000,
+                },
+            ],
+        });
+
+        const noticeText = texts.find((text) =>
+            text.includes('reached its query limit'),
+        );
+        expect(noticeText).toBe(
+            'ℹ️ - x reached its query limit; additional rows may exist (5000 rows delivered)',
+        );
+        expect(noticeText).not.toContain('<a href');
+    });
+
+    it('adds no notice widget when the delivery had none', async () => {
+        const texts = await widgetTexts({
+            webhookUrl: 'https://chat.googleapis.com/v1/spaces/abc',
+            title: 'App delivery',
+            name: 'App delivery',
+            description: 'desc',
+            ctaUrl: 'https://app.lightdash.com/apps/abc',
+            csvUrls: [csvUrl],
+            footer: 'footer',
+        });
+
+        expect(
+            texts.some((text) => text.includes('reached its query limit')),
+        ).toBe(false);
+    });
+
     it.each([
         ['the warning branch', [csvUrl]],
         ['the all-failed branch', [] as AttachmentUrl[]],

--- a/packages/backend/src/clients/GoogleChat/GoogleChatClient.ts
+++ b/packages/backend/src/clients/GoogleChat/GoogleChatClient.ts
@@ -8,6 +8,7 @@ import {
     PartialFailureType,
     sanitizeHtml,
     ThresholdOptions,
+    type DeliveryNotice,
     type PartialFailure,
 } from '@lightdash/common';
 import Logger from '../../logging/logger';
@@ -238,6 +239,7 @@ export class GoogleChatClient {
         csvUrls,
         footer,
         failures,
+        notices,
     }: {
         webhookUrl: string;
         title: string;
@@ -247,6 +249,7 @@ export class GoogleChatClient {
         csvUrls: AttachmentUrl[];
         footer: string;
         failures?: PartialFailure[];
+        notices?: DeliveryNotice[];
     }): Promise<void> {
         Logger.info('Sending dashboard CSVs to Google Chat via webhook');
 
@@ -324,6 +327,24 @@ export class GoogleChatClient {
                     },
                 });
             }
+        }
+
+        if (notices && notices.length > 0) {
+            const noticeLines = notices
+                .map(
+                    (notice) =>
+                        `- ${stripMarkup(
+                            notice.label,
+                        )} reached its query limit; additional rows may exist (${
+                            notice.rowCount
+                        } rows delivered)`,
+                )
+                .join('\n');
+            widgets.push({
+                textParagraph: {
+                    text: `ℹ️ ${noticeLines}`,
+                },
+            });
         }
 
         widgets.push({

--- a/packages/backend/src/clients/MicrosoftTeams/MicrosoftTeamsClient.test.ts
+++ b/packages/backend/src/clients/MicrosoftTeams/MicrosoftTeamsClient.test.ts
@@ -124,6 +124,92 @@ describe('postCsvsWithWebhook app failure lines', () => {
         expect(text).toContain('evil');
     };
 
+    const cardTextBlocks = async (
+        args: Parameters<MicrosoftTeamsClient['postCsvsWithWebhook']>[0],
+    ): Promise<string[]> => {
+        const fetchMock = vi
+            .spyOn(globalThis, 'fetch')
+            .mockResolvedValue({ ok: true, status: 200 } as Response);
+        try {
+            await client.postCsvsWithWebhook(args);
+            const [, init] = fetchMock.mock.calls[0];
+            const payload = JSON.parse(init?.body as string);
+            return payload.attachments[0].content.body.map(
+                (block: { text?: string }) => block.text ?? '',
+            );
+        } finally {
+            fetchMock.mockRestore();
+        }
+    };
+
+    // Limit notices reached email and Slack but were silently dropped here.
+    it('renders limit-reached notices, escaping the label', async () => {
+        const texts = await cardTextBlocks({
+            webhookUrl: 'https://outlook.office.com/webhook/abc',
+            title: 'App delivery',
+            name: 'App delivery',
+            description: 'desc',
+            ctaUrl: 'https://app.lightdash.com/apps/abc',
+            csvUrls: [csvUrl],
+            footer: 'footer',
+            notices: [
+                { type: 'limit_reached', label: 'Sessions', rowCount: 5000 },
+            ],
+        });
+
+        expect(
+            texts.find((text) => text.includes('reached its query limit')),
+        ).toBe(
+            'ℹ️ Sessions reached its query limit; additional rows may exist (5000 rows delivered)',
+        );
+    });
+
+    // Notice labels are app-authored like the failure labels, so they must go
+    // through the same escaping.
+    it('escapes hostile markup in a notice label', async () => {
+        const texts = await cardTextBlocks({
+            webhookUrl: 'https://outlook.office.com/webhook/abc',
+            title: 'App delivery',
+            name: 'App delivery',
+            description: 'desc',
+            ctaUrl: 'https://app.lightdash.com/apps/abc',
+            csvUrls: [csvUrl],
+            footer: 'footer',
+            notices: [
+                {
+                    type: 'limit_reached',
+                    label: HOSTILE_LABEL,
+                    rowCount: 5000,
+                },
+            ],
+        });
+
+        const noticeText = texts.find((text) =>
+            text.includes('reached its query limit'),
+        );
+        expect(noticeText).toBeDefined();
+        expect(noticeText).not.toContain('[x](https://evil)');
+        expect(noticeText).not.toContain('<a href');
+        // Escaped, not dropped.
+        expect(noticeText).toContain('evil');
+    });
+
+    it('adds no notice block when the delivery had none', async () => {
+        const texts = await cardTextBlocks({
+            webhookUrl: 'https://outlook.office.com/webhook/abc',
+            title: 'App delivery',
+            name: 'App delivery',
+            description: 'desc',
+            ctaUrl: 'https://app.lightdash.com/apps/abc',
+            csvUrls: [csvUrl],
+            footer: 'footer',
+        });
+
+        expect(
+            texts.some((text) => text.includes('reached its query limit')),
+        ).toBe(false);
+    });
+
     it.each([
         ['the warning switch', [csvUrl]],
         ['the all-failed switch', [] as AttachmentUrl[]],

--- a/packages/backend/src/clients/MicrosoftTeams/MicrosoftTeamsClient.ts
+++ b/packages/backend/src/clients/MicrosoftTeams/MicrosoftTeamsClient.ts
@@ -9,6 +9,7 @@ import {
     PartialFailureType,
     sanitizeHtml,
     ThresholdOptions,
+    type DeliveryNotice,
     type PartialFailure,
 } from '@lightdash/common';
 import { createHash } from 'crypto';
@@ -330,6 +331,7 @@ export class MicrosoftTeamsClient {
         csvUrls,
         footer,
         failures,
+        notices,
     }: {
         webhookUrl: string;
         title: string;
@@ -339,6 +341,7 @@ export class MicrosoftTeamsClient {
         csvUrls: AttachmentUrl[];
         footer: string;
         failures?: PartialFailure[];
+        notices?: DeliveryNotice[];
     }): Promise<void> {
         if (!this.lightdashConfig.microsoftTeams.enabled) {
             throw new MissingConfigError('Microsoft Teams is not enabled');
@@ -525,6 +528,21 @@ export class MicrosoftTeamsClient {
             ];
         };
 
+        const getNoticeBlocks = (): {
+            type: string;
+            text: string;
+            wrap: boolean;
+        }[] =>
+            (notices ?? []).map((notice) => ({
+                type: 'TextBlock',
+                text: `ℹ️ ${stripMarkup(
+                    notice.label,
+                )} reached its query limit; additional rows may exist (${
+                    notice.rowCount
+                } rows delivered)`,
+                wrap: true,
+            }));
+
         // https://adaptivecards.io/explorer/
         const payload = {
             type: 'message',
@@ -575,6 +593,7 @@ export class MicrosoftTeamsClient {
                                   ]
                                 : []),
                             ...getFailureBlocks(),
+                            ...getNoticeBlocks(),
                             {
                                 type: 'TextBlock',
                                 text: footer,

--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -2164,6 +2164,7 @@ describe('app delivery target senders', () => {
             webhookUrl: 'https://webhook.example.com/teams',
             csvUrls: page.csvUrls,
             failures: page.failures,
+            notices: page.notices,
         });
     });
 

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -2186,6 +2186,7 @@ export default class SchedulerTask {
                 pdfFile,
                 pdfPageCount,
                 failures,
+                notices,
             } = notificationPageData;
 
             const schedulerType =
@@ -2261,6 +2262,7 @@ export default class SchedulerTask {
                         ...getBlocksArgs,
                         csvUrls,
                         failures,
+                        notices,
                     });
                 } else {
                     throw new UnexpectedServerError('Not implemented');
@@ -6803,6 +6805,7 @@ export default class SchedulerTask {
                 pdfFile,
                 pdfPageCount,
                 failures,
+                notices,
             } = notificationPageData;
 
             const schedulerType =
@@ -6878,6 +6881,7 @@ export default class SchedulerTask {
                         ...getBlocksArgs,
                         csvUrls,
                         failures,
+                        notices,
                     });
                 } else {
                     throw new UnexpectedServerError('Not implemented');


### PR DESCRIPTION
Closes: <!-- reference the related issue e.g. #150 -->

### Description:

`DeliveryNotice` (limit-reached) information was already being surfaced in email and Slack notifications, but was silently dropped when sending to Google Chat and Microsoft Teams webhooks. This adds notice rendering to both clients so that recipients are informed when a chart or dashboard has hit its query row limit.

For Google Chat, notices are appended as a single `textParagraph` widget with HTML markup stripped from the label. For Microsoft Teams, each notice becomes a `TextBlock` in the Adaptive Card body, also with markup stripped to prevent injection. The `notices` field is now forwarded through `SchedulerTask` to both webhook senders.

Tests cover:
- Correct rendering of the notice text including row count
- Stripping/escaping of hostile markup in notice labels (e.g. markdown links and raw HTML anchor tags)
- No notice block/widget being added when there are no notices

Relates: PROD-9383
