### PR TITLE
fix(data-apps): show explicit viz render errors

### DIFF
--- a/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
@@ -1,5 +1,5 @@
 import { MantineProvider } from '@mantine/core';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
@@ -20,10 +20,25 @@ const mocks = vi.hoisted(() => ({
                       colorPalette: null;
                   };
               }
+            | {
+                  state: 'building';
+                  latestBuildInProgress: true;
+              }
+            | {
+                  state: 'failed';
+                  latestBuildInProgress: false;
+              }
             | undefined,
     },
+    metadataError: {
+        current: undefined as ReturnType<typeof apiError> | undefined,
+    },
     token: { current: 'preview-token' as string | undefined },
+    tokenError: {
+        current: undefined as ReturnType<typeof apiError> | undefined,
+    },
     embedToken: { current: undefined as string | undefined },
+    dataAppVizUuid: { current: 'viz-uuid' as string | undefined },
     iframePreview: vi.fn(() => null),
     renderMetadataHook: vi.fn(),
     previewTokenHook: vi.fn(),
@@ -42,11 +57,14 @@ vi.mock('../../features/apps/AppIframePreview', () => ({
 vi.mock('../../features/apps/hooks/useDataAppVizRender', () => ({
     useDataAppVizRenderMetadata: (...args: unknown[]) => {
         mocks.renderMetadataHook(...args);
-        return { data: mocks.metadata.current };
+        return {
+            data: mocks.metadata.current,
+            error: mocks.metadataError.current,
+        };
     },
     useDataAppVizPreviewToken: (...args: unknown[]) => {
         mocks.previewTokenHook(...args);
-        return { data: mocks.token.current };
+        return { data: mocks.token.current, error: mocks.tokenError.current };
     },
 }));
 vi.mock('../../features/apps/previewOrigin', () => ({
@@ -60,7 +78,7 @@ vi.mock('../LightdashVisualization/useVisualizationContext', () => ({
         visualizationConfig: {
             chartConfig: {
                 validConfig: {
-                    dataAppVizUuid: 'viz-uuid',
+                    dataAppVizUuid: mocks.dataAppVizUuid.current,
                     fieldMapping: { category: 'orders.category' },
                     optionValues: { title: 12 },
                 },
@@ -76,6 +94,18 @@ vi.mock('../LightdashVisualization/useVisualizationContext', () => ({
 }));
 
 import DataAppVizRenderer from './index';
+
+function apiError(statusCode: number) {
+    return {
+        status: 'error' as const,
+        error: {
+            name: 'ApiError',
+            statusCode,
+            message: 'Request failed',
+            data: {},
+        },
+    };
+}
 
 const renderRenderer = () =>
     render(
@@ -105,20 +135,111 @@ const readyMetadata = () => ({
 describe('DataAppVizRenderer', () => {
     beforeEach(() => {
         mocks.metadata.current = readyMetadata();
+        mocks.metadataError.current = undefined;
         mocks.token.current = 'preview-token';
+        mocks.tokenError.current = undefined;
         mocks.embedToken.current = undefined;
+        mocks.dataAppVizUuid.current = 'viz-uuid';
         mocks.iframePreview.mockClear();
         mocks.renderMetadataHook.mockClear();
         mocks.previewTokenHook.mockClear();
         mocks.setFetchAll.mockClear();
     });
 
-    it('waits for render metadata before mounting the iframe', () => {
+    it('prompts for a visualization when none is selected', () => {
+        mocks.dataAppVizUuid.current = undefined;
+
+        renderRenderer();
+
+        expect(
+            screen.getByText('Pick a data app visualization to render.'),
+        ).toBeInTheDocument();
+    });
+
+    it('shows a neutral loading state while render metadata is pending', () => {
         mocks.metadata.current = undefined;
 
         renderRenderer();
 
+        expect(
+            screen.getByText('Loading data app visualization…'),
+        ).toBeInTheDocument();
         expect(mocks.iframePreview).not.toHaveBeenCalled();
+    });
+
+    it('shows generating only for metadata building state', () => {
+        mocks.metadata.current = {
+            state: 'building',
+            latestBuildInProgress: true,
+        };
+
+        renderRenderer();
+
+        expect(
+            screen.getByText('Data app visualization is still generating…'),
+        ).toBeInTheDocument();
+    });
+
+    it('shows a build failure for metadata failed state', () => {
+        mocks.metadata.current = {
+            state: 'failed',
+            latestBuildInProgress: false,
+        };
+
+        renderRenderer();
+
+        expect(
+            screen.getByText('Data app visualization failed to generate.'),
+        ).toBeInTheDocument();
+    });
+
+    it.each([
+        [
+            'metadata',
+            403,
+            "You don't have access to this data app visualization.",
+        ],
+        ['token', 403, "You don't have access to this data app visualization."],
+        [
+            'metadata',
+            404,
+            'This data app visualization could not be found. It may have been deleted.',
+        ],
+        [
+            'token',
+            404,
+            'This data app visualization could not be found. It may have been deleted.',
+        ],
+    ])(
+        'maps a %s HTTP %s response to its explicit state',
+        (source, statusCode, message) => {
+            if (source === 'metadata') {
+                mocks.metadata.current = undefined;
+                mocks.metadataError.current = apiError(statusCode);
+            } else {
+                mocks.token.current = undefined;
+                mocks.tokenError.current = apiError(statusCode);
+            }
+
+            renderRenderer();
+
+            expect(screen.getByText(message)).toBeInTheDocument();
+            expect(mocks.iframePreview).not.toHaveBeenCalled();
+        },
+    );
+
+    it('shows a load failure for an unexpected request error', () => {
+        mocks.token.current = undefined;
+        mocks.tokenError.current = apiError(500);
+
+        renderRenderer();
+
+        expect(
+            screen.getByText('Data app visualization could not be loaded.'),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText('Data app visualization is still generating…'),
+        ).not.toBeInTheDocument();
     });
 
     it('uses the metadata schema to deliver effective options', () => {
@@ -153,6 +274,35 @@ describe('DataAppVizRenderer', () => {
             }),
             undefined,
         );
+    });
+
+    it('renders the last good version while a newer build is running', () => {
+        mocks.metadata.current = {
+            ...readyMetadata(),
+            latestBuildInProgress: true,
+        };
+
+        renderRenderer();
+
+        expect(mocks.iframePreview).toHaveBeenCalled();
+        expect(
+            screen.queryByText('Data app visualization is still generating…'),
+        ).not.toBeInTheDocument();
+    });
+
+    it('keeps rendering the last good version after a transient metadata refetch error', () => {
+        mocks.metadata.current = {
+            ...readyMetadata(),
+            latestBuildInProgress: true,
+        };
+        mocks.metadataError.current = apiError(500);
+
+        renderRenderer();
+
+        expect(mocks.iframePreview).toHaveBeenCalled();
+        expect(
+            screen.queryByText('Data app visualization could not be loaded.'),
+        ).not.toBeInTheDocument();
     });
 
     it('selects the embed route target when an embed JWT is present', () => {

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -1,5 +1,6 @@
 import {
     getEffectiveOptionValues,
+    type ApiError,
     type DataAppVizContext,
 } from '@lightdash/common';
 import { Stack, Text } from '@mantine/core';
@@ -31,6 +32,20 @@ const DataAppVizPlaceholder: FC<{ message: string }> = ({ message }) => (
         </Text>
     </Stack>
 );
+
+const getTerminalRequestErrorMessage = (
+    errors: Array<ApiError | null | undefined>,
+): string | undefined => {
+    if (errors.some((error) => error?.error.statusCode === 403)) {
+        return "You don't have access to this data app visualization.";
+    }
+
+    if (errors.some((error) => error?.error.statusCode === 404)) {
+        return 'This data app visualization could not be found. It may have been deleted.';
+    }
+
+    return undefined;
+};
 
 const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
@@ -71,14 +86,15 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
         () => ({ isEmbedded: !!embedToken, savedChartUuid }),
         [embedToken, savedChartUuid],
     );
-    const { data: renderMetadata } = useDataAppVizRenderMetadata(
-        projectUuid,
-        dataAppVizUuid || undefined,
-        renderTarget,
-    );
+    const { data: renderMetadata, error: renderMetadataError } =
+        useDataAppVizRenderMetadata(
+            projectUuid,
+            dataAppVizUuid || undefined,
+            renderTarget,
+        );
     const readyMetadata =
         renderMetadata?.state === 'ready' ? renderMetadata : undefined;
-    const { data: token } = useDataAppVizPreviewToken(
+    const { data: token, error: previewTokenError } = useDataAppVizPreviewToken(
         projectUuid,
         dataAppVizUuid || undefined,
         readyMetadata?.version,
@@ -123,13 +139,51 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
         );
     }
 
-    if (!readyMetadata || !token) {
+    const terminalRequestErrorMessage = getTerminalRequestErrorMessage([
+        renderMetadataError,
+        previewTokenError,
+    ]);
+    if (terminalRequestErrorMessage) {
+        return <DataAppVizPlaceholder message={terminalRequestErrorMessage} />;
+    }
+
+    if (!renderMetadata) {
+        return (
+            <DataAppVizPlaceholder
+                message={
+                    renderMetadataError
+                        ? 'Data app visualization could not be loaded.'
+                        : 'Loading data app visualization…'
+                }
+            />
+        );
+    }
+
+    if (renderMetadata.state === 'building') {
         return (
             <DataAppVizPlaceholder message="Data app visualization is still generating…" />
         );
     }
 
-    const previewUrl = `${previewOrigin}/api/apps/${dataAppVizUuid}/versions/${readyMetadata.version}/t/${token}/?r=0#transport=postMessage&projectUuid=${projectUuid}`;
+    if (renderMetadata.state === 'failed') {
+        return (
+            <DataAppVizPlaceholder message="Data app visualization failed to generate." />
+        );
+    }
+
+    if (!token) {
+        return (
+            <DataAppVizPlaceholder
+                message={
+                    previewTokenError
+                        ? 'Data app visualization could not be loaded.'
+                        : 'Loading data app visualization…'
+                }
+            />
+        );
+    }
+
+    const previewUrl = `${previewOrigin}/api/apps/${dataAppVizUuid}/versions/${renderMetadata.version}/t/${token}/?r=0#transport=postMessage&projectUuid=${projectUuid}`;
 
     return (
         <AppIframePreview

--- a/packages/frontend/src/features/apps/hooks/useDataAppVizRender.test.tsx
+++ b/packages/frontend/src/features/apps/hooks/useDataAppVizRender.test.tsx
@@ -18,7 +18,21 @@ type CapturedQuery = {
     queryFn: () => Promise<unknown>;
     enabled: boolean;
     refetchInterval?: (data: unknown) => number | false;
+    retry?: (
+        failureCount: number,
+        error: ReturnType<typeof apiError>,
+    ) => boolean;
 };
+
+const apiError = (statusCode: number) => ({
+    status: 'error' as const,
+    error: {
+        name: 'ApiError',
+        statusCode,
+        message: 'Request failed',
+        data: {},
+    },
+});
 
 describe('useDataAppVizRender', () => {
     beforeEach(() => {
@@ -106,5 +120,47 @@ describe('useDataAppVizRender', () => {
         expect((result.current as unknown as CapturedQuery).enabled).toBe(
             false,
         );
+    });
+
+    it.each([
+        ['metadata', 403],
+        ['metadata', 404],
+        ['token', 403],
+        ['token', 404],
+    ])(
+        'does not retry terminal %s HTTP %s responses',
+        (queryType, statusCode) => {
+            const target = {
+                isEmbedded: false,
+                savedChartUuid: 'chart-1',
+            };
+            const { result } = renderHook(() =>
+                queryType === 'metadata'
+                    ? useDataAppVizRenderMetadata('project-1', 'viz-1', target)
+                    : useDataAppVizPreviewToken(
+                          'project-1',
+                          'viz-1',
+                          7,
+                          target,
+                      ),
+            );
+            const query = result.current as unknown as CapturedQuery;
+
+            expect(query.retry?.(0, apiError(statusCode))).toBe(false);
+        },
+    );
+
+    it('retries transient failures at most three times', () => {
+        const { result } = renderHook(() =>
+            useDataAppVizRenderMetadata('project-1', 'viz-1', {
+                isEmbedded: false,
+                savedChartUuid: 'chart-1',
+            }),
+        );
+        const query = result.current as unknown as CapturedQuery;
+
+        expect(query.retry?.(0, apiError(500))).toBe(true);
+        expect(query.retry?.(2, apiError(500))).toBe(true);
+        expect(query.retry?.(3, apiError(500))).toBe(false);
     });
 });

--- a/packages/frontend/src/features/apps/hooks/useDataAppVizRender.ts
+++ b/packages/frontend/src/features/apps/hooks/useDataAppVizRender.ts
@@ -8,6 +8,7 @@ import { useQuery } from '@tanstack/react-query';
 import { lightdashApi } from '../../../api';
 
 const DATA_APP_VIZ_RENDER_POLL_INTERVAL_MS = 3000;
+const DATA_APP_VIZ_RENDER_MAX_RETRIES = 3;
 
 type DataAppVizRenderTarget = {
     isEmbedded: boolean;
@@ -32,6 +33,17 @@ const isTargetReady = (
     !!dataAppVizUuid &&
     (!target.isEmbedded || !!target.savedChartUuid);
 
+const shouldRetryDataAppVizRenderQuery = (
+    failureCount: number,
+    error: ApiError,
+): boolean => {
+    if (error.error.statusCode === 403 || error.error.statusCode === 404) {
+        return false;
+    }
+
+    return failureCount < DATA_APP_VIZ_RENDER_MAX_RETRIES;
+};
+
 export const useDataAppVizRenderMetadata = (
     projectUuid: string | undefined,
     dataAppVizUuid: string | undefined,
@@ -55,6 +67,7 @@ export const useDataAppVizRenderMetadata = (
                 )}/render-metadata`,
             }),
         enabled: isTargetReady(projectUuid, dataAppVizUuid, target),
+        retry: shouldRetryDataAppVizRenderQuery,
         refetchInterval: (metadata) =>
             metadata?.latestBuildInProgress
                 ? DATA_APP_VIZ_RENDER_POLL_INTERVAL_MS
@@ -93,4 +106,5 @@ export const useDataAppVizPreviewToken = (
             isTargetReady(projectUuid, dataAppVizUuid, target) &&
             version !== undefined &&
             version > 0,
+        retry: shouldRetryDataAppVizRenderQuery,
     });


### PR DESCRIPTION
### Description

- Shows distinct placeholders for request loading, visualization builds in progress, failed builds, forbidden access, deleted visualizations, and unexpected request failures.
- Keeps rendering the exact last-good version while a newer build is running or a metadata poll fails transiently.
- Stops retrying terminal 403 and 404 responses so deliberate access restrictions and deleted resources surface immediately.

## Screenshots

Tested locally against a real generated data app viz (Jaffle shop, `orders` explore).

### Nothing selected

`Pick a data app visualization to render.`

<img width="1440" height="900" alt="state-nothing-selected" src="https://github.com/user-attachments/assets/9e4f2679-5b55-4ea8-8e70-07a3f6430752" />


### Building

Latest version in progress, no renderable version yet — the only case that still says "generating".

`Data app visualization is still generating…`

<img width="1440" height="900" alt="state-building" src="https://github.com/user-attachments/assets/5b5df58a-f97b-4f02-881c-e41a57e1ca36" />


### Build failed

Latest version terminal with no renderable version. Previously showed the "still generating" message forever.

`Data app visualization failed to generate.`

<img width="1440" height="900" alt="state-failed" src="https://github.com/user-attachments/assets/754be288-a058-4f1c-8f88-6086f3edcb8f" />


### Forbidden (HTTP 403)

Viewer opening a chart that renders a data app viz they cannot access.

`You don't have access to this data app visualization.`

<img width="1440" height="900" alt="state-forbidden" src="https://github.com/user-attachments/assets/8154750f-8dc5-4fa5-aa17-e87681ace1e0" />


### Not found / deleted (HTTP 404)

`This data app visualization could not be found. It may have been deleted.`
<img width="1440" height="900" alt="state-not-found" src="https://github.com/user-attachments/assets/238a4a55-0ccb-4468-b477-b8b347632c1f" />



### Ready

<img width="1440" height="900" alt="state-ready" src="https://github.com/user-attachments/assets/34f7be64-89ab-4cc3-aa5f-9a962220ecbb" />


### Ready while a newer build is in progress

Metadata returns `{ state: 'ready', version: 1, latestBuildInProgress: true }` and the last good version keeps rendering instead of falling back to a placeholder.

<img width="1440" height="900" alt="state-ready-while-rebuilding" src="https://github.com/user-attachments/assets/3f7a6d0d-8879-4691-b278-7f4f00f660bf" />

