### PR TITLE
fix(data-apps): read queries from ref to correctly merge same-batch events

### DIFF
--- a/packages/frontend/src/features/apps/hooks/useTrackedAppQueries.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useTrackedAppQueries.test.ts
@@ -110,6 +110,40 @@ describe('useTrackedAppQueries', () => {
         expect(result.current.queries).toHaveLength(1);
     });
 
+    // Events arrive from postMessage handlers and can be delivered without a
+    // re-render in between, so the merge has to read the freshest list rather
+    // than the last rendered one.
+    it('merges two events delivered in the same batch', () => {
+        const { result } = renderHook(() => useTrackedAppQueries());
+
+        act(() => {
+            result.current.handleQueryEvent(
+                baseEvent({
+                    id: POST_ID_A,
+                    status: 'pending',
+                    // Only carried by the POST initiation — it survives solely
+                    // because the running event merges into the pending entry.
+                    rawMetricQuery: { limit: 10 } as never,
+                }),
+            );
+            result.current.handleQueryEvent(
+                baseEvent({
+                    id: POST_ID_A,
+                    status: 'running',
+                    queryUuid: QUERY_UUID,
+                }),
+            );
+        });
+
+        expect(result.current.queries).toHaveLength(1);
+        expect(result.current.queries[0]).toMatchObject({
+            id: POST_ID_A,
+            status: 'running',
+            queryUuid: QUERY_UUID,
+            rawMetricQuery: { limit: 10 },
+        });
+    });
+
     describe('resetKey', () => {
         it('does not clear on mount', () => {
             const { result } = renderHook(() => useTrackedAppQueries(1));
@@ -384,6 +418,72 @@ describe('useTrackedAppQueries', () => {
                 status: 'ready',
                 rowCount: 7,
             });
+        });
+
+        // The reverse order of the test above: the recycled uuid is reclaimed
+        // by the new request BEFORE the old request's late terminal lands. The
+        // id exclusion (checked first, and never reclaimed) is what keeps the
+        // late event out.
+        it('drops the old late terminal even after the recycled uuid was reclaimed', () => {
+            const { result, rerender } = renderHook(
+                (resetKey: number | undefined) =>
+                    useTrackedAppQueries(resetKey),
+                { initialProps: 1 },
+            );
+
+            act(() => {
+                result.current.handleQueryEvent(
+                    baseEvent({ id: POST_ID_A, status: 'pending' }),
+                );
+            });
+            act(() => {
+                result.current.handleQueryEvent(
+                    baseEvent({
+                        id: POST_ID_A,
+                        status: 'running',
+                        queryUuid: QUERY_UUID,
+                    }),
+                );
+            });
+
+            rerender(2);
+
+            // New request reclaims the uuid first.
+            act(() => {
+                result.current.handleQueryEvent(
+                    baseEvent({ id: POST_ID_B, status: 'pending' }),
+                );
+            });
+            act(() => {
+                result.current.handleQueryEvent(
+                    baseEvent({
+                        id: POST_ID_B,
+                        status: 'running',
+                        queryUuid: QUERY_UUID,
+                    }),
+                );
+            });
+
+            // Now the PRE-reset request's late terminal arrives.
+            act(() => {
+                result.current.handleQueryEvent(
+                    baseEvent({
+                        id: POST_ID_A,
+                        status: 'ready',
+                        queryUuid: QUERY_UUID,
+                        rowCount: 99,
+                    }),
+                );
+            });
+
+            expect(result.current.queries).toHaveLength(1);
+            expect(result.current.queries[0]).toMatchObject({
+                id: POST_ID_B,
+                status: 'running',
+            });
+            expect(
+                countReadyQueriesSinceBoundary(result.current.queries, 0),
+            ).toBe(0);
         });
 
         // Linked charts emit no `pending` placeholder — their first event is

--- a/packages/frontend/src/features/apps/hooks/useTrackedAppQueries.ts
+++ b/packages/frontend/src/features/apps/hooks/useTrackedAppQueries.ts
@@ -71,10 +71,19 @@ export const useTrackedAppQueries = (
     // permanent: handleQueryEvent hands a uuid back to a live request that
     // the backend gave the same uuid to, so a valid new version isn't muted.
     const interruptedQueryUuidsRef = useRef<Set<string>>(new Set());
+    // Mirror of `queries`, kept in sync by commitQueries. Reading state from a
+    // ref instead of a functional updater keeps the exclusion bookkeeping (ref
+    // mutations) out of the updater, which React may invoke more than once.
+    const queriesRef = useRef<QueryEvent[]>([]);
+
+    const commitQueries = useCallback((next: QueryEvent[]) => {
+        queriesRef.current = next;
+        setQueries(next);
+    }, []);
 
     const clearQueries = useCallback(() => {
-        setQueries([]);
-    }, []);
+        commitQueries([]);
+    }, [commitQueries]);
 
     // Like clearQueries(), but for a resource-boundary reset (version switch)
     // rather than an explicit "clear the log" action: the parent-owned
@@ -85,16 +94,14 @@ export const useTrackedAppQueries = (
     // new boundary's count — mirroring why interruptInFlightQueries registers
     // ids instead of just dropping entries.
     const resetQueries = useCallback(() => {
-        setQueries((prev) => {
-            prev.forEach((q) => {
-                interruptedRequestIdsRef.current.add(q.id);
-                if (q.queryUuid) {
-                    interruptedQueryUuidsRef.current.add(q.queryUuid);
-                }
-            });
-            return [];
+        queriesRef.current.forEach((q) => {
+            interruptedRequestIdsRef.current.add(q.id);
+            if (q.queryUuid) {
+                interruptedQueryUuidsRef.current.add(q.queryUuid);
+            }
         });
-    }, []);
+        commitQueries([]);
+    }, [commitQueries]);
 
     // Resets on every resetKey change but not on mount, so a caller passing
     // e.g. the previewed version never loses queries fired during initial load.
@@ -110,32 +117,31 @@ export const useTrackedAppQueries = (
     // have polled their queryUuids is dead, so they would otherwise sit
     // non-terminal forever.
     const interruptInFlightQueries = useCallback(() => {
-        setQueries((prev) => {
-            let mutated = false;
-            const next = prev.map((q) => {
-                if (q.status !== 'pending' && q.status !== 'running') {
-                    return q;
-                }
-                mutated = true;
-                interruptedRequestIdsRef.current.add(q.id);
-                return {
-                    ...q,
-                    status: 'error' as const,
-                    error: 'Interrupted by reload',
-                };
-            });
-            return mutated ? next : prev;
+        let mutated = false;
+        const next = queriesRef.current.map((q) => {
+            if (q.status !== 'pending' && q.status !== 'running') {
+                return q;
+            }
+            mutated = true;
+            interruptedRequestIdsRef.current.add(q.id);
+            return {
+                ...q,
+                status: 'error' as const,
+                error: 'Interrupted by reload',
+            };
         });
-    }, []);
+        if (mutated) commitQueries(next);
+    }, [commitQueries]);
 
-    const handleQueryEvent = useCallback((event: QueryEvent) => {
-        // Drop late events (typically the POST-resolution `running` event)
-        // for requests we already marked interrupted — without this they
-        // either un-terminal the entry or get appended as a ghost.
-        if (interruptedRequestIdsRef.current.has(event.id)) {
-            return;
-        }
-        setQueries((prev) => {
+    const handleQueryEvent = useCallback(
+        (event: QueryEvent) => {
+            // Drop late events (typically the POST-resolution `running` event)
+            // for requests we already marked interrupted — without this they
+            // either un-terminal the entry or get appended as a ghost.
+            if (interruptedRequestIdsRef.current.has(event.id)) {
+                return;
+            }
+            const prev = queriesRef.current;
             // Same drop, keyed by queryUuid — but reclaimable, because the
             // backend can hand a NEW submission a recycled uuid: a tracked id
             // or a non-terminal event means a live request owns it now.
@@ -147,7 +153,7 @@ export const useTrackedAppQueries = (
                     event.status === 'pending' ||
                     event.status === 'running' ||
                     prev.some((q) => q.id === event.id);
-                if (!isLiveRequest) return prev;
+                if (!isLiveRequest) return;
                 interruptedQueryUuidsRef.current.delete(event.queryUuid);
             }
             // If this event has a queryUuid, merge it with an existing entry
@@ -164,37 +170,41 @@ export const useTrackedAppQueries = (
                         existing.status === 'ready' ||
                         existing.status === 'error'
                     ) {
-                        return prev;
+                        return;
                     }
-                    return prev
-                        .map((q) =>
-                            q.queryUuid === event.queryUuid
-                                ? {
-                                      ...q,
-                                      label: event.label ?? q.label,
-                                      status: event.status,
-                                      rowCount: event.rowCount ?? q.rowCount,
-                                      durationMs:
-                                          event.durationMs ?? q.durationMs,
-                                      error: event.error ?? q.error,
-                                      rawMetricQuery:
-                                          event.rawMetricQuery ??
-                                          q.rawMetricQuery,
-                                  }
-                                : q,
-                        )
-                        .filter(
-                            // Drop this event's own now-redundant `pending`
-                            // placeholder — results-cache dedupe means a
-                            // second POST can fold into an entry it didn't
-                            // create, stranding its own placeholder row.
-                            (q) =>
-                                !(
-                                    q.id === event.id &&
-                                    q.status === 'pending' &&
-                                    q.queryUuid !== event.queryUuid
-                                ),
-                        );
+                    commitQueries(
+                        prev
+                            .map((q) =>
+                                q.queryUuid === event.queryUuid
+                                    ? {
+                                          ...q,
+                                          label: event.label ?? q.label,
+                                          status: event.status,
+                                          rowCount:
+                                              event.rowCount ?? q.rowCount,
+                                          durationMs:
+                                              event.durationMs ?? q.durationMs,
+                                          error: event.error ?? q.error,
+                                          rawMetricQuery:
+                                              event.rawMetricQuery ??
+                                              q.rawMetricQuery,
+                                      }
+                                    : q,
+                            )
+                            .filter(
+                                // Drop this event's own now-redundant `pending`
+                                // placeholder — results-cache dedupe means a
+                                // second POST can fold into an entry it didn't
+                                // create, stranding its own placeholder row.
+                                (q) =>
+                                    !(
+                                        q.id === event.id &&
+                                        q.status === 'pending' &&
+                                        q.queryUuid !== event.queryUuid
+                                    ),
+                            ),
+                    );
+                    return;
                 }
             }
             // If this is a POST initiation with queryUuid, check if we
@@ -203,15 +213,18 @@ export const useTrackedAppQueries = (
                 (q) => q.id === event.id && q.status === 'pending',
             );
             if (pendingIdx >= 0) {
-                return prev.map((q, i) =>
-                    i === pendingIdx
-                        ? {
-                              ...event,
-                              rawMetricQuery:
-                                  event.rawMetricQuery ?? q.rawMetricQuery,
-                          }
-                        : q,
+                commitQueries(
+                    prev.map((q, i) =>
+                        i === pendingIdx
+                            ? {
+                                  ...event,
+                                  rawMetricQuery:
+                                      event.rawMetricQuery ?? q.rawMetricQuery,
+                              }
+                            : q,
+                    ),
                 );
+                return;
             }
             const isTerminal =
                 event.status === 'ready' || event.status === 'error';
@@ -223,11 +236,12 @@ export const useTrackedAppQueries = (
                 isTerminal &&
                 prev.some((q) => q.id === event.id)
             ) {
-                return prev;
+                return;
             }
-            return [...prev, event];
-        });
-    }, []);
+            commitQueries([...prev, event]);
+        },
+        [commitQueries],
+    );
 
     return {
         queries,


### PR DESCRIPTION
Closes:

### Description:

`useTrackedAppQueries` previously used React functional updaters (`setQueries(prev => ...)`) to read the current query list inside `handleQueryEvent` and other callbacks. Because `postMessage` events can arrive in rapid succession without a re-render in between, each updater was reading stale state from the previous render rather than the result of the immediately preceding update. This caused batched events (e.g. a `pending` followed immediately by a `running` event for the same request) to lose data — specifically, fields like `rawMetricQuery` that are only present on the first event would be dropped when the second event couldn't see the first event's merged result.

To fix this, a `queriesRef` is introduced as a mirror of the `queries` state array. A new `commitQueries` helper keeps the ref and the state in sync on every write. All internal callbacks (`handleQueryEvent`, `resetQueries`, `interruptInFlightQueries`, `clearQueries`) now read from `queriesRef.current` instead of relying on functional updater closures, ensuring they always operate on the freshest list regardless of render timing.

As a secondary benefit, `resetQueries` no longer needs to perform ref mutations inside a state updater (which React may invoke more than once in strict/concurrent mode), making the side-effect bookkeeping for `interruptedRequestIdsRef` and `interruptedQueryUuidsRef` safer.

Two new test cases are added:
- Verifies that two events delivered in the same `act()` batch correctly merge, preserving fields from the first event into the second.
- Verifies that a late terminal event arriving after a reset is correctly dropped even when the recycled `queryUuid` has already been reclaimed by a new request under a different id.

Relates: PROD-9383
