### PR TITLE
feat(cli): validate data apps locally

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -1087,6 +1087,7 @@ Data apps can be **downloaded as source, versioned in git, edited, and re-upload
 Opt-in flags on the existing `lightdash download` / `lightdash upload` commands (off by default — core users never touch app code paths unless they ask):
 
 - **`lightdash apps create "<name>"`** — create a new app locally at `lightdash/apps/<slug>/` from the E2B starter template. The command requires npm and first asks the user to accept that it will download packages and run shadcn locally. It then lists the exact direct dependencies and shadcn components for a second approval before writing anything. After approval, it checks that the slug is available in the selected project and adds the complete runnable source tree, manifest, agent skills, and a fresh project context snapshot. `--slug`, `--description`, `--project`, and `--path` override the defaults; `--assume-yes` approves installation in non-interactive environments.
+- **`lightdash apps validate [paths...]`** — validate one or more local app folders without building or uploading. It checks source parsing, semantic references, manifest slug/viz schema, declared dependencies, and that statically resolved `externalFetch` aliases exist in the manifest. Offline mode uses the downloaded semantic-layer snapshot and reports unresolved call-site coverage; `--live` fetches fresh explores from each app's project. `--format json` emits CI-friendly output, and validation errors produce a non-zero exit.
 - **`lightdash download --apps <appReferences...>`** — download specific data apps by UUID, slug, or app URL into `lightdash/apps/<slug>/`; **`--include-apps`** downloads all of the project's apps (capped at `--apps-limit`, default 50). Each folder holds `lightdash-app.yml` (manifest) + the app's `src/` tree. The built `dist` is intentionally excluded — it's regenerated on upload.
 - **`lightdash upload --apps <appReferences...>`** — upload specific apps by UUID, slug, or app URL, matched against each local folder's manifest (`slug` or `appUuid`); **`--include-apps`** uploads every `lightdash/apps/<slug>/` folder on disk. The server rebuilds the source. **Fire-and-forget:** the CLI posts and returns immediately — the app shows `building` in the UI until the server finishes. **Unchanged apps are skipped server-side** (no new version, no rebuild — the CLI reports `unchanged`); `--force` rebuilds anyway. When the per-project build cap rejects an upload (HTTP 429), the CLI **waits and retries** instead of failing (see below).
 
