### PR TITLE
feat: allow hiding a dbt model's base explore via `meta.hidden`

### DIFF
--- a/packages/common/src/compiler/lightdashModelConverter.ts
+++ b/packages/common/src/compiler/lightdashModelConverter.ts
@@ -92,6 +92,7 @@ export function convertLightdashModelToDbtModel(
         required_filters: model.required_filters,
         default_filters: model.default_filters,
         explores: model.explores,
+        hidden: model.hidden,
         ai_hint: model.ai_hint,
         parameters: model.parameters,
         primary_key: model.primary_key,

--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -1519,6 +1519,108 @@ describe('explore-scoped additional dimensions', () => {
         ).toEqual([]);
     });
 
+    it('should keep additional explore tags when the model defines metrics', async () => {
+        const modelWithMetricsAndExploreTags: DbtModelNode = {
+            ...MODEL_WITH_EXPLORE_SCOPED_DIMENSIONS,
+            config: {
+                ...MODEL_WITH_EXPLORE_SCOPED_DIMENSIONS.config,
+                tags: ['internal'],
+                meta: {
+                    metrics: {
+                        row_count: {
+                            type: MetricType.COUNT,
+                            sql: '${TABLE}.order_id',
+                        },
+                    },
+                    explores: {
+                        curated: {
+                            label: 'Curated',
+                            tags: ['ai'],
+                        },
+                    },
+                },
+            },
+            meta: {},
+        };
+
+        const explores = await convertExplores(
+            [modelWithMetricsAndExploreTags],
+            false,
+            SupportedDbtAdapter.POSTGRES,
+            warehouseClientMock,
+            {
+                spotlight: DEFAULT_SPOTLIGHT_CONFIG,
+            },
+        );
+
+        expect(
+            explores.find((explore) => explore.name === 'test_model')?.tags,
+        ).toEqual(['internal']);
+        expect(
+            explores.find((explore) => explore.name === 'curated')?.tags,
+        ).toEqual(['ai']);
+    });
+
+    it('should not create a base explore when the model is hidden', async () => {
+        const hiddenModel: DbtModelNode = {
+            ...MODEL_WITH_EXPLORE_SCOPED_DIMENSIONS,
+            config: {
+                ...MODEL_WITH_EXPLORE_SCOPED_DIMENSIONS.config,
+                meta: {
+                    hidden: true,
+                    explores: {
+                        curated: {
+                            label: 'Curated',
+                            tags: ['ai'],
+                        },
+                    },
+                },
+            },
+            meta: {},
+        };
+
+        const explores = await convertExplores(
+            [hiddenModel],
+            false,
+            SupportedDbtAdapter.POSTGRES,
+            warehouseClientMock,
+            {
+                spotlight: DEFAULT_SPOTLIGHT_CONFIG,
+            },
+        );
+
+        expect(explores.map((explore) => explore.name)).toEqual(['curated']);
+        // The hidden model is still the base table of the curated explore
+        const curated = explores[0] as Explore;
+        expect(curated.baseTable).toEqual('test_model');
+        expect(Object.keys(curated.tables.test_model.dimensions)).toEqual(
+            expect.arrayContaining(['order_id', 'amount']),
+        );
+    });
+
+    it('should create no explores when a hidden model has no additional explores', async () => {
+        const hiddenModel: DbtModelNode = {
+            ...MODEL_WITH_EXPLORE_SCOPED_DIMENSIONS,
+            config: {
+                ...MODEL_WITH_EXPLORE_SCOPED_DIMENSIONS.config,
+                meta: { hidden: true },
+            },
+            meta: {},
+        };
+
+        const explores = await convertExplores(
+            [hiddenModel],
+            false,
+            SupportedDbtAdapter.POSTGRES,
+            warehouseClientMock,
+            {
+                spotlight: DEFAULT_SPOTLIGHT_CONFIG,
+            },
+        );
+
+        expect(explores).toEqual([]);
+    });
+
     const MODEL_WITH_DATE_EXPLORE_DIMENSION: DbtModelNode = {
         ...MODEL_WITH_EXPLORE_SCOPED_DIMENSIONS,
         meta: {

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -1218,21 +1218,28 @@ export const convertExplores = async (
         const tags =
             configTags && configTags.length > 0 ? configTags : model.tags;
 
-        // Create an array of explores to generate: base explore + any additional explores
+        // Create an array of explores to generate: base explore + any additional explores.
+        // `meta.hidden` skips the base explore - the model is still compiled as a
+        // table, so it stays available as a join target and as the base table for
+        // the explores defined under `meta.explores`.
         const exploresToCreate = [
-            {
-                name: model.name,
-                label: meta.label || friendlyName(model.name),
-                tags: tags || [],
-                groupLabel: meta.group_label,
-                ...(meta.groups && meta.groups.length > 0
-                    ? { groups: meta.groups }
-                    : {}),
-                joins: meta?.joins || [],
-                description: meta.description,
-                caseSensitive: meta.case_sensitive,
-                tables: tableLookup,
-            },
+            ...(meta.hidden
+                ? []
+                : [
+                      {
+                          name: model.name,
+                          label: meta.label || friendlyName(model.name),
+                          tags: tags || [],
+                          groupLabel: meta.group_label,
+                          ...(meta.groups && meta.groups.length > 0
+                              ? { groups: meta.groups }
+                              : {}),
+                          joins: meta?.joins || [],
+                          description: meta.description,
+                          caseSensitive: meta.case_sensitive,
+                          tables: tableLookup,
+                      },
+                  ]),
             ...(meta.explores
                 ? Object.entries(meta.explores).map(
                       ([exploreName, exploreConfig]) => {

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -1122,6 +1122,10 @@
                     "description": "Alias for default_filters (deprecated, use default_filters instead)",
                     "items": { "$ref": "#/$defs/filterItem" }
                 },
+                "hidden": {
+                    "type": "boolean",
+                    "description": "When true, no explore is generated for the model itself. The model is still available as a join target and as the base table for explores defined under `explores`."
+                },
                 "explores": {
                     "type": "object",
                     "description": "Defines custom explores for this model",

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -191,6 +191,12 @@ export type DbtModelLightdashConfig = ExploreConfig &
                 SharedDbtModelLightdashConfig &
                 DbtLightdashFieldTags
         >;
+        /**
+         * When true, no explore is generated for the model itself. The model is
+         * still compiled as a table, so it remains available as a join target
+         * and as the base table for explores defined under `explores`.
+         */
+        hidden?: boolean;
         ai_hint?: string | string[];
         parameters?: LightdashProjectConfig['parameters'];
         primary_key?: string | string[];


### PR DESCRIPTION
Closes: lightdash/lightdash#26840

### Description:

A common pattern is one base dbt model with a curated explore layered on top via `meta.explores`, where only the curated explore should be exposed (e.g. to an AI agent). Today the base explore is always generated and always reachable, and there was no opt-out.

This adds a model-level `meta.hidden: true` that skips generating the explore for the model itself. The model is still compiled as a table, so it remains available as a join target and as the base table for its `meta.explores` entries:

```yaml
models:
  - name: base_model
    config:
      meta:
        hidden: true
        explores:
          curated:
            label: 'Curated'
            tags: ['ai']
```

With the base explore gone, explore-level `tags` are enough to scope an agent to the curated explore, and no field-level tags are needed (which would otherwise flip tables into field-level tag mode).

Changes: the base-explore entry in `convertExplores` is now conditional, plus the `DbtModelLightdashConfig` type, the `lightdash-dbt-2.0.json` CLI schema, and pass-through in the Lightdash-YAML model converter.

**On the reported dropped explore tags:** I could not reproduce the compiler dropping explore-level `tags` when the model defines metrics — `convertExplores` keeps `tags: ["ai"]` with model-level metrics, column-level metrics, and metrics in `meta` vs `config.meta`, and nothing between the manifest and the served/cached explore rewrites `tags`. I've added a regression test covering explore tags alongside model metrics. The most likely explanation for the reported symptom is `filterExploreByTags` (`hasTableAnyFieldTags`): once *any* field in a table defines `tags`, that table switches to field-level mode and a matching explore tag no longer exposes its fields — which makes a correctly tagged curated explore look empty to the agent. That behaviour is documented/intentional, so I left it alone; worth a follow-up decision.

Docs for `meta.hidden` still need adding in the docs repo (`references/tables.mdx`).

Verified with `pnpm -F common test` (all suites) and `pnpm -F common typecheck`; no running app in this environment, so this was not exercised end-to-end against a warehouse.