### PR TITLE
fix(scheduler): don't abort a Google Sheets sync when one chart fails

### DIFF
--- a/packages/backend/src/clients/Google/GoogleDriveClient.ts
+++ b/packages/backend/src/clients/Google/GoogleDriveClient.ts
@@ -196,6 +196,69 @@ export class GoogleDriveClient {
         return response.data;
     }
 
+    /** Renames a tab, e.g. the default first tab of a freshly created sheet. */
+    async renameSheet(
+        refreshToken: string,
+        fileId: string,
+        sheetId: number,
+        title: string,
+    ) {
+        if (!this.isEnabled) {
+            throw new MissingConfigError('Google Drive is not enabled');
+        }
+        const auth = await this.getCredentials(refreshToken);
+        const sheets = google.sheets({ version: 'v4', auth });
+
+        await GoogleDriveClient.catchApiError(
+            sheets.spreadsheets.batchUpdate({
+                spreadsheetId: fileId,
+                requestBody: {
+                    requests: [
+                        {
+                            updateSheetProperties: {
+                                properties: {
+                                    sheetId,
+                                    title: title.replaceAll(':', '.'),
+                                },
+                                fields: 'title',
+                            },
+                        },
+                    ],
+                },
+            }),
+        );
+    }
+
+    /** Tab title -> gid, so links can address a specific tab. */
+    async getSheetIdsByTitle(
+        refreshToken: string,
+        fileId: string,
+    ): Promise<Record<string, number>> {
+        if (!this.isEnabled) {
+            throw new MissingConfigError('Google Drive is not enabled');
+        }
+        const auth = await this.getCredentials(refreshToken);
+        const sheets = google.sheets({ version: 'v4', auth });
+
+        const response = await GoogleDriveClient.catchApiError(
+            sheets.spreadsheets.get({
+                spreadsheetId: fileId,
+                fields: 'sheets.properties.sheetId,sheets.properties.title',
+            }),
+        );
+
+        return (response.data.sheets ?? []).reduce<Record<string, number>>(
+            (acc, sheet) => {
+                const { title, sheetId } = sheet.properties ?? {};
+                if (!title || sheetId === null || sheetId === undefined) {
+                    return acc;
+                }
+                return { ...acc, [title]: sheetId };
+            },
+            {},
+        );
+    }
+
     async assertFileIsGoogleSheet(refreshToken: string, fileId: string) {
         const auth = await this.getCredentials(refreshToken);
         const sheets = google.sheets({ version: 'v4', auth });

--- a/packages/backend/src/controllers/googleDriveController.ts
+++ b/packages/backend/src/controllers/googleDriveController.ts
@@ -3,6 +3,7 @@ import {
     ApiGdriveAccessTokenResponse,
     ApiJobScheduledResponse,
     assertRegisteredAccount,
+    ExportDashboardGsheetRequest,
     UploadGsheetFromRows,
     UploadMetricGsheet,
 } from '@lightdash/common';
@@ -11,6 +12,7 @@ import {
     Get,
     Middlewares,
     OperationId,
+    Path,
     Post,
     Request,
     Response,
@@ -69,6 +71,36 @@ export class GoogleDriveController extends BaseController {
             results: await req.services
                 .getGdriveService()
                 .scheduleUploadGsheet(req.account!, body),
+        };
+    }
+
+    /**
+     * Export every output of a dashboard into a newly created Google Sheet.
+     * @summary Export dashboard to Google Sheets
+     * @param req express request
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/export-dashboard/{projectUuid}/{dashboardUuid}')
+    @OperationId('exportDashboardToGsheet')
+    async postExportDashboard(
+        @Path() projectUuid: string,
+        @Path() dashboardUuid: string,
+        @Body() body: ExportDashboardGsheetRequest,
+        @Request() req: express.Request,
+    ): Promise<ApiJobScheduledResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await req.services
+                .getGdriveService()
+                .scheduleExportDashboardGsheet(
+                    req.account,
+                    projectUuid,
+                    dashboardUuid,
+                    body,
+                ),
         };
     }
 

--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -27,6 +27,7 @@ import {
     NotFoundError,
     ParameterError,
     Scheduler,
+    SCHEDULER_TASKS,
     SchedulerAndTargets,
     SchedulerBase,
     SchedulerEmailTarget,
@@ -1958,7 +1959,10 @@ export class SchedulerModel {
     async getGsheetExportStatus(jobId: string, userUuid: string) {
         const jobs = await this.database(SchedulerLogTableName)
             .where(`job_id`, jobId)
-            .andWhere('task', 'uploadGsheetFromQuery')
+            .whereIn('task', [
+                SCHEDULER_TASKS.UPLOAD_GSHEET_FROM_QUERY,
+                SCHEDULER_TASKS.EXPORT_DASHBOARD_GSHEET,
+            ])
             .orderBy('scheduled_time', 'desc')
             .returning('*');
 

--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -5,6 +5,7 @@ import {
     CreateSchedulerTarget,
     EmailBatchNotificationPayload,
     EmailNotificationPayload,
+    ExportDashboardGsheetPayload,
     FeatureFlags,
     getSchedulerTargetUuid,
     getSchedulerUuid,
@@ -1220,6 +1221,34 @@ export class SchedulerClient {
                 exploreId: payload.exploreId,
                 metricQuery: payload.metricQuery,
                 organizationUuid: payload.organizationUuid,
+            },
+        });
+
+        return { jobId };
+    }
+
+    async exportDashboardGsheetJob(payload: ExportDashboardGsheetPayload) {
+        const graphileClient = await this.graphileUtils;
+        const now = new Date();
+        const jobId = await SchedulerClient.addJob(
+            graphileClient,
+            SCHEDULER_TASKS.EXPORT_DASHBOARD_GSHEET,
+            payload,
+            now,
+            JobPriority.HIGH,
+            1,
+        );
+
+        await this.schedulerModel.logSchedulerJob({
+            task: SCHEDULER_TASKS.EXPORT_DASHBOARD_GSHEET,
+            jobId,
+            scheduledTime: now,
+            status: SchedulerJobStatus.SCHEDULED,
+            details: {
+                createdByUserUuid: payload.userUuid,
+                projectUuid: payload.projectUuid,
+                organizationUuid: payload.organizationUuid,
+                dashboardUuid: payload.dashboardUuid,
             },
         });
 

--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -996,6 +996,312 @@ describe('uploadGsheets — pivot routing', () => {
     });
 });
 
+describe('uploadGsheets — dashboard tile failures', () => {
+    const itemMap = buildItemMapFromColumns([
+        { key: 'orders_count', type: 'number' },
+    ]);
+
+    const makeChart = (uuid: string) => ({
+        uuid,
+        projectUuid: 'project-1',
+        chartConfig: { type: ChartType.TABLE, config: {} },
+        metricQuery: {
+            dimensions: [],
+            metrics: ['orders_count'],
+            filters: {},
+            sorts: [],
+            limit: 500,
+            tableCalculations: [],
+            additionalMetrics: [],
+        },
+        pivotConfig: undefined,
+        tableConfig: { columnOrder: ['orders_count'] },
+    });
+
+    // Two-tile dashboard where the caller decides which tiles fail to query,
+    // how they fail, and whether the sheet write itself fails.
+    const setup = ({
+        failingChartUuids,
+        queryError = new Error('query exploded'),
+        appendToSheetError,
+        sharedChartUuid,
+    }: {
+        failingChartUuids: string[];
+        queryError?: Error;
+        appendToSheetError?: Error;
+        // When set, both tiles point at this one saved chart.
+        sharedChartUuid?: string;
+    }) => {
+        const appendToSheet = appendToSheetError
+            ? vi.fn().mockRejectedValue(appendToSheetError)
+            : vi.fn().mockResolvedValue(undefined);
+        const createNewTab = vi
+            .fn()
+            .mockImplementation((_token, _id, name) => Promise.resolve(name));
+        const logSchedulerJob = vi.fn().mockResolvedValue(undefined);
+        const brokenChartUuid = sharedChartUuid ?? 'chart-broken';
+        const healthyChartUuid = sharedChartUuid ?? 'chart-ok';
+        const scheduler = {
+            schedulerUuid: 'scheduler-1',
+            name: 'Daily sync',
+            createdBy: 'user-1',
+            format: SchedulerFormat.GSHEETS,
+            savedChartUuid: null,
+            dashboardUuid: 'dashboard-1',
+            savedSqlUuid: null,
+            cron: '0 7 * * *',
+            timezone: 'UTC',
+            options: { gdriveId: 'sheet-1' },
+            thresholds: undefined,
+            filters: undefined,
+        };
+
+        const task = makeTaskWithDeps({
+            googleDriveClient: asDep<'googleDriveClient'>({
+                isEnabled: true,
+                uploadMetadata: vi.fn().mockResolvedValue(undefined),
+                createNewTab,
+                appendToSheet,
+                appendCsvToSheet: vi.fn().mockResolvedValue(undefined),
+            }),
+            schedulerService: asDep<'schedulerService'>({
+                schedulerModel: {
+                    getSchedulerAndTargets: vi
+                        .fn()
+                        .mockResolvedValue(scheduler),
+                },
+                savedChartModel: {
+                    get: vi
+                        .fn()
+                        .mockImplementation((uuid: string) =>
+                            Promise.resolve(makeChart(uuid)),
+                        ),
+                },
+                getSchedulerDefaultTimezone: vi.fn().mockResolvedValue('UTC'),
+                logSchedulerJob,
+            }),
+            userService: asDep<'userService'>({
+                getSessionByUserUuid: vi.fn().mockResolvedValue({}),
+                getAccountByUserUuid: vi.fn().mockResolvedValue({
+                    user: { email: 'demo@lightdash.com' },
+                    organization: { organizationUuid: 'org-1' },
+                }),
+                getRefreshToken: vi.fn().mockResolvedValue('refresh-token'),
+            }),
+            asyncQueryService: asDep<'asyncQueryService'>({
+                executeDashboardChartQueryAndGetResults: vi
+                    .fn()
+                    .mockImplementation(
+                        ({ chartUuid }: { chartUuid: string }) =>
+                            failingChartUuids.includes(chartUuid)
+                                ? Promise.reject(queryError)
+                                : Promise.resolve({
+                                      rows: [{ orders_count: 1 }],
+                                      fields: itemMap,
+                                      pivotDetails: null,
+                                      displayTimezone: null,
+                                  }),
+                    ),
+            }),
+            dashboardService: asDep<'dashboardService'>({
+                getByIdOrSlug: vi.fn().mockResolvedValue({
+                    uuid: 'dashboard-1',
+                    projectUuid: 'project-1',
+                    filters: {
+                        dimensions: [],
+                        metrics: [],
+                        tableCalculations: [],
+                    },
+                    tiles: [
+                        {
+                            uuid: 'tile-1',
+                            type: DashboardTileTypes.SAVED_CHART,
+                            properties: {
+                                title: 'Broken chart',
+                                savedChartUuid: brokenChartUuid,
+                            },
+                        },
+                        {
+                            uuid: 'tile-2',
+                            type: DashboardTileTypes.SAVED_CHART,
+                            properties: {
+                                title: 'Healthy chart',
+                                savedChartUuid: healthyChartUuid,
+                            },
+                        },
+                    ],
+                    displayTimezone: null,
+                }),
+            }),
+            analytics: asDep<'analytics'>({ track: vi.fn() }),
+            lightdashConfig: asDep<'lightdashConfig'>({
+                siteUrl: 'http://localhost:8090',
+            }),
+        });
+
+        const run = () =>
+            (
+                task as unknown as {
+                    uploadGsheets(
+                        jobId: string,
+                        notification: {
+                            schedulerUuid: string;
+                            scheduledTime: Date;
+                            jobGroup: string;
+                            userUuid: string;
+                            organizationUuid: string;
+                            projectUuid: string;
+                        },
+                    ): Promise<void>;
+                }
+            ).uploadGsheets('job-1', {
+                schedulerUuid: scheduler.schedulerUuid,
+                scheduledTime: new Date('2026-08-04T07:00:00Z'),
+                jobGroup: 'scheduled_delivery',
+                userUuid: 'user-1',
+                organizationUuid: 'org-1',
+                projectUuid: 'project-1',
+            });
+
+        return { appendToSheet, createNewTab, logSchedulerJob, run };
+    };
+
+    it('still exports healthy tiles when one tile fails', async () => {
+        const result = setup({ failingChartUuids: ['chart-broken'] });
+
+        await result.run();
+
+        // Pins the write contract through the extracted writer: the healthy
+        // tile's rows land on its own tab, with its chart column order.
+        expect(result.appendToSheet).toHaveBeenCalledExactlyOnceWith(
+            'refresh-token',
+            'sheet-1',
+            [{ orders_count: 1 }],
+            itemMap,
+            false,
+            'Healthy chart',
+            ['orders_count'],
+            undefined,
+            [],
+            undefined,
+        );
+        expect(result.logSchedulerJob).toHaveBeenLastCalledWith(
+            expect.objectContaining({ status: 'completed' }),
+        );
+    });
+
+    it('records the failed tile as a partial failure', async () => {
+        const result = setup({ failingChartUuids: ['chart-broken'] });
+
+        await result.run();
+
+        expect(result.logSchedulerJob).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                details: expect.objectContaining({
+                    // Rolls the parent run up to PARTIAL_FAILURE.
+                    partialFailure: true,
+                    partialFailures: [
+                        expect.objectContaining({
+                            type: PartialFailureType.DASHBOARD_CHART,
+                            chartUuid: 'chart-broken',
+                            chartName: 'Broken chart',
+                            tileUuid: 'tile-1',
+                        }),
+                    ],
+                }),
+            }),
+        );
+    });
+
+    it('leaves no partial-failure marker on a fully healthy run', async () => {
+        const result = setup({ failingChartUuids: [] });
+
+        await result.run();
+
+        expect(result.logSchedulerJob).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                details: expect.not.objectContaining({
+                    partialFailure: expect.anything(),
+                }),
+            }),
+        );
+    });
+
+    it('fails the job when every tile fails', async () => {
+        const result = setup({
+            failingChartUuids: ['chart-broken', 'chart-ok'],
+        });
+
+        await expect(result.run()).rejects.toThrow();
+        expect(result.appendToSheet).not.toHaveBeenCalled();
+    });
+
+    // The error class decides whether the delivery is retried or the sync is
+    // disabled. Flattening it into a generic server error would make a
+    // permanently broken sync retry forever instead of being disabled.
+    it('keeps a permanent failure non-retryable when every tile fails', async () => {
+        const result = setup({
+            failingChartUuids: ['chart-broken', 'chart-ok'],
+            queryError: new ForbiddenError('lost access to the chart'),
+        });
+
+        await expect(result.run()).rejects.toMatchObject({
+            name: 'SchedulerDeliveryError',
+            isNonRetryable: true,
+        });
+    });
+
+    // A transient failure must stay retryable so the worker retries it.
+    it('keeps a transient failure retryable when every tile fails', async () => {
+        const result = setup({
+            failingChartUuids: ['chart-broken', 'chart-ok'],
+            queryError: new Error('temporary blip'),
+        });
+
+        await expect(result.run()).rejects.toMatchObject({
+            name: 'SchedulerDeliveryError',
+            isNonRetryable: false,
+        });
+    });
+
+    // Tabs are keyed by tile, not by chart, so a dashboard showing the same
+    // saved chart twice gets a tab per tile instead of one overwriting the other.
+    it('gives each tile its own tab when two tiles share a saved chart', async () => {
+        const result = setup({
+            failingChartUuids: [],
+            sharedChartUuid: 'chart-shared',
+        });
+
+        await result.run();
+
+        expect(result.createNewTab).toHaveBeenCalledTimes(2);
+        expect(result.createNewTab).toHaveBeenCalledWith(
+            'refresh-token',
+            'sheet-1',
+            'Broken chart',
+        );
+        expect(result.createNewTab).toHaveBeenCalledWith(
+            'refresh-token',
+            'sheet-1',
+            'Healthy chart',
+        );
+    });
+
+    // A sheet-level failure is not chart-scoped: swallowing it would report a
+    // completed sync while tabs silently kept stale data.
+    it('propagates a Google Sheets write failure instead of recording it', async () => {
+        const result = setup({
+            failingChartUuids: [],
+            appendToSheetError: new Error('Quota exceeded'),
+        });
+
+        await expect(result.run()).rejects.toThrow('Quota exceeded');
+        expect(result.logSchedulerJob).not.toHaveBeenCalledWith(
+            expect.objectContaining({ status: 'completed' }),
+        );
+    });
+});
+
 describe('handleScheduledDelivery execution identity', () => {
     const persistedScheduler = {
         schedulerUuid: 'scheduler-1',

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -9,6 +9,7 @@ import {
     CreateSchedulerAndTargets,
     CreateSchedulerLog,
     CreateSchedulerTarget,
+    DashboardChartPartialFailure,
     DashboardChartTile,
     DashboardFilterRule,
     DashboardFilters,
@@ -281,6 +282,30 @@ export function buildSchedulerLogContext(args: {
 export type SchedulerLogContextUpdater = (
     update: Pick<ExecutionContextInfo, 'scheduler'>,
 ) => void;
+
+// A dashboard chart tile destined for its own Google Sheets tab.
+export type DashboardChartTab = {
+    tileUuid: string;
+    chartUuid: string;
+    tabName: string;
+};
+
+export type WrittenDashboardChartTab = {
+    status: 'written';
+    tileUuid: string;
+    tabName: string;
+};
+
+export type FailedDashboardChartTab = {
+    status: 'failed';
+    tileUuid: string;
+    failure: DashboardChartPartialFailure;
+    cause: unknown;
+};
+
+export type DashboardChartTabResult =
+    | WrittenDashboardChartTab
+    | FailedDashboardChartTab;
 
 const defaultSchedulerLogContextUpdater: SchedulerLogContextUpdater = (
     update,
@@ -3695,6 +3720,203 @@ export default class SchedulerTask {
         return SchedulerTask.evaluateThreshold(thresholds, results).met;
     }
 
+    // One dashboard chart tile to write, keyed by tile so two tiles sharing a
+    // saved chart get their own tabs.
+    private static dashboardChartTabs(
+        chartTiles: DashboardChartTile[],
+    ): DashboardChartTab[] {
+        return chartTiles.reduce<DashboardChartTab[]>((acc, tile) => {
+            const chartUuid = tile.properties.savedChartUuid;
+            if (!chartUuid) {
+                return acc;
+            }
+            return [
+                ...acc,
+                {
+                    tileUuid: tile.uuid,
+                    chartUuid,
+                    tabName:
+                        tile.properties.title ||
+                        tile.properties.chartName ||
+                        chartUuid,
+                },
+            ];
+        }, []);
+    }
+
+    // A chart tile that could not be queried. Its cause is kept so the caller
+    // can rethrow the original error class, which decides whether a sync is
+    // retried or disabled.
+    private static toChartQueryFailure(
+        tab: DashboardChartTab,
+        cause: unknown,
+    ): FailedDashboardChartTab {
+        return {
+            status: 'failed',
+            tileUuid: tab.tileUuid,
+            cause,
+            failure: {
+                type: PartialFailureType.DASHBOARD_CHART,
+                chartUuid: tab.chartUuid,
+                chartName: tab.tabName,
+                tileUuid: tab.tileUuid,
+                error: getErrorMessage(cause),
+            },
+        };
+    }
+
+    // Writes one tab per dashboard chart tile into an existing Google Sheet.
+    // A chart whose query fails is recorded and skipped so the remaining charts
+    // still reach the sheet; a failure of the sheet itself (quota, revoked
+    // access, transient Google error) aborts the whole write so the job is
+    // retried or disabled rather than silently leaving tabs stale.
+    protected async writeDashboardChartTabs({
+        account,
+        refreshToken,
+        gdriveId,
+        projectUuid,
+        dashboardUuid,
+        dashboardFilters,
+        parameters,
+        tabs,
+        context,
+    }: {
+        account: AccountType;
+        refreshToken: string;
+        gdriveId: string;
+        projectUuid: string;
+        dashboardUuid: string;
+        dashboardFilters: DashboardFilters;
+        parameters: ParametersValuesMap | undefined;
+        tabs: DashboardChartTab[];
+        context: QueryExecutionContext;
+    }): Promise<DashboardChartTabResult[]> {
+        const results: DashboardChartTabResult[] = [];
+
+        // Charts are processed in sequence so we don't hold every chart's
+        // results in memory at once.
+        await tabs.reduce(async (promise, tab) => {
+            await promise;
+            const { chartUuid, tabName } = tab;
+
+            // Only the query is recoverable per chart. Anything the Google
+            // Sheets client throws below is sheet-wide and must abort the run.
+            let queryResult;
+            try {
+                const chart =
+                    await this.schedulerService.savedChartModel.get(chartUuid);
+                const shouldPivotChart =
+                    isTableChartConfig(chart.chartConfig.config) &&
+                    !!getPivotConfig(chart);
+
+                const {
+                    rows,
+                    fields: itemMap,
+                    pivotDetails,
+                    displayTimezone,
+                } = await this.asyncQueryService.executeDashboardChartQueryAndGetResults(
+                    {
+                        account,
+                        projectUuid,
+                        tileUuid: tab.tileUuid,
+                        chartUuid,
+                        dashboardUuid,
+                        dashboardFilters,
+                        dashboardSorts: [],
+                        invalidateCache: true,
+                        context,
+                        pivotResults: shouldPivotChart,
+                        parameters,
+                    },
+                    SCHEDULER_POLLING_OPTIONS,
+                );
+                queryResult = {
+                    chart,
+                    rows,
+                    itemMap,
+                    pivotDetails,
+                    displayTimezone,
+                };
+            } catch (error) {
+                Logger.warn(
+                    `Skipping Google Sheets tab for chart ${tabName} (${chartUuid}): ${getErrorMessage(
+                        error,
+                    )}`,
+                );
+                results.push(SchedulerTask.toChartQueryFailure(tab, error));
+                return;
+            }
+
+            const { chart, rows, itemMap, pivotDetails, displayTimezone } =
+                queryResult;
+            const showTableNames = isTableChartConfig(chart.chartConfig.config)
+                ? (chart.chartConfig.config.showTableNames ?? false)
+                : true;
+            const customLabels = getCustomLabelsFromTableConfig(
+                chart.chartConfig.config,
+            );
+
+            const chartTabName = await this.googleDriveClient.createNewTab(
+                refreshToken,
+                gdriveId,
+                tabName,
+            );
+            const pivotConfig = getPivotConfig(chart);
+            if (
+                pivotConfig &&
+                pivotDetails &&
+                isTableChartConfig(chart.chartConfig.config)
+            ) {
+                // pivotResultsAsCsv expects a formatted ResultRow[] type, so we need to convert it first
+                const formattedRows = formatRows(
+                    rows,
+                    itemMap,
+                    undefined,
+                    undefined,
+                    displayTimezone ?? undefined,
+                );
+
+                const pivotedResults = pivotResultsAsCsv({
+                    pivotConfig,
+                    rows: formattedRows,
+                    itemMap,
+                    customLabels,
+                    onlyRaw: true,
+                    pivotDetails,
+                    timezone: displayTimezone ?? undefined,
+                });
+
+                await this.googleDriveClient.appendCsvToSheet(
+                    refreshToken,
+                    gdriveId,
+                    pivotedResults,
+                    chartTabName,
+                );
+            } else {
+                await this.googleDriveClient.appendToSheet(
+                    refreshToken,
+                    gdriveId,
+                    rows,
+                    itemMap,
+                    showTableNames,
+                    chartTabName,
+                    chart.tableConfig.columnOrder,
+                    customLabels,
+                    getHiddenTableFields(chart.chartConfig),
+                    displayTimezone ?? undefined,
+                );
+            }
+
+            results.push({
+                status: 'written',
+                tileUuid: tab.tileUuid,
+                tabName: chartTabName,
+            });
+        }, Promise.resolve());
+
+        return results;
+    }
+
     protected async uploadGsheets(
         jobId: string,
         notification: GsheetsNotificationPayload,
@@ -3724,6 +3946,7 @@ export default class SchedulerTask {
         let sessionUser: SessionUser | undefined;
         let account: AccountType | undefined;
         let scheduler: SchedulerAndTargets | undefined;
+        let partialFailures: DashboardChartPartialFailure[] = [];
 
         let deliveryUrl = `${this.lightdashConfig.siteUrl}/generalSettings/projectManagement/${notification.projectUuid}/scheduledDeliveries?tab=scheduled-deliveries&schedulerUuid=${schedulerUuid}`;
         try {
@@ -3916,19 +4139,7 @@ export default class SchedulerTask {
                     scheduler.createdBy,
                 );
 
-                const chartNames = chartTiles.reduce<Record<string, string>>(
-                    (acc, tile) => {
-                        const chartUuid = tile.properties.savedChartUuid!;
-                        return {
-                            ...acc,
-                            [chartUuid]:
-                                tile.properties.title ||
-                                tile.properties.chartName ||
-                                chartUuid,
-                        };
-                    },
-                    {},
-                );
+                const chartTabs = SchedulerTask.dashboardChartTabs(chartTiles);
 
                 await this.googleDriveClient.uploadMetadata(
                     refreshToken,
@@ -3937,7 +4148,7 @@ export default class SchedulerTask {
                         scheduler.cron,
                         scheduler.timezone ?? defaultSchedulerTimezone,
                     ),
-                    Object.values(chartNames),
+                    chartTabs.map((chartTab) => chartTab.tabName),
                 );
 
                 Logger.debug(
@@ -3961,106 +4172,38 @@ export default class SchedulerTask {
                 const dashboardParameters =
                     getDashboardParametersValuesMap(dashboard);
 
-                // We want to process all charts in sequence, so we don't load all chart results in memory
-                await chartTiles
-                    .reduce(async (promise, tile) => {
-                        await promise;
-                        const chartUuid = tile.properties.savedChartUuid!;
-                        const chart =
-                            await this.schedulerService.savedChartModel.get(
-                                chartUuid,
-                            );
-                        const shouldPivotChart =
-                            isTableChartConfig(chart.chartConfig.config) &&
-                            !!getPivotConfig(chart);
+                const tabResults = await this.writeDashboardChartTabs({
+                    account: account!,
+                    refreshToken,
+                    gdriveId,
+                    projectUuid: dashboard.projectUuid,
+                    dashboardUuid,
+                    dashboardFilters,
+                    parameters: dashboardParameters,
+                    tabs: chartTabs,
+                    context: QueryExecutionContext.SCHEDULED_GSHEETS_DASHBOARD,
+                });
 
-                        const {
-                            rows,
-                            fields: itemMap,
-                            pivotDetails,
-                            displayTimezone,
-                        } = await this.asyncQueryService.executeDashboardChartQueryAndGetResults(
-                            {
-                                account: account!,
-                                projectUuid: dashboard.projectUuid,
-                                tileUuid: tile.uuid,
-                                chartUuid,
-                                dashboardUuid,
-                                dashboardFilters,
-                                dashboardSorts: [],
-                                invalidateCache: true,
-                                context:
-                                    QueryExecutionContext.SCHEDULED_GSHEETS_DASHBOARD,
-                                pivotResults: shouldPivotChart,
-                                parameters: dashboardParameters,
-                            },
-                            SCHEDULER_POLLING_OPTIONS,
-                        );
-                        const showTableNames = isTableChartConfig(
-                            chart.chartConfig.config,
-                        )
-                            ? (chart.chartConfig.config.showTableNames ?? false)
-                            : true;
-                        const customLabels = getCustomLabelsFromTableConfig(
-                            chart.chartConfig.config,
-                        );
+                const failedTabs = tabResults.filter(
+                    (result): result is FailedDashboardChartTab =>
+                        result.status === 'failed',
+                );
 
-                        const chartTabName =
-                            await this.googleDriveClient.createNewTab(
-                                refreshToken,
-                                gdriveId,
-                                chartNames[chartUuid] || chartUuid,
-                            );
-                        const pivotConfig = getPivotConfig(chart);
-                        if (
-                            pivotConfig &&
-                            pivotDetails &&
-                            isTableChartConfig(chart.chartConfig.config)
-                        ) {
-                            // pivotResultsAsCsv expects a formatted ResultRow[] type, so we need to convert it first
-                            const formattedRows = formatRows(
-                                rows,
-                                itemMap,
-                                undefined,
-                                undefined,
-                                displayTimezone ?? undefined,
-                            );
-
-                            const pivotedResults = pivotResultsAsCsv({
-                                pivotConfig,
-                                rows: formattedRows,
-                                itemMap,
-                                customLabels,
-                                onlyRaw: true,
-                                pivotDetails,
-                                timezone: displayTimezone ?? undefined,
-                            });
-
-                            await this.googleDriveClient.appendCsvToSheet(
-                                refreshToken,
-                                gdriveId,
-                                pivotedResults,
-                                chartTabName,
-                            );
-                        } else {
-                            await this.googleDriveClient.appendToSheet(
-                                refreshToken,
-                                gdriveId,
-                                rows,
-                                itemMap,
-                                showTableNames,
-                                chartTabName,
-                                chart.tableConfig.columnOrder,
-                                customLabels,
-                                getHiddenTableFields(chart.chartConfig),
-                                displayTimezone ?? undefined,
-                            );
-                        }
-                    }, Promise.resolve())
-                    .catch((error) => {
-                        Logger.debug('Error processing charts:', error);
-                        throw error;
-                    });
+                // No chart reaching the sheet means the sync produced nothing.
+                // Rethrow the original cause so the delivery keeps its error
+                // class, which decides whether the sync is retried or disabled.
+                if (
+                    failedTabs.length > 0 &&
+                    failedTabs.length === tabResults.length
+                ) {
+                    throw failedTabs[0].cause;
+                }
+                if (failedTabs.length > 0) {
+                    Logger.warn(
+                        `Google Sheets sync completed with ${failedTabs.length} failed chart(s) out of ${tabResults.length}`,
+                    );
+                    partialFailures = failedTabs.map(({ failure }) => failure);
+                }
             } else if (scheduler.savedSqlUuid) {
                 const sqlChart =
                     await this.asyncQueryService.savedSqlModel.getByUuid(
@@ -4146,6 +4289,8 @@ export default class SchedulerTask {
                     format,
                     ...getSchedulerResourceTypeAndId(scheduler),
                     sendNow: schedulerUuid === undefined,
+                    hasPartialFailures: partialFailures.length > 0,
+                    partialFailuresCount: partialFailures.length,
                 },
             });
             await this.schedulerService.logSchedulerJob({
@@ -4161,6 +4306,12 @@ export default class SchedulerTask {
                     projectUuid: notification.projectUuid,
                     organizationUuid: notification.organizationUuid,
                     createdByUserUuid: notification.userUuid,
+                    // `partialFailure` is what rolls the parent run up to
+                    // PARTIAL_FAILURE; `partialFailures` carries the detail.
+                    ...(partialFailures.length > 0 && {
+                        partialFailure: true,
+                        partialFailures,
+                    }),
                 },
             });
         } catch (e) {

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -20,8 +20,14 @@ import {
     DownloadFileType,
     EmailNotificationPayload,
     expandSelectedTabs,
+    EXPORT_DASHBOARD_GSHEET_INDEX_TAB,
+    EXPORT_DASHBOARD_GSHEET_MAX_CELLS,
+    EXPORT_DASHBOARD_GSHEET_MAX_ROWS_PER_TAB,
     ExportContentPayload,
     ExportCsvDashboardPayload,
+    ExportDashboardGsheetOutput,
+    ExportDashboardGsheetOutputStatus,
+    ExportDashboardGsheetPayload,
     FeatureFlags,
     FieldReferenceError,
     FieldType,
@@ -38,6 +44,7 @@ import {
     getHiddenFieldsFromVizTableConfig,
     getHiddenTableFields,
     getHumanReadableCronExpression,
+    getItemLabelWithoutTableName,
     getItemMap,
     getPivotConfig,
     getRequestMethod,
@@ -3915,6 +3922,453 @@ export default class SchedulerTask {
         }, Promise.resolve());
 
         return results;
+    }
+
+    // Chart tile results as CSV-shaped rows, pivoted when the chart is.
+    private async exportChartTileRows({
+        account,
+        dashboardUuid,
+        projectUuid,
+        dashboardFilters,
+        parameters,
+        tile,
+        chartUuid,
+    }: {
+        account: AccountType;
+        dashboardUuid: string;
+        projectUuid: string;
+        dashboardFilters: DashboardFilters;
+        parameters: ParametersValuesMap | undefined;
+        tile: DashboardChartTile;
+        chartUuid: string;
+    }): Promise<string[][]> {
+        const chart =
+            await this.schedulerService.savedChartModel.get(chartUuid);
+        const pivotConfig = getPivotConfig(chart);
+        const shouldPivotChart =
+            isTableChartConfig(chart.chartConfig.config) && !!pivotConfig;
+
+        const {
+            rows,
+            fields: itemMap,
+            pivotDetails,
+            displayTimezone,
+        } = await this.asyncQueryService.executeDashboardChartQueryAndGetResults(
+            {
+                account,
+                projectUuid,
+                tileUuid: tile.uuid,
+                chartUuid,
+                dashboardUuid,
+                dashboardFilters,
+                dashboardSorts: [],
+                invalidateCache: true,
+                context: QueryExecutionContext.GSHEETS,
+                pivotResults: shouldPivotChart,
+                parameters,
+            },
+            SCHEDULER_POLLING_OPTIONS,
+        );
+
+        const customLabels = getCustomLabelsFromTableConfig(
+            chart.chartConfig.config,
+        );
+        const formattedRows = formatRows(
+            rows,
+            itemMap,
+            undefined,
+            undefined,
+            displayTimezone ?? undefined,
+        );
+
+        if (
+            pivotConfig &&
+            pivotDetails &&
+            isTableChartConfig(chart.chartConfig.config)
+        ) {
+            return pivotResultsAsCsv({
+                pivotConfig,
+                rows: formattedRows,
+                itemMap,
+                customLabels,
+                onlyRaw: true,
+                pivotDetails,
+                timezone: displayTimezone ?? undefined,
+            });
+        }
+
+        const hiddenFields = getHiddenTableFields(chart.chartConfig);
+        const columnOrder = chart.tableConfig.columnOrder.filter(
+            (columnId) => !hiddenFields.includes(columnId),
+        );
+        const header = columnOrder.map(
+            (columnId) =>
+                customLabels?.[columnId] ??
+                getItemLabelWithoutTableName(itemMap[columnId]) ??
+                columnId,
+        );
+
+        return [
+            header,
+            ...formattedRows.map((row) =>
+                columnOrder.map((columnId) =>
+                    String(row[columnId]?.value?.formatted ?? ''),
+                ),
+            ),
+        ];
+    }
+
+    // SQL chart tile results as CSV-shaped rows.
+    private async exportSqlChartTileRows({
+        account,
+        dashboardUuid,
+        projectUuid,
+        dashboardFilters,
+        tile,
+        savedSqlUuid,
+    }: {
+        account: AccountType;
+        dashboardUuid: string;
+        projectUuid: string;
+        dashboardFilters: DashboardFilters;
+        tile: DashboardSqlChartTile;
+        savedSqlUuid: string;
+    }): Promise<string[][]> {
+        const { rows } =
+            await this.asyncQueryService.executeDashboardSqlChartQueryAndGetResults(
+                {
+                    account,
+                    projectUuid,
+                    savedSqlUuid,
+                    invalidateCache: true,
+                    context: QueryExecutionContext.GSHEETS,
+                    dashboardUuid,
+                    tileUuid: tile.uuid,
+                    dashboardFilters,
+                    dashboardSorts: [],
+                },
+                SCHEDULER_POLLING_OPTIONS,
+            );
+
+        if (rows.length === 0) {
+            return [[]];
+        }
+        const columnNames = Object.keys(rows[0]);
+        return [
+            columnNames,
+            ...rows.map((row) =>
+                columnNames.map((column) => {
+                    const value = row[column];
+                    if (value === null || value === undefined) return '';
+                    if (value instanceof Date) return value.toISOString();
+                    return String(value);
+                }),
+            ),
+        ];
+    }
+
+    // Rows to write into the export's first tab, so someone opening the sheet
+    // can see what it holds and which output each tab came from.
+    private static buildExportIndexRows({
+        dashboardName,
+        dashboardUrl,
+        exportedAt,
+        outputs,
+        sheetUrlsByTab,
+    }: {
+        dashboardName: string;
+        dashboardUrl: string;
+        exportedAt: Date;
+        outputs: ExportDashboardGsheetOutput[];
+        sheetUrlsByTab: Record<string, string>;
+    }): string[][] {
+        const statusLabel: Record<ExportDashboardGsheetOutputStatus, string> = {
+            success: 'Success',
+            truncated: 'Truncated',
+            failed: 'Failed',
+            unsupported: 'Unsupported',
+        };
+
+        return [
+            ['Lightdash dashboard export'],
+            ['Dashboard', dashboardName],
+            ['Dashboard link', dashboardUrl],
+            ['Exported at', exportedAt.toISOString()],
+            ['Outputs', `${outputs.length}`],
+            [],
+            ['Tab', 'Source', 'Status', 'Rows', 'Details', 'Link'],
+            ...outputs.map((output) => [
+                output.tabName,
+                output.sourceName,
+                statusLabel[output.status],
+                `${output.rowCount}`,
+                output.error ?? '',
+                sheetUrlsByTab[output.tabName] ?? '',
+            ]),
+        ];
+    }
+
+    /**
+     * Exports every chart and SQL chart tile of a dashboard into a newly
+     * created Google Sheet, one tab per output plus an index tab. An output
+     * that cannot be exported still gets a tab carrying its error, so nothing
+     * silently disappears from the sheet.
+     */
+    protected async exportDashboardGsheet(
+        jobId: string,
+        scheduledTime: Date,
+        payload: ExportDashboardGsheetPayload,
+    ) {
+        await this.logWrapper<string>(
+            {
+                task: SCHEDULER_TASKS.EXPORT_DASHBOARD_GSHEET,
+                jobId,
+                scheduledTime,
+                details: {
+                    createdByUserUuid: payload.userUuid,
+                    projectUuid: payload.projectUuid,
+                    organizationUuid: payload.organizationUuid,
+                },
+            },
+            async () => {
+                if (!this.googleDriveClient.isEnabled) {
+                    throw new MissingConfigError('Google Drive is not enabled');
+                }
+
+                const account = await this.userService.getAccountByUserUuid(
+                    payload.userUuid,
+                );
+                const refreshToken = await this.userService.getRefreshToken(
+                    payload.userUuid,
+                );
+                const sessionUser = await this.userService.getSessionByUserUuid(
+                    payload.userUuid,
+                );
+                const dashboard = await this.dashboardService.getByIdOrSlug(
+                    sessionUser,
+                    payload.dashboardUuid,
+                );
+
+                const dashboardUrl = `${this.lightdashConfig.siteUrl}/projects/${dashboard.projectUuid}/dashboards/${payload.dashboardUuid}/view`;
+                const exportedAt = new Date();
+
+                const spreadsheet = await this.googleDriveClient.createNewSheet(
+                    refreshToken,
+                    `${dashboard.name} (Lightdash export ${exportedAt
+                        .toISOString()
+                        .slice(0, 16)
+                        .replace('T', ' ')})`,
+                );
+                const spreadsheetId = spreadsheet.spreadsheetId!;
+                const firstSheetId =
+                    spreadsheet.sheets?.[0]?.properties?.sheetId ?? 0;
+
+                await this.googleDriveClient.renameSheet(
+                    refreshToken,
+                    spreadsheetId,
+                    firstSheetId,
+                    EXPORT_DASHBOARD_GSHEET_INDEX_TAB,
+                );
+
+                const exportableTiles = sortTilesByDashboardOrder(
+                    dashboard.tiles.filter(
+                        (
+                            tile,
+                        ): tile is DashboardChartTile | DashboardSqlChartTile =>
+                            (isDashboardChartTileType(tile) &&
+                                !!tile.properties.savedChartUuid) ||
+                            (isDashboardSqlChartTile(tile) &&
+                                !!tile.properties.savedSqlUuid),
+                    ),
+                    dashboard.tabs,
+                ).filter((tile) =>
+                    isTileInSelectedTabs(tile, payload.selectedTabs ?? null),
+                );
+
+                const dashboardFilters =
+                    payload.dashboardFilters ?? dashboard.filters;
+                const parameters =
+                    payload.parameters ??
+                    getDashboardParametersValuesMap(dashboard);
+
+                const outputs: ExportDashboardGsheetOutput[] = [];
+                let cellsRemaining = EXPORT_DASHBOARD_GSHEET_MAX_CELLS;
+
+                // Sequential so a wide dashboard doesn't hold every tile's
+                // results in memory, and to stay well inside the per-user
+                // Google Sheets write quota.
+                await exportableTiles.reduce(async (promise, tile) => {
+                    await promise;
+
+                    const tabTitle =
+                        tile.properties.title ||
+                        ('chartName' in tile.properties
+                            ? tile.properties.chartName
+                            : undefined) ||
+                        tile.uuid;
+
+                    // A tile whose chart reference is missing can't be
+                    // queried, so it gets a tab explaining that rather than
+                    // disappearing from the sheet.
+                    const chartUuid = isDashboardChartTileType(tile)
+                        ? tile.properties.savedChartUuid
+                        : tile.properties.savedSqlUuid;
+                    if (!chartUuid) {
+                        const tabName =
+                            await this.googleDriveClient.createNewTab(
+                                refreshToken,
+                                spreadsheetId,
+                                tabTitle,
+                            );
+                        await this.googleDriveClient.appendCsvToSheet(
+                            refreshToken,
+                            spreadsheetId,
+                            [['This output is not linked to a saved chart']],
+                            tabName,
+                        );
+                        outputs.push({
+                            tileUuid: tile.uuid,
+                            tabName,
+                            sourceName: tabTitle,
+                            status: 'unsupported',
+                            rowCount: 0,
+                            error: 'Tile is not linked to a saved chart',
+                        });
+                        return;
+                    }
+
+                    let csvRows: string[][];
+                    try {
+                        csvRows = isDashboardChartTileType(tile)
+                            ? await this.exportChartTileRows({
+                                  account,
+                                  dashboardUuid: payload.dashboardUuid,
+                                  projectUuid: dashboard.projectUuid,
+                                  dashboardFilters,
+                                  parameters,
+                                  tile,
+                                  chartUuid,
+                              })
+                            : await this.exportSqlChartTileRows({
+                                  account,
+                                  dashboardUuid: payload.dashboardUuid,
+                                  projectUuid: dashboard.projectUuid,
+                                  dashboardFilters,
+                                  tile,
+                                  savedSqlUuid: chartUuid,
+                              });
+                    } catch (error) {
+                        Logger.warn(
+                            `Dashboard export could not read tile ${tabTitle}: ${getErrorMessage(
+                                error,
+                            )}`,
+                        );
+                        const tabName =
+                            await this.googleDriveClient.createNewTab(
+                                refreshToken,
+                                spreadsheetId,
+                                tabTitle,
+                            );
+                        await this.googleDriveClient.appendCsvToSheet(
+                            refreshToken,
+                            spreadsheetId,
+                            [
+                                ['This output could not be exported'],
+                                [getErrorMessage(error)],
+                            ],
+                            tabName,
+                        );
+                        outputs.push({
+                            tileUuid: tile.uuid,
+                            tabName,
+                            sourceName: tabTitle,
+                            status: 'failed',
+                            rowCount: 0,
+                            error: getErrorMessage(error),
+                        });
+                        return;
+                    }
+
+                    // Header row always survives; the budget only trims data.
+                    const columnCount = csvRows[0]?.length ?? 1;
+                    const maxRowsByBudget = Math.max(
+                        1,
+                        Math.floor(cellsRemaining / Math.max(columnCount, 1)),
+                    );
+                    const maxRows = Math.min(
+                        maxRowsByBudget,
+                        EXPORT_DASHBOARD_GSHEET_MAX_ROWS_PER_TAB + 1,
+                    );
+                    const isTruncated = csvRows.length > maxRows;
+                    const writtenRows = isTruncated
+                        ? csvRows.slice(0, maxRows)
+                        : csvRows;
+                    cellsRemaining -= writtenRows.length * columnCount;
+
+                    const tabName = await this.googleDriveClient.createNewTab(
+                        refreshToken,
+                        spreadsheetId,
+                        tabTitle,
+                    );
+                    await this.googleDriveClient.appendCsvToSheet(
+                        refreshToken,
+                        spreadsheetId,
+                        writtenRows,
+                        tabName,
+                    );
+
+                    outputs.push({
+                        tileUuid: tile.uuid,
+                        tabName,
+                        sourceName: tabTitle,
+                        status: isTruncated ? 'truncated' : 'success',
+                        rowCount: Math.max(writtenRows.length - 1, 0),
+                        error: isTruncated
+                            ? `Truncated to ${Math.max(
+                                  writtenRows.length - 1,
+                                  0,
+                              )} rows to stay within the spreadsheet cell limit`
+                            : null,
+                    });
+                }, Promise.resolve());
+
+                const sheetIds =
+                    await this.googleDriveClient.getSheetIdsByTitle(
+                        refreshToken,
+                        spreadsheetId,
+                    );
+                const sheetUrlsByTab = Object.entries(sheetIds).reduce<
+                    Record<string, string>
+                >(
+                    (acc, [title, sheetId]) => ({
+                        ...acc,
+                        [title]: `https://docs.google.com/spreadsheets/d/${spreadsheetId}/edit#gid=${sheetId}`,
+                    }),
+                    {},
+                );
+
+                await this.googleDriveClient.appendCsvToSheet(
+                    refreshToken,
+                    spreadsheetId,
+                    SchedulerTask.buildExportIndexRows({
+                        dashboardName: dashboard.name,
+                        dashboardUrl,
+                        exportedAt,
+                        outputs,
+                        sheetUrlsByTab,
+                    }),
+                    EXPORT_DASHBOARD_GSHEET_INDEX_TAB,
+                );
+
+                return {
+                    fileUrl: `https://docs.google.com/spreadsheets/d/${spreadsheetId}/edit`,
+                    outputCount: `${outputs.length}`,
+                    failedCount: `${
+                        outputs.filter((o) => o.status === 'failed').length
+                    }`,
+                };
+            },
+        );
     }
 
     protected async uploadGsheets(

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -145,6 +145,12 @@ const getTagsForTask: {
         'project.uuid': payload.projectUuid,
     }),
 
+    [SCHEDULER_TASKS.EXPORT_DASHBOARD_GSHEET]: (payload) => ({
+        'organization.uuid': payload.organizationUuid,
+        'user.uuid': payload.userUuid,
+        'project.uuid': payload.projectUuid,
+    }),
+
     [SCHEDULER_TASKS.EXPORT_CONTENT]: (payload) => ({
         'organization.uuid': payload.organizationUuid,
         'user.uuid': payload.userUuid,

--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -1128,6 +1128,42 @@ export class SchedulerWorker extends SchedulerTask {
                     },
                 );
             },
+            [SCHEDULER_TASKS.EXPORT_DASHBOARD_GSHEET]: async (
+                payload,
+                helpers,
+            ) => {
+                await tryJobOrTimeout(
+                    SchedulerClient.processJob(
+                        SCHEDULER_TASKS.EXPORT_DASHBOARD_GSHEET,
+                        helpers.job.id,
+                        helpers.job.run_at,
+                        payload,
+                        async () => {
+                            await this.exportDashboardGsheet(
+                                helpers.job.id,
+                                helpers.job.run_at,
+                                payload,
+                            );
+                        },
+                    ),
+                    helpers.job,
+                    this.lightdashConfig.scheduler.jobTimeout,
+                    async (job, e) => {
+                        await this.schedulerService.logSchedulerJob({
+                            task: SCHEDULER_TASKS.EXPORT_DASHBOARD_GSHEET,
+                            jobId: job.id,
+                            scheduledTime: job.run_at,
+                            status: SchedulerJobStatus.ERROR,
+                            details: {
+                                projectUuid: payload.projectUuid,
+                                organizationUuid: payload.organizationUuid,
+                                error: getErrorMessage(e),
+                                createdByUserUuid: payload.userUuid,
+                            },
+                        });
+                    },
+                );
+            },
             [SCHEDULER_TASKS.EXPORT_CONTENT]: async (payload, helpers) => {
                 await tryJobOrTimeout(
                     SchedulerClient.processJob(

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -6972,6 +6972,54 @@ export class AsyncQueryService extends ProjectService {
     }
 
     /**
+     * Execute a dashboard SQL chart tile query and wait for all results.
+     * Mirrors executeSqlChartQueryAndGetResults but keeps the dashboard's
+     * filters and tile context.
+     */
+    async executeDashboardSqlChartQueryAndGetResults(
+        args: Parameters<
+            AsyncQueryService['executeAsyncDashboardSqlChartQuery']
+        >[0],
+        pollingOptions?: PollingOptions,
+    ): Promise<{ rows: Record<string, unknown>[] }> {
+        const { account, projectUuid } = args;
+
+        const { queryUuid } =
+            await this.executeAsyncDashboardSqlChartQuery(args);
+
+        await this.pollForQueryCompletion({
+            account,
+            projectUuid,
+            queryUuid,
+            ...pollingOptions,
+        });
+
+        const queryHistory = await this.queryHistoryModel.get(
+            queryUuid,
+            projectUuid,
+            account,
+        );
+
+        if (!queryHistory.resultsFileName) {
+            throw new Error('Results file name not found for query');
+        }
+
+        const resultsStream = await this.getResultsStorageClientForContext(
+            queryHistory.context,
+        ).getDownloadStream(queryHistory.resultsFileName);
+
+        const rows: Record<string, unknown>[] = [];
+        await streamJsonlData<void>({
+            readStream: resultsStream,
+            onRow: (rawRow) => {
+                rows.push(rawRow);
+            },
+        });
+
+        return { rows };
+    }
+
+    /**
      * Execute dashboard chart query and wait for all results.
      * Returns raw rows from warehouse with pivot details.
      */

--- a/packages/backend/src/services/GdriveService/GdriveService.ts
+++ b/packages/backend/src/services/GdriveService/GdriveService.ts
@@ -2,6 +2,7 @@ import { subject } from '@casl/ability';
 import {
     Account,
     CustomSqlQueryForbiddenError,
+    ExportDashboardGsheetRequest,
     ForbiddenError,
     GoogleNotConnectedError,
     isCustomSqlDimension,
@@ -125,6 +126,73 @@ export class GdriveService extends BaseService {
 
         const { jobId } =
             await this.schedulerClient.uploadGsheetFromQueryJob(payload);
+
+        return { jobId };
+    }
+
+    /**
+     * Queues an ad-hoc export of a dashboard into a newly created Google Sheet.
+     */
+    async scheduleExportDashboardGsheet(
+        account: Account,
+        projectUuid: string,
+        dashboardUuid: string,
+        options: ExportDashboardGsheetRequest,
+    ) {
+        const projectSummary = await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(account);
+        const projectMetadata = {
+            projectUuid: projectSummary.projectUuid,
+            projectName: projectSummary.name,
+        };
+
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('ExportCsv', {
+                    organizationUuid: projectSummary.organizationUuid,
+                    projectUuid: projectSummary.projectUuid,
+                    metadata: projectMetadata,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('GoogleSheets', {
+                    organizationUuid: projectSummary.organizationUuid,
+                    projectUuid: projectSummary.projectUuid,
+                    metadata: projectMetadata,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        try {
+            await this.userOAuthGrantsModel.getRefreshToken(
+                account.user.id,
+                OpenIdIdentityIssuerType.GOOGLE,
+            );
+        } catch (e) {
+            if (e instanceof NotFoundError) {
+                throw new GoogleNotConnectedError(
+                    'Google account not connected',
+                );
+            }
+            throw e;
+        }
+
+        const { jobId } = await this.schedulerClient.exportDashboardGsheetJob({
+            ...options,
+            dashboardUuid,
+            projectUuid,
+            userUuid: account.user.id,
+            organizationUuid: projectSummary.organizationUuid,
+        });
 
         return { jobId };
     }

--- a/packages/common/src/types/gdrive.ts
+++ b/packages/common/src/types/gdrive.ts
@@ -63,3 +63,32 @@ export const UPLOAD_GSHEET_FROM_ROWS_MAX_BYTES = 25 * 1024 * 1024;
 
 /** Max row count accepted by /gdrive/upload-gsheet-from-rows. */
 export const UPLOAD_GSHEET_FROM_ROWS_MAX_ROWS = 100_000;
+
+/**
+ * Google caps a spreadsheet at 10 million cells across all tabs. Budget half of
+ * that so a large dashboard export fails predictably by truncating tabs rather
+ * than being rejected mid-write.
+ */
+export const EXPORT_DASHBOARD_GSHEET_MAX_CELLS = 5_000_000;
+
+/** Max rows written to any single tab of a dashboard export. */
+export const EXPORT_DASHBOARD_GSHEET_MAX_ROWS_PER_TAB = 50_000;
+
+/** Title of the index tab written as the first tab of a dashboard export. */
+export const EXPORT_DASHBOARD_GSHEET_INDEX_TAB = 'Export summary';
+
+export type ExportDashboardGsheetOutputStatus =
+    | 'success'
+    | 'truncated'
+    | 'failed'
+    | 'unsupported';
+
+/** One dashboard output and how it fared in the export. */
+export type ExportDashboardGsheetOutput = {
+    tileUuid: string;
+    tabName: string;
+    sourceName: string;
+    status: ExportDashboardGsheetOutputStatus;
+    rowCount: number;
+    error: string | null;
+};

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -879,6 +879,22 @@ export type ExportContentPayload = TraceTaskBase & {
     encodedJwt?: string;
 };
 
+/** Ad-hoc export of a dashboard into a newly created Google Sheet. */
+export type ExportDashboardGsheetPayload = TraceTaskBase & {
+    dashboardUuid: string;
+    dashboardFilters?: DashboardFilters;
+    dateZoomGranularity?: DateGranularity | string;
+    selectedTabs?: string[] | null;
+    parameters?: ParametersValuesMap;
+};
+
+export type ExportDashboardGsheetRequest = {
+    dashboardFilters?: DashboardFilters;
+    dateZoomGranularity?: DateGranularity | string;
+    selectedTabs?: string[] | null;
+    parameters?: ParametersValuesMap;
+};
+
 export type ExportContentRequest = {
     format: ExportContentFormat;
     options?: SchedulerCsvOptions | SchedulerImageOptions;

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -29,6 +29,7 @@ import {
     type EmailNotificationPayload,
     type ExportContentPayload,
     type ExportCsvDashboardPayload,
+    type ExportDashboardGsheetPayload,
     type GoogleChatBatchNotificationPayload,
     type GoogleChatNotificationPayload,
     type GsheetsNotificationPayload,
@@ -191,6 +192,7 @@ export const SCHEDULER_TASKS = {
     INDEX_CATALOG: 'indexCatalog',
     GENERATE_DAILY_JOBS: 'generateDailyJobs',
     EXPORT_CSV_DASHBOARD: 'exportCsvDashboard',
+    EXPORT_DASHBOARD_GSHEET: 'exportDashboardGsheet',
     EXPORT_CONTENT: 'exportContent',
     RENAME_RESOURCES: 'renameResources',
     MATERIALIZE_PRE_AGGREGATE: 'materializePreAggregate',
@@ -237,6 +239,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.INDEX_CATALOG]: SchedulerIndexCatalogJobPayload;
     [SCHEDULER_TASKS.GENERATE_DAILY_JOBS]: TraceTaskBase;
     [SCHEDULER_TASKS.EXPORT_CSV_DASHBOARD]: ExportCsvDashboardPayload;
+    [SCHEDULER_TASKS.EXPORT_DASHBOARD_GSHEET]: ExportDashboardGsheetPayload;
     [SCHEDULER_TASKS.EXPORT_CONTENT]: ExportContentPayload;
     [SCHEDULER_TASKS.SLACK_AI_PROMPT]: SlackPromptJobPayload;
     [SCHEDULER_TASKS.RENAME_RESOURCES]: RenameResourcesPayload;

--- a/packages/frontend/src/api/csv.ts
+++ b/packages/frontend/src/api/csv.ts
@@ -1,6 +1,7 @@
 import {
     type ApiDownloadCsv,
     type ApiScheduledDownloadCsv,
+    type ExportDashboardGsheetRequest,
 } from '@lightdash/common';
 import { lightdashApi } from '../api';
 
@@ -9,4 +10,18 @@ export const getCsvFileUrl = async ({ jobId }: ApiScheduledDownloadCsv) =>
         url: `/csv/${jobId}`,
         method: 'GET',
         body: undefined,
+    });
+
+export const exportDashboardToGsheet = async ({
+    projectUuid,
+    dashboardUuid,
+    ...body
+}: ExportDashboardGsheetRequest & {
+    projectUuid: string;
+    dashboardUuid: string;
+}) =>
+    lightdashApi<ApiScheduledDownloadCsv>({
+        url: `/gdrive/export-dashboard/${projectUuid}/${dashboardUuid}`,
+        method: 'POST',
+        body: JSON.stringify(body),
     });

--- a/packages/frontend/src/components/SchedulersView/RunDetailsModal.tsx
+++ b/packages/frontend/src/components/SchedulersView/RunDetailsModal.tsx
@@ -862,21 +862,23 @@ const RunDetailsModal: FC<RunDetailsModalProps> = ({
         };
     }, [jobSummaries]);
 
-    // Extract partial failures from the parent job's completed log details
+    // Partial failures are reported either by the parent delivery job, or by a
+    // child job that completed with some of its outputs missing (a Google
+    // Sheets sync that skipped an unqueryable chart, for example).
     const partialFailures = useMemo<PartialFailure[]>(() => {
         if (!childLogs) return [];
 
-        // Find the parent job's completed log (handleScheduledDelivery task)
-        const parentCompletedLog = childLogs.find(
-            (log) =>
-                log.isParent &&
-                log.task === 'handleScheduledDelivery' &&
-                log.status === SchedulerJobStatus.COMPLETED,
-        );
-
-        if (!parentCompletedLog?.details?.partialFailures) return [];
-
-        return parentCompletedLog.details.partialFailures as PartialFailure[];
+        return childLogs
+            .filter(
+                (log) =>
+                    log.status === SchedulerJobStatus.COMPLETED &&
+                    ((log.isParent && log.task === 'handleScheduledDelivery') ||
+                        log.details?.partialFailure === true),
+            )
+            .flatMap(
+                (log) =>
+                    (log.details?.partialFailures as PartialFailure[]) ?? [],
+            );
     }, [childLogs]);
 
     if (!run) return null;

--- a/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
@@ -14,6 +14,7 @@ import {
     Text,
     Tooltip,
 } from '@mantine/core';
+import { IconTableExport } from '@tabler/icons-react';
 import {
     IconCsv,
     IconFileExport,
@@ -23,6 +24,8 @@ import {
     IconScreenshot,
 } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
+import { exportDashboardToGsheet } from '../../../api/csv';
+import { useExportToGoogleSheet } from '../../../features/export/hooks/useExportToGoogleSheet';
 import { PreviewAndCustomizeScreenshot } from '../../../features/preview';
 import { CsvFormattingOptions } from '../../../features/scheduler/components/CsvFormattingOptions';
 import { Limit, Values } from '../../../features/scheduler/components/types';
@@ -31,6 +34,7 @@ import {
     useExportDashboardContent,
     useExportDashboardContentPreview,
 } from '../../../hooks/dashboard/useDashboard';
+import useHealth from '../../../hooks/health/useHealth';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
 import Callout from '../Callout';
 import MantineIcon from '../MantineIcon';
@@ -51,8 +55,13 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
     dashboard,
 }) => {
     const [exportType, setExportType] = useState<
-        SchedulerFormat.IMAGE | SchedulerFormat.CSV | SchedulerFormat.XLSX
+        | SchedulerFormat.IMAGE
+        | SchedulerFormat.CSV
+        | SchedulerFormat.XLSX
+        | SchedulerFormat.GSHEETS
     >(SchedulerFormat.IMAGE);
+    const health = useHealth();
+    const isGoogleSheetsEnabled = !!health.data?.auth.google.enabled;
     const exportDashboardContentMutation = useExportDashboardContent();
     const dashboardFilters = useDashboardContext((c) => c.allFilters);
     const dateZoomGranularity = useDashboardContext(
@@ -130,6 +139,7 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
     );
 
     const handleAsyncExport = useCallback(() => {
+        if (exportType === SchedulerFormat.GSHEETS) return;
         exportDashboardContentMutation.mutate({
             dashboard,
             format: exportType,
@@ -157,6 +167,29 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
         parameterValues,
         previewChoice,
     ]);
+
+    // Each export creates a brand new sheet, so nothing the user already has
+    // is overwritten.
+    const {
+        startExporting: startGsheetExport,
+        isExporting: isGsheetExporting,
+    } = useExportToGoogleSheet({
+        getGsheetLink: () =>
+            exportDashboardToGsheet({
+                projectUuid: dashboard.projectUuid,
+                dashboardUuid: dashboard.uuid,
+                dashboardFilters,
+                dateZoomGranularity,
+                parameters: parameterValues,
+                selectedTabs: exportSelectedTabs,
+            }),
+    });
+
+    // The polling query lives in this component, so the modal has to stay
+    // mounted until the export resolves; closing it would strand the toast.
+    const handleGsheetExport = useCallback(() => {
+        startGsheetExport();
+    }, [startGsheetExport]);
 
     const handleImageExport = useCallback(() => {
         if (previewChoice && previews[getPreviewKey(previewChoice)]) {
@@ -211,6 +244,19 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
             );
         }
 
+        if (exportType === SchedulerFormat.GSHEETS) {
+            return (
+                <Button
+                    loading={isGsheetExporting}
+                    onClick={handleGsheetExport}
+                    disabled={!hasTilesInSelectedTabs()}
+                    leftSection={<MantineIcon icon={IconTableExport} />}
+                >
+                    Export to Google Sheets
+                </Button>
+            );
+        }
+
         if (exportType === SchedulerFormat.XLSX) {
             return (
                 <Button
@@ -257,6 +303,14 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
                             { label: 'Image', value: SchedulerFormat.IMAGE },
                             { label: '.csv', value: SchedulerFormat.CSV },
                             { label: '.xlsx', value: SchedulerFormat.XLSX },
+                            ...(isGoogleSheetsEnabled
+                                ? [
+                                      {
+                                          label: 'Google Sheets',
+                                          value: SchedulerFormat.GSHEETS,
+                                      },
+                                  ]
+                                : []),
                         ]}
                         w="min-content"
                         radius="md"
@@ -266,48 +320,57 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
                                 value as
                                     | SchedulerFormat.IMAGE
                                     | SchedulerFormat.CSV
-                                    | SchedulerFormat.XLSX,
+                                    | SchedulerFormat.XLSX
+                                    | SchedulerFormat.GSHEETS,
                             )
                         }
                     />
-                    {exportType !== SchedulerFormat.IMAGE && (
+                    {exportType === SchedulerFormat.GSHEETS && (
                         <Text fs="italic" fz="sm" c="dimmed">
-                            Charts from the selected tabs will be exported as
-                            tables
-                            {exportType === SchedulerFormat.XLSX &&
-                            xlsxFileLayout === 'workbook'
-                                ? ' in one workbook.'
-                                : ' in a ZIP file.'}
+                            A new Google Sheet will be created, with one tab per
+                            chart and a summary tab listing them.
                         </Text>
                     )}
+                    {exportType !== SchedulerFormat.IMAGE &&
+                        exportType !== SchedulerFormat.GSHEETS && (
+                            <Text fs="italic" fz="sm" c="dimmed">
+                                Charts from the selected tabs will be exported
+                                as tables
+                                {exportType === SchedulerFormat.XLSX &&
+                                xlsxFileLayout === 'workbook'
+                                    ? ' in one workbook.'
+                                    : ' in a ZIP file.'}
+                            </Text>
+                        )}
                 </Stack>
 
-                {exportType !== SchedulerFormat.IMAGE && (
-                    <Stack gap="xs">
-                        {!!dateZoomGranularity && (
-                            <Callout
-                                title="Date zoom is enabled"
-                                variant="info"
-                            >
-                                Your export will include data for the selected
-                                date zoom granularity.
-                            </Callout>
-                        )}
-                        <CsvFormattingOptions
-                            format={exportType}
-                            formatted={formatted}
-                            onFormattedChange={setFormatted}
-                            limit={limit}
-                            onLimitChange={setLimit}
-                            customLimit={customLimit}
-                            onCustomLimitChange={setCustomLimit}
-                            exportPivotedData={exportPivotedData}
-                            onExportPivotedDataChange={setExportPivotedData}
-                            xlsxFileLayout={xlsxFileLayout}
-                            onXlsxFileLayoutChange={setXlsxFileLayout}
-                        />
-                    </Stack>
-                )}
+                {exportType !== SchedulerFormat.IMAGE &&
+                    exportType !== SchedulerFormat.GSHEETS && (
+                        <Stack gap="xs">
+                            {!!dateZoomGranularity && (
+                                <Callout
+                                    title="Date zoom is enabled"
+                                    variant="info"
+                                >
+                                    Your export will include data for the
+                                    selected date zoom granularity.
+                                </Callout>
+                            )}
+                            <CsvFormattingOptions
+                                format={exportType}
+                                formatted={formatted}
+                                onFormattedChange={setFormatted}
+                                limit={limit}
+                                onLimitChange={setLimit}
+                                customLimit={customLimit}
+                                onCustomLimitChange={setCustomLimit}
+                                exportPivotedData={exportPivotedData}
+                                onExportPivotedDataChange={setExportPivotedData}
+                                xlsxFileLayout={xlsxFileLayout}
+                                onXlsxFileLayoutChange={setXlsxFileLayout}
+                            />
+                        </Stack>
+                    )}
 
                 {isDashboardTabsAvailable && dashboard.tabs.length > 1 && (
                     <Stack gap="xs">


### PR DESCRIPTION
Groundwork for: https://linear.app/lightdash/issue/PROD-926/i-want-to-export-dashboard-csvs-to-google-sheets

> This PR does **not** satisfy PROD-926. It fixes a live bug in the existing scheduled
> Google Sheets sync and extracts the shared tab-writing seam that the export feature
> builds on. The feature itself — creating a new spreadsheet, the index tab, and the
> export action — lands in a follow-up PR.

## Summary

A dashboard Google Sheets sync writes one tab per chart tile. If any single chart failed to query — a deleted field, a broken metric, a warehouse hiccup — the whole sync died and **no tab was written at all**, including for the charts that were perfectly healthy.

Chart-level and sheet-level failures were treated identically, which is the root of both the lost data and the missing reporting.

## Root cause

`uploadGsheets` walked the chart tiles in a sequential `reduce` with no per-chart error handling, so the first rejection propagated straight out of the loop and failed the job:

```ts
await chartTiles.reduce(async (promise, tile) => {
    await promise;
    // query the chart, then create + write its tab
    // any rejection here aborts every remaining tile
}, Promise.resolve());
```

The loop wrote tabs one at a time, so a chart failing partway through also left the tabs already written holding fresh data while the rest kept the previous run's — with the job marked `error` and no indication of which chart was responsible.

## Fix

Extracts the loop into `writeDashboardChartTabs` and splits each tile **by phase**, because the two kinds of failure need opposite handling:

- **Chart-scoped** (fetching the chart, running its query) — recoverable. Recorded as a partial failure and skipped, so the other charts still reach the sheet.
- **Sheet-scoped** (every `googleDriveClient` call) — fatal. Left outside the `try`, so quota, revoked access, and transient Google errors still abort the run and let the worker retry or disable the sync. Swallowing these would report a completed sync while tabs silently went stale.

- `packages/backend/src/scheduler/SchedulerTask.ts` — extracts `writeDashboardChartTabs`, returning a `written` / `failed` result per tile. On total failure it rethrows the **original error** rather than wrapping it, so the delivery keeps the error class `shouldDisableSync` uses to choose between retry and disable. Tabs are now keyed by tile rather than by saved chart, so two tiles showing the same chart no longer collapse onto one tab.
- `packages/frontend/src/components/SchedulersView/RunDetailsModal.tsx` — reads partial failures from child jobs, not just the parent, so the failed charts are actually listed.

Failed charts keep their previous tab contents. The run now reports itself as degraded, but writing an error marker into the failed chart's tab is the ticket's specified behaviour and lands in a follow-up.

## Before / After

Same dashboard (10 chart tiles), same spreadsheet, one chart pointed at a non-existent metric, run against the real Google Sheets API:

```
Before
  job status      error
  tabs written    0 of 10   ██
  reporting       "Tried to reference metric with unknown field id: ..."
                  (no indication which chart)

After
  job status      completed
  tabs written    9 of 10   ██████████████████░░
  reporting       partialFailure: true
                  partialFailures[0].chartName = the failing chart
  run history     runStatus: "partial_failure"
```

## Test plan

- [x] `pnpm -F backend typecheck && pnpm -F backend lint` — clean
- [x] `pnpm -F frontend typecheck && pnpm -F frontend lint` — clean
- [x] `vitest run src/scheduler/SchedulerTask.test.ts` — 82 pass, including new regression tests: healthy tiles still export when one fails, the failure is recorded, a write failure propagates instead of being recorded, permanent vs transient total failures keep the right retryability, and two tiles sharing a chart get separate tabs
- [x] Manual: real dashboard sync to a real Google Sheet — 10 chart tabs + metadata written, pivot branch included, data verified via the Sheets API
- [x] Manual: reproduced the bug on pre-fix code against real Google (0/10 tabs), then confirmed the fix on the same scenario (9/10 tabs, failing chart named)
- [x] Manual: run history reports `partial_failure` rather than a green `completed`
