### PR TITLE
feat(ai-agents): hide preview projects by default in agents admin table

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminAgentsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminAgentsTable.tsx
@@ -1,4 +1,4 @@
-import { type AiAgentSummary } from '@lightdash/common';
+import { ProjectType, type AiAgentSummary } from '@lightdash/common';
 import {
     ActionIcon,
     Badge,
@@ -8,6 +8,7 @@ import {
     Group,
     Menu,
     Paper,
+    Switch,
     Text,
     Tooltip,
     useMantineTheme,
@@ -64,6 +65,7 @@ const AiAgentAdminAgentsTable = () => {
     const [selectedProjectUuids, setSelectedProjectUuids] = useState<string[]>(
         () => projectsParam?.split(',').filter(Boolean) ?? [],
     );
+    const [hidePreviewProjects, setHidePreviewProjects] = useState(true);
 
     useEffect(() => {
         setSelectedProjectUuids(
@@ -141,6 +143,15 @@ const AiAgentAdminAgentsTable = () => {
 
         let filtered = agents;
 
+        // Hide agents that belong to preview projects
+        if (hidePreviewProjects) {
+            filtered = filtered.filter(
+                (agent) =>
+                    projectsMap.get(agent.projectUuid)?.type !==
+                    ProjectType.PREVIEW,
+            );
+        }
+
         // Filter by project
         if (selectedProjectUuids.length > 0) {
             filtered = filtered.filter((agent) =>
@@ -169,15 +180,23 @@ const AiAgentAdminAgentsTable = () => {
         }
 
         return filtered;
-    }, [agents, selectedProjectUuids, deferredSearch, projectsMap]);
+    }, [
+        agents,
+        selectedProjectUuids,
+        deferredSearch,
+        projectsMap,
+        hidePreviewProjects,
+    ]);
 
     const hasActiveFilters =
         (search !== undefined && search !== '') ||
-        selectedProjectUuids.length > 0;
+        selectedProjectUuids.length > 0 ||
+        !hidePreviewProjects;
 
     const handleClearFilters = () => {
         setSearch(undefined);
         handleSelectedProjectUuidsChange([]);
+        setHidePreviewProjects(true);
     };
 
     const columns: ContentTableColumnDef<AiAgentSummary>[] = useMemo(
@@ -611,6 +630,25 @@ const AiAgentAdminAgentsTable = () => {
                                 handleSelectedProjectUuidsChange
                             }
                             tooltipLabel="Filter agents by project"
+                        />
+
+                        <Divider
+                            orientation="vertical"
+                            w={1}
+                            h={20}
+                            style={{
+                                alignSelf: 'center',
+                            }}
+                        />
+                        <Switch
+                            size="xs"
+                            label="Hide preview projects"
+                            checked={hidePreviewProjects}
+                            onChange={(event) =>
+                                setHidePreviewProjects(
+                                    event.currentTarget.checked,
+                                )
+                            }
                         />
 
                         {hasActiveFilters && (


### PR DESCRIPTION
## Summary
Adds a "Hide preview projects" switch (on by default) to the Ask AI agents admin table (`/generalSettings/ai/agents`), so preview-project agents don't clutter the list by default. Toggling it off shows all agents again, and it resets via "Clear all filters".

## Changes
- `AiAgentAdminAgentsTable.tsx`: new `hidePreviewProjects` state (default `true`), filters `filteredAgents` against `ProjectType.PREVIEW` using the existing `projectsMap` join, and adds a `Switch` control in the toolbar next to the project filter.

## Test plan
- [ ] Load `/generalSettings/ai/agents` with agents in both default and preview projects — verify preview-project agents are hidden by default
- [ ] Toggle "Hide preview projects" off — verify preview-project agents appear
- [ ] Combine with search/project filters — verify filters compose correctly
- [ ] Click "Clear all filters" — verify the switch resets to hidden (default) state