### PR TITLE
fix(deep-research): give the agent the query UUIDs its charts must cite

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -765,6 +765,7 @@ export const getAgentTools = (
         createOrUpdateArtifact: dependencies.createOrUpdateArtifact,
         maxLimit: args.maxQueryLimit,
         maxContextRows: args.maxContextRows,
+        exposeQueryUuid: args.execution.mode === 'deep_research',
         enableDataAccess: args.enableDataAccess,
     });
 

--- a/packages/backend/src/ee/services/ai/prompts/deepResearch.ts
+++ b/packages/backend/src/ee/services/ai/prompts/deepResearch.ts
@@ -19,9 +19,9 @@ Structure:
 - Cite external evidence inline with markers such as [1], and list each source in a final "## Sources" section.
 
 Charts:
-- Define every chart in the charts argument and reference it exactly once in markdown as <chart id="<key>" title="<chart title>" description="<standalone summary>">.
+- Every chart is warehouse-backed by one query from this run. Its queryUuid must be copied exactly from the "This execution's queryUuid is ..." line in that query's result — never composed, guessed, or reused from anywhere else. There is no way to chart data a query did not return, so run a query for anything worth charting.
+- A chart's queryUuid is also its id in the markdown. Define it in the charts argument and reference it exactly once as <chart id="<queryUuid>" title="<chart title>" description="<standalone summary>">, using that same queryUuid verbatim as the id — not a slug, name, or any other label. For example a chart whose queryUuid is 681831ec-b696-4cda-85ef-de7b6ddae850 is referenced as <chart id="681831ec-b696-4cda-85ef-de7b6ddae850" title="Weekly orders" description="Orders fell from the week of Dec 15.">.
 - Keep each chart description at most ${AI_DEEP_RESEARCH_MAX_CHART_DESCRIPTION_CHARS} characters.
-- Every chart is warehouse-backed: its queryUuid must come from a query result produced during this run. There is no way to chart data a query did not return, so run a query for anything worth charting.
 - Include no more than ${AI_DEEP_RESEARCH_MAX_CHARTS} charts. A report with zero charts is valid.
 
 Callouts:

--- a/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
@@ -189,6 +189,7 @@ const makeAgentTools = () => {
             getPrompt: noop,
             maxLimit: 500,
             maxContextRows: Number.POSITIVE_INFINITY,
+            exposeQueryUuid: false,
             runAsyncQuery: noop,
             sendFile: noop,
             updateProgress: noopAsync,

--- a/packages/backend/src/ee/services/ai/tools/runQuery.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/runQuery.test.ts
@@ -72,6 +72,7 @@ const executeTool = async (
     runAsyncQuery: RunAsyncQueryFn,
     enableDataAccess = true,
     prompt: AiWebAppPrompt | SlackPrompt = makePrompt(),
+    exposeQueryUuid = false,
 ) => {
     const queryTool = getRunQuery({
         updateProgress: vi.fn().mockResolvedValue(undefined),
@@ -81,6 +82,7 @@ const executeTool = async (
         createOrUpdateArtifact: vi.fn().mockResolvedValue(undefined),
         maxLimit: 500,
         maxContextRows: Number.POSITIVE_INFINITY,
+        exposeQueryUuid,
         enableDataAccess,
     });
 
@@ -156,5 +158,47 @@ describe('getRunQuery', () => {
         );
 
         expect(output.metadata).toEqual({ status: 'error' });
+    });
+});
+
+describe('getRunQuery query UUID visibility', () => {
+    const runAsyncQuery: RunAsyncQueryFn = vi.fn().mockResolvedValue({
+        queryUuid: '11111111-1111-4111-8111-111111111111',
+        rows: [{ a_dim1: 'one', a_met1: 1 }],
+        cacheMetadata: { cacheHit: false },
+        fields: {},
+    });
+
+    it('keeps the query UUID out of the model result by default', async () => {
+        const output = await executeTool(runAsyncQuery);
+
+        expect(output.result).not.toContain(
+            '11111111-1111-4111-8111-111111111111',
+        );
+    });
+
+    it('states the query UUID in the model result when charts must cite it', async () => {
+        const output = await executeTool(
+            runAsyncQuery,
+            true,
+            makePrompt(),
+            true,
+        );
+
+        // Without this the agent cannot cite a real execution and invents one.
+        expect(output.result).toContain(
+            "This execution's queryUuid is 11111111-1111-4111-8111-111111111111",
+        );
+    });
+
+    it('states the query UUID even when row data is hidden', async () => {
+        const output = await executeTool(
+            runAsyncQuery,
+            false,
+            makeSlackPrompt(),
+            true,
+        );
+
+        expect(output.result).toContain('11111111-1111-4111-8111-111111111111');
     });
 });

