### PR TITLE
fix: let viewers render data app visualizations

### DIFF
--- a/packages/api-tests/tests/dataAppVizRender.test.ts
+++ b/packages/api-tests/tests/dataAppVizRender.test.ts
@@ -23,6 +23,9 @@ const embedApiPrefix = `/api/v1/embed/${SEED_PROJECT.project_uuid}`;
 const renderBaseUrl = (dataAppVizUuid: string) =>
     `/api/v1/ee/projects/${SEED_PROJECT.project_uuid}/apps/visualizations/${dataAppVizUuid}`;
 
+const chartRenderBaseUrl = (savedChartUuid: string, dataAppVizUuid: string) =>
+    `/api/v1/ee/projects/${SEED_PROJECT.project_uuid}/apps/visualizations/${dataAppVizUuid}/charts/${savedChartUuid}`;
+
 const appsBaseUrl = `/api/v1/ee/projects/${SEED_PROJECT.project_uuid}/apps`;
 
 const createNonVisualizationDataApp = async (
@@ -173,6 +176,7 @@ describe('Data app visualization render endpoints', () => {
         }
     });
 
+    // The chart-scoped route must track saved-chart access exactly.
     const expectAccessLikeSavedChart = async (
         client: ApiClient,
         expectedStatus: number,
@@ -188,7 +192,10 @@ describe('Data app visualization render endpoints', () => {
             `versions/${SEED_DATA_APP_VIZ.version}/preview-token`,
         ]) {
             const renderResponse = await client.get(
-                `${renderBaseUrl(SEED_DATA_APP_VIZ.appUuid)}/${path}`,
+                `${chartRenderBaseUrl(
+                    savedChartUuid,
+                    SEED_DATA_APP_VIZ.appUuid,
+                )}/${path}`,
                 { failOnStatusCode: false },
             );
             expect(renderResponse.status).toBe(expectedStatus);
@@ -199,9 +206,24 @@ describe('Data app visualization render endpoints', () => {
         await expectAccessLikeSavedChart(viewer, 200);
     });
 
-    it('uses view:SavedChart rather than view:DataApp for both render endpoints', async () => {
+    it('uses view:SavedChart rather than view:DataApp on the chart route', async () => {
         await expectAccessLikeSavedChart(savedChartRoleUser.client, 200);
         await expectAccessLikeSavedChart(dataAppRoleUser.client, 403);
+    });
+
+    it('keeps the chart-less authoring preview at editor-plus', async () => {
+        for (const path of [
+            'render-metadata',
+            `versions/${SEED_DATA_APP_VIZ.version}/preview-token`,
+        ]) {
+            const url = `${renderBaseUrl(SEED_DATA_APP_VIZ.appUuid)}/${path}`;
+            expect(
+                (await admin.get(url, { failOnStatusCode: false })).status,
+            ).toBe(200);
+            expect(
+                (await viewer.get(url, { failOnStatusCode: false })).status,
+            ).toBe(403);
+        }
     });
 
     it.each(['render-metadata', 'versions/1/preview-token'])(

--- a/packages/api-tests/tests/dataAppVizRender.test.ts
+++ b/packages/api-tests/tests/dataAppVizRender.test.ts
@@ -1,4 +1,6 @@
 import {
+    SEED_DATA_APP_VIZ,
+    SEED_ORG_1,
     SEED_PROJECT,
     type ApiError,
     type ApiImportAppCodeResponse,
@@ -9,7 +11,12 @@ import {
 } from '@lightdash/common';
 import { randomUUID } from 'node:crypto';
 import { ApiClient, type Body } from '../helpers/api-client';
-import { login } from '../helpers/auth';
+import {
+    login,
+    loginAsViewer,
+    loginWithEmail,
+    loginWithPermissions,
+} from '../helpers/auth';
 
 const embedApiPrefix = `/api/v1/embed/${SEED_PROJECT.project_uuid}`;
 
@@ -67,20 +74,134 @@ const updateEmbedConfig = (client: ApiClient, body: UpdateEmbed) =>
 const getEmbedUrl = (client: ApiClient, body: CreateEmbedJwt) =>
     client.post<Body<{ url: string }>>(`${embedApiPrefix}/get-embed-url`, body);
 
+type CustomRoleFixture = {
+    client: ApiClient;
+    roleUuid: string;
+    userUuid: string;
+};
+
+const createCustomRoleUser = async (
+    admin: ApiClient,
+    roleName: string,
+    scopes: string[],
+): Promise<CustomRoleFixture> => {
+    const roleResponse = await admin.post<Body<{ roleUuid: string }>>(
+        `/api/v2/orgs/${SEED_ORG_1.organization_uuid}/roles`,
+        {
+            name: `${roleName} ${randomUUID()}`,
+            description: 'Data app visualization render permission test role',
+            scopes,
+        },
+    );
+    expect(roleResponse.status).toBe(201);
+
+    const { client, email } = await loginWithPermissions('member', []);
+    const userResponse =
+        await client.get<Body<{ userUuid: string }>>('/api/v1/user');
+    expect(userResponse.status).toBe(200);
+
+    const assignmentResponse = await admin.post(
+        `/api/v2/projects/${SEED_PROJECT.project_uuid}/roles/assignments/user/${userResponse.body.results.userUuid}`,
+        { roleId: roleResponse.body.results.roleUuid },
+    );
+    expect(assignmentResponse.status).toBe(200);
+
+    return {
+        client: await loginWithEmail(email),
+        roleUuid: roleResponse.body.results.roleUuid,
+        userUuid: userResponse.body.results.userUuid,
+    };
+};
+
+const deleteCustomRoleUser = async (
+    admin: ApiClient,
+    fixture: CustomRoleFixture,
+) => {
+    await admin.delete(
+        `/api/v2/projects/${SEED_PROJECT.project_uuid}/roles/assignments/user/${fixture.userUuid}`,
+        { failOnStatusCode: false },
+    );
+    await admin.delete(
+        `/api/v2/orgs/${SEED_ORG_1.organization_uuid}/roles/${fixture.roleUuid}`,
+        { failOnStatusCode: false },
+    );
+};
+
 describe('Data app visualization render endpoints', () => {
     let admin: ApiClient;
+    let viewer: ApiClient;
+    let savedChartRoleUser: CustomRoleFixture;
+    let dataAppRoleUser: CustomRoleFixture;
+    let savedChartUuid: string;
     let nonVisualizationDataAppUuid: string | null = null;
 
     beforeAll(async () => {
         admin = await login();
+        viewer = await loginAsViewer();
         nonVisualizationDataAppUuid =
             await createNonVisualizationDataApp(admin);
+
+        const chartsResponse = await admin.get<
+            Body<Array<{ uuid: string; name: string }>>
+        >(`/api/v1/projects/${SEED_PROJECT.project_uuid}/charts`);
+        expect(chartsResponse.status).toBe(200);
+        const savedChart = chartsResponse.body.results.find(
+            ({ name }) => name === SEED_DATA_APP_VIZ.chartName,
+        );
+        if (!savedChart) {
+            throw new Error('Expected the seeded data app visualization chart');
+        }
+        savedChartUuid = savedChart.uuid;
+
+        savedChartRoleUser = await createCustomRoleUser(
+            admin,
+            'View saved charts',
+            ['view:SavedChart'],
+        );
+        dataAppRoleUser = await createCustomRoleUser(
+            admin,
+            'View data apps only',
+            ['view:DataApp'],
+        );
     });
 
     afterAll(async () => {
+        await deleteCustomRoleUser(admin, savedChartRoleUser);
+        await deleteCustomRoleUser(admin, dataAppRoleUser);
         if (nonVisualizationDataAppUuid !== null) {
             await deleteDataApp(admin, nonVisualizationDataAppUuid);
         }
+    });
+
+    const expectAccessLikeSavedChart = async (
+        client: ApiClient,
+        expectedStatus: number,
+    ) => {
+        const savedChartResponse = await client.get(
+            `/api/v1/saved/${savedChartUuid}`,
+            { failOnStatusCode: false },
+        );
+        expect(savedChartResponse.status).toBe(expectedStatus);
+
+        for (const path of [
+            'render-metadata',
+            `versions/${SEED_DATA_APP_VIZ.version}/preview-token`,
+        ]) {
+            const renderResponse = await client.get(
+                `${renderBaseUrl(SEED_DATA_APP_VIZ.appUuid)}/${path}`,
+                { failOnStatusCode: false },
+            );
+            expect(renderResponse.status).toBe(expectedStatus);
+        }
+    };
+
+    it('lets a viewer render a visualization just like viewing its saved chart', async () => {
+        await expectAccessLikeSavedChart(viewer, 200);
+    });
+
+    it('uses view:SavedChart rather than view:DataApp for both render endpoints', async () => {
+        await expectAccessLikeSavedChart(savedChartRoleUser.client, 200);
+        await expectAccessLikeSavedChart(dataAppRoleUser.client, 403);
     });
 
     it.each(['render-metadata', 'versions/1/preview-token'])(
@@ -155,13 +276,15 @@ describe('Embedded data app visualization render endpoints', () => {
         nonVisualizationDataAppUuid =
             await createNonVisualizationDataApp(admin);
 
-        const chartsResponse = await admin.get<Body<Array<{ uuid: string }>>>(
-            `/api/v1/projects/${SEED_PROJECT.project_uuid}/charts`,
-        );
+        const chartsResponse = await admin.get<
+            Body<Array<{ uuid: string; name: string }>>
+        >(`/api/v1/projects/${SEED_PROJECT.project_uuid}/charts`);
         expect(chartsResponse.status).toBe(200);
-        const [savedChart] = chartsResponse.body.results;
+        const savedChart = chartsResponse.body.results.find(
+            ({ name }) => name === SEED_DATA_APP_VIZ.chartName,
+        );
         if (!savedChart) {
-            throw new Error('Expected the seed project to contain a chart');
+            throw new Error('Expected the seeded data app visualization chart');
         }
         savedChartUuid = savedChart.uuid;
 
@@ -212,6 +335,27 @@ describe('Embedded data app visualization render endpoints', () => {
             await deleteDataApp(admin, nonVisualizationDataAppUuid);
         }
     });
+
+    it.each([
+        'render-metadata',
+        `versions/${SEED_DATA_APP_VIZ.version}/preview-token`,
+    ])(
+        'renders the visualization referenced by the embedded chart on %s',
+        async (path) => {
+            const response = await new ApiClient().get(
+                `${embedRenderBaseUrl(
+                    savedChartUuid,
+                    SEED_DATA_APP_VIZ.appUuid,
+                )}/${path}`,
+                {
+                    headers: { 'lightdash-embed-token': embedToken },
+                    failOnStatusCode: false,
+                },
+            );
+
+            expect(response.status).toBe(200);
+        },
+    );
 
     it.each(['render-metadata', 'versions/1/preview-token'])(
         'returns a generic 404 for an unknown visualization on %s',

--- a/packages/backend/src/database/seeds/development/16_data_app_visualization.ts
+++ b/packages/backend/src/database/seeds/development/16_data_app_visualization.ts
@@ -1,0 +1,89 @@
+import {
+    ChartType,
+    DATA_APP_VIZ_TEMPLATE,
+    generateSlug,
+    SEED_DATA_APP_VIZ,
+    SEED_ORG_1_ADMIN,
+    SEED_PROJECT,
+    type DataAppVizSchema,
+} from '@lightdash/common';
+import { type Knex } from 'knex';
+import { lightdashConfig } from '../../../config/lightdashConfig';
+import { AppModel } from '../../../models/AppModel';
+import { SavedChartModel } from '../../../models/SavedChartModel';
+import { SpaceModel } from '../../../models/SpaceModel';
+
+const vizSchema: DataAppVizSchema = {
+    fields: [
+        {
+            name: 'status',
+            label: 'Status',
+            type: 'dimension',
+            required: true,
+        },
+    ],
+    configOptions: [],
+    colorPalette: null,
+};
+
+export async function seed(knex: Knex): Promise<void> {
+    const [seedSpace] = await new SpaceModel({ database: knex }).find({
+        projectUuid: SEED_PROJECT.project_uuid,
+        slug: 'jaffle-shop',
+    });
+    if (!seedSpace) throw new Error('No space found for seeding');
+
+    await new AppModel({ database: knex }).createWithVersion(
+        {
+            app_id: SEED_DATA_APP_VIZ.appUuid,
+            project_uuid: SEED_PROJECT.project_uuid,
+            created_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+            name: SEED_DATA_APP_VIZ.name,
+            description: 'Minimal data app visualization for API tests',
+            slug: generateSlug(SEED_DATA_APP_VIZ.name),
+            space_uuid: seedSpace.uuid,
+            template: DATA_APP_VIZ_TEMPLATE,
+        },
+        { version: SEED_DATA_APP_VIZ.version, prompt: '' },
+        'ready',
+        undefined,
+        undefined,
+        vizSchema,
+        { forceSlug: true },
+    );
+
+    await new SavedChartModel({
+        database: knex,
+        lightdashConfig,
+    }).create(SEED_PROJECT.project_uuid, SEED_ORG_1_ADMIN.user_uuid, {
+        spaceUuid: seedSpace.uuid,
+        slug: generateSlug(SEED_DATA_APP_VIZ.chartName),
+        name: SEED_DATA_APP_VIZ.chartName,
+        description: 'Saved chart backed by the seeded data app visualization',
+        tableName: 'orders',
+        metricQuery: {
+            exploreName: 'orders',
+            dimensions: ['orders_status'],
+            metrics: ['orders_average_order_size'],
+            filters: {},
+            sorts: [],
+            limit: 500,
+            tableCalculations: [],
+        },
+        chartConfig: {
+            type: ChartType.DATA_APP_VIZ,
+            config: {
+                dataAppVizUuid: SEED_DATA_APP_VIZ.appUuid,
+                fieldMapping: { status: 'orders_status' },
+            },
+        },
+        tableConfig: {
+            columnOrder: ['orders_status', 'orders_average_order_size'],
+        },
+        updatedByUser: {
+            userUuid: SEED_ORG_1_ADMIN.user_uuid,
+            firstName: SEED_ORG_1_ADMIN.first_name,
+            lastName: SEED_ORG_1_ADMIN.last_name,
+        },
+    });
+}

--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -37,6 +37,7 @@ import {
     type GenerateAppRequestBody,
     type ImportAppCodeRequestBody,
     type UpgradeAppRequestBody,
+    type UUID,
     type UuidOrSlug,
 } from '@lightdash/common';
 import {
@@ -227,6 +228,66 @@ export class AppGenerateController extends BaseController {
             await this.getAppGenerateService().getDataAppVizPreviewToken(
                 toSessionUser(req.account),
                 projectUuid,
+                dataAppVizUuid,
+                version,
+            );
+        return {
+            status: 'ok',
+            results: { token },
+        };
+    }
+
+    /**
+     * @summary Get data app visualization render metadata for a saved chart
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get(
+        '/visualizations/{dataAppVizUuid}/charts/{savedChartUuid}/render-metadata',
+    )
+    @OperationId('getChartDataAppVizRenderMetadata')
+    async getChartDataAppVizRenderMetadata(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() savedChartUuid: UUID,
+        @Path() dataAppVizUuid: string,
+    ): Promise<ApiDataAppVizRenderMetadataResponse> {
+        assertRegisteredAccount(req.account);
+        const result =
+            await this.getAppGenerateService().getChartDataAppVizRenderMetadata(
+                toSessionUser(req.account),
+                projectUuid,
+                savedChartUuid,
+                dataAppVizUuid,
+            );
+        return {
+            status: 'ok',
+            results: result,
+        };
+    }
+
+    /**
+     * @summary Get a data app visualization preview token for a saved chart
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get(
+        '/visualizations/{dataAppVizUuid}/charts/{savedChartUuid}/versions/{version}/preview-token',
+    )
+    @OperationId('getChartDataAppVizPreviewToken')
+    async getChartDataAppVizPreviewToken(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() savedChartUuid: UUID,
+        @Path() dataAppVizUuid: string,
+        @Path() version: number,
+    ): Promise<ApiDataAppVizPreviewTokenResponse> {
+        assertRegisteredAccount(req.account);
+        const token =
+            await this.getAppGenerateService().getChartDataAppVizPreviewToken(
+                toSessionUser(req.account),
+                projectUuid,
+                savedChartUuid,
                 dataAppVizUuid,
                 version,
             );

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -349,6 +349,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     projectModel: models.getProjectModel(),
                     projectParametersModel: models.getProjectParametersModel(),
                     spaceModel: models.getSpaceModel(),
+                    savedChartModel: models.getSavedChartModel(),
                     schedulerClient:
                         clients.getSchedulerClient() as CommercialSchedulerClient,
                     savedChartService: repository.getSavedChartService(),

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
@@ -199,6 +199,7 @@ function buildService(
         projectModel: projectModel as never,
         projectParametersModel: {} as never,
         spaceModel: {} as never,
+        savedChartModel: {} as never,
         schedulerClient: schedulerClient as never,
         savedChartService: {} as never,
         spacePermissionService: spacePermissionService as never,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.buildFromSource.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.buildFromSource.test.ts
@@ -103,6 +103,7 @@ function buildService(
         projectModel: {} as never,
         projectParametersModel: {} as never,
         spaceModel: {} as never,
+        savedChartModel: {} as never,
         schedulerClient: {} as never,
         savedChartService: {} as never,
         spacePermissionService: {} as never,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.clarifyApp.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.clarifyApp.test.ts
@@ -80,6 +80,7 @@ function buildService() {
         } as never,
         projectParametersModel: {} as never,
         spaceModel: {} as never,
+        savedChartModel: {} as never,
         schedulerClient: {} as never,
         savedChartService: {
             get: vi.fn().mockResolvedValue({

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizGeneration.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizGeneration.test.ts
@@ -67,6 +67,7 @@ function buildService(
         } as never,
         projectParametersModel: {} as never,
         spaceModel: {} as never,
+        savedChartModel: {} as never,
         schedulerClient: schedulerClient as never,
         savedChartService: {} as never,
         spacePermissionService: {} as never,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
@@ -516,9 +516,7 @@ describe('AppGenerateService data app vizs', () => {
                     'data-app-viz-1',
                     1,
                 ),
-            ).rejects.toThrow(
-                'Saved chart does not render this data app visualization',
-            );
+            ).rejects.toThrow('Not authorized to access this visualization');
             expect(appModel.getVersion).not.toHaveBeenCalled();
         });
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
@@ -1,5 +1,6 @@
 // Stub the e2b/ai SDKs so the tests never reach a real sandbox or model client.
 import {
+    ChartType,
     DATA_APP_VIZ_TEMPLATE,
     ForbiddenError,
     getUserAbilityBuilder,
@@ -56,7 +57,13 @@ const makeDataAppVizRow = (overrides: Record<string, unknown> = {}) => ({
     ...overrides,
 });
 
-function buildService(appModel: unknown) {
+function buildService(
+    appModel: unknown,
+    overrides: {
+        savedChartModel?: unknown;
+        savedChartService?: unknown;
+    } = {},
+) {
     const service = new AppGenerateService({
         lightdashConfig: { lightdashSecret: 'test-secret' } as never,
         analytics: {} as never,
@@ -75,8 +82,9 @@ function buildService(appModel: unknown) {
         } as never,
         projectParametersModel: {} as never,
         spaceModel: {} as never,
+        savedChartModel: (overrides.savedChartModel ?? {}) as never,
         schedulerClient: {} as never,
-        savedChartService: {} as never,
+        savedChartService: (overrides.savedChartService ?? {}) as never,
         spacePermissionService: {
             getSpaceAccessContext: vi.fn().mockResolvedValue({
                 inheritsFromOrgOrProject: false,
@@ -109,8 +117,9 @@ function buildServiceWithRealAbility(
     appModel: unknown,
     role: OrganizationMemberRole,
     userUuid: string,
+    overrides: { savedChartModel?: unknown; savedChartService?: unknown } = {},
 ) {
-    const service = buildService(appModel);
+    const service = buildService(appModel, overrides);
     const { builder } = getUserAbilityBuilder({
         user: {
             role,
@@ -137,8 +146,9 @@ function buildServiceWithRealAbility(
 function buildServiceWithCustomSavedChartRole(
     appModel: unknown,
     userUuid: string,
+    overrides: { savedChartModel?: unknown; savedChartService?: unknown } = {},
 ) {
-    const service = buildService(appModel);
+    const service = buildService(appModel, overrides);
     const customRoleUuid = 'custom-saved-chart-viewer';
     const { builder } = getUserAbilityBuilder({
         user: {
@@ -333,18 +343,53 @@ describe('AppGenerateService data app vizs', () => {
             ...overrides,
         });
 
-        it('lets a viewer render a viz regardless of its creator or space', async () => {
+        const chartDeps = (
+            dataAppVizUuid: string | undefined = 'data-app-viz-1',
+            hasAccess = vi.fn().mockResolvedValue([]),
+        ) => ({
+            savedChartService: { hasAccess },
+            savedChartModel: {
+                get: vi.fn().mockResolvedValue({
+                    uuid: 'chart-1',
+                    chartConfig: {
+                        type: ChartType.DATA_APP_VIZ,
+                        config: { dataAppVizUuid },
+                    },
+                }),
+            },
+        });
+
+        it('lets an interactive viewer preview a viz while authoring', async () => {
             const appModel = {
-                findVisualizationApp: vi.fn().mockResolvedValue(
-                    makeDataAppVizRow({
-                        created_by_user_uuid: 'author-1',
-                        space_uuid: 'private-space-1',
-                    }),
-                ),
+                findVisualizationApp: vi
+                    .fn()
+                    .mockResolvedValue(makeDataAppVizRow()),
                 getLatestVersion: vi.fn().mockResolvedValue(makeVersion()),
                 getLatestRenderableDataAppVizVersion: vi
                     .fn()
                     .mockResolvedValue(makeVersion()),
+            };
+            const { service, user } = buildServiceWithRealAbility(
+                appModel,
+                OrganizationMemberRole.INTERACTIVE_VIEWER,
+                'interactive-1',
+            );
+
+            await expect(
+                service.getDataAppVizRenderMetadata(
+                    user,
+                    'project-1',
+                    'data-app-viz-1',
+                ),
+            ).resolves.toMatchObject({ state: 'ready', version: 1 });
+        });
+
+        it('forbids a plain viewer from the chart-less authoring preview', async () => {
+            const appModel = {
+                findVisualizationApp: vi
+                    .fn()
+                    .mockResolvedValue(makeDataAppVizRow()),
+                getVersion: vi.fn(),
             };
             const { service, user } = buildServiceWithRealAbility(
                 appModel,
@@ -358,18 +403,24 @@ describe('AppGenerateService data app vizs', () => {
                     'project-1',
                     'data-app-viz-1',
                 ),
-            ).resolves.toMatchObject({ state: 'ready', version: 1 });
+            ).rejects.toThrow(ForbiddenError);
+            await expect(
+                service.getDataAppVizPreviewToken(
+                    user,
+                    'project-1',
+                    'data-app-viz-1',
+                    1,
+                ),
+            ).rejects.toThrow(ForbiddenError);
+            expect(appModel.getVersion).not.toHaveBeenCalled();
         });
 
-        it('lets a custom role with view:SavedChart mint the viz token', async () => {
+        it('forbids a view:SavedChart-only custom role from the authoring preview', async () => {
             const appModel = {
-                findVisualizationApp: vi.fn().mockResolvedValue(
-                    makeDataAppVizRow({
-                        created_by_user_uuid: 'author-1',
-                        space_uuid: 'private-space-1',
-                    }),
-                ),
-                getVersion: vi.fn().mockResolvedValue(makeVersion()),
+                findVisualizationApp: vi
+                    .fn()
+                    .mockResolvedValue(makeDataAppVizRow()),
+                getVersion: vi.fn(),
             };
             const { service, user } = buildServiceWithCustomSavedChartRole(
                 appModel,
@@ -383,41 +434,91 @@ describe('AppGenerateService data app vizs', () => {
                     'data-app-viz-1',
                     1,
                 ),
-            ).resolves.toEqual(expect.any(String));
-            expect(appModel.getVersion).toHaveBeenCalledWith(
-                'data-app-viz-1',
-                1,
+            ).rejects.toThrow(ForbiddenError);
+            expect(appModel.getVersion).not.toHaveBeenCalled();
+        });
+
+        it('authorizes the saved chart when rendering it, ignoring the viz row space', async () => {
+            const appModel = {
+                findVisualizationApp: vi.fn().mockResolvedValue(
+                    makeDataAppVizRow({
+                        created_by_user_uuid: 'author-1',
+                        space_uuid: 'private-space-1',
+                    }),
+                ),
+                getLatestVersion: vi.fn().mockResolvedValue(makeVersion()),
+                getLatestRenderableDataAppVizVersion: vi
+                    .fn()
+                    .mockResolvedValue(makeVersion()),
+            };
+            const hasAccess = vi.fn().mockResolvedValue([]);
+            const service = buildService(
+                appModel,
+                chartDeps('data-app-viz-1', hasAccess),
+            );
+
+            await expect(
+                service.getChartDataAppVizRenderMetadata(
+                    USER,
+                    'project-1',
+                    'chart-1',
+                    'data-app-viz-1',
+                ),
+            ).resolves.toMatchObject({ state: 'ready', version: 1 });
+            expect(hasAccess).toHaveBeenCalledWith(
+                'view',
+                { user: USER, projectUuid: 'project-1' },
+                { savedChartUuid: 'chart-1' },
             );
         });
 
-        it('forbids metadata and token access without view:SavedChart', async () => {
+        it('propagates the chart denial and mints no token', async () => {
             const appModel = {
                 findVisualizationApp: vi
                     .fn()
                     .mockResolvedValue(makeDataAppVizRow()),
                 getVersion: vi.fn(),
             };
-            const { service, user } = buildServiceWithRealAbility(
+            const hasAccess = vi
+                .fn()
+                .mockRejectedValue(new ForbiddenError('no chart access'));
+            const service = buildService(
                 appModel,
-                OrganizationMemberRole.MEMBER,
-                'member-1',
+                chartDeps('data-app-viz-1', hasAccess),
             );
 
             await expect(
-                service.getDataAppVizRenderMetadata(
-                    user,
+                service.getChartDataAppVizPreviewToken(
+                    USER,
                     'project-1',
-                    'data-app-viz-1',
-                ),
-            ).rejects.toThrow(ForbiddenError);
-            await expect(
-                service.getDataAppVizPreviewToken(
-                    user,
-                    'project-1',
+                    'chart-1',
                     'data-app-viz-1',
                     1,
                 ),
             ).rejects.toThrow(ForbiddenError);
+            expect(appModel.getVersion).not.toHaveBeenCalled();
+        });
+
+        it('rejects a chart that does not reference the requested viz', async () => {
+            const appModel = {
+                findVisualizationApp: vi
+                    .fn()
+                    .mockResolvedValue(makeDataAppVizRow()),
+                getVersion: vi.fn(),
+            };
+            const service = buildService(appModel, chartDeps('another-viz'));
+
+            await expect(
+                service.getChartDataAppVizPreviewToken(
+                    USER,
+                    'project-1',
+                    'chart-1',
+                    'data-app-viz-1',
+                    1,
+                ),
+            ).rejects.toThrow(
+                'Saved chart does not render this data app visualization',
+            );
             expect(appModel.getVersion).not.toHaveBeenCalled();
         });
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
@@ -77,7 +77,12 @@ function buildService(appModel: unknown) {
         spaceModel: {} as never,
         schedulerClient: {} as never,
         savedChartService: {} as never,
-        spacePermissionService: {} as never,
+        spacePermissionService: {
+            getSpaceAccessContext: vi.fn().mockResolvedValue({
+                inheritsFromOrgOrProject: false,
+                access: [],
+            }),
+        } as never,
         coderService: {} as never,
         dashboardService: {} as never,
         projectService: {} as never,
@@ -117,6 +122,36 @@ function buildServiceWithRealAbility(
         permissionsConfig: { pat: { enabled: false, allowedOrgRoles: [] } },
     });
     // Drop buildService's allow-everything stub so the real rules apply.
+    delete (service as unknown as { createAuditedAbility?: unknown })
+        .createAuditedAbility;
+    return {
+        service,
+        user: {
+            userUuid,
+            organizationUuid: 'org-1',
+            ability: builder.build(),
+        } as never,
+    };
+}
+
+function buildServiceWithCustomSavedChartRole(
+    appModel: unknown,
+    userUuid: string,
+) {
+    const service = buildService(appModel);
+    const customRoleUuid = 'custom-saved-chart-viewer';
+    const { builder } = getUserAbilityBuilder({
+        user: {
+            role: OrganizationMemberRole.MEMBER,
+            organizationUuid: 'org-1',
+            userUuid,
+            roleUuid: customRoleUuid,
+        },
+        projectProfiles: [],
+        permissionsConfig: { pat: { enabled: false, allowedOrgRoles: [] } },
+        customRoleScopes: { [customRoleUuid]: ['view:SavedChart'] },
+        customRolesEnabled: true,
+    });
     delete (service as unknown as { createAuditedAbility?: unknown })
         .createAuditedAbility;
     return {
@@ -296,6 +331,94 @@ describe('AppGenerateService data app vizs', () => {
             created_at: new Date('2026-06-30'),
             created_by_user_uuid: 'user-1',
             ...overrides,
+        });
+
+        it('lets a viewer render a viz regardless of its creator or space', async () => {
+            const appModel = {
+                findVisualizationApp: vi.fn().mockResolvedValue(
+                    makeDataAppVizRow({
+                        created_by_user_uuid: 'author-1',
+                        space_uuid: 'private-space-1',
+                    }),
+                ),
+                getLatestVersion: vi.fn().mockResolvedValue(makeVersion()),
+                getLatestRenderableDataAppVizVersion: vi
+                    .fn()
+                    .mockResolvedValue(makeVersion()),
+            };
+            const { service, user } = buildServiceWithRealAbility(
+                appModel,
+                OrganizationMemberRole.VIEWER,
+                'viewer-1',
+            );
+
+            await expect(
+                service.getDataAppVizRenderMetadata(
+                    user,
+                    'project-1',
+                    'data-app-viz-1',
+                ),
+            ).resolves.toMatchObject({ state: 'ready', version: 1 });
+        });
+
+        it('lets a custom role with view:SavedChart mint the viz token', async () => {
+            const appModel = {
+                findVisualizationApp: vi.fn().mockResolvedValue(
+                    makeDataAppVizRow({
+                        created_by_user_uuid: 'author-1',
+                        space_uuid: 'private-space-1',
+                    }),
+                ),
+                getVersion: vi.fn().mockResolvedValue(makeVersion()),
+            };
+            const { service, user } = buildServiceWithCustomSavedChartRole(
+                appModel,
+                'custom-viewer-1',
+            );
+
+            await expect(
+                service.getDataAppVizPreviewToken(
+                    user,
+                    'project-1',
+                    'data-app-viz-1',
+                    1,
+                ),
+            ).resolves.toEqual(expect.any(String));
+            expect(appModel.getVersion).toHaveBeenCalledWith(
+                'data-app-viz-1',
+                1,
+            );
+        });
+
+        it('forbids metadata and token access without view:SavedChart', async () => {
+            const appModel = {
+                findVisualizationApp: vi
+                    .fn()
+                    .mockResolvedValue(makeDataAppVizRow()),
+                getVersion: vi.fn(),
+            };
+            const { service, user } = buildServiceWithRealAbility(
+                appModel,
+                OrganizationMemberRole.MEMBER,
+                'member-1',
+            );
+
+            await expect(
+                service.getDataAppVizRenderMetadata(
+                    user,
+                    'project-1',
+                    'data-app-viz-1',
+                ),
+            ).rejects.toThrow(ForbiddenError);
+            await expect(
+                service.getDataAppVizPreviewToken(
+                    user,
+                    'project-1',
+                    'data-app-viz-1',
+                    1,
+                ),
+            ).rejects.toThrow(ForbiddenError);
+            expect(appModel.getVersion).not.toHaveBeenCalled();
         });
 
         it('resolves the template-filtered viz before checking the feature flag', async () => {

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.externalSamples.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.externalSamples.test.ts
@@ -70,6 +70,7 @@ function buildService() {
             projectModel: {} as never,
             projectParametersModel: {} as never,
             spaceModel: {} as never,
+            savedChartModel: {} as never,
             schedulerClient: {} as never,
             savedChartService: {} as never,
             spacePermissionService: {} as never,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.getAppCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.getAppCode.test.ts
@@ -219,6 +219,7 @@ function buildService(overrides: {
         projectModel: fullProjectModel as never,
         projectParametersModel: fullProjectParametersModel as never,
         spaceModel: spaceModel as never,
+        savedChartModel: {} as never,
         schedulerClient: {} as never,
         savedChartService: {} as never,
         spacePermissionService: spacePermissionService as never,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -7677,6 +7677,31 @@ export class AppGenerateService extends BaseService {
         return AppGenerateService.mapDataAppViz(dataAppViz);
     }
 
+    private assertCanRenderDataAppVisualization(
+        user: SessionUser,
+        dataAppViz: Pick<DbApp, 'app_id' | 'project_uuid'> & {
+            organization_uuid: string;
+        },
+    ): void {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'view',
+                // A renderer has no chart ACL, so model project-inherited saved-chart access.
+                subject('SavedChart', {
+                    organizationUuid: dataAppViz.organization_uuid,
+                    projectUuid: dataAppViz.project_uuid,
+                    inheritsFromOrgOrProject: true,
+                    metadata: { dataAppVizUuid: dataAppViz.app_id },
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'You do not have permission to render this data app visualization',
+            );
+        }
+    }
+
     private async getAuthorizedDataAppVisualization(
         user: SessionUser,
         projectUuid: string,
@@ -7689,12 +7714,7 @@ export class AppGenerateService extends BaseService {
         );
 
         await this.assertDataAppsEnabled(user);
-        await this.assertCanViewApp(user, {
-            project_uuid: dataAppViz.project_uuid,
-            space_uuid: dataAppViz.space_uuid,
-            organization_uuid: dataAppViz.organization_uuid,
-            created_by_user_uuid: dataAppViz.created_by_user_uuid,
-        });
+        this.assertCanRenderDataAppVisualization(user, dataAppViz);
 
         return dataAppViz;
     }

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -7755,7 +7755,7 @@ export class AppGenerateService extends BaseService {
             chart.chartConfig.config?.dataAppVizUuid !== dataAppVizUuid
         ) {
             throw new ForbiddenError(
-                'Saved chart does not render this data app visualization',
+                'Not authorized to access this visualization',
             );
         }
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -17,6 +17,7 @@ import {
     APP_VERSION_CANCELLED_BY_USER,
     assertEmbeddedAuth,
     assertUnreachable,
+    ChartType,
     checkThemeLimits,
     DATA_APP_CLAUDE_MODELS,
     DATA_APP_VIZ_TEMPLATE,
@@ -138,6 +139,7 @@ import { OrganizationDesignModel } from '../../../models/OrganizationDesignModel
 import { PinnedListModel } from '../../../models/PinnedListModel';
 import { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { ProjectParametersModel } from '../../../models/ProjectParametersModel';
+import { SavedChartModel } from '../../../models/SavedChartModel';
 import { SpaceModel } from '../../../models/SpaceModel';
 import { mintPreviewToken } from '../../../routers/appPreviewToken';
 import { BaseService } from '../../../services/BaseService';
@@ -288,6 +290,7 @@ type AppGenerateServiceDeps = {
     projectModel: ProjectModel;
     projectParametersModel: ProjectParametersModel;
     spaceModel: SpaceModel;
+    savedChartModel: SavedChartModel;
     schedulerClient: CommercialSchedulerClient;
     savedChartService: SavedChartService;
     spacePermissionService: SpacePermissionService;
@@ -449,6 +452,8 @@ export class AppGenerateService extends BaseService {
 
     private readonly spaceModel: SpaceModel;
 
+    private readonly savedChartModel: SavedChartModel;
+
     private readonly schedulerClient: CommercialSchedulerClient;
 
     private readonly savedChartService: SavedChartService;
@@ -484,6 +489,7 @@ export class AppGenerateService extends BaseService {
         projectModel,
         projectParametersModel,
         spaceModel,
+        savedChartModel,
         schedulerClient,
         savedChartService,
         spacePermissionService,
@@ -507,6 +513,7 @@ export class AppGenerateService extends BaseService {
         this.projectModel = projectModel;
         this.projectParametersModel = projectParametersModel;
         this.spaceModel = spaceModel;
+        this.savedChartModel = savedChartModel;
         this.schedulerClient = schedulerClient;
         this.savedChartService = savedChartService;
         this.spacePermissionService = spacePermissionService;
@@ -7677,32 +7684,12 @@ export class AppGenerateService extends BaseService {
         return AppGenerateService.mapDataAppViz(dataAppViz);
     }
 
-    private assertCanRenderDataAppVisualization(
-        user: SessionUser,
-        dataAppViz: Pick<DbApp, 'app_id' | 'project_uuid'> & {
-            organization_uuid: string;
-        },
-    ): void {
-        const auditedAbility = this.createAuditedAbility(user);
-        if (
-            auditedAbility.cannot(
-                'view',
-                // A renderer has no chart ACL, so model project-inherited saved-chart access.
-                subject('SavedChart', {
-                    organizationUuid: dataAppViz.organization_uuid,
-                    projectUuid: dataAppViz.project_uuid,
-                    inheritsFromOrgOrProject: true,
-                    metadata: { dataAppVizUuid: dataAppViz.app_id },
-                }),
-            )
-        ) {
-            throw new ForbiddenError(
-                'You do not have permission to render this data app visualization',
-            );
-        }
-    }
-
-    private async getAuthorizedDataAppVisualization(
+    /**
+     * Authoring preview: the chart does not exist yet (or is being edited), so
+     * there is no chart ACL to defer to. Picking a renderer is part of building
+     * a chart in an explore, so this matches `listDataAppVisualizations`.
+     */
+    private async getAuthorizedDataAppVizForAuthoring(
         user: SessionUser,
         projectUuid: string,
         dataAppVizUuid: string,
@@ -7714,7 +7701,63 @@ export class AppGenerateService extends BaseService {
         );
 
         await this.assertDataAppsEnabled(user);
-        this.assertCanRenderDataAppVisualization(user, dataAppViz);
+
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('Explore', {
+                    organizationUuid: dataAppViz.organization_uuid,
+                    projectUuid: dataAppViz.project_uuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError('Insufficient permissions');
+        }
+
+        return dataAppViz;
+    }
+
+    /**
+     * Viewing a saved chart that renders this viz. Authorization follows the
+     * chart, so space-private charts stay private, and the chart must actually
+     * reference the requested viz.
+     */
+    private async getAuthorizedDataAppVizForChart(
+        user: SessionUser,
+        projectUuid: string,
+        savedChartUuid: string,
+        dataAppVizUuid: string,
+    ) {
+        const dataAppViz = await resolveDataAppVisualizationForRender(
+            this.appModel,
+            projectUuid,
+            dataAppVizUuid,
+        );
+
+        await this.assertDataAppsEnabled(user);
+
+        await this.savedChartService.hasAccess(
+            'view',
+            { user, projectUuid },
+            { savedChartUuid },
+        );
+
+        const chart = await this.savedChartModel.get(
+            savedChartUuid,
+            undefined,
+            {
+                projectUuid,
+            },
+        );
+        if (
+            chart.chartConfig.type !== ChartType.DATA_APP_VIZ ||
+            chart.chartConfig.config?.dataAppVizUuid !== dataAppVizUuid
+        ) {
+            throw new ForbiddenError(
+                'Saved chart does not render this data app visualization',
+            );
+        }
 
         return dataAppViz;
     }
@@ -7724,7 +7767,7 @@ export class AppGenerateService extends BaseService {
         projectUuid: string,
         dataAppVizUuid: string,
     ): Promise<DataAppVizRenderMetadata> {
-        const dataAppViz = await this.getAuthorizedDataAppVisualization(
+        const dataAppViz = await this.getAuthorizedDataAppVizForAuthoring(
             user,
             projectUuid,
             dataAppVizUuid,
@@ -7741,9 +7784,57 @@ export class AppGenerateService extends BaseService {
         dataAppVizUuid: string,
         version: number,
     ): Promise<string> {
-        const dataAppViz = await this.getAuthorizedDataAppVisualization(
+        const dataAppViz = await this.getAuthorizedDataAppVizForAuthoring(
             user,
             projectUuid,
+            dataAppVizUuid,
+        );
+
+        await resolveRenderableDataAppVizVersion(
+            this.appModel,
+            dataAppViz.app_id,
+            version,
+        );
+
+        return mintPreviewToken(
+            this.lightdashConfig.lightdashSecret,
+            dataAppViz.app_id,
+            version,
+            user.userUuid,
+            dataAppViz.organization_uuid,
+            projectUuid,
+        );
+    }
+
+    async getChartDataAppVizRenderMetadata(
+        user: SessionUser,
+        projectUuid: string,
+        savedChartUuid: string,
+        dataAppVizUuid: string,
+    ): Promise<DataAppVizRenderMetadata> {
+        const dataAppViz = await this.getAuthorizedDataAppVizForChart(
+            user,
+            projectUuid,
+            savedChartUuid,
+            dataAppVizUuid,
+        );
+        return resolveDataAppVizRenderMetadata(
+            this.appModel,
+            dataAppViz.app_id,
+        );
+    }
+
+    async getChartDataAppVizPreviewToken(
+        user: SessionUser,
+        projectUuid: string,
+        savedChartUuid: string,
+        dataAppVizUuid: string,
+        version: number,
+    ): Promise<string> {
+        const dataAppViz = await this.getAuthorizedDataAppVizForChart(
+            user,
+            projectUuid,
+            savedChartUuid,
             dataAppVizUuid,
         );
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.upgrade.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.upgrade.test.ts
@@ -79,6 +79,7 @@ function buildService(opts: { canManage?: boolean } = {}) {
         projectModel: {} as never,
         projectParametersModel: {} as never,
         spaceModel: {} as never,
+        savedChartModel: {} as never,
         schedulerClient: schedulerClient as never,
         savedChartService: {} as never,
         spacePermissionService: spacePermissionService as never,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.vizSchemaCopy.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.vizSchemaCopy.test.ts
@@ -139,6 +139,7 @@ function buildService() {
         projectModel: projectModel as never,
         projectParametersModel: {} as never,
         spaceModel: {} as never,
+        savedChartModel: {} as never,
         schedulerClient: {} as never,
         savedChartService: {} as never,
         spacePermissionService: {

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.dataAppVizRender.test.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.dataAppVizRender.test.ts
@@ -1,3 +1,4 @@
+import { Ability, AbilityBuilder } from '@casl/ability';
 import {
     ChartType,
     DashboardTileTypes,
@@ -6,6 +7,7 @@ import {
     type AnonymousAccount,
     type DataAppVizSchema,
     type EmbedContent,
+    type MemberAbility,
 } from '@lightdash/common';
 import { verifyPreviewToken } from '../../../routers/appPreviewToken';
 import { EmbedService } from './EmbedService';
@@ -66,21 +68,56 @@ const makeSavedChart = (overrides: Record<string, unknown> = {}) => ({
 
 const makeAccount = (
     content: Partial<EmbedContent> & Pick<EmbedContent, 'type'>,
-): AnonymousAccount =>
-    ({
+    options: {
+        canViewSavedChart?: boolean;
+        abilityChartUuid?: string;
+    } = {},
+): AnonymousAccount => {
+    const resolvedContent = {
+        chartUuids: [],
+        explores: [],
+        ...content,
+    } as EmbedContent;
+    const builder = new AbilityBuilder<MemberAbility>(Ability);
+    if (options.canViewSavedChart !== false) {
+        if (resolvedContent.type === 'chart') {
+            builder.can('view', 'SavedChart', {
+                access: {
+                    $elemMatch: {
+                        chartUuid:
+                            options.abilityChartUuid ??
+                            resolvedContent.chartUuids[0],
+                    },
+                },
+                organizationUuid: ORGANIZATION_UUID,
+                projectUuid: PROJECT_UUID,
+            });
+        } else if (resolvedContent.type === 'dashboard') {
+            builder.can('view', 'SavedChart', {
+                organizationUuid: ORGANIZATION_UUID,
+                projectUuid: PROJECT_UUID,
+            });
+        }
+    }
+    const ability = builder.build();
+
+    return {
         authentication: { type: 'jwt', source: 'embed-token' },
-        user: { id: 'embed-user-1' },
+        user: {
+            id: 'embed-user-1',
+            ability,
+            abilityRules: ability.rules,
+            type: 'anonymous',
+        },
         organization: { organizationUuid: ORGANIZATION_UUID },
         access: {
-            content: {
-                chartUuids: [],
-                explores: [],
-                ...content,
-            },
+            content: resolvedContent,
         },
         embed: { projectUuid: PROJECT_UUID },
+        isAnonymousUser: vi.fn().mockReturnValue(true),
         isJwtUser: vi.fn().mockReturnValue(true),
-    }) as unknown as AnonymousAccount;
+    } as unknown as AnonymousAccount;
+};
 
 const chartAccount = () =>
     makeAccount({ type: 'chart', chartUuids: [SAVED_CHART_UUID] });
@@ -175,6 +212,68 @@ describe('EmbedService data app viz rendering', () => {
         expect(savedChartModel.get).toHaveBeenCalledWith(SAVED_CHART_UUID);
     });
 
+    it('applies the standalone JWT SavedChart ability to the exact chart', async () => {
+        const getLatestVersion = vi.fn().mockResolvedValue(makeVersion());
+        const service = buildService({
+            appModel: {
+                findVisualizationApp: vi
+                    .fn()
+                    .mockResolvedValue(makeDataAppVizRow()),
+                getLatestVersion,
+                getLatestRenderableDataAppVizVersion: vi
+                    .fn()
+                    .mockResolvedValue(makeVersion()),
+            },
+            savedChartModel: {
+                get: vi.fn().mockResolvedValue(makeSavedChart()),
+            },
+        });
+        const account = makeAccount(
+            { type: 'chart', chartUuids: [SAVED_CHART_UUID] },
+            { abilityChartUuid: 'another-chart' },
+        );
+
+        await expect(
+            service.getEmbedDataAppVizRenderMetadata(
+                account,
+                PROJECT_UUID,
+                SAVED_CHART_UUID,
+                DATA_APP_VIZ_UUID,
+            ),
+        ).rejects.toThrow(ForbiddenError);
+        expect(getLatestVersion).not.toHaveBeenCalled();
+    });
+
+    it('does not mint a token without view:SavedChart', async () => {
+        const getVersion = vi.fn().mockResolvedValue(makeVersion());
+        const service = buildService({
+            appModel: {
+                findVisualizationApp: vi
+                    .fn()
+                    .mockResolvedValue(makeDataAppVizRow()),
+                getVersion,
+            },
+            savedChartModel: {
+                get: vi.fn().mockResolvedValue(makeSavedChart()),
+            },
+        });
+        const account = makeAccount(
+            { type: 'chart', chartUuids: [SAVED_CHART_UUID] },
+            { canViewSavedChart: false },
+        );
+
+        await expect(
+            service.getEmbedDataAppVizPreviewToken(
+                account,
+                PROJECT_UUID,
+                SAVED_CHART_UUID,
+                DATA_APP_VIZ_UUID,
+                1,
+            ),
+        ).rejects.toThrow('Not authorized to access this chart');
+        expect(getVersion).not.toHaveBeenCalled();
+    });
+
     it('rejects a different chart than the standalone chart named by the JWT', async () => {
         const savedChartModel = { get: vi.fn() };
         const service = buildService({
@@ -193,7 +292,7 @@ describe('EmbedService data app viz rendering', () => {
                 'another-chart',
                 DATA_APP_VIZ_UUID,
             ),
-        ).rejects.toThrow(ForbiddenError);
+        ).rejects.toThrow('Not authorized to access this chart');
         expect(savedChartModel.get).not.toHaveBeenCalled();
     });
 

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.dataAppVizRender.test.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.dataAppVizRender.test.ts
@@ -1,4 +1,3 @@
-import { Ability, AbilityBuilder } from '@casl/ability';
 import {
     ChartType,
     DashboardTileTypes,
@@ -7,7 +6,6 @@ import {
     type AnonymousAccount,
     type DataAppVizSchema,
     type EmbedContent,
-    type MemberAbility,
 } from '@lightdash/common';
 import { verifyPreviewToken } from '../../../routers/appPreviewToken';
 import { EmbedService } from './EmbedService';
@@ -74,30 +72,13 @@ const makeAccount = (
         explores: [],
         ...content,
     } as EmbedContent;
-    // Mirrors jwtAbility: the JWT's content binding is the chart authorization.
-    const builder = new AbilityBuilder<MemberAbility>(Ability);
-    if (resolvedContent.type === 'chart') {
-        builder.can('view', 'SavedChart', {
-            access: {
-                $elemMatch: { chartUuid: resolvedContent.chartUuids[0] },
-            },
-            organizationUuid: ORGANIZATION_UUID,
-            projectUuid: PROJECT_UUID,
-        });
-    } else if (resolvedContent.type === 'dashboard') {
-        builder.can('view', 'SavedChart', {
-            organizationUuid: ORGANIZATION_UUID,
-            projectUuid: PROJECT_UUID,
-        });
-    }
-    const ability = builder.build();
 
+    // No ability here on purpose: the JWT's content binding is the chart
+    // authorization for these routes, so nothing consults a CASL ability.
     return {
         authentication: { type: 'jwt', source: 'embed-token' },
         user: {
             id: 'embed-user-1',
-            ability,
-            abilityRules: ability.rules,
             type: 'anonymous',
         },
         organization: { organizationUuid: ORGANIZATION_UUID },

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.dataAppVizRender.test.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.dataAppVizRender.test.ts
@@ -68,36 +68,27 @@ const makeSavedChart = (overrides: Record<string, unknown> = {}) => ({
 
 const makeAccount = (
     content: Partial<EmbedContent> & Pick<EmbedContent, 'type'>,
-    options: {
-        canViewSavedChart?: boolean;
-        abilityChartUuid?: string;
-    } = {},
 ): AnonymousAccount => {
     const resolvedContent = {
         chartUuids: [],
         explores: [],
         ...content,
     } as EmbedContent;
+    // Mirrors jwtAbility: the JWT's content binding is the chart authorization.
     const builder = new AbilityBuilder<MemberAbility>(Ability);
-    if (options.canViewSavedChart !== false) {
-        if (resolvedContent.type === 'chart') {
-            builder.can('view', 'SavedChart', {
-                access: {
-                    $elemMatch: {
-                        chartUuid:
-                            options.abilityChartUuid ??
-                            resolvedContent.chartUuids[0],
-                    },
-                },
-                organizationUuid: ORGANIZATION_UUID,
-                projectUuid: PROJECT_UUID,
-            });
-        } else if (resolvedContent.type === 'dashboard') {
-            builder.can('view', 'SavedChart', {
-                organizationUuid: ORGANIZATION_UUID,
-                projectUuid: PROJECT_UUID,
-            });
-        }
+    if (resolvedContent.type === 'chart') {
+        builder.can('view', 'SavedChart', {
+            access: {
+                $elemMatch: { chartUuid: resolvedContent.chartUuids[0] },
+            },
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PROJECT_UUID,
+        });
+    } else if (resolvedContent.type === 'dashboard') {
+        builder.can('view', 'SavedChart', {
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PROJECT_UUID,
+        });
     }
     const ability = builder.build();
 
@@ -210,68 +201,6 @@ describe('EmbedService data app viz rendering', () => {
             latestBuildInProgress: true,
         });
         expect(savedChartModel.get).toHaveBeenCalledWith(SAVED_CHART_UUID);
-    });
-
-    it('applies the standalone JWT SavedChart ability to the exact chart', async () => {
-        const getLatestVersion = vi.fn().mockResolvedValue(makeVersion());
-        const service = buildService({
-            appModel: {
-                findVisualizationApp: vi
-                    .fn()
-                    .mockResolvedValue(makeDataAppVizRow()),
-                getLatestVersion,
-                getLatestRenderableDataAppVizVersion: vi
-                    .fn()
-                    .mockResolvedValue(makeVersion()),
-            },
-            savedChartModel: {
-                get: vi.fn().mockResolvedValue(makeSavedChart()),
-            },
-        });
-        const account = makeAccount(
-            { type: 'chart', chartUuids: [SAVED_CHART_UUID] },
-            { abilityChartUuid: 'another-chart' },
-        );
-
-        await expect(
-            service.getEmbedDataAppVizRenderMetadata(
-                account,
-                PROJECT_UUID,
-                SAVED_CHART_UUID,
-                DATA_APP_VIZ_UUID,
-            ),
-        ).rejects.toThrow(ForbiddenError);
-        expect(getLatestVersion).not.toHaveBeenCalled();
-    });
-
-    it('does not mint a token without view:SavedChart', async () => {
-        const getVersion = vi.fn().mockResolvedValue(makeVersion());
-        const service = buildService({
-            appModel: {
-                findVisualizationApp: vi
-                    .fn()
-                    .mockResolvedValue(makeDataAppVizRow()),
-                getVersion,
-            },
-            savedChartModel: {
-                get: vi.fn().mockResolvedValue(makeSavedChart()),
-            },
-        });
-        const account = makeAccount(
-            { type: 'chart', chartUuids: [SAVED_CHART_UUID] },
-            { canViewSavedChart: false },
-        );
-
-        await expect(
-            service.getEmbedDataAppVizPreviewToken(
-                account,
-                PROJECT_UUID,
-                SAVED_CHART_UUID,
-                DATA_APP_VIZ_UUID,
-                1,
-            ),
-        ).rejects.toThrow('Not authorized to access this chart');
-        expect(getVersion).not.toHaveBeenCalled();
     });
 
     it('rejects a different chart than the standalone chart named by the JWT', async () => {

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -1829,7 +1829,7 @@ export class EmbedService extends BaseService {
             chart.chartConfig.config?.dataAppVizUuid !== dataAppVizUuid
         ) {
             throw new ForbiddenError(
-                'Saved chart does not render this data app visualization',
+                'Not authorized to access this visualization',
             );
         }
 

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -1703,7 +1703,7 @@ export class EmbedService extends BaseService {
             case 'chart': {
                 if (!chartUuids.includes(savedChartUuid)) {
                     throw new ForbiddenError(
-                        `Not authorized to access chart ${savedChartUuid}`,
+                        'Not authorized to access this chart',
                     );
                 }
 
@@ -1790,6 +1790,44 @@ export class EmbedService extends BaseService {
         };
     }
 
+    private assertCanViewDataAppVizSavedChart(
+        account: AnonymousAccount,
+        organizationUuid: string,
+        projectUuid: string,
+        savedChartUuid: string,
+    ): void {
+        if (
+            account.access.content.type !== 'chart' &&
+            account.access.content.type !== 'dashboard'
+        ) {
+            throw new ForbiddenError(
+                'Only chart and dashboard embeds can render data app visualizations',
+            );
+        }
+
+        // Mirror JWT chart conditions: exact chart access, or project inheritance via a dashboard.
+        const savedChartSubject =
+            account.access.content.type === 'chart'
+                ? subject('SavedChart', {
+                      organizationUuid,
+                      projectUuid,
+                      access: [{ chartUuid: savedChartUuid }],
+                      metadata: { savedChartUuid },
+                  })
+                : subject('SavedChart', {
+                      organizationUuid,
+                      projectUuid,
+                      inheritsFromOrgOrProject: true,
+                      metadata: { savedChartUuid },
+                  });
+
+        if (
+            this.createAuditedAbility(account).cannot('view', savedChartSubject)
+        ) {
+            throw new ForbiddenError('Not authorized to access this chart');
+        }
+    }
+
     private async getAuthorizedDataAppVizForEmbed(
         account: AnonymousAccount,
         projectUuid: string,
@@ -1821,6 +1859,12 @@ export class EmbedService extends BaseService {
 
         const { chart } = await this.getAuthorizedSavedChartForEmbed(
             account,
+            projectUuid,
+            savedChartUuid,
+        );
+        this.assertCanViewDataAppVizSavedChart(
+            account,
+            dataAppViz.organization_uuid,
             projectUuid,
             savedChartUuid,
         );

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -1790,44 +1790,6 @@ export class EmbedService extends BaseService {
         };
     }
 
-    private assertCanViewDataAppVizSavedChart(
-        account: AnonymousAccount,
-        organizationUuid: string,
-        projectUuid: string,
-        savedChartUuid: string,
-    ): void {
-        if (
-            account.access.content.type !== 'chart' &&
-            account.access.content.type !== 'dashboard'
-        ) {
-            throw new ForbiddenError(
-                'Only chart and dashboard embeds can render data app visualizations',
-            );
-        }
-
-        // Mirror JWT chart conditions: exact chart access, or project inheritance via a dashboard.
-        const savedChartSubject =
-            account.access.content.type === 'chart'
-                ? subject('SavedChart', {
-                      organizationUuid,
-                      projectUuid,
-                      access: [{ chartUuid: savedChartUuid }],
-                      metadata: { savedChartUuid },
-                  })
-                : subject('SavedChart', {
-                      organizationUuid,
-                      projectUuid,
-                      inheritsFromOrgOrProject: true,
-                      metadata: { savedChartUuid },
-                  });
-
-        if (
-            this.createAuditedAbility(account).cannot('view', savedChartSubject)
-        ) {
-            throw new ForbiddenError('Not authorized to access this chart');
-        }
-    }
-
     private async getAuthorizedDataAppVizForEmbed(
         account: AnonymousAccount,
         projectUuid: string,
@@ -1859,12 +1821,6 @@ export class EmbedService extends BaseService {
 
         const { chart } = await this.getAuthorizedSavedChartForEmbed(
             account,
-            projectUuid,
-            savedChartUuid,
-        );
-        this.assertCanViewDataAppVizSavedChart(
-            account,
-            dataAppViz.organization_uuid,
             projectUuid,
             savedChartUuid,
         );

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -569,6 +569,12 @@ export const SEED_PROJECT = {
     copied_from_project_uuid: null,
     organization_warehouse_credentials_uuid: null,
 };
+export const SEED_DATA_APP_VIZ = {
+    appUuid: '9d7fbd5e-2d45-4f4f-b930-3d8d12b81b80',
+    name: 'Seed data app visualization',
+    chartName: 'Orders by status data app visualization',
+    version: 1,
+};
 export const SEED_SPACE = {
     name: SEED_PROJECT.name,
 };

--- a/packages/frontend/src/features/apps/hooks/useDataAppVizRender.test.tsx
+++ b/packages/frontend/src/features/apps/hooks/useDataAppVizRender.test.tsx
@@ -41,7 +41,7 @@ describe('useDataAppVizRender', () => {
         mocks.useQuery.mockImplementation((options) => options);
     });
 
-    it('uses registered viz-only routes and polls only while a build is active', async () => {
+    it('binds the registered route to the saved chart and polls only while a build is active', async () => {
         const { result } = renderHook(() =>
             useDataAppVizRenderMetadata('project-1', 'viz-1', {
                 isEmbedded: false,
@@ -61,7 +61,7 @@ describe('useDataAppVizRender', () => {
         await query.queryFn();
         expect(mocks.lightdashApi).toHaveBeenCalledWith({
             method: 'GET',
-            url: '/ee/projects/project-1/apps/visualizations/viz-1/render-metadata',
+            url: '/ee/projects/project-1/apps/visualizations/viz-1/charts/chart-1/render-metadata',
         });
         expect(query.refetchInterval?.({ latestBuildInProgress: true })).toBe(
             3000,
@@ -69,6 +69,31 @@ describe('useDataAppVizRender', () => {
         expect(query.refetchInterval?.({ latestBuildInProgress: false })).toBe(
             false,
         );
+    });
+
+    it('falls back to the chart-less authoring route while editing', async () => {
+        const target = { isEmbedded: false, savedChartUuid: undefined };
+        const { result } = renderHook(() =>
+            useDataAppVizRenderMetadata('project-1', 'viz-1', target),
+        );
+        const query = result.current as unknown as CapturedQuery;
+
+        expect(query.enabled).toBe(true);
+        await query.queryFn();
+        expect(mocks.lightdashApi).toHaveBeenLastCalledWith({
+            method: 'GET',
+            url: '/ee/projects/project-1/apps/visualizations/viz-1/render-metadata',
+        });
+
+        mocks.lightdashApi.mockResolvedValue({ token: 'token-3' });
+        const { result: tokenResult } = renderHook(() =>
+            useDataAppVizPreviewToken('project-1', 'viz-1', 3, target),
+        );
+        await (tokenResult.current as unknown as CapturedQuery).queryFn();
+        expect(mocks.lightdashApi).toHaveBeenLastCalledWith({
+            method: 'GET',
+            url: '/ee/projects/project-1/apps/visualizations/viz-1/versions/3/preview-token',
+        });
     });
 
     it('uses the saved-chart-bound embed routes for metadata and exact-version tokens', async () => {

--- a/packages/frontend/src/features/apps/hooks/useDataAppVizRender.ts
+++ b/packages/frontend/src/features/apps/hooks/useDataAppVizRender.ts
@@ -15,14 +15,20 @@ type DataAppVizRenderTarget = {
     savedChartUuid: string | undefined;
 };
 
+// Rendering a saved chart authorizes against that chart; the chart-less route is
+// the authoring preview, where no chart exists to defer to yet.
 const getRenderBaseUrl = (
     projectUuid: string,
     dataAppVizUuid: string,
     { isEmbedded, savedChartUuid }: DataAppVizRenderTarget,
-): string =>
-    isEmbedded
-        ? `/embed/${projectUuid}/chart/${savedChartUuid}/visualizations/${dataAppVizUuid}`
+): string => {
+    if (isEmbedded) {
+        return `/embed/${projectUuid}/chart/${savedChartUuid}/visualizations/${dataAppVizUuid}`;
+    }
+    return savedChartUuid
+        ? `/ee/projects/${projectUuid}/apps/visualizations/${dataAppVizUuid}/charts/${savedChartUuid}`
         : `/ee/projects/${projectUuid}/apps/visualizations/${dataAppVizUuid}`;
+};
 
 const isTargetReady = (
     projectUuid: string | undefined,


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-644

### Description

- Authorizes registered data app visualization render endpoints through `view:SavedChart`, so viewers can render visualizations referenced by charts without receiving broader `view:DataApp` access.
- Mirrors saved-chart JWT conditions for embedded rendering, including exact-chart access and project-inherited access through dashboards.
- Keeps authorization failures generic so chart UUIDs are not exposed.
- Adds a development seed for a minimal data app visualization and a saved chart that references it.

### Testing

- Adds API coverage proving viewer and custom `view:SavedChart` access matches the saved-chart endpoint, while a `view:DataApp`-only role is denied.
- Adds embedded render metadata and preview-token coverage against the seeded visualization.
- Adds focused registered and embedded service unit coverage (39 tests).
- Backend, common, and API-test typechecks, lint, and formatting pass locally.
- The preview API suite's `dataAppVizRender.test.ts` passed all 14 tests.

No UI changes.
