### PR TITLE
fix(ai): only suggest agent actions the user can perform

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -9194,6 +9194,16 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             }
         }
 
+        // Same reasoning as runSql above: a user who cannot save a dashboard
+        // anywhere should not have the agent build one for them, only to be
+        // refused at the save step.
+        const canCreateDashboards = hasTrustedPromptUserIdentity
+            ? await this.canCreateDashboardsInProject(user, {
+                  organizationUuid: promptProject.organizationUuid,
+                  projectUuid: promptProject.projectUuid,
+              })
+            : false;
+
         const warehouseCredentials = canRunSql
             ? await this.projectModel.getWarehouseCredentialsForProject(
                   prompt.projectUuid,
@@ -9536,6 +9546,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             repoFsRoot,
             repoFsSupportsCodeSearch,
             canRunSql,
+            canCreateDashboards,
             autoApproveSql: options.autoApproveSql ?? false,
             autoApproveSqlUserUuid: options.autoApproveSql
                 ? user.userUuid

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -1,7 +1,6 @@
 import { subject } from '@casl/ability';
 import {
     activeFollowUpTools,
-    AGENT_SUGGESTION_TOOLS,
     AgentSuggestion,
     AgentSummaryContext,
     AI_DEEP_RESEARCH_QUERY_RESULTS_RETENTION_DAYS,
@@ -100,6 +99,7 @@ import {
     ShareUrl,
     SlackPrompt,
     sleep,
+    SpaceMemberRole,
     ToolDashboardArgs,
     toolDashboardArgsSchema,
     ToolDashboardV2Args,
@@ -368,7 +368,11 @@ import { type WritebackPreviewService } from '../AiWritebackService/WritebackPre
 import { PreviewDeploySetupService } from '../PreviewDeploySetupService/PreviewDeploySetupService';
 import { ProjectContextService } from '../ProjectContextService/ProjectContextService';
 import { canAccessAiAgent, canAccessAiAgentThread } from './aiAgentAccess';
-import { canGeneratePostResponseSuggestions } from './suggestionAccess';
+import {
+    canGeneratePostResponseSuggestions,
+    filterSuggestionsByEnabledTools,
+    getEnabledSuggestionTools,
+} from './suggestionAccess';
 
 type ThreadMessageContext = Array<
     Required<Pick<MessageElement, 'text' | 'user' | 'ts'>>
@@ -1695,9 +1699,23 @@ export class AiAgentService extends BaseService {
                     },
                 }),
             );
