### PR TITLE
refactor(ai-agents): rework the agent settings page and return after save

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminAgentsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminAgentsTable.tsx
@@ -50,6 +50,7 @@ import { useProjects } from '../../../../../hooks/useProjects';
 import useSearchParams from '../../../../../hooks/useSearchParams';
 import SlackSvg from '../../../../../svgs/slack.svg?react';
 import { useAiAgentAdminAgents } from '../../hooks/useAiAgentAdmin';
+import { useAgentSettingsLinkState } from '../../utils/agentSettingsNavigation';
 import ProjectsFilter from './ProjectsFilter';
 import { SearchFilter } from './SearchFilter';
 
@@ -57,6 +58,7 @@ const AiAgentAdminAgentsTable = () => {
     const theme = useMantineTheme();
     const navigate = useNavigate();
     const { pathname, search: locationSearch } = useLocation();
+    const settingsLinkState = useAgentSettingsLinkState();
     const { data: agents, isLoading } = useAiAgentAdminAgents();
     const { data: projects } = useProjects();
     const projectsParam = useSearchParams<string>('projects');
@@ -511,6 +513,7 @@ const AiAgentAdminAgentsTable = () => {
                                         event.stopPropagation();
                                         void navigate(
                                             `/projects/${agent.projectUuid}/ai-agents/${agent.uuid}/edit`,
+                                            { state: settingsLinkState },
                                         );
                                     }}
                                 >
@@ -535,7 +538,7 @@ const AiAgentAdminAgentsTable = () => {
                 },
             },
         ],
