### PR TITLE
refactor: extract project context entry authoring seam

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -642,6 +642,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     }),
                     catalogModel: models.getCatalogModel(),
                     projectModel: models.getProjectModel(),
+                    projectContextModel:
+                        models.getProjectContextModel<ProjectContextModel>(),
                     lightdashConfig: context.lightdashConfig,
                     aiAgentReviewNotificationService:
                         repository.getAiAgentReviewNotificationService<AiAgentReviewNotificationService>(),

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.judge.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.judge.test.ts
@@ -146,6 +146,7 @@ const makeService = () =>
             getSummary: vi.fn(),
             findExploresFromCache: vi.fn(),
         } as never,
+        projectContextModel: { getDocument: vi.fn().mockResolvedValue([]) },
         lightdashConfig: {
             ai: { copilot: { providers: {}, defaultProvider: 'openai' } },
         } as never,
@@ -189,5 +190,32 @@ describe('single-tier judge', () => {
 
         expect(generateObjectMock).toHaveBeenCalledTimes(1);
         expect(result.judgeOutput).toEqual(output);
+    });
+
+    it('routes project-context findings through the authoring call', async () => {
+        const output = judgeOutput({ primaryRootCause: 'project_context' });
+        const projectContextEntry = {
+            op: 'create' as const,
+            id: null,
+            kind: 'context' as const,
+            content: 'Use the payments explore for transaction questions.',
+            terms: ['transaction'],
+            objects: [{ type: 'explore' as const, name: 'payments' }],
+        };
+        generateObjectMock
+            .mockResolvedValueOnce({ object: output } as never)
+            .mockResolvedValueOnce({
+                object: { projectContextEntry },
+            } as never);
+
+        const result = await makeService().replayJudge(replayInput);
+
+        expect(generateObjectMock).toHaveBeenCalledTimes(2);
+        expect(generateObjectMock).toHaveBeenLastCalledWith(
+            expect.objectContaining({ model: JUDGE_MODEL.model }),
+        );
+        expect(result.judgeOutput?.projectContextEntry).toEqual(
+            projectContextEntry,
+        );
     });
 });

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
@@ -272,6 +272,9 @@ describe('AiAgentReviewClassifierService', () => {
         getSummary: vi.fn(),
         findExploresFromCache: vi.fn(),
     };
+    const projectContextModel = {
+        getDocument: vi.fn(),
+    };
     const aiAgentReviewNotificationService = {
         notifyNeedsReview: vi.fn(),
     };
@@ -285,6 +288,7 @@ describe('AiAgentReviewClassifierService', () => {
         orgAiCopilotConfigResolver: orgAiCopilotConfigResolver as never,
         catalogModel: catalogModel as never,
         projectModel: projectModel as never,
+        projectContextModel,
         lightdashConfig: {} as never,
         judgeTurn,
         aiAgentReviewNotificationService:

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import {
     aiAgentReviewClassifierJudgeCallOutputSchema,
-    aiAgentReviewClassifierJudgeProjectContextCallSchema,
     assertUnreachable,
     CatalogType,
     filterExploreByTags,
@@ -48,9 +47,11 @@ import { type AiAgentDocumentModel } from '../models/AiAgentDocumentModel';
 import { type AiAgentModel } from '../models/AiAgentModel';
 import { type AiAgentReviewClassifierModel } from '../models/AiAgentReviewClassifierModel';
 import { type AiOrganizationSettingsModel } from '../models/AiOrganizationSettingsModel';
+import { type ProjectContextModel } from '../models/ProjectContextModel';
 import { defaultAgentOptions } from './ai/agents/agentV2';
 import { getModel } from './ai/models';
 import { OrgAiCopilotConfigResolver } from './ai/OrgAiCopilotConfigResolver';
+import { authorProjectContextEntry } from './ai/projectContext/authorProjectContextEntry';
 import {
     getAiCallTelemetry,
     getLanguageModelAttribution,
@@ -101,6 +102,7 @@ type AiAgentReviewClassifierServiceDependencies = {
     projectModel: Pick<ProjectModel, 'getSummary' | 'findExploresFromCache'>;
     lightdashConfig: LightdashConfig;
     aiAgentReviewNotificationService: AiAgentReviewNotificationService;
+    projectContextModel: Pick<ProjectContextModel, 'getDocument'>;
     judgeTurn?: AiAgentReviewClassifierJudge;
 };
 
@@ -295,6 +297,11 @@ export class AiAgentReviewClassifierService extends BaseService {
 
     private readonly lightdashConfig: LightdashConfig;
 
+    private readonly projectContextModel: Pick<
+        ProjectContextModel,
+        'getDocument'
+    >;
+
     private readonly judgeTurn: AiAgentReviewClassifierJudge;
 
     constructor(dependencies: AiAgentReviewClassifierServiceDependencies) {
@@ -312,6 +319,7 @@ export class AiAgentReviewClassifierService extends BaseService {
         this.aiAgentReviewNotificationService =
             dependencies.aiAgentReviewNotificationService;
         this.lightdashConfig = dependencies.lightdashConfig;
+        this.projectContextModel = dependencies.projectContextModel;
         this.judgeTurn =
             dependencies.judgeTurn ??
             ((candidate, evidencePacket) =>
@@ -1740,50 +1748,25 @@ Existing review items — dedup rules. The evidence packet field existingReviewI
             ...getLanguageModelAttribution(model.model),
         });
         try {
-            const result = await generateObject({
-                model: model.model,
-                ...defaultAgentOptions,
-                ...model.callOptions,
-                providerOptions: model.providerOptions,
-                experimental_telemetry: telemetry,
-                schema: aiAgentReviewClassifierJudgeProjectContextCallSchema,
-                messages: [
-                    {
-                        role: 'system',
-                        content: `You emit the structured living-document entry for a Lightdash AI review finding whose root cause is project_context.
-
-Set projectContextEntry ONLY when a single durable, project-specific fact (a business definition or acronym, routing/join guidance, or object-scoped context) would prevent this class of failure in future turns. Otherwise set it to null.
-- op: "update" if one of the project context entries already injected into the reviewed turn was present but insufficient (reference its id); otherwise "create".
-- id: the existing entry id when op="update", otherwise null.
-- kind: definition | context. Use "definition" for acronyms and business vocabulary ("X means Y"); use "context" for everything else (routing/join rules, guidance, durable object-scoped facts).
-- content: a single self-contained sentence stating the fact (e.g. '"HR" = the high-risk diabetes cohort, not human resources.').
-- terms: the prompt-facing trigger words/phrases that should surface this entry (e.g. ["HR","high risk"]). Required for definitions.
-- objects: typed semantic object refs derived from the finding's targetRefs. For an explore use {"type":"explore","name":"payments"}. For a field use {"type":"field","explore":"payments","fieldId":"payments_total_amount"}; the owning explore is required and must be one where that field exists. Use [] when purely prompt-driven.
-
-Use only the supplied evidence packet and finding. Do not invent project fields or facts.`,
+            const currentEntries = await this.projectContextModel.getDocument(
+                candidate.subject.projectUuid,
+            );
+            return await authorProjectContextEntry({
+                evidence: {
+                    type: 'turn',
+                    evidencePacket,
+                    finding: {
+                        reviewItem: judgeOutput.reviewItem,
+                        promotionReason: judgeOutput.promotionReason,
+                        targetRefs: judgeOutput.targetRefs,
+                        subcategories: judgeOutput.subcategories,
+                        recommendation: judgeOutput.recommendation,
                     },
-                    {
-                        role: 'user',
-                        content: JSON.stringify(
-                            {
-                                evidencePacket,
-                                finding: {
-                                    reviewItem: judgeOutput.reviewItem,
-                                    promotionReason:
-                                        judgeOutput.promotionReason,
-                                    targetRefs: judgeOutput.targetRefs,
-                                    subcategories: judgeOutput.subcategories,
-                                    recommendation: judgeOutput.recommendation,
-                                },
-                            },
-                            null,
-                            2,
-                        ),
-                    },
-                ],
+                },
+                currentEntries,
+                model,
+                telemetry,
             });
-            emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
-            return result.object.projectContextEntry;
         } catch (error) {
             Logger.error(
                 'AI review project context entry emission failed; keeping finding without an entry',

--- a/packages/backend/src/ee/services/ai/projectContext/authorProjectContextEntry.test.ts
+++ b/packages/backend/src/ee/services/ai/projectContext/authorProjectContextEntry.test.ts
@@ -1,0 +1,135 @@
+import type { ProjectContextEntry } from '@lightdash/common';
+import type { AiAgentReviewJudgeEvidencePacket } from '../../AiAgentReviewClassifierService';
+import {
+    authorProjectContextEntry,
+    type ProjectContextEntryAuthoringEvidence,
+} from './authorProjectContextEntry';
+
+const currentEntries: ProjectContextEntry[] = [
+    {
+        id: 'active-users',
+        kind: 'definition',
+        content: 'Active users signed in during the last 28 days.',
+        terms: ['active user'],
+        objects: [],
+    },
+];
+
+const evidencePacket: AiAgentReviewJudgeEvidencePacket = {
+    subject: {
+        type: 'turn_review',
+        assistantPromptUuid: 'prompt-1',
+        threadUuid: 'thread-1',
+        agentUuid: 'agent-1',
+        projectUuid: 'project-1',
+        organizationUuid: 'org-1',
+    },
+    interactionSource: 'app',
+    targetTurn: {
+        promptUuid: 'prompt-1',
+        userPrompt: 'What is an active user?',
+        assistantResponse: 'An active user signed in during the last 28 days.',
+        errorMessage: null,
+        createdAt: new Date('2026-08-05T10:00:00.000Z'),
+        respondedAt: new Date('2026-08-05T10:00:01.000Z'),
+    },
+    humanFeedback: { score: null, comment: null },
+    agentConfig: {
+        snapshotHash: null,
+        settings: [],
+        availableCapabilities: [],
+        dataAccessEnabled: null,
+        selfImprovementEnabled: null,
+        contentToolsEnabled: null,
+        instructionSummary: null,
+        knowledgeDocumentCount: 0,
+        knowledgeDocuments: [],
+        mcpServers: [],
+    },
+    semanticContext: {
+        queriedExploreNames: [],
+        queriedFieldNames: [],
+        catalogMatches: [],
+    },
+    nextUserPrompt: null,
+    previousTurns: [],
+    queryHistory: [],
+    supportingEvidence: [],
+    suggestedEvidenceExcerpts: [],
+    threadWritebackPullRequests: [],
+    toolOutcomes: [],
+    pendingApprovalTimeout: false,
+    existingReviewItems: [],
+};
+
+const evidence = {
+    type: 'turn',
+    evidencePacket,
+    finding: {
+        reviewItem: { title: 'Clarify active users', description: 'Ambiguous' },
+        promotionReason: 'The answer used the wrong definition.',
+        targetRefs: [],
+        subcategories: [],
+        recommendation: null,
+    },
+} satisfies ProjectContextEntryAuthoringEvidence;
+
+const authoringResult = {
+    projectContextEntry: {
+        op: 'update' as const,
+        id: 'active-users',
+        kind: 'definition' as const,
+        content: 'Active users signed in during the last 30 days.',
+        terms: ['active user'],
+        objects: [],
+    },
+};
+
+describe('authorProjectContextEntry', () => {
+    it('authors from turn evidence and current project-context entries', async () => {
+        const authoringLlmCall = vi.fn().mockResolvedValue(authoringResult);
+
+        const result = await authorProjectContextEntry({
+            evidence,
+            currentEntries,
+            model: {} as never,
+            telemetry: {} as never,
+            authoringLlmCall,
+        });
+
+        expect(result).toEqual(authoringResult.projectContextEntry);
+        expect(authoringLlmCall).toHaveBeenCalledOnce();
+        const userMessage = authoringLlmCall.mock.calls[0][0].messages[1];
+        expect(JSON.parse(userMessage.content)).toMatchObject({
+            evidencePacket: {
+                subject: evidencePacket.subject,
+                targetTurn: {
+                    promptUuid: 'prompt-1',
+                    createdAt: '2026-08-05T10:00:00.000Z',
+                    respondedAt: '2026-08-05T10:00:01.000Z',
+                },
+            },
+            finding: evidence.finding,
+            currentProjectContextEntries: currentEntries,
+        });
+    });
+
+    it('validates injected call output', async () => {
+        const authoringLlmCall = vi.fn().mockResolvedValue({
+            projectContextEntry: {
+                ...authoringResult.projectContextEntry,
+                id: null,
+            },
+        });
+
+        await expect(
+            authorProjectContextEntry({
+                evidence,
+                currentEntries,
+                model: {} as never,
+                telemetry: {} as never,
+                authoringLlmCall,
+            }),
+        ).rejects.toThrow('id is required when op is update');
+    });
+});

--- a/packages/backend/src/ee/services/ai/projectContext/authorProjectContextEntry.ts
+++ b/packages/backend/src/ee/services/ai/projectContext/authorProjectContextEntry.ts
@@ -1,0 +1,112 @@
+import {
+    aiAgentReviewClassifierJudgeProjectContextCallSchema,
+    type AiAgentJudgeProjectContextEntry,
+    type AiAgentReviewClassifierJudgeOutput,
+    type ProjectContextEntry,
+} from '@lightdash/common';
+import { generateObject } from 'ai';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../../analytics/aiUsage';
+import type { AiAgentReviewJudgeEvidencePacket } from '../../AiAgentReviewClassifierService';
+import { defaultAgentOptions } from '../agents/agentV2';
+import type { getModel } from '../models';
+import type { getAiCallTelemetry } from '../utils/aiCallTelemetry';
+
+type TurnFinding = Pick<
+    Omit<AiAgentReviewClassifierJudgeOutput, 'projectContextEntry'>,
+    | 'reviewItem'
+    | 'promotionReason'
+    | 'targetRefs'
+    | 'subcategories'
+    | 'recommendation'
+>;
+
+export type ProjectContextEntryAuthoringEvidence = {
+    type: 'turn';
+    evidencePacket: AiAgentReviewJudgeEvidencePacket;
+    finding: TurnFinding;
+};
+
+type AuthoringMessage = {
+    role: 'system' | 'user';
+    content: string;
+};
+
+type AuthoringLlmCallArgs = {
+    model: ReturnType<typeof getModel>;
+    telemetry: ReturnType<typeof getAiCallTelemetry>;
+    messages: AuthoringMessage[];
+};
+
+export type ProjectContextEntryAuthoringLlmCall = (
+    args: AuthoringLlmCallArgs,
+) => Promise<unknown>;
+
+const callAuthoringLlm: ProjectContextEntryAuthoringLlmCall = async ({
+    model,
+    telemetry,
+    messages,
+}) => {
+    const result = await generateObject({
+        model: model.model,
+        ...defaultAgentOptions,
+        ...model.callOptions,
+        providerOptions: model.providerOptions,
+        experimental_telemetry: telemetry,
+        schema: aiAgentReviewClassifierJudgeProjectContextCallSchema,
+        messages,
+    });
+    emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
+    return result.object;
+};
+
+const systemPrompt = `You emit the structured living-document entry for a Lightdash AI review finding whose root cause is project_context.
+
+Set projectContextEntry ONLY when a single durable, project-specific fact (a business definition or acronym, routing/join guidance, or object-scoped context) would prevent this class of failure in future turns. Otherwise set it to null.
+- op: "update" if a current project context entry is present but insufficient (reference its id); otherwise "create".
+- id: the existing entry id when op="update", otherwise null.
+- kind: definition | context. Use "definition" for acronyms and business vocabulary ("X means Y"); use "context" for everything else (routing/join rules, guidance, durable object-scoped facts).
+- content: a single self-contained sentence stating the fact (e.g. '"HR" = the high-risk diabetes cohort, not human resources.').
+- terms: the prompt-facing trigger words/phrases that should surface this entry (e.g. ["HR","high risk"]). Required for definitions.
+- objects: typed semantic object refs derived from the finding's targetRefs. For an explore use {"type":"explore","name":"payments"}. For a field use {"type":"field","explore":"payments","fieldId":"payments_total_amount"}; the owning explore is required and must be one where that field exists. Use [] when purely prompt-driven.
+
+Use only the supplied evidence packet, finding, and current project context entries. Do not invent project fields or facts.`;
+
+export const authorProjectContextEntry = async ({
+    evidence,
+    currentEntries,
+    model,
+    telemetry,
+    authoringLlmCall = callAuthoringLlm,
+}: {
+    evidence: ProjectContextEntryAuthoringEvidence;
+    currentEntries: ProjectContextEntry[];
+    model: ReturnType<typeof getModel>;
+    telemetry: ReturnType<typeof getAiCallTelemetry>;
+    authoringLlmCall?: ProjectContextEntryAuthoringLlmCall;
+}): Promise<AiAgentJudgeProjectContextEntry | null> => {
+    const output = await authoringLlmCall({
+        model,
+        telemetry,
+        messages: [
+            { role: 'system', content: systemPrompt },
+            {
+                role: 'user',
+                content: JSON.stringify(
+                    {
+                        evidencePacket: evidence.evidencePacket,
+                        finding: evidence.finding,
+                        currentProjectContextEntries: currentEntries,
+                    },
+                    null,
+                    2,
+                ),
+            },
+        ],
+    });
+
+    return aiAgentReviewClassifierJudgeProjectContextCallSchema.parse(output)
+        .projectContextEntry;
+};


### PR DESCRIPTION
## Summary

- Extract shared `authorProjectContextEntry` seam with injectable LLM call and external schema validation.
- Route review-classifier project-context authoring through the `turn` evidence case.
- Supply current cached project-context entries so authoring can emit updates.

## Verification

- Backend typecheck and lint passed.
- Focused classifier/authoring tests: 33 passed.
- Full backend suite: 5,948 passed, 1 skipped; 2 unrelated existing `SchedulerTaskTracer` failures reproduce in isolation.
- Local API health returned 200.

Closes: ZAP-788
