### PR TITLE
test(data-apps): add Google Chat XLSX delivery notification test

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -2205,4 +2205,39 @@ describe('app delivery target senders', () => {
             csvUrls: page.csvUrls,
         });
     });
+
+    it('posts an app xlsx delivery to the Google Chat webhook', async () => {
+        const postCsvsWithWebhook = vi.fn().mockResolvedValue(undefined);
+        const task = makeTaskWithDeps({
+            ...senderBaseDeps(),
+            googleChatClient: asDep<'googleChatClient'>({
+                postCsvsWithWebhook,
+            }),
+        });
+        const page = senderPage();
+
+        await (
+            task as unknown as {
+                sendGoogleChatNotification(
+                    jobId: string,
+                    notification: never,
+                ): Promise<void>;
+            }
+        ).sendGoogleChatNotification(
+            'job-1',
+            notificationOf(
+                appScheduler({ format: SchedulerFormat.XLSX }),
+                page,
+                { googleChatWebhook: 'https://webhook.example.com/chat' },
+            ),
+        );
+
+        expect(postCsvsWithWebhook).toHaveBeenCalledTimes(1);
+        expect(postCsvsWithWebhook.mock.calls[0][0]).toMatchObject({
+            webhookUrl: 'https://webhook.example.com/chat',
+            csvUrls: page.csvUrls,
+            failures: page.failures,
+            notices: page.notices,
+        });
+    });
 });


### PR DESCRIPTION
Closes:

### Description:
Adds a test to verify that XLSX app delivery notifications are correctly sent to Google Chat webhooks. The test ensures that `postCsvsWithWebhook` is called with the expected webhook URL, CSV URLs, failures, and notices when a scheduled XLSX report is delivered via Google Chat.

Relates: PROD-9383
