### PR TITLE
feat(autopilot): surface blocked attempts as dismissable actions

### DIFF
--- a/packages/backend/src/ee/models/ManagedAgentModel.ts
+++ b/packages/backend/src/ee/models/ManagedAgentModel.ts
@@ -333,6 +333,23 @@ export class ManagedAgentModel {
 
     // --- Actions ---
 
+    // Dedup for blocked-attempt visibility: one live blocked action per target
+    async hasActiveBlockedActionForTarget(
+        projectUuid: string,
+        targetUuid: string,
+    ): Promise<boolean> {
+        const row = await this.database(ManagedAgentActionsTableName)
+            .where({
+                project_uuid: projectUuid,
+                target_uuid: targetUuid,
+                action_type: ManagedAgentActionType.BLOCKED,
+            })
+            .whereNull('reversed_at')
+            .select('action_uuid')
+            .first();
+        return row !== undefined;
+    }
+
     async findLatestActiveFlagCreatedAt(
         projectUuid: string,
         targetUuid: string,

--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -441,11 +441,19 @@ export class ManagedAgentService extends BaseService {
 
     // Single choke point for admin-configured protections. Returns a blocked
     // tool result when the target may not be mutated, null when allowed.
+    // When `attempt` is provided, blocked attempts are recorded as dismissable
+    // 'blocked' actions so admins can see Autopilot tried and was stopped.
     private async checkTargetProtectionGuard(
         projectUuid: string,
         targetType: ManagedAgentTargetType,
         targetUuid: string,
         targetName: string,
+        attempt?: {
+            actor: SessionUser;
+            sessionId: string;
+            runUuid: string;
+            attemptedAction: 'flag' | 'fix' | 'soft-delete';
+        },
     ): Promise<string | null> {
         let entityType: ManagedAgentProtectedEntityType;
         switch (targetType) {
@@ -464,57 +472,137 @@ export class ManagedAgentService extends BaseService {
                     `Unknown target type: ${targetType}`,
                 );
         }
+
+        let blocked: { reason: string; message: string } | null = null;
+
         const level = await this.managedAgentModel.findProtectionLevel(
             projectUuid,
             entityType,
             targetUuid,
         );
         if (level) {
-            return JSON.stringify({
-                error: `"${targetName}" is ${level} from Autopilot by a project admin. Do not flag, fix, or delete it${
+            blocked = {
+                reason: level,
+                message: `"${targetName}" is ${level} from Autopilot by a project admin. Do not flag, fix, or delete it${
                     level === 'excluded' ? ', and do not report on it' : ''
                 }.`,
-                blocked: true,
-            });
+            };
         }
 
         // Verified content is protected by default: a human vouched for the
         // definition, so Autopilot reports instead of rewriting.
-        const policy = await this.getPolicy(projectUuid);
-        if (policy.verifiedContent === 'protected') {
-            const isVerified = await this.managedAgentModel.isContentVerified(
-                entityType === ManagedAgentProtectedEntityType.CHART
-                    ? 'chart'
-                    : 'dashboard',
-                targetUuid,
-            );
-            if (isVerified) {
-                return JSON.stringify({
-                    error: `"${targetName}" is verified content and protected by project policy. You may report on it with log_insight, but do not flag, fix, or delete it.`,
-                    blocked: true,
-                });
+        if (!blocked) {
+            const policy = await this.getPolicy(projectUuid);
+            if (policy.verifiedContent === 'protected') {
+                const isVerified =
+                    await this.managedAgentModel.isContentVerified(
+                        entityType === ManagedAgentProtectedEntityType.CHART
+                            ? 'chart'
+                            : 'dashboard',
+                        targetUuid,
+                    );
+                if (isVerified) {
+                    blocked = {
+                        reason: 'verified',
+                        message: `"${targetName}" is verified content and protected by project policy. You may report on it with log_insight, but do not flag, fix, or delete it.`,
+                    };
+                }
             }
         }
 
         // Defense in depth: content living in an out-of-scope space cannot be
         // mutated even if a read tool leaked it.
-        const spaceUuid =
-            entityType === ManagedAgentProtectedEntityType.CHART
-                ? await this.managedAgentModel.getChartSpaceUuid(targetUuid)
-                : await this.managedAgentModel.getDashboardSpaceUuid(
-                      targetUuid,
-                  );
-        if (spaceUuid) {
-            const excludedSpaces =
-                await this.getExcludedSpaceUuids(projectUuid);
-            if (excludedSpaces.has(spaceUuid)) {
-                return JSON.stringify({
-                    error: `"${targetName}" is in a space that is out of Autopilot's scope. Do not flag, fix, delete, or report on it.`,
-                    blocked: true,
-                });
+        if (!blocked) {
+            const spaceUuid =
+                entityType === ManagedAgentProtectedEntityType.CHART
+                    ? await this.managedAgentModel.getChartSpaceUuid(targetUuid)
+                    : await this.managedAgentModel.getDashboardSpaceUuid(
+                          targetUuid,
+                      );
+            if (spaceUuid) {
+                const excludedSpaces =
+                    await this.getExcludedSpaceUuids(projectUuid);
+                if (excludedSpaces.has(spaceUuid)) {
+                    blocked = {
+                        reason: 'out_of_scope',
+                        message: `"${targetName}" is in a space that is out of Autopilot's scope. Do not flag, fix, delete, or report on it.`,
+                    };
+                }
             }
         }
-        return null;
+
+        if (!blocked) {
+            return null;
+        }
+
+        if (attempt) {
+            await this.recordBlockedAttempt(
+                projectUuid,
+                targetType,
+                targetUuid,
+                targetName,
+                blocked.reason,
+                attempt,
+            );
+        }
+
+        return JSON.stringify({ error: blocked.message, blocked: true });
+    }
+
+    // One live blocked action per target: repeat attempts on the same target
+    // do not pile up until the admin dismisses the existing one.
+    private async recordBlockedAttempt(
+        projectUuid: string,
+        targetType: ManagedAgentTargetType,
+        targetUuid: string,
+        targetName: string,
+        reason: string,
+        attempt: {
+            actor: SessionUser;
+            sessionId: string;
+            runUuid: string;
+            attemptedAction: 'flag' | 'fix' | 'soft-delete';
+        },
+    ): Promise<void> {
+        try {
+            const alreadyRecorded =
+                await this.managedAgentModel.hasActiveBlockedActionForTarget(
+                    projectUuid,
+                    targetUuid,
+                );
+            if (alreadyRecorded) {
+                return;
+            }
+            const reasonText: Record<string, string> = {
+                protected: 'it is marked as protected by a project admin',
+                excluded: 'it is excluded from Autopilot by a project admin',
+                verified: 'it is verified content, protected by project policy',
+                out_of_scope: "its space is out of Autopilot's scope",
+            };
+            const action = await this.managedAgentModel.createAction({
+                projectUuid,
+                sessionId: attempt.sessionId,
+                managedAgentRunUuid: attempt.runUuid,
+                actionType: ManagedAgentActionType.BLOCKED,
+                targetType,
+                targetUuid,
+                targetName,
+                description: `Autopilot attempted to ${attempt.attemptedAction} "${targetName}" but was blocked: ${
+                    reasonText[reason] ?? reason
+                }.`,
+                metadata: {
+                    reason,
+                    attemptedAction: attempt.attemptedAction,
+                },
+            });
+            this.trackActionCreated(attempt.actor, attempt.runUuid, action);
+        } catch (error) {
+            this.logger.error(
+                `Failed to record blocked Autopilot attempt for ${targetUuid}: ${
+                    error instanceof Error ? error.message : 'Unknown'
+                }`,
+            );
+        }
     }
 
     private async syncProjectAgentConfig(projectUuid: string): Promise<void> {
@@ -1768,6 +1856,8 @@ export class ManagedAgentService extends BaseService {
                 summaryParts.push(
                     `*${counts.insight}* insight${counts.insight > 1 ? 's' : ''}`,
                 );
+            if (counts.blocked)
+                summaryParts.push(`*${counts.blocked}* blocked by protections`);
 
             // Convert agent's markdown summary to Slack mrkdwn
             // Main message: compact summary with CTA
@@ -2347,6 +2437,7 @@ chartConfig:
             ManagedAgentTargetType.CHART,
             chartUuid,
             chartName,
+            { actor, sessionId, runUuid, attemptedAction: 'fix' },
         );
         if (fixProtectionBlock) {
             return fixProtectionBlock;
@@ -2661,6 +2752,7 @@ chartConfig:
             targetType,
             targetUuid,
             targetName,
+            { actor, sessionId, runUuid, attemptedAction: 'flag' },
         );
         if (flagProtectionBlock) {
             return flagProtectionBlock;
@@ -2798,6 +2890,7 @@ chartConfig:
             targetType,
             targetUuid,
             targetName,
+            { actor, sessionId, runUuid, attemptedAction: 'soft-delete' },
         );
         if (deleteProtectionBlock) {
             return deleteProtectionBlock;

--- a/packages/common/src/ee/types/managedAgent.ts
+++ b/packages/common/src/ee/types/managedAgent.ts
@@ -9,6 +9,8 @@ export enum ManagedAgentActionType {
     FIXED_BROKEN = 'fixed_broken',
     CREATED_CONTENT = 'created_content',
     INSIGHT = 'insight',
+    // Autopilot attempted a mutation that an admin protection stopped
+    BLOCKED = 'blocked',
 }
 
 export enum ManagedAgentTargetType {

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -344,6 +344,12 @@ const ACTION_CONFIG: Record<
         label: 'Insight',
         dotColor: 'var(--mantine-color-violet-5)',
     },
+    blocked: {
+        label: 'Blocked',
+        dotColor: 'var(--mantine-color-ldGray-6)',
+        tooltip:
+            'Autopilot attempted this but an admin protection stopped it. Dismiss to acknowledge.',
+    },
 };
 
 const revertActionLabel = (


### PR DESCRIPTION
## Summary

Seventh PR of the Autopilot policy and protection stack (stacked on #26791). Closes the trust loop from the scope model: every protection we added is enforced silently from the admin's point of view; the model gets told "blocked" and adapts, but the admin never learns Autopilot wanted to touch their protected content.

- When the protection choke point blocks a flag, fix, or soft-delete, it records a `blocked` action carrying the reason (`protected`, `excluded`, `verified`, `out_of_scope`) and the attempted operation.
- Dedup rule: one live blocked action per target. Daily runs retrying the same blocked operation do not pile up rows; a new one is only recorded after the admin dismisses the existing one.
- Blocked actions render in the actions table as dismissable rows (gray dot, tooltip) and are counted in the Slack run summary ("2 blocked by protections").
- Recording is best-effort: a failure to record never blocks the guard itself.

## Regression analysis

Additive. The guard's decision logic is unchanged; it only gains recording. Existing action types, revert flows, and summaries are untouched; the new type routes through the existing dismiss category. Runs that trigger no protections produce no new rows.

## Testing

- Full backend (5,804) and common (3,342) suites green with the new action type
- Typechecks green across common, backend, frontend (the frontend ACTION_CONFIG record is exhaustively typed, so the new type is compiler-enforced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UgXBzcYYEeoMUUShzL7DsU