### PR TITLE
feat(autopilot): manage suggestions access via the space access modal

### DIFF
--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.test.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.test.ts
@@ -49,6 +49,7 @@ const buildService = ({
     ],
     serviceAccountScopes = [ServiceAccountScope.SYSTEM_MEMBER],
     serviceAccountTokens = [null, 'service-account-token'],
+    suggestionsSpaces = [],
 }: {
     projectGrants?: Array<{
         projectUuid: string;
@@ -57,6 +58,10 @@ const buildService = ({
     }>;
     serviceAccountScopes?: ServiceAccountScope[];
     serviceAccountTokens?: Array<string | null>;
+    suggestionsSpaces?: Array<{
+        uuid: string;
+        inheritParentPermissions: boolean;
+    }>;
 } = {}) => {
     const managedAgentModel = {
         getSettings: vi.fn().mockResolvedValue(settings),
@@ -122,7 +127,9 @@ const buildService = ({
         validationModel: {},
         savedChartModel: {},
         dashboardModel: {},
-        spaceModel: {},
+        spaceModel: {
+            find: vi.fn().mockResolvedValue(suggestionsSpaces),
+        },
         spacePermissionService: {},
         userModel: {},
         featureFlagModel: {},
@@ -282,6 +289,24 @@ describe('ManagedAgentService.updateSettings', () => {
 
         expect(serviceAccountModel.delete).toHaveBeenCalledWith(
             SERVICE_ACCOUNT_UUID,
+        );
+    });
+
+    it('resolves the agent audience from the suggestions space when it exists', async () => {
+        const { managedAgentClient, service } = buildService({
+            suggestionsSpaces: [
+                { uuid: 'space-uuid', inheritParentPermissions: false },
+            ],
+        });
+
+        await service.updateSettings(user, PROJECT_UUID, USER_UUID, {
+            enabled: true,
+        });
+
+        expect(managedAgentClient.syncAgent).toHaveBeenCalledWith(
+            expect.objectContaining({
+                policy: expect.objectContaining({ audience: 'admins' }),
+            }),
         );
     });
 });

--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    AGENT_SUGGESTIONS_SPACE_SLUG,
     assertUnreachable,
     computeAutopilotExcludedSpaceUuids,
     DEFAULT_MANAGED_AGENT_POLICY,
@@ -21,6 +22,7 @@ import {
     type ChartConfig,
     type ManagedAgentAction,
     type ManagedAgentActionFilters,
+    type ManagedAgentAudience,
     type ManagedAgentPolicy,
     type ManagedAgentRun,
     type ManagedAgentRunsListResponse,
@@ -298,6 +300,7 @@ export class ManagedAgentService extends BaseService {
             project.organizationUuid,
         );
         const settings = await this.managedAgentModel.getSettings(projectUuid);
+        const policy = settings?.policy ?? DEFAULT_MANAGED_AGENT_POLICY;
 
         return {
             projectUuid,
@@ -305,7 +308,13 @@ export class ManagedAgentService extends BaseService {
             resourceName: `${organization.name}:${organization.organizationUuid}:${project.projectUuid}`,
             skillIds: this.lightdashConfig.managedAgent.skillIds,
             toolSettings: settings?.toolSettings ?? {},
-            policy: settings?.policy ?? DEFAULT_MANAGED_AGENT_POLICY,
+            policy: {
+                ...policy,
+                audience: await this.resolveSuggestionsAudience(
+                    projectUuid,
+                    policy.audience,
+                ),
+            },
             persistedAgentId: agentId,
             persistedAgentConfigHash: agentConfigHash,
             persistedAgentVersion: agentVersion,
@@ -2505,17 +2514,35 @@ chartConfig:
         });
     }
 
+    private async findAgentSpace(projectUuid: string) {
+        const [space] = await this.spaceModel.find({
+            projectUuid,
+            slug: AGENT_SUGGESTIONS_SPACE_SLUG,
+        });
+        return space ?? null;
+    }
+
+    /**
+     * Once the suggestions space exists its own permissions are the source of
+     * truth — admins edit them in the space access modal — so the stored
+     * audience policy only seeds the space when it is first created.
+     */
+    private async resolveSuggestionsAudience(
+        projectUuid: string,
+        storedAudience: ManagedAgentAudience,
+    ): Promise<ManagedAgentAudience> {
+        const space = await this.findAgentSpace(projectUuid);
+        if (!space) return storedAudience;
+        return space.inheritParentPermissions ? 'everyone' : 'admins';
+    }
+
     private async getOrCreateAgentSpace(
         actor: SessionUser,
         projectUuid: string,
     ): Promise<string> {
-        // Find existing "Agent Suggestions" space
-        const spaces = await this.spaceModel.find({
-            projectUuid,
-            slug: 'agent-suggestions',
-        });
-        if (spaces.length > 0) {
-            return spaces[0].uuid;
+        const existingSpace = await this.findAgentSpace(projectUuid);
+        if (existingSpace) {
+            return existingSpace.uuid;
         }
         await this.assertActorCanCreateSpace(
             actor,

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    AGENT_SUGGESTIONS_SPACE_SLUG,
     type ApiError,
     type ContentVerificationInfo,
     countTotalFilterRules,
@@ -95,6 +96,7 @@ import { useManagedAgentLatestRun } from './hooks/useManagedAgentLatestRun';
 import { useManagedAgentRuns } from './hooks/useManagedAgentRuns';
 import { useManagedAgentSettings } from './hooks/useManagedAgentSettings';
 import classes from './ManagedAgentActivityPage.module.css';
+import { SuggestionsSpaceAccess } from './SuggestionsSpaceAccess';
 import { ToolActivityBadge } from './ToolActivityBadge';
 
 const reverseAction = async (
@@ -1243,6 +1245,13 @@ const SettingsSidebar: FC<{
     const queryClient = useQueryClient();
     const { data: slackInstallation } = useGetSlack();
     const { data: spaceSummaries } = useSpaceSummaries(projectUuid, true);
+    const suggestionsSpaceUuid = useMemo(
+        () =>
+            spaceSummaries?.find(
+                (space) => space.slug === AGENT_SUGGESTIONS_SPACE_SLUG,
+            )?.uuid,
+        [spaceSummaries],
+    );
     const organizationHasSlack = !!slackInstallation?.organizationUuid;
     const [slackNotificationsEnabled, setSlackNotificationsEnabled] =
         useState(!!slackChannelId);
@@ -1778,34 +1787,15 @@ const SettingsSidebar: FC<{
                                 />
                             </Group>
 
-                            <Group
-                                justify="space-between"
-                                align="flex-start"
-                                wrap="nowrap"
-                            >
-                                <Stack gap={3}>
-                                    <Text fz="xs" fw={500}>
-                                        Admin-only suggestions
-                                    </Text>
-                                    <Text fz={11} c="dimmed">
-                                        Restrict the Agent Suggestions space to
-                                        admins instead of all project users.
-                                    </Text>
-                                </Stack>
-                                <Switch
-                                    checked={policy.audience === 'admins'}
-                                    onChange={(e) =>
-                                        handlePolicyChange({
-                                            audience: e.currentTarget.checked
-                                                ? 'admins'
-                                                : 'everyone',
-                                        })
-                                    }
-                                    disabled={mutation.isLoading}
-                                    size="xs"
-                                    color="ldDark"
-                                />
-                            </Group>
+                            <SuggestionsSpaceAccess
+                                projectUuid={projectUuid}
+                                spaceUuid={suggestionsSpaceUuid}
+                                audience={policy.audience}
+                                disabled={mutation.isLoading}
+                                onAudienceChange={(audience) =>
+                                    handlePolicyChange({ audience })
+                                }
+                            />
 
                             <Group
                                 justify="space-between"

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -1,6 +1,5 @@
 import { subject } from '@casl/ability';
 import {
-    AGENT_SUGGESTIONS_SPACE_SLUG,
     type ApiError,
     type ContentVerificationInfo,
     countTotalFilterRules,
@@ -1245,13 +1244,6 @@ const SettingsSidebar: FC<{
     const queryClient = useQueryClient();
     const { data: slackInstallation } = useGetSlack();
     const { data: spaceSummaries } = useSpaceSummaries(projectUuid, true);
-    const suggestionsSpaceUuid = useMemo(
-        () =>
-            spaceSummaries?.find(
-                (space) => space.slug === AGENT_SUGGESTIONS_SPACE_SLUG,
-            )?.uuid,
-        [spaceSummaries],
-    );
     const organizationHasSlack = !!slackInstallation?.organizationUuid;
     const [slackNotificationsEnabled, setSlackNotificationsEnabled] =
         useState(!!slackChannelId);
@@ -1789,7 +1781,6 @@ const SettingsSidebar: FC<{
 
                             <SuggestionsSpaceAccess
                                 projectUuid={projectUuid}
-                                spaceUuid={suggestionsSpaceUuid}
                                 audience={policy.audience}
                                 disabled={mutation.isLoading}
                                 onAudienceChange={(audience) =>

--- a/packages/frontend/src/ee/features/managedAgent/SuggestionsSpaceAccess.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/SuggestionsSpaceAccess.tsx
@@ -1,0 +1,82 @@
+import { type ManagedAgentAudience } from '@lightdash/common';
+import { Button, Group, SegmentedControl, Stack, Text } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { IconUsers } from '@tabler/icons-react';
+import { type FC } from 'react';
+import ShareSpaceModal from '../../../components/common/ShareSpaceModal';
+import { useSpace } from '../../../hooks/useSpaces';
+
+const AUDIENCE_OPTIONS: { value: ManagedAgentAudience; label: string }[] = [
+    { value: 'everyone', label: 'Everyone' },
+    { value: 'admins', label: 'Admins' },
+];
+
+/**
+ * Access to Autopilot's suggestions is really access to the "Agent Suggestions"
+ * space. Once that space exists it is the source of truth, so editing happens in
+ * the space access modal; the audience policy only seeds the space on creation.
+ */
+export const SuggestionsSpaceAccess: FC<{
+    projectUuid: string;
+    spaceUuid: string | undefined;
+    audience: ManagedAgentAudience;
+    disabled: boolean;
+    onAudienceChange: (audience: ManagedAgentAudience) => void;
+}> = ({ projectUuid, spaceUuid, audience, disabled, onAudienceChange }) => {
+    const { data: space } = useSpace(projectUuid, spaceUuid);
+    const [modalOpened, { open: openModal, close: closeModal }] =
+        useDisclosure(false);
+
+    const description = (() => {
+        if (!space) {
+            return 'The "Agent Suggestions" space is created the first time Autopilot suggests content. This sets who can see it.';
+        }
+        return space.inheritParentPermissions
+            ? 'All project members can see the "Agent Suggestions" space.'
+            : 'Only admins and invited members can see the "Agent Suggestions" space.';
+    })();
+
+    return (
+        <>
+            <Group justify="space-between" align="flex-start" wrap="nowrap">
+                <Stack gap={3}>
+                    <Text fz="xs" fw={500}>
+                        Suggestions access
+                    </Text>
+                    <Text fz={11} c="dimmed">
+                        {description}
+                    </Text>
+                </Stack>
+                {space ? (
+                    <Button
+                        size="compact-xs"
+                        variant="default"
+                        leftSection={<IconUsers size={12} />}
+                        onClick={openModal}
+                    >
+                        Manage access
+                    </Button>
+                ) : (
+                    <SegmentedControl
+                        size="xs"
+                        value={audience}
+                        onChange={(value) =>
+                            onAudienceChange(value as ManagedAgentAudience)
+                        }
+                        data={AUDIENCE_OPTIONS}
+                        disabled={disabled}
+                    />
+                )}
+            </Group>
+
+            {space && (
+                <ShareSpaceModal
+                    space={space}
+                    projectUuid={projectUuid}
+                    opened={modalOpened}
+                    onClose={closeModal}
+                />
+            )}
+        </>
+    );
+};

--- a/packages/frontend/src/ee/features/managedAgent/SuggestionsSpaceAccess.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/SuggestionsSpaceAccess.tsx
@@ -1,15 +1,39 @@
-import { type ManagedAgentAudience } from '@lightdash/common';
-import { Button, Group, SegmentedControl, Stack, Text } from '@mantine/core';
+import {
+    AGENT_SUGGESTIONS_SPACE_SLUG,
+    type ManagedAgentAudience,
+    type Space,
+} from '@lightdash/common';
+import {
+    Badge,
+    Button,
+    Group,
+    SegmentedControl,
+    Skeleton,
+    Stack,
+    Text,
+} from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
-import { IconUsers } from '@tabler/icons-react';
-import { type FC } from 'react';
+import { IconLock, IconUsers } from '@tabler/icons-react';
+import { useMemo, type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
 import ShareSpaceModal from '../../../components/common/ShareSpaceModal';
-import { useSpace } from '../../../hooks/useSpaces';
+import { useSpace, useSpaceSummaries } from '../../../hooks/useSpaces';
 
 const AUDIENCE_OPTIONS: { value: ManagedAgentAudience; label: string }[] = [
     { value: 'everyone', label: 'Everyone' },
     { value: 'admins', label: 'Admins' },
 ];
+
+const countLabel = (count: number, noun: string) =>
+    `${count} ${noun}${count === 1 ? '' : 's'}`;
+
+const describeRestrictedAccess = (space: Space) => {
+    const parts = [countLabel(space.access.length, 'member')];
+    if (space.groupsAccess.length > 0) {
+        parts.push(countLabel(space.groupsAccess.length, 'group'));
+    }
+    return `${parts.join(' and ')} can see suggestions.`;
+};
 
 /**
  * Access to Autopilot's suggestions is really access to the "Agent Suggestions"
@@ -18,40 +42,86 @@ const AUDIENCE_OPTIONS: { value: ManagedAgentAudience; label: string }[] = [
  */
 export const SuggestionsSpaceAccess: FC<{
     projectUuid: string;
-    spaceUuid: string | undefined;
     audience: ManagedAgentAudience;
     disabled: boolean;
     onAudienceChange: (audience: ManagedAgentAudience) => void;
-}> = ({ projectUuid, spaceUuid, audience, disabled, onAudienceChange }) => {
-    const { data: space } = useSpace(projectUuid, spaceUuid);
+}> = ({ projectUuid, audience, disabled, onAudienceChange }) => {
+    const { data: spaceSummaries, isInitialLoading: isLoadingSummaries } =
+        useSpaceSummaries(projectUuid, true);
+    const spaceUuid = useMemo(
+        () =>
+            spaceSummaries?.find(
+                (summary) => summary.slug === AGENT_SUGGESTIONS_SPACE_SLUG,
+            )?.uuid,
+        [spaceSummaries],
+    );
+    const { data: space, isInitialLoading: isLoadingSpace } = useSpace(
+        projectUuid,
+        spaceUuid,
+    );
     const [modalOpened, { open: openModal, close: closeModal }] =
         useDisclosure(false);
 
+    // Both queries resolve after mount. Without this the row renders the
+    // "not created yet" control first and then swaps, which reads as a glitch.
+    const isLoading = isLoadingSummaries || isLoadingSpace;
+
     const description = (() => {
+        if (isLoading) return 'Checking who can see suggestions…';
         if (!space) {
             return 'The "Agent Suggestions" space is created the first time Autopilot suggests content. This sets who can see it.';
         }
         return space.inheritParentPermissions
-            ? 'All project members can see the "Agent Suggestions" space.'
-            : 'Only admins and invited members can see the "Agent Suggestions" space.';
+            ? 'Everyone on this project can see suggestions.'
+            : describeRestrictedAccess(space);
     })();
 
     return (
         <>
             <Group justify="space-between" align="flex-start" wrap="nowrap">
                 <Stack gap={3}>
-                    <Text fz="xs" fw={500}>
-                        Suggestions access
-                    </Text>
+                    <Group gap="xs">
+                        <Text fz="xs" fw={500}>
+                            Suggestions access
+                        </Text>
+                        {space && (
+                            <Badge
+                                size="xs"
+                                variant="light"
+                                color={
+                                    space.inheritParentPermissions
+                                        ? 'gray'
+                                        : 'orange'
+                                }
+                                leftSection={
+                                    <MantineIcon
+                                        icon={
+                                            space.inheritParentPermissions
+                                                ? IconUsers
+                                                : IconLock
+                                        }
+                                        size={10}
+                                    />
+                                }
+                            >
+                                {space.inheritParentPermissions
+                                    ? 'Everyone'
+                                    : 'Restricted'}
+                            </Badge>
+                        )}
+                    </Group>
                     <Text fz={11} c="dimmed">
                         {description}
                     </Text>
                 </Stack>
-                {space ? (
+
+                {isLoading ? (
+                    <Skeleton height={26} width={110} radius="sm" />
+                ) : space ? (
                     <Button
                         size="compact-xs"
                         variant="default"
-                        leftSection={<IconUsers size={12} />}
+                        leftSection={<MantineIcon icon={IconUsers} size={12} />}
                         onClick={openModal}
                     >
                         Manage access


### PR DESCRIPTION
The "Admin-only suggestions" switch in Autopilot settings was a crude proxy for the permissions of the "Agent Suggestions" space, and it only ever applied when that space was first created — once the space existed, flipping it did nothing.

Now the space itself is the source of truth once it exists: the setting shows the space's current access and offers a **Manage access** button that opens the standard space access modal (restricted/inherit toggle, per-user and per-group roles). Before the space exists there's nothing to open, so the audience policy is still editable as an Everyone/Admins segmented control that seeds the space on creation.

Backend: the agent's system prompt says whether its suggestions space is admin-only, so the audience handed to the agent config is now resolved from the space's `inheritParentPermissions` when the space exists, instead of the (potentially stale) stored policy.

Verified with frontend/backend typecheck, lint, format and the `ManagedAgentService` unit tests (new case covers the audience resolution).
