### PR TITLE
fix(ai): bump @ai-sdk/anthropic so Claude 5 models get real output-token limits

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -50,7 +50,7 @@
     },
     "dependencies": {
         "@ai-sdk/amazon-bedrock": "4.0.48",
-        "@ai-sdk/anthropic": "3.0.76",
+        "@ai-sdk/anthropic": "3.0.104",
         "@ai-sdk/azure": "3.0.26",
         "@ai-sdk/mcp": "1.0.41",
         "@ai-sdk/openai": "3.0.68",

--- a/packages/backend/src/ee/services/ai/models/types.ts
+++ b/packages/backend/src/ee/services/ai/models/types.ts
@@ -11,7 +11,7 @@ export type AiProvider = keyof AiCopilotConfigSchemaType['providers'];
 export type ProviderOptionsMap = {
     openai: OpenAIResponsesProviderOptions;
     azure: OpenAIResponsesProviderOptions;
-    anthropic: AnthropicProviderOptions;
+    anthropic: Omit<AnthropicProviderOptions, 'fallbacks'>;
     openrouter: Record<string, JSONValue>;
     bedrock: BedrockProviderOptions;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,8 +124,8 @@ importers:
         specifier: 4.0.48
         version: 4.0.48(zod@3.25.55)
       '@ai-sdk/anthropic':
-        specifier: 3.0.76
-        version: 3.0.76(zod@3.25.55)
+        specifier: 3.0.104
+        version: 3.0.104(zod@3.25.55)
       '@ai-sdk/azure':
         specifier: 3.0.26
         version: 3.0.26(zod@3.25.55)
@@ -1867,14 +1867,14 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/anthropic@3.0.36':
-    resolution: {integrity: sha512-GHQccfwC0j1JltN9M47RSlBpOyHoUam0mvbYMf8zpE0UD1tzIX5sDw2m/8nRlrTz6wGuKfaDxmoC3XH7uhTrXg==}
+  '@ai-sdk/anthropic@3.0.104':
+    resolution: {integrity: sha512-D1d/whdUWF8KrXr9TzK6/S1wD9WmmxJ5DRWgGJX6Ip8iZW0up/yRtWuZwTkuX86bOPQTd2c370lIVteEBUGxPg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/anthropic@3.0.76':
-    resolution: {integrity: sha512-kOuvT9e6PygFvgYpkr4v9gjvmcMPfJp79jaXjeRl9Gpoj2OXdtc3ero7o1ic+tiSBw5IMubxXFO68BCA/axGJA==}
+  '@ai-sdk/anthropic@3.0.36':
+    resolution: {integrity: sha512-GHQccfwC0j1JltN9M47RSlBpOyHoUam0mvbYMf8zpE0UD1tzIX5sDw2m/8nRlrTz6wGuKfaDxmoC3XH7uhTrXg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -1927,8 +1927,18 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.41':
+    resolution: {integrity: sha512-I7hhjfw01yEI8NkuAsT8Mv6xbWFr/lqLXMdaJQ2zWfXEpxog1eT7skDcv1+RY29/+5btzH8wD+vVvy48bk9oNQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@3.0.10':
     resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.14':
+    resolution: {integrity: sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==}
     engines: {node: '>=18'}
 
   '@ai-sdk/provider@3.0.7':
@@ -16259,16 +16269,16 @@ snapshots:
       aws4fetch: 1.0.20
       zod: 3.25.55
 
+  '@ai-sdk/anthropic@3.0.104(zod@3.25.55)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.41(zod@3.25.55)
+      zod: 3.25.55
+
   '@ai-sdk/anthropic@3.0.36(zod@3.25.55)':
     dependencies:
       '@ai-sdk/provider': 3.0.7
       '@ai-sdk/provider-utils': 4.0.13(zod@3.25.55)
-      zod: 3.25.55
-
-  '@ai-sdk/anthropic@3.0.76(zod@3.25.55)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.27(zod@3.25.55)
       zod: 3.25.55
 
   '@ai-sdk/azure@3.0.26(zod@3.25.55)':
@@ -16325,7 +16335,19 @@ snapshots:
       eventsource-parser: 3.0.8
       zod: 3.25.55
 
+  '@ai-sdk/provider-utils@4.0.41(zod@3.25.55)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      undici: 6.27.0
+      zod: 3.25.55
+
   '@ai-sdk/provider@3.0.10':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@3.0.14':
     dependencies:
       json-schema: 0.4.0
 


### PR DESCRIPTION
Cloud has been seeing bursts of `AI_InvalidToolInputError` (`AiAgentToolCallInvalid`) concentrated on `claude-sonnet-5` — 140 of 146 events in the last 14 days, across 8 orgs. Tool inputs arrive as `{}` or as a valid-JSON prefix missing every trailing required field (e.g. `submitInvestigationReport` called with only `{"verdict":"inconclusive"}`), the signature of a generation cut off mid tool call. The root cause is that `@ai-sdk/anthropic@3.0.76`'s model-capabilities table predates the Claude 5 model IDs, so they fall through to the unknown-model default of `max_tokens: 4096`; our presets set no explicit `maxOutputTokens`, and with adaptive thinking counting toward the cap, any step with a large tool input gets truncated. Regular chat mostly self-heals by retrying, but Deep Research retries its forced report submission until the truncations burn the run's token budget and the run fails.

The fix is a dependency bump: pin `@ai-sdk/anthropic` to `3.0.104`, whose capabilities table knows `claude-sonnet-5` (128k output tokens, `isKnownModel: true`), giving it the same effective limit `claude-sonnet-4-6` already runs with today. 3.0.104 is the newest version that clears the repo's 3-day `minimumReleaseAge` supply-chain policy (3.0.105 was published within the window). The bump also required a one-line type change: 3.0.10x added a `fallbacks` provider option whose upstream typing uses `Record<string, unknown>` fields, making `AnthropicProviderOptions` no longer assignable to the SDK's JSON-only `providerOptions`; since we never set `fallbacks`, our `ProviderOptionsMap` now omits it. The Bedrock provider bundles its own internal copy of `@ai-sdk/anthropic`, but the affected preset is the direct-Anthropic `claude-sonnet-5`, which resolves the bumped package.

Closes: ZAP-784

Fixes LIGHTDASH-BACKEND-D70

🤖 Generated with [Claude Code](https://claude.com/claude-code)