-        const enabledTools = AGENT_SUGGESTION_TOOLS.filter((tool) => {
-            if (tool === 'runSql') return canRunSql;
-            return true;
+        const canCreateDashboards = await this.canCreateDashboardsInProject(
+            user,
+            { organizationUuid, projectUuid },
+        );
+        const canManageContent =
+            agent.enableContentTools &&
+            auditedAbility.can(
+                'create',
+                subject('ContentAsCode', {
+                    organizationUuid,
+                    projectUuid,
+                    metadata: { agentUuid, threadUuid },
+                }),
+            );
+        const enabledTools = getEnabledSuggestionTools({
+            canRunSql,
+            canCreateDashboards,
         });
 
         const availableExplores = await this.getAvailableExplores(
@@ -1767,7 +1785,11 @@ export class AiAgentService extends BaseService {
         };
 
         const startedAt = Date.now();
-        let chips: AgentSuggestion[] = SUGGESTION_FALLBACK_CHIPS;
+        const fallbackChips = filterSuggestionsByEnabledTools(
+            SUGGESTION_FALLBACK_CHIPS,
+            enabledTools,
+        );
+        let chips: AgentSuggestion[] = fallbackChips;
         let usingFallback = true;
         let modelId = 'fallback';
 
@@ -1789,7 +1811,7 @@ export class AiAgentService extends BaseService {
                 {
                     agentName: agent.name,
                     agentInstruction: agent.instruction,
-                    canManageContent: agent.enableContentTools,
+                    canManageContent,
                     enabledTools,
                     explores,
                     warehouseTables,
@@ -1851,7 +1873,7 @@ export class AiAgentService extends BaseService {
                 );
             }
             if (validated.length === 0) {
-                chips = SUGGESTION_FALLBACK_CHIPS;
+                chips = fallbackChips;
                 usingFallback = true;
             } else {
                 chips = validated;
@@ -1886,6 +1908,69 @@ export class AiAgentService extends BaseService {
         });
 
         return { chips };
+    }
+
+    /**
+     * Mirrors the space picker in the agent's save-dashboard modal: a generated
+     * dashboard is only actionable if the user can write one somewhere.
+     */
+    private async canCreateDashboardsInProject(
+        user: SessionUser,
+        {
+            organizationUuid,
+            projectUuid,
+        }: { organizationUuid: string; projectUuid: string },
+    ): Promise<boolean> {
+        const auditedAbility = this.createAuditedAbility(user);
+        try {
+            const spaces = await this.projectService.getSpaces(
+                user,
+                projectUuid,
+            );
+            const canWriteToExistingSpace = spaces.some((space) =>
+                auditedAbility.can(
+                    'create',
+                    subject('Dashboard', {
+                        ...space,
+                        access: space.userAccess ? [space.userAccess] : [],
+                    }),
+                ),
+            );
+            if (canWriteToExistingSpace) return true;
+
+            // Creating a space makes the creator its admin, so also allow the
+            // "save into a new space" path the modal offers.
+            return (
+                auditedAbility.can(
+                    'create',
+                    subject('Space', { organizationUuid, projectUuid }),
+                ) &&
+                auditedAbility.can(
+                    'create',
+                    subject('Dashboard', {
+                        organizationUuid,
+                        projectUuid,
+                        access: [
+                            {
+                                userUuid: user.userUuid,
+                                role: SpaceMemberRole.ADMIN,
+                                hasDirectAccess: true,
+                                projectRole: undefined,
+                                inheritedRole: undefined,
+                                inheritedFrom: undefined,
+                            },
+                        ],
+                    }),
+                )
+            );
+        } catch (error) {
+            Logger.warn(
+                `[AiAgentService] Failed to resolve dashboard write access for suggestions, assuming none: ${String(
+                    error,
+                )}`,
+            );
+            return false;
+        }
     }
 
     // Flattens the cached warehouse catalog to up to 50 `database.schema.table`

--- a/packages/backend/src/ee/services/AiAgentService/suggestionAccess.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/suggestionAccess.test.ts
@@ -1,4 +1,9 @@
-import { canGeneratePostResponseSuggestions } from './suggestionAccess';
+import type { AgentSuggestion } from '@lightdash/common';
+import {
+    canGeneratePostResponseSuggestions,
+    filterSuggestionsByEnabledTools,
+    getEnabledSuggestionTools,
+} from './suggestionAccess';
 
 describe('canGeneratePostResponseSuggestions', () => {
     it('allows owned web app threads', () => {
@@ -26,5 +31,83 @@ describe('canGeneratePostResponseSuggestions', () => {
                 user: { uuid: 'user-1' },
             }),
         ).toBe(false);
+    });
+});
+
+describe('getEnabledSuggestionTools', () => {
+    it('enables every tool when the user can run SQL and write dashboards', () => {
+        expect(
+            getEnabledSuggestionTools({
+                canRunSql: true,
+                canCreateDashboards: true,
+            }),
+        ).toEqual([
+            'generateDashboard',
+            'generateVisualization',
+            'runSql',
+            'findContent',
+        ]);
+    });
+
+    it('drops generateDashboard without dashboard write access', () => {
+        expect(
+            getEnabledSuggestionTools({
+                canRunSql: false,
+                canCreateDashboards: false,
+            }),
+        ).toEqual(['generateVisualization', 'findContent']);
+    });
+
+    it('drops runSql without SQL access', () => {
+        expect(
+            getEnabledSuggestionTools({
+                canRunSql: false,
+                canCreateDashboards: true,
+            }),
+        ).toEqual([
+            'generateDashboard',
+            'generateVisualization',
+            'findContent',
+        ]);
+    });
+});
+
+describe('filterSuggestionsByEnabledTools', () => {
+    const promptChip = (
+        tool: 'generateDashboard' | 'generateVisualization',
+    ): AgentSuggestion => ({
+        kind: 'prompt',
+        label: `chip for ${tool}`,
+        tool,
+        defaults: {
+            explore: null,
+            dimensions: [],
+            metrics: [],
+            timeframe: null,
+        },
+    });
+
+    const navigateChip: AgentSuggestion = {
+        kind: 'navigate',
+        label: 'Resume your revenue analysis',
+        url: '/projects/p/ai-agents/a/threads/t',
+    };
+
+    it('removes prompt chips for disabled tools', () => {
+        expect(
+            filterSuggestionsByEnabledTools(
+                [
+                    promptChip('generateDashboard'),
+                    promptChip('generateVisualization'),
+                ],
+                ['generateVisualization'],
+            ),
+        ).toEqual([promptChip('generateVisualization')]);
+    });
+
+    it('keeps navigate chips, which carry no tool', () => {
+        expect(
+            filterSuggestionsByEnabledTools([navigateChip], ['findContent']),
+        ).toEqual([navigateChip]);
     });
 });

--- a/packages/backend/src/ee/services/AiAgentService/suggestionAccess.ts
+++ b/packages/backend/src/ee/services/AiAgentService/suggestionAccess.ts
@@ -1,3 +1,10 @@
+import {
+    AGENT_SUGGESTION_TOOLS,
+    assertUnreachable,
+    type AgentSuggestion,
+    type AgentSuggestionTool,
+} from '@lightdash/common';
+
 type SuggestionThread = {
     createdFrom: string;
     user: {
@@ -9,3 +16,44 @@ export const canGeneratePostResponseSuggestions = (
     userUuid: string,
     thread: SuggestionThread,
 ) => thread.createdFrom === 'web_app' && thread.user.uuid === userUuid;
+
+type SuggestionAbilities = {
+    canRunSql: boolean;
+    canCreateDashboards: boolean;
+};
+
+/**
+ * Chips must only offer actions the current user can actually carry out —
+ * suggesting a dashboard to someone without dashboard write access sends them
+ * down a dead end.
+ */
+export const getEnabledSuggestionTools = ({
+    canRunSql,
+    canCreateDashboards,
+}: SuggestionAbilities): AgentSuggestionTool[] =>
+    AGENT_SUGGESTION_TOOLS.filter((tool) => {
+        switch (tool) {
+            case 'runSql':
+                return canRunSql;
+            case 'generateDashboard':
+                return canCreateDashboards;
+            // Reading data and locating existing content are already covered by
+            // the access checks that let the user open a thread at all.
+            case 'generateVisualization':
+            case 'findContent':
+                return true;
+            default:
+                return assertUnreachable(
+                    tool,
+                    `Unknown agent suggestion tool ${tool}`,
+                );
+        }
+    });
+
+export const filterSuggestionsByEnabledTools = (
+    chips: AgentSuggestion[],
+    enabledTools: AgentSuggestionTool[],
+): AgentSuggestion[] =>
+    chips.filter(
+        (chip) => chip.kind === 'navigate' || enabledTools.includes(chip.tool),
+    );

--- a/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
@@ -611,8 +611,10 @@ describe('getAgentTools workstream tool gate', () => {
         enableCodingAgent: boolean;
         enableAiWriteback: boolean;
         aiAgentMemoryEnabled?: boolean;
+        canCreateDashboards?: boolean;
     }): AiAgentArgs =>
         ({
+            canCreateDashboards: true,
             agentSettings: { name: 'test-agent' },
             autoApproveSql: false,
             autoApproveSqlUserUuid: null,
@@ -655,6 +657,7 @@ describe('getAgentTools workstream tool gate', () => {
         enableCodingAgent: boolean;
         enableAiWriteback: boolean;
         aiAgentMemoryEnabled?: boolean;
+        canCreateDashboards?: boolean;
     }) =>
         Object.keys(
             getAgentTools(buildArgs(flags), depsStub(), [], mcpStub, new Map()),
@@ -680,6 +683,30 @@ describe('getAgentTools workstream tool gate', () => {
         });
 
         expect(names).toContain('loadProjectContext');
+    });
+
+    it('withholds generateDashboard from users who cannot save one', () => {
+        const names = toolNames({
+            enableCodingAgent: false,
+            enableAiWriteback: false,
+            canCreateDashboards: false,
+        });
+
+        expect(names).not.toContain('generateDashboard');
+        // The read-only companion and the chart tool stay: the user can still
+        // inspect existing dashboards and build visualizations.
+        expect(names).toContain('getDashboardCharts');
+        expect(names).toContain('generateVisualization');
+    });
+
+    it('exposes generateDashboard when the user can save one', () => {
+        expect(
+            toolNames({
+                enableCodingAgent: false,
+                enableAiWriteback: false,
+                canCreateDashboards: true,
+            }),
+        ).toContain('generateDashboard');
     });
 
     it('does not expose loadMcpTools when there are no MCP tools', () => {

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -790,10 +790,12 @@ export const getAgentTools = (
           })
         : null;
 
-    const generateDashboard = getGenerateDashboardV2({
-        getPrompt: dependencies.getPrompt,
-        createOrUpdateArtifact: dependencies.createOrUpdateArtifact,
-    });
+    const generateDashboard = args.canCreateDashboards
+        ? getGenerateDashboardV2({
+              getPrompt: dependencies.getPrompt,
+              createOrUpdateArtifact: dependencies.createOrUpdateArtifact,
+          })
+        : null;
 
     const editContent = getEditContent({
         editContent: dependencies.editContent,
@@ -1000,7 +1002,7 @@ export const getAgentTools = (
               }
             : {
                   getDashboardCharts,
-                  generateDashboard,
+                  ...(generateDashboard ? { generateDashboard } : {}),
               }),
         generateVisualization,
         runSavedChart,

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -235,6 +235,10 @@ export type AiAgentArgs = AnyAiModel & {
     // Drives whether the prompt tells the agent to use `search`.
     repoFsSupportsCodeSearch: boolean;
     canRunSql: boolean;
+    // Whether the user can save a generated dashboard anywhere in the project.
+    // Gates generateDashboard so the agent does not build one the user is then
+    // refused permission to keep.
+    canCreateDashboards: boolean;
     autoApproveSql: boolean;
     autoApproveSqlUserUuid: string | null;
     // When the modern Slack streaming card is driving progress, tools render

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
@@ -29,6 +29,7 @@ import { SaveToSpaceOrDashboard } from '../../../../../components/common/modal/C
 import { useVisualizationContext } from '../../../../../components/LightdashVisualization/useVisualizationContext';
 import useEmbed from '../../../../../ee/providers/Embed/useEmbed';
 import useToaster from '../../../../../hooks/toaster/useToaster';
+import useCreateInAnySpaceAccess from '../../../../../hooks/user/useCreateInAnySpaceAccess';
 import { useCreateShareMutation } from '../../../../../hooks/useShare';
 import useApp from '../../../../../providers/App/useApp';
 import useTracking from '../../../../../providers/Tracking/useTracking';
@@ -98,6 +99,16 @@ export const AiChartQuickOptions = ({
     const canCreateScheduledDeliveries = user.data?.ability?.can(
         'create',
         subject('ScheduledDeliveries', {
+            organizationUuid: user.data?.organizationUuid,
+            projectUuid,
+        }),
+    );
+    // The save modal only lists spaces the user can write to, so without one
+    // the option opens an empty space picker.
+    const canSaveChart = useCreateInAnySpaceAccess(projectUuid, 'SavedChart');
+    const canUseSqlRunner = user.data?.ability?.can(
+        'manage',
+        subject('SqlRunner', {
             organizationUuid: user.data?.organizationUuid,
             projectUuid,
         }),
@@ -438,14 +449,20 @@ export const AiChartQuickOptions = ({
                                         Save to current dashboard
                                     </Menu.Item>
                                 )}
-                                <Menu.Item
-                                    onClick={() => open()}
-                                    leftSection={
-                                        <MantineIcon icon={IconDeviceFloppy} />
-                                    }
-                                >
-                                    {quickSaveDashboard ? 'Save to…' : 'Save'}
-                                </Menu.Item>
+                                {canSaveChart && (
+                                    <Menu.Item
+                                        onClick={() => open()}
+                                        leftSection={
+                                            <MantineIcon
+                                                icon={IconDeviceFloppy}
+                                            />
+                                        }
+                                    >
+                                        {quickSaveDashboard
+                                            ? 'Save to…'
+                                            : 'Save'}
+                                    </Menu.Item>
+                                )}
                             </>
                         )}
 
@@ -470,7 +487,7 @@ export const AiChartQuickOptions = ({
                             </Menu.Item>
                         )}
 
-                        {!!compiledSql && !isEmbed ? (
+                        {!!compiledSql && !isEmbed && canUseSqlRunner ? (
                             <Menu.Item
                                 component={Link}
                                 to={{

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDashboardQuickOptions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDashboardQuickOptions.tsx
@@ -12,6 +12,7 @@ import {
 import { Fragment, useState, type FC } from 'react';
 import { Link } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
+import useCreateInAnySpaceAccess from '../../../../../hooks/user/useCreateInAnySpaceAccess';
 import { AiDashboardSaveModal } from './AiDashboardSaveModal';
 
 type Props = {
@@ -28,6 +29,12 @@ export const AiDashboardQuickOptions: FC<Props> = ({
     dashboardConfig,
 }) => {
     const [isModalOpen, setIsModalOpen] = useState(false);
+    // The save modal only lists spaces the user can write to, so without one
+    // the option opens an empty space picker.
+    const canSaveDashboard = useCreateInAnySpaceAccess(
+        projectUuid,
+        'Dashboard',
+    );
 
     const handleSaveDashboard = () => {
         setIsModalOpen(true);
@@ -41,6 +48,11 @@ export const AiDashboardQuickOptions: FC<Props> = ({
         // TODO persist on artifact
         setIsModalOpen(false);
     };
+
+    // Nothing to view and nothing to save leaves an empty dropdown.
+    if (!artifactData.savedDashboardUuid && !canSaveDashboard) {
+        return null;
+    }
 
     return (
         <Fragment>
@@ -64,14 +76,16 @@ export const AiDashboardQuickOptions: FC<Props> = ({
                             View saved dashboard
                         </Menu.Item>
                     ) : (
-                        <Menu.Item
-                            onClick={handleSaveDashboard}
-                            leftSection={
-                                <MantineIcon icon={IconDeviceFloppy} />
-                            }
-                        >
-                            Save dashboard
-                        </Menu.Item>
+                        canSaveDashboard && (
+                            <Menu.Item
+                                onClick={handleSaveDashboard}
+                                leftSection={
+                                    <MantineIcon icon={IconDeviceFloppy} />
+                                }
+                            >
+                                Save dashboard
+                            </Menu.Item>
+                        )
                     )}
                 </Menu.Dropdown>
             </Menu>


### PR DESCRIPTION
### Description:

Agent suggestion chips advertised `generateDashboard` to everyone, so an interactive viewer without dashboard write access was offered a "build a dashboard" chip that went nowhere when clicked.

`getAgentSuggestions` already gated `runSql` on the user's ability; this extends the same treatment to `generateDashboard`. It's enabled only when the user can create a dashboard in at least one space — or can create a space to put one in — which mirrors the space picker in the agent's save-dashboard modal (`AiDashboardSaveModal`). A project-level `Dashboard` check would have been wrong here: for every role below project admin, dashboard write access is space-scoped.

Two related gaps closed while in there:

- `SUGGESTION_FALLBACK_CHIPS` bypassed the existing chip validation and always included a hardcoded "Build a quick overview dashboard" chip. It's now filtered by the same enabled-tool list.
- `canManageContent`, which decides whether the prompt permits content-editing chips, used the `agent.enableContentTools` flag alone. It's now ANDed with the user's `create ContentAsCode` ability, matching how the runtime agent computes `canUseContentTools`.

The tool-gating and chip-filtering logic lives in `suggestionAccess.ts` as pure functions with unit tests. Fixing the empty response itself is ZAP-812.

Verified: `pnpm -F backend typecheck`, `lint`, `format`, and the 19 test files under `src/ee/services/AiAgentService/` plus `suggestionGenerator.test.ts` (106 tests) all pass. No app instance was available in this environment, so the chip row wasn't exercised in a browser.
