### PR TITLE
feat(permissions): add preview-scoped data app scopes for CLI users

### DIFF
--- a/packages/backend/src/ee/models/ExternalConnectionModel.ts
+++ b/packages/backend/src/ee/models/ExternalConnectionModel.ts
@@ -7,6 +7,7 @@ import {
     type ExternalConnection,
     type ExternalConnectionSample,
     type ExternalConnectionSampleRequest,
+    type ProjectType,
     type UpdateExternalConnection,
 } from '@lightdash/common';
 import { type Knex } from 'knex';
@@ -377,6 +378,50 @@ export class ExternalConnectionModel {
                 'organizations.organization_uuid',
             );
         return row?.organization_uuid ?? null;
+    }
+
+    /**
+     * Project fields a `DataApp` CASL subject carries: the org (never trusted
+     * from the caller) plus the preview attributes the `@preview` data app
+     * scopes match on.
+     */
+    async findProjectAbilityContext(projectUuid: string): Promise<
+        | {
+              organizationUuid: string;
+              projectType: ProjectType;
+              projectCreatedByUserUuid: string | null;
+              upstreamProjectUuid: string | null;
+          }
+        | undefined
+    > {
+        const row = await this.database('projects')
+            .innerJoin(
+                'organizations',
+                'organizations.organization_id',
+                'projects.organization_id',
+            )
+            .where('projects.project_uuid', projectUuid)
+            .first<
+                | {
+                      organization_uuid: string;
+                      project_type: ProjectType;
+                      created_by_user_uuid: string | null;
+                      copied_from_project_uuid: string | null;
+                  }
+                | undefined
+            >(
+                'organizations.organization_uuid',
+                'projects.project_type',
+                'projects.created_by_user_uuid',
+                'projects.copied_from_project_uuid',
+            );
+        if (!row) return undefined;
+        return {
+            organizationUuid: row.organization_uuid,
+            projectType: row.project_type,
+            projectCreatedByUserUuid: row.created_by_user_uuid,
+            upstreamProjectUuid: row.copied_from_project_uuid,
+        };
     }
 
     /** Strips the secret — returns the READ shape only. */

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppPreviewScope.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppPreviewScope.test.ts
@@ -1,0 +1,203 @@
+import { Ability, AbilityBuilder } from '@casl/ability';
+import {
+    buildAbilityFromScopes,
+    ForbiddenError,
+    ProjectType,
+    type MemberAbility,
+    type SessionUser,
+} from '@lightdash/common';
+import { AppGenerateService } from './AppGenerateService';
+
+vi.mock('e2b', () => ({
+    Sandbox: class {},
+    CommandExitError: class extends Error {},
+    ALL_TRAFFIC: '*',
+}));
+vi.mock('ai', () => ({
+    generateObject: vi.fn(),
+}));
+
+const ORG_UUID = 'org-1';
+const USER_UUID = 'user-1';
+const PRODUCTION_PROJECT_UUID = 'production-1';
+const OWN_PREVIEW_UUID = 'preview-own';
+const OTHERS_PREVIEW_UUID = 'preview-others';
+
+const PROJECTS = {
+    [PRODUCTION_PROJECT_UUID]: {
+        organizationUuid: ORG_UUID,
+        projectUuid: PRODUCTION_PROJECT_UUID,
+        name: 'Production',
+        type: ProjectType.DEFAULT,
+        createdByUserUuid: USER_UUID,
+        upstreamProjectUuid: undefined,
+    },
+    [OWN_PREVIEW_UUID]: {
+        organizationUuid: ORG_UUID,
+        projectUuid: OWN_PREVIEW_UUID,
+        name: 'Own preview',
+        type: ProjectType.PREVIEW,
+        createdByUserUuid: USER_UUID,
+        upstreamProjectUuid: PRODUCTION_PROJECT_UUID,
+    },
+    [OTHERS_PREVIEW_UUID]: {
+        organizationUuid: ORG_UUID,
+        projectUuid: OTHERS_PREVIEW_UUID,
+        name: "Someone else's preview",
+        type: ProjectType.PREVIEW,
+        createdByUserUuid: 'another-user',
+        upstreamProjectUuid: PRODUCTION_PROJECT_UUID,
+    },
+};
+
+/**
+ * A CLI-style custom role assigned on the production project: it may create
+ * previews and author data apps inside them, but has no production data app
+ * rights.
+ */
+const buildPreviewOnlyUser = (scopes: string[]): SessionUser => {
+    const builder = new AbilityBuilder<MemberAbility>(Ability);
+    buildAbilityFromScopes(
+        {
+            userUuid: USER_UUID,
+            projectUuid: PRODUCTION_PROJECT_UUID,
+            scopes,
+            isEnterprise: true,
+        },
+        builder,
+    );
+    return {
+        userUuid: USER_UUID,
+        organizationUuid: ORG_UUID,
+        ability: builder.build(),
+    } as unknown as SessionUser;
+};
+
+type AssertFn = (
+    user: SessionUser,
+    action: 'view' | 'create' | 'manage',
+    projectUuid: string,
+    errorMessage: string,
+    extraContext?: Record<string, unknown>,
+) => Promise<void>;
+
+const buildAssert = (): AssertFn => {
+    const service = new AppGenerateService({
+        lightdashConfig: {} as never,
+        analytics: {} as never,
+        analyticsModel: {} as never,
+        catalogModel: {} as never,
+        appModel: {} as never,
+        featureFlagModel: {} as never,
+        organizationDesignModel: {} as never,
+        pinnedListModel: {} as never,
+        projectModel: {
+            getSummary: vi
+                .fn()
+                .mockImplementation(async (projectUuid: string) => {
+                    const project =
+                        PROJECTS[projectUuid as keyof typeof PROJECTS];
+                    if (!project) throw new Error('unknown project');
+                    return project;
+                }),
+        } as never,
+        projectParametersModel: {} as never,
+        spaceModel: {} as never,
+        savedChartModel: {} as never,
+        schedulerClient: {} as never,
+        savedChartService: {} as never,
+        spacePermissionService: {} as never,
+        coderService: {} as never,
+        dashboardService: {} as never,
+        projectService: {} as never,
+        promoteService: {} as never,
+        externalConnectionModel: {} as never,
+        sandboxRegistryModel: {} as never,
+        orgAiCopilotConfigResolver: {} as never,
+    });
+    return (
+        service as unknown as { assertDataAppAbility: AssertFn }
+    ).assertDataAppAbility.bind(service);
+};
+
+describe('DataApp preview scopes', () => {
+    const previewOnlyScopes = [
+        'view:Project',
+        'create:Project@preview',
+        'create:DataApp@preview',
+        'manage:DataApp@preview',
+    ];
+
+    it('allows creating and iterating on apps in a preview the user created', async () => {
+        const assertDataAppAbility = buildAssert();
+        const user = buildPreviewOnlyUser(previewOnlyScopes);
+
+        await expect(
+            assertDataAppAbility(user, 'create', OWN_PREVIEW_UUID, 'denied'),
+        ).resolves.toBeUndefined();
+        await expect(
+            assertDataAppAbility(user, 'manage', OWN_PREVIEW_UUID, 'denied', {
+                createdByUserUuid: USER_UUID,
+            }),
+        ).resolves.toBeUndefined();
+    });
+
+    it('refuses uploads to production and to previews created by someone else', async () => {
+        const assertDataAppAbility = buildAssert();
+        const user = buildPreviewOnlyUser(previewOnlyScopes);
+
+        await expect(
+            assertDataAppAbility(
+                user,
+                'create',
+                PRODUCTION_PROJECT_UUID,
+                'denied',
+            ),
+        ).rejects.toThrow(ForbiddenError);
+        await expect(
+            assertDataAppAbility(user, 'create', OTHERS_PREVIEW_UUID, 'denied'),
+        ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('explains that the role is preview-only when it is', async () => {
+        const assertDataAppAbility = buildAssert();
+        const user = buildPreviewOnlyUser(previewOnlyScopes);
+
+        await expect(
+            assertDataAppAbility(
+                user,
+                'create',
+                PRODUCTION_PROJECT_UUID,
+                'Insufficient permissions to create data apps',
+            ),
+        ).rejects.toThrow(/only allows data apps in preview projects/);
+    });
+
+    it('keeps the generic message for roles with no preview-only grant', async () => {
+        const assertDataAppAbility = buildAssert();
+        const user = buildPreviewOnlyUser(['view:Project']);
+
+        await expect(
+            assertDataAppAbility(
+                user,
+                'create',
+                PRODUCTION_PROJECT_UUID,
+                'Insufficient permissions to create data apps',
+            ),
+        ).rejects.toThrow(/^Insufficient permissions to create data apps$/);
+    });
+
+    it('leaves create:DataApp reaching production as before', async () => {
+        const assertDataAppAbility = buildAssert();
+        const user = buildPreviewOnlyUser(['view:Project', 'create:DataApp']);
+
+        await expect(
+            assertDataAppAbility(
+                user,
+                'create',
+                PRODUCTION_PROJECT_UUID,
+                'denied',
+            ),
+        ).resolves.toBeUndefined();
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -11,7 +11,7 @@ import {
     type ObjectIdentifier,
     type S3ClientConfig,
 } from '@aws-sdk/client-s3';
-import { subject } from '@casl/ability';
+import { subject, type Ability } from '@casl/ability';
 import {
     AlreadyExistsError,
     APP_VERSION_CANCELLED_BY_USER,
@@ -40,6 +40,7 @@ import {
     MissingConfigError,
     NotFoundError,
     ParameterError,
+    ProjectType,
     QueryExecutionContext,
     resolveDefaultVisibleDataAppClaudeModel,
     sanitizeAppPackageJsonScripts,
@@ -131,6 +132,7 @@ import {
     type DbAppActivityRow,
     type DbAppVersion,
 } from '../../../database/entities/apps';
+import { type CaslAuditWrapper } from '../../../logging/caslAuditWrapper';
 import { AnalyticsModel } from '../../../models/AnalyticsModel';
 import { AppModel } from '../../../models/AppModel';
 import { CatalogModel } from '../../../models/CatalogModel/CatalogModel';
@@ -176,7 +178,10 @@ import {
     type SandboxHandle,
     type SandboxSpec,
 } from '../SandboxRuntime';
-import { assertCanViewApp as assertUserCanViewApp } from './appAuthz';
+import {
+    assertCanViewApp as assertUserCanViewApp,
+    type DataAppProjectContext,
+} from './appAuthz';
 import {
     buildManifest,
     contentTypeForPath,
@@ -527,41 +532,80 @@ export class AppGenerateService extends BaseService {
     }
 
     /**
-     * Resolve the organization UUID for a project. Used to derive the CASL
-     * subject's `organizationUuid` from the resource (the project itself)
-     * rather than the user — so cross-org access attempts are denied by
-     * CASL instead of relying only on upstream project scoping.
+     * Resolve the project attributes every `DataApp` CASL subject carries:
+     * the organization (derived from the resource, not the user, so a check
+     * is a genuine cross-org guard) plus the preview attributes the
+     * `create:DataApp@preview` / `manage:DataApp@preview` scopes match on.
+     * The project ones are prefixed because plain `createdByUserUuid` on this
+     * subject already means the *app's* creator.
      */
-    private async getProjectOrgUuid(projectUuid: string): Promise<string> {
+    private async getDataAppProjectContext(
+        projectUuid: string,
+    ): Promise<DataAppProjectContext> {
         const summary = await this.projectModel.getSummary(projectUuid);
-        return summary.organizationUuid;
+        return {
+            organizationUuid: summary.organizationUuid,
+            projectUuid,
+            projectType: summary.type,
+            projectCreatedByUserUuid: summary.createdByUserUuid,
+            upstreamProjectUuid: summary.upstreamProjectUuid ?? null,
+        };
+    }
+
+    /**
+     * A role whose only data app grant is preview-scoped
+     * (`create:DataApp@preview` / `manage:DataApp@preview`) targeting a
+     * project it can't reach is the expected misconfiguration for CLI users,
+     * so say that instead of the generic "insufficient permissions". Reads
+     * the rules rather than re-running a check, to avoid a misleading second
+     * audit event on the deny path.
+     */
+    private static isPreviewOnlyDataAppGrant(
+        rules: CaslAuditWrapper<Ability>['rules'],
+    ): boolean {
+        const dataAppRules = rules.filter(
+            (rule) => rule.subject === 'DataApp' && !rule.inverted,
+        );
+        return (
+            dataAppRules.length > 0 &&
+            dataAppRules.every(
+                (rule) =>
+                    (rule.conditions as Record<string, unknown> | undefined)
+                        ?.projectType === ProjectType.PREVIEW,
+            )
+        );
     }
 
     /**
      * Run a CASL check on `DataApp`, throwing `ForbiddenError` if denied.
-     * Callers must pass the resource-derived organizationUuid so that the
-     * check is a genuine cross-org guard, not a tautology on the user's own
-     * org.
      */
-    private assertDataAppAbility(
+    private async assertDataAppAbility(
         user: SessionUser,
         action: 'view' | 'create' | 'manage',
-        organizationUuid: string,
         projectUuid: string,
         errorMessage: string,
         extraContext: Record<string, unknown> = {},
-    ): void {
+    ): Promise<void> {
+        const projectContext = await this.getDataAppProjectContext(projectUuid);
         const auditedAbility = this.createAuditedAbility(user);
         if (
             auditedAbility.cannot(
                 action,
                 subject('DataApp', {
-                    organizationUuid,
-                    projectUuid,
+                    ...projectContext,
                     ...extraContext,
                 }),
             )
         ) {
+            if (
+                AppGenerateService.isPreviewOnlyDataAppGrant(
+                    auditedAbility.rules,
+                )
+            ) {
+                throw new ForbiddenError(
+                    `${errorMessage}. Your role only allows data apps in preview projects you created, and this is not one.`,
+                );
+            }
             throw new ForbiddenError(errorMessage);
         }
     }
@@ -619,6 +663,8 @@ export class AppGenerateService extends BaseService {
                         userUuid,
                         spaceUuid,
                     ),
+                getProjectContext: (projectUuid) =>
+                    this.getDataAppProjectContext(projectUuid),
             },
             user,
             app,
@@ -650,10 +696,9 @@ export class AppGenerateService extends BaseService {
                   app.space_uuid,
               )
             : {};
-        this.assertDataAppAbility(
+        await this.assertDataAppAbility(
             user,
             'manage',
-            app.organization_uuid,
             app.project_uuid,
             errorMessage,
             {
@@ -1455,11 +1500,9 @@ export class AppGenerateService extends BaseService {
                 'Insufficient permissions to upload app files',
             );
         } else {
-            const organizationUuid = await this.getProjectOrgUuid(projectUuid);
-            this.assertDataAppAbility(
+            await this.assertDataAppAbility(
                 user,
                 'create',
-                organizationUuid,
                 projectUuid,
                 'Insufficient permissions to upload app files',
             );
@@ -3626,7 +3669,9 @@ export class AppGenerateService extends BaseService {
             // fail with EPERM. Same reason as in writeCatalogAndPrompt.
             await sandbox.commands.run(
                 'rm -f /tmp/prompt.txt 2>/dev/null; true',
-                { timeoutMs: 10_000 },
+                {
+                    timeoutMs: 10_000,
+                },
             );
             await sandbox.files.write('/tmp/prompt.txt', `${fixPrompt}\n`);
 
@@ -5138,11 +5183,11 @@ export class AppGenerateService extends BaseService {
         fileIds?: string[],
     ): Promise<{ questions: string[] }> {
         await this.assertDataAppsEnabled(user);
-        const organizationUuid = await this.getProjectOrgUuid(projectUuid);
-        this.assertDataAppAbility(
+        const { organizationUuid } =
+            await this.getDataAppProjectContext(projectUuid);
+        await this.assertDataAppAbility(
             user,
             'create',
-            organizationUuid,
             projectUuid,
             'Insufficient permissions to create data apps',
         );
@@ -5463,11 +5508,11 @@ export class AppGenerateService extends BaseService {
         const { creationExperience, designUuidInput, externalConnections } =
             options;
         await this.assertDataAppsEnabled(user);
-        const organizationUuid = await this.getProjectOrgUuid(projectUuid);
-        this.assertDataAppAbility(
+        const { organizationUuid } =
+            await this.getDataAppProjectContext(projectUuid);
+        await this.assertDataAppAbility(
             user,
             'create',
-            organizationUuid,
             projectUuid,
             'Insufficient permissions to create data apps',
         );
@@ -5485,10 +5530,9 @@ export class AppGenerateService extends BaseService {
                     user.userUuid,
                     spaceUuid,
                 );
-            this.assertDataAppAbility(
+            await this.assertDataAppAbility(
                 user,
                 'manage',
-                organizationUuid,
                 projectUuid,
                 'Insufficient permissions to create a data app in this space',
                 spaceContext,
@@ -5712,7 +5756,7 @@ export class AppGenerateService extends BaseService {
         // 403 rather than a model-visibility error. Scoped to the project's
         // organization (not the caller's) to match generateApp.
         const claudeModel = await this.resolveClaudeModel(
-            await this.getProjectOrgUuid(projectUuid),
+            (await this.getDataAppProjectContext(projectUuid)).organizationUuid,
             claudeModelInput,
         );
 
@@ -6615,10 +6659,9 @@ export class AppGenerateService extends BaseService {
 
         // Authoring rights on the upstream project itself — viewers of the
         // preview must not be able to write into production.
-        this.assertDataAppAbility(
+        await this.assertDataAppAbility(
             user,
             'create',
-            upstreamOrganizationUuid,
             upstreamProjectUuid,
             'Insufficient permissions to promote into the upstream project',
         );
@@ -6938,10 +6981,9 @@ export class AppGenerateService extends BaseService {
         // The duplicate lands as a personal app in the same project. We need
         // `create:DataApp` on the project itself — viewers who can read a
         // shared app but can't author new ones must not be able to fork it.
-        this.assertDataAppAbility(
+        await this.assertDataAppAbility(
             user,
             'create',
-            sourceApp.organization_uuid,
             projectUuid,
             'Insufficient permissions to duplicate this data app',
         );
@@ -8197,10 +8239,9 @@ export class AppGenerateService extends BaseService {
             });
         } else {
             await this.assertDataAppsEnabled(user);
-            this.assertDataAppAbility(
+            await this.assertDataAppAbility(
                 user,
                 'manage',
-                app.organization_uuid,
                 projectUuid,
                 'Insufficient permissions to restore data apps',
             );
@@ -8243,10 +8284,9 @@ export class AppGenerateService extends BaseService {
             });
         } else {
             await this.assertDataAppsEnabled(user);
-            this.assertDataAppAbility(
+            await this.assertDataAppAbility(
                 user,
                 'manage',
-                app.organization_uuid,
                 projectUuid,
                 'Insufficient permissions to delete data apps',
             );
@@ -8407,10 +8447,9 @@ export class AppGenerateService extends BaseService {
                     user.userUuid,
                     targetSpaceUuid,
                 );
-            this.assertDataAppAbility(
+            await this.assertDataAppAbility(
                 user,
                 'manage',
-                app.organization_uuid,
                 projectUuid,
                 "You don't have access to the space this data app is being moved to",
                 targetSpaceContext,
@@ -9491,11 +9530,11 @@ export class AppGenerateService extends BaseService {
         designUuid: string | null,
     ): Promise<DataAppContext> {
         await this.assertDataAppsEnabled(user);
-        const organizationUuid = await this.getProjectOrgUuid(projectUuid);
-        this.assertDataAppAbility(
+        const { organizationUuid } =
+            await this.getDataAppProjectContext(projectUuid);
+        await this.assertDataAppAbility(
             user,
             'create',
-            organizationUuid,
             projectUuid,
             'Insufficient permissions to create data apps',
         );
@@ -9772,7 +9811,8 @@ export class AppGenerateService extends BaseService {
             );
         }
 
-        const organizationUuid = await this.getProjectOrgUuid(projectUuid);
+        const { organizationUuid } =
+            await this.getDataAppProjectContext(projectUuid);
 
         // Resolve manifest external-connection links up front so a broken
         // bundle rejects before creating anything.
@@ -10123,10 +10163,9 @@ export class AppGenerateService extends BaseService {
                         user.userUuid,
                         manifestSpaceUuid,
                     );
-                this.assertDataAppAbility(
+                await this.assertDataAppAbility(
                     user,
                     'manage',
-                    organizationUuid,
                     projectUuid,
                     'Insufficient permissions to move this data app into the manifest space',
                     spaceContext,
@@ -10156,10 +10195,9 @@ export class AppGenerateService extends BaseService {
                     : undefined,
             );
         } else {
-            this.assertDataAppAbility(
+            await this.assertDataAppAbility(
                 user,
                 'create',
-                organizationUuid,
                 projectUuid,
                 'Insufficient permissions to create data apps',
             );
@@ -10179,10 +10217,9 @@ export class AppGenerateService extends BaseService {
                         user.userUuid,
                         targetSpaceUuid,
                     );
-                this.assertDataAppAbility(
+                await this.assertDataAppAbility(
                     user,
                     'manage',
-                    organizationUuid,
                     projectUuid,
                     'Insufficient permissions to create a data app in this space',
                     spaceContext,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.upgrade.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.upgrade.test.ts
@@ -1,4 +1,4 @@
-import { ForbiddenError, ParameterError } from '@lightdash/common';
+import { ForbiddenError, ParameterError, ProjectType } from '@lightdash/common';
 import { AppGenerateService } from './AppGenerateService';
 
 vi.mock('e2b', () => ({
@@ -76,7 +76,14 @@ function buildService(opts: { canManage?: boolean } = {}) {
         featureFlagModel: featureFlagModel as never,
         organizationDesignModel: {} as never,
         pinnedListModel: {} as never,
-        projectModel: {} as never,
+        projectModel: {
+            getSummary: vi.fn().mockResolvedValue({
+                organizationUuid: USER_ORG_UUID,
+                projectUuid: PROJECT_UUID,
+                type: ProjectType.DEFAULT,
+                createdByUserUuid: USER_UUID,
+            }),
+        } as never,
         projectParametersModel: {} as never,
         spaceModel: {} as never,
         savedChartModel: {} as never,
@@ -99,6 +106,7 @@ function buildService(opts: { canManage?: boolean } = {}) {
     ).mockReturnValue({
         can: () => canManage,
         cannot: () => !canManage,
+        rules: [],
     });
 
     return { service, appModel, schedulerClient, analytics };

--- a/packages/backend/src/ee/services/AppGenerateService/appAuthz.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/appAuthz.ts
@@ -1,5 +1,9 @@
 import { subject, type Ability } from '@casl/ability';
-import { ForbiddenError, type SessionUser } from '@lightdash/common';
+import {
+    ForbiddenError,
+    type ProjectType,
+    type SessionUser,
+} from '@lightdash/common';
 import { type CaslAuditWrapper } from '../../../logging/caslAuditWrapper';
 
 export type AppViewAuthzApp = {
@@ -9,12 +13,27 @@ export type AppViewAuthzApp = {
     organization_uuid: string;
 };
 
+/**
+ * The project half of a `DataApp` CASL subject. `projectType` /
+ * `projectCreatedByUserUuid` are prefixed because plain `createdByUserUuid`
+ * on this subject already means the app's creator — the preview-scoped rules
+ * (`create:DataApp@preview`, `manage:DataApp@preview`) need the project's.
+ */
+export type DataAppProjectContext = {
+    organizationUuid: string;
+    projectUuid: string;
+    projectType: ProjectType;
+    projectCreatedByUserUuid: string | null;
+    upstreamProjectUuid: string | null;
+};
+
 export type AppViewAuthzDeps = {
     auditedAbility: CaslAuditWrapper<Ability>;
     getSpaceAccessContext: (
         userUuid: string,
         spaceUuid: string,
     ) => Promise<Record<string, unknown>>;
+    getProjectContext: (projectUuid: string) => Promise<DataAppProjectContext>;
 };
 
 async function userCanViewApp(
@@ -22,14 +41,16 @@ async function userCanViewApp(
     user: SessionUser,
     app: AppViewAuthzApp,
 ): Promise<boolean> {
-    const spaceContext = app.space_uuid
-        ? await deps.getSpaceAccessContext(user.userUuid, app.space_uuid)
-        : {};
+    const [spaceContext, projectContext] = await Promise.all([
+        app.space_uuid
+            ? deps.getSpaceAccessContext(user.userUuid, app.space_uuid)
+            : Promise.resolve({}),
+        deps.getProjectContext(app.project_uuid),
+    ]);
     return deps.auditedAbility.can(
         'view',
         subject('DataApp', {
-            organizationUuid: app.organization_uuid,
-            projectUuid: app.project_uuid,
+            ...projectContext,
             ...spaceContext,
             createdByUserUuid: app.created_by_user_uuid,
         }),

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.proxy.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.proxy.test.ts
@@ -1,6 +1,7 @@
 import {
     ForbiddenError,
     ParameterError,
+    ProjectType,
     type ExternalConnection,
     type SessionUser,
 } from '@lightdash/common';
@@ -75,6 +76,12 @@ function buildService(opts: {
         resolveAppAlias: vi.fn().mockResolvedValue(opts.connection),
         getDecryptedSecret: vi.fn().mockResolvedValue(opts.secret ?? null),
         incrementRateCounter: vi.fn().mockResolvedValue(opts.rateCount ?? 1),
+        findProjectAbilityContext: vi.fn().mockResolvedValue({
+            organizationUuid: 'org-1',
+            projectType: ProjectType.DEFAULT,
+            projectCreatedByUserUuid: null,
+            upstreamProjectUuid: null,
+        }),
     };
     const googleTokenProvider = {
         getAccessToken: vi

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
@@ -3,6 +3,7 @@ import {
     MissingConfigError,
     NotFoundError,
     ParameterError,
+    ProjectType,
     type ExternalConnection,
     type ExternalConnectionConfigProposal,
     type ExternalConnectionSample,
@@ -115,6 +116,12 @@ function buildService(opts: {
                 opts.connection !== undefined ? opts.connection : connection,
             ),
         getProjectOrganizationUuid: vi.fn().mockResolvedValue(orgUuid),
+        findProjectAbilityContext: vi.fn().mockResolvedValue({
+            organizationUuid: orgUuid,
+            projectType: ProjectType.DEFAULT,
+            projectCreatedByUserUuid: null,
+            upstreamProjectUuid: null,
+        }),
         list: vi.fn().mockResolvedValue([connection]),
         getDecryptedSecret: vi.fn().mockResolvedValue(opts.secret ?? 's3cr3t'),
         update:

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
@@ -35,7 +35,10 @@ import { generateExternalConnectionConfigProposal } from '../ai/agents/externalC
 import { getModel } from '../ai/models';
 import { type GeneratorModelOptions } from '../ai/models/types';
 import { type OrgAiCopilotConfigResolver } from '../ai/OrgAiCopilotConfigResolver';
-import { assertCanViewApp } from '../AppGenerateService/appAuthz';
+import {
+    assertCanViewApp,
+    type DataAppProjectContext,
+} from '../AppGenerateService/appAuthz';
 import {
     validateExternalConnectionConfig,
     validateServiceAccountKeyfile,
@@ -129,6 +132,24 @@ export class ExternalConnectionService extends BaseService {
     }
 
     /**
+     * Project half of a `DataApp` CASL subject — the org (derived, never
+     * trusted from the caller) plus the preview attributes the `@preview`
+     * data app scopes match on.
+     */
+    private async getDataAppProjectContext(
+        projectUuid: string,
+    ): Promise<DataAppProjectContext> {
+        const context =
+            await this.externalConnectionModel.findProjectAbilityContext(
+                projectUuid,
+            );
+        if (!context) {
+            throw new NotFoundError('Project not found');
+        }
+        return { ...context, projectUuid };
+    }
+
+    /**
      * Loads the app row and asserts the caller can `manage` the DataApp,
      * mirroring AppGenerateService's assertCanManageApp pattern (space
      * context + createdByUserUuid). Returns the app row for downstream use.
@@ -154,14 +175,16 @@ export class ExternalConnectionService extends BaseService {
                   app.space_uuid,
               )
             : {};
+        const projectContext = await this.getDataAppProjectContext(
+            app.project_uuid,
+        );
 
         const ability = this.createAuditedAbility(account);
         if (
             ability.cannot(
                 'manage',
                 subject('DataApp', {
-                    organizationUuid: app.organization_uuid,
-                    projectUuid: app.project_uuid,
+                    ...projectContext,
                     createdByUserUuid: app.created_by_user_uuid,
                     ...spaceContext,
                 }),
@@ -556,6 +579,8 @@ export class ExternalConnectionService extends BaseService {
                         userUuid,
                         spaceUuid,
                     ),
+                getProjectContext: (appProjectUuid) =>
+                    this.getDataAppProjectContext(appProjectUuid),
             },
             user,
             app,

--- a/packages/cli/src/handlers/dbt/apiClient.ts
+++ b/packages/cli/src/handlers/dbt/apiClient.ts
@@ -175,6 +175,14 @@ export const getContentAsCodeUploadPermissions = async (
             },
         ],
     };
+    // A DataApp subject spells the project's type/creator with a `project`
+    // prefix — plain `createdByUserUuid` on this subject means the *app's*
+    // creator — so the `@preview` data app scopes can be evaluated here.
+    const dataAppSubject = subject('DataApp', {
+        ...accessibleResourceSubject,
+        projectType: project.type,
+        projectCreatedByUserUuid: project.createdByUserUuid,
+    });
     const canManageScheduledDeliveries = ability.can(
         'manage',
         subject('ScheduledDeliveries', {
@@ -207,14 +215,8 @@ export const getContentAsCodeUploadPermissions = async (
             (canManageScheduledDeliveries || canCreateScheduledDeliveries) &&
             ability.can('manage', subject('GoogleSheets', { ...baseSubject })),
         dataApps:
-            ability.can(
-                'create',
-                subject('DataApp', { ...accessibleResourceSubject }),
-            ) ||
-            ability.can(
-                'manage',
-                subject('DataApp', { ...accessibleResourceSubject }),
-            ),
+            ability.can('create', dataAppSubject) ||
+            ability.can('manage', dataAppSubject),
         externalConnections: ability.can(
             'manage',
             subject('ExternalConnection', { ...baseSubject }),

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -3328,7 +3328,7 @@ export const uploadHandler = async (
             output.startItem('Data apps');
             GlobalState.log(
                 styles.warning(
-                    `Skipping data apps: create:DataApp or manage:DataApp permission is required. Dashboard tiles will resolve only if their apps already exist in this project.`,
+                    `Skipping data apps: create:DataApp or manage:DataApp permission is required for this project (create:DataApp@preview only covers preview projects you created). Dashboard tiles will resolve only if their apps already exist in this project.`,
                 ),
             );
             output.completeItem('permission denied', 'warning');

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -388,6 +388,20 @@ export const applyOrganizationMemberStaticAbilities: Record<
             type: ProjectType.PREVIEW,
             createdByUserUuid: member.userUuid,
         });
+        // Redundant with the create grant developers inherit from editor, but
+        // kept so the system role mirrors the `create:DataApp@preview` /
+        // `manage:DataApp@preview` scopes a custom role would carry without
+        // production data app rights.
+        can('create', 'DataApp', {
+            organizationUuid: member.organizationUuid,
+            projectType: ProjectType.PREVIEW,
+            projectCreatedByUserUuid: member.userUuid,
+        });
+        can('manage', 'DataApp', {
+            organizationUuid: member.organizationUuid,
+            projectType: ProjectType.PREVIEW,
+            projectCreatedByUserUuid: member.userUuid,
+        });
         can('view', 'JobStatus', {
             organizationUuid: member.organizationUuid,
         });

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -322,6 +322,20 @@ export const projectMemberAbilities: Record<
             type: ProjectType.PREVIEW,
             createdByUserUuid: member.userUuid,
         });
+        // Redundant with the create grant developers inherit from editor, but
+        // kept so the system role mirrors the `create:DataApp@preview` /
+        // `manage:DataApp@preview` scopes a custom role would carry without
+        // production data app rights.
+        can('create', 'DataApp', {
+            projectUuid: member.projectUuid,
+            projectType: ProjectType.PREVIEW,
+            projectCreatedByUserUuid: member.userUuid,
+        });
+        can('manage', 'DataApp', {
+            projectUuid: member.projectUuid,
+            projectType: ProjectType.PREVIEW,
+            projectCreatedByUserUuid: member.userUuid,
+        });
         can('view', 'JobStatus', {
             projectUuid: member.projectUuid,
         });

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -130,6 +130,8 @@ const BASE_ROLE_SCOPES = {
         'manage:SavedChart@self',
         'manage:Space@self',
         'manage:Explore@self',
+        'create:DataApp@preview',
+        'manage:DataApp@preview',
         'view:JobStatus', // All jobs in project
         'view:SourceCode',
         'manage:SourceCode',
@@ -278,6 +280,8 @@ export const getNonEnterpriseScopesForRole = (
         'manage:DataApp',
         'manage:DataApp@space',
         'create:DataApp',
+        'create:DataApp@preview',
+        'manage:DataApp@preview',
         'view:DataApp@self',
         'manage:DataApp@self',
         'view:ExternalConnection',

--- a/packages/common/src/authorization/scopeAbilityBuilder.test.ts
+++ b/packages/common/src/authorization/scopeAbilityBuilder.test.ts
@@ -2903,4 +2903,167 @@ describe('scopeAbilityBuilder', () => {
             expect(ability.rules.length).toBe(0);
         });
     });
+    describe('data app preview scopes', () => {
+        const buildDataAppAbility = (scopes: string[]) => {
+            const builder = new AbilityBuilder<MemberAbility>(Ability);
+            buildAbilityFromScopes({ ...baseContext, scopes }, builder);
+            return builder.build();
+        };
+
+        const ownPreviewFromDirectProject = {
+            organizationUuid: 'org-123',
+            projectUuid: 'project-123',
+            upstreamProjectUuid: 'upstream-project',
+            projectType: ProjectType.PREVIEW,
+            projectCreatedByUserUuid: 'user1',
+        };
+        const ownPreviewFromUpstreamProject = {
+            organizationUuid: 'org-123',
+            projectUuid: 'preview-123',
+            upstreamProjectUuid: 'project-123',
+            projectType: ProjectType.PREVIEW,
+            projectCreatedByUserUuid: 'user1',
+        };
+        const ownProduction = {
+            organizationUuid: 'org-123',
+            projectUuid: 'project-123',
+            upstreamProjectUuid: null,
+            projectType: ProjectType.DEFAULT,
+            projectCreatedByUserUuid: 'user1',
+        };
+        const othersPreview = {
+            organizationUuid: 'org-123',
+            projectUuid: 'preview-123',
+            upstreamProjectUuid: 'project-123',
+            projectType: ProjectType.PREVIEW,
+            projectCreatedByUserUuid: 'another-user',
+        };
+
+        it('create:DataApp@preview only reaches previews the user created', () => {
+            const ability = buildDataAppAbility(['create:DataApp@preview']);
+
+            expect(
+                ability.can(
+                    'create',
+                    subject('DataApp', ownPreviewFromDirectProject),
+                ),
+            ).toBe(true);
+            expect(
+                ability.can(
+                    'create',
+                    subject('DataApp', ownPreviewFromUpstreamProject),
+                ),
+            ).toBe(true);
+
+            expect(
+                ability.can('create', subject('DataApp', ownProduction)),
+            ).toBe(false);
+            expect(
+                ability.can('create', subject('DataApp', othersPreview)),
+            ).toBe(false);
+        });
+
+        it('manage:DataApp@preview lets the user iterate on apps inside their own preview', () => {
+            const ability = buildDataAppAbility(['manage:DataApp@preview']);
+
+            // Personal (spaceless) app uploaded by the CLI — no space access
+            // context, matched by the project-wide own-preview rule.
+            expect(
+                ability.can(
+                    'manage',
+                    subject('DataApp', {
+                        ...ownPreviewFromDirectProject,
+                        createdByUserUuid: 'user1',
+                    }),
+                ),
+            ).toBe(true);
+
+            expect(
+                ability.can(
+                    'manage',
+                    subject('DataApp', {
+                        ...ownProduction,
+                        createdByUserUuid: 'user1',
+                    }),
+                ),
+            ).toBe(false);
+            expect(
+                ability.can(
+                    'manage',
+                    subject('DataApp', {
+                        ...othersPreview,
+                        createdByUserUuid: 'user1',
+                    }),
+                ),
+            ).toBe(false);
+        });
+
+        it('the preview scopes do not grant the production create/manage rules', () => {
+            const ability = buildDataAppAbility([
+                'create:DataApp@preview',
+                'manage:DataApp@preview',
+            ]);
+
+            // A subject with no project preview context (the shape every
+            // production check produces) matches neither rule.
+            expect(
+                ability.can(
+                    'create',
+                    subject('DataApp', {
+                        organizationUuid: 'org-123',
+                        projectUuid: 'project-123',
+                    }),
+                ),
+            ).toBe(false);
+        });
+
+        it('create:DataApp still covers production and previews alike', () => {
+            const ability = buildDataAppAbility(['create:DataApp']);
+
+            expect(
+                ability.can('create', subject('DataApp', ownProduction)),
+            ).toBe(true);
+            expect(
+                ability.can(
+                    'create',
+                    subject('DataApp', ownPreviewFromDirectProject),
+                ),
+            ).toBe(true);
+        });
+
+        it('grants nothing for org-level assignments outside the user own previews', () => {
+            const builder = new AbilityBuilder<MemberAbility>(Ability);
+            buildAbilityFromScopes(
+                {
+                    ...baseContextWithOrg,
+                    scopes: ['create:DataApp@preview'],
+                },
+                builder,
+            );
+            const ability = builder.build();
+
+            expect(
+                ability.can(
+                    'create',
+                    subject('DataApp', {
+                        organizationUuid: 'org-123',
+                        projectUuid: 'preview-123',
+                        projectType: ProjectType.PREVIEW,
+                        projectCreatedByUserUuid: 'user1',
+                    }),
+                ),
+            ).toBe(true);
+            expect(
+                ability.can(
+                    'create',
+                    subject('DataApp', {
+                        organizationUuid: 'org-123',
+                        projectUuid: 'preview-123',
+                        projectType: ProjectType.PREVIEW,
+                        projectCreatedByUserUuid: 'another-user',
+                    }),
+                ),
+            ).toBe(false);
+        });
+    });
 });

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -56,14 +56,36 @@ const isSelfPreview = (context: ScopeContext) =>
         context.projectCreatedByUserUuid === context.userUuid,
     );
 
-const ownPreviewProjectConditions = (context: ScopeContext) => {
+/**
+ * Subject field names the own-preview conditions match the project's type and
+ * creator on. Subjects that already use `createdByUserUuid` for their *own*
+ * creator (DataApp) carry the project's under prefixed keys, so the two
+ * meanings never collide on the same subject.
+ */
+const PROJECT_PREVIEW_FIELDS = {
+    type: 'type',
+    createdByUserUuid: 'createdByUserUuid',
+} as const;
+
+const DATA_APP_PREVIEW_FIELDS = {
+    type: 'projectType',
+    createdByUserUuid: 'projectCreatedByUserUuid',
+} as const;
+
+const ownPreviewProjectConditions = (
+    context: ScopeContext,
+    fields: {
+        type: string;
+        createdByUserUuid: string;
+    } = PROJECT_PREVIEW_FIELDS,
+) => {
     if (context.organizationUuid) {
         return [
             {
                 // Org assignments can reach any preview created by this principal.
                 organizationUuid: context.organizationUuid,
-                createdByUserUuid: context.userUuid || false,
-                type: ProjectType.PREVIEW,
+                [fields.createdByUserUuid]: context.userUuid || false,
+                [fields.type]: ProjectType.PREVIEW,
             },
         ];
     }
@@ -74,17 +96,20 @@ const ownPreviewProjectConditions = (context: ScopeContext) => {
         {
             // Direct preview assignment: the grant is on the preview itself.
             projectUuid: context.projectUuid,
-            createdByUserUuid: context.userUuid,
-            type: ProjectType.PREVIEW,
+            [fields.createdByUserUuid]: context.userUuid,
+            [fields.type]: ProjectType.PREVIEW,
         },
         {
             // Upstream assignment: the grant is on the source project.
             upstreamProjectUuid: context.projectUuid,
-            createdByUserUuid: context.userUuid,
-            type: ProjectType.PREVIEW,
+            [fields.createdByUserUuid]: context.userUuid,
+            [fields.type]: ProjectType.PREVIEW,
         },
     ];
 };
+
+const ownPreviewDataAppConditions = (context: ScopeContext) =>
+    ownPreviewProjectConditions(context, DATA_APP_PREVIEW_FIELDS);
 
 /**
  * Project-wide grant inside the user's own preview. For subjects with no space
@@ -1414,6 +1439,49 @@ const scopes: Scope[] = [
             },
         ],
         getConditions: addDefaultUuidCondition,
+    },
+    {
+        // `@self` is already taken on this subject for "apps the user
+        // created" (anywhere), so the preview-project variant — the one that
+        // mirrors `manage:ContentAsCode@self` / `manage:DeployProject@self` —
+        // is spelled `@preview`, like `create:Project@preview`.
+        name: 'create:DataApp@preview',
+        description: 'Create data apps in preview projects created by the user',
+        isEnterprise: false,
+        group: ScopeGroup.AI,
+        dependencies: [
+            { name: 'view:Project' },
+            { name: 'create:Project@preview' },
+            {
+                name: 'manage:Explore@self',
+                description: 'Run apps that query data in your preview',
+            },
+            {
+                name: 'view:ExternalConnection',
+                description: 'Link external connections while building',
+            },
+            {
+                name: 'manage:DataApp@preview',
+                description: 'Open and iterate on the apps you upload',
+            },
+        ],
+        getConditions: ownPreviewDataAppConditions,
+    },
+    {
+        name: 'manage:DataApp@preview',
+        description:
+            'Edit and delete data apps in preview projects created by the user',
+        isEnterprise: false,
+        group: ScopeGroup.AI,
+        dependencies: [
+            { name: 'view:Project' },
+            { name: 'create:Project@preview' },
+            {
+                name: 'create:DataApp@preview',
+                description: 'Create the apps you iterate on',
+            },
+        ],
+        getConditions: ownPreviewDataAppConditions,
     },
     {
         name: 'view:DataApp@self',


### PR DESCRIPTION
Closes: lightdash/lightdash#26915

### Description:

`create:DataApp` is all-or-nothing per project, so any role that lets someone build a data app in a preview also lets them upload one straight to production. This adds the missing preview-scoped variant, matching the pattern `manage:ContentAsCode@self` / `manage:DeployProject@self` already use.

* **New scopes** `create:DataApp@preview` and `manage:DataApp@preview`, conditioned on the existing own-preview project rules (both the direct-preview and upstream-project assignment shapes). `@self` is already taken on this subject with different semantics (apps the user created, anywhere), hence `@preview` — as with `create:Project@preview`. Both are added because iterating on an already-uploaded app needs `manage`, so the split mirrors the existing `create:DataApp` / `manage:DataApp` vocabulary.
* **The** `DataApp` **ability subject now carries the project's** `type`**, creator and upstream project**, so those conditions can be evaluated. They travel as `projectType` / `projectCreatedByUserUuid` / `upstreamProjectUuid`, prefixed because plain `createdByUserUuid` on this subject already means the *app's* creator (used by `manage:DataApp@self` and the space/creator checks) — the two must not collide. `assertDataAppAbility` resolves them from the project rather than taking a caller-supplied org uuid, so the cross-org guard is unchanged.
* **Clearer refusal**: when a role's only data app grant is preview-scoped and it targets a project it can't reach, the 403 now says so instead of the generic "Insufficient permissions to upload app files". The CLI's pre-flight skip message mentions the preview scope too.
* Both scopes are wired into the developer tier (redundant there, but surfaced so an admin-cloned custom role can drop production data app rights and keep preview authoring) with mirroring rules in the system-role builders. No `scoped_roles` migration needed — these are new scope names, no existing rows change.

The custom roles UI derives from `scopes.ts`, so the new scopes and their dependencies appear automatically.

Not covered here: the in-app UI still gates data app buttons on the production scopes. That matches how every other `@self` preview scope behaves today (the frontend doesn't pass project preview attributes into any subject), so it's left as a separate change.

**Testing:** new scope-condition tests in `scopeAbilityBuilder.test.ts` and a service-level test (`AppGenerateService.dataAppPreviewScope.test.ts`) covering a preview-only role creating/iterating in its own preview, being refused on production and on someone else's preview, and `create:DataApp` continuing to reach production. Ran the `common` authorization suite, the `AppGenerateService` + `ExternalConnectionService` suites, and typecheck/lint/format for `common`, `backend` and `cli`. One pre-existing unrelated failure (`readDesignForDownload` timeout) reproduces on `main`.