@@ -1134,13 +1135,14 @@ All scaffolding and context files are read-only reference — see [Upload is sou
 #### The local loop
 
 ```sh
-lightdash apps create "<name>"  →  edit src/  →  npm run build  →  lightdash apps preview  →  lightdash upload --apps <slug>  →  server rebuilds
+lightdash apps create "<name>"  →  edit src/  →  lightdash apps validate  →  npm run build  →  lightdash apps preview  →  lightdash upload --apps <slug>  →  server rebuilds
 ```
 
 1. Edit files under `src/`.
-2. Optionally run `npm install && npm run build` as a pre-flight compile check against the downloaded scaffolding. A local install or build failure is a non-blocking warning: keep the failure details because they may predict a server build problem, but continue to upload rather than changing local machine or registry configuration to force the pre-check to pass.
-3. Optionally run `lightdash apps preview` to test against real data using the current CLI login.
-4. Upload with `lightdash upload --apps <slug>` — or `--include-apps` for every downloaded app folder (fire-and-forget, as in Phase 1). The server rebuilds in its trusted sandbox.
+2. Run `lightdash apps validate` against the downloaded context, or add `--live` to validate semantic references against the project's current explores. Partial static coverage is reported explicitly; unresolved values are not errors.
+3. Optionally run `npm install && npm run build` as a pre-flight compile check against the downloaded scaffolding. A local install or build failure is a non-blocking warning: keep the failure details because they may predict a server build problem, but continue to upload rather than changing local machine or registry configuration to force the pre-check to pass.
+4. Optionally run `lightdash apps preview` to test against real data using the current CLI login.
+5. Upload with `lightdash upload --apps <slug>` — or `--include-apps` for every downloaded app folder (fire-and-forget, as in Phase 1). The server rebuilds in its trusted sandbox.
 
 **The server's build is authoritative.** Your local build is an optional compile check only; the deployed app is always the server's output. The server build status on the app page, not the local pre-check, determines whether the app ships.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -64,9 +64,15 @@ Build and upload it with:
 
 ```shell
 cd lightdash/apps/revenue-explorer
+lightdash apps validate --live
 npm run build
 lightdash upload --apps revenue-explorer
 ```
+
+`lightdash apps validate [paths...]` checks app source, manifests,
+dependencies, external-connection aliases, and semantic references. It uses
+the downloaded semantic-layer snapshot by default; `--live` fetches the
+project's current explores, and `--format json` provides CI output.
 
 The local build is a pre-flight check; Lightdash rebuilds the source when it is
 uploaded. Existing apps can still be checked out with

--- a/packages/cli/src/handlers/apps/authoring/README.md.tmpl
+++ b/packages/cli/src/handlers/apps/authoring/README.md.tmpl
@@ -4,9 +4,10 @@ Created or downloaded with the Lightdash CLI.
 
 ## Edit → build → upload
 1. Edit files under `src/`.
-2. Optionally, run `npm run build` to check it compiles locally. `lightdash apps create` installs the initial dependencies after asking permission; after `lightdash download`, run `npm install` first if `node_modules` is absent. If the local install or build fails in your environment, treat it as a non-blocking warning and continue to upload. Keep the failure details because they may predict a server build problem, but don't change machine or registry config to force the pre-check to pass — the server build on upload is authoritative and surfaces its result on the app page.
-3. Optionally, preview against real data: `lightdash apps preview` (needs a successful `npm install`).
-4. `lightdash upload --apps <slug>` (the `slug` from `lightdash-app.yml`) — Lightdash rebuilds and serves the app.
+2. Run `lightdash apps validate` to check the source, manifest, dependencies, external-connection aliases, and semantic references against the downloaded context. Use `--live` for fresh project explores or `--format json` in CI.
+3. Optionally, run `npm run build` to check it compiles locally. `lightdash apps create` installs the initial dependencies after asking permission; after `lightdash download`, run `npm install` first if `node_modules` is absent. If the local install or build fails in your environment, treat it as a non-blocking warning and continue to upload. Keep the failure details because they may predict a server build problem, but don't change machine or registry config to force the pre-check to pass — the server build on upload is authoritative and surfaces its result on the app page.
+4. Optionally, preview against real data: `lightdash apps preview` (needs a successful `npm install`).
+5. `lightdash upload --apps <slug>` (the `slug` from `lightdash-app.yml`) — Lightdash rebuilds and serves the app.
 
 Local preview uses your existing CLI login through a project- and route-restricted loopback proxy; the credential is not written into this folder or exposed to browser code. It runs local tooling as your OS user (with access to that user's files, including the existing CLI config) and shows data under your own permissions, so preview only source/dependencies you trust. Host-mediated features such as external connections and data-app-viz context still need testing after upload.
 

--- a/packages/cli/src/handlers/apps/authoring/developing-data-apps-locally/SKILL.md
+++ b/packages/cli/src/handlers/apps/authoring/developing-data-apps-locally/SKILL.md
@@ -28,8 +28,9 @@ You are editing a Lightdash **data app** that was created or downloaded with the
 ## The edit → build → upload loop
 
 1. Edit files under `src/` only.
-2. Optionally, run `npm run build` to check it compiles. Apps made with `lightdash apps create` already have their initial dependencies installed. After `lightdash download`, if you choose to do the local pre-check and `node_modules` is absent, run `npm install` first. This is an **optional local pre-check** — see below.
-3. `lightdash upload --apps <slug>` (the `slug` from this folder's `lightdash-app.yml`) — the **server** rebuilds and serves the app. The server rebuild, not your local build, is what ships.
+2. Run `lightdash apps validate` to check the source, manifest, dependencies, external-connection aliases, and semantic references against the downloaded context. Use `--live` to check against fresh project explores; use `--format json` in CI. A green run reports any call sites it could not fully analyze instead of silently claiming complete coverage.
+3. Optionally, run `npm run build` to check it compiles. Apps made with `lightdash apps create` already have their initial dependencies installed. After `lightdash download`, if you choose to do the local pre-check and `node_modules` is absent, run `npm install` first. This is an **optional local pre-check** — see below.
+4. `lightdash upload --apps <slug>` (the `slug` from this folder's `lightdash-app.yml`) — the **server** rebuilds and serves the app. The server rebuild, not your local build, is what ships.
 
 ## The local build is optional — never fight a failing install
 

--- a/packages/cli/src/handlers/apps/validate.test.ts
+++ b/packages/cli/src/handlers/apps/validate.test.ts
@@ -206,11 +206,33 @@ describe('validateLocalDataApp', () => {
 
         const result = await validateLocalDataApp(dir, {
             live: true,
+            liveProjectUuid: 'configured-project-uuid',
             loadLiveIndex,
         });
 
         expect(result.valid).toBe(true);
-        expect(loadLiveIndex).toHaveBeenCalledWith('project-uuid');
+        expect(result.projectUuid).toBe('configured-project-uuid');
+        expect(loadLiveIndex).toHaveBeenCalledWith('configured-project-uuid');
+    });
+
+    it('explains how to configure a project for live validation', async () => {
+        const dir = await makeApp({ semanticLayout: 'none' });
+
+        const result = await validateLocalDataApp(dir, {
+            live: true,
+            loadLiveIndex: unusedLiveLoader,
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.projectUuid).toBeNull();
+        expect(result.errors).toContainEqual(
+            expect.objectContaining({
+                code: 'semantic_layer',
+                message: expect.stringContaining(
+                    'lightdash config set-project',
+                ),
+            }),
+        );
     });
 
     it('gives an upgrade path instead of crashing on a missing offline snapshot', async () => {

--- a/packages/cli/src/handlers/apps/validate.test.ts
+++ b/packages/cli/src/handlers/apps/validate.test.ts
@@ -1,0 +1,330 @@
+import {
+    buildDataAppExploreIndexFromModelFiles,
+    type DataAppCode,
+    type DataAppManifest,
+} from '@lightdash/common';
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { writeBundleToDir } from './appCodeFiles';
+import {
+    buildAppsValidationReport,
+    renderAppsValidationHuman,
+    validateLocalDataApp,
+} from './validate';
+
+const semanticLayer = [
+    'models:',
+    '  - name: orders',
+    '    meta:',
+    '      metrics:',
+    '        total_revenue:',
+    '          type: sum',
+    '    columns:',
+    '      - name: status',
+].join('\n');
+
+const defaultManifest: DataAppManifest = {
+    codeVersion: 1,
+    projectUuid: 'project-uuid',
+    slug: 'orders-app',
+    version: 1,
+    name: 'Orders app',
+    description: '',
+    template: null,
+    downloadedAt: '2026-08-01T00:00:00.000Z',
+    externalConnections: [{ alias: 'stripe', connectionSlug: 'stripe-api' }],
+};
+
+const validSource = `
+    import { query } from '@lightdash/query-sdk';
+    query('orders').dimensions(['status']).metrics(['total_revenue']);
+    lightdash.externalFetch('stripe', { path: '/charges' });
+`;
+
+const makeApp = async (args?: {
+    source?: string;
+    manifest?: DataAppManifest;
+    semanticLayout?: 'legacy' | 'sharded' | 'none';
+    packageJson?: string;
+    lockfile?: string;
+}): Promise<string> => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-app-validate-'));
+    const code: DataAppCode = {
+        manifest: args?.manifest ?? defaultManifest,
+        files: [
+            {
+                path: 'src/App.tsx',
+                contentBase64: Buffer.from(
+                    args?.source ?? validSource,
+                ).toString('base64'),
+            },
+        ],
+    };
+    await writeBundleToDir(dir, code);
+
+    const layout = args?.semanticLayout ?? 'sharded';
+    if (layout === 'legacy') {
+        const contextDir = path.join(dir, '.lightdash', 'context');
+        await fs.mkdir(contextDir, { recursive: true });
+        await fs.writeFile(
+            path.join(contextDir, 'semantic-layer.yml'),
+            semanticLayer,
+        );
+    } else if (layout === 'sharded') {
+        const modelsDir = path.join(dir, '.lightdash', 'context', 'models');
+        await fs.mkdir(modelsDir, { recursive: true });
+        await Promise.all([
+            fs.writeFile(
+                path.join(dir, '.lightdash', 'context', 'semantic-layer.yml'),
+                '# See models/',
+            ),
+            fs.writeFile(path.join(modelsDir, 'orders.yml'), semanticLayer),
+        ]);
+    }
+
+    if (args?.packageJson !== undefined) {
+        await fs.writeFile(path.join(dir, 'package.json'), args.packageJson);
+    }
+    if (args?.lockfile !== undefined) {
+        await fs.writeFile(path.join(dir, 'pnpm-lock.yaml'), args.lockfile);
+    }
+    return dir;
+};
+
+const unusedLiveLoader = (): never => {
+    throw new Error('live semantic layer should not be loaded');
+};
+
+const liveIndex = buildDataAppExploreIndexFromModelFiles([
+    { path: 'orders.yml', content: semanticLayer },
+]);
+
+describe('validateLocalDataApp', () => {
+    it.each(['sharded', 'legacy'] as const)(
+        'validates a correct app against a %s offline semantic layer',
+        async (semanticLayout) => {
+            const dir = await makeApp({ semanticLayout });
+
+            const result = await validateLocalDataApp(dir, {
+                live: false,
+                loadLiveIndex: unusedLiveLoader,
+            });
+
+            expect(result.valid).toBe(true);
+            expect(result.errors).toEqual([]);
+            expect(result.coverage).toMatchObject({
+                callSites: 2,
+                fullyResolved: 2,
+                unanalyzed: 0,
+            });
+        },
+    );
+
+    it('reports semantic errors and undeclared externalFetch aliases with source locations', async () => {
+        const dir = await makeApp({
+            source: `
+                import { query } from '@lightdash/query-sdk';
+                query('ordrs').dimensions(['missing_field']);
+                client.externalFetch('salesforce', { path: '/accounts' });
+            `,
+        });
+
+        const result = await validateLocalDataApp(dir, {
+            live: false,
+            loadLiveIndex: unusedLiveLoader,
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.errors).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    code: 'semantic_reference',
+                    message:
+                        "Explore 'ordrs' does not exist — did you mean 'orders'?",
+                    location: expect.objectContaining({ path: 'src/App.tsx' }),
+                }),
+                expect.objectContaining({
+                    code: 'external_connection',
+                    message: expect.stringContaining('salesforce'),
+                    location: expect.objectContaining({ path: 'src/App.tsx' }),
+                }),
+            ]),
+        );
+    });
+
+    it('counts dynamic query call sites as unanalyzed without failing', async () => {
+        const dir = await makeApp({
+            source: `
+                import { query } from '@lightdash/query-sdk';
+                function build(explore) {
+                    return query(explore).dimensions(['status']);
+                }
+            `,
+        });
+
+        const result = await validateLocalDataApp(dir, {
+            live: false,
+            loadLiveIndex: unusedLiveLoader,
+        });
+
+        expect(result.valid).toBe(true);
+        expect(result.coverage).toMatchObject({
+            callSites: 1,
+            unresolved: 1,
+            unanalyzed: 1,
+        });
+    });
+
+    it('does not treat a dynamic externalFetch alias as an error', async () => {
+        const dir = await makeApp({
+            source: `
+                function load(client, alias) {
+                    return client.externalFetch(alias, { path: '/resource' });
+                }
+            `,
+            semanticLayout: 'none',
+        });
+
+        const result = await validateLocalDataApp(dir, {
+            live: false,
+            loadLiveIndex: unusedLiveLoader,
+        });
+
+        expect(result.valid).toBe(true);
+        expect(result.errors).toEqual([]);
+        expect(result.coverage).toMatchObject({
+            callSites: 1,
+            unresolved: 1,
+            unanalyzed: 1,
+        });
+    });
+
+    it('uses the live semantic layer and does not require a local snapshot', async () => {
+        const dir = await makeApp({ semanticLayout: 'none' });
+        const loadLiveIndex = vi.fn().mockResolvedValue(liveIndex);
+
+        const result = await validateLocalDataApp(dir, {
+            live: true,
+            loadLiveIndex,
+        });
+
+        expect(result.valid).toBe(true);
+        expect(loadLiveIndex).toHaveBeenCalledWith('project-uuid');
+    });
+
+    it('gives an upgrade path instead of crashing on a missing offline snapshot', async () => {
+        const dir = await makeApp({ semanticLayout: 'none' });
+
+        const result = await validateLocalDataApp(dir, {
+            live: false,
+            loadLiveIndex: unusedLiveLoader,
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContainEqual(
+            expect.objectContaining({
+                code: 'semantic_layer',
+                message: expect.stringContaining('Re-download the app'),
+            }),
+        );
+    });
+
+    it('validates slug and vizSchema from the manifest', async () => {
+        const manifest = {
+            ...defaultManifest,
+            slug: '../invalid',
+            vizSchema: { fields: 'not-an-array' },
+        } as unknown as DataAppManifest;
+        const dir = await makeApp({ manifest });
+
+        const result = await validateLocalDataApp(dir, {
+            live: false,
+            loadLiveIndex: unusedLiveLoader,
+        });
+
+        expect(result.errors).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    code: 'manifest',
+                    message: expect.stringContaining('Invalid slug'),
+                }),
+                expect.objectContaining({
+                    code: 'manifest',
+                    message: expect.stringContaining('Invalid vizSchema'),
+                }),
+            ]),
+        );
+    });
+
+    it('requires a pnpm lockfile for custom dependencies', async () => {
+        const dir = await makeApp({
+            packageJson: JSON.stringify({
+                dependencies: { 'left-pad': '1.3.0' },
+            }),
+        });
+
+        const result = await validateLocalDataApp(dir, {
+            live: false,
+            loadLiveIndex: unusedLiveLoader,
+        });
+
+        expect(result.errors).toContainEqual(
+            expect.objectContaining({
+                code: 'dependencies',
+                message: expect.stringContaining('pnpm-lock.yaml'),
+            }),
+        );
+    });
+
+    it('surfaces parser failures as warnings rather than errors', async () => {
+        const dir = await makeApp({
+            source: 'const broken = ;',
+            semanticLayout: 'none',
+        });
+
+        const result = await validateLocalDataApp(dir, {
+            live: false,
+            loadLiveIndex: unusedLiveLoader,
+        });
+
+        expect(result.valid).toBe(true);
+        expect(result.warnings).toContainEqual(
+            expect.objectContaining({ code: 'source_parse' }),
+        );
+    });
+});
+
+describe('renderAppsValidationHuman', () => {
+    it('makes partial green coverage explicit', () => {
+        const report = buildAppsValidationReport(
+            [
+                {
+                    path: '/tmp/orders-app',
+                    name: 'Orders app',
+                    projectUuid: 'project-uuid',
+                    valid: true,
+                    errors: [],
+                    warnings: [],
+                    coverage: {
+                        callSites: 14,
+                        fullyResolved: 11,
+                        partiallyResolved: 2,
+                        unresolved: 1,
+                        unanalyzed: 3,
+                    },
+                },
+            ],
+            false,
+        );
+
+        const output = renderAppsValidationHuman(report);
+
+        expect(output).toContain(
+            "3 of 14 data-reference call site(s) couldn't be fully analyzed",
+        );
+        expect(output).toContain('unresolved values were skipped');
+        expect(output).toContain('Validation passed');
+        expect(output).toContain('Offline snapshots may be stale');
+    });
+});

