### PR TITLE
fix(ai): exclude SQL result preview from stored tool result when data access is off

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -771,6 +771,7 @@ export const getAgentTools = (
               storeToolResults: dependencies.storeToolResults,
               createOrUpdateArtifact: dependencies.createOrUpdateArtifact,
               maxQueryLimit: args.runSqlMaxLimit,
+              enableDataAccess: args.enableDataAccess,
               autoApproveSql: args.autoApproveSql,
               autoApproveSqlUserUuid: args.autoApproveSqlUserUuid,
               useSlackStreamCard: args.useSlackStreamCard,

--- a/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
@@ -200,6 +200,7 @@ const makeAgentTools = () => {
         }),
         runSql: getRunSql({
             createOrUpdateArtifact: noop,
+            enableDataAccess: true,
             getPrompt: noop,
             recordSqlApproval: noop,
             isThreadSqlAutoApproved: noop,

--- a/packages/backend/src/ee/services/ai/tools/runSql.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.test.ts
@@ -12,6 +12,7 @@ type MakeToolOptions = {
     waitForSqlApproval?: import('vitest').Mock;
     recordSqlApproval?: import('vitest').Mock;
     maxQueryLimit?: number;
+    enableDataAccess?: boolean;
 };
 
 const executeRunSql = (tool: RunSqlTool, toolCallId: string = 'tool-call-1') =>
@@ -57,6 +58,7 @@ const makeTool = ({
     waitForSqlApproval = vi.fn().mockResolvedValue('approved'),
     recordSqlApproval = vi.fn().mockResolvedValue(true),
     maxQueryLimit = 5000,
+    enableDataAccess = true,
     useSlackStreamCard = false,
     prompt = makePrompt(),
 }: MakeToolOptions & {
@@ -83,6 +85,7 @@ const makeTool = ({
         autoApproveSql,
         autoApproveSqlUserUuid,
         maxQueryLimit,
+        enableDataAccess,
         useSlackStreamCard,
     };
 
@@ -229,6 +232,30 @@ describe('getRunSql', () => {
             'tool-call-1',
         );
         expect(dependencies.runSqlJob).not.toHaveBeenCalled();
+    });
+
+    it('includes a CSV preview in the result when data access is enabled', async () => {
+        const { tool } = makeTool({ autoApproveSql: true });
+
+        const output = await executeRunSql(tool);
+
+        expect(output.metadata?.status).toBe('success');
+        expect(output.result).toContain('1 rows. Columns: answer.');
+        expect(output.result).toContain('```csv');
+        expect(output.result).toContain('answer');
+    });
+
+    it('returns only a summary when data access is disabled', async () => {
+        const { tool } = makeTool({
+            autoApproveSql: true,
+            enableDataAccess: false,
+        });
+
+        const output = await executeRunSql(tool);
+
+        expect(output.metadata?.status).toBe('success');
+        expect(output.result).toBe('1 rows. Columns: answer.');
+        expect(output.result).not.toContain('```csv');
     });
 
     it('rejects nested SQL execution functions before approval', async () => {

--- a/packages/backend/src/ee/services/ai/tools/runSql.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.ts
@@ -37,6 +37,7 @@ type Dependencies = {
     storeToolResults: StoreToolResultsFn;
     createOrUpdateArtifact: CreateOrUpdateArtifactFn;
     maxQueryLimit: number;
+    enableDataAccess: boolean;
     autoApproveSql?: boolean;
     autoApproveSqlUserUuid?: string | null;
     useSlackStreamCard?: boolean;
@@ -97,6 +98,7 @@ export const getRunSql = ({
     storeToolResults,
     createOrUpdateArtifact,
     maxQueryLimit,
+    enableDataAccess,
     autoApproveSql = false,
     autoApproveSqlUserUuid = null,
     useSlackStreamCard = false,
@@ -347,6 +349,17 @@ export const getRunSql = ({
                     }
                 }
 
+                const resultSummary = `${rowCount} rows. Columns: ${columns.join(
+                    ', ',
+                )}.`;
+
+                if (!enableDataAccess) {
+                    return await persistResumeResult({
+                        result: resultSummary,
+                        metadata: { status: 'success', rowCount },
+                    });
+                }
+
                 const previewRows = rows.slice(0, PREVIEW_ROW_LIMIT);
                 const previewCsv = stringify(
                     previewRows.map((row) =>
@@ -364,9 +377,10 @@ export const getRunSql = ({
                         : '';
 
                 return await persistResumeResult({
-                    result: `${rowCount} rows. Columns: ${columns.join(
-                        ', ',
-                    )}.${truncatedNote}\n${serializeData(previewCsv, 'csv')}`,
+                    result: `${resultSummary}${truncatedNote}\n${serializeData(
+                        previewCsv,
+                        'csv',
+                    )}`,
                     metadata: { status: 'success', rowCount },
                 });
             } catch (e) {


### PR DESCRIPTION
The \`runSql\` agent tool always embedded a 50-row CSV preview of warehouse results into the persisted tool result (\`ai_agent_tool_result\`), even when the agent had data access disabled — unlike \`runQuery\`, which returns a summary-only result in that mode. The data-access toggle is documented as metadata-only behavior, so row values shouldn't land in thread storage when it's off.

The tool now receives \`enableDataAccess\` (the arg was already available in the agent wiring) and, when disabled, returns just the row count and column names — the CSV preview is only built and stored when data access is on. Slack-side rendering (inline preview, CSV file upload) is unchanged, mirroring \`runQuery\`'s behavior.

Closes ZAP-782