### PR TITLE
fix(explorer): show hidden filters in custom metric modal

### DIFF
--- a/packages/frontend/src/components/Explorer/CustomMetricModal/FilterForm.test.tsx
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/FilterForm.test.tsx
@@ -1,0 +1,76 @@
+import {
+    DimensionType,
+    FieldType,
+    type FilterableDimension,
+} from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../../../testing/testUtils';
+import FiltersProvider from '../../common/Filters/FiltersProvider';
+import { FilterForm } from './FilterForm';
+
+vi.mock('../../../features/explorer/store', () => ({
+    selectIsEditMode: vi.fn(),
+    useExplorerSelector: () => true,
+}));
+
+const dimension = (name: string, hidden: boolean): FilterableDimension => ({
+    fieldType: FieldType.DIMENSION,
+    type: DimensionType.STRING,
+    name,
+    label: name,
+    table: 'orders',
+    tableLabel: 'Orders',
+    sql: `\${TABLE}.${name}`,
+    hidden,
+});
+
+const hiddenDimension = dimension('credit_card_amount', true);
+const visibleDimension = dimension('status', false);
+
+const renderFilterForm = (
+    itemsMap: Record<string, FilterableDimension>,
+    setFilters = vi.fn(),
+) => {
+    renderWithProviders(
+        <FiltersProvider itemsMap={itemsMap}>
+            <FilterForm
+                defaultFilterRuleFieldId={undefined}
+                customMetricFiltersWithIds={[]}
+                setCustomMetricFiltersWithIds={setFilters}
+            />
+        </FiltersProvider>,
+    );
+
+    return setFilters;
+};
+
+describe('FilterForm', () => {
+    it('uses a visible dimension when adding a filter', async () => {
+        const user = userEvent.setup();
+        const setFilters = renderFilterForm({
+            orders_credit_card_amount: hiddenDimension,
+            orders_status: visibleDimension,
+        });
+
+        await user.click(screen.getByRole('button', { name: 'Add filter' }));
+
+        expect(setFilters).toHaveBeenCalledWith([
+            expect.objectContaining({
+                target: expect.objectContaining({
+                    fieldId: 'orders_status',
+                }),
+            }),
+        ]);
+    });
+
+    it('disables Add filter when only hidden dimensions are available', () => {
+        renderFilterForm({
+            orders_credit_card_amount: hiddenDimension,
+        });
+
+        expect(
+            screen.getByRole('button', { name: 'Add filter' }),
+        ).toBeDisabled();
+    });
+});

