### PR TITLE
feat: complete memory promotion writeback

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -31,6 +31,7 @@ import {
     WarehouseTypes,
     type AiAgentMemoryConsolidationTrigger,
     type AiAgentMemoryScope,
+    type AiAgentMemoryStatus,
     type AiAgentReviewItemStatus,
     type AiAgentReviewItemWritebackBlockedReason,
     type AiAgentReviewItemWritebackStrategy,
@@ -3071,7 +3072,7 @@ export type AiAgentMemoryViewedEvent = BaseTrack & {
         projectId: string;
         agentId: string | null;
         memoryId: string;
-        status: 'active' | 'superseded' | 'retired';
+        status: AiAgentMemoryStatus;
         provenanceType: 'source_thread' | 'consolidated';
     };
 };

--- a/packages/backend/src/ee/models/AiAgentMemoryModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentMemoryModel.integration.test.ts
@@ -1856,7 +1856,7 @@ describe('AiAgentMemoryModel integration', () => {
         );
     });
 
-    it.each(['superseded', 'retired'] as const)(
+    it.each(['superseded', 'retired', 'promoted'] as const)(
         'skips a thread whose memory is %s and keeps it out of the next sweep',
         async (status) => {
             const activity = new Date('2026-07-22T05:00:00Z');

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
@@ -2,6 +2,7 @@ import { ProjectType } from '@lightdash/common';
 import knex, { Knex } from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
 import { AiPromptTableName } from '../database/entities/ai';
+import { AiAgentMemoryTableName } from '../database/entities/aiAgentMemory';
 import {
     AiAgentReviewClassifierRunTableName,
     AiAgentReviewItemEventsTableName,
@@ -1735,8 +1736,11 @@ describe('AiAgentReviewClassifierModel', () => {
     });
 
     describe('reconcileReviewItemPrState', () => {
-        it('updates status and pr_state for a fingerprint in the org', async () => {
-            tracker.on.update(AiAgentReviewItemTableName).responseOnce(1);
+        it('promotes an active source memory when its pull request merges', async () => {
+            tracker.on
+                .update(AiAgentReviewItemTableName)
+                .responseOnce([{ source_ai_agent_memory_uuid: USER_UUID }]);
+            tracker.on.update(AiAgentMemoryTableName).responseOnce(1);
 
             await model.reconcileReviewItemPrState({
                 fingerprint: FINGERPRINT,
@@ -1745,12 +1749,69 @@ describe('AiAgentReviewClassifierModel', () => {
                 prState: 'merged',
             });
 
-            expect(tracker.history.update).toHaveLength(1);
+            expect(tracker.history.update).toHaveLength(2);
             expect(tracker.history.update[0].sql).toContain(
                 AiAgentReviewItemTableName,
             );
             expect(tracker.history.update[0].bindings).toContain('resolved');
             expect(tracker.history.update[0].bindings).toContain('merged');
+            expect(tracker.history.update[1].sql).toContain(
+                AiAgentMemoryTableName,
+            );
+            expect(tracker.history.update[1].bindings).toContain('active');
+            expect(tracker.history.update[1].bindings).toContain('promoted');
+        });
+
+        it('leaves the source memory untouched when the pull request closes', async () => {
+            tracker.on
+                .update(AiAgentReviewItemTableName)
+                .responseOnce([{ source_ai_agent_memory_uuid: USER_UUID }]);
+
+            await model.reconcileReviewItemPrState({
+                fingerprint: FINGERPRINT,
+                organizationUuid: ORGANIZATION_UUID,
+                status: 'open',
+                prState: 'closed',
+            });
+
+            expect(tracker.history.update).toHaveLength(1);
+            expect(tracker.history.update[0].bindings).toContain('open');
+            expect(tracker.history.update[0].bindings).toContain('closed');
+        });
+
+        it('resolves a merged item when its source memory is no longer active', async () => {
+            tracker.on
+                .update(AiAgentReviewItemTableName)
+                .responseOnce([{ source_ai_agent_memory_uuid: USER_UUID }]);
+            tracker.on.update(AiAgentMemoryTableName).responseOnce(0);
+
+            await expect(
+                model.reconcileReviewItemPrState({
+                    fingerprint: FINGERPRINT,
+                    organizationUuid: ORGANIZATION_UUID,
+                    status: 'resolved',
+                    prState: 'merged',
+                }),
+            ).resolves.toBeUndefined();
+
+            expect(tracker.history.update).toHaveLength(2);
+        });
+
+        it('resolves a merged item after its source memory was deleted', async () => {
+            tracker.on
+                .update(AiAgentReviewItemTableName)
+                .responseOnce([{ source_ai_agent_memory_uuid: null }]);
+
+            await expect(
+                model.reconcileReviewItemPrState({
+                    fingerprint: FINGERPRINT,
+                    organizationUuid: ORGANIZATION_UUID,
+                    status: 'resolved',
+                    prState: 'merged',
+                }),
+            ).resolves.toBeUndefined();
+
+            expect(tracker.history.update).toHaveLength(1);
         });
     });
 });

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -2661,15 +2661,36 @@ export class AiAgentReviewClassifierModel {
         status: AiAgentReviewItemStatus;
         prState: AiAgentReviewItemPrState;
     }): Promise<void> {
-        await this.database<AiAgentReviewItemTable>(AiAgentReviewItemTableName)
-            .where('fingerprint', args.fingerprint)
-            .where('organization_uuid', args.organizationUuid)
-            .update({
-                status: args.status,
-                pr_state: args.prState,
-                status_updated_at: this.database.fn.now() as never,
-                updated_at: this.database.fn.now() as never,
-            });
+        await this.database.transaction(async (trx) => {
+            const [item] = await trx<AiAgentReviewItemTable>(
+                AiAgentReviewItemTableName,
+            )
+                .where('fingerprint', args.fingerprint)
+                .where('organization_uuid', args.organizationUuid)
+                .update({
+                    status: args.status,
+                    pr_state: args.prState,
+                    status_updated_at: trx.fn.now() as never,
+                    updated_at: trx.fn.now() as never,
+                })
+                .returning('source_ai_agent_memory_uuid');
+
+            if (
+                args.prState !== 'merged' ||
+                !item?.source_ai_agent_memory_uuid
+            ) {
+                return;
+            }
+
+            await trx<AiAgentMemoryTable>(AiAgentMemoryTableName)
+                .where('ai_agent_memory_uuid', item.source_ai_agent_memory_uuid)
+                .where('organization_uuid', args.organizationUuid)
+                .where('status', 'active')
+                .update({
+                    status: 'promoted',
+                    updated_at: trx.fn.now(),
+                });
+        });
     }
 
     async listReviewSignals(

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -11,6 +11,8 @@ import {
     type SessionUser,
 } from '@lightdash/common';
 import {
+    getInstallationToken,
+    getPullRequest,
     getPullRequestComments,
     getPullRequestDiffFiles,
 } from '../../clients/github/Github';
@@ -724,6 +726,152 @@ describe('AiAgentAdminService.getAllMemories', () => {
     });
 });
 
+describe('AiAgentAdminService memory promotion reconciliation', () => {
+    const memoryReviewItem = () =>
+        makeReviewItem({
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PROJECT_UUID,
+            agentUuid: AGENT_UUID,
+            source: 'memory',
+            primaryRootCause: 'project_context',
+            projectContextEntry: {
+                op: 'create',
+                id: null,
+                kind: 'definition',
+                content: 'Revenue means completed order revenue.',
+                terms: ['revenue'],
+                objects: [],
+            },
+            sourceMemory: {
+                uuid: 'memory-1',
+                slug: 'revenue-definition',
+            },
+            linkedPrUrl: PR_URL,
+            prState: 'open',
+        });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(getInstallationToken).mockResolvedValue('token');
+    });
+
+    it('resolves a merged item and enqueues project context ingest', async () => {
+        vi.mocked(getPullRequest).mockResolvedValue({
+            state: 'closed',
+            merged: true,
+        } as Awaited<ReturnType<typeof getPullRequest>>);
+        const reconcileReviewItemPrState = vi.fn().mockResolvedValue(undefined);
+        const ingestProjectContext = vi.fn().mockResolvedValue(undefined);
+        const service = makeService({
+            aiAgentReviewClassifierModel: {
+                listReviewItems: vi
+                    .fn()
+                    .mockResolvedValue([memoryReviewItem()]),
+                reconcileReviewItemPrState,
+            },
+            projectModel: {
+                get: vi.fn().mockResolvedValue({
+                    organizationUuid: ORGANIZATION_UUID,
+                    dbtConnection: { type: DbtProjectType.GITHUB },
+                }),
+            },
+            githubAppInstallationsModel: {
+                findInstallationId: vi.fn().mockResolvedValue('installation-1'),
+            },
+            schedulerClient: { ingestProjectContext },
+        });
+
+        const [item] = await service.listReviewItems(makeAdminUser());
+
+        expect(reconcileReviewItemPrState).toHaveBeenCalledWith({
+            fingerprint: 'fingerprint-1',
+            organizationUuid: ORGANIZATION_UUID,
+            status: 'resolved',
+            prState: 'merged',
+        });
+        expect(ingestProjectContext).toHaveBeenCalledWith({
+            projectUuid: PROJECT_UUID,
+            organizationUuid: ORGANIZATION_UUID,
+            userUuid: USER_UUID,
+        });
+        expect(item).toMatchObject({ status: 'resolved', prState: 'merged' });
+    });
+
+    it('does not ingest project context when the feature is disabled', async () => {
+        vi.mocked(getPullRequest).mockResolvedValue({
+            state: 'closed',
+            merged: true,
+        } as Awaited<ReturnType<typeof getPullRequest>>);
+        const ingestProjectContext = vi.fn().mockResolvedValue(undefined);
+        const service = makeService({
+            aiAgentReviewClassifierModel: {
+                listReviewItems: vi
+                    .fn()
+                    .mockResolvedValue([memoryReviewItem()]),
+                reconcileReviewItemPrState: vi
+                    .fn()
+                    .mockResolvedValue(undefined),
+            },
+            projectModel: {
+                get: vi.fn().mockResolvedValue({
+                    organizationUuid: ORGANIZATION_UUID,
+                    dbtConnection: { type: DbtProjectType.GITHUB },
+                }),
+            },
+            githubAppInstallationsModel: {
+                findInstallationId: vi.fn().mockResolvedValue('installation-1'),
+            },
+            schedulerClient: { ingestProjectContext },
+            aiOrganizationSettingsService: {
+                isAiAgentReviewsEnabled: vi.fn().mockResolvedValue(false),
+            },
+        });
+
+        const [item] = await service.listReviewItems(makeAdminUser());
+
+        expect(ingestProjectContext).not.toHaveBeenCalled();
+        expect(item).toMatchObject({ status: 'resolved', prState: 'merged' });
+    });
+
+    it('reopens an item when its pull request closes without merging', async () => {
+        vi.mocked(getPullRequest).mockResolvedValue({
+            state: 'closed',
+            merged: false,
+        } as Awaited<ReturnType<typeof getPullRequest>>);
+        const reconcileReviewItemPrState = vi.fn().mockResolvedValue(undefined);
+        const ingestProjectContext = vi.fn().mockResolvedValue(undefined);
+        const service = makeService({
+            aiAgentReviewClassifierModel: {
+                listReviewItems: vi
+                    .fn()
+                    .mockResolvedValue([memoryReviewItem()]),
+                reconcileReviewItemPrState,
+            },
+            projectModel: {
+                get: vi.fn().mockResolvedValue({
+                    organizationUuid: ORGANIZATION_UUID,
+                    dbtConnection: { type: DbtProjectType.GITHUB },
+                }),
+            },
+            githubAppInstallationsModel: {
+                findInstallationId: vi.fn().mockResolvedValue('installation-1'),
+            },
+            schedulerClient: { ingestProjectContext },
+        });
+
+        const [item] = await service.listReviewItems(makeAdminUser());
+
+        expect(reconcileReviewItemPrState).toHaveBeenCalledWith({
+            fingerprint: 'fingerprint-1',
+            organizationUuid: ORGANIZATION_UUID,
+            status: 'open',
+            prState: 'closed',
+        });
+        expect(ingestProjectContext).not.toHaveBeenCalled();
+        expect(item).toMatchObject({ status: 'open', prState: 'closed' });
+    });
+});
+
 describe('AiAgentAdminService.getAllEvals', () => {
     it('rejects principals without manage access to any project', async () => {
         const service = makeService();
@@ -1309,6 +1457,44 @@ describe('getAiAgentReviewItemWritebackEligibility', () => {
                     latestFinding: null,
                     findingCount: 0,
                     primaryRootCause: 'project_context',
+                }),
+                reviewsEnabled: true,
+                projectContextEnabled: true,
+                projectAccess: {
+                    provider: PullRequestProvider.GITHUB,
+                    hasGitAppInstallation: true,
+                },
+                hasSemanticWritebackConfig: false,
+                sourceThreadHasWritebackPr: false,
+            }),
+        ).toEqual({
+            eligible: true,
+            provider: PullRequestProvider.GITHUB,
+            strategy: 'project_context',
+            reason: null,
+        });
+    });
+
+    it('allows memory project context writeback without a source finding', () => {
+        expect(
+            getAiAgentReviewItemWritebackEligibility({
+                item: makeReviewItem({
+                    source: 'memory',
+                    latestFinding: null,
+                    findingCount: 0,
+                    primaryRootCause: 'project_context',
+                    projectContextEntry: {
+                        op: 'create',
+                        id: null,
+                        kind: 'definition',
+                        content: 'Revenue means completed order revenue.',
+                        terms: ['revenue'],
+                        objects: [],
+                    },
+                    sourceMemory: {
+                        uuid: 'memory-1',
+                        slug: 'revenue-definition',
+                    },
                 }),
                 reviewsEnabled: true,
                 projectContextEnabled: true,

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -33,6 +33,7 @@ import {
     FeatureFlags,
     ForbiddenError,
     getErrorMessage,
+    getReviewItemProjectContextEntry,
     isHiddenAiAgentReviewRootCause,
     JobStatusType,
     KnexPaginateArgs,
@@ -217,7 +218,8 @@ const getWritebackStrategy = (
             ),
         };
     }
-    if (!item.latestFinding?.projectContextEntry) {
+    const projectContextEntry = getReviewItemProjectContextEntry(item);
+    if (!projectContextEntry) {
         if (item.source === 'manual') {
             return { strategy: 'project_context' };
         }

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
@@ -539,6 +539,26 @@ describe('AiAgentMemoryService', () => {
         expect(updateStatus).not.toHaveBeenCalled();
     });
 
+    it('keeps promoted memories read-only', async () => {
+        const { service, findByProjectAndUuid, updateStatus } = build();
+        findByProjectAndUuid.mockResolvedValue(
+            memoryRow({
+                user_uuid: 'current-user',
+                status: 'promoted',
+            }),
+        );
+
+        await expect(
+            service.updateMemoryStatus(
+                buildUser(true),
+                'project-enabled',
+                'memory-1',
+                'retired',
+            ),
+        ).rejects.toThrow('Promoted memories are read-only');
+        expect(updateStatus).not.toHaveBeenCalled();
+    });
+
     it('decides access from the memory row without loading the source thread', async () => {
         const { service, findByProjectAndSlug, findThreadOwnership } = build();
         findByProjectAndSlug.mockResolvedValue({

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
@@ -880,8 +880,10 @@ export class AiAgentMemoryService extends BaseService {
             memoryUuid,
         );
 
-        if (memory.status === 'superseded') {
-            throw new ParameterError('Superseded memories are read-only');
+        if (memory.status === 'superseded' || memory.status === 'promoted') {
+            const label =
+                memory.status.charAt(0).toUpperCase() + memory.status.slice(1);
+            throw new ParameterError(`${label} memories are read-only`);
         }
 
         if (status === 'active' && memory.source_thread_uuid) {

--- a/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.test.ts
+++ b/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.test.ts
@@ -165,6 +165,33 @@ describe('planReviewWriteback', () => {
         expect(plan).toEqual({ strategy: 'project_context', entry });
     });
 
+    it('reads a memory proposal from the review item', () => {
+        const entry = {
+            op: 'create' as const,
+            id: null,
+            kind: 'definition' as const,
+            content: 'Revenue means completed order revenue.',
+            terms: ['revenue'],
+            objects: [{ type: 'explore' as const, name: 'orders' }],
+        };
+
+        const plan = planReviewWriteback(
+            baseItem({
+                source: 'memory',
+                primaryRootCause: 'project_context',
+                latestFinding: null,
+                findingCount: 0,
+                projectContextEntry: entry,
+                sourceMemory: {
+                    uuid: 'memory-1',
+                    slug: 'revenue-definition',
+                },
+            }),
+        );
+
+        expect(plan).toEqual({ strategy: 'project_context', entry });
+    });
+
     it('builds a project_context entry from a manual issue', () => {
         const plan = planReviewWriteback(
             baseItem({

--- a/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.ts
+++ b/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.ts
@@ -1,5 +1,6 @@
 import {
     assertUnreachable,
+    getReviewItemProjectContextEntry,
     isExploreError,
     type AiAgentJudgeProjectContextEntry,
     type AiAgentReviewItemSummary,
@@ -154,7 +155,7 @@ export const planReviewWriteback = (
         return buildSemanticLayerWritebackPrompt(item, ymlPathByModel);
     }
     if (item.primaryRootCause === 'project_context') {
-        const entry = item.latestFinding?.projectContextEntry ?? null;
+        const entry = getReviewItemProjectContextEntry(item);
         if (entry) {
             return { strategy: 'project_context', entry };
         }

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -350,7 +350,11 @@ export type AiAgentMemorySource = {
     threadSummary: string;
 };
 
-export type AiAgentMemoryStatus = 'active' | 'superseded' | 'retired';
+export type AiAgentMemoryStatus =
+    | 'active'
+    | 'superseded'
+    | 'retired'
+    | 'promoted';
 
 export type AiAgentMemoryEditableStatus = 'active' | 'retired';
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/memoryStatus.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/memoryStatus.ts
@@ -4,10 +4,12 @@ export const MEMORY_STATUS_LABELS: Record<AiAgentMemoryStatus, string> = {
     active: 'Active',
     superseded: 'Superseded',
     retired: 'Retired',
+    promoted: 'Promoted',
 };
 
 export const MEMORY_STATUS_COLORS: Record<AiAgentMemoryStatus, string> = {
     active: 'green',
     superseded: 'yellow',
     retired: 'gray',
+    promoted: 'violet',
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.module.css
@@ -190,6 +190,10 @@
     background: var(--mantine-color-teal-6);
 }
 
+.statusDot[data-status='promoted'] {
+    background: var(--mantine-color-violet-6);
+}
+
 .statusTrigger {
     border-radius: var(--mantine-radius-sm);
     padding: 3px 5px;

--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.tsx
@@ -111,6 +111,13 @@ export const MemoryDetails: FC<MemoryDetailsProps> = ({
         memory.replacementSlug && agentUuid
             ? `/projects/${projectUuid}/ai-agents/${agentUuid}/memories/${memory.replacementSlug}`
             : null;
+    const promotionReviewPath =
+        memory.status === 'promoted' && memory.promotionReviewItem
+            ? `/generalSettings/ai/issues?${new URLSearchParams({
+                  reviewProjectUuid: projectUuid,
+                  reviewItemUuid: memory.promotionReviewItem.uuid,
+              }).toString()}`
+            : null;
     const sources =
         memory.provenance.type === 'source_thread'
             ? [memory.provenance.source]
@@ -138,7 +145,17 @@ export const MemoryDetails: FC<MemoryDetailsProps> = ({
                             message: styles.statusCalloutText,
                         }}
                     >
-                        {replacementPath ? (
+                        {promotionReviewPath ? (
+                            <Anchor
+                                component={Link}
+                                to={promotionReviewPath}
+                                c="ldGray.8"
+                                fz="xs"
+                                fw={600}
+                            >
+                                View the promotion proposal
+                            </Anchor>
+                        ) : replacementPath ? (
                             <Anchor
                                 component={Link}
                                 to={replacementPath}

--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryPromotionAction.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryPromotionAction.test.tsx
@@ -173,6 +173,29 @@ describe('MemoryPromotionAction', () => {
         ).not.toBeInTheDocument();
     });
 
+    it('links a promoted memory to its resolved review item', () => {
+        renderAction({
+            status: 'promoted',
+            promotionReviewItem: {
+                uuid: 'review-1',
+                status: 'resolved',
+                blocksNewNomination: false,
+            },
+        });
+
+        expect(
+            screen.getByRole('link', { name: 'View proposal' }),
+        ).toHaveAttribute(
+            'href',
+            '/generalSettings/ai/issues?reviewProjectUuid=project-1&reviewItemUuid=review-1',
+        );
+        expect(
+            screen.queryByRole('button', {
+                name: 'Propose for project context',
+            }),
+        ).not.toBeInTheDocument();
+    });
+
     it('disables promotion with the feature gate reason', async () => {
         settings.current.aiAgentReviewsEnabled = false;
         const user = userEvent.setup();

--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryPromotionAction.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryPromotionAction.tsx
@@ -50,11 +50,14 @@ export const MemoryPromotionAction: FC<Props> = ({
         action: 'manage',
     });
 
-    if (promotionReviewItem?.blocksNewNomination) {
+    const shouldLinkReviewItem =
+        promotionReviewItem &&
+        (promotionReviewItem.blocksNewNomination || status === 'promoted');
+    if (shouldLinkReviewItem) {
         if (!canManageProjectAgent && !canManageOrganizationAgent) {
             return (
                 <Badge variant="light" color="violet" size="lg">
-                    Proposal pending
+                    {status === 'promoted' ? 'Promoted' : 'Proposal pending'}
                 </Badge>
             );
         }

--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryStatusControls.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryStatusControls.test.tsx
@@ -1,0 +1,36 @@
+import { screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+import { MemoryStatusAction, MemoryStatusMenu } from './MemoryStatusControls';
+
+vi.mock('../../hooks/useAiAgentMemory', () => ({
+    useUpdateAiAgentMemoryStatus: () => ({
+        isLoading: false,
+        mutate: vi.fn(),
+    }),
+}));
+
+describe('promoted memory controls', () => {
+    it('renders the promoted status without edit actions', () => {
+        renderWithProviders(
+            <MemoryRouter>
+                <MemoryStatusMenu
+                    projectUuid="project-1"
+                    memoryUuid="memory-1"
+                    slug="revenue-convention"
+                    status="promoted"
+                />
+                <MemoryStatusAction
+                    projectUuid="project-1"
+                    memoryUuid="memory-1"
+                    slug="revenue-convention"
+                    status="promoted"
+                />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByText('Promoted')).toBeInTheDocument();
+        expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryStatusControls.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryStatusControls.tsx
@@ -17,6 +17,10 @@ type Props = {
 };
 
 const editableStatuses: AiAgentMemoryEditableStatus[] = ['active', 'retired'];
+const isEditableStatus = (
+    status: AiAgentMemoryStatus,
+): status is AiAgentMemoryEditableStatus =>
+    status === 'active' || status === 'retired';
 
 export const MemoryStatusMenu: FC<Props> = ({
     projectUuid,
@@ -26,7 +30,7 @@ export const MemoryStatusMenu: FC<Props> = ({
 }) => {
     const updateStatus = useUpdateAiAgentMemoryStatus();
 
-    if (status === 'superseded') {
+    if (!isEditableStatus(status)) {
         return (
             <Group gap={8} wrap="nowrap">
                 <Box className={styles.statusDot} data-status={status} />
@@ -93,7 +97,7 @@ export const MemoryStatusAction: FC<Props> = ({
 }) => {
     const updateStatus = useUpdateAiAgentMemoryStatus();
 
-    if (status === 'superseded') return null;
+    if (!isEditableStatus(status)) return null;
 
     const nextStatus = status === 'active' ? 'retired' : 'active';
     const label = status === 'active' ? 'Retire memory' : 'Reactivate memory';


### PR DESCRIPTION
Closes: ZAP-791

### Description
- build project-context writeback plans directly from memory review items
- reconcile merged PRs by resolving the item, atomically marking active source memory promoted, and refreshing project context
- keep closed or inactive-source paths safe and preserve review provenance
- render promoted memories as terminal, read-only, and linked to their resolved proposal

### Investigation decisions
- no zap-791 database migration is required: memory status and distill outcome are unconstrained text columns in committed migration history
- source-memory FK ownership remains downstack and uses validated `ON DELETE SET NULL`
- rollback never converts or deletes promoted memories
- restore the `projectContextEnabled` reconciliation gate so existing PR machinery remains unchanged
- use the shared common project-context entry resolver introduced downstack

### Validation
- backend focused tests: 209 passed
- frontend focused tests: 6 passed
- promoted-memory re-distill integration: 1 passed
- backend typecheck, scoped lint, format, and `git diff --check`
- repository-wide migration-history search confirms neither removed CHECK constraint was ever created
- local migration record for the removed no-op migration was rolled back; full migration directory is already up to date
- PostgreSQL confirms the downstack source-memory FK is validated `ON DELETE SET NULL`
- real worker re-distill job persisted `outcome = skipped` for a promoted source thread; fixture restored afterward
