### PR TITLE
fix: show Explore from here in editable SDK embeds

### DIFF
--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
@@ -40,6 +40,7 @@ import {
 } from '../../../../../hooks/dashboard/useDashboard';
 import { useServerFeatureFlag } from '../../../../../hooks/useServerOrClientFeatureFlag';
 import useDashboardContext from '../../../../../providers/Dashboard/useDashboardContext';
+import { type EmbedExploreChart } from '../../../../providers/Embed/types';
 import useEmbed from '../../../../providers/Embed/useEmbed';
 import { embedContractClass } from '../../styles/embedClassContract';
 import { useEmbedDashboard } from '../hooks';
@@ -75,6 +76,7 @@ const EmbedDashboardGrid: FC<{
     onDeleteTile: (tile: DashboardTile) => void;
     onEditTile: (tile: DashboardTile) => void;
     onEditChart?: (chart: SavedChart) => void;
+    onExplore?: (options: { chart: EmbedExploreChart }) => void;
     useDashboardEditorTileQueries: boolean;
 }> = ({
     filteredTiles,
@@ -92,6 +94,7 @@ const EmbedDashboardGrid: FC<{
     onDeleteTile,
     onEditTile,
     onEditChart,
+    onExplore,
     useDashboardEditorTileQueries,
 }) => (
     <Group grow pt="sm" px="xs">
@@ -146,6 +149,7 @@ const EmbedDashboardGrid: FC<{
                                         onDelete={() => onDeleteTile(tile)}
                                         onEdit={onEditTile}
                                         onEditChart={onEditChart}
+                                        onExplore={onExplore}
                                         canExportCsv={dashboard.canExportCsv}
                                         canExportImages={
                                             dashboard.canExportImages
@@ -274,6 +278,7 @@ const EmbedDashboard: FC<{
         embedToken,
         embedWriteContext,
         mode,
+        onExplore,
         paletteUuid,
         writeActions,
     } = useEmbed();
@@ -832,6 +837,7 @@ const EmbedDashboard: FC<{
                 onDeleteTile={handleDeleteTile}
                 onEditTile={handleEditTile}
                 onEditChart={canAddNewChart ? setChartToEdit : undefined}
+                onExplore={onExplore}
                 useDashboardEditorTileQueries={canWriteDashboard}
             />
         </>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-9677

### Description:
Editable SDK dashboard embeds with write actions used an editor tile path that did not receive the explore callback, which hid **Explore from here** even when exploration was enabled.
This forwards the callback through that path so editable embeds support dashboard-to-Explore navigation consistently.
Validated with frontend and SDK typechecks, an SDK production build, lint and format checks, and a local end-to-end SDK flow.

### Screenshots

#### Editable dashboard menu

<img width="1983" height="1277" alt="sdk-explore-menu" src="https://github.com/user-attachments/assets/e71ee5b3-abda-4363-8d7b-bece1ad582a8" />

#### Explore view

<img width="1983" height="1277" alt="sdk-explore-view" src="https://github.com/user-attachments/assets/53f15823-e9ad-4ec1-aeb2-a025b0fe9693" />
