### PR TITLE
feat: add organization controls for AI agent memories

### DIFF
--- a/packages/backend/src/database/entities/organizations.ts
+++ b/packages/backend/src/database/entities/organizations.ts
@@ -25,6 +25,7 @@ export type DbOrganization = {
     default_project_uuid: string | null;
     color_palette_uuid: string | null;
     impersonation_enabled: boolean;
+    ai_agent_memory_enabled: boolean | null;
     brand: DbOrganizationBrand | null;
 };
 
@@ -36,6 +37,7 @@ export type DbOrganizationUpdate = Partial<
         | 'default_project_uuid'
         | 'color_palette_uuid'
         | 'impersonation_enabled'
+        | 'ai_agent_memory_enabled'
         | 'brand'
     >
 >;

--- a/packages/backend/src/database/migrations/20260804120000_add_ai_agent_memory_enabled_to_organizations.ts
+++ b/packages/backend/src/database/migrations/20260804120000_add_ai_agent_memory_enabled_to_organizations.ts
@@ -1,0 +1,34 @@
+import { Knex } from 'knex';
+
+const OrganizationsTableName = 'organizations';
+const FeatureFlagOverridesTableName = 'feature_flag_overrides';
+const AiAgentMemoryFlag = 'ai-agent-memory';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(OrganizationsTableName, (table) => {
+        table.boolean('ai_agent_memory_enabled').nullable();
+    });
+
+    if (await knex.schema.hasTable(FeatureFlagOverridesTableName)) {
+        await knex.raw(`
+            UPDATE ${OrganizationsTableName} o
+            SET ai_agent_memory_enabled = true
+            FROM ${FeatureFlagOverridesTableName} ffo
+            WHERE ffo.organization_uuid = o.organization_uuid
+              AND ffo.user_uuid IS NULL
+              AND ffo.flag_id = '${AiAgentMemoryFlag}'
+              AND ffo.enabled = true
+        `);
+    }
+
+    await knex.raw(`
+        ALTER TABLE ${OrganizationsTableName}
+        ALTER COLUMN ai_agent_memory_enabled SET DEFAULT true
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(OrganizationsTableName, (table) => {
+        table.dropColumn('ai_agent_memory_enabled');
+    });
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -166,6 +166,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     projectModel: models.getProjectModel(),
                     userModel: models.getUserModel(),
                     featureFlagService: repository.getFeatureFlagService(),
+                    aiOrganizationSettingsService:
+                        repository.getAiOrganizationSettingsService(),
                     schedulerClient:
                         clients.getSchedulerClient() as CommercialSchedulerClient,
                     consolidationDryRun:
@@ -645,6 +647,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     organizationModel: models.getOrganizationModel(),
                     commercialFeatureFlagModel:
                         models.getFeatureFlagModel() as CommercialFeatureFlagModel,
+                    featureFlagService: repository.getFeatureFlagService(),
                     lightdashConfig: context.lightdashConfig,
                     orgAiCopilotConfigResolver: new OrgAiCopilotConfigResolver({
                         lightdashConfig: context.lightdashConfig,

--- a/packages/backend/src/ee/models/AiAgentMemoryModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentMemoryModel.integration.test.ts
@@ -279,6 +279,15 @@ describe('AiAgentMemoryModel integration', () => {
             projectModel,
             userModel: { findSessionUserAndOrgByUuid: vi.fn() } as never,
             featureFlagService,
+            aiOrganizationSettingsService: {
+                isAiAgentMemoryEnabled: async (user) =>
+                    (
+                        await featureFlagService.get({
+                            user,
+                            featureFlagId: FeatureFlags.AiAgentMemory,
+                        })
+                    ).enabled,
+            },
             schedulerClient,
             consolidationDryRun: false,
             distillCall,

--- a/packages/backend/src/ee/models/AiOrganizationSettingsModel.ts
+++ b/packages/backend/src/ee/models/AiOrganizationSettingsModel.ts
@@ -23,6 +23,11 @@ type Dependencies = {
     encryptionUtil: EncryptionUtil;
 };
 
+export type StoredAiOrganizationSettings = Omit<
+    AiOrganizationSettings,
+    'aiAgentMemoryEnabled'
+>;
+
 export type AiOrgProviderApiKeys = {
     anthropic?: string;
     openai?: string;
@@ -103,7 +108,7 @@ export class AiOrganizationSettingsModel {
 
     private mapDbToEntity(
         db: DbAiOrganizationSettings,
-    ): AiOrganizationSettings {
+    ): StoredAiOrganizationSettings {
         const keys = this.decryptProviderApiKeys(
             db.encrypted_provider_api_keys,
         );
@@ -131,8 +136,9 @@ export class AiOrganizationSettingsModel {
 
     async findByOrganizationUuid(
         organizationUuid: string,
-    ): Promise<AiOrganizationSettings | null> {
-        const row = await this.database
+        database: Knex = this.database,
+    ): Promise<StoredAiOrganizationSettings | null> {
+        const row = await database
             .select<DbAiOrganizationSettings>()
             .from(AiOrganizationSettingsTableName)
             .where('organization_uuid', organizationUuid)
@@ -143,8 +149,12 @@ export class AiOrganizationSettingsModel {
 
     async getByOrganizationUuid(
         organizationUuid: string,
-    ): Promise<AiOrganizationSettings> {
-        const settings = await this.findByOrganizationUuid(organizationUuid);
+        database: Knex = this.database,
+    ): Promise<StoredAiOrganizationSettings> {
+        const settings = await this.findByOrganizationUuid(
+            organizationUuid,
+            database,
+        );
         if (!settings) {
             throw new NotFoundError(
                 `AI organization settings not found for organization ${organizationUuid}`,
@@ -173,10 +183,11 @@ export class AiOrganizationSettingsModel {
 
     async create(
         data: CreateAiOrganizationSettings,
-    ): Promise<AiOrganizationSettings> {
+        database: Knex = this.database,
+    ): Promise<StoredAiOrganizationSettings> {
         const keys = applyProviderApiKeyUpdates({}, data.providerApiKeys ?? {});
 
-        const [row] = await this.database<AiOrganizationSettingsTable>(
+        const [row] = await database<AiOrganizationSettingsTable>(
             AiOrganizationSettingsTableName,
         )
             .insert({
@@ -201,7 +212,8 @@ export class AiOrganizationSettingsModel {
     async update(
         organizationUuid: string,
         data: UpdateAiOrganizationSettings,
-    ): Promise<AiOrganizationSettings> {
+        database: Knex = this.database,
+    ): Promise<StoredAiOrganizationSettings> {
         const updateData: Partial<
             Pick<
                 DbAiOrganizationSettings,
@@ -246,7 +258,7 @@ export class AiOrganizationSettingsModel {
         }
         if (data.providerApiKeys !== undefined) {
             const providerApiKeyUpdates = data.providerApiKeys;
-            return this.database.transaction(async (trx) => {
+            return database.transaction(async (trx) => {
                 const currentRow = await trx(AiOrganizationSettingsTableName)
                     .select('encrypted_provider_api_keys')
                     .where('organization_uuid', organizationUuid)
@@ -294,10 +306,10 @@ export class AiOrganizationSettingsModel {
             });
         }
         if (Object.keys(updateData).length === 0) {
-            return this.getByOrganizationUuid(organizationUuid);
+            return this.getByOrganizationUuid(organizationUuid, database);
         }
 
-        const [row] = await this.database<AiOrganizationSettingsTable>(
+        const [row] = await database<AiOrganizationSettingsTable>(
             AiOrganizationSettingsTableName,
         )
             .where('organization_uuid', organizationUuid)
@@ -316,26 +328,40 @@ export class AiOrganizationSettingsModel {
     async upsert(
         organizationUuid: string,
         data: UpdateAiOrganizationSettings,
-    ): Promise<AiOrganizationSettings> {
-        const existing = await this.findByOrganizationUuid(organizationUuid);
+        database: Knex = this.database,
+    ): Promise<StoredAiOrganizationSettings> {
+        const existing = await this.findByOrganizationUuid(
+            organizationUuid,
+            database,
+        );
 
         if (existing) {
-            return this.update(organizationUuid, data);
+            return this.update(organizationUuid, data, database);
         }
-        return this.create({
-            organizationUuid,
-            aiAgentsVisible: data.aiAgentsVisible ?? true,
-            aiAgentReviewsEnabled: data.aiAgentReviewsEnabled ?? false,
-            deepResearchLimits:
-                data.deepResearchLimits ?? AI_DEEP_RESEARCH_DEFAULT_LIMITS,
-            mcpContentWritesEnabled: data.mcpContentWritesEnabled ?? true,
-            requireExplicitSlackChannelLinking:
-                data.requireExplicitSlackChannelLinking ?? false,
-            defaultAiAgentModelConfig: data.defaultAiAgentModelConfig ?? null,
-            modelVisibility: data.modelVisibility ?? null,
-            dataAppModelVisibility: data.dataAppModelVisibility ?? null,
-            providerApiKeys: data.providerApiKeys,
-        });
+        return this.create(
+            {
+                organizationUuid,
+                aiAgentsVisible: data.aiAgentsVisible ?? true,
+                aiAgentReviewsEnabled: data.aiAgentReviewsEnabled ?? false,
+                deepResearchLimits:
+                    data.deepResearchLimits ?? AI_DEEP_RESEARCH_DEFAULT_LIMITS,
+                mcpContentWritesEnabled: data.mcpContentWritesEnabled ?? true,
+                requireExplicitSlackChannelLinking:
+                    data.requireExplicitSlackChannelLinking ?? false,
+                defaultAiAgentModelConfig:
+                    data.defaultAiAgentModelConfig ?? null,
+                modelVisibility: data.modelVisibility ?? null,
+                dataAppModelVisibility: data.dataAppModelVisibility ?? null,
+                providerApiKeys: data.providerApiKeys,
+            },
+            database,
+        );
+    }
+
+    async transaction<T>(
+        callback: (trx: Knex.Transaction) => Promise<T>,
+    ): Promise<T> {
+        return this.database.transaction(callback);
     }
 
     async delete(organizationUuid: string): Promise<void> {

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -360,6 +360,7 @@ const makeService = ({
         },
         aiOrganizationSettingsService: {
             isAiAgentReviewsEnabled: vi.fn().mockResolvedValue(true),
+            isAiAgentMemoryEnabled: vi.fn().mockResolvedValue(true),
             ...aiOrganizationSettingsService,
         },
         projectModel: {
@@ -593,10 +594,10 @@ describe('AiAgentAdminService review access', () => {
 });
 
 describe('AiAgentAdminService.getAllMemories', () => {
-    it('rejects when the memory feature flag is disabled', async () => {
+    it('rejects when AI agent memory is disabled', async () => {
         const service = makeService({
-            featureFlagService: {
-                get: vi.fn().mockResolvedValue({ enabled: false }),
+            aiOrganizationSettingsService: {
+                isAiAgentMemoryEnabled: vi.fn().mockResolvedValue(false),
             },
         });
 

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -764,11 +764,11 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        const { enabled } = await this.featureFlagService.get({
-            featureFlagId: FeatureFlags.AiAgentMemory,
-            user,
-        });
-        if (!enabled) {
+        if (
+            !(await this.aiOrganizationSettingsService.isAiAgentMemoryEnabled(
+                user,
+            ))
+        ) {
             throw new ForbiddenError('AI agent memory is not enabled');
         }
 

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryConsolidation.integration.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryConsolidation.integration.test.ts
@@ -277,6 +277,15 @@ describe('AI agent memory consolidation integration', () => {
                 ),
             },
             featureFlagService,
+            aiOrganizationSettingsService: {
+                isAiAgentMemoryEnabled: async (user) =>
+                    (
+                        await featureFlagService.get({
+                            user,
+                            featureFlagId: FeatureFlags.AiAgentMemory,
+                        })
+                    ).enabled,
+            },
             schedulerClient: schedulerClientOverride ?? schedulerClient,
             consolidationDryRun,
             consolidateCall,

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.consolidateLlm.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.consolidateLlm.test.ts
@@ -84,6 +84,9 @@ const build = () => {
                 enabled: true,
             })),
         } as AnyType,
+        aiOrganizationSettingsService: {
+            isAiAgentMemoryEnabled: vi.fn().mockResolvedValue(true),
+        },
         schedulerClient: {
             aiAgentMemoryDistill: vi.fn(),
             aiAgentMemoryConsolidatePartition: vi.fn(),

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
@@ -265,6 +265,15 @@ describe('AiAgentMemoryService', () => {
             } as AnyType,
             userModel: { findSessionUserAndOrgByUuid } as AnyType,
             featureFlagService: { get: getFlag } as AnyType,
+            aiOrganizationSettingsService: {
+                isAiAgentMemoryEnabled: async (user) =>
+                    (
+                        await getFlag({
+                            user,
+                            featureFlagId: FeatureFlags.AiAgentMemory,
+                        })
+                    ).enabled,
+            },
             schedulerClient: {
                 aiAgentMemoryDistill,
                 aiAgentMemoryConsolidatePartition,

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
@@ -1,7 +1,6 @@
 import { subject } from '@casl/ability';
 import {
     CommercialFeatureFlags,
-    FeatureFlags,
     ForbiddenError,
     getAiProjectContextObjectKey,
     getErrorMessage,
@@ -67,6 +66,7 @@ import {
     getLanguageModelAttribution,
 } from '../ai/utils/aiCallTelemetry';
 import { canAccessAiAgentThread } from '../AiAgentService/aiAgentAccess';
+import { type AiOrganizationSettingsService } from '../AiOrganizationSettingsService';
 import {
     AI_AGENT_MEMORY_CONSOLIDATION_CALL_TIMEOUT_MS,
     AI_AGENT_MEMORY_CONSOLIDATION_INPUT_LIMIT,
@@ -173,6 +173,10 @@ type Dependencies = {
     projectModel: Pick<ProjectModel, 'findExploresFromCache' | 'getSummary'>;
     userModel: Pick<UserModel, 'findSessionUserAndOrgByUuid'>;
     featureFlagService: FeatureFlagService;
+    aiOrganizationSettingsService: Pick<
+        AiOrganizationSettingsService,
+        'isAiAgentMemoryEnabled'
+    >;
     schedulerClient: MemorySchedulerClient;
     /** Runs consolidation without applying its proposed operations. */
     consolidationDryRun: boolean;
@@ -199,6 +203,8 @@ export class AiAgentMemoryService extends BaseService {
 
     private readonly featureFlagService: FeatureFlagService;
 
+    private readonly aiOrganizationSettingsService: Dependencies['aiOrganizationSettingsService'];
+
     private readonly schedulerClient: MemorySchedulerClient;
 
     private readonly consolidationDryRun: boolean;
@@ -222,6 +228,8 @@ export class AiAgentMemoryService extends BaseService {
         this.projectModel = dependencies.projectModel;
         this.userModel = dependencies.userModel;
         this.featureFlagService = dependencies.featureFlagService;
+        this.aiOrganizationSettingsService =
+            dependencies.aiOrganizationSettingsService;
         this.schedulerClient = dependencies.schedulerClient;
         this.consolidationDryRun = dependencies.consolidationDryRun;
         this.prometheusMetrics = dependencies.prometheusMetrics;
@@ -376,17 +384,14 @@ export class AiAgentMemoryService extends BaseService {
 
     private async isEnabled(organizationUuid: UUID): Promise<boolean> {
         const user = { userUuid: 'system', organizationUuid };
-        const [copilot, memory] = await Promise.all([
+        const [copilot, memoryEnabled] = await Promise.all([
             this.featureFlagService.get({
                 user,
                 featureFlagId: CommercialFeatureFlags.AiCopilot,
             }),
-            this.featureFlagService.get({
-                user,
-                featureFlagId: FeatureFlags.AiAgentMemory,
-            }),
+            this.aiOrganizationSettingsService.isAiAgentMemoryEnabled(user),
         ]);
-        return copilot.enabled && memory.enabled;
+        return copilot.enabled && memoryEnabled;
     }
 
     private async filterByEnabledOrganizations<
@@ -459,17 +464,14 @@ export class AiAgentMemoryService extends BaseService {
             throw new ForbiddenError('Cannot view project');
         }
 
-        const [copilot, memoryFlag] = await Promise.all([
+        const [copilot, memoryEnabled] = await Promise.all([
             this.featureFlagService.get({
                 user,
                 featureFlagId: CommercialFeatureFlags.AiCopilot,
             }),
-            this.featureFlagService.get({
-                user,
-                featureFlagId: FeatureFlags.AiAgentMemory,
-            }),
+            this.aiOrganizationSettingsService.isAiAgentMemoryEnabled(user),
         ]);
-        if (!copilot.enabled || !memoryFlag.enabled) {
+        if (!copilot.enabled || !memoryEnabled) {
             throw new NotFoundError(notFoundMessage);
         }
 

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -8973,11 +8973,10 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         // the agent's stream starts pulling.
         const stepProgressEmitter =
             stream && !isSlackPrompt(prompt) ? new EventEmitter() : undefined;
-        const { enabled: aiAgentMemoryEnabled } =
-            await this.featureFlagService.get({
+        const aiAgentMemoryEnabled =
+            await this.aiOrganizationSettingsService.isAiAgentMemoryEnabled(
                 user,
-                featureFlagId: FeatureFlags.AiAgentMemory,
-            });
+            );
 
         const {
             listExplores,
@@ -10076,10 +10075,12 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
     // Markers are stripped from Slack prose, so cited memories surface as native
     // citation elements instead. Slugs without an active memory row are dropped.
     private async getSlackMemoryCitationBlocks({
+        user,
         slackPrompt,
         agent,
         response,
     }: {
+        user: SessionUser;
         slackPrompt: SlackPrompt;
         agent: AiAgent | undefined;
         response: string;
@@ -10090,6 +10091,12 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         if (slugs.length === 0) return [];
 
         try {
+            const memoryEnabled =
+                await this.aiOrganizationSettingsService.isAiAgentMemoryEnabled(
+                    user,
+                );
+            if (!memoryEnabled) return [];
+
             const ownerUserUuid = await this.findThreadMemoryOwnerUuid({
                 organizationUuid: slackPrompt.organizationUuid,
                 projectUuid: slackPrompt.projectUuid,
@@ -10263,6 +10270,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 : [];
 
         const memoryCitationBlocks = await this.getSlackMemoryCitationBlocks({
+            user,
             slackPrompt,
             agent,
             response,

--- a/packages/backend/src/ee/services/AiOrganizationSettingsService.test.ts
+++ b/packages/backend/src/ee/services/AiOrganizationSettingsService.test.ts
@@ -18,6 +18,7 @@ const settingsWithKeys: AiOrganizationSettings = {
     organizationUuid: 'org-uuid',
     aiAgentsVisible: true,
     aiAgentReviewsEnabled: false,
+    aiAgentMemoryEnabled: false,
     deepResearchLimits: AI_DEEP_RESEARCH_DEFAULT_LIMITS,
     mcpContentWritesEnabled: true,
     requireExplicitSlackChannelLinking: false,
@@ -289,16 +290,28 @@ describe('upsertSettings model validation', () => {
         storedDefault?: unknown;
     } = {}) => {
         const upsert = vi.fn(async (_org: string, data: unknown) => data);
+        const updateAiAgentMemoryEnabled = vi.fn();
+        const transaction = vi.fn(
+            async (callback: (trx: unknown) => Promise<unknown>) =>
+                callback('transaction'),
+        );
         const service = new AiOrganizationSettingsService({
             aiOrganizationSettingsModel: {
                 findByOrganizationUuid: async () => ({
                     defaultAiAgentModelConfig: storedDefault,
                 }),
                 upsert,
+                transaction,
             },
-            organizationModel: {},
+            organizationModel: {
+                getAiAgentMemoryEnabled: async () => false,
+                updateAiAgentMemoryEnabled,
+            },
             commercialFeatureFlagModel: {
                 get: async () => ({ enabled: true }),
+            },
+            featureFlagService: {
+                get: async () => ({ enabled: false }),
             },
             lightdashConfig: ANTHROPIC_ONLY_CONFIG,
             orgAiCopilotConfigResolver: {
@@ -318,7 +331,18 @@ describe('upsertSettings model validation', () => {
         (
             service as unknown as { createAuditedAbility: () => unknown }
         ).createAuditedAbility = () => ({ can: () => true });
-        return { service, upsert };
+        const getSettings = vi.fn().mockResolvedValue({
+            organizationUuid: 'org-uuid',
+            aiAgentMemoryEnabled: false,
+        });
+        service.getSettings = getSettings;
+        return {
+            service,
+            getSettings,
+            upsert,
+            transaction,
+            updateAiAgentMemoryEnabled,
+        };
     };
 
     const user = { organizationUuid: 'org-uuid' } as never;
@@ -412,6 +436,42 @@ describe('upsertSettings model validation', () => {
         });
     });
 
+    it('stores an explicit off setting without writing AI settings', async () => {
+        const { service, getSettings, upsert, updateAiAgentMemoryEnabled } =
+            buildService();
+
+        await service.upsertSettings(user, { aiAgentMemoryEnabled: false });
+
+        expect(upsert).not.toHaveBeenCalled();
+        expect(updateAiAgentMemoryEnabled).toHaveBeenCalledWith(
+            'org-uuid',
+            false,
+        );
+        expect(getSettings).toHaveBeenCalledWith(user);
+    });
+
+    it('updates memory with other settings in one transaction', async () => {
+        const { service, transaction, upsert, updateAiAgentMemoryEnabled } =
+            buildService();
+
+        await service.upsertSettings(user, {
+            aiAgentMemoryEnabled: false,
+            aiAgentsVisible: false,
+        });
+
+        expect(transaction).toHaveBeenCalledOnce();
+        expect(upsert).toHaveBeenCalledWith(
+            'org-uuid',
+            { aiAgentsVisible: false },
+            'transaction',
+        );
+        expect(updateAiAgentMemoryEnabled).toHaveBeenCalledWith(
+            'org-uuid',
+            false,
+            'transaction',
+        );
+    });
+
     it('repoints a stored default that the new visibility hides', async () => {
         const { service, upsert } = buildService({
             storedDefault: {
@@ -428,6 +488,58 @@ describe('upsertSettings model validation', () => {
                 modelProvider: 'anthropic',
             },
         });
+    });
+});
+
+describe('isAiAgentMemoryEnabled', () => {
+    const buildService = (
+        settingEnabled: boolean | null,
+        flagEnabled: boolean,
+    ) => {
+        const getFlag = vi.fn().mockResolvedValue({ enabled: flagEnabled });
+        const service = new AiOrganizationSettingsService({
+            organizationModel: {
+                getAiAgentMemoryEnabled: vi
+                    .fn()
+                    .mockResolvedValue(settingEnabled),
+            },
+            featureFlagService: {
+                get: getFlag,
+            },
+        } as never);
+        return { getFlag, service };
+    };
+
+    it.each([
+        [null, false, false],
+        [null, true, true],
+        [false, true, false],
+        [true, false, true],
+        [true, true, true],
+    ])(
+        'resolves persisted=%s with flag=%s as %s',
+        async (settingEnabled, flagEnabled, expected) => {
+            await expect(
+                buildService(
+                    settingEnabled,
+                    flagEnabled,
+                ).service.isAiAgentMemoryEnabled({
+                    organizationUuid: 'org-uuid',
+                    userUuid: 'user-uuid',
+                }),
+            ).resolves.toBe(expected);
+        },
+    );
+
+    it('does not read the flag after an explicit choice', async () => {
+        const { getFlag, service } = buildService(false, true);
+
+        await service.isAiAgentMemoryEnabled({
+            organizationUuid: 'org-uuid',
+            userUuid: 'user-uuid',
+        });
+
+        expect(getFlag).not.toHaveBeenCalled();
     });
 });
 

--- a/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
+++ b/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
@@ -5,6 +5,7 @@ import {
     BYO_AI_PROVIDERS,
     CommercialFeatureFlags,
     ComputedAiOrganizationSettings,
+    FeatureFlags,
     ForbiddenError,
     getVisibleDataAppClaudeModels,
     LightdashUser,
@@ -21,7 +22,11 @@ import {
 import { LightdashConfig } from '../../config/parseConfig';
 import { OrganizationModel } from '../../models/OrganizationModel';
 import { BaseService } from '../../services/BaseService';
-import { AiOrganizationSettingsModel } from '../models/AiOrganizationSettingsModel';
+import { FeatureFlagService } from '../../services/FeatureFlag/FeatureFlagService';
+import {
+    AiOrganizationSettingsModel,
+    type StoredAiOrganizationSettings,
+} from '../models/AiOrganizationSettingsModel';
 import { CommercialFeatureFlagModel } from '../models/CommercialFeatureFlagModel';
 import {
     filterModelsForOrg,
@@ -95,9 +100,9 @@ export const pickReplacementDefaultModelConfig = (
  * endpoint (agent chat surfaces) and must not see key hints.
  */
 export const maskProviderKeyExposure = (
-    settings: AiOrganizationSettings,
+    settings: StoredAiOrganizationSettings,
     canManage: boolean,
-): AiOrganizationSettings =>
+): StoredAiOrganizationSettings =>
     canManage
         ? settings
         : {
@@ -151,6 +156,7 @@ type AiOrganizationSettingsServiceDependencies = {
     aiOrganizationSettingsModel: AiOrganizationSettingsModel;
     organizationModel: OrganizationModel;
     commercialFeatureFlagModel: CommercialFeatureFlagModel;
+    featureFlagService: FeatureFlagService;
     lightdashConfig: LightdashConfig;
     orgAiCopilotConfigResolver: OrgAiCopilotConfigResolver;
 };
@@ -161,6 +167,8 @@ export class AiOrganizationSettingsService extends BaseService {
     private readonly organizationModel: OrganizationModel;
 
     private readonly commercialFeatureFlagModel: CommercialFeatureFlagModel;
+
+    private readonly featureFlagService: FeatureFlagService;
 
     private readonly lightdashConfig: LightdashConfig;
 
@@ -176,6 +184,7 @@ export class AiOrganizationSettingsService extends BaseService {
         this.organizationModel = dependencies.organizationModel;
         this.commercialFeatureFlagModel =
             dependencies.commercialFeatureFlagModel;
+        this.featureFlagService = dependencies.featureFlagService;
         this.lightdashConfig = dependencies.lightdashConfig;
         this.orgAiCopilotConfigResolver =
             dependencies.orgAiCopilotConfigResolver;
@@ -293,6 +302,22 @@ export class AiOrganizationSettingsService extends BaseService {
         return settings?.requireExplicitSlackChannelLinking ?? false;
     }
 
+    async isAiAgentMemoryEnabled(
+        user: Pick<LightdashUser, 'userUuid' | 'organizationUuid'>,
+    ): Promise<boolean> {
+        if (!user.organizationUuid) return false;
+        const settingEnabled =
+            await this.organizationModel.getAiAgentMemoryEnabled(
+                user.organizationUuid,
+            );
+        if (settingEnabled !== null) return settingEnabled;
+        const flag = await this.featureFlagService.get({
+            user,
+            featureFlagId: FeatureFlags.AiAgentMemory,
+        });
+        return flag.enabled;
+    }
+
     async getSettings(
         user: SessionUser,
     ): Promise<AiOrganizationSettings & ComputedAiOrganizationSettings> {
@@ -308,10 +333,12 @@ export class AiOrganizationSettingsService extends BaseService {
             user.organizationUuid,
         );
 
-        const settings =
-            await this.aiOrganizationSettingsModel.findByOrganizationUuid(
+        const [settings, aiAgentMemoryEnabled] = await Promise.all([
+            this.aiOrganizationSettingsModel.findByOrganizationUuid(
                 user.organizationUuid,
-            );
+            ),
+            this.isAiAgentMemoryEnabled(user),
+        ]);
 
         // Partial key material (hints) and the "key is set" booleans are only
         // exposed to org admins; other members read this endpoint too (agent
@@ -344,6 +371,7 @@ export class AiOrganizationSettingsService extends BaseService {
                 isCopilotEnabled,
                 aiAgentsVisible: true,
                 aiAgentReviewsEnabled: false,
+                aiAgentMemoryEnabled,
                 deepResearchLimits: AI_DEEP_RESEARCH_DEFAULT_LIMITS,
                 mcpContentWritesEnabled: true,
                 requireExplicitSlackChannelLinking: false,
@@ -363,6 +391,7 @@ export class AiOrganizationSettingsService extends BaseService {
 
         return {
             ...maskProviderKeyExposure(settings, canManage),
+            aiAgentMemoryEnabled,
             // Surface the effective visibility (implicit BYOK defaults merged in)
             // so the admin card reflects what users actually see.
             modelVisibility: effectiveModelVisibility,
@@ -381,14 +410,28 @@ export class AiOrganizationSettingsService extends BaseService {
         user: SessionUser,
         data: UpdateAiOrganizationSettings,
     ): Promise<AiOrganizationSettings> {
-        if (!user.organizationUuid) {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
             throw new ForbiddenError('User must belong to an organization');
         }
 
         this.checkManageAiAgentAccess(user);
 
-        if (data.deepResearchLimits !== undefined) {
-            validateDeepResearchLimits(data.deepResearchLimits);
+        const { aiAgentMemoryEnabled, ...aiSettingsUpdate } = data;
+        const isMemoryOnlyUpdate =
+            aiAgentMemoryEnabled !== undefined &&
+            Object.keys(aiSettingsUpdate).length === 0;
+
+        if (isMemoryOnlyUpdate) {
+            await this.organizationModel.updateAiAgentMemoryEnabled(
+                organizationUuid,
+                aiAgentMemoryEnabled,
+            );
+            return this.getSettings(user);
+        }
+
+        if (aiSettingsUpdate.deepResearchLimits !== undefined) {
+            validateDeepResearchLimits(aiSettingsUpdate.deepResearchLimits);
         }
 
         // Set when hiding models orphans the org's configured default, so the
@@ -401,8 +444,8 @@ export class AiOrganizationSettingsService extends BaseService {
         // that can't reach it → zero models). Require separate requests so the
         // two never race.
         if (
-            data.providerApiKeys !== undefined &&
-            data.modelVisibility !== undefined
+            aiSettingsUpdate.providerApiKeys !== undefined &&
+            aiSettingsUpdate.modelVisibility !== undefined
         ) {
             throw new ParameterError(
                 'Update provider API keys and model visibility in separate requests',
@@ -410,16 +453,14 @@ export class AiOrganizationSettingsService extends BaseService {
         }
 
         if (
-            data.providerApiKeys !== undefined ||
-            data.modelVisibility !== undefined
+            aiSettingsUpdate.providerApiKeys !== undefined ||
+            aiSettingsUpdate.modelVisibility !== undefined
         ) {
             // BYO keys and model visibility require both AI copilot (env/ai-copilot
             // flag) and the org-ai-provider-api-keys flag to be enabled for this org.
             const [copilotEnabled, byoKeysEnabled] = await Promise.all([
                 this.getIsCopilotEnabled(user),
-                this.orgAiCopilotConfigResolver.isEnabled(
-                    user.organizationUuid,
-                ),
+                this.orgAiCopilotConfigResolver.isEnabled(organizationUuid),
             ]);
             if (!copilotEnabled || !byoKeysEnabled) {
                 throw new ForbiddenError(
@@ -428,9 +469,9 @@ export class AiOrganizationSettingsService extends BaseService {
             }
         }
 
-        if (data.providerApiKeys !== undefined) {
+        if (aiSettingsUpdate.providerApiKeys !== undefined) {
             const unconfigured = findUnconfiguredProviderKeyWrites(
-                data.providerApiKeys,
+                aiSettingsUpdate.providerApiKeys,
                 this.lightdashConfig.ai.copilot.providers,
             );
             if (unconfigured.length > 0) {
@@ -446,7 +487,10 @@ export class AiOrganizationSettingsService extends BaseService {
         // lands on, whether or not this request is the one changing it —
         // visibility filters model LISTINGS only, never resolution, so a
         // default pointing at a restricted model would still be served.
-        if (data.modelVisibility || data.defaultAiAgentModelConfig) {
+        if (
+            aiSettingsUpdate.modelVisibility ||
+            aiSettingsUpdate.defaultAiAgentModelConfig
+        ) {
             // Validate against the EFFECTIVE visibility (implicit auto-hide
             // merged under the submission) and real key access — so disabling
             // the only provider whose toggle isn't locked can't leave an empty
@@ -455,16 +499,16 @@ export class AiOrganizationSettingsService extends BaseService {
             // visibility, validate against what is already stored.
             const [overrides, submittedVisibility] = await Promise.all([
                 this.orgAiCopilotConfigResolver.getOrgModelOverrides(
-                    user.organizationUuid,
+                    organizationUuid,
                 ),
-                data.modelVisibility
+                aiSettingsUpdate.modelVisibility
                     ? this.orgAiCopilotConfigResolver.resolveEffectiveModelVisibilityForOrg(
-                          user.organizationUuid,
-                          data.modelVisibility,
+                          organizationUuid,
+                          aiSettingsUpdate.modelVisibility,
                       )
                     : null,
             ]);
-            const effectiveVisibility = data.modelVisibility
+            const effectiveVisibility = aiSettingsUpdate.modelVisibility
                 ? submittedVisibility
                 : overrides.modelVisibility;
             const remaining = filterModelsForOrg(
@@ -474,16 +518,16 @@ export class AiOrganizationSettingsService extends BaseService {
                     keyAccessibleModelIds: overrides.keyAccessibleModelIds,
                 },
             );
-            if (data.modelVisibility && remaining.length === 0) {
+            if (aiSettingsUpdate.modelVisibility && remaining.length === 0) {
                 throw new ParameterError(
                     'At least one AI model must remain available',
                 );
             }
 
             if (
-                data.defaultAiAgentModelConfig &&
+                aiSettingsUpdate.defaultAiAgentModelConfig &&
                 !isModelConfigAvailable(
-                    data.defaultAiAgentModelConfig,
+                    aiSettingsUpdate.defaultAiAgentModelConfig,
                     remaining,
                 )
             ) {
@@ -498,12 +542,12 @@ export class AiOrganizationSettingsService extends BaseService {
             // instance default, which may be the very model this org just
             // restricted.
             if (
-                data.modelVisibility &&
-                data.defaultAiAgentModelConfig === undefined
+                aiSettingsUpdate.modelVisibility &&
+                aiSettingsUpdate.defaultAiAgentModelConfig === undefined
             ) {
                 const currentDefault = (
                     await this.aiOrganizationSettingsModel.findByOrganizationUuid(
-                        user.organizationUuid,
+                        organizationUuid,
                     )
                 )?.defaultAiAgentModelConfig;
                 if (
@@ -520,9 +564,9 @@ export class AiOrganizationSettingsService extends BaseService {
             }
         }
 
-        if (data.dataAppModelVisibility) {
+        if (aiSettingsUpdate.dataAppModelVisibility) {
             const remainingDataAppModels = getVisibleDataAppClaudeModels(
-                data.dataAppModelVisibility,
+                aiSettingsUpdate.dataAppModelVisibility,
             );
             if (remainingDataAppModels.length === 0) {
                 throw new ParameterError(
@@ -531,15 +575,42 @@ export class AiOrganizationSettingsService extends BaseService {
             }
         }
 
-        return this.aiOrganizationSettingsModel.upsert(
-            user.organizationUuid,
+        const update =
             reconciledDefaultModelConfig === undefined
-                ? data
+                ? aiSettingsUpdate
                 : {
-                      ...data,
+                      ...aiSettingsUpdate,
                       defaultAiAgentModelConfig: reconciledDefaultModelConfig,
-                  },
-        );
+                  };
+        const settings =
+            aiAgentMemoryEnabled === undefined
+                ? await this.aiOrganizationSettingsModel.upsert(
+                      organizationUuid,
+                      update,
+                  )
+                : await this.aiOrganizationSettingsModel.transaction(
+                      async (trx) => {
+                          const updatedSettings =
+                              await this.aiOrganizationSettingsModel.upsert(
+                                  organizationUuid,
+                                  update,
+                                  trx,
+                              );
+                          await this.organizationModel.updateAiAgentMemoryEnabled(
+                              organizationUuid,
+                              aiAgentMemoryEnabled,
+                              trx,
+                          );
+                          return updatedSettings;
+                      },
+                  );
+
+        return {
+            ...settings,
+            aiAgentMemoryEnabled:
+                aiAgentMemoryEnabled ??
+                (await this.isAiAgentMemoryEnabled(user)),
+        };
     }
 
     async isAiAgentReviewsEnabled(

--- a/packages/backend/src/models/OrganizationModel.ts
+++ b/packages/backend/src/models/OrganizationModel.ts
@@ -220,6 +220,27 @@ export class OrganizationModel {
         return orgs.map((org) => org.organization_uuid);
     }
 
+    async getAiAgentMemoryEnabled(
+        organizationUuid: string,
+    ): Promise<boolean | null> {
+        const org = await this.database(OrganizationTableName)
+            .select('ai_agent_memory_enabled')
+            .where('organization_uuid', organizationUuid)
+            .first<Pick<DbOrganization, 'ai_agent_memory_enabled'>>();
+        return org?.ai_agent_memory_enabled ?? null;
+    }
+
+    async updateAiAgentMemoryEnabled(
+        organizationUuid: string,
+        enabled: boolean,
+        database: Knex = this.database,
+    ): Promise<void> {
+        const updated = await database(OrganizationTableName)
+            .where('organization_uuid', organizationUuid)
+            .update({ ai_agent_memory_enabled: enabled });
+        if (updated === 0) throw new NotFoundError('No organization found');
+    }
+
     async get(organizationUuid: string): Promise<Organization> {
         const [org] = await this.database(OrganizationTableName)
             .where('organization_uuid', organizationUuid)

--- a/packages/common/src/ee/AiAgent/adminTypes.ts
+++ b/packages/common/src/ee/AiAgent/adminTypes.ts
@@ -326,6 +326,7 @@ export type AiOrganizationSettings = {
     organizationUuid: string;
     aiAgentsVisible: boolean;
     aiAgentReviewsEnabled: boolean;
+    aiAgentMemoryEnabled: boolean;
     deepResearchLimits: AiDeepResearchLimits;
     mcpContentWritesEnabled: boolean;
     requireExplicitSlackChannelLinking?: boolean;
@@ -341,7 +342,7 @@ export type AiOrganizationSettings = {
 
 export type CreateAiOrganizationSettings = Omit<
     AiOrganizationSettings,
-    'providerApiKeysSet' | 'providerApiKeyHints'
+    'providerApiKeysSet' | 'providerApiKeyHints' | 'aiAgentMemoryEnabled'
 > & {
     providerApiKeys?: UpdateAiProviderApiKeys;
 };
@@ -349,6 +350,7 @@ export type CreateAiOrganizationSettings = Omit<
 export type UpdateAiOrganizationSettings = {
     aiAgentsVisible?: boolean;
     aiAgentReviewsEnabled?: boolean;
+    aiAgentMemoryEnabled?: boolean;
     deepResearchLimits?: AiDeepResearchLimits;
     mcpContentWritesEnabled?: boolean;
     requireExplicitSlackChannelLinking?: boolean;

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
@@ -26,6 +26,7 @@ import {
     useDefaultAiAgentModel,
 } from '../../../hooks/useAiAgentModelSelection';
 import {
+    resolveAiAgentMemoryEnabled,
     useAiOrganizationSettings,
     useUpdateAiOrganizationSettings,
 } from '../../../hooks/useAiOrganizationSettings';
@@ -47,6 +48,7 @@ export const AiGeneralSettingsPage = () => {
         FeatureFlags.OrgAiProviderApiKeys,
     );
     const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
+    const aiAgentMemoryFlag = useServerFeatureFlag(FeatureFlags.AiAgentMemory);
 
     const aiRouterQuery = useAiRouterConfig();
     const isRouterEnabled = aiRouterQuery.data?.enabled ?? false;
@@ -60,6 +62,10 @@ export const AiGeneralSettingsPage = () => {
     const reviewsPausedByByok = settings?.aiAgentReviewsPausedByByok ?? false;
     const reviewsEffectivelyOn =
         Boolean(settings?.aiAgentReviewsEnabled) && !reviewsPausedByByok;
+    const aiAgentMemoryEnabled = resolveAiAgentMemoryEnabled(
+        settings,
+        aiAgentMemoryFlag.data,
+    );
     const {
         fallbackModelLabel: systemDefaultModelLabel,
         selectedModel: selectedDefaultModel,
@@ -333,6 +339,56 @@ export const AiGeneralSettingsPage = () => {
                                 <ReviewNotificationsSettings />
                             )}
                         </Stack>
+                    </SettingsCard>
+
+                    <SettingsCard>
+                        <Group
+                            justify="space-between"
+                            wrap="nowrap"
+                            align="flex-start"
+                            gap="md"
+                        >
+                            <Box maw={620}>
+                                <Group gap="xs" mb={4}>
+                                    <Title order={5}>
+                                        Enable AI agent memories
+                                    </Title>
+                                    <BetaBadge />
+                                </Group>
+                                <Text c="dimmed" fz="xs">
+                                    Let Ask AI learn from each user&apos;s agent
+                                    conversations and reuse those memories in
+                                    future answers. Disable to stop learning
+                                    from and using memories while keeping
+                                    existing data intact.
+                                    {aiAgentMemoryEnabled && (
+                                        <>
+                                            {' '}
+                                            Manage them in{' '}
+                                            <Anchor
+                                                component={Link}
+                                                to="/generalSettings/ai/memories"
+                                                fz="inherit"
+                                            >
+                                                Ask AI &gt; Memories
+                                            </Anchor>
+                                            .
+                                        </>
+                                    )}
+                                </Text>
+                            </Box>
+                            <Switch
+                                size="md"
+                                checked={aiAgentMemoryEnabled}
+                                disabled={isUpdatingSettings}
+                                onChange={(event) =>
+                                    updateSettings({
+                                        aiAgentMemoryEnabled:
+                                            event.currentTarget.checked,
+                                    })
+                                }
+                            />
+                        </Group>
                     </SettingsCard>
 
                     <SettingsCard>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.test.tsx
@@ -12,8 +12,13 @@ import {
 import { rehypeAiAgentContentLinks } from './rehypeContentLinks';
 import { rehypeMemoryCitationIndices } from './rehypeMemoryCitations';
 
-const { statusMutationSpy } = vi.hoisted(() => ({
+const { memoryEnabled, statusMutationSpy } = vi.hoisted(() => ({
+    memoryEnabled: { current: true },
     statusMutationSpy: vi.fn(),
+}));
+
+vi.mock('../../hooks/useAiOrganizationSettings', () => ({
+    useAiAgentMemoryEnabled: () => memoryEnabled.current,
 }));
 
 vi.mock('../../hooks/useAiAgentMemory', () => ({
@@ -60,6 +65,10 @@ Use net revenue for future revenue questions.`,
 }));
 
 describe('MemoryCitation', () => {
+    beforeEach(() => {
+        memoryEnabled.current = true;
+    });
+
     const renderMarkdown = (markdown: string) =>
         render(
             <QueryClientProvider client={new QueryClient()}>
@@ -101,6 +110,20 @@ describe('MemoryCitation', () => {
         const marker = screen.getByTitle('Memory: net-revenue');
         expect(marker).toHaveTextContent('1');
         expect(marker.tagName).toBe('BUTTON');
+        expect(screen.getByText(/Supported sentence/)).toBeInTheDocument();
+    });
+
+    it('renders a non-interactive marker when memories are disabled', () => {
+        memoryEnabled.current = false;
+
+        renderMarkdown(
+            'Supported sentence.<ld-mem-cite id="net-revenue"></ld-mem-cite>',
+        );
+
+        expect(
+            screen.queryByTitle('Memory: net-revenue'),
+        ).not.toBeInTheDocument();
+        expect(screen.getByText('1').tagName).toBe('SPAN');
         expect(screen.getByText(/Supported sentence/)).toBeInTheDocument();
     });
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.tsx
@@ -14,6 +14,7 @@ import { IconArrowRight } from '@tabler/icons-react';
 import { useState } from 'react';
 import { useParams } from 'react-router';
 import { useAiAgentMemory } from '../../hooks/useAiAgentMemory';
+import { useAiAgentMemoryEnabled } from '../../hooks/useAiOrganizationSettings';
 import { MemoryDetailsModal } from '../MemoryDetails/MemoryDetails';
 import styles from './MemoryCitation.module.css';
 
@@ -30,13 +31,22 @@ export const MemoryCitation = ({
     const [detailsOpened, { open: openDetails, close: closeDetails }] =
         useDisclosure(false);
     const { projectUuid, agentUuid } = useParams();
+    const memoryEnabled = useAiAgentMemoryEnabled();
     const slug = id?.replace(/^user-content-/, '');
     const memoryQuery = useAiAgentMemory({
         projectUuid,
         agentUuid,
         slug,
-        enabled: hasOpened,
+        enabled: memoryEnabled && hasOpened,
     });
+
+    if (!memoryEnabled) {
+        return (
+            <span className={styles.marker} aria-hidden="true">
+                {memoryIndex ?? '·'}
+            </span>
+        );
+    }
 
     return (
         <>

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiOrganizationSettings.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiOrganizationSettings.ts
@@ -1,4 +1,5 @@
 import {
+    FeatureFlags,
     type ApiAiOrganizationSettingsResponse,
     type ApiError,
     type ApiUpdateAiOrganizationSettingsResponse,
@@ -13,6 +14,17 @@ import {
 } from '@tanstack/react-query';
 import { lightdashApi } from '../../../../api';
 import useToaster from '../../../../hooks/toaster/useToaster';
+import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
+
+export const resolveAiAgentMemoryEnabled = (
+    settings:
+        | Pick<
+              ApiAiOrganizationSettingsResponse['results'],
+              'aiAgentMemoryEnabled'
+          >
+        | undefined,
+    featureFlag: { enabled: boolean } | undefined,
+): boolean => settings?.aiAgentMemoryEnabled ?? featureFlag?.enabled ?? false;
 
 const getAiOrganizationSettings = async () => {
     return lightdashApi<ApiAiOrganizationSettingsResponse['results']>({
@@ -34,6 +46,14 @@ export const useAiOrganizationSettings = (
         keepPreviousData: true,
         ...queryOptions,
     });
+};
+
+export const useAiAgentMemoryEnabled = (): boolean => {
+    const { data: settings } = useAiOrganizationSettings();
+    const { data: featureFlag } = useServerFeatureFlag(
+        FeatureFlags.AiAgentMemory,
+    );
+    return resolveAiAgentMemoryEnabled(settings, featureFlag);
 };
 
 const updateAiOrganizationSettings = async (

--- a/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
@@ -1,4 +1,4 @@
-import { FeatureFlags, type AiAgent } from '@lightdash/common';
+import { type AiAgent } from '@lightdash/common';
 import { Box, Group, Loader, Stack, Text, TextInput } from '@mantine-8/core';
 import { IconShare2 } from '@tabler/icons-react';
 import { useCallback, useState } from 'react';
@@ -11,7 +11,6 @@ import {
 } from 'react-router';
 import MantineModal from '../../../components/common/MantineModal';
 import { ShareLinkButton } from '../../../components/common/ShareLinkButton';
-import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../providers/App/useApp';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
@@ -27,6 +26,7 @@ import {
     isEmbedAiAgentRoute,
 } from '../../features/aiCopilot/hooks/aiAgentRouting';
 import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentPermission';
+import { useAiAgentMemoryEnabled } from '../../features/aiCopilot/hooks/useAiOrganizationSettings';
 import {
     useProjectAiAgent as useAiAgent,
     useAiAgentThread,
@@ -79,9 +79,7 @@ const AgentPage = () => {
     const [isShareModalOpen, setIsShareModalOpen] = useState(false);
     const [shareUrl, setShareUrl] = useState<string | null>(null);
     const [isMemoriesModalOpen, setIsMemoriesModalOpen] = useState(false);
-    const { data: memoryFlag } = useServerFeatureFlag(
-        FeatureFlags.AiAgentMemory,
-    );
+    const memoryEnabled = useAiAgentMemoryEnabled();
 
     const handleMinimize = useCallback(
         (targetUrl?: string, options?: NavigateFromAgentChatOptions) => {
@@ -241,7 +239,7 @@ const AgentPage = () => {
                         }
                         isSharing={isCreatingShare}
                         onOpenMemories={
-                            memoryFlag?.enabled
+                            memoryEnabled
                                 ? () => setIsMemoriesModalOpen(true)
                                 : undefined
                         }

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -1,5 +1,4 @@
 import {
-    FeatureFlags,
     type AiPromptContext,
     type AiPromptContextInput,
 } from '@lightdash/common';
@@ -30,7 +29,6 @@ import {
 import { LightdashUserAvatar } from '../../../components/Avatar';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useProject } from '../../../hooks/useProject';
-import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { AgentSettingsSelector } from '../../features/aiCopilot/components/AgentSelector';
 import { AutoModeSidebar } from '../../features/aiCopilot/components/AiAgentPageLayout/AgentSidebar';
 import { AiAgentPageLayout } from '../../features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout';
@@ -48,6 +46,7 @@ import { useAiAgentModelSelection } from '../../features/aiCopilot/hooks/useAiAg
 import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentPermission';
 import { useAiAgentRouterFlow } from '../../features/aiCopilot/hooks/useAiAgentRouterFlow';
 import { useAiAgentSqlModeAvailable } from '../../features/aiCopilot/hooks/useAiAgentSqlModeAvailable';
+import { useAiAgentMemoryEnabled } from '../../features/aiCopilot/hooks/useAiOrganizationSettings';
 import { usePinnedContext } from '../../features/aiCopilot/hooks/usePinnedContext';
 import {
     useCreateAgentThreadMutation,
@@ -77,9 +76,7 @@ const AgentsRouterPage = () => {
 
     const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
     const [isMemoriesModalOpen, setIsMemoriesModalOpen] = useState(false);
-    const { data: memoryFlag } = useServerFeatureFlag(
-        FeatureFlags.AiAgentMemory,
-    );
+    const memoryEnabled = useAiAgentMemoryEnabled();
 
     const [sqlMode, setSqlMode] = useState(true);
     const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
@@ -300,7 +297,7 @@ const AgentsRouterPage = () => {
         >
             <Box className={classes.routerView}>
                 <Group gap={4} className={classes.routerActions}>
-                    {memoryFlag?.enabled && (
+                    {memoryEnabled && (
                         <UnstyledButton
                             type="button"
                             className={classes.memoriesButton}

--- a/packages/frontend/src/hooks/settings/useSettingsContext.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsContext.ts
@@ -1,7 +1,10 @@
 import { subject } from '@casl/ability';
 import { CommercialFeatureFlags, FeatureFlags } from '@lightdash/common';
 import { useIsGitProject } from '../../components/Explorer/WriteBackModal/hooks';
-import { useAiOrganizationSettings } from '../../ee/features/aiCopilot/hooks/useAiOrganizationSettings';
+import {
+    resolveAiAgentMemoryEnabled,
+    useAiOrganizationSettings,
+} from '../../ee/features/aiCopilot/hooks/useAiOrganizationSettings';
 import useApp from '../../providers/App/useApp';
 import { useOrganization } from '../organization/useOrganization';
 import { useActiveProjectUuid } from '../useActiveProject';
@@ -44,7 +47,10 @@ export const useSettingsContext = (): SettingsContext => {
     const { data: aiAgentMemoryFlag } = useServerFeatureFlag(
         FeatureFlags.AiAgentMemory,
     );
-    const shouldShowAiAgentMemories = aiAgentMemoryFlag?.enabled ?? false;
+    const shouldShowAiAgentMemories = resolveAiAgentMemoryEnabled(
+        aiOrganizationSettingsQuery.data,
+        aiAgentMemoryFlag,
+    );
 
     const { data: serviceAccountsFlag } = useServerFeatureFlag(
         CommercialFeatureFlags.ServiceAccounts,


### PR DESCRIPTION
## Summary

- add an organization-level AI agent memories toggle under Ask AI settings
- keep untouched existing organizations on the legacy feature-flag rollout while explicit admin choices take precedence
- enable memories by default for new organizations and apply the effective setting across backend and frontend memory paths

## Verification

- common, backend, and frontend typechecks and lint
- common tests: 3,305 passed, 1 skipped
- backend changed suite: 5,433 passed, 1 skipped
- migration rollback and reapply
- PostgreSQL cohort checks for existing, flag-enabled, user-only override, and new organizations
- browser check that explicit off overrides the legacy flag

Closes: https://linear.app/lightdash/issue/ZAP-772/add-organization-level-controls-for-ai-agent-memories
