### PR TITLE
fix(warehouses): stream the validated DuckDB prepared statement instead of re-preparing

### DIFF
--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
@@ -113,12 +113,15 @@ const createMockExtractStatements = (
         count: number;
         statementType: number;
     }>,
+    streamMock?: Mock,
 ) =>
     vi.fn(async () => ({
         count: overrides?.count ?? 1,
         prepare: async () => ({
             statementType: overrides?.statementType ?? 1, // SELECT
             destroySync: vi.fn(),
+            bind: vi.fn(),
+            stream: streamMock ?? (async () => getMockStreamResult([], [])),
         }),
     }));
 
@@ -134,7 +137,8 @@ const createMockConnection = (
         run: runMock,
         stream: streamMock,
         extractStatements:
-            opts?.extractStatements ?? createMockExtractStatements(),
+            opts?.extractStatements ??
+            createMockExtractStatements(undefined, streamMock),
         interrupt: opts?.interrupt ?? vi.fn(),
         closeSync: vi.fn(),
         disconnectSync: vi.fn(),
@@ -1548,7 +1552,10 @@ describe('DuckdbWarehouseClient', () => {
                 const streamMock = vi.fn(async () =>
                     getMockStreamResult([rows], [DUCKDB_TYPE_IDS.INTEGER]),
                 );
-                const extractStatementsMock = createMockExtractStatements();
+                const extractStatementsMock = createMockExtractStatements(
+                    undefined,
+                    streamMock,
+                );
 
                 createInstanceMock.mockResolvedValue(
                     createMockConnection(streamMock, vi.fn(), {
@@ -1778,6 +1785,101 @@ describe('DuckdbWarehouseClient', () => {
                 'SELECT id, name FROM users WHERE id = 1',
             );
             expect(result.rows).toEqual([{ id: 1, name: 'test' }]);
+        });
+
+        it('should stream the validated prepared statement instead of re-preparing', async () => {
+            const rows = [{ val: 1 }];
+            const connectionStreamMock = vi.fn();
+            const stmtStreamMock = vi.fn(async () =>
+                getMockStreamResult([rows], [DUCKDB_TYPE_IDS.INTEGER]),
+            );
+            const stmtDestroyMock = vi.fn();
+            const prepareMock = vi.fn(async () => ({
+                statementType: 1, // SELECT
+                destroySync: stmtDestroyMock,
+                bind: vi.fn(),
+                stream: stmtStreamMock,
+            }));
+            const extractStatementsMock = vi.fn(async () => ({
+                count: 1,
+                prepare: prepareMock,
+            }));
+
+            createInstanceMock.mockResolvedValue(
+                createMockConnection(connectionStreamMock, vi.fn(), {
+                    extractStatements: extractStatementsMock,
+                }),
+            );
+
+            const client = new DuckdbWarehouseClient();
+            const result = await client.runQuery('SELECT val FROM t');
+
+            expect(result.rows).toEqual(rows);
+            expect(extractStatementsMock).toHaveBeenCalledTimes(1);
+            expect(prepareMock).toHaveBeenCalledTimes(1);
+            expect(stmtStreamMock).toHaveBeenCalledTimes(1);
+            expect(stmtDestroyMock).toHaveBeenCalledTimes(1);
+            expect(connectionStreamMock).not.toHaveBeenCalled();
+        });
+
+        it('should bind values on the validated prepared statement', async () => {
+            const stmtBindMock = vi.fn();
+            const stmtStreamMock = vi.fn(async () =>
+                getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+            );
+            const extractStatementsMock = vi.fn(async () => ({
+                count: 1,
+                prepare: async () => ({
+                    statementType: 1, // SELECT
+                    destroySync: vi.fn(),
+                    bind: stmtBindMock,
+                    stream: stmtStreamMock,
+                }),
+            }));
+
+            createInstanceMock.mockResolvedValue(
+                createMockConnection(vi.fn(), vi.fn(), {
+                    extractStatements: extractStatementsMock,
+                }),
+            );
+
+            const client = new DuckdbWarehouseClient();
+            await client.runQuery(
+                'SELECT $1 AS val',
+                undefined,
+                undefined,
+                [1],
+            );
+
+            expect(stmtBindMock).toHaveBeenCalledWith([1]);
+            expect(stmtStreamMock).toHaveBeenCalledTimes(1);
+        });
+
+        it('should destroy the prepared statement when streaming fails', async () => {
+            const stmtDestroyMock = vi.fn();
+            const extractStatementsMock = vi.fn(async () => ({
+                count: 1,
+                prepare: async () => ({
+                    statementType: 1, // SELECT
+                    destroySync: stmtDestroyMock,
+                    bind: vi.fn(),
+                    stream: vi.fn(async () => {
+                        throw new Error('stream failed');
+                    }),
+                }),
+            }));
+
+            createInstanceMock.mockResolvedValue(
+                createMockConnection(vi.fn(), vi.fn(), {
+                    extractStatements: extractStatementsMock,
+                }),
+            );
+
+            const client = new DuckdbWarehouseClient();
+            await expect(client.runQuery('SELECT 1 AS val')).rejects.toThrow(
+                'stream failed',
+            );
+            expect(stmtDestroyMock).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -52,6 +52,8 @@ type DuckdbRunResult = {
 type DuckdbPreparedStatement = {
     statementType: number;
     destroySync: () => void;
+    bind: (values: AnyType[] | Record<string, AnyType>) => void;
+    stream: () => Promise<DuckdbStreamResult>;
 };
 
 type DuckdbExtractedStatements = {
@@ -1997,7 +1999,7 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
     private async validateSelectSql(
         db: DuckdbConnection,
         sql: string,
-    ): Promise<void> {
+    ): Promise<DuckdbPreparedStatement> {
         const extracted = await db.extractStatements(sql);
 
         if (extracted.count === 0) {
@@ -2011,32 +2013,31 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         }
 
         const stmt = await extracted.prepare(0);
-        try {
-            if (!ALLOWED_STATEMENT_TYPES_USER_SQL.has(stmt.statementType)) {
-                throw new Error(
-                    `SQL validation error: only SELECT statements are allowed (got statement type ${stmt.statementType})`,
-                );
-            }
-        } finally {
+        const { statementType } = stmt;
+        if (!ALLOWED_STATEMENT_TYPES_USER_SQL.has(statementType)) {
             stmt.destroySync();
+            throw new Error(
+                `SQL validation error: only SELECT statements are allowed (got statement type ${statementType})`,
+            );
         }
+        return stmt;
     }
 
     private async validateUserSql(
         db: DuckdbConnection,
         sql: string,
-    ): Promise<void> {
+    ): Promise<DuckdbPreparedStatement> {
         DuckdbWarehouseClient.validateSqlFunctions(sql);
         DuckdbWarehouseClient.validateUserSqlFileAccess(sql);
-        await this.validateSelectSql(db, sql);
+        return this.validateSelectSql(db, sql);
     }
 
     private async validatePreAggregateSql(
         db: DuckdbConnection,
         sql: string,
-    ): Promise<void> {
+    ): Promise<DuckdbPreparedStatement> {
         DuckdbWarehouseClient.validateSqlFunctions(sql);
-        await this.validateSelectSql(db, sql);
+        return this.validateSelectSql(db, sql);
     }
 
     private async validateInternalSql(
@@ -2126,18 +2127,26 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
                         "SET disabled_filesystems = 'LocalFileSystem';",
                     );
                 }
-                if (this.allowsPreAggregateFileReads) {
-                    await this.validatePreAggregateSql(db, sql);
-                } else {
-                    await this.validateUserSql(db, sql);
-                }
+                const sqlWithMetadata = this.getSQLWithMetadata(
+                    sql,
+                    options?.tags,
+                );
+                const stmt = this.allowsPreAggregateFileReads
+                    ? await this.validatePreAggregateSql(db, sqlWithMetadata)
+                    : await this.validateUserSql(db, sqlWithMetadata);
                 reportPhase?.('session', performance.now() - sessionStart);
 
                 const queryStart = performance.now();
-                const result = await db.stream(
-                    this.getSQLWithMetadata(sql, options?.tags),
-                    this.getBindValues(options),
-                );
+                let result: DuckdbStreamResult;
+                try {
+                    const bindValues = this.getBindValues(options);
+                    if (bindValues) {
+                        stmt.bind(bindValues);
+                    }
+                    result = await stmt.stream();
+                } finally {
+                    stmt.destroySync();
+                }
                 const fields =
                     DuckdbWarehouseClient.getFieldsFromStreamResult(result);
 

--- a/packages/warehouses/src/warehouseClients/MotherduckInstanceCache.security.test.ts
+++ b/packages/warehouses/src/warehouseClients/MotherduckInstanceCache.security.test.ts
@@ -31,6 +31,8 @@ const createMockInstance = (streamMock: Mock) => ({
             prepare: async () => ({
                 statementType: 1,
                 destroySync: vi.fn(),
+                bind: vi.fn(),
+                stream: streamMock,
             }),
         })),
         interrupt: vi.fn(),


### PR DESCRIPTION
## What

`DuckdbWarehouseClient.streamQuery()` parsed and bound every query twice: once in `validateSelectSql()` (`extractStatements` + `prepare(0)` to read `statementType`, then destroyed the statement) and again inside `db.stream()`, which `@duckdb/node-api` implements as `runUntilLast(sql)` → `prepare` → `stream` → `destroy`. On MotherDuck each `prepare()` is a server round trip.

This change keeps the prepared statement from validation, binds values on it, and streams it directly: one parse+bind round trip per query instead of two.

## Safety semantics (unchanged)

Same checks, same order, all before anything executes: blocked-function patterns → blocked file-access patterns → single-statement check → statement-type allow-list (SELECT only). What changed is only *which* prepared statement executes: the one that was validated, rather than a second identical one. Two small improvements fall out:

- validation now covers the exact executed SQL (including the metadata tag comment that was previously appended only after validation)
- the validated statement is destroyed on bind/stream failure as well as on the success path

## Expected impact

Removes one redundant parse+bind round trip per query — worth roughly 0.3–0.9s per query under load for large compiled SQL (~100KB class), less for small SQL. It does **not** remove the dominant per-connection catalog-resolution cost observed while investigating MotherDuck query latency on very large catalogs (thousands of relations): that cost is paid by whichever operation touches the catalog first on a fresh connection, and is being addressed separately (MotherDuck instance reuse, #26808).

## Evidence (controlled experiments)

Measured with probe scripts against a Lightdash-owned MotherDuck test account (catalog scaled synthetically up to 7,501 relations) plus local DuckDB 1.5.2:

- `extractStatements` is parse-only (parses SQL referencing missing tables without error); `prepare()` binds and resolves the catalog (server-side on `md:`) — so the second prepare inside `stream()` was pure duplicate work.
- Fresh-connection prepare cost scales with catalog size; warm stays flat:

  | catalog | fresh prepare (small SQL) | warm prepare (small SQL) |
  |---|---|---|
  | 1 relation | ~3ms | ~3ms |
  | 801 relations | ~101ms | ~3ms |
  | 7,501 relations | ~1,269ms | ~3ms |

- First-touch attribution at 7,501 relations, fresh connection per pattern: validate-then-stream (today) ≈ stream-only end-to-end (~1.38s both) — the cost moves to whichever op touches the catalog first. Second prepare on the same connection is ~2ms **even against a schema the connection never touched** — catalog resolution is per-connection, not per-schema.
- Concurrency (fresh instances, N parallel prepares vs N parallel streams): walls stay flat at N=1–4 and inflate together at N=8 (~2.9s both arms) — no prepare-specific serialization at this scale; prepares and streams queue alike server-side.
- Side observation: creating the 7,500 tables took 42 minutes with superlinear slowdown per batch — server-side catalog operation cost grows with catalog size.
- Caveat: the test account hit its daily compute limit during the large-catalog runs; absolute timings may be inflated, but the fresh-vs-warm contrast (~1,269ms vs ~3ms on the same catalog) is structural.
- Live smoke test of this branch against the test account: SELECT returns rows with phases `connect=674ms session=405ms query=909ms`; `CREATE TABLE` rejected (`only SELECT statements are allowed`); multi-statement rejected; `read_parquet()` rejected; `$1`/`$2` value binding works.

## Verification

- `DuckdbWarehouseClient.test.ts`: 81 tests pass, including new coverage — streams the validated prepared statement (exactly one prepare, connection-level `stream` never called), binds values on it, destroys it on stream failure. All existing validation-rejection tests unchanged and passing.
- Full `@lightdash/warehouses` suite: 348 tests pass (2 pre-existing skips). Typecheck (warehouses + backend), oxlint, oxfmt clean.
- Live against MotherDuck (test account): `MotherduckInstanceCache.integration.test.ts` passes with this change in place (held vs fresh instance behavior, catalog freshness).

Linear: SPK-844
