### PR TITLE
fix(query): reject injected metric-query identifiers

### DIFF
--- a/packages/backend/src/queryCompiler.test.ts
+++ b/packages/backend/src/queryCompiler.test.ts
@@ -1523,3 +1523,144 @@ describe('compileMetricQuery rejects injected sort field ids (PROD-9482)', () =>
         ).not.toThrow();
     });
 });
+
+describe('compileMetricQuery rejects injected generated identifiers and template refs (PROD-9485)', () => {
+    const injectedIdentifiers = [
+        'injected" DESC --',
+        'injected` DESC --',
+        'injected\\',
+    ];
+
+    it.each(injectedIdentifiers)(
+        'throws a CompileError for custom dimension id %j',
+        (id) => {
+            expect(() =>
+                compileMetricQuery({
+                    explore: EXPLORE,
+                    metricQuery: {
+                        ...METRIC_QUERY_NO_CALCS,
+                        dimensions: [...METRIC_QUERY_NO_CALCS.dimensions, id],
+                        customDimensions: [
+                            {
+                                id,
+                                name: 'Injected custom dimension',
+                                table: 'table1',
+                                type: CustomDimensionType.SQL,
+                                sql: '${TABLE}.dim_1',
+                                dimensionType: DimensionType.STRING,
+                            },
+                        ],
+                    },
+                    warehouseSqlBuilder: warehouseClientMock,
+                    availableParameters: [],
+                }),
+            ).toThrow(/quote or backslash/);
+        },
+    );
+
+    it.each(injectedIdentifiers)(
+        'throws a CompileError for additional metric name %j',
+        (name) => {
+            expect(() =>
+                compileMetricQuery({
+                    explore: EXPLORE,
+                    metricQuery: {
+                        ...METRIC_QUERY_NO_CALCS,
+                        metrics: [
+                            ...METRIC_QUERY_NO_CALCS.metrics,
+                            `table1_${name}`,
+                        ],
+                        additionalMetrics: [
+                            {
+                                name,
+                                table: 'table1',
+                                type: MetricType.COUNT,
+                                sql: '${TABLE}.dim_1',
+                            },
+                        ],
+                    },
+                    warehouseSqlBuilder: warehouseClientMock,
+                    availableParameters: [],
+                }),
+            ).toThrow(/quote or backslash/);
+        },
+    );
+
+    it.each(injectedIdentifiers)(
+        'throws a CompileError for table calculation name %j',
+        (name) => {
+            expect(() =>
+                compileMetricQuery({
+                    explore: EXPLORE,
+                    metricQuery: {
+                        ...METRIC_QUERY_NO_CALCS,
+                        tableCalculations: [
+                            {
+                                name,
+                                displayName: 'Injected table calculation',
+                                sql: '${table1.dim_1}',
+                            },
+                        ],
+                    },
+                    warehouseSqlBuilder: warehouseClientMock,
+                    availableParameters: [],
+                }),
+            ).toThrow(/quote or backslash/);
+        },
+    );
+
+    test('throws a CompileError for unknown template field references', () => {
+        expect(() =>
+            compileMetricQuery({
+                explore: EXPLORE,
+                metricQuery: {
+                    ...METRIC_QUERY_NO_CALCS,
+                    tableCalculations: [
+                        {
+                            name: 'percent_of_total',
+                            displayName: 'Percent of total',
+                            template: {
+                                type: TableCalculationTemplateType.PERCENT_OF_COLUMN_TOTAL,
+                                fieldId: 'not_in_query',
+                                partitionBy: [],
+                            },
+                        },
+                    ],
+                },
+                warehouseSqlBuilder: warehouseClientMock,
+                availableParameters: [],
+            }),
+        ).toThrow(/isn't included in the query/);
+    });
+
+    test('throws a CompileError for injected template order and partition references', () => {
+        expect(() =>
+            compileMetricQuery({
+                explore: EXPLORE,
+                metricQuery: {
+                    ...METRIC_QUERY_NO_CALCS,
+                    tableCalculations: [
+                        {
+                            name: 'windowed_total',
+                            displayName: 'Windowed total',
+                            template: {
+                                type: TableCalculationTemplateType.WINDOW_FUNCTION,
+                                windowFunction: WindowFunctionType.SUM,
+                                fieldId: 'table_3_metric_1',
+                                orderBy: [
+                                    {
+                                        fieldId: 'table1_dim_1" DESC --',
+                                        order: 'asc',
+                                    },
+                                ],
+                                partitionBy: ['table1_dim_1" DESC --'],
+                            },
+                        },
+                    ],
+                },
+                warehouseSqlBuilder: warehouseClientMock,
+                availableParameters: [],
+            }),
+        ).toThrow(/quote or backslash/);
+    });
+});

--- a/packages/backend/src/queryCompiler.ts
+++ b/packages/backend/src/queryCompiler.ts
@@ -24,6 +24,7 @@ import {
     MetricType,
     PivotConfiguration,
     TableCalculation,
+    TableCalculationTemplate,
     type WarehouseSqlBuilder,
 } from '@lightdash/common';
 import {
@@ -46,6 +47,20 @@ const getTableCalculationReferences = (sql: string): string[] => {
     return matches.map((match) => match.slice(2, -1)); // Remove ${ and }
 };
 
+const getTemplateFieldReferences = (
+    template: TableCalculationTemplate,
+): string[] => [
+    ...('fieldId' in template && template.fieldId !== null
+        ? [template.fieldId]
+        : []),
+    ...('orderBy' in template
+        ? template.orderBy.map(({ fieldId }) => fieldId)
+        : []),
+    ...('partitionBy' in template && template.partitionBy
+        ? template.partitionBy
+        : []),
+];
+
 const buildTableCalculationDependencyGraph = (
     tableCalculations: TableCalculation[],
 ): DependencyNode[] =>
@@ -58,28 +73,9 @@ const buildTableCalculationDependencyGraph = (
         }
 
         if (isTemplateTableCalculation(calc)) {
-            const fieldIdDependency =
-                'fieldId' in calc.template && calc.template.fieldId !== null
-                    ? [calc.template.fieldId]
-                    : [];
-
-            const orderByFields =
-                'orderBy' in calc.template
-                    ? calc.template.orderBy.map((ob) => ob.fieldId)
-                    : [];
-
-            const partitionByFields =
-                'partitionBy' in calc.template && calc.template.partitionBy
-                    ? calc.template.partitionBy
-                    : [];
-
             return {
                 name: calc.name,
-                dependencies: [
-                    ...fieldIdDependency,
-                    ...orderByFields,
-                    ...partitionByFields,
-                ],
+                dependencies: getTemplateFieldReferences(calc.template),
             };
         }
 
@@ -231,6 +227,54 @@ const compileTableCalculation = (
     );
 };
 
+// Caller-created identifiers are later rendered inside quoted SQL identifiers.
+// Reject every dialect's field quote chars and backslash before rendering.
+const forbiddenIdentifierChars = /["`\\]/;
+
+const assertSafeGeneratedIdentifier = (
+    value: string,
+    description: string,
+): void => {
+    if (forbiddenIdentifierChars.test(value)) {
+        throw new CompileError(
+            `Invalid ${description} "${value}": identifiers cannot contain quote or backslash characters.`,
+        );
+    }
+};
+
+const assertKnownTemplateReference = (
+    reference: string,
+    validFieldIds: string[],
+    dependencyGraph: DependencyNode[],
+): void => {
+    assertSafeGeneratedIdentifier(
+        reference,
+        'table calculation template reference',
+    );
+
+    if (
+        validFieldIds.includes(reference) ||
+        dependencyGraph.some((dep) => dep.name === reference)
+    ) {
+        return;
+    }
+
+    throw new CompileError(
+        `Table calculation contains a reference "${reference}" to a field or table calculation that isn't included in the query.`,
+        {},
+    );
+};
+
+const assertKnownTemplateReferences = (
+    template: TableCalculationTemplate,
+    validFieldIds: string[],
+    dependencyGraph: DependencyNode[],
+): void => {
+    getTemplateFieldReferences(template).forEach((reference) =>
+        assertKnownTemplateReference(reference, validFieldIds, dependencyGraph),
+    );
+};
+
 const compileTableCalculations = (
     tableCalculations: TableCalculation[],
     validFieldIds: string[],
@@ -242,6 +286,13 @@ const compileTableCalculations = (
     if (tableCalculations.length === 0) {
         return [];
     }
+
+    tableCalculations.forEach((tableCalculation) =>
+        assertSafeGeneratedIdentifier(
+            tableCalculation.name,
+            'table calculation name',
+        ),
+    );
 
     // Build dependency graph to check for circular dependencies
     const dependencyGraph =
@@ -255,6 +306,14 @@ const compileTableCalculations = (
     const compiledTableCalculations: CompiledTableCalculation[] = [];
 
     for (const tableCalculation of tableCalculations) {
+        if (isTemplateTableCalculation(tableCalculation)) {
+            assertKnownTemplateReferences(
+                tableCalculation.template,
+                validFieldIds,
+                dependencyGraph,
+            );
+        }
+
         const compiled = compileTableCalculation(
             tableCalculation,
             validFieldIds,
@@ -400,18 +459,9 @@ type CompileMetricQueryArgs = {
     warehouseSqlBuilder: WarehouseSqlBuilder;
     availableParameters: string[];
 };
-// Sort field ids are rendered verbatim inside quoted identifiers in ORDER BY, so
-// a field quote character (" or `) or a backslash can only be an attempt to break
-// out and inject SQL. Rejected across every dialect's quote char, not just the
-// current one, because compiled queries are persisted and replayed elsewhere.
-const forbiddenSortFieldIdChars = /["`\\]/;
 
 const assertSafeSortFieldId = (fieldId: string): void => {
-    if (forbiddenSortFieldIdChars.test(fieldId)) {
-        throw new CompileError(
-            `Invalid sort field "${fieldId}": field ids cannot contain quote or backslash characters.`,
-        );
-    }
+    assertSafeGeneratedIdentifier(fieldId, 'sort field');
 };
 
 export const compileMetricQuery = ({
@@ -421,6 +471,18 @@ export const compileMetricQuery = ({
     availableParameters,
 }: CompileMetricQueryArgs): CompiledMetricQuery => {
     metricQuery.sorts.forEach((sort) => assertSafeSortFieldId(sort.fieldId));
+    (metricQuery.customDimensions || []).forEach((customDimension) =>
+        assertSafeGeneratedIdentifier(
+            customDimension.id,
+            'custom dimension id',
+        ),
+    );
+    (metricQuery.additionalMetrics || []).forEach((additionalMetric) =>
+        assertSafeGeneratedIdentifier(
+            additionalMetric.name,
+            'additional metric name',
+        ),
+    );
 
     const fieldQuoteChar = warehouseSqlBuilder.getFieldQuoteChar();
 

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -2690,6 +2690,55 @@ LIMIT 10`;
             expect(result.query).toContain('"base_calc" * 2');
         });
 
+        test('Should encode dependent table calculation CTE names that are not bare identifiers', () => {
+            const baseName = 'base calc); DROP';
+            const dependentName = 'dependent calc';
+            const metricQueryWithDependentTableCalcs = {
+                ...METRIC_QUERY,
+                tableCalculations: [
+                    {
+                        name: baseName,
+                        displayName: 'Base Calc',
+                        sql: '${table1.metric1} + 50',
+                    },
+                    {
+                        name: dependentName,
+                        displayName: 'Dependent Calc',
+                        sql: '${base calc); DROP} * 2',
+                    },
+                ],
+                compiledTableCalculations: [
+                    {
+                        name: baseName,
+                        displayName: 'Base Calc',
+                        sql: '${table1.metric1} + 50',
+                        compiledSql: '"table1_metric1" + 50',
+                        dependsOn: [],
+                    },
+                    {
+                        name: dependentName,
+                        displayName: 'Dependent Calc',
+                        sql: '${base calc); DROP} * 2',
+                        compiledSql: '"base calc); DROP" * 2',
+                        dependsOn: [baseName],
+                    },
+                ],
+            };
+
+            const result = buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: metricQueryWithDependentTableCalcs,
+                warehouseSqlBuilder: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: QUERY_BUILDER_UTC_TIMEZONE,
+            });
+
+            expect(result.query).not.toContain(`tc_${baseName} AS (`);
+            expect(result.query).not.toContain(`tc_${dependentName} AS (`);
+            expect(result.query).toContain(`AS "${baseName}"`);
+            expect(result.query).toContain(`"base calc); DROP" * 2`);
+        });
+
         test('Should build query with mixed table calculations (some with CTEs, some inline)', () => {
             const metricQueryWithMixedTableCalcs = {
                 ...METRIC_QUERY,

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -58,6 +58,7 @@ import {
     parseTableCalculationFunctions,
     PivotConfiguration,
     QueryWarning,
+    quoteFieldReference,
     renderFilterRuleSqlFromField,
     renderTableCalculationFilterRuleSql,
     resolveTimestampFilterContext,
@@ -3492,6 +3493,18 @@ export class MetricQueryBuilder {
         return `${name} AS (\n${MetricQueryBuilder.assembleSqlParts(parts)}\n)`;
     }
 
+    private static getTableCalculationCteName(name: string): string {
+        if (/^\w+$/.test(name)) {
+            return `tc_${name}`;
+        }
+
+        const encodedName = Array.from(name)
+            .map((char) => (char.codePointAt(0) ?? 0).toString(36))
+            .join('_');
+
+        return `tc_${encodedName}`;
+    }
+
     /**
      * Builds CTE(s) for distinct metrics (sum_distinct, average_distinct) using ROW_NUMBER deduplication.
      *
@@ -4371,13 +4384,15 @@ export class MetricQueryBuilder {
                 // because each CTE does SELECT * from the previous one
                 const mostRecentIndex = currentIndex - 1;
                 if (mostRecentIndex >= 0) {
-                    return `tc_${sortedTableCalcs[mostRecentIndex].name}`;
+                    return MetricQueryBuilder.getTableCalculationCteName(
+                        sortedTableCalcs[mostRecentIndex].name,
+                    );
                 }
                 // If no previous CTE, it should be in table_calculations
                 return 'table_calculations';
             }
 
-            return `tc_${refName}`;
+            return MetricQueryBuilder.getTableCalculationCteName(refName);
         }
 
         // Otherwise, it's a simple table calc in the shared table_calculations CTE
@@ -4392,7 +4407,9 @@ export class MetricQueryBuilder {
 
             if (currentIndex > 0) {
                 // It should be available from the previous CTE
-                return `tc_${sortedTableCalcs[currentIndex - 1].name}`;
+                return MetricQueryBuilder.getTableCalculationCteName(
+                    sortedTableCalcs[currentIndex - 1].name,
+                );
             }
             return 'table_calculations';
         }
@@ -4416,7 +4433,9 @@ export class MetricQueryBuilder {
         let lastCteName = currentName;
 
         for (const tc of sortedTableCalcs) {
-            const cteName = `tc_${tc.name}`;
+            const cteName = MetricQueryBuilder.getTableCalculationCteName(
+                tc.name,
+            );
 
             // Replace total()/row_total() refs with column aliases before function parsing
             let compiledSql: string | null = this.replaceTotalReferences(
@@ -5073,13 +5092,17 @@ export class MetricQueryBuilder {
                 (dimId) =>
                     `  ${fieldQuoteChar}${dimId}${fieldQuoteChar} AS ${fieldQuoteChar}${SOURCE_AGGREGATIONS_GRAIN_PREFIX}${dimId}${fieldQuoteChar}`,
             );
-            const aggregationSelects = aggregations.columns.map(
-                (column) =>
-                    `  ${getSourceAggregationSql(
-                        column.aggregation,
-                        `${fieldQuoteChar}${column.reference}${fieldQuoteChar}`,
-                    )} AS ${fieldQuoteChar}${column.reference}${fieldQuoteChar}`,
-            );
+            const aggregationSelects = aggregations.columns.map((column) => {
+                const quotedReference = quoteFieldReference(
+                    column.reference,
+                    fieldQuoteChar,
+                    this.args.warehouseSqlBuilder.getAdapterType(),
+                );
+                return `  ${getSourceAggregationSql(
+                    column.aggregation,
+                    quotedReference,
+                )} AS ${quotedReference}`;
+            });
             leadingCtes.push(
                 `${SOURCE_AGGREGATIONS_CTE_NAME} AS (\n${MetricQueryBuilder.assembleSqlParts(
                     [
@@ -5697,8 +5720,14 @@ export class MetricQueryBuilder {
                     return column;
                 });
                 const aggregationColumns = aggregations.columns.map(
-                    ({ reference }) =>
-                        `  ${SOURCE_AGGREGATIONS_CTE_NAME}.${fieldQuoteChar}${reference}${fieldQuoteChar} AS ${fieldQuoteChar}${reference}${fieldQuoteChar}`,
+                    ({ reference }) => {
+                        const quotedReference = quoteFieldReference(
+                            reference,
+                            fieldQuoteChar,
+                            this.args.warehouseSqlBuilder.getAdapterType(),
+                        );
+                        return `  ${SOURCE_AGGREGATIONS_CTE_NAME}.${quotedReference} AS ${quotedReference}`;
+                    },
                 );
                 const aggregationsJoin =
                     aggregations.grainDimensions.length > 0

--- a/packages/backend/src/utils/QueryBuilder/SqlQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/SqlQueryBuilder.ts
@@ -4,6 +4,7 @@ import {
     FilterGroup,
     isAndFilterGroup,
     isFilterGroup,
+    quoteFieldReference,
     renderFilterRuleSql,
     SupportedDbtAdapter,
     WeekDay,
@@ -65,7 +66,11 @@ export class SqlQueryBuilder {
     }
 
     private quotedName(value: string) {
-        return `${this.config.fieldQuoteChar}${value}${this.config.fieldQuoteChar}`;
+        return quoteFieldReference(
+            value,
+            this.config.fieldQuoteChar,
+            this.config.adapterType,
+        );
     }
 
     private getReference(reference: string): ReferenceObject {

--- a/packages/backend/src/utils/QueryBuilder/SqlQueryComposer.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/SqlQueryComposer.test.ts
@@ -1,9 +1,11 @@
 import {
     DimensionType,
+    FilterOperator,
     PivotConfiguration,
     SortByDirection,
     VizAggregationOptions,
     VizIndexType,
+    type DashboardFilters,
 } from '@lightdash/common';
 import { warehouseClientMock } from './MetricQueryBuilder.mock';
 import {
@@ -79,5 +81,49 @@ describe('SqlQueryComposer', () => {
         expect(sql).not.toBe(composer.compile().query);
         expect(sql).toMatchSnapshot();
         expect(composer.getPivotConfiguration()).toBe(PIVOT_CONFIGURATION);
+    });
+
+    it('escapes active quote characters in raw SQL chart column references', () => {
+        const dashboardFilters: DashboardFilters = {
+            dimensions: [
+                {
+                    id: 'filter-total-revenue',
+                    label: undefined,
+                    operator: FilterOperator.GREATER_THAN,
+                    target: {
+                        fieldId: 'total"revenue',
+                        tableName: SQL_QUERY_MOCK_EXPLORER_NAME,
+                        isSqlColumn: true,
+                        fallbackType: DimensionType.NUMBER,
+                    },
+                    values: [100],
+                    tileTargets: {
+                        tile_1: {
+                            fieldId: 'total"revenue',
+                            tableName: SQL_QUERY_MOCK_EXPLORER_NAME,
+                            isSqlColumn: true,
+                            fallbackType: DimensionType.NUMBER,
+                        },
+                    },
+                },
+            ],
+            metrics: [],
+            tableCalculations: [],
+        };
+        const composer = new SqlQueryComposer({
+            ...baseArgs,
+            columns: [{ name: 'total"revenue', type: DimensionType.NUMBER }],
+            dashboardFilters,
+            tileUuid: 'tile_1',
+            pivotConfiguration: undefined,
+        });
+
+        expect(
+            composer.getExplore().tables[SQL_QUERY_MOCK_EXPLORER_NAME]
+                .dimensions['total"revenue'].sql,
+        ).toBe('"total""revenue"');
+        expect(composer.compile().query).toContain(
+            '("total""revenue") > (100)',
+        );
     });
 });

--- a/packages/backend/src/utils/QueryBuilder/SqlQueryComposer.ts
+++ b/packages/backend/src/utils/QueryBuilder/SqlQueryComposer.ts
@@ -4,6 +4,7 @@ import {
     createVirtualView,
     getDashboardFilterRulesForTileAndReferences,
     getItemMap,
+    quoteFieldReference,
     type DashboardFilters,
     type DimensionType,
     type Explore,
@@ -130,12 +131,17 @@ export class SqlQueryComposer extends QueryComposer {
         ).map((d) => convertFieldRefToFieldId(d.name, virtualView.name));
 
         const fieldQuoteChar = warehouseClient.getFieldQuoteChar();
+        const adapterType = warehouseClient.getAdapterType();
 
         const referenceMap: ReferenceMap = {};
         vizColumns.forEach((col) => {
             referenceMap[col.reference] = {
                 type: col.type,
-                sql: `${fieldQuoteChar}${col.reference}${fieldQuoteChar}`,
+                sql: quoteFieldReference(
+                    col.reference,
+                    fieldQuoteChar,
+                    adapterType,
+                ),
             };
         });
 

--- a/packages/common/src/utils/virtualView.test.ts
+++ b/packages/common/src/utils/virtualView.test.ts
@@ -131,4 +131,17 @@ describe('createVirtualView', () => {
             region: 'EU',
         });
     });
+
+    test('should escape active quote characters in raw column references', () => {
+        const result = createVirtualView(
+            'my_view',
+            'SELECT 1 AS "total""revenue"',
+            [{ reference: 'total"revenue', type: DimensionType.NUMBER }],
+            fakeWarehouseClient,
+        );
+
+        expect(result.tables.my_view.dimensions['total"revenue'].sql).toBe(
+            '"total""revenue"',
+        );
+    });
 });

--- a/packages/common/src/utils/virtualView.ts
+++ b/packages/common/src/utils/virtualView.ts
@@ -15,7 +15,7 @@ import {
 } from '../types/warehouse';
 import { type VizColumn } from '../visualizations/types';
 import { WeekDay } from './timeFrames';
-import { defaultNullSafeEqualSql } from './warehouse';
+import { defaultNullSafeEqualSql, quoteFieldReference } from './warehouse';
 
 export const createVirtualView = (
     virtualViewName: string,
@@ -37,7 +37,11 @@ export const createVirtualView = (
                 type: column.type ?? DimensionType.STRING,
                 table: virtualViewName,
                 fieldType: FieldType.DIMENSION,
-                sql: `${fieldQuoteChar}${column.reference}${fieldQuoteChar}`,
+                sql: quoteFieldReference(
+                    column.reference,
+                    fieldQuoteChar,
+                    warehouseClient.getAdapterType(),
+                ),
                 tableLabel: friendlyName(virtualViewName),
                 hidden: false,
             };

--- a/packages/common/src/utils/warehouse.test.ts
+++ b/packages/common/src/utils/warehouse.test.ts
@@ -1,0 +1,42 @@
+import { SupportedDbtAdapter } from '../types/dbt';
+import type { WarehouseSqlBuilder } from '../types/warehouse';
+import { VizAggregationOptions } from '../visualizations/types';
+import { getAggregatedField, quoteFieldReference } from './warehouse';
+
+describe('quoteFieldReference', () => {
+    test('escapes ANSI-style active field quote characters', () => {
+        expect(quoteFieldReference('total"revenue', '"')).toBe(
+            '"total""revenue"',
+        );
+        expect(quoteFieldReference('total`revenue', '`')).toBe(
+            '`total``revenue`',
+        );
+    });
+
+    test('escapes BigQuery backticks and backslashes', () => {
+        expect(
+            quoteFieldReference(
+                'total`revenue\\path',
+                '`',
+                SupportedDbtAdapter.BIGQUERY,
+            ),
+        ).toBe('`total\\`revenue\\\\path`');
+    });
+});
+
+describe('getAggregatedField', () => {
+    test('escapes raw column references before aggregation', () => {
+        const warehouseSqlBuilder = {
+            getFieldQuoteChar: () => '"',
+            getAdapterType: () => SupportedDbtAdapter.POSTGRES,
+        } as WarehouseSqlBuilder;
+
+        expect(
+            getAggregatedField(
+                warehouseSqlBuilder,
+                VizAggregationOptions.SUM,
+                'total"revenue',
+            ),
+        ).toBe('sum("total""revenue")');
+    });
+});

--- a/packages/common/src/utils/warehouse.ts
+++ b/packages/common/src/utils/warehouse.ts
@@ -107,13 +107,31 @@ export const getFieldQuoteChar = (
     return '"';
 };
 
+export const quoteFieldReference = (
+    reference: string,
+    fieldQuoteChar: string,
+    adapterType?: SupportedDbtAdapter,
+): string => {
+    if (
+        fieldQuoteChar === '`' &&
+        adapterType === SupportedDbtAdapter.BIGQUERY
+    ) {
+        return `\`${reference.replace(/\\/g, '\\\\').replace(/`/g, '\\`')}\``;
+    }
+
+    return `${fieldQuoteChar}${reference
+        .split(fieldQuoteChar)
+        .join(`${fieldQuoteChar}${fieldQuoteChar}`)}${fieldQuoteChar}`;
+};
+
 export const getAggregatedField = (
     warehouseSqlBuilder: WarehouseSqlBuilder,
     aggregation: VizAggregationOptions,
     reference: string,
 ): string => {
-    const q = warehouseSqlBuilder.getFieldQuoteChar();
     const adapterType = warehouseSqlBuilder.getAdapterType();
+    const q = warehouseSqlBuilder.getFieldQuoteChar();
+    const quotedReference = quoteFieldReference(reference, q, adapterType);
     switch (adapterType) {
         case SupportedDbtAdapter.BIGQUERY:
         case SupportedDbtAdapter.DATABRICKS:
@@ -127,18 +145,18 @@ export const getAggregatedField = (
                 aggregation === VizAggregationOptions.ANY
                     ? 'ANY_VALUE'
                     : aggregation;
-            return `${aggregationFunction}(${q}${reference}${q})`;
+            return `${aggregationFunction}(${quotedReference})`;
 
         case SupportedDbtAdapter.POSTGRES:
             if (aggregation === VizAggregationOptions.ANY) {
                 // ANY_VALUE on Postgres is only available from version v16+
-                return `(ARRAY_AGG(${q}${reference}${q}))[1]`;
+                return `(ARRAY_AGG(${quotedReference}))[1]`;
             }
             break;
         case SupportedDbtAdapter.CLICKHOUSE:
             if (aggregation === VizAggregationOptions.ANY) {
                 // ClickHouse uses any() function for ANY_VALUE equivalent
-                return `any(${q}${reference}${q})`;
+                return `any(${quotedReference})`;
             }
             break;
         default:
@@ -147,5 +165,5 @@ export const getAggregatedField = (
                 `Unknown warehouse type ${adapterType}`,
             );
     }
-    return `${aggregation}(${q}${reference}${q})`;
+    return `${aggregation}(${quotedReference})`;
 };


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9485/identifier-injection-via-custom-dimension-ids-table-calc-template-refs

## Summary

Rejects injected metric-query identifiers before they reach warehouse SQL rendering. The shared compiler now covers custom-dimension IDs, additional-metric names, table-calculation names, and table-calculation template references on both metric-query routes.

Raw SQL-result column names remain usable when they contain dialect quote characters because virtual-view and SQL-chart paths now use adapter-aware identifier escaping.

## Root cause

`compileMetricQuery` only rejected unsafe `sorts[].fieldId` values. Other caller-created identifiers and template references flowed into later SQL builders, where they were wrapped with dialect quote characters without first proving they were safe or part of the selected query.

```ts
const quotedOrderFieldId = `${quoteChar}${orderFieldReference}${quoteChar}`;
```

A request value containing `"`, `` ` ``, or `\` could therefore break out of the quoted identifier in generated SQL. PROD-9482 closed this for sort field IDs; this PR applies the same fail-closed boundary to the remaining scoped fields.

## Fix

- `packages/backend/src/queryCompiler.ts` — validates generated metric-query identifiers and verifies every template reference is either a selected field or a table-calculation dependency before template SQL is rendered.
- `packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts` — encodes dependent table-calculation CTE names that are not bare identifiers and reuses escaped raw-column references for source-query aggregation aliases.
- `packages/common/src/utils/warehouse.ts` — adds adapter-aware raw identifier quoting: ANSI double-quote doubling, BigQuery backslash escaping, and Spark/Databricks doubled backticks.
- `packages/common/src/utils/virtualView.ts` and SQL-chart query builder/composer paths — use the shared raw-column quoting helper.
- Out of scope: arbitrary SQL intentionally accepted in `tableCalculations[].sql`, and pivot identifier handling tracked separately.

## Before

A template reference could be compiled into SQL with the injected identifier content still present:

```text
request: orderBy[].fieldId = table1_dim_1" DESC --
compiled: SUM("table_3_metric_1") OVER (PARTITION BY "table1_dim_1" DESC --" ORDER BY "table1_dim_1" DESC --" ASC)
```

## After

```text
request identifiers / template refs
  -> compileMetricQuery rejects quote/backslash characters
  -> template refs must match selected fields or table-calculation deps
  -> SQL renderer receives only known safe generated aliases
```

Local API evidence after the final patch:

- `POST /api/v1/.../explores/orders/compileQuery` clean payload: `200`, query includes `running_total`.
- `POST /api/v1/.../explores/orders/compileQuery` injected template ref: `400`, `Invalid table calculation template reference ... identifiers cannot contain quote or backslash characters.`
- `POST /api/v2/.../query/metric-query` injected template ref: `400`, same compile error before execution.

## Test plan

- [x] `pnpm -F common test src/utils/warehouse.test.ts src/utils/virtualView.test.ts` — 7 tests pass.
- [x] `pnpm -F backend test src/utils/QueryBuilder/MetricQueryBuilder.test.ts src/utils/QueryBuilder/SqlQueryComposer.test.ts src/queryCompiler.test.ts` — 269 tests pass.
- [x] `pnpm -F common linter src/utils/warehouse.ts src/utils/warehouse.test.ts src/utils/virtualView.ts src/utils/virtualView.test.ts`.
- [x] `pnpm -F backend linter src/queryCompiler.ts src/queryCompiler.test.ts src/utils/QueryBuilder/MetricQueryBuilder.ts src/utils/QueryBuilder/MetricQueryBuilder.test.ts src/utils/QueryBuilder/SqlQueryBuilder.ts src/utils/QueryBuilder/SqlQueryComposer.ts src/utils/QueryBuilder/SqlQueryComposer.test.ts`.
- [x] `pnpm -F common typecheck`.
- [x] `pnpm -F backend typecheck`.
- [x] `git diff --check`.
- [x] Manual: local v1/v2 API curl checks for clean compile and injected template rejection.