### PR TITLE
fix: secure persistent download URLs

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -46,6 +46,7 @@ import {
     type DataAppClaudeModel,
     type DataAppCreationExperience,
     type DataAppTemplate,
+    type PersistentDownloadFileAccessMode,
     type PlaygroundProjectTrigger,
     type PullRequestProvider,
 } from '@lightdash/common';
@@ -2266,6 +2267,7 @@ export type PersistentFileGenerationRequestedEvent = BaseTrack & {
         createdByUserUuid: string | null;
         fileType: string;
         source: PersistentDownloadFileSource;
+        accessMode: PersistentDownloadFileAccessMode;
         expirationSeconds: number;
     };
 };
@@ -2280,6 +2282,7 @@ export type PersistentFileGenerationCompletedEvent = BaseTrack & {
         createdByUserUuid: string | null;
         fileType: string;
         source: PersistentDownloadFileSource;
+        accessMode: PersistentDownloadFileAccessMode;
         expirationSeconds: number;
         durationMs: number;
     };
@@ -2294,6 +2297,7 @@ export type PersistentFileUrlRequestedEvent = BaseTrack & {
         projectId: string | null;
         createdByUserUuid: string | null;
         requestedByUserUuid: string | null;
+        accessMode: PersistentDownloadFileAccessMode;
         source: 'api';
     };
 };
