### PR TITLE
feat(homepage): collapsible announcements setting, five recent cards by default

### DIFF
--- a/packages/common/src/ee/homepage/schema.ts
+++ b/packages/common/src/ee/homepage/schema.ts
@@ -87,7 +87,10 @@ const resourcesBlockSchema = z.object({
 const announcementsBlockSchema = z.object({
     id: z.string(),
     type: z.literal('announcements'),
-    config: z.object({ title: z.string() }),
+    config: z.object({
+        title: z.string(),
+        collapseAfterFirst: z.boolean().optional(),
+    }),
 });
 
 const quickActionSchema = z

--- a/packages/common/src/ee/homepage/types.ts
+++ b/packages/common/src/ee/homepage/types.ts
@@ -154,7 +154,12 @@ export type HomepageAnnouncementsBlock = {
     id: string;
     type: 'announcements';
     /** Feed reference — items live in `project_announcements`. */
-    config: { title: string };
+    config: {
+        title: string;
+        // Optional for back-compat: undefined renders every recent
+        // announcement expanded.
+        collapseAfterFirst?: boolean;
+    };
 };
 
 export type HomepageQuickActionTarget =

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AnnouncementsBlock.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AnnouncementsBlock.test.tsx
@@ -4,6 +4,7 @@ import {
 } from '@lightdash/common';
 import { MantineProvider } from '@mantine/core';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { AnnouncementsBlockView } from './AnnouncementsBlock';
 
 const mockCan = vi.fn();
@@ -112,34 +113,65 @@ it('shows admin actions and drafts for a manager', () => {
     );
 });
 
-it('collapses every announcement but the first when configured', () => {
-    const second: ProjectAnnouncement = {
+const collapsedBlock: HomepageBlock = {
+    ...block,
+    type: 'announcements',
+    config: { title: 'From the data team', collapseAfterFirst: true },
+};
+
+const laterAnnouncements = (count: number): ProjectAnnouncement[] =>
+    Array.from({ length: count }, (_, index) => ({
         ...announcement,
-        announcementUuid: 'ann-2',
-        title: 'Revenue dashboard moved',
-    };
+        announcementUuid: `ann-${index + 2}`,
+        title: `Announcement ${index + 2}`,
+    }));
+
+// Seven unpinned announcements: two past RECENT_LIMIT, so the default mode
+// tucks a tail behind the "earlier announcements" toggle while the collapsed
+// mode puts all six non-lead ones there. Fewer and the modes converge.
+const sevenAnnouncements = [announcement, ...laterAnnouncements(6)];
+
+it('puts every announcement but the lead behind one toggle when configured', () => {
     mockCan.mockReturnValue(true);
-    mockUseAnnouncements.mockReturnValue(feed([announcement, second]));
-    renderView({
-        ...block,
-        type: 'announcements',
-        config: { title: 'From the data team', collapseAfterFirst: true },
-    });
-    // Both titles are listed, but only the lead renders as a full card.
-    expect(screen.queryAllByText('Orders explore refreshed')).toHaveLength(1);
-    expect(screen.queryAllByText('Revenue dashboard moved')).toHaveLength(1);
+    mockUseAnnouncements.mockReturnValue(feed(sevenAnnouncements));
+    renderView(collapsedBlock);
+    // One lead card, and the whole tail collapsed behind a single toggle.
     expect(screen.getAllByLabelText('Edit announcement')).toHaveLength(1);
-    expect(screen.queryAllByText(/earlier announcement/)).toHaveLength(0);
+    expect(screen.getByText('Orders explore refreshed')).toBeInTheDocument();
+    expect(screen.getByText(/6 earlier announcements/)).toBeInTheDocument();
+    expect(screen.queryByText('Announcement 2')).not.toBeInTheDocument();
+    expect(screen.queryByText('Announcement 7')).not.toBeInTheDocument();
 });
 
-it('expands recent announcements by default', () => {
-    const second: ProjectAnnouncement = {
-        ...announcement,
-        announcementUuid: 'ann-2',
-        title: 'Revenue dashboard moved',
-    };
+it('reveals the whole tail when the collapsed toggle is opened', async () => {
     mockCan.mockReturnValue(true);
-    mockUseAnnouncements.mockReturnValue(feed([announcement, second]));
+    mockUseAnnouncements.mockReturnValue(feed(sevenAnnouncements));
+    renderView(collapsedBlock);
+    await userEvent.click(screen.getByText(/6 earlier announcements/));
+    // Every one of the six, not a capped subset.
+    expect(screen.getByText('Announcement 2')).toBeInTheDocument();
+    expect(screen.getByText('Announcement 7')).toBeInTheDocument();
+    expect(screen.getByText(/Show fewer/)).toBeInTheDocument();
+});
+
+it('expands up to RECENT_LIMIT cards and defers the tail by default', () => {
+    mockCan.mockReturnValue(true);
+    mockUseAnnouncements.mockReturnValue(feed(sevenAnnouncements));
     renderView();
-    expect(screen.getAllByLabelText('Edit announcement')).toHaveLength(2);
+    expect(screen.getAllByLabelText('Edit announcement')).toHaveLength(5);
+    expect(screen.getByText(/2 earlier announcements/)).toBeInTheDocument();
+    expect(screen.queryByText('Announcement 7')).not.toBeInTheDocument();
+});
+
+it('leads with the pinned announcement when collapsed', () => {
+    mockCan.mockReturnValue(true);
+    const [second, third] = laterAnnouncements(2);
+    mockUseAnnouncements.mockReturnValue(
+        feed([announcement, second, { ...third, pinned: true }]),
+    );
+    renderView(collapsedBlock);
+    // The pinned one leads as the card even though it is not the newest.
+    expect(screen.getByText('Pinned')).toBeInTheDocument();
+    expect(screen.getByText('Announcement 3')).toBeInTheDocument();
+    expect(screen.getAllByLabelText('Edit announcement')).toHaveLength(1);
 });

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AnnouncementsBlock.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AnnouncementsBlock.test.tsx
@@ -56,11 +56,11 @@ const feed = (items: ProjectAnnouncement[]) => ({
     isError: false,
 });
 
-const renderView = () =>
+const renderView = (blockOverride: HomepageBlock = block) =>
     render(
         <MantineProvider env="test">
             <AnnouncementsBlockView
-                block={block}
+                block={blockOverride}
                 projectUuid="p1"
                 itemSpan={null}
                 standalone
@@ -110,4 +110,36 @@ it('shows admin actions and drafts for a manager', () => {
         'p1',
         expect.objectContaining({ includeUnpublished: true }),
     );
+});
+
+it('collapses every announcement but the first when configured', () => {
+    const second: ProjectAnnouncement = {
+        ...announcement,
+        announcementUuid: 'ann-2',
+        title: 'Revenue dashboard moved',
+    };
+    mockCan.mockReturnValue(true);
+    mockUseAnnouncements.mockReturnValue(feed([announcement, second]));
+    renderView({
+        ...block,
+        type: 'announcements',
+        config: { title: 'From the data team', collapseAfterFirst: true },
+    });
+    // Both titles are listed, but only the lead renders as a full card.
+    expect(screen.queryAllByText('Orders explore refreshed')).toHaveLength(1);
+    expect(screen.queryAllByText('Revenue dashboard moved')).toHaveLength(1);
+    expect(screen.getAllByLabelText('Edit announcement')).toHaveLength(1);
+    expect(screen.queryAllByText(/earlier announcement/)).toHaveLength(0);
+});
+
+it('expands recent announcements by default', () => {
+    const second: ProjectAnnouncement = {
+        ...announcement,
+        announcementUuid: 'ann-2',
+        title: 'Revenue dashboard moved',
+    };
+    mockCan.mockReturnValue(true);
+    mockUseAnnouncements.mockReturnValue(feed([announcement, second]));
+    renderView();
+    expect(screen.getAllByLabelText('Edit announcement')).toHaveLength(2);
 });

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AnnouncementsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AnnouncementsBlock.tsx
@@ -60,7 +60,7 @@ import { TiptapMarkdownEditor } from './markdownEditor/TiptapMarkdownEditor';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
 const FEED_PAGE_SIZE = 25;
-const RECENT_LIMIT = 3;
+const RECENT_LIMIT = 5;
 
 const NOOP = () => {};
 
@@ -202,12 +202,12 @@ const AnnouncementCard: FC<{
     </div>
 );
 
-/** Title-only rows that expand into a full card in place. */
-const CollapsedRows: FC<{
+const EarlierSection: FC<{
     projectUuid: string;
     items: ProjectAnnouncement[];
     renderActions?: (announcement: ProjectAnnouncement) => ReactNode;
 }> = ({ projectUuid, items, renderActions }) => {
+    const [open, setOpen] = useState(false);
     const [expanded, setExpanded] = useState<Set<string>>(new Set());
     const toggleRow = (uuid: string) =>
         setExpanded((prev) => {
@@ -215,52 +215,6 @@ const CollapsedRows: FC<{
             if (!next.delete(uuid)) next.add(uuid);
             return next;
         });
-    return (
-        <div className={classes.earlierList}>
-            {items.map((announcement) =>
-                expanded.has(announcement.announcementUuid) ? (
-                    <div key={announcement.announcementUuid}>
-                        <AnnouncementCard
-                            projectUuid={projectUuid}
-                            announcement={announcement}
-                            actions={renderActions?.(announcement)}
-                        />
-                        <button
-                            type="button"
-                            className={classes.earlierToggle}
-                            onClick={() =>
-                                toggleRow(announcement.announcementUuid)
-                            }
-                        >
-                            Show less
-                        </button>
-                    </div>
-                ) : (
-                    <button
-                        key={announcement.announcementUuid}
-                        type="button"
-                        className={classes.earlierRow}
-                        onClick={() => toggleRow(announcement.announcementUuid)}
-                    >
-                        <span className={classes.earlierRowTitle}>
-                            {announcement.title}
-                        </span>
-                        <span className={classes.earlierRowMeta}>
-                            <Timestamp announcement={announcement} />
-                        </span>
-                    </button>
-                ),
-            )}
-        </div>
-    );
-};
-
-const EarlierSection: FC<{
-    projectUuid: string;
-    items: ProjectAnnouncement[];
-    renderActions?: (announcement: ProjectAnnouncement) => ReactNode;
-}> = ({ projectUuid, items, renderActions }) => {
-    const [open, setOpen] = useState(false);
     if (items.length === 0) return null;
     return (
         <div>
@@ -280,11 +234,44 @@ const EarlierSection: FC<{
                       }`}
             </button>
             {open && (
-                <CollapsedRows
-                    projectUuid={projectUuid}
-                    items={items}
-                    renderActions={renderActions}
-                />
+                <div className={classes.earlierList}>
+                    {items.map((announcement) =>
+                        expanded.has(announcement.announcementUuid) ? (
+                            <div key={announcement.announcementUuid}>
+                                <AnnouncementCard
+                                    projectUuid={projectUuid}
+                                    announcement={announcement}
+                                    actions={renderActions?.(announcement)}
+                                />
+                                <button
+                                    type="button"
+                                    className={classes.earlierToggle}
+                                    onClick={() =>
+                                        toggleRow(announcement.announcementUuid)
+                                    }
+                                >
+                                    Show less
+                                </button>
+                            </div>
+                        ) : (
+                            <button
+                                key={announcement.announcementUuid}
+                                type="button"
+                                className={classes.earlierRow}
+                                onClick={() =>
+                                    toggleRow(announcement.announcementUuid)
+                                }
+                            >
+                                <span className={classes.earlierRowTitle}>
+                                    {announcement.title}
+                                </span>
+                                <span className={classes.earlierRowMeta}>
+                                    <Timestamp announcement={announcement} />
+                                </span>
+                            </button>
+                        ),
+                    )}
+                </div>
             )}
         </div>
     );
@@ -300,6 +287,8 @@ const AnnouncementFeed: FC<{
         const pinned = announcements.filter((a) => a.pinned);
         const rest = announcements.filter((a) => !a.pinned);
         const ordered = [...pinned, ...rest];
+        // A project has at most one pinned announcement, so the lead is that
+        // one when it exists and the most recent otherwise.
         if (collapseAfterFirst)
             return { top: ordered.slice(0, 1), earlier: ordered.slice(1) };
         return {
@@ -308,8 +297,8 @@ const AnnouncementFeed: FC<{
         };
     }, [announcements, collapseAfterFirst]);
 
-    // Collapsed mode keeps the lead card and lists everything else as rows,
-    // always visible rather than tucked behind another toggle.
+    // Collapsed mode keeps one lead card and puts everything else behind the
+    // single toggle, rather than listing part of the tail alongside it.
     if (collapseAfterFirst)
         return (
             <>
@@ -321,7 +310,7 @@ const AnnouncementFeed: FC<{
                         actions={renderActions?.(announcement)}
                     />
                 ))}
-                <CollapsedRows
+                <EarlierSection
                     projectUuid={projectUuid}
                     items={earlier}
                     renderActions={renderActions}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AnnouncementsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AnnouncementsBlock.tsx
@@ -202,12 +202,12 @@ const AnnouncementCard: FC<{
     </div>
 );
 
-const EarlierSection: FC<{
+/** Title-only rows that expand into a full card in place. */
+const CollapsedRows: FC<{
     projectUuid: string;
     items: ProjectAnnouncement[];
     renderActions?: (announcement: ProjectAnnouncement) => ReactNode;
 }> = ({ projectUuid, items, renderActions }) => {
-    const [open, setOpen] = useState(false);
     const [expanded, setExpanded] = useState<Set<string>>(new Set());
     const toggleRow = (uuid: string) =>
         setExpanded((prev) => {
@@ -215,6 +215,52 @@ const EarlierSection: FC<{
             if (!next.delete(uuid)) next.add(uuid);
             return next;
         });
+    return (
+        <div className={classes.earlierList}>
+            {items.map((announcement) =>
+                expanded.has(announcement.announcementUuid) ? (
+                    <div key={announcement.announcementUuid}>
+                        <AnnouncementCard
+                            projectUuid={projectUuid}
+                            announcement={announcement}
+                            actions={renderActions?.(announcement)}
+                        />
+                        <button
+                            type="button"
+                            className={classes.earlierToggle}
+                            onClick={() =>
+                                toggleRow(announcement.announcementUuid)
+                            }
+                        >
+                            Show less
+                        </button>
+                    </div>
+                ) : (
+                    <button
+                        key={announcement.announcementUuid}
+                        type="button"
+                        className={classes.earlierRow}
+                        onClick={() => toggleRow(announcement.announcementUuid)}
+                    >
+                        <span className={classes.earlierRowTitle}>
+                            {announcement.title}
+                        </span>
+                        <span className={classes.earlierRowMeta}>
+                            <Timestamp announcement={announcement} />
+                        </span>
+                    </button>
+                ),
+            )}
+        </div>
+    );
+};
+
+const EarlierSection: FC<{
+    projectUuid: string;
+    items: ProjectAnnouncement[];
+    renderActions?: (announcement: ProjectAnnouncement) => ReactNode;
+}> = ({ projectUuid, items, renderActions }) => {
+    const [open, setOpen] = useState(false);
     if (items.length === 0) return null;
     return (
         <div>
@@ -234,44 +280,11 @@ const EarlierSection: FC<{
                       }`}
             </button>
             {open && (
-                <div className={classes.earlierList}>
-                    {items.map((announcement) =>
-                        expanded.has(announcement.announcementUuid) ? (
-                            <div key={announcement.announcementUuid}>
-                                <AnnouncementCard
-                                    projectUuid={projectUuid}
-                                    announcement={announcement}
-                                    actions={renderActions?.(announcement)}
-                                />
-                                <button
-                                    type="button"
-                                    className={classes.earlierToggle}
-                                    onClick={() =>
-                                        toggleRow(announcement.announcementUuid)
-                                    }
-                                >
-                                    Show less
-                                </button>
-                            </div>
-                        ) : (
-                            <button
-                                key={announcement.announcementUuid}
-                                type="button"
-                                className={classes.earlierRow}
-                                onClick={() =>
-                                    toggleRow(announcement.announcementUuid)
-                                }
-                            >
-                                <span className={classes.earlierRowTitle}>
-                                    {announcement.title}
-                                </span>
-                                <span className={classes.earlierRowMeta}>
-                                    <Timestamp announcement={announcement} />
-                                </span>
-                            </button>
-                        ),
-                    )}
-                </div>
+                <CollapsedRows
+                    projectUuid={projectUuid}
+                    items={items}
+                    renderActions={renderActions}
+                />
             )}
         </div>
     );
@@ -280,16 +293,41 @@ const EarlierSection: FC<{
 const AnnouncementFeed: FC<{
     projectUuid: string;
     announcements: ProjectAnnouncement[];
+    collapseAfterFirst: boolean;
     renderActions?: (announcement: ProjectAnnouncement) => ReactNode;
-}> = ({ projectUuid, announcements, renderActions }) => {
+}> = ({ projectUuid, announcements, collapseAfterFirst, renderActions }) => {
     const { top, earlier } = useMemo(() => {
         const pinned = announcements.filter((a) => a.pinned);
         const rest = announcements.filter((a) => !a.pinned);
+        const ordered = [...pinned, ...rest];
+        if (collapseAfterFirst)
+            return { top: ordered.slice(0, 1), earlier: ordered.slice(1) };
         return {
             top: [...pinned, ...rest.slice(0, RECENT_LIMIT)],
             earlier: rest.slice(RECENT_LIMIT),
         };
-    }, [announcements]);
+    }, [announcements, collapseAfterFirst]);
+
+    // Collapsed mode keeps the lead card and lists everything else as rows,
+    // always visible rather than tucked behind another toggle.
+    if (collapseAfterFirst)
+        return (
+            <>
+                {top.map((announcement) => (
+                    <AnnouncementCard
+                        key={announcement.announcementUuid}
+                        projectUuid={projectUuid}
+                        announcement={announcement}
+                        actions={renderActions?.(announcement)}
+                    />
+                ))}
+                <CollapsedRows
+                    projectUuid={projectUuid}
+                    items={earlier}
+                    renderActions={renderActions}
+                />
+            </>
+        );
 
     // 3+ recent cards render as a bento grid: a full-width lead, the rest
     // tiled two-up, and a lone trailing tile spanning full width so the grid
@@ -569,6 +607,9 @@ export const AnnouncementsBlockView: FC<BlockComponentProps> = ({
                 <AnnouncementFeed
                     projectUuid={projectUuid}
                     announcements={announcements}
+                    collapseAfterFirst={
+                        block.config.collapseAfterFirst ?? false
+                    }
                     renderActions={
                         canManage
                             ? (announcement) => (
@@ -864,7 +905,7 @@ const AnnouncementFormModal: FC<{
 export const AnnouncementsBlockBuild: FC<BuildComponentProps> = ({
     block,
     projectUuid,
-    onChange: _onChange,
+    onChange,
 }) => {
     const [creating, setCreating] = useState(false);
     const [editing, setEditing] = useState<ProjectAnnouncement | null>(null);
@@ -878,6 +919,7 @@ export const AnnouncementsBlockBuild: FC<BuildComponentProps> = ({
     const { data: slack } = useGetSlack();
     const slackInstalled = !!slack?.organizationUuid;
     if (block.type !== 'announcements') return null;
+    const collapseAfterFirst = block.config.collapseAfterFirst ?? false;
 
     const itemActions = (announcement: ProjectAnnouncement) => (
         <AnnouncementItemActions
@@ -891,6 +933,20 @@ export const AnnouncementsBlockBuild: FC<BuildComponentProps> = ({
     return (
         <Stack gap="sm">
             <BlockHeader icon={IconSpeakerphone} title={block.config.title} />
+            <Switch
+                size="xs"
+                label="Collapse all but the first announcement"
+                checked={collapseAfterFirst}
+                onChange={(e) =>
+                    onChange({
+                        ...block,
+                        config: {
+                            ...block.config,
+                            collapseAfterFirst: e.currentTarget.checked,
+                        },
+                    })
+                }
+            />
             <Button
                 variant="default"
                 size="xs"
@@ -914,6 +970,7 @@ export const AnnouncementsBlockBuild: FC<BuildComponentProps> = ({
                 <AnnouncementFeed
                     projectUuid={projectUuid}
                     announcements={announcements}
+                    collapseAfterFirst={collapseAfterFirst}
                     renderActions={itemActions}
                 />
             )}


### PR DESCRIPTION
### Description:

Adds a **Collapse all but the first announcement** toggle to the announcements block in the homepage builder (`collapseAfterFirst` on the block config, optional so existing configs keep their shape).

**Toggle on** — one lead card, everything else behind the single "Show N earlier announcements" section:

```
┌──────────────────────────────┐
│ Lead card                    │
└──────────────────────────────┘
  > Show 14 earlier announcements
```

The lead is the pinned announcement when there is one and the most recent otherwise. A project has at most one pinned announcement, enforced both by the `project_announcements_one_pinned_per_project` partial unique index and by `updateAnnouncement`, which unpins the previous lead in the same transaction.

**Toggle off** — unchanged in shape, but the bento grid now shows up to `RECENT_LIMIT` 5 cards before deferring the tail, raised from 3:

```
┌──────────────────────────────┐
│ Card 1  (lead, full width)   │
├──────────────┬───────────────┤
│ Card 2       │ Card 3        │
├──────────────┼───────────────┤
│ Card 4       │ Card 5        │
└──────────────┴───────────────┘
  > Show 10 earlier announcements
```

The builder preview honours the setting, so admins see the effect while editing.

### Regression analysis:

**`RECENT_LIMIT` 3 → 5 affects existing homepages.** `collapseAfterFirst` defaults to off, so every project with the announcements block and more than three announcements now renders five cards instead of three and a correspondingly shorter "earlier" count. This is intended, not incidental. The bento grid already handles five without a layout change: `asBento` triggers at 3+, the lead spans full width, and `restIsOdd` is false at five so the remaining four tile two-up with no lone full-width trailing tile.

**The collapsed branch is fully gated.** Everything new sits behind `if (collapseAfterFirst)`. An existing config has it `undefined`, which `?? false` resolves to the default path. The read-more clamp, the draft and scheduled tags, the pinned tag and the admin actions are untouched in both modes.

**Row rendering is shared, not duplicated.** Collapsed mode reuses `EarlierSection` rather than a parallel list, so the expand-in-place behaviour, the "Show less" affordance and the empty-list guard are one implementation used by both modes.

### Tests:

`AnnouncementsBlock.test.tsx` drives both modes off one seven-announcement fixture, which is the smallest size where they diverge: collapsed puts all six non-lead ones behind the toggle, default shows five cards and defers two. Also covers opening the toggle to reveal the whole tail rather than a capped subset, and the pinned announcement leading even when it is not the newest.

Each assertion was checked against a deliberately broken implementation — reintroducing a row cap, and reverting `RECENT_LIMIT` to 3 — to confirm it fails when the behaviour regresses.

Verified in the local app against a 15-announcement feed.
