### PR TITLE
feat(homepage): default homepage v2 on for EE-licensed orgs

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -192,7 +192,6 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     projectHomepageModel:
                         models.getProjectHomepageModel<ProjectHomepageModel>(),
                     analytics: context.lightdashAnalytics,
-                    featureFlagService: repository.getFeatureFlagService(),
                     groupsModel: models.getGroupsModel(),
                     projectModel: models.getProjectModel(),
                     fileStorageClient: clients.getFileStorageClient(),

--- a/packages/backend/src/ee/services/ProjectHomepageService.test.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.test.ts
@@ -110,7 +110,6 @@ const makeViewerUser = (): SessionUser => ({
 });
 
 const makeService = ({
-    flagEnabled = true,
     projectHomepageModel = {},
     groupsModel = {},
     projectModel = {},
@@ -120,7 +119,6 @@ const makeService = ({
     slackInstalled = true,
     schedulerClient = {},
 }: {
-    flagEnabled?: boolean;
     projectHomepageModel?: Partial<
         ProjectHomepageServiceArguments['projectHomepageModel']
     >;
@@ -140,12 +138,6 @@ const makeService = ({
 } = {}) =>
     new ProjectHomepageService({
         analytics: { track: vi.fn() },
-        featureFlagService: {
-            get: vi.fn().mockResolvedValue({
-                id: 'homepage-builder',
-                enabled: flagEnabled,
-            }),
-        },
         projectHomepageModel: {
             getDefault: vi.fn().mockResolvedValue(undefined),
             getByUuid: vi.fn().mockResolvedValue(makeHomepage()),
@@ -224,39 +216,38 @@ describe('ProjectHomepageService', () => {
         expect(() => makeService()).not.toThrow();
     });
 
-    it('getPublishedHomepage throws ForbiddenError when flag is disabled', async () => {
-        const service = makeService({ flagEnabled: false });
-
-        await expect(
-            service.getResolvedHomepage(makeAdminUser(), PROJECT_UUID),
-        ).rejects.toThrow(ForbiddenError);
-    });
-
-    it('org settings opt-in enables the homepage even when the flag is off', async () => {
+    it('getPublishedHomepage throws ForbiddenError when the org opted out', async () => {
         const service = makeService({
-            flagEnabled: false,
             projectHomepageModel: {
                 findOrgHomepageSettings: vi.fn().mockResolvedValue({
                     organizationUuid: ORGANIZATION_UUID,
-                    enabled: true,
-                    opening: 'content-first',
+                    enabled: false,
+                    opening: null,
                 }),
             },
         });
 
         await expect(
             service.getResolvedHomepage(makeAdminUser(), PROJECT_UUID),
+        ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('the homepage is enabled by default, without any org settings row', async () => {
+        const service = makeService();
+
+        await expect(
+            service.getResolvedHomepage(makeAdminUser(), PROJECT_UUID),
         ).resolves.toBeNull();
     });
 
-    it('getOrgHomepageSettings returns defaults when the org never opted in', async () => {
+    it('getOrgHomepageSettings defaults to enabled when there is no row', async () => {
         const service = makeService();
 
         await expect(
             service.getOrgHomepageSettings(makeViewerUser()),
         ).resolves.toEqual({
             organizationUuid: ORGANIZATION_UUID,
-            enabled: false,
+            enabled: true,
             opening: null,
         });
     });

--- a/packages/backend/src/ee/services/ProjectHomepageService.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.ts
@@ -2,7 +2,7 @@ import { subject } from '@casl/ability';
 import {
     ANNOUNCEMENT_BODY_MAX_LENGTH,
     assertUnreachable,
-    CommercialFeatureFlags,
+    DEFAULT_HOMEPAGE_ENABLED,
     defaultHomepageConfig,
     ForbiddenError,
     getErrorMessage,
@@ -42,7 +42,6 @@ import { type GroupsModel } from '../../models/GroupsModel';
 import { type ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { type SlackAuthenticationModel } from '../../models/SlackAuthenticationModel';
 import { BaseService } from '../../services/BaseService';
-import { type FeatureFlagService } from '../../services/FeatureFlag/FeatureFlagService';
 import { type PersistentDownloadFileService } from '../../services/PersistentDownloadFileService/PersistentDownloadFileService';
 import { secureFetch } from '../../utils/secureFetch/secureFetch';
 import { type ProjectHomepageModel } from '../models/ProjectHomepageModel';
@@ -192,7 +191,6 @@ export type ProjectHomepageServiceArguments = {
         | 'swapHeroBlocks'
     >;
     analytics: Pick<LightdashAnalytics, 'track'>;
-    featureFlagService: Pick<FeatureFlagService, 'get'>;
     groupsModel: Pick<GroupsModel, 'findUserGroups'>;
     projectModel: Pick<ProjectModel, 'getProjectMemberAccess' | 'getSummary'>;
     fileStorageClient: FileStorageClient;
@@ -214,8 +212,6 @@ export class ProjectHomepageService extends BaseService {
 
     private readonly analytics: ProjectHomepageServiceArguments['analytics'];
 
-    private readonly featureFlagService: ProjectHomepageServiceArguments['featureFlagService'];
-
     private readonly groupsModel: ProjectHomepageServiceArguments['groupsModel'];
 
     private readonly projectModel: ProjectHomepageServiceArguments['projectModel'];
@@ -236,7 +232,6 @@ export class ProjectHomepageService extends BaseService {
         super();
         this.projectHomepageModel = args.projectHomepageModel;
         this.analytics = args.analytics;
-        this.featureFlagService = args.featureFlagService;
         this.groupsModel = args.groupsModel;
         this.projectModel = args.projectModel;
         this.fileStorageClient = args.fileStorageClient;
@@ -247,22 +242,16 @@ export class ProjectHomepageService extends BaseService {
         this.schedulerClient = args.schedulerClient;
     }
 
-    // Homepage v2 is on when the org opted in via settings OR the commercial
-    // flag is set — the flag remains as the legacy enablement path and
-    // kill-switch while the opt-in flow rolls out.
+    // Homepage v2 is on for every licensed org — this service only exists when
+    // the EE bundle loads with a valid license. Orgs can still opt out
+    // explicitly, which is the only thing that turns it back off.
     private async isHomepageEnabled(user: SessionUser): Promise<boolean> {
-        if (user.organizationUuid) {
-            const settings =
-                await this.projectHomepageModel.findOrgHomepageSettings(
-                    user.organizationUuid,
-                );
-            if (settings?.enabled) return true;
-        }
-        const flag = await this.featureFlagService.get({
-            user,
-            featureFlagId: CommercialFeatureFlags.HomepageBuilder,
-        });
-        return flag.enabled;
+        if (!user.organizationUuid) return false;
+        const settings =
+            await this.projectHomepageModel.findOrgHomepageSettings(
+                user.organizationUuid,
+            );
+        return settings?.enabled ?? DEFAULT_HOMEPAGE_ENABLED;
     }
 
     private async assertFlagEnabled(user: SessionUser): Promise<void> {
@@ -284,7 +273,7 @@ export class ProjectHomepageService extends BaseService {
         return (
             settings ?? {
                 organizationUuid: user.organizationUuid,
-                enabled: false,
+                enabled: DEFAULT_HOMEPAGE_ENABLED,
                 opening: null,
             }
         );

--- a/packages/common/src/ee/homepage/orgSettings.ts
+++ b/packages/common/src/ee/homepage/orgSettings.ts
@@ -13,10 +13,13 @@ export const isHomepageOpening = (value: unknown): value is HomepageOpening =>
     typeof value === 'string' &&
     HOMEPAGE_OPENINGS.includes(value as HomepageOpening);
 
+/** Homepage v2 is on for every EE-licensed organization; an org only leaves it
+ * by explicitly switching back to the classic homepage. */
+export const DEFAULT_HOMEPAGE_ENABLED = true;
+
 /** Org-wide homepage v2 state. `enabled` turns the new homepage on for every
- * project in the organization; the commercial flag remains as a kill-switch.
- * `opening: null` means "auto" — AI availability decides, which is the legacy
- * behaviour for orgs enabled via the flag before this setting existed. */
+ * project in the organization. `opening: null` means "auto" — AI availability
+ * decides, which is the behaviour for orgs that never picked an opening. */
 export type OrganizationHomepageSettings = {
     organizationUuid: string;
     enabled: boolean;

--- a/packages/frontend/src/ee/features/homepageBuilder/AdminHomepageControls.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/AdminHomepageControls.test.tsx
@@ -14,7 +14,7 @@ vi.mock('../../../providers/Ability', () => ({
 
 const { settings } = vi.hoisted(() => ({
     settings: {
-        current: { enabled: false, opening: null } as {
+        current: { enabled: true, opening: null } as {
             enabled: boolean;
             opening: 'ask-first' | 'content-first' | null;
         },
@@ -41,7 +41,7 @@ const renderControls = () =>
 
 describe('AdminHomepageControls', () => {
     beforeEach(() => {
-        settings.current = { enabled: false, opening: null };
+        settings.current = { enabled: true, opening: null };
     });
 
     it('only renders homepage curation controls', () => {
@@ -58,18 +58,7 @@ describe('AdminHomepageControls', () => {
         ).not.toBeInTheDocument();
     });
 
-    it('hides the switch-back control for flag-enabled orgs (no opt-in row)', () => {
-        renderControls();
-
-        expect(
-            screen.queryByRole('button', {
-                name: 'Switch back to classic homepage',
-            }),
-        ).toBeNull();
-    });
-
-    it('offers switch-back when the org opted in via settings', () => {
-        settings.current = { enabled: true, opening: 'content-first' };
+    it('offers switch-back by default, without any opt-in', () => {
         renderControls();
 
         expect(
@@ -77,5 +66,16 @@ describe('AdminHomepageControls', () => {
                 name: 'Switch back to classic homepage',
             }),
         ).toBeInTheDocument();
+    });
+
+    it('hides the switch-back control once the org is on classic', () => {
+        settings.current = { enabled: false, opening: null };
+        renderControls();
+
+        expect(
+            screen.queryByRole('button', {
+                name: 'Switch back to classic homepage',
+            }),
+        ).toBeNull();
     });
 });

--- a/packages/frontend/src/ee/features/homepageBuilder/AdminHomepageControls.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/AdminHomepageControls.tsx
@@ -18,8 +18,8 @@ type Props = {
     showNewHomepage?: boolean;
 };
 
-// Quiet escape hatch for the opt-in flow: only offered when the org enabled
-// homepage v2 via settings (flag-enabled orgs have no settings row to unset).
+// Quiet escape hatch from the default: homepage v2 is on for every licensed
+// org, and this is the only thing that turns it back off.
 const SwitchBackButton: FC<{ organizationUuid: string | undefined }> = ({
     organizationUuid,
 }) => {

--- a/packages/frontend/src/ee/features/homepageBuilder/TryNewHomepagePromo.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/TryNewHomepagePromo.tsx
@@ -301,9 +301,10 @@ export const TryNewHomepageModal: FC<{
 };
 
 /** Dismissible invitation on the classic homepage, shown only to org admins —
- * the one role that can complete the org-wide opt-in. The modal itself lives
- * at page level (it must survive the homepage flip), so opening it is the
- * parent's job. */
+ * the one role that can turn homepage v2 back on org-wide. Licensed orgs are
+ * on v2 by default, so this only reaches orgs that switched back. The modal
+ * itself lives at page level (it must survive the homepage flip), so opening
+ * it is the parent's job. */
 export const TryNewHomepageCard: FC<{
     organizationUuid: string | undefined;
     onTryNow: () => void;

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useHomepageBuilderFlag.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useHomepageBuilderFlag.test.ts
@@ -1,0 +1,57 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useHomepageBuilderFlag } from './useProjectHomepage';
+
+const state = vi.hoisted(() => ({
+    licenseValid: true,
+    settings: { enabled: true } as { enabled: boolean } | undefined,
+    settingsQueryEnabled: undefined as boolean | undefined,
+}));
+
+vi.mock('../../../../providers/App/useApp', () => ({
+    default: () => ({
+        health: {
+            data: { license: { valid: state.licenseValid } },
+            isInitialLoading: false,
+        },
+    }),
+}));
+
+vi.mock('./useOrgHomepageSettings', () => ({
+    useOrgHomepageSettings: ({ enabled }: { enabled?: boolean } = {}) => {
+        state.settingsQueryEnabled = enabled;
+        return {
+            data: enabled ? state.settings : undefined,
+            isInitialLoading: false,
+        };
+    },
+}));
+
+describe('useHomepageBuilderFlag', () => {
+    beforeEach(() => {
+        state.licenseValid = true;
+        state.settings = { enabled: true };
+        state.settingsQueryEnabled = undefined;
+    });
+
+    it('is on for a licensed org that never opted in', () => {
+        const { result } = renderHook(() => useHomepageBuilderFlag());
+
+        expect(result.current.isEnabled).toBe(true);
+    });
+
+    it('is off for an org that switched back to the classic homepage', () => {
+        state.settings = { enabled: false };
+        const { result } = renderHook(() => useHomepageBuilderFlag());
+
+        expect(result.current.isEnabled).toBe(false);
+    });
+
+    it('is off without a valid license, and skips the enterprise request', () => {
+        state.licenseValid = false;
+        const { result } = renderHook(() => useHomepageBuilderFlag());
+
+        expect(result.current.isEnabled).toBe(false);
+        expect(state.settingsQueryEnabled).toBe(false);
+    });
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useOrgHomepageSettings.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useOrgHomepageSettings.ts
@@ -18,8 +18,11 @@ const getOrgHomepageSettingsApi = async () =>
         body: undefined,
     });
 
-export const useOrgHomepageSettings = () =>
+export const useOrgHomepageSettings = ({
+    enabled = true,
+}: { enabled?: boolean } = {}) =>
     useQuery<OrganizationHomepageSettings, ApiError>({
+        enabled,
         queryKey: [ORG_HOMEPAGE_SETTINGS_QUERY_KEY],
         queryFn: getOrgHomepageSettingsApi,
     });

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useProjectHomepage.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useProjectHomepage.ts
@@ -1,5 +1,4 @@
 import {
-    CommercialFeatureFlags,
     type ApiError,
     type CreateProjectHomepageRequest,
     type HomepageAssignment,
@@ -14,7 +13,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { lightdashApi } from '../../../../api';
 import useToaster from '../../../../hooks/toaster/useToaster';
-import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
+import useApp from '../../../../providers/App/useApp';
 import { IS_MOBILE } from '../../../../utils/isMobile';
 import { ANNOUNCEMENTS_QUERY_KEY } from './useAnnouncements';
 import { useOrgHomepageSettings } from './useOrgHomepageSettings';
@@ -126,19 +125,19 @@ const updateGroupPrioritiesApi = async (
     });
 
 export const useHomepageBuilderFlag = () => {
-    const { data: flag, isLoading: isFlagLoading } = useServerFeatureFlag(
-        CommercialFeatureFlags.HomepageBuilder,
-    );
-    // Homepage v2 is on when the org opted in via settings OR the commercial
-    // flag is set — the flag remains as the legacy path/kill-switch while the
-    // opt-in flow rolls out. Must match the backend rule in
-    // ProjectHomepageService.isHomepageEnabled.
-    const settings = useOrgHomepageSettings();
+    // The homepage builder is an enterprise feature: unlicensed instances have
+    // no backing service, so don't ask them for its settings either.
+    const { health } = useApp();
+    const hasValidLicense = !!health.data?.license?.valid;
+    // Homepage v2 is the default for licensed orgs; settings only carry an
+    // explicit switch back to the classic homepage. Must match the backend
+    // rule in ProjectHomepageService.isHomepageEnabled.
+    const settings = useOrgHomepageSettings({ enabled: hasValidLicense });
     // The homepage builder / new onboarding surfaces are desktop-only for now,
     // so fall back to the classic homepage on mobile.
     return {
-        isEnabled: !IS_MOBILE && (!!flag?.enabled || !!settings.data?.enabled),
-        isLoading: isFlagLoading || settings.isInitialLoading,
+        isEnabled: !IS_MOBILE && settings.data?.enabled === true,
+        isLoading: health.isInitialLoading || settings.isInitialLoading,
     };
 };
 

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -56,8 +56,8 @@ const Home: FC = () => {
 
     const { user } = useApp();
     const isAiAgentsEnabled = useAiAgentButtonVisibility();
-    // The commercial flag (per-org, default-off) is the only gate — AI-less
-    // orgs get the day-0/builder experience with the non-AI hero variant.
+    // On by default for EE-licensed orgs — AI-less orgs get the day-0/builder
+    // experience with the non-AI hero variant.
     const {
         isEnabled: isHomepageBuilderEnabled,
         isLoading: isHomepageBuilderFlagLoading,
@@ -187,7 +187,8 @@ const Home: FC = () => {
                                 userName={user.data?.firstName}
                                 projectUuid={project.data.projectUuid}
                             />
-                            {/* Below the greeting on purpose: an admin-only promo
+                            {/* Only orgs that switched back to classic land here.
+                            Below the greeting on purpose: an admin-only promo
                             shouldn't outrank the page's own hero */}
                             {!isHomepageBuilderEnabled && (
                                 <TryNewHomepageCard


### PR DESCRIPTION
Homepage v2 previously needed an org-wide opt-in (a `organization_homepage_settings` row with `enabled: true`) or the `homepage-builder` commercial flag. It's now on by default for any instance where the EE bundle loads with a valid license — the license stays the only gate, and the settings row is left carrying just the explicit switch back to the classic homepage.

- Backend `isHomepageEnabled` no longer consults the commercial flag; it defaults to on unless the org has a row with `enabled: false`, and `getOrgHomepageSettings` returns that same default when there's no row. `featureFlagService` dropped from the service since it's now unused (the flag itself stays, it's still used by onboarding provisioning).
- Frontend `useHomepageBuilderFlag` gates on `health.license.valid` + the settings row, and skips the EE-only settings request entirely on unlicensed instances rather than letting it error.
- The "Classic homepage" switch-back in `AdminHomepageControls` now shows for every licensed org, and the `TryNewHomepageCard` promo is only reachable by orgs that used it — it's the way back on.

Verified with `pnpm -F backend test src/ee/services/ProjectHomepageService.test.ts`, the frontend homepage/AppRoute/pages suites, and typecheck + lint on common/backend/frontend. Not exercised in a running app: no license key available in this environment, so v2 can't be turned on end-to-end here.
