### PR TITLE
feat: add storage-aware canonical agent thread reads

### DIFF
--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -12,7 +12,11 @@ import {
     type DataAppModelVisibility,
 } from '@lightdash/common';
 import { Knex } from 'knex';
-import type { AiAgentStorageVersion, AiThreadLineageKind } from './aiAgentV3';
+import type {
+    AiAgentStorageVersion,
+    AiCanonicalContextEntityType,
+    AiThreadLineageKind,
+} from './aiAgentV3';
 
 export const AiThreadTableName = 'ai_thread';
 
@@ -424,6 +428,17 @@ export type AiAgentToolCallErrorTable = Knex.CompositeTableType<
 >;
 
 export const AiAgentToolResultTableName = 'ai_agent_tool_result';
+const AI_AGENT_TOOL_RESULT_ERROR_STATUS = 'error';
+
+export type AiAgentToolResultMetadata = Record<string, unknown>;
+export type AiAgentToolResultErrorMetadata = AiAgentToolResultMetadata & {
+    status: typeof AI_AGENT_TOOL_RESULT_ERROR_STATUS;
+};
+
+export const isAiAgentToolResultError = (
+    metadata: AiAgentToolResultMetadata | null,
+): metadata is AiAgentToolResultErrorMetadata =>
+    metadata?.status === AI_AGENT_TOOL_RESULT_ERROR_STATUS;
 
 export type DbAiAgentToolResult = {
     ai_agent_tool_result_uuid: string;
@@ -431,7 +446,7 @@ export type DbAiAgentToolResult = {
     tool_call_id: string;
     tool_name: string;
     result: string;
-    metadata: object | null;
+    metadata: AiAgentToolResultMetadata | null;
     created_at: Date;
     // TODO add updated_at
 };
@@ -448,21 +463,11 @@ export type AiAgentToolResultTable = Knex.CompositeTableType<
 
 export const AiPromptContextTableName = 'ai_prompt_context';
 
-export type AiPromptContextEntityType =
-    | 'chart'
-    | 'dashboard'
-    | 'thread'
-    | 'file'
-    | 'repository'
-    | 'pull_request'
-    | 'proposed_change'
-    | 'review_finding'
-    | 'preview_environment';
+export type AiPromptContextEntityType = AiCanonicalContextEntityType;
 
-export type DbAiPromptContext = {
+type DbAiPromptContextBase = {
     ai_prompt_context_uuid: string;
     ai_prompt_uuid: string;
-    entity_type: AiPromptContextEntityType;
     // UUID-keyed entities (chart/dashboard/thread) store their uuid here;
     // string-keyed entities (file/repository) leave it null and use entity_ref.
     entity_uuid: string | null;
@@ -471,12 +476,27 @@ export type DbAiPromptContext = {
     entity_ref: string | null;
     pinned_version_uuid: string | null;
     display_name: string | null;
-    runtime_overrides:
-        | AiChartRuntimeOverrides
-        | AiDashboardRuntimeOverrides
-        | null;
     created_at: Date;
 };
+
+export type DbAiPromptContext = DbAiPromptContextBase &
+    (
+        | {
+              entity_type: 'chart';
+              runtime_overrides: AiChartRuntimeOverrides | null;
+          }
+        | {
+              entity_type: 'dashboard';
+              runtime_overrides: AiDashboardRuntimeOverrides | null;
+          }
+        | {
+              entity_type: Exclude<
+                  AiPromptContextEntityType,
+                  'chart' | 'dashboard'
+              >;
+              runtime_overrides: null;
+          }
+    );
 
 export type AiPromptContextTable = Knex.CompositeTableType<
     DbAiPromptContext,

--- a/packages/backend/src/ee/database/entities/aiAgentV3.ts
+++ b/packages/backend/src/ee/database/entities/aiAgentV3.ts
@@ -1,4 +1,8 @@
-import { type AiThreadCreatedFrom } from '@lightdash/common';
+import {
+    type AiChartRuntimeOverrides,
+    type AiDashboardRuntimeOverrides,
+    type AiThreadCreatedFrom,
+} from '@lightdash/common';
 import { type Knex } from 'knex';
 
 export const AiThreadMessageSequenceTableName = 'ai_thread_message_sequence';
@@ -48,6 +52,20 @@ export const AI_MESSAGE_PART_TYPES = [
 ] as const;
 export type AiMessagePartType = (typeof AI_MESSAGE_PART_TYPES)[number];
 export type AiMessagePartTypeOrUnknown = AiMessagePartType | (string & {});
+
+export const AI_CONTEXT_ENTITY_TYPES = [
+    'chart',
+    'dashboard',
+    'thread',
+    'file',
+    'repository',
+    'pull_request',
+    'proposed_change',
+    'review_finding',
+    'preview_environment',
+] as const;
+export type AiCanonicalContextEntityType =
+    (typeof AI_CONTEXT_ENTITY_TYPES)[number];
 
 export const AI_TOOL_PART_STATES = [
     'input-streaming',
@@ -249,7 +267,7 @@ export type AiV3PartWrite =
           artifactVersionUuid?: never;
       });
 
-export type AiV3CanonicalPart = {
+export type AiCanonicalPart = {
     uuid: string;
     type: AiMessagePartTypeOrUnknown;
     payloadVersion: number;
@@ -258,10 +276,71 @@ export type AiV3CanonicalPart = {
     artifactVersionUuid: string | null;
 };
 
-export type AiV3CanonicalMessage = {
+type AiCanonicalContextBase = {
+    uuid: string;
+    entityUuid: string | null;
+    entityRef: string | null;
+    pinnedVersionUuid: string | null;
+    displayName: string | null;
+    createdAt: string;
+};
+
+export type AiCanonicalContext = AiCanonicalContextBase &
+    (
+        | {
+              entityType: 'chart';
+              runtimeOverrides: AiChartRuntimeOverrides | null;
+          }
+        | {
+              entityType: 'dashboard';
+              runtimeOverrides: AiDashboardRuntimeOverrides | null;
+          }
+        | {
+              entityType: Exclude<
+                  AiCanonicalContextEntityType,
+                  'chart' | 'dashboard'
+              >;
+              runtimeOverrides: null;
+          }
+    );
+
+export type AiCanonicalReferencedArtifact = {
+    artifactVersionUuid: string;
+    artifactUuid: string;
+    projectUuid: string;
+    similarityScore: number | null;
+    versionNumber: number;
+    title: string | null;
+    description: string | null;
+    artifactType: string;
+    createdAt: string;
+};
+
+export type AiCanonicalLegacyMetadata =
+    | {
+          type: 'response';
+          vizConfigOutput: unknown;
+          filtersOutput: unknown;
+          metricQuery: unknown;
+          savedQueryUuid: string | null;
+          humanScore: number | null;
+          humanFeedback: string | null;
+          referencedArtifacts: AiCanonicalReferencedArtifact[];
+          interrupts: {
+              createdByUserUuid: string | null;
+              createdAt: string;
+          }[];
+      }
+    | {
+          type: 'steer';
+          consumedAt: string | null;
+          consumedStep: number | null;
+      };
+
+export type AiCanonicalMessage = {
     uuid: string;
     role: AiThreadMessageRole;
-    parts: AiV3CanonicalPart[];
+    parts: AiCanonicalPart[];
     metadata: {
         createdAt: string;
         createdByUserUuid: string | null;
@@ -270,16 +349,22 @@ export type AiV3CanonicalMessage = {
         modelConfig: AiModelConfigEnvelope | null;
         tokenUsage: AiTokenUsageEnvelope | null;
         error: AiRunErrorEnvelope | null;
+        hidden: boolean;
+        context: AiCanonicalContext[];
+        legacy: AiCanonicalLegacyMetadata | null;
     };
 };
 
-export type AiV3CanonicalThread = {
+export type AiCanonicalThread = {
     uuid: string;
-    storageVersion: 3;
+    storageVersion: AiAgentStorageVersion;
     organizationUuid: string;
     projectUuid: string;
     agentUuid: string | null;
     createdAt: string;
+    updatedAt: string | null;
+    createdFrom: AiThreadCreatedFrom;
+    title: string | null;
     lineage: AiV3ThreadLineage;
-    messages: AiV3CanonicalMessage[];
+    messages: AiCanonicalMessage[];
 };

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -34,6 +34,8 @@ import { AiAgentMemoryModel } from './models/AiAgentMemoryModel';
 import { AiAgentModel } from './models/AiAgentModel';
 import { AiAgentReviewClassifierModel } from './models/AiAgentReviewClassifierModel';
 import { AiAgentReviewNotificationModel } from './models/AiAgentReviewNotificationModel';
+import { AiAgentThreadRepository } from './models/AiAgentThreadRepository';
+import { AiAgentV1ReadAdapter } from './models/AiAgentV1ReadAdapter';
 import { AiAgentV3Model } from './models/AiAgentV3Model';
 import { AiDeepResearchRunModel } from './models/AiDeepResearchRunModel';
 import { AiOrganizationSettingsModel } from './models/AiOrganizationSettingsModel';
@@ -1115,6 +1117,12 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     database,
                     lightdashConfig,
                     encryptionUtil: utils.getEncryptionUtil(),
+                }),
+            aiAgentThreadRepository: ({ database, repository }) =>
+                new AiAgentThreadRepository({
+                    database,
+                    v1ReadAdapter: new AiAgentV1ReadAdapter({ database }),
+                    v3Model: repository.getAiAgentV3Model<AiAgentV3Model>(),
                 }),
             aiAgentV3Model: ({ database }) => new AiAgentV3Model({ database }),
             aiAgentMemoryModel: ({ database }) =>

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -6298,7 +6298,7 @@ export class AiAgentModel {
             }
             default:
                 return assertUnreachable(
-                    row.entity_type,
+                    row,
                     `Unknown ai_prompt_context.entity_type`,
                 );
         }

--- a/packages/backend/src/ee/models/AiAgentThreadRepository.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentThreadRepository.integration.test.ts
@@ -1,0 +1,200 @@
+import { SEED_ORG_1, SEED_ORG_1_ADMIN, SEED_PROJECT } from '@lightdash/common';
+import { type Knex } from 'knex';
+import { getTestContext } from '../../vitest.setup.integration';
+import {
+    AiAgentToolCallTableName,
+    AiAgentToolResultTableName,
+    AiPromptContextTableName,
+    AiPromptSteerTableName,
+    AiPromptTableName,
+    AiThreadTableName,
+} from '../database/entities/ai';
+import { AiAgentThreadRepository } from './AiAgentThreadRepository';
+import { AiAgentV1ReadAdapter } from './AiAgentV1ReadAdapter';
+import { AiAgentV3Model } from './AiAgentV3Model';
+
+describe('AiAgentThreadRepository', () => {
+    let database: Knex;
+    let repository: AiAgentThreadRepository;
+    let v3Model: AiAgentV3Model;
+    const threadUuids = new Set<string>();
+
+    beforeAll(() => {
+        database = getTestContext().db;
+        v3Model = new AiAgentV3Model({ database });
+        repository = new AiAgentThreadRepository({
+            database,
+            v1ReadAdapter: new AiAgentV1ReadAdapter({ database }),
+            v3Model,
+        });
+    });
+
+    afterEach(async () => {
+        if (threadUuids.size > 0) {
+            await database(AiThreadTableName)
+                .whereIn('ai_thread_uuid', [...threadUuids])
+                .delete();
+        }
+        threadUuids.clear();
+    });
+
+    it('reads v1 rows through the adapter and v3 rows natively', async () => {
+        const [legacyThread] = await database(AiThreadTableName)
+            .insert({
+                organization_uuid: SEED_ORG_1.organization_uuid,
+                project_uuid: SEED_PROJECT.project_uuid,
+                agent_uuid: null,
+                created_from: 'web_app',
+            })
+            .returning('ai_thread_uuid');
+        threadUuids.add(legacyThread.ai_thread_uuid);
+        const [prompt] = await database(AiPromptTableName)
+            .insert({
+                ai_thread_uuid: legacyThread.ai_thread_uuid,
+                created_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+                prompt: 'What is revenue?',
+            })
+            .returning('ai_prompt_uuid');
+        await database(AiPromptTableName)
+            .where('ai_prompt_uuid', prompt.ai_prompt_uuid)
+            .update({
+                response: 'Revenue is 42',
+                viz_config_output: { type: 'bar' },
+                filters_output: { dimensions: ['orders.status'] },
+                metric_query: { metrics: ['orders.total'] },
+                human_score: 1,
+                human_feedback: 'Useful answer',
+                responded_at: database.fn.now(),
+            });
+        const [context] = await database(AiPromptContextTableName)
+            .insert({
+                ai_prompt_uuid: prompt.ai_prompt_uuid,
+                entity_type: 'chart',
+                entity_uuid: '00000000-0000-4000-8000-000000000001',
+                display_name: 'Revenue chart',
+            })
+            .returning('ai_prompt_context_uuid');
+        await database(AiAgentToolCallTableName).insert({
+            ai_prompt_uuid: prompt.ai_prompt_uuid,
+            tool_call_id: 'revenue-call',
+            tool_name: 'runQuery',
+            tool_args: { metric: 'revenue' },
+            ai_mcp_server_uuid: null,
+            parent_tool_call_id: null,
+        });
+        await database(AiAgentToolResultTableName).insert({
+            ai_prompt_uuid: prompt.ai_prompt_uuid,
+            tool_call_id: 'revenue-call',
+            tool_name: 'runQuery',
+            result: '42',
+            metadata: { status: 'success' },
+        });
+        await database(AiPromptSteerTableName).insert({
+            ai_prompt_uuid: prompt.ai_prompt_uuid,
+            created_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+            message: 'Use gross revenue',
+        });
+
+        const legacyRead = await repository.getThread(
+            legacyThread.ai_thread_uuid,
+        );
+
+        expect(legacyRead).toMatchObject({
+            uuid: legacyThread.ai_thread_uuid,
+            storageVersion: 1,
+            messages: [
+                {
+                    role: 'user',
+                    metadata: {
+                        context: [
+                            {
+                                uuid: context.ai_prompt_context_uuid,
+                                entityType: 'chart',
+                                entityUuid:
+                                    '00000000-0000-4000-8000-000000000001',
+                                displayName: 'Revenue chart',
+                            },
+                        ],
+                    },
+                    parts: [
+                        {
+                            type: 'text',
+                            payload: { text: 'What is revenue?' },
+                        },
+                    ],
+                },
+                {
+                    role: 'assistant',
+                    metadata: {
+                        legacy: {
+                            vizConfigOutput: { type: 'bar' },
+                            filtersOutput: {
+                                dimensions: ['orders.status'],
+                            },
+                            metricQuery: { metrics: ['orders.total'] },
+                            humanScore: 1,
+                            humanFeedback: 'Useful answer',
+                        },
+                    },
+                    parts: [
+                        {
+                            type: 'tool',
+                            toolCallId: 'revenue-call',
+                            payload: {
+                                state: 'output-available',
+                                output: '42',
+                            },
+                        },
+                        {
+                            type: 'text',
+                            payload: { text: 'Revenue is 42' },
+                        },
+                    ],
+                },
+                {
+                    role: 'user',
+                    parts: [
+                        {
+                            type: 'text',
+                            payload: { text: 'Use gross revenue' },
+                        },
+                    ],
+                },
+            ],
+        });
+
+        const v3Thread = await v3Model.createThread({
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            projectUuid: SEED_PROJECT.project_uuid,
+            agentUuid: null,
+            createdFrom: 'web_app',
+            lineage: null,
+        });
+        threadUuids.add(v3Thread.uuid);
+        await v3Model.appendUserMessage({
+            threadUuid: v3Thread.uuid,
+            createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            parts: [
+                {
+                    partIndex: 0,
+                    type: 'text',
+                    payloadVersion: 1,
+                    payload: { text: 'Native v3' },
+                },
+            ],
+        });
+
+        await expect(
+            repository.getThread(v3Thread.uuid),
+        ).resolves.toMatchObject({
+            uuid: v3Thread.uuid,
+            storageVersion: 3,
+            messages: [
+                {
+                    role: 'user',
+                    parts: [{ type: 'text', payload: { text: 'Native v3' } }],
+                },
+            ],
+        });
+    });
+});

--- a/packages/backend/src/ee/models/AiAgentThreadRepository.ts
+++ b/packages/backend/src/ee/models/AiAgentThreadRepository.ts
@@ -1,0 +1,49 @@
+import { assertUnreachable, NotFoundError } from '@lightdash/common';
+import { type Knex } from 'knex';
+import { AiThreadTableName } from '../database/entities/ai';
+import { type AiCanonicalThread } from '../database/entities/aiAgentV3';
+import { AiAgentV1ReadAdapter } from './AiAgentV1ReadAdapter';
+import { AiAgentV3Model } from './AiAgentV3Model';
+
+export class AiAgentThreadRepository {
+    private readonly database: Knex;
+
+    private readonly v1ReadAdapter: AiAgentV1ReadAdapter;
+
+    private readonly v3Model: AiAgentV3Model;
+
+    constructor({
+        database,
+        v1ReadAdapter,
+        v3Model,
+    }: {
+        database: Knex;
+        v1ReadAdapter: AiAgentV1ReadAdapter;
+        v3Model: AiAgentV3Model;
+    }) {
+        this.database = database;
+        this.v1ReadAdapter = v1ReadAdapter;
+        this.v3Model = v3Model;
+    }
+
+    async getThread(threadUuid: string): Promise<AiCanonicalThread> {
+        const thread = await this.database(AiThreadTableName)
+            .where('ai_thread_uuid', threadUuid)
+            .first();
+        if (thread === undefined) {
+            throw new NotFoundError('Thread not found');
+        }
+
+        switch (thread.storage_version) {
+            case 1:
+                return this.v1ReadAdapter.getThread(thread);
+            case 3:
+                return this.v3Model.getThreadFromRow(thread);
+            default:
+                return assertUnreachable(
+                    thread.storage_version,
+                    'Unsupported thread storage version',
+                );
+        }
+    }
+}

--- a/packages/backend/src/ee/models/AiAgentV1ReadAdapter.test.ts
+++ b/packages/backend/src/ee/models/AiAgentV1ReadAdapter.test.ts
@@ -1,0 +1,581 @@
+import { projectV1Thread, type V1ThreadRows } from './AiAgentV1ReadAdapter';
+
+const threadUuid = '00000000-0000-4000-8000-000000000001';
+const promptUuid = '00000000-0000-4000-8000-000000000002';
+
+describe('projectV1Thread', () => {
+    it('projects a legacy turn into deterministic canonical messages', () => {
+        const rows: V1ThreadRows = {
+            thread: {
+                ai_thread_uuid: threadUuid,
+                organization_uuid: '00000000-0000-4000-8000-000000000003',
+                project_uuid: '00000000-0000-4000-8000-000000000004',
+                agent_uuid: null,
+                created_at: new Date('2026-01-01T00:00:00.000Z'),
+                updated_at: new Date('2026-01-01T00:00:09.000Z'),
+                created_from: 'web_app',
+                title: 'Revenue thread',
+                storage_version: 1,
+            },
+            prompts: [
+                {
+                    ai_prompt_uuid: promptUuid,
+                    created_at: new Date('2026-01-01T00:00:01.000Z'),
+                    created_by_user_uuid:
+                        '00000000-0000-4000-8000-000000000005',
+                    prompt: 'Show revenue',
+                    response: 'Revenue is 42',
+                    error_message: null,
+                    responded_at: new Date('2026-01-01T00:00:09.000Z'),
+                    model_config: {
+                        modelName: 'claude-sonnet-4-5',
+                        modelProvider: 'anthropic',
+                    },
+                    token_usage: { totalTokens: 12 },
+                    viz_config_output: { type: 'bar' },
+                    filters_output: { dimensions: ['orders.status'] },
+                    metric_query: { metrics: ['orders.total'] },
+                    saved_query_uuid: '00000000-0000-4000-8000-000000000006',
+                    human_score: 1,
+                    human_feedback: 'Useful answer',
+                    hidden: false,
+                },
+            ],
+            reasonings: [
+                {
+                    ai_agent_reasoning_uuid:
+                        '00000000-0000-4000-8000-000000000012',
+                    ai_prompt_uuid: promptUuid,
+                    reasoning_id: 'reasoning-1',
+                    text: 'I should query orders',
+                    created_at: new Date('2026-01-01T00:00:02.000Z'),
+                },
+            ],
+            toolCalls: [
+                {
+                    ai_agent_tool_call_uuid:
+                        '00000000-0000-4000-8000-000000000011',
+                    ai_prompt_uuid: promptUuid,
+                    tool_call_id: 'call-success',
+                    tool_name: 'runQuery',
+                    tool_args: { metric: 'revenue' },
+                    parent_tool_call_id: null,
+                    ai_mcp_server_uuid: '00000000-0000-4000-8000-000000000007',
+                    created_at: new Date('2026-01-01T00:00:02.000Z'),
+                },
+                {
+                    ai_agent_tool_call_uuid:
+                        '00000000-0000-4000-8000-000000000014',
+                    ai_prompt_uuid: promptUuid,
+                    tool_call_id: 'call-error',
+                    tool_name: 'runSql',
+                    tool_args: { sql: 'bad sql' },
+                    parent_tool_call_id: null,
+                    ai_mcp_server_uuid: null,
+                    created_at: new Date('2026-01-01T00:00:04.000Z'),
+                },
+            ],
+            toolResults: [
+                {
+                    ai_agent_tool_result_uuid:
+                        '00000000-0000-4000-8000-000000000023',
+                    ai_prompt_uuid: promptUuid,
+                    tool_call_id: 'call-success',
+                    tool_name: 'runQuery',
+                    result: '{"rows":[{"revenue":43}]}',
+                    metadata: { status: 'success' },
+                    created_at: new Date('2026-01-01T00:00:03.500Z'),
+                },
+                {
+                    ai_agent_tool_result_uuid:
+                        '00000000-0000-4000-8000-000000000021',
+                    ai_prompt_uuid: promptUuid,
+                    tool_call_id: 'call-success',
+                    tool_name: 'runQuery',
+                    result: '{"rows":[{"revenue":42}]}',
+                    metadata: { status: 'success' },
+                    created_at: new Date('2026-01-01T00:00:03.000Z'),
+                },
+                {
+                    ai_agent_tool_result_uuid:
+                        '00000000-0000-4000-8000-000000000022',
+                    ai_prompt_uuid: promptUuid,
+                    tool_call_id: 'call-error',
+                    tool_name: 'runSql',
+                    result: 'syntax error',
+                    metadata: { status: 'error', errorCode: 'invalid_sql' },
+                    created_at: new Date('2026-01-01T00:00:05.000Z'),
+                },
+                {
+                    ai_agent_tool_result_uuid:
+                        '00000000-0000-4000-8000-000000000024',
+                    ai_prompt_uuid: promptUuid,
+                    tool_call_id: 'orphan-result',
+                    tool_name: 'legacyTool',
+                    result: 'orphan output',
+                    metadata: { status: 'success' },
+                    created_at: new Date('2026-01-01T00:00:05.500Z'),
+                },
+            ],
+            toolCallErrors: [
+                {
+                    ai_agent_tool_call_error_uuid:
+                        '00000000-0000-4000-8000-000000000013',
+                    ai_prompt_uuid: promptUuid,
+                    tool_call_id: 'invalid-call',
+                    tool_name: 'runSql',
+                    error_message: 'Invalid tool input',
+                    raw_args: '{"sql":',
+                    created_at: new Date('2026-01-01T00:00:03.000Z'),
+                },
+            ],
+            steers: [
+                {
+                    ai_prompt_steer_uuid:
+                        '00000000-0000-4000-8000-000000000031',
+                    ai_prompt_uuid: promptUuid,
+                    created_by_user_uuid:
+                        '00000000-0000-4000-8000-000000000005',
+                    message: 'Use gross revenue',
+                    created_at: new Date('2026-01-01T00:00:06.000Z'),
+                    consumed_at: new Date('2026-01-01T00:00:06.500Z'),
+                    consumed_step: 2,
+                },
+            ],
+            interrupts: [],
+            artifacts: [
+                {
+                    ai_artifact_version_uuid:
+                        '00000000-0000-4000-8000-000000000041',
+                    ai_artifact_uuid: '00000000-0000-4000-8000-000000000042',
+                    ai_prompt_uuid: promptUuid,
+                    version_number: 1,
+                    title: 'Revenue chart',
+                    description: null,
+                    artifact_type: 'chart' as const,
+                    created_at: new Date('2026-01-01T00:00:07.000Z'),
+                },
+            ],
+            contexts: [
+                {
+                    ai_prompt_context_uuid:
+                        '00000000-0000-4000-8000-000000000051',
+                    ai_prompt_uuid: promptUuid,
+                    entity_type: 'chart',
+                    entity_uuid: '00000000-0000-4000-8000-000000000052',
+                    entity_ref: null,
+                    pinned_version_uuid: '00000000-0000-4000-8000-000000000053',
+                    display_name: 'Revenue chart',
+                    runtime_overrides: {},
+                    created_at: new Date('2026-01-01T00:00:08.000Z'),
+                },
+            ],
+            referencedArtifacts: [
+                {
+                    ai_prompt_uuid: promptUuid,
+                    ai_artifact_version_uuid:
+                        '00000000-0000-4000-8000-000000000061',
+                    ai_artifact_uuid: '00000000-0000-4000-8000-000000000062',
+                    project_uuid: '00000000-0000-4000-8000-000000000004',
+                    similarity_score: 0.9,
+                    version_number: 2,
+                    title: 'Prior revenue chart',
+                    description: 'Referenced input',
+                    artifact_type: 'chart',
+                    created_at: new Date('2026-01-01T00:00:00.500Z'),
+                },
+            ],
+        };
+
+        const first = projectV1Thread(rows);
+        const second = projectV1Thread({
+            ...rows,
+            toolCalls: [...rows.toolCalls].reverse(),
+            toolResults: [...rows.toolResults].reverse(),
+            toolCallErrors: [...rows.toolCallErrors].reverse(),
+        });
+
+        expect(second).toEqual(first);
+        expect(() =>
+            projectV1Thread({
+                ...rows,
+                thread: { ...rows.thread, storage_version: 3 },
+            }),
+        ).toThrow('Thread is not storage version 1');
+        expect(first).toMatchObject({
+            uuid: threadUuid,
+            storageVersion: 1,
+            createdFrom: 'web_app',
+            title: 'Revenue thread',
+            updatedAt: '2026-01-01T00:00:09.000Z',
+            messages: [
+                {
+                    uuid: promptUuid,
+                    role: 'user',
+                    parts: [
+                        { type: 'text', payload: { text: 'Show revenue' } },
+                    ],
+                    metadata: {
+                        hidden: false,
+                        context: [
+                            {
+                                uuid: '00000000-0000-4000-8000-000000000051',
+                                entityType: 'chart',
+                                entityUuid:
+                                    '00000000-0000-4000-8000-000000000052',
+                                entityRef: null,
+                                pinnedVersionUuid:
+                                    '00000000-0000-4000-8000-000000000053',
+                                displayName: 'Revenue chart',
+                                runtimeOverrides: {},
+                                createdAt: '2026-01-01T00:00:08.000Z',
+                            },
+                        ],
+                    },
+                },
+                {
+                    role: 'assistant',
+                    metadata: {
+                        status: 'completed',
+                        hidden: false,
+                        legacy: {
+                            vizConfigOutput: { type: 'bar' },
+                            filtersOutput: {
+                                dimensions: ['orders.status'],
+                            },
+                            metricQuery: { metrics: ['orders.total'] },
+                            savedQueryUuid:
+                                '00000000-0000-4000-8000-000000000006',
+                            humanScore: 1,
+                            humanFeedback: 'Useful answer',
+                            referencedArtifacts: [
+                                {
+                                    artifactVersionUuid:
+                                        '00000000-0000-4000-8000-000000000061',
+                                    artifactUuid:
+                                        '00000000-0000-4000-8000-000000000062',
+                                    projectUuid:
+                                        '00000000-0000-4000-8000-000000000004',
+                                    similarityScore: 0.9,
+                                    versionNumber: 2,
+                                    title: 'Prior revenue chart',
+                                    description: 'Referenced input',
+                                    artifactType: 'chart',
+                                    createdAt: '2026-01-01T00:00:00.500Z',
+                                },
+                            ],
+                        },
+                    },
+                    parts: [
+                        {
+                            uuid: '00000000-0000-4000-8000-000000000011',
+                            type: 'tool',
+                            toolCallId: 'call-success',
+                            payload: {
+                                state: 'output-available',
+                                toolName: 'runQuery',
+                                input: { metric: 'revenue' },
+                                output: '{"rows":[{"revenue":43}]}',
+                                metadata: { status: 'success' },
+                                mcpServerUuid:
+                                    '00000000-0000-4000-8000-000000000007',
+                                legacyResults: [
+                                    {
+                                        uuid: '00000000-0000-4000-8000-000000000021',
+                                        result: '{"rows":[{"revenue":42}]}',
+                                    },
+                                    {
+                                        uuid: '00000000-0000-4000-8000-000000000023',
+                                        result: '{"rows":[{"revenue":43}]}',
+                                    },
+                                ],
+                            },
+                        },
+                        {
+                            uuid: '00000000-0000-4000-8000-000000000012',
+                            type: 'reasoning',
+                            payload: {
+                                reasoningId: 'reasoning-1',
+                                text: 'I should query orders',
+                            },
+                        },
+                        {
+                            uuid: '00000000-0000-4000-8000-000000000013',
+                            type: 'tool',
+                            toolCallId: 'invalid-call',
+                            payload: {
+                                state: 'output-error',
+                                toolName: 'runSql',
+                                input: '{"sql":',
+                                errorText: 'Invalid tool input',
+                            },
+                        },
+                        {
+                            uuid: '00000000-0000-4000-8000-000000000014',
+                            type: 'tool',
+                            toolCallId: 'call-error',
+                            payload: {
+                                state: 'output-error',
+                                toolName: 'runSql',
+                                input: { sql: 'bad sql' },
+                                errorText: 'syntax error',
+                                metadata: {
+                                    status: 'error',
+                                    errorCode: 'invalid_sql',
+                                },
+                            },
+                        },
+                        {
+                            uuid: '00000000-0000-4000-8000-000000000024',
+                            type: 'tool',
+                            toolCallId: 'orphan-result',
+                            payload: {
+                                state: 'output-available',
+                                toolName: 'legacyTool',
+                                input: null,
+                                output: 'orphan output',
+                                metadata: { status: 'success' },
+                                legacyResultUuid:
+                                    '00000000-0000-4000-8000-000000000024',
+                            },
+                        },
+                        { type: 'text', payload: { text: 'Revenue is 42' } },
+                        {
+                            uuid: '00000000-0000-4000-8000-000000000041',
+                            type: 'artifact',
+                            artifactVersionUuid:
+                                '00000000-0000-4000-8000-000000000041',
+                        },
+                    ],
+                },
+                {
+                    uuid: '00000000-0000-4000-8000-000000000031',
+                    role: 'user',
+                    metadata: {
+                        legacy: {
+                            type: 'steer',
+                            consumedAt: '2026-01-01T00:00:06.500Z',
+                            consumedStep: 2,
+                        },
+                    },
+                    parts: [
+                        {
+                            type: 'text',
+                            payload: { text: 'Use gross revenue' },
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('projects active, failed, canceled, and hidden legacy turns', () => {
+        const activePromptUuid = '00000000-0000-4000-8000-000000000061';
+        const failedPromptUuid = '00000000-0000-4000-8000-000000000062';
+        const canceledPromptUuid = '00000000-0000-4000-8000-000000000063';
+        const hiddenPromptUuid = '00000000-0000-4000-8000-000000000064';
+        const prompt = (
+            uuid: string,
+            createdAt: string,
+            overrides: Record<string, unknown> = {},
+        ) => ({
+            ai_prompt_uuid: uuid,
+            created_at: new Date(createdAt),
+            created_by_user_uuid: '00000000-0000-4000-8000-000000000005',
+            prompt: uuid,
+            response: null,
+            error_message: null,
+            responded_at: null,
+            model_config: null,
+            token_usage: null,
+            viz_config_output: null,
+            filters_output: null,
+            metric_query: null,
+            saved_query_uuid: null,
+            human_score: null,
+            human_feedback: null,
+            hidden: false,
+            ...overrides,
+        });
+        const rows: V1ThreadRows = {
+            thread: {
+                ai_thread_uuid: threadUuid,
+                organization_uuid: '00000000-0000-4000-8000-000000000003',
+                project_uuid: '00000000-0000-4000-8000-000000000004',
+                agent_uuid: null,
+                created_at: new Date('2026-01-01T00:00:00.000Z'),
+                updated_at: null,
+                created_from: 'web_app',
+                title: null,
+                storage_version: 1,
+            },
+            prompts: [
+                prompt(activePromptUuid, '2026-01-01T00:00:01.000Z'),
+                prompt(failedPromptUuid, '2026-01-01T00:00:02.000Z', {
+                    error_message: 'Provider failed',
+                }),
+                prompt(canceledPromptUuid, '2026-01-01T00:00:03.000Z', {
+                    error_message: 'Interrupted provider call',
+                }),
+                prompt(hiddenPromptUuid, '2026-01-01T00:00:04.000Z', {
+                    response: 'Hidden response',
+                    responded_at: new Date('2026-01-01T00:00:05.000Z'),
+                    hidden: true,
+                }),
+            ],
+            reasonings: [],
+            toolCalls: [
+                {
+                    ai_agent_tool_call_uuid:
+                        '00000000-0000-4000-8000-000000000071',
+                    ai_prompt_uuid: activePromptUuid,
+                    tool_call_id: 'unfinished-call',
+                    tool_name: 'runSql',
+                    tool_args: { sql: 'select 1' },
+                    parent_tool_call_id: null,
+                    ai_mcp_server_uuid: null,
+                    created_at: new Date('2026-01-01T00:00:01.250Z'),
+                },
+                {
+                    ai_agent_tool_call_uuid:
+                        '00000000-0000-4000-8000-000000000065',
+                    ai_prompt_uuid: activePromptUuid,
+                    tool_call_id: 'unfinished-call',
+                    tool_name: 'runSql',
+                    tool_args: { sql: 'select 1' },
+                    parent_tool_call_id: null,
+                    ai_mcp_server_uuid: null,
+                    created_at: new Date('2026-01-01T00:00:01.500Z'),
+                },
+            ],
+            toolResults: [],
+            toolCallErrors: [
+                {
+                    ai_agent_tool_call_error_uuid:
+                        '00000000-0000-4000-8000-000000000069',
+                    ai_prompt_uuid: failedPromptUuid,
+                    tool_call_id: 'duplicate-invalid-call',
+                    tool_name: 'runSql',
+                    error_message: 'First invalid call',
+                    raw_args: '{}',
+                    created_at: new Date('2026-01-01T00:00:02.250Z'),
+                },
+                {
+                    ai_agent_tool_call_error_uuid:
+                        '00000000-0000-4000-8000-000000000070',
+                    ai_prompt_uuid: failedPromptUuid,
+                    tool_call_id: 'duplicate-invalid-call',
+                    tool_name: 'runSql',
+                    error_message: 'Second invalid call',
+                    raw_args: '{}',
+                    created_at: new Date('2026-01-01T00:00:02.500Z'),
+                },
+            ],
+            steers: [
+                {
+                    ai_prompt_steer_uuid:
+                        '00000000-0000-4000-8000-000000000066',
+                    ai_prompt_uuid: hiddenPromptUuid,
+                    created_by_user_uuid:
+                        '00000000-0000-4000-8000-000000000005',
+                    message: 'Hidden steer',
+                    created_at: new Date('2026-01-01T00:00:04.500Z'),
+                    consumed_at: null,
+                    consumed_step: null,
+                },
+            ],
+            interrupts: [
+                {
+                    ai_prompt_interrupt_uuid:
+                        '00000000-0000-4000-8000-000000000067',
+                    ai_prompt_uuid: canceledPromptUuid,
+                    created_by_user_uuid:
+                        '00000000-0000-4000-8000-000000000005',
+                    created_at: new Date('2026-01-01T00:00:03.500Z'),
+                },
+                {
+                    ai_prompt_interrupt_uuid:
+                        '00000000-0000-4000-8000-000000000068',
+                    ai_prompt_uuid: canceledPromptUuid,
+                    created_by_user_uuid: null,
+                    created_at: new Date('2026-01-01T00:00:03.750Z'),
+                },
+            ],
+            artifacts: [],
+            contexts: [],
+            referencedArtifacts: [],
+        };
+        const projected = projectV1Thread(rows);
+        const assistantFor = (uuid: string) => {
+            const userIndex = projected.messages.findIndex(
+                (message) => message.uuid === uuid,
+            );
+            return projected.messages[userIndex + 1];
+        };
+
+        expect(assistantFor(activePromptUuid)).toMatchObject({
+            metadata: { status: 'in_progress', error: null },
+            parts: [
+                {
+                    type: 'tool',
+                    payload: {
+                        state: 'input-available',
+                        input: { sql: 'select 1' },
+                    },
+                },
+                {
+                    type: 'tool',
+                    payload: {
+                        state: 'input-available',
+                        input: { sql: 'select 1' },
+                    },
+                },
+            ],
+        });
+        expect(assistantFor(failedPromptUuid)).toMatchObject({
+            metadata: {
+                status: 'error',
+                error: { name: 'legacy_error', message: 'Provider failed' },
+            },
+        });
+        const failedToolCallIds = assistantFor(failedPromptUuid)
+            .parts.filter((part) => part.type === 'tool')
+            .map((part) => part.toolCallId);
+        expect(new Set(failedToolCallIds).size).toBe(failedToolCallIds.length);
+        expect(assistantFor(canceledPromptUuid)).toMatchObject({
+            metadata: {
+                status: 'canceled',
+                error: null,
+                legacy: {
+                    interrupts: [
+                        {
+                            createdByUserUuid:
+                                '00000000-0000-4000-8000-000000000005',
+                            createdAt: '2026-01-01T00:00:03.500Z',
+                        },
+                        {
+                            createdByUserUuid: null,
+                            createdAt: '2026-01-01T00:00:03.750Z',
+                        },
+                    ],
+                },
+            },
+        });
+        expect(assistantFor(hiddenPromptUuid)).toMatchObject({
+            metadata: { hidden: false },
+        });
+        expect(
+            projected.messages.find(
+                (message) =>
+                    message.uuid === '00000000-0000-4000-8000-000000000066',
+            ),
+        ).toMatchObject({ metadata: { hidden: true } });
+        expect(
+            projectV1Thread({
+                ...rows,
+                toolCalls: [...rows.toolCalls].reverse(),
+                toolCallErrors: [...rows.toolCallErrors].reverse(),
+            }),
+        ).toEqual(projected);
+    });
+});

--- a/packages/backend/src/ee/models/AiAgentV1ReadAdapter.ts
+++ b/packages/backend/src/ee/models/AiAgentV1ReadAdapter.ts
@@ -1,0 +1,809 @@
+import { ConflictError } from '@lightdash/common';
+import { type Knex } from 'knex';
+import { v5 as uuidv5 } from 'uuid';
+import {
+    AiAgentReasoningTableName,
+    type DbAiAgentReasoning,
+} from '../../database/entities/aiAgentReasoning';
+import {
+    AiAgentToolCallErrorTableName,
+    AiAgentToolCallTableName,
+    AiAgentToolResultTableName,
+    AiPromptContextTableName,
+    AiPromptInterruptTableName,
+    AiPromptSteerTableName,
+    AiPromptTableName,
+    isAiAgentToolResultError,
+    type DbAiAgentToolCall,
+    type DbAiAgentToolCallError,
+    type DbAiAgentToolResult,
+    type DbAiPrompt,
+    type DbAiPromptContext,
+    type DbAiPromptInterrupt,
+    type DbAiPromptSteer,
+    type DbAiThread,
+} from '../database/entities/ai';
+import {
+    type AiAssistantMessageStatus,
+    type AiCanonicalContext,
+    type AiCanonicalMessage,
+    type AiCanonicalPart,
+    type AiCanonicalThread,
+} from '../database/entities/aiAgentV3';
+import {
+    AiArtifactsTableName,
+    AiArtifactVersionsTableName,
+    AiPromptArtifactReferencesTableName,
+    type DbAiArtifact,
+    type DbAiArtifactVersion,
+    type DbAiPromptArtifactReference,
+} from '../database/entities/aiArtifacts';
+
+const V1_READ_ADAPTER_NAMESPACE = '8858350c-5ca8-4ad6-bfa8-43b4f8d04ad7';
+
+type V1Prompt = Pick<
+    DbAiPrompt,
+    | 'ai_prompt_uuid'
+    | 'created_at'
+    | 'created_by_user_uuid'
+    | 'prompt'
+    | 'response'
+    | 'error_message'
+    | 'responded_at'
+    | 'model_config'
+    | 'token_usage'
+    | 'viz_config_output'
+    | 'filters_output'
+    | 'metric_query'
+    | 'saved_query_uuid'
+    | 'human_score'
+    | 'human_feedback'
+    | 'hidden'
+>;
+
+type V1Artifact = Pick<
+    DbAiArtifactVersion,
+    | 'ai_artifact_version_uuid'
+    | 'ai_artifact_uuid'
+    | 'ai_prompt_uuid'
+    | 'created_at'
+    | 'version_number'
+    | 'title'
+    | 'description'
+> &
+    Pick<DbAiArtifact, 'artifact_type'>;
+
+type V1ReferencedArtifact = Pick<
+    DbAiPromptArtifactReference,
+    | 'ai_prompt_uuid'
+    | 'ai_artifact_version_uuid'
+    | 'project_uuid'
+    | 'similarity_score'
+    | 'created_at'
+> &
+    Pick<
+        DbAiArtifactVersion,
+        'ai_artifact_uuid' | 'version_number' | 'title' | 'description'
+    > &
+    Pick<DbAiArtifact, 'artifact_type'>;
+
+export type V1ThreadRows = {
+    thread: Pick<
+        DbAiThread,
+        | 'ai_thread_uuid'
+        | 'organization_uuid'
+        | 'project_uuid'
+        | 'agent_uuid'
+        | 'created_at'
+        | 'updated_at'
+        | 'created_from'
+        | 'title'
+        | 'storage_version'
+    >;
+    prompts: V1Prompt[];
+    reasonings: DbAiAgentReasoning[];
+    toolCalls: DbAiAgentToolCall[];
+    toolResults: DbAiAgentToolResult[];
+    toolCallErrors: DbAiAgentToolCallError[];
+    steers: Array<
+        Pick<
+            DbAiPromptSteer,
+            | 'ai_prompt_steer_uuid'
+            | 'ai_prompt_uuid'
+            | 'created_by_user_uuid'
+            | 'message'
+            | 'created_at'
+            | 'consumed_at'
+            | 'consumed_step'
+        >
+    >;
+    interrupts: Array<
+        Pick<
+            DbAiPromptInterrupt,
+            | 'ai_prompt_interrupt_uuid'
+            | 'ai_prompt_uuid'
+            | 'created_by_user_uuid'
+            | 'created_at'
+        >
+    >;
+    artifacts: V1Artifact[];
+    contexts: DbAiPromptContext[];
+    referencedArtifacts: V1ReferencedArtifact[];
+};
+
+type V1AssistantRows = Pick<
+    V1ThreadRows,
+    'toolCalls' | 'toolResults' | 'toolCallErrors' | 'reasonings' | 'artifacts'
+>;
+
+type OrderedPart = {
+    createdAt: Date;
+    uuid: string;
+    part: AiCanonicalPart;
+};
+
+const syntheticUuid = (kind: string, sourceUuid: string) =>
+    uuidv5(`${kind}:${sourceUuid}`, V1_READ_ADAPTER_NAMESPACE);
+
+const byDateAndUuid =
+    <T>(getDate: (row: T) => Date, getUuid: (row: T) => string) =>
+    (left: T, right: T) =>
+        getDate(left).getTime() - getDate(right).getTime() ||
+        (getUuid(left) < getUuid(right)
+            ? -1
+            : Number(getUuid(left) > getUuid(right)));
+
+const sortedByDateAndUuid = <T>(
+    rows: T[],
+    getDate: (row: T) => Date,
+    getUuid: (row: T) => string,
+) => [...rows].sort(byDateAndUuid(getDate, getUuid));
+
+const assertV1Storage = (thread: V1ThreadRows['thread']) => {
+    if (thread.storage_version !== 1) {
+        throw new ConflictError('Thread is not storage version 1');
+    }
+};
+
+const groupByPromptUuid = <T extends { ai_prompt_uuid: string | null }>(
+    rows: T[],
+) => {
+    const grouped = new Map<string, T[]>();
+    rows.forEach((row) => {
+        if (row.ai_prompt_uuid === null) return;
+        const promptRows = grouped.get(row.ai_prompt_uuid) ?? [];
+        promptRows.push(row);
+        grouped.set(row.ai_prompt_uuid, promptRows);
+    });
+    return grouped;
+};
+
+const toCanonicalContext = (context: DbAiPromptContext): AiCanonicalContext => {
+    const base = {
+        uuid: context.ai_prompt_context_uuid,
+        entityUuid: context.entity_uuid,
+        entityRef: context.entity_ref,
+        pinnedVersionUuid: context.pinned_version_uuid,
+        displayName: context.display_name,
+        createdAt: context.created_at.toISOString(),
+    };
+    switch (context.entity_type) {
+        case 'chart':
+            return {
+                ...base,
+                entityType: context.entity_type,
+                runtimeOverrides: context.runtime_overrides,
+            };
+        case 'dashboard':
+            return {
+                ...base,
+                entityType: context.entity_type,
+                runtimeOverrides: context.runtime_overrides,
+            };
+        default:
+            return {
+                ...base,
+                entityType: context.entity_type,
+                runtimeOverrides: null,
+            };
+    }
+};
+
+const getPromptStatus = ({
+    prompt,
+    interrupted,
+}: {
+    prompt: V1Prompt;
+    interrupted: boolean;
+}): AiAssistantMessageStatus => {
+    if (interrupted) return 'canceled';
+    if (prompt.error_message !== null) return 'error';
+    if (prompt.response === null || prompt.responded_at === null) {
+        return 'in_progress';
+    }
+    return 'completed';
+};
+
+const canonicalPart = (
+    uuid: string,
+    type: AiCanonicalPart['type'],
+    payload: Record<string, unknown>,
+    attributes: Pick<AiCanonicalPart, 'toolCallId' | 'artifactVersionUuid'> = {
+        toolCallId: null,
+        artifactVersionUuid: null,
+    },
+): AiCanonicalPart => ({
+    uuid,
+    type,
+    payloadVersion: 1,
+    payload,
+    ...attributes,
+});
+
+const baseMetadata = ({
+    createdAt,
+    createdByUserUuid,
+    hidden,
+}: {
+    createdAt: Date;
+    createdByUserUuid: string | null;
+    hidden: boolean;
+}): AiCanonicalMessage['metadata'] => ({
+    createdAt: createdAt.toISOString(),
+    createdByUserUuid,
+    status: null,
+    lastHeartbeatAt: null,
+    modelConfig: null,
+    tokenUsage: null,
+    error: null,
+    hidden,
+    context: [],
+    legacy: null,
+});
+
+const projectAssistantParts = (
+    rows: V1AssistantRows,
+    prompt: V1Prompt,
+    status: AiAssistantMessageStatus,
+): AiCanonicalPart[] => {
+    const sortedResults = sortedByDateAndUuid(
+        rows.toolResults,
+        (result) => result.created_at,
+        (result) => result.ai_agent_tool_result_uuid,
+    );
+    const resultsByCallId = new Map<string, DbAiAgentToolResult[]>();
+    sortedResults.forEach((result) => {
+        const results = resultsByCallId.get(result.tool_call_id) ?? [];
+        results.push(result);
+        resultsByCallId.set(result.tool_call_id, results);
+    });
+    const ordered: OrderedPart[] = [];
+    const sortedToolCalls = sortedByDateAndUuid(
+        rows.toolCalls,
+        (call) => call.created_at,
+        (call) => call.ai_agent_tool_call_uuid,
+    );
+    const persistedToolCallIds = new Set(
+        sortedToolCalls.map((call) => call.tool_call_id),
+    );
+    const claimedToolCallIds = new Set<string>();
+    // Canonical tool call IDs stay unique even when legacy rows collide.
+    const uniqueToolCallId = (toolCallId: string, sourceUuid: string) => {
+        if (!claimedToolCallIds.has(toolCallId)) {
+            claimedToolCallIds.add(toolCallId);
+            return toolCallId;
+        }
+        const uniqueId = syntheticUuid('legacy-tool-call-id', sourceUuid);
+        claimedToolCallIds.add(uniqueId);
+        return uniqueId;
+    };
+    const toLegacyResult = (result: DbAiAgentToolResult) => ({
+        uuid: result.ai_agent_tool_result_uuid,
+        toolName: result.tool_name,
+        result: result.result,
+        metadata: result.metadata,
+        createdAt: result.created_at.toISOString(),
+    });
+
+    sortedToolCalls.forEach((call) => {
+        const results = resultsByCallId.get(call.tool_call_id) ?? [];
+        // The latest row is the terminal view; legacyResults preserves all rows.
+        const result = results.at(-1);
+        const resultIsError = isAiAgentToolResultError(
+            result?.metadata ?? null,
+        );
+        const basePayload = {
+            toolName: call.tool_name,
+            input: call.tool_args,
+            parentToolCallId: call.parent_tool_call_id,
+            mcpServerUuid: call.ai_mcp_server_uuid,
+            legacyResults: results.map(toLegacyResult),
+        };
+        let payload: Record<string, unknown>;
+        if (result === undefined) {
+            payload =
+                status === 'in_progress'
+                    ? {
+                          ...basePayload,
+                          state: 'input-available',
+                      }
+                    : {
+                          ...basePayload,
+                          state: 'output-error',
+                          errorText: 'Tool execution did not complete',
+                      };
+        } else if (resultIsError) {
+            payload = {
+                ...basePayload,
+                state: 'output-error',
+                errorText: result.result,
+                metadata: result.metadata,
+            };
+        } else {
+            payload = {
+                ...basePayload,
+                state: 'output-available',
+                output: result.result,
+                metadata: result.metadata,
+            };
+        }
+        ordered.push({
+            createdAt: call.created_at,
+            uuid: call.ai_agent_tool_call_uuid,
+            part: canonicalPart(call.ai_agent_tool_call_uuid, 'tool', payload, {
+                toolCallId: uniqueToolCallId(
+                    call.tool_call_id,
+                    call.ai_agent_tool_call_uuid,
+                ),
+                artifactVersionUuid: null,
+            }),
+        });
+    });
+
+    sortedResults
+        .filter((result) => !persistedToolCallIds.has(result.tool_call_id))
+        .forEach((result) => {
+            const resultIsError = isAiAgentToolResultError(result.metadata);
+            ordered.push({
+                createdAt: result.created_at,
+                uuid: result.ai_agent_tool_result_uuid,
+                part: canonicalPart(
+                    result.ai_agent_tool_result_uuid,
+                    'tool',
+                    {
+                        state: resultIsError
+                            ? 'output-error'
+                            : 'output-available',
+                        toolName: result.tool_name,
+                        input: null,
+                        ...(resultIsError
+                            ? { errorText: result.result }
+                            : { output: result.result }),
+                        metadata: result.metadata,
+                        legacyResultUuid: result.ai_agent_tool_result_uuid,
+                    },
+                    {
+                        toolCallId: uniqueToolCallId(
+                            result.tool_call_id,
+                            result.ai_agent_tool_result_uuid,
+                        ),
+                        artifactVersionUuid: null,
+                    },
+                ),
+            });
+        });
+
+    rows.reasonings.forEach((reasoning) => {
+        ordered.push({
+            createdAt: reasoning.created_at,
+            uuid: reasoning.ai_agent_reasoning_uuid,
+            part: canonicalPart(
+                reasoning.ai_agent_reasoning_uuid,
+                'reasoning',
+                {
+                    reasoningId: reasoning.reasoning_id,
+                    text: reasoning.text,
+                },
+            ),
+        });
+    });
+
+    sortedByDateAndUuid(
+        rows.toolCallErrors,
+        (error) => error.created_at,
+        (error) => error.ai_agent_tool_call_error_uuid,
+    ).forEach((error) => {
+        ordered.push({
+            createdAt: error.created_at,
+            uuid: error.ai_agent_tool_call_error_uuid,
+            part: canonicalPart(
+                error.ai_agent_tool_call_error_uuid,
+                'tool',
+                {
+                    state: 'output-error',
+                    toolName: error.tool_name,
+                    input: error.raw_args,
+                    errorText: error.error_message,
+                    legacyToolCallId: error.tool_call_id,
+                },
+                {
+                    toolCallId: uniqueToolCallId(
+                        error.tool_call_id,
+                        error.ai_agent_tool_call_error_uuid,
+                    ),
+                    artifactVersionUuid: null,
+                },
+            ),
+        });
+    });
+
+    ordered.sort(
+        byDateAndUuid(
+            (row) => row.createdAt,
+            (row) => row.uuid,
+        ),
+    );
+
+    const parts = ordered.map(({ part }) => part);
+    if (prompt.response !== null) {
+        parts.push(
+            canonicalPart(
+                syntheticUuid('assistant-text', prompt.ai_prompt_uuid),
+                'text',
+                { text: prompt.response },
+            ),
+        );
+    }
+    sortedByDateAndUuid(
+        rows.artifacts,
+        (row) => row.created_at,
+        (row) => row.ai_artifact_version_uuid,
+    ).forEach((artifact) => {
+        parts.push(
+            canonicalPart(
+                artifact.ai_artifact_version_uuid,
+                'artifact',
+                {
+                    artifactUuid: artifact.ai_artifact_uuid,
+                    versionNumber: artifact.version_number,
+                    title: artifact.title,
+                    description: artifact.description,
+                    artifactType: artifact.artifact_type,
+                },
+                {
+                    toolCallId: null,
+                    artifactVersionUuid: artifact.ai_artifact_version_uuid,
+                },
+            ),
+        );
+    });
+    return parts;
+};
+
+export const projectV1Thread = (rows: V1ThreadRows): AiCanonicalThread => {
+    assertV1Storage(rows.thread);
+    const messages: AiCanonicalMessage[] = [];
+    const toolCallsByPromptUuid = groupByPromptUuid(rows.toolCalls);
+    const toolResultsByPromptUuid = groupByPromptUuid(rows.toolResults);
+    const toolCallErrorsByPromptUuid = groupByPromptUuid(rows.toolCallErrors);
+    const reasoningsByPromptUuid = groupByPromptUuid(rows.reasonings);
+    const artifactsByPromptUuid = groupByPromptUuid(rows.artifacts);
+    const contextsByPromptUuid = groupByPromptUuid(rows.contexts);
+    const steersByPromptUuid = groupByPromptUuid(rows.steers);
+    const referencesByPromptUuid = groupByPromptUuid(rows.referencedArtifacts);
+    const interruptsByPromptUuid = groupByPromptUuid(rows.interrupts);
+
+    sortedByDateAndUuid(
+        rows.prompts,
+        (row) => row.created_at,
+        (row) => row.ai_prompt_uuid,
+    ).forEach((prompt) => {
+        messages.push({
+            uuid: prompt.ai_prompt_uuid,
+            role: 'user',
+            parts: [
+                canonicalPart(
+                    syntheticUuid('user-text', prompt.ai_prompt_uuid),
+                    'text',
+                    { text: prompt.prompt },
+                ),
+            ],
+            metadata: {
+                ...baseMetadata({
+                    createdAt: prompt.created_at,
+                    createdByUserUuid: prompt.created_by_user_uuid,
+                    hidden: prompt.hidden,
+                }),
+                context: sortedByDateAndUuid(
+                    contextsByPromptUuid.get(prompt.ai_prompt_uuid) ?? [],
+                    (context) => context.created_at,
+                    (context) => context.ai_prompt_context_uuid,
+                ).map(toCanonicalContext),
+            },
+        });
+
+        const interrupts = sortedByDateAndUuid(
+            interruptsByPromptUuid.get(prompt.ai_prompt_uuid) ?? [],
+            (row) => row.created_at,
+            (row) => row.ai_prompt_interrupt_uuid,
+        );
+        const status = getPromptStatus({
+            prompt,
+            interrupted: interrupts.length > 0,
+        });
+        messages.push({
+            uuid: syntheticUuid('assistant', prompt.ai_prompt_uuid),
+            role: 'assistant',
+            parts: projectAssistantParts(
+                {
+                    toolCalls:
+                        toolCallsByPromptUuid.get(prompt.ai_prompt_uuid) ?? [],
+                    toolResults:
+                        toolResultsByPromptUuid.get(prompt.ai_prompt_uuid) ??
+                        [],
+                    toolCallErrors:
+                        toolCallErrorsByPromptUuid.get(prompt.ai_prompt_uuid) ??
+                        [],
+                    reasonings:
+                        reasoningsByPromptUuid.get(prompt.ai_prompt_uuid) ?? [],
+                    artifacts:
+                        artifactsByPromptUuid.get(prompt.ai_prompt_uuid) ?? [],
+                },
+                prompt,
+                status,
+            ),
+            metadata: {
+                ...baseMetadata({
+                    createdAt: prompt.responded_at ?? prompt.created_at,
+                    createdByUserUuid: null,
+                    hidden: false,
+                }),
+                status,
+                modelConfig: prompt.model_config
+                    ? {
+                          version: 1,
+                          ...prompt.model_config,
+                          reasoning: {
+                              enabled: false,
+                              effort: null,
+                              budgetTokens: null,
+                          },
+                          limits: {
+                              maxSteps: null,
+                              maxOutputTokens: null,
+                          },
+                          sampling: { temperature: null, topP: null },
+                          providerOptions: null,
+                      }
+                    : null,
+                tokenUsage: prompt.token_usage
+                    ? {
+                          version: 1,
+                          inputTokens: null,
+                          outputTokens: null,
+                          totalTokens: prompt.token_usage.totalTokens,
+                          reasoningTokens: null,
+                          cachedInputTokens: null,
+                      }
+                    : null,
+                error:
+                    status === 'error'
+                        ? {
+                              version: 1,
+                              name: 'legacy_error',
+                              message:
+                                  prompt.error_message ?? 'Legacy run failed',
+                              data: null,
+                          }
+                        : null,
+                legacy: {
+                    type: 'response',
+                    vizConfigOutput: prompt.viz_config_output,
+                    filtersOutput: prompt.filters_output,
+                    metricQuery: prompt.metric_query,
+                    savedQueryUuid: prompt.saved_query_uuid,
+                    humanScore: prompt.human_score,
+                    humanFeedback: prompt.human_feedback,
+                    referencedArtifacts: sortedByDateAndUuid(
+                        referencesByPromptUuid.get(prompt.ai_prompt_uuid) ?? [],
+                        (reference) => reference.created_at,
+                        (reference) => reference.ai_artifact_version_uuid,
+                    ).map((reference) => ({
+                        artifactVersionUuid: reference.ai_artifact_version_uuid,
+                        artifactUuid: reference.ai_artifact_uuid,
+                        projectUuid: reference.project_uuid,
+                        similarityScore: reference.similarity_score,
+                        versionNumber: reference.version_number,
+                        title: reference.title,
+                        description: reference.description,
+                        artifactType: reference.artifact_type,
+                        createdAt: reference.created_at.toISOString(),
+                    })),
+                    interrupts: interrupts.map((interrupt) => ({
+                        createdByUserUuid: interrupt.created_by_user_uuid,
+                        createdAt: interrupt.created_at.toISOString(),
+                    })),
+                },
+            },
+        });
+
+        sortedByDateAndUuid(
+            steersByPromptUuid.get(prompt.ai_prompt_uuid) ?? [],
+            (row) => row.created_at,
+            (row) => row.ai_prompt_steer_uuid,
+        ).forEach((steer) => {
+            messages.push({
+                uuid: steer.ai_prompt_steer_uuid,
+                role: 'user',
+                parts: [
+                    canonicalPart(
+                        syntheticUuid('steer-text', steer.ai_prompt_steer_uuid),
+                        'text',
+                        { text: steer.message },
+                    ),
+                ],
+                metadata: {
+                    ...baseMetadata({
+                        createdAt: steer.created_at,
+                        createdByUserUuid: steer.created_by_user_uuid,
+                        hidden: prompt.hidden,
+                    }),
+                    legacy: {
+                        type: 'steer',
+                        consumedAt: steer.consumed_at?.toISOString() ?? null,
+                        consumedStep: steer.consumed_step,
+                    },
+                },
+            });
+        });
+    });
+
+    return {
+        uuid: rows.thread.ai_thread_uuid,
+        storageVersion: 1,
+        organizationUuid: rows.thread.organization_uuid,
+        projectUuid: rows.thread.project_uuid,
+        agentUuid: rows.thread.agent_uuid,
+        createdAt: rows.thread.created_at.toISOString(),
+        updatedAt: rows.thread.updated_at?.toISOString() ?? null,
+        createdFrom: rows.thread.created_from,
+        title: rows.thread.title,
+        lineage: null,
+        messages,
+    };
+};
+
+export class AiAgentV1ReadAdapter {
+    private readonly database: Knex;
+
+    constructor({ database }: { database: Knex }) {
+        this.database = database;
+    }
+
+    async getThread(
+        thread: V1ThreadRows['thread'],
+    ): Promise<AiCanonicalThread> {
+        assertV1Storage(thread);
+        const prompts = await this.database(AiPromptTableName)
+            .where('ai_thread_uuid', thread.ai_thread_uuid)
+            .orderBy([{ column: 'created_at' }, { column: 'ai_prompt_uuid' }]);
+        const promptUuids = prompts.map((prompt) => prompt.ai_prompt_uuid);
+        if (promptUuids.length === 0) {
+            return projectV1Thread({
+                thread,
+                prompts,
+                reasonings: [],
+                toolCalls: [],
+                toolResults: [],
+                toolCallErrors: [],
+                steers: [],
+                interrupts: [],
+                artifacts: [],
+                contexts: [],
+                referencedArtifacts: [],
+            });
+        }
+
+        const [
+            reasonings,
+            toolCalls,
+            toolResults,
+            toolCallErrors,
+            steers,
+            interrupts,
+            contexts,
+            artifacts,
+            referencedArtifacts,
+        ] = await Promise.all([
+            this.database(AiAgentReasoningTableName).whereIn(
+                'ai_prompt_uuid',
+                promptUuids,
+            ),
+            this.database(AiAgentToolCallTableName).whereIn(
+                'ai_prompt_uuid',
+                promptUuids,
+            ),
+            this.database(AiAgentToolResultTableName).whereIn(
+                'ai_prompt_uuid',
+                promptUuids,
+            ),
+            this.database(AiAgentToolCallErrorTableName).whereIn(
+                'ai_prompt_uuid',
+                promptUuids,
+            ),
+            this.database(AiPromptSteerTableName).whereIn(
+                'ai_prompt_uuid',
+                promptUuids,
+            ),
+            this.database(AiPromptInterruptTableName).whereIn(
+                'ai_prompt_uuid',
+                promptUuids,
+            ),
+            this.database(AiPromptContextTableName).whereIn(
+                'ai_prompt_uuid',
+                promptUuids,
+            ),
+            this.database(AiArtifactVersionsTableName)
+                .join(
+                    AiArtifactsTableName,
+                    `${AiArtifactVersionsTableName}.ai_artifact_uuid`,
+                    `${AiArtifactsTableName}.ai_artifact_uuid`,
+                )
+                .whereIn(
+                    `${AiArtifactVersionsTableName}.ai_prompt_uuid`,
+                    promptUuids,
+                )
+                .select<V1Artifact[]>(
+                    `${AiArtifactVersionsTableName}.ai_artifact_version_uuid`,
+                    `${AiArtifactVersionsTableName}.ai_artifact_uuid`,
+                    `${AiArtifactVersionsTableName}.ai_prompt_uuid`,
+                    `${AiArtifactVersionsTableName}.created_at`,
+                    `${AiArtifactVersionsTableName}.version_number`,
+                    `${AiArtifactVersionsTableName}.title`,
+                    `${AiArtifactVersionsTableName}.description`,
+                    `${AiArtifactsTableName}.artifact_type`,
+                ),
+            this.database(AiPromptArtifactReferencesTableName)
+                .join(
+                    AiArtifactVersionsTableName,
+                    `${AiPromptArtifactReferencesTableName}.ai_artifact_version_uuid`,
+                    `${AiArtifactVersionsTableName}.ai_artifact_version_uuid`,
+                )
+                .join(
+                    AiArtifactsTableName,
+                    `${AiArtifactVersionsTableName}.ai_artifact_uuid`,
+                    `${AiArtifactsTableName}.ai_artifact_uuid`,
+                )
+                .whereIn(
+                    `${AiPromptArtifactReferencesTableName}.ai_prompt_uuid`,
+                    promptUuids,
+                )
+                .select<V1ReferencedArtifact[]>({
+                    ai_prompt_uuid: `${AiPromptArtifactReferencesTableName}.ai_prompt_uuid`,
+                    ai_artifact_version_uuid: `${AiPromptArtifactReferencesTableName}.ai_artifact_version_uuid`,
+                    project_uuid: `${AiPromptArtifactReferencesTableName}.project_uuid`,
+                    similarity_score: `${AiPromptArtifactReferencesTableName}.similarity_score`,
+                    created_at: `${AiPromptArtifactReferencesTableName}.created_at`,
+                    ai_artifact_uuid: `${AiArtifactVersionsTableName}.ai_artifact_uuid`,
+                    version_number: `${AiArtifactVersionsTableName}.version_number`,
+                    title: `${AiArtifactVersionsTableName}.title`,
+                    description: `${AiArtifactVersionsTableName}.description`,
+                    artifact_type: `${AiArtifactsTableName}.artifact_type`,
+                }),
+        ]);
+
+        return projectV1Thread({
+            thread,
+            prompts,
+            reasonings,
+            toolCalls,
+            toolResults,
+            toolCallErrors,
+            steers,
+            interrupts,
+            artifacts,
+            contexts,
+            referencedArtifacts,
+        });
+    }
+}

--- a/packages/backend/src/ee/models/AiAgentV3Model.ts
+++ b/packages/backend/src/ee/models/AiAgentV3Model.ts
@@ -17,11 +17,11 @@ import {
     MODEL_VISIBLE_AI_MESSAGE_PART_TYPES,
     NON_USER_AI_MESSAGE_PART_TYPES,
     type AiAssistantMessageTerminalStatus,
+    type AiCanonicalPart,
+    type AiCanonicalThread,
     type AiModelConfigEnvelope,
     type AiRunErrorEnvelope,
     type AiTokenUsageEnvelope,
-    type AiV3CanonicalPart,
-    type AiV3CanonicalThread,
     type AiV3PartWrite,
     type AiV3ThreadLineage,
     type CreateAiV3Thread,
@@ -178,7 +178,7 @@ export class AiAgentV3Model {
         trx: Knex.Transaction,
         messageUuid: string,
         parts: AiV3PartWrite[],
-    ): Promise<AiV3CanonicalPart[]> {
+    ): Promise<AiCanonicalPart[]> {
         if (parts.length === 0) return [];
         const rows = await trx(AiMessagePartTableName)
             .insert(
@@ -196,7 +196,7 @@ export class AiAgentV3Model {
         return rows.map(AiAgentV3Model.toCanonicalPart);
     }
 
-    private static toCanonicalPart(part: DbAiMessagePart): AiV3CanonicalPart {
+    private static toCanonicalPart(part: DbAiMessagePart): AiCanonicalPart {
         return {
             uuid: part.ai_message_part_uuid,
             type: part.type,
@@ -460,7 +460,7 @@ export class AiAgentV3Model {
     }: {
         messageUuid: string;
         parts: AiV3PartWrite[];
-    }): Promise<AiV3CanonicalPart[]> {
+    }): Promise<AiCanonicalPart[]> {
         AiAgentV3Model.assertPartWrites(parts, 'assistant');
         return this.database.transaction(async (trx) => {
             await AiAgentV3Model.getWritableAssistantMessage(trx, messageUuid);
@@ -478,7 +478,7 @@ export class AiAgentV3Model {
         partUuid: string;
         payloadVersion: number;
         payload: Record<string, unknown>;
-    }): Promise<AiV3CanonicalPart> {
+    }): Promise<AiCanonicalPart> {
         return this.database.transaction(async (trx) => {
             await AiAgentV3Model.getWritableAssistantMessage(trx, messageUuid);
             const [part] = await trx(AiMessagePartTableName)
@@ -555,19 +555,23 @@ export class AiAgentV3Model {
         });
     }
 
-    async getThread(threadUuid: string): Promise<AiV3CanonicalThread> {
+    async getThread(threadUuid: string): Promise<AiCanonicalThread> {
         const thread = await this.database(AiThreadTableName)
             .where('ai_thread_uuid', threadUuid)
             .first();
         if (thread === undefined) {
             throw new NotFoundError('Thread not found');
         }
+        return this.getThreadFromRow(thread);
+    }
+
+    async getThreadFromRow(thread: DbAiThread): Promise<AiCanonicalThread> {
         if (thread.storage_version !== 3) {
             throw new ConflictError('Thread is not storage version 3');
         }
 
         const messages = await this.database(AiThreadMessageTableName)
-            .where('ai_thread_uuid', threadUuid)
+            .where('ai_thread_uuid', thread.ai_thread_uuid)
             .orderBy('thread_seq');
         const messageUuids = messages.map(
             (message) => message.ai_thread_message_uuid,
@@ -581,7 +585,7 @@ export class AiAgentV3Model {
                           { column: 'ai_thread_message_uuid' },
                           { column: 'part_index' },
                       ]);
-        const partsByMessageUuid = new Map<string, AiV3CanonicalPart[]>();
+        const partsByMessageUuid = new Map<string, AiCanonicalPart[]>();
         parts.forEach((part) => {
             const messageParts =
                 partsByMessageUuid.get(part.ai_thread_message_uuid) ?? [];
@@ -596,6 +600,9 @@ export class AiAgentV3Model {
             projectUuid: thread.project_uuid,
             agentUuid: thread.agent_uuid,
             createdAt: thread.created_at.toISOString(),
+            updatedAt: thread.updated_at?.toISOString() ?? null,
+            createdFrom: thread.created_from,
+            title: thread.title,
             lineage: AiAgentV3Model.toLineage(thread),
             messages: messages.map((message) => ({
                 uuid: message.ai_thread_message_uuid,
@@ -612,6 +619,9 @@ export class AiAgentV3Model {
                     modelConfig: message.model_config,
                     tokenUsage: message.token_usage,
                     error: message.error,
+                    hidden: false,
+                    context: [],
+                    legacy: null,
                 },
             })),
         };

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -152,6 +152,7 @@ export type ModelManifest = {
     /** An implementation signature for these models are not available at this stage */
     aiAgentMemoryModel: unknown;
     aiAgentModel: unknown;
+    aiAgentThreadRepository: unknown;
     aiAgentV3Model: unknown;
     homepageRecommendedActionSkipsModel: unknown;
     projectHomepageModel: unknown;
@@ -822,6 +823,10 @@ export class ModelRepository
 
     public getAiAgentModel<ModelImplT>(): ModelImplT {
         return this.getModel('aiAgentModel');
+    }
+
+    public getAiAgentThreadRepository<ModelImplT>(): ModelImplT {
+        return this.getModel('aiAgentThreadRepository');
     }
 
     public getAiAgentV3Model<ModelImplT>(): ModelImplT {

--- a/packages/common/src/ee/AiAgent/groupIntoTurns.test.ts
+++ b/packages/common/src/ee/AiAgent/groupIntoTurns.test.ts
@@ -1,0 +1,100 @@
+import { groupIntoTurns, type TurnGroupingMessage } from './groupIntoTurns';
+
+type Message = TurnGroupingMessage & { uuid: string };
+
+const message = (
+    uuid: string,
+    role: Message['role'],
+    hidden = false,
+): Message => ({ uuid, role, metadata: { hidden } });
+
+describe('groupIntoTurns', () => {
+    it('attaches steers and omits hidden assistant turns', () => {
+        const firstUser = message('first-user', 'user');
+        const firstAssistant = message('first-assistant', 'assistant');
+        const firstSteer = message('first-steer', 'user');
+        const secondSteer = message('second-steer', 'user');
+        const hiddenUser = message('hidden-user', 'user', true);
+        const hiddenAssistant = message('hidden-assistant', 'assistant', true);
+        const secondUser = message('second-user', 'user');
+        const secondAssistant = message('second-assistant', 'assistant');
+
+        expect(
+            groupIntoTurns([
+                firstUser,
+                firstAssistant,
+                firstSteer,
+                secondSteer,
+                hiddenUser,
+                hiddenAssistant,
+                secondUser,
+                secondAssistant,
+            ]),
+        ).toEqual([
+            {
+                userMessage: firstUser,
+                assistantMessage: firstAssistant,
+                steerMessages: [firstSteer, secondSteer],
+            },
+            {
+                userMessage: secondUser,
+                assistantMessage: secondAssistant,
+                steerMessages: [],
+            },
+        ]);
+    });
+
+    it('keeps a visible assistant reply when its user message is hidden', () => {
+        const hiddenUser = message('hidden-user', 'user', true);
+        const assistant = message('assistant', 'assistant');
+
+        expect(groupIntoTurns([hiddenUser, assistant])).toEqual([
+            {
+                userMessage: hiddenUser,
+                assistantMessage: assistant,
+                steerMessages: [],
+            },
+        ]);
+    });
+
+    it('attaches trailing user messages to the active turn', () => {
+        const firstUser = message('first-user', 'user');
+        const activeAssistant = message('active-assistant', 'assistant');
+        const activeSteer = message('active-steer', 'user');
+
+        expect(
+            groupIntoTurns([firstUser, activeAssistant, activeSteer]),
+        ).toEqual([
+            {
+                userMessage: firstUser,
+                assistantMessage: activeAssistant,
+                steerMessages: [activeSteer],
+            },
+        ]);
+    });
+
+    it('preserves initial user messages before the answered turn', () => {
+        const contextMessage = message('context', 'user');
+        const userMessage = message('user', 'user');
+        const assistantMessage = message('assistant', 'assistant');
+
+        expect(
+            groupIntoTurns([contextMessage, userMessage, assistantMessage]),
+        ).toEqual([
+            {
+                userMessage: contextMessage,
+                assistantMessage: null,
+                steerMessages: [],
+            },
+            {
+                userMessage,
+                assistantMessage,
+                steerMessages: [],
+            },
+        ]);
+    });
+
+    it('ignores assistant messages without a preceding user message', () => {
+        expect(groupIntoTurns([message('assistant', 'assistant')])).toEqual([]);
+    });
+});

--- a/packages/common/src/ee/AiAgent/groupIntoTurns.ts
+++ b/packages/common/src/ee/AiAgent/groupIntoTurns.ts
@@ -1,0 +1,96 @@
+import assertUnreachable from '../../utils/assertUnreachable';
+
+export type TurnGroupingMessage = {
+    role: 'user' | 'assistant' | 'compaction';
+    metadata: { hidden: boolean };
+};
+
+type UserMessage<T extends TurnGroupingMessage> = T & { role: 'user' };
+type AssistantMessage<T extends TurnGroupingMessage> = T & {
+    role: 'assistant';
+};
+
+const isUserMessage = <T extends TurnGroupingMessage>(
+    message: T,
+): message is UserMessage<T> => message.role === 'user';
+
+const isAssistantMessage = <T extends TurnGroupingMessage>(
+    message: T,
+): message is AssistantMessage<T> => message.role === 'assistant';
+
+export type AiTurnGroup<T extends TurnGroupingMessage> = {
+    userMessage: UserMessage<T>;
+    assistantMessage: AssistantMessage<T> | null;
+    steerMessages: UserMessage<T>[];
+};
+
+const appendPendingUserTurns = <T extends TurnGroupingMessage>(
+    turns: AiTurnGroup<T>[],
+    pendingUsers: UserMessage<T>[],
+) => {
+    pendingUsers.forEach((userMessage) => {
+        turns.push({
+            userMessage,
+            assistantMessage: null,
+            steerMessages: [],
+        });
+    });
+};
+
+export const groupIntoTurns = <T extends TurnGroupingMessage>(
+    messages: T[],
+): AiTurnGroup<T>[] => {
+    const turns: AiTurnGroup<T>[] = [];
+    let pendingUsers: UserMessage<T>[] = [];
+
+    messages.forEach((message) => {
+        switch (message.role) {
+            case 'compaction':
+                return;
+            case 'user':
+                if (isUserMessage(message)) pendingUsers.push(message);
+                return;
+            case 'assistant': {
+                if (!isAssistantMessage(message)) return;
+                // Earlier pending users are steers for the previous active turn.
+                const userMessage = pendingUsers.pop();
+                if (userMessage === undefined) return;
+                const previousTurn = turns.at(-1);
+                if (previousTurn !== undefined) {
+                    previousTurn.steerMessages.push(...pendingUsers);
+                } else {
+                    appendPendingUserTurns(turns, pendingUsers);
+                }
+                turns.push({
+                    userMessage,
+                    assistantMessage: message,
+                    steerMessages: [],
+                });
+                pendingUsers = [];
+                return;
+            }
+            default:
+                assertUnreachable(message.role, 'Unknown message role');
+        }
+    });
+
+    const lastTurn = turns.at(-1);
+    if (lastTurn !== undefined) {
+        lastTurn.steerMessages.push(...pendingUsers);
+    } else {
+        appendPendingUserTurns(turns, pendingUsers);
+    }
+
+    return turns
+        .filter((turn) =>
+            turn.assistantMessage !== null
+                ? !turn.assistantMessage.metadata.hidden
+                : !turn.userMessage.metadata.hidden,
+        )
+        .map((turn) => ({
+            ...turn,
+            steerMessages: turn.steerMessages.filter(
+                (steer) => !steer.metadata.hidden,
+            ),
+        }));
+};

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -1237,3 +1237,4 @@ export type AiModelOption = {
 };
 
 export type ApiAiAgentModelOptionsResponse = ApiSuccess<AiModelOption[]>;
+export * from './groupIntoTurns';


### PR DESCRIPTION
## Summary

- add storage-aware canonical thread reads for v1 and v3
- project deterministic v1 history with tools, steers, context, artifacts, and metadata
- add the shared pure turn-grouping helper

## Tests

- backend unit suite: 5958 passed, 1 skipped
- common unit suite: 3384 passed, 1 skipped
- backend/common typecheck
- real PostgreSQL repository e2e
- independent code review and behavioral verification

Closes: ZAP-799