### PR TITLE
feat(data-apps): add Cloud-parity builds to data app validation

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -64,15 +64,19 @@ Build and upload it with:
 
 ```shell
 cd lightdash/apps/revenue-explorer
-lightdash apps validate --live
-npm run build
+lightdash apps validate --live --build
 lightdash upload --apps revenue-explorer
 ```
 
 `lightdash apps validate [paths...]` checks app source, manifests,
 dependencies, external-connection aliases, and semantic references. It uses
 the downloaded semantic-layer snapshot by default; `--live` fetches the
-project's current explores, and `--format json` provides CI output.
+project's current explores, and `--format json` provides CI output. Add
+`--build` to run the same bare Vite production build as Lightdash Cloud against
+the CLI's vendored template. Standard apps need `npm install` to have populated
+`node_modules`; custom dependencies are restored with `pnpm install` using
+`--frozen-lockfile --ignore-scripts` first. Build failures include the Vite
+output and make validation exit non-zero.
 
 The local build is a pre-flight check; Lightdash rebuilds the source when it is
 uploaded. Existing apps can still be checked out with

--- a/packages/cli/src/handlers/apps/authoring/AGENTS.md.tmpl
+++ b/packages/cli/src/handlers/apps/authoring/AGENTS.md.tmpl
@@ -2,11 +2,11 @@
 
 Two skills in `.claude/skills/` describe how to edit this app:
 - `lightdash-data-app` — the Lightdash SDK surface (querying data, filters, downloads).
-- `developing-data-apps-locally` — the local workflow: edit `src/`, `npm run build`, `lightdash apps preview`, `lightdash upload --apps <slug>`; the SDK is the only data access; `.lightdash/context/` holds the project's semantic layer and theme.
+- `developing-data-apps-locally` — the local workflow: edit `src/`, `lightdash apps validate --build`, `lightdash apps preview`, `lightdash upload --apps <slug>`; the SDK is the only data access; `.lightdash/context/` holds the project's semantic layer and theme.
 
 Edit only `src/`. Root config files are read-only reference — the server rebuilds against a trusted template.
 
-The local build is an optional pre-check. Apps made with `lightdash apps create` already have dependencies installed and can run `npm run build`; after `lightdash download`, use `npm install && npm run build` if you choose to build locally. If the local install or build fails, report it as a non-blocking warning with a short failure summary, then continue to upload — never modify machine config, npmrc, or dependency files to force it. The local pre-check does not decide whether the app ships; the server build is authoritative and surfaces its result on the app page.
+Use `lightdash apps validate --build` for the Cloud-parity local pre-check. It builds `src/` against the CLI's trusted template and reports Vite failures as validation errors. Apps made with `lightdash apps create` already have dependencies installed; after `lightdash download`, run `npm install` first if `node_modules` is absent. Never modify machine config, npmrc, or dependency files to force the check to pass. The server still rebuilds on upload and surfaces its final result on the app page.
 
 Build with the template's preinstalled dependency set (see `package.json`). Adding new npm packages only works when the Lightdash organization has custom dependencies enabled — assume it does not; ask the user before considering a new library, and never vendor library source into `src/` as a workaround. Where enabled, adding a dependency is the one workflow that still requires pnpm: upload requires a matching `pnpm-lock.yaml`, so `pnpm add <pkg>` (or `pnpm install --lockfile-only`) must succeed locally. If it fails, stop and report the error — hand-editing `package.json` without the lockfile makes the upload fail.
 

--- a/packages/cli/src/handlers/apps/authoring/README.md.tmpl
+++ b/packages/cli/src/handlers/apps/authoring/README.md.tmpl
@@ -4,10 +4,9 @@ Created or downloaded with the Lightdash CLI.
 
 ## Edit → build → upload
 1. Edit files under `src/`.
