### PR TITLE
feat(ai-agents): first-run memory tour on agent page

### DIFF
--- a/packages/frontend/src/components/common/GuidedTour/GuidedTour.module.css
+++ b/packages/frontend/src/components/common/GuidedTour/GuidedTour.module.css
@@ -63,35 +63,17 @@
     z-index: 1101;
 }
 
-/* The card must not read as regular UI: accent ring, deep elevation and a
-   coachmark caret pointing back at the spotlight. */
+/* The card must not read as regular UI: deep elevation and a coachmark caret
+   pointing back at the spotlight. */
 .paper {
     position: relative;
     background: light-dark(
         var(--mantine-color-body),
         var(--mantine-color-dark-6)
     );
-    box-shadow:
-        0 0 0 1px
-            light-dark(
-                var(--mantine-color-indigo-2),
-                var(--mantine-color-indigo-8)
-            ),
-        0 18px 45px light-dark(rgba(17, 24, 39, 0.22), rgba(0, 0, 0, 0.6));
+    box-shadow: 0 18px 45px
+        light-dark(rgba(17, 24, 39, 0.22), rgba(0, 0, 0, 0.6));
     animation: ldTourCardIn 160ms ease-out;
-}
-
-/* accent bar along the top edge */
-.paper::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 3px;
-    background: var(--mantine-color-indigo-5);
-    border-top-left-radius: var(--mantine-radius-md);
-    border-top-right-radius: var(--mantine-radius-md);
 }
 
 @keyframes ldTourCardIn {
@@ -117,7 +99,8 @@
 
 .caretTop {
     top: -8px;
-    border-bottom: 8px solid var(--mantine-color-indigo-5);
+    border-bottom: 8px solid
+        light-dark(var(--mantine-color-body), var(--mantine-color-dark-6));
 }
 
 .caretBottom {

--- a/packages/frontend/src/components/common/GuidedTour/GuidedTour.tsx
+++ b/packages/frontend/src/components/common/GuidedTour/GuidedTour.tsx
@@ -14,6 +14,12 @@ type GuidedTourProps = {
     steps: GuidedTourStep[];
     opened: boolean;
     onClose: () => void;
+    /**
+     * Fired when the user navigates to another step (Next/Back), with the new
+     * step index. Not fired on close, so side effects (e.g. a modal a step
+     * opened) survive finishing the tour.
+     */
+    onStepChange?: (stepIndex: number) => void;
 };
 
 const SPOTLIGHT_PADDING = 6;
@@ -127,7 +133,12 @@ const cardLayout = (rect: DOMRect, cardHeight: number): CardLayout => {
     };
 };
 
-export const GuidedTour: FC<GuidedTourProps> = ({ steps, opened, onClose }) => {
+export const GuidedTour: FC<GuidedTourProps> = ({
+    steps,
+    opened,
+    onClose,
+    onStepChange,
+}) => {
     const [stepIndex, setStepIndex] = useState(0);
     const [cardHeight, cardRef] = useCardHeight();
 
@@ -147,9 +158,12 @@ export const GuidedTour: FC<GuidedTourProps> = ({ steps, opened, onClose }) => {
         setStepIndex(0);
         onClose();
     };
-    const handleNext = () =>
-        isLast ? handleClose() : setStepIndex((i) => i + 1);
-    const handleBack = () => setStepIndex((i) => Math.max(0, i - 1));
+    const goToStep = (index: number) => {
+        setStepIndex(index);
+        onStepChange?.(index);
+    };
+    const handleNext = () => (isLast ? handleClose() : goToStep(stepIndex + 1));
+    const handleBack = () => goToStep(Math.max(0, stepIndex - 1));
 
     const cardBody = (
         <Paper

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentPageHeader.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentPageHeader.tsx
@@ -55,6 +55,7 @@ export const AgentPageHeader: FC<Props> = ({
                     <Button
                         variant="default"
                         className={styles.action}
+                        data-tour="memories-header-button"
                         onClick={onOpenMemories}
                         leftSection={
                             <MantineIcon

--- a/packages/frontend/src/ee/features/aiCopilot/components/MyMemories/MyMemoriesModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MyMemories/MyMemoriesModal.tsx
@@ -153,7 +153,7 @@ export const MyMemoriesModal: FC<MyMemoriesModalProps> = ({
         );
     } else {
         content = (
-            <Box className={styles.layout}>
+            <Box className={styles.layout} data-tour="my-memories-modal">
                 <Stack gap={0} className={styles.list}>
                     <Box className={styles.search}>
                         <TextInput

--- a/packages/frontend/src/ee/features/aiCopilot/components/MyMemories/onboarding/index.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MyMemories/onboarding/index.ts
@@ -1,0 +1,1 @@
+export { MEMORY_TOUR_STEPS } from './steps';

--- a/packages/frontend/src/ee/features/aiCopilot/components/MyMemories/onboarding/steps.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MyMemories/onboarding/steps.tsx
@@ -1,0 +1,14 @@
+import { type GuidedTourStep } from '../../../../../../components/common/GuidedTour';
+
+export const MEMORY_TOUR_STEPS: GuidedTourStep[] = [
+    {
+        target: '[data-tour="memories-header-button"]',
+        title: 'Your agents remember',
+        body: 'As you chat, agents save useful facts about you and how you like your data. Open Memories any time to see what they have picked up.',
+    },
+    {
+        target: '[data-tour="my-memories-modal"]',
+        title: 'Review and manage memories',
+        body: 'These are the memories agents saved from your conversations. Select one to see the details, and retire anything you no longer want agents to use.',
+    },
+];

--- a/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
@@ -9,8 +9,10 @@ import {
     useParams,
     useSearchParams,
 } from 'react-router';
+import { GuidedTour } from '../../../components/common/GuidedTour';
 import MantineModal from '../../../components/common/MantineModal';
 import { ShareLinkButton } from '../../../components/common/ShareLinkButton';
+import { useOnboardingTour } from '../../../hooks/useOnboardingTour';
 import useApp from '../../../providers/App/useApp';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
@@ -21,10 +23,12 @@ import { AiAgentPageLayout } from '../../features/aiCopilot/components/AiAgentPa
 import { launcherSession } from '../../features/aiCopilot/components/Launcher/launcherSession';
 import { useLauncherDock } from '../../features/aiCopilot/components/Launcher/useLauncherDock';
 import { MyMemoriesModal } from '../../features/aiCopilot/components/MyMemories/MyMemoriesModal';
+import { MEMORY_TOUR_STEPS } from '../../features/aiCopilot/components/MyMemories/onboarding';
 import {
     getAiAgentPageBase,
     isEmbedAiAgentRoute,
 } from '../../features/aiCopilot/hooks/aiAgentRouting';
+import { useMyAiAgentMemories } from '../../features/aiCopilot/hooks/useAiAgentMemory';
 import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentPermission';
 import { useAiAgentMemoryEnabled } from '../../features/aiCopilot/hooks/useAiOrganizationSettings';
 import {
@@ -80,6 +84,18 @@ const AgentPage = () => {
     const [shareUrl, setShareUrl] = useState<string | null>(null);
     const [isMemoriesModalOpen, setIsMemoriesModalOpen] = useState(false);
     const memoryEnabled = useAiAgentMemoryEnabled();
+
+    const { shouldShow: shouldShowMemoryTour, closeTour: closeMemoryTour } =
+        useOnboardingTour({
+            tour: 'memoryTour',
+            enabled: memoryEnabled && !isEmbed,
+        });
+    // The tour is only worth showing once the user has something to look at
+    const { data: myMemories } = useMyAiAgentMemories({
+        projectUuid,
+        enabled: shouldShowMemoryTour,
+    });
+    const hasMemories = (myMemories?.data.memories.length ?? 0) > 0;
 
     const handleMinimize = useCallback(
         (targetUrl?: string, options?: NavigateFromAgentChatOptions) => {
@@ -298,6 +314,14 @@ const AgentPage = () => {
                 opened={isMemoriesModalOpen}
                 onClose={() => setIsMemoriesModalOpen(false)}
                 projectUuid={projectUuid!}
+            />
+            <GuidedTour
+                steps={MEMORY_TOUR_STEPS}
+                opened={shouldShowMemoryTour && hasMemories}
+                onClose={closeMemoryTour}
+                onStepChange={(stepIndex) =>
+                    setIsMemoriesModalOpen(stepIndex === 1)
+                }
             />
             <Outlet
                 context={{

--- a/packages/frontend/src/hooks/useOnboardingTour.ts
+++ b/packages/frontend/src/hooks/useOnboardingTour.ts
@@ -46,7 +46,6 @@ type UseOnboardingTourResult = {
  * `user_onboarding` table so a tour shows once per user across devices. Pair
  * with the `<GuidedTour>` component for the spotlight rendering.
  */
-// ts-unused-exports:disable-next-line
 export const useOnboardingTour = ({
     tour,
     enabled = true,


### PR DESCRIPTION
Stacked on #26932 (onboarding storage/API/hook).

First-run guided tour on the AI agent page, shown only to users who already have at least one agent memory:

- **Step 1** spotlights the **Memories** button in the agent page header.
- **Step 2** opens the **My memories** modal and spotlights its content. Finishing the tour ("Got it") leaves the modal open.

The seen-flag is persisted server-side (via #26932) so the tour shows once ever per user, across devices.

## How

- `GuidedTour` gains an `onStepChange` prop (fires on Next/Back, intentionally not on close) which AgentPage uses to open/close the memories modal on step 2.
- Step copy lives in `MyMemories/onboarding/` per the onboarding-tour kit convention. Gated on memory enabled + not embed + ≥1 memory.
- Also removes the tour card's indigo accent bar/ring, which rendered as a glitchy border.

## Testing

- Verified end-to-end in the browser: tour auto-opens on step 1, Next opens the modal with the step 2 spotlight above the overlay, "Got it" closes the tour, keeps the modal open, and fires the POST (row persisted in `user_onboarding`), reload does not re-show the tour.
- Typecheck + lint + `unused-exports` clean on frontend; `GuidedTour` unit tests pass.

Closes: ZAP-813

🤖 Generated with [Claude Code](https://claude.com/claude-code)
