### PR TITLE
fix(filters): clarify period-to-date operator label and tooltip

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterPeriodToDateSelect.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterPeriodToDateSelect.tsx
@@ -8,10 +8,10 @@ import { Select } from '@mantine/core';
 import { useMemo, type FC } from 'react';
 
 const allPeriodOptions = [
-    { value: UnitOfTime.years, label: 'year to date (YTD)' },
-    { value: UnitOfTime.quarters, label: 'quarter to date (QTD)' },
-    { value: UnitOfTime.months, label: 'month to date (MTD)' },
-    { value: UnitOfTime.weeks, label: 'week to date (WTD)' },
+    { value: UnitOfTime.years, label: 'years to date' },
+    { value: UnitOfTime.quarters, label: 'quarters to date' },
+    { value: UnitOfTime.months, label: 'months to date' },
+    { value: UnitOfTime.weeks, label: 'weeks to date' },
 ];
 
 /**

--- a/packages/frontend/src/components/common/Filters/FilterInputs/constants.ts
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/constants.ts
@@ -20,12 +20,18 @@ export const filterOperatorLabel: Record<FilterOperator, string> = {
     [FilterOperator.NOT_IN_THE_CURRENT]: 'not in the current',
     [FilterOperator.IN_BETWEEN]: 'is between',
     [FilterOperator.NOT_IN_BETWEEN]: 'is not between',
-    [FilterOperator.IN_PERIOD_TO_DATE]: 'is period to date',
+    [FilterOperator.IN_PERIOD_TO_DATE]: 'in all',
+};
+
+export const filterOperatorDropdownLabel: Partial<
+    Record<FilterOperator, string>
+> = {
+    [FilterOperator.IN_PERIOD_TO_DATE]: 'in all periods to date',
 };
 
 export const filterOperatorDescription: Partial<
     Record<FilterOperator, string>
 > = {
     [FilterOperator.IN_PERIOD_TO_DATE]:
-        "Includes rows where the position within the selected period is on or before today's position. Useful for period-over-period comparisons (e.g., YTD, QTD, MTD, WTD).",
+        'Trims every period in the range to the same point as today — e.g. with weeks selected, if today is Thursday, you get Mon–Thu of every week. Useful for like-for-like comparisons (WTD, MTD, QTD, YTD). For just the current period so far, use "in the current" instead.',
 };

--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
@@ -17,7 +17,10 @@ import FieldSelect from '../FieldSelect';
 import MantineIcon from '../MantineIcon';
 import { FILTER_SELECT_LIMIT } from './constants';
 import FilterInputComponent from './FilterInputs';
-import { filterOperatorDescription } from './FilterInputs/constants';
+import {
+    filterOperatorDescription,
+    filterOperatorDropdownLabel,
+} from './FilterInputs/constants';
 import { getFilterOperatorOptions } from './FilterInputs/utils';
 import useFiltersContext from './useFiltersContext';
 
@@ -190,6 +193,10 @@ const FilterRuleForm: FC<Props> = memo(
                             filterOperatorDescription[
                                 option.value as FilterOperator
                             ];
+                        const dropdownLabel =
+                            filterOperatorDropdownLabel[
+                                option.value as FilterOperator
+                            ] ?? option.label;
                         if (description) {
                             return (
                                 <Tooltip
@@ -199,11 +206,11 @@ const FilterRuleForm: FC<Props> = memo(
                                     maw={300}
                                     withinPortal
                                 >
-                                    <span>{option.label}</span>
+                                    <Box w="100%">{dropdownLabel}</Box>
                                 </Tooltip>
                             );
                         }
-                        return <span>{option.label}</span>;
+                        return <span>{dropdownLabel}</span>;
                     }}
                     onChange={(value) => {
                         if (!value) return;


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/AE-394/rename-period-to-date-filter-to-reduce-confusion

### Description:
Improved the period to date filter to make it clear that this filter is filtering all periods up until today's position in the selected timeframe. This was as a result of user confusion with the filter. Also made it so that the filter tooltip triggers on the entire bar not only the text. 