-2. Run `lightdash apps validate` to check the source, manifest, dependencies, external-connection aliases, and semantic references against the downloaded context. Use `--live` for fresh project explores or `--format json` in CI.
-3. Optionally, run `npm run build` to check it compiles locally. `lightdash apps create` installs the initial dependencies after asking permission; after `lightdash download`, run `npm install` first if `node_modules` is absent. If the local install or build fails in your environment, treat it as a non-blocking warning and continue to upload. Keep the failure details because they may predict a server build problem, but don't change machine or registry config to force the pre-check to pass — the server build on upload is authoritative and surfaces its result on the app page.
-4. Optionally, preview against real data: `lightdash apps preview` (needs a successful `npm install`).
-5. `lightdash upload --apps <slug>` (the `slug` from `lightdash-app.yml`) — Lightdash rebuilds and serves the app.
+2. Run `lightdash apps validate` to check the source, manifest, dependencies, external-connection aliases, and semantic references against the downloaded context. Use `lightdash apps validate --build` to add the Cloud-parity Vite production build; use `--live` for fresh project explores or `--format json` in CI. `lightdash apps create` installs the initial dependencies after asking permission; after `lightdash download`, run `npm install` first if `node_modules` is absent. Custom dependencies are installed from `pnpm-lock.yaml` with a frozen lockfile and lifecycle scripts disabled. A build failure is a validation error with the Vite output and a non-zero exit.
+3. Optionally, preview against real data: `lightdash apps preview` (needs a successful `npm install`).
+4. `lightdash upload --apps <slug>` (the `slug` from `lightdash-app.yml`) — Lightdash rebuilds and serves the app.
 
 Local preview uses your existing CLI login through a project- and route-restricted loopback proxy; the credential is not written into this folder or exposed to browser code. It runs local tooling as your OS user (with access to that user's files, including the existing CLI config) and shows data under your own permissions, so preview only source/dependencies you trust. Host-mediated features such as external connections and data-app-viz context still need testing after upload.
 

--- a/packages/cli/src/handlers/apps/authoring/developing-data-apps-locally/SKILL.md
+++ b/packages/cli/src/handlers/apps/authoring/developing-data-apps-locally/SKILL.md
@@ -28,16 +28,15 @@ You are editing a Lightdash **data app** that was created or downloaded with the
 ## The edit → build → upload loop
 
 1. Edit files under `src/` only.
-2. Run `lightdash apps validate` to check the source, manifest, dependencies, external-connection aliases, and semantic references against the downloaded context. Use `--live` to check against fresh project explores; use `--format json` in CI. A green run reports any call sites it could not fully analyze instead of silently claiming complete coverage.
-3. Optionally, run `npm run build` to check it compiles. Apps made with `lightdash apps create` already have their initial dependencies installed. After `lightdash download`, if you choose to do the local pre-check and `node_modules` is absent, run `npm install` first. This is an **optional local pre-check** — see below.
-4. `lightdash upload --apps <slug>` (the `slug` from this folder's `lightdash-app.yml`) — the **server** rebuilds and serves the app. The server rebuild, not your local build, is what ships.
+2. Run `lightdash apps validate` to check the source, manifest, dependencies, external-connection aliases, and semantic references against the downloaded context. Use `lightdash apps validate --build` to add the Cloud-parity Vite production build; use `--live` to check against fresh project explores or `--format json` in CI. A green run reports any call sites it could not fully analyze instead of silently claiming complete coverage.
+3. `lightdash upload --apps <slug>` (the `slug` from this folder's `lightdash-app.yml`) — the **server** rebuilds and serves the app. The server rebuild remains the final result that ships.
 
-## The local build is optional — never fight a failing install
+## Cloud-parity local builds
 
-- If `npm install` fails (registry policy, an unavailable pinned SDK version, no network access), **skip the local build entirely and go straight to upload**. The server rebuild is authoritative and surfaces build errors on the app page.
-- Treat any standard local install or build failure as a **non-blocking warning**, not as an upload error or a failed task. Preserve a short summary of the local failure because it may predict a server build problem, then continue to upload. Make it explicit that the local pre-check did not complete, but that it does not decide whether the app ships; the server build does.
-- Do **not** modify machine configuration, `.npmrc` files, registry settings, or the project's dependency files to force an install to work.
-- A missing `node_modules` is a normal state, not a problem to fix. Never run installs just because it is absent.
+- `lightdash apps validate --build` assembles `src/` in an isolated copy of the CLI's trusted template and invokes bare `vite build` — it deliberately does not typecheck because the Cloud build does not typecheck.
+- Apps made with `lightdash apps create` already have the standard template dependencies installed. After `lightdash download`, run `npm install` before requesting `--build` if `node_modules` is absent. Validation does not install the standard dependency set implicitly.
+- Apps with custom dependencies are restored into the isolated build directory with `pnpm install --frozen-lockfile --ignore-scripts`, matching Cloud. An install or Vite failure is a validation error, includes the command output, and exits non-zero.
+- Do **not** modify machine configuration, `.npmrc` files, registry settings, or the project's dependency files to force the check to pass. The server rebuild on upload remains authoritative.
 - **Exception — adding a dependency** (only for organizations with custom dependencies enabled — see "Library boundaries" above). This is the one workflow that still requires pnpm: upload rejects new dependencies unless `pnpm-lock.yaml` was regenerated to match `package.json`, so dependency resolution MUST succeed locally. Use `pnpm add <pkg>` — prefixed with Socket Firewall when available (`sfw pnpm add <pkg>`; check with `command -v sfw`) to block known-malicious packages — or after editing `package.json` run `pnpm install --lockfile-only` (updates the lockfile without installing). If resolution fails, **stop and report the exact pnpm error to the user** — never hand-edit `package.json` and proceed without the lockfile; the upload will fail.
 - **Never run dependency lifecycle scripts.** The app's `.npmrc` sets `ignore-scripts=true` — leave it. A downloaded app can be authored by someone else, and their dependencies' install scripts must not execute on this machine. Explicit `npm run build`/`npm run dev` and `pnpm build`/`pnpm dev` commands still work.
 

--- a/packages/cli/src/handlers/apps/scaffolding.test.ts
+++ b/packages/cli/src/handlers/apps/scaffolding.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'os';
 import {
     buildStaticAuthoringFiles,
     firstExistingDir,
+    loadVendoredBuildScaffold,
     loadVendoredStarterSource,
     rewriteWorkspaceDeps,
 } from './scaffolding';
@@ -90,28 +91,47 @@ describe('buildStaticAuthoringFiles', () => {
 
     it('uses npm for the standard local workflow', () => {
         expect(text('README.md')).toContain('run `npm install` first');
-        expect(text('AGENTS.md')).toContain('npm install && npm run build');
+        expect(text('AGENTS.md')).toContain('run `npm install` first');
         expect(
             text('.claude/skills/developing-data-apps-locally/SKILL.md'),
-        ).toContain('run `npm install` first');
+        ).toContain('run `npm install` before');
         expect(text('.npmrc')).toContain('ignore-scripts=true');
         expect(text('.npmrc')).not.toContain('shamefully-hoist');
     });
 
-    it('classifies local build failures as non-blocking warnings', () => {
+    it('documents Cloud-parity validation builds', () => {
         for (const path of [
             'README.md',
             'AGENTS.md',
             '.claude/skills/developing-data-apps-locally/SKILL.md',
         ]) {
-            expect(text(path)).toContain('non-blocking warning');
-            expect(text(path)).toContain('continue to upload');
-            expect(text(path)).toContain('server build');
+            expect(text(path)).toContain('validate --build');
+            expect(text(path)).toContain('Cloud-parity');
         }
     });
 
     it('never writes app source (no src/ files)', () => {
         expect(files.every((f) => !f.path.startsWith('src/'))).toBe(true);
+    });
+});
+
+describe('loadVendoredBuildScaffold', () => {
+    const files = loadVendoredBuildScaffold('0.3275.0');
+    const byPath = (p: string) => files.find((file) => file.path === p);
+
+    it('loads the trusted build files without app source', () => {
+        expect(byPath('vite.config.js')).toBeDefined();
+        expect(byPath('index.html')).toBeDefined();
+        expect(files.every((file) => !file.path.startsWith('src/'))).toBe(true);
+    });
+
+    it('pins the SDK used by the local build', () => {
+        const packageJson = Buffer.from(
+            byPath('package.json')!.contentBase64,
+            'base64',
+        ).toString('utf-8');
+        expect(packageJson).toContain('"@lightdash/query-sdk": "0.3275.0"');
+        expect(packageJson).not.toContain('workspace:');
     });
 });
 

--- a/packages/cli/src/handlers/apps/scaffolding.ts
+++ b/packages/cli/src/handlers/apps/scaffolding.ts
@@ -115,6 +115,25 @@ const loadVendoredTemplate = (): DataAppCodeFile[] => {
     return walkDir(templateDir, templateDir, SKIP);
 };
 
+export const loadVendoredBuildScaffold = (
+    sdkVersion: string,
+): DataAppCodeFile[] =>
+    loadVendoredTemplate().map((file) =>
+        file.path === 'package.json'
+            ? {
+                  ...file,
+                  contentBase64: Buffer.from(
+                      rewriteWorkspaceDeps(
+                          Buffer.from(file.contentBase64, 'base64').toString(
+                              'utf-8',
+                          ),
+                          sdkVersion,
+                      ),
+                  ).toString('base64'),
+              }
+            : file,
+    );
+
 export const loadVendoredStarterSource = (): DataAppCodeFile[] => {
     const { templateDir } = resolveVendorDirs();
     return walkDir(path.join(templateDir, 'src'), templateDir, new Set());
@@ -133,19 +152,8 @@ export const buildStaticAuthoringFiles = (args: {
     const files: DataAppCodeFile[] = [];
 
     // 1. Template scaffold files (src/, scripts/, skill.md excluded)
-    for (const file of loadVendoredTemplate()) {
-        if (file.path === 'package.json') {
-            const rewritten = rewriteWorkspaceDeps(
-                Buffer.from(file.contentBase64, 'base64').toString('utf-8'),
-                sdkVersion,
-            );
-            files.push({
-                path: 'package.json',
-                contentBase64: Buffer.from(rewritten).toString('base64'),
-            });
-        } else {
-            files.push(file);
-        }
+    for (const file of loadVendoredBuildScaffold(sdkVersion)) {
+        files.push(file);
     }
 
     // 2. skill.md → .claude/skills/lightdash-data-app/SKILL.md

--- a/packages/cli/src/handlers/apps/validate.test.ts
+++ b/packages/cli/src/handlers/apps/validate.test.ts
@@ -471,6 +471,25 @@ describe('validateDataAppBuild', () => {
         ]);
     });
 
+    it('handles non-object command failures without masking them', async () => {
+        const dir = await makeApp();
+        await fs.mkdir(path.join(dir, 'node_modules'));
+        const bundle = await readBundleFromDir(dir);
+
+        const issues = await validateDataAppBuild({
+            appDir: dir,
+            bundle,
+            runCommand: vi.fn().mockRejectedValue(null),
+        });
+
+        expect(issues).toEqual([
+            expect.objectContaining({
+                code: 'build',
+                message: expect.stringContaining('Unknown object error'),
+            }),
+        ]);
+    });
+
     it('requires local template dependencies without installing them', async () => {
         const dir = await makeApp();
         const bundle = await readBundleFromDir(dir);

--- a/packages/cli/src/handlers/apps/validate.test.ts
+++ b/packages/cli/src/handlers/apps/validate.test.ts
@@ -6,11 +6,13 @@ import {
 import { promises as fs } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { writeBundleToDir } from './appCodeFiles';
+import { readBundleFromDir, writeBundleToDir } from './appCodeFiles';
 import {
     buildAppsValidationReport,
     renderAppsValidationHuman,
+    validateDataAppBuild,
     validateLocalDataApp,
+    type RunDataAppBuildCommand,
 } from './validate';
 
 const semanticLayer = [
@@ -315,6 +317,179 @@ describe('validateLocalDataApp', () => {
             expect.objectContaining({ code: 'source_parse' }),
         );
     });
+
+    it('includes Cloud-parity build failures when --build is enabled', async () => {
+        const dir = await makeApp();
+        const runBuild = vi.fn().mockResolvedValue([
+            {
+                code: 'build' as const,
+                message: 'Vite build failed: broken import',
+                location: null,
+            },
+        ]);
+
+        const result = await validateLocalDataApp(dir, {
+            build: true,
+            live: false,
+            loadLiveIndex: unusedLiveLoader,
+            runBuild,
+        });
+
+        expect(runBuild).toHaveBeenCalledOnce();
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContainEqual(
+            expect.objectContaining({
+                code: 'build',
+                message: expect.stringContaining('broken import'),
+            }),
+        );
+    });
+});
+
+describe('validateDataAppBuild', () => {
+    it('builds source in an isolated vendored scaffold with bare Vite', async () => {
+        const dir = await makeApp();
+        await fs.mkdir(path.join(dir, 'node_modules'));
+        const bundle = await readBundleFromDir(dir);
+        const runCommand: RunDataAppBuildCommand = vi.fn(async (command) => {
+            expect(command).toMatchObject({
+                command: 'vite',
+                args: ['build'],
+                preferLocal: true,
+                timeoutMs: 60_000,
+            });
+            expect(command.args).not.toContain('tsc');
+            await expect(
+                fs.readFile(path.join(command.cwd, 'vite.config.js'), 'utf-8'),
+            ).resolves.toContain('defineConfig');
+            await expect(
+                fs.readFile(path.join(command.cwd, 'src', 'App.tsx'), 'utf-8'),
+            ).resolves.toContain("query('orders')");
+            expect(
+                (
+                    await fs.lstat(path.join(command.cwd, 'node_modules'))
+                ).isSymbolicLink(),
+            ).toBe(true);
+        });
+
+        const issues = await validateDataAppBuild({
+            appDir: dir,
+            bundle,
+            runCommand,
+        });
+
+        expect(issues).toEqual([]);
+        expect(runCommand).toHaveBeenCalledOnce();
+    });
+
+    it('restores custom dependencies with a frozen lockfile before Vite', async () => {
+        const dir = await makeApp({
+            packageJson: JSON.stringify({
+                name: 'custom-app',
+                version: '1.0.0',
+                dependencies: { 'left-pad': '1.3.0' },
+                devDependencies: { malicious: '1.0.0' },
+                scripts: { build: 'tsc --noEmit' },
+            }),
+            lockfile: [
+                "lockfileVersion: '9.0'",
+                'packages:',
+                '  left-pad@1.3.0: {}',
+            ].join('\n'),
+        });
+        const bundle = await readBundleFromDir(dir);
+        const commands: Parameters<RunDataAppBuildCommand>[0][] = [];
+        const runCommand: RunDataAppBuildCommand = vi.fn(async (command) => {
+            commands.push(command);
+            if (command.command === 'pnpm') {
+                const packageJson = JSON.parse(
+                    await fs.readFile(
+                        path.join(command.cwd, 'package.json'),
+                        'utf-8',
+                    ),
+                ) as {
+                    dependencies: Record<string, string>;
+                    devDependencies: Record<string, string>;
+                    scripts: Record<string, string>;
+                };
+                expect(packageJson.dependencies).toEqual({
+                    'left-pad': '1.3.0',
+                });
+                expect(packageJson.scripts).toEqual(
+                    expect.objectContaining({ build: 'vite build' }),
+                );
+                expect(packageJson.devDependencies).not.toHaveProperty(
+                    'malicious',
+                );
+            }
+        });
+
+        const issues = await validateDataAppBuild({
+            appDir: dir,
+            bundle,
+            runCommand,
+        });
+
+        expect(issues).toEqual([]);
+        expect(commands).toEqual([
+            expect.objectContaining({
+                command: 'pnpm',
+                args: ['install', '--frozen-lockfile', '--ignore-scripts'],
+                env: { CI: 'true' },
+                timeoutMs: 120_000,
+            }),
+            expect.objectContaining({
+                command: 'vite',
+                args: ['build'],
+                preferLocal: true,
+            }),
+        ]);
+    });
+
+    it('reports Vite output as a build validation error', async () => {
+        const dir = await makeApp();
+        await fs.mkdir(path.join(dir, 'node_modules'));
+        const bundle = await readBundleFromDir(dir);
+        const viteError = Object.assign(new Error('Command failed'), {
+            stderr: 'src/App.tsx:7: Could not resolve "missing-package"',
+            stdout: 'vite v8 building for production',
+        });
+
+        const issues = await validateDataAppBuild({
+            appDir: dir,
+            bundle,
+            runCommand: vi.fn().mockRejectedValue(viteError),
+        });
+
+        expect(issues).toEqual([
+            expect.objectContaining({
+                code: 'build',
+                message: expect.stringContaining(
+                    'Could not resolve "missing-package"',
+                ),
+            }),
+        ]);
+    });
+
+    it('requires local template dependencies without installing them', async () => {
+        const dir = await makeApp();
+        const bundle = await readBundleFromDir(dir);
+        const runCommand = vi.fn();
+
+        const issues = await validateDataAppBuild({
+            appDir: dir,
+            bundle,
+            runCommand,
+        });
+
+        expect(issues).toEqual([
+            expect.objectContaining({
+                code: 'dependencies',
+                message: expect.stringContaining("Run 'npm install'"),
+            }),
+        ]);
+        expect(runCommand).not.toHaveBeenCalled();
+    });
 });
 
 describe('renderAppsValidationHuman', () => {
@@ -338,6 +513,7 @@ describe('renderAppsValidationHuman', () => {
                 },
             ],
             false,
+            true,
         );
 
         const output = renderAppsValidationHuman(report);
@@ -348,5 +524,6 @@ describe('renderAppsValidationHuman', () => {
         expect(output).toContain('unresolved values were skipped');
         expect(output).toContain('Validation passed');
         expect(output).toContain('Offline snapshots may be stale');
+        expect(output).toContain('running Vite production builds');
     });
 });

--- a/packages/cli/src/handlers/apps/validate.ts
+++ b/packages/cli/src/handlers/apps/validate.ts
@@ -9,16 +9,20 @@ import {
     isSummaryExploreError,
     isValidDataAppSlug,
     ParameterError,
+    sanitizeAppPackageJsonScripts,
     validateDataAppDependencies,
     type ApiExploreResults,
     type ApiExploresResults,
+    type DataAppCode,
     type DataAppDataReferences,
     type DataAppExploreIndex,
     type DataAppManifest,
     type DataAppSourceFile,
     type DataReferenceLocation,
 } from '@lightdash/common';
+import execa from 'execa';
 import { promises as fs } from 'fs';
+import * as os from 'os';
 import pLimit from 'p-limit';
 import * as path from 'path';
 import { getConfig } from '../../config';
@@ -30,18 +34,24 @@ import {
     applySdkMirrorToTemplateDeps,
     readBundleFromDir,
     readDependenciesFromDir,
+    writeFilesToDir,
 } from './appCodeFiles';
-import { loadTemplateDependencies } from './scaffolding';
+import {
+    loadTemplateDependencies,
+    loadVendoredBuildScaffold,
+} from './scaffolding';
 
 export type AppsValidateFormat = 'human' | 'json';
 
 export type AppsValidateOptions = {
+    build: boolean;
     format: AppsValidateFormat;
     live: boolean;
     verbose: boolean;
 };
 
 export type AppsValidationIssueCode =
+    | 'build'
     | 'bundle'
     | 'dependencies'
     | 'external_connection'
@@ -71,6 +81,7 @@ export type AppValidationResult = {
 };
 
 export type AppsValidationReport = {
+    build: boolean;
     valid: boolean;
     mode: 'live' | 'offline';
     summary: {
@@ -84,9 +95,14 @@ export type AppsValidationReport = {
 };
 
 type ValidateAppOptions = {
+    build?: boolean;
     live: boolean;
     liveProjectUuid?: string;
     loadLiveIndex: (projectUuid: string) => Promise<DataAppExploreIndex>;
+    runBuild?: (args: {
+        appDir: string;
+        bundle: DataAppCode;
+    }) => Promise<AppsValidationIssue[]>;
 };
 
 const emptyCoverage = (): AppsValidationCoverage => ({
@@ -266,6 +282,214 @@ const validateDependencies = async (
     }
 };
 
+type DataAppBuildCommand = {
+    command: string;
+    args: string[];
+    cwd: string;
+    env?: NodeJS.ProcessEnv;
+    preferLocal?: boolean;
+    timeoutMs: number;
+};
+
+export type RunDataAppBuildCommand = (
+    command: DataAppBuildCommand,
+) => Promise<void>;
+
+const runDataAppBuildCommand: RunDataAppBuildCommand = async (command) => {
+    await execa(command.command, command.args, {
+        cwd: command.cwd,
+        env: command.env,
+        localDir: command.preferLocal ? command.cwd : undefined,
+        preferLocal: command.preferLocal,
+        timeout: command.timeoutMs,
+    });
+};
+
+const commandFailureOutput = (error: unknown): string => {
+    const commandError = error as {
+        stderr?: unknown;
+        stdout?: unknown;
+    };
+    const output = [commandError.stderr, commandError.stdout]
+        .filter(
+            (value): value is string | Buffer =>
+                typeof value === 'string' || Buffer.isBuffer(value),
+        )
+        .map(String)
+        .filter(Boolean)
+        .join('\n')
+        .trim();
+    return (output || getErrorMessage(error)).slice(-2000);
+};
+
+const hasNodeModules = async (appDir: string): Promise<boolean> =>
+    fs
+        .stat(path.join(appDir, 'node_modules'))
+        .then((entry) => entry.isDirectory())
+        .catch(() => false);
+
+const buildPackageJsonForCustomDependencies = (
+    scaffold: DataAppCode['files'],
+    packageJson: string,
+): string => {
+    const packageFile = scaffold.find((file) => file.path === 'package.json');
+    if (packageFile === undefined) {
+        throw new Error('Vendored data app template is missing package.json.');
+    }
+    const templatePackage = JSON.parse(
+        Buffer.from(packageFile.contentBase64, 'base64').toString('utf-8'),
+    ) as {
+        scripts?: Record<string, string>;
+        devDependencies?: Record<string, string>;
+    };
+    if (
+        templatePackage.scripts === undefined ||
+        templatePackage.devDependencies === undefined
+    ) {
+        throw new Error(
+            'Vendored data app template package.json is missing scripts or devDependencies.',
+        );
+    }
+    return sanitizeAppPackageJsonScripts(
+        packageJson,
+        templatePackage.scripts,
+        templatePackage.devDependencies,
+    );
+};
+
+export const validateDataAppBuild = async (args: {
+    appDir: string;
+    bundle: DataAppCode;
+    runCommand?: RunDataAppBuildCommand;
+}): Promise<AppsValidationIssue[]> => {
+    const runCommand = args.runCommand ?? runDataAppBuildCommand;
+    let dependencies: Awaited<ReturnType<typeof readDependenciesFromDir>>;
+    let hasCustomDependencies: boolean;
+    try {
+        dependencies = await readDependenciesFromDir(args.appDir);
+        const templateDependencies =
+            dependencies === null
+                ? loadTemplateDependencies(CLI_VERSION)
+                : applySdkMirrorToTemplateDeps(
+                      loadTemplateDependencies(CLI_VERSION),
+                      dependencies.packageJson,
+                  );
+        const customDependencies =
+            dependencies === null
+                ? {}
+                : computeCustomDependencies(
+                      dependencies.packageJson,
+                      templateDependencies,
+                  );
+        hasCustomDependencies = Object.keys(customDependencies).length > 0;
+    } catch (error) {
+        return [issue('dependencies', getErrorMessage(error))];
+    }
+
+    if (!hasCustomDependencies && !(await hasNodeModules(args.appDir))) {
+        return [
+            issue(
+                'dependencies',
+                `Dependencies are not installed. Run 'npm install' in ${args.appDir} before using lightdash apps validate --build.`,
+            ),
+        ];
+    }
+    if (
+        hasCustomDependencies &&
+        dependencies !== null &&
+        dependencies.lockfile === null
+    ) {
+        return [
+            issue(
+                'dependencies',
+                'Custom dependencies require pnpm-lock.yaml before the Cloud-parity build can run.',
+            ),
+        ];
+    }
+
+    let buildDir: string | undefined;
+    try {
+        buildDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'lightdash-app-build-'),
+        );
+        const scaffold = loadVendoredBuildScaffold(CLI_VERSION);
+        await writeFilesToDir(buildDir, [...scaffold, ...args.bundle.files]);
+
+        if (
+            hasCustomDependencies &&
+            dependencies !== null &&
+            dependencies.lockfile !== null
+        ) {
+            await Promise.all([
+                fs.writeFile(
+                    path.join(buildDir, 'package.json'),
+                    buildPackageJsonForCustomDependencies(
+                        scaffold,
+                        dependencies.packageJson,
+                    ),
+                ),
+                fs.writeFile(
+                    path.join(buildDir, 'pnpm-lock.yaml'),
+                    dependencies.lockfile,
+                ),
+            ]);
+            try {
+                await runCommand({
+                    command: 'pnpm',
+                    args: ['install', '--frozen-lockfile', '--ignore-scripts'],
+                    cwd: buildDir,
+                    env: { CI: 'true' },
+                    timeoutMs: 120_000,
+                });
+            } catch (error) {
+                return [
+                    issue(
+                        'dependencies',
+                        `Dependency install failed: ${commandFailureOutput(error)}`,
+                    ),
+                ];
+            }
+        } else {
+            await fs.symlink(
+                path.resolve(args.appDir, 'node_modules'),
+                path.join(buildDir, 'node_modules'),
+                process.platform === 'win32' ? 'junction' : 'dir',
+            );
+        }
+
+        try {
+            await runCommand({
+                command: 'vite',
+                args: ['build'],
+                cwd: buildDir,
+                preferLocal: true,
+                timeoutMs: 60_000,
+            });
+        } catch (error) {
+            return [
+                issue(
+                    'build',
+                    `Vite build failed:\n${commandFailureOutput(error)}`,
+                ),
+            ];
+        }
+        return [];
+    } catch (error) {
+        return [
+            issue(
+                'build',
+                `Could not prepare the Vite build: ${getErrorMessage(error)}`,
+            ),
+        ];
+    } finally {
+        if (buildDir !== undefined) {
+            await fs
+                .rm(buildDir, { recursive: true, force: true })
+                .catch(() => undefined);
+        }
+    }
+};
+
 const sourceFilesFromBundle = (
     files: { path: string; contentBase64: string }[],
 ): DataAppSourceFile[] =>
@@ -325,7 +549,8 @@ export const validateLocalDataApp = async (
     const { manifest } = bundle;
     const manifestResult = validateManifest(manifest);
     errors.push(...manifestResult.errors);
-    errors.push(...(await validateDependencies(appDir)));
+    const dependencyErrors = await validateDependencies(appDir);
+    errors.push(...dependencyErrors);
 
     const sourceFiles = sourceFilesFromBundle(bundle.files);
     if (sourceFiles.length === 0) {
@@ -417,6 +642,15 @@ export const validateLocalDataApp = async (
         projectUuid = manifest.projectUuid;
     }
 
+    if (options.build && dependencyErrors.length === 0) {
+        errors.push(
+            ...(await (options.runBuild ?? validateDataAppBuild)({
+                appDir,
+                bundle,
+            })),
+        );
+    }
+
     return {
         path: appDir,
         name: typeof manifest.name === 'string' ? manifest.name : null,
@@ -431,6 +665,7 @@ export const validateLocalDataApp = async (
 export const buildAppsValidationReport = (
     apps: AppValidationResult[],
     live: boolean,
+    build = false,
 ): AppsValidationReport => {
     const errors = apps.reduce((count, app) => count + app.errors.length, 0);
     const warnings = apps.reduce(
@@ -438,6 +673,7 @@ export const buildAppsValidationReport = (
         0,
     );
     return {
+        build,
         valid: errors === 0,
         mode: live ? 'live' : 'offline',
         summary: {
@@ -482,7 +718,7 @@ export const renderAppsValidationHuman = (
             report.mode === 'live'
                 ? 'the live project semantic layer'
                 : 'local semantic layer snapshots'
-        }.`,
+        }${report.build ? ' and running Vite production builds' : ''}.`,
     ];
     if (report.mode === 'offline') {
         lines.push(
@@ -553,10 +789,11 @@ export const appsValidateHandler = async (
                 live: options.live,
                 liveProjectUuid,
                 loadLiveIndex,
+                build: options.build,
             }),
         ),
     );
-    const report = buildAppsValidationReport(apps, options.live);
+    const report = buildAppsValidationReport(apps, options.live, options.build);
     process.stdout.write(
         options.format === 'json'
             ? `${JSON.stringify(report, null, 2)}\n`

--- a/packages/cli/src/handlers/apps/validate.ts
+++ b/packages/cli/src/handlers/apps/validate.ts
@@ -306,10 +306,13 @@ const runDataAppBuildCommand: RunDataAppBuildCommand = async (command) => {
 };
 
 const commandFailureOutput = (error: unknown): string => {
-    const commandError = error as {
-        stderr?: unknown;
-        stdout?: unknown;
-    };
+    const commandError =
+        typeof error === 'object' && error !== null
+            ? (error as {
+                  stderr?: unknown;
+                  stdout?: unknown;
+              })
+            : {};
     const output = [commandError.stderr, commandError.stdout]
         .filter(
             (value): value is string | Buffer =>

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1163,6 +1163,11 @@ appsProgram
         'Validate against fresh explores from each app project instead of its downloaded semantic-layer snapshot.',
         false,
     )
+    .option(
+        '--build',
+        'Run the same Vite production build as Lightdash Cloud.',
+        false,
+    )
     .addOption(
         new Option('--format <format>', 'Output format: human or json')
             .choices(['human', 'json'])


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9450/lightdash-apps-validate-build-local-build-parity-with-the-cloud-build

## What changed

- add `--build` to `lightdash apps validate`
- assemble app source in an isolated copy of the CLI's trusted vendored scaffold
- invoke bare `vite build` without TypeScript typechecking, matching the Cloud build
- restore custom dependencies with `pnpm install --frozen-lockfile --ignore-scripts`
- report dependency-install and Vite output as validation errors with a non-zero exit
- update generated app guidance and CLI documentation

## Why

`lightdash apps validate` checked manifests, dependencies, connection aliases, and semantic references, but an app could still fail during the production Vite build after upload. This adds an explicit local build mode that follows the same build boundary as Cloud: uploaded `src/` over trusted template tooling.


## Developer impact

Developers can run `lightdash apps validate --build` locally or in CI and receive actionable Vite output before upload. Standard apps reuse their installed template dependencies; apps declaring custom dependencies verify their frozen pnpm lockfile first.

## Validation

- `pnpm -F @lightdash/cli format`
- `pnpm -F @lightdash/cli typecheck`
- `pnpm -F @lightdash/cli lint`
- `pnpm -F @lightdash/cli test` (490 tests)
- `pnpm cli-build`
- compiled CLI smoke test for JSON reporting and the non-zero frozen-lockfile failure path