### PR TITLE
fix(data-apps): document prefix-colliding field IDs

### DIFF
--- a/sandboxes/data-apps/template/references/chart-references.md
+++ b/sandboxes/data-apps/template/references/chart-references.md
@@ -139,6 +139,7 @@ generation, so author them normally.)
 **Important:** The field IDs in metric queries use qualified names (e.g.,
 `orders_total_revenue`). When mapping to SDK calls:
 - **Base explore fields:** Strip the explore name prefix. `orders_total_revenue` → `total_revenue`
+  - **Prefix-collision exception:** If the remaining short name still begins with the explore name and an underscore, keep the original qualified ID. For example, `custom_roles_custom_roles_created` must stay fully qualified; shortening it to `custom_roles_created` makes the SDK mistake it for an already-qualified ID.
 - **Joined table fields:** Convert to dot notation. If the explore is `orders` and the field is
   `customers_customer_name`, that's a joined table field — use `customers.customer_name`.
   **Only strip the prefix if it matches the explore name.** If it doesn't match, it's a joined table.

--- a/sandboxes/data-apps/template/skill.md
+++ b/sandboxes/data-apps/template/skill.md
@@ -226,7 +226,11 @@ export function RevenueBySegment() {
 
 ### Field names
 
-Use **short names** like `total_revenue`, not qualified names like `orders_total_revenue`. The SDK qualifies them automatically. For joined table fields, use **dot notation** like `customers.name` (see "Joined table fields" above).
+Use **short names** like `total_revenue` for base-explore fields; the SDK qualifies them automatically. Already-qualified base field IDs such as `orders_total_revenue` are also accepted.
+
+There is one important ambiguity: if a base field's short name already begins with the explore name and an underscore, keep its **fully qualified ID**. For example, the `custom_roles_created` metric on the `custom_roles` explore must be passed as `custom_roles_custom_roles_created`. Passing the short name would be mistaken for an already-qualified ID and sent to the API unchanged. Query result keys match the identifier passed to the builder, so use that same fully qualified ID when reading rows or calling `format`.
+
+For joined table fields, use **dot notation** like `customers.name` (see "Joined table fields" above).
 
 ### Query builder
 
@@ -1182,7 +1186,7 @@ The action-menu example above shows typical `drillDown()` usage. For the full AP
 | Unused dimensions in `.dimensions()` | Changes GROUP BY → wrong numbers | Only include dimensions you render |
 | Querying hidden fields (`customer_id`) | Leaks internal IDs | Skip fields with `hidden: true` |
 | Calling `createClient()` in app code | Not needed — client is set up in `main.jsx` | `import { query, useLightdash } from '@lightdash/query-sdk'` |
-| Qualified names like `orders_total_revenue` | Double-qualified → unknown field | Short names only |
+| Short base field name starts with the explore prefix: `query('custom_roles').metrics(['custom_roles_created'])` | Mistaken for an already-qualified ID → unknown field | Preserve the full ID: `custom_roles_custom_roles_created` |
 | Joined table field without dot notation: `customer_name` | Resolves to `orders_customer_name` → unknown field | Use `customers.customer_name` for joined tables |
 | `value: '2025'` for a number column | String won't match number | `value: 2025` |
 | Not filtering on grain dimensions you don't render | Duplicates, mixed data, wrong totals | Identify the grain, filter dimensions you don't display |


### PR DESCRIPTION
## What changed

- clarify that the query SDK accepts already-qualified base field IDs
- document the prefix-collision exception for fields whose short name begins with the explore name
- apply the same rule when converting attached chart metric queries into SDK calls
- replace the outdated warning that all qualified IDs are double-qualified

## Why

A dashboard query using `custom_roles_custom_roles_created` was converted to the short name `custom_roles_created`. Because that short name already begins with `custom_roles_`, the SDK treated it as qualified and sent the nonexistent field ID unchanged.

The corrected guidance tells the data-app authoring agent to preserve `custom_roles_custom_roles_created` in this case.

## Validation

- `git diff --check`
- `pnpm -F cli test -- src/handlers/apps/scaffolding.test.ts` (40 files, 471 tests)