### PR TITLE
feat(ai): show failed tool results

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDebugDrawer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDebugDrawer.tsx
@@ -4,6 +4,7 @@ import type {
     AiAgentToolResult,
 } from '@lightdash/common';
 import {
+    Badge,
     Box,
     Collapse,
     Drawer,
@@ -189,6 +190,12 @@ const AgentChatDebugDrawer: React.FC<Props> = ({
                                     toolCall.toolArgs,
                                     2,
                                 );
+                                const toolResult = toolResultsMap.get(
+                                    toolCall.toolCallId,
+                                );
+                                const isError =
+                                    toolResult?.metadata?.status === 'error';
+
                                 return (
                                     <Box
                                         key={callId}
@@ -224,6 +231,15 @@ const AgentChatDebugDrawer: React.FC<Props> = ({
                                                         {toolCall.toolName ||
                                                             'Unknown'}
                                                     </Text>
+                                                    {isError && (
+                                                        <Badge
+                                                            color="red"
+                                                            size="xs"
+                                                            variant="light"
+                                                        >
+                                                            Error
+                                                        </Badge>
+                                                    )}
                                                 </Group>
                                             </Group>
                                         </Box>
@@ -271,9 +287,7 @@ const AgentChatDebugDrawer: React.FC<Props> = ({
 
                                                 <ToolResults
                                                     toolCall={toolCall}
-                                                    toolResult={toolResultsMap.get(
-                                                        toolCall.toolCallId,
-                                                    )}
+                                                    toolResult={toolResult}
                                                 />
                                             </Stack>
                                         </Collapse>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolResults/ToolResults.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolResults/ToolResults.test.tsx
@@ -1,0 +1,42 @@
+import type { AiAgentToolCall, AiAgentToolResult } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../../../../../testing/testUtils';
+import { ToolResults } from './ToolResults';
+
+const toolCall = {
+    uuid: 'tool-call-uuid',
+    promptUuid: 'prompt-uuid',
+    toolCallId: 'tool-call-id',
+    parentToolCallId: null,
+    createdAt: new Date('2026-08-04T16:56:32.774Z'),
+    toolArgs: {},
+    toolType: 'built-in',
+    toolName: 'generateVisualization',
+} satisfies AiAgentToolCall;
+
+const toolResult = {
+    uuid: 'tool-result-uuid',
+    promptUuid: 'prompt-uuid',
+    toolCallId: 'tool-call-id',
+    createdAt: new Date('2026-08-04T16:56:32.774Z'),
+    result: 'Problem: "greaterThan" is not available for string fields.',
+    toolType: 'built-in',
+    toolName: 'generateVisualization',
+    metadata: { status: 'error' },
+} satisfies AiAgentToolResult;
+
+describe('ToolResults', () => {
+    it('renders the raw result for a failed tool call', () => {
+        renderWithProviders(
+            <ToolResults toolCall={toolCall} toolResult={toolResult} />,
+        );
+
+        expect(screen.getByText('Error')).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                'Problem: "greaterThan" is not available for string fields.',
+            ),
+        ).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolResults/ToolResults.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolResults/ToolResults.tsx
@@ -1,5 +1,5 @@
 import type { AiAgentToolCall, AiAgentToolResult } from '@lightdash/common';
-import { Divider, Stack } from '@mantine/core';
+import { Code, Divider, Stack, Text } from '@mantine/core';
 import { RankingDisplay } from './RankingDisplay';
 import { parseToolResultMetadata } from './utils';
 
@@ -7,6 +7,29 @@ export const ToolResults: React.FC<{
     toolCall: AiAgentToolCall;
     toolResult: AiAgentToolResult | undefined;
 }> = ({ toolCall, toolResult }) => {
+    if (toolResult?.metadata?.status === 'error') {
+        return (
+            <Stack gap="xs">
+                <Divider />
+                <Text fw={500} size="xs" c="red.7">
+                    Error
+                </Text>
+                <Code
+                    block
+                    c="red.9"
+                    bg="red.0"
+                    style={{
+                        fontSize: '11px',
+                        overflowWrap: 'anywhere',
+                        whiteSpace: 'pre-wrap',
+                    }}
+                >
+                    {toolResult.result}
+                </Code>
+            </Stack>
+        );
+    }
+
     const toolResultMetadata = parseToolResultMetadata(
         toolResult,
         toolCall.toolName,


### PR DESCRIPTION
- mark failed agent tool calls in the debug drawer
- show the persisted raw error response when a failed call is expanded
- cover generic failed tool results, not only visualizations
