### PR TITLE
chore: start orb development services asynchronously

### DIFF
--- a/.agents/resume
+++ b/.agents/resume
@@ -24,4 +24,13 @@ if [[ "$(node --version)" != "v${NODE_VERSION}" ]]; then
     exit 1
 fi
 
-echo "Lightdash orb ready: Node.js $(node --version), pnpm $(pnpm --version)"
+cd "$REPO_ROOT"
+if amp orb service status docker >/dev/null 2>&1 \
+    && amp orb service status lightdash >/dev/null 2>&1; then
+    echo "Supervised development stack is already running"
+else
+    echo "Ensuring the supervised development stack is running"
+    amp orb service ensure
+fi
+
+echo "Lightdash orb resumed: Node.js $(node --version), pnpm $(pnpm --version)"

--- a/.agents/setup
+++ b/.agents/setup
@@ -31,6 +31,25 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
     python3.11-venv \
     xz-utils
 
+if ! command -v docker >/dev/null 2>&1; then
+    echo "==> Installing Docker"
+    sudo install -m 0755 -d /etc/apt/keyrings
+    sudo curl -fsSL https://download.docker.com/linux/debian/gpg \
+        -o /etc/apt/keyrings/docker.asc
+    sudo chmod a+r /etc/apt/keyrings/docker.asc
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+        | sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
+    sudo apt-get update -qq
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+        docker-ce \
+        docker-ce-cli \
+        containerd.io \
+        docker-buildx-plugin \
+        docker-compose-plugin
+else
+    echo "==> Docker is already installed"
+fi
+
 if [[ ! -x "$NODE_ROOT/bin/node" ]]; then
     echo "==> Installing Node.js ${NODE_VERSION}"
     archive="node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz"
@@ -79,30 +98,21 @@ pnpm --version
 echo "==> Installing JavaScript dependencies"
 pnpm install --frozen-lockfile --prefer-offline
 
-echo "==> Building shared workspace packages"
-pnpm formula:build
-pnpm common-build
-pnpm warehouses-build
-
-echo "==> Preparing the Python 3.11 dbt environment"
-SHARED_VENV="$HOME/.lightdash/dev-venv"
-if [[ ! -x "$SHARED_VENV/bin/dbt" ]]; then
-    rm -rf "$SHARED_VENV"
-    mkdir -p "$(dirname "$SHARED_VENV")"
-    python3.11 -m venv "$SHARED_VENV"
-    "$SHARED_VENV/bin/pip" install --disable-pip-version-check \
-        'dbt-core==1.7.0' \
-        'dbt-postgres==1.7.0' \
-        'protobuf>=4.0.0,<5.0.0'
-    ln -sf dbt "$SHARED_VENV/bin/dbt1.7"
+if amp orb service status docker >/dev/null 2>&1 \
+    && amp orb service status lightdash >/dev/null 2>&1; then
+    echo "==> Development stack is already running"
 else
-    echo "dbt environment is already installed"
-fi
-
-if [[ ! -e venv ]]; then
-    ln -s "$SHARED_VENV" venv
-elif [[ -L venv && ! -e venv/bin/dbt ]]; then
-    ln -sfn "$SHARED_VENV" venv
+    echo "==> Starting the development stack asynchronously"
+    set +e
+    timeout 5s amp orb service ensure
+    ensure_status=$?
+    set -e
+    if [[ "$ensure_status" -eq 124 ]]; then
+        echo "Development stack is still starting; inspect it with: amp orb service status lightdash"
+    elif [[ "$ensure_status" -ne 0 ]]; then
+        echo "Failed to start the development stack" >&2
+        exit "$ensure_status"
+    fi
 fi
 
 echo "==> Orb setup complete"

--- a/.amp/services.yaml
+++ b/.amp/services.yaml
@@ -1,0 +1,17 @@
+services:
+    docker:
+        command: sudo dockerd --group "$(id -gn)"
+    lightdash:
+        command: |
+            until docker info >/dev/null 2>&1; do
+              sleep 1
+            done
+            export LD_FRONTEND_PORT_OVERRIDE="$PORT"
+            export LD_FRONTEND_PORT_RESERVED=true
+            export PATH="$HOME/.local/share/lightdash/node-current/bin:$PWD/node_modules/.bin:$PATH"
+            ./scripts/dev-fast-start.sh
+            exec pnpm exec pm2 logs --raw --lines 0
+        port: 3000
+        portal:
+            title: Lightdash
+            description: Log in with demo@lightdash.com / demo_password!

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -150,6 +150,7 @@ export default defineConfig({
             '.lightdash.dev', // for cloudflared tunnels,
             '.exe.xyz', // for exe.dev devboxes
             '.e2b.app', // for Amp orb portals
+            '.onamp.dev', // for Amp orb portals
             ...(FE_HOST ? [FE_HOST] : []),
         ],
         watch: {

--- a/scripts/dev-ports.sh
+++ b/scripts/dev-ports.sh
@@ -79,7 +79,7 @@ compute_ports() {
     # (e.g. slot 3 FRONTEND_PORT=3030 vs slot 0 SDK_TEST_PORT=3030).
     # validate_slot_ports() checks lsof at claim time to catch these at runtime.
     PG_PORT=$((5432 + slot * 100))
-    FRONTEND_PORT=$((3000 + slot * 10))
+    FRONTEND_PORT="${LD_FRONTEND_PORT_OVERRIDE:-$((3000 + slot * 10))}"
     API_PORT=$((8080 + slot * 10))
     SCHEDULER_PORT=$((8081 + slot * 10))
     DEBUG_PORT=$((9229 + slot * 10))
@@ -129,7 +129,12 @@ validate_slot_ports() {
     compute_ports "$slot"
 
     # Only check per-instance ports (shared services are not our concern)
-    local all_ports="$PG_PORT $FRONTEND_PORT $API_PORT $SCHEDULER_PORT $DEBUG_PORT $SDK_TEST_PORT $SPOTLIGHT_PORT $PROMETHEUS_PORT"
+    local all_ports="$PG_PORT $API_PORT $SCHEDULER_PORT $DEBUG_PORT $SDK_TEST_PORT $SPOTLIGHT_PORT $PROMETHEUS_PORT"
+    # Amp reserves the declared portal port before this script runs. It is not
+    # an application listener, so allow the matching frontend slot in an orb.
+    if [ "${LD_FRONTEND_PORT_RESERVED:-}" != true ] || [ "$FRONTEND_PORT" != "${PORT:-}" ]; then
+        all_ports="$FRONTEND_PORT $all_ports"
+    fi
 
     for port in $all_ports; do
         if ! check_port_available "$port"; then


### PR DESCRIPTION
## Summary

- install and supervise Docker automatically in fresh orbs
- start the canonical Lightdash bootstrap asynchronously so database setup can continue while coding begins
- preserve the portal frontend port alongside multi-instance backend port allocation
- avoid restarting healthy services during setup and resume
- allow current Amp portal hostnames in Vite

## Verification

- ran orb setup twice; repeat setup completed in 4 seconds without restarting services
- ran orb resume; completed in under 2 seconds without restarting services
- verified Docker and Lightdash supervisor units are active
- verified frontend, backend health endpoint, and Amp portal return HTTP 200
- ran Bash syntax checks, formatting checks, and git diff validation
