### PR TITLE
feat(ai): filter AI agent issues by agent

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AgentsFilter.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AgentsFilter.tsx
@@ -128,8 +128,8 @@ const AgentsFilter: FC<AgentsFilterProps> = ({
             onChange={setSelectedAgentUuids}
             tooltipLabel={
                 hasSelectedProjects
-                    ? 'Filter threads by AI agent (filtered by selected projects)'
-                    : 'Filter threads by AI agent'
+                    ? 'Filter by AI agent (limited to selected projects)'
+                    : 'Filter by AI agent'
             }
             emptyLabel={
                 searchValue

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AgentsFilter.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AgentsFilter.tsx
@@ -128,8 +128,8 @@ const AgentsFilter: FC<AgentsFilterProps> = ({
             onChange={setSelectedAgentUuids}
             tooltipLabel={
                 hasSelectedProjects
-                    ? 'Filter by AI agent (limited to selected projects)'
-                    : 'Filter by AI agent'
+                    ? 'Filter threads by AI agent (filtered by selected projects)'
+                    : 'Filter threads by AI agent'
             }
             emptyLabel={
                 searchValue

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
@@ -65,7 +65,6 @@ import {
     useUpdateAiAgentReviewItemStatus,
 } from '../../hooks/useAiAgentAdmin';
 import { AgentNamePill } from '../AgentNamePill';
-import AgentsFilter from './AgentsFilter';
 import styles from './AiAgentAdminReviewItemsTable.module.css';
 import { EXAMPLE_REVIEW_ITEMS, isExampleReviewItem } from './onboarding';
 import {
@@ -529,9 +528,8 @@ const AiAgentAdminReviewItemsTable = ({
         );
     }, [searchFilteredReviewSignals, selectedProjectUuids]);
 
-    // Agent selections outside the selected projects can't match anything, so
-    // scoping by agent after project keeps the two filters consistent with the
-    // agent picker, which dims agents from unselected projects.
+    // Agents are scoped after projects so the agent options only ever list
+    // agents that appear in the project-filtered view.
     const scopedReviewItems = useMemo(() => {
         if (selectedAgentUuids.length === 0) {
             return projectFilteredReviewItems;
@@ -617,6 +615,48 @@ const AiAgentAdminReviewItemsTable = ({
         reviewSurface,
         searchFilteredReviewItems,
         searchFilteredReviewSignals,
+        selectedRootCauses,
+        selectedSignals,
+    ]);
+
+    const agentFacetOptions = useMemo((): FilterFacetOption[] => {
+        const counts = new Map<string, number>();
+        const source =
+            reviewSurface === 'findings'
+                ? projectFilteredReviewItems
+                      .filter((item) => {
+                          if (selectedRootCauses.length === 0) return true;
+                          return selectedRootCauses.includes(
+                              item.primaryRootCause,
+                          );
+                      })
+                      .map(getReviewItemAgentUuid)
+                : projectFilteredReviewSignals
+                      .filter((signal) => {
+                          if (selectedSignals.length === 0) return true;
+                          return selectedSignals.includes(signal.signal);
+                      })
+                      .map((signal) => signal.agentUuid);
+
+        for (const agentUuid of source) {
+            if (!agentUuid) continue;
+            counts.set(agentUuid, (counts.get(agentUuid) ?? 0) + 1);
+        }
+
+        return Array.from(counts.entries())
+            .map(([agentUuid, count]) => ({
+                value: agentUuid,
+                label: agentsMap.get(agentUuid)?.name ?? 'Unknown agent',
+                count,
+            }))
+            .sort(
+                (a, b) => b.count - a.count || a.label.localeCompare(b.label),
+            );
+    }, [
+        agentsMap,
+        reviewSurface,
+        projectFilteredReviewItems,
+        projectFilteredReviewSignals,
         selectedRootCauses,
         selectedSignals,
     ]);
@@ -761,10 +801,14 @@ const AiAgentAdminReviewItemsTable = ({
                             emptyLabel="No projects in current view"
                             tooltipLabel="Filter by project"
                         />
-                        <AgentsFilter
-                            selectedAgentUuids={selectedAgentUuids}
-                            setSelectedAgentUuids={setSelectedAgentUuids}
-                            selectedProjectUuids={selectedProjectUuids}
+                        <FilterFacet
+                            label="Agent"
+                            icon={IconRobotFace}
+                            options={agentFacetOptions}
+                            selected={selectedAgentUuids}
+                            onChange={setSelectedAgentUuids}
+                            emptyLabel="No agents in current view"
+                            tooltipLabel="Filter by agent"
                         />
                         <FilterFacet
                             label="Cause"

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
@@ -65,6 +65,7 @@ import {
     useUpdateAiAgentReviewItemStatus,
 } from '../../hooks/useAiAgentAdmin';
 import { AgentNamePill } from '../AgentNamePill';
+import AgentsFilter from './AgentsFilter';
 import styles from './AiAgentAdminReviewItemsTable.module.css';
 import { EXAMPLE_REVIEW_ITEMS, isExampleReviewItem } from './onboarding';
 import {
@@ -78,6 +79,8 @@ import {
     getActionLabel,
     getIssueTitle,
     getRecommendationActionLabel,
+    getReviewItemAgentUuid,
+    getReviewItemProjectUuid,
     getSuggestedNextStep,
     getWhatHappened,
     getWhyText,
@@ -125,6 +128,7 @@ type AiAgentAdminReviewItemsTableProps = {
      */
     showOnboardingExamples?: boolean;
     initialProjectUuids?: string[];
+    initialAgentUuids?: string[];
 };
 
 const getSignalResultLabel = (signal: AiAgentReviewSignalSummary): string => {
@@ -380,6 +384,7 @@ const AiAgentAdminReviewItemsTable = ({
     selectedReviewItemUuid,
     showOnboardingExamples = false,
     initialProjectUuids = [],
+    initialAgentUuids = [],
 }: AiAgentAdminReviewItemsTableProps) => {
     const theme = useMantineTheme();
     const [search, setSearch] = useState<string | undefined>(undefined);
@@ -387,6 +392,9 @@ const AiAgentAdminReviewItemsTable = ({
         useState<ReviewSurface>('findings');
     const [selectedProjectUuids, setSelectedProjectUuids] = useState<string[]>(
         () => initialProjectUuids,
+    );
+    const [selectedAgentUuids, setSelectedAgentUuids] = useState<string[]>(
+        () => initialAgentUuids,
     );
     const [selectedRootCauses, setSelectedRootCauses] = useState<
         AiAgentRootCause[]
@@ -438,10 +446,8 @@ const AiAgentAdminReviewItemsTable = ({
             reviewItem: AiAgentReviewItemSummary,
             searchLower: string,
         ): boolean => {
-            const agentUuid =
-                reviewItem.latestFinding?.agentUuid ?? reviewItem.agentUuid;
-            const projectUuid =
-                reviewItem.latestFinding?.projectUuid ?? reviewItem.projectUuid;
+            const agentUuid = getReviewItemAgentUuid(reviewItem);
+            const projectUuid = getReviewItemProjectUuid(reviewItem);
             const agent = agentUuid ? agentsMap.get(agentUuid) : undefined;
             const project = projectUuid
                 ? projectsMap.get(projectUuid)
@@ -486,11 +492,6 @@ const AiAgentAdminReviewItemsTable = ({
         [agentsMap, projectsMap],
     );
 
-    const getReviewItemProjectUuid = (
-        reviewItem: AiAgentReviewItemSummary,
-    ): string | null =>
-        reviewItem.latestFinding?.projectUuid ?? reviewItem.projectUuid ?? null;
-
     const searchFilteredReviewItems = useMemo(() => {
         if (!deferredSearch) return reviewItems;
         const searchLower = deferredSearch.toLowerCase();
@@ -528,8 +529,32 @@ const AiAgentAdminReviewItemsTable = ({
         );
     }, [searchFilteredReviewSignals, selectedProjectUuids]);
 
+    // Agent selections outside the selected projects can't match anything, so
+    // scoping by agent after project keeps the two filters consistent with the
+    // agent picker, which dims agents from unselected projects.
+    const scopedReviewItems = useMemo(() => {
+        if (selectedAgentUuids.length === 0) {
+            return projectFilteredReviewItems;
+        }
+        const agentSet = new Set(selectedAgentUuids);
+        return projectFilteredReviewItems.filter((item) => {
+            const agentUuid = getReviewItemAgentUuid(item);
+            return agentUuid !== null && agentSet.has(agentUuid);
+        });
+    }, [projectFilteredReviewItems, selectedAgentUuids]);
+
+    const scopedReviewSignals = useMemo(() => {
+        if (selectedAgentUuids.length === 0) {
+            return projectFilteredReviewSignals;
+        }
+        const agentSet = new Set(selectedAgentUuids);
+        return projectFilteredReviewSignals.filter((signal) =>
+            agentSet.has(signal.agentUuid),
+        );
+    }, [projectFilteredReviewSignals, selectedAgentUuids]);
+
     const filteredReviewItems = useMemo(() => {
-        let items = projectFilteredReviewItems;
+        let items = scopedReviewItems;
         if (selectedRootCauses.length > 0) {
             const rootCauseSet = new Set(selectedRootCauses);
             items = items.filter((item) =>
@@ -542,17 +567,17 @@ const AiAgentAdminReviewItemsTable = ({
             );
         }
         return items;
-    }, [projectFilteredReviewItems, selectedRootCauses, selectedAssignees]);
+    }, [scopedReviewItems, selectedRootCauses, selectedAssignees]);
 
     const filteredReviewSignals = useMemo(() => {
         if (selectedSignals.length === 0) {
-            return projectFilteredReviewSignals;
+            return scopedReviewSignals;
         }
         const signalSet = new Set(selectedSignals);
-        return projectFilteredReviewSignals.filter((signal) =>
+        return scopedReviewSignals.filter((signal) =>
             signalSet.has(signal.signal),
         );
-    }, [projectFilteredReviewSignals, selectedSignals]);
+    }, [scopedReviewSignals, selectedSignals]);
 
     const projectFacetOptions = useMemo((): FilterFacetOption[] => {
         const counts = new Map<string, number>();
@@ -598,7 +623,7 @@ const AiAgentAdminReviewItemsTable = ({
 
     const rootCauseFacetOptions = useMemo((): FilterFacetOption[] => {
         const counts = new Map<AiAgentRootCause, number>();
-        for (const item of projectFilteredReviewItems) {
+        for (const item of scopedReviewItems) {
             counts.set(
                 item.primaryRootCause,
                 (counts.get(item.primaryRootCause) ?? 0) + 1,
@@ -613,21 +638,21 @@ const AiAgentAdminReviewItemsTable = ({
             .sort(
                 (a, b) => b.count - a.count || a.label.localeCompare(b.label),
             );
-    }, [projectFilteredReviewItems]);
+    }, [scopedReviewItems]);
 
     const assigneeFacetOptions = useMemo(
         (): FilterFacetOption[] =>
             buildAssigneeFacetOptions({
-                items: projectFilteredReviewItems,
+                items: scopedReviewItems,
                 usersByUuid: orgUsersByUuid,
                 currentUserUuid,
             }),
-        [projectFilteredReviewItems, orgUsersByUuid, currentUserUuid],
+        [scopedReviewItems, orgUsersByUuid, currentUserUuid],
     );
 
     const _signalFacetOptions = useMemo((): FilterFacetOption[] => {
         const counts = new Map<AiAgentTurnSignal, number>();
-        for (const signal of projectFilteredReviewSignals) {
+        for (const signal of scopedReviewSignals) {
             counts.set(signal.signal, (counts.get(signal.signal) ?? 0) + 1);
         }
         return (Object.keys(signalLabels) as AiAgentTurnSignal[])
@@ -639,7 +664,7 @@ const AiAgentAdminReviewItemsTable = ({
             .sort(
                 (a, b) => b.count - a.count || a.label.localeCompare(b.label),
             );
-    }, [projectFilteredReviewSignals]);
+    }, [scopedReviewSignals]);
 
     const hasDefaultRootCauseSelection =
         selectedRootCauses.length === DEFAULT_VISIBLE_ROOT_CAUSES.length &&
@@ -649,12 +674,14 @@ const AiAgentAdminReviewItemsTable = ({
 
     const hasActiveFilters =
         selectedProjectUuids.length > 0 ||
+        selectedAgentUuids.length > 0 ||
         !hasDefaultRootCauseSelection ||
         selectedSignals.length > 0 ||
         selectedAssignees.length > 0;
 
     const clearAllFilters = useCallback(() => {
         setSelectedProjectUuids([]);
+        setSelectedAgentUuids([]);
         setSelectedRootCauses(DEFAULT_VISIBLE_ROOT_CAUSES);
         setSelectedSignals([]);
         setSelectedAssignees([]);
@@ -733,6 +760,11 @@ const AiAgentAdminReviewItemsTable = ({
                             onChange={setSelectedProjectUuids}
                             emptyLabel="No projects in current view"
                             tooltipLabel="Filter by project"
+                        />
+                        <AgentsFilter
+                            selectedAgentUuids={selectedAgentUuids}
+                            setSelectedAgentUuids={setSelectedAgentUuids}
+                            selectedProjectUuids={selectedProjectUuids}
                         />
                         <FilterFacet
                             label="Cause"

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
@@ -51,6 +51,7 @@ import {
     useReorderReviewItems,
     useUpdateAiAgentReviewItemStatus,
 } from '../../hooks/useAiAgentAdmin';
+import AgentsFilter from './AgentsFilter';
 import { type AiAgentAdminReviewItemPreviewTarget } from './AiAgentAdminReviewItemsTable';
 import { EXAMPLE_REVIEW_ITEMS } from './onboarding';
 import {
@@ -60,6 +61,8 @@ import {
 import {
     DEFAULT_VISIBLE_ROOT_CAUSES,
     getIssueTitle,
+    getReviewItemAgentUuid,
+    getReviewItemProjectUuid,
     reviewRootCauseLabels,
     SURFACED_ROOT_CAUSES,
 } from './reviewItemDetails';
@@ -88,6 +91,7 @@ type Props = {
     onReviewItemSelect: (target: AiAgentAdminReviewItemPreviewTarget) => void;
     showOnboardingExamples?: boolean;
     initialProjectUuids?: string[];
+    initialAgentUuids?: string[];
 };
 
 const toTarget = (
@@ -177,11 +181,15 @@ export const ReviewKanbanBoard: FC<Props> = ({
     onReviewItemSelect,
     showOnboardingExamples = false,
     initialProjectUuids = [],
+    initialAgentUuids = [],
 }) => {
     const [search, setSearch] = useState<string | undefined>(undefined);
     const deferredSearch = useDeferredValue(search);
     const [selectedProjectUuids, setSelectedProjectUuids] = useState<string[]>(
         () => initialProjectUuids,
+    );
+    const [selectedAgentUuids, setSelectedAgentUuids] = useState<string[]>(
+        () => initialAgentUuids,
     );
     const [selectedRootCauses, setSelectedRootCauses] = useState<
         AiAgentRootCause[]
@@ -247,14 +255,25 @@ export const ReviewKanbanBoard: FC<Props> = ({
         if (selectedProjectUuids.length === 0) return searchFilteredItems;
         const projectSet = new Set(selectedProjectUuids);
         return searchFilteredItems.filter((item) => {
-            const projectUuid =
-                item.latestFinding?.projectUuid ?? item.projectUuid ?? null;
+            const projectUuid = getReviewItemProjectUuid(item);
             return projectUuid !== null && projectSet.has(projectUuid);
         });
     }, [searchFilteredItems, selectedProjectUuids]);
 
+    // Agent selections outside the selected projects can't match anything, so
+    // scoping by agent after project keeps the two filters consistent with the
+    // agent picker, which dims agents from unselected projects.
+    const scopedItems = useMemo<AiAgentReviewItemSummary[]>(() => {
+        if (selectedAgentUuids.length === 0) return projectFilteredItems;
+        const agentSet = new Set(selectedAgentUuids);
+        return projectFilteredItems.filter((item) => {
+            const agentUuid = getReviewItemAgentUuid(item);
+            return agentUuid !== null && agentSet.has(agentUuid);
+        });
+    }, [projectFilteredItems, selectedAgentUuids]);
+
     const items = useMemo<AiAgentReviewItemSummary[]>(() => {
-        let next = projectFilteredItems;
+        let next = scopedItems;
         if (selectedRootCauses.length > 0) {
             const rootCauseSet = new Set(selectedRootCauses);
             next = next.filter((item) =>
@@ -267,7 +286,7 @@ export const ReviewKanbanBoard: FC<Props> = ({
             );
         }
         return next;
-    }, [projectFilteredItems, selectedRootCauses, selectedAssignees]);
+    }, [scopedItems, selectedRootCauses, selectedAssignees]);
 
     const projectFacetOptions = useMemo((): FilterFacetOption[] => {
         const counts = new Map<string, number>();
@@ -278,8 +297,7 @@ export const ReviewKanbanBoard: FC<Props> = ({
             if (selectedRootCauses.length === 0) return true;
             return selectedRootCauses.includes(item.primaryRootCause);
         })) {
-            const projectUuid =
-                item.latestFinding?.projectUuid ?? item.projectUuid ?? null;
+            const projectUuid = getReviewItemProjectUuid(item);
             if (!projectUuid) continue;
             counts.set(projectUuid, (counts.get(projectUuid) ?? 0) + 1);
         }
@@ -298,7 +316,7 @@ export const ReviewKanbanBoard: FC<Props> = ({
 
     const rootCauseFacetOptions = useMemo((): FilterFacetOption[] => {
         const counts = new Map<AiAgentRootCause, number>();
-        for (const item of projectFilteredItems) {
+        for (const item of scopedItems) {
             counts.set(
                 item.primaryRootCause,
                 (counts.get(item.primaryRootCause) ?? 0) + 1,
@@ -313,16 +331,16 @@ export const ReviewKanbanBoard: FC<Props> = ({
                 b.count - a.count ||
                 String(a.label).localeCompare(String(b.label)),
         );
-    }, [projectFilteredItems]);
+    }, [scopedItems]);
 
     const assigneeFacetOptions = useMemo(
         (): FilterFacetOption[] =>
             buildAssigneeFacetOptions({
-                items: projectFilteredItems,
+                items: scopedItems,
                 usersByUuid: orgUsersByUuid,
                 currentUserUuid,
             }),
-        [projectFilteredItems, orgUsersByUuid, currentUserUuid],
+        [scopedItems, orgUsersByUuid, currentUserUuid],
     );
 
     const lanes = useMemo(() => {
@@ -495,6 +513,11 @@ export const ReviewKanbanBoard: FC<Props> = ({
                     onChange={setSelectedProjectUuids}
                     emptyLabel="No projects in current view"
                     tooltipLabel="Filter by project"
+                />
+                <AgentsFilter
+                    selectedAgentUuids={selectedAgentUuids}
+                    setSelectedAgentUuids={setSelectedAgentUuids}
+                    selectedProjectUuids={selectedProjectUuids}
                 />
                 <FilterFacet
                     label="Cause"

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
@@ -35,7 +35,7 @@ import {
     type AiAgentRootCause,
 } from '@lightdash/common';
 import { Badge, Box, Button, Group, Stack, Text } from '@mantine/core';
-import { IconBox, IconTag, IconUser } from '@tabler/icons-react';
+import { IconBox, IconRobotFace, IconTag, IconUser } from '@tabler/icons-react';
 import { useQueryClient } from '@tanstack/react-query';
 import { type FC, useDeferredValue, useMemo, useState } from 'react';
 import FilterFacet, {
@@ -46,12 +46,12 @@ import { useProjects } from '../../../../../hooks/useProjects';
 import useApp from '../../../../../providers/App/useApp';
 import {
     applyOptimisticReviewBoardOrder,
+    useAiAgentAdminAgents,
     useAiAgentAdminReviewItems,
     useCreateAiAgentReviewItemWriteback,
     useReorderReviewItems,
     useUpdateAiAgentReviewItemStatus,
 } from '../../hooks/useAiAgentAdmin';
-import AgentsFilter from './AgentsFilter';
 import { type AiAgentAdminReviewItemPreviewTarget } from './AiAgentAdminReviewItemsTable';
 import { EXAMPLE_REVIEW_ITEMS } from './onboarding';
 import {
@@ -199,6 +199,7 @@ export const ReviewKanbanBoard: FC<Props> = ({
         statuses: BOARD_STATUSES,
     });
     const { data: projects } = useProjects();
+    const { data: agents } = useAiAgentAdminAgents();
     const { user } = useApp();
     const currentUserUuid = user.data?.userUuid ?? null;
     const orgUsersByUuid = useOrgUsersByUuid();
@@ -231,6 +232,11 @@ export const ReviewKanbanBoard: FC<Props> = ({
         return new Map(projects.map((p) => [p.projectUuid, p]));
     }, [projects]);
 
+    const agentsMap = useMemo(() => {
+        if (!agents) return new Map<string, { name: string }>();
+        return new Map(agents.map((agent) => [agent.uuid, agent]));
+    }, [agents]);
+
     const allItems = useMemo<AiAgentReviewItemSummary[]>(() => {
         // Tie the examples to the tour being open (not to emptiness) so the same
         // cards get highlighted every run, even on a populated board.
@@ -260,9 +266,8 @@ export const ReviewKanbanBoard: FC<Props> = ({
         });
     }, [searchFilteredItems, selectedProjectUuids]);
 
-    // Agent selections outside the selected projects can't match anything, so
-    // scoping by agent after project keeps the two filters consistent with the
-    // agent picker, which dims agents from unselected projects.
+    // Agents are scoped after projects so the agent options only ever list
+    // agents that appear in the project-filtered view.
     const scopedItems = useMemo<AiAgentReviewItemSummary[]>(() => {
         if (selectedAgentUuids.length === 0) return projectFilteredItems;
         const agentSet = new Set(selectedAgentUuids);
@@ -313,6 +318,30 @@ export const ReviewKanbanBoard: FC<Props> = ({
                     String(a.label).localeCompare(String(b.label)),
             );
     }, [projectsMap, searchFilteredItems, selectedRootCauses]);
+
+    const agentFacetOptions = useMemo((): FilterFacetOption[] => {
+        const counts = new Map<string, number>();
+        for (const item of projectFilteredItems.filter((item) => {
+            if (getReviewLane(item) === 'done') return false;
+            if (selectedRootCauses.length === 0) return true;
+            return selectedRootCauses.includes(item.primaryRootCause);
+        })) {
+            const agentUuid = getReviewItemAgentUuid(item);
+            if (!agentUuid) continue;
+            counts.set(agentUuid, (counts.get(agentUuid) ?? 0) + 1);
+        }
+        return Array.from(counts.entries())
+            .map(([agentUuid, count]) => ({
+                value: agentUuid,
+                label: agentsMap.get(agentUuid)?.name ?? 'Unknown agent',
+                count,
+            }))
+            .sort(
+                (a, b) =>
+                    b.count - a.count ||
+                    String(a.label).localeCompare(String(b.label)),
+            );
+    }, [agentsMap, projectFilteredItems, selectedRootCauses]);
 
     const rootCauseFacetOptions = useMemo((): FilterFacetOption[] => {
         const counts = new Map<AiAgentRootCause, number>();
@@ -514,10 +543,14 @@ export const ReviewKanbanBoard: FC<Props> = ({
                     emptyLabel="No projects in current view"
                     tooltipLabel="Filter by project"
                 />
-                <AgentsFilter
-                    selectedAgentUuids={selectedAgentUuids}
-                    setSelectedAgentUuids={setSelectedAgentUuids}
-                    selectedProjectUuids={selectedProjectUuids}
+                <FilterFacet
+                    label="Agent"
+                    icon={IconRobotFace}
+                    options={agentFacetOptions}
+                    selected={selectedAgentUuids}
+                    onChange={setSelectedAgentUuids}
+                    emptyLabel="No agents in current view"
+                    tooltipLabel="Filter by agent"
                 />
                 <FilterFacet
                     label="Cause"

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.ts
@@ -197,6 +197,16 @@ const getTargetLabel = (targetRefs: AiAgentTargetRef[]): string | null => {
     }
 };
 
+export const getReviewItemAgentUuid = (
+    reviewItem: AiAgentReviewItemSummary,
+): string | null =>
+    reviewItem.latestFinding?.agentUuid ?? reviewItem.agentUuid ?? null;
+
+export const getReviewItemProjectUuid = (
+    reviewItem: AiAgentReviewItemSummary,
+): string | null =>
+    reviewItem.latestFinding?.projectUuid ?? reviewItem.projectUuid ?? null;
+
 const isTriageReviewItem = (reviewItem: AiAgentReviewItemSummary): boolean =>
     reviewItem.source !== 'manual' &&
     (reviewItem.primaryRootCause === 'ambiguous' ||

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
@@ -56,12 +56,18 @@ export const AiReviewsSettingsPage = () => {
 
     const isSidebarOpen = selectedReviewItem !== null;
 
-    // Seeds the board/table project filter when arriving from a project's
-    // "Review AI findings" promo (e.g. `?projects=<uuid>`).
+    // Seeds the board/table filters when arriving from a project's "Review AI
+    // findings" promo or an agent deep link (e.g. `?projects=<uuid>&agents=<uuid>`).
     const initialProjectUuids = useMemo(() => {
         const projectsParam = searchParams.get('projects');
         if (!projectsParam) return [];
         return projectsParam.split(',').filter(Boolean);
+    }, [searchParams]);
+
+    const initialAgentUuids = useMemo(() => {
+        const agentsParam = searchParams.get('agents');
+        if (!agentsParam) return [];
+        return agentsParam.split(',').filter(Boolean);
     }, [searchParams]);
 
     // While the tour runs, the board always shows the same sample cards so the
@@ -202,6 +208,7 @@ export const AiReviewsSettingsPage = () => {
                             onReviewItemSelect={handleReviewItemSelect}
                             showOnboardingExamples={isTourOpen}
                             initialProjectUuids={initialProjectUuids}
+                            initialAgentUuids={initialAgentUuids}
                         />
                     ) : (
                         <AiAgentAdminReviewItemsTable
@@ -210,6 +217,7 @@ export const AiReviewsSettingsPage = () => {
                             }
                             onReviewItemSelect={handleReviewItemSelect}
                             initialProjectUuids={initialProjectUuids}
+                            initialAgentUuids={initialAgentUuids}
                         />
                     )}
                 </SettingsPage>


### PR DESCRIPTION
### Description:

Adds an **Agent** filter to the AI Issues page (both the Kanban board and the table), so issues can be narrowed to a single AI agent — e.g. the "AI Analyst" — instead of only by project/cause/assignee.

It works exactly like the neighbouring Project selector: a `FilterFacet` whose options are derived from the issues currently in view, with per-agent counts, so only agents that actually have issues are listed. Agent options are computed after the project filter, so picking a project narrows the agent list too. Filtering is client-side on `agentUuid`, which the review items API already returns, so no backend change. The filter feeds the cause/assignee facet counts, and can be seeded from the URL via `?agents=`, mirroring the existing `?projects=` param.

Verified with frontend typecheck, lint, and format. I couldn't drive the UI end-to-end in this environment (no running app/database), so a quick visual check on the Issues board/table would be worth it before merging.
