### PR TITLE
feat(data-apps): persist extracted data references

### DIFF
--- a/packages/backend/src/database/entities/apps.ts
+++ b/packages/backend/src/database/entities/apps.ts
@@ -6,6 +6,7 @@ import {
     type DataAppGenerationUsage,
     type DataAppTemplate,
     type DataAppVizSchema,
+    type PersistedDataAppDataReferences,
 } from '@lightdash/common';
 import { type Knex } from 'knex';
 
@@ -96,6 +97,9 @@ export type DbAppVersion = {
     dependencies: AppVersionDependencies | null;
     // Declared schema for data-app-viz versions; null otherwise.
     viz_schema: DataAppVizSchema | null;
+    // Static data references found in this version's source. Null when not
+    // recorded, including versions created before persistence was added.
+    data_references: PersistedDataAppDataReferences | null;
     // Token/cost spend for this version's generation. Null when the version
     // predates spend recording or never called the model.
     generation_usage: DataAppGenerationUsage | null;
@@ -147,6 +151,7 @@ export type AppVersionsTable = Knex.CompositeTableType<
             | 'status_history'
             | 'status_updated_at'
             | 'viz_schema'
+            | 'data_references'
             | 'generation_usage'
         >
     >

--- a/packages/backend/src/database/migrations/20260806084811_add_data_references_to_app_versions.ts
+++ b/packages/backend/src/database/migrations/20260806084811_add_data_references_to_app_versions.ts
@@ -1,0 +1,15 @@
+import { type Knex } from 'knex';
+
+const AppVersionsTableName = 'app_versions';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AppVersionsTableName, (table) => {
+        table.jsonb('data_references').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AppVersionsTableName, (table) => {
+        table.dropColumn('data_references');
+    });
+}

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
@@ -131,6 +131,7 @@ function buildService(
         createVersion: vi.fn().mockResolvedValue({ version: 1 }),
         getLatestVersion: vi.fn().mockResolvedValue(null),
         countInProgressVersionsForProject: vi.fn().mockResolvedValue(0),
+        updateVersionDataReferences: vi.fn().mockResolvedValue(undefined),
         updateApp: vi.fn().mockResolvedValue({}),
         moveToSpace: vi.fn().mockResolvedValue(undefined),
     };
@@ -323,6 +324,47 @@ describe('AppGenerateService.importAppCode', () => {
                 customDependencies: [],
             }),
         });
