### PR TITLE
fix(scheduler): show headless browser hint for disabled image option in apps

### DIFF
--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.test.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.test.tsx
@@ -20,10 +20,14 @@ import { SchedulerDataFormatSection } from './SchedulerDataFormatSection';
 
 type SchedulerForm = ReturnType<typeof useSchedulerForm>;
 
+const health = vi.hoisted(() => ({
+    hasHeadlessBrowser: true,
+}));
+
 vi.mock('../../../../../hooks/health/useHealth', () => ({
     default: vi.fn(() => ({
         data: {
-            hasHeadlessBrowser: true,
+            hasHeadlessBrowser: health.hasHeadlessBrowser,
             query: { csvCellsLimit: 100000 },
         },
     })),
@@ -92,6 +96,29 @@ const savedCsvAppScheduler: SchedulerAndTargets = {
 } as AppScheduler & { targets: [] };
 
 describe('SchedulerDataFormatSection - app formats', () => {
+    afterEach(() => {
+        health.hasHeadlessBrowser = true;
+    });
+
+    // The Image segment is greyed out for apps too, so the hint that explains
+    // why has to show there as well.
+    it.each([true, false])(
+        'explains the disabled image option when the headless browser is off (isApp: %s)',
+        (isApp) => {
+            health.hasHeadlessBrowser = false;
+            renderSection({
+                isApp,
+                appUuid: isApp ? 'app-uuid' : undefined,
+                capturedQueryCount: 3,
+            });
+
+            expect(screen.getByRole('radio', { name: 'Image' })).toBeDisabled();
+            expect(
+                screen.getByRole('link', { name: 'headless browser' }),
+            ).toBeInTheDocument();
+        },
+    );
+
     it('shows csv/xlsx/image (no PDF) and the query-count caption when the app has captured queries', () => {
         renderSection({ capturedQueryCount: 3 });
 

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.tsx
@@ -186,7 +186,7 @@ export const SchedulerDataFormatSection: FC<Props> = ({
                         {appQueryCountCaption}
                     </Text>
                 )}
-                {isImageDisabled && !isApp && (
+                {isImageDisabled && (
                     <Text size="xs" c="ldGray.6">
                         You must enable the
                         <Anchor href="https://docs.lightdash.com/self-host/customize-deployment/enable-headless-browser-for-lightdash">


### PR DESCRIPTION
Closes:

### Description:

The "headless browser" hint explaining why the Image option is disabled was previously only shown for non-app schedulers. This fix ensures the hint is also displayed when the Image option is disabled in app schedulers, since the Image segment is greyed out in both cases.

A parameterized test has been added to verify that the disabled Image radio button and the headless browser documentation link are both present regardless of whether the scheduler is an app or not, when `hasHeadlessBrowser` is `false`.

Relates: PROD-9383
