### PR TITLE
fix(pre-aggregates): cover manifest validation

### DIFF
--- a/packages/common/src/dbt/validation.test.ts
+++ b/packages/common/src/dbt/validation.test.ts
@@ -7,6 +7,14 @@ const metadataSchemaId =
 const defaultTimeDimensionValidator = ManifestValidator.getValidator(
     `${metadataSchemaId}#/definitions/DefaultTimeDimension`,
 );
+const modelMetadataValidator = ManifestValidator.getValidator(
+    `${metadataSchemaId}#/definitions/LightdashModelMetadata`,
+);
+const basePreAggregate = {
+    name: 'orders_rollup',
+    dimensions: ['status'],
+    metrics: ['order_count'],
+};
 const withMeta = (meta: Record<string, unknown>): DbtRawModelNode =>
     ({ ...model, meta }) as unknown as DbtRawModelNode;
 
@@ -78,6 +86,143 @@ describe('DefaultTimeDimension metadata schema', () => {
             }),
         ).toEqual([true, undefined]);
     });
+});
+
+describe('PreAggregate metadata schema', () => {
+    test.each([
+        {
+            name: 'omitted sorts',
+            preAggregate: basePreAggregate,
+        },
+        {
+            name: 'disabled sorts',
+            preAggregate: { ...basePreAggregate, sorts: false },
+        },
+        {
+            name: 'disabled sorts with an empty array',
+            preAggregate: { ...basePreAggregate, sorts: [] },
+        },
+        {
+            name: 'canonical sorts',
+            preAggregate: {
+                ...basePreAggregate,
+                sorts: [{ fieldId: 'orders_status', descending: false }],
+            },
+        },
+    ])('accepts $name', ({ preAggregate }) => {
+        expect(
+            ManifestValidator.isValid(modelMetadataValidator, {
+                pre_aggregates: [preAggregate],
+            }),
+        ).toEqual([true, undefined]);
+    });
+
+    test.each([
+        {
+            name: 'a non-array pre_aggregates value',
+            metadata: { pre_aggregates: basePreAggregate },
+        },
+        {
+            name: 'a missing required property',
+            metadata: {
+                pre_aggregates: [
+                    {
+                        name: basePreAggregate.name,
+                        dimensions: basePreAggregate.dimensions,
+                    },
+                ],
+            },
+        },
+        {
+            name: 'a non-object filter',
+            metadata: {
+                pre_aggregates: [{ ...basePreAggregate, filters: [null] }],
+            },
+        },
+        {
+            name: 'a non-array, non-false sorts value',
+            metadata: {
+                pre_aggregates: [{ ...basePreAggregate, sorts: true }],
+            },
+        },
+        {
+            name: 'a sort entry missing descending',
+            metadata: {
+                pre_aggregates: [
+                    {
+                        ...basePreAggregate,
+                        sorts: [{ fieldId: 'orders_status' }],
+                    },
+                ],
+            },
+        },
+        {
+            // The production validator does not coerce types, so a numeric
+            // fieldId must fail even though coercing AJV configs accept it.
+            name: 'a non-string sort fieldId',
+            metadata: {
+                pre_aggregates: [
+                    {
+                        ...basePreAggregate,
+                        sorts: [{ fieldId: 123, descending: false }],
+                    },
+                ],
+            },
+        },
+        {
+            name: 'an invalid materialization role',
+            metadata: {
+                pre_aggregates: [
+                    {
+                        ...basePreAggregate,
+                        materialization_role: {
+                            email: 'materialize@example.com',
+                            attributes: { region: [123] },
+                        },
+                    },
+                ],
+            },
+        },
+    ])('rejects $name', ({ metadata }) => {
+        const [isValid, error] = ManifestValidator.isValid(
+            modelMetadataValidator,
+            metadata,
+        );
+
+        expect(isValid).toBe(false);
+        expect(error).toContain('pre_aggregates');
+    });
+
+    test.each(Object.values(DbtManifestVersion))(
+        'is composed into %s manifest model validation',
+        (manifestVersion) => {
+            const modelWithPreAggregates = {
+                ...model,
+                ...(manifestVersion === DbtManifestVersion.V7
+                    ? { root_path: 'root' }
+                    : {}),
+                meta: {
+                    pre_aggregates: [
+                        {
+                            ...basePreAggregate,
+                            sorts: [
+                                {
+                                    fieldId: 'orders_status',
+                                    descending: false,
+                                },
+                            ],
+                        },
+                    ],
+                },
+            } satisfies DbtRawModelNode;
+
+            expect(
+                new ManifestValidator(manifestVersion).isModelValid(
+                    modelWithPreAggregates,
+                ),
+            ).toEqual([true, undefined]);
+        },
+    );
 });
 
 describe('AI hint manifest compatibility', () => {

--- a/packages/common/src/preAggregates/schema.test.ts
+++ b/packages/common/src/preAggregates/schema.test.ts
@@ -1,6 +1,7 @@
 import Ajv from 'ajv';
 import AjvErrors from 'ajv-errors';
 import addFormats from 'ajv-formats';
+import lightdashMetadataSchema from '../dbt/schemas/lightdashMetadata.json';
 import lightdashDbtYamlSchema from '../schemas/json/lightdash-dbt-2.0.json';
 import modelAsCodeSchema from '../schemas/json/model-as-code-1.0.json';
 
@@ -20,6 +21,10 @@ const modelYamlAjv = new Ajv({
 addFormats(modelYamlAjv);
 
 const validateDbtYaml = dbtYamlAjv.compile(lightdashDbtYamlSchema);
+dbtYamlAjv.addSchema(lightdashMetadataSchema);
+const validateManifestMetadata = dbtYamlAjv.compile({
+    $ref: `${lightdashMetadataSchema.$id}#/definitions/LightdashModelMetadata`,
+});
 const validateModelYaml = modelYamlAjv.compile(modelAsCodeSchema);
 
 const basePreAggregate = {
@@ -28,7 +33,7 @@ const basePreAggregate = {
     metrics: ['order_count'],
 };
 
-const validateInBothSchemas = (
+const validateInAllSchemas = (
     preAggregate: Record<string, unknown>,
     expected: boolean,
 ) => {
@@ -56,6 +61,9 @@ const validateInBothSchemas = (
     };
 
     expect(validateDbtYaml(dbtDocument)).toBe(expected);
+    expect(validateManifestMetadata({ pre_aggregates: [preAggregate] })).toBe(
+        expected,
+    );
     expect(validateModelYaml(modelDocument)).toBe(expected);
 };
 
@@ -100,6 +108,24 @@ describe('pre-aggregate sort schema parity', () => {
             name: 'omitted sorts',
             preAggregate: basePreAggregate,
             valid: true,
+        },
+        {
+            name: 'sorts set to true',
+            preAggregate: { ...basePreAggregate, sorts: true },
+            valid: false,
+        },
+        {
+            name: 'sorts set to null',
+            preAggregate: { ...basePreAggregate, sorts: null },
+            valid: false,
+        },
+        {
+            name: 'sorts as a single object instead of an array',
+            preAggregate: {
+                ...basePreAggregate,
+                sorts: { fieldId: 'orders_status', descending: false },
+            },
+            valid: false,
         },
         {
             name: 'a non-object entry',
@@ -178,6 +204,6 @@ describe('pre-aggregate sort schema parity', () => {
             valid: false,
         },
     ])('$name is valid: $valid', ({ preAggregate, valid }) => {
-        validateInBothSchemas(preAggregate, valid);
+        validateInAllSchemas(preAggregate, valid);
     });
 });


### PR DESCRIPTION
Related: ZAP-767

Covers accepted and rejected pre-aggregate manifest shapes across every supported dbt manifest version.
Extends sort contract parity across dbt YAML, manifest metadata, and model-as-code schemas.
