### PR TITLE
fix: prefill external connection test path

### DIFF
--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/AddConnectionWizard.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/AddConnectionWizard.tsx
@@ -47,7 +47,11 @@ import {
     type ConnectionWizardMode,
 } from './ConnectionModeChooser';
 import { WizardTestStep } from './WizardTestStep';
-import { applyProposalToWizardValues, type WizardValues } from './wizardValues';
+import {
+    applyProposalToWizardValues,
+    getSuggestedTestPath,
+    type WizardValues,
+} from './wizardValues';
 
 // Content types stay hidden in the onboarding wizard and the optional numeric
 // limits fall back to server defaults. Power users tune them in the Edit form.
@@ -372,6 +376,10 @@ export const AddConnectionWizard: FC<Props> = ({
     });
 
     const config = toCreatePayload(form.values);
+    const initialTestPath =
+        proposal && form.values.allowedMethods.includes('GET')
+            ? getSuggestedTestPath(description, form.values.origin)
+            : '';
 
     // Going back may change the config, so a captured test result no longer
     // describes what would be created — drop it until the user re-tests.
@@ -574,6 +582,7 @@ export const AddConnectionWizard: FC<Props> = ({
                             projectUuid={projectUuid}
                             config={config}
                             allowedMethods={config.allowedMethods}
+                            initialPath={initialTestPath}
                             onTestResult={setTestResult}
                             saveSample={saveSample}
                             onSaveSampleChange={setSaveSample}

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/WizardTestStep.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/WizardTestStep.tsx
@@ -23,6 +23,7 @@ type Props = {
     projectUuid: string;
     config: CreateExternalConnection;
     allowedMethods: ExternalConnectionMethod[];
+    initialPath: string;
     onTestResult: (result: ConnectionTestResultValue | null) => void;
     saveSample: boolean;
     onSaveSampleChange: (value: boolean) => void;
@@ -35,11 +36,12 @@ export const WizardTestStep: FC<Props> = ({
     projectUuid,
     config,
     allowedMethods,
+    initialPath,
     onTestResult,
     saveSample,
     onSaveSampleChange,
 }) => {
-    const [path, setPath] = useState('');
+    const [path, setPath] = useState(initialPath);
     const [selectedMethod, setSelectedMethod] =
         useState<ExternalConnectionMethod | null>(null);
     const [body, setBody] = useState('');

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/wizardValues.test.ts
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/wizardValues.test.ts
@@ -1,6 +1,9 @@
 import { type ExternalConnectionConfigProposal } from '@lightdash/common';
 import { describe, expect, it } from 'vitest';
-import { applyProposalToWizardValues } from './wizardValues';
+import {
+    applyProposalToWizardValues,
+    getSuggestedTestPath,
+} from './wizardValues';
 
 const proposal = (
     overrides: Partial<ExternalConnectionConfigProposal> = {},
@@ -64,5 +67,49 @@ describe('applyProposalToWizardValues', () => {
             { name: 'anthropic-version', value: '2023-06-01' },
         ]);
         expect(values.instructions).toBe('Use POST /v1/messages');
+    });
+});
+
+describe('getSuggestedTestPath', () => {
+    it('extracts the path from an example URL on the proposed origin', () => {
+        expect(
+            getSuggestedTestPath(
+                'Plot maps using https://cdn.jsdelivr.net/npm/world-atlas/countries-110m.json',
+                'https://cdn.jsdelivr.net',
+            ),
+        ).toBe('/npm/world-atlas/countries-110m.json');
+    });
+
+    it('finds a matching URL after unrelated links', () => {
+        expect(
+            getSuggestedTestPath(
+                'See https://example.com/docs, then fetch <https://api.example.com/v1/items?limit=10>.',
+                'https://api.example.com',
+            ),
+        ).toBe('/v1/items');
+    });
+
+    it('returns no suggestion for another origin or an origin-only URL', () => {
+        expect(
+            getSuggestedTestPath(
+                'Use https://other.example.com/v1/items',
+                'https://api.example.com',
+            ),
+        ).toBe('');
+        expect(
+            getSuggestedTestPath(
+                'Use https://api.example.com/',
+                'https://api.example.com',
+            ),
+        ).toBe('');
+    });
+
+    it('returns no suggestion for an invalid origin', () => {
+        expect(
+            getSuggestedTestPath(
+                'Use https://api.example.com/v1/items',
+                'api.example.com',
+            ),
+        ).toBe('');
     });
 });

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/wizardValues.ts
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/wizardValues.ts
@@ -29,6 +29,39 @@ export type WizardValues = {
     instructions: string;
 };
 
+const DESCRIPTION_URL_PATTERN = /https:\/\/\S+/gi;
+const TRAILING_URL_PUNCTUATION = /[>\])},.!?;:]+$/;
+
+/** Find the first concrete URL in the automatic-setup description that uses
+ *  the proposed origin, and return its path for the wizard's test request. */
+export const getSuggestedTestPath = (
+    description: string,
+    origin: string,
+): string => {
+    let normalizedOrigin: string;
+    try {
+        const originUrl = new URL(origin);
+        if (originUrl.protocol !== 'https:') return '';
+        normalizedOrigin = originUrl.origin;
+    } catch {
+        return '';
+    }
+
+    for (const match of description.matchAll(DESCRIPTION_URL_PATTERN)) {
+        const value = match[0].replace(TRAILING_URL_PUNCTUATION, '');
+        try {
+            const url = new URL(value);
+            if (url.origin === normalizedOrigin && url.pathname !== '/') {
+                return url.pathname;
+            }
+        } catch {
+            // Continue looking for another URL in the description.
+        }
+    }
+
+    return '';
+};
+
 /** Map an AI proposal onto the wizard form. The secret is always blank — the
  *  user pastes the credential themselves on the Auth step. */
 export const applyProposalToWizardValues = (


### PR DESCRIPTION
## Summary

- derive an initial test path from a concrete HTTPS URL in the automatic-setup description when it matches the generated origin
- prefill the wizard Test step for generated GET connections while leaving manual and generic prompts unchanged
- cover matching URLs, unrelated links, origin-only URLs, query strings, and invalid origins

## Why

Automatic setup generated the connection policy but always initialized the final test path as blank. Even when the user supplied an exact URL, they had to find and copy its relative path manually.

## User impact

A prompt such as `https://cdn.jsdelivr.net/npm/world-atlas/countries-110m.json` now reaches the Test step with `/npm/world-atlas/countries-110m.json` already populated. Generic prompts such as "connect to GitHub" still generate a proposal without inventing a test endpoint.

Linear: https://linear.app/lightdash/issue/GLITCH-654/prepopulate-get-path-for-external-connections-testing

## Validation

- `pnpm -F frontend test src/components/Settings/DataAppConnectionsPanel/wizardValues.test.ts` — 8 tests passed
- `pnpm -F frontend typecheck`
- `pnpm -F frontend lint`
- formatter and diff checks
- Chrome smoke test on `localhost:3010`: generated the world-atlas connection, verified the prefilled path, and received `200 application/json` from **Send test**
