### PR TITLE
fix(ai-reviews): join the Slack channel when review notifications are configured

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -576,6 +576,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         models.getGitlabAppInstallationsModel(),
                     schedulerClient:
                         clients.getSchedulerClient() as CommercialSchedulerClient,
+                    slackClient: clients.getSlackClient(),
                     userModel: models.getUserModel(),
                     lightdashConfig: context.lightdashConfig,
                     writebackPreviewService:

--- a/packages/backend/src/ee/scheduler/tasks/sendReviewNotification.ts
+++ b/packages/backend/src/ee/scheduler/tasks/sendReviewNotification.ts
@@ -12,6 +12,7 @@ import {
     buildReviewAssignedBlocks,
     buildReviewNeedsReviewBlocks,
 } from '../../../clients/Slack/SlackReviewMessageBlocks';
+import Logger from '../../../logging/logger';
 import { type OpenIdIdentityModel } from '../../../models/OpenIdIdentitiesModel';
 import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { type AiAgentReviewClassifierModel } from '../../models/AiAgentReviewClassifierModel';
@@ -125,6 +126,9 @@ export const sendReviewNotification =
                 );
             } catch (error) {
                 const message = getErrorMessage(error);
+                Logger.error(
+                    `Unable to post AI review notification to Slack channel ${settings.slackChannelId} for organization ${payload.organizationUuid}: ${message}`,
+                );
                 await deps.model.recordError({
                     organizationUuid: payload.organizationUuid,
                     fingerprint: payload.fingerprints[0],
@@ -208,6 +212,9 @@ export const sendReviewNotification =
             );
         } catch (error) {
             const message = getErrorMessage(error);
+            Logger.error(
+                `Unable to send AI review assignment DM to user ${payload.assigneeUserUuid}: ${message}`,
+            );
             await deps.model.recordError({
                 organizationUuid: payload.organizationUuid,
                 fingerprint: payload.fingerprints[0],

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -260,6 +260,7 @@ const makeService = ({
     jobModel = {},
     userModel = {},
     aiAgentReviewNotificationService = {},
+    slackClient = {},
 }: {
     aiAgentModel?: Record<string, unknown>;
     aiAgentMemoryModel?: Record<string, unknown>;
@@ -279,6 +280,7 @@ const makeService = ({
     jobModel?: Record<string, unknown>;
     userModel?: Record<string, unknown>;
     aiAgentReviewNotificationService?: Record<string, unknown>;
+    slackClient?: Record<string, unknown>;
 } = {}) =>
     new AiAgentAdminService({
         analytics: { track: vi.fn() },
@@ -434,6 +436,10 @@ const makeService = ({
         aiAgentReviewNotificationService: {
             notifyAssigned: vi.fn().mockResolvedValue(undefined),
             ...aiAgentReviewNotificationService,
+        },
+        slackClient: {
+            joinChannels: vi.fn().mockResolvedValue(undefined),
+            ...slackClient,
         },
         lightdashConfig: {
             siteUrl: SITE_URL,
@@ -1212,6 +1218,39 @@ describe('AiAgentAdminService review notification settings', () => {
             'Insufficient permissions to access organization-wide AI agent data',
         );
         expect(upsertSettings).not.toHaveBeenCalled();
+    });
+
+    it('joins the configured channel so the app can post to it', async () => {
+        const joinChannels = vi.fn().mockResolvedValue(undefined);
+        const service = makeService({ slackClient: { joinChannels } });
+
+        await service.updateReviewNotificationSettings(makeAdminUser(), {
+            enabled: true,
+            slackChannelId: 'C123',
+        });
+
+        expect(joinChannels).toHaveBeenCalledWith(ORGANIZATION_UUID, ['C123']);
+    });
+
+    it('does not join a channel when notifications are disabled', async () => {
+        const joinChannels = vi.fn().mockResolvedValue(undefined);
+        const service = makeService({
+            slackClient: { joinChannels },
+            aiAgentReviewNotificationModel: {
+                upsertSettings: vi.fn().mockResolvedValue({
+                    organizationUuid: ORGANIZATION_UUID,
+                    enabled: false,
+                    slackChannelId: 'C123',
+                }),
+            },
+        });
+
+        await service.updateReviewNotificationSettings(makeAdminUser(), {
+            enabled: false,
+            slackChannelId: 'C123',
+        });
+
+        expect(joinChannels).not.toHaveBeenCalled();
     });
 });
 

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -71,6 +71,7 @@ import {
     getPullRequestComments,
     getPullRequestDiffFiles,
 } from '../../clients/github/Github';
+import { type SlackClient } from '../../clients/Slack/SlackClient';
 import { type LightdashConfig } from '../../config/parseConfig';
 import { isUniqueConstraintViolation } from '../../database/errors';
 import { type GithubAppInstallationsModel } from '../../models/GithubAppInstallations/GithubAppInstallationsModel';
@@ -122,6 +123,7 @@ type AiAgentAdminServiceDependencies = {
     githubAppInstallationsModel: GithubAppInstallationsModel;
     gitlabAppInstallationsModel: GitlabAppInstallationsModel;
     schedulerClient: CommercialSchedulerClient;
+    slackClient: Pick<SlackClient, 'joinChannels'>;
     userModel: UserModel;
     lightdashConfig: LightdashConfig;
     writebackPreviewService: WritebackPreviewService;
@@ -373,6 +375,8 @@ export class AiAgentAdminService extends BaseService {
 
     private readonly schedulerClient: CommercialSchedulerClient;
 
+    private readonly slackClient: Pick<SlackClient, 'joinChannels'>;
+
     private readonly userModel: UserModel;
 
     private readonly writebackPreviewService: WritebackPreviewService;
@@ -406,6 +410,7 @@ export class AiAgentAdminService extends BaseService {
         this.gitlabAppInstallationsModel =
             dependencies.gitlabAppInstallationsModel;
         this.schedulerClient = dependencies.schedulerClient;
+        this.slackClient = dependencies.slackClient;
         this.userModel = dependencies.userModel;
         this.lightdashConfig = dependencies.lightdashConfig;
         this.writebackPreviewService = dependencies.writebackPreviewService;
@@ -827,10 +832,21 @@ export class AiAgentAdminService extends BaseService {
         }
         this.checkOrganizationAdminAccess(user);
 
-        return this.aiAgentReviewNotificationModel.upsertSettings({
-            organizationUuid,
-            ...settings,
-        });
+        const updated =
+            await this.aiAgentReviewNotificationModel.upsertSettings({
+                organizationUuid,
+                ...settings,
+            });
+
+        // Slack rejects chat.postMessage with not_in_channel unless the app is
+        // a member, so join on save the same way scheduled deliveries do.
+        if (updated.enabled && updated.slackChannelId) {
+            await this.slackClient.joinChannels(organizationUuid, [
+                updated.slackChannelId,
+            ]);
+        }
+
+        return updated;
     }
 
     async listReviewItems(


### PR DESCRIPTION
### Description:

AI review notifications never arrived in the configured Slack channel. Slack rejects `chat.postMessage` with `not_in_channel` unless the app is a member of the target channel, and `updateReviewNotificationSettings` saved the channel without joining it — unlike every other channel target in the codebase (schedulers, dashboard deliveries, failed-delivery notifications), which all call `slackClient.joinChannels` on save.

The failure was also invisible: `sendReviewNotification` caught the error, wrote it to `ai_agent_review_notification`, and returned without logging anything.

- `AiAgentAdminService.updateReviewNotificationSettings` now joins the channel when notifications are enabled with a channel set.
- `sendReviewNotification` logs Slack delivery failures for both the channel post and the assignment DM.

Existing installs with a channel already configured pick up the join on the next settings save (or by inviting the app manually).
