### PR TITLE
fix(pre-aggregates): harden definition parsing

### DIFF
--- a/packages/common/src/dbt/schemas/lightdashMetadata.json
+++ b/packages/common/src/dbt/schemas/lightdashMetadata.json
@@ -472,6 +472,104 @@
                 }
             }
         },
+        "PreAggregateSort": {
+            "type": "object",
+            "properties": {
+                "fieldId": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "descending": {
+                    "description": "Whether to sort descending.",
+                    "enum": [true, false]
+                }
+            },
+            "required": ["fieldId", "descending"],
+            "additionalProperties": false
+        },
+        "PreAggregate": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "dimensions": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "metrics": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "sorts": {
+                    "oneOf": [
+                        {
+                            "const": false
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/PreAggregateSort"
+                            }
+                        }
+                    ]
+                },
+                "filters": {
+                    "type": "array",
+                    "items": {
+                        "type": "object"
+                    }
+                },
+                "time_dimension": {
+                    "type": "string"
+                },
+                "granularity": {
+                    "type": "string"
+                },
+                "max_rows": {
+                    "type": "integer"
+                },
+                "refresh": {
+                    "type": "object",
+                    "properties": {
+                        "cron": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "materialization_role": {
+                    "type": "object",
+                    "properties": {
+                        "email": {
+                            "type": "string"
+                        },
+                        "attributes": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "oneOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "required": ["email", "attributes"],
+                    "additionalProperties": false
+                }
+            },
+            "required": ["name", "dimensions", "metrics"]
+        },
         "LightdashModelMetadata": {
             "type": "object",
             "required": [],
@@ -577,6 +675,12 @@
                 },
                 "default_time_dimension": {
                     "$ref": "#/definitions/DefaultTimeDimension"
+                },
+                "pre_aggregates": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/PreAggregate"
+                    }
                 }
             },
             "default": {}

--- a/packages/common/src/dbt/validation.test.ts
+++ b/packages/common/src/dbt/validation.test.ts
@@ -1,6 +1,5 @@
 import { model } from '../compiler/translator.mock';
 import { DbtManifestVersion, type DbtRawModelNode } from '../types/dbt';
-import lightdashMetadataSchema from './schemas/lightdashMetadata.json';
 import { ManifestValidator } from './validation';
 
 const metadataSchemaId =
@@ -78,15 +77,6 @@ describe('DefaultTimeDimension metadata schema', () => {
                 interval: 'MONTH',
             }),
         ).toEqual([true, undefined]);
-    });
-});
-
-describe('pre-aggregate manifest validation boundary', () => {
-    test('keeps runtime parsing responsible while metadata schema omits pre-aggregates', () => {
-        expect(
-            lightdashMetadataSchema.definitions.LightdashModelMetadata
-                .properties,
-        ).not.toHaveProperty('pre_aggregates');
     });
 });
 

--- a/packages/common/src/preAggregates/definition.test.ts
+++ b/packages/common/src/preAggregates/definition.test.ts
@@ -90,6 +90,11 @@ describe('parseDbtPreAggregateDef', () => {
             message: '"fieldId" must be a non-empty string',
         },
         {
+            name: 'a blank fieldId after normalization',
+            sorts: [{ fieldId: '   ', descending: false }],
+            message: '"fieldId" must be a non-empty string',
+        },
+        {
             name: 'a missing direction',
             sorts: [{ fieldId: 'orders_order_date_day' }],
             message: '"descending" is required',
@@ -127,7 +132,7 @@ describe('parseDbtPreAggregateDef', () => {
             message: 'has unsupported "sorts" fields: nulls_first',
         },
         {
-            name: 'a duplicate fieldId',
+            name: 'a duplicate normalized fieldId',
             sorts: [
                 { fieldId: 'orders_status', descending: false },
                 { fieldId: ' orders_status ', descending: true },


### PR DESCRIPTION
Related: ZAP-767

Adds `pre_aggregates` to the manifest metadata schema so compiled dbt artifacts are validated by AJV.
Retains full runtime structural validation for model-as-code and other paths that do not pass through manifest validation, plus field ID normalization and duplicate detection.
Malformed values that were previously ignored now fail manifest validation instead of silently changing behavior.