+    });
+
+    it('persists extracted references without the extractor version', async () => {
+        const { service, appModel } = buildService();
+        appModel.findApp.mockResolvedValue(undefined);
+
+        await service.importAppCode(makeUser(), PROJECT_UUID, {
+            code: makeCode([
+                {
+                    path: 'src/App.tsx',
+                    contentBase64: Buffer.from(
+                        `import { query } from '@lightdash/query-sdk';
+                         query('orders').metrics(['orders_total_sales']);`,
+                    ).toString('base64'),
+                },
+            ]),
+        } as ImportAppCodeRequestBody);
+
+        expect(appModel.updateVersionDataReferences).toHaveBeenCalledWith(
+            NEW_APP_UUID,
+            1,
+            {
+                references: [
+                    expect.objectContaining({
+                        kind: 'query',
+                        explore: 'orders',
+                        metrics: ['orders_total_sales'],
+                    }),
+                ],
+                parseErrors: [],
+                stats: {
+                    callSites: 1,
+                    fullyResolved: 1,
+                    partiallyResolved: 0,
+                    unresolved: 0,
+                },
+            },
+        );
+        expect(
+            appModel.updateVersionDataReferences.mock.calls[0][2],
+        ).not.toHaveProperty('extractorVersion');
     });
 
     it('append mode: appends version 5 when latest is 4 and enqueues build', async () => {
@@ -938,6 +980,100 @@ describe('AppGenerateService.importAppCode', () => {
         });
 
         expect(entryNames).toEqual(['src/App.jsx']);
+    });
+});
+
+describe('AppGenerateService generated source references', () => {
+    const makeTar = (path: string, content: string) =>
+        new Promise<Buffer>((resolve, reject) => {
+            const packer = tarPack();
+            const chunks: Buffer[] = [];
+            packer.on('data', (chunk: Buffer) => chunks.push(chunk));
+            packer.on('end', () => resolve(Buffer.concat(chunks)));
+            packer.on('error', reject);
+            packer.entry({ name: path }, content, (error) => {
+                if (error) reject(error);
+                else packer.finalize();
+            });
+        });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        s3SendSpy.mockResolvedValue({});
+    });
+
+    it('persists references from the source archive during deployment', async () => {
+        const { service, appModel } = buildService();
+        const distTar = await makeTar('dist/index.html', '<html></html>');
+        const sourceTar = await makeTar(
+            'src/App.tsx',
+            `import { savedChart } from '@lightdash/query-sdk';
+             savedChart('chart-uuid');`,
+        );
+
+        await (
+            service as unknown as {
+                uploadToS3: (
+                    client: unknown,
+                    bucket: string,
+                    appUuid: string,
+                    version: number,
+                    dist: Buffer,
+                    source: Buffer,
+                ) => Promise<number>;
+            }
+        ).uploadToS3(
+            { send: s3SendSpy },
+            'test-bucket',
+            NEW_APP_UUID,
+            2,
+            distTar,
+            sourceTar,
+        );
+
+        expect(appModel.updateVersionDataReferences).toHaveBeenCalledWith(
+            NEW_APP_UUID,
+            2,
+            expect.objectContaining({
+                references: [
+                    expect.objectContaining({
+                        kind: 'savedChart',
+                        chartUuid: 'chart-uuid',
+                    }),
+                ],
+            }),
+        );
+    });
+
+    it('does not fail deployment when reference persistence fails', async () => {
+        const { service, appModel } = buildService();
+        appModel.updateVersionDataReferences.mockRejectedValue(
+            new Error('database unavailable'),
+        );
+
+        const distTar = await makeTar('dist/index.html', '<html></html>');
+        const sourceTar = await makeTar('src/App.tsx', 'export default null;');
+        const upload = (
+            service as unknown as {
+                uploadToS3: (
+                    client: unknown,
+                    bucket: string,
+                    appUuid: string,
+                    version: number,
+                    dist: Buffer,
+                    source: Buffer,
+                ) => Promise<number>;
+            }
+        ).uploadToS3(
+            { send: s3SendSpy },
+            'test-bucket',
+            NEW_APP_UUID,
+            2,
+            distTar,
+            sourceTar,
+        );
+
+        await expect(upload).resolves.toEqual(expect.any(Number));
     });
 });
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -24,6 +24,7 @@ import {
     dataAppVizJsonSchema,
     dataAppVizSchema,
     DEFAULT_DATA_APP_CLAUDE_MODEL,
+    extractDataAppDataReferences,
     extractLockfilePackages,
     FeatureFlags,
     FilterOperator,
@@ -93,6 +94,7 @@ import {
     type LightdashProjectParameter,
     type MetricQuery,
     type ModelRequiredFilterRule,
+    type PersistedDataAppDataReferences,
     type PromoteAppAction,
     type PromoteAppDiff,
     type SavedChart,
@@ -3826,6 +3828,12 @@ export class AppGenerateService extends BaseService {
                 }),
         ]);
 
