### PR TITLE
feat: add v3 agent storage spine

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,0 +1,5 @@
+# Context Map
+
+Bounded contexts and where their glossaries live.
+
+- **Agents v3** — agent conversation persistence (threads, messages, parts): [docs/agents-v3/CONTEXT.md](docs/agents-v3/CONTEXT.md)

--- a/docs/agents-v3/CONTEXT.md
+++ b/docs/agents-v3/CONTEXT.md
@@ -1,0 +1,86 @@
+# Agents v3 — Context
+
+Glossary of canonical terms for agent conversation persistence. Terms only — no implementation detail.
+
+## Terms
+
+### Thread
+A single agent conversation, scoped to an organization/project and optionally an agent. The stable identity all conversation consumers reference. Canonical term — "session" is not used except when quoting external systems (OpenCode/Pi/Codex call this a session).
+
+### Storage version
+The immutable format (v1 legacy or v3) a Thread's history is persisted in, fixed at thread creation. A thread is never hybrid: v1 threads remain readable and read-only; new feature-flagged threads are v3.
+
+### Message (v3)
+A single unit within a Thread with exactly one Role. Content lives entirely in its Parts. System prompts are derived from agent configuration at run time and are never persisted as Messages; tool activity and reasoning belong to assistant Messages as Parts.
+
+### Role
+The kind of a Message: `user`, `assistant`, or `compaction`. The first two are speakers; `compaction` marks an in-band boundary row, not an utterance. Model-level `system`/`tool` messages are synthesized by adapters.
+
+### Part (v3)
+An ordered, typed unit of Message content. The only place conversation content is persisted. Canonical types: `text`, `reasoning`, `tool`, `file`, `artifact`, `step-start`, `source`, `compaction`. The set is extensible in code without migration; each type declares model-visible vs UI-only. `viz` is not a part type — visualization output is deprecated in favor of Artifacts.
+
+### Artifact part
+A Part referencing a specific artifact version produced during an assistant Message. A Message may contain any number of Artifact parts, ordered like any other Part.
+
+### Steer
+A user utterance arriving while a run is active. Persisted as an ordinary user Message; its position in the thread order captures the mid-run timing. Not a distinct entity in v3.
+
+### Pinned context
+User-selected chart/dashboard references attached to a user Message when it is sent. Rides in Message metadata, never in Parts; rendered as reference chips. Model exposure is a server-side prompt concern.
+
+### Context message
+A user Message ingested from the surrounding Slack conversation under thread-access consent, rather than addressed to the agent. Authored by no resolved Lightdash user (`created_by_user_uuid` is null); the true Slack author is recorded in the Slack satellite. An ordinary user Message in every other respect.
+
+### Frozen message
+An assistant Message whose run has reached a terminal state. Its content (and Parts) never changes afterwards; only Annotations may be added. The sole sanctioned exception is Redaction.
+
+### Annotation
+Post-hoc data attached to a Message without changing its content — feedback, scores, visibility flags. Lives beside Messages, never inside them.
+
+### Redaction
+A privileged, audited, repository-layer overwrite of Part payloads in place — rows, identifiers, and ordering preserved, never row deletion. The sole sanctioned exception to Frozen message immutability; because Forks inherit prefixes logically, redacting a parent redacts every descendant. Not built at launch. Distinct from edit (a Fork) and from visibility Annotations.
+
+### Provider metadata
+Opaque, provider-namespaced JSON returned by a model provider and stored losslessly inside a Part's payload — including reasoning signatures and encrypted reasoning blobs. Never promoted to schema columns; replayed only to the provider that produced it.
+
+### Run status
+The mutable lifecycle of an assistant Message's run: `in_progress`, `completed`, `error`, or `canceled`. A projection beside content, kept live by heartbeat; reaching a terminal value is what freezes the Message. Never derived from timestamps at read time.
+
+### Healing at freeze
+The terminal-status transition that moves any tool Part still mid-lifecycle to its interrupted error state, so persisted history is always well-formed and read adapters never synthesize missing results.
+
+### Tool approval
+A segment of the tool Part lifecycle (`approval-requested` → `approval-responded` → execution or `output-denied`) persisted in the Part and replayable to the model. Tool-agnostic, covering MCP tools. The deciding user and time live in a satellite record, never in the frozen Part.
+
+### Transient part
+Stream-only content (keepalives, step progress) that is never persisted. Anything durable must be a first-class typed Part; no generic data part exists.
+
+### Envelope
+A versioned jsonb value on an assistant or compaction Message row recording run facts outside content: `model_config` (what actually ran), `token_usage`, and `error` (named machine code + user-facing message, present only on `error` status).
+
+### Compaction row
+An in-band Message with role `compaction`, appended at its own thread_seq when earlier history is summarized; never rewrites anything. Its `compaction` Part holds the summary (model- and UI-visible) and the exact summarizer input for audit (invisible); its Envelope records summarizer cost. Replay: the latest compaction row on the composed path wins — emit its summary as a tag-wrapped user message, then only rows after it; earlier rows stay on disk. Forks inherit it iff the fork point is at or after its seq. Triggered between turns only, client-side, best-effort: a failed summarize writes nothing.
+
+### Lineage
+The immutable, creation-time relationship linking a Thread to the Thread it descends from. Two kinds: Spawn and Fork. Threads form a tree; a Thread without lineage is a root. Each Thread stays strictly linear inside. Every Thread in a lineage tree shares the root's organization/project/agent scope, fixed at creation; the tree is deleted as a unit (cascade on the parent link), so a dangling inherited prefix is impossible. Lineage never grants read access in either direction.
+
+### Fork
+A new Thread that logically inherits a prefix of another Thread's history — nothing is copied. The only way to regenerate or branch history; Messages themselves never carry branch structure. Forks are first-class Threads; only non-Spawn Threads may be forked.
+
+### Spawn
+A Thread created by a parent run's delegate tool call to execute a sub-agent. Inherits no parent history; its first user Message is the agent-authored task prompt. Hidden from Thread lists, reachable only through its parent; shares the root Thread's scoping and lifecycle. Each execution attempt is its own Spawn.
+
+### Anchor
+The exact tool Part (Message + tool call id) in a parent Thread that a Spawn descends from. Several Spawn attempts may share one Anchor.
+
+### Deep research run
+An orchestrated multi-phase research execution (planner → parallel investigators → judge) whose lifecycle — status, budgets, cancellation, report expiry — lives on a satellite run record beside the Thread, never in Messages. On v3, the judge phase runs as the parent Thread's assistant Message; planner and investigator phases are Spawns created deterministically by the executor with their context packed into each task prompt — never by model delegation. The report stays on the run record; the frozen Message carries only a reference Part.
+
+### Read adapter (v1)
+The quarantined module that projects immutable v1 turn aggregates into the v3 wire shape — the only code that reads v1 rows. Order within a v1 turn is synthesized deterministically (chronological, uuid tiebreak); content is lossless. A view, never a write path.
+
+### Read-only thread
+A thread whose transcript is frozen for conversation mutations (send, steer, interrupt, generate) for the current viewer; annotations and thread management (feedback, rename, delete) remain allowed. All v1 threads are read-only; other causes exist (Slack-driven threads, viewing another user's thread). Clients learn this from a computed, viewer-specific `readOnly` capability plus a reason code — never by branching on Storage version.
+
+### Turn (v1)
+Legacy v1 aggregate (`ai_prompt`): one row holding both a user prompt and the assistant response under a single identity. Superseded in v3 by Messages.

--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -428,6 +428,14 @@ import {
     AiAgentUserPreferencesTableName,
 } from '../ee/database/entities/aiAgentUserPreferences';
 import {
+    AiMessagePartTable,
+    AiMessagePartTableName,
+    AiThreadMessageSequenceTable,
+    AiThreadMessageSequenceTableName,
+    AiThreadMessageTable,
+    AiThreadMessageTableName,
+} from '../ee/database/entities/aiAgentV3';
+import {
     AiArtifactsTable,
     AiArtifactsTableName,
     AiArtifactVersionsTable,
@@ -624,6 +632,9 @@ declare module 'knex/types/tables' {
         [PullRequestsTableName]: PullRequestsTable;
         [DashboardTileCommentsTableName]: DashboardTileCommentsTable;
         [AiThreadTableName]: AiThreadTable;
+        [AiThreadMessageSequenceTableName]: AiThreadMessageSequenceTable;
+        [AiThreadMessageTableName]: AiThreadMessageTable;
+        [AiMessagePartTableName]: AiMessagePartTable;
         [AiThreadShareTableName]: AiThreadShareTable;
         [AiSlackThreadTableName]: AiSlackThreadTable;
         [AiWebAppThreadTableName]: AiWebAppThreadTable;

--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -12,6 +12,7 @@ import {
     type DataAppModelVisibility,
 } from '@lightdash/common';
 import { Knex } from 'knex';
+import type { AiAgentStorageVersion, AiThreadLineageKind } from './aiAgentV3';
 
 export const AiThreadTableName = 'ai_thread';
 
@@ -29,6 +30,12 @@ export type DbAiThread = {
     title: string | null;
     title_generated_at: Date | null;
     sql_auto_approved_at: Date | null;
+    storage_version: AiAgentStorageVersion;
+    parent_thread_uuid: string | null;
+    lineage_kind: AiThreadLineageKind | null;
+    parent_message_uuid: string | null;
+    parent_tool_call_id: string | null;
+    fork_boundary_seq: number | null;
 };
 
 export type AiThreadTable = Knex.CompositeTableType<
@@ -36,7 +43,18 @@ export type AiThreadTable = Knex.CompositeTableType<
     Pick<
         DbAiThread,
         'organization_uuid' | 'project_uuid' | 'created_from' | 'agent_uuid'
-    >,
+    > &
+        Partial<
+            Pick<
+                DbAiThread,
+                | 'storage_version'
+                | 'parent_thread_uuid'
+                | 'lineage_kind'
+                | 'parent_message_uuid'
+                | 'parent_tool_call_id'
+                | 'fork_boundary_seq'
+            >
+        >,
     Partial<
         Pick<
             DbAiThread,

--- a/packages/backend/src/ee/database/entities/aiAgentV3.ts
+++ b/packages/backend/src/ee/database/entities/aiAgentV3.ts
@@ -1,0 +1,285 @@
+import { type AiThreadCreatedFrom } from '@lightdash/common';
+import { type Knex } from 'knex';
+
+export const AiThreadMessageSequenceTableName = 'ai_thread_message_sequence';
+export const AiThreadMessageTableName = 'ai_thread_message';
+export const AiMessagePartTableName = 'ai_message_part';
+
+export const AI_AGENT_STORAGE_VERSIONS = [1, 3] as const;
+export type AiAgentStorageVersion = (typeof AI_AGENT_STORAGE_VERSIONS)[number];
+
+export const AI_THREAD_LINEAGE_KINDS = ['spawn', 'fork'] as const;
+export type AiThreadLineageKind = (typeof AI_THREAD_LINEAGE_KINDS)[number];
+
+export const AI_THREAD_MESSAGE_ROLES = [
+    'user',
+    'assistant',
+    'compaction',
+] as const;
+export type AiThreadMessageRole = (typeof AI_THREAD_MESSAGE_ROLES)[number];
+
+export const AI_ASSISTANT_MESSAGE_STATUSES = [
+    'in_progress',
+    'completed',
+    'error',
+    'canceled',
+] as const;
+export type AiAssistantMessageStatus =
+    (typeof AI_ASSISTANT_MESSAGE_STATUSES)[number];
+export type AiAssistantMessageTerminalStatus = Exclude<
+    AiAssistantMessageStatus,
+    'in_progress'
+>;
+export const AI_ASSISTANT_MESSAGE_TERMINAL_STATUSES = [
+    'completed',
+    'error',
+    'canceled',
+] as const satisfies readonly AiAssistantMessageTerminalStatus[];
+
+export const AI_MESSAGE_PART_TYPES = [
+    'text',
+    'reasoning',
+    'tool',
+    'file',
+    'artifact',
+    'step-start',
+    'source',
+    'compaction',
+] as const;
+export type AiMessagePartType = (typeof AI_MESSAGE_PART_TYPES)[number];
+export type AiMessagePartTypeOrUnknown = AiMessagePartType | (string & {});
+
+export const AI_TOOL_PART_STATES = [
+    'input-streaming',
+    'input-available',
+    'approval-requested',
+    'approval-responded',
+    'output-available',
+    'output-error',
+    'output-denied',
+] as const;
+export type AiToolPartState = (typeof AI_TOOL_PART_STATES)[number];
+export const AI_TOOL_PART_TERMINAL_STATES = [
+    'output-available',
+    'output-error',
+    'output-denied',
+] as const satisfies readonly AiToolPartState[];
+export const AI_TOOL_PART_INTERRUPTED_STATE =
+    'output-error' as const satisfies AiToolPartState;
+
+export const MODEL_VISIBLE_AI_MESSAGE_PART_TYPES = [
+    'text',
+    'reasoning',
+    'tool',
+    'file',
+    'compaction',
+] as const satisfies readonly AiMessagePartType[];
+
+export const NON_USER_AI_MESSAGE_PART_TYPES = [
+    'reasoning',
+    'tool',
+    'artifact',
+    'step-start',
+    'compaction',
+] as const satisfies readonly AiMessagePartType[];
+
+export type AiModelConfigEnvelope = {
+    version: number;
+    modelName: string;
+    modelProvider: string;
+    reasoning: {
+        enabled: boolean;
+        effort: string | null;
+        budgetTokens: number | null;
+    };
+    limits: {
+        maxSteps: number | null;
+        maxOutputTokens: number | null;
+    };
+    sampling: {
+        temperature: number | null;
+        topP: number | null;
+    };
+    providerOptions: Record<string, unknown> | null;
+};
+
+export type AiTokenUsageEnvelope = {
+    version: number;
+    inputTokens: number | null;
+    outputTokens: number | null;
+    totalTokens: number | null;
+    reasoningTokens: number | null;
+    cachedInputTokens: number | null;
+};
+
+export type AiRunErrorEnvelope = {
+    version: number;
+    name: string;
+    message: string;
+    data: Record<string, unknown> | null;
+};
+
+export type DbAiThreadMessageSequence = {
+    ai_thread_uuid: string;
+    next_thread_seq: number;
+};
+
+export type AiThreadMessageSequenceTable = Knex.CompositeTableType<
+    DbAiThreadMessageSequence,
+    Pick<DbAiThreadMessageSequence, 'ai_thread_uuid'> &
+        Partial<Pick<DbAiThreadMessageSequence, 'next_thread_seq'>>,
+    Pick<DbAiThreadMessageSequence, 'next_thread_seq'>
+>;
+
+export type DbAiThreadMessage = {
+    ai_thread_message_uuid: string;
+    ai_thread_uuid: string;
+    thread_seq: number;
+    role: AiThreadMessageRole;
+    created_by_user_uuid: string | null;
+    status: AiAssistantMessageStatus | null;
+    last_heartbeat_at: Date | null;
+    model_config: AiModelConfigEnvelope | null;
+    token_usage: AiTokenUsageEnvelope | null;
+    error: AiRunErrorEnvelope | null;
+    created_at: Date;
+};
+
+type AiThreadMessageHeartbeatWrite = {
+    last_heartbeat_at?: Date | Knex.Raw;
+};
+
+type AiThreadMessageInsert = Pick<
+    DbAiThreadMessage,
+    'ai_thread_uuid' | 'thread_seq' | 'role'
+> &
+    Partial<
+        Pick<
+            DbAiThreadMessage,
+            | 'created_by_user_uuid'
+            | 'status'
+            | 'model_config'
+            | 'token_usage'
+            | 'error'
+            | 'created_at'
+        >
+    > &
+    AiThreadMessageHeartbeatWrite;
+
+type AiThreadMessageUpdate = Partial<
+    Pick<DbAiThreadMessage, 'status' | 'token_usage' | 'error'>
+> &
+    AiThreadMessageHeartbeatWrite;
+
+export type AiThreadMessageTable = Knex.CompositeTableType<
+    DbAiThreadMessage,
+    AiThreadMessageInsert,
+    AiThreadMessageUpdate
+>;
+
+export type DbAiMessagePart = {
+    ai_message_part_uuid: string;
+    ai_thread_message_uuid: string;
+    part_index: number;
+    type: AiMessagePartTypeOrUnknown;
+    payload_version: number;
+    payload: Record<string, unknown>;
+    tool_call_id: string | null;
+    ai_artifact_version_uuid: string | null;
+    created_at: Date;
+};
+
+export type AiMessagePartTable = Knex.CompositeTableType<
+    DbAiMessagePart,
+    Pick<
+        DbAiMessagePart,
+        'ai_thread_message_uuid' | 'part_index' | 'payload_version' | 'payload'
+    > & {
+        type: AiMessagePartType;
+    } & Partial<
+            Pick<DbAiMessagePart, 'tool_call_id' | 'ai_artifact_version_uuid'>
+        >,
+    Partial<Pick<DbAiMessagePart, 'payload_version'>> & {
+        payload?: Record<string, unknown> | Knex.Raw;
+    }
+>;
+
+export type AiV3ThreadLineage =
+    | null
+    | {
+          kind: 'spawn';
+          parentThreadUuid: string;
+          parentMessageUuid: string;
+          parentToolCallId: string;
+      }
+    | {
+          kind: 'fork';
+          parentThreadUuid: string;
+          forkBoundarySeq: number;
+      };
+
+export type CreateAiV3Thread = {
+    organizationUuid: string;
+    projectUuid: string;
+    agentUuid: string | null;
+    createdFrom: AiThreadCreatedFrom;
+    lineage: AiV3ThreadLineage;
+};
+
+type AiV3PartWriteBase = {
+    partIndex: number;
+    payloadVersion: number;
+    payload: Record<string, unknown>;
+};
+
+export type AiV3PartWrite =
+    | (AiV3PartWriteBase & {
+          type: 'tool';
+          toolCallId: string;
+          artifactVersionUuid?: never;
+      })
+    | (AiV3PartWriteBase & {
+          type: 'artifact';
+          artifactVersionUuid: string;
+          toolCallId?: never;
+      })
+    | (AiV3PartWriteBase & {
+          type: Exclude<AiMessagePartType, 'tool' | 'artifact'>;
+          toolCallId?: never;
+          artifactVersionUuid?: never;
+      });
+
+export type AiV3CanonicalPart = {
+    uuid: string;
+    type: AiMessagePartTypeOrUnknown;
+    payloadVersion: number;
+    payload: Record<string, unknown>;
+    toolCallId: string | null;
+    artifactVersionUuid: string | null;
+};
+
+export type AiV3CanonicalMessage = {
+    uuid: string;
+    role: AiThreadMessageRole;
+    parts: AiV3CanonicalPart[];
+    metadata: {
+        createdAt: string;
+        createdByUserUuid: string | null;
+        status: AiAssistantMessageStatus | null;
+        lastHeartbeatAt: string | null;
+        modelConfig: AiModelConfigEnvelope | null;
+        tokenUsage: AiTokenUsageEnvelope | null;
+        error: AiRunErrorEnvelope | null;
+    };
+};
+
+export type AiV3CanonicalThread = {
+    uuid: string;
+    storageVersion: 3;
+    organizationUuid: string;
+    projectUuid: string;
+    agentUuid: string | null;
+    createdAt: string;
+    lineage: AiV3ThreadLineage;
+    messages: AiV3CanonicalMessage[];
+};

--- a/packages/backend/src/ee/database/migrations/20260806080000_add_ai_agent_v3_storage.ts
+++ b/packages/backend/src/ee/database/migrations/20260806080000_add_ai_agent_v3_storage.ts
@@ -1,0 +1,157 @@
+import { type Knex } from 'knex';
+
+const AiThreadTableName = 'ai_thread';
+const AiArtifactVersionsTableName = 'ai_artifact_versions';
+const AiThreadMessageSequenceTableName = 'ai_thread_message_sequence';
+const AiThreadMessageTableName = 'ai_thread_message';
+const AiMessagePartTableName = 'ai_message_part';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AiThreadTableName, (table) => {
+        table.smallint('storage_version').notNullable().defaultTo(1);
+        table
+            .uuid('parent_thread_uuid')
+            .nullable()
+            .references('ai_thread_uuid')
+            .inTable(AiThreadTableName)
+            .onDelete('CASCADE')
+            .index();
+        table.text('lineage_kind').nullable();
+        // foreign key added once ai_thread_message exists
+        table.uuid('parent_message_uuid').nullable().index();
+        table.text('parent_tool_call_id').nullable();
+        table.integer('fork_boundary_seq').nullable();
+    });
+    await knex.raw(`
+        ALTER TABLE ${AiThreadTableName}
+        ADD CONSTRAINT ai_thread_lineage_shape_check CHECK (
+            (lineage_kind IS NULL
+                AND parent_thread_uuid IS NULL
+                AND parent_message_uuid IS NULL
+                AND parent_tool_call_id IS NULL
+                AND fork_boundary_seq IS NULL)
+            OR (lineage_kind = 'spawn'
+                AND parent_thread_uuid IS NOT NULL
+                AND parent_message_uuid IS NOT NULL
+                AND parent_tool_call_id IS NOT NULL
+                AND fork_boundary_seq IS NULL)
+            OR (lineage_kind = 'fork'
+                AND parent_thread_uuid IS NOT NULL
+                AND parent_message_uuid IS NULL
+                AND parent_tool_call_id IS NULL
+                AND fork_boundary_seq IS NOT NULL)
+        )
+    `);
+
+    await knex.schema.createTable(AiThreadMessageSequenceTableName, (table) => {
+        table
+            .uuid('ai_thread_uuid')
+            .primary()
+            .references('ai_thread_uuid')
+            .inTable(AiThreadTableName)
+            .onDelete('CASCADE');
+        table.integer('next_thread_seq').notNullable().defaultTo(1);
+    });
+
+    await knex.schema.createTable(AiThreadMessageTableName, (table) => {
+        table
+            .uuid('ai_thread_message_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('ai_thread_uuid')
+            .notNullable()
+            .references('ai_thread_uuid')
+            .inTable(AiThreadTableName)
+            .onDelete('CASCADE');
+        table.integer('thread_seq').notNullable();
+        table.text('role').notNullable();
+        table
+            .uuid('created_by_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable('users')
+            .onDelete('SET NULL')
+            .index();
+        table.text('status').nullable();
+        table.timestamp('last_heartbeat_at', { useTz: false }).nullable();
+        table.jsonb('model_config').nullable();
+        table.jsonb('token_usage').nullable();
+        table.jsonb('error').nullable();
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        // also indexes the ai_thread_uuid foreign key
+        table.unique(['ai_thread_uuid', 'thread_seq']);
+    });
+    await knex.raw(`
+        ALTER TABLE ${AiThreadMessageTableName}
+        ADD CONSTRAINT ai_thread_message_role_status_check
+            CHECK ((role = 'assistant') = (status IS NOT NULL))
+    `);
+
+    await knex.schema.createTable(AiMessagePartTableName, (table) => {
+        table
+            .uuid('ai_message_part_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('ai_thread_message_uuid')
+            .notNullable()
+            .references('ai_thread_message_uuid')
+            .inTable(AiThreadMessageTableName)
+            .onDelete('CASCADE');
+        table.integer('part_index').notNullable();
+        table.text('type').notNullable();
+        table.integer('payload_version').notNullable();
+        table.jsonb('payload').notNullable();
+        table.text('tool_call_id').nullable();
+        table
+            .uuid('ai_artifact_version_uuid')
+            .nullable()
+            .references('ai_artifact_version_uuid')
+            .inTable(AiArtifactVersionsTableName)
+            .onDelete('CASCADE')
+            .index();
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        // also indexes the ai_thread_message_uuid foreign key
+        table.unique(['ai_thread_message_uuid', 'part_index']);
+        table.unique(['ai_thread_message_uuid', 'tool_call_id']);
+    });
+    await knex.raw(`
+        ALTER TABLE ${AiMessagePartTableName}
+        ADD CONSTRAINT ai_message_part_tool_call_shape_check
+            CHECK (tool_call_id IS NULL OR type = 'tool'),
+        ADD CONSTRAINT ai_message_part_artifact_version_shape_check
+            CHECK (ai_artifact_version_uuid IS NULL OR type = 'artifact')
+    `);
+
+    await knex.schema.alterTable(AiThreadTableName, (table) => {
+        table
+            .foreign('parent_message_uuid')
+            .references('ai_thread_message_uuid')
+            .inTable(AiThreadMessageTableName)
+            .onDelete('CASCADE');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    // dropping the columns also drops their checks, indexes and foreign keys
+    await knex.schema.alterTable(AiThreadTableName, (table) => {
+        table.dropColumns(
+            'storage_version',
+            'parent_thread_uuid',
+            'lineage_kind',
+            'parent_message_uuid',
+            'parent_tool_call_id',
+            'fork_boundary_seq',
+        );
+    });
+    await knex.schema.dropTableIfExists(AiMessagePartTableName);
+    await knex.schema.dropTableIfExists(AiThreadMessageTableName);
+    await knex.schema.dropTableIfExists(AiThreadMessageSequenceTableName);
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -34,6 +34,7 @@ import { AiAgentMemoryModel } from './models/AiAgentMemoryModel';
 import { AiAgentModel } from './models/AiAgentModel';
 import { AiAgentReviewClassifierModel } from './models/AiAgentReviewClassifierModel';
 import { AiAgentReviewNotificationModel } from './models/AiAgentReviewNotificationModel';
+import { AiAgentV3Model } from './models/AiAgentV3Model';
 import { AiDeepResearchRunModel } from './models/AiDeepResearchRunModel';
 import { AiOrganizationSettingsModel } from './models/AiOrganizationSettingsModel';
 import { AiRouterModel } from './models/AiRouterModel';
@@ -1115,6 +1116,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     lightdashConfig,
                     encryptionUtil: utils.getEncryptionUtil(),
                 }),
+            aiAgentV3Model: ({ database }) => new AiAgentV3Model({ database }),
             aiAgentMemoryModel: ({ database }) =>
                 new AiAgentMemoryModel({ database }),
             aiAgentDocumentModel: ({ database }) =>

--- a/packages/backend/src/ee/models/AiAgentV3Model.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentV3Model.integration.test.ts
@@ -1,0 +1,900 @@
+import {
+    SEED_ORG_1,
+    SEED_ORG_1_ADMIN,
+    SEED_ORG_2,
+    SEED_PROJECT,
+} from '@lightdash/common';
+import { randomUUID } from 'crypto';
+import { type Knex } from 'knex';
+import { getTestContext } from '../../vitest.setup.integration';
+import { AiThreadTableName } from '../database/entities/ai';
+import {
+    AiMessagePartTableName,
+    AiThreadMessageSequenceTableName,
+    AiThreadMessageTableName,
+} from '../database/entities/aiAgentV3';
+import {
+    AiArtifactsTableName,
+    AiArtifactVersionsTableName,
+} from '../database/entities/aiArtifacts';
+import { AiAgentV3Model } from './AiAgentV3Model';
+
+const modelConfig = {
+    version: 1,
+    modelName: 'claude-sonnet-4-5',
+    modelProvider: 'anthropic',
+    reasoning: { enabled: true, effort: 'high', budgetTokens: null },
+    limits: { maxSteps: 12, maxOutputTokens: null },
+    sampling: { temperature: 0.2, topP: null },
+    providerOptions: null,
+};
+
+const textPart = (partIndex: number, text: string) => ({
+    partIndex,
+    type: 'text' as const,
+    payloadVersion: 1,
+    payload: { text },
+});
+
+describe('AiAgentV3Model', () => {
+    let database: Knex;
+    let model: AiAgentV3Model;
+    const rootThreadUuids = new Set<string>();
+
+    beforeAll(() => {
+        database = getTestContext().db;
+        model = new AiAgentV3Model({ database });
+    });
+
+    afterEach(async () => {
+        if (rootThreadUuids.size > 0) {
+            await database(AiThreadTableName)
+                .whereIn('ai_thread_uuid', [...rootThreadUuids])
+                .delete();
+        }
+        rootThreadUuids.clear();
+    });
+
+    const createRootThread = async () => {
+        const thread = await model.createThread({
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            projectUuid: SEED_PROJECT.project_uuid,
+            agentUuid: null,
+            createdFrom: 'web_app',
+            lineage: null,
+        });
+        rootThreadUuids.add(thread.uuid);
+        return thread;
+    };
+
+    it('keeps legacy threads at storage version 1 and initializes v3 threads', async () => {
+        const [legacyThread] = await database(AiThreadTableName)
+            .insert({
+                organization_uuid: SEED_ORG_1.organization_uuid,
+                project_uuid: SEED_PROJECT.project_uuid,
+                agent_uuid: null,
+                created_from: 'web_app',
+            })
+            .returning(['ai_thread_uuid', 'storage_version']);
+        rootThreadUuids.add(legacyThread.ai_thread_uuid);
+
+        const v3Thread = await createRootThread();
+        const sequence = await database(AiThreadMessageSequenceTableName)
+            .where('ai_thread_uuid', v3Thread.uuid)
+            .first();
+
+        expect(legacyThread.storage_version).toBe(1);
+        expect(v3Thread.storageVersion).toBe(3);
+        expect(sequence).toMatchObject({ next_thread_seq: 1 });
+        await expect(
+            model.appendUserMessage({
+                threadUuid: legacyThread.ai_thread_uuid,
+                createdByUserUuid: null,
+                parts: [textPart(0, 'legacy write')],
+            }),
+        ).rejects.toThrow('Thread is not writable v3 storage');
+        await expect(
+            model.createThread({
+                organizationUuid: SEED_ORG_1.organization_uuid,
+                projectUuid: SEED_PROJECT.project_uuid,
+                agentUuid: null,
+                createdFrom: 'web_app',
+                lineage: {
+                    kind: 'fork',
+                    parentThreadUuid: legacyThread.ai_thread_uuid,
+                    forkBoundarySeq: 1,
+                },
+            }),
+        ).rejects.toThrow('Lineage parent must use storage version 3');
+    });
+
+    it('allocates unique ordered message sequences for concurrent writers', async () => {
+        const thread = await createRootThread();
+
+        await Promise.all(
+            Array.from({ length: 12 }, (_, index) =>
+                model.appendUserMessage({
+                    threadUuid: thread.uuid,
+                    createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                    parts: [textPart(0, `message-${index}`)],
+                }),
+            ),
+        );
+
+        const rows = await database(AiThreadMessageTableName)
+            .select(['thread_seq'])
+            .where('ai_thread_uuid', thread.uuid)
+            .orderBy('thread_seq');
+        const canonical = await model.getThread(thread.uuid);
+
+        expect(rows.map((row) => row.thread_seq)).toEqual(
+            Array.from({ length: 12 }, (_, index) => index + 1),
+        );
+        expect(canonical.messages).toHaveLength(12);
+        expect(
+            new Set(
+                canonical.messages.map(
+                    (message) => message.parts[0].payload.text,
+                ),
+            ).size,
+        ).toBe(12);
+    });
+
+    it('reports a missing thread when appending a message', async () => {
+        await expect(
+            model.appendUserMessage({
+                threadUuid: randomUUID(),
+                createdByUserUuid: null,
+                parts: [textPart(0, 'missing')],
+            }),
+        ).rejects.toThrow('Thread not found');
+    });
+
+    it('returns messages and typed parts in canonical order', async () => {
+        const thread = await createRootThread();
+        const importedCreatedAt = new Date('2024-01-02T03:04:05.000Z');
+        const userMessage = await model.appendUserMessage({
+            threadUuid: thread.uuid,
+            createdByUserUuid: null,
+            createdAt: importedCreatedAt,
+            parts: [
+                textPart(2, 'third'),
+                textPart(0, 'first'),
+                {
+                    partIndex: 1,
+                    type: 'source',
+                    payloadVersion: 2,
+                    payload: { url: 'https://example.com' },
+                },
+            ],
+        });
+        const assistantMessage = await model.createAssistantMessage({
+            threadUuid: thread.uuid,
+            modelConfig,
+        });
+        await model.appendParts({
+            messageUuid: assistantMessage.uuid,
+            parts: [textPart(0, 'answer')],
+        });
+        await expect(
+            model.appendParts({
+                messageUuid: userMessage.uuid,
+                parts: [textPart(3, 'late mutation')],
+            }),
+        ).rejects.toThrow('Message is not an assistant message');
+
+        const canonical = await model.getThread(thread.uuid);
+
+        expect(canonical).toMatchObject({
+            uuid: thread.uuid,
+            storageVersion: 3,
+            messages: [
+                {
+                    uuid: userMessage.uuid,
+                    role: 'user',
+                    metadata: {
+                        createdAt: importedCreatedAt.toISOString(),
+                        createdByUserUuid: null,
+                    },
+                    parts: [
+                        { type: 'text', payload: { text: 'first' } },
+                        {
+                            type: 'source',
+                            payloadVersion: 2,
+                            payload: { url: 'https://example.com' },
+                        },
+                        { type: 'text', payload: { text: 'third' } },
+                    ],
+                },
+                {
+                    uuid: assistantMessage.uuid,
+                    role: 'assistant',
+                    metadata: {
+                        status: 'in_progress',
+                        modelConfig,
+                    },
+                    parts: [{ type: 'text', payload: { text: 'answer' } }],
+                },
+            ],
+        });
+    });
+
+    it('scopes part indexes and provider tool call ids to each message', async () => {
+        const thread = await createRootThread();
+        const [firstMessage, secondMessage] = await Promise.all([
+            model.createAssistantMessage({
+                threadUuid: thread.uuid,
+                modelConfig,
+            }),
+            model.createAssistantMessage({
+                threadUuid: thread.uuid,
+                modelConfig,
+            }),
+        ]);
+        const part = {
+            partIndex: 0,
+            type: 'tool' as const,
+            payloadVersion: 1,
+            toolCallId: 'provider-call-id',
+            payload: { state: 'input-available', toolName: 'findExplores' },
+        };
+
+        const [[firstPart], [secondPart]] = await Promise.all([
+            model.appendParts({
+                messageUuid: firstMessage.uuid,
+                parts: [part],
+            }),
+            model.appendParts({
+                messageUuid: secondMessage.uuid,
+                parts: [part],
+            }),
+        ]);
+
+        expect(firstPart.uuid).not.toBe(secondPart.uuid);
+        await expect(
+            model.appendParts({
+                messageUuid: firstMessage.uuid,
+                parts: [{ ...part, partIndex: 1 }],
+            }),
+        ).rejects.toMatchObject({
+            constraint:
+                'ai_message_part_ai_thread_message_uuid_tool_call_id_unique',
+        });
+        await expect(
+            model.appendParts({
+                messageUuid: firstMessage.uuid,
+                parts: [textPart(0, 'duplicate index')],
+            }),
+        ).rejects.toMatchObject({
+            constraint:
+                'ai_message_part_ai_thread_message_uuid_part_index_unique',
+        });
+    });
+
+    it('updates a part while its assistant message is writable', async () => {
+        const thread = await createRootThread();
+        const assistant = await model.createAssistantMessage({
+            threadUuid: thread.uuid,
+            modelConfig,
+        });
+        const [part] = await model.appendParts({
+            messageUuid: assistant.uuid,
+            parts: [
+                {
+                    partIndex: 0,
+                    type: 'tool',
+                    payloadVersion: 1,
+                    toolCallId: 'update-part',
+                    payload: {
+                        state: 'input-available',
+                        toolName: 'findExplores',
+                    },
+                },
+            ],
+        });
+
+        const updated = await model.updatePart({
+            messageUuid: assistant.uuid,
+            partUuid: part.uuid,
+            payloadVersion: 2,
+            payload: { state: 'output-available', output: ['orders'] },
+        });
+
+        expect(updated).toMatchObject({
+            uuid: part.uuid,
+            payloadVersion: 2,
+            payload: { state: 'output-available', output: ['orders'] },
+        });
+        expect(
+            (await model.getThread(thread.uuid)).messages[0].parts[0],
+        ).toMatchObject(updated);
+        await expect(
+            model.updatePart({
+                messageUuid: assistant.uuid,
+                partUuid: randomUUID(),
+                payloadVersion: 2,
+                payload: { state: 'output-available', output: [] },
+            }),
+        ).rejects.toThrow('Message part not found');
+    });
+
+    it('enforces type-specific part references', async () => {
+        const thread = await createRootThread();
+        const assistant = await model.createAssistantMessage({
+            threadUuid: thread.uuid,
+            modelConfig,
+        });
+
+        await expect(
+            model.appendParts({
+                messageUuid: assistant.uuid,
+                parts: [
+                    {
+                        ...textPart(0, 'invalid'),
+                        toolCallId: 'not-a-text-attribute',
+                    } as never,
+                ],
+            }),
+        ).rejects.toThrow('Tool call id is only valid on tool parts');
+        await expect(
+            model.appendParts({
+                messageUuid: assistant.uuid,
+                parts: [
+                    {
+                        partIndex: 0,
+                        type: 'tool',
+                        payloadVersion: 1,
+                        payload: {},
+                    } as never,
+                ],
+            }),
+        ).rejects.toThrow('Tool part requires a tool call id');
+        await expect(
+            model.appendParts({
+                messageUuid: assistant.uuid,
+                parts: [
+                    {
+                        partIndex: 0,
+                        type: 'artifact',
+                        payloadVersion: 1,
+                        payload: {},
+                    } as never,
+                ],
+            }),
+        ).rejects.toThrow('Artifact part requires an artifact version uuid');
+        await expect(
+            model.appendUserMessage({
+                threadUuid: thread.uuid,
+                createdByUserUuid: null,
+                parts: [
+                    {
+                        partIndex: 0,
+                        type: 'reasoning',
+                        payloadVersion: 1,
+                        payload: {},
+                    },
+                ],
+            }),
+        ).rejects.toThrow('reasoning parts are not valid on user messages');
+        await expect(
+            model.appendParts({
+                messageUuid: assistant.uuid,
+                parts: [
+                    {
+                        partIndex: 0,
+                        type: 'compaction',
+                        payloadVersion: 1,
+                        payload: { summary: 'not an assistant part' },
+                    },
+                ],
+            }),
+        ).rejects.toThrow(
+            'compaction parts are not valid on assistant messages',
+        );
+        await expect(
+            database(AiMessagePartTableName).insert({
+                ai_thread_message_uuid: assistant.uuid,
+                part_index: 10,
+                type: 'text',
+                payload_version: 1,
+                payload: {},
+                tool_call_id: 'invalid-text-reference',
+            }),
+        ).rejects.toMatchObject({
+            constraint: 'ai_message_part_tool_call_shape_check',
+        });
+        await expect(
+            database(AiMessagePartTableName).insert({
+                ai_thread_message_uuid: assistant.uuid,
+                part_index: 11,
+                type: 'text',
+                payload_version: 1,
+                payload: {},
+                ai_artifact_version_uuid: randomUUID(),
+            }),
+        ).rejects.toMatchObject({
+            constraint: 'ai_message_part_artifact_version_shape_check',
+        });
+        await expect(
+            model.appendUserMessage({
+                threadUuid: thread.uuid,
+                createdByUserUuid: null,
+                parts: [],
+            }),
+        ).rejects.toThrow('User message requires content');
+    });
+
+    it('deletes artifact parts when their version is deleted', async () => {
+        const thread = await createRootThread();
+        const [artifact] = await database(AiArtifactsTableName)
+            .insert({ ai_thread_uuid: thread.uuid, artifact_type: 'chart' })
+            .returning('ai_artifact_uuid');
+        const [version] = await database(AiArtifactVersionsTableName)
+            .insert({
+                ai_artifact_uuid: artifact.ai_artifact_uuid,
+                version_number: 1,
+            })
+            .returning('ai_artifact_version_uuid');
+        const assistant = await model.createAssistantMessage({
+            threadUuid: thread.uuid,
+            modelConfig,
+        });
+        const [part] = await model.appendParts({
+            messageUuid: assistant.uuid,
+            parts: [
+                {
+                    partIndex: 0,
+                    type: 'artifact',
+                    payloadVersion: 1,
+                    payload: {},
+                    artifactVersionUuid: version.ai_artifact_version_uuid,
+                },
+            ],
+        });
+
+        await database(AiArtifactVersionsTableName)
+            .where('ai_artifact_version_uuid', version.ai_artifact_version_uuid)
+            .delete();
+
+        expect(
+            await database(AiMessagePartTableName)
+                .where('ai_message_part_uuid', part.uuid)
+                .first(),
+        ).toBeUndefined();
+    });
+
+    it('freezes terminal assistant messages and heals active tool parts', async () => {
+        const thread = await createRootThread();
+        const assistantMessage = await model.createAssistantMessage({
+            threadUuid: thread.uuid,
+            modelConfig,
+        });
+        const [toolPart] = await model.appendParts({
+            messageUuid: assistantMessage.uuid,
+            parts: [
+                {
+                    partIndex: 0,
+                    type: 'tool',
+                    payloadVersion: 1,
+                    toolCallId: 'call-1',
+                    payload: {
+                        state: 'input-available',
+                        toolName: 'findExplores',
+                        input: {},
+                    },
+                },
+            ],
+        });
+
+        await model.finishAssistantMessage({
+            messageUuid: assistantMessage.uuid,
+            status: 'canceled',
+            tokenUsage: {
+                version: 1,
+                inputTokens: 12,
+                outputTokens: 3,
+                totalTokens: 15,
+                reasoningTokens: 1,
+                cachedInputTokens: 2,
+            },
+            error: null,
+        });
+
+        await expect(
+            model.appendParts({
+                messageUuid: assistantMessage.uuid,
+                parts: [textPart(1, 'late')],
+            }),
+        ).rejects.toThrow('Assistant message is frozen');
+        await expect(
+            model.updatePart({
+                messageUuid: assistantMessage.uuid,
+                partUuid: toolPart.uuid,
+                payloadVersion: 2,
+                payload: { state: 'output-available', output: 'late' },
+            }),
+        ).rejects.toThrow('Assistant message is frozen');
+
+        const canonical = await model.getThread(thread.uuid);
+        expect(canonical.messages[0]).toMatchObject({
+            metadata: {
+                status: 'canceled',
+                tokenUsage: { totalTokens: 15 },
+            },
+            parts: [
+                {
+                    uuid: toolPart.uuid,
+                    payload: {
+                        state: 'output-error',
+                        error: {
+                            name: 'interrupted',
+                            message: 'Tool execution was interrupted',
+                        },
+                    },
+                },
+            ],
+        });
+    });
+
+    it('requires model-visible content before completion', async () => {
+        const thread = await createRootThread();
+        const assistantMessage = await model.createAssistantMessage({
+            threadUuid: thread.uuid,
+            modelConfig,
+        });
+        await model.appendParts({
+            messageUuid: assistantMessage.uuid,
+            parts: [
+                {
+                    partIndex: 0,
+                    type: 'step-start',
+                    payloadVersion: 1,
+                    payload: {},
+                },
+            ],
+        });
+
+        await expect(
+            model.finishAssistantMessage({
+                messageUuid: assistantMessage.uuid,
+                status: 'completed',
+                tokenUsage: null,
+                error: null,
+            }),
+        ).rejects.toThrow('Completed assistant message requires content');
+
+        await model.appendParts({
+            messageUuid: assistantMessage.uuid,
+            parts: [textPart(1, 'done')],
+        });
+        await model.finishAssistantMessage({
+            messageUuid: assistantMessage.uuid,
+            status: 'completed',
+            tokenUsage: null,
+            error: null,
+        });
+
+        expect(
+            (await model.getThread(thread.uuid)).messages[0].metadata.status,
+        ).toBe('completed');
+    });
+
+    it('persists versioned run envelopes and validates error transitions', async () => {
+        const thread = await createRootThread();
+        const assistantMessage = await model.createAssistantMessage({
+            threadUuid: thread.uuid,
+            modelConfig,
+        });
+        const error = {
+            version: 1,
+            name: 'provider_error',
+            message: 'Provider failed',
+            data: { retryable: true },
+        };
+
+        await expect(
+            model.finishAssistantMessage({
+                messageUuid: assistantMessage.uuid,
+                status: 'error',
+                tokenUsage: null,
+                error: null,
+            }),
+        ).rejects.toThrow('Error status requires an error envelope');
+        await expect(
+            model.finishAssistantMessage({
+                messageUuid: assistantMessage.uuid,
+                status: 'canceled',
+                tokenUsage: null,
+                error,
+            }),
+        ).rejects.toThrow('Error envelope requires error status');
+
+        await model.finishAssistantMessage({
+            messageUuid: assistantMessage.uuid,
+            status: 'error',
+            tokenUsage: null,
+            error,
+        });
+
+        expect(
+            (await model.getThread(thread.uuid)).messages[0].metadata,
+        ).toMatchObject({
+            status: 'error',
+            modelConfig,
+            error,
+        });
+    });
+
+    it('enforces lineage shape, scope, anchors, and fork boundaries', async () => {
+        const root = await createRootThread();
+        await expect(
+            database(AiThreadMessageTableName).insert({
+                ai_thread_uuid: root.uuid,
+                thread_seq: 999,
+                role: 'user',
+                status: 'in_progress',
+            } as never),
+        ).rejects.toMatchObject({
+            constraint: 'ai_thread_message_role_status_check',
+        });
+        await expect(
+            database(AiThreadTableName)
+                .where('ai_thread_uuid', root.uuid)
+                .update({ lineage_kind: 'fork' } as never),
+        ).rejects.toMatchObject({
+            constraint: 'ai_thread_lineage_shape_check',
+        });
+        const assistant = await model.createAssistantMessage({
+            threadUuid: root.uuid,
+            modelConfig,
+        });
+        await model.appendParts({
+            messageUuid: assistant.uuid,
+            parts: [
+                {
+                    partIndex: 0,
+                    type: 'tool',
+                    payloadVersion: 1,
+                    toolCallId: 'delegate-1',
+                    payload: { state: 'input-available', toolName: 'delegate' },
+                },
+            ],
+        });
+        const userToolMessage = await model.appendUserMessage({
+            threadUuid: root.uuid,
+            createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            parts: [textPart(0, 'user message during run')],
+        });
+        await database(AiMessagePartTableName).insert({
+            ai_thread_message_uuid: userToolMessage.uuid,
+            part_index: 1,
+            type: 'tool',
+            payload_version: 1,
+            tool_call_id: 'user-tool',
+            payload: { state: 'input-available', toolName: 'delegate' },
+        });
+
+        const spawn = await model.createThread({
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            projectUuid: SEED_PROJECT.project_uuid,
+            agentUuid: null,
+            createdFrom: 'web_app',
+            lineage: {
+                kind: 'spawn',
+                parentThreadUuid: root.uuid,
+                parentMessageUuid: assistant.uuid,
+                parentToolCallId: 'delegate-1',
+            },
+        });
+        await expect(
+            model.createThread({
+                organizationUuid: SEED_ORG_1.organization_uuid,
+                projectUuid: SEED_PROJECT.project_uuid,
+                agentUuid: null,
+                createdFrom: 'web_app',
+                lineage: {
+                    kind: 'fork',
+                    parentThreadUuid: root.uuid,
+                    forkBoundarySeq: assistant.threadSeq,
+                },
+            }),
+        ).rejects.toThrow('Fork boundary assistant message must be frozen');
+        await expect(
+            model.createThread({
+                organizationUuid: SEED_ORG_1.organization_uuid,
+                projectUuid: SEED_PROJECT.project_uuid,
+                agentUuid: null,
+                createdFrom: 'web_app',
+                lineage: {
+                    kind: 'fork',
+                    parentThreadUuid: root.uuid,
+                    forkBoundarySeq: userToolMessage.threadSeq,
+                },
+            }),
+        ).rejects.toThrow('Fork prefix contains an active assistant message');
+        await model.finishAssistantMessage({
+            messageUuid: assistant.uuid,
+            status: 'canceled',
+            tokenUsage: null,
+            error: null,
+        });
+        const fork = await model.createThread({
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            projectUuid: SEED_PROJECT.project_uuid,
+            agentUuid: null,
+            createdFrom: 'web_app',
+            lineage: {
+                kind: 'fork',
+                parentThreadUuid: root.uuid,
+                forkBoundarySeq: userToolMessage.threadSeq,
+            },
+        });
+
+        await expect(
+            model.createThread({
+                organizationUuid: SEED_ORG_2.organization_uuid,
+                projectUuid: SEED_PROJECT.project_uuid,
+                agentUuid: null,
+                createdFrom: 'web_app',
+                lineage: {
+                    kind: 'fork',
+                    parentThreadUuid: root.uuid,
+                    forkBoundarySeq: assistant.threadSeq,
+                },
+            }),
+        ).rejects.toThrow('Lineage scope must match its parent');
+        await expect(
+            model.createThread({
+                organizationUuid: SEED_ORG_1.organization_uuid,
+                projectUuid: SEED_PROJECT.project_uuid,
+                agentUuid: null,
+                createdFrom: 'web_app',
+                lineage: {
+                    kind: 'fork',
+                    parentThreadUuid: root.uuid,
+                    forkBoundarySeq: 999,
+                },
+            }),
+        ).rejects.toThrow('Fork boundary does not exist');
+        await expect(
+            model.createThread({
+                organizationUuid: SEED_ORG_1.organization_uuid,
+                projectUuid: SEED_PROJECT.project_uuid,
+                agentUuid: null,
+                createdFrom: 'web_app',
+                lineage: {
+                    kind: 'spawn',
+                    parentThreadUuid: root.uuid,
+                    parentMessageUuid: assistant.uuid,
+                    parentToolCallId: 'missing',
+                },
+            }),
+        ).rejects.toThrow('Spawn anchor does not exist');
+        await expect(
+            model.createThread({
+                organizationUuid: SEED_ORG_1.organization_uuid,
+                projectUuid: SEED_PROJECT.project_uuid,
+                agentUuid: null,
+                createdFrom: 'web_app',
+                lineage: {
+                    kind: 'spawn',
+                    parentThreadUuid: root.uuid,
+                    parentMessageUuid: userToolMessage.uuid,
+                    parentToolCallId: 'user-tool',
+                },
+            }),
+        ).rejects.toThrow('Spawn anchor does not exist');
+        await expect(
+            model.createThread({
+                organizationUuid: SEED_ORG_1.organization_uuid,
+                projectUuid: SEED_PROJECT.project_uuid,
+                agentUuid: null,
+                createdFrom: 'web_app',
+                lineage: {
+                    kind: 'fork',
+                    parentThreadUuid: spawn.uuid,
+                    forkBoundarySeq: 1,
+                },
+            }),
+        ).rejects.toThrow('Spawn threads cannot be forked');
+
+        expect(spawn.lineage).toMatchObject({ kind: 'spawn' });
+        expect(fork.lineage).toMatchObject({ kind: 'fork' });
+    });
+
+    it('cascades deletion through the entire lineage tree', async () => {
+        const root = await createRootThread();
+        const rootAssistant = await model.createAssistantMessage({
+            threadUuid: root.uuid,
+            modelConfig,
+        });
+        await model.appendParts({
+            messageUuid: rootAssistant.uuid,
+            parts: [
+                {
+                    partIndex: 0,
+                    type: 'tool',
+                    payloadVersion: 1,
+                    toolCallId: 'delegate-root',
+                    payload: { state: 'input-available', toolName: 'delegate' },
+                },
+            ],
+        });
+        await model.finishAssistantMessage({
+            messageUuid: rootAssistant.uuid,
+            status: 'canceled',
+            tokenUsage: null,
+            error: null,
+        });
+        const child = await model.createThread({
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            projectUuid: SEED_PROJECT.project_uuid,
+            agentUuid: null,
+            createdFrom: 'web_app',
+            lineage: {
+                kind: 'fork',
+                parentThreadUuid: root.uuid,
+                forkBoundarySeq: rootAssistant.threadSeq,
+            },
+        });
+        const childAssistant = await model.createAssistantMessage({
+            threadUuid: child.uuid,
+            modelConfig,
+        });
+        await model.appendParts({
+            messageUuid: childAssistant.uuid,
+            parts: [
+                {
+                    partIndex: 0,
+                    type: 'tool',
+                    payloadVersion: 1,
+                    toolCallId: 'delegate-child',
+                    payload: { state: 'input-available', toolName: 'delegate' },
+                },
+            ],
+        });
+        const grandchild = await model.createThread({
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            projectUuid: SEED_PROJECT.project_uuid,
+            agentUuid: null,
+            createdFrom: 'web_app',
+            lineage: {
+                kind: 'spawn',
+                parentThreadUuid: child.uuid,
+                parentMessageUuid: childAssistant.uuid,
+                parentToolCallId: 'delegate-child',
+            },
+        });
+
+        await database(AiThreadTableName)
+            .where('ai_thread_uuid', root.uuid)
+            .delete();
+
+        const [threads, messages, parts] = await Promise.all([
+            database(AiThreadTableName)
+                .select('ai_thread_uuid')
+                .whereIn('ai_thread_uuid', [
+                    root.uuid,
+                    child.uuid,
+                    grandchild.uuid,
+                ]),
+            database(AiThreadMessageTableName)
+                .select('ai_thread_message_uuid')
+                .whereIn('ai_thread_uuid', [
+                    root.uuid,
+                    child.uuid,
+                    grandchild.uuid,
+                ]),
+            database(AiMessagePartTableName)
+                .select('ai_message_part_uuid')
+                .whereIn('ai_thread_message_uuid', [
+                    rootAssistant.uuid,
+                    childAssistant.uuid,
+                ]),
+        ]);
+
+        expect(threads).toHaveLength(0);
+        expect(messages).toHaveLength(0);
+        expect(parts).toHaveLength(0);
+    });
+});

--- a/packages/backend/src/ee/models/AiAgentV3Model.ts
+++ b/packages/backend/src/ee/models/AiAgentV3Model.ts
@@ -1,0 +1,619 @@
+import {
+    assertUnreachable,
+    ConflictError,
+    NotFoundError,
+    ParameterError,
+    UnexpectedServerError,
+} from '@lightdash/common';
+import { type Knex } from 'knex';
+import { AiThreadTableName, type DbAiThread } from '../database/entities/ai';
+import {
+    AI_ASSISTANT_MESSAGE_TERMINAL_STATUSES,
+    AI_TOOL_PART_INTERRUPTED_STATE,
+    AI_TOOL_PART_TERMINAL_STATES,
+    AiMessagePartTableName,
+    AiThreadMessageSequenceTableName,
+    AiThreadMessageTableName,
+    MODEL_VISIBLE_AI_MESSAGE_PART_TYPES,
+    NON_USER_AI_MESSAGE_PART_TYPES,
+    type AiAssistantMessageTerminalStatus,
+    type AiModelConfigEnvelope,
+    type AiRunErrorEnvelope,
+    type AiTokenUsageEnvelope,
+    type AiV3CanonicalPart,
+    type AiV3CanonicalThread,
+    type AiV3PartWrite,
+    type AiV3ThreadLineage,
+    type CreateAiV3Thread,
+    type DbAiMessagePart,
+    type DbAiThreadMessage,
+} from '../database/entities/aiAgentV3';
+
+type Dependencies = {
+    database: Knex;
+};
+
+type CreatedMessage = {
+    uuid: string;
+    threadSeq: number;
+};
+
+const TERMINAL_TOOL_STATE_PLACEHOLDERS = AI_TOOL_PART_TERMINAL_STATES.map(
+    () => '?',
+).join(', ');
+
+export class AiAgentV3Model {
+    private readonly database: Knex;
+
+    constructor({ database }: Dependencies) {
+        this.database = database;
+    }
+
+    private static toLineage(row: DbAiThread): AiV3ThreadLineage {
+        switch (row.lineage_kind) {
+            case null:
+                return null;
+            case 'spawn':
+                if (
+                    row.parent_thread_uuid === null ||
+                    row.parent_message_uuid === null ||
+                    row.parent_tool_call_id === null
+                ) {
+                    throw new UnexpectedServerError('Invalid spawn lineage');
+                }
+                return {
+                    kind: 'spawn',
+                    parentThreadUuid: row.parent_thread_uuid,
+                    parentMessageUuid: row.parent_message_uuid,
+                    parentToolCallId: row.parent_tool_call_id,
+                };
+            case 'fork':
+                if (
+                    row.parent_thread_uuid === null ||
+                    row.fork_boundary_seq === null
+                ) {
+                    throw new UnexpectedServerError('Invalid fork lineage');
+                }
+                return {
+                    kind: 'fork',
+                    parentThreadUuid: row.parent_thread_uuid,
+                    forkBoundarySeq: row.fork_boundary_seq,
+                };
+            default:
+                return assertUnreachable(
+                    row.lineage_kind,
+                    'Invalid lineage kind',
+                );
+        }
+    }
+
+    private static assertLineageScope(
+        parent: DbAiThread,
+        data: CreateAiV3Thread,
+    ): void {
+        if (
+            parent.organization_uuid !== data.organizationUuid ||
+            parent.project_uuid !== data.projectUuid ||
+            parent.agent_uuid !== data.agentUuid
+        ) {
+            throw new ParameterError('Lineage scope must match its parent');
+        }
+        if (parent.storage_version !== 3) {
+            throw new ParameterError(
+                'Lineage parent must use storage version 3',
+            );
+        }
+    }
+
+    private static async allocateThreadSeq(
+        trx: Knex.Transaction,
+        threadUuid: string,
+    ): Promise<number> {
+        const [row] = await trx(AiThreadMessageSequenceTableName)
+            .where('ai_thread_uuid', threadUuid)
+            .increment('next_thread_seq', 1)
+            .returning('next_thread_seq');
+        if (row === undefined) {
+            const thread = await trx(AiThreadTableName)
+                .where('ai_thread_uuid', threadUuid)
+                .first();
+            if (thread === undefined) {
+                throw new NotFoundError('Thread not found');
+            }
+            throw new ConflictError('Thread is not writable v3 storage');
+        }
+        return row.next_thread_seq - 1;
+    }
+
+    private static assertPartWrites(
+        parts: AiV3PartWrite[],
+        role: 'user' | 'assistant',
+    ): void {
+        parts.forEach((part) => {
+            if (
+                role === 'user' &&
+                NON_USER_AI_MESSAGE_PART_TYPES.some(
+                    (partType) => partType === part.type,
+                )
+            ) {
+                throw new ParameterError(
+                    `${part.type} parts are not valid on user messages`,
+                );
+            }
+            if (role === 'assistant' && part.type === 'compaction') {
+                throw new ParameterError(
+                    'compaction parts are not valid on assistant messages',
+                );
+            }
+            if (part.type === 'tool' && !part.toolCallId) {
+                throw new ParameterError('Tool part requires a tool call id');
+            }
+            if (part.type === 'artifact' && !part.artifactVersionUuid) {
+                throw new ParameterError(
+                    'Artifact part requires an artifact version uuid',
+                );
+            }
+            if (
+                part.type !== 'tool' &&
+                'toolCallId' in part &&
+                part.toolCallId !== undefined
+            ) {
+                throw new ParameterError(
+                    'Tool call id is only valid on tool parts',
+                );
+            }
+            if (
+                part.type !== 'artifact' &&
+                'artifactVersionUuid' in part &&
+                part.artifactVersionUuid !== undefined
+            ) {
+                throw new ParameterError(
+                    'Artifact version uuid is only valid on artifact parts',
+                );
+            }
+        });
+    }
+
+    private static async insertParts(
+        trx: Knex.Transaction,
+        messageUuid: string,
+        parts: AiV3PartWrite[],
+    ): Promise<AiV3CanonicalPart[]> {
+        if (parts.length === 0) return [];
+        const rows = await trx(AiMessagePartTableName)
+            .insert(
+                parts.map((part) => ({
+                    ai_thread_message_uuid: messageUuid,
+                    part_index: part.partIndex,
+                    type: part.type,
+                    payload_version: part.payloadVersion,
+                    payload: part.payload,
+                    tool_call_id: part.toolCallId,
+                    ai_artifact_version_uuid: part.artifactVersionUuid,
+                })),
+            )
+            .returning('*');
+        return rows.map(AiAgentV3Model.toCanonicalPart);
+    }
+
+    private static toCanonicalPart(part: DbAiMessagePart): AiV3CanonicalPart {
+        return {
+            uuid: part.ai_message_part_uuid,
+            type: part.type,
+            payloadVersion: part.payload_version,
+            payload: part.payload,
+            toolCallId: part.tool_call_id,
+            artifactVersionUuid: part.ai_artifact_version_uuid,
+        };
+    }
+
+    private static async getWritableAssistantMessage(
+        trx: Knex.Transaction,
+        messageUuid: string,
+    ): Promise<DbAiThreadMessage> {
+        const message = await trx(AiThreadMessageTableName)
+            .where('ai_thread_message_uuid', messageUuid)
+            .forUpdate()
+            .first();
+        if (message === undefined) {
+            throw new NotFoundError('Assistant message not found');
+        }
+        if (message.role !== 'assistant') {
+            throw new ConflictError('Message is not an assistant message');
+        }
+        if (message.status !== 'in_progress') {
+            throw new ConflictError('Assistant message is frozen');
+        }
+        return message;
+    }
+
+    async createThread(data: CreateAiV3Thread) {
+        return this.database.transaction(async (trx) => {
+            let parent: DbAiThread | undefined;
+            if (data.lineage !== null) {
+                parent = await trx(AiThreadTableName)
+                    .where('ai_thread_uuid', data.lineage.parentThreadUuid)
+                    .first();
+                if (parent === undefined) {
+                    throw new NotFoundError('Lineage parent thread not found');
+                }
+                AiAgentV3Model.assertLineageScope(parent, data);
+
+                switch (data.lineage.kind) {
+                    case 'spawn': {
+                        const anchor = await trx(AiThreadMessageTableName)
+                            .innerJoin(
+                                AiMessagePartTableName,
+                                `${AiMessagePartTableName}.ai_thread_message_uuid`,
+                                `${AiThreadMessageTableName}.ai_thread_message_uuid`,
+                            )
+                            .where(
+                                `${AiThreadMessageTableName}.ai_thread_message_uuid`,
+                                data.lineage.parentMessageUuid,
+                            )
+                            .where(
+                                `${AiThreadMessageTableName}.ai_thread_uuid`,
+                                data.lineage.parentThreadUuid,
+                            )
+                            .where(
+                                `${AiThreadMessageTableName}.role`,
+                                'assistant',
+                            )
+                            .where(`${AiMessagePartTableName}.type`, 'tool')
+                            .where(
+                                `${AiMessagePartTableName}.tool_call_id`,
+                                data.lineage.parentToolCallId,
+                            )
+                            .first();
+                        if (anchor === undefined) {
+                            throw new ParameterError(
+                                'Spawn anchor does not exist',
+                            );
+                        }
+                        break;
+                    }
+                    case 'fork': {
+                        if (parent.lineage_kind === 'spawn') {
+                            throw new ParameterError(
+                                'Spawn threads cannot be forked',
+                            );
+                        }
+                        const boundary = await trx(AiThreadMessageTableName)
+                            .where(
+                                'ai_thread_uuid',
+                                data.lineage.parentThreadUuid,
+                            )
+                            .where('thread_seq', data.lineage.forkBoundarySeq)
+                            .first();
+                        if (boundary === undefined) {
+                            throw new ParameterError(
+                                'Fork boundary does not exist',
+                            );
+                        }
+                        if (
+                            boundary.role === 'assistant' &&
+                            !AI_ASSISTANT_MESSAGE_TERMINAL_STATUSES.some(
+                                (status) => status === boundary.status,
+                            )
+                        ) {
+                            throw new ParameterError(
+                                'Fork boundary assistant message must be frozen',
+                            );
+                        }
+                        const activeAssistantInPrefix = await trx(
+                            AiThreadMessageTableName,
+                        )
+                            .where(
+                                'ai_thread_uuid',
+                                data.lineage.parentThreadUuid,
+                            )
+                            .where(
+                                'thread_seq',
+                                '<=',
+                                data.lineage.forkBoundarySeq,
+                            )
+                            .where('role', 'assistant')
+                            .where('status', 'in_progress')
+                            .first();
+                        if (activeAssistantInPrefix !== undefined) {
+                            throw new ParameterError(
+                                'Fork prefix contains an active assistant message',
+                            );
+                        }
+                        break;
+                    }
+                    default:
+                        assertUnreachable(data.lineage, 'Invalid lineage');
+                }
+            }
+
+            const { lineage } = data;
+            const [thread] = await trx(AiThreadTableName)
+                .insert({
+                    organization_uuid: data.organizationUuid,
+                    project_uuid: data.projectUuid,
+                    agent_uuid: data.agentUuid,
+                    created_from: data.createdFrom,
+                    storage_version: 3,
+                    parent_thread_uuid: lineage?.parentThreadUuid,
+                    lineage_kind: lineage?.kind,
+                    parent_message_uuid:
+                        lineage?.kind === 'spawn'
+                            ? lineage.parentMessageUuid
+                            : undefined,
+                    parent_tool_call_id:
+                        lineage?.kind === 'spawn'
+                            ? lineage.parentToolCallId
+                            : undefined,
+                    fork_boundary_seq:
+                        lineage?.kind === 'fork'
+                            ? lineage.forkBoundarySeq
+                            : undefined,
+                })
+                .returning('*');
+            if (thread === undefined) {
+                throw new UnexpectedServerError('Failed to create v3 thread');
+            }
+            await trx(AiThreadMessageSequenceTableName).insert({
+                ai_thread_uuid: thread.ai_thread_uuid,
+            });
+
+            return {
+                uuid: thread.ai_thread_uuid,
+                storageVersion: 3 as const,
+                lineage: AiAgentV3Model.toLineage(thread),
+            };
+        });
+    }
+
+    async appendUserMessage({
+        threadUuid,
+        createdByUserUuid,
+        createdAt,
+        parts,
+    }: {
+        threadUuid: string;
+        createdByUserUuid: string | null;
+        createdAt?: Date;
+        parts: AiV3PartWrite[];
+    }): Promise<CreatedMessage> {
+        if (parts.length === 0) {
+            throw new ParameterError('User message requires content');
+        }
+        AiAgentV3Model.assertPartWrites(parts, 'user');
+        return this.database.transaction(async (trx) => {
+            const threadSeq = await AiAgentV3Model.allocateThreadSeq(
+                trx,
+                threadUuid,
+            );
+            const [message] = await trx(AiThreadMessageTableName)
+                .insert({
+                    ai_thread_uuid: threadUuid,
+                    thread_seq: threadSeq,
+                    role: 'user',
+                    created_by_user_uuid: createdByUserUuid,
+                    created_at: createdAt,
+                })
+                .returning(['ai_thread_message_uuid', 'created_at']);
+            if (message === undefined) {
+                throw new UnexpectedServerError(
+                    'Failed to append user message',
+                );
+            }
+            await AiAgentV3Model.insertParts(
+                trx,
+                message.ai_thread_message_uuid,
+                parts,
+            );
+            await trx(AiThreadTableName)
+                .where('ai_thread_uuid', threadUuid)
+                .update({
+                    updated_at: trx.raw('GREATEST(??, ?)', [
+                        'updated_at',
+                        message.created_at,
+                    ]),
+                });
+            return {
+                uuid: message.ai_thread_message_uuid,
+                threadSeq,
+            };
+        });
+    }
+
+    async createAssistantMessage({
+        threadUuid,
+        modelConfig,
+    }: {
+        threadUuid: string;
+        modelConfig: AiModelConfigEnvelope;
+    }): Promise<CreatedMessage> {
+        return this.database.transaction(async (trx) => {
+            const threadSeq = await AiAgentV3Model.allocateThreadSeq(
+                trx,
+                threadUuid,
+            );
+            const [message] = await trx(AiThreadMessageTableName)
+                .insert({
+                    ai_thread_uuid: threadUuid,
+                    thread_seq: threadSeq,
+                    role: 'assistant',
+                    status: 'in_progress',
+                    last_heartbeat_at: trx.fn.now(),
+                    model_config: modelConfig,
+                })
+                .returning('ai_thread_message_uuid');
+            if (message === undefined) {
+                throw new UnexpectedServerError(
+                    'Failed to create assistant message',
+                );
+            }
+            return {
+                uuid: message.ai_thread_message_uuid,
+                threadSeq,
+            };
+        });
+    }
+
+    async appendParts({
+        messageUuid,
+        parts,
+    }: {
+        messageUuid: string;
+        parts: AiV3PartWrite[];
+    }): Promise<AiV3CanonicalPart[]> {
+        AiAgentV3Model.assertPartWrites(parts, 'assistant');
+        return this.database.transaction(async (trx) => {
+            await AiAgentV3Model.getWritableAssistantMessage(trx, messageUuid);
+            return AiAgentV3Model.insertParts(trx, messageUuid, parts);
+        });
+    }
+
+    async updatePart({
+        messageUuid,
+        partUuid,
+        payloadVersion,
+        payload,
+    }: {
+        messageUuid: string;
+        partUuid: string;
+        payloadVersion: number;
+        payload: Record<string, unknown>;
+    }): Promise<AiV3CanonicalPart> {
+        return this.database.transaction(async (trx) => {
+            await AiAgentV3Model.getWritableAssistantMessage(trx, messageUuid);
+            const [part] = await trx(AiMessagePartTableName)
+                .where('ai_message_part_uuid', partUuid)
+                .where('ai_thread_message_uuid', messageUuid)
+                .update({
+                    payload_version: payloadVersion,
+                    payload,
+                })
+                .returning('*');
+            if (part === undefined) {
+                throw new NotFoundError('Message part not found');
+            }
+            return AiAgentV3Model.toCanonicalPart(part);
+        });
+    }
+
+    async finishAssistantMessage({
+        messageUuid,
+        status,
+        tokenUsage,
+        error,
+    }: {
+        messageUuid: string;
+        status: AiAssistantMessageTerminalStatus;
+        tokenUsage: AiTokenUsageEnvelope | null;
+        error: AiRunErrorEnvelope | null;
+    }): Promise<void> {
+        if (status === 'error' && error === null) {
+            throw new ParameterError('Error status requires an error envelope');
+        }
+        if (status !== 'error' && error !== null) {
+            throw new ParameterError('Error envelope requires error status');
+        }
+        await this.database.transaction(async (trx) => {
+            await AiAgentV3Model.getWritableAssistantMessage(trx, messageUuid);
+            if (status === 'completed') {
+                const visiblePart = await trx(AiMessagePartTableName)
+                    .where('ai_thread_message_uuid', messageUuid)
+                    .whereIn('type', [...MODEL_VISIBLE_AI_MESSAGE_PART_TYPES])
+                    .first();
+                if (visiblePart === undefined) {
+                    throw new ConflictError(
+                        'Completed assistant message requires content',
+                    );
+                }
+            }
+
+            await trx(AiMessagePartTableName)
+                .where('ai_thread_message_uuid', messageUuid)
+                .where('type', 'tool')
+                .whereRaw(
+                    `COALESCE(payload->>'state', '') NOT IN (${TERMINAL_TOOL_STATE_PLACEHOLDERS})`,
+                    [...AI_TOOL_PART_TERMINAL_STATES],
+                )
+                .update({
+                    payload: trx.raw('payload || ?::jsonb', [
+                        JSON.stringify({
+                            state: AI_TOOL_PART_INTERRUPTED_STATE,
+                            error: {
+                                name: 'interrupted',
+                                message: 'Tool execution was interrupted',
+                            },
+                        }),
+                    ]),
+                });
+            await trx(AiThreadMessageTableName)
+                .where('ai_thread_message_uuid', messageUuid)
+                .update({
+                    status,
+                    token_usage: tokenUsage,
+                    error,
+                });
+        });
+    }
+
+    async getThread(threadUuid: string): Promise<AiV3CanonicalThread> {
+        const thread = await this.database(AiThreadTableName)
+            .where('ai_thread_uuid', threadUuid)
+            .first();
+        if (thread === undefined) {
+            throw new NotFoundError('Thread not found');
+        }
+        if (thread.storage_version !== 3) {
+            throw new ConflictError('Thread is not storage version 3');
+        }
+
+        const messages = await this.database(AiThreadMessageTableName)
+            .where('ai_thread_uuid', threadUuid)
+            .orderBy('thread_seq');
+        const messageUuids = messages.map(
+            (message) => message.ai_thread_message_uuid,
+        );
+        const parts =
+            messageUuids.length === 0
+                ? []
+                : await this.database(AiMessagePartTableName)
+                      .whereIn('ai_thread_message_uuid', messageUuids)
+                      .orderBy([
+                          { column: 'ai_thread_message_uuid' },
+                          { column: 'part_index' },
+                      ]);
+        const partsByMessageUuid = new Map<string, AiV3CanonicalPart[]>();
+        parts.forEach((part) => {
+            const messageParts =
+                partsByMessageUuid.get(part.ai_thread_message_uuid) ?? [];
+            messageParts.push(AiAgentV3Model.toCanonicalPart(part));
+            partsByMessageUuid.set(part.ai_thread_message_uuid, messageParts);
+        });
+
+        return {
+            uuid: thread.ai_thread_uuid,
+            storageVersion: 3,
+            organizationUuid: thread.organization_uuid,
+            projectUuid: thread.project_uuid,
+            agentUuid: thread.agent_uuid,
+            createdAt: thread.created_at.toISOString(),
+            lineage: AiAgentV3Model.toLineage(thread),
+            messages: messages.map((message) => ({
+                uuid: message.ai_thread_message_uuid,
+                role: message.role,
+                parts:
+                    partsByMessageUuid.get(message.ai_thread_message_uuid) ??
+                    [],
+                metadata: {
+                    createdAt: message.created_at.toISOString(),
+                    createdByUserUuid: message.created_by_user_uuid,
+                    status: message.status,
+                    lastHeartbeatAt:
+                        message.last_heartbeat_at?.toISOString() ?? null,
+                    modelConfig: message.model_config,
+                    tokenUsage: message.token_usage,
+                    error: message.error,
+                },
+            })),
+        };
+    }
+}

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -152,6 +152,7 @@ export type ModelManifest = {
     /** An implementation signature for these models are not available at this stage */
     aiAgentMemoryModel: unknown;
     aiAgentModel: unknown;
+    aiAgentV3Model: unknown;
     homepageRecommendedActionSkipsModel: unknown;
     projectHomepageModel: unknown;
     aiAgentDocumentModel: unknown;
@@ -821,6 +822,10 @@ export class ModelRepository
 
     public getAiAgentModel<ModelImplT>(): ModelImplT {
         return this.getModel('aiAgentModel');
+    }
+
+    public getAiAgentV3Model<ModelImplT>(): ModelImplT {
+        return this.getModel('aiAgentV3Model');
     }
 
     public getAiAgentMemoryModel<ModelImplT>(): ModelImplT {


### PR DESCRIPTION
## Summary

- add v3 thread, message, part, sequence, envelope, and lineage schema
- add transactional repository writes, terminal freeze/healing, and canonical ordered reads
- add Postgres integration coverage plus the agents-v3 context glossary

## Verification

- backend lint and typecheck
- backend unit suite: 395 files, 5,956 passed
- v3 repository Postgres integration suite: 10 passed
- local repository execution and psql schema/data checks

Closes: ZAP-798