-        [projectsMap, slackChannels, navigate],
+        [projectsMap, slackChannels, navigate, settingsLinkState],
     );
 
     const table = useContentTable({

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSettingsActionBar.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSettingsActionBar.module.css
@@ -1,0 +1,25 @@
+.root {
+    position: sticky;
+    bottom: 0;
+    z-index: 2;
+    border-top: 1px solid var(--mantine-color-ldGray-2);
+    background-color: var(--mantine-color-white);
+    /* Spans the full main column, ignoring the content column's gutters. */
+    margin-inline: calc(-1 * var(--mantine-spacing-md));
+    padding-inline: var(--mantine-spacing-md);
+    padding-block: var(--mantine-spacing-sm);
+}
+
+.inner {
+    margin-inline: auto;
+    width: 100%;
+    max-width: var(--page-content-width);
+}
+
+.statusDot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background-color: var(--mantine-color-orange-5);
+    flex-shrink: 0;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSettingsActionBar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSettingsActionBar.tsx
@@ -1,0 +1,50 @@
+import { Box, Button, Group, Text } from '@mantine/core';
+import { type FC } from 'react';
+import classes from './AgentSettingsActionBar.module.css';
+
+type Props = {
+    mode: 'create' | 'edit';
+    hasUnsavedChanges: boolean;
+    isSaving: boolean;
+    onSave: () => void;
+    onCancel: () => void;
+};
+
+export const AgentSettingsActionBar: FC<Props> = ({
+    mode,
+    hasUnsavedChanges,
+    isSaving,
+    onSave,
+    onCancel,
+}) => (
+    <Box className={classes.root}>
+        <Group className={classes.inner} justify="space-between" gap="md">
+            <Group gap="xs" align="center">
+                {hasUnsavedChanges && (
+                    <>
+                        <Box className={classes.statusDot} />
+                        <Text size="xs" c="dimmed">
+                            You have unsaved changes
+                        </Text>
+                    </>
+                )}
+            </Group>
+            <Group gap="xs">
+                <Button
+                    variant="default"
+                    onClick={onCancel}
+                    disabled={isSaving}
+                >
+                    Cancel
+                </Button>
+                <Button
+                    onClick={onSave}
+                    loading={isSaving}
+                    disabled={mode === 'edit' && !hasUnsavedChanges}
+                >
+                    {mode === 'create' ? 'Create agent' : 'Save changes'}
+                </Button>
+            </Group>
+        </Group>
+    </Box>
+);

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSettingsSection.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSettingsSection.module.css
@@ -1,0 +1,4 @@
+.root {
+    /* Anchor links must clear the fixed app navbar and the sticky action bar. */
+    scroll-margin-top: calc(var(--navbar-height) + var(--mantine-spacing-md));
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSettingsSection.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSettingsSection.tsx
@@ -1,0 +1,61 @@
+import { Group, Paper, Stack, Text, Title } from '@mantine/core';
+import { type Icon as TablerIcon } from '@tabler/icons-react';
+import { type FC, type ReactNode } from 'react';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import classes from './AgentSettingsSection.module.css';
+
+type Props = {
+    /** Anchor target for the settings section index. */
+    id: string;
+    icon: TablerIcon;
+    title: string;
+    /** One line on what the section controls. */
+    description?: ReactNode;
+    /** Rendered next to the title, e.g. a beta badge. */
+    badge?: ReactNode;
+    /** Rendered at the far right of the header, e.g. a secondary button. */
+    action?: ReactNode;
+    children: ReactNode;
+};
+
+export const AgentSettingsSection: FC<Props> = ({
+    id,
+    icon,
+    title,
+    description,
+    badge,
+    action,
+    children,
+}) => (
+    <Paper component="section" id={id} p="xl" className={classes.root}>
+        <Stack gap="md">
+            <Group
+                align="flex-start"
+                justify="space-between"
+                gap="md"
+                wrap="wrap"
+            >
+                <Group align="flex-start" gap="xs" wrap="nowrap">
+                    <Paper p="xxs" withBorder radius="sm">
+                        <MantineIcon icon={icon} size="md" />
+                    </Paper>
+                    <Stack gap={2}>
+                        <Group gap="xs" align="center">
+                            <Title order={5} c="ldGray.9" fw={700}>
+                                {title}
+                            </Title>
+                            {badge}
+                        </Group>
+                        {description && (
+                            <Text size="xs" c="dimmed">
+                                {description}
+                            </Text>
+                        )}
+                    </Stack>
+                </Group>
+                {action}
+            </Group>
+            {children}
+        </Stack>
+    </Paper>
+);

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSettingsSectionNav.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSettingsSectionNav.module.css
@@ -1,0 +1,30 @@
+.list {
+    /* Indents the section index under its parent "Setup" nav item, with a rail
+       tying the two together. */
+    margin-left: var(--mantine-spacing-md);
+    padding-left: var(--mantine-spacing-xs);
+    border-left: 1px solid var(--mantine-color-ldGray-2);
+}
+
+.item {
+    display: block;
+    width: 100%;
+    padding: 4px var(--mantine-spacing-xs);
+    border: none;
+    border-radius: var(--mantine-radius-sm);
+    background: none;
+    text-align: left;
+    cursor: pointer;
+    font-size: var(--mantine-font-size-xs);
+    color: var(--mantine-color-dimmed);
+}
+
+.item:hover {
+    background-color: var(--mantine-color-ldGray-0);
+    color: var(--mantine-color-ldGray-9);
+}
+
+.item[data-active='true'] {
+    color: var(--mantine-color-ldGray-9);
+    font-weight: 600;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSettingsSectionNav.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSettingsSectionNav.tsx
@@ -1,0 +1,77 @@
+import { Stack, UnstyledButton } from '@mantine/core';
+import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
+import { NAVBAR_HEIGHT } from '../../../../components/common/Page/constants';
+import {
+    getAgentSettingsSections,
+    type AgentSettingsSectionId,
+} from '../utils/agentSettingsSections';
+import classes from './AgentSettingsSectionNav.module.css';
+
+const SCROLL_OFFSET = NAVBAR_HEIGHT + 24;
+
+type Props = {
+    mode: 'create' | 'edit';
+};
+
+export const AgentSettingsSectionNav: FC<Props> = ({ mode }) => {
+    const sections = useMemo(() => getAgentSettingsSections(mode), [mode]);
+    const [activeId, setActiveId] = useState<AgentSettingsSectionId | null>(
+        null,
+    );
+
+    // Scroll-spy: the active section is the last one whose top has passed
+    // under the fixed navbar.
+    useEffect(() => {
+        let frame: number | null = null;
+
+        const measure = () => {
+            frame = null;
+            const passed = sections.filter((section) => {
+                const element = document.getElementById(section.id);
+                return (
+                    element !== null &&
+                    element.getBoundingClientRect().top <= SCROLL_OFFSET
+                );
+            });
+            setActiveId(passed.at(-1)?.id ?? sections[0]?.id ?? null);
+        };
+
+        const onScroll = () => {
+            if (frame === null) {
+                frame = window.requestAnimationFrame(measure);
+            }
+        };
+
+        measure();
+        window.addEventListener('scroll', onScroll, { passive: true });
+        window.addEventListener('resize', onScroll);
+        return () => {
+            if (frame !== null) {
+                window.cancelAnimationFrame(frame);
+            }
+            window.removeEventListener('scroll', onScroll);
+            window.removeEventListener('resize', onScroll);
+        };
+    }, [sections]);
+
+    const handleClick = useCallback((id: AgentSettingsSectionId) => {
+        document
+            .getElementById(id)
+            ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }, []);
+
+    return (
+        <Stack gap={2} className={classes.list}>
+            {sections.map((section) => (
+                <UnstyledButton
+                    key={section.id}
+                    className={classes.item}
+                    data-active={activeId === section.id}
+                    onClick={() => handleClick(section.id)}
+                >
+                    {section.label}
+                </UnstyledButton>
+            ))}
+        </Stack>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
@@ -8,6 +8,7 @@ import {
     Card,
     Code,
     Collapse,
+    Divider,
     FileButton,
     Group,
     HoverCard,
@@ -29,13 +30,13 @@ import {
 import { type useForm } from '@mantine/form';
 import { useDisclosure } from '@mantine/hooks';
 import {
-    IconAdjustmentsAlt,
     IconAlertTriangle,
     IconBook2,
+    IconBrandSlack,
     IconCode,
+    IconId,
     IconInfoCircle,
     IconLock,
-    IconPlug,
     IconPointFilled,
     IconSparkles,
     IconTrash,
@@ -50,7 +51,6 @@ import { getModelKey } from '../../../../components/common/ModelSelector/utils';
 import { SlackChannelSelect } from '../../../../components/common/SlackChannelSelect';
 import { useGetSlack } from '../../../../hooks/slack/useSlack';
 import { useOrganizationGroups } from '../../../../hooks/useOrganizationGroups';
-import { useProject } from '../../../../hooks/useProject';
 import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../providers/App/useApp';
 import { UserAccessMultiSelect } from '../../../components/UserAccessMultiSelect';
@@ -63,6 +63,7 @@ import {
 import { useAiOrganizationSettings } from '../hooks/useAiOrganizationSettings';
 import { useDeleteAiAgentMutation } from '../hooks/useProjectAiAgents';
 import { useGetAgentExploreAccessSummary } from '../hooks/useUserAgentPreferences';
+import { AgentSettingsSection } from './AgentSettingsSection';
 import AiAgentAsCodeModal from './AiAgentAsCodeModal';
 import { AiAgentKnowledgeFilesSection } from './AiAgentKnowledgeFilesSection';
 import { AiAgentMcpServersInput } from './AiAgentMcpServersInput';
@@ -119,6 +120,7 @@ export const AiAgentFormSetup = ({
     projectUuid,
     agentUuid,
     isSavingAgent,
+    onSubmit,
     persistedMcpServerUuids,
     avatarMode,
     avatarFileName,
@@ -132,6 +134,7 @@ export const AiAgentFormSetup = ({
     projectUuid: string;
     agentUuid?: string;
     isSavingAgent?: boolean;
+    onSubmit: () => void;
     persistedMcpServerUuids?: string[];
     avatarMode: 'upload' | 'link';
     avatarFileName: string | null;
@@ -140,7 +143,6 @@ export const AiAgentFormSetup = ({
     onAvatarRemove: () => void;
     onAvatarRevert: (() => void) | null;
 }) => {
-    const { data: project } = useProject(projectUuid);
     const { data: aiOrganizationSettings } = useAiOrganizationSettings();
     const modelOptions = aiOrganizationSettings?.defaultAiAgentModelOptions;
     const exploreAccessSummaryQuery = useGetAgentExploreAccessSummary(
@@ -288,602 +290,635 @@ export const AiAgentFormSetup = ({
 
     return (
         <>
-            <form>
+            <form
+                onSubmit={(event) => {
+                    event.preventDefault();
+                    onSubmit();
+                }}
+            >
                 <Stack gap="sm">
-                    <Paper p="xl">
-                        <Group align="center" justify="space-between" mb="md">
-                            <Group align="center" gap="xs">
-                                <Paper p="xxs" withBorder radius="sm">
-                                    <MantineIcon
-                                        icon={IconAdjustmentsAlt}
-                                        size="md"
-                                    />
-                                </Paper>
-                                <Title order={5} c="ldGray.9" fw={700}>
-                                    Basic information
-                                </Title>
-                            </Group>
-                            {mode === 'edit' &&
-                                agentUuid &&
-                                canViewContentAsCode && (
-                                    <Button
-                                        variant="default"
-                                        onClick={asCodeModalHandlers.open}
-                                        leftSection={
-                                            <MantineIcon icon={IconCode} />
-                                        }
-                                    >
-                                        View as code
-                                    </Button>
-                                )}
-                        </Group>
-                        <Stack>
-                            <Group>
+                    <AgentSettingsSection
+                        id="identity"
+                        icon={IconId}
+                        title="Identity"
+                        description="How this agent introduces itself wherever it appears."
+                        action={
+                            mode === 'edit' &&
+                            agentUuid &&
+                            canViewContentAsCode ? (
+                                <Button
+                                    variant="default"
+                                    size="xs"
+                                    onClick={asCodeModalHandlers.open}
+                                    leftSection={
+                                        <MantineIcon icon={IconCode} />
+                                    }
+                                >
+                                    View as code
+                                </Button>
+                            ) : null
+                        }
+                    >
+                        <TextInput
+                            label="Name"
+                            placeholder="Enter a name for this agent"
+                            variant="subtle"
+                            {...form.getInputProps('name')}
+                        />
+                        <CommitOnBlurTextarea
+                            key={`description-${
+                                form.values.description != null
+                            }`}
+                            variant="subtle"
+                            label="Description"
+                            description="A brief description of what this agent does and its purpose."
+                            placeholder="Describe what this agent specializes in..."
+                            minRows={3}
+                            maxRows={6}
+                            error={form.errors.description}
+                            defaultValue={form.values.description ?? ''}
+                            onCommit={(value) =>
+                                form.setFieldValue(
+                                    'description',
+                                    value ? value : null,
+                                )
+                            }
+                        />
+                        <Box>
+                            <Text size="sm" fw={500}>
+                                Avatar
+                            </Text>
+                            <Text size="xs" c="dimmed" mt={2}>
+                                Upload an image (PNG, JPG, GIF) or use an image
+                                URL. Images are cropped to a square; a default
+                                avatar is used if none is set.
+                            </Text>
+
+                            {avatarMode === 'link' ? (
                                 <TextInput
-                                    label="Agent Name"
-                                    placeholder="Enter a name for this agent"
-                                    {...form.getInputProps('name')}
-                                    style={{ flexGrow: 1 }}
+                                    mt="sm"
                                     variant="subtle"
+                                    label="Avatar image URL"
+                                    placeholder="https://example.com/avatar.jpg"
+                                    type="url"
+                                    {...form.getInputProps('imageUrl')}
+                                    onChange={(e) => {
+                                        const value = e.target.value;
+                                        form.setFieldValue(
+                                            'imageUrl',
+                                            value ? value : null,
+                                        );
+                                    }}
                                 />
-                                <Tooltip label="Agents can only be created within the context of the current project.">
-                                    <TextInput
-                                        label="Project"
-                                        placeholder="Enter a project"
-                                        value={project?.name}
-                                        readOnly
-                                        style={{ flexGrow: 1 }}
-                                        variant="subtle"
-                                    />
-                                </Tooltip>
-                            </Group>
-                            <CommitOnBlurTextarea
-                                key={`description-${
-                                    form.values.description != null
-                                }`}
-                                variant="subtle"
-                                label="Description"
-                                description="A brief description of what this agent does and its purpose."
-                                placeholder="Describe what this agent specializes in..."
-                                minRows={3}
-                                maxRows={6}
-                                error={form.errors.description}
-                                defaultValue={form.values.description ?? ''}
-                                onCommit={(value) =>
-                                    form.setFieldValue(
-                                        'description',
-                                        value ? value : null,
-                                    )
-                                }
-                            />
-                            <Box>
-                                <Text size="sm" fw={500}>
-                                    Avatar
-                                </Text>
-                                <Text size="xs" c="dimmed" mt={2}>
-                                    Upload an image (PNG, JPG, GIF) or use an
-                                    image URL. Images are cropped to a square; a
-                                    default avatar is used if none is set.
-                                </Text>
-
-                                {avatarMode === 'link' ? (
-                                    <TextInput
-                                        mt="sm"
-                                        variant="subtle"
-                                        label="Avatar image URL"
-                                        placeholder="https://example.com/avatar.jpg"
-                                        type="url"
-                                        {...form.getInputProps('imageUrl')}
-                                        onChange={(e) => {
-                                            const value = e.target.value;
-                                            form.setFieldValue(
-                                                'imageUrl',
-                                                value ? value : null,
-                                            );
-                                        }}
-                                    />
-                                ) : (
-                                    <Group align="center" gap="sm" mt="sm">
-                                        <FileButton
-                                            accept="image/png,image/jpeg,image/gif"
-                                            onChange={onAvatarFileChange}
-                                        >
-                                            {(props) => (
-                                                <Button
-                                                    {...props}
-                                                    size="xs"
-                                                    variant="light"
-                                                    leftSection={
-                                                        <MantineIcon
-                                                            icon={IconUpload}
-                                                        />
-                                                    }
-                                                >
-                                                    Upload image
-                                                </Button>
-                                            )}
-                                        </FileButton>
-                                        {avatarFileName !== null && (
-                                            <Text size="xs" c="dimmed">
-                                                {avatarFileName}
-                                            </Text>
+                            ) : (
+                                <Group align="center" gap="sm" mt="sm">
+                                    <FileButton
+                                        accept="image/png,image/jpeg,image/gif"
+                                        onChange={onAvatarFileChange}
+                                    >
+                                        {(props) => (
+                                            <Button
+                                                {...props}
+                                                size="xs"
+                                                variant="light"
+                                                leftSection={
+                                                    <MantineIcon
+                                                        icon={IconUpload}
+                                                    />
+                                                }
+                                            >
+                                                Upload image
+                                            </Button>
                                         )}
-                                    </Group>
-                                )}
+                                    </FileButton>
+                                    {avatarFileName !== null && (
+                                        <Text size="xs" c="dimmed">
+                                            {avatarFileName}
+                                        </Text>
+                                    )}
+                                </Group>
+                            )}
 
-                                <Group gap="md" mt="xs">
+                            <Group gap="md" mt="xs">
+                                <Anchor
+                                    component="button"
+                                    type="button"
+                                    size="xs"
+                                    c="dimmed"
+                                    onClick={() =>
+                                        onAvatarModeChange(
+                                            avatarMode === 'link'
+                                                ? 'upload'
+                                                : 'link',
+                                        )
+                                    }
+                                >
+                                    {avatarMode === 'link'
+                                        ? 'Upload an image instead'
+                                        : 'Use an image URL instead'}
+                                </Anchor>
+                                {onAvatarRevert !== null && (
                                     <Anchor
                                         component="button"
                                         type="button"
                                         size="xs"
                                         c="dimmed"
-                                        onClick={() =>
-                                            onAvatarModeChange(
-                                                avatarMode === 'link'
-                                                    ? 'upload'
-                                                    : 'link',
-                                            )
+                                        onClick={onAvatarRevert}
+                                    >
+                                        Revert
+                                    </Anchor>
+                                )}
+                                {(avatarFileName !== null ||
+                                    form.values.imageUrl) && (
+                                    <Anchor
+                                        component="button"
+                                        type="button"
+                                        size="xs"
+                                        c="red"
+                                        onClick={onAvatarRemove}
+                                    >
+                                        Remove
+                                    </Anchor>
+                                )}
+                            </Group>
+                        </Box>
+                    </AgentSettingsSection>
+
+                    <AgentSettingsSection
+                        id="behaviour"
+                        icon={IconSparkles}
+                        title="Behaviour"
+                        description="How the agent answers, and which model it thinks with."
+                    >
+                        <CommitOnBlurTextarea
+                            key={`instruction-${
+                                form.values.instruction != null
+                            }`}
+                            variant="subtle"
+                            label="Instructions"
+                            description="Set the overall behavior and task for the agent. This defines how it should respond and what its purpose is."
+                            placeholder="You are a marketing analytics expert. Focus on campaign performance, customer acquisition costs, and ROI metrics. Always use bar charts and tables to visualize data."
+                            resize="vertical"
+                            autosize
+                            minRows={3}
+                            maxRows={8}
+                            error={form.errors.instruction}
+                            defaultValue={form.values.instruction ?? ''}
+                            onCommit={(value) =>
+                                form.setFieldValue(
+                                    'instruction',
+                                    value ? value : null,
+                                )
+                            }
+                        />
+                        <Stack gap="sm">
+                            <Box>
+                                <Title
+                                    order={6}
+                                    c="ldGray.7"
+                                    size="sm"
+                                    fw={500}
+                                >
+                                    Guidelines
+                                </Title>
+                                <Text c="dimmed" size="xs">
+                                    When writing instructions, consider the
+                                    following guidelines to help the agent
+                                    perform its tasks effectively.
+                                </Text>
+                            </Box>
+                            <InstructionsGuidelines />
+                            <Text c="dimmed" size="xs">
+                                Visit our{' '}
+                                <Anchor
+                                    href="https://docs.lightdash.com/guides/ai-agents#writing-effective-instructions"
+                                    target="_blank"
+                                >
+                                    docs
+                                </Anchor>{' '}
+                                to learn more about instructions and how they
+                                work.
+                            </Text>
+                        </Stack>
+
+                        <Divider />
+
+                        <Select
+                            variant="subtle"
+                            label="Default model"
+                            description="Used for new chats with this agent. Users can still change it in each chat."
+                            value={selectedModelKey}
+                            disabled={isSavingAgent || !modelOptions?.length}
+                            placeholder={organizationDefaultModelLabel}
+                            clearable
+                            data={(modelOptions ?? []).map((model) => ({
+                                value: getModelKey(model),
+                                label: model.displayName,
+                            }))}
+                            onChange={(modelKey) => {
+                                const model = getModelOptionByKey(
+                                    modelOptions,
+                                    modelKey,
+                                );
+                                form.setFieldValue(
+                                    'modelConfig',
+                                    model
+                                        ? (getAiAgentModelConfig(
+                                              model,
+                                              form.values.modelConfig
+                                                  ?.reasoning ??
+                                                  aiOrganizationSettings
+                                                      ?.defaultAiAgentModelConfig
+                                                      ?.reasoning ??
+                                                  false,
+                                          ) ?? null)
+                                        : null,
+                                );
+                            }}
+                        />
+
+                        {showReasoningDefault && (
+                            <Switch
+                                variant="subtle"
+                                label="High reasoning"
+                                description="Use high reasoning for new chats with this agent."
+                                checked={
+                                    form.values.modelConfig?.reasoning === true
+                                }
+                                disabled={isSavingAgent}
+                                onChange={(event) => {
+                                    if (!selectedModel) return;
+                                    form.setFieldValue('modelConfig', {
+                                        ...form.values.modelConfig,
+                                        modelName: selectedModel.name,
+                                        modelProvider: selectedModel.provider,
+                                        reasoning: event.currentTarget.checked,
+                                    });
+                                }}
+                            />
+                        )}
+
+                        <Switch
+                            variant="subtle"
+                            label={
+                                <Group gap="xs">
+                                    <Text fz="sm" fw={500}>
+                                        Pass user information
+                                    </Text>
+                                    <Tooltip
+                                        label="Only applies when the agent knows who is asking — on Slack this requires the OAuth requirement to be enabled in the organization's Slack settings."
+                                        withArrow
+                                        withinPortal
+                                        multiline
+                                        position="right"
+                                        maw="300px"
+                                    >
+                                        <MantineIcon icon={IconInfoCircle} />
+                                    </Tooltip>
+                                </Group>
+                            }
+                            description="Shares the requesting user's name, role, and group memberships with the agent so it can tailor answers to who is asking."
+                            {...form.getInputProps('enableUserContext', {
+                                type: 'checkbox',
+                            })}
+                        />
+                    </AgentSettingsSection>
+
+                    {agentUuid && (
+                        <AgentSettingsSection
+                            id="knowledge"
+                            icon={IconBook2}
+                            title="Knowledge"
+                            description="Reference documents can be retrieved when relevant or always included in the agent context. A short summary is generated for each file."
+                        >
+                            <AiAgentKnowledgeFilesSection
+                                agentUuid={agentUuid}
+                                projectUuid={projectUuid}
+                                withHeading={false}
+                            />
+                        </AgentSettingsSection>
+                    )}
+
+                    <AgentSettingsSection
+                        id="data-access"
+                        icon={IconLock}
+                        title="Data access"
+                        description="What this agent is allowed to read and change in Lightdash."
+                    >
+                        <Switch
+                            variant="subtle"
+                            label={
+                                <Group gap="xs">
+                                    <Text fz="sm" fw={500}>
+                                        Read underlying data
+                                    </Text>
+                                    <Tooltip
+                                        label="When enabled, the AI agent can analyze chart data and provide insights. When disabled, the agent only creates visualizations without accessing the underlying data."
+                                        withArrow
+                                        withinPortal
+                                        multiline
+                                        position="right"
+                                        maw="300px"
+                                    >
+                                        <MantineIcon icon={IconInfoCircle} />
+                                    </Tooltip>
+                                </Group>
+                            }
+                            description={
+                                <>
+                                    Allows the agent to access and analyze the
+                                    actual data behind charts to provide
+                                    detailed insights and answer questions about
+                                    the data.{' '}
+                                    <Anchor
+                                        href="https://docs.lightdash.com/guides/ai-agents#data-access-control"
+                                        target="_blank"
+                                        size="xs"
+                                    >
+                                        Learn more
+                                    </Anchor>
+                                </>
+                            }
+                            {...form.getInputProps('enableDataAccess', {
+                                type: 'checkbox',
+                            })}
+                            onChange={(event) => {
+                                const enabled = event.currentTarget.checked;
+
+                                form.setFieldValue('enableDataAccess', enabled);
+
+                                if (!enabled) {
+                                    form.setFieldValue(
+                                        'enableContentTools',
+                                        false,
+                                    );
+                                }
+                            }}
+                        />
+                        <Switch
+                            variant="subtle"
+                            label={
+                                <Group gap="xs">
+                                    <Text fz="sm" fw={500}>
+                                        Manage Lightdash content
+                                    </Text>
+                                    <Tooltip
+                                        label="Requires data access to be enabled. Only works for users with content-as-code access (admins, developers, and editors)."
+                                        withArrow
+                                        withinPortal
+                                        multiline
+                                        position="right"
+                                        maw="300px"
+                                    >
+                                        <MantineIcon icon={IconInfoCircle} />
+                                    </Tooltip>
+                                    <Badge
+                                        color="indigo"
+                                        radius="sm"
+                                        variant="light"
+                                        leftSection={
+                                            <MantineIcon icon={IconSparkles} />
                                         }
                                     >
-                                        {avatarMode === 'link'
-                                            ? 'Upload an image instead'
-                                            : 'Use an image URL instead'}
-                                    </Anchor>
-                                    {onAvatarRevert !== null && (
-                                        <Anchor
-                                            component="button"
-                                            type="button"
-                                            size="xs"
-                                            c="dimmed"
-                                            onClick={onAvatarRevert}
-                                        >
-                                            Revert
-                                        </Anchor>
-                                    )}
-                                    {(avatarFileName !== null ||
-                                        form.values.imageUrl) && (
-                                        <Anchor
-                                            component="button"
-                                            type="button"
-                                            size="xs"
-                                            c="red"
-                                            onClick={onAvatarRemove}
-                                        >
-                                            Remove
-                                        </Anchor>
-                                    )}
+                                        Beta
+                                    </Badge>
                                 </Group>
-                            </Box>
-                        </Stack>
-                    </Paper>
+                            }
+                            description="Agent can build new dashboards and charts and update existing ones — add or rearrange tiles, organize tabs, change filters, and more. Can also create scheduled deliveries, which go live as soon as they are created."
+                            {...form.getInputProps('enableContentTools', {
+                                type: 'checkbox',
+                            })}
+                            disabled={!form.values.enableDataAccess}
+                        />
+                        <Switch
+                            variant="subtle"
+                            label={
+                                <Group gap="xs">
+                                    <Text fz="sm" fw={500}>
+                                        Enable SQL Runner by default
+                                    </Text>
+                                    <Tooltip
+                                        label="SQL Runner is only available to users whose role includes SQL Runner access (project developers and admins by default). This setting never grants permission: users without access cannot use SQL Runner, whether this is on or off."
+                                        withArrow
+                                        withinPortal
+                                        multiline
+                                        position="right"
+                                        maw="300px"
+                                    >
+                                        <MantineIcon icon={IconInfoCircle} />
+                                    </Tooltip>
+                                </Group>
+                            }
+                            description="Let the agent query your warehouse directly when it helps answer a question. Users can still turn SQL Runner on or off for each conversation."
+                            {...form.getInputProps('enableSqlMode', {
+                                type: 'checkbox',
+                            })}
+                        />
 
-                    <Paper p="xl">
-                        <Stack gap="md">
-                            <Group align="center" gap="xs">
-                                <Paper p="xxs" withBorder radius="sm">
-                                    <MantineIcon
-                                        icon={IconSparkles}
-                                        size="md"
-                                    />
-                                </Paper>
-                                <Title order={5} c="ldGray.9" fw={700}>
-                                    Model
-                                </Title>
-                            </Group>
+                        <Divider />
 
-                            <Select
+                        <SpaceAccessSelect
+                            projectUuid={projectUuid}
+                            value={form.values.spaceAccess}
+                            onChange={(value) => {
+                                form.setFieldValue('spaceAccess', value);
+                            }}
+                        />
+
+                        <Box>
+                            <TagsInput
                                 variant="subtle"
-                                label="Default model"
-                                description="Used for new chats with this agent. Users can still change it in each chat."
-                                value={selectedModelKey}
-                                disabled={
-                                    isSavingAgent || !modelOptions?.length
+                                label={
+                                    <Group gap="xs">
+                                        <Text fz="sm" fw={500}>
+                                            Tags
+                                        </Text>
+                                        <HoverCard position="right" withArrow>
+                                            <HoverCard.Target>
+                                                <MantineIcon
+                                                    icon={IconInfoCircle}
+                                                />
+                                            </HoverCard.Target>
+                                            <HoverCard.Dropdown maw="250px">
+                                                <Text fz="xs">
+                                                    Add tags to control which
+                                                    metrics and dimensions your
+                                                    AI agent can access. See
+                                                    more in our{' '}
+                                                    <Anchor
+                                                        fz="xs"
+                                                        c="dimmed"
+                                                        underline="always"
+                                                        href="https://docs.lightdash.com/guides/ai-agents#limiting-access-to-specific-explores-and-fields"
+                                                        target="_blank"
+                                                    >
+                                                        docs
+                                                    </Anchor>
+                                                </Text>
+                                            </HoverCard.Dropdown>
+                                        </HoverCard>
+                                    </Group>
                                 }
-                                placeholder={organizationDefaultModelLabel}
-                                clearable
-                                data={(modelOptions ?? []).map((model) => ({
-                                    value: getModelKey(model),
-                                    label: model.displayName,
-                                }))}
-                                onChange={(modelKey) => {
-                                    const model = getModelOptionByKey(
-                                        modelOptions,
-                                        modelKey,
-                                    );
+                                placeholder="Select tags"
+                                inputWrapperOrder={[
+                                    'label',
+                                    'input',
+                                    'description',
+                                ]}
+                                description={
+                                    exploreAccessSummaryQuery.isSuccess ? (
+                                        exploreAccessSummaryQuery.data
+                                            .length === 0 ? (
+                                            'No explorers are available for this tag selection. Make sure to use the correct tags, or tag the project with the correct tags and redeploy the project.'
+                                        ) : (
+                                            <>
+                                                {
+                                                    exploreAccessSummaryQuery
+                                                        .data.length
+                                                }{' '}
+                                                explores will be available to
+                                                this agent.{' '}
+                                                <Anchor
+                                                    size="xs"
+                                                    onClick={
+                                                        toggleExploreAccessSummary
+                                                    }
+                                                >
+                                                    Click here
+                                                </Anchor>{' '}
+                                                to see detailed list with
+                                                metrics and dimensions.
+                                            </>
+                                        )
+                                    ) : (
+                                        `Loading AI access information...`
+                                    )
+                                }
+                                {...form.getInputProps('tags')}
+                                value={form.getInputProps('tags').value ?? []}
+                                onChange={(value) => {
                                     form.setFieldValue(
-                                        'modelConfig',
-                                        model
-                                            ? (getAiAgentModelConfig(
-                                                  model,
-                                                  form.values.modelConfig
-                                                      ?.reasoning ??
-                                                      aiOrganizationSettings
-                                                          ?.defaultAiAgentModelConfig
-                                                          ?.reasoning ??
-                                                      false,
-                                              ) ?? null)
-                                            : null,
+                                        'tags',
+                                        value.length > 0 ? value : null,
                                     );
                                 }}
                             />
 
-                            {showReasoningDefault && (
-                                <Switch
-                                    variant="subtle"
-                                    label="High reasoning"
-                                    description="Use high reasoning for new chats with this agent."
-                                    checked={
-                                        form.values.modelConfig?.reasoning ===
-                                        true
-                                    }
-                                    disabled={isSavingAgent}
-                                    onChange={(event) => {
-                                        if (!selectedModel) return;
-                                        form.setFieldValue('modelConfig', {
-                                            ...form.values.modelConfig,
-                                            modelName: selectedModel.name,
-                                            modelProvider:
-                                                selectedModel.provider,
-                                            reasoning:
-                                                event.currentTarget.checked,
-                                        });
+                            {exploreAccessSummaryQuery.isSuccess ? (
+                                <Collapse
+                                    mt="xs"
+                                    in={isExploreAccessSummaryOpen}
+                                >
+                                    <Card>
+                                        <AiExploreAccessTree
+                                            exploreAccessSummary={
+                                                exploreAccessSummaryQuery.data
+                                            }
+                                        />
+                                    </Card>
+                                </Collapse>
+                            ) : null}
+                        </Box>
+                    </AgentSettingsSection>
+
+                    <AgentSettingsSection
+                        id="who-can-use"
+                        icon={IconUsers}
+                        title="Who can use it"
+                        description="Which people in this project can see and chat with this agent."
+                    >
+                        <Radio.Group
+                            value={accessMode}
+                            onChange={handleAccessModeChange}
+                        >
+                            <Stack gap="sm">
+                                <Radio
+                                    value="everyone"
+                                    label="Everyone in the project"
+                                    description="All project members can see and use this agent."
+                                />
+                                <Radio
+                                    value="admins"
+                                    label="Admins & developers only"
+                                    description="Hidden from everyone else — useful while setting up or testing the agent."
+                                />
+                                <Radio
+                                    value="specific"
+                                    label={`Specific users ${isGroupsEnabled ? ' & groups' : ''}`}
+                                    description={`Only the users${isGroupsEnabled ? ' and groups ' : ' '}you choose. Admins and developers (Manage AI Agents scope) always have access.`}
+                                />
+                            </Stack>
+                        </Radio.Group>
+
+                        {accessMode === 'specific' && (
+                            <Stack pl="xl">
+                                <UserAccessMultiSelect
+                                    projectUuid={projectUuid!}
+                                    isGroupsEnabled={isGroupsEnabled}
+                                    value={form.values.userAccess}
+                                    onChange={(value) => {
+                                        form.setFieldValue('userAccess', value);
                                     }}
                                 />
-                            )}
-                        </Stack>
-                    </Paper>
 
-                    <Paper p="xl">
-                        <Group align="center" gap="xs" mb="md">
-                            <Paper p="xxs" withBorder radius="sm">
-                                <MantineIcon icon={IconUsers} size="md" />
-                            </Paper>
-                            <Title order={5} c="ldGray.9" fw={700}>
-                                Access control
-                            </Title>
-                        </Group>
-                        <Stack>
-                            <Radio.Group
-                                value={accessMode}
-                                onChange={handleAccessModeChange}
-                            >
-                                <Stack gap="sm">
-                                    <Radio
-                                        value="everyone"
-                                        label="Everyone in the project"
-                                        description="All project members can see and use this agent."
-                                    />
-                                    <Radio
-                                        value="admins"
-                                        label="Admins & developers only"
-                                        description="Hidden from everyone else — useful while setting up or testing the agent."
-                                    />
-                                    <Radio
-                                        value="specific"
-                                        label={`Specific users ${isGroupsEnabled ? ' & groups' : ''}`}
-                                        description={`Only the users${isGroupsEnabled ? ' and groups ' : ' '}you choose. Admins and developers (Manage AI Agents scope) always have access.`}
-                                    />
-                                </Stack>
-                            </Radio.Group>
-
-                            {accessMode === 'specific' && (
-                                <Stack pl="xl">
-                                    <UserAccessMultiSelect
-                                        projectUuid={projectUuid!}
-                                        isGroupsEnabled={isGroupsEnabled}
-                                        value={form.values.userAccess}
+                                {isGroupsEnabled && (
+                                    <MultiSelect
+                                        variant="subtle"
+                                        label={
+                                            <Group gap="xs">
+                                                <Text fz="sm" fw={500}>
+                                                    Group Access
+                                                </Text>
+                                                <Tooltip
+                                                    label="Admins and developers (Manage AI Agents scope) will always have access to this agent."
+                                                    withArrow
+                                                    withinPortal
+                                                    multiline
+                                                    position="right"
+                                                    maw="250px"
+                                                >
+                                                    <MantineIcon
+                                                        icon={IconInfoCircle}
+                                                    />
+                                                </Tooltip>
+                                            </Group>
+                                        }
+                                        description="Select groups that can access this agent."
+                                        placeholder={
+                                            isLoadingGroups
+                                                ? 'Loading groups...'
+                                                : groupOptions.length === 0
+                                                  ? 'No groups available'
+                                                  : 'Select groups or leave empty for all users'
+                                        }
+                                        data={groupOptions}
+                                        disabled={
+                                            isLoadingGroups ||
+                                            groupOptions.length === 0
+                                        }
+                                        comboboxProps={{
+                                            transitionProps: {
+                                                transition: 'pop',
+                                                duration: 200,
+                                            },
+                                        }}
+                                        clearable
+                                        {...form.getInputProps('groupAccess')}
+                                        value={
+                                            form.getInputProps('groupAccess')
+                                                .value ?? []
+                                        }
                                         onChange={(value) => {
                                             form.setFieldValue(
-                                                'userAccess',
-                                                value,
+                                                'groupAccess',
+                                                value.length > 0 ? value : [],
                                             );
                                         }}
                                     />
-
-                                    {isGroupsEnabled && (
-                                        <MultiSelect
-                                            variant="subtle"
-                                            label={
-                                                <Group gap="xs">
-                                                    <Text fz="sm" fw={500}>
-                                                        Group Access
-                                                    </Text>
-                                                    <Tooltip
-                                                        label="Admins and developers (Manage AI Agents scope) will always have access to this agent."
-                                                        withArrow
-                                                        withinPortal
-                                                        multiline
-                                                        position="right"
-                                                        maw="250px"
-                                                    >
-                                                        <MantineIcon
-                                                            icon={
-                                                                IconInfoCircle
-                                                            }
-                                                        />
-                                                    </Tooltip>
-                                                </Group>
-                                            }
-                                            description="Select groups that can access this agent."
-                                            placeholder={
-                                                isLoadingGroups
-                                                    ? 'Loading groups...'
-                                                    : groupOptions.length === 0
-                                                      ? 'No groups available'
-                                                      : 'Select groups or leave empty for all users'
-                                            }
-                                            data={groupOptions}
-                                            disabled={
-                                                isLoadingGroups ||
-                                                groupOptions.length === 0
-                                            }
-                                            comboboxProps={{
-                                                transitionProps: {
-                                                    transition: 'pop',
-                                                    duration: 200,
-                                                },
-                                            }}
-                                            clearable
-                                            {...form.getInputProps(
-                                                'groupAccess',
-                                            )}
-                                            value={
-                                                form.getInputProps(
-                                                    'groupAccess',
-                                                ).value ?? []
-                                            }
-                                            onChange={(value) => {
-                                                form.setFieldValue(
-                                                    'groupAccess',
-                                                    value.length > 0
-                                                        ? value
-                                                        : [],
-                                                );
-                                            }}
-                                        />
-                                    )}
-                                </Stack>
-                            )}
-                        </Stack>
-                    </Paper>
-
-                    <Paper p="xl">
-                        <Stack gap="md">
-                            <Group align="center" gap="xs">
-                                <Paper p="xxs" withBorder radius="sm">
-                                    <MantineIcon icon={IconBook2} size="md" />
-                                </Paper>
-                                <Title order={5} c="ldGray.9" fw={700}>
-                                    Knowledge & expertise
-                                </Title>
-                            </Group>
-                            <Stack gap="xs">
-                                <CommitOnBlurTextarea
-                                    key={`instruction-${
-                                        form.values.instruction != null
-                                    }`}
-                                    variant="subtle"
-                                    label="Instructions"
-                                    description="Set the overall behavior and task for the agent. This defines how it should respond and what its purpose is."
-                                    placeholder="You are a marketing analytics expert. Focus on campaign performance, customer acquisition costs, and ROI metrics. Always use bar charts and tables to visualize data."
-                                    resize="vertical"
-                                    autosize
-                                    minRows={3}
-                                    maxRows={8}
-                                    error={form.errors.instruction}
-                                    defaultValue={form.values.instruction ?? ''}
-                                    onCommit={(value) =>
-                                        form.setFieldValue(
-                                            'instruction',
-                                            value ? value : null,
-                                        )
-                                    }
-                                />
+                                )}
                             </Stack>
-                            <Stack gap="sm">
-                                <Box>
-                                    <Title
-                                        order={6}
-                                        c="ldGray.7"
-                                        size="sm"
-                                        fw={500}
-                                    >
-                                        Guidelines
-                                    </Title>
-                                    <Text c="dimmed" size="xs">
-                                        When writing instructions, consider the
-                                        following guidelines to help the agent
-                                        perform its tasks effectively.
-                                    </Text>
-                                </Box>
-                                <InstructionsGuidelines />
-                                <Text c="dimmed" size="xs">
-                                    Visit our{' '}
-                                    <Anchor
-                                        href="https://docs.lightdash.com/guides/ai-agents#writing-effective-instructions"
-                                        target="_blank"
-                                    >
-                                        docs
-                                    </Anchor>{' '}
-                                    to learn more about instructions and how
-                                    they work.
-                                </Text>
-                            </Stack>
-                            {agentUuid && (
-                                <AiAgentKnowledgeFilesSection
-                                    agentUuid={agentUuid}
-                                    projectUuid={projectUuid}
-                                />
-                            )}
-                            <Stack gap="sm">
-                                <Box>
-                                    <Title
-                                        order={6}
-                                        c="ldGray.7"
-                                        size="sm"
-                                        fw={500}
-                                    >
-                                        Configuration
-                                    </Title>
-                                    <Text c="dimmed" size="xs">
-                                        Control how this agent interacts with
-                                        your data and semantic layer.
-                                    </Text>
-                                </Box>
-                            </Stack>
-                            <Switch
-                                variant="subtle"
-                                label={
-                                    <Group gap="xs">
-                                        <Text fz="sm" fw={500}>
-                                            Enable Data Access
-                                        </Text>
-                                        <Tooltip
-                                            label="When enabled, the AI agent can analyze chart data and provide insights. When disabled, the agent only creates visualizations without accessing the underlying data."
-                                            withArrow
-                                            withinPortal
-                                            multiline
-                                            position="right"
-                                            maw="300px"
-                                        >
-                                            <MantineIcon
-                                                icon={IconInfoCircle}
-                                            />
-                                        </Tooltip>
-                                    </Group>
-                                }
-                                description={
-                                    <>
-                                        Allows the agent to access and analyze
-                                        the actual data behind charts to provide
-                                        detailed insights and answer questions
-                                        about the data.{' '}
-                                        <Anchor
-                                            href="https://docs.lightdash.com/guides/ai-agents#data-access-control"
-                                            target="_blank"
-                                            size="xs"
-                                        >
-                                            Learn more
-                                        </Anchor>
-                                    </>
-                                }
-                                {...form.getInputProps('enableDataAccess', {
-                                    type: 'checkbox',
-                                })}
-                                onChange={(event) => {
-                                    const enabled = event.currentTarget.checked;
-
-                                    form.setFieldValue(
-                                        'enableDataAccess',
-                                        enabled,
-                                    );
-
-                                    if (!enabled) {
-                                        form.setFieldValue(
-                                            'enableContentTools',
-                                            false,
-                                        );
-                                    }
-                                }}
-                            />
-                            <Switch
-                                variant="subtle"
-                                label={
-                                    <Group gap="xs">
-                                        <Text fz="sm" fw={500}>
-                                            Allow agent to manage Lightdash
-                                            content
-                                        </Text>
-                                        <Tooltip
-                                            label="Requires data access to be enabled. Only works for users with content-as-code access (admins, developers, and editors)."
-                                            withArrow
-                                            withinPortal
-                                            multiline
-                                            position="right"
-                                            maw="300px"
-                                        >
-                                            <MantineIcon
-                                                icon={IconInfoCircle}
-                                            />
-                                        </Tooltip>
-                                        <Badge
-                                            color="indigo"
-                                            radius="sm"
-                                            variant="light"
-                                            leftSection={
-                                                <MantineIcon
-                                                    icon={IconSparkles}
-                                                />
-                                            }
-                                        >
-                                            Beta
-                                        </Badge>
-                                    </Group>
-                                }
-                                description={
-                                    'Agent can build new dashboards and charts and update existing ones — add or rearrange tiles, organize tabs, change filters, and more. Can also create scheduled deliveries, which go live as soon as they are created.'
-                                }
-                                {...form.getInputProps('enableContentTools', {
-                                    type: 'checkbox',
-                                })}
-                                disabled={!form.values.enableDataAccess}
-                            />
-                            <Switch
-                                variant="subtle"
-                                label={
-                                    <Group gap="xs">
-                                        <Text fz="sm" fw={500}>
-                                            Pass user information
-                                        </Text>
-                                        <Tooltip
-                                            label="Only applies when the agent knows who is asking — on Slack this requires the OAuth requirement to be enabled in the organization's Slack settings."
-                                            withArrow
-                                            withinPortal
-                                            multiline
-                                            position="right"
-                                            maw="300px"
-                                        >
-                                            <MantineIcon
-                                                icon={IconInfoCircle}
-                                            />
-                                        </Tooltip>
-                                    </Group>
-                                }
-                                description={
-                                    "Shares the requesting user's name, role, and group memberships with the agent so it can tailor answers to who is asking."
-                                }
-                                {...form.getInputProps('enableUserContext', {
-                                    type: 'checkbox',
-                                })}
-                            />
-                            <Switch
-                                variant="subtle"
-                                label={
-                                    <Group gap="xs">
-                                        <Text fz="sm" fw={500}>
-                                            Enable SQL Runner by default
-                                        </Text>
-                                        <Tooltip
-                                            label="SQL Runner is only available to users whose role includes SQL Runner access (project developers and admins by default). This setting never grants permission: users without access cannot use SQL Runner, whether this is on or off."
-                                            withArrow
-                                            withinPortal
-                                            multiline
-                                            position="right"
-                                            maw="300px"
-                                        >
-                                            <MantineIcon
-                                                icon={IconInfoCircle}
-                                            />
-                                        </Tooltip>
-                                    </Group>
-                                }
-                                description="Let the agent query your warehouse directly when it helps answer a question. Users can still turn SQL Runner on or off for each conversation."
-                                {...form.getInputProps('enableSqlMode', {
-                                    type: 'checkbox',
-                                })}
-                            />
-                        </Stack>
-                    </Paper>
+                        )}
+                    </AgentSettingsSection>
 
                     <AiAgentMcpServersInput
                         agentUuid={agentUuid}
@@ -897,251 +932,97 @@ export const AiAgentFormSetup = ({
                         }}
                     />
 
-                    <Paper p="xl">
-                        <Group align="center" gap="xs" mb="md">
-                            <Paper p="xxs" withBorder radius="sm">
-                                <MantineIcon icon={IconLock} size="md" />
+                    <AgentSettingsSection
+                        id="slack"
+                        icon={IconBrandSlack}
+                        title="Slack"
+                        description="Channels where people can talk to this agent."
+                        action={
+                            <Group
+                                c={
+                                    slackChannelsConfigured
+                                        ? 'green.4'
+                                        : 'dimmed'
+                                }
+                                gap="xxs"
+                                align="center"
+                                wrap="nowrap"
+                            >
+                                <MantineIcon icon={IconPointFilled} size={16} />
+                                <Text size="xs">
+                                    {!slackInstallation?.organizationUuid
+                                        ? 'Disabled'
+                                        : !slackChannelsConfigured
+                                          ? 'Channels not configured'
+                                          : 'Enabled'}
+                                </Text>
+                            </Group>
+                        }
+                    >
+                        <LoadingOverlay visible={isLoadingSlackInstallation} />
+                        {!slackInstallation?.organizationUuid ? (
+                            <Paper variant="dotted" p="sm">
+                                <Text size="xs" c="dimmed" ta="center">
+                                    To enable AI agent interactions through
+                                    Slack, please connect your Slack workspace
+                                    in the{' '}
+                                    <Anchor
+                                        c="dimmed"
+                                        underline="always"
+                                        href="/generalSettings/integrations"
+                                        target="_blank"
+                                    >
+                                        Integrations settings
+                                    </Anchor>
+                                    . Once connected, you can select channels
+                                    where this agent will be available.
+                                </Text>
                             </Paper>
-                            <Title order={5} c="ldGray.9" fw={700}>
-                                Data access
-                            </Title>
-                        </Group>
-                        <Stack>
-                            <SpaceAccessSelect
-                                projectUuid={projectUuid}
-                                value={form.values.spaceAccess}
-                                onChange={(value) => {
-                                    form.setFieldValue('spaceAccess', value);
-                                }}
-                            />
-
-                            <Box>
-                                <TagsInput
+                        ) : (
+                            <Stack gap="xs">
+                                {slackChannelsConfigured && (
+                                    <Text size="sm" c="dimmed">
+                                        Tag the Slack app{' '}
+                                        <Code>
+                                            @{slackInstallation.appName}
+                                        </Code>{' '}
+                                        to get started.
+                                    </Text>
+                                )}
+                                <SlackChannelSelect
+                                    includeGroups
+                                    multiple
+                                    withRefresh
+                                    size="sm"
                                     variant="subtle"
-                                    label={
-                                        <Group gap="xs">
-                                            <Text fz="sm" fw={500}>
-                                                Tags
-                                            </Text>
-                                            <HoverCard
-                                                position="right"
-                                                withArrow
-                                            >
-                                                <HoverCard.Target>
-                                                    <MantineIcon
-                                                        icon={IconInfoCircle}
-                                                    />
-                                                </HoverCard.Target>
-                                                <HoverCard.Dropdown maw="250px">
-                                                    <Text fz="xs">
-                                                        Add tags to control
-                                                        which metrics and
-                                                        dimensions your AI agent
-                                                        can access. See more in
-                                                        our{' '}
-                                                        <Anchor
-                                                            fz="xs"
-                                                            c="dimmed"
-                                                            underline="always"
-                                                            href="https://docs.lightdash.com/guides/ai-agents#limiting-access-to-specific-explores-and-fields"
-                                                            target="_blank"
-                                                        >
-                                                            docs
-                                                        </Anchor>
-                                                    </Text>
-                                                </HoverCard.Dropdown>
-                                            </HoverCard>
-                                        </Group>
-                                    }
-                                    placeholder="Select tags"
-                                    inputWrapperOrder={[
-                                        'label',
-                                        'input',
-                                        'description',
-                                    ]}
-                                    description={
-                                        exploreAccessSummaryQuery.isSuccess ? (
-                                            exploreAccessSummaryQuery.data
-                                                .length === 0 ? (
-                                                'No explorers are available for this tag selection. Make sure to use the correct tags, or tag the project with the correct tags and redeploy the project.'
-                                            ) : (
-                                                <>
-                                                    {
-                                                        exploreAccessSummaryQuery
-                                                            .data.length
-                                                    }{' '}
-                                                    explores will be available
-                                                    to this agent.{' '}
-                                                    <Anchor
-                                                        size="xs"
-                                                        onClick={
-                                                            toggleExploreAccessSummary
-                                                        }
-                                                    >
-                                                        Click here
-                                                    </Anchor>{' '}
-                                                    to see detailed list with
-                                                    metrics and dimensions.
-                                                </>
-                                            )
-                                        ) : (
-                                            `Loading AI access information...`
-                                        )
-                                    }
-                                    {...form.getInputProps('tags')}
-                                    value={
-                                        form.getInputProps('tags').value ?? []
-                                    }
+                                    label="Channels"
+                                    placeholder="Search channel(s)"
+                                    value={form.values.integrations.map(
+                                        (i) => i.channelId,
+                                    )}
                                     onChange={(value) => {
                                         form.setFieldValue(
-                                            'tags',
-                                            value.length > 0 ? value : null,
+                                            'integrations',
+                                            value.map(
+                                                (v) =>
+                                                    ({
+                                                        type: 'slack',
+                                                        channelId: v,
+                                                    }) as const,
+                                            ),
                                         );
                                     }}
                                 />
-
-                                {exploreAccessSummaryQuery.isSuccess ? (
-                                    <Collapse
-                                        mt="xs"
-                                        in={isExploreAccessSummaryOpen}
-                                    >
-                                        <Card>
-                                            <AiExploreAccessTree
-                                                exploreAccessSummary={
-                                                    exploreAccessSummaryQuery.data
-                                                }
-                                            />
-                                        </Card>
-                                    </Collapse>
-                                ) : null}
-                            </Box>
-                        </Stack>
-                    </Paper>
-
-                    <Paper p="xl">
-                        <Group align="center" gap="xs" mb="md">
-                            <Paper p="xxs" withBorder radius="sm">
-                                <MantineIcon icon={IconPlug} size="md" />
-                            </Paper>
-                            <Title order={5} c="ldGray.9" fw={700}>
-                                Integrations
-                            </Title>
-                        </Group>
-                        <Stack gap="sm">
-                            <Group
-                                align="center"
-                                justify="space-between"
-                                gap="xs"
-                            >
-                                <Title order={6}>Slack</Title>
-                                <Group
-                                    c={
-                                        slackChannelsConfigured
-                                            ? 'green.4'
-                                            : 'dimmed'
-                                    }
-                                    gap="xxs"
-                                    align="flex-start"
-                                >
-                                    <MantineIcon
-                                        icon={IconPointFilled}
-                                        size={16}
-                                    />
-                                    <Text size="xs">
-                                        {!slackInstallation?.organizationUuid
-                                            ? 'Disabled'
-                                            : !slackChannelsConfigured
-                                              ? 'Channels not configured'
-                                              : 'Enabled'}
-                                    </Text>
-                                </Group>
-                            </Group>
-
-                            <LoadingOverlay
-                                visible={isLoadingSlackInstallation}
-                            />
-                            {!slackInstallation?.organizationUuid ? (
-                                <Paper variant="dotted" p="sm">
-                                    <Text size="xs" c="dimmed" ta="center">
-                                        To enable AI agent interactions through
-                                        Slack, please connect your Slack
-                                        workspace in the{' '}
-                                        <Anchor
-                                            c="dimmed"
-                                            underline="always"
-                                            href="/generalSettings/integrations"
-                                            target="_blank"
-                                        >
-                                            Integrations settings
-                                        </Anchor>
-                                        . Once connected, you can select
-                                        channels where this agent will be
-                                        available.
-                                    </Text>
-                                </Paper>
-                            ) : (
-                                <Box>
-                                    <Stack gap="xs">
-                                        <Text size="sm" c="dimmed">
-                                            Select the channels where this agent
-                                            will be available.
-                                            {slackChannelsConfigured && (
-                                                <>
-                                                    {' '}
-                                                    Tag the Slack app{' '}
-                                                    <Code>
-                                                        @
-                                                        {
-                                                            slackInstallation.appName
-                                                        }
-                                                    </Code>{' '}
-                                                    to get started.
-                                                </>
-                                            )}
-                                        </Text>
-                                        <SlackChannelSelect
-                                            includeGroups
-                                            multiple
-                                            withRefresh
-                                            size="sm"
-                                            variant="subtle"
-                                            label="Channels"
-                                            placeholder="Search channel(s)"
-                                            value={form.values.integrations.map(
-                                                (i) => i.channelId,
-                                            )}
-                                            onChange={(value) => {
-                                                form.setFieldValue(
-                                                    'integrations',
-                                                    value.map(
-                                                        (v) =>
-                                                            ({
-                                                                type: 'slack',
-                                                                channelId: v,
-                                                            }) as const,
-                                                    ),
-                                                );
-                                            }}
-                                        />
-                                    </Stack>
-                                </Box>
-                            )}
-                        </Stack>
-                    </Paper>
+                            </Stack>
+                        )}
+                    </AgentSettingsSection>
 
                     {mode === 'edit' && (
-                        <Paper p="xl" withBorder>
-                            <Group align="center" gap="xs" mb="md">
-                                <Paper p="xxs" withBorder radius="sm">
-                                    <MantineIcon
-                                        icon={IconAlertTriangle}
-                                        size="md"
-                                    />
-                                </Paper>
-                                <Title order={5} c="ldGray.9" fw={700}>
-                                    Danger zone
-                                </Title>
-                            </Group>
+                        <AgentSettingsSection
+                            id="danger-zone"
+                            icon={IconAlertTriangle}
+                            title="Danger zone"
+                        >
                             <Group
                                 gap="xs"
                                 align="center"
@@ -1172,7 +1053,7 @@ export const AiAgentFormSetup = ({
                                     Delete
                                 </Button>
                             </Group>
-                        </Paper>
+                        </AgentSettingsSection>
                     )}
                 </Stack>
             </form>

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeFilesSection.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeFilesSection.tsx
@@ -121,11 +121,14 @@ const getPendingActionModalConfig = (
 type Props = {
     agentUuid: string;
     projectUuid: string;
+    /** Set to false when the surrounding section already carries the heading. */
+    withHeading: boolean;
 };
 
 export const AiAgentKnowledgeFilesSection = ({
     agentUuid,
     projectUuid,
+    withHeading,
 }: Props) => {
     const { data, isLoading } = useAiAgentDocuments(projectUuid, agentUuid);
     const createDocument = useCreateAiAgentDocument(projectUuid, agentUuid);
@@ -289,35 +292,43 @@ export const AiAgentKnowledgeFilesSection = ({
 
     return (
         <Stack gap="md">
-            <Group justify="space-between" align="flex-start">
-                <Box style={{ flex: 1 }}>
-                    <Title order={6} c="ldGray.7" size="sm" fw={500}>
-                        Knowledge documents
-                    </Title>
-                    <Text c="dimmed" size="xs">
-                        Reference documents can be retrieved when relevant or
-                        always included in the agent context. A short summary is
-                        generated for each file.
-                    </Text>
-                </Box>
-                {!isEmpty && (
-                    <FileButton
-                        onChange={handleFiles}
-                        accept={ACCEPT_ATTR}
-                        multiple
-                    >
-                        {(props) => (
-                            <Button
-                                {...props}
-                                size="xs"
-                                leftSection={<MantineIcon icon={IconUpload} />}
-                            >
-                                Upload
-                            </Button>
-                        )}
-                    </FileButton>
-                )}
-            </Group>
+            {(withHeading || !isEmpty) && (
+                <Group justify="space-between" align="flex-start">
+                    {withHeading && (
+                        <Box flex={1}>
+                            <Title order={6} c="ldGray.7" size="sm" fw={500}>
+                                Knowledge documents
+                            </Title>
+                            <Text c="dimmed" size="xs">
+                                Reference documents can be retrieved when
+                                relevant or always included in the agent
+                                context. A short summary is generated for each
+                                file.
+                            </Text>
+                        </Box>
+                    )}
+                    {!isEmpty && (
+                        <FileButton
+                            onChange={handleFiles}
+                            accept={ACCEPT_ATTR}
+                            multiple
+                        >
+                            {(props) => (
+                                <Button
+                                    {...props}
+                                    size="xs"
+                                    ml="auto"
+                                    leftSection={
+                                        <MantineIcon icon={IconUpload} />
+                                    }
+                                >
+                                    Upload
+                                </Button>
+                            )}
+                        </FileButton>
+                    )}
+                </Group>
+            )}
 
             <Paper
                 p={0}

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
@@ -11,7 +11,6 @@ import {
     Badge,
     Box,
     Button,
-    Center,
     Checkbox,
     Collapse,
     Divider,
@@ -25,7 +24,6 @@ import {
     Stack,
     Text,
     TextInput,
-    Title,
     Tooltip,
 } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
@@ -67,6 +65,7 @@ import {
     formatTokenEstimate,
     MCP_TOOL_TOKEN_WARNING_THRESHOLD,
 } from '../utils/mcpToolTokenEstimates';
+import { AgentSettingsSection } from './AgentSettingsSection';
 import { AiAgentMcpServerToolsPanel } from './AiAgentMcpServerToolsPanel';
 import { AiMcpServerIcon } from './AiMcpServerIcon';
 import { GithubMcpConnectModal } from './GithubMcpConnectModal';
@@ -1355,24 +1354,14 @@ export const AiAgentMcpServersInput = ({
 
     return (
         <>
-            <Paper p="xl">
-                <Group
-                    justify="space-between"
-                    align="center"
-                    gap="md"
-                    mb="md"
-                    wrap="wrap"
-                >
-                    <Group align="center" gap="xs">
-                        <Paper p="xxs" withBorder radius="sm">
-                            <MantineIcon icon={IconPlug} size="md" />
-                        </Paper>
-                        <Title order={5} c="ldGray.9" fw={700}>
-                            MCP servers
-                        </Title>
-                        <BetaBadge />
-                    </Group>
-                    {selectedMcpServers.length > 0 && (
+            <AgentSettingsSection
+                id="mcp-servers"
+                icon={IconPlug}
+                title="MCP servers"
+                description="External tool servers this agent can call."
+                badge={<BetaBadge />}
+                action={
+                    selectedMcpServers.length > 0 && (
                         <Group align="center" gap="sm" wrap="wrap">
                             {persistedSelectedMcpServers.length > 0 && (
                                 <Group gap={4} wrap="nowrap">
@@ -1444,17 +1433,12 @@ export const AiAgentMcpServersInput = ({
                                 + Add
                             </Button>
                         </Group>
-                    )}
-                </Group>
+                    )
+                }
+            >
                 <Stack gap="sm">
                     {selectedMcpServers.length === 0 && (
-                        <Center
-                            py="xl"
-                            style={{
-                                border: '1px dashed var(--mantine-color-ldGray-4)',
-                                borderRadius: 'var(--mantine-radius-md)',
-                            }}
-                        >
+                        <Paper variant="dotted" py="xl">
                             <Stack align="center" gap="xs">
                                 <Text size="sm" c="dimmed">
                                     No MCP servers attached
@@ -1490,7 +1474,7 @@ export const AiAgentMcpServersInput = ({
                                     </Button>
                                 </Group>
                             </Stack>
-                        </Center>
+                        </Paper>
                     )}
                     {selectedMcpServers.length > 0 && (
                         <Stack gap="sm">
@@ -1787,7 +1771,7 @@ export const AiAgentMcpServersInput = ({
                         </Stack>
                     )}
                 </Stack>
-            </Paper>
+            </AgentSettingsSection>
             <CreateMcpServerModal
                 opened={isCreateMcpServerModalOpen}
                 onClose={createMcpServerModalHandlers.close}

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentPageHeader.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentPageHeader.tsx
@@ -8,6 +8,7 @@ import {
 import { type FC, type ReactNode } from 'react';
 import { Link } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
+import { useAgentSettingsLinkState } from '../../utils/agentSettingsNavigation';
 import styles from './agentPageHeader.module.css';
 
 type Props = {
@@ -26,73 +27,82 @@ export const AgentPageHeader: FC<Props> = ({
     onOpenMemories,
     isSharing,
     settingsHref,
-}) => (
-    <Group align="center" justify="space-between" className={styles.root}>
-        <Box>{leftSection}</Box>
-        <Group gap={4}>
-            {onShare && (
-                <Tooltip label="Share thread" position="bottom">
-                    <ActionIcon
+}) => {
+    const settingsLinkState = useAgentSettingsLinkState();
+
+    return (
+        <Group align="center" justify="space-between" className={styles.root}>
+            <Box>{leftSection}</Box>
+            <Group gap={4}>
+                {onShare && (
+                    <Tooltip label="Share thread" position="bottom">
+                        <ActionIcon
+                            variant="default"
+                            className={styles.action}
+                            onClick={onShare}
+                            loading={isSharing}
+                            aria-label="Share thread"
+                        >
+                            <MantineIcon
+                                icon={IconShare2}
+                                size={14}
+                                stroke={1.8}
+                            />
+                        </ActionIcon>
+                    </Tooltip>
+                )}
+                {onOpenMemories && (
+                    <Button
                         variant="default"
                         className={styles.action}
-                        onClick={onShare}
-                        loading={isSharing}
-                        aria-label="Share thread"
+                        onClick={onOpenMemories}
+                        leftSection={
+                            <MantineIcon
+                                icon={IconNotebook}
+                                size={14}
+                                stroke={1.8}
+                            />
+                        }
                     >
-                        <MantineIcon icon={IconShare2} size={14} stroke={1.8} />
-                    </ActionIcon>
-                </Tooltip>
-            )}
-            {onOpenMemories && (
-                <Button
-                    variant="default"
-                    className={styles.action}
-                    onClick={onOpenMemories}
-                    leftSection={
-                        <MantineIcon
-                            icon={IconNotebook}
-                            size={14}
-                            stroke={1.8}
-                        />
-                    }
-                >
-                    Memories
-                </Button>
-            )}
-            {onMinimize && (
-                <Button
-                    variant="default"
-                    className={styles.action}
-                    onClick={onMinimize}
-                    leftSection={
-                        <MantineIcon
-                            icon={IconWindowMinimize}
-                            size={14}
-                            stroke={1.8}
-                            className={styles.flippedIcon}
-                        />
-                    }
-                >
-                    Minimize
-                </Button>
-            )}
-            {settingsHref && (
-                <Button
-                    component={Link}
-                    variant="default"
-                    className={styles.action}
-                    to={settingsHref}
-                    leftSection={
-                        <MantineIcon
-                            icon={IconSettings}
-                            size={14}
-                            stroke={1.8}
-                        />
-                    }
-                >
-                    Settings
-                </Button>
-            )}
+                        Memories
+                    </Button>
+                )}
+                {onMinimize && (
+                    <Button
+                        variant="default"
+                        className={styles.action}
+                        onClick={onMinimize}
+                        leftSection={
+                            <MantineIcon
+                                icon={IconWindowMinimize}
+                                size={14}
+                                stroke={1.8}
+                                className={styles.flippedIcon}
+                            />
+                        }
+                    >
+                        Minimize
+                    </Button>
+                )}
+                {settingsHref && (
+                    <Button
+                        component={Link}
+                        variant="default"
+                        className={styles.action}
+                        to={settingsHref}
+                        state={settingsLinkState}
+                        leftSection={
+                            <MantineIcon
+                                icon={IconSettings}
+                                size={14}
+                                stroke={1.8}
+                            />
+                        }
+                    >
+                        Settings
+                    </Button>
+                )}
+            </Group>
         </Group>
-    </Group>
-);
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/InstructionsSupport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/InstructionsSupport.tsx
@@ -1,4 +1,4 @@
-import { Grid, Group, HoverCard, Paper, Text, Title } from '@mantine/core';
+import { Group, SimpleGrid, Stack, Text } from '@mantine/core';
 import {
     IconBuilding,
     IconChartBar,
@@ -18,21 +18,17 @@ const InstructionsGuidelinesItem = ({
     title: string;
     description: string;
 }) => (
-    <HoverCard>
-        <HoverCard.Target>
-            <Paper variant="dotted" p="xs" style={{ cursor: 'help' }}>
-                <Group align="center" gap="xs">
-                    <MantineIcon icon={icon} size={20} color="gray" />
-                    <Title order={6} c="ldGray.7" size="xs">
-                        {title}
-                    </Title>
-                </Group>
-            </Paper>
-        </HoverCard.Target>
-        <HoverCard.Dropdown maw={200}>
-            <Text size="xs">{description}</Text>
-        </HoverCard.Dropdown>
-    </HoverCard>
+    <Group align="flex-start" gap="xs" wrap="nowrap">
+        <MantineIcon icon={icon} size={16} color="gray" />
+        <Stack gap={2}>
+            <Text size="xs" fw={600} c="ldGray.9">
+                {title}
+            </Text>
+            <Text size="xs" c="dimmed">
+                {description}
+            </Text>
+        </Stack>
+    </Group>
 );
 
 const guidelines = [
@@ -63,11 +59,9 @@ const guidelines = [
 ];
 
 export const InstructionsGuidelines = () => (
-    <Grid gutter="xs">
+    <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md" verticalSpacing="sm">
         {guidelines.map((guideline) => (
-            <Grid.Col span={3} key={guideline.title}>
-                <InstructionsGuidelinesItem {...guideline} />
-            </Grid.Col>
+            <InstructionsGuidelinesItem key={guideline.title} {...guideline} />
         ))}
-    </Grid>
+    </SimpleGrid>
 );

--- a/packages/frontend/src/ee/features/aiCopilot/utils/agentSettingsNavigation.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/agentSettingsNavigation.ts
@@ -1,0 +1,41 @@
+import { useMemo } from 'react';
+import { useLocation } from 'react-router';
+
+/**
+ * Agent settings can be opened from the agent chat page, the admin agents
+ * table, or a thread sidebar. The opener records where it came from so that
+ * saving or cancelling returns there instead of a hardcoded destination.
+ */
+export type AgentSettingsLocationState = {
+    returnTo: string;
+};
+
+// Only same-origin relative paths are honoured; anything else falls back.
+const isSafeReturnTo = (value: string): boolean =>
+    value.startsWith('/') && !value.startsWith('//');
+
+const readReturnTo = (state: unknown): string | null => {
+    if (typeof state !== 'object' || state === null) {
+        return null;
+    }
+    const { returnTo } = state as Partial<AgentSettingsLocationState>;
+    if (typeof returnTo !== 'string' || !isSafeReturnTo(returnTo)) {
+        return null;
+    }
+    return returnTo;
+};
+
+export const resolveReturnTo = (state: unknown, fallback: string): string =>
+    readReturnTo(state) ?? fallback;
+
+/**
+ * Builds the location state to attach when linking into agent settings, so the
+ * settings page knows where to send the user back to.
+ */
+export const useAgentSettingsLinkState = (): AgentSettingsLocationState => {
+    const { pathname, search } = useLocation();
+    return useMemo(
+        () => ({ returnTo: `${pathname}${search}` }),
+        [pathname, search],
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/utils/agentSettingsSections.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/agentSettingsSections.ts
@@ -1,0 +1,38 @@
+const AGENT_SETTINGS_SECTION_IDS = [
+    'identity',
+    'behaviour',
+    'knowledge',
+    'data-access',
+    'who-can-use',
+    'mcp-servers',
+    'slack',
+    'danger-zone',
+] as const;
+
+export type AgentSettingsSectionId =
+    (typeof AGENT_SETTINGS_SECTION_IDS)[number];
+
+type AgentSettingsSectionMeta = {
+    id: AgentSettingsSectionId;
+    label: string;
+    /** Sections that only exist once the agent has been created. */
+    editOnly: boolean;
+};
+
+const SECTIONS: AgentSettingsSectionMeta[] = [
+    { id: 'identity', label: 'Identity', editOnly: false },
+    { id: 'behaviour', label: 'Behaviour', editOnly: false },
+    { id: 'knowledge', label: 'Knowledge', editOnly: true },
+    { id: 'data-access', label: 'Data access', editOnly: false },
+    { id: 'who-can-use', label: 'Who can use it', editOnly: false },
+    { id: 'mcp-servers', label: 'MCP servers', editOnly: false },
+    { id: 'slack', label: 'Slack', editOnly: false },
+    { id: 'danger-zone', label: 'Danger zone', editOnly: true },
+];
+
+export const getAgentSettingsSections = (
+    mode: 'create' | 'edit',
+): AgentSettingsSectionMeta[] =>
+    mode === 'edit'
+        ? SECTIONS
+        : SECTIONS.filter((section) => !section.editOnly);

--- a/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.module.css
+++ b/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.module.css
@@ -1,0 +1,28 @@
+/* Flex column so the action bar sits at the viewport bottom even when the form
+   is shorter than the screen, and sticks there once the page scrolls. */
+.mainInner {
+    display: flex;
+    flex-direction: column;
+    min-height: calc(100vh - var(--navbar-height));
+    padding-right: var(--mantine-spacing-md);
+}
+
+.mainInner[data-with-banner='true'] {
+    min-height: calc(100vh - var(--navbar-height) - var(--banner-height));
+}
+
+.panel {
+    flex: 1;
+    padding-top: var(--mantine-spacing-md);
+}
+
+.content {
+    margin-inline: auto;
+    width: 100%;
+    max-width: var(--page-content-width);
+}
+
+.navbarHeader {
+    border-bottom: 1px solid var(--mantine-color-ldGray-2);
+    padding-bottom: var(--mantine-spacing-md);
+}

--- a/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
@@ -6,6 +6,7 @@ import {
     Container,
     Group,
     Paper,
+    ScrollArea,
     Stack,
     Text,
     Title,
@@ -18,7 +19,7 @@ import {
     IconCircleCheck,
     IconMessageCircleShare,
 } from '@tabler/icons-react';
-import { useEffect, useState, type FC } from 'react';
+import { useCallback, useEffect, useRef, useState, type FC } from 'react';
 import {
     Link,
     useBlocker,
@@ -29,6 +30,7 @@ import {
 import { z } from 'zod';
 import { LightdashUserAvatar } from '../../../components/Avatar';
 import MantineIcon from '../../../components/common/MantineIcon';
+import MantineModal from '../../../components/common/MantineModal';
 import {
     BANNER_HEIGHT,
     NAVBAR_HEIGHT,
@@ -37,6 +39,8 @@ import { useProjects } from '../../../hooks/useProjects';
 import useApp from '../../../providers/App/useApp';
 import { VerifiedArtifactDetail } from '../../features/aiCopilot/components/Admin/VerifiedArtifactDetail';
 import { VerifiedArtifactsLayout } from '../../features/aiCopilot/components/Admin/VerifiedArtifactsLayout';
+import { AgentSettingsActionBar } from '../../features/aiCopilot/components/AgentSettingsActionBar';
+import { AgentSettingsSectionNav } from '../../features/aiCopilot/components/AgentSettingsSectionNav';
 import { AiAgentFormSetup } from '../../features/aiCopilot/components/AiAgentFormSetup';
 import { EvalDetail } from '../../features/aiCopilot/components/Evals/EvalDetail';
 import { EvalRunDetails } from '../../features/aiCopilot/components/Evals/EvalRunDetails';
@@ -49,7 +53,9 @@ import {
     useProjectUpdateAiAgentMutation,
 } from '../../features/aiCopilot/hooks/useProjectAiAgents';
 import { useAgentAiMcpServers } from '../../features/aiCopilot/hooks/useProjectAiMcpServers';
+import { resolveReturnTo } from '../../features/aiCopilot/utils/agentSettingsNavigation';
 import { EvalsSetup } from './EvalsSetup';
+import classes from './ProjectAiAgentEditPage.module.css';
 
 // Uploaded avatars open in upload mode (never expose the persistent file URL);
 // user-provided URLs open in link mode.
@@ -123,11 +129,11 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
         projectUuid,
     });
     const { data: projects } = useProjects();
-    const isCurrentProjectPreview = !!projects?.find(
-        (project) =>
-            project.projectUuid === projectUuid &&
-            project.type === ProjectType.PREVIEW,
+    const currentProject = projects?.find(
+        (project) => project.projectUuid === projectUuid,
     );
+    const isCurrentProjectPreview =
+        currentProject?.type === ProjectType.PREVIEW;
     const { user } = useApp();
 
     const actualAgentUuid = !isCreateMode && agentUuid ? agentUuid : undefined;
@@ -137,6 +143,15 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
     );
     const { data: agentMcpServers, isFetched: isAgentMcpServersFetched } =
         useAgentAiMcpServers(projectUuid, actualAgentUuid);
+
+    // Where Back, Cancel and a successful save return to. Openers record their
+    // own location so admins land back on the table they came from.
+    const returnTo = resolveReturnTo(
+        location.state,
+        isCreateMode
+            ? `/projects/${projectUuid}/ai-agents`
+            : `/projects/${projectUuid}/ai-agents/${actualAgentUuid}`,
+    );
 
     const form = useForm<z.infer<typeof formSchema>>({
         initialValues: {
@@ -216,6 +231,22 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
         useProjectUpdateAiAgentMutation(projectUuid!);
     const { mutateAsync: uploadAgentAvatar, isLoading: isUploadingAvatar } =
         useProjectUploadAiAgentAvatarMutation(projectUuid!);
+
+    const isSaving = isCreatingAgent || isUpdatingAgent || isUploadingAvatar;
+
+    // Lets the intentional post-save navigation through the unsaved-changes
+    // blocker, whose captured state is a render behind resetDirty().
+    const isLeavingAfterSaveRef = useRef(false);
+
+    // Tab navigation carries returnTo forward, so Back and Save still know
+    // where the user came from after a detour through Evals.
+    const navigateWithinSettings = useCallback(
+        (path: string) => {
+            void navigate(path, { state: location.state });
+        },
+        [navigate, location.state],
+    );
+
     const handleSubmit = form.onSubmit(async (values) => {
         if (!projectUuid || !user?.data) {
             return;
@@ -226,26 +257,20 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
                 ...values,
                 projectUuid,
             });
-            let finalAgent = createdAgent;
 
             if (avatarFile) {
                 try {
-                    finalAgent = await uploadAgentAvatar({
+                    await uploadAgentAvatar({
                         agentUuid: createdAgent.uuid,
                         file: avatarFile,
                     });
                 } catch {
-                    finalAgent = createdAgent;
+                    // upload mutation already shows an error toast
                 }
             }
 
             setAvatarFile(null);
-            const nextValues = {
-                ...values,
-                imageUrl: finalAgent.imageUrl,
-            };
-            form.setValues(nextValues);
-            form.resetDirty(nextValues);
+            isLeavingAfterSaveRef.current = true;
             void navigate(
                 `/projects/${projectUuid}/ai-agents/${createdAgent.uuid}`,
             );
@@ -253,7 +278,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
         }
 
         if (actualAgentUuid) {
-            let finalAgent = await updateAgent({
+            await updateAgent({
                 uuid: actualAgentUuid,
                 projectUuid,
                 ...values,
@@ -261,7 +286,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
 
             if (avatarFile) {
                 try {
-                    finalAgent = await uploadAgentAvatar({
+                    await uploadAgentAvatar({
                         agentUuid: actualAgentUuid,
                         file: avatarFile,
                     });
@@ -271,33 +296,19 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
             }
 
             setAvatarFile(null);
-            const nextValues = {
-                ...values,
-                imageUrl: finalAgent.imageUrl,
-            };
-            form.setValues(nextValues);
-            form.resetDirty(nextValues);
+            isLeavingAfterSaveRef.current = true;
+            void navigate(returnTo);
         }
     });
 
-    const hasUnsavedChanges =
-        (form.isDirty() || !!avatarFile) &&
-        !isCreatingAgent &&
-        !isUpdatingAgent &&
-        !isUploadingAvatar;
+    const hasUnsavedChanges = (form.isDirty() || !!avatarFile) && !isSaving;
 
-    useBlocker(({ currentLocation, nextLocation }) => {
-        if (
-            !hasUnsavedChanges ||
-            currentLocation.pathname === nextLocation.pathname
-        ) {
-            return false;
-        }
-
-        return !window.confirm(
-            'You have unsaved changes to this agent. Are you sure you want to leave without saving?',
-        );
-    });
+    const blocker = useBlocker(
+        ({ currentLocation, nextLocation }) =>
+            !isLeavingAfterSaveRef.current &&
+            hasUnsavedChanges &&
+            currentLocation.pathname !== nextLocation.pathname,
+    );
 
     useEffect(() => {
         if (!canManageAgents) {
@@ -351,93 +362,80 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
                 width: 300,
                 breakpoint: 'sm',
             }}
-            bg="#fcfcfc"
+            bg="ldGray.0"
         >
             <AppShell.Navbar p="md">
-                <Stack gap="lg">
-                    <Stack gap="md" align="center">
-                        <Group justify="space-between" w="100%">
+                <AppShell.Section>
+                    <Stack gap="md" className={classes.navbarHeader}>
+                        <Button
+                            variant="subtle"
+                            color="ldGray.7"
+                            size="xs"
+                            justify="flex-start"
+                            leftSection={<MantineIcon icon={IconArrowLeft} />}
+                            onClick={() => {
+                                void navigate(returnTo);
+                            }}
+                        >
+                            Back
+                        </Button>
+                        <Stack gap="xs" align="center">
+                            <LightdashUserAvatar
+                                name={isCreateMode ? '+' : form.values.name}
+                                src={
+                                    !isCreateMode
+                                        ? (avatarPreviewUrl ??
+                                          form.values.imageUrl ??
+                                          undefined)
+                                        : (avatarPreviewUrl ?? undefined)
+                                }
+                                size={72}
+                            />
+                            <Stack gap={0} align="center">
+                                <Title order={5} ta="center" lineClamp={2}>
+                                    {isCreateMode
+                                        ? 'New agent'
+                                        : agent?.name || 'Agent'}
+                                </Title>
+                                {currentProject && (
+                                    <Text size="xs" c="dimmed" ta="center">
+                                        {currentProject.name}
+                                    </Text>
+                                )}
+                            </Stack>
+                        </Stack>
+                    </Stack>
+                </AppShell.Section>
+                <AppShell.Section grow component={ScrollArea} mt="lg">
+                    <Stack gap="xs">
+                        <Stack gap={4}>
                             <Button
-                                variant="subtle"
-                                color="ldGray.4"
-                                size="xs"
+                                variant={
+                                    activeTab === 'setup' ? 'light' : 'subtle'
+                                }
+                                fullWidth
+                                justify="flex-start"
                                 leftSection={
-                                    <MantineIcon icon={IconArrowLeft} />
+                                    <MantineIcon icon={IconAdjustmentsAlt} />
                                 }
                                 onClick={() => {
                                     if (isCreateMode) {
-                                        void navigate(
-                                            `/projects/${projectUuid}/ai-agents`,
-                                        );
-                                    } else {
-                                        void navigate(
-                                            `/projects/${projectUuid}/ai-agents/${actualAgentUuid}`,
-                                        );
+                                        // In create mode, we can't navigate to agent-specific routes
+                                        return;
                                     }
+                                    navigateWithinSettings(
+                                        `/projects/${projectUuid}/ai-agents/${actualAgentUuid}/edit`,
+                                    );
                                 }}
                             >
-                                Back
+                                Setup
                             </Button>
-                            {(form.isDirty() || !!avatarFile) && (
-                                <Button
-                                    size="xs"
-                                    disabled={
-                                        (!form.isDirty() && !avatarFile) ||
-                                        isCreatingAgent ||
-                                        isUpdatingAgent ||
-                                        isUploadingAvatar
-                                    }
-                                    loading={
-                                        isCreatingAgent ||
-                                        isUpdatingAgent ||
-                                        isUploadingAvatar
-                                    }
-                                    onClick={() => handleSubmit()}
-                                >
-                                    Save changes
-                                </Button>
+                            {activeTab === 'setup' && (
+                                <AgentSettingsSectionNav
+                                    mode={isCreateMode ? 'create' : 'edit'}
+                                />
                             )}
-                        </Group>
-                        <LightdashUserAvatar
-                            name={isCreateMode ? '+' : form.values.name}
-                            src={
-                                !isCreateMode
-                                    ? (avatarPreviewUrl ??
-                                      form.values.imageUrl ??
-                                      undefined)
-                                    : (avatarPreviewUrl ?? undefined)
-                            }
-                            size={80}
-                        />
-                        <Stack gap="xs" align="center">
-                            <Title order={4} ta="center" lineClamp={2}>
-                                {isCreateMode
-                                    ? 'New Agent'
-                                    : agent?.name || 'Agent'}
-                            </Title>
                         </Stack>
-                    </Stack>
-
-                    <Stack gap="xs">
-                        <Button
-                            variant={activeTab === 'setup' ? 'light' : 'subtle'}
-                            fullWidth
-                            justify="flex-start"
-                            leftSection={
-                                <MantineIcon icon={IconAdjustmentsAlt} />
-                            }
-                            onClick={() => {
-                                if (isCreateMode) {
-                                    // In create mode, we can't navigate to agent-specific routes
-                                    return;
-                                }
-                                void navigate(
-                                    `/projects/${projectUuid}/ai-agents/${actualAgentUuid}/edit`,
-                                );
-                            }}
-                        >
-                            Setup
-                        </Button>
                         {!isCreateMode && (
                             <Button
                                 variant={
@@ -447,7 +445,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
                                 justify="flex-start"
                                 leftSection={<MantineIcon icon={IconBook2} />}
                                 onClick={() => {
-                                    void navigate(
+                                    navigateWithinSettings(
                                         `/projects/${projectUuid}/ai-agents/${actualAgentUuid}/edit/evals`,
                                     );
                                 }}
@@ -468,7 +466,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
                                     <MantineIcon icon={IconCircleCheck} />
                                 }
                                 onClick={() => {
-                                    void navigate(
+                                    navigateWithinSettings(
                                         `/projects/${projectUuid}/ai-agents/${actualAgentUuid}/edit/verified-artifacts`,
                                     );
                                 }}
@@ -493,104 +491,122 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
                             </Button>
                         )}
                     </Stack>
-                </Stack>
+                </AppShell.Section>
             </AppShell.Navbar>
-            <AppShell.Main
-                pt={0}
-                pr={0}
-                pb="emptySpace"
-                mih={`calc(100vh - ${navbarHeight}px)`}
-                bg="ldGray.0"
-            >
-                <Box>
-                    {activeTab === 'setup' && (
-                        <Box pt="sm" pr="sm">
-                            <AiAgentFormSetup
-                                mode={isCreateMode ? 'create' : 'edit'}
-                                agentUuid={actualAgentUuid}
-                                form={form}
-                                projectUuid={projectUuid!}
-                                isSavingAgent={
-                                    isCreatingAgent ||
-                                    isUpdatingAgent ||
-                                    isUploadingAvatar
-                                }
-                                persistedMcpServerUuids={agentMcpServers?.map(
-                                    (mcpServer) => mcpServer.uuid,
-                                )}
-                                avatarMode={avatarMode}
-                                avatarFileName={avatarFile?.name ?? null}
-                                onAvatarFileChange={(file) => {
-                                    setAvatarFile(file);
-                                    setAvatarMode('upload');
-                                }}
-                                onAvatarModeChange={(nextMode) => {
-                                    if (nextMode === 'link') {
+            <AppShell.Main pt={0} pr={0} pb={0}>
+                <Box
+                    className={classes.mainInner}
+                    data-with-banner={isCurrentProjectPreview}
+                >
+                    <Box className={classes.panel}>
+                        {activeTab === 'setup' && (
+                            <Box className={classes.content}>
+                                <AiAgentFormSetup
+                                    mode={isCreateMode ? 'create' : 'edit'}
+                                    agentUuid={actualAgentUuid}
+                                    form={form}
+                                    projectUuid={projectUuid!}
+                                    isSavingAgent={isSaving}
+                                    onSubmit={handleSubmit}
+                                    persistedMcpServerUuids={agentMcpServers?.map(
+                                        (mcpServer) => mcpServer.uuid,
+                                    )}
+                                    avatarMode={avatarMode}
+                                    avatarFileName={avatarFile?.name ?? null}
+                                    onAvatarFileChange={(file) => {
+                                        setAvatarFile(file);
+                                        setAvatarMode('upload');
+                                    }}
+                                    onAvatarModeChange={(nextMode) => {
+                                        if (nextMode === 'link') {
+                                            setAvatarFile(null);
+                                        }
+                                        setAvatarMode(nextMode);
+                                    }}
+                                    onAvatarRemove={() => {
                                         setAvatarFile(null);
+                                        form.setFieldValue('imageUrl', null);
+                                        setAvatarMode('upload');
+                                    }}
+                                    onAvatarRevert={
+                                        !isCreateMode &&
+                                        (!!avatarFile ||
+                                            (form.values.imageUrl ?? null) !==
+                                                (agent?.imageUrl ?? null))
+                                            ? () => {
+                                                  setAvatarFile(null);
+                                                  form.setFieldValue(
+                                                      'imageUrl',
+                                                      agent?.imageUrl ?? null,
+                                                  );
+                                                  setAvatarMode(
+                                                      getAvatarModeForAgent(
+                                                          agent,
+                                                      ),
+                                                  );
+                                              }
+                                            : null
                                     }
-                                    setAvatarMode(nextMode);
-                                }}
-                                onAvatarRemove={() => {
-                                    setAvatarFile(null);
-                                    form.setFieldValue('imageUrl', null);
-                                    setAvatarMode('upload');
-                                }}
-                                onAvatarRevert={
-                                    !isCreateMode &&
-                                    (!!avatarFile ||
-                                        (form.values.imageUrl ?? null) !==
-                                            (agent?.imageUrl ?? null))
-                                        ? () => {
-                                              setAvatarFile(null);
-                                              form.setFieldValue(
-                                                  'imageUrl',
-                                                  agent?.imageUrl ?? null,
-                                              );
-                                              setAvatarMode(
-                                                  getAvatarModeForAgent(agent),
-                                              );
-                                          }
-                                        : null
-                                }
-                            />
-                        </Box>
-                    )}
+                                />
+                            </Box>
+                        )}
 
-                    {activeTab === 'evals' && (
-                        <EvalSectionLayout>
-                            {runUuid ? (
-                                <EvalRunDetails
-                                    projectUuid={projectUuid!}
-                                    agentUuid={actualAgentUuid!}
-                                    evalUuid={evalUuid!}
-                                    runUuid={runUuid}
-                                />
-                            ) : evalUuid ? (
-                                <EvalDetail
-                                    projectUuid={projectUuid!}
-                                    agentUuid={actualAgentUuid!}
-                                    evalUuid={evalUuid}
-                                />
-                            ) : (
-                                <EvalsSetup
-                                    projectUuid={projectUuid!}
-                                    agentUuid={actualAgentUuid!}
-                                />
-                            )}
-                        </EvalSectionLayout>
-                    )}
+                        {activeTab === 'evals' && (
+                            <EvalSectionLayout>
+                                {runUuid ? (
+                                    <EvalRunDetails
+                                        projectUuid={projectUuid!}
+                                        agentUuid={actualAgentUuid!}
+                                        evalUuid={evalUuid!}
+                                        runUuid={runUuid}
+                                    />
+                                ) : evalUuid ? (
+                                    <EvalDetail
+                                        projectUuid={projectUuid!}
+                                        agentUuid={actualAgentUuid!}
+                                        evalUuid={evalUuid}
+                                    />
+                                ) : (
+                                    <EvalsSetup
+                                        projectUuid={projectUuid!}
+                                        agentUuid={actualAgentUuid!}
+                                    />
+                                )}
+                            </EvalSectionLayout>
+                        )}
 
-                    {activeTab === 'verified-artifacts' && (
-                        <>
-                            {artifactUuid ? (
+                        {activeTab === 'verified-artifacts' &&
+                            (artifactUuid ? (
                                 <VerifiedArtifactDetail />
                             ) : (
                                 <VerifiedArtifactsLayout />
-                            )}
-                        </>
+                            ))}
+                    </Box>
+
+                    {activeTab === 'setup' && (
+                        <AgentSettingsActionBar
+                            mode={isCreateMode ? 'create' : 'edit'}
+                            hasUnsavedChanges={hasUnsavedChanges}
+                            isSaving={isSaving}
+                            onSave={handleSubmit}
+                            onCancel={() => void navigate(returnTo)}
+                        />
                     )}
                 </Box>
             </AppShell.Main>
+
+            <MantineModal
+                opened={blocker.state === 'blocked'}
+                onClose={() => blocker.reset?.()}
+                title="Discard unsaved changes?"
+                icon={IconAdjustmentsAlt}
+                role="alertdialog"
+                size="md"
+                description="Your changes to this agent have not been saved. Leaving now will discard them."
+                confirmLabel="Discard changes"
+                onConfirm={() => blocker.proceed?.()}
+                cancelLabel="Keep editing"
+            />
         </AppShell>
     );
 };


### PR DESCRIPTION
## What

Reworks the AI agent settings page (`/projects/:projectUuid/ai-agents/:agentUuid/edit`) and makes saving return you to where you came from.

## Why

Two problems on the same page:

**Saving went nowhere.** After a successful save you stayed on the form, with no signal that anything had happened beyond a toast. There was also no way back to the thing you were configuring the agent *for*.

**The primary action was unreachable.** The only Save button lived in the sidebar header and was rendered only while the form was dirty. The form is ~3000px tall, so from the bottom of it — the Danger zone, Slack, MCP servers — you had to scroll all the way back up to save, and the button appearing and disappearing shifted the sidebar layout.

The section grouping had also drifted. Three unrelated things were each called some variant of "access": an `Access control` card (who may use the agent), a `Data access` card (which spaces and tags it can read), and an `Enable Data Access` toggle living inside `Knowledge & expertise`. `Knowledge & expertise` had become a catch-all holding instructions, writing guidelines, uploaded documents, and three capability switches.

## Changes

**Return-to-origin navigation.** Openers record their own location as `returnTo` link state (`useAgentSettingsLinkState`), and the settings page resolves it with a fallback (`resolveReturnTo`). Opening settings from the admin agents table now returns you to the table instead of dropping you on the agent chat page; opening from the agent returns to the agent; a direct link falls back to the agent. Only same-origin relative paths are honoured. Back and Cancel use the same destination, and tab navigation within settings carries the state forward so a detour through Evals doesn't lose it.

**A sticky action bar.** Cancel and Save sit in a bar pinned to the bottom of the viewport at any scroll position, with an explicit unsaved-changes indicator. Save is removed from the sidebar.

**Regrouped sections**, each with a single purpose: Identity, Behaviour, Knowledge, Data access, Who can use it, MCP servers, Slack, Danger zone. The capability switches now sit with the space/tag scope they relate to under Data access, and the audience radios stand alone under "Who can use it". The read-only `Project` text input — a disabled field that existed only to display a value — is replaced by the project name in the sidebar.

**A shared `AgentSettingsSection` component** replaces section-header markup that was duplicated in seven places across two files, including `AiAgentMcpServersInput`.

**Guidelines are legible.** The four instruction guidelines were bordered chips with icons that read as buttons but were hover-only tooltips with `cursor: help`, so their content was invisible until you happened to hover. They are now plain always-visible text in a two-column grid.

**Smaller fixes along the way:** the unsaved-changes guard is a `MantineModal` rather than `window.confirm`; the sidebar scrolls instead of overflowing on short viewports; content is constrained to the standard page width instead of running edge-to-edge; the sidebar carries a section index with scroll-spy; and a hardcoded `#fcfcfc` background plus three inline `style` props are replaced with theme colours and CSS modules.

The bare `<form>` had no `onSubmit`, so pressing Enter in a text field triggered a native form submission. It is now wired to the save handler.

## Testing

Driven in a browser against a running instance:

- Save from the agent chat page returns to the agent
- Save from the admin agents table returns to the table
- Save from a direct link falls back to the agent
- Create flow lands on the newly created agent
- Leaving with unsaved changes opens the discard modal; "Keep editing" stays, "Discard changes" leaves
- Persistence confirmed against the database, and a discarded edit confirmed not saved

`typecheck`, `lint`, `unused-exports` and unit tests pass.

Note for reviewers: `packages/backend/src/ee/services/AiWritebackService/scripts.test.ts` has two cases that fail whenever the whole monorepo suite runs concurrently (`pnpm test`) but pass when the backend package runs alone. Confirmed pre-existing on `main` with this branch stashed — unrelated to this change, which touches no backend files.
