### PR TITLE
fix(data-apps): use `resetQueries` to drop phantom rows from late in-flight terminal events on refresh/navigate

### DIFF
--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -745,7 +745,9 @@ const AppGenerate: FC = () => {
         setFileAttachments([]);
         setLocalMessages([]);
         setPin(null);
-        clearQueries();
+        // resetQueries: navigating away tears down the preview but not the
+        // parent-owned fetch/poll of an in-flight query.
+        resetQueries();
         clearExternalRequests();
         setInspectorEnabled(false);
         setInspectorAvailable(false);
@@ -768,7 +770,7 @@ const AppGenerate: FC = () => {
         );
         sentImagesByPrompt.current.clear();
         sentFilesByPrompt.current.clear();
-    }, [clearQueries, clearExternalRequests]);
+    }, [resetQueries, clearExternalRequests]);
     useEffect(() => {
         const prev = prevUrlAppUuid.current;
         prevUrlAppUuid.current = urlAppUuid;
@@ -1386,13 +1388,16 @@ const AppGenerate: FC = () => {
             interruptInFlightQueries();
             interruptInFlightRequests();
         } else {
-            clearQueries();
+            // resetQueries (not clearQueries): the reload leaves the
+            // parent-owned fetch/poll running, so a late terminal event would
+            // otherwise land as a phantom row.
+            resetQueries();
             clearExternalRequests();
         }
     }, [
         persistLogs,
         interruptInFlightQueries,
-        clearQueries,
+        resetQueries,
         interruptInFlightRequests,
         clearExternalRequests,
     ]);

--- a/packages/frontend/src/pages/AppPreviewTest.capturedQueryCount.test.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.capturedQueryCount.test.tsx
@@ -9,6 +9,7 @@ type IframePreviewProps = {
 
 type HeaderActionsProps = {
     capturedQueryCount?: number;
+    onRefresh?: () => void;
 };
 
 const mocks = vi.hoisted(() => ({
@@ -103,6 +104,26 @@ const latestHeaderActionsProps = (): HeaderActionsProps => {
     return calls[calls.length - 1][0];
 };
 
+const pendingEvent = (id: string): QueryEvent => ({
+    id,
+    timestamp: Date.now(),
+    label: null,
+    exploreName: '',
+    dimensions: [],
+    metrics: [],
+    filters: {},
+    sorts: [],
+    tableCalculations: [],
+    additionalMetrics: [],
+    limit: 0,
+    queryUuid: null,
+    status: 'pending',
+    rowCount: null,
+    durationMs: null,
+    error: null,
+    rawMetricQuery: null,
+});
+
 const readyEvent = (id: string): QueryEvent => ({
     id,
     timestamp: Date.now(),
@@ -142,6 +163,29 @@ describe('AppPreviewTest capturedQueryCount', () => {
         // remount) — the previous version's ready query must not survive.
         mocks.versionParam = '2';
         rerender(<AppPreviewTest />);
+
+        expect(latestHeaderActionsProps().capturedQueryCount).toBe(0);
+    });
+
+    // Manual refresh reloads the iframe, but the parent-owned fetch/poll of a
+    // query already in flight is not torn down — its late terminal must not
+    // land as a phantom row in the new count.
+    it('drops a late terminal event for a query in flight when the user refreshes', () => {
+        mocks.versionParam = '1';
+        renderWithProviders(<AppPreviewTest />);
+
+        act(() => {
+            latestIframeProps().onQueryEvent?.(pendingEvent('q1'));
+        });
+        expect(latestHeaderActionsProps().capturedQueryCount).toBe(0);
+
+        act(() => {
+            latestHeaderActionsProps().onRefresh?.();
+        });
+
+        act(() => {
+            latestIframeProps().onQueryEvent?.(readyEvent('q1'));
+        });
 
         expect(latestHeaderActionsProps().capturedQueryCount).toBe(0);
     });

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -116,7 +116,7 @@ export default function AppPreviewTest() {
     // clears stale entries on version navigation — this component re-renders
     // rather than remounting, so without it a previous version's queries
     // would survive and corrupt the live capturedQueryCount gate.
-    const { queries, handleQueryEvent, clearQueries } =
+    const { queries, handleQueryEvent, clearQueries, resetQueries } =
         useTrackedAppQueries(version);
     const {
         externalRequests,
@@ -133,9 +133,12 @@ export default function AppPreviewTest() {
     const handleRefresh = useCallback(() => {
         setRefreshKey((k) => k + 1);
         setInvalidateCache(true);
-        clearQueries();
+        // resetQueries (not clearQueries): the reload doesn't tear down the
+        // parent-owned fetch/poll, so an in-flight query's late terminal event
+        // would otherwise land as a phantom row.
+        resetQueries();
         clearExternalRequests();
-    }, [clearQueries, clearExternalRequests]);
+    }, [resetQueries, clearExternalRequests]);
 
     const handleToggleLineage = useCallback(() => {
         setLineageEnabled((v) => !v);


### PR DESCRIPTION
Closes:

### Description:

Replaces calls to `clearQueries` with `resetQueries` in `AppGenerate` and `AppPreviewTest` for two specific scenarios: navigating away from a preview and triggering a manual refresh.

When a user navigates away or refreshes, the iframe/preview is torn down but the parent-owned fetch/poll for any in-flight query continues running. Previously, using `clearQueries` meant that when the late terminal event (e.g. a `ready` status) eventually arrived, it would be recorded as a phantom row in the new query count. `resetQueries` discards the tracked query IDs so that any late-arriving terminal events for those queries are ignored and do not corrupt the `capturedQueryCount`.

A new test case covers this scenario: a query is started, a refresh is triggered, and the late terminal event for the original query is verified to not increment the captured query count.

Relates: PROD-9383
