### PR TITLE
fix(data-apps): authorize viz render against the previewed chart version

### DIFF
--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -251,6 +251,7 @@ export class AppGenerateController extends BaseController {
         @Path() projectUuid: string,
         @Path() savedChartUuid: UUID,
         @Path() dataAppVizUuid: string,
+        @Query() chartVersionUuid?: UUID,
     ): Promise<ApiDataAppVizRenderMetadataResponse> {
         assertRegisteredAccount(req.account);
         const result =
@@ -259,6 +260,7 @@ export class AppGenerateController extends BaseController {
                 projectUuid,
                 savedChartUuid,
                 dataAppVizUuid,
+                chartVersionUuid,
             );
         return {
             status: 'ok',
@@ -281,6 +283,7 @@ export class AppGenerateController extends BaseController {
         @Path() savedChartUuid: UUID,
         @Path() dataAppVizUuid: string,
         @Path() version: number,
+        @Query() chartVersionUuid?: UUID,
     ): Promise<ApiDataAppVizPreviewTokenResponse> {
         assertRegisteredAccount(req.account);
         const token =
@@ -290,6 +293,7 @@ export class AppGenerateController extends BaseController {
                 savedChartUuid,
                 dataAppVizUuid,
                 version,
+                chartVersionUuid,
             );
         return {
             status: 'ok',

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
@@ -499,6 +499,42 @@ describe('AppGenerateService data app vizs', () => {
             expect(appModel.getVersion).not.toHaveBeenCalled();
         });
 
+        it('authorizes against the requested chart version, not the latest', async () => {
+            const appModel = {
+                findVisualizationApp: vi
+                    .fn()
+                    .mockResolvedValue(makeDataAppVizRow()),
+                getLatestVersion: vi.fn().mockResolvedValue(makeVersion()),
+                getLatestRenderableDataAppVizVersion: vi
+                    .fn()
+                    .mockResolvedValue(makeVersion()),
+            };
+            const get = vi.fn().mockResolvedValue({
+                uuid: 'chart-1',
+                chartConfig: {
+                    type: ChartType.DATA_APP_VIZ,
+                    config: { dataAppVizUuid: 'data-app-viz-1' },
+                },
+            });
+            const service = buildService(appModel, {
+                savedChartService: { hasAccess: vi.fn().mockResolvedValue([]) },
+                savedChartModel: { get },
+            });
+
+            await expect(
+                service.getChartDataAppVizRenderMetadata(
+                    USER,
+                    'project-1',
+                    'chart-1',
+                    'data-app-viz-1',
+                    'chart-version-7',
+                ),
+            ).resolves.toMatchObject({ state: 'ready' });
+            expect(get).toHaveBeenCalledWith('chart-1', 'chart-version-7', {
+                projectUuid: 'project-1',
+            });
+        });
+
         it('rejects a chart that does not reference the requested viz', async () => {
             const appModel = {
                 findVisualizationApp: vi

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -7728,6 +7728,7 @@ export class AppGenerateService extends BaseService {
         projectUuid: string,
         savedChartUuid: string,
         dataAppVizUuid: string,
+        chartVersionUuid?: string,
     ) {
         const dataAppViz = await resolveDataAppVisualizationForRender(
             this.appModel,
@@ -7743,12 +7744,12 @@ export class AppGenerateService extends BaseService {
             { savedChartUuid },
         );
 
+        // Version history previews an older config, so authorize against the
+        // version actually being rendered rather than the latest one.
         const chart = await this.savedChartModel.get(
             savedChartUuid,
-            undefined,
-            {
-                projectUuid,
-            },
+            chartVersionUuid,
+            { projectUuid },
         );
         if (
             chart.chartConfig.type !== ChartType.DATA_APP_VIZ ||
@@ -7811,12 +7812,14 @@ export class AppGenerateService extends BaseService {
         projectUuid: string,
         savedChartUuid: string,
         dataAppVizUuid: string,
+        chartVersionUuid?: string,
     ): Promise<DataAppVizRenderMetadata> {
         const dataAppViz = await this.getAuthorizedDataAppVizForChart(
             user,
             projectUuid,
             savedChartUuid,
             dataAppVizUuid,
+            chartVersionUuid,
         );
         return resolveDataAppVizRenderMetadata(
             this.appModel,
@@ -7830,12 +7833,14 @@ export class AppGenerateService extends BaseService {
         savedChartUuid: string,
         dataAppVizUuid: string,
         version: number,
+        chartVersionUuid?: string,
     ): Promise<string> {
         const dataAppViz = await this.getAuthorizedDataAppVizForChart(
             user,
             projectUuid,
             savedChartUuid,
             dataAppVizUuid,
+            chartVersionUuid,
         );
 
         await resolveRenderableDataAppVizVersion(

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -9,6 +9,7 @@ import { useEffect, useMemo, useRef, type FC } from 'react';
 import { useParams } from 'react-router';
 import useEmbed from '../../ee/providers/Embed/useEmbed';
 import AppIframePreview from '../../features/apps/AppIframePreview';
+import { useChartVersionPreview } from '../../features/apps/ChartVersionPreview/useChartVersionPreview';
 import {
     useDataAppVizPreviewToken,
     useDataAppVizRenderMetadata,
@@ -82,9 +83,10 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
     const optionValues = config?.optionValues;
     const rows = resultsData?.rows;
 
+    const chartVersionUuid = useChartVersionPreview();
     const renderTarget = useMemo(
-        () => ({ isEmbedded: !!embedToken, savedChartUuid }),
-        [embedToken, savedChartUuid],
+        () => ({ isEmbedded: !!embedToken, savedChartUuid, chartVersionUuid }),
+        [embedToken, savedChartUuid, chartVersionUuid],
     );
     const { data: renderMetadata, error: renderMetadataError } =
         useDataAppVizRenderMetadata(

--- a/packages/frontend/src/features/apps/ChartVersionPreview/ChartVersionPreviewProvider.tsx
+++ b/packages/frontend/src/features/apps/ChartVersionPreview/ChartVersionPreviewProvider.tsx
@@ -1,0 +1,13 @@
+import { type FC, type ReactNode } from 'react';
+import { ChartVersionPreviewContext } from './context';
+
+const ChartVersionPreviewProvider: FC<{
+    versionUuid: string | undefined;
+    children: ReactNode;
+}> = ({ versionUuid, children }) => (
+    <ChartVersionPreviewContext.Provider value={versionUuid}>
+        {children}
+    </ChartVersionPreviewContext.Provider>
+);
+
+export default ChartVersionPreviewProvider;

--- a/packages/frontend/src/features/apps/ChartVersionPreview/context.ts
+++ b/packages/frontend/src/features/apps/ChartVersionPreview/context.ts
@@ -1,0 +1,10 @@
+import { createContext } from 'react';
+
+/**
+ * The saved-chart version currently being previewed, when a surface renders an
+ * older config than the chart's latest one. Undefined everywhere else, which
+ * means "the latest version".
+ */
+export const ChartVersionPreviewContext = createContext<string | undefined>(
+    undefined,
+);

--- a/packages/frontend/src/features/apps/ChartVersionPreview/useChartVersionPreview.ts
+++ b/packages/frontend/src/features/apps/ChartVersionPreview/useChartVersionPreview.ts
@@ -1,0 +1,5 @@
+import { useContext } from 'react';
+import { ChartVersionPreviewContext } from './context';
+
+export const useChartVersionPreview = (): string | undefined =>
+    useContext(ChartVersionPreviewContext);

--- a/packages/frontend/src/features/apps/hooks/useDataAppVizRender.test.tsx
+++ b/packages/frontend/src/features/apps/hooks/useDataAppVizRender.test.tsx
@@ -56,6 +56,7 @@ describe('useDataAppVizRender', () => {
             'viz-1',
             'registered',
             'chart-1',
+            undefined,
         ]);
         expect(query.enabled).toBe(true);
         await query.queryFn();
@@ -69,6 +70,38 @@ describe('useDataAppVizRender', () => {
         expect(query.refetchInterval?.({ latestBuildInProgress: false })).toBe(
             false,
         );
+    });
+
+    it('passes the previewed chart version through to the registered route', async () => {
+        const target = {
+            isEmbedded: false,
+            savedChartUuid: 'chart-1',
+            chartVersionUuid: 'version-9',
+        };
+        const { result } = renderHook(() =>
+            useDataAppVizRenderMetadata('project-1', 'viz-1', target),
+        );
+        await (result.current as unknown as CapturedQuery).queryFn();
+        expect(mocks.lightdashApi).toHaveBeenLastCalledWith({
+            method: 'GET',
+            url: '/ee/projects/project-1/apps/visualizations/viz-1/charts/chart-1/render-metadata?chartVersionUuid=version-9',
+        });
+    });
+
+    it('does not send a chart version on the embed route', async () => {
+        const target = {
+            isEmbedded: true,
+            savedChartUuid: 'chart-1',
+            chartVersionUuid: 'version-9',
+        };
+        const { result } = renderHook(() =>
+            useDataAppVizRenderMetadata('project-1', 'viz-1', target),
+        );
+        await (result.current as unknown as CapturedQuery).queryFn();
+        expect(mocks.lightdashApi).toHaveBeenLastCalledWith({
+            method: 'GET',
+            url: '/embed/project-1/chart/chart-1/visualizations/viz-1/render-metadata',
+        });
     });
 
     it('falls back to the chart-less authoring route while editing', async () => {
@@ -127,6 +160,7 @@ describe('useDataAppVizRender', () => {
             7,
             'embed',
             'chart-1',
+            undefined,
         ]);
         expect(mocks.lightdashApi).toHaveBeenLastCalledWith({
             method: 'GET',

--- a/packages/frontend/src/features/apps/hooks/useDataAppVizRender.ts
+++ b/packages/frontend/src/features/apps/hooks/useDataAppVizRender.ts
@@ -13,6 +13,9 @@ const DATA_APP_VIZ_RENDER_MAX_RETRIES = 3;
 type DataAppVizRenderTarget = {
     isEmbedded: boolean;
     savedChartUuid: string | undefined;
+    // Set only while previewing an older chart version; the backend authorizes
+    // against that version's config instead of the latest.
+    chartVersionUuid?: string | undefined;
 };
 
 // Rendering a saved chart authorizes against that chart; the chart-less route is
@@ -29,6 +32,15 @@ const getRenderBaseUrl = (
         ? `/ee/projects/${projectUuid}/apps/visualizations/${dataAppVizUuid}/charts/${savedChartUuid}`
         : `/ee/projects/${projectUuid}/apps/visualizations/${dataAppVizUuid}`;
 };
+
+const getChartVersionQuery = ({
+    isEmbedded,
+    savedChartUuid,
+    chartVersionUuid,
+}: DataAppVizRenderTarget): string =>
+    !isEmbedded && savedChartUuid && chartVersionUuid
+        ? `?chartVersionUuid=${chartVersionUuid}`
+        : '';
 
 const isTargetReady = (
     projectUuid: string | undefined,
@@ -62,6 +74,7 @@ export const useDataAppVizRenderMetadata = (
             dataAppVizUuid,
             target.isEmbedded ? 'embed' : 'registered',
             target.savedChartUuid,
+            target.chartVersionUuid,
         ],
         queryFn: () =>
             lightdashApi<ApiDataAppVizRenderMetadataResponse['results']>({
@@ -70,7 +83,7 @@ export const useDataAppVizRenderMetadata = (
                     projectUuid!,
                     dataAppVizUuid!,
                     target,
-                )}/render-metadata`,
+                )}/render-metadata${getChartVersionQuery(target)}`,
             }),
         enabled: isTargetReady(projectUuid, dataAppVizUuid, target),
         retry: shouldRetryDataAppVizRenderQuery,
@@ -94,6 +107,7 @@ export const useDataAppVizPreviewToken = (
             version,
             target.isEmbedded ? 'embed' : 'registered',
             target.savedChartUuid,
+            target.chartVersionUuid,
         ],
         queryFn: async () => {
             const { token } = await lightdashApi<
@@ -104,7 +118,9 @@ export const useDataAppVizPreviewToken = (
                     projectUuid!,
                     dataAppVizUuid!,
                     target,
-                )}/versions/${version}/preview-token`,
+                )}/versions/${version}/preview-token${getChartVersionQuery(
+                    target,
+                )}`,
             });
             return token;
         },

--- a/packages/frontend/src/pages/ChartHistory.tsx
+++ b/packages/frontend/src/pages/ChartHistory.tsx
@@ -24,6 +24,7 @@ import Page from '../components/common/Page/Page';
 import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import Explorer from '../components/Explorer';
+import ChartVersionPreviewProvider from '../features/apps/ChartVersionPreview/ChartVersionPreviewProvider';
 import {
     buildInitialExplorerState,
     createExplorerStore,
@@ -90,7 +91,11 @@ const ChartHistoryExplorer = memo<{ selectedVersionUuid: string | undefined }>(
 
         return (
             <Provider store={store}>
-                <ChartHistoryContent />
+                <ChartVersionPreviewProvider
+                    versionUuid={chartVersionQuery.data.versionUuid}
+                >
+                    <ChartHistoryContent />
+                </ChartVersionPreviewProvider>
             </Provider>
         );
     },


### PR DESCRIPTION
Stacked on #26838.

Closes the chart-version-history regression that #26838 introduced.

### Problem

Chart version history renders an older chart config, so it requests the viz *that version* referenced. `getAuthorizedDataAppVizForChart` read the chart with `savedChartModel.get(uuid, undefined, …)` — the **latest** version — and compared against that. Any chart whose viz had been swapped showed "You don't have access to this data app visualization" on its older versions.

Fails closed, so it was a correctness regression rather than an access hole.

### Fix

The chart-scoped route takes an optional `chartVersionUuid` and loads that exact version, which `savedChartModel.get` already supported. Omitting it still means the latest version, so every other surface is unchanged.

On the frontend, `ChartHistory` provides the previewed version through a small page-scoped context that `DataAppVizRenderer` consumes, rather than growing the Explorer or VisualizationProvider prop APIs.

### Verified live

| request | before | after |
| --- | --- | --- |
| historical viz + its version uuid | 403 | **200** |
| current viz + current version uuid | 200 | 200 |
| historical viz, no version (latest differs) | 403 | 403 |
| historical viz + *current* version uuid | 403 | 403 |
| current viz + *older* version uuid | — | 403 |
| malformed `chartVersionUuid` | — | 422 |

Rows 4 and 5 are the point: the binding stays exact per version, so this is narrower than accepting any viz the chart ever referenced.

Version history confirmed rendering in the browser, and each version now sends its own `chartVersionUuid`.

### Tests

- Backend unit test asserting `savedChartModel.get` receives the version
- Frontend tests for the version reaching the registered route, and for the embed route not sending one
- 274 backend service tests, 25 frontend viz tests, typecheck and lint clean