### PR TITLE
fix(unfurl): align app delivery ready-wait assertion with budgeted timeout

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.test.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.test.ts
@@ -510,7 +510,7 @@ describe('UnfurlService', () => {
             );
             expect(page.waitForSelector).toHaveBeenCalledWith(
                 SCREENSHOT_SELECTORS.READY_INDICATOR,
-                { state: 'attached', timeout: 45_000 },
+                { state: 'attached', timeout: 180_000 },
             );
             expect(page.evaluate).toHaveBeenCalledWith(
                 expect.any(Function),


### PR DESCRIPTION
## Problem

Main is red: `UnfurlService.test.ts > captureAppDeliveryManifest > returns the validated manifest published on the window global` fails on every PR's merge-ref build.

This is a semantic conflict between two PRs that were each green in isolation:
- #26794 made app renders use the configurable screenshot timeout, asserting `timeout: 45_000`
- #26815 changed the same test's `setup()` to configure `screenshotTimeoutMs: 180_000` to budget the browserless session for the ready-wait

Combined, the service correctly waits with the configured 180s, but the stale assertion still expects 45s.

## Fix

Update the assertion to match the timeout the test itself configures. No production code changes.

## Regression analysis

Test-only change; the behavior under test (ready-wait uses the configured `screenshotTimeoutMs`) is unchanged and now asserted consistently with the test's own config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyiazBkUVWYouA2pWer6jH