### PR TITLE
fix(query): resolve dimension references in cross-table metric SQL

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
@@ -2109,6 +2109,77 @@ export const METRIC_QUERY_CROSS_TABLE: CompiledMetricQuery = {
     compiledCustomDimensions: [],
 };
 
+// Non-aggregate metric whose SQL references a dimension on a joined table
+export const EXPLORE_WITH_CROSS_TABLE_DIMENSION_REFERENCE: Explore = {
+    ...EXPLORE_WITH_CROSS_TABLE_METRICS,
+    tables: {
+        ...EXPLORE_WITH_CROSS_TABLE_METRICS.tables,
+        customers: {
+            ...EXPLORE_WITH_CROSS_TABLE_METRICS.tables.customers,
+            dimensions: {
+                ...EXPLORE_WITH_CROSS_TABLE_METRICS.tables.customers.dimensions,
+                customer_tier: {
+                    type: DimensionType.STRING,
+                    name: 'customer_tier',
+                    label: 'Customer Tier',
+                    table: 'customers',
+                    tableLabel: 'customers',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.customer_tier',
+                    compiledSql: '"customers".customer_tier',
+                    tablesReferences: ['customers'],
+                    hidden: false,
+                },
+            },
+        },
+        orders: {
+            ...EXPLORE_WITH_CROSS_TABLE_METRICS.tables.orders,
+            metrics: {
+                ...EXPLORE_WITH_CROSS_TABLE_METRICS.tables.orders.metrics,
+                premium_order_rate: {
+                    type: MetricType.NUMBER,
+                    name: 'premium_order_rate',
+                    label: 'Premium Order Rate',
+                    table: 'orders',
+                    tableLabel: 'orders',
+                    fieldType: FieldType.METRIC,
+                    sql: "${orders.total_order_amount} / NULLIF(COUNT(CASE WHEN ${customers.customer_tier} = 'Premium' THEN 1 END), 0)",
+                    compiledSql:
+                        'SUM("orders".amount) / NULLIF(COUNT(CASE WHEN "customers".customer_tier = \'Premium\' THEN 1 END), 0)',
+                    tablesReferences: ['orders', 'customers'],
+                    hidden: false,
+                },
+            },
+        },
+    },
+};
+
+export const METRIC_QUERY_CROSS_TABLE_DIMENSION_REFERENCE: CompiledMetricQuery =
+    {
+        ...METRIC_QUERY_CROSS_TABLE,
+        metrics: ['orders_premium_order_rate'],
+    };
+
+// Same shape, but the cross-table reference points at a field that does not exist
+export const EXPLORE_WITH_CROSS_TABLE_UNKNOWN_REFERENCE: Explore = {
+    ...EXPLORE_WITH_CROSS_TABLE_DIMENSION_REFERENCE,
+    tables: {
+        ...EXPLORE_WITH_CROSS_TABLE_DIMENSION_REFERENCE.tables,
+        orders: {
+            ...EXPLORE_WITH_CROSS_TABLE_DIMENSION_REFERENCE.tables.orders,
+            metrics: {
+                ...EXPLORE_WITH_CROSS_TABLE_DIMENSION_REFERENCE.tables.orders
+                    .metrics,
+                premium_order_rate: {
+                    ...EXPLORE_WITH_CROSS_TABLE_DIMENSION_REFERENCE.tables
+                        .orders.metrics.premium_order_rate,
+                    sql: '${orders.total_order_amount} / ${customers.does_not_exist}',
+                },
+            },
+        },
+    },
+};
+
 // Expected SQL for cross-table metric references with CTEs
 export const EXPECTED_SQL_WITH_CROSS_TABLE_METRICS = `WITH cte_keys_customers AS (
     SELECT DISTINCT

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -36,7 +36,9 @@ import {
     EXPLORE_NESTED_AGG_NAME_COLLISION,
     EXPLORE_WITH_AVERAGE_DISTINCT,
     EXPLORE_WITH_CROSS_MODEL_SUM_DISTINCT,
+    EXPLORE_WITH_CROSS_TABLE_DIMENSION_REFERENCE,
     EXPLORE_WITH_CROSS_TABLE_METRICS,
+    EXPLORE_WITH_CROSS_TABLE_UNKNOWN_REFERENCE,
     EXPLORE_WITH_DATE_DIMENSION,
     EXPLORE_WITH_DATE_DIMENSION_ZOOMED,
     EXPLORE_WITH_FANOUT_AND_DD_REFERENCE,
@@ -53,6 +55,7 @@ import {
     METRIC_QUERY_CROSS_MODEL_SUM_DISTINCT,
     METRIC_QUERY_CROSS_MODEL_SUM_DISTINCT_NO_DIMS,
     METRIC_QUERY_CROSS_TABLE,
+    METRIC_QUERY_CROSS_TABLE_DIMENSION_REFERENCE,
     METRIC_QUERY_FANOUT_AND_DD_REFERENCE,
     METRIC_QUERY_NESTED_AGG_COMPLEX,
     METRIC_QUERY_NESTED_AGG_CONDITIONAL,
@@ -1894,6 +1897,59 @@ LIMIT 10`;
                     ),
                 ),
             ).toBe(true);
