### PR TITLE
fix(deep-research): make charts warehouse-only so one chart cannot lose a report

### DIFF
--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
@@ -1457,52 +1457,7 @@ describe('AiDeepResearchService', () => {
             );
         });
 
-        it('rejects inline charts from query-backed reports', async () => {
-            const inlineChart = {
-                source: 'inline' as const,
-                key: 'refund-share',
-                title: 'Refund share by month',
-                chartConfig: chart.chartConfig,
-                columns: [
-                    { id: 'month', label: 'Month', type: 'string' as const },
-                    {
-                        id: 'refund_share',
-                        label: 'Refund share',
-                        type: 'number' as const,
-                    },
-                ],
-                rows: [
-                    ['2026-05', 0.12],
-                    ['2026-06', 0.19],
-                ],
-                derivedFrom: [
-                    chart.queryUuid,
-                    '00000000-0000-4000-8000-000000000009',
-                ],
-            };
-            const inlineMarkdown = reportMarkdown.replace(
-                'The baseline trend is stable.',
-                `The baseline trend is stable.\n\n<chart id="${inlineChart.key}" title="${inlineChart.title}" description="The enterprise ratio was lower than the SMB ratio.">`,
-            );
-            const { service, model } = buildService({
-                executor: vi.fn().mockResolvedValue({
-                    status: 'completed',
-                    report: {
-                        markdown: inlineMarkdown,
-                        charts: [inlineChart],
-                    },
-                    warehouseQueryUuids: [chart.queryUuid],
-                }),
-            });
-
-            await expect(
-                service.executeRun({ aiDeepResearchRunUuid: 'run-1' }),
-            ).rejects.toThrow('evidence could not be verified');
-            expect(model.markCompleted).not.toHaveBeenCalled();
-            expect(model.markFailed).toHaveBeenCalled();
-        });
-
-        it('rejects a query that was not returned by this run', async () => {
+        it('drops a chart whose query this run did not return', async () => {
             const { service, model, queryHistoryModel } = buildService({
                 executor: vi.fn().mockResolvedValue({
                     status: 'completed',
@@ -1511,16 +1466,23 @@ describe('AiDeepResearchService', () => {
                 }),
             });
 
-            await expect(
-                service.executeRun({ aiDeepResearchRunUuid: 'run-1' }),
-            ).rejects.toThrow('evidence could not be verified');
+            await service.executeRun({ aiDeepResearchRunUuid: 'run-1' });
 
+            // A queryUuid outside the run's own set is rejected without even
+            // reaching query history.
             expect(queryHistoryModel.getByQueryUuid).not.toHaveBeenCalled();
-            expect(model.markCompleted).not.toHaveBeenCalled();
-            expect(model.markFailed).toHaveBeenCalled();
+            expect(model.markFailed).not.toHaveBeenCalled();
+            expect(model.markCompleted).toHaveBeenCalledWith(
+                'run-1',
+                expect.not.stringContaining(chart.queryUuid),
+            );
+            expect(model.markCompleted).toHaveBeenCalledWith(
+                'run-1',
+                expect.stringContaining('The baseline trend is stable.'),
+            );
         });
 
-        it('rejects a replayed same-user query that predates this run', async () => {
+        it('drops a chart backed by a replayed query that predates this run', async () => {
             const { service, model } = buildService({
                 executor: vi.fn().mockResolvedValue({
                     status: 'completed',
@@ -1553,14 +1515,21 @@ describe('AiDeepResearchService', () => {
                 },
             });
 
-            await expect(
-                service.executeRun({ aiDeepResearchRunUuid: 'run-1' }),
-            ).rejects.toThrow('evidence could not be verified');
-            expect(model.markCompleted).not.toHaveBeenCalled();
-            expect(model.markFailed).toHaveBeenCalled();
+            await service.executeRun({ aiDeepResearchRunUuid: 'run-1' });
+
+            // The narrative still publishes; only the unverifiable chart goes.
+            expect(model.markFailed).not.toHaveBeenCalled();
+            expect(model.markCompleted).toHaveBeenCalledWith(
+                'run-1',
+                expect.not.stringContaining(chart.queryUuid),
+            );
+            expect(model.markCompleted).toHaveBeenCalledWith(
+                'run-1',
+                expect.stringContaining('The baseline trend is stable.'),
+            );
         });
 
-        it('rejects chart fields that are absent from the verified query', async () => {
+        it('drops a chart whose fields are absent from the verified query', async () => {
             const { service, model } = buildService({
                 executor: vi.fn().mockResolvedValue({
                     status: 'completed',
@@ -1588,11 +1557,18 @@ describe('AiDeepResearchService', () => {
                 },
             });
 
-            await expect(
-                service.executeRun({ aiDeepResearchRunUuid: 'run-1' }),
-            ).rejects.toThrow('evidence could not be verified');
-            expect(model.markCompleted).not.toHaveBeenCalled();
-            expect(model.markFailed).toHaveBeenCalled();
+            await service.executeRun({ aiDeepResearchRunUuid: 'run-1' });
+
+            // The narrative still publishes; only the unverifiable chart goes.
+            expect(model.markFailed).not.toHaveBeenCalled();
+            expect(model.markCompleted).toHaveBeenCalledWith(
+                'run-1',
+                expect.not.stringContaining(chart.queryUuid),
+            );
+            expect(model.markCompleted).toHaveBeenCalledWith(
+                'run-1',
+                expect.stringContaining('The baseline trend is stable.'),
+            );
         });
 
         it('lets a concurrent cancellation request win over completion', async () => {
@@ -1837,37 +1813,6 @@ describe('AiDeepResearchService', () => {
                     chartKey: chart.queryUuid,
                 }),
             ).rejects.toBeInstanceOf(NotFoundError);
-            expect(
-                asyncQueryService.executeAsyncMetricQuery,
-            ).not.toHaveBeenCalled();
-        });
-
-        it('rejects refreshing an inline chart', async () => {
-            const { service, asyncQueryService } = buildService({
-                model: {
-                    findByUuidScoped: vi.fn().mockResolvedValue(
-                        runRow({
-                            result_chart_data: {
-                                'refund-share': {
-                                    ...chartDataEntry,
-                                    source: 'inline' as const,
-                                    queryUuid: null,
-                                },
-                            },
-                        }),
-                    ),
-                },
-            });
-
-            await expect(
-                service.refreshChart({
-                    account: {} as AnyType,
-                    user: userWithProjectAccess(),
-                    projectUuid: 'project-1',
-                    aiDeepResearchRunUuid: 'run-1',
-                    chartKey: 'refund-share',
-                }),
-            ).rejects.toBeInstanceOf(ParameterError);
             expect(
                 asyncQueryService.executeAsyncMetricQuery,
             ).not.toHaveBeenCalled();

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
@@ -14,6 +14,7 @@ import {
     ParameterError,
     QueryExecutionContext,
     QueryHistoryStatus,
+    removeDeepResearchChartRefs,
     UnexpectedServerError,
     type Account,
     type AiDeepResearchBudget,
@@ -854,14 +855,8 @@ export class AiDeepResearchService extends BaseService {
                 `Deep Research chart ${args.chartKey} not found`,
             );
         }
-        const legacyChart = run.result_chart_data?.[args.chartKey];
-        if (legacyChart?.source === 'inline') {
-            throw new ParameterError(
-                'Only warehouse-backed Deep Research charts can be refreshed',
-            );
-        }
         const chart =
-            legacyChart ??
+            run.result_chart_data?.[args.chartKey] ??
             (await this.getChart({
                 user: args.user,
                 projectUuid: args.projectUuid,
@@ -1137,6 +1132,11 @@ export class AiDeepResearchService extends BaseService {
         }
     }
 
+    /**
+     * A chart whose evidence cannot be verified is dropped from the report,
+     * never allowed to discard it: the narrative is the deliverable, and losing
+     * a finished report over one chart is the worse failure.
+     */
     private async prepareEvidenceReport(
         run: DbAiDeepResearchRun,
         report: AiDeepResearchSubmittedReport,
@@ -1146,37 +1146,34 @@ export class AiDeepResearchService extends BaseService {
 
         await Promise.all(
             report.charts.map(async (chart) => {
-                const key =
-                    chart.source === 'warehouse' ? chart.queryUuid : chart.key;
                 try {
-                    const entry =
-                        chart.source === 'warehouse'
-                            ? await this.buildWarehouseChartData(
-                                  run,
-                                  chart,
-                                  runQueryUuids,
-                              )
-                            : null;
+                    const entry = await this.buildWarehouseChartData(
+                        run,
+                        chart,
+                        runQueryUuids,
+                    );
                     if (!entry) {
-                        omittedKeys.add(key);
+                        omittedKeys.add(chart.queryUuid);
                     }
                 } catch (error) {
                     this.logger.error(
-                        `Deep Research run ${run.ai_deep_research_run_uuid} could not prepare chart ${key}: ${getErrorMessage(error)}`,
+                        `Deep Research run ${run.ai_deep_research_run_uuid} could not prepare chart ${chart.queryUuid}: ${getErrorMessage(error)}`,
                     );
-                    omittedKeys.add(key);
+                    omittedKeys.add(chart.queryUuid);
                 }
             }),
         );
 
-        if (omittedKeys.size === 0) {
-            return { markdown: report.markdown };
+        if (omittedKeys.size > 0) {
+            this.logger.warn(
+                `Deep Research run ${run.ai_deep_research_run_uuid} published without unverifiable chart(s): ${[
+                    ...omittedKeys,
+                ].join(', ')}`,
+            );
         }
-        throw new UnexpectedServerError(
-            `Deep Research report evidence could not be verified for chart(s): ${[
-                ...omittedKeys,
-            ].join(', ')}`,
-        );
+        return {
+            markdown: removeDeepResearchChartRefs(report.markdown, omittedKeys),
+        };
     }
 
     private async findRunWarehouseChart(
@@ -1247,7 +1244,6 @@ export class AiDeepResearchService extends BaseService {
             title: chart.title,
             chartConfig: chart.chartConfig,
             queryUuid: chart.queryUuid,
-            derivedFrom: null,
             metricQuery: queryHistory.metricQuery,
             fields: queryHistory.fields,
             snapshot: null,

--- a/packages/backend/src/ee/services/ai/prompts/deepResearch.ts
+++ b/packages/backend/src/ee/services/ai/prompts/deepResearch.ts
@@ -1,8 +1,6 @@
 import {
     AI_DEEP_RESEARCH_MAX_CHART_DESCRIPTION_CHARS,
     AI_DEEP_RESEARCH_MAX_CHARTS,
-    AI_DEEP_RESEARCH_MAX_INLINE_COLUMNS,
-    AI_DEEP_RESEARCH_MAX_INLINE_ROWS,
 } from '@lightdash/common';
 
 export const AI_DEEP_RESEARCH_INSTRUCTIONS = `You are running a Deep Research investigation using this agent's full configured context and tools.
@@ -23,8 +21,7 @@ Structure:
 Charts:
 - Define every chart in the charts argument and reference it exactly once in markdown as <chart id="<key>" title="<chart title>" description="<standalone summary>">.
 - Keep each chart description at most ${AI_DEEP_RESEARCH_MAX_CHART_DESCRIPTION_CHARS} characters.
-- A warehouse chart's queryUuid must come from a query result produced during this run.
-- Use inline charts only for derived or external data that no single warehouse query produced. They may contain at most ${AI_DEEP_RESEARCH_MAX_INLINE_ROWS} rows and ${AI_DEEP_RESEARCH_MAX_INLINE_COLUMNS} columns.
+- Every chart is warehouse-backed: its queryUuid must come from a query result produced during this run. There is no way to chart data a query did not return, so run a query for anything worth charting.
 - Include no more than ${AI_DEEP_RESEARCH_MAX_CHARTS} charts. A report with zero charts is valid.
 
 Callouts:

--- a/packages/common/src/ee/aiDeepResearch/markdown.test.ts
+++ b/packages/common/src/ee/aiDeepResearch/markdown.test.ts
@@ -5,6 +5,7 @@ import {
     findDeepResearchChartRefs,
     getDeepResearchChartKey,
     lintDeepResearchReport,
+    removeDeepResearchChartRefs,
     renderDeepResearchChartRefs,
     spliceDeepResearchRanges,
     type AiDeepResearchChartDefinition,
@@ -41,24 +42,6 @@ const warehouseChart = (
     queryUuid,
     title,
     chartConfig,
-});
-
-const inlineChart = (
-    key: string,
-    title = 'Derived ratio',
-): AiDeepResearchChartDefinition => ({
-    source: 'inline',
-    key,
-    title,
-    chartConfig,
-    columns: [
-        { id: 'segment', label: 'Segment', type: 'string' },
-        { id: 'ratio', label: 'Ratio', type: 'number' },
-    ],
-    rows: [
-        ['enterprise', 0.8],
-        ['smb', 2.4],
-    ],
 });
 
 const validReport = `The seasonal dip is driven by B2B churn, with high confidence overall.
@@ -147,6 +130,36 @@ describe('findDeepResearchChartRefs', () => {
     });
 });
 
+describe('removeDeepResearchChartRefs', () => {
+    it('drops only the named charts and keeps the narrative', () => {
+        const markdown = `a ${chartTag('k1', 'X')} b ${chartTag('k2', 'Y')} c`;
+
+        const result = removeDeepResearchChartRefs(markdown, new Set(['k1']));
+
+        expect(result).not.toContain('id="k1"');
+        expect(result).toContain('id="k2"');
+        expect(result).toContain('a ');
+        expect(result).toContain(' c');
+    });
+
+    it('returns the report untouched when nothing was omitted', () => {
+        expect(removeDeepResearchChartRefs(validReport, new Set())).toBe(
+            validReport,
+        );
+    });
+
+    it('leaves a readable report when every chart is dropped', () => {
+        const result = removeDeepResearchChartRefs(
+            validReport,
+            new Set([UUID_A]),
+        );
+
+        expect(findDeepResearchChartRefs(result)).toEqual([]);
+        expect(result).toContain('The dip aligns with contract renewals.');
+        expect(result).toContain('## Conclusion');
+    });
+});
+
 describe('spliceDeepResearchRanges', () => {
     it('replaces multiple ranges without invalidating offsets', () => {
         const markdown = `a ${chartTag('k1', 'X')} b ${chartTag('k2', 'Y')} c`;
@@ -172,11 +185,18 @@ describe('countDeepResearchFindings', () => {
 });
 
 describe('chart definition schemas', () => {
-    it('derives keys per source', () => {
+    it('keys a chart by the execution it is evidence of', () => {
         expect(getDeepResearchChartKey(warehouseChart(UUID_A))).toBe(UUID_A);
-        expect(getDeepResearchChartKey(inlineChart('tickets-per-1k'))).toBe(
-            'tickets-per-1k',
-        );
+    });
+
+    it('rejects a chart that is not warehouse-backed', () => {
+        const result = aiDeepResearchChartDefinitionSchema.safeParse({
+            source: 'inline',
+            key: 'tickets-per-1k',
+            title: 'Derived ratio',
+            chartConfig,
+        });
+        expect(result.success).toBe(false);
     });
 });
 
@@ -184,16 +204,6 @@ describe('lintDeepResearchReport', () => {
     it('accepts a valid report', () => {
         expect(
             lintDeepResearchReport(validReport, [warehouseChart(UUID_A)]),
-        ).toEqual([]);
-    });
-
-    it('accepts an inline chart referenced by key', () => {
-        const markdown = validReport.replace(
-            chartTag(UUID_A),
-            chartTag('tickets-per-1k', 'Derived ratio'),
-        );
-        expect(
-            lintDeepResearchReport(markdown, [inlineChart('tickets-per-1k')]),
         ).toEqual([]);
     });
 
@@ -460,24 +470,6 @@ describe('chart definition validation', () => {
                 ),
             ).toBe(true);
         }
-    });
-
-    it('rejects inline rows wider than the columns', () => {
-        const chart = inlineChart('bad-rows');
-        const result = aiDeepResearchChartDefinitionSchema.safeParse({
-            ...chart,
-            rows: [['enterprise', 0.8, 'extra']],
-        });
-        expect(result.success).toBe(false);
-    });
-
-    it('rejects inline charts exceeding the row cap', () => {
-        const chart = inlineChart('too-big');
-        const result = aiDeepResearchChartDefinitionSchema.safeParse({
-            ...chart,
-            rows: Array.from({ length: 101 }, (_, i) => [`s${i}`, i]),
-        });
-        expect(result.success).toBe(false);
     });
 });
 

--- a/packages/common/src/ee/aiDeepResearch/markdown.ts
+++ b/packages/common/src/ee/aiDeepResearch/markdown.ts
@@ -1,15 +1,6 @@
 import { z } from 'zod';
 import { getErrorMessage } from '../../types/errors';
 import {
-    DimensionType,
-    FieldType,
-    MetricType,
-    type Dimension,
-    type ItemsMap,
-    type Metric,
-} from '../../types/field';
-import { type MetricQuery } from '../../types/metricQuery';
-import {
     AI_DEEP_RESEARCH_CONFIDENCE_LEVELS,
     type AiDeepResearchChartConfig,
 } from './types';
@@ -17,8 +8,6 @@ import {
 export const AI_DEEP_RESEARCH_CHART_LANGUAGE = 'chart';
 export const AI_DEEP_RESEARCH_MAX_CHARTS = 8;
 export const AI_DEEP_RESEARCH_MAX_CHART_DESCRIPTION_CHARS = 300;
-export const AI_DEEP_RESEARCH_MAX_INLINE_ROWS = 100;
-export const AI_DEEP_RESEARCH_MAX_INLINE_COLUMNS = 10;
 export const AI_DEEP_RESEARCH_MAX_REPORT_MARKDOWN_CHARS = 60_000;
 
 /**
@@ -72,22 +61,10 @@ const rejectGroupBy = (
     }
 };
 
-const inlineValueSchema = z.union([
-    z.string(),
-    z.number(),
-    z.boolean(),
-    z.null(),
-]);
-
-export const aiDeepResearchInlineColumnSchema = z.object({
-    id: z.string().min(1),
-    label: z.string().min(1),
-    type: z.enum(['string', 'number', 'boolean', 'date']),
-});
-
 /**
- * A chart backed by a completed run_metric_query execution. The backend
- * verifies the queryUuid and injects the snapshot at publish time.
+ * A chart backed by a completed run_metric_query execution. Every report chart
+ * is one of these: the backend verifies the queryUuid and injects the snapshot
+ * at publish time, so a chart can never assert data no query produced.
  */
 const warehouseChartObjectSchema = z.object({
     source: z.literal('warehouse'),
@@ -96,125 +73,21 @@ const warehouseChartObjectSchema = z.object({
     chartConfig: chartConfigSchema,
 });
 
-/**
- * A chart whose data the agent computed itself (derived analysis, MCP or
- * web data). Snapshot-only; `derivedFrom` cites the verified executions
- * the computation used, when any.
- */
-const inlineChartObjectSchema = z.object({
-    source: z.literal('inline'),
-    key: z
-        .string()
-        .regex(
-            /^[a-z0-9][a-z0-9-]{1,47}$/,
-            'must be a short lowercase slug (letters, numbers, hyphens)',
-        ),
-    title: z.string().min(1),
-    chartConfig: chartConfigSchema,
-    columns: z
-        .array(aiDeepResearchInlineColumnSchema)
-        .min(1)
-        .max(AI_DEEP_RESEARCH_MAX_INLINE_COLUMNS),
-    rows: z
-        .array(z.array(inlineValueSchema))
-        .min(1)
-        .max(AI_DEEP_RESEARCH_MAX_INLINE_ROWS),
-    derivedFrom: z.array(z.string().uuid()).optional(),
-});
-
-export const aiDeepResearchChartDefinitionSchema = z
-    .discriminatedUnion('source', [
-        warehouseChartObjectSchema,
-        inlineChartObjectSchema,
-    ])
-    .superRefine((chart, context) => {
+export const aiDeepResearchChartDefinitionSchema =
+    warehouseChartObjectSchema.superRefine((chart, context) => {
         rejectGroupBy(chart.chartConfig, context);
-        if (chart.source === 'inline') {
-            chart.rows.forEach((row, rowIndex) => {
-                if (row.length !== chart.columns.length) {
-                    context.addIssue({
-                        code: 'custom',
-                        path: ['rows', rowIndex],
-                        message: `row ${rowIndex + 1} has ${row.length} values but there are ${chart.columns.length} columns`,
-                    });
-                }
-            });
-        }
     });
 
 export type AiDeepResearchWarehouseChart = z.infer<
     typeof warehouseChartObjectSchema
 >;
-export type AiDeepResearchInlineChart = z.infer<typeof inlineChartObjectSchema>;
 export type AiDeepResearchChartDefinition = z.infer<
     typeof aiDeepResearchChartDefinitionSchema
 >;
 
 export const getDeepResearchChartKey = (
     chart: AiDeepResearchChartDefinition,
-): string => (chart.source === 'warehouse' ? chart.queryUuid : chart.key);
-
-const INLINE_CHART_TABLE = 'inline';
-
-/**
- * Synthesizes a fields map for an inline (agent-computed) chart so it renders
- * through the same pipeline as warehouse-backed charts: number columns become
- * metrics, everything else dimensions.
- */
-export const buildInlineChartFields = (
-    columns: AiDeepResearchInlineChart['columns'],
-): ItemsMap =>
-    Object.fromEntries(
-        columns.map((column) => {
-            const base = {
-                name: column.id,
-                label: column.label,
-                table: INLINE_CHART_TABLE,
-                tableLabel: '',
-                sql: '',
-                hidden: false,
-            };
-            if (column.type === 'number') {
-                const metric: Metric = {
-                    ...base,
-                    fieldType: FieldType.METRIC,
-                    type: MetricType.NUMBER,
-                };
-                return [column.id, metric];
-            }
-            const dimensionTypes: Record<string, DimensionType> = {
-                date: DimensionType.DATE,
-                boolean: DimensionType.BOOLEAN,
-                string: DimensionType.STRING,
-            };
-            const dimensionType =
-                dimensionTypes[column.type] ?? DimensionType.STRING;
-            const dimension: Dimension = {
-                ...base,
-                fieldType: FieldType.DIMENSION,
-                type: dimensionType,
-            };
-            return [column.id, dimension];
-        }),
-    );
-
-/** Synthesizes a metric query describing an inline chart's embedded data. */
-export const buildInlineChartMetricQuery = (
-    chart: Pick<AiDeepResearchInlineChart, 'columns' | 'rows'>,
-): MetricQuery => ({
-    exploreName: INLINE_CHART_TABLE,
-    dimensions: chart.columns
-        .filter((column) => column.type !== 'number')
-        .map((column) => column.id),
-    metrics: chart.columns
-        .filter((column) => column.type === 'number')
-        .map((column) => column.id),
-    filters: {},
-    sorts: [],
-    limit: chart.rows.length,
-    tableCalculations: [],
-    additionalMetrics: [],
-});
+): string => chart.queryUuid;
 
 // ---------------------------------------------------------------------------
 // Chart references: chart data is stored separately, while the markdown keeps
@@ -479,6 +352,24 @@ export const findDeepResearchChartRefs = (
     }
     return refs;
 };
+
+/**
+ * Drops the `<chart>` references whose data could not be published, leaving the
+ * surrounding narrative intact. A chart that cannot be verified must cost the
+ * report that chart, never the whole report.
+ */
+export const removeDeepResearchChartRefs = (
+    markdown: string,
+    keys: ReadonlySet<string>,
+): string =>
+    keys.size === 0
+        ? markdown
+        : spliceDeepResearchRanges(
+              markdown,
+              findDeepResearchChartRefs(markdown)
+                  .filter((ref) => keys.has(ref.key))
+                  .map((match) => ({ match, replacement: '' })),
+          );
 
 export const renderDeepResearchChartRefs = (markdown: string): string =>
     spliceDeepResearchRanges(

--- a/packages/common/src/ee/aiDeepResearch/types.ts
+++ b/packages/common/src/ee/aiDeepResearch/types.ts
@@ -239,14 +239,11 @@ export type AiDeepResearchChartSnapshot = {
  * publish time; the markdown only carries compact <chart> references.
  */
 export type AiDeepResearchChartData = {
-    source: 'warehouse' | 'inline';
+    source: 'warehouse';
     title: string;
     chartConfig: AiDeepResearchChartConfig;
-    /** Warehouse charts: the verified execution this chart is evidence of. */
-    queryUuid: string | null;
-    /** Inline charts: verified executions the data was derived from. */
-    derivedFrom: string[] | null;
-    /** Real for warehouse charts, synthesized for inline ones. */
+    /** The verified execution this chart is evidence of. */
+    queryUuid: string;
     metricQuery: MetricQuery;
     /** Selected + filter fields; drives labels and value formatting. */
     fields: ItemsMap;

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchChartTile.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchChartTile.test.tsx
@@ -73,7 +73,6 @@ const chart: AiDeepResearchChartData = {
         secondaryYAxisLabel: null,
     },
     queryUuid: QUERY_UUID,
-    derivedFrom: null,
     metricQuery: {
         exploreName: 'orders',
         dimensions: ['orders_order_month'],
@@ -204,19 +203,6 @@ describe('DeepResearchChartTile', () => {
         expect(screen.getByText('Report data')).toBeVisible();
         expect(screen.getByTestId('visualization')).toBeVisible();
         expect(screen.queryByText(/Snapshot from/)).not.toBeInTheDocument();
-    });
-
-    it('labels agent-computed charts and offers no live view', () => {
-        renderTile({ source: 'inline', queryUuid: null });
-
-        expect(screen.getByText('Agent-computed')).toBeVisible();
-        expect(
-            screen.queryByRole('button', { name: 'View live data' }),
-        ).not.toBeInTheDocument();
-        expect(screen.getByTestId('visualization')).toHaveAttribute(
-            'data-load-explore',
-            'false',
-        );
     });
 
     it('shows the live error state even while a page fetch is marked in-flight', () => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchChartTile.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchChartTile.tsx
@@ -5,7 +5,7 @@ import {
     type ApiAiAgentThreadMessageVizQuery,
     type ToolRunQueryArgs,
 } from '@lightdash/common';
-import { Badge, Box, Button, Group, Text, Tooltip } from '@mantine/core';
+import { Box, Button, Group, Text } from '@mantine/core';
 import { IconCamera, IconRefresh } from '@tabler/icons-react';
 import { useMemo, useState } from 'react';
 import EmptyStateLoader from '../../../../../components/common/EmptyStateLoader';
@@ -155,17 +155,6 @@ export const DeepResearchChartTile = ({
         >
             <Group gap="xs" justify="space-between" mb="xs" wrap="wrap">
                 <Group gap="xs">
-                    {chart.source === 'inline' ? (
-                        <Tooltip
-                            label="The research agent computed this dataset itself; it is not backed by a single warehouse query."
-                            multiline
-                            maw={280}
-                        >
-                            <Badge size="xs" variant="light" color="grape">
-                                Agent-computed
-                            </Badge>
-                        </Tooltip>
-                    ) : null}
                     {!isLive && snapshotTakenAt ? (
                         <Group gap={4}>
                             <MantineIcon

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/fixtures.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/fixtures.ts
@@ -81,7 +81,6 @@ const deepResearchChartDataFixture: AiDeepResearchChartDataMap = {
         title: deepResearchChartFixture.title,
         chartConfig: deepResearchChartFixture.chartConfig,
         queryUuid: deepResearchChartQueryUuid,
-        derivedFrom: null,
         metricQuery: {
             exploreName: 'renewals',
             dimensions: ['incident_exposure'],


### PR DESCRIPTION
## Summary

PR 3 of 9 for [PROD-9678](https://linear.app/lightdash/issue/PROD-9678/deep-research-20). Removes inline charts and stops an unverifiable chart from discarding a finished report. Also fixes a live regression on `main`.

Stacks on top of PR 2 ([#26896](https://github.com/lightdash/lightdash/pull/26896)) which bounded run limits.

Closes: https://linear.app/lightdash/issue/PROD-9693

## Root cause

`prepareEvidenceReport` treats every non-warehouse chart as unverifiable, and one unverifiable chart discards the whole report:

```ts
const entry = chart.source === 'warehouse'
    ? await this.buildWarehouseChartData(run, chart, runQueryUuids)
    : null;              // every inline chart lands here
if (!entry) omittedKeys.add(key);
...
if (omittedKeys.size === 0) return { markdown: report.markdown };
throw new UnexpectedServerError(`...could not be verified for chart(s): ...`);
```

`executeRun`'s catch then calls `markFailed(FAILED_RUN_ERROR_MESSAGE, 'internal_error')`, so the user sees "Deep Research could not finish. Please try again." and loses a completed report.

Reachable today: the report prompt documents inline charts and the agent uses them. Observed on a local run that emitted four (`funnel-overall`, `weekly-funnel-trend`, `checkout-started-vs-completed`, `daily-aov`) and discarded 15 tool calls and 10 warehouse queries of finished work. Introduced by #26665, which made retained query results the source of truth for report charts — `buildInlineChartFields` and `buildInlineChartMetricQuery` have had no callers since.

## Changes

**Common**
- `aiDeepResearchChartDefinitionSchema` is the warehouse object alone, no longer a discriminated union. Drops `buildInlineChartFields`, `buildInlineChartMetricQuery`, the inline row/column limits and `derivedFrom`.
- `AiDeepResearchChartData.source` narrows to `'warehouse'`; `queryUuid` becomes non-nullable.
- New `removeDeepResearchChartRefs(markdown, keys)` strips the `<chart>` references of charts that could not be published.

**Backend**
- `prepareEvidenceReport` drops unverifiable charts and publishes the narrative, logging what it omitted. Inline guidance removed from the report prompt.

**Frontend**
- `DeepResearchChartTile` loses the "Agent-computed" badge and its inline branch.

## What is still refused

Verification is unchanged — the difference is what a failure costs.

```
chart cites a query this run did not return   → dropped   (was: run failed)
chart replays a query predating the run       → dropped   (was: run failed)
chart fields absent from the verified query   → dropped   (was: run failed)
report narrative                              → published (was: discarded)
```

The narrative is the deliverable; losing it over one chart is the worse failure.

## Test plan

- [x] `pnpm -F common|backend|frontend typecheck`
- [x] `pnpm -F common|backend|frontend lint`
- [x] `pnpm -F common test` — 3376 pass
- [x] `pnpm -F backend test` — 2707 pass across `src/ee`
- [x] `pnpm -F frontend test` — 598 pass across `src/ee`
- [x] Rewrote the three chart-verification tests to assert the chart is dropped and the report still publishes, rather than asserting the run dies
- [x] `removeDeepResearchChartRefs` coverage: drops only named charts, no-op when nothing omitted, report stays readable when every chart goes
- [x] Manual smoke: a run whose charts all failed verification now publishes instead of failing
- [x] Checked no persisted run carries inline chart data (0 rows), so nothing is stranded

🤖 Generated with [Claude Code](https://claude.com/claude-code)