--- a/packages/backend/src/ee/services/ai/tools/runQuery.ts
+++ b/packages/backend/src/ee/services/ai/tools/runQuery.ts
@@ -58,6 +58,8 @@ type Dependencies = {
     createOrUpdateArtifact: CreateOrUpdateArtifactFn;
     maxLimit: number;
     maxContextRows: number;
+    /** Deep Research report charts must cite the execution they came from. */
+    exposeQueryUuid: boolean;
     enableDataAccess: boolean;
 };
 
@@ -176,6 +178,7 @@ export const getRunQuery = ({
     createOrUpdateArtifact,
     maxLimit,
     maxContextRows,
+    exposeQueryUuid,
     enableDataAccess,
 }: Dependencies) =>
     tool({
@@ -336,9 +339,16 @@ export const getRunQuery = ({
                     maxLimit,
                 });
 
+                // The queryUuid otherwise lives only in metadata, which never
+                // reaches the model — leaving it unable to cite the execution
+                // a report chart is evidence of.
+                const queryReference = exposeQueryUuid
+                    ? ` This execution's queryUuid is ${queryResults.queryUuid}; use exactly this value to reference it.`
+                    : '';
+
                 if (!enableDataAccess) {
                     return {
-                        result: `Success. ${resultSummary}`,
+                        result: `Success. ${resultSummary}${queryReference}`,
                         metadata: {
                             status: 'success',
                             chartImageUrl,
@@ -356,7 +366,7 @@ export const getRunQuery = ({
                         `${resultSummary}${getContextTruncationNote({
                             rowCount: queryResults.rows.length,
                             maxContextRows,
-                        })}`,
+                        })}${queryReference}`,
                         serializeData(csv, 'csv'),
                     ].join('\n\n'),
                     metadata: {


### PR DESCRIPTION
## Summary

PR 5 of 9 for [PROD-9678](https://linear.app/lightdash/issue/PROD-9678/deep-research-20). Deep Research charts have never worked — every run recorded on a seeded instance has `chart_count = 0`, including runs that finished `completed` on `main`. Reports have been text-only the whole time.

Stacks on top of PR 4 ([#26898](https://github.com/lightdash/lightdash/pull/26898)) which bounded query context.

Closes: https://linear.app/lightdash/issue/PROD-9700

## Root cause

Two independent failures, both required for a chart to publish.

**1. The agent could not learn a real queryUuid.** `runQuery` returns it in `metadata`, and `toModelOutput` passes only `output.result` to the model:

```ts
export const toModelOutput = <T extends ToolOutput>(output: T) => {
    if (output.metadata.status === 'error') return { type: 'error-text', value: output.result };
    return { type: 'text', value: output.result };   // metadata never reaches the model
};
```

So "a warehouse chart's queryUuid must come from a query result produced during this run" was impossible to satisfy. The agent invented plausible UUIDs — `a1b2c3d4-0001-0001-0001-000000000001` observed live — and `buildWarehouseChartData` correctly refused them.

**2. Even citing real UUIDs, every report was rejected.** The format said to reference a chart as `<chart id="<key>" ...>`. "Key" meant a slug back when inline charts had slug keys; for a warehouse chart the key *is* the queryUuid, but nothing said so. The agent referenced charts by readable slugs and the lint failed on both sides:

```
Chart 681831ec-b696-4cda-85ef-de7b6ddae850 must be referenced exactly once … (found 0 references).
The markdown references chart funnel-overview but no chart with that key is defined.
```

## Changes

**Backend**
- `runQuery` states the queryUuid in the model-visible result for deep-research runs, gated by a new `exposeQueryUuid` dependency. Other modes are unchanged — they do not cite executions and do not need the tokens.
- The report format says the queryUuid *is* the markdown id, and shows an example.

## Verification chain

```
agent runs a query      → result now carries "This execution's queryUuid is <uuid>"
agent defines a chart   → queryUuid copied verbatim from that line
agent writes markdown   → <chart id="<same uuid>" …>
server verifies         → uuid ∈ run's executions, fields ⊆ verified metricQuery
                          ├── pass → chart published
                          └── fail → chart dropped, narrative still published (PR 3)
```

Verification is untouched. A fabricated or unverifiable queryUuid is still refused; since PR 3 it costs only its own chart.

## Test plan

- [x] `pnpm -F common|backend|frontend typecheck`
- [x] `pnpm -F common|backend|frontend lint`
- [x] `pnpm -F backend test` — 2723 pass across `src/ee`
- [x] New coverage: queryUuid absent from the model result by default, present when charts must cite it, present even when row data is hidden
- [x] Manual smoke: confirmed against a live run that the agent now cites real executions — all three cited UUIDs were in the run's verified set, where the previous run cited fabricated ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)