@@ -2307,6 +2311,7 @@ export type PersistentFileUrlRespondedEvent = BaseTrack & {
         projectId: string | null;
         createdByUserUuid: string | null;
         requestedByUserUuid: string | null;
+        accessMode: PersistentDownloadFileAccessMode;
         source: 'api';
         statusCode: number;
         responseMs: number;

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -2967,9 +2967,8 @@ export const parseConfig = (): LightdashConfig => {
                 : undefined,
         },
         persistentDownloadUrls: {
-            // Off unless explicitly enabled (preserves existing behavior).
-            // Note: links over 7 days always use persistent URLs regardless of
-            // this flag — see PersistentDownloadFileService.
+            // Protected links always use the persistent URL service. Signed
+            // links can retain the direct S3 behavior when this is disabled.
             enabled: process.env.PERSISTENT_DOWNLOAD_URLS_ENABLED === 'true',
             expirationSeconds:
                 getIntegerFromEnvironmentVariable(

--- a/packages/backend/src/controllers/fileController.ts
+++ b/packages/backend/src/controllers/fileController.ts
@@ -1,8 +1,10 @@
 import { ApiErrorPayload, NotFoundError } from '@lightdash/common';
 import {
     Get,
+    Middlewares,
     OperationId,
     Path,
+    Query,
     Request,
     Response,
     Route,
@@ -12,9 +14,22 @@ import express from 'express';
 import path from 'path';
 import { pipeline } from 'stream/promises';
 import { createContentDispositionHeader } from '../utils/FileDownloadUtils/FileDownloadUtils';
+import { allowApiKeyAuthentication } from './authentication';
 import { BaseController } from './baseController';
 
 const NANOID_REGEX = /^[\w-]{21}$/;
+
+const optionallyAuthenticateDownload: express.RequestHandler = (
+    req,
+    res,
+    next,
+) => {
+    if (!req.headers.authorization) {
+        next();
+        return;
+    }
+    allowApiKeyAuthentication(req, res, next);
+};
 
 // Maps the stored `file_type` (values originate from DownloadFileType, but
 // callers also pass raw strings like 'pdf', 'zip', 'gsheets') to a response
@@ -40,11 +55,13 @@ export class FileController extends BaseController {
      * @summary Get file
      * @param fileId the persistent file nanoid
      */
+    @Middlewares([optionallyAuthenticateDownload])
     @Get('{fileId}')
     @OperationId('getFile')
     async getFile(
         @Path() fileId: string,
         @Request() req: express.Request,
+        @Query() downloadToken?: string,
     ): Promise<void> {
         if (!NANOID_REGEX.test(fileId)) {
             throw new NotFoundError('Cannot find file');
@@ -53,9 +70,10 @@ export class FileController extends BaseController {
         const { stream, fileType, s3Key } = await this.services
             .getPersistentDownloadFileService()
             .getFileStream(fileId, {
+                account: req.account,
+                downloadToken,
                 ip: req.ip,
                 userAgent: req.headers['user-agent'],
-                requestedByUserUuid: req.user?.userUuid ?? null,
             });
 
         const res = req.res!;

--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -14,6 +14,7 @@ import {
     isExecuteAsyncDashboardSqlChartByUuidParams,
     isExecuteAsyncSqlChartByUuidParams,
     isJwtUser,
+    PersistentDownloadFileAccessMode,
     QueryExecutionContext,
     type ApiDownloadAsyncQueryResults,
     type ApiDownloadAsyncQueryResultsAsCsv,
@@ -574,6 +575,9 @@ export class QueryController extends BaseController {
 
         const results = await this.services.getAsyncQueryService().download({
             account: req.account!,
+            accessMode: req.account!.isJwtUser()
+                ? PersistentDownloadFileAccessMode.SIGNED
+                : PersistentDownloadFileAccessMode.AUTHENTICATED_CREATOR,
             projectUuid,
             queryUuid,
             type: body.type,

--- a/packages/backend/src/database/entities/persistentDownloadFile.ts
+++ b/packages/backend/src/database/entities/persistentDownloadFile.ts
@@ -1,3 +1,4 @@
+import { type PersistentDownloadFileAccessMode } from '@lightdash/common';
 import { Knex } from 'knex';
 
 export const PersistentDownloadFileTableName = 'persistent_download_files';
@@ -9,6 +10,7 @@ export type DbPersistentDownloadFile = {
     organization_uuid: string;
     project_uuid: string | null;
     created_by_user_uuid: string | null;
+    access_mode: PersistentDownloadFileAccessMode;
     created_at: Date;
     expires_at: Date;
 };

--- a/packages/backend/src/database/migrations/20260805120000_add_access_mode_to_persistent_download_files.ts
+++ b/packages/backend/src/database/migrations/20260805120000_add_access_mode_to_persistent_download_files.ts
@@ -1,0 +1,33 @@
+import { Knex } from 'knex';
+
+const TABLE_NAME = 'persistent_download_files';
+const CONSTRAINT_NAME = 'persistent_download_files_access_mode_check';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(TABLE_NAME, (table) => {
+        table.text('access_mode').notNullable().defaultTo('legacy_public');
+    });
+
+    await knex.raw(`
+        ALTER TABLE ${TABLE_NAME}
+            ADD CONSTRAINT ${CONSTRAINT_NAME}
+                CHECK (access_mode IN (
+                    'authenticated_creator',
+                    'authenticated_project',
+                    'signed',
+                    'legacy_public'
+                )),
+            ALTER COLUMN access_mode SET DEFAULT 'authenticated_creator'
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`
+        ALTER TABLE ${TABLE_NAME}
+            DROP CONSTRAINT IF EXISTS ${CONSTRAINT_NAME}
+    `);
+
+    await knex.schema.alterTable(TABLE_NAME, (table) => {
+        table.dropColumn('access_mode');
+    });
+}

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -3,6 +3,7 @@ import {
     getErrorMessage,
     getManagedAgentScheduleCron,
     isSchedulerTaskName,
+    PersistentDownloadFileAccessMode,
     SCHEDULER_TASKS,
     SchedulerJobStatus,
     type AnonymousAccount,
@@ -932,6 +933,8 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                                             );
                                         return this.asyncQueryService.download({
                                             account,
+                                            accessMode:
+                                                PersistentDownloadFileAccessMode.SIGNED,
                                             ...payload,
                                         });
                                     },

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -92,6 +92,7 @@ import {
     OpenIdIdentityIssuerType,
     ParameterError,
     parseVizConfig,
+    PersistentDownloadFileAccessMode,
     ProjectType,
     PullRequestProvider,
     QueryExecutionContext,
@@ -4543,6 +4544,8 @@ export class AiAgentService extends BaseService {
                 organizationUuid,
                 projectUuid: agent.projectUuid,
                 createdByUserUuid: user.userUuid,
+                accessMode:
+                    PersistentDownloadFileAccessMode.AUTHENTICATED_PROJECT,
                 expirationSeconds: AGENT_AVATAR_PERSISTENT_URL_EXPIRY_SECONDS,
             });
 

--- a/packages/backend/src/ee/services/ProjectHomepageService.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.ts
@@ -9,6 +9,7 @@ import {
     NotFoundError,
     ParameterError,
     parseHomepageConfig,
+    PersistentDownloadFileAccessMode,
     type AnnouncementsPage,
     type CreateAnnouncementRequest,
     type CreateProjectHomepageRequest,
@@ -1314,6 +1315,8 @@ export class ProjectHomepageService extends BaseService {
                 organizationUuid: user.organizationUuid,
                 projectUuid,
                 createdByUserUuid: user.userUuid,
+                accessMode:
+                    PersistentDownloadFileAccessMode.AUTHENTICATED_PROJECT,
                 expirationSeconds:
                     ANNOUNCEMENT_IMAGE_PERSISTENT_URL_EXPIRY_SECONDS,
             });

--- a/packages/backend/src/logging/sanitizeRequestUrl.test.ts
+++ b/packages/backend/src/logging/sanitizeRequestUrl.test.ts
@@ -1,0 +1,23 @@
+import { sanitizeRequestUrl } from './winston';
+
+describe('sanitizeRequestUrl', () => {
+    it('redacts download tokens without redacting file identifiers', () => {
+        expect(
+            sanitizeRequestUrl(
+                '/api/v1/file/Zoswz_V59FXISG5hlZ_l3?downloadToken=secret',
+            ),
+        ).toBe('/api/v1/file/Zoswz_V59FXISG5hlZ_l3?downloadToken=[REDACTED]');
+    });
+
+    it('redacts download tokens on any request URL', () => {
+        expect(
+            sanitizeRequestUrl('/other?downloadToken=secret&next=value'),
+        ).toBe('/other?downloadToken=[REDACTED]&next=value');
+    });
+
+    it('leaves unrelated request URLs unchanged', () => {
+        expect(sanitizeRequestUrl('/api/v1/projects/project-uuid')).toBe(
+            '/api/v1/projects/project-uuid',
+        );
+    });
+});

--- a/packages/backend/src/logging/winston.ts
+++ b/packages/backend/src/logging/winston.ts
@@ -284,11 +284,15 @@ declare global {
     }
 }
 
+export const sanitizeRequestUrl = (url: string): string =>
+    url.replace(/([?&]downloadToken=)[^&#\s]*/gi, '$1[REDACTED]');
+
 export const expressWinstonMiddleware: express.RequestHandler =
     expressWinston.logger({
         winstonInstance: winstonLogger,
         level: 'http',
-        msg: '{{req.method}} {{req.url}} {{res.statusCode}} - {{res.responseTime}} ms',
+        msg: (req, res) =>
+            `${req.method} ${sanitizeRequestUrl(req.url)} ${res.statusCode} - ${(res as typeof res & { responseTime?: number }).responseTime} ms`,
         colorize: false,
         meta: true,
         metaField: null, // on root of log
@@ -303,6 +307,10 @@ export const expressWinstonMiddleware: express.RequestHandler =
             includesResponse: true,
         }),
         requestWhitelist: ['url', 'headers', 'method'],
+        requestFilter: (req, propertyName) => {
+            if (propertyName === 'url') return sanitizeRequestUrl(req.url);
+            return (req as unknown as Record<string, unknown>)[propertyName];
+        },
         responseWhitelist: ['statusCode'],
         headerBlacklist: [
             'cookie',
@@ -321,10 +329,10 @@ export const expressWinstonPreResponseMiddleware: express.RequestHandler = (
     if (lightdashConfig.mode !== LightdashMode.DEV) {
         winstonLogger.log({
             level: 'http',
-            message: `${req.method} ${req.url}`,
+            message: `${req.method} ${sanitizeRequestUrl(req.url)}`,
             req: {
                 method: req.method,
-                url: req.url,
+                url: sanitizeRequestUrl(req.url),
                 headers: req.headers,
             },
             includesResponse: false,

--- a/packages/backend/src/models/PersistentDownloadFileModel.ts
+++ b/packages/backend/src/models/PersistentDownloadFileModel.ts
@@ -1,8 +1,11 @@
-import { NotFoundError } from '@lightdash/common';
+import {
+    NotFoundError,
+    type PersistentDownloadFileAccessMode,
+} from '@lightdash/common';
 import { Knex } from 'knex';
 import {
-    DbPersistentDownloadFile,
     PersistentDownloadFileTableName,
+    type DbPersistentDownloadFile,
 } from '../database/entities/persistentDownloadFile';
 
 type PersistentDownloadFileModelArguments = {
@@ -23,6 +26,7 @@ export class PersistentDownloadFileModel {
         organizationUuid: string;
         projectUuid: string | null;
         createdByUserUuid: string | null;
+        accessMode: PersistentDownloadFileAccessMode;
         expiresAt: Date;
     }): Promise<void> {
         await this.database(PersistentDownloadFileTableName).insert({
@@ -32,6 +36,7 @@ export class PersistentDownloadFileModel {
             organization_uuid: data.organizationUuid,
             project_uuid: data.projectUuid,
             created_by_user_uuid: data.createdByUserUuid,
+            access_mode: data.accessMode,
             expires_at: data.expiresAt,
         });
     }

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -76,6 +76,7 @@ import {
     ParameterError,
     ParametersValuesMap,
     PartialFailureType,
+    PersistentDownloadFileAccessMode,
     pivotResultsAsCsv,
     QueryExecutionContext,
     ReadFileError,
@@ -668,6 +669,10 @@ export default class SchedulerTask {
         // Embed/JWT exports pass a pre-resolved anonymous account (no DB user),
         // used for CSV/XLSX tile queries in place of getAccountByUserUuid.
         overrideAccount?: AccountType,
+        downloadAccessMode: Exclude<
+            PersistentDownloadFileAccessMode,
+            PersistentDownloadFileAccessMode.LEGACY_PUBLIC
+        > = PersistentDownloadFileAccessMode.SIGNED,
     ): Promise<
         NotificationPayloadBase['page'] & {
             deliveryQueries?: SchedulerDeliveryQuery[];
@@ -843,6 +848,7 @@ export default class SchedulerTask {
                                     organizationUuid,
                                     projectUuid,
                                     createdByUserUuid: userUuid,
+                                    accessMode: downloadAccessMode,
                                     expirationSeconds:
                                         expirationSecondsOverride,
                                     source: 'scheduler',
@@ -1030,6 +1036,7 @@ export default class SchedulerTask {
                                 this.asyncQueryService.downloadSyncQueryResults(
                                     {
                                         account,
+                                        accessMode: downloadAccessMode,
                                         projectUuid,
                                         queryUuid: item.queryUuid,
                                         type: downloadFileType,
@@ -1151,6 +1158,7 @@ export default class SchedulerTask {
                                 organizationUuid,
                                 projectUuid,
                                 createdByUserUuid: userUuid,
+                                accessMode: downloadAccessMode,
                                 expirationSecondsOverride,
                             });
                         }
@@ -1196,6 +1204,7 @@ export default class SchedulerTask {
                             await this.asyncQueryService.downloadSyncQueryResults(
                                 {
                                     account,
+                                    accessMode: downloadAccessMode,
                                     projectUuid,
                                     queryUuid: query.queryUuid,
                                     type: downloadFileType,
@@ -1389,6 +1398,7 @@ export default class SchedulerTask {
                                 await this.asyncQueryService.downloadSyncQueryResults(
                                     {
                                         account,
+                                        accessMode: downloadAccessMode,
                                         projectUuid,
                                         queryUuid: query.queryUuid,
                                         type: downloadFileType,
@@ -1468,6 +1478,7 @@ export default class SchedulerTask {
                                 await this.asyncQueryService.downloadSyncQueryResults(
                                     {
                                         account,
+                                        accessMode: downloadAccessMode,
                                         projectUuid,
                                         queryUuid: query.queryUuid,
                                         type: downloadFileType,
@@ -1600,6 +1611,7 @@ export default class SchedulerTask {
                                 organizationUuid,
                                 projectUuid,
                                 createdByUserUuid: userUuid,
+                                accessMode: downloadAccessMode,
                                 expirationSecondsOverride,
                             });
                         }
@@ -5191,6 +5203,7 @@ export default class SchedulerTask {
         organizationUuid,
         projectUuid,
         createdByUserUuid,
+        accessMode,
         logContext,
     }: {
         files: {
@@ -5203,6 +5216,10 @@ export default class SchedulerTask {
         organizationUuid: string;
         projectUuid: string;
         createdByUserUuid: string | null;
+        accessMode: Exclude<
+            PersistentDownloadFileAccessMode,
+            PersistentDownloadFileAccessMode.LEGACY_PUBLIC
+        >;
         logContext?: string;
     }) {
         if (!this.fileStorageClient.isEnabled()) {
@@ -5333,6 +5350,7 @@ export default class SchedulerTask {
             organizationUuid,
             projectUuid,
             createdByUserUuid,
+            accessMode,
             source: 'scheduler',
         });
     }
@@ -5345,6 +5363,10 @@ export default class SchedulerTask {
         organizationUuid: string;
         projectUuid: string;
         createdByUserUuid: string;
+        accessMode: Exclude<
+            PersistentDownloadFileAccessMode,
+            PersistentDownloadFileAccessMode.LEGACY_PUBLIC
+        >;
         expirationSecondsOverride?: number;
     }): Promise<NonNullable<NotificationPayloadBase['page']['csvUrls']>> {
         const workbookResult = await this.createWorkbookDownloadUrl(args);
@@ -5364,6 +5386,7 @@ export default class SchedulerTask {
         organizationUuid,
         projectUuid,
         createdByUserUuid,
+        accessMode,
         expirationSecondsOverride,
     }: {
         files: NonNullable<NotificationPayloadBase['page']['csvUrls']>;
@@ -5371,6 +5394,10 @@ export default class SchedulerTask {
         organizationUuid: string;
         projectUuid: string;
         createdByUserUuid: string;
+        accessMode: Exclude<
+            PersistentDownloadFileAccessMode,
+            PersistentDownloadFileAccessMode.LEGACY_PUBLIC
+        >;
         expirationSecondsOverride?: number;
     }) {
         if (!this.fileStorageClient.isEnabled()) {
@@ -5426,6 +5453,7 @@ export default class SchedulerTask {
                 organizationUuid,
                 projectUuid,
                 createdByUserUuid,
+                accessMode,
                 expirationSeconds: expirationSecondsOverride,
                 source: 'scheduler',
             }),
@@ -5497,6 +5525,9 @@ export default class SchedulerTask {
                     },
                     undefined,
                     overrideAccount,
+                    overrideAccount?.isJwtUser()
+                        ? PersistentDownloadFileAccessMode.SIGNED
+                        : PersistentDownloadFileAccessMode.AUTHENTICATED_CREATOR,
                 );
 
                 if (payload.format === SchedulerFormat.IMAGE) {
@@ -5556,6 +5587,9 @@ export default class SchedulerTask {
                         createdByUserUuid: overrideAccount
                             ? null
                             : payload.userUuid,
+                        accessMode: overrideAccount?.isJwtUser()
+                            ? PersistentDownloadFileAccessMode.SIGNED
+                            : PersistentDownloadFileAccessMode.AUTHENTICATED_CREATOR,
                     });
 
                     return {
@@ -5720,6 +5754,8 @@ export default class SchedulerTask {
                     organizationUuid,
                     projectUuid,
                     createdByUserUuid: userUuid,
+                    accessMode:
+                        PersistentDownloadFileAccessMode.AUTHENTICATED_CREATOR,
                     logContext: `dashboard ${dashboardUuid}`,
                 });
 
@@ -5786,6 +5822,9 @@ export default class SchedulerTask {
             await this.asyncQueryService.downloadSyncQueryResults(
                 {
                     account,
+                    accessMode: account.isJwtUser()
+                        ? PersistentDownloadFileAccessMode.SIGNED
+                        : PersistentDownloadFileAccessMode.AUTHENTICATED_CREATOR,
                     projectUuid,
                     queryUuid: query.queryUuid,
                     type: DownloadFileType.CSV,
@@ -5854,6 +5893,9 @@ export default class SchedulerTask {
             await this.asyncQueryService.downloadSyncQueryResults(
                 {
                     account,
+                    accessMode: account.isJwtUser()
+                        ? PersistentDownloadFileAccessMode.SIGNED
+                        : PersistentDownloadFileAccessMode.AUTHENTICATED_CREATOR,
                     projectUuid,
                     queryUuid: query.queryUuid,
                     type: DownloadFileType.CSV,
@@ -5979,6 +6021,8 @@ export default class SchedulerTask {
                 );
                 return this.asyncQueryService.download({
                     account,
+                    accessMode:
+                        PersistentDownloadFileAccessMode.AUTHENTICATED_CREATOR,
                     ...payload,
                 });
             },

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -13,6 +13,7 @@ import {
     ForbiddenError,
     NotFoundError,
     OrganizationAccessStatus,
+    PersistentDownloadFileAccessMode,
     PossibleAbilities,
     QueryExecutionContext,
     QueryHistory,
@@ -2381,6 +2382,8 @@ describe('AsyncQueryService', () => {
             await expect(
                 internals.downloadAsyncQueryResults({
                     account: sessionAccount,
+                    accessMode:
+                        PersistentDownloadFileAccessMode.AUTHENTICATED_CREATOR,
                     projectUuid,
                     queryUuid: 'test-query-uuid',
                     type: DownloadFileType.CSV,
@@ -2436,6 +2439,8 @@ describe('AsyncQueryService', () => {
             await expect(
                 internals.downloadAsyncQueryResults({
                     account: sessionAccount,
+                    accessMode:
+                        PersistentDownloadFileAccessMode.AUTHENTICATED_CREATOR,
                     projectUuid,
                     queryUuid: 'test-query-uuid',
                     type: DownloadFileType.CSV,
@@ -2501,6 +2506,8 @@ describe('AsyncQueryService', () => {
             await expect(
                 internals.downloadAsyncQueryResults({
                     account: sessionAccount,
+                    accessMode:
+                        PersistentDownloadFileAccessMode.AUTHENTICATED_CREATOR,
                     projectUuid,
                     queryUuid: 'test-query-uuid',
                     type: DownloadFileType.CSV,
@@ -2569,6 +2576,8 @@ describe('AsyncQueryService', () => {
             await expect(
                 internals.downloadAsyncQueryResults({
                     account: sessionAccount,
+                    accessMode:
+                        PersistentDownloadFileAccessMode.AUTHENTICATED_CREATOR,
                     projectUuid,
                     queryUuid: 'test-query-uuid',
                     type: DownloadFileType.CSV,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -74,6 +74,7 @@ import {
     OrganizationAccessStatus,
     ParameterError,
     ParseError,
+    PersistentDownloadFileAccessMode,
     PivotConfig,
     PivotConfiguration,
     ProjectType,
@@ -1506,6 +1507,7 @@ export class AsyncQueryService extends ProjectService {
         expirationSecondsOverride,
         conditionalFormattings,
         showColumnTotals = false,
+        accessMode,
     }: DownloadAsyncQueryResultsArgs): Promise<DownloadAsyncQueryResultsInternal> {
         assertIsAccountWithOrg(account);
 
@@ -1706,6 +1708,7 @@ export class AsyncQueryService extends ProjectService {
                         createdByUserUuid: isJwtUser(account)
                             ? null
                             : account.user.userUuid,
+                        accessMode,
                         expirationSecondsOverride,
                         timezone: displayTimezone ?? undefined,
                     });
@@ -1733,6 +1736,7 @@ export class AsyncQueryService extends ProjectService {
                         createdByUserUuid: isJwtUser(account)
                             ? null
                             : account.user.userUuid,
+                        accessMode,
                         fileType: DownloadFileType.CSV,
                         expirationSecondsOverride,
                     },
@@ -1820,6 +1824,7 @@ export class AsyncQueryService extends ProjectService {
                             createdByUserUuid: isJwtUser(account)
                                 ? null
                                 : account.user.userUuid,
+                            accessMode,
                             expirationSeconds: expirationSecondsOverride,
                             source: 'async_query',
                         },
@@ -1878,6 +1883,10 @@ export class AsyncQueryService extends ProjectService {
             organizationUuid: string;
             projectUuid: string;
             createdByUserUuid: string | null;
+            accessMode: Exclude<
+                PersistentDownloadFileAccessMode,
+                PersistentDownloadFileAccessMode.LEGACY_PUBLIC
+            >;
             fileType: DownloadFileType;
             expirationSecondsOverride?: number;
         },
@@ -1953,6 +1962,7 @@ export class AsyncQueryService extends ProjectService {
                     organizationUuid: persistentUrlContext.organizationUuid,
                     projectUuid: persistentUrlContext.projectUuid,
                     createdByUserUuid: persistentUrlContext.createdByUserUuid,
+                    accessMode: persistentUrlContext.accessMode,
                     expirationSeconds:
                         persistentUrlContext.expirationSecondsOverride,
                     source: 'async_query',

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -2,6 +2,7 @@ import {
     Account,
     DownloadFileType,
     MetricQuery,
+    PersistentDownloadFileAccessMode,
     PivotConfig,
     PivotConfiguration,
     type AndFilterGroup,
@@ -48,6 +49,10 @@ export type DownloadAsyncQueryResultsArgs = Omit<
     CommonAsyncQueryArgs,
     'invalidateCache' | 'context' | 'parameters'
 > & {
+    accessMode: Exclude<
+        PersistentDownloadFileAccessMode,
+        PersistentDownloadFileAccessMode.LEGACY_PUBLIC
+    >;
     queryUuid: string;
     type?: DownloadFileType;
     onlyRaw?: boolean;

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -21,6 +21,7 @@ import {
     MetricQuery,
     MissingConfigError,
     ParameterError,
+    PersistentDownloadFileAccessMode,
     PivotConfig,
     SCHEDULER_TASKS,
     SchedulerCsvOptions,
@@ -534,6 +535,8 @@ export class CsvService extends BaseService {
                     organizationUuid,
                     projectUuid,
                     createdByUserUuid,
+                    accessMode:
+                        PersistentDownloadFileAccessMode.AUTHENTICATED_CREATOR,
                     source: 'analytics',
                 });
             return {

--- a/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.test.ts
+++ b/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.test.ts
@@ -1,6 +1,14 @@
-import { NotFoundError } from '@lightdash/common';
+import { Ability } from '@casl/ability';
+import {
+    NotFoundError,
+    PersistentDownloadFileAccessMode,
+    PossibleAbilities,
+    type Account,
+} from '@lightdash/common';
+import jwt from 'jsonwebtoken';
 import { Readable } from 'stream';
 import type { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
+import { buildAccount } from '../../auth/account/account.mock';
 import { type FileStorageClient } from '../../clients/FileStorage/FileStorageClient';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import type { LightdashConfig } from '../../config/parseConfig';
@@ -12,13 +20,15 @@ const mockS3GetFileUrl = vi.fn();
 const mockS3GetFileStream = vi.fn();
 const mockModelCreate = vi.fn();
 const mockModelGet = vi.fn();
+const mockTrack = vi.fn();
 
 const baseData = {
     s3Key: 'exports/test-file.csv',
     fileType: 'csv',
-    organizationUuid: 'org-uuid-123',
-    projectUuid: 'project-uuid-456',
-    createdByUserUuid: 'user-uuid-789',
+    organizationUuid: 'test-org-uuid',
+    projectUuid: 'test-project-uuid',
+    createdByUserUuid: 'test-user-uuid',
+    accessMode: PersistentDownloadFileAccessMode.AUTHENTICATED_CREATOR as const,
 };
 
 const createService = (
@@ -26,12 +36,13 @@ const createService = (
 ) =>
     new PersistentDownloadFileService({
         analytics: {
-            track: vi.fn(),
+            track: mockTrack,
         } as unknown as LightdashAnalytics,
         lightdashConfig: {
             ...lightdashConfigMock,
             persistentDownloadUrls: {
                 ...lightdashConfigMock.persistentDownloadUrls,
+                enabled: true,
                 ...configOverrides,
             },
         },
@@ -45,55 +56,70 @@ const createService = (
         } as unknown as FileStorageClient,
     });
 
+const requestContext = (account?: Account, downloadToken?: string) => ({
+    account,
+    downloadToken,
+    ip: '127.0.0.1',
+    userAgent: 'test-agent',
+});
+
+const fileRow = (
+    accessMode: PersistentDownloadFileAccessMode,
+    overrides: Partial<DbPersistentDownloadFile> = {},
+): DbPersistentDownloadFile => ({
+    nanoid: 'test-nanoid-123456789',
+    s3_key: 'exports/test-file.csv',
+    file_type: 'csv',
+    organization_uuid: 'test-org-uuid',
+    project_uuid: 'test-project-uuid',
+    created_by_user_uuid: 'test-user-uuid',
+    access_mode: accessMode,
+    created_at: new Date(),
+    expires_at: new Date(Date.now() + 60 * 60 * 1000),
+    ...overrides,
+});
+
+const accountWith = ({
+    userUuid = 'test-user-uuid',
+    organizationUuid = 'test-org-uuid',
+    canViewProject = true,
+}: {
+    userUuid?: string;
+    organizationUuid?: string;
+    canViewProject?: boolean;
+} = {}): Account => {
+    const account = buildAccount();
+    return {
+        ...account,
+        organization: {
+            ...account.organization,
+            organizationUuid,
+        },
+        user: {
+            ...account.user,
+            userUuid,
+            id: userUuid,
+            ability: new Ability<PossibleAbilities>(
+                canViewProject ? [{ subject: 'Project', action: 'view' }] : [],
+            ),
+        },
+    };
+};
+
 describe('PersistentDownloadFileService', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        mockModelCreate.mockResolvedValue(undefined);
+        mockS3GetFileStream.mockResolvedValue(Readable.from(['hello,world\n']));
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
     });
 
     describe('createPersistentUrl', () => {
-        it('should return raw S3 URL (honoring the requested expiry) when feature is disabled', async () => {
-            mockS3GetFileUrl.mockResolvedValue(
-                'https://s3.amazonaws.com/bucket/test-file.csv',
-            );
+        it('always creates an access-controlled persistent URL', async () => {
             const service = createService({ enabled: false });
-
-            const url = await service.createPersistentUrl({
-                ...baseData,
-                expirationSeconds: 86400,
-            });
-
-            expect(url).toBe('https://s3.amazonaws.com/bucket/test-file.csv');
-            // The requested expiry is forwarded to the raw presigned URL.
-            expect(mockS3GetFileUrl).toHaveBeenCalledWith(
-                baseData.s3Key,
-                86400,
-            );
-            expect(mockModelCreate).not.toHaveBeenCalled();
-        });
-
-        it('should transparently use persistent URLs when the requested expiry exceeds the 7-day S3 limit, even with the feature off', async () => {
-            mockModelCreate.mockResolvedValue(undefined);
-            const service = createService({ enabled: false });
-
-            // 14 days — longer than a raw S3 presigned URL can live.
-            const url = await service.createPersistentUrl({
-                ...baseData,
-                expirationSeconds: 14 * 86400,
-            });
-
-            expect(url).toMatch(
-                /^https:\/\/test\.lightdash\.cloud\/api\/v1\/file\/[\w-]{21}$/,
-            );
-            expect(mockModelCreate).toHaveBeenCalled();
-            expect(mockS3GetFileUrl).not.toHaveBeenCalled();
-        });
-
-        it('should create persistent URL when feature is enabled', async () => {
-            mockModelCreate.mockResolvedValue(undefined);
-            const service = createService({
-                enabled: true,
-                expirationSeconds: 3600,
-            });
 
             const url = await service.createPersistentUrl(baseData);
 
@@ -102,182 +128,416 @@ describe('PersistentDownloadFileService', () => {
             );
             expect(mockModelCreate).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    s3Key: baseData.s3Key,
-                    fileType: baseData.fileType,
-                    organizationUuid: baseData.organizationUuid,
-                    projectUuid: baseData.projectUuid,
-                    createdByUserUuid: baseData.createdByUserUuid,
+                    ...baseData,
                     expiresAt: expect.any(Date),
                 }),
             );
             expect(mockS3GetFileUrl).not.toHaveBeenCalled();
         });
 
-        it('should set expiresAt based on configured expirationSeconds', async () => {
-            mockModelCreate.mockResolvedValue(undefined);
-            const now = Date.now();
-            vi.spyOn(Date, 'now').mockReturnValue(now);
-
-            const service = createService({
-                enabled: true,
-                expirationSeconds: 7200,
-            });
-
-            await service.createPersistentUrl(baseData);
-
-            const createCall = mockModelCreate.mock.calls[0][0];
-            expect(createCall.expiresAt.getTime()).toBe(now + 7200 * 1000);
-
-            vi.restoreAllMocks();
-        });
-
-        it('should use expirationSeconds override when provided', async () => {
-            mockModelCreate.mockResolvedValue(undefined);
-            const now = Date.now();
-            vi.spyOn(Date, 'now').mockReturnValue(now);
-
-            const service = createService({
-                enabled: true,
-                expirationSeconds: 259200,
-            });
-
-            await service.createPersistentUrl({
-                ...baseData,
-                expirationSeconds: 86400,
-            });
-
-            const createCall = mockModelCreate.mock.calls[0][0];
-            expect(createCall.expiresAt.getTime()).toBe(now + 86400 * 1000);
-
-            vi.restoreAllMocks();
-        });
-
-        it('should fall back to config expirationSeconds when override is undefined', async () => {
-            mockModelCreate.mockResolvedValue(undefined);
-            const now = Date.now();
-            vi.spyOn(Date, 'now').mockReturnValue(now);
-
-            const service = createService({
-                enabled: true,
-                expirationSeconds: 259200,
-            });
-
-            await service.createPersistentUrl({
-                ...baseData,
-                expirationSeconds: undefined,
-            });
-
-            const createCall = mockModelCreate.mock.calls[0][0];
-            expect(createCall.expiresAt.getTime()).toBe(now + 259200 * 1000);
-
-            vi.restoreAllMocks();
-        });
-    });
-
-    describe('getSignedUrl', () => {
-        it('should return fresh S3 signed URL for valid file', async () => {
-            const futureDate = new Date(Date.now() + 3600 * 1000);
-            mockModelGet.mockResolvedValue({
-                nanoid: 'test-nanoid-123456789',
-                s3_key: 'exports/test-file.csv',
-                expires_at: futureDate,
-            } as DbPersistentDownloadFile);
+        it('retains direct S3 URLs for signed files when persistent URLs are disabled', async () => {
             mockS3GetFileUrl.mockResolvedValue(
-                'http://mock-s3:9000/mock_bucket/exports/test-file.csv?signed',
+                'https://storage.test/presigned-file',
+            );
+            const service = createService({ enabled: false });
+
+            await expect(
+                service.createPersistentUrl({
+                    ...baseData,
+                    accessMode: PersistentDownloadFileAccessMode.SIGNED,
+                    expirationSeconds: 3600,
+                }),
+            ).resolves.toBe('https://storage.test/presigned-file');
+            expect(mockS3GetFileUrl).toHaveBeenCalledWith(baseData.s3Key, 3600);
+            expect(mockModelCreate).not.toHaveBeenCalled();
+        });
+
+        it('adds a file-bound token only for signed URLs', async () => {
+            const service = createService();
+
+            const url = new URL(
+                await service.createPersistentUrl({
+                    ...baseData,
+                    accessMode: PersistentDownloadFileAccessMode.SIGNED,
+                }),
             );
 
-            const service = createService({ enabled: true });
-            const url = await service.getSignedUrl('test-nanoid-123456789');
-
-            expect(url).toBe(
-                'http://mock-s3:9000/mock_bucket/exports/test-file.csv?signed',
-            );
-            expect(mockModelGet).toHaveBeenCalledWith('test-nanoid-123456789');
-            expect(mockS3GetFileUrl).toHaveBeenCalledWith(
-                'exports/test-file.csv',
-                300,
+            expect(url.searchParams.get('downloadToken')).toBeTruthy();
+            expect(mockModelCreate).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    accessMode: PersistentDownloadFileAccessMode.SIGNED,
+                }),
             );
         });
 
-        it('should throw NotFoundError for expired file', async () => {
-            const pastDate = new Date(Date.now() - 3600 * 1000);
-            mockModelGet.mockResolvedValue({
-                nanoid: 'test-nanoid-123456789',
-                s3_key: 'exports/test-file.csv',
-                expires_at: pastDate,
-            } as DbPersistentDownloadFile);
+        it('keeps signed tokens valid for the configured file lifetime', async () => {
+            const now = Date.now();
+            vi.spyOn(Date, 'now').mockReturnValue(now);
+            const service = createService({ enabled: false });
 
-            const service = createService({ enabled: true });
+            const url = new URL(
+                await service.createPersistentUrl({
+                    ...baseData,
+                    accessMode: PersistentDownloadFileAccessMode.SIGNED,
+                    expirationSeconds: 30 * 24 * 60 * 60,
+                }),
+            );
+            const decoded = jwt.decode(
+                url.searchParams.get('downloadToken')!,
+            ) as jwt.JwtPayload;
 
-            await expect(
-                service.getSignedUrl('test-nanoid-123456789'),
-            ).rejects.toThrow(NotFoundError);
-            expect(mockS3GetFileUrl).not.toHaveBeenCalled();
+            expect(decoded.exp! - decoded.iat!).toBe(30 * 24 * 60 * 60);
+            expect(mockModelCreate.mock.calls[0][0].expiresAt.getTime()).toBe(
+                now + 30 * 24 * 60 * 60 * 1000,
+            );
+            vi.restoreAllMocks();
         });
 
-        it('should throw NotFoundError when file does not exist', async () => {
-            mockModelGet.mockRejectedValue(
-                new NotFoundError('Cannot find file'),
+        it('uses the configured expiry and includes IDs in analytics', async () => {
+            const now = Date.now();
+            vi.spyOn(Date, 'now').mockReturnValue(now);
+            const service = createService({ expirationSeconds: 7200 });
+
+            const url = new URL(await service.createPersistentUrl(baseData));
+            const fileId = url.pathname.split('/').at(-1)!;
+
+            expect(mockModelCreate.mock.calls[0][0].expiresAt.getTime()).toBe(
+                now + 7200 * 1000,
+            );
+            expect(mockTrack).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    properties: expect.objectContaining({
+                        fileUuid: fileId,
+                    }),
+                }),
+            );
+            vi.restoreAllMocks();
+        });
+
+        it('keeps signed tokens out of service logs', async () => {
+            const service = createService();
+            const logger = {
+                debug: vi.fn(),
+                info: vi.fn(),
+                warn: vi.fn(),
+            };
+            Object.assign(service, { logger });
+            const signedUrl = new URL(
+                await service.createPersistentUrl({
+                    ...baseData,
+                    accessMode: PersistentDownloadFileAccessMode.SIGNED,
+                }),
+            );
+            const fileId = signedUrl.pathname.split('/').at(-1)!;
+            const downloadToken = signedUrl.searchParams.get('downloadToken')!;
+            mockModelGet.mockResolvedValue(
+                fileRow(PersistentDownloadFileAccessMode.SIGNED, {
+                    nanoid: fileId,
+                }),
             );
 
-            const service = createService({ enabled: true });
+            await service.getFileStream(
+                fileId,
+                requestContext(undefined, downloadToken),
+            );
 
-            await expect(
-                service.getSignedUrl('nonexistent-nanoid1234'),
-            ).rejects.toThrow(NotFoundError);
+            const serializedLogs = JSON.stringify(
+                Object.values(logger).flatMap((method) => method.mock.calls),
+            );
+            expect(serializedLogs).toContain(fileId);
+            expect(serializedLogs).not.toContain(downloadToken);
         });
     });
 
     describe('getFileStream', () => {
-        it('should return S3 stream and metadata for valid file', async () => {
-            const futureDate = new Date(Date.now() + 3600 * 1000);
-            mockModelGet.mockResolvedValue({
-                nanoid: 'test-nanoid-123456789',
-                s3_key: 'exports/test-file.csv',
-                file_type: 'csv',
-                expires_at: futureDate,
-            } as DbPersistentDownloadFile);
-            const fakeStream = Readable.from(['hello,world\n']);
-            mockS3GetFileStream.mockResolvedValue(fakeStream);
-
-            const service = createService({ enabled: true });
-            const result = await service.getFileStream('test-nanoid-123456789');
-
-            expect(result.stream).toBe(fakeStream);
-            expect(result.fileType).toBe('csv');
-            expect(result.s3Key).toBe('exports/test-file.csv');
-            expect(mockS3GetFileStream).toHaveBeenCalledWith(
-                'exports/test-file.csv',
+        it('allows a creator who can still view the project', async () => {
+            mockModelGet.mockResolvedValue(
+                fileRow(PersistentDownloadFileAccessMode.AUTHENTICATED_CREATOR),
             );
-            expect(mockS3GetFileUrl).not.toHaveBeenCalled();
-        });
-
-        it('should throw NotFoundError for expired file', async () => {
-            const pastDate = new Date(Date.now() - 3600 * 1000);
-            mockModelGet.mockResolvedValue({
-                nanoid: 'test-nanoid-123456789',
-                s3_key: 'exports/test-file.csv',
-                file_type: 'csv',
-                expires_at: pastDate,
-            } as DbPersistentDownloadFile);
-
-            const service = createService({ enabled: true });
+            const service = createService();
 
             await expect(
-                service.getFileStream('test-nanoid-123456789'),
+                service.getFileStream(
+                    'test-nanoid-123456789',
+                    requestContext(accountWith()),
+                ),
+            ).resolves.toMatchObject({
+                fileType: 'csv',
+                s3Key: 'exports/test-file.csv',
+            });
+            expect(mockS3GetFileStream).toHaveBeenCalledOnce();
+        });
+
+        it('denies another project member for a creator-bound export', async () => {
+            mockModelGet.mockResolvedValue(
+                fileRow(PersistentDownloadFileAccessMode.AUTHENTICATED_CREATOR),
+            );
+            const service = createService();
+
+            await expect(
+                service.getFileStream(
+                    'test-nanoid-123456789',
+                    requestContext(accountWith({ userUuid: 'other-user' })),
+                ),
             ).rejects.toThrow(NotFoundError);
             expect(mockS3GetFileStream).not.toHaveBeenCalled();
         });
 
-        it('should throw NotFoundError when file does not exist', async () => {
-            mockModelGet.mockRejectedValue(
-                new NotFoundError('Cannot find file'),
+        it('allows the creator through personal access token authentication', async () => {
+            mockModelGet.mockResolvedValue(
+                fileRow(PersistentDownloadFileAccessMode.AUTHENTICATED_CREATOR),
             );
-
-            const service = createService({ enabled: true });
+            const account = {
+                ...accountWith(),
+                authentication: { type: 'pat', source: 'test-token' },
+            } as Account;
+            const service = createService();
 
             await expect(
-                service.getFileStream('nonexistent-nanoid1234'),
+                service.getFileStream(
+                    'test-nanoid-123456789',
+                    requestContext(account),
+                ),
+            ).resolves.toMatchObject({ fileType: 'csv' });
+        });
+
+        it('denies creator-bound rows without a creator UUID', async () => {
+            mockModelGet.mockResolvedValue(
+                fileRow(
+                    PersistentDownloadFileAccessMode.AUTHENTICATED_CREATOR,
+                    {
+                        created_by_user_uuid: null,
+                    },
+                ),
+            );
+            const service = createService();
+
+            await expect(
+                service.getFileStream(
+                    'test-nanoid-123456789',
+                    requestContext(accountWith()),
+                ),
+            ).rejects.toThrow(NotFoundError);
+            expect(mockS3GetFileStream).not.toHaveBeenCalled();
+        });
+
+        it('denies the creator after project access is removed', async () => {
+            mockModelGet.mockResolvedValue(
+                fileRow(PersistentDownloadFileAccessMode.AUTHENTICATED_CREATOR),
+            );
+            const service = createService();
+
+            await expect(
+                service.getFileStream(
+                    'test-nanoid-123456789',
+                    requestContext(accountWith({ canViewProject: false })),
+                ),
+            ).rejects.toThrow(NotFoundError);
+        });
+
+        it('allows another project member to read a shared project asset', async () => {
+            mockModelGet.mockResolvedValue(
+                fileRow(PersistentDownloadFileAccessMode.AUTHENTICATED_PROJECT),
+            );
+            const service = createService();
+
+            await expect(
+                service.getFileStream(
+                    'test-nanoid-123456789',
+                    requestContext(accountWith({ userUuid: 'other-user' })),
+                ),
+            ).resolves.toMatchObject({ fileType: 'csv' });
+        });
+
+        it('allows inactive service account principals to read shared project assets', async () => {
+            mockModelGet.mockResolvedValue(
+                fileRow(PersistentDownloadFileAccessMode.AUTHENTICATED_PROJECT),
+            );
+            const baseAccount = accountWith({ userUuid: 'service-user' });
+            const account = {
+                ...baseAccount,
+                authentication: {
+                    type: 'service-account',
+                    source: 'test-token',
+                    serviceAccountUuid: 'service-account-uuid',
+                    serviceAccountDescription: 'test',
+                },
+                user: { ...baseAccount.user, isActive: false },
+            } as Account;
+            const service = createService();
+
+            await expect(
+                service.getFileStream(
+                    'test-nanoid-123456789',
+                    requestContext(account),
+                ),
+            ).resolves.toMatchObject({ fileType: 'csv' });
+        });
+
+        it('allows projectless assets only within the owning organization', async () => {
+            mockModelGet.mockResolvedValue(
+                fileRow(
+                    PersistentDownloadFileAccessMode.AUTHENTICATED_PROJECT,
+                    { project_uuid: null },
+                ),
+            );
+            const service = createService();
+
+            await expect(
+                service.getFileStream(
+                    'test-nanoid-123456789',
+                    requestContext(accountWith({ userUuid: 'other-user' })),
+                ),
+            ).resolves.toMatchObject({ fileType: 'csv' });
+            await expect(
+                service.getFileStream(
+                    'test-nanoid-123456789',
+                    requestContext(
+                        accountWith({ organizationUuid: 'other-org' }),
+                    ),
+                ),
+            ).rejects.toThrow(NotFoundError);
+        });
+
+        it('allows a valid signed token without authentication', async () => {
+            const service = createService();
+            const signedUrl = new URL(
+                await service.createPersistentUrl({
+                    ...baseData,
+                    accessMode: PersistentDownloadFileAccessMode.SIGNED,
+                }),
+            );
+            const fileId = signedUrl.pathname.split('/').at(-1)!;
+            mockModelGet.mockResolvedValue(
+                fileRow(PersistentDownloadFileAccessMode.SIGNED, {
+                    nanoid: fileId,
+                }),
+            );
+
+            await expect(
+                service.getFileStream(
+                    fileId,
+                    requestContext(
+                        undefined,
+                        signedUrl.searchParams.get('downloadToken')!,
+                    ),
+                ),
+            ).resolves.toMatchObject({ fileType: 'csv' });
+        });
+
+        it('rejects a token bound to another file', async () => {
+            const service = createService();
+            const signedUrl = new URL(
+                await service.createPersistentUrl({
+                    ...baseData,
+                    accessMode: PersistentDownloadFileAccessMode.SIGNED,
+                }),
+            );
+            mockModelGet.mockResolvedValue(
+                fileRow(PersistentDownloadFileAccessMode.SIGNED),
+            );
+
+            await expect(
+                service.getFileStream(
+                    'test-nanoid-123456789',
+                    requestContext(
+                        undefined,
+                        signedUrl.searchParams.get('downloadToken')!,
+                    ),
+                ),
+            ).rejects.toThrow(NotFoundError);
+            expect(mockS3GetFileStream).not.toHaveBeenCalled();
+        });
+
+        it('rejects a tampered token before opening S3', async () => {
+            const service = createService();
+            const signedUrl = new URL(
+                await service.createPersistentUrl({
+                    ...baseData,
+                    accessMode: PersistentDownloadFileAccessMode.SIGNED,
+                }),
+            );
+            const fileId = signedUrl.pathname.split('/').at(-1)!;
+            const tokenParts = signedUrl.searchParams
+                .get('downloadToken')!
+                .split('.');
+            const signature = tokenParts[2];
+            const middle = Math.floor(signature.length / 2);
+            tokenParts[2] = `${signature.slice(0, middle)}${signature[middle] === 'a' ? 'b' : 'a'}${signature.slice(middle + 1)}`;
+            mockModelGet.mockResolvedValue(
+                fileRow(PersistentDownloadFileAccessMode.SIGNED, {
+                    nanoid: fileId,
+                }),
+            );
+
+            await expect(
+                service.getFileStream(
+                    fileId,
+                    requestContext(undefined, tokenParts.join('.')),
+                ),
+            ).rejects.toThrow(NotFoundError);
+            expect(mockS3GetFileStream).not.toHaveBeenCalled();
+        });
+
+        it('rejects an expired token before opening S3', async () => {
+            const now = Date.now();
+            const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(now);
+            const service = createService();
+            const signedUrl = new URL(
+                await service.createPersistentUrl({
+                    ...baseData,
+                    accessMode: PersistentDownloadFileAccessMode.SIGNED,
+                    expirationSeconds: 1,
+                }),
+            );
+            const fileId = signedUrl.pathname.split('/').at(-1)!;
+            mockModelGet.mockResolvedValue(
+                fileRow(PersistentDownloadFileAccessMode.SIGNED, {
+                    nanoid: fileId,
+                    expires_at: new Date(now + 60 * 60 * 1000),
+                }),
+            );
+            nowSpy.mockReturnValue(now + 2000);
+
+            await expect(
+                service.getFileStream(
+                    fileId,
+                    requestContext(
+                        undefined,
+                        signedUrl.searchParams.get('downloadToken')!,
+                    ),
+                ),
+            ).rejects.toThrow(NotFoundError);
+            expect(mockS3GetFileStream).not.toHaveBeenCalled();
+        });
+
+        it('preserves anonymous access for legacy rows until expiry', async () => {
+            mockModelGet.mockResolvedValue(
+                fileRow(PersistentDownloadFileAccessMode.LEGACY_PUBLIC),
+            );
+            const service = createService();
+
+            await expect(
+                service.getFileStream(
+                    'test-nanoid-123456789',
+                    requestContext(),
+                ),
+            ).resolves.toMatchObject({ fileType: 'csv' });
+        });
+
+        it('rejects expired rows before opening S3', async () => {
+            mockModelGet.mockResolvedValue(
+                fileRow(PersistentDownloadFileAccessMode.LEGACY_PUBLIC, {
+                    expires_at: new Date(Date.now() - 1000),
+                }),
+            );
+            const service = createService();
+
+            await expect(
+                service.getFileStream(
+                    'test-nanoid-123456789',
+                    requestContext(),
+                ),
             ).rejects.toThrow(NotFoundError);
             expect(mockS3GetFileStream).not.toHaveBeenCalled();
         });

--- a/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.ts
+++ b/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.ts
@@ -1,8 +1,14 @@
+import { subject } from '@casl/ability';
 import {
+    assertUnreachable,
     NotFoundError,
     ParameterError,
+    PersistentDownloadFileAccessMode,
     S3_PRESIGNED_URL_MAX_EXPIRATION_SECONDS,
+    type Account,
 } from '@lightdash/common';
+import { createHmac } from 'crypto';
+import jwt from 'jsonwebtoken';
 import { nanoid } from 'nanoid';
 import { type Readable } from 'stream';
 import {
@@ -11,6 +17,7 @@ import {
 } from '../../analytics/LightdashAnalytics';
 import { type FileStorageClient } from '../../clients/FileStorage/FileStorageClient';
 import { LightdashConfig } from '../../config/parseConfig';
+import { type DbPersistentDownloadFile } from '../../database/entities/persistentDownloadFile';
 import { PersistentDownloadFileModel } from '../../models/PersistentDownloadFileModel';
 import { BaseService } from '../BaseService';
 
@@ -32,6 +39,26 @@ type PersistentDownloadFileServiceArguments = {
 };
 
 const PERSISTENT_URL_S3_EXPIRY_SECONDS = 300; // 5 minutes
+const DOWNLOAD_TOKEN_TYPE = 'persistent-download';
+const DOWNLOAD_TOKEN_ISSUER = 'lightdash';
+const DOWNLOAD_TOKEN_AUDIENCE = 'persistent-download';
+
+type DownloadTokenPayload = {
+    type: typeof DOWNLOAD_TOKEN_TYPE;
+    fileId: string;
+};
+
+type PersistentDownloadRequestContext = {
+    account: Account | undefined;
+    downloadToken: string | undefined;
+    ip: string | undefined;
+    userAgent: string | undefined;
+};
+
+const deriveDownloadSigningKey = (lightdashSecret: string): Buffer =>
+    createHmac('sha256', lightdashSecret)
+        .update('persistent-download-token')
+        .digest();
 
 export class PersistentDownloadFileService extends BaseService {
     private readonly analytics: LightdashAnalytics;
@@ -61,26 +88,21 @@ export class PersistentDownloadFileService extends BaseService {
         organizationUuid: string;
         projectUuid: string | null;
         createdByUserUuid: string | null;
+        accessMode: Exclude<
+            PersistentDownloadFileAccessMode,
+            PersistentDownloadFileAccessMode.LEGACY_PUBLIC
+        >;
         expirationSeconds?: number;
         source?: PersistentDownloadFileSource;
     }): Promise<string> {
-        // Use the persistent-URL system when the instance enables it
-        // (PERSISTENT_DOWNLOAD_URLS_ENABLED, off by default), or transparently
-        // when the requested expiry exceeds what a raw S3 presigned URL can do
-        // (7 days) — that's the only way a link can live that long, so it wins
-        // even when the instance hasn't opted in. Otherwise hand back a raw
-        // presigned URL honoring the requested expiry (undefined falls back to
-        // the S3 default).
         const exceedsS3Limit =
             data.expirationSeconds !== undefined &&
             data.expirationSeconds > S3_PRESIGNED_URL_MAX_EXPIRATION_SECONDS;
-        const usePersistent =
-            this.lightdashConfig.persistentDownloadUrls.enabled ||
-            exceedsS3Limit;
-        if (!usePersistent) {
-            this.logger.debug(
-                'Persistent download URLs disabled, returning raw S3 URL',
-            );
+        if (
+            data.accessMode === PersistentDownloadFileAccessMode.SIGNED &&
+            !this.lightdashConfig.persistentDownloadUrls.enabled &&
+            !exceedsS3Limit
+        ) {
             return this.fileStorageClient.getFileUrl(
                 data.s3Key,
                 data.expirationSeconds,
@@ -104,6 +126,7 @@ export class PersistentDownloadFileService extends BaseService {
                 createdByUserUuid: data.createdByUserUuid,
                 fileType: data.fileType,
                 source,
+                accessMode: data.accessMode,
                 expirationSeconds,
             },
         });
@@ -114,6 +137,7 @@ export class PersistentDownloadFileService extends BaseService {
             organizationUuid: data.organizationUuid,
             projectUuid: data.projectUuid,
             createdByUserUuid: data.createdByUserUuid,
+            accessMode: data.accessMode,
             expiresAt,
         });
         this.analytics.track({
@@ -126,6 +150,7 @@ export class PersistentDownloadFileService extends BaseService {
                 createdByUserUuid: data.createdByUserUuid,
                 fileType: data.fileType,
                 source,
+                accessMode: data.accessMode,
                 expirationSeconds,
                 durationMs: Date.now() - createStartedAt,
             },
@@ -134,13 +159,37 @@ export class PersistentDownloadFileService extends BaseService {
         const url = new URL(
             `/api/v1/file/${fileNanoid}`,
             this.lightdashConfig.siteUrl,
-        ).href;
-
-        this.logger.debug(
-            `Created persistent download URL: nanoid=${fileNanoid}, fileType=${data.fileType}, expiresAt=${expiresAt.toISOString()}`,
         );
 
-        return url;
+        if (data.accessMode === PersistentDownloadFileAccessMode.SIGNED) {
+            url.searchParams.set(
+                'downloadToken',
+                jwt.sign(
+                    {
+                        type: DOWNLOAD_TOKEN_TYPE,
+                        fileId: fileNanoid,
+                    } satisfies DownloadTokenPayload,
+                    deriveDownloadSigningKey(
+                        this.lightdashConfig.lightdashSecret,
+                    ),
+                    {
+                        expiresIn: Math.max(1, expirationSeconds),
+                        issuer: DOWNLOAD_TOKEN_ISSUER,
+                        audience: DOWNLOAD_TOKEN_AUDIENCE,
+                        algorithm: 'HS256',
+                    },
+                ),
+            );
+        }
+
+        this.logger.debug('Created persistent download URL', {
+            fileUuid: fileNanoid,
+            fileType: data.fileType,
+            accessMode: data.accessMode,
+            expiresAt: expiresAt.toISOString(),
+        });
+
+        return url.href;
     }
 
     /**
@@ -166,10 +215,113 @@ export class PersistentDownloadFileService extends BaseService {
         const file = await this.persistentDownloadFileModel.get(fileNanoid);
 
         if (file.expires_at < new Date()) {
-            this.logger.debug(
-                `Persistent download link expired: nanoid=${fileNanoid}, expiredAt=${file.expires_at.toISOString()}`,
-            );
+            this.logger.debug('Persistent download link expired', {
+                fileUuid: fileNanoid,
+                expiredAt: file.expires_at.toISOString(),
+            });
             throw new NotFoundError('This download link has expired');
+        }
+
+        return file;
+    }
+
+    private isActiveRegisteredAccount(
+        account: Account | undefined,
+    ): account is Account & { user: Account['user'] & { userUuid: string } } {
+        return Boolean(
+            account &&
+            account.user.type === 'registered' &&
+            (account.authentication.type === 'service-account' ||
+                account.user.isActive),
+        );
+    }
+
+    private async getAuthorizedFile(
+        fileNanoid: string,
+        requestContext: PersistentDownloadRequestContext,
+    ): Promise<DbPersistentDownloadFile> {
+        const file = await this.getValidFile(fileNanoid);
+        const canViewFileProject = (): boolean => {
+            const { account } = requestContext;
+            if (!this.isActiveRegisteredAccount(account)) return false;
+            if (
+                account.organization.organizationUuid !== file.organization_uuid
+            ) {
+                return false;
+            }
+            if (file.project_uuid === null) return true;
+
+            return this.createAuditedAbility(account).can(
+                'view',
+                subject('Project', {
+                    organizationUuid: file.organization_uuid,
+                    projectUuid: file.project_uuid,
+                }),
+            );
+        };
+        const canCreatorAccess = (): boolean => {
+            const { account } = requestContext;
+            return (
+                this.isActiveRegisteredAccount(account) &&
+                file.created_by_user_uuid !== null &&
+                file.created_by_user_uuid === account.user.userUuid &&
+                canViewFileProject()
+            );
+        };
+        const hasValidDownloadToken = (): boolean => {
+            if (!requestContext.downloadToken) return false;
+
+            try {
+                const decoded = jwt.verify(
+                    requestContext.downloadToken,
+                    deriveDownloadSigningKey(
+                        this.lightdashConfig.lightdashSecret,
+                    ),
+                    {
+                        algorithms: ['HS256'],
+                        issuer: DOWNLOAD_TOKEN_ISSUER,
+                        audience: DOWNLOAD_TOKEN_AUDIENCE,
+                    },
+                );
+                return (
+                    typeof decoded !== 'string' &&
+                    decoded.type === DOWNLOAD_TOKEN_TYPE &&
+                    decoded.fileId === fileNanoid
+                );
+            } catch {
+                return false;
+            }
+        };
+        let isAuthorized: boolean;
+
+        switch (file.access_mode) {
+            case PersistentDownloadFileAccessMode.LEGACY_PUBLIC:
+                isAuthorized = true;
+                break;
+            case PersistentDownloadFileAccessMode.AUTHENTICATED_CREATOR:
+                isAuthorized = canCreatorAccess();
+                break;
+            case PersistentDownloadFileAccessMode.AUTHENTICATED_PROJECT:
+                isAuthorized = canViewFileProject();
+                break;
+            case PersistentDownloadFileAccessMode.SIGNED:
+                isAuthorized = hasValidDownloadToken() || canCreatorAccess();
+                break;
+            default:
+                return assertUnreachable(
+                    file.access_mode,
+                    'Unknown persistent download access mode',
+                );
+        }
+
+        if (!isAuthorized) {
+            this.logger.warn('Persistent download denied', {
+                fileUuid: fileNanoid,
+                accessMode: file.access_mode,
+                ip: requestContext.ip,
+                userAgent: requestContext.userAgent,
+            });
+            throw new NotFoundError('Cannot find file');
         }
 
         return file;
@@ -181,40 +333,39 @@ export class PersistentDownloadFileService extends BaseService {
      */
     async getSignedUrl(
         fileNanoid: string,
-        requestContext?: {
-            ip: string | undefined;
-            userAgent: string | undefined;
-            requestedByUserUuid: string | null;
-        },
+        requestContext: PersistentDownloadRequestContext,
     ): Promise<string> {
-        const file = await this.getValidFile(fileNanoid);
+        const file = await this.getAuthorizedFile(fileNanoid, requestContext);
 
         const signedUrl = await this.fileStorageClient.getFileUrl(
             file.s3_key,
             PERSISTENT_URL_S3_EXPIRY_SECONDS,
         );
 
-        this.logger.info(
-            `Serving persistent download (redirect): nanoid=${fileNanoid}, ip=${requestContext?.ip}, userAgent=${requestContext?.userAgent}`,
-        );
+        this.logger.info('Serving persistent download redirect', {
+            fileUuid: fileNanoid,
+            accessMode: file.access_mode,
+            ip: requestContext.ip,
+            userAgent: requestContext.userAgent,
+        });
         return signedUrl;
     }
 
     async getFileStream(
         fileNanoid: string,
-        requestContext?: {
-            ip: string | undefined;
-            userAgent: string | undefined;
-            requestedByUserUuid: string | null;
-        },
+        requestContext: PersistentDownloadRequestContext,
     ): Promise<{
         stream: Readable;
         fileType: string;
         s3Key: string;
     }> {
-        const file = await this.getValidFile(fileNanoid);
+        const file = await this.getAuthorizedFile(fileNanoid, requestContext);
         const requestStartedAt = Date.now();
-        const requestedByUserUuid = requestContext?.requestedByUserUuid ?? null;
+        const requestedByUserUuid = this.isActiveRegisteredAccount(
+            requestContext.account,
+        )
+            ? requestContext.account.user.userUuid
+            : null;
         this.analytics.track({
             event: 'persistent_file.url_requested',
             userId: requestedByUserUuid ?? ANONYMOUS_TRACKING_UUID,
@@ -224,6 +375,7 @@ export class PersistentDownloadFileService extends BaseService {
                 projectId: file.project_uuid,
                 createdByUserUuid: file.created_by_user_uuid,
                 requestedByUserUuid,
+                accessMode: file.access_mode,
                 source: 'api',
             },
         });
@@ -239,15 +391,19 @@ export class PersistentDownloadFileService extends BaseService {
                 projectId: file.project_uuid,
                 createdByUserUuid: file.created_by_user_uuid,
                 requestedByUserUuid,
+                accessMode: file.access_mode,
                 source: 'api',
                 statusCode: 200,
                 responseMs: Date.now() - requestStartedAt,
             },
         });
 
-        this.logger.info(
-            `Serving persistent download (stream): nanoid=${fileNanoid}, ip=${requestContext?.ip}, userAgent=${requestContext?.userAgent}`,
-        );
+        this.logger.info('Serving persistent download stream', {
+            fileUuid: fileNanoid,
+            accessMode: file.access_mode,
+            ip: requestContext.ip,
+            userAgent: requestContext.userAgent,
+        });
 
         return {
             stream,

--- a/packages/backend/src/services/PivotTableService/PivotTableService.ts
+++ b/packages/backend/src/services/PivotTableService/PivotTableService.ts
@@ -5,6 +5,7 @@ import {
     getErrorMessage,
     ItemsMap,
     MetricQuery,
+    PersistentDownloadFileAccessMode,
     PivotConfig,
     pivotResultsAsCsv,
     UnexpectedServerError,
@@ -113,6 +114,7 @@ export class PivotTableService extends BaseService {
         warehouseGrandTotals,
         organizationUuid,
         createdByUserUuid,
+        accessMode,
         expirationSecondsOverride,
         timezone,
     }: {
@@ -136,6 +138,10 @@ export class PivotTableService extends BaseService {
         };
         organizationUuid: string;
         createdByUserUuid: string | null;
+        accessMode: Exclude<
+            PersistentDownloadFileAccessMode,
+            PersistentDownloadFileAccessMode.LEGACY_PUBLIC
+        >;
         expirationSecondsOverride?: number;
         timezone?: string;
     }): Promise<{ fileUrl: string; s3FileUrl?: string; truncated: boolean }> {
@@ -198,6 +204,7 @@ export class PivotTableService extends BaseService {
             warehouseGrandTotals,
             organizationUuid,
             createdByUserUuid,
+            accessMode,
             expirationSecondsOverride,
             timezone,
         });
@@ -229,6 +236,7 @@ export class PivotTableService extends BaseService {
         warehouseGrandTotals,
         organizationUuid,
         createdByUserUuid,
+        accessMode,
         expirationSecondsOverride,
         timezone,
     }: {
@@ -248,6 +256,10 @@ export class PivotTableService extends BaseService {
         metricsAsRows?: boolean;
         organizationUuid: string;
         createdByUserUuid: string | null;
+        accessMode: Exclude<
+            PersistentDownloadFileAccessMode,
+            PersistentDownloadFileAccessMode.LEGACY_PUBLIC
+        >;
         expirationSecondsOverride?: number;
         timezone?: string;
     }): Promise<AttachmentUrl> {
@@ -314,6 +326,7 @@ export class PivotTableService extends BaseService {
             truncated,
             organizationUuid,
             createdByUserUuid,
+            accessMode,
             expirationSecondsOverride,
         });
     }
@@ -328,6 +341,7 @@ export class PivotTableService extends BaseService {
         truncated = false,
         organizationUuid,
         createdByUserUuid,
+        accessMode,
         expirationSecondsOverride,
     }: {
         csvContent: string;
@@ -336,6 +350,10 @@ export class PivotTableService extends BaseService {
         truncated?: boolean;
         organizationUuid: string;
         createdByUserUuid: string | null;
+        accessMode: Exclude<
+            PersistentDownloadFileAccessMode,
+            PersistentDownloadFileAccessMode.LEGACY_PUBLIC
+        >;
         expirationSecondsOverride?: number;
     }): Promise<AttachmentUrl> {
         const fileId = PivotTableService.generateFileId(fileName, truncated);
@@ -373,6 +391,7 @@ export class PivotTableService extends BaseService {
                     organizationUuid,
                     projectUuid,
                     createdByUserUuid,
+                    accessMode,
                     expirationSeconds: expirationSecondsOverride,
                     source: 'pivot',
                 });

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -159,6 +159,7 @@ export * from './types/paginateResults';
 export * from './types/parameters';
 export * from './types/periodOverPeriodComparison';
 export * from './types/personalAccessToken';
+export * from './types/persistentDownloadFile';
 export * from './types/pinning';
 export * from './types/pivot';
 export * from './types/preAggregate';

--- a/packages/common/src/types/persistentDownloadFile.ts
+++ b/packages/common/src/types/persistentDownloadFile.ts
@@ -1,0 +1,6 @@
+export enum PersistentDownloadFileAccessMode {
+    AUTHENTICATED_CREATOR = 'authenticated_creator',
+    AUTHENTICATED_PROJECT = 'authenticated_project',
+    SIGNED = 'signed',
+    LEGACY_PUBLIC = 'legacy_public',
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-9496

### Description:
Binds interactive persistent downloads to their creator and current project access, while preserving shared project assets and signed scheduled-delivery and embed links.
Adds per-file access modes, file-bound signed tokens, optional multi-method authentication, and download-token redaction without changing existing short-lived signed S3 behavior when persistent URLs are disabled.
Validated with focused backend tests, common and backend builds and typechecks, API generation, lint, and an anonymous signed-link smoke test.
