### PR TITLE
fix: generate data app slug from async name

### DIFF
--- a/packages/backend/src/database/entities/apps.ts
+++ b/packages/backend/src/database/entities/apps.ts
@@ -68,6 +68,7 @@ export type AppsTable = Knex.CompositeTableType<
             DbApp,
             | 'name'
             | 'description'
+            | 'slug'
             | 'space_uuid'
             | 'sandbox_id'
             | 'design_uuid'

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -4224,19 +4224,20 @@ export class AppGenerateService extends BaseService {
             )
                 .then(async (metadata) => {
                     if (metadata.name) {
-                        // Only fills fields the user hasn't already set — the
-                        // build is async, so the user may have renamed the app
-                        // while it was building.
-                        await this.appModel.setMetadataIfUnset(
-                            appUuid,
-                            projectUuid,
-                            {
-                                name: metadata.name,
-                                description: metadata.description,
-                            },
-                        );
+                        // Only fills fields the user hasn't already set. When
+                        // the name is applied, the temporary slug is replaced
+                        // from the same generated name.
+                        const updatedApp =
+                            await this.appModel.setMetadataIfUnset(
+                                appUuid,
+                                projectUuid,
+                                {
+                                    name: metadata.name,
+                                    description: metadata.description,
+                                },
+                            );
                         this.logger.info(
-                            `App ${appUuid}: auto-named "${metadata.name}"`,
+                            `App ${appUuid}: auto-named "${updatedApp.name}" (slug=${updatedApp.slug})`,
                         );
                     }
                     return AppGenerateService.elapsed(metadataStart);

--- a/packages/backend/src/models/AppModel.test.ts
+++ b/packages/backend/src/models/AppModel.test.ts
@@ -1,0 +1,115 @@
+import knex from 'knex';
+import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import { AppsTableName, type DbApp } from '../database/entities/apps';
+import { AppModel } from './AppModel';
+
+const appId = '11111111-1111-4111-8111-111111111111';
+const projectUuid = '22222222-2222-4222-8222-222222222222';
+
+const appRow: DbApp = {
+    app_id: appId,
+    name: '',
+    description: '',
+    project_uuid: projectUuid,
+    slug: 'app-1',
+    space_uuid: null,
+    sandbox_id: null,
+    template: null,
+    design_uuid: null,
+    upstream_app_uuid: null,
+    created_at: new Date(),
+    created_by_user_uuid: '33333333-3333-4333-8333-333333333333',
+    deleted_at: null,
+    deleted_by_user_uuid: null,
+    views_count: 0,
+    search_vector: '',
+};
+
+describe('AppModel.setMetadataIfUnset', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new AppModel({ database });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    beforeEach(() => {
+        tracker.on.select('pg_advisory_xact_lock').response({});
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    it('replaces the temporary slug with one derived from the generated name', async () => {
+        const updatedApp = {
+            ...appRow,
+            name: 'Sales Performance Overview',
+            description: 'A view of sales performance.',
+            slug: 'sales-performance-overview',
+        };
+        tracker.on.select(AppsTableName).responseOnce(appRow);
+        tracker.on.select(AppsTableName).responseOnce([]);
+        tracker.on.update(AppsTableName).responseOnce([updatedApp]);
+
+        const result = await model.setMetadataIfUnset(appId, projectUuid, {
+            name: 'Sales Performance Overview',
+            description: 'A view of sales performance.',
+        });
+
+        expect(result).toEqual(updatedApp);
+        expect(tracker.history.update[0].bindings).toContain(
+            'sales-performance-overview',
+        );
+    });
+
+    it('preserves project-scoped uniqueness for the generated slug', async () => {
+        const updatedApp = {
+            ...appRow,
+            name: 'Sales Performance Overview',
+            description: 'A view of sales performance.',
+            slug: 'sales-performance-overview-1',
+        };
+        tracker.on.select(AppsTableName).responseOnce(appRow);
+        tracker.on
+            .select(AppsTableName)
+            .responseOnce([{ slug: 'sales-performance-overview' }]);
+        tracker.on.select(AppsTableName).responseOnce([]);
+        tracker.on.update(AppsTableName).responseOnce([updatedApp]);
+
+        const result = await model.setMetadataIfUnset(appId, projectUuid, {
+            name: 'Sales Performance Overview',
+            description: 'A view of sales performance.',
+        });
+
+        expect(result.slug).toBe('sales-performance-overview-1');
+        expect(tracker.history.update[0].bindings).toContain(
+            'sales-performance-overview-1',
+        );
+    });
+
+    it('does not change the name or slug after a user has named the app', async () => {
+        const manuallyNamedApp = {
+            ...appRow,
+            name: 'My Revenue App',
+            slug: 'my-revenue-app',
+        };
+        const updatedApp = {
+            ...manuallyNamedApp,
+            description: 'A generated description.',
+        };
+        tracker.on.select(AppsTableName).responseOnce(manuallyNamedApp);
+        tracker.on.update(AppsTableName).responseOnce([updatedApp]);
+
+        const result = await model.setMetadataIfUnset(appId, projectUuid, {
+            name: 'Generated Revenue Overview',
+            description: 'A generated description.',
+        });
+
+        expect(result).toEqual(updatedApp);
+        expect(tracker.history.select).toHaveLength(1);
+        expect(tracker.history.update[0].sql).not.toContain('"slug"');
+        expect(tracker.history.update[0].sql).not.toContain('"name"');
+    });
+});

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -1077,34 +1077,60 @@ export class AppModel {
     }
 
     /**
-     * Atomically set auto-generated name/description, but only for fields
-     * that are still at their empty-string default. Used by the background
-     * pipeline so it cannot clobber edits the user made while the build
-     * was running.
+     * Atomically set auto-generated metadata for fields that are still unset.
+     * When the generated name wins the race, replace the temporary app-N slug
+     * with a unique slug derived from that name.
      */
     async setMetadataIfUnset(
         appId: string,
         projectUuid: string,
         metadata: { name: string; description: string },
     ): Promise<DbApp> {
-        const [row] = await this.database(AppsTableName)
-            .where({ app_id: appId, project_uuid: projectUuid })
-            .whereNull('deleted_at')
-            .update({
-                name: this.database.raw(
-                    `CASE WHEN ${AppsTableName}.name = '' THEN ? ELSE ${AppsTableName}.name END`,
-                    [metadata.name],
-                ) as unknown as string,
-                description: this.database.raw(
+        return this.database.transaction(async (trx) => {
+            const app = await trx(AppsTableName)
+                .where({ app_id: appId, project_uuid: projectUuid })
+                .whereNull('deleted_at')
+                .forUpdate()
+                .first();
+            if (!app) {
+                throw new NotFoundError(`App not found: ${appId}`);
+            }
+
+            const update: Partial<
+                Pick<DbApp, 'name' | 'description' | 'slug'>
+            > = {
+                description: trx.raw(
                     `CASE WHEN ${AppsTableName}.description = '' THEN ? ELSE ${AppsTableName}.description END`,
                     [metadata.description],
                 ) as unknown as string,
-            })
-            .returning('*');
-        if (!row) {
-            throw new NotFoundError(`App not found: ${appId}`);
-        }
-        return row;
+            };
+
+            if (app.name === '') {
+                const baseSlug = generateSlug(metadata.name).slice(0, 255);
+                let { slug } = app;
+                if (baseSlug !== app.slug) {
+                    await acquireProjectSlugLock(trx, projectUuid, baseSlug);
+                    slug = await generateUniqueSlugScopedToProject(
+                        trx,
+                        projectUuid,
+                        AppsTableName,
+                        baseSlug,
+                    );
+                }
+                update.name = metadata.name;
+                update.slug = slug;
+            }
+
+            const [row] = await trx(AppsTableName)
+                .where({ app_id: appId, project_uuid: projectUuid })
+                .whereNull('deleted_at')
+                .update(update)
+                .returning('*');
+            if (!row) {
+                throw new NotFoundError(`App not found: ${appId}`);
+            }
+            return row;
+        });
     }
 
     async moveToSpace(


### PR DESCRIPTION
Closes: [PROD-9663](https://linear.app/lightdash/issue/PROD-9663)

### Description:

New Data Apps are initially created before their AI-generated metadata is available, so they receive temporary slugs such as `app-1`. The async metadata update previously set the generated name and description but left that temporary slug unchanged.

This change updates the slug atomically when the generated name is applied:

- derives a human-readable slug from the generated app name
- preserves project-scoped slug uniqueness
- preserves a user's name and slug if they rename the app while generation is running
- logs the final generated name and slug
- adds model tests covering slug replacement, uniqueness, and concurrent user edits

### Impact:

Generated Data Apps now receive readable URLs such as `f1-season-2026-insights` instead of retaining a generic `app-N` slug.

### Validation:

- `pnpm -F backend typecheck`
- `pnpm -F backend test -- AppModel.test.ts` — 5,933 passed, 1 skipped
- verified end to end locally with async Data App generation