### PR TITLE
feat(auth): limit failed password login attempts

### DIFF
--- a/packages/backend/src/database/entities/passwordLogins.ts
+++ b/packages/backend/src/database/entities/passwordLogins.ts
@@ -4,6 +4,9 @@ export type DbPasswordLogin = {
     user_id: number;
     password_hash: string;
     created_at: Date;
+    failed_attempt_count: number;
+    last_attempt_at: Date;
+    blocked_until: Date | null;
 };
 
 export type DbPasswordLoginIn = Pick<

--- a/packages/backend/src/database/migrations/20260805100000_add_password_login_attempt_limits.ts
+++ b/packages/backend/src/database/migrations/20260805100000_add_password_login_attempt_limits.ts
@@ -1,0 +1,23 @@
+import { Knex } from 'knex';
+import { PasswordLoginTableName } from '../entities/passwordLogins';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(PasswordLoginTableName, (table) => {
+        table.integer('failed_attempt_count').notNullable().defaultTo(0);
+        table
+            .timestamp('last_attempt_at')
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table.timestamp('blocked_until').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(PasswordLoginTableName, (table) => {
+        table.dropColumns(
+            'failed_attempt_count',
+            'last_attempt_at',
+            'blocked_until',
+        );
+    });
+}

--- a/packages/backend/src/models/UserModel.test.ts
+++ b/packages/backend/src/models/UserModel.test.ts
@@ -5,6 +5,7 @@ import {
     MemberAbility,
     NotFoundError,
     OrganizationMemberRole,
+    PasswordLoginBlockedError,
     projectMemberAbilities,
     ProjectMemberRole,
     ServiceAccountScope,
@@ -460,6 +461,121 @@ describe('UserModel', () => {
             ).rejects.toThrow(NotFoundError);
 
             expect(compareSpy).not.toHaveBeenCalled();
+            compareSpy.mockRestore();
+        });
+
+        const createLoginDatabase = (
+            login: Record<string, unknown>,
+            updatedAttemptCount = 1,
+        ) => {
+            const updates: Record<string, unknown>[] = [];
+            let queryCount = 0;
+            const database = vi.fn(() => {
+                queryCount += 1;
+                const result =
+                    queryCount === 1
+                        ? [login]
+                        : [{ failed_attempt_count: updatedAttemptCount }];
+                const query: unknown = new Proxy(
+                    {},
+                    {
+                        get: (_target, prop) => {
+                            if (prop === 'then') {
+                                return (
+                                    resolve: (value: unknown[]) => unknown,
+                                ) => resolve(result);
+                            }
+                            if (prop === 'update') {
+                                return (update: Record<string, unknown>) => {
+                                    updates.push(update);
+                                    return query;
+                                };
+                            }
+                            return () => query;
+                        },
+                    },
+                );
+                return query;
+            }) as unknown as Knex;
+            database.raw = vi.fn((sql: string) => sql) as Knex['raw'];
+            return { database, updates };
+        };
+
+        const passwordLogin = {
+            ...userDetails,
+            password_hash: 'hash',
+            failed_attempt_count: 0,
+            last_attempt_at: new Date(),
+            blocked_until: null,
+        };
+
+        it('rejects a blocked login without comparing the password', async () => {
+            const { database } = createLoginDatabase({
+                ...passwordLogin,
+                blocked_until: new Date(Date.now() + 60_000),
+            });
+            const model = new UserModel({
+                database,
+                lightdashConfig,
+                featureFlagModel,
+            });
+            const compareSpy = vi.spyOn(bcrypt, 'compare');
+
+            await expect(
+                model.getUserByPrimaryEmailAndPassword(
+                    'user@example.com',
+                    'password1!',
+                ),
+            ).rejects.toThrow(PasswordLoginBlockedError);
+            expect(compareSpy).not.toHaveBeenCalled();
+            compareSpy.mockRestore();
+        });
+
+        it('blocks the account when the fifth password attempt fails', async () => {
+            const { database, updates } = createLoginDatabase(passwordLogin, 5);
+            const model = new UserModel({
+                database,
+                lightdashConfig,
+                featureFlagModel,
+            });
+            const compareSpy = vi
+                .spyOn(bcrypt, 'compare')
+                .mockResolvedValue(false);
+
+            await expect(
+                model.getUserByPrimaryEmailAndPassword(
+                    'user@example.com',
+                    'wrong',
+                ),
+            ).rejects.toThrow(PasswordLoginBlockedError);
+            expect(updates[0]).toMatchObject({
+                last_attempt_at: expect.any(Date),
+            });
+            compareSpy.mockRestore();
+        });
+
+        it('clears failed attempts after a successful login', async () => {
+            const { database, updates } = createLoginDatabase(passwordLogin);
+            const model = new UserModel({
+                database,
+                lightdashConfig,
+                featureFlagModel,
+            });
+            vi.spyOn(model, 'hasAuthentication').mockResolvedValue(true);
+            const compareSpy = vi
+                .spyOn(bcrypt, 'compare')
+                .mockResolvedValue(true);
+
+            await model.getUserByPrimaryEmailAndPassword(
+                'user@example.com',
+                'password1!',
+            );
+
+            expect(updates[0]).toMatchObject({
+                failed_attempt_count: 0,
+                last_attempt_at: expect.any(Date),
+                blocked_until: null,
+            });
             compareSpy.mockRestore();
         });
     });

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -23,6 +23,7 @@ import {
     OpenIdUser,
     OrganizationMemberRole,
     ParameterError,
+    PasswordLoginBlockedError,
     PersonalAccessToken,
     ProjectAbilityProfile,
     projectMemberAbilities,
@@ -457,10 +458,14 @@ export class UserModel {
             // this is already empty for them — the explicit guard documents
             // intent and survives any join refactor.
             .andWhere(`${UserTableName}.is_internal`, false)
-            .select<(DbUserDetails & { password_hash: string })[]>(
-                '*',
-                'organizations.created_at as organization_created_at',
-            );
+            .select<
+                (DbUserDetails & {
+                    password_hash: string | null;
+                    failed_attempt_count: number;
+                    last_attempt_at: Date;
+                    blocked_until: Date | null;
+                })[]
+            >('*', 'organizations.created_at as organization_created_at');
         if (user === undefined) {
             throw new NotFoundError(
                 `No user found with email ${email} and password`,
@@ -471,12 +476,43 @@ export class UserModel {
                 `No User found with email ${email} and password`,
             );
         }
+        const now = new Date();
+        if (user.blocked_until && user.blocked_until > now) {
+            throw new PasswordLoginBlockedError();
+        }
         const match = await bcrypt.compare(password, user.password_hash);
         if (!match) {
+            const [loginAttempt] = await this.database(PasswordLoginTableName)
+                .where('user_id', user.user_id)
+                .update({
+                    failed_attempt_count: this.database.raw(
+                        'CASE WHEN last_attempt_at > ? THEN failed_attempt_count + 1 ELSE 1 END',
+                        [new Date(now.getTime() - 5 * 60 * 1000)],
+                    ),
+                    last_attempt_at: now,
+                    blocked_until: this.database.raw(
+                        'CASE WHEN (CASE WHEN last_attempt_at > ? THEN failed_attempt_count + 1 ELSE 1 END) >= 5 THEN ? ELSE NULL END',
+                        [
+                            new Date(now.getTime() - 5 * 60 * 1000),
+                            new Date(now.getTime() + 30 * 60 * 1000),
+                        ],
+                    ),
+                })
+                .returning(['failed_attempt_count']);
+            if (loginAttempt.failed_attempt_count >= 5) {
+                throw new PasswordLoginBlockedError();
+            }
             throw new NotFoundError(
                 `No User found with email ${email} and password`,
             );
         }
+        await this.database(PasswordLoginTableName)
+            .where('user_id', user.user_id)
+            .update({
+                failed_attempt_count: 0,
+                last_attempt_at: now,
+                blocked_until: null,
+            });
         return mapDbUserDetailsToLightdashUser(
             user,
             await this.hasAuthentication(user.user_uuid),

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -48,6 +48,7 @@ import {
     OpenIdUser,
     OrganizationMemberRole,
     ParameterError,
+    PasswordLoginBlockedError,
     PasswordReset,
     ProjectMemberRole,
     RedshiftAuthenticationType,
@@ -1649,7 +1650,9 @@ export class UserService extends BaseService {
                     'Email and password not recognized',
                 );
             }
-            if (e instanceof DeactivatedAccountError) {
+            if (e instanceof PasswordLoginBlockedError) {
+                emitFailure('Too many failed login attempts');
+            } else if (e instanceof DeactivatedAccountError) {
                 emitFailure('Account is deactivated');
             } else if (e instanceof AuthorizationError) {
                 emitFailure('Email and password not recognized');

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -98,6 +98,20 @@ export class AuthorizationError extends LightdashError {
     }
 }
 
+export class PasswordLoginBlockedError extends LightdashError {
+    constructor(
+        message = 'Too many failed login attempts. Please try again later.',
+        data: { [key: string]: AnyType } = {},
+    ) {
+        super({
+            message,
+            name: 'PasswordLoginBlockedError',
+            statusCode: 429,
+            data,
+        });
+    }
+}
+
 export class ExpiredError extends LightdashError {
     constructor(message: string) {
         super({


### PR DESCRIPTION
## What changed

Adds persistent password-login attempt tracking and temporarily blocks accounts after five failures within five minutes. Successful logins reset the counters, while blocked attempts return a dedicated HTTP 429 error.

## Validation status

> ⚠️ The generated patch is not working in the live preview yet. PostgreSQL rejects the `blocked_until` update because the CASE expression resolves to `text` instead of `timestamp with time zone`. The attempted follow-up made no code changes because that runner resumed Codex in read-only mode.

## Diagnostic evidence

![The preview currently shows generic login failures instead of the expected lockout message](https://ld-linear-agent.exe.xyz/artifacts/dc4727f95931e837/1/1-password-lockout-threshold.jpg)

_This screenshot records the current failure state; it does not verify the intended lockout behavior._

## Preview

[Open the Lightdash preview](https://ldlin-dc4727f95931.exe.xyz)

Login: `demo@lightdash.com` / `demo_password!`

## Linear

PROD-3005: Max login attempts

> Generated by the Lightdash Linear agent. Review and test all changes before merging.