--- a/packages/cli/src/handlers/apps/validate.ts
+++ b/packages/cli/src/handlers/apps/validate.ts
@@ -21,6 +21,7 @@ import {
 import { promises as fs } from 'fs';
 import pLimit from 'p-limit';
 import * as path from 'path';
+import { getConfig } from '../../config';
 import { CLI_VERSION } from '../../env';
 import GlobalState from '../../globalState';
 import * as styles from '../../styles';
@@ -84,6 +85,7 @@ export type AppsValidationReport = {
 
 type ValidateAppOptions = {
     live: boolean;
+    liveProjectUuid?: string;
     loadLiveIndex: (projectUuid: string) => Promise<DataAppExploreIndex>;
 };
 
@@ -366,16 +368,13 @@ export const validateLocalDataApp = async (
         try {
             let exploreIndex: DataAppExploreIndex;
             if (options.live) {
-                if (
-                    typeof manifest.projectUuid !== 'string' ||
-                    manifest.projectUuid.length === 0
-                ) {
+                if (!options.liveProjectUuid) {
                     throw new Error(
-                        'lightdash-app.yml is missing projectUuid, which is required for --live validation.',
+                        "No project selected. Run 'lightdash config set-project' before using --live validation.",
                     );
                 }
                 exploreIndex = await options.loadLiveIndex(
-                    manifest.projectUuid,
+                    options.liveProjectUuid,
                 );
             } else {
                 const semanticFiles = await readSemanticLayerFiles(appDir);
@@ -411,13 +410,17 @@ export const validateLocalDataApp = async (
         }
     }
 
+    let projectUuid: string | null = null;
+    if (options.live) {
+        projectUuid = options.liveProjectUuid ?? null;
+    } else if (typeof manifest.projectUuid === 'string') {
+        projectUuid = manifest.projectUuid;
+    }
+
     return {
         path: appDir,
         name: typeof manifest.name === 'string' ? manifest.name : null,
-        projectUuid:
-            typeof manifest.projectUuid === 'string'
-                ? manifest.projectUuid
-                : null,
+        projectUuid,
         valid: errors.length === 0,
         errors,
         warnings,
@@ -530,6 +533,9 @@ export const appsValidateHandler = async (
             paths.map((appPath) => path.resolve(process.cwd(), appPath)),
         ),
     ];
+    const liveProjectUuid = options.live
+        ? (await getConfig()).context?.project
+        : undefined;
     const liveIndexes = new Map<string, Promise<DataAppExploreIndex>>();
     const loadLiveIndex = (
         projectUuid: string,
@@ -545,6 +551,7 @@ export const appsValidateHandler = async (
         resolvedPaths.map((appPath) =>
             validateLocalDataApp(appPath, {
                 live: options.live,
+                liveProjectUuid,
                 loadLiveIndex,
             }),
         ),

--- a/packages/cli/src/handlers/apps/validate.ts
+++ b/packages/cli/src/handlers/apps/validate.ts
@@ -1,0 +1,564 @@
+import {
+    buildDataAppExploreIndexFromExplores,
+    buildDataAppExploreIndexFromModelFiles,
+    checkDataAppDataReferences,
+    computeCustomDependencies,
+    dataAppVizSchema,
+    extractDataAppDataReferences,
+    getErrorMessage,
+    isSummaryExploreError,
+    isValidDataAppSlug,
+    ParameterError,
+    validateDataAppDependencies,
+    type ApiExploreResults,
+    type ApiExploresResults,
+    type DataAppDataReferences,
+    type DataAppExploreIndex,
+    type DataAppManifest,
+    type DataAppSourceFile,
+    type DataReferenceLocation,
+} from '@lightdash/common';
+import { promises as fs } from 'fs';
+import pLimit from 'p-limit';
+import * as path from 'path';
+import { CLI_VERSION } from '../../env';
+import GlobalState from '../../globalState';
+import * as styles from '../../styles';
+import { lightdashApi } from '../dbt/apiClient';
+import {
+    applySdkMirrorToTemplateDeps,
+    readBundleFromDir,
+    readDependenciesFromDir,
+} from './appCodeFiles';
+import { loadTemplateDependencies } from './scaffolding';
+
+export type AppsValidateFormat = 'human' | 'json';
+
+export type AppsValidateOptions = {
+    format: AppsValidateFormat;
+    live: boolean;
+    verbose: boolean;
+};
+
+export type AppsValidationIssueCode =
+    | 'bundle'
+    | 'dependencies'
+    | 'external_connection'
+    | 'manifest'
+    | 'semantic_layer'
+    | 'semantic_reference'
+    | 'source_parse';
+
+export type AppsValidationIssue = {
+    code: AppsValidationIssueCode;
+    message: string;
+    location: DataReferenceLocation | null;
+};
+
+export type AppsValidationCoverage = DataAppDataReferences['stats'] & {
+    unanalyzed: number;
+};
+
+export type AppValidationResult = {
+    path: string;
+    name: string | null;
+    projectUuid: string | null;
+    valid: boolean;
+    errors: AppsValidationIssue[];
+    warnings: AppsValidationIssue[];
+    coverage: AppsValidationCoverage;
+};
+
+export type AppsValidationReport = {
+    valid: boolean;
+    mode: 'live' | 'offline';
+    summary: {
+        apps: number;
+        errors: number;
+        warnings: number;
+        callSites: number;
+        unanalyzedCallSites: number;
+    };
+    apps: AppValidationResult[];
+};
+
+type ValidateAppOptions = {
+    live: boolean;
+    loadLiveIndex: (projectUuid: string) => Promise<DataAppExploreIndex>;
+};
+
+const emptyCoverage = (): AppsValidationCoverage => ({
+    callSites: 0,
+    fullyResolved: 0,
+    partiallyResolved: 0,
+    unresolved: 0,
+    unanalyzed: 0,
+});
+
+const toCoverage = (
+    stats: DataAppDataReferences['stats'],
+): AppsValidationCoverage => ({
+    ...stats,
+    unanalyzed: stats.partiallyResolved + stats.unresolved,
+});
+
+const issue = (
+    code: AppsValidationIssueCode,
+    message: string,
+    location: DataReferenceLocation | null = null,
+): AppsValidationIssue => ({ code, message, location });
+
+const readSemanticLayerFiles = async (
+    appDir: string,
+): Promise<DataAppSourceFile[]> => {
+    const contextDir = path.join(appDir, '.lightdash', 'context');
+    const candidates = [path.join(contextDir, 'semantic-layer.yml')];
+    const modelsDir = path.join(contextDir, 'models');
+    const modelEntries = await fs
+        .readdir(modelsDir, { withFileTypes: true })
+        .catch((error: NodeJS.ErrnoException) => {
+            if (error.code === 'ENOENT') return [];
+            throw error;
+        });
+
+    for (const entry of modelEntries) {
+        if (entry.isFile()) candidates.push(path.join(modelsDir, entry.name));
+    }
+
+    const files = await Promise.all(
+        candidates.map(async (filePath) => {
+            try {
+                const content = await fs.readFile(filePath, 'utf-8');
+                return {
+                    path: path
+                        .relative(appDir, filePath)
+                        .split(path.sep)
+                        .join('/'),
+                    content,
+                };
+            } catch (error) {
+                if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+                    return null;
+                }
+                throw error;
+            }
+        }),
+    );
+    return files.filter((file): file is DataAppSourceFile => file !== null);
+};
+
+const validateManifest = (
+    manifest: DataAppManifest,
+): { errors: AppsValidationIssue[]; aliases: Set<string> } => {
+    const errors: AppsValidationIssue[] = [];
+    if (manifest.slug !== undefined && !isValidDataAppSlug(manifest.slug)) {
+        errors.push(
+            issue(
+                'manifest',
+                `Invalid slug "${manifest.slug}" in lightdash-app.yml. Slugs must start with a lowercase letter or digit and contain only lowercase letters, digits, and hyphens, up to 255 characters.`,
+            ),
+        );
+    }
+
+    if (manifest.vizSchema !== undefined) {
+        const parsed = dataAppVizSchema.safeParse(manifest.vizSchema);
+        if (!parsed.success) {
+            const details = parsed.error.issues
+                .map((entry) => `${entry.path.join('.')}: ${entry.message}`)
+                .join('; ');
+            errors.push(
+                issue(
+                    'manifest',
+                    `Invalid vizSchema in lightdash-app.yml (${details}).`,
+                ),
+            );
+        }
+    }
+
+    const aliases = new Set<string>();
+    const links = manifest.externalConnections;
+    if (links === undefined) return { errors, aliases };
+    if (!Array.isArray(links)) {
+        errors.push(
+            issue(
+                'manifest',
+                'Invalid externalConnections in lightdash-app.yml: expected a list.',
+            ),
+        );
+        return { errors, aliases };
+    }
+
+    for (const link of links) {
+        if (
+            !link ||
+            typeof link !== 'object' ||
+            typeof link.alias !== 'string' ||
+            typeof link.connectionSlug !== 'string'
+        ) {
+            errors.push(
+                issue(
+                    'manifest',
+                    'Invalid externalConnections entry in lightdash-app.yml: expected alias and connectionSlug strings.',
+                ),
+            );
+        } else {
+            const duplicate = aliases.has(link.alias);
+            aliases.add(link.alias);
+            if (!/^[a-z0-9_-]+$/i.test(link.alias) || link.alias.length > 64) {
+                errors.push(
+                    issue(
+                        'manifest',
+                        `Invalid external connection alias "${link.alias}" in lightdash-app.yml: aliases must contain only letters, numbers, hyphens, and underscores (max 64 characters).`,
+                    ),
+                );
+            } else if (duplicate) {
+                errors.push(
+                    issue(
+                        'manifest',
+                        `Duplicate external connection alias "${link.alias}" in lightdash-app.yml.`,
+                    ),
+                );
+            }
+        }
+    }
+    return { errors, aliases };
+};
+
+const validateDependencies = async (
+    appDir: string,
+): Promise<AppsValidationIssue[]> => {
+    try {
+        const deps = await readDependenciesFromDir(appDir);
+        if (deps === null) return [];
+        const templateDependencies = applySdkMirrorToTemplateDeps(
+            loadTemplateDependencies(CLI_VERSION),
+            deps.packageJson,
+        );
+
+        if (deps.lockfile === null) {
+            const customDeps = computeCustomDependencies(
+                deps.packageJson,
+                templateDependencies,
+            );
+            if (Object.keys(customDeps).length > 0) {
+                const hint = deps.hasNpmLockfile
+                    ? 'package-lock.json is not used by the server; run `pnpm install` to generate pnpm-lock.yaml.'
+                    : 'Run `pnpm install` to generate pnpm-lock.yaml.';
+                return [
+                    issue(
+                        'dependencies',
+                        `Custom dependencies require pnpm-lock.yaml. ${hint}`,
+                    ),
+                ];
+            }
+            return [];
+        }
+
+        validateDataAppDependencies(
+            { packageJson: deps.packageJson, lockfile: deps.lockfile },
+            { templateDependencies },
+        );
+        return [];
+    } catch (error) {
+        return [issue('dependencies', getErrorMessage(error))];
+    }
+};
+
+const sourceFilesFromBundle = (
+    files: { path: string; contentBase64: string }[],
+): DataAppSourceFile[] =>
+    files.map((file) => ({
+        path: file.path,
+        content: Buffer.from(file.contentBase64, 'base64').toString('utf-8'),
+    }));
+
+export const fetchLiveDataAppExploreIndex = async (
+    projectUuid: string,
+): Promise<DataAppExploreIndex> => {
+    const summaries = await lightdashApi<ApiExploresResults>({
+        method: 'GET',
+        url: `/api/v1/projects/${projectUuid}/explores`,
+        body: undefined,
+    });
+    const limit = pLimit(8);
+    const explores = await Promise.all(
+        summaries
+            .filter((summary) => !isSummaryExploreError(summary))
+            .map((summary) =>
+                limit(() =>
+                    lightdashApi<ApiExploreResults>({
+                        method: 'GET',
+                        url: `/api/v1/projects/${projectUuid}/explores/${encodeURIComponent(summary.name)}`,
+                        body: undefined,
+                    }),
+                ),
+            ),
+    );
+    return buildDataAppExploreIndexFromExplores(explores);
+};
+
+export const validateLocalDataApp = async (
+    appPath: string,
+    options: ValidateAppOptions,
+): Promise<AppValidationResult> => {
+    const appDir = path.resolve(appPath);
+    const errors: AppsValidationIssue[] = [];
+    const warnings: AppsValidationIssue[] = [];
+    let bundle: Awaited<ReturnType<typeof readBundleFromDir>>;
+
+    try {
+        bundle = await readBundleFromDir(appDir);
+    } catch (error) {
+        return {
+            path: appDir,
+            name: null,
+            projectUuid: null,
+            valid: false,
+            errors: [issue('bundle', getErrorMessage(error))],
+            warnings,
+            coverage: emptyCoverage(),
+        };
+    }
+
+    const { manifest } = bundle;
+    const manifestResult = validateManifest(manifest);
+    errors.push(...manifestResult.errors);
+    errors.push(...(await validateDependencies(appDir)));
+
+    const sourceFiles = sourceFilesFromBundle(bundle.files);
+    if (sourceFiles.length === 0) {
+        errors.push(
+            issue('bundle', 'App bundle has no files under src/ to validate.'),
+        );
+    }
+
+    const extracted = extractDataAppDataReferences(sourceFiles);
+    const coverage = toCoverage(extracted.stats);
+    warnings.push(
+        ...extracted.parseErrors.map((parseError) =>
+            issue(
+                'source_parse',
+                `Could not statically analyze ${parseError.path}: ${parseError.message}`,
+            ),
+        ),
+    );
+
+    for (const ref of extracted.references) {
+        if (
+            ref.kind === 'externalFetch' &&
+            ref.alias !== null &&
+            !manifestResult.aliases.has(ref.alias)
+        ) {
+            errors.push(
+                issue(
+                    'external_connection',
+                    `externalFetch alias "${ref.alias}" is not declared in lightdash-app.yml externalConnections.`,
+                    ref.location,
+                ),
+            );
+        }
+    }
+
+    const hasSemanticReferences = extracted.references.some(
+        (ref) => ref.kind !== 'externalFetch',
+    );
+    if (hasSemanticReferences) {
+        try {
+            let exploreIndex: DataAppExploreIndex;
+            if (options.live) {
+                if (
+                    typeof manifest.projectUuid !== 'string' ||
+                    manifest.projectUuid.length === 0
+                ) {
+                    throw new Error(
+                        'lightdash-app.yml is missing projectUuid, which is required for --live validation.',
+                    );
+                }
+                exploreIndex = await options.loadLiveIndex(
+                    manifest.projectUuid,
+                );
+            } else {
+                const semanticFiles = await readSemanticLayerFiles(appDir);
+                if (semanticFiles.length === 0) {
+                    throw new Error('No local semantic layer snapshot found.');
+                }
+                exploreIndex =
+                    buildDataAppExploreIndexFromModelFiles(semanticFiles);
+            }
+            errors.push(
+                ...checkDataAppDataReferences(
+                    extracted.references,
+                    exploreIndex,
+                ).map((referenceError) =>
+                    issue(
+                        'semantic_reference',
+                        referenceError.error,
+                        referenceError.location,
+                    ),
+                ),
+            );
+        } catch (error) {
+            const message = getErrorMessage(error);
+            let semanticLayerMessage: string;
+            if (options.live) {
+                semanticLayerMessage = `Could not load live semantic layer: ${message}`;
+            } else if (message.toLowerCase().includes('re-download')) {
+                semanticLayerMessage = message;
+            } else {
+                semanticLayerMessage = `${message} Re-download the app to refresh its local semantic layer snapshot.`;
+            }
+            errors.push(issue('semantic_layer', semanticLayerMessage));
+        }
+    }
+
+    return {
+        path: appDir,
+        name: typeof manifest.name === 'string' ? manifest.name : null,
+        projectUuid:
+            typeof manifest.projectUuid === 'string'
+                ? manifest.projectUuid
+                : null,
+        valid: errors.length === 0,
+        errors,
+        warnings,
+        coverage,
+    };
+};
+
+export const buildAppsValidationReport = (
+    apps: AppValidationResult[],
+    live: boolean,
+): AppsValidationReport => {
+    const errors = apps.reduce((count, app) => count + app.errors.length, 0);
+    const warnings = apps.reduce(
+        (count, app) => count + app.warnings.length,
+        0,
+    );
+    return {
+        valid: errors === 0,
+        mode: live ? 'live' : 'offline',
+        summary: {
+            apps: apps.length,
+            errors,
+            warnings,
+            callSites: apps.reduce(
+                (count, app) => count + app.coverage.callSites,
+                0,
+            ),
+            unanalyzedCallSites: apps.reduce(
+                (count, app) => count + app.coverage.unanalyzed,
+                0,
+            ),
+        },
+        apps,
+    };
+};
+
+const formatCoverage = (coverage: AppsValidationCoverage): string => {
+    if (coverage.callSites === 0) {
+        return 'Coverage: no data-reference call sites found.';
+    }
+    if (coverage.unanalyzed === 0) {
+        return `Coverage: all ${coverage.callSites} data-reference call site(s) were statically analyzed.`;
+    }
+    return `Coverage: ${coverage.unanalyzed} of ${coverage.callSites} data-reference call site(s) couldn't be fully analyzed; unresolved values were skipped and are not errors.`;
+};
+
+const formatIssue = (entry: AppsValidationIssue): string => {
+    const prefix = entry.location
+        ? `${entry.location.path}:${entry.location.line}:${entry.location.column} — `
+        : '';
+    return `${prefix}${entry.message}`;
+};
+
+export const renderAppsValidationHuman = (
+    report: AppsValidationReport,
+): string => {
+    const lines = [
+        `Validating ${report.summary.apps} data app(s) using ${
+            report.mode === 'live'
+                ? 'the live project semantic layer'
+                : 'local semantic layer snapshots'
+        }.`,
+    ];
+    if (report.mode === 'offline') {
+        lines.push(
+            styles.secondary(
+                'Offline snapshots may be stale. Use --live for upload-time semantic validation parity.',
+            ),
+        );
+    }
+
+    for (const app of report.apps) {
+        lines.push('');
+        const label = app.name ? `${app.name} (${app.path})` : app.path;
+        lines.push(
+            `${app.valid ? styles.success('✓') : styles.error('✗')} ${label}`,
+        );
+        lines.push(`  ${formatCoverage(app.coverage)}`);
+        for (const warning of app.warnings) {
+            lines.push(
+                `  ${styles.warning('warning')} ${formatIssue(warning)}`,
+            );
+        }
+        for (const error of app.errors) {
+            lines.push(`  ${styles.error('error')} ${formatIssue(error)}`);
+        }
+    }
+
+    lines.push('');
+    lines.push(
+        report.valid
+            ? styles.success(
+                  `Validation passed for ${report.summary.apps} data app(s) with ${report.summary.warnings} warning(s).`,
+              )
+            : styles.error(
+                  `Validation failed with ${report.summary.errors} error(s) across ${report.summary.apps} data app(s).`,
+              ),
+    );
+    return `${lines.join('\n')}\n`;
+};
+
+export const appsValidateHandler = async (
+    pathArgs: string[] | undefined,
+    options: AppsValidateOptions,
+): Promise<void> => {
+    GlobalState.setVerbose(options.verbose);
+    const paths = pathArgs && pathArgs.length > 0 ? pathArgs : ['.'];
+    const resolvedPaths = [
+        ...new Set(
+            paths.map((appPath) => path.resolve(process.cwd(), appPath)),
+        ),
+    ];
+    const liveIndexes = new Map<string, Promise<DataAppExploreIndex>>();
+    const loadLiveIndex = (
+        projectUuid: string,
+    ): Promise<DataAppExploreIndex> => {
+        const cached = liveIndexes.get(projectUuid);
+        if (cached) return cached;
+        const pending = fetchLiveDataAppExploreIndex(projectUuid);
+        liveIndexes.set(projectUuid, pending);
+        return pending;
+    };
+
+    const apps = await Promise.all(
+        resolvedPaths.map((appPath) =>
+            validateLocalDataApp(appPath, {
+                live: options.live,
+                loadLiveIndex,
+            }),
+        ),
+    );
+    const report = buildAppsValidationReport(apps, options.live);
+    process.stdout.write(
+        options.format === 'json'
+            ? `${JSON.stringify(report, null, 2)}\n`
+            : renderAppsValidationHuman(report),
+    );
+
+    if (!report.valid) {
+        throw new ParameterError(
+            `Data app validation failed with ${report.summary.errors} error(s).`,
+        );
+    }
+};

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,6 +18,10 @@ import { getDiagnosticsHint } from './error';
 import GlobalState from './globalState';
 import { createAppHandler } from './handlers/apps/createApp';
 import { appsPreviewHandler } from './handlers/apps/preview';
+import {
+    appsValidateHandler,
+    type AppsValidateFormat,
+} from './handlers/apps/validate';
 import { compileHandler } from './handlers/compile';
 import { connectSnowflakeHandler } from './handlers/connectSnowflake';
 import { refreshHandler } from './handlers/dbt/refresh';
@@ -1135,6 +1139,23 @@ appsProgram
     )
     .option('--verbose', undefined, false)
     .action(appsPreviewHandler);
+appsProgram
+    .command('validate [paths...]')
+    .description(
+        'Validate data app source, manifests, dependencies, and semantic-layer references locally.',
+    )
+    .option(
+        '--live',
+        'Validate against fresh explores from each app project instead of its downloaded semantic-layer snapshot.',
+        false,
+    )
+    .addOption(
+        new Option('--format <format>', 'Output format: human or json')
+            .choices(['human', 'json'])
+            .default('human' satisfies AppsValidateFormat),
+    )
+    .option('--verbose', undefined, false)
+    .action(appsValidateHandler);
 
 program
     .command('deploy')


### PR DESCRIPTION
## Summary

- add `lightdash apps validate [paths...]` with human and JSON output
- validate app bundles, dependencies, slugs, viz schemas, semantic references, and declared `externalFetch` aliases
- support offline semantic-layer snapshots by default and fresh project explores with `--live`
- report unresolved static-analysis coverage without treating unknown values as errors
- document the validation step in the local data-app authoring workflow

## Why

Data-app authors currently discover invalid semantic references and manifest/dependency problems too late. This adds a standalone local validation surface suitable for development, pre-commit hooks, and CI without coupling it to the existing dbt-oriented `lightdash validate` command.

The offline path uses the downloaded semantic-layer context and calls out that it may be stale. The live path fetches the current explores for stronger upload-time semantic validation parity.

## Developer impact

The command accepts one or more app directories, so all downloaded apps can be checked with a shell glob such as:

```sh
lightdash apps validate ./lightdash/apps/* --live
```


## Tests
1) Added a mistake to the code and it spotted the code diverging from the local semantic layer
2) Added the same "mistake" in the local semantic layer. Everything turns green again.
3) Ran the command `--live`, which spots the mistake again.

<img width="1148" height="564" alt="image" src="https://github.com/user-attachments/assets/b93c2ab3-cf30-4f83-b9b5-f8ffdc7b8715" />


Same validation for external fetches:
<img width="1104" height="227" alt="image" src="https://github.com/user-attachments/assets/c0161cc2-04ba-42c3-94f1-54c209b9b903" />



Machine-readable CI output is available with `--format json`, and validation errors exit non-zero.


Closes #25964