### PR TITLE
feat(pre-aggregates): add required filter dimensions

### DIFF
--- a/packages/backend/src/ee/preAggregates/generatePreAggregateExplores.ts
+++ b/packages/backend/src/ee/preAggregates/generatePreAggregateExplores.ts
@@ -1,6 +1,7 @@
 import {
     InlineErrorType,
     isExploreError,
+    preAggregateUtils,
     type Explore,
     type ExploreError,
     type PreAggregateDef,
@@ -39,10 +40,16 @@ export const generatePreAggregateExplores = ({
 
         parsedPreAggregates.forEach((preAggregateDef) => {
             try {
+                // Resolve deferral entries into the effective definition first;
+                // the cached explore and the registry only ever see resolved defs.
+                const effectiveDef = preAggregateUtils.resolvePreAggregateDef({
+                    sourceExplore: compiled,
+                    preAggregateDef,
+                });
                 generatedPreAggregateExplores.push(
-                    buildPreAggregateExplore(compiled, preAggregateDef),
+                    buildPreAggregateExplore(compiled, effectiveDef),
                 );
-                validPreAggregates.push(preAggregateDef);
+                validPreAggregates.push(effectiveDef);
             } catch (error) {
                 generationErrors.push(
                     error instanceof Error

--- a/packages/backend/src/ee/preAggregates/matcher.test.ts
+++ b/packages/backend/src/ee/preAggregates/matcher.test.ts
@@ -1333,6 +1333,287 @@ describe('findMatch', () => {
             });
         });
 
+        describe('required filter deferral (required_filter_dimensions)', () => {
+            // Effective defs are built with the same resolution code the
+            // explore-generation seam uses, mirroring what the matcher sees.
+            const resolveDefs = (explore: Explore): Explore => ({
+                ...explore,
+                preAggregates: (explore.preAggregates ?? []).map(
+                    (preAggregateDef) =>
+                        preAggregateUtils.resolvePreAggregateDef({
+                            sourceExplore: explore,
+                            preAggregateDef,
+                        }),
+                ),
+            });
+
+            const deferredStatusExplore = () =>
+                resolveDefs(
+                    getExploreWithRequiredFilters({
+                        requiredFilters: [
+                            makeRequiredStatusFilter(['completed']),
+                        ],
+                        preAggregates: [
+                            {
+                                name: 'orders_deferred_rollup',
+                                dimensions: ['status'],
+                                metrics: ['order_count'],
+                                requiredFilterDimensions: ['status'],
+                            },
+                        ],
+                    }),
+                );
+
+            it('matches a filterless query against a deferred rollup', () => {
+                const result = preAggregateUtils.findMatch(
+                    makeMetricQuery({
+                        dimensions: ['orders_status'],
+                        metrics: ['orders_order_count'],
+                    }),
+                    deferredStatusExplore(),
+                );
+
+                expect(result).toStrictEqual({
+                    hit: true,
+                    preAggregateName: 'orders_deferred_rollup',
+                    miss: null,
+                });
+            });
+
+            it('matches a query that overrides the deferred required filter with any value', () => {
+                const result = preAggregateUtils.findMatch(
+                    makeMetricQuery({
+                        dimensions: ['orders_status'],
+                        metrics: ['orders_order_count'],
+                        filters: {
+                            dimensions: makeAndFilterGroup(
+                                makeStatusFilterRule(['shipped']),
+                            ),
+                        },
+                    }),
+                    deferredStatusExplore(),
+                );
+
+                expect(result).toStrictEqual({
+                    hit: true,
+                    preAggregateName: 'orders_deferred_rollup',
+                    miss: null,
+                });
+            });
+
+            it('still misses the overriding query when the required filter is not deferred', () => {
+                const result = preAggregateUtils.findMatch(
+                    makeMetricQuery({
+                        dimensions: ['orders_status'],
+                        metrics: ['orders_order_count'],
+                        filters: {
+                            dimensions: makeAndFilterGroup(
+                                makeStatusFilterRule(['shipped']),
+                            ),
+                        },
+                    }),
+                    getExploreWithRequiredFilters({
+                        requiredFilters: [
+                            makeRequiredStatusFilter(['completed']),
+                        ],
+                        preAggregates: [
+                            {
+                                name: 'orders_baked_rollup',
+                                dimensions: ['status'],
+                                metrics: ['order_count'],
+                            },
+                        ],
+                    }),
+                );
+
+                expect(result.miss).toStrictEqual({
+                    reason: PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED,
+                    fieldId: 'orders_status',
+                });
+            });
+
+            it('matches queries beyond the required window when the time filter is deferred', () => {
+                const explore = resolveDefs(
+                    getExploreWithRequiredFilters({
+                        requiredFilters: [
+                            {
+                                id: 'required-order-date-filter',
+                                target: { fieldRef: 'order_date_day' },
+                                operator: FilterOperator.IN_THE_PAST,
+                                values: [10],
+                                settings: { unitOfTime: UnitOfTime.days },
+                                required: true,
+                            },
+                        ],
+                        preAggregates: [
+                            {
+                                name: 'orders_daily',
+                                dimensions: ['order_date'],
+                                metrics: ['order_count'],
+                                timeDimension: 'order_date',
+                                granularity: TimeFrames.DAY,
+                                requiredFilterDimensions: ['order_date'],
+                            },
+                        ],
+                    }),
+                );
+
+                const beyondWindowResult = preAggregateUtils.findMatch(
+                    makeMetricQuery({
+                        dimensions: [],
+                        metrics: ['orders_order_count'],
+                        filters: {
+                            dimensions: {
+                                id: 'query-filters',
+                                and: [
+                                    {
+                                        id: 'query-date-filter',
+                                        target: {
+                                            fieldId: 'orders_order_date_day',
+                                        },
+                                        operator: FilterOperator.IN_THE_PAST,
+                                        values: [30],
+                                        settings: {
+                                            unitOfTime: UnitOfTime.days,
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    }),
+                    explore,
+                );
+                expect(beyondWindowResult.hit).toBe(true);
+
+                const filterlessResult = preAggregateUtils.findMatch(
+                    makeMetricQuery({
+                        dimensions: [],
+                        metrics: ['orders_order_count'],
+                    }),
+                    explore,
+                );
+                expect(filterlessResult.hit).toBe(true);
+            });
+
+            describe('deferred fallback against an explicit pre-aggregate filter', () => {
+                const boundedDeferredExplore = (requiredMonths: number) =>
+                    resolveDefs(
+                        getExploreWithRequiredFilters({
+                            requiredFilters: [
+                                {
+                                    id: 'required-order-date-filter',
+                                    target: { fieldRef: 'order_date_day' },
+                                    operator: FilterOperator.IN_THE_PAST,
+                                    values: [requiredMonths],
+                                    settings: { unitOfTime: UnitOfTime.months },
+                                    required: true,
+                                },
+                            ],
+                            preAggregates: [
+                                {
+                                    name: 'orders_bounded_daily',
+                                    dimensions: ['order_date'],
+                                    metrics: ['order_count'],
+                                    filters: [
+                                        {
+                                            id: 'rollup-date-filter',
+                                            target: { fieldRef: 'order_date' },
+                                            operator:
+                                                FilterOperator.IN_THE_PAST,
+                                            values: [12],
+                                            settings: {
+                                                unitOfTime: UnitOfTime.months,
+                                            },
+                                        },
+                                    ],
+                                    timeDimension: 'order_date',
+                                    granularity: TimeFrames.DAY,
+                                    requiredFilterDimensions: ['order_date'],
+                                },
+                            ],
+                        }),
+                    );
+
+                it('matches a filterless query when the deferred fallback narrows the explicit bound', () => {
+                    const result = preAggregateUtils.findMatch(
+                        makeMetricQuery({
+                            dimensions: [],
+                            metrics: ['orders_order_count'],
+                        }),
+                        boundedDeferredExplore(3),
+                    );
+
+                    expect(result).toStrictEqual({
+                        hit: true,
+                        preAggregateName: 'orders_bounded_daily',
+                        miss: null,
+                    });
+                });
+
+                it('misses a filterless query when the deferred fallback exceeds the explicit bound', () => {
+                    const result = preAggregateUtils.findMatch(
+                        makeMetricQuery({
+                            dimensions: [],
+                            metrics: ['orders_order_count'],
+                        }),
+                        boundedDeferredExplore(15),
+                    );
+
+                    expect(result.miss).toStrictEqual({
+                        reason: PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED,
+                        fieldId: 'orders_order_date',
+                    });
+                });
+
+                it('still misses a filterless query when the required filter is not deferred', () => {
+                    const result = preAggregateUtils.findMatch(
+                        makeMetricQuery({
+                            dimensions: [],
+                            metrics: ['orders_order_count'],
+                        }),
+                        getExploreWithRequiredFilters({
+                            requiredFilters: [
+                                {
+                                    id: 'required-order-date-filter',
+                                    target: { fieldRef: 'order_date_day' },
+                                    operator: FilterOperator.IN_THE_PAST,
+                                    values: [3],
+                                    settings: { unitOfTime: UnitOfTime.months },
+                                    required: true,
+                                },
+                            ],
+                            preAggregates: [
+                                {
+                                    name: 'orders_bounded_daily',
+                                    dimensions: ['order_date'],
+                                    metrics: ['order_count'],
+                                    filters: [
+                                        {
+                                            id: 'rollup-date-filter',
+                                            target: { fieldRef: 'order_date' },
+                                            operator:
+                                                FilterOperator.IN_THE_PAST,
+                                            values: [12],
+                                            settings: {
+                                                unitOfTime: UnitOfTime.months,
+                                            },
+                                        },
+                                    ],
+                                    timeDimension: 'order_date',
+                                    granularity: TimeFrames.DAY,
+                                },
+                            ],
+                        }),
+                    );
+
+                    expect(result.miss).toStrictEqual({
+                        reason: PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED,
+                        fieldId: 'orders_order_date',
+                    });
+                });
+            });
+        });
+
         it('rejects an unsafe same-shape candidate before the selection tie-break', () => {
             const explore = getExploreWithRequiredFilters({
                 requiredFilters: [makeRequiredStatusFilter(['completed'])],
@@ -1579,6 +1860,94 @@ describe('findMatch', () => {
             queryGranularity: TimeFrames.DAY,
             preAggregateGranularity: TimeFrames.MONTH,
             preAggregateTimeDimension: 'order_date',
+        });
+    });
+
+    it('returns granularity_too_fine when a filter-only time field is finer than rollup', () => {
+        const explore = {
+            ...baseExplore(),
+            preAggregates: [
+                {
+                    name: 'orders_monthly',
+                    dimensions: ['status', 'order_date'],
+                    metrics: ['order_count'],
+                    timeDimension: 'order_date',
+                    granularity: TimeFrames.MONTH,
+                },
+            ],
+        };
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['orders_status'],
+                metrics: ['orders_order_count'],
+                filters: {
+                    dimensions: {
+                        id: 'query-filters',
+                        and: [
+                            {
+                                id: 'query-date-filter',
+                                operator: FilterOperator.IN_THE_PAST,
+                                target: { fieldId: 'orders_order_date_day' },
+                                values: [3],
+                                settings: { unitOfTime: UnitOfTime.days },
+                            },
+                        ],
+                    },
+                },
+            }),
+            explore,
+        );
+
+        expect(result.miss).toStrictEqual({
+            reason: PreAggregateMissReason.GRANULARITY_TOO_FINE,
+            fieldId: 'orders_order_date_day',
+            queryGranularity: TimeFrames.DAY,
+            preAggregateGranularity: TimeFrames.MONTH,
+            preAggregateTimeDimension: 'order_date',
+        });
+    });
+
+    it('accepts a filter-only time field at the rollup granularity', () => {
+        const explore = {
+            ...baseExplore(),
+            preAggregates: [
+                {
+                    name: 'orders_monthly',
+                    dimensions: ['status', 'order_date'],
+                    metrics: ['order_count'],
+                    timeDimension: 'order_date',
+                    granularity: TimeFrames.MONTH,
+                },
+            ],
+        };
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['orders_status'],
+                metrics: ['orders_order_count'],
+                filters: {
+                    dimensions: {
+                        id: 'query-filters',
+                        and: [
+                            {
+                                id: 'query-date-filter',
+                                operator: FilterOperator.IN_THE_PAST,
+                                target: { fieldId: 'orders_order_date_month' },
+                                values: [3],
+                                settings: { unitOfTime: UnitOfTime.months },
+                            },
+                        ],
+                    },
+                },
+            }),
+            explore,
+        );
+
+        expect(result).toStrictEqual({
+            hit: true,
+            preAggregateName: 'orders_monthly',
+            miss: null,
         });
     });
 

--- a/packages/backend/src/ee/preAggregates/postProcessor.test.ts
+++ b/packages/backend/src/ee/preAggregates/postProcessor.test.ts
@@ -4,6 +4,7 @@ import {
     DimensionType,
     ExploreType,
     InlineErrorType,
+    isExploreError,
     PRE_AGGREGATE_MATERIALIZED_TABLE_PLACEHOLDER,
     SupportedDbtAdapter,
     TimeFrames,
@@ -322,6 +323,117 @@ describe('pre-aggregate virtual explore generation', () => {
                 }),
             ]),
         );
+    });
+
+    it('resolves required filter deferrals into the effective definition', async () => {
+        process.env.PRE_AGGREGATES_ENABLED = 'true';
+
+        const explores = await convertExplores(
+            [
+                {
+                    ...MODEL_WITH_METRIC,
+                    meta: {
+                        default_filters: [{ user_id: '123', required: true }],
+                        pre_aggregates: [
+                            {
+                                name: 'rollup',
+                                dimensions: ['num_participating_athletes'],
+                                metrics: [
+                                    'myTable_total_num_participating_athletes',
+                                ],
+                                required_filter_dimensions: ['user_id'],
+                            },
+                        ],
+                    },
+                },
+            ],
+            false,
+            SupportedDbtAdapter.POSTGRES,
+            warehouseClientMock,
+            {
+                spotlight: DEFAULT_SPOTLIGHT_CONFIG,
+            },
+            { postProcessors: [preAggregatePostProcessor] },
+        );
+
+        expect(explores).toHaveLength(2);
+
+        const baseExplore = explores.find(
+            (explore) => !('errors' in explore) && explore.name === 'myTable',
+        );
+        const preAggregateExplore = explores.find(
+            (explore) =>
+                !('errors' in explore) &&
+                explore.name === '__preagg__myTable__rollup',
+        );
+        if (
+            !baseExplore ||
+            isExploreError(baseExplore) ||
+            !preAggregateExplore ||
+            isExploreError(preAggregateExplore)
+        ) {
+            throw new Error('Expected generated pre-aggregate explores');
+        }
+
+        // The registry and matcher only ever see the resolved (effective) def:
+        // the deferred target is unioned into the physical grain.
+        expect(baseExplore.preAggregates).toStrictEqual([
+            {
+                name: 'rollup',
+                dimensions: ['num_participating_athletes', 'user_id'],
+                metrics: ['myTable_total_num_participating_athletes'],
+                requiredFilterDimensions: ['user_id'],
+            },
+        ]);
+        expect(
+            preAggregateExplore.tables.myTable.dimensions.user_id,
+        ).toBeDefined();
+        expect(
+            preAggregateExplore.tables.myTable.requiredFilters,
+        ).toStrictEqual(baseExplore.tables.myTable.requiredFilters);
+    });
+
+    it('excludes definitions with invalid required filter deferrals and surfaces a warning', async () => {
+        process.env.PRE_AGGREGATES_ENABLED = 'true';
+
+        const explores = await convertExplores(
+            [
+                {
+                    ...MODEL_WITH_METRIC,
+                    meta: {
+                        pre_aggregates: [
+                            {
+                                name: 'rollup',
+                                dimensions: ['num_participating_athletes'],
+                                metrics: [
+                                    'myTable_total_num_participating_athletes',
+                                ],
+                                required_filter_dimensions: ['user_id'],
+                            },
+                        ],
+                    },
+                },
+            ],
+            false,
+            SupportedDbtAdapter.POSTGRES,
+            warehouseClientMock,
+            {
+                spotlight: DEFAULT_SPOTLIGHT_CONFIG,
+            },
+            { postProcessors: [preAggregatePostProcessor] },
+        );
+
+        expect(explores).toHaveLength(1);
+        const [baseExplore] = explores;
+        if (!baseExplore || isExploreError(baseExplore)) {
+            throw new Error('Expected the base explore');
+        }
+        expect(baseExplore.preAggregates).toStrictEqual([]);
+        expect(baseExplore.warnings).toContainEqual({
+            type: InlineErrorType.FIELD_ERROR,
+            message:
+                'Pre-aggregate "rollup" required_filter_dimensions entry "user_id" does not match any required filter on the model',
+        });
     });
 
     it('keeps the base explore when pre-aggregate generation fails', async () => {

--- a/packages/backend/src/ee/preAggregates/resolvePreAggregateDef.test.ts
+++ b/packages/backend/src/ee/preAggregates/resolvePreAggregateDef.test.ts
@@ -1,0 +1,372 @@
+import {
+    DimensionType,
+    FieldType,
+    FilterOperator,
+    MetricType,
+    preAggregateUtils,
+    SupportedDbtAdapter,
+    TimeFrames,
+    UnitOfTime,
+    type CompiledDimension,
+    type CompiledMetric,
+    type Explore,
+    type ModelRequiredFilterRule,
+    type PreAggregateDef,
+} from '@lightdash/common';
+
+const makeDimension = ({
+    name,
+    table = 'orders',
+    type = DimensionType.STRING,
+    timeInterval,
+    timeIntervalBaseDimensionName,
+    isIntervalBase,
+}: {
+    name: string;
+    table?: string;
+    type?: DimensionType;
+    timeInterval?: TimeFrames;
+    timeIntervalBaseDimensionName?: string;
+    isIntervalBase?: boolean;
+}): CompiledDimension => ({
+    index: 0,
+    fieldType: FieldType.DIMENSION,
+    type,
+    name,
+    label: name,
+    sql: '${TABLE}.x',
+    table,
+    tableLabel: table,
+    hidden: false,
+    compiledSql: 'x',
+    tablesReferences: [],
+    ...(timeInterval ? { timeInterval } : {}),
+    ...(timeIntervalBaseDimensionName ? { timeIntervalBaseDimensionName } : {}),
+    ...(isIntervalBase !== undefined ? { isIntervalBase } : {}),
+});
+
+const makeMetric = ({
+    name,
+    type,
+    table = 'orders',
+}: {
+    name: string;
+    type: MetricType;
+    table?: string;
+}): CompiledMetric => ({
+    index: 0,
+    fieldType: FieldType.METRIC,
+    type,
+    name,
+    label: name,
+    sql: '${TABLE}.x',
+    table,
+    tableLabel: table,
+    hidden: false,
+    compiledSql: 'x',
+    tablesReferences: [],
+});
+
+const getExplore = (requiredFilters: ModelRequiredFilterRule[]): Explore => ({
+    name: 'orders',
+    label: 'Orders',
+    tags: [],
+    baseTable: 'orders',
+    joinedTables: [],
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+    tables: {
+        orders: {
+            name: 'orders',
+            label: 'Orders',
+            database: 'db',
+            schema: 'public',
+            sqlTable: 'orders',
+            dimensions: {
+                status: makeDimension({ name: 'status' }),
+                order_date: makeDimension({
+                    name: 'order_date',
+                    type: DimensionType.DATE,
+                    isIntervalBase: true,
+                }),
+                order_date_day: makeDimension({
+                    name: 'order_date_day',
+                    type: DimensionType.DATE,
+                    timeInterval: TimeFrames.DAY,
+                    timeIntervalBaseDimensionName: 'order_date',
+                }),
+                order_date_month: makeDimension({
+                    name: 'order_date_month',
+                    type: DimensionType.DATE,
+                    timeInterval: TimeFrames.MONTH,
+                    timeIntervalBaseDimensionName: 'order_date',
+                }),
+                shipped_date: makeDimension({
+                    name: 'shipped_date',
+                    type: DimensionType.DATE,
+                    isIntervalBase: true,
+                }),
+                shipped_date_day: makeDimension({
+                    name: 'shipped_date_day',
+                    type: DimensionType.DATE,
+                    timeInterval: TimeFrames.DAY,
+                    timeIntervalBaseDimensionName: 'shipped_date',
+                }),
+            },
+            metrics: {
+                order_count: makeMetric({
+                    name: 'order_count',
+                    type: MetricType.COUNT,
+                }),
+            },
+            lineageGraph: {},
+            requiredFilters,
+        },
+        customers: {
+            name: 'customers',
+            label: 'Customers',
+            database: 'db',
+            schema: 'public',
+            sqlTable: 'customers',
+            dimensions: {
+                first_name: makeDimension({
+                    name: 'first_name',
+                    table: 'customers',
+                }),
+            },
+            metrics: {},
+            lineageGraph: {},
+        },
+    },
+});
+
+const requiredStatusFilter: ModelRequiredFilterRule = {
+    id: 'required-status-filter',
+    target: { fieldRef: 'status' },
+    operator: FilterOperator.EQUALS,
+    values: ['completed'],
+    required: true,
+};
+
+const requiredDateDayFilter: ModelRequiredFilterRule = {
+    id: 'required-date-filter',
+    target: { fieldRef: 'order_date_day' },
+    operator: FilterOperator.IN_THE_PAST,
+    values: [10],
+    settings: { unitOfTime: UnitOfTime.days },
+    required: true,
+};
+
+const makeDef = (partial: Partial<PreAggregateDef>): PreAggregateDef => ({
+    name: 'orders_rollup',
+    dimensions: ['order_date'],
+    metrics: ['order_count'],
+    timeDimension: 'order_date',
+    granularity: TimeFrames.DAY,
+    ...partial,
+});
+
+describe('resolvePreAggregateDef', () => {
+    it('returns the definition as-is when required_filter_dimensions is omitted', () => {
+        const preAggregateDef = makeDef({});
+
+        const result = preAggregateUtils.resolvePreAggregateDef({
+            sourceExplore: getExplore([requiredStatusFilter]),
+            preAggregateDef,
+        });
+
+        expect(result).toBe(preAggregateDef);
+    });
+
+    it('unions a non-time target into dimensions and keeps the deferral marker', () => {
+        const result = preAggregateUtils.resolvePreAggregateDef({
+            sourceExplore: getExplore([requiredStatusFilter]),
+            preAggregateDef: makeDef({
+                requiredFilterDimensions: ['status'],
+            }),
+        });
+
+        expect(result.dimensions).toStrictEqual(['order_date', 'status']);
+        expect(result.requiredFilterDimensions).toStrictEqual(['status']);
+    });
+
+    it('does not duplicate a target already declared under another reference form', () => {
+        const result = preAggregateUtils.resolvePreAggregateDef({
+            sourceExplore: getExplore([requiredStatusFilter]),
+            preAggregateDef: makeDef({
+                dimensions: ['order_date', 'orders.status'],
+                requiredFilterDimensions: ['status'],
+            }),
+        });
+
+        expect(result.dimensions).toStrictEqual([
+            'order_date',
+            'orders.status',
+        ]);
+    });
+
+    it('is idempotent', () => {
+        const sourceExplore = getExplore([requiredStatusFilter]);
+        const resolved = preAggregateUtils.resolvePreAggregateDef({
+            sourceExplore,
+            preAggregateDef: makeDef({
+                requiredFilterDimensions: ['status'],
+            }),
+        });
+
+        expect(
+            preAggregateUtils.resolvePreAggregateDef({
+                sourceExplore,
+                preAggregateDef: resolved,
+            }),
+        ).toStrictEqual(resolved);
+    });
+
+    it('unions a joined-table target into dimensions', () => {
+        const result = preAggregateUtils.resolvePreAggregateDef({
+            sourceExplore: getExplore([
+                {
+                    id: 'required-customer-filter',
+                    target: {
+                        fieldRef: 'customers.first_name',
+                        tableName: 'customers',
+                    },
+                    operator: FilterOperator.EQUALS,
+                    values: ['Alice'],
+                    required: true,
+                },
+            ]),
+            preAggregateDef: makeDef({
+                requiredFilterDimensions: ['customers.first_name'],
+            }),
+        });
+
+        expect(result.dimensions).toStrictEqual([
+            'order_date',
+            'customers.first_name',
+        ]);
+    });
+
+    it('accepts a time target at exactly the configured granularity without changing the grain', () => {
+        const preAggregateDef = makeDef({
+            requiredFilterDimensions: ['order_date'],
+        });
+
+        const result = preAggregateUtils.resolvePreAggregateDef({
+            sourceExplore: getExplore([requiredDateDayFilter]),
+            preAggregateDef,
+        });
+
+        expect(result).toBe(preAggregateDef);
+    });
+
+    it('throws for an unknown dimension entry', () => {
+        expect(() =>
+            preAggregateUtils.resolvePreAggregateDef({
+                sourceExplore: getExplore([requiredStatusFilter]),
+                preAggregateDef: makeDef({
+                    requiredFilterDimensions: ['nonexistent'],
+                }),
+            }),
+        ).toThrow(
+            'Pre-aggregate "orders_rollup" references unknown dimension "nonexistent" in "required_filter_dimensions"',
+        );
+    });
+
+    it('throws for an entry that matches no required filter', () => {
+        expect(() =>
+            preAggregateUtils.resolvePreAggregateDef({
+                sourceExplore: getExplore([requiredDateDayFilter]),
+                preAggregateDef: makeDef({
+                    requiredFilterDimensions: ['status'],
+                }),
+            }),
+        ).toThrow(
+            'Pre-aggregate "orders_rollup" required_filter_dimensions entry "status" does not match any required filter on the model',
+        );
+    });
+
+    it('throws for an entry that targets a required:false filter', () => {
+        expect(() =>
+            preAggregateUtils.resolvePreAggregateDef({
+                sourceExplore: getExplore([
+                    { ...requiredStatusFilter, required: false },
+                ]),
+                preAggregateDef: makeDef({
+                    requiredFilterDimensions: ['status'],
+                }),
+            }),
+        ).toThrow(
+            'Pre-aggregate "orders_rollup" required_filter_dimensions entry "status" targets a filter with "required: false", which is never enforced — there is nothing to defer',
+        );
+    });
+
+    it('throws for a time target when the pre-aggregate has no time dimension', () => {
+        expect(() =>
+            preAggregateUtils.resolvePreAggregateDef({
+                sourceExplore: getExplore([requiredDateDayFilter]),
+                preAggregateDef: makeDef({
+                    dimensions: ['status'],
+                    timeDimension: undefined,
+                    granularity: undefined,
+                    requiredFilterDimensions: ['order_date'],
+                }),
+            }),
+        ).toThrow(
+            'Pre-aggregate "orders_rollup" cannot defer the time-based required filter on "order_date" without "time_dimension" and "granularity"',
+        );
+    });
+
+    it('throws for a time target on a different family than the configured time dimension', () => {
+        expect(() =>
+            preAggregateUtils.resolvePreAggregateDef({
+                sourceExplore: getExplore([
+                    {
+                        ...requiredDateDayFilter,
+                        target: { fieldRef: 'shipped_date_day' },
+                    },
+                ]),
+                preAggregateDef: makeDef({
+                    requiredFilterDimensions: ['shipped_date'],
+                }),
+            }),
+        ).toThrow(
+            'Pre-aggregate "orders_rollup" can only defer time-based required filters on its time dimension "order_date", but "shipped_date" targets a different time dimension',
+        );
+    });
+
+    it('throws for a required filter that targets the raw time dimension', () => {
+        expect(() =>
+            preAggregateUtils.resolvePreAggregateDef({
+                sourceExplore: getExplore([
+                    {
+                        ...requiredDateDayFilter,
+                        target: { fieldRef: 'order_date' },
+                    },
+                ]),
+                preAggregateDef: makeDef({
+                    requiredFilterDimensions: ['order_date'],
+                }),
+            }),
+        ).toThrow(
+            'Pre-aggregate "orders_rollup" cannot defer the required filter on "order_date": it targets the raw time dimension. Point the required filter at "order_date_day" or align the granularities',
+        );
+    });
+
+    it('throws for a required filter at a different granularity than the pre-aggregate', () => {
+        expect(() =>
+            preAggregateUtils.resolvePreAggregateDef({
+                sourceExplore: getExplore([
+                    {
+                        ...requiredDateDayFilter,
+                        target: { fieldRef: 'order_date_month' },
+                    },
+                ]),
+                preAggregateDef: makeDef({
+                    requiredFilterDimensions: ['order_date'],
+                }),
+            }),
+        ).toThrow(
+            'Pre-aggregate "orders_rollup" cannot defer the required filter on "order_date_month": it uses MONTH granularity but the pre-aggregate materializes DAY. Align the granularities to defer it',
+        );
+    });
+});

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.test.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.test.ts
@@ -279,7 +279,10 @@ const getSourceExplore = (): Explore =>
         },
     }) as Explore;
 
-const buildFilterlessMaterializationSql = (required: boolean): string => {
+const buildFilterlessMaterializationSql = (
+    required: boolean,
+    requiredFilterDimensions?: string[],
+): string => {
     const sourceExplore = getSourceExplore();
     sourceExplore.tables.orders.requiredFilters = [
         {
@@ -297,6 +300,7 @@ const buildFilterlessMaterializationSql = (required: boolean): string => {
             name: 'orders_rollup',
             dimensions: ['status'],
             metrics: ['order_count'],
+            ...(requiredFilterDimensions ? { requiredFilterDimensions } : {}),
         },
         materializationConfig: { maxRows: null },
     });
@@ -471,6 +475,150 @@ describe('buildMaterializationMetricQuery', () => {
             expect(sql.includes("'completed'")).toBe(restrictsMaterialization);
         },
     );
+
+    describe('required filter deferral (required_filter_dimensions)', () => {
+        const getExploreWithRequiredStatusFilter = (): Explore => {
+            const sourceExplore = getSourceExplore();
+            sourceExplore.tables.orders.requiredFilters = [
+                {
+                    id: 'model-status-filter',
+                    target: { fieldRef: 'status' },
+                    operator: FilterOperator.EQUALS,
+                    values: ['completed'],
+                    required: true,
+                },
+            ];
+            return sourceExplore;
+        };
+
+        it('suppresses a deferred required filter with an enabled same-target tautology', () => {
+            const result = buildMaterializationMetricQuery({
+                sourceExplore: getExploreWithRequiredStatusFilter(),
+                preAggregateDef: {
+                    name: 'orders_rollup',
+                    dimensions: ['status'],
+                    metrics: ['order_count'],
+                    requiredFilterDimensions: ['status'],
+                },
+                materializationConfig: { maxRows: null },
+            });
+
+            expect(result.metricQuery.filters.dimensions).toStrictEqual({
+                id: 'pre-aggregate-filters',
+                and: [
+                    {
+                        id: 'deferred-required-filter:orders_status',
+                        or: [
+                            {
+                                id: 'deferred-required-filter:orders_status:null',
+                                target: { fieldId: 'orders_status' },
+                                operator: FilterOperator.NULL,
+                                values: [],
+                            },
+                            {
+                                id: 'deferred-required-filter:orders_status:not-null',
+                                target: { fieldId: 'orders_status' },
+                                operator: FilterOperator.NOT_NULL,
+                                values: [],
+                            },
+                        ],
+                    },
+                ],
+            });
+        });
+
+        it('emits the deferral tautology for a time target at the grain granularity', () => {
+            const sourceExplore = getSourceExplore();
+            sourceExplore.tables.orders.requiredFilters = [
+                {
+                    id: 'model-date-filter',
+                    target: { fieldRef: 'order_date_day' },
+                    operator: FilterOperator.IN_THE_PAST,
+                    values: [10],
+                    settings: { unitOfTime: UnitOfTime.days },
+                    required: true,
+                },
+            ];
+
+            const result = buildMaterializationMetricQuery({
+                sourceExplore,
+                preAggregateDef: {
+                    name: 'orders_rollup',
+                    dimensions: ['status'],
+                    metrics: ['order_count'],
+                    timeDimension: 'order_date',
+                    granularity: TimeFrames.DAY,
+                    requiredFilterDimensions: ['order_date'],
+                },
+                materializationConfig: { maxRows: null },
+            });
+
+            expect(result.metricQuery.filters.dimensions).toStrictEqual({
+                id: 'pre-aggregate-filters',
+                and: [
+                    {
+                        id: 'deferred-required-filter:orders_order_date_day',
+                        or: [
+                            {
+                                id: 'deferred-required-filter:orders_order_date_day:null',
+                                target: { fieldId: 'orders_order_date_day' },
+                                operator: FilterOperator.NULL,
+                                values: [],
+                            },
+                            {
+                                id: 'deferred-required-filter:orders_order_date_day:not-null',
+                                target: { fieldId: 'orders_order_date_day' },
+                                operator: FilterOperator.NOT_NULL,
+                                values: [],
+                            },
+                        ],
+                    },
+                ],
+            });
+        });
+
+        it('does not bake a deferred required filter into the materialization SQL', () => {
+            // The mixed-version guarantee: the persisted payload suppresses the
+            // model fallback through presence semantics alone, so any
+            // MetricQueryBuilder version replaying it materializes unrestricted.
+            const sql = buildFilterlessMaterializationSql(true, ['status']);
+
+            expect(sql.includes("'completed'")).toBe(false);
+            expect(sql).toContain('IS NULL');
+            expect(sql).toContain('IS NOT NULL');
+        });
+
+        it('throws when the definition has unresolved required filter deferrals', () => {
+            const sourceExplore = getSourceExplore();
+            sourceExplore.tables.orders.requiredFilters = [
+                {
+                    id: 'model-customer-filter',
+                    target: {
+                        fieldRef: 'customers.first_name',
+                        tableName: 'customers',
+                    },
+                    operator: FilterOperator.EQUALS,
+                    values: ['Alice'],
+                    required: true,
+                },
+            ];
+
+            expect(() =>
+                buildMaterializationMetricQuery({
+                    sourceExplore,
+                    preAggregateDef: {
+                        name: 'orders_rollup',
+                        dimensions: ['status'],
+                        metrics: ['order_count'],
+                        requiredFilterDimensions: ['customers.first_name'],
+                    },
+                    materializationConfig: { maxRows: null },
+                }),
+            ).toThrow(
+                'Pre-aggregate "orders_rollup" definition has unresolved "required_filter_dimensions"; resolve the definition before building its materialization query',
+            );
+        });
+    });
 
     it('emits pre-aggregate filters into materialization dimension filters', () => {
         const preAggregateDef: PreAggregateDef = {

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.ts
@@ -3,6 +3,7 @@ import {
     getItemId,
     getPreAggregateMetricComponentColumnName,
     MetricType,
+    ParameterError,
     PreAggregateMetricRepresentationKind,
     preAggregateUtils,
     type AdditionalMetric,
@@ -104,6 +105,18 @@ export const buildMaterializationMetricQuery = ({
     preAggregateDef: PreAggregateDef;
     materializationConfig: MaterializationConfig;
 }): MaterializationMetricQueryPayload => {
+    // Callers must pass the effective definition from resolvePreAggregateDef —
+    // an unresolved deferral would materialize without its target in the grain.
+    const resolvedDef = preAggregateUtils.resolvePreAggregateDef({
+        sourceExplore,
+        preAggregateDef,
+    });
+    if (resolvedDef.dimensions.length !== preAggregateDef.dimensions.length) {
+        throw new ParameterError(
+            `Pre-aggregate "${preAggregateDef.name}" definition has unresolved "required_filter_dimensions"; resolve the definition before building its materialization query`,
+        );
+    }
+
     const dimensionsByReference = getDimensionsByReference(sourceExplore);
     const dimensionReferences = [...preAggregateDef.dimensions];
     const { materializedMetrics } = selectPreAggregateMetrics({
@@ -258,8 +271,8 @@ export const buildMaterializationMetricQuery = ({
         materializationConfig.maxRows ??
         SYSTEM_MAX_ROWS;
     const dimensionFilters = preAggregateUtils.getPreAggregateDimensionFilters({
-        filters: preAggregateDef.filters,
-        baseTable: sourceExplore.baseTable,
+        sourceExplore,
+        preAggregateDef,
     });
 
     const metricQuery: MetricQuery = {

--- a/packages/common/src/ee/preAggregates/filters.ts
+++ b/packages/common/src/ee/preAggregates/filters.ts
@@ -1,9 +1,13 @@
+import type { Explore } from '../../types/explore';
 import { convertFieldRefToFieldId } from '../../types/field';
-import type {
-    FilterGroup,
+import {
     FilterOperator,
-    FilterRule,
+    type FilterGroup,
+    type FilterGroupItem,
+    type FilterRule,
 } from '../../types/filter';
+import type { PreAggregateDef } from '../../types/preAggregate';
+import { resolveRequiredFilterDeferrals } from './resolvePreAggregateDef';
 
 type PreAggregateFilterRule = FilterRule<
     FilterOperator,
@@ -12,20 +16,26 @@ type PreAggregateFilterRule = FilterRule<
     unknown
 >;
 
+/**
+ * Single conversion shared by the materialization payload builder and the
+ * matcher: turns a definition's explicit filters into a dimension filter group
+ * and emits one enabled same-target tautology per deferred required filter.
+ * The tautology suppresses the model fallback through the documented
+ * required-filter presence semantics, so any MetricQueryBuilder version that
+ * replays the persisted payload materializes without the baked filter — while
+ * the rollup read path still re-applies it from the explore's requiredFilters —
+ * and the matcher's fallback reduction drops the deferred rule the same way.
+ */
 export const getPreAggregateDimensionFilters = ({
-    filters,
-    baseTable,
+    sourceExplore,
+    preAggregateDef,
 }: {
-    filters: PreAggregateFilterRule[] | undefined;
-    baseTable: string;
+    sourceExplore: Explore;
+    preAggregateDef: PreAggregateDef;
 }): FilterGroup | undefined => {
-    if (!filters || filters.length === 0) {
-        return undefined;
-    }
-
-    return {
-        id: 'pre-aggregate-filters',
-        and: filters.map<FilterRule>((filter) => ({
+    const { baseTable } = sourceExplore;
+    const filterRules = (preAggregateDef.filters ?? []).map<FilterRule>(
+        (filter: PreAggregateFilterRule) => ({
             id: filter.id,
             target: {
                 fieldId: convertFieldRefToFieldId(
@@ -42,6 +52,44 @@ export const getPreAggregateDimensionFilters = ({
             ...(filter.disabled !== undefined
                 ? { disabled: filter.disabled }
                 : {}),
-        })),
+        }),
+    );
+
+    const deferredTargetFieldIds = Array.from(
+        new Set(
+            resolveRequiredFilterDeferrals({
+                sourceExplore,
+                preAggregateDef,
+            }).map(({ targetFieldId }) => targetFieldId),
+        ),
+    );
+    const deferralTautologies = deferredTargetFieldIds.map<FilterGroup>(
+        (fieldId) => ({
+            id: `deferred-required-filter:${fieldId}`,
+            or: [
+                {
+                    id: `deferred-required-filter:${fieldId}:null`,
+                    target: { fieldId },
+                    operator: FilterOperator.NULL,
+                    values: [],
+                },
+                {
+                    id: `deferred-required-filter:${fieldId}:not-null`,
+                    target: { fieldId },
+                    operator: FilterOperator.NOT_NULL,
+                    values: [],
+                },
+            ],
+        }),
+    );
+
+    const items: FilterGroupItem[] = [...filterRules, ...deferralTautologies];
+    if (items.length === 0) {
+        return undefined;
+    }
+
+    return {
+        id: 'pre-aggregate-filters',
+        and: items,
     };
 };

--- a/packages/common/src/ee/preAggregates/matcher.ts
+++ b/packages/common/src/ee/preAggregates/matcher.ts
@@ -29,12 +29,16 @@ import {
 import type { TimeFrames } from '../../types/timeFrames';
 import assertUnreachable from '../../utils/assertUnreachable';
 import { getMetricsMapFromTables } from '../../utils/fields';
-import { reduceRequiredDimensionFiltersToFilterRules } from '../../utils/filters';
+import {
+    createFilterRuleFromModelRequiredFilterRule,
+    reduceRequiredDimensionFiltersToFilterRules,
+} from '../../utils/filters';
 import { getItemId } from '../../utils/item';
 import { timeFrameOrder } from '../../utils/timeFrames';
 import { isCompatible } from './additivity';
 import { getPreAggregateDimensionFilters } from './filters';
 import { getDimensionReferences, getMetricReferences } from './references';
+import { resolveRequiredFilterDeferrals } from './resolvePreAggregateDef';
 
 export type PreAggregateMatchResult =
     | { hit: true; preAggregateName: string; miss: null }
@@ -757,6 +761,7 @@ const getUnsatisfiedPreAggregateFilterMiss = ({
     explore,
     preAggregateDef,
     dimensionsByFieldId,
+    queryRequiredFallbackIds,
 }: {
     metricQuery: MetricQuery;
     explore: Explore;
@@ -765,20 +770,56 @@ const getUnsatisfiedPreAggregateFilterMiss = ({
         FieldId,
         Explore['tables'][string]['dimensions'][string]
     >;
+    queryRequiredFallbackIds: ReadonlySet<string>;
 }): UnsatisfiedMaterializationFilterMiss | null => {
     const preAggregateFilters = preAggregateDef.filters || [];
-    const unsatisfiedFilter = preAggregateFilters.find(
-        (preAggregateFilter) =>
-            !filterGroupImpliesMaterializationFilter({
+    if (preAggregateFilters.length === 0) {
+        return null;
+    }
+
+    // A deferred required filter keeps its target in the physical grain, and the
+    // rollup read path re-applies the model fallback whenever the query has no
+    // same-target filter — so an active fallback may satisfy an explicit
+    // pre-aggregate filter it is equivalent to or narrower than. Non-deferred
+    // targets keep the #26811 ban: only explicit query filters count.
+    const activeDeferredFallbackRules = resolveRequiredFilterDeferrals({
+        sourceExplore: explore,
+        preAggregateDef,
+    })
+        .filter(({ rule }) => queryRequiredFallbackIds.has(rule.id))
+        .map(({ rule }) =>
+            createFilterRuleFromModelRequiredFilterRule(
+                rule,
+                explore.tables[explore.baseTable].name,
+            ),
+        );
+
+    const unsatisfiedFilter = preAggregateFilters.find((preAggregateFilter) => {
+        const materializationFilter: MaterializationFilter = {
+            source: 'pre_aggregate',
+            filter: preAggregateFilter,
+        };
+
+        if (
+            filterGroupImpliesMaterializationFilter({
                 filterGroup: metricQuery.filters.dimensions,
-                materializationFilter: {
-                    source: 'pre_aggregate',
-                    filter: preAggregateFilter,
-                },
+                materializationFilter,
+                explore,
+                dimensionsByFieldId,
+            })
+        ) {
+            return false;
+        }
+
+        return !activeDeferredFallbackRules.some((fallbackRule) =>
+            isFilterRuleEquivalentOrNarrower({
+                queryFilterRule: fallbackRule,
+                materializationFilter,
                 explore,
                 dimensionsByFieldId,
             }),
-    );
+        );
+    });
 
     if (!unsatisfiedFilter) {
         return null;
@@ -812,8 +853,8 @@ const getUnsatisfiedRequiredModelFilterMiss = ({
     queryRequiredFallbackIds: ReadonlySet<string>;
 }): UnsatisfiedMaterializationFilterMiss | null => {
     const preAggregateDimensionFilters = getPreAggregateDimensionFilters({
-        filters: preAggregateDef.filters,
-        baseTable: explore.baseTable,
+        sourceExplore: explore,
+        preAggregateDef,
     });
     const materializationRequiredFilters =
         reduceRequiredDimensionFiltersToFilterRules(
@@ -861,7 +902,15 @@ const getGranularityMissForDef = (
         return null;
     }
 
-    for (const dimensionFieldId of metricQuery.dimensions) {
+    // Filter-only fields matter too: finer-grain siblings of the rollup time
+    // dimension are excluded from the pre-aggregate explore, so a finer filter
+    // could never be applied at read time — turn that error path into a miss.
+    const queryFieldIds = [
+        ...metricQuery.dimensions,
+        ...extractDimensionFilterFieldIds(metricQuery),
+    ];
+
+    for (const dimensionFieldId of queryFieldIds) {
         const dimension = dimensionsByFieldId.get(dimensionFieldId);
         const queryGranularity = dimension?.timeInterval;
         const matchesRollupTimeDimension =
@@ -1025,6 +1074,7 @@ const getMissForDef = ({
             explore,
             preAggregateDef,
             dimensionsByFieldId,
+            queryRequiredFallbackIds,
         });
     if (unsatisfiedPreAggregateFilterMiss) {
         return unsatisfiedPreAggregateFilterMiss;
@@ -1102,6 +1152,9 @@ export const findMatch = (
         explore.tables[explore.baseTable].requiredFilters?.filter(
             (filter) => filter.required !== false,
         ) ?? [];
+    // Required-filter rule ids are minted per compile, so id-based matching is
+    // only safe because every reduce in this call reads the same explore object.
+    // Never persist these ids or compare them across compiles.
     const queryRequiredFallbackIds = new Set(
         reduceRequiredDimensionFiltersToFilterRules(
             requiredModelFilters,

--- a/packages/common/src/ee/preAggregates/resolvePreAggregateDef.ts
+++ b/packages/common/src/ee/preAggregates/resolvePreAggregateDef.ts
@@ -1,0 +1,255 @@
+import { ParameterError } from '../../types/errors';
+import type { Explore } from '../../types/explore';
+import {
+    convertFieldRefToFieldId,
+    type CompiledDimension,
+    type FieldId,
+} from '../../types/field';
+import type { ModelRequiredFilterRule } from '../../types/filter';
+import type { PreAggregateDef } from '../../types/preAggregate';
+import { getItemId } from '../../utils/item';
+import { getDimensionBaseName, getDimensionReferences } from './references';
+
+export type RequiredFilterDeferral = {
+    /** The required_filter_dimensions entry that selected this rule. */
+    entry: string;
+    rule: ModelRequiredFilterRule;
+    /** Field id of the rule's target dimension (may be a granularity sibling). */
+    targetFieldId: FieldId;
+    targetDimension: CompiledDimension;
+};
+
+const isTimeIntervalFamilyDimension = (
+    dimension: CompiledDimension,
+    sourceExplore: Explore,
+): boolean =>
+    dimension.isIntervalBase === true ||
+    dimension.timeInterval !== undefined ||
+    Object.values(sourceExplore.tables[dimension.table]?.dimensions ?? {}).some(
+        (candidate) =>
+            candidate.timeIntervalBaseDimensionName === dimension.name,
+    );
+
+const getDimensionsByFieldId = (
+    sourceExplore: Explore,
+): Map<FieldId, CompiledDimension> => {
+    const dimensionsByFieldId = new Map<FieldId, CompiledDimension>();
+    Object.values(sourceExplore.tables).forEach((table) => {
+        Object.values(table.dimensions).forEach((dimension) => {
+            dimensionsByFieldId.set(getItemId(dimension), dimension);
+        });
+    });
+    return dimensionsByFieldId;
+};
+
+const matchRequiredFilterRulesForEntry = ({
+    entry,
+    rules,
+    sourceExplore,
+    dimensionsByFieldId,
+}: {
+    entry: string;
+    rules: ModelRequiredFilterRule[];
+    sourceExplore: Explore;
+    dimensionsByFieldId: Map<FieldId, CompiledDimension>;
+}): RequiredFilterDeferral[] =>
+    rules.flatMap<RequiredFilterDeferral>((rule) => {
+        const targetFieldId = convertFieldRefToFieldId(
+            rule.target.fieldRef,
+            sourceExplore.tables[sourceExplore.baseTable].name,
+        );
+        const targetDimension = dimensionsByFieldId.get(targetFieldId);
+        if (!targetDimension) {
+            return [];
+        }
+
+        // Per-base matching: granularity siblings collapse to base-name
+        // references, so an entry names the base dimension of the rule target.
+        const targetReferences = getDimensionReferences({
+            dimension: targetDimension,
+            baseTable: sourceExplore.baseTable,
+        });
+        return targetReferences.includes(entry)
+            ? [{ entry, rule, targetFieldId, targetDimension }]
+            : [];
+    });
+
+/**
+ * Resolves required_filter_dimensions entries to the required model filter
+ * rules they defer. Lenient by design: entries that do not resolve are skipped,
+ * so the matcher and the materialization payload builder always partition
+ * required filters identically. resolvePreAggregateDef enforces validity at
+ * explore-generation time, before a definition can be persisted or matched.
+ */
+export const resolveRequiredFilterDeferrals = ({
+    sourceExplore,
+    preAggregateDef,
+}: {
+    sourceExplore: Explore;
+    preAggregateDef: PreAggregateDef;
+}): RequiredFilterDeferral[] => {
+    const entries = preAggregateDef.requiredFilterDimensions ?? [];
+    if (entries.length === 0) {
+        return [];
+    }
+
+    const baseTable = sourceExplore.tables[sourceExplore.baseTable];
+    if (!baseTable) {
+        return [];
+    }
+
+    const requiredRules = (baseTable.requiredFilters ?? []).filter(
+        (rule) => rule.required !== false,
+    );
+    if (requiredRules.length === 0) {
+        return [];
+    }
+
+    const dimensionsByFieldId = getDimensionsByFieldId(sourceExplore);
+
+    return entries.flatMap((entry) =>
+        matchRequiredFilterRulesForEntry({
+            entry,
+            rules: requiredRules,
+            sourceExplore,
+            dimensionsByFieldId,
+        }),
+    );
+};
+
+/**
+ * Returns the effective definition for a parsed pre-aggregate: every
+ * required_filter_dimensions entry is validated against the compiled explore,
+ * non-time targets are unioned into the definition's dimensions (so the rollup
+ * read path can re-apply the deferred filter), and time targets are reconciled
+ * against the configured time dimension at strictly equal granularity. The
+ * result is idempotent — resolving an effective definition returns it as-is.
+ * Throws on invalid entries; generatePreAggregateExplores turns the throw into
+ * an explore warning and excludes the definition, so it can never match.
+ */
+export const resolvePreAggregateDef = ({
+    sourceExplore,
+    preAggregateDef,
+}: {
+    sourceExplore: Explore;
+    preAggregateDef: PreAggregateDef;
+}): PreAggregateDef => {
+    const entries = preAggregateDef.requiredFilterDimensions ?? [];
+    if (entries.length === 0) {
+        return preAggregateDef;
+    }
+
+    const baseTable = sourceExplore.tables[sourceExplore.baseTable];
+    if (!baseTable) {
+        throw new ParameterError(
+            `Pre-aggregate "${preAggregateDef.name}" cannot resolve "required_filter_dimensions": base table "${sourceExplore.baseTable}" was not found`,
+        );
+    }
+
+    const dimensionsByFieldId = getDimensionsByFieldId(sourceExplore);
+    const knownDimensionReferences = new Set(
+        Array.from(dimensionsByFieldId.values()).flatMap((dimension) =>
+            getDimensionReferences({
+                dimension,
+                baseTable: sourceExplore.baseTable,
+            }),
+        ),
+    );
+    const deferrals = resolveRequiredFilterDeferrals({
+        sourceExplore,
+        preAggregateDef,
+    });
+
+    const dimensionsToUnion: string[] = [];
+
+    entries.forEach((entry) => {
+        const entryDeferrals = deferrals.filter(
+            (deferral) => deferral.entry === entry,
+        );
+
+        if (entryDeferrals.length === 0) {
+            if (!knownDimensionReferences.has(entry)) {
+                throw new ParameterError(
+                    `Pre-aggregate "${preAggregateDef.name}" references unknown dimension "${entry}" in "required_filter_dimensions"`,
+                );
+            }
+
+            const matchesRequiredFalseRule =
+                matchRequiredFilterRulesForEntry({
+                    entry,
+                    rules: (baseTable.requiredFilters ?? []).filter(
+                        (rule) => rule.required === false,
+                    ),
+                    sourceExplore,
+                    dimensionsByFieldId,
+                }).length > 0;
+            if (matchesRequiredFalseRule) {
+                throw new ParameterError(
+                    `Pre-aggregate "${preAggregateDef.name}" required_filter_dimensions entry "${entry}" targets a filter with "required: false", which is never enforced — there is nothing to defer`,
+                );
+            }
+
+            throw new ParameterError(
+                `Pre-aggregate "${preAggregateDef.name}" required_filter_dimensions entry "${entry}" does not match any required filter on the model`,
+            );
+        }
+
+        entryDeferrals.forEach(({ rule, targetDimension }) => {
+            if (isTimeIntervalFamilyDimension(targetDimension, sourceExplore)) {
+                if (
+                    !preAggregateDef.timeDimension ||
+                    !preAggregateDef.granularity
+                ) {
+                    throw new ParameterError(
+                        `Pre-aggregate "${preAggregateDef.name}" cannot defer the time-based required filter on "${entry}" without "time_dimension" and "granularity"`,
+                    );
+                }
+                if (
+                    getDimensionBaseName(targetDimension) !==
+                    preAggregateDef.timeDimension
+                ) {
+                    throw new ParameterError(
+                        `Pre-aggregate "${preAggregateDef.name}" can only defer time-based required filters on its time dimension "${preAggregateDef.timeDimension}", but "${entry}" targets a different time dimension`,
+                    );
+                }
+                if (targetDimension.timeInterval === undefined) {
+                    throw new ParameterError(
+                        `Pre-aggregate "${preAggregateDef.name}" cannot defer the required filter on "${rule.target.fieldRef}": it targets the raw time dimension. Point the required filter at "${getDimensionBaseName(
+                            targetDimension,
+                        )}_${preAggregateDef.granularity.toLowerCase()}" or align the granularities`,
+                    );
+                }
+                if (
+                    targetDimension.timeInterval !== preAggregateDef.granularity
+                ) {
+                    throw new ParameterError(
+                        `Pre-aggregate "${preAggregateDef.name}" cannot defer the required filter on "${rule.target.fieldRef}": it uses ${targetDimension.timeInterval} granularity but the pre-aggregate materializes ${preAggregateDef.granularity}. Align the granularities to defer it`,
+                    );
+                }
+                return;
+            }
+
+            const targetReferences = getDimensionReferences({
+                dimension: targetDimension,
+                baseTable: sourceExplore.baseTable,
+            });
+            const alreadyDeclared = targetReferences.some(
+                (reference) =>
+                    preAggregateDef.dimensions.includes(reference) ||
+                    dimensionsToUnion.includes(reference),
+            );
+            if (!alreadyDeclared) {
+                dimensionsToUnion.push(entry);
+            }
+        });
+    });
+
+    if (dimensionsToUnion.length === 0) {
+        return preAggregateDef;
+    }
+
+    return {
+        ...preAggregateDef,
+        dimensions: [...preAggregateDef.dimensions, ...dimensionsToUnion],
+    };
+};

--- a/packages/common/src/ee/preAggregates/utils.ts
+++ b/packages/common/src/ee/preAggregates/utils.ts
@@ -17,6 +17,11 @@ export {
 export { getPreAggregateDimensionFilters } from './filters';
 export { applyUserBypass, findMatch } from './matcher';
 export {
+    resolvePreAggregateDef,
+    resolveRequiredFilterDeferrals,
+    type RequiredFilterDeferral,
+} from './resolvePreAggregateDef';
+export {
     getMetricRepresentation,
     isSupportedMetricType,
     supportedMetricTypes,

--- a/packages/common/src/preAggregates/definition.test.ts
+++ b/packages/common/src/preAggregates/definition.test.ts
@@ -196,4 +196,78 @@ describe('parseDbtPreAggregateDef', () => {
             ),
         ).toThrow();
     });
+
+    describe('required_filter_dimensions', () => {
+        it('parses trimmed entries and carries them verbatim', () => {
+            const result = parseDbtPreAggregateDef(
+                {
+                    ...basePreAggregate,
+                    required_filter_dimensions: [' status ', 'order_date'],
+                },
+                'orders',
+            );
+
+            expect(result.requiredFilterDimensions).toStrictEqual([
+                'status',
+                'order_date',
+            ]);
+        });
+
+        it('omits the field when it is not set', () => {
+            const result = parseDbtPreAggregateDef(basePreAggregate, 'orders');
+
+            expect(result).not.toHaveProperty('requiredFilterDimensions');
+        });
+
+        it('throws when set to an empty array', () => {
+            expect(() =>
+                parseDbtPreAggregateDef(
+                    {
+                        ...basePreAggregate,
+                        required_filter_dimensions: [],
+                    },
+                    'orders',
+                ),
+            ).toThrow(
+                new ParseError(
+                    'Pre-aggregate "orders_rollup" in model "orders" must define a non-empty "required_filter_dimensions" array when set',
+                ),
+            );
+        });
+
+        it.each([[[42]], [['']], [['   ']], ['status']])(
+            'throws for invalid value %j',
+            (value) => {
+                expect(() =>
+                    parseDbtPreAggregateDef(
+                        {
+                            ...basePreAggregate,
+                            required_filter_dimensions: value,
+                        },
+                        'orders',
+                    ),
+                ).toThrow(ParseError);
+            },
+        );
+
+        it('throws on duplicate entries', () => {
+            expect(() =>
+                parseDbtPreAggregateDef(
+                    {
+                        ...basePreAggregate,
+                        required_filter_dimensions: [
+                            'status',
+                            'order_date',
+                            ' status',
+                        ],
+                    },
+                    'orders',
+                ),
+            ).toThrow(
+                new ParseError(
+                    'Pre-aggregate "orders_rollup" in model "orders" has duplicate "required_filter_dimensions" entries: status',
+                ),
+            );
+        });
+    });
 });

--- a/packages/common/src/preAggregates/definition.ts
+++ b/packages/common/src/preAggregates/definition.ts
@@ -51,6 +51,40 @@ const parsePreAggregateStringArray = (
     });
 };
 
+const parseRequiredFilterDimensions = (
+    value: unknown,
+    modelName: string,
+    preAggregateName: string,
+): string[] => {
+    if (!Array.isArray(value) || value.length === 0) {
+        throw new ParseError(
+            `Pre-aggregate "${preAggregateName}" in model "${modelName}" must define a non-empty "required_filter_dimensions" array when set`,
+        );
+    }
+
+    const entries = value.map((item) => {
+        if (typeof item !== 'string' || item.trim().length === 0) {
+            throw new ParseError(
+                `Pre-aggregate "${preAggregateName}" in model "${modelName}" has invalid "required_filter_dimensions" value`,
+            );
+        }
+        return item.trim();
+    });
+
+    const duplicateEntries = entries.filter(
+        (entry, index) => entries.indexOf(entry) !== index,
+    );
+    if (duplicateEntries.length > 0) {
+        throw new ParseError(
+            `Pre-aggregate "${preAggregateName}" in model "${modelName}" has duplicate "required_filter_dimensions" entries: ${Array.from(
+                new Set(duplicateEntries),
+            ).join(', ')}`,
+        );
+    }
+
+    return entries;
+};
+
 const parseMaterializationRoleAttributes = (
     value: unknown,
     modelName: string,
@@ -211,11 +245,23 @@ export const parseDbtPreAggregateDef = (
         ? parseFilters(safePreAggregate.filters)
         : undefined;
 
+    // Syntactic validation only; entries are resolved against the compiled
+    // explore by resolvePreAggregateDef at explore-generation time.
+    const requiredFilterDimensions =
+        safePreAggregate?.required_filter_dimensions !== undefined
+            ? parseRequiredFilterDimensions(
+                  safePreAggregate.required_filter_dimensions,
+                  modelName,
+                  name,
+              )
+            : undefined;
+
     return {
         name,
         dimensions,
         metrics,
         ...(filters ? { filters } : {}),
+        ...(requiredFilterDimensions ? { requiredFilterDimensions } : {}),
         ...(timeDimension ? { timeDimension } : {}),
         ...(granularity ? { granularity } : {}),
         ...(maxRows !== undefined ? { maxRows } : {}),

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -882,6 +882,15 @@
                                     "type": "object"
                                 }
                             },
+                            "required_filter_dimensions": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "minItems": 1,
+                                "uniqueItems": true,
+                                "description": "Required (default) model filter targets to keep as query-time filters instead of baking them into the materialization. Each entry names the target dimension of a required model filter; the dimension is added to the rollup grain so the filter is re-applied when reading the rollup. Time-based targets must match the pre-aggregate's time_dimension at exactly the configured granularity."
+                            },
                             "time_dimension": {
                                 "type": "string"
                             },

--- a/packages/common/src/schemas/json/model-as-code-1.0.json
+++ b/packages/common/src/schemas/json/model-as-code-1.0.json
@@ -102,6 +102,15 @@
                                 },
                                 "description": "Static filters applied when materializing the pre-aggregate"
                             },
+                            "required_filter_dimensions": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "minItems": 1,
+                                "uniqueItems": true,
+                                "description": "Required (default) model filter targets to keep as query-time filters instead of baking them into the materialization. Each entry names the target dimension of a required model filter; the dimension is added to the rollup grain so the filter is re-applied when reading the rollup. Time-based targets must match the pre-aggregate's time_dimension at exactly the configured granularity."
+                            },
                             "time_dimension": {
                                 "type": "string"
                             },

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -137,6 +137,7 @@ export type DbtPreAggregateDef = {
     dimensions: string[];
     metrics: string[];
     filters?: Record<string, AnyType>[];
+    required_filter_dimensions?: string[];
     time_dimension?: string;
     granularity?: string;
     max_rows?: number;

--- a/packages/common/src/types/preAggregate.ts
+++ b/packages/common/src/types/preAggregate.ts
@@ -65,6 +65,13 @@ export type PreAggregateDef = {
     dimensions: string[];
     metrics: string[];
     filters?: MetricFilterRule[];
+    /**
+     * Required model filter targets deferred to query time instead of being
+     * baked into the materialization. Resolution unions non-time targets into
+     * `dimensions` (see resolvePreAggregateDef), so the rollup read path can
+     * re-apply the filter; entries are carried verbatim as the deferral marker.
+     */
+    requiredFilterDimensions?: string[];
     // Parser validation enforces that timeDimension and granularity are provided together
     timeDimension?: string;
     granularity?: TimeFrames;


### PR DESCRIPTION
Related: ZAP-769

Adds explicit `required_filter_dimensions` configuration for required model filters that should remain query-time-variable.
Resolves declared targets into the materialized grain, validates strict time-granularity compatibility, and uses rolling-deploy-safe neutral filters so required fallbacks are re-applied when reading the rollup.

Omission preserves existing fallback-specialized materialization behavior. Includes parser, schema, matcher, payload, generation, and mixed-version regression coverage.
