### PR TITLE
feat(dashboards): export a dashboard to a new Google Sheet

### DIFF
--- a/packages/backend/src/clients/Google/GoogleDriveClient.ts
+++ b/packages/backend/src/clients/Google/GoogleDriveClient.ts
@@ -196,6 +196,69 @@ export class GoogleDriveClient {
         return response.data;
     }
 
+    /** Renames a tab, e.g. the default first tab of a freshly created sheet. */
+    async renameSheet(
+        refreshToken: string,
+        fileId: string,
+        sheetId: number,
+        title: string,
+    ) {
+        if (!this.isEnabled) {
+            throw new MissingConfigError('Google Drive is not enabled');
+        }
+        const auth = await this.getCredentials(refreshToken);
+        const sheets = google.sheets({ version: 'v4', auth });
+
+        await GoogleDriveClient.catchApiError(
+            sheets.spreadsheets.batchUpdate({
+                spreadsheetId: fileId,
+                requestBody: {
+                    requests: [
+                        {
+                            updateSheetProperties: {
+                                properties: {
+                                    sheetId,
+                                    title: title.replaceAll(':', '.'),
+                                },
+                                fields: 'title',
+                            },
+                        },
+                    ],
+                },
+            }),
+        );
+    }
+
+    /** Tab title -> gid, so links can address a specific tab. */
+    async getSheetIdsByTitle(
+        refreshToken: string,
+        fileId: string,
+    ): Promise<Record<string, number>> {
+        if (!this.isEnabled) {
+            throw new MissingConfigError('Google Drive is not enabled');
+        }
+        const auth = await this.getCredentials(refreshToken);
+        const sheets = google.sheets({ version: 'v4', auth });
+
+        const response = await GoogleDriveClient.catchApiError(
+            sheets.spreadsheets.get({
+                spreadsheetId: fileId,
+                fields: 'sheets.properties.sheetId,sheets.properties.title',
+            }),
+        );
+
+        return (response.data.sheets ?? []).reduce<Record<string, number>>(
+            (acc, sheet) => {
+                const { title, sheetId } = sheet.properties ?? {};
+                if (!title || sheetId === null || sheetId === undefined) {
+                    return acc;
+                }
+                return { ...acc, [title]: sheetId };
+            },
+            {},
+        );
+    }
+
     async assertFileIsGoogleSheet(refreshToken: string, fileId: string) {
         const auth = await this.getCredentials(refreshToken);
         const sheets = google.sheets({ version: 'v4', auth });

--- a/packages/backend/src/controllers/googleDriveController.ts
+++ b/packages/backend/src/controllers/googleDriveController.ts
@@ -3,6 +3,7 @@ import {
     ApiGdriveAccessTokenResponse,
     ApiJobScheduledResponse,
     assertRegisteredAccount,
+    ExportDashboardGsheetRequest,
     UploadGsheetFromRows,
     UploadMetricGsheet,
 } from '@lightdash/common';
@@ -11,6 +12,7 @@ import {
     Get,
     Middlewares,
     OperationId,
+    Path,
     Post,
     Request,
     Response,
@@ -69,6 +71,36 @@ export class GoogleDriveController extends BaseController {
             results: await req.services
                 .getGdriveService()
                 .scheduleUploadGsheet(req.account!, body),
+        };
+    }
+
+    /**
+     * Export every output of a dashboard into a newly created Google Sheet.
+     * @summary Export dashboard to Google Sheets
+     * @param req express request
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/export-dashboard/{projectUuid}/{dashboardUuid}')
+    @OperationId('exportDashboardToGsheet')
+    async postExportDashboard(
+        @Path() projectUuid: string,
+        @Path() dashboardUuid: string,
+        @Body() body: ExportDashboardGsheetRequest,
+        @Request() req: express.Request,
+    ): Promise<ApiJobScheduledResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await req.services
+                .getGdriveService()
+                .scheduleExportDashboardGsheet(
+                    req.account,
+                    projectUuid,
+                    dashboardUuid,
+                    body,
+                ),
         };
     }
 

--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -27,6 +27,7 @@ import {
     NotFoundError,
     ParameterError,
     Scheduler,
+    SCHEDULER_TASKS,
     SchedulerAndTargets,
     SchedulerBase,
     SchedulerEmailTarget,
@@ -1958,7 +1959,10 @@ export class SchedulerModel {
     async getGsheetExportStatus(jobId: string, userUuid: string) {
         const jobs = await this.database(SchedulerLogTableName)
             .where(`job_id`, jobId)
-            .andWhere('task', 'uploadGsheetFromQuery')
+            .whereIn('task', [
+                SCHEDULER_TASKS.UPLOAD_GSHEET_FROM_QUERY,
+                SCHEDULER_TASKS.EXPORT_DASHBOARD_GSHEET,
+            ])
             .orderBy('scheduled_time', 'desc')
             .returning('*');
 

--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -5,6 +5,7 @@ import {
     CreateSchedulerTarget,
     EmailBatchNotificationPayload,
     EmailNotificationPayload,
+    ExportDashboardGsheetPayload,
     FeatureFlags,
     getSchedulerTargetUuid,
     getSchedulerUuid,
@@ -1220,6 +1221,34 @@ export class SchedulerClient {
                 exploreId: payload.exploreId,
                 metricQuery: payload.metricQuery,
                 organizationUuid: payload.organizationUuid,
+            },
+        });
+
+        return { jobId };
+    }
+
+    async exportDashboardGsheetJob(payload: ExportDashboardGsheetPayload) {
+        const graphileClient = await this.graphileUtils;
+        const now = new Date();
+        const jobId = await SchedulerClient.addJob(
+            graphileClient,
+            SCHEDULER_TASKS.EXPORT_DASHBOARD_GSHEET,
+            payload,
+            now,
+            JobPriority.HIGH,
+            1,
+        );
+
+        await this.schedulerModel.logSchedulerJob({
+            task: SCHEDULER_TASKS.EXPORT_DASHBOARD_GSHEET,
+            jobId,
+            scheduledTime: now,
+            status: SchedulerJobStatus.SCHEDULED,
+            details: {
+                createdByUserUuid: payload.userUuid,
+                projectUuid: payload.projectUuid,
+                organizationUuid: payload.organizationUuid,
+                dashboardUuid: payload.dashboardUuid,
             },
         });
 

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -20,8 +20,14 @@ import {
     DownloadFileType,
     EmailNotificationPayload,
     expandSelectedTabs,
+    EXPORT_DASHBOARD_GSHEET_INDEX_TAB,
+    EXPORT_DASHBOARD_GSHEET_MAX_CELLS,
+    EXPORT_DASHBOARD_GSHEET_MAX_ROWS_PER_TAB,
     ExportContentPayload,
     ExportCsvDashboardPayload,
+    ExportDashboardGsheetOutput,
+    ExportDashboardGsheetOutputStatus,
+    ExportDashboardGsheetPayload,
     FeatureFlags,
     FieldReferenceError,
     FieldType,
@@ -38,6 +44,7 @@ import {
     getHiddenFieldsFromVizTableConfig,
     getHiddenTableFields,
     getHumanReadableCronExpression,
+    getItemLabelWithoutTableName,
     getItemMap,
     getPivotConfig,
     getRequestMethod,
@@ -3915,6 +3922,418 @@ export default class SchedulerTask {
         }, Promise.resolve());
 
         return results;
+    }
+
+    // Chart tile results as CSV-shaped rows, pivoted when the chart is.
+    private async exportChartTileRows({
+        account,
+        dashboardUuid,
+        projectUuid,
+        dashboardFilters,
+        parameters,
+        tile,
+    }: {
+        account: AccountType;
+        dashboardUuid: string;
+        projectUuid: string;
+        dashboardFilters: DashboardFilters;
+        parameters: ParametersValuesMap | undefined;
+        tile: DashboardChartTile;
+    }): Promise<string[][]> {
+        const chartUuid = tile.properties.savedChartUuid!;
+        const chart =
+            await this.schedulerService.savedChartModel.get(chartUuid);
+        const pivotConfig = getPivotConfig(chart);
+        const shouldPivotChart =
+            isTableChartConfig(chart.chartConfig.config) && !!pivotConfig;
+
+        const {
+            rows,
+            fields: itemMap,
+            pivotDetails,
+            displayTimezone,
+        } = await this.asyncQueryService.executeDashboardChartQueryAndGetResults(
+            {
+                account,
+                projectUuid,
+                tileUuid: tile.uuid,
+                chartUuid,
+                dashboardUuid,
+                dashboardFilters,
+                dashboardSorts: [],
+                invalidateCache: true,
+                context: QueryExecutionContext.GSHEETS,
+                pivotResults: shouldPivotChart,
+                parameters,
+            },
+            SCHEDULER_POLLING_OPTIONS,
+        );
+
+        const customLabels = getCustomLabelsFromTableConfig(
+            chart.chartConfig.config,
+        );
+        const formattedRows = formatRows(
+            rows,
+            itemMap,
+            undefined,
+            undefined,
+            displayTimezone ?? undefined,
+        );
+
+        if (
+            pivotConfig &&
+            pivotDetails &&
+            isTableChartConfig(chart.chartConfig.config)
+        ) {
+            return pivotResultsAsCsv({
+                pivotConfig,
+                rows: formattedRows,
+                itemMap,
+                customLabels,
+                onlyRaw: true,
+                pivotDetails,
+                timezone: displayTimezone ?? undefined,
+            });
+        }
+
+        const hiddenFields = getHiddenTableFields(chart.chartConfig);
+        const columnOrder = chart.tableConfig.columnOrder.filter(
+            (columnId) => !hiddenFields.includes(columnId),
+        );
+        const header = columnOrder.map(
+            (columnId) =>
+                customLabels?.[columnId] ??
+                getItemLabelWithoutTableName(itemMap[columnId]) ??
+                columnId,
+        );
+
+        return [
+            header,
+            ...formattedRows.map((row) =>
+                columnOrder.map((columnId) =>
+                    String(row[columnId]?.value?.formatted ?? ''),
+                ),
+            ),
+        ];
+    }
+
+    // SQL chart tile results as CSV-shaped rows.
+    private async exportSqlChartTileRows({
+        account,
+        dashboardUuid,
+        projectUuid,
+        dashboardFilters,
+        tile,
+    }: {
+        account: AccountType;
+        dashboardUuid: string;
+        projectUuid: string;
+        dashboardFilters: DashboardFilters;
+        tile: DashboardSqlChartTile;
+    }): Promise<string[][]> {
+        const { rows } =
+            await this.asyncQueryService.executeDashboardSqlChartQueryAndGetResults(
+                {
+                    account,
+                    projectUuid,
+                    savedSqlUuid: tile.properties.savedSqlUuid!,
+                    invalidateCache: true,
+                    context: QueryExecutionContext.GSHEETS,
+                    dashboardUuid,
+                    tileUuid: tile.uuid,
+                    dashboardFilters,
+                    dashboardSorts: [],
+                },
+                SCHEDULER_POLLING_OPTIONS,
+            );
+
+        if (rows.length === 0) {
+            return [[]];
+        }
+        const columnNames = Object.keys(rows[0]);
+        return [
+            columnNames,
+            ...rows.map((row) =>
+                columnNames.map((column) => {
+                    const value = row[column];
+                    if (value === null || value === undefined) return '';
+                    if (value instanceof Date) return value.toISOString();
+                    return String(value);
+                }),
+            ),
+        ];
+    }
+
+    // Rows to write into the export's first tab, so someone opening the sheet
+    // can see what it holds and which output each tab came from.
+    private static buildExportIndexRows({
+        dashboardName,
+        dashboardUrl,
+        exportedAt,
+        outputs,
+        sheetUrlsByTab,
+    }: {
+        dashboardName: string;
+        dashboardUrl: string;
+        exportedAt: Date;
+        outputs: ExportDashboardGsheetOutput[];
+        sheetUrlsByTab: Record<string, string>;
+    }): string[][] {
+        const statusLabel: Record<ExportDashboardGsheetOutputStatus, string> = {
+            success: 'Success',
+            truncated: 'Truncated',
+            failed: 'Failed',
+            unsupported: 'Unsupported',
+        };
+
+        return [
+            ['Lightdash dashboard export'],
+            ['Dashboard', dashboardName],
+            ['Dashboard link', dashboardUrl],
+            ['Exported at', exportedAt.toISOString()],
+            ['Outputs', `${outputs.length}`],
+            [],
+            ['Tab', 'Source', 'Status', 'Rows', 'Details', 'Link'],
+            ...outputs.map((output) => [
+                output.tabName,
+                output.sourceName,
+                statusLabel[output.status],
+                `${output.rowCount}`,
+                output.error ?? '',
+                sheetUrlsByTab[output.tabName] ?? '',
+            ]),
+        ];
+    }
+
+    /**
+     * Exports every chart and SQL chart tile of a dashboard into a newly
+     * created Google Sheet, one tab per output plus an index tab. An output
+     * that cannot be exported still gets a tab carrying its error, so nothing
+     * silently disappears from the sheet.
+     */
+    protected async exportDashboardGsheet(
+        jobId: string,
+        scheduledTime: Date,
+        payload: ExportDashboardGsheetPayload,
+    ) {
+        await this.logWrapper<string>(
+            {
+                task: SCHEDULER_TASKS.EXPORT_DASHBOARD_GSHEET,
+                jobId,
+                scheduledTime,
+                details: {
+                    createdByUserUuid: payload.userUuid,
+                    projectUuid: payload.projectUuid,
+                    organizationUuid: payload.organizationUuid,
+                },
+            },
+            async () => {
+                if (!this.googleDriveClient.isEnabled) {
+                    throw new MissingConfigError('Google Drive is not enabled');
+                }
+
+                const account = await this.userService.getAccountByUserUuid(
+                    payload.userUuid,
+                );
+                const refreshToken = await this.userService.getRefreshToken(
+                    payload.userUuid,
+                );
+                const sessionUser = await this.userService.getSessionByUserUuid(
+                    payload.userUuid,
+                );
+                const dashboard = await this.dashboardService.getByIdOrSlug(
+                    sessionUser,
+                    payload.dashboardUuid,
+                );
+
+                const dashboardUrl = `${this.lightdashConfig.siteUrl}/projects/${dashboard.projectUuid}/dashboards/${payload.dashboardUuid}/view`;
+                const exportedAt = new Date();
+
+                const spreadsheet = await this.googleDriveClient.createNewSheet(
+                    refreshToken,
+                    `${dashboard.name} (Lightdash export ${exportedAt
+                        .toISOString()
+                        .slice(0, 16)
+                        .replace('T', ' ')})`,
+                );
+                const spreadsheetId = spreadsheet.spreadsheetId!;
+                const firstSheetId =
+                    spreadsheet.sheets?.[0]?.properties?.sheetId ?? 0;
+
+                await this.googleDriveClient.renameSheet(
+                    refreshToken,
+                    spreadsheetId,
+                    firstSheetId,
+                    EXPORT_DASHBOARD_GSHEET_INDEX_TAB,
+                );
+
+                const exportableTiles = sortTilesByDashboardOrder(
+                    dashboard.tiles.filter(
+                        (
+                            tile,
+                        ): tile is DashboardChartTile | DashboardSqlChartTile =>
+                            (isDashboardChartTileType(tile) &&
+                                !!tile.properties.savedChartUuid) ||
+                            (isDashboardSqlChartTile(tile) &&
+                                !!tile.properties.savedSqlUuid),
+                    ),
+                    dashboard.tabs,
+                ).filter((tile) =>
+                    isTileInSelectedTabs(tile, payload.selectedTabs ?? null),
+                );
+
+                const dashboardFilters =
+                    payload.dashboardFilters ?? dashboard.filters;
+                const parameters =
+                    payload.parameters ??
+                    getDashboardParametersValuesMap(dashboard);
+
+                const outputs: ExportDashboardGsheetOutput[] = [];
+                let cellsRemaining = EXPORT_DASHBOARD_GSHEET_MAX_CELLS;
+
+                // Sequential so a wide dashboard doesn't hold every tile's
+                // results in memory, and to stay well inside the per-user
+                // Google Sheets write quota.
+                await exportableTiles.reduce(async (promise, tile) => {
+                    await promise;
+
+                    const tabTitle =
+                        tile.properties.title ||
+                        ('chartName' in tile.properties
+                            ? tile.properties.chartName
+                            : undefined) ||
+                        tile.uuid;
+
+                    let csvRows: string[][];
+                    try {
+                        csvRows = isDashboardChartTileType(tile)
+                            ? await this.exportChartTileRows({
+                                  account,
+                                  dashboardUuid: payload.dashboardUuid,
+                                  projectUuid: dashboard.projectUuid,
+                                  dashboardFilters,
+                                  parameters,
+                                  tile,
+                              })
+                            : await this.exportSqlChartTileRows({
+                                  account,
+                                  dashboardUuid: payload.dashboardUuid,
+                                  projectUuid: dashboard.projectUuid,
+                                  dashboardFilters,
+                                  tile,
+                              });
+                    } catch (error) {
+                        Logger.warn(
+                            `Dashboard export could not read tile ${tabTitle}: ${getErrorMessage(
+                                error,
+                            )}`,
+                        );
+                        const tabName =
+                            await this.googleDriveClient.createNewTab(
+                                refreshToken,
+                                spreadsheetId,
+                                tabTitle,
+                            );
+                        await this.googleDriveClient.appendCsvToSheet(
+                            refreshToken,
+                            spreadsheetId,
+                            [
+                                ['This output could not be exported'],
+                                [getErrorMessage(error)],
+                            ],
+                            tabName,
+                        );
+                        outputs.push({
+                            tileUuid: tile.uuid,
+                            tabName,
+                            sourceName: tabTitle,
+                            status: 'failed',
+                            rowCount: 0,
+                            error: getErrorMessage(error),
+                        });
+                        return;
+                    }
+
+                    // Header row always survives; the budget only trims data.
+                    const columnCount = csvRows[0]?.length ?? 1;
+                    const maxRowsByBudget = Math.max(
+                        1,
+                        Math.floor(cellsRemaining / Math.max(columnCount, 1)),
+                    );
+                    const maxRows = Math.min(
+                        maxRowsByBudget,
+                        EXPORT_DASHBOARD_GSHEET_MAX_ROWS_PER_TAB + 1,
+                    );
+                    const isTruncated = csvRows.length > maxRows;
+                    const writtenRows = isTruncated
+                        ? csvRows.slice(0, maxRows)
+                        : csvRows;
+                    cellsRemaining -= writtenRows.length * columnCount;
+
+                    const tabName = await this.googleDriveClient.createNewTab(
+                        refreshToken,
+                        spreadsheetId,
+                        tabTitle,
+                    );
+                    await this.googleDriveClient.appendCsvToSheet(
+                        refreshToken,
+                        spreadsheetId,
+                        writtenRows,
+                        tabName,
+                    );
+
+                    outputs.push({
+                        tileUuid: tile.uuid,
+                        tabName,
+                        sourceName: tabTitle,
+                        status: isTruncated ? 'truncated' : 'success',
+                        rowCount: Math.max(writtenRows.length - 1, 0),
+                        error: isTruncated
+                            ? `Truncated to ${Math.max(
+                                  writtenRows.length - 1,
+                                  0,
+                              )} rows to stay within the spreadsheet cell limit`
+                            : null,
+                    });
+                }, Promise.resolve());
+
+                const sheetIds =
+                    await this.googleDriveClient.getSheetIdsByTitle(
+                        refreshToken,
+                        spreadsheetId,
+                    );
+                const sheetUrlsByTab = Object.entries(sheetIds).reduce<
+                    Record<string, string>
+                >(
+                    (acc, [title, sheetId]) => ({
+                        ...acc,
+                        [title]: `https://docs.google.com/spreadsheets/d/${spreadsheetId}/edit#gid=${sheetId}`,
+                    }),
+                    {},
+                );
+
+                await this.googleDriveClient.appendCsvToSheet(
+                    refreshToken,
+                    spreadsheetId,
+                    SchedulerTask.buildExportIndexRows({
+                        dashboardName: dashboard.name,
+                        dashboardUrl,
+                        exportedAt,
+                        outputs,
+                        sheetUrlsByTab,
+                    }),
+                    EXPORT_DASHBOARD_GSHEET_INDEX_TAB,
+                );
+
+                return {
+                    fileUrl: `https://docs.google.com/spreadsheets/d/${spreadsheetId}/edit`,
+                    outputCount: `${outputs.length}`,
+                    failedCount: `${
+                        outputs.filter((o) => o.status === 'failed').length
+                    }`,
+                };
+            },
+        );
     }
 
     protected async uploadGsheets(

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -3932,6 +3932,7 @@ export default class SchedulerTask {
         dashboardFilters,
         parameters,
         tile,
+        chartUuid,
     }: {
         account: AccountType;
         dashboardUuid: string;
@@ -3939,8 +3940,8 @@ export default class SchedulerTask {
         dashboardFilters: DashboardFilters;
         parameters: ParametersValuesMap | undefined;
         tile: DashboardChartTile;
+        chartUuid: string;
     }): Promise<string[][]> {
-        const chartUuid = tile.properties.savedChartUuid!;
         const chart =
             await this.schedulerService.savedChartModel.get(chartUuid);
         const pivotConfig = getPivotConfig(chart);
@@ -4024,19 +4025,21 @@ export default class SchedulerTask {
         projectUuid,
         dashboardFilters,
         tile,
+        savedSqlUuid,
     }: {
         account: AccountType;
         dashboardUuid: string;
         projectUuid: string;
         dashboardFilters: DashboardFilters;
         tile: DashboardSqlChartTile;
+        savedSqlUuid: string;
     }): Promise<string[][]> {
         const { rows } =
             await this.asyncQueryService.executeDashboardSqlChartQueryAndGetResults(
                 {
                     account,
                     projectUuid,
-                    savedSqlUuid: tile.properties.savedSqlUuid!,
+                    savedSqlUuid,
                     invalidateCache: true,
                     context: QueryExecutionContext.GSHEETS,
                     dashboardUuid,
@@ -4204,6 +4207,36 @@ export default class SchedulerTask {
                             : undefined) ||
                         tile.uuid;
 
+                    // A tile whose chart reference is missing can't be
+                    // queried, so it gets a tab explaining that rather than
+                    // disappearing from the sheet.
+                    const chartUuid = isDashboardChartTileType(tile)
+                        ? tile.properties.savedChartUuid
+                        : tile.properties.savedSqlUuid;
+                    if (!chartUuid) {
+                        const tabName =
+                            await this.googleDriveClient.createNewTab(
+                                refreshToken,
+                                spreadsheetId,
+                                tabTitle,
+                            );
+                        await this.googleDriveClient.appendCsvToSheet(
+                            refreshToken,
+                            spreadsheetId,
+                            [['This output is not linked to a saved chart']],
+                            tabName,
+                        );
+                        outputs.push({
+                            tileUuid: tile.uuid,
+                            tabName,
+                            sourceName: tabTitle,
+                            status: 'unsupported',
+                            rowCount: 0,
+                            error: 'Tile is not linked to a saved chart',
+                        });
+                        return;
+                    }
+
                     let csvRows: string[][];
                     try {
                         csvRows = isDashboardChartTileType(tile)
@@ -4214,6 +4247,7 @@ export default class SchedulerTask {
                                   dashboardFilters,
                                   parameters,
                                   tile,
+                                  chartUuid,
                               })
                             : await this.exportSqlChartTileRows({
                                   account,
@@ -4221,6 +4255,7 @@ export default class SchedulerTask {
                                   projectUuid: dashboard.projectUuid,
                                   dashboardFilters,
                                   tile,
+                                  savedSqlUuid: chartUuid,
                               });
                     } catch (error) {
                         Logger.warn(

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -145,6 +145,12 @@ const getTagsForTask: {
         'project.uuid': payload.projectUuid,
     }),
 
+    [SCHEDULER_TASKS.EXPORT_DASHBOARD_GSHEET]: (payload) => ({
+        'organization.uuid': payload.organizationUuid,
+        'user.uuid': payload.userUuid,
+        'project.uuid': payload.projectUuid,
+    }),
+
     [SCHEDULER_TASKS.EXPORT_CONTENT]: (payload) => ({
         'organization.uuid': payload.organizationUuid,
         'user.uuid': payload.userUuid,

--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -1128,6 +1128,42 @@ export class SchedulerWorker extends SchedulerTask {
                     },
                 );
             },
+            [SCHEDULER_TASKS.EXPORT_DASHBOARD_GSHEET]: async (
+                payload,
+                helpers,
+            ) => {
+                await tryJobOrTimeout(
+                    SchedulerClient.processJob(
+                        SCHEDULER_TASKS.EXPORT_DASHBOARD_GSHEET,
+                        helpers.job.id,
+                        helpers.job.run_at,
+                        payload,
+                        async () => {
+                            await this.exportDashboardGsheet(
+                                helpers.job.id,
+                                helpers.job.run_at,
+                                payload,
+                            );
+                        },
+                    ),
+                    helpers.job,
+                    this.lightdashConfig.scheduler.jobTimeout,
+                    async (job, e) => {
+                        await this.schedulerService.logSchedulerJob({
+                            task: SCHEDULER_TASKS.EXPORT_DASHBOARD_GSHEET,
+                            jobId: job.id,
+                            scheduledTime: job.run_at,
+                            status: SchedulerJobStatus.ERROR,
+                            details: {
+                                projectUuid: payload.projectUuid,
+                                organizationUuid: payload.organizationUuid,
+                                error: getErrorMessage(e),
+                                createdByUserUuid: payload.userUuid,
+                            },
+                        });
+                    },
+                );
+            },
             [SCHEDULER_TASKS.EXPORT_CONTENT]: async (payload, helpers) => {
                 await tryJobOrTimeout(
                     SchedulerClient.processJob(

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -6972,6 +6972,54 @@ export class AsyncQueryService extends ProjectService {
     }
 
     /**
+     * Execute a dashboard SQL chart tile query and wait for all results.
+     * Mirrors executeSqlChartQueryAndGetResults but keeps the dashboard's
+     * filters and tile context.
+     */
+    async executeDashboardSqlChartQueryAndGetResults(
+        args: Parameters<
+            AsyncQueryService['executeAsyncDashboardSqlChartQuery']
+        >[0],
+        pollingOptions?: PollingOptions,
+    ): Promise<{ rows: Record<string, unknown>[] }> {
+        const { account, projectUuid } = args;
+
+        const { queryUuid } =
+            await this.executeAsyncDashboardSqlChartQuery(args);
+
+        await this.pollForQueryCompletion({
+            account,
+            projectUuid,
+            queryUuid,
+            ...pollingOptions,
+        });
+
+        const queryHistory = await this.queryHistoryModel.get(
+            queryUuid,
+            projectUuid,
+            account,
+        );
+
+        if (!queryHistory.resultsFileName) {
+            throw new Error('Results file name not found for query');
+        }
+
+        const resultsStream = await this.getResultsStorageClientForContext(
+            queryHistory.context,
+        ).getDownloadStream(queryHistory.resultsFileName);
+
+        const rows: Record<string, unknown>[] = [];
+        await streamJsonlData<void>({
+            readStream: resultsStream,
+            onRow: (rawRow) => {
+                rows.push(rawRow);
+            },
+        });
+
+        return { rows };
+    }
+
+    /**
      * Execute dashboard chart query and wait for all results.
      * Returns raw rows from warehouse with pivot details.
      */

--- a/packages/backend/src/services/GdriveService/GdriveService.ts
+++ b/packages/backend/src/services/GdriveService/GdriveService.ts
@@ -2,6 +2,7 @@ import { subject } from '@casl/ability';
 import {
     Account,
     CustomSqlQueryForbiddenError,
+    ExportDashboardGsheetRequest,
     ForbiddenError,
     GoogleNotConnectedError,
     isCustomSqlDimension,
@@ -125,6 +126,73 @@ export class GdriveService extends BaseService {
 
         const { jobId } =
             await this.schedulerClient.uploadGsheetFromQueryJob(payload);
+
+        return { jobId };
+    }
+
+    /**
+     * Queues an ad-hoc export of a dashboard into a newly created Google Sheet.
+     */
+    async scheduleExportDashboardGsheet(
+        account: Account,
+        projectUuid: string,
+        dashboardUuid: string,
+        options: ExportDashboardGsheetRequest,
+    ) {
+        const projectSummary = await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(account);
+        const projectMetadata = {
+            projectUuid: projectSummary.projectUuid,
+            projectName: projectSummary.name,
+        };
+
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('ExportCsv', {
+                    organizationUuid: projectSummary.organizationUuid,
+                    projectUuid: projectSummary.projectUuid,
+                    metadata: projectMetadata,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('GoogleSheets', {
+                    organizationUuid: projectSummary.organizationUuid,
+                    projectUuid: projectSummary.projectUuid,
+                    metadata: projectMetadata,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        try {
+            await this.userOAuthGrantsModel.getRefreshToken(
+                account.user.id,
+                OpenIdIdentityIssuerType.GOOGLE,
+            );
+        } catch (e) {
+            if (e instanceof NotFoundError) {
+                throw new GoogleNotConnectedError(
+                    'Google account not connected',
+                );
+            }
+            throw e;
+        }
+
+        const { jobId } = await this.schedulerClient.exportDashboardGsheetJob({
+            ...options,
+            dashboardUuid,
+            projectUuid,
+            userUuid: account.user.id,
+            organizationUuid: projectSummary.organizationUuid,
+        });
 
         return { jobId };
     }

--- a/packages/common/src/types/gdrive.ts
+++ b/packages/common/src/types/gdrive.ts
@@ -63,3 +63,32 @@ export const UPLOAD_GSHEET_FROM_ROWS_MAX_BYTES = 25 * 1024 * 1024;
 
 /** Max row count accepted by /gdrive/upload-gsheet-from-rows. */
 export const UPLOAD_GSHEET_FROM_ROWS_MAX_ROWS = 100_000;
+
+/**
+ * Google caps a spreadsheet at 10 million cells across all tabs. Budget half of
+ * that so a large dashboard export fails predictably by truncating tabs rather
+ * than being rejected mid-write.
+ */
+export const EXPORT_DASHBOARD_GSHEET_MAX_CELLS = 5_000_000;
+
+/** Max rows written to any single tab of a dashboard export. */
+export const EXPORT_DASHBOARD_GSHEET_MAX_ROWS_PER_TAB = 50_000;
+
+/** Title of the index tab written as the first tab of a dashboard export. */
+export const EXPORT_DASHBOARD_GSHEET_INDEX_TAB = 'Export summary';
+
+export type ExportDashboardGsheetOutputStatus =
+    | 'success'
+    | 'truncated'
+    | 'failed'
+    | 'unsupported';
+
+/** One dashboard output and how it fared in the export. */
+export type ExportDashboardGsheetOutput = {
+    tileUuid: string;
+    tabName: string;
+    sourceName: string;
+    status: ExportDashboardGsheetOutputStatus;
+    rowCount: number;
+    error: string | null;
+};

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -879,6 +879,22 @@ export type ExportContentPayload = TraceTaskBase & {
     encodedJwt?: string;
 };
 
+/** Ad-hoc export of a dashboard into a newly created Google Sheet. */
+export type ExportDashboardGsheetPayload = TraceTaskBase & {
+    dashboardUuid: string;
+    dashboardFilters?: DashboardFilters;
+    dateZoomGranularity?: DateGranularity | string;
+    selectedTabs?: string[] | null;
+    parameters?: ParametersValuesMap;
+};
+
+export type ExportDashboardGsheetRequest = {
+    dashboardFilters?: DashboardFilters;
+    dateZoomGranularity?: DateGranularity | string;
+    selectedTabs?: string[] | null;
+    parameters?: ParametersValuesMap;
+};
+
 export type ExportContentRequest = {
     format: ExportContentFormat;
     options?: SchedulerCsvOptions | SchedulerImageOptions;

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -29,6 +29,7 @@ import {
     type EmailNotificationPayload,
     type ExportContentPayload,
     type ExportCsvDashboardPayload,
+    type ExportDashboardGsheetPayload,
     type GoogleChatBatchNotificationPayload,
     type GoogleChatNotificationPayload,
     type GsheetsNotificationPayload,
@@ -191,6 +192,7 @@ export const SCHEDULER_TASKS = {
     INDEX_CATALOG: 'indexCatalog',
     GENERATE_DAILY_JOBS: 'generateDailyJobs',
     EXPORT_CSV_DASHBOARD: 'exportCsvDashboard',
+    EXPORT_DASHBOARD_GSHEET: 'exportDashboardGsheet',
     EXPORT_CONTENT: 'exportContent',
     RENAME_RESOURCES: 'renameResources',
     MATERIALIZE_PRE_AGGREGATE: 'materializePreAggregate',
@@ -237,6 +239,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.INDEX_CATALOG]: SchedulerIndexCatalogJobPayload;
     [SCHEDULER_TASKS.GENERATE_DAILY_JOBS]: TraceTaskBase;
     [SCHEDULER_TASKS.EXPORT_CSV_DASHBOARD]: ExportCsvDashboardPayload;
+    [SCHEDULER_TASKS.EXPORT_DASHBOARD_GSHEET]: ExportDashboardGsheetPayload;
     [SCHEDULER_TASKS.EXPORT_CONTENT]: ExportContentPayload;
     [SCHEDULER_TASKS.SLACK_AI_PROMPT]: SlackPromptJobPayload;
     [SCHEDULER_TASKS.RENAME_RESOURCES]: RenameResourcesPayload;

--- a/packages/frontend/src/api/csv.ts
+++ b/packages/frontend/src/api/csv.ts
@@ -1,6 +1,7 @@
 import {
     type ApiDownloadCsv,
     type ApiScheduledDownloadCsv,
+    type ExportDashboardGsheetRequest,
 } from '@lightdash/common';
 import { lightdashApi } from '../api';
 
@@ -9,4 +10,18 @@ export const getCsvFileUrl = async ({ jobId }: ApiScheduledDownloadCsv) =>
         url: `/csv/${jobId}`,
         method: 'GET',
         body: undefined,
+    });
+
+export const exportDashboardToGsheet = async ({
+    projectUuid,
+    dashboardUuid,
+    ...body
+}: ExportDashboardGsheetRequest & {
+    projectUuid: string;
+    dashboardUuid: string;
+}) =>
+    lightdashApi<ApiScheduledDownloadCsv>({
+        url: `/gdrive/export-dashboard/${projectUuid}/${dashboardUuid}`,
+        method: 'POST',
+        body: JSON.stringify(body),
     });

--- a/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
@@ -14,6 +14,7 @@ import {
     Text,
     Tooltip,
 } from '@mantine/core';
+import { IconTableExport } from '@tabler/icons-react';
 import {
     IconCsv,
     IconFileExport,
@@ -23,6 +24,8 @@ import {
     IconScreenshot,
 } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
+import { exportDashboardToGsheet } from '../../../api/csv';
+import { useExportToGoogleSheet } from '../../../features/export/hooks/useExportToGoogleSheet';
 import { PreviewAndCustomizeScreenshot } from '../../../features/preview';
 import { CsvFormattingOptions } from '../../../features/scheduler/components/CsvFormattingOptions';
 import { Limit, Values } from '../../../features/scheduler/components/types';
@@ -31,6 +34,7 @@ import {
     useExportDashboardContent,
     useExportDashboardContentPreview,
 } from '../../../hooks/dashboard/useDashboard';
+import useHealth from '../../../hooks/health/useHealth';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
 import Callout from '../Callout';
 import MantineIcon from '../MantineIcon';
@@ -51,8 +55,13 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
     dashboard,
 }) => {
     const [exportType, setExportType] = useState<
-        SchedulerFormat.IMAGE | SchedulerFormat.CSV | SchedulerFormat.XLSX
+        | SchedulerFormat.IMAGE
+        | SchedulerFormat.CSV
+        | SchedulerFormat.XLSX
+        | SchedulerFormat.GSHEETS
     >(SchedulerFormat.IMAGE);
+    const health = useHealth();
+    const isGoogleSheetsEnabled = !!health.data?.auth.google.enabled;
     const exportDashboardContentMutation = useExportDashboardContent();
     const dashboardFilters = useDashboardContext((c) => c.allFilters);
     const dateZoomGranularity = useDashboardContext(
@@ -130,6 +139,7 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
     );
 
     const handleAsyncExport = useCallback(() => {
+        if (exportType === SchedulerFormat.GSHEETS) return;
         exportDashboardContentMutation.mutate({
             dashboard,
             format: exportType,
@@ -157,6 +167,28 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
         parameterValues,
         previewChoice,
     ]);
+
+    // Each export creates a brand new sheet, so nothing the user already has
+    // is overwritten.
+    const {
+        startExporting: startGsheetExport,
+        isExporting: isGsheetExporting,
+    } = useExportToGoogleSheet({
+        getGsheetLink: () =>
+            exportDashboardToGsheet({
+                projectUuid: dashboard.projectUuid,
+                dashboardUuid: dashboard.uuid,
+                dashboardFilters,
+                dateZoomGranularity,
+                parameters: parameterValues,
+                selectedTabs: exportSelectedTabs,
+            }),
+    });
+
+    const handleGsheetExport = useCallback(() => {
+        startGsheetExport();
+        onClose();
+    }, [startGsheetExport, onClose]);
 
     const handleImageExport = useCallback(() => {
         if (previewChoice && previews[getPreviewKey(previewChoice)]) {
@@ -211,6 +243,19 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
             );
         }
 
+        if (exportType === SchedulerFormat.GSHEETS) {
+            return (
+                <Button
+                    loading={isGsheetExporting}
+                    onClick={handleGsheetExport}
+                    disabled={!hasTilesInSelectedTabs()}
+                    leftSection={<MantineIcon icon={IconTableExport} />}
+                >
+                    Export to Google Sheets
+                </Button>
+            );
+        }
+
         if (exportType === SchedulerFormat.XLSX) {
             return (
                 <Button
@@ -257,6 +302,14 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
                             { label: 'Image', value: SchedulerFormat.IMAGE },
                             { label: '.csv', value: SchedulerFormat.CSV },
                             { label: '.xlsx', value: SchedulerFormat.XLSX },
+                            ...(isGoogleSheetsEnabled
+                                ? [
+                                      {
+                                          label: 'Google Sheets',
+                                          value: SchedulerFormat.GSHEETS,
+                                      },
+                                  ]
+                                : []),
                         ]}
                         w="min-content"
                         radius="md"
@@ -266,48 +319,57 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
                                 value as
                                     | SchedulerFormat.IMAGE
                                     | SchedulerFormat.CSV
-                                    | SchedulerFormat.XLSX,
+                                    | SchedulerFormat.XLSX
+                                    | SchedulerFormat.GSHEETS,
                             )
                         }
                     />
-                    {exportType !== SchedulerFormat.IMAGE && (
+                    {exportType === SchedulerFormat.GSHEETS && (
                         <Text fs="italic" fz="sm" c="dimmed">
-                            Charts from the selected tabs will be exported as
-                            tables
-                            {exportType === SchedulerFormat.XLSX &&
-                            xlsxFileLayout === 'workbook'
-                                ? ' in one workbook.'
-                                : ' in a ZIP file.'}
+                            A new Google Sheet will be created, with one tab per
+                            chart and a summary tab listing them.
                         </Text>
                     )}
+                    {exportType !== SchedulerFormat.IMAGE &&
+                        exportType !== SchedulerFormat.GSHEETS && (
+                            <Text fs="italic" fz="sm" c="dimmed">
+                                Charts from the selected tabs will be exported
+                                as tables
+                                {exportType === SchedulerFormat.XLSX &&
+                                xlsxFileLayout === 'workbook'
+                                    ? ' in one workbook.'
+                                    : ' in a ZIP file.'}
+                            </Text>
+                        )}
                 </Stack>
 
-                {exportType !== SchedulerFormat.IMAGE && (
-                    <Stack gap="xs">
-                        {!!dateZoomGranularity && (
-                            <Callout
-                                title="Date zoom is enabled"
-                                variant="info"
-                            >
-                                Your export will include data for the selected
-                                date zoom granularity.
-                            </Callout>
-                        )}
-                        <CsvFormattingOptions
-                            format={exportType}
-                            formatted={formatted}
-                            onFormattedChange={setFormatted}
-                            limit={limit}
-                            onLimitChange={setLimit}
-                            customLimit={customLimit}
-                            onCustomLimitChange={setCustomLimit}
-                            exportPivotedData={exportPivotedData}
-                            onExportPivotedDataChange={setExportPivotedData}
-                            xlsxFileLayout={xlsxFileLayout}
-                            onXlsxFileLayoutChange={setXlsxFileLayout}
-                        />
-                    </Stack>
-                )}
+                {exportType !== SchedulerFormat.IMAGE &&
+                    exportType !== SchedulerFormat.GSHEETS && (
+                        <Stack gap="xs">
+                            {!!dateZoomGranularity && (
+                                <Callout
+                                    title="Date zoom is enabled"
+                                    variant="info"
+                                >
+                                    Your export will include data for the
+                                    selected date zoom granularity.
+                                </Callout>
+                            )}
+                            <CsvFormattingOptions
+                                format={exportType}
+                                formatted={formatted}
+                                onFormattedChange={setFormatted}
+                                limit={limit}
+                                onLimitChange={setLimit}
+                                customLimit={customLimit}
+                                onCustomLimitChange={setCustomLimit}
+                                exportPivotedData={exportPivotedData}
+                                onExportPivotedDataChange={setExportPivotedData}
+                                xlsxFileLayout={xlsxFileLayout}
+                                onXlsxFileLayoutChange={setXlsxFileLayout}
+                            />
+                        </Stack>
+                    )}
 
                 {isDashboardTabsAvailable && dashboard.tabs.length > 1 && (
                     <Stack gap="xs">

--- a/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
@@ -185,10 +185,11 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
             }),
     });
 
+    // The polling query lives in this component, so the modal has to stay
+    // mounted until the export resolves; closing it would strand the toast.
     const handleGsheetExport = useCallback(() => {
         startGsheetExport();
-        onClose();
-    }, [startGsheetExport, onClose]);
+    }, [startGsheetExport]);
 
     const handleImageExport = useCallback(() => {
         if (previewChoice && previews[getPreviewKey(previewChoice)]) {


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-926/i-want-to-export-dashboard-csvs-to-google-sheets

Stacks on top of #26894 (the bug fix and shared tab-writing seam). Review that one first; this PR's diff is against it.

## Screenshot

<img width="2400" height="1726" alt="02-export-modal-gsheets-selected" src="https://github.com/user-attachments/assets/23ff9aff-fc70-48b3-9111-c8d15480af43" />

## Summary

Adds "Google Sheets" as an export option on a dashboard. Each export creates a **brand new** spreadsheet with one tab per output and an index tab first, so exports never overwrite each other and the sheet explains itself.

The customer ask was to stop copy-pasting a dashboard chart-by-chart into a sheet each reporting cycle, and specifically *not* a sync — every export needs to be its own artifact.

## How it works

```
POST /gdrive/export-dashboard/{projectUuid}/{dashboardUuid}
   |
   v
GdriveService.scheduleExportDashboardGsheet     ExportCsv + GoogleSheets ability,
   |                                            requires a connected Google account
   v
scheduler task: exportDashboardGsheet
   |
   +-- createNewSheet            "<Dashboard> (Lightdash export <when>)"
   +-- renameSheet               first tab -> "Export summary"
   +-- for each tile, in order   chart + SQL chart, dashboard layout order
   |     ok    -> createNewTab + write rows
   |     failed-> createNewTab + write the error
   +-- getSheetIdsByTitle        tab -> gid, for per-tab links
   +-- write the index tab
```

Tabs are written sequentially: it keeps one tile's results in memory at a time and stays well inside the 60-writes-per-minute-per-user Sheets quota, which a customer has hit before at scale.

## The index tab

```
Lightdash dashboard export
Dashboard      | Pivot Table Dashboard
Dashboard link | http://.../dashboards/<uuid>/view
Exported at    | 2026-08-05T17:22:27.967Z
Outputs        | 10

Tab | Source | Status | Rows | Details | Link
... one row per output
```

Status is `Success`, `Truncated`, or `Failed`. A failed output still gets its own tab containing the error, so a chart that didn't make it is visible in the sheet rather than silently absent.

## Limits

Google caps a spreadsheet at 10M cells across all tabs, so a whole-export budget of 5M cells plus a 50k row-per-tab cap is applied as tabs are written. A tab trimmed by either is marked `Truncated` in the index with its row count, rather than failing the export.

## Notes

- The index is written with the same `RAW` value mode as every other sheet write. `USER_ENTERED` would make `=HYPERLINK()` links possible but would let user-controlled chart names inject formulas, so the Link column holds plain `#gid` URLs instead.
- Uses the `drive.file` scope already granted for Sheets syncs — no new or broader OAuth scope. The new sheet lands in the exporting user's My Drive.
### Why there's no destination picker

The export always lands in the exporting user's My Drive root, with no folder chooser. That's deliberate:

- Choosing a destination means the **Google Picker**, which needs `GOOGLE_DRIVE_API_KEY`. That isn't set on every deployment — the existing Picker-gated "Export to Google Sheets" chart action is invisible without it — so making a one-click dashboard export depend on it would hide the feature for some users.
- `drive.file` can write into a *picked* folder, but cannot create folders or list files it didn't create, so the picker cannot be worked around. Avoiding a broader Drive scope keeps this off Google's sensitive/restricted-scope track and away from re-verification.
- PROD-4744 asked for a folder picker on Sheets syncs and was cancelled, so this isn't a new gap.

A user who wants the sheet elsewhere can move it in Drive, and the export link is opened for them on completion.

## Test plan

- [x] `pnpm -F common|backend|frontend typecheck` and `lint` — all clean
- [x] Real export against the Google Sheets API: new spreadsheet created, `Export summary` first, 10 chart tabs after it, data verified by reading tabs back
- [x] Real failure case: one chart pointed at a non-existent metric — export still completes, all 11 tabs present, the failed output's tab reads "This output could not be exported" plus the error, and the index marks it `Failed` while the other nine show `Success`
- [x] Index verified end to end: dashboard link, timestamp, per-output tab/source/status/rows and per-tab `#gid` links
- [x] Manual: exported from the dashboard modal in the UI — this surfaced two defects now fixed in this PR: the status endpoint only matched the old `uploadGsheetFromQuery` task so the toast never resolved, and the modal closed on click which unmounted the polling query

### Known issue

One UI run of a 10-tile dashboard logged `Job timed out after 600000ms` and then completed anyway (sheet written, one output failed). Earlier runs of the same dashboard finished in ~40s, so this is contention-dependent rather than a fixed cost — tiles are queried sequentially with `invalidateCache: true`. Worth deciding whether this needs concurrency before merge; it's the same shape as a previously reported dashboard→Sheets slowdown.
