### PR TITLE
feat(ai): agent-level default for SQL mode

### DIFF
--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -1162,7 +1162,8 @@ export class AiAgentController extends BaseController {
                           {
                               agentUuid,
                               threadUuid,
-                              enableSqlMode: body?.enableSqlMode ?? false,
+                              // Undefined falls back to the agent's default.
+                              enableSqlMode: body?.enableSqlMode,
                               autoApproveSql: body?.autoApproveSql ?? false,
                               toolHints: body?.toolHints ?? [],
                           },

--- a/packages/backend/src/ee/database/entities/aiAgent.ts
+++ b/packages/backend/src/ee/database/entities/aiAgent.ts
@@ -17,6 +17,7 @@ export type DbAiAgent = {
     enable_self_improvement: boolean;
     enable_content_tools: boolean;
     enable_user_context: boolean;
+    enable_sql_mode: boolean;
     admin_only: boolean;
     model_config: AiAgentModelConfig | null;
     /**

--- a/packages/backend/src/ee/database/migrations/20260805120000_add_enable_sql_mode_column_to_ai_agent.ts
+++ b/packages/backend/src/ee/database/migrations/20260805120000_add_enable_sql_mode_column_to_ai_agent.ts
@@ -1,0 +1,19 @@
+import { Knex } from 'knex';
+
+const AiAgentTableName = 'ai_agent';
+
+export async function up(knex: Knex): Promise<void> {
+    if (!(await knex.schema.hasTable(AiAgentTableName))) return;
+
+    await knex.schema.alterTable(AiAgentTableName, (table) => {
+        table.boolean('enable_sql_mode').defaultTo(true).notNullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (!(await knex.schema.hasTable(AiAgentTableName))) return;
+
+    await knex.schema.alterTable(AiAgentTableName, (table) => {
+        table.dropColumn('enable_sql_mode');
+    });
+}

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -510,6 +510,7 @@ export class AiAgentModel {
                 enableSelfImprovement: `${AiAgentTableName}.enable_self_improvement`,
                 enableContentTools: `${AiAgentTableName}.enable_content_tools`,
                 enableUserContext: `${AiAgentTableName}.enable_user_context`,
+                enableSqlMode: `${AiAgentTableName}.enable_sql_mode`,
                 adminOnly: `${AiAgentTableName}.admin_only`,
                 modelConfig: `${AiAgentTableName}.model_config`,
                 version: `${AiAgentTableName}.version`,
@@ -648,6 +649,7 @@ export class AiAgentModel {
                 enableSelfImprovement: `${AiAgentTableName}.enable_self_improvement`,
                 enableContentTools: `${AiAgentTableName}.enable_content_tools`,
                 enableUserContext: `${AiAgentTableName}.enable_user_context`,
+                enableSqlMode: `${AiAgentTableName}.enable_sql_mode`,
                 adminOnly: `${AiAgentTableName}.admin_only`,
                 modelConfig: `${AiAgentTableName}.model_config`,
                 version: `${AiAgentTableName}.version`,
@@ -733,6 +735,7 @@ export class AiAgentModel {
                 | 'enableSelfImprovement'
                 | 'enableContentTools'
                 | 'enableUserContext'
+                | 'enableSqlMode'
                 | 'modelConfig'
                 | 'updatedAt'
             > & { uuid: string }
@@ -763,6 +766,7 @@ export class AiAgentModel {
                 enableSelfImprovement: `${AiAgentTableName}.enable_self_improvement`,
                 enableContentTools: `${AiAgentTableName}.enable_content_tools`,
                 enableUserContext: `${AiAgentTableName}.enable_user_context`,
+                enableSqlMode: `${AiAgentTableName}.enable_sql_mode`,
                 modelConfig: `${AiAgentTableName}.model_config`,
                 updatedAt: `${AiAgentTableName}.updated_at`,
                 instruction: this.database.raw(`
@@ -1923,6 +1927,7 @@ export class AiAgentModel {
             | 'enableSelfImprovement'
             | 'enableContentTools'
             | 'enableUserContext'
+            | 'enableSqlMode'
             | 'adminOnly'
             | 'modelConfig'
             | 'version'
@@ -1957,6 +1962,7 @@ export class AiAgentModel {
                     enable_self_improvement: args.enableSelfImprovement,
                     enable_content_tools: args.enableContentTools ?? false,
                     enable_user_context: args.enableUserContext ?? false,
+                    enable_sql_mode: args.enableSqlMode ?? true,
                     admin_only: args.adminOnly ?? false,
                     model_config: args.modelConfig ?? null,
                     version: args.version,
@@ -2061,6 +2067,7 @@ export class AiAgentModel {
                 enableSelfImprovement: agent.enable_self_improvement,
                 enableContentTools: agent.enable_content_tools,
                 enableUserContext: agent.enable_user_context,
+                enableSqlMode: agent.enable_sql_mode,
                 adminOnly: agent.admin_only,
                 modelConfig: agent.model_config,
                 version: agent.version,
@@ -2116,6 +2123,7 @@ export class AiAgentModel {
                 enableSelfImprovement: false,
                 enableContentTools: false,
                 enableUserContext: false,
+                enableSqlMode: true,
                 modelConfig: null,
                 version: 1,
                 mcpServerUuids: [],
@@ -2179,6 +2187,9 @@ export class AiAgentModel {
                         : {}),
                     ...(args.enableUserContext !== undefined
                         ? { enable_user_context: args.enableUserContext }
+                        : {}),
+                    ...(args.enableSqlMode !== undefined
+                        ? { enable_sql_mode: args.enableSqlMode }
                         : {}),
                     ...(args.adminOnly !== undefined
                         ? { admin_only: args.adminOnly }
@@ -2354,6 +2365,7 @@ export class AiAgentModel {
                 enableSelfImprovement: agent.enable_self_improvement,
                 enableContentTools: agent.enable_content_tools,
                 enableUserContext: agent.enable_user_context,
+                enableSqlMode: agent.enable_sql_mode,
                 adminOnly: agent.admin_only,
                 modelConfig: agent.model_config,
                 version: agent.version,

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.integration.test.ts
@@ -123,6 +123,7 @@ describe('AiDeepResearchRunModel integration', () => {
                 enable_self_improvement: false,
                 enable_content_tools: true,
                 enable_user_context: false,
+                enable_sql_mode: true,
                 admin_only: false,
                 model_config: null,
                 is_system: false,

--- a/packages/backend/src/ee/services/AiAgentCoderService/AiAgentCoderService.ts
+++ b/packages/backend/src/ee/services/AiAgentCoderService/AiAgentCoderService.ts
@@ -69,6 +69,7 @@ const toAgentAsCode = (
     enableSelfImprovement: agent.enableSelfImprovement,
     enableContentTools: agent.enableContentTools,
     enableUserContext: agent.enableUserContext,
+    enableSqlMode: agent.enableSqlMode,
     modelConfig: agent.modelConfig,
     evaluations: [...evaluations]
         .sort((left, right) => left.title.localeCompare(right.title))
@@ -88,6 +89,7 @@ const getComparableAgent = (agent: AgentAsCode) => ({
     enableSelfImprovement: agent.enableSelfImprovement,
     enableContentTools: agent.enableContentTools,
     enableUserContext: agent.enableUserContext,
+    enableSqlMode: agent.enableSqlMode ?? true,
     modelConfig: agent.modelConfig,
 });
 
@@ -383,6 +385,7 @@ export class AiAgentCoderService extends BaseService {
                         enableSelfImprovement: agent.enableSelfImprovement,
                         enableContentTools: agent.enableContentTools,
                         enableUserContext: agent.enableUserContext,
+                        enableSqlMode: agent.enableSqlMode ?? true,
                         modelConfig: agent.modelConfig,
                     });
                     agentChanged = true;
@@ -402,6 +405,7 @@ export class AiAgentCoderService extends BaseService {
                     enableSelfImprovement: agent.enableSelfImprovement,
                     enableContentTools: agent.enableContentTools,
                     enableUserContext: agent.enableUserContext,
+                    enableSqlMode: agent.enableSqlMode ?? true,
                     modelConfig: agent.modelConfig,
                     integrations: [],
                     groupAccess: [],

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryConsolidation.integration.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryConsolidation.integration.test.ts
@@ -142,6 +142,7 @@ describe('AI agent memory consolidation integration', () => {
                 enable_self_improvement: false,
                 enable_content_tools: false,
                 enable_user_context: false,
+                enable_sql_mode: true,
                 admin_only: false,
                 model_config: null,
                 is_system: false,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -2970,6 +2970,7 @@ export class AiAgentService extends BaseService {
             enableContentTools:
                 body.enableDataAccess && (body.enableContentTools ?? false),
             enableUserContext: body.enableUserContext ?? false,
+            enableSqlMode: body.enableSqlMode ?? true,
             adminOnly: body.adminOnly ?? false,
             modelConfig: body.modelConfig ?? null,
             version: body.version,
@@ -3414,6 +3415,7 @@ export class AiAgentService extends BaseService {
                     enableSelfImprovement: agent.enableSelfImprovement,
                     enableContentTools: agent.enableContentTools,
                     enableUserContext: agent.enableUserContext,
+                    enableSqlMode: agent.enableSqlMode,
                 },
                 model: {
                     provider: modelConfig?.modelProvider ?? null,
@@ -4339,6 +4341,7 @@ export class AiAgentService extends BaseService {
                 ? body.enableContentTools
                 : false,
             enableUserContext: body.enableUserContext,
+            enableSqlMode: body.enableSqlMode,
             adminOnly: body.adminOnly,
             modelConfig: body.modelConfig,
             version: body.version,
@@ -5020,7 +5023,7 @@ export class AiAgentService extends BaseService {
         }: {
             agentUuid: string;
             threadUuid: string;
-            enableSqlMode: boolean;
+            enableSqlMode?: boolean;
             autoApproveSql?: boolean;
             toolHints: string[];
             runtimeOptions?: EmbedAiAgentRuntimeOptions;
@@ -5680,8 +5683,6 @@ export class AiAgentService extends BaseService {
                     prompt,
                     stream: false,
                     canManageAgent,
-                    // Non-stream callers (eval, etc.) preserve flag-only gating.
-                    enableSqlMode: true,
                     autoApproveSql,
                     toolHints,
                     forceToolHints,
@@ -9057,7 +9058,12 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     : undefined,
         });
 
-        const enableSqlMode = options.enableSqlMode ?? false;
+        const agentSettings = await this.getAgentSettings(user, prompt);
+
+        // Callers that have no per-request toggle (Slack, evals) leave
+        // `enableSqlMode` undefined and inherit the agent's default.
+        const enableSqlMode =
+            options.enableSqlMode ?? agentSettings.enableSqlMode;
 
         // Permission-sensitive tools need the prompt actor to be the real
         // sender. Web prompts always are; Slack prompts are only trusted when
@@ -9124,7 +9130,6 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
               null
             : null;
 
-        const agentSettings = await this.getAgentSettings(user, prompt);
         const knowledgeDocuments =
             await this.aiAgentDocumentModel.findAllContextForAgent({
                 organizationUuid: user.organizationUuid,
@@ -11035,7 +11040,6 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     stream: false,
                     canManageAgent,
                     threadMessages,
-                    enableSqlMode: true,
                     onSlackStepProgress: appendTaskUpdate,
                 },
             );

--- a/packages/backend/src/ee/services/AiRouterService/AiRouterService.test.ts
+++ b/packages/backend/src/ee/services/AiRouterService/AiRouterService.test.ts
@@ -121,6 +121,7 @@ const createCandidate = (
     enableSelfImprovement: true,
     enableContentTools: true,
     enableUserContext: false,
+    enableSqlMode: true,
     adminOnly: false,
     modelConfig: null,
     version: 1,

--- a/packages/backend/src/ee/services/McpService/McpService.routeAgent.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.routeAgent.test.ts
@@ -98,6 +98,7 @@ const selectedAgent: AiAgentWithContext = {
     enableSelfImprovement: true,
     enableContentTools: true,
     enableUserContext: false,
+    enableSqlMode: true,
     adminOnly: false,
     modelConfig: null,
     version: 1,

--- a/packages/common/src/ee/AiAgent/coder.ts
+++ b/packages/common/src/ee/AiAgent/coder.ts
@@ -25,6 +25,9 @@ export type AgentAsCode = {
     enableSelfImprovement: boolean;
     enableContentTools: boolean;
     enableUserContext: boolean;
+    // Optional for backwards compatibility with files written before the
+    // setting existed — absent means the default (on).
+    enableSqlMode?: boolean;
     modelConfig: AiAgentModelConfig | null;
     evaluations?: AgentAsCodeEvaluation[];
     updatedAt?: Date;

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -150,6 +150,7 @@ export const baseAgentSchema = z.object({
     enableSelfImprovement: z.boolean(),
     enableContentTools: z.boolean(),
     enableUserContext: z.boolean(),
+    enableSqlMode: z.boolean(),
     adminOnly: z.boolean(),
     modelConfig: z.custom<AiAgentModelConfig>().nullable(),
     version: z.number(),
@@ -178,6 +179,7 @@ export type AiAgent = Pick<
     | 'enableSelfImprovement'
     | 'enableContentTools'
     | 'enableUserContext'
+    | 'enableSqlMode'
     | 'adminOnly'
     | 'modelConfig'
     | 'version'
@@ -204,6 +206,7 @@ export type AiAgentSummary = Pick<
     | 'enableSelfImprovement'
     | 'enableContentTools'
     | 'enableUserContext'
+    | 'enableSqlMode'
     | 'adminOnly'
     | 'modelConfig'
     | 'version'
@@ -544,6 +547,7 @@ export type ApiCreateAiAgent = Pick<
 > & {
     enableContentTools?: boolean;
     enableUserContext?: boolean;
+    enableSqlMode?: boolean;
     adminOnly?: boolean;
     mcpServerUuids?: string[];
     modelConfig?: AiAgentModelConfig | null;
@@ -566,6 +570,7 @@ export type ApiUpdateAiAgent = Partial<
         | 'enableSelfImprovement'
         | 'enableContentTools'
         | 'enableUserContext'
+        | 'enableSqlMode'
         | 'adminOnly'
         | 'modelConfig'
         | 'version'

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
@@ -89,6 +89,7 @@ const formSchema = z.object({
     enableSelfImprovement: z.boolean(),
     enableContentTools: z.boolean(),
     enableUserContext: z.boolean(),
+    enableSqlMode: z.boolean(),
     adminOnly: z.boolean(),
     modelConfig: z.custom<AiAgentModelConfig>().nullable(),
     version: z.number(),
@@ -852,6 +853,32 @@ export const AiAgentFormSetup = ({
                                     "Shares the requesting user's name, role, and group memberships with the agent so it can tailor answers to who is asking."
                                 }
                                 {...form.getInputProps('enableUserContext', {
+                                    type: 'checkbox',
+                                })}
+                            />
+                            <Switch
+                                variant="subtle"
+                                label={
+                                    <Group gap="xs">
+                                        <Text fz="sm" fw={500}>
+                                            Enable SQL queries
+                                        </Text>
+                                        <Tooltip
+                                            label="Only users who already have SQL Runner access can run SQL through the agent."
+                                            withArrow
+                                            withinPortal
+                                            multiline
+                                            position="right"
+                                            maw="300px"
+                                        >
+                                            <MantineIcon
+                                                icon={IconInfoCircle}
+                                            />
+                                        </Tooltip>
+                                    </Group>
+                                }
+                                description="Sets whether new conversations start with SQL mode on, letting the agent write raw SQL when the semantic layer can't answer a question. Users can still toggle it per conversation."
+                                {...form.getInputProps('enableSqlMode', {
                                     type: 'checkbox',
                                 })}
                             />

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
@@ -174,8 +174,10 @@ const NewThreadPanel: FC<{
 
     const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
     // New threads have no uuid yet — keep the toggle in local state and seed
-    // the per-thread slice entry once the thread is created.
-    const [sqlMode, setSqlMode] = useState(true);
+    // the per-thread slice entry once the thread is created. Until the user
+    // flips it, the selected agent's setting is the default.
+    const [sqlModeOverride, setSqlMode] = useState<boolean | null>(null);
+    const sqlMode = sqlModeOverride ?? concreteAgent?.enableSqlMode ?? true;
     const [composerSeed, setComposerSeed] = useState<string | null>(null);
     const dispatchToStore = useAiAgentStoreDispatch();
     const handleToolResult = useCallback(
@@ -489,7 +491,9 @@ const ExistingThreadPanel: FC<{
     });
 
     const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
-    const sqlMode = useAiAgentStoreSelector(selectThreadSqlMode(threadId));
+    const sqlMode = useAiAgentStoreSelector(
+        selectThreadSqlMode(threadId, agent.enableSqlMode),
+    );
     const dispatchToStore = useAiAgentStoreDispatch();
     const threadContext = useMemo(
         () =>

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadModeSlice.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadModeSlice.test.ts
@@ -18,6 +18,21 @@ describe('aiAgentThreadModeSlice', () => {
         expect(selectThreadSqlMode('t1')(state)).toBe(true);
     });
 
+    it("selectThreadSqlMode falls back to the agent's default when given one", () => {
+        const state = wrap(reducer(undefined, { type: '@@init' }));
+        expect(selectThreadSqlMode('t1', false)(state)).toBe(false);
+    });
+
+    it("the stored value wins over the agent's default", () => {
+        const state = wrap(
+            reducer(
+                undefined,
+                setThreadSqlMode({ threadUuid: 't1', enabled: true }),
+            ),
+        );
+        expect(selectThreadSqlMode('t1', false)(state)).toBe(true);
+    });
+
     it('selectThreadSqlModeRaw is undefined until the thread is toggled', () => {
         const state = wrap(reducer(undefined, { type: '@@init' }));
         expect(selectThreadSqlModeRaw('t1')(state)).toBeUndefined();

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadModeSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadModeSlice.ts
@@ -35,10 +35,12 @@ export const aiAgentThreadModeSlice = createSlice({
 
 export const { setThreadSqlMode } = aiAgentThreadModeSlice.actions;
 
+// `defaultValue` is the agent's `enableSqlMode` setting where the caller knows
+// which agent the thread belongs to.
 export const selectThreadSqlMode =
-    (threadUuid: string) =>
+    (threadUuid: string, defaultValue: boolean = DEFAULT_SQL_MODE) =>
     (state: { aiAgentThreadMode: State }): boolean =>
-        state.aiAgentThreadMode[threadUuid]?.sqlMode ?? DEFAULT_SQL_MODE;
+        state.aiAgentThreadMode[threadUuid]?.sqlMode ?? defaultValue;
 
 // Returns undefined when the thread has no stored toggle yet, so a caller can
 // apply its own default while everywhere else keeps DEFAULT_SQL_MODE.

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -188,7 +188,7 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
         threadUuid: threadUuid!,
     });
     const sqlMode = useAiAgentStoreSelector(
-        selectThreadSqlMode(threadUuid ?? ''),
+        selectThreadSqlMode(threadUuid ?? '', agent.enableSqlMode),
     );
     const dispatch = useAiAgentStoreDispatch();
 

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -78,7 +78,11 @@ const AgentsRouterPage = () => {
     const [isMemoriesModalOpen, setIsMemoriesModalOpen] = useState(false);
     const memoryEnabled = useAiAgentMemoryEnabled();
 
-    const [sqlMode, setSqlMode] = useState(true);
+    // No agent is picked yet on this page, so the toggle shows the generic
+    // default until the user flips it; the agent's own setting is applied
+    // once routing resolves which agent handles the message.
+    const [sqlModeOverride, setSqlMode] = useState<boolean | null>(null);
+    const sqlMode = sqlModeOverride ?? true;
     const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
     const chartUuid = searchParams.get('chartUuid');
     const dashboardUuid = searchParams.get('dashboardUuid');
@@ -124,10 +128,16 @@ const AgentsRouterPage = () => {
             optimisticContext?: AiPromptContext;
             toolHints: string[];
         }) => {
+            const agentSqlMode =
+                sqlModeOverride ??
+                agents?.find((a) => a.uuid === args.agentUuid)
+                    ?.enableSqlMode ??
+                true;
+            const enableSqlMode = sqlModeAvailable && agentSqlMode;
             const thread = await createThread({
                 agentUuid: args.agentUuid,
                 context: args.context,
-                enableSqlMode: sqlModeAvailable && sqlMode,
+                enableSqlMode,
                 optimisticContext: args.optimisticContext,
                 prompt: args.message,
                 toolHints: args.toolHints,
@@ -136,7 +146,7 @@ const AgentsRouterPage = () => {
             dispatch(
                 setThreadSqlMode({
                     threadUuid: thread.uuid,
-                    enabled: sqlModeAvailable && sqlMode,
+                    enabled: enableSqlMode,
                 }),
             );
             return thread;
@@ -146,7 +156,8 @@ const AgentsRouterPage = () => {
             dispatch,
             isModelSelectionExplicit,
             modelConfig,
-            sqlMode,
+            agents,
+            sqlModeOverride,
             sqlModeAvailable,
         ],
     );

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -67,10 +67,12 @@ const AiAgentNewThreadPage: FC = () => {
 
     const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
     const deepResearchFlag = useServerFeatureFlag(FeatureFlags.AiDeepResearch);
-    const [sqlMode, setSqlMode] = useState(true);
+    const [sqlModeOverride, setSqlMode] = useState<boolean | null>(null);
     const dispatch = useAiAgentStoreDispatch();
     const { agent, agents, navigateFromAgentChat } =
         useOutletContext<AgentContext>();
+    // The agent's setting is the default until the user flips the toggle.
+    const sqlMode = sqlModeOverride ?? agent.enableSqlMode;
     const createdThreadRef = useRef<{
         uuid: string;
         title: string;

--- a/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
@@ -97,6 +97,7 @@ const formSchema = z.object({
     enableSelfImprovement: z.boolean(),
     enableContentTools: z.boolean(),
     enableUserContext: z.boolean(),
+    enableSqlMode: z.boolean(),
     adminOnly: z.boolean(),
     modelConfig: z.custom<AiAgentModelConfig>().nullable(),
     version: z.number(),
@@ -153,6 +154,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
             enableSelfImprovement: false,
             enableContentTools: true,
             enableUserContext: false,
+            enableSqlMode: true,
             adminOnly: false,
             modelConfig: null,
             version: 2, // INFO: Default to v2 for now
@@ -187,6 +189,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
                     (agent.enableDataAccess ?? false) &&
                     (agent.enableContentTools ?? false),
                 enableUserContext: agent.enableUserContext ?? false,
+                enableSqlMode: agent.enableSqlMode ?? true,
                 adminOnly: agent.adminOnly ?? false,
                 modelConfig: agent.modelConfig ?? null,
                 version: agent.version ?? 2, // INFO: Default to v2 for now


### PR DESCRIPTION
### Description:

Adds an **Enable SQL queries** switch to the agent Configuration section, so each agent can decide whether new conversations start with SQL mode on or off.

It's a default, not a gate: users with SQL Runner access can still flip the per-conversation toggle either way, and SQL never becomes available to users without that access — the existing CASL check on `SqlRunner` is unchanged.

- New `ai_agent.enable_sql_mode` column, defaulting to `true` so existing agents behave exactly as before.
- Web chat surfaces seed their SQL toggle from the agent's setting instead of a hardcoded `true`.
- Surfaces with no toggle (Slack, evals) now inherit the agent's setting rather than always passing `true`. Embedded agents stay hard-off as before.
- Included in agents-as-code (optional in the YAML, absent means on).
