### PR TITLE
fix(data-apps): teach agent to select sort fields

### DIFF
--- a/sandboxes/data-apps/template/skill.md
+++ b/sandboxes/data-apps/template/skill.md
@@ -242,6 +242,8 @@ const bySegment = base.label('Revenue by Segment').dimensions(['customer_segment
 const byRegion = base.label('Revenue by Region').dimensions(['region']);
 ```
 
+**Every field in `.sorts()` must also be selected by the query** — include it in `.dimensions()` or `.metrics()`, or define it as a table calculation. The backend sorts by the selected output alias, so sorting by an unselected field produces an invalid query. A field used only for ordering can stay selected in the query while being omitted from the rendered UI.
+
 **Sharing the explore-name constant:** define it in the component that uses it, or in its own module (e.g. `src/lib/constants.js`). Never export it from a component file that imports its consumers — that circular import evaluates the consumer first, the constant is `undefined` when a module-scope `query(...)` runs, and the app crashes on load.
 
 KPI cards — metrics without dimensions gives a single aggregated row:
@@ -1201,7 +1203,8 @@ The action-menu example above shows typical `drillDown()` usage. For the full AP
 | Guessing field names | API returns opaque errors | Read the dbt YAML first — always |
 | `.metrics()` on a pre-aggregated model | Re-aggregates already-aggregated values → wrong numbers | If `wins` is a dimension in the YAML, use `.dimensions(['wins'])` |
 | `.metrics(['max_cumulative_points'])` instead of `.dimensions(['cumulative_points'])` | Aggregates per-row data into a single value — collapses line charts | Check YAML: is it under `columns[].name` (dimension) or `meta.metrics` (metric)? |
-| Unused dimensions in `.dimensions()` | Changes GROUP BY → wrong numbers | Only include dimensions you render |
+| Unused dimensions in `.dimensions()` | Changes GROUP BY → wrong numbers | Only include dimensions you render or require for sorting; hidden sort fields stay selected but can be omitted from the UI |
+| Sorting by a field that is not selected | The backend orders by a missing output alias → query fails | Include every `.sorts()` field in `.dimensions()` or `.metrics()`, even when you do not render it |
 | Querying hidden fields (`customer_id`) | Leaks internal IDs | Skip fields with `hidden: true` |
 | Calling `createClient()` in app code | Not needed — client is set up in `main.jsx` | `import { query, useLightdash } from '@lightdash/query-sdk'` |
 | Short base field name starts with the explore prefix: `query('custom_roles').metrics(['custom_roles_created'])` | Mistaken for an already-qualified ID → unknown field | Preserve the full ID: `custom_roles_custom_roles_created` |


### PR DESCRIPTION
## What changed

- add an explicit core-skill rule that every `.sorts()` field must be selected by the query
- explain that sort-only fields can remain selected while being omitted from the rendered UI
- correct the existing “unused dimensions” guidance so it no longer conflicts with hidden sort keys
- add the failure mode and fix to the common-pitfalls table

## Why

The data-app agent generated a query that sorted by `round` without including `round` in `.dimensions()`. The Query SDK qualified the field to an output alias, but the alias did not exist in the selected query output, causing the warehouse query to fail at runtime.

The existing skill said to include only dimensions that are rendered. That guidance unintentionally encouraged the mistake when a field was needed solely for ordering.

## Impact

Generated data apps are instructed to select hidden sort keys while keeping them out of the rendered table or chart when appropriate. The same core skill is used by cloud generation and local data-app authoring scaffolding.

<img width="764" height="246" alt="image" src="https://github.com/user-attachments/assets/69ac9dbb-e0e3-41c1-89dc-d4cd1327844b" />


## Validation

- `git diff --check`
- benchmark mock-host changes and benchmark runs intentionally excluded from this PR