--- a/packages/frontend/src/components/Explorer/CustomMetricModal/FilterForm.tsx
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/FilterForm.tsx
@@ -43,13 +43,15 @@ export const FilterForm: FC<{
         useFiltersContext<Record<string, FilterableDimension>>();
 
     const dimensions = Object.values(dimensionsMap);
+    const selectableDimensions = dimensions.filter(({ hidden }) => !hidden);
 
     const addFieldRule = useCallback(() => {
-        const fallbackField = dimensions[0];
+        const fallbackField = selectableDimensions[0];
         const defaultField = defaultFilterRuleFieldId
             ? dimensionsMap[defaultFilterRuleFieldId]
             : undefined;
-        const field = defaultField || fallbackField;
+        const field =
+            defaultField && !defaultField.hidden ? defaultField : fallbackField;
 
         if (!field) {
             return;
@@ -71,7 +73,7 @@ export const FilterForm: FC<{
     }, [
         customMetricFiltersWithIds,
         defaultFilterRuleFieldId,
-        dimensions,
+        selectableDimensions,
         dimensionsMap,
         setCustomMetricFiltersWithIds,
     ]);
@@ -122,7 +124,7 @@ export const FilterForm: FC<{
                 onClick={() => {
                     addFieldRule();
                 }}
-                disabled={dimensions.length <= 0}
+                disabled={selectableDimensions.length <= 0}
             >
                 Add filter
             </Button>

--- a/packages/frontend/src/components/Explorer/CustomMetricModal/hooks/useDataForFiltersProvider.ts
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/hooks/useDataForFiltersProvider.ts
@@ -31,6 +31,7 @@ export const useDataForFiltersProvider = () => {
         customDimensions,
         additionalMetrics,
         tableCalculations,
+        includeHiddenFields: true,
     });
 
     return {

--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -226,6 +226,7 @@ const FiltersCard: FC = memo(() => {
         customDimensions,
         additionalMetrics,
         tableCalculations,
+        includeHiddenFields: false,
     });
 
     // Pre-compute filter rule labels for tooltip

--- a/packages/frontend/src/components/Explorer/FiltersCard/useFieldsWithSuggestions.test.ts
+++ b/packages/frontend/src/components/Explorer/FiltersCard/useFieldsWithSuggestions.test.ts
@@ -1,0 +1,75 @@
+import {
+    DimensionType,
+    FieldType,
+    SupportedDbtAdapter,
+    type CompiledDimension,
+    type Explore,
+} from '@lightdash/common';
+import { renderHook } from '@testing-library/react';
+import { useFieldsWithSuggestions } from './useFieldsWithSuggestions';
+
+const makeDimension = (name: string, hidden: boolean): CompiledDimension => ({
+    compiledSql: '',
+    tablesReferences: [],
+    fieldType: FieldType.DIMENSION,
+    type: DimensionType.STRING,
+    name,
+    label: name,
+    table: 'orders',
+    tableLabel: 'Orders',
+    sql: '',
+    hidden,
+});
+
+const explore: Explore = {
+    name: 'orders',
+    label: 'Orders',
+    tags: [],
+    baseTable: 'orders',
+    joinedTables: [],
+    tables: {
+        orders: {
+            name: 'orders',
+            label: 'Orders',
+            database: '',
+            schema: '',
+            sqlTable: 'orders',
+            dimensions: {
+                status: makeDimension('status', false),
+                order_notes: makeDimension('order_notes', true),
+            },
+            metrics: {},
+            lineageGraph: {},
+        },
+    },
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+};
+
+const renderFieldsWithSuggestions = (includeHiddenFields: boolean) =>
+    renderHook(() =>
+        useFieldsWithSuggestions({
+            exploreData: explore,
+            rows: undefined,
+            customDimensions: undefined,
+            additionalMetrics: undefined,
+            tableCalculations: undefined,
+            includeHiddenFields,
+        }),
+    );
+
+describe('useFieldsWithSuggestions', () => {
+    it('excludes hidden fields for the Explore Filters card', () => {
+        const { result } = renderFieldsWithSuggestions(false);
+
+        expect(Object.keys(result.current)).toEqual(['orders_status']);
+    });
+
+    it('includes hidden fields for the custom metric modal', () => {
+        const { result } = renderFieldsWithSuggestions(true);
+
+        expect(Object.keys(result.current).sort()).toEqual([
+            'orders_order_notes',
+            'orders_status',
+        ]);
+    });
+});

--- a/packages/frontend/src/components/Explorer/FiltersCard/useFieldsWithSuggestions.ts
+++ b/packages/frontend/src/components/Explorer/FiltersCard/useFieldsWithSuggestions.ts
@@ -1,9 +1,9 @@
 import {
     convertAdditionalMetric,
     DimensionType,
+    getFields,
     getItemId,
     getResultValueArray,
-    getVisibleFields,
     isCustomSqlDimension,
     isDimension,
     isFilterableField,
@@ -23,6 +23,7 @@ interface FieldsWithSuggestionsHookParams {
     customDimensions: CustomDimension[] | undefined;
     additionalMetrics: AdditionalMetric[] | undefined;
     tableCalculations: TableCalculation[] | undefined;
+    includeHiddenFields: boolean;
 }
 
 export type FieldWithSuggestions = FilterableField & {
@@ -37,6 +38,7 @@ export const useFieldsWithSuggestions = ({
     customDimensions,
     additionalMetrics,
     tableCalculations,
+    includeHiddenFields,
 }: FieldsWithSuggestionsHookParams) => {
     const [fieldsWithSuggestions, setFieldsWithSuggestions] =
         useState<FieldsWithSuggestions>({});
@@ -44,7 +46,9 @@ export const useFieldsWithSuggestions = ({
     useEffect(() => {
         if (exploreData) {
             setFieldsWithSuggestions((prev) => {
-                const visibleFields = getVisibleFields(exploreData);
+                const exploreFields = getFields(exploreData).filter(
+                    ({ hidden }) => includeHiddenFields || !hidden,
+                );
                 const customMetrics = (additionalMetrics || []).reduce<
                     Metric[]
                 >((acc, additionalMetric) => {
@@ -60,7 +64,7 @@ export const useFieldsWithSuggestions = ({
                 }, []);
 
                 return [
-                    ...visibleFields,
+                    ...exploreFields,
                     ...(customDimensions || []),
                     ...customMetrics,
                     ...(tableCalculations || []),
@@ -118,6 +122,7 @@ export const useFieldsWithSuggestions = ({
         additionalMetrics,
         tableCalculations,
         customDimensions,
+        includeHiddenFields,
     ]);
 
     return fieldsWithSuggestions;

--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.test.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.test.tsx
@@ -55,13 +55,19 @@ describe('FilterRuleForm', () => {
         delete (Element.prototype as Partial<Element>).scrollIntoView;
     });
 
-    it('labels and locks a filter that targets a hidden field', () => {
+    it('locks a hidden field and explains why in a tooltip', async () => {
+        const user = userEvent.setup();
         renderFilterRuleForm(hiddenDimension);
 
-        expect(screen.getByText('Hidden field')).toBeTruthy();
-        expect(screen.getByDisplayValue(hiddenDimension.label)).toBeDisabled();
+        const fieldSelect = screen.getByDisplayValue(hiddenDimension.label);
+        expect(fieldSelect).toBeDisabled();
         expect(screen.getByDisplayValue('is')).toBeEnabled();
         expect(screen.getByTestId('delete-filter-rule-button')).toBeEnabled();
+
+        await user.hover(fieldSelect);
+        expect(
+            await screen.findByText('Hidden fields cannot be changed.'),
+        ).toBeTruthy();
     });
 
     it('does not offer hidden fields when changing a visible filter', async () => {

--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.test.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.test.tsx
@@ -1,0 +1,80 @@
+import {
+    createFilterRuleFromField,
+    DimensionType,
+    FieldType,
+    type FilterableDimension,
+} from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../../../testing/testUtils';
+import FilterRuleForm from './FilterRuleForm';
+import FiltersProvider from './FiltersProvider';
+
+const hiddenDimension: FilterableDimension = {
+    fieldType: FieldType.DIMENSION,
+    type: DimensionType.NUMBER,
+    name: 'credit_card_amount',
+    label: 'Credit card amount',
+    table: 'orders',
+    tableLabel: 'Orders',
+    sql: '${TABLE}.credit_card_amount',
+    hidden: true,
+};
+
+const visibleDimension: FilterableDimension = {
+    ...hiddenDimension,
+    name: 'amount',
+    label: 'Amount',
+    sql: '${TABLE}.amount',
+    hidden: false,
+};
+
+const renderFilterRuleForm = (dimension: FilterableDimension) =>
+    renderWithProviders(
+        <FiltersProvider itemsMap={{}}>
+            <FilterRuleForm
+                fields={[visibleDimension, hiddenDimension]}
+                filterRule={createFilterRuleFromField(dimension)}
+                isEditMode
+                onChange={vi.fn()}
+                onDelete={vi.fn()}
+            />
+        </FiltersProvider>,
+    );
+
+describe('FilterRuleForm', () => {
+    beforeAll(() => {
+        Object.defineProperty(Element.prototype, 'scrollIntoView', {
+            configurable: true,
+            writable: true,
+            value: vi.fn(),
+        });
+    });
+
+    afterAll(() => {
+        delete (Element.prototype as Partial<Element>).scrollIntoView;
+    });
+
+    it('labels and locks a filter that targets a hidden field', () => {
+        renderFilterRuleForm(hiddenDimension);
+
+        expect(screen.getByText('Hidden field')).toBeTruthy();
+        expect(screen.getByDisplayValue(hiddenDimension.label)).toBeDisabled();
+        expect(screen.getByDisplayValue('is')).toBeEnabled();
+        expect(screen.getByTestId('delete-filter-rule-button')).toBeEnabled();
+    });
+
+    it('does not offer hidden fields when changing a visible filter', async () => {
+        const user = userEvent.setup();
+        renderFilterRuleForm(visibleDimension);
+
+        await user.click(screen.getByDisplayValue(visibleDimension.label));
+
+        expect(
+            await screen.findByRole('option', { name: visibleDimension.label }),
+        ).toBeTruthy();
+        expect(
+            screen.queryByRole('option', { name: hiddenDimension.label }),
+        ).toBeNull();
+    });
+});

--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
@@ -6,10 +6,20 @@ import {
     getFilterTypeFromItem,
     getItemId,
     isDateItem,
+    isField,
     type FilterableField,
     type FilterRule,
 } from '@lightdash/common';
-import { ActionIcon, Box, Group, Menu, Select, Tooltip } from '@mantine-8/core';
+import {
+    ActionIcon,
+    Badge,
+    Box,
+    Group,
+    Menu,
+    Select,
+    Stack,
+    Tooltip,
+} from '@mantine-8/core';
 import { IconDots, IconX } from '@tabler/icons-react';
 import { memo, useCallback, useMemo, type FC } from 'react';
 import FieldSelect from '../FieldSelect';
@@ -28,6 +38,9 @@ type Props = {
     onDelete: () => void;
     onConvertToGroup?: () => void;
 };
+
+const isHiddenField = (field: FilterableField) =>
+    isField(field) && field.hidden;
 
 const FilterRuleForm: FC<Props> = memo(
     ({
@@ -90,12 +103,22 @@ const FilterRuleForm: FC<Props> = memo(
         const isRequiredLabel = isRequired
             ? 'This is a required filter defined in the model configuration and cannot be removed.'
             : '';
+        const isActiveFieldHidden = activeField
+            ? isHiddenField(activeField)
+            : false;
 
         const availableFields = useMemo(() => {
-            if (!isRequired) return fields;
+            const selectableFields = fields.filter(
+                (field) =>
+                    !isHiddenField(field) ||
+                    getItemId(field) === filterRule.target.fieldId,
+            );
+            if (!isRequired) {
+                return selectableFields;
+            }
             // For required filters, restrict to same-type sub-dimensions
             const baseFieldId = filterRule.target.fieldId;
-            return fields.filter(
+            return selectableFields.filter(
                 (field) =>
                     getItemId(field).startsWith(baseFieldId) &&
                     getFilterTypeFromItem(field) === filterType,
@@ -103,7 +126,12 @@ const FilterRuleForm: FC<Props> = memo(
         }, [isRequired, fields, filterRule.target.fieldId, filterType]);
 
         const isFieldSelectDisabled =
-            !isEditMode || (isRequired && availableFields.length <= 1);
+            !isEditMode ||
+            isActiveFieldHidden ||
+            (isRequired && availableFields.length <= 1);
+        const fieldSelectDisabledReason = isActiveFieldHidden
+            ? 'Hidden fields cannot be changed.'
+            : isRequiredLabel;
 
         const isOperatorValid = useMemo(
             () =>
@@ -129,36 +157,45 @@ const FilterRuleForm: FC<Props> = memo(
                 data-testid="FilterRuleForm/filter-rule"
             >
                 <Tooltip
-                    label={isRequiredLabel}
-                    disabled={!isFieldSelectDisabled}
+                    label={fieldSelectDisabledReason}
+                    disabled={!fieldSelectDisabledReason}
                     withinPortal
                     multiline
                 >
                     <Box>
-                        <FieldSelect
-                            size="xs"
-                            disabled={isFieldSelectDisabled}
-                            comboboxProps={{
-                                withinPortal: popoverProps?.withinPortal,
-                            }}
-                            onDropdownOpen={popoverProps?.onOpen}
-                            onDropdownClose={popoverProps?.onClose}
-                            hasGrouping
-                            item={activeField}
-                            items={availableFields}
-                            onChange={(field) => {
-                                if (!field) return;
-                                onFieldChange(getItemId(field));
-                            }}
-                            baseTable={baseTable}
-                        />
+                        <Stack gap="xxs">
+                            <FieldSelect
+                                size="xs"
+                                disabled={isFieldSelectDisabled}
+                                comboboxProps={{
+                                    withinPortal: popoverProps?.withinPortal,
+                                }}
+                                onDropdownOpen={popoverProps?.onOpen}
+                                onDropdownClose={popoverProps?.onClose}
+                                hasGrouping
+                                item={activeField}
+                                items={availableFields}
+                                onChange={(field) => {
+                                    if (!field) {
+                                        return;
+                                    }
+                                    onFieldChange(getItemId(field));
+                                }}
+                                baseTable={baseTable}
+                            />
+                            {isActiveFieldHidden && (
+                                <Badge size="xs" variant="light">
+                                    Hidden field
+                                </Badge>
+                            )}
+                        </Stack>
                     </Box>
                 </Tooltip>
                 <Select
                     limit={FILTER_SELECT_LIMIT}
                     size="xs"
                     w="175px"
-                    style={{ flexShrink: 0 }}
+                    flex="0 0 auto"
                     onDropdownOpen={popoverProps?.onOpen}
                     onDropdownClose={popoverProps?.onClose}
                     disabled={!isEditMode}

--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
@@ -10,16 +10,7 @@ import {
     type FilterableField,
     type FilterRule,
 } from '@lightdash/common';
-import {
-    ActionIcon,
-    Badge,
-    Box,
-    Group,
-    Menu,
-    Select,
-    Stack,
-    Tooltip,
-} from '@mantine-8/core';
+import { ActionIcon, Box, Group, Menu, Select, Tooltip } from '@mantine-8/core';
 import { IconDots, IconX } from '@tabler/icons-react';
 import { memo, useCallback, useMemo, type FC } from 'react';
 import FieldSelect from '../FieldSelect';
@@ -163,32 +154,25 @@ const FilterRuleForm: FC<Props> = memo(
                     multiline
                 >
                     <Box>
-                        <Stack gap="xxs">
-                            <FieldSelect
-                                size="xs"
-                                disabled={isFieldSelectDisabled}
-                                comboboxProps={{
-                                    withinPortal: popoverProps?.withinPortal,
-                                }}
-                                onDropdownOpen={popoverProps?.onOpen}
-                                onDropdownClose={popoverProps?.onClose}
-                                hasGrouping
-                                item={activeField}
-                                items={availableFields}
-                                onChange={(field) => {
-                                    if (!field) {
-                                        return;
-                                    }
-                                    onFieldChange(getItemId(field));
-                                }}
-                                baseTable={baseTable}
-                            />
-                            {isActiveFieldHidden && (
-                                <Badge size="xs" variant="light">
-                                    Hidden field
-                                </Badge>
-                            )}
-                        </Stack>
+                        <FieldSelect
+                            size="xs"
+                            disabled={isFieldSelectDisabled}
+                            comboboxProps={{
+                                withinPortal: popoverProps?.withinPortal,
+                            }}
+                            onDropdownOpen={popoverProps?.onOpen}
+                            onDropdownClose={popoverProps?.onClose}
+                            hasGrouping
+                            item={activeField}
+                            items={availableFields}
+                            onChange={(field) => {
+                                if (!field) {
+                                    return;
+                                }
+                                onFieldChange(getItemId(field));
+                            }}
+                            baseTable={baseTable}
+                        />
                     </Box>
                 </Tooltip>
                 <Select


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9364/create-custom-metric-modal-drops-filters-on-hidden-dimensions-count

## Summary

Creating a custom metric from a metric with a hidden-dimension filter could show `Filters(4)` while rendering only three filter rows. The modal now shows the inherited hidden-field condition as a locked selector and lets users edit or delete the condition.

The ordinary Explore filter picker still excludes hidden fields.

## Root cause

The custom metric modal shared a visible-only field lookup with the Explore Filters card. The hidden filter remained in form state, but the rule renderer could not resolve its target field and returned no row.

```ts
const visibleFields = getVisibleFields(exploreData);
```

## Fix

The custom metric modal opts into hidden fields for resolving inherited rules. A hidden active field stays aligned with the other rows and locked; its existing tooltip explains why, while its operator, value, and delete action remain available. Hidden fields stay excluded from Add filter and every field picker.

- `CustomMetricModal` resolves hidden inherited filters and only adds visible fields.
- `FilterRuleForm` locks hidden active fields and explains the lock on hover without adding row-level decoration.
- `FiltersCard` retains its visible-only field lookup.

## Before

```text
Filters (4)
├── visible filter rows × 3
└── hidden filter → unresolved → no row
```

## After

```text
Filters (4)
├── visible filter rows × 3
└── hidden filter → aligned locked selector
    ├── tooltip explains why
    └── condition editable or deletable
```

## Test plan

- [x] `pnpm -F frontend test src/components/Explorer/CustomMetricModal src/components/Explorer/FiltersCard/useFieldsWithSuggestions.test.ts src/components/common/Filters` — 153 tests pass
- [x] `pnpm -F frontend typecheck --pretty false`
- [x] `pnpm -F frontend lint` — 0 warnings and 0 errors
- [x] `pnpm -F frontend format`
- [x] Chrome DevTools: four inherited filters render as aligned rows; the hidden field is locked and its tooltip appears on hover; operator/value edits and deletion remain available
- [x] Chrome DevTools: Add filter omits the hidden dimension; creating without edits preserves all four filter targets