### PR TITLE
fix(charts): show value labels on every stacked bar segment

### DIFF
--- a/packages/common/src/visualizations/helpers/styles/valueLabelStyles.test.ts
+++ b/packages/common/src/visualizations/helpers/styles/valueLabelStyles.test.ts
@@ -1,0 +1,28 @@
+import { CartesianSeriesType } from '../../../types/savedCharts';
+import { getValueLabelStyle } from './valueLabelStyles';
+
+describe('getValueLabelStyle', () => {
+    test.each(['inside', 'insideTop', 'insideRight'] as const)(
+        'gives %s bar labels a readable color on the bar',
+        (position) => {
+            expect(
+                getValueLabelStyle(
+                    position,
+                    CartesianSeriesType.BAR,
+                    '#000000',
+                ),
+            ).toEqual(
+                expect.objectContaining({
+                    backgroundColor: '#000000',
+                    color: expect.any(String),
+                }),
+            );
+        },
+    );
+
+    test('leaves labels outside the bar on the default foreground color', () => {
+        expect(
+            getValueLabelStyle('top', CartesianSeriesType.BAR, '#000000'),
+        ).not.toHaveProperty('backgroundColor');
+    });
+});

--- a/packages/common/src/visualizations/helpers/styles/valueLabelStyles.ts
+++ b/packages/common/src/visualizations/helpers/styles/valueLabelStyles.ts
@@ -3,6 +3,16 @@ import { getReadableTextColor } from '../../../utils/colors';
 import { BACKGROUND, FOREGROUND } from './themeColors';
 
 /**
+ * Label positions ECharts can render. Stacked bars resolve the configured
+ * position to an `inside*` variant so a segment's label is painted on its own
+ * bar instead of underneath the segment stacked after it.
+ */
+export type EChartsLabelPosition =
+    | NonNullable<NonNullable<Series['label']>['position']>
+    | 'insideTop'
+    | 'insideRight';
+
+/**
  * Get value label styling for any chart series (line, bar, area, scatter, etc.)
  * Size: 11px
  * @param position - Label position relative to data point
@@ -10,11 +20,11 @@ import { BACKGROUND, FOREGROUND } from './themeColors';
  * @param backgroundColor - Optional series color
  */
 export const getValueLabelStyle = (
-    position: 'left' | 'right' | 'top' | 'bottom' | 'inside' | undefined,
+    position: EChartsLabelPosition | undefined,
     type: Series['type'],
     backgroundColor?: string,
 ) => {
-    const isInside = position === 'inside';
+    const isInside = position?.startsWith('inside') ?? false;
 
     const base = {
         fontSize: 11,

--- a/packages/common/src/visualizations/types/index.ts
+++ b/packages/common/src/visualizations/types/index.ts
@@ -15,6 +15,7 @@ import {
     type Series,
 } from '../../types/savedCharts';
 import { type CartesianChartDisplay } from '../CartesianChartDataModel';
+import { type EChartsLabelPosition } from '../helpers/styles/valueLabelStyles';
 
 export enum VizAggregationOptions {
     SUM = 'sum',
@@ -404,7 +405,7 @@ export type EChartsSeries = {
         show?: boolean;
         fontSize?: number;
         fontWeight?: string;
-        position?: 'left' | 'top' | 'right' | 'bottom' | 'inside';
+        position?: EChartsLabelPosition;
         formatter?: (param: { data: Record<string, unknown> }) => string;
         textBorderColor?: string;
         textBorderWidth?: number;

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
@@ -28,6 +28,7 @@ import {
     getAxisDefaultMinValue,
     getAxisType,
     getCartesianLabelLayout,
+    getCartesianLabelPosition,
     getCategoryDateAxisConfig,
     getLongestLabelsForAxis,
     getMinAndMaxValues,
@@ -98,6 +99,97 @@ describe('getCartesianLabelLayout', () => {
             ).toEqual({ hideOverlap: true });
         },
     );
+});
+
+describe('getCartesianLabelPosition', () => {
+    test('moves top labels inside segments that are not the end of a stack', () => {
+        expect(
+            getCartesianLabelPosition({
+                isStacked: true,
+                isStackEnd: false,
+                seriesType: CartesianSeriesType.BAR,
+                position: 'top',
+                flipAxes: false,
+            }),
+        ).toBe('insideTop');
+    });
+
+    test('moves right labels inside segments of a horizontal stack', () => {
+        expect(
+            getCartesianLabelPosition({
+                isStacked: true,
+                isStackEnd: false,
+                seriesType: CartesianSeriesType.BAR,
+                position: 'right',
+                flipAxes: true,
+            }),
+        ).toBe('insideRight');
+    });
+
+    test.each([
+        {
+            name: 'the segment that ends the stack',
+            isStacked: true,
+            isStackEnd: true,
+            seriesType: CartesianSeriesType.BAR,
+            position: 'top' as const,
+            flipAxes: false,
+        },
+        {
+            name: 'unstacked bars',
+            isStacked: false,
+            isStackEnd: true,
+            seriesType: CartesianSeriesType.BAR,
+            position: 'top' as const,
+            flipAxes: false,
+        },
+        {
+            name: 'stacked lines',
+            isStacked: true,
+            isStackEnd: false,
+            seriesType: CartesianSeriesType.LINE,
+            position: 'top' as const,
+            flipAxes: false,
+        },
+        {
+            name: 'positions that are not painted over by the next segment',
+            isStacked: true,
+            isStackEnd: false,
+            seriesType: CartesianSeriesType.BAR,
+            position: 'bottom' as const,
+            flipAxes: false,
+        },
+        {
+            name: 'top labels on a horizontal stack',
+            isStacked: true,
+            isStackEnd: false,
+            seriesType: CartesianSeriesType.BAR,
+            position: 'top' as const,
+            flipAxes: true,
+        },
+        {
+            name: 'right labels on a vertical stack',
+            isStacked: true,
+            isStackEnd: false,
+            seriesType: CartesianSeriesType.BAR,
+            position: 'right' as const,
+            flipAxes: false,
+        },
+    ])('keeps the configured position for $name', ({ name, ...args }) => {
+        expect(getCartesianLabelPosition(args)).toBe(args.position);
+    });
+
+    test('leaves an unset position unset', () => {
+        expect(
+            getCartesianLabelPosition({
+                isStacked: true,
+                isStackEnd: false,
+                seriesType: CartesianSeriesType.BAR,
+                position: undefined,
+                flipAxes: false,
+            }),
+        ).toBeUndefined();
+    });
 });
 
 describe('resolveCartesianGranularityLabels', () => {

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -64,6 +64,7 @@ import {
     type CartesianChart,
     type ConditionalFormattingConfig,
     type CustomDimension,
+    type EChartsLabelPosition,
     type EChartsSeries,
     type EchartsLegend,
     type Field,
@@ -976,7 +977,7 @@ export const getCartesianLabelLayout = ({
     isGroupedBarChart: boolean;
     isStacked: boolean;
     seriesType: CartesianSeriesType;
-    position: NonNullable<Series['label']>['position'];
+    position: EChartsLabelPosition | undefined;
 }) => ({
     hideOverlap: !(
         isGroupedBarChart &&
@@ -985,6 +986,41 @@ export const getCartesianLabelLayout = ({
         position === 'top'
     ),
 });
+
+/**
+ * ECharts paints each series after the previous one, so a stacked segment's
+ * `top` label — which sits inside the segment stacked above it — is covered by
+ * that segment's bar. Anchor those labels inside their own segment instead, so
+ * they are painted with the bar they belong to. The segment that ends the stack
+ * has nothing painted after it and keeps the configured position.
+ */
+export const getCartesianLabelPosition = ({
+    isStacked,
+    isStackEnd,
+    seriesType,
+    position,
+    flipAxes,
+}: {
+    isStacked: boolean;
+    isStackEnd: boolean;
+    seriesType: CartesianSeriesType;
+    position: EChartsLabelPosition | undefined;
+    flipAxes: boolean;
+}): EChartsLabelPosition | undefined => {
+    if (
+        !isStacked ||
+        isStackEnd ||
+        seriesType !== CartesianSeriesType.BAR ||
+        position === undefined
+    ) {
+        return position;
+    }
+
+    if (flipAxes) {
+        return position === 'right' ? 'insideRight' : position;
+    }
+    return position === 'top' ? 'insideTop' : position;
+};
 
 /**
  * Create a labelLayout configuration for stacked bar charts.
@@ -3513,27 +3549,46 @@ const useEchartsCartesianConfig = (
 
         const seriesColors = series.map((serie) => getSeriesColor(serie));
 
+        // ECharts stacks in series order, so the last series of a stack is the
+        // one whose segment ends the stack.
+        const stackEndIndexes = new Map<string, number>();
+        series.forEach((serie, index) => {
+            const stack = getValidStack(serie);
+            if (stack !== undefined) stackEndIndexes.set(stack, index);
+        });
+
         const seriesWithValidStack = series.map<EChartsSeries>(
             (serie, index) => {
                 const computedColor = seriesColors[index];
+                const validStack = getValidStack(serie);
+                const labelPosition = getCartesianLabelPosition({
+                    isStacked: validStack !== undefined,
+                    isStackEnd:
+                        validStack === undefined ||
+                        stackEndIndexes.get(validStack) === index,
+                    seriesType: serie.type,
+                    position: serie.label?.position,
+                    flipAxes: isHorizontal,
+                });
 
                 const baseConfig = {
                     ...serie,
                     color: computedColor,
-                    stack: getValidStack(serie),
+                    stack: validStack,
                     // Ensure label styles are applied after color is known
                     ...(serie.label?.show && {
                         label: {
                             ...serie.label,
+                            position: labelPosition,
                             ...getValueLabelStyle(
-                                serie.label.position,
+                                labelPosition,
                                 serie.type,
                                 computedColor,
                             ),
                         },
                         labelLayout: getCartesianLabelLayout({
                             isGroupedBarChart,
-                            isStacked: getValidStack(serie) !== undefined,
+                            isStacked: validStack !== undefined,
                             seriesType: serie.type,
                             position: serie.label.position,
                         }),


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9384

## Summary

On a stacked bar chart with **Value labels = Top**, only the label on the segment at the top of the stack was visible — every segment below it showed no value at all, so a stack of 26 + 5 rendered a single `5`. Reported again after #26679, which fixed the same symptom for grouped (side-by-side) bars only.

Affects vertical stacks with `Top` labels and horizontal stacks with `Right` labels. Grouped and unstacked bars are unchanged.

## Root cause

Not label collision — the labels were rendered, then painted over. ECharts draws series in order, rect and labels together, so series *n*'s label is painted before series *n+1*'s rect. For a stacked segment, `position: 'top'` puts the label above that segment's own rect, which is geometrically *inside* the segment stacked on top of it. The next series then paints its bar straight over it.

```
label "26" (series 0)        x=730 y=310 w=14 h=13   painted first
rect  placed (series 1)      x=730 y=303 w=14 h=25   painted after → covers it
```

Confirmed in the SVG renderer with `document.elementFromPoint()` at the centre of the `26` label: it returns the `<path>` of the bar above, not the label.

`#26679` did not cause this. It only relaxed `hideOverlap` for grouped bars, and its condition explicitly excludes stacked series — stacked bars behaved identically before and after it.

## Fix

For a stacked bar segment that is not the end of its stack, the label is anchored *inside* the top edge of its own segment, so it is painted with the bar it belongs to and can never be covered. The segment that ends the stack has nothing painted after it and keeps its label outside the bar, exactly as today.

```
Before                          After
                                              5  ← end of stack: unchanged
      ┌────┐   5                        ┌────┐
      │    │                            │    │
      ├────┤   (26 painted here,        ├────┤
      │    │    then covered)           │26  │  ← anchored inside its own segment
      └────┘                            └────┘
```

- `packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts` — new `getCartesianLabelPosition` maps `top` → `insideTop` (vertical) and `right` → `insideRight` (horizontal) for non-end stacked bar segments; the resolved position drives both `label.position` and `getValueLabelStyle`, so relocated labels get the readable-on-bar treatment already used by the `Inside` position.
- `packages/common/src/visualizations/helpers/styles/valueLabelStyles.ts` — new `EChartsLabelPosition` type; `isInside` now matches any `inside*` variant.
- `packages/common/src/visualizations/types/index.ts` — `EChartsSeries['label']['position']` widened to that type. The saved-chart `Series` type is untouched: `insideTop` is a render-time value, never persisted.
- Out of scope: the SQL runner's `CartesianChartDataModel` path, and `showOverlappingLabels`, whose dynamic font-size callback is separately overwritten in the final series map (pre-dates #26679).

## Verification

Jaffle `orders`, unique order count by month pivoted on status, in the local dev instance. The oracle is DOM hit-testing every value label: before, the lower segments' labels resolve to a bar `<path>`; after, they resolve to themselves.

```
Vertical stack, 2 series, Top     before: 2 labels covered   after: 0 covered
Vertical stack, 5 series, Top     after: 0 covered (middle segments visible)
Horizontal stack, Right           after: 0 covered
Grouped bars, Top (#26679)        after: 0 covered — unchanged
```

## Test plan

- [x] `pnpm -F frontend typecheck && pnpm -F frontend lint`
- [x] `pnpm -F common typecheck && pnpm -F common lint`
- [x] `vitest src/hooks/echarts src/components/common/ChartDownload` — 244 pass (added `getCartesianLabelPosition` suite)
- [x] `vitest src/visualizations` in common — 52 pass (added `valueLabelStyles` suite)
- [x] Manual: repro from the ticket — every stacked segment now shows its value
- [x] Manual: grouped bars, horizontal stacks, and 5-segment stacks re-checked in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)