### PR TITLE
fix: validate data app sort selection

### DIFF
--- a/packages/common/src/ee/apps/dataReferenceChecker.test.ts
+++ b/packages/common/src/ee/apps/dataReferenceChecker.test.ts
@@ -148,16 +148,43 @@ describe.each(indexes)('checkDataAppDataReferences (%s)', (_, index) => {
                         'customer_segment',
                         'orders_region', // SDK passes explore-prefixed refs through unchanged
                         'customers.name', // joined table via dot notation
+                        'order_date_month',
                     ],
                     metrics: ['total_revenue'],
                     dimensionFilterFields: ['status'],
                     metricFilterFields: ['customers.customer_count'],
-                    sortFields: ['order_date_month', 'total_revenue'],
+                    sortFields: [
+                        'order_date_month',
+                        'customers.name',
+                        'total_revenue',
+                    ],
                 }),
             ],
             index,
         );
         expect(errors).toEqual([]);
+    });
+
+    it('reports a sort field that is not selected by the query', () => {
+        const errors = checkDataAppDataReferences(
+            [
+                queryRef({
+                    explore: 'orders',
+                    dimensions: ['region'],
+                    sortFields: ['order_date_month'],
+                }),
+            ],
+            index,
+        );
+
+        expect(errors).toEqual([
+            expect.objectContaining({
+                errorType: ValidationErrorType.Sorting,
+                error: "Sort field 'order_date_month' must be included in .dimensions() or .metrics()",
+                modelName: 'orders',
+                fieldName: 'order_date_month',
+            }),
+        ]);
     });
 
     it('reports a missing explore with a close-name suggestion', () => {
@@ -296,6 +323,7 @@ describe.each(indexes)('checkDataAppDataReferences (%s)', (_, index) => {
                 queryRef({
                     explore: 'orders',
                     dimensions: ['customer_segmnet'],
+                    sortFields: ['order_date_month'],
                     unresolved: ['dimensions'],
                 }),
             ],

--- a/packages/common/src/ee/apps/dataReferenceChecker.ts
+++ b/packages/common/src/ee/apps/dataReferenceChecker.ts
@@ -327,6 +327,48 @@ class DataAppReferenceChecker {
         for (const sortField of ref.sortFields) {
             this.checkFieldRef(scope, sortField, 'sort', ref.location);
         }
+        this.checkSortFieldsAreSelected(ref, scope);
+    }
+
+    private checkSortFieldsAreSelected(
+        ref: ExtractedQueryReference,
+        scope: FieldScope,
+    ): void {
+        if (
+            ref.unresolved.includes('dimensions') ||
+            ref.unresolved.includes('metrics')
+        ) {
+            return;
+        }
+
+        const selectedFieldIds = new Set(
+            [...ref.dimensions, ...ref.metrics].map((field) =>
+                qualifyFieldRef(scope.explore, field),
+            ),
+        );
+
+        for (const sortField of ref.sortFields) {
+            const id = qualifyFieldRef(scope.explore, sortField);
+            const isLocalField = DataAppReferenceChecker.isLocalField(
+                scope,
+                sortField,
+                id,
+            );
+            const fieldExists =
+                isLocalField ||
+                scope.fields.dimensionIds.has(id) ||
+                scope.fields.metricIds.has(id);
+
+            if (fieldExists && !isLocalField && !selectedFieldIds.has(id)) {
+                this.errors.push({
+                    errorType: ValidationErrorType.Sorting,
+                    error: `Sort field '${sortField}' must be included in .dimensions() or .metrics()`,
+                    modelName: scope.explore,
+                    fieldName: sortField,
+                    location: ref.location,
+                });
+            }
+        }
     }
 
     private checkFieldRef(


### PR DESCRIPTION
## What changed

- reject statically resolved data-app sort fields that are not selected in the query dimensions or metrics
- preserve partial-analysis behavior when the selected field lists are unresolved
- avoid reporting a second selection error when the sort field itself does not exist

## Why

The Query SDK qualifies sort fields into output aliases, and the backend orders by those aliases. If a field is used in `.sorts()` without also being selected, the generated warehouse query references an alias that does not exist. The semantic-reference validator previously confirmed only that the field existed in the explore, allowing a guaranteed runtime query failure to pass validation.

## Impact

`lightdash apps validate` now reports the invalid sort configuration at the query call site. The shared checker also makes the rule available to other persisted-reference validation consumers.

## Validation

- `pnpm -F common test -- dataReferenceChecker.test.ts` (129 files, 3381 tests passed, 1 skipped)
- `pnpm -F common format`
- `pnpm -F common lint`
- `pnpm -F common typecheck`
- `git diff --check`
- checked the original F1 app source against its downloaded semantic snapshot; it now reports `Sort field 'round' must be included in .dimensions() or .metrics()`