### PR TITLE
feat(ai-agents): hide product capability issues from review boards

### DIFF
--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
@@ -637,6 +637,23 @@ describe('AiAgentReviewClassifierModel', () => {
             );
         });
 
+        it('excludes hidden root causes from both the signal and manual queries, keeping unclassified rows', async () => {
+            tracker.on.select(AiAgentTurnSignalTableName).responseOnce([]);
+            tracker.on.select(AiAgentReviewItemTableName).responseOnce([]);
+
+            await model.listReviewItems({
+                organizationUuid: ORGANIZATION_UUID,
+            });
+
+            const [signalQuery, manualQuery] = tracker.history.select;
+            for (const query of [signalQuery, manualQuery]) {
+                expect(query.bindings).toContain('product_capability');
+                // NULL NOT IN (...) is unknown, so unclassified rows need the
+                // explicit IS NULL branch to stay visible.
+                expect(query.sql).toMatch(/primary_root_cause"? is null/i);
+            }
+        });
+
         it('overlays persisted human state and PR linkage onto the projection', async () => {
             tracker.on.select(AiAgentTurnSignalTableName).responseOnce([
                 {
@@ -1110,6 +1127,9 @@ describe('AiAgentReviewClassifierModel', () => {
             });
 
             expect(result).toHaveLength(1);
+            const [query] = tracker.history.select;
+            expect(query.bindings).toContain('product_capability');
+            expect(query.sql).toMatch(/primary_root_cause"? is null/i);
             expect(result[0]).toEqual(
                 expect.objectContaining({
                     uuid: TURN_SIGNAL_UUID,

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
@@ -654,6 +654,41 @@ describe('AiAgentReviewClassifierModel', () => {
             }
         });
 
+        // The judge is told to reuse an existing item's key even when it assigns
+        // a different root cause, so a card kept alive by visible findings can
+        // have a hidden one as its most recent signal.
+        it('drops a card whose resolved root cause is hidden', async () => {
+            tracker.on.select(AiAgentTurnSignalTableName).responseOnce([
+                {
+                    fingerprint: FINGERPRINT,
+                    first_seen_at: SEEN_AT,
+                    last_seen_at: SEEN_AT,
+                    finding_count: '1',
+                },
+            ]);
+            tracker.on.select(AiAgentTurnSignalTableName).responseOnce([
+                makeTurnSignalRow({
+                    primary_root_cause: 'product_capability',
+                }),
+            ]);
+            tracker.on.select(AiAgentReviewItemTableName).responseOnce([]);
+            tracker.on.select(AiAgentReviewItemTableName).responseOnce([]);
+            tracker.on
+                .select(AiAgentReviewRemediationTableName)
+                .responseOnce([]);
+
+            const result = await model.listReviewItems({
+                organizationUuid: ORGANIZATION_UUID,
+            });
+
+            expect(result).toEqual([]);
+            // The latest-signal lookup is filtered too, so the card's face comes
+            // from its latest visible finding rather than the hidden one.
+            expect(tracker.history.select[1].bindings).toContain(
+                'product_capability',
+            );
+        });
+
         it('overlays persisted human state and PR linkage onto the projection', async () => {
             tracker.on.select(AiAgentTurnSignalTableName).responseOnce([
                 {

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -1,5 +1,6 @@
 import {
     AiSlackThreadCreatedFrom,
+    HIDDEN_AI_AGENT_REVIEW_ROOT_CAUSES,
     ProjectType,
     QueryExecutionContext,
     shouldReopenReviewItem,
@@ -127,6 +128,19 @@ const defaultWritebackEligibility: AiAgentReviewItemWritebackEligibility = {
     provider: null,
     strategy: null,
 };
+
+// Read-side gate for root causes that are classified but never surfaced (see
+// HIDDEN_AI_AGENT_REVIEW_ROOT_CAUSES). Rows with a null root cause stay visible,
+// so this cannot be written as a bare NOT IN (NULL NOT IN (...) is unknown).
+const excludeHiddenRootCauses =
+    (column: string) =>
+    (query: Knex.QueryBuilder): void => {
+        void query.where((builder) => {
+            void builder
+                .whereNull(column)
+                .orWhereNotIn(column, [...HIDDEN_AI_AGENT_REVIEW_ROOT_CAUSES]);
+        });
+    };
 
 const ACTIVE_REMEDIATION_STATUSES: AiAgentReviewRemediationStatus[] = [
     'queued',
@@ -1215,6 +1229,11 @@ export class AiAgentReviewClassifierModel {
             )
             .where(`${AiAgentTurnSignalTableName}.promoted_to_finding`, true)
             .whereNotNull(`${AiAgentTurnSignalTableName}.fingerprint`)
+            .modify(
+                excludeHiddenRootCauses(
+                    `${AiAgentTurnSignalTableName}.primary_root_cause`,
+                ),
+            )
             .modify((query) => {
                 if (args.projectUuid) {
                     void query.where(
@@ -1414,6 +1433,7 @@ export class AiAgentReviewClassifierModel {
         )
             .where('organization_uuid', args.organizationUuid)
             .where('source', 'manual')
+            .modify(excludeHiddenRootCauses('primary_root_cause'))
             .modify((query) => {
                 if (args.projectUuid) {
                     void query.where('project_uuid', args.projectUuid);
@@ -2141,6 +2161,7 @@ export class AiAgentReviewClassifierModel {
             .where('organization_uuid', organizationUuid)
             .where('fingerprint', fingerprint)
             .where('promoted_to_finding', true)
+            .modify(excludeHiddenRootCauses('primary_root_cause'))
             .orderBy('created_at', 'desc')
             .first('project_uuid', 'agent_uuid');
         if (!row) {
@@ -2168,6 +2189,7 @@ export class AiAgentReviewClassifierModel {
         )
             .where('organization_uuid', organizationUuid)
             .where('fingerprint', fingerprint)
+            .modify(excludeHiddenRootCauses('primary_root_cause'))
             .first('project_uuid', 'agent_uuid');
         if (!row) {
             return null;
@@ -2440,6 +2462,7 @@ export class AiAgentReviewClassifierModel {
                 recommendation: 'signal.recommendation',
             })
             .where('signal.organization_uuid', args.organizationUuid)
+            .modify(excludeHiddenRootCauses('signal.primary_root_cause'))
             .modify((query) => {
                 if (args.projectUuid) {
                     void query.where('signal.project_uuid', args.projectUuid);

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -1,6 +1,7 @@
 import {
     AiSlackThreadCreatedFrom,
     HIDDEN_AI_AGENT_REVIEW_ROOT_CAUSES,
+    isHiddenAiAgentReviewRootCause,
     ProjectType,
     QueryExecutionContext,
     shouldReopenReviewItem,
@@ -1305,6 +1306,11 @@ export class AiAgentReviewClassifierModel {
                       .select('*')
                       .where('organization_uuid', args.organizationUuid)
                       .whereIn('fingerprint', fingerprints)
+                      // The judge is told to reuse an existing item's key even
+                      // when it assigns a different root cause, so one card can
+                      // carry a hidden finding as its most recent signal. The
+                      // card's face must come from its latest VISIBLE finding.
+                      .modify(excludeHiddenRootCauses('primary_root_cause'))
                       .modify((query) => {
                           if (args.projectUuid) {
                               void query.where(
@@ -1422,7 +1428,12 @@ export class AiAgentReviewClassifierModel {
             })
             .filter(
                 (reviewItem): reviewItem is AiAgentReviewItemSummary =>
-                    reviewItem !== null,
+                    reviewItem !== null &&
+                    // Last line of defence: whatever the projection resolved to,
+                    // a hidden root cause never leaves the model.
+                    !isHiddenAiAgentReviewRootCause(
+                        reviewItem.primaryRootCause,
+                    ),
             );
 
         const aiFingerprints = new Set(

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -516,6 +516,27 @@ describe('AiAgentAdminService review access', () => {
         expect(listReviewSignals).not.toHaveBeenCalled();
     });
 
+    it('refuses to create an issue under a category that is never listed', async () => {
+        const createManualReviewItem = vi.fn();
+        const service = makeService({
+            aiAgentReviewClassifierModel: { createManualReviewItem },
+        });
+
+        await expect(
+            service.createReviewItem(makeAdminUser(), {
+                title: 'Cannot pivot this chart',
+                description: null,
+                projectUuid: PROJECT_UUID,
+                agentUuid: null,
+                assignedToUserUuid: null,
+                primaryRootCause: 'product_capability',
+                priority: 'none',
+                targetRefs: [],
+            }),
+        ).rejects.toThrow('not an available issue category');
+        expect(createManualReviewItem).not.toHaveBeenCalled();
+    });
+
     it('forbids starting writeback without manage:SourceCode', async () => {
         const findExploresFromCache = vi.fn();
         const aiAgentReviewWriteback = vi.fn();

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -33,6 +33,7 @@ import {
     FeatureFlags,
     ForbiddenError,
     getErrorMessage,
+    isHiddenAiAgentReviewRootCause,
     JobStatusType,
     KnexPaginateArgs,
     KnexPaginatedData,
@@ -952,6 +953,14 @@ export class AiAgentAdminService extends BaseService {
         const title = body.title.trim();
         if (title.length === 0) {
             throw new ParameterError('Issue title is required');
+        }
+
+        // Hidden root causes are never listed, so an issue filed under one
+        // would vanish the moment it was created.
+        if (isHiddenAiAgentReviewRootCause(body.primaryRootCause)) {
+            throw new ParameterError(
+                `${body.primaryRootCause} is not an available issue category`,
+            );
         }
 
         const project = await this.projectModel.get(body.projectUuid);

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
@@ -837,7 +837,7 @@ describe('AiAgentReviewClassifierService', () => {
         expect(model.listTurnReviewCandidates).toHaveBeenCalledTimes(1);
     });
 
-    it('stores product capability findings as grouped review projections', async () => {
+    it('keeps classifying product capability findings but never announces them', async () => {
         judgeTurn.mockResolvedValueOnce(makeProductJudgeOutput());
         model.listTurnReviewCandidates.mockResolvedValue([
             makeCandidate({
@@ -863,6 +863,10 @@ describe('AiAgentReviewClassifierService', () => {
                 }),
             }),
         );
+        // Hidden root causes never reach a board, so there is nothing to open.
+        expect(
+            aiAgentReviewNotificationService.notifyNeedsReview,
+        ).not.toHaveBeenCalled();
     });
 
     it('passes existing review items to the judge as dedup candidates', async () => {

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -9,6 +9,7 @@ import {
     getAiAgentConfigSnapshotHash,
     getAiAgentReviewItemFingerprint,
     isExploreError,
+    isHiddenAiAgentReviewRootCause,
     ProjectType,
     type AiAgentAvailableCapability,
     type AiAgentConfigSnapshot,
@@ -667,8 +668,14 @@ export class AiAgentReviewClassifierService extends BaseService {
                         reviewItemFingerprints.add(fingerprint);
                         reviewItemCount = reviewItemFingerprints.size;
                         // Only newly created items ping Slack; a recurrence
-                        // accrues onto its existing card without re-notifying.
-                        if (reviewItemOutcome === 'created') {
+                        // accrues onto its existing card without re-notifying,
+                        // and hidden root causes never reach a board to open.
+                        if (
+                            reviewItemOutcome === 'created' &&
+                            !isHiddenAiAgentReviewRootCause(
+                                classifiedTurn.finding.primaryRootCause,
+                            )
+                        ) {
                             const projectFingerprints =
                                 reviewItemFingerprintsByProject.get(
                                     classifiedTurn.signal.subject.projectUuid,

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.test.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.test.ts
@@ -6,6 +6,8 @@ import {
     getAiAgentConfigSnapshotHash,
     getAiAgentReviewItemFingerprint,
     getAiAgentReviewItemFingerprintScope,
+    getVisibleAiAgentReviewRootCauses,
+    isHiddenAiAgentReviewRootCause,
     persistedAiAgentJudgeProjectContextEntrySchema,
     shouldReopenReviewItem,
     type AiAgentConfigSnapshot,
@@ -301,6 +303,28 @@ describe('shouldReopenReviewItem', () => {
         expect(shouldReopenReviewItem('triage', null)).toBe(false);
         expect(shouldReopenReviewItem('open', null)).toBe(false);
         expect(shouldReopenReviewItem('in_progress', null)).toBe(false);
+    });
+});
+
+describe('hidden review root causes', () => {
+    it('hides product capability findings and nothing else', () => {
+        expect(isHiddenAiAgentReviewRootCause('product_capability')).toBe(true);
+        expect(isHiddenAiAgentReviewRootCause('semantic_layer')).toBe(false);
+        expect(isHiddenAiAgentReviewRootCause('ambiguous')).toBe(false);
+    });
+
+    it('treats an unclassified root cause as visible', () => {
+        expect(isHiddenAiAgentReviewRootCause(null)).toBe(false);
+    });
+
+    it('drops hidden root causes while keeping the given order', () => {
+        expect(
+            getVisibleAiAgentReviewRootCauses([
+                'semantic_layer',
+                'product_capability',
+                'runtime_reliability',
+            ]),
+        ).toEqual(['semantic_layer', 'runtime_reliability']);
     });
 });
 

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -71,6 +71,26 @@ export type AiAgentRootCause =
     | 'not_a_failure'
     | 'ambiguous';
 
+// Root causes the judge keeps assigning but that are never surfaced as issues:
+// a Lightdash capability gap is not something a customer can action on their
+// board. Findings are still classified and persisted for internal analysis.
+export const HIDDEN_AI_AGENT_REVIEW_ROOT_CAUSES: readonly AiAgentRootCause[] = [
+    'product_capability',
+];
+
+export const isHiddenAiAgentReviewRootCause = (
+    rootCause: AiAgentRootCause | null,
+): boolean =>
+    rootCause !== null &&
+    HIDDEN_AI_AGENT_REVIEW_ROOT_CAUSES.includes(rootCause);
+
+export const getVisibleAiAgentReviewRootCauses = (
+    rootCauses: AiAgentRootCause[],
+): AiAgentRootCause[] =>
+    rootCauses.filter(
+        (rootCause) => !isHiddenAiAgentReviewRootCause(rootCause),
+    );
+
 export type AiAgentFixTarget =
     | 'semantic_yaml_patch'
     | 'project_context_rule'

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
@@ -1,4 +1,5 @@
 import {
+    getVisibleAiAgentReviewRootCauses,
     type AiAgentReviewItemStatus,
     type AiAgentReviewItemSummary,
     type AiAgentReviewSignalSummary,
@@ -277,16 +278,17 @@ const rootCauseHelp: Record<
     ambiguous: { desc: 'Not clear, worth a look', opensPr: false },
 };
 
-const rootCauseHelpOrder: AiAgentRootCause[] = [
-    'semantic_layer',
-    'project_context',
-    'agent_configuration',
-    'product_capability',
-    'runtime_reliability',
-    'feedback_quality',
-    'not_a_failure',
-    'ambiguous',
-];
+const rootCauseHelpOrder: AiAgentRootCause[] =
+    getVisibleAiAgentReviewRootCauses([
+        'semantic_layer',
+        'project_context',
+        'agent_configuration',
+        'product_capability',
+        'runtime_reliability',
+        'feedback_quality',
+        'not_a_failure',
+        'ambiguous',
+    ]);
 
 const ReviewConceptHelp = () => (
     <HoverCard

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
@@ -61,6 +61,7 @@ import {
     DEFAULT_VISIBLE_ROOT_CAUSES,
     getIssueTitle,
     reviewRootCauseLabels,
+    SURFACED_ROOT_CAUSES,
 } from './reviewItemDetails';
 import styles from './ReviewKanbanBoard.module.css';
 import { ReviewKanbanCard } from './ReviewKanbanCard';
@@ -303,17 +304,15 @@ export const ReviewKanbanBoard: FC<Props> = ({
                 (counts.get(item.primaryRootCause) ?? 0) + 1,
             );
         }
-        return (Object.keys(reviewRootCauseLabels) as AiAgentRootCause[])
-            .map((rootCause) => ({
-                value: rootCause,
-                label: reviewRootCauseLabels[rootCause],
-                count: counts.get(rootCause) ?? 0,
-            }))
-            .sort(
-                (a, b) =>
-                    b.count - a.count ||
-                    String(a.label).localeCompare(String(b.label)),
-            );
+        return SURFACED_ROOT_CAUSES.map((rootCause) => ({
+            value: rootCause,
+            label: reviewRootCauseLabels[rootCause],
+            count: counts.get(rootCause) ?? 0,
+        })).sort(
+            (a, b) =>
+                b.count - a.count ||
+                String(a.label).localeCompare(String(b.label)),
+        );
     }, [projectFilteredItems]);
 
     const assigneeFacetOptions = useMemo(

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.test.ts
@@ -1,10 +1,12 @@
 import { type AiAgentReviewItemSummary } from '@lightdash/common';
 import { describe, expect, it } from 'vitest';
 import {
+    DEFAULT_VISIBLE_ROOT_CAUSES,
     formatRelativeReviewDate,
     getIssueTitle,
     getReviewReasoningText,
     getTargetAnchor,
+    SURFACED_ROOT_CAUSES,
 } from './reviewItemDetails';
 
 const makeItem = (
@@ -30,6 +32,14 @@ const makeItem = (
                       ...overrides.latestFinding,
                   },
     }) as unknown as AiAgentReviewItemSummary;
+
+describe('SURFACED_ROOT_CAUSES', () => {
+    it('never offers product capability as a category', () => {
+        expect(SURFACED_ROOT_CAUSES).not.toContain('product_capability');
+        expect(SURFACED_ROOT_CAUSES).toContain('semantic_layer');
+        expect(DEFAULT_VISIBLE_ROOT_CAUSES).not.toContain('product_capability');
+    });
+});
 
 describe('getIssueTitle', () => {
     it('no longer special-cases semantic_layer into a "Review {target}" title', () => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.ts
@@ -1,5 +1,6 @@
 import {
     formatAiProjectContextObjectRef,
+    getVisibleAiAgentReviewRootCauses,
     type AiAgentRecommendationAction,
     type AiAgentReviewItemPriority,
     type AiAgentReviewItemSummary,
@@ -19,14 +20,22 @@ export const reviewRootCauseLabels: Record<AiAgentRootCause, string> = {
     ambiguous: 'Ambiguous',
 };
 
+// Every root cause a user can ever see or pick. Root causes the judge keeps
+// assigning but the API never returns (product capability gaps) are dropped
+// here, so no filter, legend or picker offers a category with nothing behind it.
+export const SURFACED_ROOT_CAUSES = getVisibleAiAgentReviewRootCauses(
+    Object.keys(reviewRootCauseLabels) as AiAgentRootCause[],
+);
+
+// Of the surfaced ones, which start selected in the board filter.
 const DEFAULT_HIDDEN_ROOT_CAUSES: AiAgentRootCause[] = [
     'agent_configuration',
     'runtime_reliability',
 ];
 
-export const DEFAULT_VISIBLE_ROOT_CAUSES = (
-    Object.keys(reviewRootCauseLabels) as AiAgentRootCause[]
-).filter((rootCause) => !DEFAULT_HIDDEN_ROOT_CAUSES.includes(rootCause));
+export const DEFAULT_VISIBLE_ROOT_CAUSES = SURFACED_ROOT_CAUSES.filter(
+    (rootCause) => !DEFAULT_HIDDEN_ROOT_CAUSES.includes(rootCause),
+);
 
 export const reviewRootCauseColors: Record<AiAgentRootCause, string> = {
     semantic_layer: 'indigo',

--- a/packages/frontend/src/ee/features/aiCopilot/components/CreateIssue/CreateIssueModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/CreateIssue/CreateIssueModal.tsx
@@ -38,7 +38,6 @@ const rootCauseOptions: { value: AiAgentRootCause; label: string }[] = [
     { value: 'semantic_layer', label: 'Semantic layer' },
     { value: 'project_context', label: 'Project context' },
     { value: 'agent_configuration', label: 'Agent configuration' },
-    { value: 'product_capability', label: 'Product capability' },
     { value: 'runtime_reliability', label: 'Runtime reliability' },
     { value: 'feedback_quality', label: 'Feedback quality' },
     { value: 'not_a_failure', label: 'Not a failure' },


### PR DESCRIPTION
## Summary

The review judge classifies some agent turns as `product_capability` — "the agent can't do this yet", i.e. a Lightdash capability gap. That verdict is useful to us, but it is not something a customer can action on their issues board, so it should never reach the client.

**The classification is unchanged.** Signals and findings are still judged, fingerprinted and persisted with `primary_root_cause = 'product_capability'`, so the data stays available for internal analysis. Only the read paths change.

## What's hidden

Backend (the enforcement sits in the model, so every caller inherits it):

- `listReviewItems` — both the AI-derived projection and manual rows.
- `listReviewSignals` — the signals tab no longer shows a "Product" verdict.
- `getReviewItemScope` — per-item reads *and* mutations (status, assignee, priority, comments, writeback) now 404 rather than acting on an invisible issue. `getReviewItem` funnels through `listReviewItems`, so the single-item endpoint is covered by the same filter.
- New-item Slack / in-app notifications are skipped for hidden root causes, so nothing links to a board card that isn't there.
- Manual issue creation rejects the category with a 400 instead of creating an item that would vanish on the next list.

Frontend: the category is gone from the create-issue picker, the board's root-cause filter facet, and the root-cause legend. The label/colour maps keep their entry only because the union type still has the member.

One shared list drives all of it — `HIDDEN_AI_AGENT_REVIEW_ROOT_CAUSES` in `@lightdash/common` — so hiding another category later is a one-line change.

## Note on the SQL

The predicate keeps an explicit `IS NULL` branch: `NULL NOT IN (...)` is unknown in Postgres, so a bare `NOT IN` would have silently dropped every unclassified item too. There is a test asserting both halves.

## Testing

- Unit tests added in common (helper), backend model (SQL shape for both queries), admin service (create rejected), classifier service (still classified, never announced), and frontend (category not offered).
- typecheck, lint and unit tests pass across the affected packages.
- Verified by effect against a running instance with three seeded rows — a `product_capability` issue, a `semantic_layer` control and a NULL-root-cause control:
  - `GET /review-items` returns the two controls and not the product one (the NULL row stays visible).
  - `GET /review-items/{fingerprint}` → 404 for the hidden one, 200 for the control.
  - `PATCH /review-items/{fingerprint}` → 404 for the hidden one.
  - `POST /review-items` with `primaryRootCause: product_capability` → 400 "not an available issue category".
- Not covered: no browser pass over the board UI; the filter/legend/picker changes are covered by unit tests only.

No Linear ticket for this one (confirmed with the author).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWLPMSC3Npv14bq3kf4Hyb
