### PR TITLE
chore(data-apps): simplify follow-host-theme feature description

### DIFF
--- a/packages/common/src/ee/apps/sdkFeatures.ts
+++ b/packages/common/src/ee/apps/sdkFeatures.ts
@@ -91,7 +91,7 @@ export const SDK_FEATURES: SdkFeature[] = [
         key: 'follow-host-theme',
         label: 'Follow the host light/dark mode',
         description:
-            "Render in whatever light or dark mode the viewer's Lightdash (or embed) is set to, instead of a fixed theme, and restyle live when they switch.",
+            "Match the light or dark mode of the viewer's Lightdash (or embed) instead of a fixed theme, and restyle live when they switch.",
         wiring: 'Keep complete light tokens in :root and dark tokens in .dark, remove any fixed dark class from the app shell, and use useColorScheme() only for colours that cannot be expressed in CSS.',
     },
 ];

--- a/packages/query-sdk/src/features.ts
+++ b/packages/query-sdk/src/features.ts
@@ -91,7 +91,7 @@ export const SDK_FEATURES: SdkFeature[] = [
         key: 'follow-host-theme',
         label: 'Follow the host light/dark mode',
         description:
-            "Render in whatever light or dark mode the viewer's Lightdash (or embed) is set to, instead of a fixed theme, and restyle live when they switch.",
+            "Match the light or dark mode of the viewer's Lightdash (or embed) instead of a fixed theme, and restyle live when they switch.",
         wiring: 'Keep complete light tokens in :root and dark tokens in .dark, remove any fixed dark class from the app shell, and use useColorScheme() only for colours that cannot be expressed in CSS.',
     },
 ];


### PR DESCRIPTION
Reworded the `follow-host-theme` SDK feature description so it reads more simply in the host's feature list.

Before:
> Render in whatever light or dark mode the viewer's Lightdash (or embed) is set to, instead of a fixed theme, and restyle live when they switch.

After:
> Match the light or dark mode of the viewer's Lightdash (or embed) instead of a fixed theme, and restyle live when they switch.

Both mirrored copies of the registry are updated (`packages/common` and `packages/query-sdk`), so the sync test stays green.