+        await this.extractAndPersistVersionDataReferencesFromTar(
+            appUuid,
+            version,
+            sourceTar,
+        );
+
         const durationMs = AppGenerateService.elapsed(start);
         const totalBytes = distResult.totalBytes + sourceTar.length;
         this.logger.info(
@@ -6215,6 +6223,11 @@ export class AppGenerateService extends BaseService {
             // strips the contract from every chart bound to it.
             source.viz_schema ?? undefined,
         );
+        await this.persistVersionDataReferences(
+            appUuid,
+            newVersion,
+            source.data_references,
+        );
         await this.appModel.updateStatusMessage(
             appUuid,
             newVersion,
@@ -6727,6 +6740,11 @@ export class AppGenerateService extends BaseService {
                     targetAppUuid,
                 );
             }
+            await this.persistVersionDataReferences(
+                targetAppUuid,
+                targetVersion,
+                sourceVersion.data_references,
+            );
             await this.appModel.updateStatusMessage(
                 targetAppUuid,
                 targetVersion,
@@ -7009,6 +7027,11 @@ export class AppGenerateService extends BaseService {
                 undefined,
                 sourceVersion.viz_schema ?? undefined,
             );
+            await this.persistVersionDataReferences(
+                newAppUuid,
+                newVersion,
+                sourceVersion.data_references,
+            );
             await this.linkResolvedExternalConnections(
                 newAppUuid,
                 externalConnectionResources,
@@ -7256,6 +7279,11 @@ export class AppGenerateService extends BaseService {
                 resources,
                 undefined,
                 sourceVersion.viz_schema ?? undefined,
+            );
+            await this.persistVersionDataReferences(
+                newAppUuid,
+                newVersion,
+                sourceVersion.data_references,
             );
             // Link back to the upstream app so a later promote updates it
             // instead of creating a duplicate.
@@ -9297,6 +9325,80 @@ export class AppGenerateService extends BaseService {
         });
     }
 
+    private static extractPersistedDataReferences(
+        files: DataAppCodeFile[],
+    ): PersistedDataAppDataReferences {
+        const extracted = extractDataAppDataReferences(
+            files.map(({ path, contentBase64 }) => ({
+                path,
+                content: Buffer.from(contentBase64, 'base64').toString('utf8'),
+            })),
+        );
+        return {
+            references: extracted.references,
+            parseErrors: extracted.parseErrors,
+            stats: extracted.stats,
+        };
+    }
+
+    private async persistVersionDataReferences(
+        appUuid: string,
+        version: number,
+        dataReferences: PersistedDataAppDataReferences | null | undefined,
+    ): Promise<void> {
+        if (dataReferences == null) return;
+        try {
+            await this.appModel.updateVersionDataReferences(
+                appUuid,
+                version,
+                dataReferences,
+            );
+        } catch (error) {
+            this.logger.warn(
+                `App ${appUuid}: failed to persist data references for version ${version}: ${getErrorMessage(error)}`,
+            );
+        }
+    }
+
+    private async extractAndPersistVersionDataReferences(
+        appUuid: string,
+        version: number,
+        files: DataAppCodeFile[],
+    ): Promise<void> {
+        try {
+            const dataReferences =
+                AppGenerateService.extractPersistedDataReferences(files);
+            await this.persistVersionDataReferences(
+                appUuid,
+                version,
+                dataReferences,
+            );
+        } catch (error) {
+            this.logger.warn(
+                `App ${appUuid}: failed to extract data references for version ${version}: ${getErrorMessage(error)}`,
+            );
+        }
+    }
+
+    private async extractAndPersistVersionDataReferencesFromTar(
+        appUuid: string,
+        version: number,
+        sourceTar: Buffer,
+    ): Promise<void> {
+        try {
+            const files = await AppGenerateService.extractTarFiles(sourceTar);
+            await this.extractAndPersistVersionDataReferences(
+                appUuid,
+                version,
+                files,
+            );
+        } catch (error) {
+            this.logger.warn(
+                `App ${appUuid}: failed to read source for data-reference extraction in version ${version}: ${getErrorMessage(error)}`,
+            );
+        }
+    }
+
     /**
      * Manifest spaceSlug → space uuid in the target project, creating the
      * space if missing (same machinery as dashboards-as-code). Returns
@@ -10226,6 +10328,12 @@ export class AppGenerateService extends BaseService {
                 resolvedLinks,
             );
         }
+
+        await this.extractAndPersistVersionDataReferences(
+            newAppUuid,
+            newVersion,
+            sourceFiles,
+        );
 
         // Re-tar the source files into a single source.tar Buffer
         const sourceTar = await new Promise<Buffer>((resolve, reject) => {

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.vizSchemaCopy.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.vizSchemaCopy.test.ts
@@ -1,7 +1,5 @@
-// Every path that snapshots an app version into a new one must carry the
-// version's viz_schema — it exists only in the database (generation structured
-// output), so a copy that drops it produces a data app viz that never appears
-// in the viz picker.
+// Version metadata stored outside S3 must move with source snapshots so copied
+// versions preserve viz contracts and extracted data references.
 import { type AppVersionDependencies } from '@lightdash/common';
 import { AppGenerateService } from './AppGenerateService';
 
@@ -65,6 +63,17 @@ const DEPENDENCIES: AppVersionDependencies = {
     lockfileHash: 'a'.repeat(64),
 };
 
+const DATA_REFERENCES = {
+    references: [],
+    parseErrors: [],
+    stats: {
+        callSites: 0,
+        fullyResolved: 0,
+        partiallyResolved: 0,
+        unresolved: 0,
+    },
+};
+
 const sourceVersion = {
     app_version_id: 'version-id',
     app_id: SOURCE_APP_UUID,
@@ -75,6 +84,7 @@ const sourceVersion = {
     resources: null,
     dependencies: null,
     viz_schema: VIZ_SCHEMA,
+    data_references: DATA_REFERENCES,
 };
 
 const makeUser = () =>
@@ -97,6 +107,7 @@ function buildService() {
         setUpstreamAppUuid: vi.fn().mockResolvedValue(undefined),
         syncPromotedApp: vi.fn().mockResolvedValue(undefined),
         updateStatusMessage: vi.fn().mockResolvedValue(undefined),
+        updateVersionDataReferences: vi.fn().mockResolvedValue(undefined),
         recordBuildNarration: vi.fn().mockResolvedValue(undefined),
         listAppsByProject: vi.fn().mockResolvedValue([sourceApp]),
         remapPreviewDashboardTileApps: vi.fn().mockResolvedValue(undefined),
@@ -170,7 +181,7 @@ function buildService() {
     return { service, appModel, externalConnectionModel };
 }
 
-describe('viz_schema propagation on app copy paths', () => {
+describe('version metadata propagation on app copy paths', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         vi.spyOn(
@@ -193,6 +204,13 @@ describe('viz_schema propagation on app copy paths', () => {
             expect.any(Object),
             undefined, // no declared dependencies
             VIZ_SCHEMA,
+        );
+        const duplicatedAppUuid =
+            appModel.createWithVersion.mock.calls[0][0].app_id;
+        expect(appModel.updateVersionDataReferences).toHaveBeenCalledWith(
+            duplicatedAppUuid,
+            1,
+            DATA_REFERENCES,
         );
     });
 

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -14,6 +14,7 @@ import {
     type DataAppVizSchema,
     type KnexPaginateArgs,
     type KnexPaginatedData,
+    type PersistedDataAppDataReferences,
 } from '@lightdash/common';
 import { Knex } from 'knex';
 import { validate as isValidUuid, v4 as uuidv4 } from 'uuid';
@@ -238,6 +239,20 @@ export class AppModel {
                         usage.costUsd,
                     ],
                 ) as unknown as DataAppGenerationUsage,
+            });
+    }
+
+    async updateVersionDataReferences(
+        appId: string,
+        version: number,
+        dataReferences: PersistedDataAppDataReferences,
+    ): Promise<void> {
+        await this.database(AppVersionsTableName)
+            .where({ app_id: appId, version })
+            .update({
+                data_references: JSON.stringify(
+                    dataReferences,
+                ) as unknown as PersistedDataAppDataReferences,
             });
     }
 

--- a/packages/common/src/ee/apps/dataReferences.ts
+++ b/packages/common/src/ee/apps/dataReferences.ts
@@ -114,6 +114,12 @@ export type DataAppDataReferences = {
     stats: DataReferenceStats;
 };
 
+/** Version-scoped extraction persisted without the extractor version. */
+export type PersistedDataAppDataReferences = Pick<
+    DataAppDataReferences,
+    'references' | 'parseErrors' | 'stats'
+>;
+
 export function isReferenceFullyResolved(ref: ExtractedDataReference): boolean {
     return ref.unresolved.length === 0;
 }


### PR DESCRIPTION

Closes: https://linear.app/lightdash/issue/PROD-9447/data-apps-persist-extracted-data-references-per-app-version

## What changed

- add a nullable `data_references` JSONB payload to each data app version
- persist extracted references for newly uploaded and generated versions
- carry stored references through restore, duplicate, promote, and preview-copy flows
- keep persistence best-effort so validation metadata cannot fail an app build
- store references, parse errors, and coverage stats without persisting the extractor version

## Why

Server-side data app validation needs a stored view of referenced explores, fields, charts, and external connections. This introduces progressive coverage for new app versions without a synchronous backfill, lazy S3 reads, or cache invalidation machinery. Existing versions remain `NULL` and can be skipped by validators.


## Validation

- `pnpm -F backend test:dev:nowatch` — 341 files passed, 5,618 tests passed, 1 skipped
- `pnpm -F common typecheck`
- `pnpm -F backend typecheck`
- `pnpm -F common lint`
- `NODE_OPTIONS="--max-old-space-size=8192" pnpm -F backend lint`
- targeted formatting and `git diff --check`
