### PR TITLE
feat: add memory promotion UI

### DIFF
--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -1695,14 +1695,22 @@ export class AiAgentReviewClassifierModel {
     }): Promise<
         | Pick<
               DbAiAgentReviewItem,
-              'fingerprint' | 'status' | 'dismissed_reason'
+              | 'ai_agent_review_item_uuid'
+              | 'fingerprint'
+              | 'status'
+              | 'dismissed_reason'
           >
         | undefined
     > {
         return this.database<AiAgentReviewItemTable>(AiAgentReviewItemTableName)
             .where('organization_uuid', args.organizationUuid)
             .where('source_ai_agent_memory_uuid', args.memoryUuid)
-            .first('fingerprint', 'status', 'dismissed_reason');
+            .first(
+                'ai_agent_review_item_uuid',
+                'fingerprint',
+                'status',
+                'dismissed_reason',
+            );
     }
 
     async upsertMemoryReviewItem(

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryPromotion.integration.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryPromotion.integration.test.ts
@@ -256,6 +256,39 @@ describe('AI agent memory promotion integration', () => {
         ).resolves.toMatchObject({
             nomination_reason: 'Useful across the project',
         });
+
+        await expect(
+            service.getMemory(
+                getTestContext().testUser,
+                SEED_PROJECT.project_uuid,
+                item.sourceMemory!.slug,
+            ),
+        ).resolves.toMatchObject({
+            promotionReviewItem: {
+                uuid: item.uuid,
+                status: 'open',
+                blocksNewNomination: true,
+            },
+        });
+
+        await database(AiAgentReviewItemTableName)
+            .where('fingerprint', item.fingerprint)
+            .update({
+                status: 'dismissed',
+                dismissed_reason: 'expected_behavior',
+            });
+        await expect(
+            service.getMemory(
+                getTestContext().testUser,
+                SEED_PROJECT.project_uuid,
+                item.sourceMemory!.slug,
+            ),
+        ).resolves.toMatchObject({
+            promotionReviewItem: {
+                status: 'dismissed',
+                blocksNewNomination: true,
+            },
+        });
     });
 
     it('creates a proposal without a nomination reason', async () => {

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
@@ -584,6 +584,11 @@ export class AiAgentMemoryService extends BaseService {
             result.memory,
             slug,
         );
+        const promotionReviewItem =
+            await this.aiAgentReviewClassifierModel.findMemoryReviewItem({
+                organizationUuid,
+                memoryUuid: result.memory.ai_agent_memory_uuid,
+            });
 
         // Reading the memory grants its lineage: the check above already covers
         // the whole row, so there is nothing left to redact per source.
@@ -618,6 +623,16 @@ export class AiAgentMemoryService extends BaseService {
                     ? { type: 'source_thread', source: sources[0] }
                     : { type: 'consolidated', sources },
             replacementSlug: result.replacement?.slug ?? null,
+            promotionReviewItem: promotionReviewItem
+                ? {
+                      uuid: promotionReviewItem.ai_agent_review_item_uuid,
+                      status: promotionReviewItem.status,
+                      blocksNewNomination: !shouldReopenReviewItem(
+                          promotionReviewItem.status,
+                          promotionReviewItem.dismissed_reason,
+                      ),
+                  }
+                : null,
         };
 
         this.track({

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -809,6 +809,13 @@ export type AiAgentReviewItemSummary = AiAgentReviewItem & {
     } | null;
 };
 
+export const getReviewItemProjectContextEntry = (
+    item: AiAgentReviewItemSummary,
+): AiAgentJudgeProjectContextEntry | null =>
+    item.source === 'memory'
+        ? item.projectContextEntry
+        : (item.latestFinding?.projectContextEntry ?? null);
+
 export type ApiAiAgentReviewItemsResponse = ApiSuccess<
     AiAgentReviewItemSummary[]
 >;

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -16,6 +16,7 @@ import type {
     ToolVerticalBarArgs,
 } from '../..';
 import assertUnreachable from '../../utils/assertUnreachable';
+import { type AiAgentReviewItemStatus } from './aiAgentReviewClassifierTypes';
 import { type AiEvalRunResultAssessment } from './aiEvalAssessment';
 import { type AiProjectContextTypedObjectRef } from './projectContext';
 import {
@@ -376,6 +377,11 @@ export type AiAgentMemory = {
         | { type: 'source_thread'; source: AiAgentMemorySource }
         | { type: 'consolidated'; sources: AiAgentMemorySource[] };
     replacementSlug: string | null;
+    promotionReviewItem: {
+        uuid: string;
+        status: AiAgentReviewItemStatus;
+        blocksNewNomination: boolean;
+    } | null;
 };
 
 export type ApiAiAgentMemoryResponse = ApiSuccess<AiAgentMemory>;

--- a/packages/frontend/src/ee/CommercialRoutes.tsx
+++ b/packages/frontend/src/ee/CommercialRoutes.tsx
@@ -306,6 +306,16 @@ const COMMERCIAL_AI_AGENTS_ROUTES: RouteObject[] = [
                 },
             },
             {
+                path: 'memories/:slug',
+                lazy: async () => {
+                    const AiAgentMemoryPage = await loadLazyRouteDefault(
+                        './pages/AiAgents/AiAgentMemoryPage',
+                        () => import('./pages/AiAgents/AiAgentMemoryPage'),
+                    );
+                    return { Component: AiAgentMemoryPage };
+                },
+            },
+            {
                 path: ':agentUuid/memories/:slug',
                 lazy: async () => {
                     const AiAgentMemoryPage = await loadLazyRouteDefault(

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.test.tsx
@@ -1,6 +1,7 @@
 import { type AiAgentReviewItemSummary } from '@lightdash/common';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../../../testing/testUtils';
 import { IssueDetailModal } from './IssueDetailModal';
@@ -114,10 +115,6 @@ vi.mock('../../../../../hooks/useProjects', () => ({
     }),
 }));
 
-vi.mock('../../../../../hooks/useOrganizationUsers', () => ({
-    useOrgUsersByUuid: () => new Map(),
-}));
-
 // Heavy children stubbed so the test exercises modal composition, not their
 // full dependency trees.
 vi.mock('../ChatElements/AgentChatDisplay', () => ({
@@ -136,14 +133,16 @@ vi.mock('../../../../../components/common/AiMarkdown', () => ({
 
 const renderModal = () =>
     renderWithProviders(
-        <IssueDetailModal
-            projectUuid="project-1"
-            agentUuid="agent-1"
-            threadUuid="thread-1"
-            selectedReviewItemUuid="ri-1"
-            isOpen
-            onClose={() => {}}
-        />,
+        <MemoryRouter>
+            <IssueDetailModal
+                projectUuid="project-1"
+                agentUuid="agent-1"
+                threadUuid="thread-1"
+                selectedReviewItemUuid="ri-1"
+                isOpen
+                onClose={() => {}}
+            />
+        </MemoryRouter>,
     );
 
 describe('IssueDetailModal', () => {
@@ -225,5 +224,52 @@ describe('IssueDetailModal', () => {
         );
 
         expect(await screen.findByText('chat-evidence')).toBeInTheDocument();
+    });
+
+    it('shows memory provenance instead of turn evidence for promotion items', () => {
+        mockReviewItem.current = makeReviewItem({
+            source: 'memory',
+            description: 'Legacy description\n\nNominated by Wrong user',
+            createdByUserUuid: 'user-1',
+            nominationReason:
+                'Useful across the project\n\nNominated by is valid reason text',
+            nominator: {
+                name: 'Giorgi Bagdavadze',
+                email: 'giorgi@example.com',
+            },
+            sourceMemory: { uuid: 'memory-1', slug: 'revenue-convention' },
+            projectContextEntry: {
+                op: 'create',
+                id: 'revenue-convention',
+                kind: 'definition',
+                content: 'Revenue means completed purchases.',
+                terms: ['revenue'],
+                objects: [],
+            },
+            latestFinding: null,
+        });
+
+        renderModal();
+
+        expect(screen.getByText('Memory provenance')).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                (_content, element) =>
+                    element?.tagName === 'P' &&
+                    element.textContent ===
+                        'Useful across the project\n\nNominated by is valid reason text',
+            ),
+        ).toBeInTheDocument();
+        expect(screen.getByText('Giorgi Bagdavadze')).toBeInTheDocument();
+        expect(
+            screen.getByRole('link', { name: 'View source memory' }),
+        ).toHaveAttribute(
+            'href',
+            '/projects/project-1/ai-agents/memories/revenue-convention',
+        );
+        expect(screen.queryByText('Evidence')).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: /Read full conversation/i }),
+        ).not.toBeInTheDocument();
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.tsx
@@ -1,4 +1,4 @@
-import { capitalize } from '@lightdash/common';
+import { capitalize, type AiAgentReviewItemSummary } from '@lightdash/common';
 import {
     Anchor,
     Box,
@@ -32,6 +32,7 @@ import { AgentChatDisplay } from '../ChatElements/AgentChatDisplay';
 import { getRenderableExcerpts } from './evidenceExcerptHelpers';
 import { EvidenceExcerpts } from './EvidenceExcerpts';
 import styles from './IssueDetailModal.module.css';
+import { MemoryProvenance } from './MemoryProvenance';
 import { RemediationActivityTimeline } from './RemediationActivityTimeline';
 import { ReviewAssigneeMenu } from './ReviewAssigneeMenu';
 import { ReviewItemActions } from './ReviewItemActions';
@@ -63,6 +64,11 @@ type Props = {
     isOpen: boolean;
     onClose: () => void;
 };
+
+const isMemoryReviewItem = (
+    item: AiAgentReviewItemSummary,
+): item is AiAgentReviewItemSummary & { source: 'memory' } =>
+    item.source === 'memory';
 
 const RailRow: FC<{ label: string; children: React.ReactNode }> = ({
     label,
@@ -130,7 +136,6 @@ export const IssueDetailModal: FC<Props> = ({
     const targetAnchor = item ? getTargetAnchor(item) : null;
     const excerpts = item?.latestFinding?.evidenceExcerpts ?? [];
     const hasExcerpts = getRenderableExcerpts(excerpts).length > 0;
-
     const blockedReason =
         item && !item.writebackEligibility.eligible
             ? item.writebackEligibility.reason
@@ -254,71 +259,80 @@ export const IssueDetailModal: FC<Props> = ({
                                     </Box>
                                 </Stack>
 
-                                {/* Evidence — the curated turns the review cited.
-                                The full conversation opens in a stacked modal so
-                                a long thread keeps the room it needs to read.
-                                Manual issues have neither, so the section is
-                                omitted. */}
-                                {(hasThread || hasExcerpts) && (
-                                    <Stack
-                                        gap="md"
-                                        className={styles.evidenceSection}
-                                    >
-                                        <Group
-                                            justify="space-between"
-                                            align="center"
-                                            wrap="nowrap"
+                                {isMemoryReviewItem(item) && (
+                                    <MemoryProvenance
+                                        item={item}
+                                        projectUuid={projectUuid}
+                                    />
+                                )}
+
+                                {item.source !== 'memory' &&
+                                    (hasThread || hasExcerpts) && (
+                                        <Stack
+                                            gap="md"
+                                            className={styles.evidenceSection}
                                         >
-                                            <Text
-                                                className={styles.sectionLabel}
+                                            <Group
+                                                justify="space-between"
+                                                align="center"
+                                                wrap="nowrap"
                                             >
-                                                Evidence
-                                            </Text>
-                                            {hasThread && (
-                                                <Button
-                                                    variant="subtle"
-                                                    color="gray"
-                                                    size="compact-xs"
+                                                <Text
                                                     className={
-                                                        styles.conversationButton
-                                                    }
-                                                    onClick={openThread}
-                                                    leftSection={
-                                                        <MantineIcon
-                                                            icon={IconMessages}
-                                                            size={14}
-                                                            stroke={1.6}
-                                                        />
-                                                    }
-                                                    rightSection={
-                                                        <MantineIcon
-                                                            icon={
-                                                                IconArrowRight
-                                                            }
-                                                            size={13}
-                                                            stroke={1.6}
-                                                        />
+                                                        styles.sectionLabel
                                                     }
                                                 >
-                                                    Read full conversation
-                                                </Button>
+                                                    Evidence
+                                                </Text>
+                                                {hasThread && (
+                                                    <Button
+                                                        variant="subtle"
+                                                        color="gray"
+                                                        size="compact-xs"
+                                                        className={
+                                                            styles.conversationButton
+                                                        }
+                                                        onClick={openThread}
+                                                        leftSection={
+                                                            <MantineIcon
+                                                                icon={
+                                                                    IconMessages
+                                                                }
+                                                                size={14}
+                                                                stroke={1.6}
+                                                            />
+                                                        }
+                                                        rightSection={
+                                                            <MantineIcon
+                                                                icon={
+                                                                    IconArrowRight
+                                                                }
+                                                                size={13}
+                                                                stroke={1.6}
+                                                            />
+                                                        }
+                                                    >
+                                                        Read full conversation
+                                                    </Button>
+                                                )}
+                                            </Group>
+                                            {hasExcerpts ? (
+                                                <EvidenceExcerpts
+                                                    excerpts={excerpts}
+                                                />
+                                            ) : (
+                                                <Text
+                                                    className={
+                                                        styles.evidenceEmpty
+                                                    }
+                                                >
+                                                    No excerpts were captured —
+                                                    open the full conversation
+                                                    to see what triggered this.
+                                                </Text>
                                             )}
-                                        </Group>
-                                        {hasExcerpts ? (
-                                            <EvidenceExcerpts
-                                                excerpts={excerpts}
-                                            />
-                                        ) : (
-                                            <Text
-                                                className={styles.evidenceEmpty}
-                                            >
-                                                No excerpts were captured — open
-                                                the full conversation to see
-                                                what triggered this.
-                                            </Text>
-                                        )}
-                                    </Stack>
-                                )}
+                                        </Stack>
+                                    )}
                             </Stack>
                         </Stack>
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/MemoryProvenance.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/MemoryProvenance.tsx
@@ -1,0 +1,57 @@
+import { type AiAgentReviewItemSummary } from '@lightdash/common';
+import { Anchor, Box, Stack, Text } from '@mantine/core';
+import { IconArrowRight } from '@tabler/icons-react';
+import { type FC } from 'react';
+import { Link } from 'react-router';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import styles from './IssueDetailModal.module.css';
+
+type Props = {
+    item: AiAgentReviewItemSummary & { source: 'memory' };
+    projectUuid: string | null;
+};
+
+export const MemoryProvenance: FC<Props> = ({ item, projectUuid }) => {
+    const sourceMemoryProjectUuid = item.projectUuid ?? projectUuid;
+    const nominationReason = item.nominationReason ?? item.description;
+    const nominator =
+        item.nominator?.name ?? item.nominator?.email ?? 'Unknown user';
+
+    return (
+        <Stack gap="md" className={styles.evidenceSection}>
+            <Text className={styles.sectionLabel}>Memory provenance</Text>
+            <Stack gap="sm">
+                <Box>
+                    <Text fz="xs" fw={600} c="dimmed">
+                        Nomination reason
+                    </Text>
+                    <Text fz="sm">{nominationReason}</Text>
+                </Box>
+                <Box>
+                    <Text fz="xs" fw={600} c="dimmed">
+                        Nominated by
+                    </Text>
+                    <Text fz="sm">{nominator}</Text>
+                </Box>
+                {item.sourceMemory && sourceMemoryProjectUuid ? (
+                    <Anchor
+                        component={Link}
+                        to={`/projects/${sourceMemoryProjectUuid}/ai-agents/memories/${item.sourceMemory.slug}`}
+                        className={styles.toggle}
+                    >
+                        View source memory
+                        <MantineIcon
+                            icon={IconArrowRight}
+                            size={13}
+                            stroke={1.5}
+                        />
+                    </Anchor>
+                ) : (
+                    <Text fz="sm" c="dimmed">
+                        Source memory unavailable
+                    </Text>
+                )}
+            </Stack>
+        </Stack>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.test.ts
@@ -5,7 +5,9 @@ import {
     formatRelativeReviewDate,
     getIssueTitle,
     getReviewReasoningText,
+    getReviewSecondaryDetail,
     getTargetAnchor,
+    getWhyText,
     SURFACED_ROOT_CAUSES,
 } from './reviewItemDetails';
 
@@ -25,6 +27,7 @@ const makeItem = (
                 ? null
                 : {
                       fixTargets: [],
+                      subcategories: [],
                       targetRefs: [],
                       evidenceExcerpts: [],
                       recommendation: null,
@@ -92,6 +95,82 @@ describe('getReviewReasoningText', () => {
         });
 
         expect(getReviewReasoningText(item)).toContain('Objects: orders.');
+    });
+
+    it('uses the review item project context entry for memory nominations', () => {
+        const item = makeItem({
+            source: 'memory',
+            projectContextEntry: {
+                op: 'create',
+                id: null,
+                kind: 'context',
+                content: 'Use approved net revenue definitions.',
+                terms: [],
+                objects: ['orders'],
+            },
+            latestFinding: null,
+        });
+
+        expect(getReviewReasoningText(item)).toContain(
+            'Use approved net revenue definitions.',
+        );
+    });
+
+    it('ignores finding entries for memory items without an item entry', () => {
+        const item = makeItem({
+            source: 'memory',
+            nominationReason: 'Promote the approved revenue definition.',
+            projectContextEntry: null,
+            latestFinding: {
+                projectContextEntry: {
+                    op: 'create',
+                    id: null,
+                    kind: 'context',
+                    content: 'Stray finding entry.',
+                    terms: [],
+                    objects: [],
+                },
+            },
+        });
+
+        expect(getReviewReasoningText(item)).toBe(
+            'Promote the approved revenue definition.',
+        );
+        expect(getReviewSecondaryDetail(item)).toBeNull();
+    });
+
+    it('ignores item entries for non-memory items', () => {
+        const item = makeItem({
+            source: 'manual',
+            description: 'Manually filed issue.',
+            projectContextEntry: {
+                op: 'create',
+                id: null,
+                kind: 'context',
+                content: 'Stray item entry.',
+                terms: [],
+                objects: [],
+            },
+            latestFinding: null,
+        });
+
+        expect(getReviewReasoningText(item)).toBe('Manually filed issue.');
+        expect(getReviewSecondaryDetail(item)).toBeNull();
+    });
+});
+
+describe('getWhyText', () => {
+    it('keeps delimiter-like text in a structured nomination reason', () => {
+        const reason = 'Useful\n\nNominated by is part of the reason';
+        expect(
+            getWhyText(
+                makeItem({
+                    source: 'memory',
+                    description: 'Legacy description',
+                    nominationReason: reason,
+                }),
+            ),
+        ).toBe(reason);
     });
 });
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.ts
@@ -1,5 +1,6 @@
 import {
     formatAiProjectContextObjectRef,
+    getReviewItemProjectContextEntry,
     getVisibleAiAgentReviewRootCauses,
     type AiAgentRecommendationAction,
     type AiAgentReviewItemPriority,
@@ -249,6 +250,10 @@ export const getWhyText = (reviewItem: AiAgentReviewItemSummary): string => {
         return reviewItem.description || 'Manually filed issue.';
     }
 
+    if (reviewItem.source === 'memory') {
+        return reviewItem.nominationReason ?? reviewItem.description;
+    }
+
     return (
         reviewItem.latestFinding?.recommendation?.rationale ??
         `Review agent judged this as ${reviewRootCauseLabels[reviewItem.primaryRootCause].toLowerCase()}.`
@@ -258,7 +263,7 @@ export const getWhyText = (reviewItem: AiAgentReviewItemSummary): string => {
 export const getReviewReasoningText = (
     reviewItem: AiAgentReviewItemSummary,
 ): string => {
-    const contextEntry = reviewItem.latestFinding?.projectContextEntry ?? null;
+    const contextEntry = getReviewItemProjectContextEntry(reviewItem);
 
     if (contextEntry) {
         const objectRefs = contextEntry.objects
@@ -309,7 +314,7 @@ export const getSuggestedNextStep = (
 export const getReviewSecondaryDetail = (
     reviewItem: AiAgentReviewItemSummary,
 ): string | null => {
-    const contextEntry = reviewItem.latestFinding?.projectContextEntry ?? null;
+    const contextEntry = getReviewItemProjectContextEntry(reviewItem);
     if (contextEntry) {
         return contextEntry.kind;
     }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.test.tsx
@@ -25,6 +25,13 @@ const { memoryEnabled, statusMutationSpy } = vi.hoisted(() => ({
 
 vi.mock('../../hooks/useAiOrganizationSettings', () => ({
     useAiAgentMemoryEnabled: () => memoryEnabled.current,
+    useAiOrganizationSettings: () => ({
+        data: {
+            aiAgentReviewsEnabled: true,
+            aiAgentReviewsPausedByByok: false,
+        },
+        isLoading: false,
+    }),
 }));
 
 vi.mock('../../hooks/useAiAgentMemory', () => ({
@@ -62,11 +69,16 @@ Use net revenue for future revenue questions.`,
                 },
             },
             replacementSlug: null,
+            promotionReviewItem: null,
         },
     }),
     useUpdateAiAgentMemoryStatus: () => ({
         isLoading: false,
         mutate: statusMutationSpy,
+    }),
+    usePromoteAiAgentMemory: () => ({
+        isLoading: false,
+        mutate: vi.fn(),
     }),
 }));
 
@@ -281,6 +293,7 @@ describe('MemoryCitation', () => {
                                 },
                             },
                             replacementSlug: null,
+                            promotionReviewItem: null,
                         }}
                     />
                 </MantineProvider>

--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryActions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryActions.tsx
@@ -1,0 +1,31 @@
+import { type AiAgentMemory } from '@lightdash/common';
+import { Group } from '@mantine/core';
+import { type FC } from 'react';
+import { MemoryPromotionAction } from './MemoryPromotionAction';
+import { MemoryStatusAction } from './MemoryStatusControls';
+
+type Props = {
+    projectUuid: string;
+    memory: Pick<
+        AiAgentMemory,
+        'uuid' | 'slug' | 'status' | 'promotionReviewItem'
+    >;
+};
+
+export const MemoryActions: FC<Props> = ({ projectUuid, memory }) => (
+    <Group gap="xs">
+        <MemoryPromotionAction
+            projectUuid={projectUuid}
+            memoryUuid={memory.uuid}
+            slug={memory.slug}
+            status={memory.status}
+            promotionReviewItem={memory.promotionReviewItem}
+        />
+        <MemoryStatusAction
+            projectUuid={projectUuid}
+            memoryUuid={memory.uuid}
+            slug={memory.slug}
+            status={memory.status}
+        />
+    </Group>
+);

--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.tsx
@@ -29,8 +29,9 @@ import Callout from '../../../../../components/common/Callout';
 import MantineModal from '../../../../../components/common/MantineModal';
 import { parseAiAgentMemorySections } from '../../utils/memory';
 import { MEMORY_SCOPE_LABELS } from '../Admin/memoryScope';
+import { MemoryActions } from './MemoryActions';
 import styles from './MemoryDetails.module.css';
-import { MemoryStatusAction, MemoryStatusMenu } from './MemoryStatusControls';
+import { MemoryStatusMenu } from './MemoryStatusControls';
 
 type Memory = ApiAiAgentMemoryResponse['results'];
 
@@ -384,12 +385,7 @@ export const MemoryDetailsModal: FC<MemoryDetailsModalProps> = ({
         modalBodyProps={{ px: 0, py: 0 }}
         bodyScrollAreaMaxHeight="calc(85vh - 120px)"
         headerActions={
-            <MemoryStatusAction
-                projectUuid={projectUuid}
-                memoryUuid={memory.uuid}
-                slug={memory.slug}
-                status={memory.status}
-            />
+            <MemoryActions projectUuid={projectUuid} memory={memory} />
         }
     >
         <MemoryDetails

--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryPromotionAction.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryPromotionAction.test.tsx
@@ -1,0 +1,192 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+import { MemoryPromotionAction } from './MemoryPromotionAction';
+
+const { mutate, permissions, settings } = vi.hoisted(() => ({
+    mutate: vi.fn(),
+    permissions: {
+        canManageOrganization: false,
+        canManageProject: true,
+    },
+    settings: {
+        current: {
+            aiAgentReviewsEnabled: true,
+            aiAgentReviewsPausedByByok: false,
+        },
+    },
+}));
+
+vi.mock('../../hooks/useAiAgentMemory', () => ({
+    usePromoteAiAgentMemory: () => ({ isLoading: false, mutate }),
+}));
+
+vi.mock('../../hooks/useAiOrganizationSettings', () => ({
+    useAiOrganizationSettings: () => ({ data: settings.current }),
+}));
+
+vi.mock('../../hooks/useAiAgentPermission', () => ({
+    useAiAgentPermission: () => permissions.canManageProject,
+    useAiAgentOrgPermission: () => permissions.canManageOrganization,
+}));
+
+const renderAction = (
+    overrides: Partial<React.ComponentProps<typeof MemoryPromotionAction>> = {},
+) =>
+    renderWithProviders(
+        <MemoryRouter>
+            <MemoryPromotionAction
+                projectUuid="project-1"
+                memoryUuid="memory-1"
+                slug="revenue-convention"
+                status="active"
+                promotionReviewItem={null}
+                {...overrides}
+            />
+        </MemoryRouter>,
+    );
+
+describe('MemoryPromotionAction', () => {
+    beforeEach(() => {
+        mutate.mockClear();
+        settings.current = {
+            aiAgentReviewsEnabled: true,
+            aiAgentReviewsPausedByByok: false,
+        };
+        permissions.canManageOrganization = false;
+        permissions.canManageProject = true;
+    });
+
+    it('submits a nomination reason', async () => {
+        const user = userEvent.setup();
+        renderAction();
+
+        await user.click(
+            screen.getByRole('button', { name: 'Propose for project context' }),
+        );
+        await user.type(
+            screen.getByRole('textbox', {
+                name: /Why should this become project context?/,
+            }),
+            '  Useful across the project  ',
+        );
+        await user.click(
+            screen.getByRole('button', { name: 'Create proposal' }),
+        );
+
+        expect(mutate).toHaveBeenCalledWith(
+            {
+                projectUuid: 'project-1',
+                memoryUuid: 'memory-1',
+                slug: 'revenue-convention',
+                reason: 'Useful across the project',
+            },
+            expect.objectContaining({ onSuccess: expect.any(Function) }),
+        );
+    });
+
+    it('submits without a nomination reason', async () => {
+        const user = userEvent.setup();
+        renderAction();
+
+        await user.click(
+            screen.getByRole('button', { name: 'Propose for project context' }),
+        );
+        expect(
+            screen.getByText(
+                'This proposes making this guidance available to everyone in the project. Only text from the memory itself is used — evidence and query results are never included — and nothing changes until a reviewer approves it.',
+            ),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('textbox', {
+                name: /Why should this become project context?/,
+            }),
+        ).not.toBeRequired();
+        await user.click(
+            screen.getByRole('button', { name: 'Create proposal' }),
+        );
+
+        expect(mutate).toHaveBeenCalledWith(
+            {
+                projectUuid: 'project-1',
+                memoryUuid: 'memory-1',
+                slug: 'revenue-convention',
+            },
+            expect.objectContaining({ onSuccess: expect.any(Function) }),
+        );
+    });
+
+    it('links a live promotion candidate to its board item', () => {
+        renderAction({
+            promotionReviewItem: {
+                uuid: 'review-1',
+                status: 'open',
+                blocksNewNomination: true,
+            },
+        });
+
+        expect(
+            screen.getByRole('link', { name: 'View proposal' }),
+        ).toHaveAttribute(
+            'href',
+            '/generalSettings/ai/issues?reviewProjectUuid=project-1&reviewItemUuid=review-1',
+        );
+        expect(
+            screen.queryByRole('button', {
+                name: 'Propose for project context',
+            }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('links an expected-behavior dismissal that blocks re-nomination', () => {
+        renderAction({
+            promotionReviewItem: {
+                uuid: 'review-1',
+                status: 'dismissed',
+                blocksNewNomination: true,
+            },
+        });
+
+        expect(
+            screen.getByRole('link', { name: 'View proposal' }),
+        ).toHaveAttribute(
+            'href',
+            '/generalSettings/ai/issues?reviewProjectUuid=project-1&reviewItemUuid=review-1',
+        );
+    });
+
+    it('does not link a proposal when the nominator cannot open the board', () => {
+        permissions.canManageProject = false;
+        renderAction({
+            promotionReviewItem: {
+                uuid: 'review-1',
+                status: 'open',
+                blocksNewNomination: true,
+            },
+        });
+
+        expect(screen.getByText('Proposal pending')).toBeInTheDocument();
+        expect(
+            screen.queryByRole('link', { name: 'View proposal' }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('disables promotion with the feature gate reason', async () => {
+        settings.current.aiAgentReviewsEnabled = false;
+        const user = userEvent.setup();
+        renderAction();
+
+        const button = screen.getByRole('button', {
+            name: 'Propose for project context',
+        });
+        expect(button).toBeDisabled();
+        await user.hover(button.parentElement!);
+        expect(
+            await screen.findByText(
+                'Enable project context reviews before proposing a memory.',
+            ),
+        ).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryPromotionAction.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryPromotionAction.tsx
@@ -1,0 +1,167 @@
+import type { AiAgentMemory, AiAgentMemoryStatus } from '@lightdash/common';
+import {
+    Badge,
+    Box,
+    Button,
+    Stack,
+    Text,
+    Textarea,
+    Tooltip,
+} from '@mantine/core';
+import { IconArrowRight } from '@tabler/icons-react';
+import { type FC, type FormEvent, useState } from 'react';
+import { Link } from 'react-router';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import MantineModal from '../../../../../components/common/MantineModal';
+import { usePromoteAiAgentMemory } from '../../hooks/useAiAgentMemory';
+import {
+    useAiAgentOrgPermission,
+    useAiAgentPermission,
+} from '../../hooks/useAiAgentPermission';
+import { useAiOrganizationSettings } from '../../hooks/useAiOrganizationSettings';
+
+const MEMORY_PROMOTION_FORM_ID = 'memory-promotion-form';
+
+type Props = {
+    projectUuid: string;
+    memoryUuid: string;
+    slug: string;
+    status: AiAgentMemoryStatus;
+    promotionReviewItem: AiAgentMemory['promotionReviewItem'];
+};
+
+export const MemoryPromotionAction: FC<Props> = ({
+    projectUuid,
+    memoryUuid,
+    slug,
+    status,
+    promotionReviewItem,
+}) => {
+    const [opened, setOpened] = useState(false);
+    const [reason, setReason] = useState('');
+    const { data: settings, isLoading: isLoadingSettings } =
+        useAiOrganizationSettings();
+    const promoteMemory = usePromoteAiAgentMemory();
+    const canManageProjectAgent = useAiAgentPermission({
+        action: 'manage',
+        projectUuid,
+    });
+    const canManageOrganizationAgent = useAiAgentOrgPermission({
+        action: 'manage',
+    });
+
+    if (promotionReviewItem?.blocksNewNomination) {
+        if (!canManageProjectAgent && !canManageOrganizationAgent) {
+            return (
+                <Badge variant="light" color="violet" size="lg">
+                    Proposal pending
+                </Badge>
+            );
+        }
+        const params = new URLSearchParams({
+            reviewProjectUuid: projectUuid,
+            reviewItemUuid: promotionReviewItem.uuid,
+        });
+        return (
+            <Button
+                component={Link}
+                to={`/generalSettings/ai/issues?${params.toString()}`}
+                variant="light"
+                color="violet"
+                size="xs"
+                rightSection={<MantineIcon icon={IconArrowRight} size={14} />}
+            >
+                View proposal
+            </Button>
+        );
+    }
+
+    const reviewsEnabled =
+        settings?.aiAgentReviewsEnabled === true &&
+        settings.aiAgentReviewsPausedByByok !== true;
+    const disabledReason =
+        status !== 'active'
+            ? 'Only active memories can be proposed.'
+            : !isLoadingSettings && !reviewsEnabled
+              ? 'Enable project context reviews before proposing a memory.'
+              : null;
+    const nominationReason = reason.trim();
+
+    const resetAndClose = () => {
+        setOpened(false);
+        setReason('');
+    };
+    const close = () => {
+        if (promoteMemory.isLoading) return;
+        resetAndClose();
+    };
+    const submit = (event?: FormEvent<HTMLFormElement>) => {
+        event?.preventDefault();
+        promoteMemory.mutate(
+            {
+                projectUuid,
+                memoryUuid,
+                slug,
+                ...(nominationReason ? { reason: nominationReason } : {}),
+            },
+            { onSuccess: resetAndClose },
+        );
+    };
+
+    return (
+        <>
+            <Tooltip label={disabledReason} disabled={!disabledReason}>
+                <Box component="span">
+                    <Button
+                        variant="default"
+                        size="xs"
+                        disabled={isLoadingSettings || !!disabledReason}
+                        onClick={() => setOpened(true)}
+                    >
+                        Propose for project context
+                    </Button>
+                </Box>
+            </Tooltip>
+
+            <MantineModal
+                opened={opened}
+                onClose={close}
+                title="Propose memory for project context"
+                size="md"
+                cancelDisabled={promoteMemory.isLoading}
+                actions={
+                    <Button
+                        type="submit"
+                        form={MEMORY_PROMOTION_FORM_ID}
+                        loading={promoteMemory.isLoading}
+                    >
+                        Create proposal
+                    </Button>
+                }
+            >
+                <form id={MEMORY_PROMOTION_FORM_ID} onSubmit={submit}>
+                    <Stack gap="sm">
+                        <Text fz="sm" c="dimmed">
+                            This proposes making this guidance available to
+                            everyone in the project. Only text from the memory
+                            itself is used — evidence and query results are
+                            never included — and nothing changes until a
+                            reviewer approves it.
+                        </Text>
+                        <Textarea
+                            label="Why should this become project context?"
+                            description="Optional — shown to reviewers and used to guide the proposal."
+                            value={reason}
+                            onChange={(event) =>
+                                setReason(event.currentTarget.value)
+                            }
+                            minRows={3}
+                            autosize
+                            autoFocus
+                        />
+                    </Stack>
+                </form>
+            </MantineModal>
+        </>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/MyMemories/MyMemoriesModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MyMemories/MyMemoriesModal.tsx
@@ -18,8 +18,8 @@ import {
     useMyAiAgentMemories,
     useMyAiAgentMemory,
 } from '../../hooks/useAiAgentMemory';
+import { MemoryActions } from '../MemoryDetails/MemoryActions';
 import { MemoryDetails } from '../MemoryDetails/MemoryDetails';
-import { MemoryStatusAction } from '../MemoryDetails/MemoryStatusControls';
 import styles from './MyMemoriesModal.module.css';
 
 type MyMemoriesModalProps = {
@@ -73,11 +73,9 @@ const MemoryDetailPane: FC<{
                     {memory.title}
                 </Text>
                 {memoryQuery.data ? (
-                    <MemoryStatusAction
+                    <MemoryActions
                         projectUuid={projectUuid}
-                        memoryUuid={memoryQuery.data.uuid}
-                        slug={memoryQuery.data.slug}
-                        status={memoryQuery.data.status}
+                        memory={memoryQuery.data}
                     />
                 ) : null}
             </Group>

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentMemory.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentMemory.ts
@@ -1,6 +1,7 @@
 import type {
     AiAgentMemoryEditableStatus,
     ApiAiAgentMemoryResponse,
+    ApiPromoteAiAgentMemoryResponse,
     ApiAiAgentUserMemoriesResponse,
     ApiError,
     ApiUpdateAiAgentMemoryStatusRequest,
@@ -53,19 +54,82 @@ const getMyAiAgentMemory = (projectUuid: string, slug: string) =>
 export const useMyAiAgentMemory = ({
     projectUuid,
     slug,
+    enabled = true,
 }: {
     projectUuid: string | undefined;
     slug: string | undefined;
+    enabled?: boolean;
 }) =>
     useQuery<ApiAiAgentMemoryResponse['results'], ApiError>({
         queryKey: ['aiAgentMemory', projectUuid, slug],
         queryFn: () => getMyAiAgentMemory(projectUuid!, slug!),
-        enabled: Boolean(projectUuid && slug),
+        enabled: enabled && Boolean(projectUuid && slug),
         retry: (failureCount, error) =>
             error.error?.statusCode !== 404 && failureCount < 2,
     });
 
 const MY_AI_AGENT_MEMORIES_QUERY_KEY = 'my-ai-agent-memories';
+
+const promoteAiAgentMemory = ({
+    projectUuid,
+    memoryUuid,
+    reason,
+}: {
+    projectUuid: string;
+    memoryUuid: string;
+    slug: string;
+    reason?: string;
+}) =>
+    lightdashApi<ApiPromoteAiAgentMemoryResponse['results']>({
+        version: 'v1',
+        url: `/projects/${projectUuid}/aiAgentMemories/${memoryUuid}/promote`,
+        method: 'POST',
+        body: JSON.stringify({ reason }),
+    });
+
+export const usePromoteAiAgentMemory = () => {
+    const queryClient = useQueryClient();
+    const { showToastSuccess, showToastApiError } = useToaster();
+
+    return useMutation<
+        ApiPromoteAiAgentMemoryResponse['results'],
+        ApiError,
+        {
+            projectUuid: string;
+            memoryUuid: string;
+            slug: string;
+            reason?: string;
+        }
+    >({
+        mutationFn: promoteAiAgentMemory,
+        onSuccess: (reviewItem, { projectUuid, slug }) => {
+            queryClient.setQueryData<ApiAiAgentMemoryResponse['results']>(
+                ['aiAgentMemory', projectUuid, slug],
+                (memory) =>
+                    memory
+                        ? {
+                              ...memory,
+                              promotionReviewItem: {
+                                  uuid: reviewItem.uuid,
+                                  status: reviewItem.status,
+                                  blocksNewNomination: true,
+                              },
+                          }
+                        : memory,
+            );
+            void queryClient.invalidateQueries({
+                queryKey: ['ai-agent-admin-review-items'],
+            });
+            showToastSuccess({ title: 'Proposal created' });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: "Couldn't create proposal",
+                apiError: error,
+            });
+        },
+    });
+};
 
 // A user owns few memories per project, so one generous page is enough for v0
 const MY_AI_AGENT_MEMORIES_PAGE_SIZE = 100;

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentMemoryPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentMemoryPage.tsx
@@ -3,16 +3,30 @@ import { IconArrowLeft } from '@tabler/icons-react';
 import { Link, useParams } from 'react-router';
 import ErrorState from '../../../components/common/ErrorState';
 import PageSpinner from '../../../components/PageSpinner';
+import { MemoryActions } from '../../features/aiCopilot/components/MemoryDetails/MemoryActions';
 import { MemoryDetails } from '../../features/aiCopilot/components/MemoryDetails/MemoryDetails';
-import { MemoryStatusAction } from '../../features/aiCopilot/components/MemoryDetails/MemoryStatusControls';
-import { useAiAgentMemory } from '../../features/aiCopilot/hooks/useAiAgentMemory';
+import {
+    useAiAgentMemory,
+    useMyAiAgentMemory,
+} from '../../features/aiCopilot/hooks/useAiAgentMemory';
 import styles from './AiAgentMemoryPage.module.css';
 
 const AiAgentMemoryPage = () => {
     const { projectUuid, agentUuid, slug } = useParams();
-    const memoryQuery = useAiAgentMemory({ projectUuid, agentUuid, slug });
+    const agentMemoryQuery = useAiAgentMemory({
+        projectUuid,
+        agentUuid,
+        slug,
+        enabled: Boolean(agentUuid),
+    });
+    const projectMemoryQuery = useMyAiAgentMemory({
+        projectUuid,
+        slug,
+        enabled: !agentUuid,
+    });
+    const memoryQuery = agentUuid ? agentMemoryQuery : projectMemoryQuery;
 
-    if (!projectUuid || !agentUuid || !slug) return <ErrorState />;
+    if (!projectUuid || !slug) return <ErrorState />;
     if (memoryQuery.isLoading) return <PageSpinner />;
     if (memoryQuery.isError || !memoryQuery.data) {
         return <ErrorState error={memoryQuery.error?.error} />;
@@ -43,18 +57,16 @@ const AiAgentMemoryPage = () => {
                         >
                             {memoryQuery.data.title}
                         </Text>
-                        <MemoryStatusAction
+                        <MemoryActions
                             projectUuid={projectUuid}
-                            memoryUuid={memoryQuery.data.uuid}
-                            slug={memoryQuery.data.slug}
-                            status={memoryQuery.data.status}
+                            memory={memoryQuery.data}
                         />
                     </Group>
                     <Divider />
                     <MemoryDetails
                         memory={memoryQuery.data}
                         projectUuid={projectUuid}
-                        agentUuid={agentUuid}
+                        agentUuid={agentUuid ?? null}
                     />
                 </Paper>
             </Stack>


### PR DESCRIPTION
### Description
- add proposal action and persisted live-state link to memory details
- expose source memory, nominator, and nomination reason on review items
- keep memory-source items free of thread evidence

### Verification
- common, backend, frontend full test suites
- package lint and typechecks
- browser: propose → review item → source memory → reload persistence
- local API and PostgreSQL state correlation

Closes: ZAP-790