### PR TITLE
fix(docker): resync corepack pnpm pin to 11.20.0

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -16,7 +16,7 @@ ENV PATH="$PNPM_HOME:$PATH"
 ENV COREPACK_HOME="/usr/local/corepack"
 RUN npm i -g corepack@latest
 RUN corepack enable
-RUN corepack prepare pnpm@11.17.0 --activate && chmod -R a+rX "$COREPACK_HOME"
+RUN corepack prepare pnpm@11.20.0 --activate && chmod -R a+rX "$COREPACK_HOME"
 RUN pnpm config set store-dir /pnpm/store
 
 WORKDIR /usr/app


### PR DESCRIPTION
## Problem

Release `1.84.0-commercial` crash-looped **every `lightdash-backend` pod in both the US and EU clusters** (~86 pods per cluster, 161 namespaces). Service stayed up only because the rollout stalled — new pods never went Ready, so the previous release kept serving at reduced capacity.

The root `package.json` `packageManager` field was bumped `pnpm@11.17.0` → `pnpm@11.20.0`, but the `dockerfile` hardcodes `corepack prepare pnpm@11.17.0`. Nothing keeps the two in sync.

At container boot:

1. `docker/prod-entrypoint.sh` runs `pnpm -F backend migrate-production`
2. `pnpm` is a corepack shim — corepack treats `packageManager` as a **hard contract** and demands exactly `11.20.0`; it does not fall back to the baked `11.17.0`
3. only `11.17.0` is in `COREPACK_HOME` (confirmed inside a running pod)
4. the prod stage sets `COREPACK_ENABLE_NETWORK=0`, so the download fails: `Network access disabled by the environment`
5. `set -e` aborts the entrypoint → the container never reaches `node dist/index.js` → CrashLoopBackOff

Introduced in `1.81.0`; `1.80.0` was the last good release. Present on `main`, so every subsequent release carries it.

### Why CI didn't catch it

`COREPACK_ENABLE_NETWORK=0` is set **only in the final prod stage**. Builder stages have network, so corepack quietly downloaded `11.20.0` during the build and every check passed. The image is built under different corepack rules than it runs under, so no build-time check could reproduce the runtime failure.

## Change

One line — resync the corepack pin in `dockerfile` to `11.20.0` so the baked pnpm matches what `packageManager` declares.

## Verification

Built the `pnpm-base` stage and ran it with `--network none`:

| Case | Result |
|---|---|
| pin matched to `packageManager` (this PR) | `pnpm --version` → `11.20.0`, **exit 0** |
| pin as on `main` (`11.17.0`) | reproduces the exact production error, **exit 1** |

## Follow-ups (deliberately not in this PR)

Tracked in SPK-851 — this PR is kept to the minimum needed to stop the outage:

- take `pnpm` off the container boot path (call `knex` directly), so a future desync can't break boot at all
- set `COREPACK_ENABLE_NETWORK=0` in `pnpm-base` so the builder runs under the same corepack rules as prod and a desync fails loudly at build time
- `dockerfile-prs` carries the same desync; it doesn't crash because it never disables corepack's network, but preview containers now download pnpm on every boot

This PR also does **not** address the currently-stuck rollout — rolling `customer-versions.yaml` back to `1.80.0`, or deploying a build from this branch, is a separate operational call. The migration never ran, so a revert is clean.

Linear: SPK-850