+        });
+
+        test('Should handle a non-aggregate metric referencing a dimension on a joined table', () => {
+            const result = buildQuery({
+                explore: EXPLORE_WITH_CROSS_TABLE_DIMENSION_REFERENCE,
+                compiledMetricQuery:
+                    METRIC_QUERY_CROSS_TABLE_DIMENSION_REFERENCE,
+                warehouseSqlBuilder: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: QUERY_BUILDER_UTC_TIMEZONE,
+            });
+
+            expect(result.query).toContain(
+                'SUM("orders".amount) / NULLIF(COUNT(CASE WHEN "customers".customer_tier = \'Premium\' THEN 1 END), 0) AS "orders_premium_order_rate"',
+            );
+            expect(result.query).toContain(
+                'LEFT OUTER JOIN orders AS "orders"',
+            );
+        });
+
+        test('Should throw when the referenced dimension table is aggregated in its own CTE', () => {
+            expect(() =>
+                buildQuery({
+                    explore: EXPLORE_WITH_CROSS_TABLE_DIMENSION_REFERENCE,
+                    compiledMetricQuery: {
+                        ...METRIC_QUERY_CROSS_TABLE_DIMENSION_REFERENCE,
+                        metrics: [
+                            'orders_premium_order_rate',
+                            'customers_total_customers',
+                        ],
+                    },
+                    warehouseSqlBuilder: warehouseClientMock,
+                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
+                }),
+            ).toThrow(
+                'Tried to reference dimension "customers_customer_tier" from a metric on a table that is aggregated separately',
+            );
+        });
+
+        test('Should still throw when a metric references an unknown field id', () => {
+            expect(() =>
+                buildQuery({
+                    explore: EXPLORE_WITH_CROSS_TABLE_UNKNOWN_REFERENCE,
+                    compiledMetricQuery:
+                        METRIC_QUERY_CROSS_TABLE_DIMENSION_REFERENCE,
+                    warehouseSqlBuilder: warehouseClientMock,
+                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
+                }),
+            ).toThrow(
+                'Tried to reference metric with unknown field id: customers_does_not_exist',
+            );
         });
 
         test('Should handle metrics referencing other metrics when base metrics are also selected', () => {

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -2755,6 +2755,7 @@ export class MetricQueryBuilder {
         const nonAggReferencingDd =
             this.getNonAggregateMetricsReferencingDistinct();
         const metricsWithCteReferences: Array<CompiledMetric> = [];
+        const skippedDimensionReferences: Array<CompiledDimension> = [];
         const referencedMetricObjects = metricsObjects.reduce<CompiledMetric[]>(
             (acc, metricObject) => {
                 const referencesAnotherTable =
@@ -2780,35 +2781,33 @@ export class MetricQueryBuilder {
                         metricObject.table,
                     );
                     metricReferences.forEach((metricReference) => {
+                        const referenceId = getItemId({
+                            table: metricReference.refTable,
+                            name: metricReference.refName,
+                        });
+                        // Dimension references are resolved by the raw scan, so
+                        // they must not go through the metric lookup. Validated
+                        // below once every referenced metric is known.
+                        const referencedDimension =
+                            this.exploreDimensions[referenceId];
+                        if (referencedDimension) {
+                            skippedDimensionReferences.push(
+                                referencedDimension,
+                            );
+                            return;
+                        }
                         const isInMetricsObjects = metricsObjects.some(
-                            (metric) =>
-                                getItemId(metric) ===
-                                getItemId({
-                                    table: metricReference.refTable,
-                                    name: metricReference.refName,
-                                }),
+                            (metric) => getItemId(metric) === referenceId,
                         );
                         const isInReferencedMetricObjects = acc.some(
-                            (metric) =>
-                                getItemId(metric) ===
-                                getItemId({
-                                    table: metricReference.refTable,
-                                    name: metricReference.refName,
-                                }),
+                            (metric) => getItemId(metric) === referenceId,
                         );
                         // Only add if doesn't exist in metricsObjects or referencedMetricObjects
                         if (
                             !isInMetricsObjects &&
                             !isInReferencedMetricObjects
                         ) {
-                            acc.push(
-                                this.getMetricFromId(
-                                    getItemId({
-                                        table: metricReference.refTable,
-                                        name: metricReference.refName,
-                                    }),
-                                ),
-                            );
+                            acc.push(this.getMetricFromId(referenceId));
                         }
                     });
                 }
@@ -2816,6 +2815,26 @@ export class MetricQueryBuilder {
             },
             [],
         );
+
+        // A dimension reference only resolves when its table has no metric CTE.
+        // Once one exists, the reference is rewritten to that CTE, which never
+        // projects the dimension. Keep failing loudly rather than emit bad SQL.
+        const tablesWithMetricCte = new Set(
+            [...metricsObjects, ...referencedMetricObjects].map(
+                (metric) => metric.table,
+            ),
+        );
+        skippedDimensionReferences.forEach((dimension) => {
+            if (tablesWithMetricCte.has(dimension.table)) {
+                throw new FieldReferenceError(
+                    `Tried to reference dimension "${getItemId(
+                        dimension,
+                    )}" from a metric on a table that is aggregated separately. Reference a metric on "${
+                        dimension.table
+                    }" instead.`,
+                );
+            }
+        });
 
         // Warn user about metrics with fanouts which we don't have a solution for yet.
         const warnings: QueryWarning[] = [];


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9675

## Summary

A non-aggregate metric whose `sql` referenced a dimension on a joined table failed to compile, returning 400 with an error naming that dimension as an unknown *metric*.

## Root cause

`packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts` — inside `getExperimentalMetricsCteSQL`, `parseAllReferences` returns every `${...}` reference in a metric's SQL, dimensions included. Each was passed to `getMetricFromId`, which only consults `availableMetrics` and throws when the id is absent. There was no dimension fallback, so a legitimate cross-table dimension reference aborted the query.

```
metric.sql: "... ${a.plan_tier} ... ${b.is_closed_won} ..."
                      |                     |
        parseAllReferences splits both out
                      v                     v
             getMetricFromId()       getMetricFromId()
                      |                     |
        availableMetrics["a_plan_tier"]   found
                      |
                  undefined  ->  THROW FieldReferenceError

   dimensions map never consulted  <-- the defect
```

## How it works

Dimension references are now skipped when collecting referenced metrics, since they resolve against the raw scan rather than needing materialisation in a CTE.

There is a second case. When the dimension's table also contributes a metric to the query, that table gets its own metric CTE and the reference is rewritten to it — but the CTE never projects the dimension, which would yield invalid SQL that fails later at the warehouse:

```sql
cte_metrics_customers AS (
  SELECT COUNT("customers".customer_id) AS "customers_total_customers"  -- customer_tier absent
)
SELECT ... cte_metrics_customers."customers_customer_tier" ...
```

That case throws a `FieldReferenceError` explaining the constraint instead of emitting bad SQL. Fixing it properly means projecting metric-referenced dimensions into the keys/metrics CTEs, which changes the `SELECT DISTINCT` dedup grain and so can change metric values — a separate, wider change.

**Before:** every path touched here threw `FieldReferenceError`.
**After:** the resolvable case compiles; the unresolvable case throws a message that says why.

Because the prior behavior was "always throw", this can only relax behavior — it cannot break a query that works today.

## Scope

The guard triggers when the dimension's table contributes any metric, which is a deliberate superset of "a metric CTE was actually built". A few cases that would produce valid SQL still throw. That conservatism is intentional; narrowing it belongs with the CTE-projection work.

## Test plan

- `pnpm -F backend test` — 5950 passed, 1 skipped
- `pnpm -F backend typecheck`, `lint`, `format` — clean

Three tests added to `MetricQueryBuilder.test.ts`:

- Non-aggregate metric referencing a dimension on a joined table compiles, asserting the emitted SQL and the join. Fails without the fix.
- The aggregated-table case throws the new message. Fails without the fix (throws the old message).
- An unknown field id still throws the original error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)