### PR TITLE
fix(data-apps): delay data app thumbnail requests

### DIFF
--- a/packages/frontend/src/features/apps/components/AppThumbnailHoverCard.tsx
+++ b/packages/frontend/src/features/apps/components/AppThumbnailHoverCard.tsx
@@ -2,6 +2,8 @@ import { Box, Image, Popover, Stack } from '@mantine/core';
 import { useEffect, useState, type FC, type ReactNode } from 'react';
 import { useAppThumbnailUrl } from '../hooks/useAppThumbnail';
 
+const THUMBNAIL_HOVER_DELAY_MS = 300;
+
 type AppThumbnailHoverCardState = {
     hasThumbnailPreview: boolean;
     isLoadingThumbnail: boolean;
@@ -37,7 +39,9 @@ const AppThumbnailHoverCard: FC<AppThumbnailHoverCardProps> = ({
     );
     const [isTargetHovered, setIsTargetHovered] = useState(false);
     const [isClosestRowHovered, setIsClosestRowHovered] = useState(false);
-    const isActive = active ?? (isClosestRowHovered || isTargetHovered);
+    const isHovered = isClosestRowHovered || isTargetHovered;
+    const [isHoverIntentActive, setIsHoverIntentActive] = useState(false);
+    const isActive = active ?? isHoverIntentActive;
     const thumbnail = useAppThumbnailUrl(
         projectUuid,
         appUuid,
@@ -59,6 +63,20 @@ const AppThumbnailHoverCard: FC<AppThumbnailHoverCardProps> = ({
         typeof children === 'function'
             ? children({ hasThumbnailPreview, isLoadingThumbnail })
             : children;
+
+    useEffect(() => {
+        if (active !== undefined || !isHovered) {
+            setIsHoverIntentActive(false);
+            return;
+        }
+
+        const timeout = window.setTimeout(
+            () => setIsHoverIntentActive(true),
+            THUMBNAIL_HOVER_DELAY_MS,
+        );
+
+        return () => window.clearTimeout(timeout);
+    }, [active, isHovered]);
 
     useEffect(() => {
         if (!activateOnClosestRow || !targetElement) return;


### PR DESCRIPTION
## Description

Adds a 300 ms hover-intent delay before requesting a data app thumbnail. Pending activation is cancelled when the pointer leaves, so moving quickly through the data app list no longer triggers a request for every crossed row.

Previously, thumbnail queries were enabled as soon as a row or card received a mouse-enter event. This made incidental cursor movement generate many unnecessary requests.

## Validation

- End-to-end tested locally
- Frontend test suite: 2,204 tests passed
- Frontend typecheck
- Targeted frontend lint and formatting checks
- Commit hooks, including unused-export validation