### PR TITLE
fix(ai-writeback): block workflow files in every writeback

### DIFF
--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -2329,10 +2329,6 @@ export class AiWritebackService extends BaseService {
                 prDescription,
                 prSummary,
                 workstream: config.mode,
-                // The general agent must never commit CI/workflow files (R3);
-                // dbt writeback may (preview-deploy setup). Secrets are denied
-                // in both regardless.
-                denyCiPaths: config.mode === 'general',
             });
             pauseOnExit = applied.pauseOnExit;
 
@@ -4250,7 +4246,6 @@ export class AiWritebackService extends BaseService {
         prDescription,
         prSummary,
         workstream,
-        denyCiPaths,
     }: {
         sandbox: SandboxHandle;
         sandboxUuid: string;
@@ -4266,8 +4261,6 @@ export class AiWritebackService extends BaseService {
         prDescription: string | null;
         prSummary: string | null;
         workstream: CodingAgentConfig['mode'];
-        /** Reject the commit if it touches CI/workflow paths (general agent). */
-        denyCiPaths: boolean;
     }): Promise<AppliedChanges> {
         if (!hasChanges) {
             this.logger.info(
@@ -4307,7 +4300,6 @@ export class AiWritebackService extends BaseService {
                     ),
                     user,
                     setStage,
-                    denyCiPaths,
                 });
             this.logger.info(
                 `AiWriteback: updated PR ${targetPrUrl} (sandboxId=${sandbox.sandboxId})`,
@@ -4353,7 +4345,6 @@ export class AiWritebackService extends BaseService {
                 ),
                 user,
                 setStage,
-                denyCiPaths,
             });
         this.logger.info(
             `AiWriteback: opened PR ${prUrl} (sandboxId=${sandbox.sandboxId})`,

--- a/packages/backend/src/ee/services/AiWritebackService/deniedPaths.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/deniedPaths.test.ts
@@ -45,31 +45,20 @@ describe('findDeniedCommitPaths', () => {
         'lib/myenv.py',
     ];
 
-    it('always denies secret paths regardless of denyCiPaths', () => {
-        expect(findDeniedCommitPaths(secrets, { denyCiPaths: false })).toEqual(
-            secrets,
-        );
-        expect(findDeniedCommitPaths(secrets, { denyCiPaths: true })).toEqual(
-            secrets,
-        );
+    it('denies secret paths', () => {
+        expect(findDeniedCommitPaths(secrets)).toEqual(secrets);
     });
 
-    it('denies CI/workflow paths only when denyCiPaths is set', () => {
-        expect(findDeniedCommitPaths(ci, { denyCiPaths: false })).toEqual([]);
-        expect(findDeniedCommitPaths(ci, { denyCiPaths: true })).toEqual(ci);
+    it('denies CI/workflow paths', () => {
+        expect(findDeniedCommitPaths(ci)).toEqual(ci);
     });
 
     it('never denies ordinary source/docs paths', () => {
-        expect(findDeniedCommitPaths(allowed, { denyCiPaths: true })).toEqual(
-            [],
-        );
+        expect(findDeniedCommitPaths(allowed)).toEqual([]);
     });
 
     it('returns only the offending paths from a mixed changeset', () => {
         const mixed = ['README.md', '.env', 'src/app.ts', 'Jenkinsfile'];
-        expect(findDeniedCommitPaths(mixed, { denyCiPaths: true })).toEqual([
-            '.env',
-            'Jenkinsfile',
-        ]);
+        expect(findDeniedCommitPaths(mixed)).toEqual(['.env', 'Jenkinsfile']);
     });
 });

--- a/packages/backend/src/ee/services/AiWritebackService/deniedPaths.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/deniedPaths.ts
@@ -7,15 +7,12 @@ import { ForbiddenError } from '@lightdash/common';
  * so this is the single place we can hard-stop a malicious or mistaken change
  * before it reaches a pull request.
  *
- * Two classes:
- * - SECRET paths (`.env*`, private keys, credential files): denied for EVERY
- *   coding-agent commit (dbt writeback included) — secrets must never land in a
+ * Two classes, both denied for every coding-agent commit:
+ * - SECRET paths (`.env*`, private keys, credential files) must never land in a
  *   PR (R6).
  * - CI/workflow paths (`.github/**`, `.gitlab-ci.yml`, `Jenkinsfile`,
- *   `.circleci/**`): denied for the GENERAL agent only (R3 — a malicious
- *   workflow file is RCE in the customer's CI). The dbt-writeback path legitimately
- *   adds `.github/workflows` when setting up Lightdash preview deploys, so CI
- *   denial is opt-in via `denyCiPaths`.
+ *   `.circleci/**`) can execute code in the customer's CI (R3). Trusted preview
+ *   workflows are generated outside the coding agent by PreviewDeploySetupService.
  */
 
 /** Secret/credential files — denied on every coding-agent commit. */
@@ -37,7 +34,7 @@ const SECRET_PATH_PATTERNS: RegExp[] = [
 ];
 
 /**
- * CI/workflow files — denied for the general agent (RCE in customer CI). Every
+ * CI/workflow files — denied for every coding agent (RCE in customer CI). Every
  * single-file CI config matches both `.yml` and `.yaml` (`ya?ml`); a malicious
  * workflow under the alternate extension must not slip the gate (R3).
  */
@@ -50,6 +47,8 @@ const CI_PATH_PATTERNS: RegExp[] = [
     /(^|\/)azure-pipelines\.ya?ml$/i,
     /(^|\/)bitbucket-pipelines\.ya?ml$/i,
 ];
+
+const DENIED_PATH_PATTERNS = [...SECRET_PATH_PATTERNS, ...CI_PATH_PATTERNS];
 
 /**
  * Thrown when a staged commit touches a denied path; no PR is opened. Extends
@@ -74,15 +73,8 @@ export class DeniedPathError extends ForbiddenError {
 
 /**
  * Return the subset of `paths` that a coding-agent commit must not touch.
- * Secrets are always denied; CI/workflow paths are denied only when
- * `denyCiPaths` is set (the general agent).
  */
-export const findDeniedCommitPaths = (
-    paths: string[],
-    { denyCiPaths }: { denyCiPaths: boolean },
-): string[] => {
-    const patterns = denyCiPaths
-        ? [...SECRET_PATH_PATTERNS, ...CI_PATH_PATTERNS]
-        : SECRET_PATH_PATTERNS;
-    return paths.filter((path) => patterns.some((re) => re.test(path)));
-};
+export const findDeniedCommitPaths = (paths: string[]): string[] =>
+    paths.filter((path) =>
+        DENIED_PATH_PATTERNS.some((pattern) => pattern.test(path)),
+    );

--- a/packages/backend/src/ee/services/AiWritebackService/providers/GitProvider.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/providers/GitProvider.ts
@@ -22,13 +22,6 @@ export type OpenPullRequestArgs = {
     /** The Lightdash user who triggered the run, credited as a commit co-author. */
     user: SessionUser;
     setStage: SetStage;
-    /**
-     * Reject the commit (no PR) if it touches CI/workflow files. Set for the
-     * general coding agent (R3); false for dbt writeback, which legitimately
-     * adds `.github/workflows` for preview-deploy setup. Secret files are denied
-     * regardless of this flag.
-     */
-    denyCiPaths: boolean;
 };
 
 export type UpdatePullRequestArgs = OpenPullRequestArgs & {

--- a/packages/backend/src/ee/services/AiWritebackService/providers/GithubProvider.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/providers/GithubProvider.ts
@@ -280,7 +280,6 @@ export class GithubProvider implements GitProvider {
             description,
             user,
             setStage,
-            denyCiPaths: args.denyCiPaths,
         });
 
         setStage('pull_request');
@@ -330,7 +329,6 @@ export class GithubProvider implements GitProvider {
             description,
             user,
             setStage,
-            denyCiPaths: args.denyCiPaths,
         });
 
         setStage('pull_request');
@@ -457,7 +455,6 @@ export class GithubProvider implements GitProvider {
         description,
         user,
         setStage,
-        denyCiPaths,
     }: {
         sandbox: SandboxHandle;
         connection: GithubConnection;
@@ -468,7 +465,6 @@ export class GithubProvider implements GitProvider {
         description: string;
         user: SessionUser;
         setStage: SetStage;
-        denyCiPaths: boolean;
     }): Promise<LandedCommit> {
         setStage('commit');
         const projectPaths = await resolveDbtProjectPaths(
@@ -477,7 +473,7 @@ export class GithubProvider implements GitProvider {
             this.logger,
         );
         await stageChanges(sandbox, projectPaths, this.logger);
-        const fileChanges = await collectFileChanges(sandbox, { denyCiPaths });
+        const fileChanges = await collectFileChanges(sandbox);
         // Read the line stat while the change is still staged — the local commit
         // below clears the index.
         const diffStat = await collectDiffStat(sandbox);

--- a/packages/backend/src/ee/services/AiWritebackService/providers/GitlabProvider.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/providers/GitlabProvider.test.ts
@@ -103,7 +103,6 @@ describe('GitlabProvider.openPullRequest', () => {
             description: 'Adds revenue.',
             user: { userUuid: 'u1' } as never,
             setStage: vi.fn(),
-            denyCiPaths: false,
         });
 
         expect(result.prUrl).toBe(
@@ -149,7 +148,6 @@ describe('GitlabProvider.openPullRequest', () => {
                 email: 'jane@acme.com',
             } as never,
             setStage: vi.fn(),
-            denyCiPaths: false,
         });
 
         expect(sandbox.git.commit).toHaveBeenCalledWith(
@@ -159,7 +157,7 @@ describe('GitlabProvider.openPullRequest', () => {
         );
     });
 
-    it('rejects a CI-touching commit (general agent) without pushing or opening an MR', async () => {
+    it('rejects a CI-touching commit without pushing or opening an MR', async () => {
         const sandbox = fakeSandbox();
         // The denied-path gate probes staged paths with `--name-status -z`;
         // return a CI/workflow path for that call, empty for everything else.
@@ -178,7 +176,6 @@ describe('GitlabProvider.openPullRequest', () => {
                 description: 'Adds CI.',
                 user: { userUuid: 'u1' } as never,
                 setStage: vi.fn(),
-                denyCiPaths: true,
             }),
         ).rejects.toBeInstanceOf(DeniedPathError);
 

--- a/packages/backend/src/ee/services/AiWritebackService/providers/GitlabProvider.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/providers/GitlabProvider.ts
@@ -243,7 +243,6 @@ export class GitlabProvider implements GitProvider {
             title,
             user,
             setStage,
-            denyCiPaths: args.denyCiPaths,
         });
 
         setStage('pull_request');
@@ -284,7 +283,6 @@ export class GitlabProvider implements GitProvider {
             title,
             user,
             setStage,
-            denyCiPaths: args.denyCiPaths,
         });
 
         setStage('pull_request');
@@ -423,7 +421,6 @@ export class GitlabProvider implements GitProvider {
         title,
         user,
         setStage,
-        denyCiPaths,
     }: {
         sandbox: SandboxHandle;
         connection: GitlabConnection;
@@ -432,7 +429,6 @@ export class GitlabProvider implements GitProvider {
         title: string;
         user: SessionUser;
         setStage: SetStage;
-        denyCiPaths: boolean;
     }): Promise<LandedCommit> {
         setStage('commit');
         const projectPaths = await resolveDbtProjectPaths(
@@ -443,8 +439,8 @@ export class GitlabProvider implements GitProvider {
         await stageChanges(sandbox, projectPaths, this.logger);
         // Host-side denied-path gate (GitLab pushes via git, so check the staged
         // paths here rather than in collectFileChanges). Reject the whole commit
-        // — secrets always, CI/workflow for the general agent.
-        await assertStagedPathsAllowed(sandbox, { denyCiPaths });
+        // before any commit or push reaches the remote.
+        await assertStagedPathsAllowed(sandbox);
         // Read the line stat while still staged — the local commit clears it.
         const diffStat = await collectDiffStat(sandbox);
         const userTrailer = buildUserCoAuthorTrailer(user);

--- a/packages/backend/src/ee/services/AiWritebackService/providers/sandboxGit.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/providers/sandboxGit.test.ts
@@ -23,11 +23,11 @@ const sandboxWith = (nameStatusZ: string) =>
 const b64 = (s: string) => Buffer.from(s, 'utf-8').toString('base64');
 
 describe('collectFileChanges — GitHub commit gate', () => {
-    it('throws DeniedPathError on a staged secret even when denyCiPaths is false, and never reads/commits it', async () => {
+    it('throws DeniedPathError on a staged secret and never reads/commits it', async () => {
         const sandbox = sandboxWith('A\0.env\0M\0models/x.sql\0');
-        await expect(
-            collectFileChanges(sandbox, { denyCiPaths: false }),
-        ).rejects.toBeInstanceOf(DeniedPathError);
+        await expect(collectFileChanges(sandbox)).rejects.toBeInstanceOf(
+            DeniedPathError,
+        );
         // A denied changeset must abort before any file content is read.
         expect(
             (sandbox as unknown as { files: { read: import('vitest').Mock } })
@@ -35,34 +35,22 @@ describe('collectFileChanges — GitHub commit gate', () => {
         ).not.toHaveBeenCalled();
     });
 
-    it('denies a CI/workflow file only for the general agent (denyCiPaths:true)', async () => {
+    it('denies a CI/workflow file for every writeback mode', async () => {
         const ci = 'A\0.github/workflows/deploy.yml\0';
         await expect(
-            collectFileChanges(sandboxWith(ci), { denyCiPaths: true }),
+            collectFileChanges(sandboxWith(ci)),
         ).rejects.toBeInstanceOf(DeniedPathError);
-
-        // dbt writeback legitimately adds .github/workflows for preview deploys,
-        // so the same path must pass when CI denial is off.
-        const ok = await collectFileChanges(sandboxWith(ci), {
-            denyCiPaths: false,
-        });
-        expect(ok.additions.map((a) => a.path)).toEqual([
-            '.github/workflows/deploy.yml',
-        ]);
     });
 
     it('catches a denied deletion too (rename collapses to delete+add via --no-renames)', async () => {
         await expect(
-            collectFileChanges(sandboxWith('D\0.env\0'), {
-                denyCiPaths: false,
-            }),
+            collectFileChanges(sandboxWith('D\0.env\0')),
         ).rejects.toBeInstanceOf(DeniedPathError);
     });
 
     it('passes an allowed changeset through to base64 additions + deletions', async () => {
         const result = await collectFileChanges(
             sandboxWith('A\0models/x.sql\0D\0old_model.sql\0'),
-            { denyCiPaths: true },
         );
         expect(result.additions).toEqual([
             { path: 'models/x.sql', contents: b64('contents') },
@@ -72,29 +60,22 @@ describe('collectFileChanges — GitHub commit gate', () => {
 });
 
 describe('assertStagedPathsAllowed — GitLab push gate', () => {
-    it('throws DeniedPathError on a staged secret regardless of denyCiPaths', async () => {
+    it('throws DeniedPathError on a staged secret', async () => {
         await expect(
-            assertStagedPathsAllowed(sandboxWith('A\0deploy/id_rsa\0'), {
-                denyCiPaths: false,
-            }),
+            assertStagedPathsAllowed(sandboxWith('A\0deploy/id_rsa\0')),
         ).rejects.toBeInstanceOf(DeniedPathError);
     });
 
-    it('denies a CI/workflow file only for the general agent, allows it otherwise', async () => {
+    it('denies a CI/workflow file', async () => {
         const ci = 'A\0.gitlab-ci.yml\0';
         await expect(
-            assertStagedPathsAllowed(sandboxWith(ci), { denyCiPaths: true }),
+            assertStagedPathsAllowed(sandboxWith(ci)),
         ).rejects.toBeInstanceOf(DeniedPathError);
-        await expect(
-            assertStagedPathsAllowed(sandboxWith(ci), { denyCiPaths: false }),
-        ).resolves.toBeUndefined();
     });
 
     it('allows an ordinary source changeset', async () => {
         await expect(
-            assertStagedPathsAllowed(sandboxWith('A\0models/x.sql\0'), {
-                denyCiPaths: true,
-            }),
+            assertStagedPathsAllowed(sandboxWith('A\0models/x.sql\0')),
         ).resolves.toBeUndefined();
     });
 });
@@ -253,17 +234,15 @@ describe('stageChanges', () => {
         };
     };
 
-    it('stages the given paths as files and also the repo-root workflows dir', async () => {
+    it('stages only the given project paths', async () => {
         const { sandbox, add, run } = stagingSandbox();
         const paths = ['fabrics/.../core', 'packages/.../analytics'];
         await stageChanges(sandbox, paths, logger);
         expect(add).toHaveBeenCalledWith(expect.any(String), { files: paths });
-        expect(run).toHaveBeenCalledWith(
-            expect.stringContaining('add .github/workflows'),
-        );
+        expect(run).not.toHaveBeenCalled();
     });
 
-    it('falls back to --all (and skips workflows) when the project is the repo root', async () => {
+    it('falls back to --all when the project is the repo root', async () => {
         const { sandbox, add, run } = stagingSandbox();
         await stageChanges(sandbox, ['.'], logger);
         expect(add).toHaveBeenCalledWith(expect.any(String), { all: true });

--- a/packages/backend/src/ee/services/AiWritebackService/providers/sandboxGit.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/providers/sandboxGit.ts
@@ -200,15 +200,6 @@ export const stageChanges = async (
         CWD,
         scopedToProject ? { files: paths } : { all: true },
     );
-    if (scopedToProject) {
-        // Also stage Lightdash CI workflow files the agent may have added when
-        // setting up preview deploys — they live at the repo root, outside the
-        // dbt subtree. `.github/workflows` is a known-safe path; tolerate its
-        // absence when no preview-deploy setup happened this turn.
-        await sandbox.commands.run(
-            `git -C ${CWD} add .github/workflows 2>/dev/null || true`,
-        );
-    }
 };
 
 /**
@@ -220,20 +211,19 @@ export const stageChanges = async (
  */
 export const collectFileChanges = async (
     sandbox: SandboxHandle,
-    { denyCiPaths }: { denyCiPaths: boolean } = { denyCiPaths: false },
 ): Promise<GithubFileChanges> => {
     const { stdout } = await sandbox.commands.run(
         `git -C ${CWD} diff --cached --name-status --no-renames -z`,
     );
     const { addPaths, deletions } = parseGitNameStatus(stdout);
     // Host-side denied-path gate: reject the whole commit (no PR) if any staged
-    // path is a secret file (always) or a CI/workflow file (general agent). The
+    // path is a secret or CI/workflow file. The
     // agent has no Bash and commits via the host, so this is the enforceable
     // chokepoint — not just a prompt instruction.
-    const denied = findDeniedCommitPaths(
-        [...addPaths, ...deletions.map((d) => d.path)],
-        { denyCiPaths },
-    );
+    const denied = findDeniedCommitPaths([
+        ...addPaths,
+        ...deletions.map((deletion) => deletion.path),
+    ]);
     if (denied.length > 0) {
         throw new DeniedPathError(denied);
     }
@@ -253,21 +243,19 @@ export const collectFileChanges = async (
  * Reject the staged commit (throwing {@link DeniedPathError}) if it touches a
  * denied path. For providers that push via git (GitLab) rather than committing
  * through {@link collectFileChanges} (GitHub), so the same denied-path guard
- * still applies. Secrets are always denied; CI/workflow paths only when
- * `denyCiPaths` is set.
+ * still applies.
  */
 export const assertStagedPathsAllowed = async (
     sandbox: SandboxHandle,
-    { denyCiPaths }: { denyCiPaths: boolean },
 ): Promise<void> => {
     const { stdout } = await sandbox.commands.run(
         `git -C ${CWD} diff --cached --name-status --no-renames -z`,
     );
     const { addPaths, deletions } = parseGitNameStatus(stdout);
-    const denied = findDeniedCommitPaths(
-        [...addPaths, ...deletions.map((d) => d.path)],
-        { denyCiPaths },
-    );
+    const denied = findDeniedCommitPaths([
+        ...addPaths,
+        ...deletions.map((deletion) => deletion.path),
+    ]);
     if (denied.length > 0) {
         throw new DeniedPathError(denied);
     }


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9474/veria-102-arbitrary-code-execution-in-customer-ci-via-ai-writeback

## Summary

AI writeback can no longer commit agent-authored CI or workflow files in dbt mode. The host rejects those paths for every writeback mode before a commit, push, or pull request can reach the customer's repository.

The dedicated `setupPreviewDeploy` tool still creates its reviewed workflow templates through the deterministic, permission-gated `PreviewDeploySetupService` path.

## Root cause

Preview-deploy setup originally ran inside the dbt writeback sandbox, so dbt mode explicitly staged `.github/workflows` and disabled the CI-path commit gate. Preview setup later moved to a separate deterministic service, but the old exemption remained and allowed arbitrary workflow content from the dbt agent to reach a branch.

```ts
denyCiPaths: config.mode === 'general'
```

## Fix

The writeback commit boundary now has one invariant: secrets and CI/workflow paths are denied for every coding-agent commit.

- Removes the mode-dependent opt-out from the writeback and git-provider APIs.
- Stops nested dbt projects from explicitly staging repo-root `.github/workflows`.
- Keeps the trusted `PreviewDeploySetupService` generation path unchanged.
- Leaves broader denylist pattern hardening to PROD-8684.

## Before

```text
Dbt agent
  ├─ stages dbt project
  ├─ stages .github/workflows
  └─ dbt exemption → commit / push / PR → customer CI can execute
```

## After

```text
Dbt or general agent
  └─ staged change → unconditional host denylist → DeniedPathError
                                                  └─ no commit / push / PR

setupPreviewDeploy
  └─ deterministic reviewed templates → signed GitHub API commit → setup PR
```

## Test plan

- [x] Regression test fails before the fix when dbt mode accepts `.github/workflows/deploy.yml`, then passes after the fix.
- [x] 37 denylist, staging, GitLab provider, and preview-deploy setup tests pass.
- [x] 133 AiWritebackService and GitHub provider tests pass.
- [x] `pnpm -F backend typecheck`
- [x] `pnpm -F backend lint`
- [x] `pnpm -F backend format`
- [x] `git diff --check`