### PR TITLE
feat(data-apps): store app delivery query selections on schedulers

### DIFF
--- a/packages/backend/src/contentAsCode/fieldCoverage/alert.test.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/alert.test.ts
@@ -6,6 +6,7 @@ describeContentAsCodeSchemaContract({
     documentSchema: 'AlertAsCode',
     skippedModelFields: [
         'appName',
+        'appQuerySelections',
         'appState',
         'appUuid',
         'createdAt',

--- a/packages/backend/src/contentAsCode/fieldCoverage/google_sheets_sync.test.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/google_sheets_sync.test.ts
@@ -6,6 +6,7 @@ describeContentAsCodeSchemaContract({
     documentSchema: 'GoogleSheetsSyncAsCode',
     skippedModelFields: [
         'appName',
+        'appQuerySelections',
         'appState',
         'appUuid',
         'createdAt',

--- a/packages/backend/src/contentAsCode/fieldCoverage/scheduled_delivery.test.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/scheduled_delivery.test.ts
@@ -6,6 +6,7 @@ describeContentAsCodeSchemaContract({
     documentSchema: 'ScheduledDeliveryAsCode',
     skippedModelFields: [
         'appName',
+        'appQuerySelections',
         'appState',
         'appUuid',
         'createdAt',

--- a/packages/backend/src/database/entities/scheduler.ts
+++ b/packages/backend/src/database/entities/scheduler.ts
@@ -9,6 +9,7 @@ import {
     SchedulerGoogleChatTarget,
     SchedulerMsTeamsTarget,
     SchedulerSlackTarget,
+    type AppQuerySelection,
     type DashboardFilterRule,
     type Filters,
     type NotificationFrequency,
@@ -48,6 +49,7 @@ export type SchedulerDb = {
     filters: DashboardFilterRule[] | Filters | null;
     parameters: ParametersValuesMap | null;
     app_state: SchedulerAppState | null;
+    app_query_selections: AppQuerySelection[] | null;
     custom_viewport_width: number | null;
     thresholds: ThresholdOptions[] | null;
     enabled: boolean;
@@ -65,6 +67,7 @@ export type ChartSchedulerDb = SchedulerDb & {
     app_uuid: null;
     filters: Filters | null;
     app_state: null;
+    app_query_selections: null;
 };
 export type DashboardSchedulerDB = SchedulerDb & {
     saved_chart_uuid: null;
@@ -73,6 +76,7 @@ export type DashboardSchedulerDB = SchedulerDb & {
     app_uuid: null;
     filters: DashboardFilterRule[] | null;
     app_state: null;
+    app_query_selections: null;
 };
 export type SqlChartSchedulerDb = SchedulerDb & {
     saved_chart_uuid: null;
@@ -80,6 +84,7 @@ export type SqlChartSchedulerDb = SchedulerDb & {
     saved_sql_uuid: string;
     app_uuid: null;
     app_state: null;
+    app_query_selections: null;
 };
 export type AppSchedulerDb = SchedulerDb & {
     saved_chart_uuid: null;
@@ -145,6 +150,7 @@ type SchedulerJsonWrite = {
     parameters: string | null;
     thresholds: string | null;
     app_state: string | null;
+    app_query_selections: string | null;
 };
 
 export type SchedulerInsert = Omit<
@@ -160,6 +166,7 @@ export type SchedulerInsert = Omit<
     | 'parameters'
     | 'thresholds'
     | 'app_state'
+    | 'app_query_selections'
 > &
     SchedulerJsonWrite;
 

--- a/packages/backend/src/database/migrations/20260806102912_add_app_query_selections_to_scheduler.ts
+++ b/packages/backend/src/database/migrations/20260806102912_add_app_query_selections_to_scheduler.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex';
+
+const SCHEDULER_TABLE = 'scheduler';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SCHEDULER_TABLE, (table) => {
+        table.jsonb('app_query_selections').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SCHEDULER_TABLE, (table) => {
+        table.dropColumn('app_query_selections');
+    });
+}

--- a/packages/backend/src/models/SchedulerModel/SchedulerModel.test.ts
+++ b/packages/backend/src/models/SchedulerModel/SchedulerModel.test.ts
@@ -1,4 +1,12 @@
-import { AnyType, SchedulerJobStatus, SchedulerLog } from '@lightdash/common';
+import {
+    AnyType,
+    SchedulerFormat,
+    SchedulerJobStatus,
+    SchedulerLog,
+    type AppQuerySelection,
+    type CreateSchedulerAndTargets,
+    type UpdateSchedulerAndTargets,
+} from '@lightdash/common';
 import knex from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
 import { SchedulerTableName } from '../../database/entities/scheduler';
@@ -221,6 +229,218 @@ describe('Scheduler model test', () => {
             expect(getSchedulerForProjectSpy).toHaveBeenCalledWith('project-2');
             expect(getSchedulersByUuidSpy).not.toHaveBeenCalled();
             expect(result.data).toEqual([]);
+        });
+    });
+
+    describe('app_query_selections round-trip', () => {
+        const selections: AppQuerySelection[] = [
+            {
+                captureKey: 'v1:abc123',
+                label: 'Revenue by month',
+                exploreName: 'orders',
+                excluded: false,
+            },
+            {
+                captureKey: 'v1:def456',
+                label: 'Broken query',
+                exploreName: null,
+                excluded: true,
+            },
+        ];
+
+        const baseAppCreate = {
+            name: 'App delivery',
+            format: SchedulerFormat.CSV,
+            cron: '0 9 * * *',
+            createdBy: 'user-uuid',
+            savedChartUuid: null,
+            dashboardUuid: null,
+            savedSqlUuid: null,
+            appUuid: 'app-uuid',
+            appName: 'App',
+            options: { formatted: true, limit: 'table' as const },
+            enabled: true,
+            includeLinks: true,
+            targets: [],
+        } as unknown as CreateSchedulerAndTargets;
+
+        describe('toSchedulerInsert (create)', () => {
+            it('serializes a populated selection array', () => {
+                const insert = SchedulerModel['toSchedulerInsert'](
+                    { ...baseAppCreate, appQuerySelections: selections },
+                    'project-uuid',
+                    'app-delivery',
+                );
+                expect(insert.app_query_selections).toBe(
+                    JSON.stringify(selections),
+                );
+            });
+
+            it('stores null for explicit null (no curation)', () => {
+                const insert = SchedulerModel['toSchedulerInsert'](
+                    { ...baseAppCreate, appQuerySelections: null },
+                    'project-uuid',
+                    'app-delivery',
+                );
+                expect(insert.app_query_selections).toBeNull();
+            });
+
+            it('stores null when the field is omitted', () => {
+                const insert = SchedulerModel['toSchedulerInsert'](
+                    baseAppCreate,
+                    'project-uuid',
+                    'app-delivery',
+                );
+                expect(insert.app_query_selections).toBeNull();
+            });
+
+            it('never sets app_query_selections for a chart scheduler', () => {
+                const chartCreate = {
+                    name: 'Chart delivery',
+                    format: SchedulerFormat.CSV,
+                    cron: '0 9 * * *',
+                    createdBy: 'user-uuid',
+                    savedChartUuid: 'chart-uuid',
+                    dashboardUuid: null,
+                    savedSqlUuid: null,
+                    appUuid: null,
+                    savedChartName: 'Chart',
+                    options: { formatted: true, limit: 'table' as const },
+                    enabled: true,
+                    includeLinks: true,
+                    targets: [],
+                    // A rogue client field — must never reach the DB row for
+                    // a non-app scheduler even if present on the payload.
+                    appQuerySelections: selections,
+                } as unknown as CreateSchedulerAndTargets;
+
+                const insert = SchedulerModel['toSchedulerInsert'](
+                    chartCreate,
+                    'project-uuid',
+                    'chart-delivery',
+                );
+                expect(insert.app_query_selections).toBeNull();
+            });
+        });
+
+        describe('convertScheduler (read)', () => {
+            const baseRow = {
+                scheduler_uuid: 'scheduler-uuid',
+                project_uuid: 'project-uuid',
+                slug: 'app-delivery',
+                name: 'App delivery',
+                message: undefined,
+                format: SchedulerFormat.CSV,
+                created_at: new Date('2026-01-01'),
+                updated_at: new Date('2026-01-01'),
+                created_by: 'user-uuid',
+                created_by_name: 'User',
+                cron: '0 9 * * *',
+                timezone: 'UTC',
+                saved_chart_uuid: null,
+                saved_chart_name: null,
+                dashboard_uuid: null,
+                dashboard_name: null,
+                saved_sql_uuid: null,
+                saved_sql_name: null,
+                app_uuid: 'app-uuid',
+                app_name: 'App',
+                options: { formatted: true, limit: 'table' as const },
+                filters: null,
+                parameters: null,
+                app_state: { view: 'orders' },
+                app_query_selections: selections,
+                custom_viewport_width: null,
+                thresholds: null,
+                enabled: true,
+                notification_frequency: null,
+                selected_tabs: null,
+                include_links: true,
+                deleted_at: null,
+                deleted_by_user_uuid: null,
+            };
+
+            it('maps a populated column onto appQuerySelections', () => {
+                const scheduler = SchedulerModel.convertScheduler(
+                    baseRow as AnyType,
+                );
+                expect('appQuerySelections' in scheduler).toBe(true);
+                expect((scheduler as AnyType).appQuerySelections).toEqual(
+                    selections,
+                );
+            });
+
+            it('maps a null column onto null (no curation)', () => {
+                const scheduler = SchedulerModel.convertScheduler({
+                    ...baseRow,
+                    app_query_selections: null,
+                } as AnyType);
+                expect((scheduler as AnyType).appQuerySelections).toBeNull();
+            });
+        });
+
+        describe('updateScheduler (clear-to-null)', () => {
+            const database = knex({ client: MockClient, dialect: 'pg' });
+            let tracker: Tracker;
+
+            beforeAll(() => {
+                tracker = getTracker();
+            });
+
+            afterEach(() => {
+                tracker.reset();
+            });
+
+            const baseUpdate = {
+                schedulerUuid: 'scheduler-uuid',
+                name: 'App delivery',
+                cron: '0 9 * * *',
+                timezone: 'UTC',
+                format: SchedulerFormat.CSV,
+                options: { formatted: true, limit: 'table' as const },
+                includeLinks: true,
+                targets: [],
+            } as unknown as UpdateSchedulerAndTargets;
+
+            const runUpdate = async (
+                overrides: Partial<UpdateSchedulerAndTargets>,
+            ) => {
+                const model = new SchedulerModel({ database });
+                vi.spyOn(model, 'getSchedulerAndTargets').mockResolvedValue(
+                    {} as AnyType,
+                );
+                tracker.on.any(() => true).response([]);
+
+                await model.updateScheduler({ ...baseUpdate, ...overrides });
+
+                // knex-mock-client doesn't bucket transaction queries under
+                // `.update`, so filter the full history by statement text.
+                const [query] = tracker.history.all.filter(
+                    (q) =>
+                        q.sql.trim().toLowerCase().startsWith('update') &&
+                        q.sql.includes(`"${SchedulerTableName}"`),
+                );
+                return query;
+            };
+
+            it('writes a serialized selection array', async () => {
+                const query = await runUpdate({
+                    appQuerySelections: selections,
+                });
+                expect(query.bindings).toContain(JSON.stringify(selections));
+            });
+
+            it('clears to null on explicit null', async () => {
+                const query = await runUpdate({ appQuerySelections: null });
+                const jsonBindings = JSON.stringify(query.bindings);
+                expect(jsonBindings).not.toContain('captureKey');
+            });
+
+            it('clears to null when the field is omitted', async () => {
+                const query = await runUpdate({});
+                const jsonBindings = JSON.stringify(query.bindings);
+                expect(jsonBindings).not.toContain('captureKey');
+            });
         });
     });
 });

--- a/packages/backend/src/models/SchedulerModel/SchedulerModel.test.ts
+++ b/packages/backend/src/models/SchedulerModel/SchedulerModel.test.ts
@@ -321,6 +321,61 @@ describe('Scheduler model test', () => {
                 );
                 expect(insert.app_query_selections).toBeNull();
             });
+
+            it('never sets app_query_selections for a dashboard scheduler', () => {
+                const dashboardCreate = {
+                    name: 'Dashboard delivery',
+                    format: SchedulerFormat.CSV,
+                    cron: '0 9 * * *',
+                    createdBy: 'user-uuid',
+                    savedChartUuid: null,
+                    dashboardUuid: 'dashboard-uuid',
+                    savedSqlUuid: null,
+                    appUuid: null,
+                    dashboardName: 'Dashboard',
+                    options: { formatted: true, limit: 'table' as const },
+                    enabled: true,
+                    includeLinks: true,
+                    targets: [],
+                    // A rogue client field — must never reach the DB row for
+                    // a non-app scheduler even if present on the payload.
+                    appQuerySelections: selections,
+                } as unknown as CreateSchedulerAndTargets;
+
+                const insert = SchedulerModel['toSchedulerInsert'](
+                    dashboardCreate,
+                    'project-uuid',
+                    'dashboard-delivery',
+                );
+                expect(insert.app_query_selections).toBeNull();
+            });
+
+            it('never sets app_query_selections for a SQL chart scheduler', () => {
+                const sqlChartCreate = {
+                    name: 'SQL chart delivery',
+                    format: SchedulerFormat.CSV,
+                    cron: '0 9 * * *',
+                    createdBy: 'user-uuid',
+                    savedChartUuid: null,
+                    dashboardUuid: null,
+                    savedSqlUuid: 'sql-chart-uuid',
+                    appUuid: null,
+                    options: { formatted: true, limit: 'table' as const },
+                    enabled: true,
+                    includeLinks: true,
+                    targets: [],
+                    // A rogue client field — must never reach the DB row for
+                    // a non-app scheduler even if present on the payload.
+                    appQuerySelections: selections,
+                } as unknown as CreateSchedulerAndTargets;
+
+                const insert = SchedulerModel['toSchedulerInsert'](
+                    sqlChartCreate,
+                    'project-uuid',
+                    'sql-chart-delivery',
+                );
+                expect(insert.app_query_selections).toBeNull();
+            });
         });
 
         describe('convertScheduler (read)', () => {

--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -197,6 +197,7 @@ export class SchedulerModel {
                 savedSqlUuid: null,
                 appUuid: scheduler.app_uuid,
                 appState: scheduler.app_state ?? undefined,
+                appQuerySelections: scheduler.app_query_selections,
             };
         }
         throw new UnexpectedServerError(
@@ -249,6 +250,7 @@ export class SchedulerModel {
                 custom_viewport_width: newScheduler.customViewportWidth ?? null,
                 selected_tabs: newScheduler.selectedTabs ?? null,
                 app_state: null,
+                app_query_selections: null,
             };
         }
         if (isChartCreateScheduler(newScheduler)) {
@@ -265,6 +267,7 @@ export class SchedulerModel {
                 custom_viewport_width: null,
                 selected_tabs: null,
                 app_state: null,
+                app_query_selections: null,
             };
         }
         if (isSqlChartScheduler(newScheduler)) {
@@ -279,6 +282,7 @@ export class SchedulerModel {
                 custom_viewport_width: null,
                 selected_tabs: null,
                 app_state: null,
+                app_query_selections: null,
             };
         }
         if (isAppCreateScheduler(newScheduler)) {
@@ -293,6 +297,9 @@ export class SchedulerModel {
                 custom_viewport_width: null,
                 selected_tabs: null,
                 app_state: SchedulerModel.toJsonColumn(newScheduler.appState),
+                app_query_selections: SchedulerModel.toJsonColumn(
+                    newScheduler.appQuerySelections,
+                ),
             };
         }
         throw new UnexpectedServerError(
@@ -1253,6 +1260,9 @@ export class SchedulerModel {
                         scheduler.parameters,
                     ),
                     app_state: SchedulerModel.toJsonColumn(scheduler.appState),
+                    app_query_selections: SchedulerModel.toJsonColumn(
+                        scheduler.appQuerySelections,
+                    ),
                     custom_viewport_width:
                         scheduler.customViewportWidth ?? null,
                     thresholds: SchedulerModel.toJsonColumn(

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -1253,5 +1253,28 @@ describe('DashboardService', () => {
                 expect.objectContaining({ dashboardUuid: dashboard.uuid }),
             );
         });
+
+        // Dashboard creation never routes through SchedulerService's app-only
+        // guard, so a stray appQuerySelections field is not rejected here —
+        // it's silently dropped by SchedulerModel.toSchedulerInsert's
+        // per-resource whitelist (see SchedulerModel.test.ts), the same way
+        // appState already is.
+        test('does not reject a stray appQuerySelections field on a dashboard scheduler create', async () => {
+            await service.createScheduler(editorUser, dashboard.slug, {
+                ...newScheduler,
+                appQuerySelections: [
+                    {
+                        captureKey: 'v1:abc123',
+                        label: 'Revenue by month',
+                        exploreName: 'orders',
+                        excluded: false,
+                    },
+                ],
+            } as unknown as Parameters<typeof service.createScheduler>[2]);
+
+            expect(schedulerModel.createScheduler).toHaveBeenCalledWith(
+                expect.objectContaining({ dashboardUuid: dashboard.uuid }),
+            );
+        });
     });
 });

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.createScheduler.test.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.createScheduler.test.ts
@@ -1,0 +1,143 @@
+import { Ability } from '@casl/ability';
+import {
+    OrganizationMemberRole,
+    PossibleAbilities,
+    SchedulerFormat,
+    type CreateSchedulerAndTargetsWithoutIds,
+} from '@lightdash/common';
+import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
+import { GoogleDriveClient } from '../../clients/Google/GoogleDriveClient';
+import { SlackClient } from '../../clients/Slack/SlackClient';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { AnalyticsModel } from '../../models/AnalyticsModel';
+import { CatalogModel } from '../../models/CatalogModel/CatalogModel';
+import { ContentVerificationModel } from '../../models/ContentVerificationModel';
+import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
+import { OrganizationModel } from '../../models/OrganizationModel';
+import { PinnedListModel } from '../../models/PinnedListModel';
+import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import { SavedChartModel } from '../../models/SavedChartModel';
+import { SchedulerModel } from '../../models/SchedulerModel';
+import { SpaceModel } from '../../models/SpaceModel';
+import { SchedulerClient } from '../../scheduler/SchedulerClient';
+import { PermissionsService } from '../PermissionsService/PermissionsService';
+import { SchedulerService } from '../SchedulerService/SchedulerService';
+import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
+import { UserService } from '../UserService';
+import { SavedChartService } from './SavedChartService';
+
+const chartUuid = 'chart-uuid';
+const projectUuid = 'project-uuid';
+const organizationUuid = 'org-uuid';
+const spaceUuid = 'space-uuid';
+
+const chartSummary = {
+    uuid: chartUuid,
+    projectUuid,
+    organizationUuid,
+    spaceUuid,
+    name: 'Orders',
+};
+
+const editorUser = {
+    userUuid: 'user-uuid',
+    organizationUuid,
+    organizationName: 'Test Org',
+    organizationCreatedAt: new Date(),
+    role: OrganizationMemberRole.EDITOR,
+    ability: new Ability<PossibleAbilities>([
+        {
+            subject: 'ScheduledDeliveries',
+            action: ['create'],
+            conditions: { projectUuid },
+        },
+    ]),
+};
+
+describe('SavedChartService createScheduler', () => {
+    const schedulerModel = {
+        createScheduler: vi.fn(async (input) => ({
+            ...input,
+            schedulerUuid: 'new-scheduler-uuid',
+        })),
+    };
+    const spacePermissionService = {
+        can: vi.fn(async () => true),
+    };
+    const schedulerClient = {
+        generateDailyJobsForScheduler: vi.fn(async () => {}),
+    };
+    const slackClient = {
+        joinChannels: vi.fn(async () => {}),
+    };
+    const projectModel = {
+        get: vi.fn(async () => ({ schedulerTimezone: 'UTC' })),
+    };
+    const savedChartModel = {
+        getSummary: vi.fn(async () => chartSummary),
+    };
+
+    const service = new SavedChartService({
+        analytics: analyticsMock,
+        lightdashConfig: lightdashConfigMock,
+        projectModel: projectModel as unknown as ProjectModel,
+        savedChartModel: savedChartModel as unknown as SavedChartModel,
+        spaceModel: {} as unknown as SpaceModel,
+        analyticsModel: {} as unknown as AnalyticsModel,
+        pinnedListModel: {} as unknown as PinnedListModel,
+        schedulerModel: schedulerModel as unknown as SchedulerModel,
+        schedulerService: {} as unknown as SchedulerService,
+        schedulerClient: schedulerClient as unknown as SchedulerClient,
+        slackClient: slackClient as unknown as SlackClient,
+        dashboardModel: {} as unknown as DashboardModel,
+        catalogModel: {} as unknown as CatalogModel,
+        permissionsService: {} as unknown as PermissionsService,
+        googleDriveClient: {} as unknown as GoogleDriveClient,
+        userService: {} as unknown as UserService,
+        spacePermissionService:
+            spacePermissionService as unknown as SpacePermissionService,
+        contentVerificationModel: {} as unknown as ContentVerificationModel,
+        organizationModel: {} as unknown as OrganizationModel,
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    // Mirrors the equivalent DashboardService/SavedSqlService tests: chart
+    // creation never routes through SchedulerService's app-only guard, so a
+    // stray appQuerySelections field is not rejected here — it's silently
+    // dropped by SchedulerModel.toSchedulerInsert's per-resource whitelist
+    // (see SchedulerModel.test.ts), the same way appState already is.
+    test('does not reject a stray appQuerySelections field on a chart scheduler create', async () => {
+        const newScheduler = {
+            name: 'My delivery',
+            cron: '0 9 * * *',
+            timezone: 'UTC',
+            format: SchedulerFormat.CSV,
+            options: { formatted: true, limit: 'table' },
+            includeLinks: true,
+            targets: [],
+            appQuerySelections: [
+                {
+                    captureKey: 'v1:abc123',
+                    label: 'Revenue by month',
+                    exploreName: 'orders',
+                    excluded: false,
+                },
+            ],
+        } as unknown as CreateSchedulerAndTargetsWithoutIds;
+
+        await service.createScheduler(
+            editorUser as unknown as Parameters<
+                typeof service.createScheduler
+            >[0],
+            chartUuid,
+            newScheduler,
+        );
+
+        expect(schedulerModel.createScheduler).toHaveBeenCalledWith(
+            expect.objectContaining({ savedChartUuid: chartUuid }),
+        );
+    });
+});

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.test.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.test.ts
@@ -217,6 +217,31 @@ describe('SavedSqlService - Scheduler authorization (PROD-7098)', () => {
             expect(schedulerModel.createScheduler).not.toHaveBeenCalled();
         });
 
+        // SQL chart creation never routes through SchedulerService's app-only
+        // guard, so a stray appQuerySelections field is not rejected here —
+        // it's silently dropped by SchedulerModel.toSchedulerInsert's
+        // per-resource whitelist (see SchedulerModel.test.ts), the same way
+        // appState already is.
+        it('does not reject a stray appQuerySelections field on a SQL chart scheduler create', async () => {
+            await expect(
+                service.createScheduler(editorUser, projectUuid, savedSqlUuid, {
+                    ...newSchedulerPayload,
+                    appQuerySelections: [
+                        {
+                            captureKey: 'v1:abc123',
+                            label: 'Revenue by month',
+                            exploreName: 'orders',
+                            excluded: false,
+                        },
+                    ],
+                } as unknown as typeof newSchedulerPayload),
+            ).resolves.toBeDefined();
+
+            expect(schedulerModel.createScheduler).toHaveBeenCalledWith(
+                expect.objectContaining({ savedSqlUuid }),
+            );
+        });
+
         it('user without space access is blocked from creating scheduler', async () => {
             spacePermissionService.can.mockResolvedValueOnce(false);
             await expect(

--- a/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
@@ -353,6 +353,7 @@ describe('SchedulerService', () => {
             const appSendPayload = (
                 format: SchedulerFormat,
                 options: unknown,
+                extra: Record<string, unknown> = {},
             ) =>
                 ({
                     name: 'send now app delivery',
@@ -368,6 +369,7 @@ describe('SchedulerService', () => {
                     enabled: true,
                     includeLinks: true,
                     targets: [{ recipient: 'recipient@example.com' }],
+                    ...extra,
                 }) as unknown as CreateSchedulerAndTargets;
 
             test.each([SchedulerFormat.GSHEETS, SchedulerFormat.PDF])(
@@ -428,6 +430,132 @@ describe('SchedulerService', () => {
                         format: SchedulerFormat.CSV,
                         appUuid: sendAppUuid,
                     }),
+                    undefined,
+                );
+            });
+
+            const validSelections = [
+                {
+                    captureKey: 'v1:abc123',
+                    label: 'Revenue by month',
+                    exploreName: 'orders',
+                    excluded: false,
+                },
+            ];
+
+            test('rejects a send-now app payload where every selection is excluded', async () => {
+                const { appSendService, appSendSchedulerClient } =
+                    buildAppSendService();
+
+                await expect(
+                    appSendService.sendScheduler(
+                        appSendActor,
+                        appSendPayload(
+                            SchedulerFormat.CSV,
+                            { formatted: true, limit: 'table' },
+                            {
+                                appState: { view: 'orders' },
+                                appQuerySelections: [
+                                    { ...validSelections[0], excluded: true },
+                                ],
+                            },
+                        ),
+                    ),
+                ).rejects.toThrowError(ParameterError);
+
+                expect(
+                    appSendSchedulerClient.addScheduledDeliveryJob,
+                ).not.toHaveBeenCalled();
+            });
+
+            test('rejects a send-now app payload with malformed selections', async () => {
+                const { appSendService, appSendSchedulerClient } =
+                    buildAppSendService();
+
+                await expect(
+                    appSendService.sendScheduler(
+                        appSendActor,
+                        appSendPayload(
+                            SchedulerFormat.CSV,
+                            { formatted: true, limit: 'table' },
+                            {
+                                appState: { view: 'orders' },
+                                appQuerySelections: [{ foo: 'bar' }],
+                            },
+                        ),
+                    ),
+                ).rejects.toThrowError(ParameterError);
+
+                expect(
+                    appSendSchedulerClient.addScheduledDeliveryJob,
+                ).not.toHaveBeenCalled();
+            });
+
+            test('rejects a send-now app payload with selections but no saved app state', async () => {
+                const { appSendService, appSendSchedulerClient } =
+                    buildAppSendService();
+
+                await expect(
+                    appSendService.sendScheduler(
+                        appSendActor,
+                        appSendPayload(
+                            SchedulerFormat.CSV,
+                            { formatted: true, limit: 'table' },
+                            { appQuerySelections: validSelections },
+                        ),
+                    ),
+                ).rejects.toThrowError(ParameterError);
+
+                expect(
+                    appSendSchedulerClient.addScheduledDeliveryJob,
+                ).not.toHaveBeenCalled();
+            });
+
+            test('accepts a send-now app payload with valid selections and saved app state', async () => {
+                const { appSendService, appSendSchedulerClient } =
+                    buildAppSendService();
+
+                await appSendService.sendScheduler(
+                    appSendActor,
+                    appSendPayload(
+                        SchedulerFormat.CSV,
+                        { formatted: true, limit: 'table' },
+                        {
+                            appState: { view: 'orders' },
+                            appQuerySelections: validSelections,
+                        },
+                    ),
+                );
+
+                expect(
+                    appSendSchedulerClient.addScheduledDeliveryJob,
+                ).toHaveBeenCalledWith(
+                    expect.any(Date),
+                    expect.objectContaining({
+                        appQuerySelections: validSelections,
+                    }),
+                    undefined,
+                );
+            });
+
+            test('accepts a send-now app payload with appQuerySelections explicitly null', async () => {
+                const { appSendService, appSendSchedulerClient } =
+                    buildAppSendService();
+
+                await appSendService.sendScheduler(
+                    appSendActor,
+                    appSendPayload(
+                        SchedulerFormat.CSV,
+                        { formatted: true, limit: 'table' },
+                        { appQuerySelections: null },
+                    ),
+                );
+
+                expect(
+                    appSendSchedulerClient.addScheduledDeliveryJob,
+                ).toHaveBeenCalledWith(
+                    expect.any(Date),
+                    expect.objectContaining({ appQuerySelections: null }),
                     undefined,
                 );
             });
@@ -725,6 +853,37 @@ describe('SchedulerService', () => {
                 schedulerUuid: chartSchedulerInPrivateSpace.schedulerUuid,
             });
         });
+
+        test('should reject appQuerySelections on a non-app scheduler via the generic update path', async () => {
+            const { updateService, updateSchedulerModel } =
+                buildUpdateService();
+
+            await expect(
+                updateService.updateScheduler(
+                    actorWithoutGoogleSheets,
+                    chartSchedulerInPrivateSpace.schedulerUuid,
+                    {
+                        name: 'scheduler',
+                        cron: '0 0 * * *',
+                        timezone: 'UTC',
+                        format: SchedulerFormat.CSV,
+                        options: { formatted: true, limit: 'table' },
+                        targets: [],
+                        appQuerySelections: [
+                            {
+                                captureKey: 'v1:abc123',
+                                label: 'Revenue by month',
+                                exploreName: 'orders',
+                                excluded: false,
+                            },
+                        ],
+                    } as unknown as UpdateSchedulerAndTargetsWithoutId,
+                    { validateGoogleSheet: false },
+                ),
+            ).rejects.toThrowError(ParameterError);
+
+            expect(updateSchedulerModel.updateScheduler).not.toHaveBeenCalled();
+        });
     });
 
     describe('createAppScheduler', () => {
@@ -793,6 +952,7 @@ describe('SchedulerService', () => {
         const appSchedulerPayload = (
             format: SchedulerFormat,
             options: unknown,
+            extra: Record<string, unknown> = {},
         ) =>
             ({
                 name: 'App delivery',
@@ -803,6 +963,7 @@ describe('SchedulerService', () => {
                 enabled: true,
                 includeLinks: true,
                 targets: [],
+                ...extra,
             }) as unknown as Parameters<
                 SchedulerService['createAppScheduler']
             >[2];
@@ -919,9 +1080,126 @@ describe('SchedulerService', () => {
             },
         );
 
+        const validSelections = [
+            {
+                captureKey: 'v1:abc123',
+                label: 'Revenue by month',
+                exploreName: 'orders',
+                excluded: false,
+            },
+        ];
+
+        test('should reject appQuerySelections where every entry is excluded', async () => {
+            const { appService, appSchedulerModel } = buildAppService();
+
+            await expect(
+                appService.createAppScheduler(
+                    appActor,
+                    appUuid,
+                    appSchedulerPayload(
+                        SchedulerFormat.CSV,
+                        { formatted: true, limit: 'table' },
+                        {
+                            appState: { view: 'orders' },
+                            appQuerySelections: [
+                                { ...validSelections[0], excluded: true },
+                            ],
+                        },
+                    ),
+                ),
+            ).rejects.toThrowError(ParameterError);
+
+            expect(appSchedulerModel.createScheduler).not.toHaveBeenCalled();
+        });
+
+        test('should reject an empty appQuerySelections array', async () => {
+            const { appService, appSchedulerModel } = buildAppService();
+
+            await expect(
+                appService.createAppScheduler(
+                    appActor,
+                    appUuid,
+                    appSchedulerPayload(
+                        SchedulerFormat.CSV,
+                        { formatted: true, limit: 'table' },
+                        {
+                            appState: { view: 'orders' },
+                            appQuerySelections: [],
+                        },
+                    ),
+                ),
+            ).rejects.toThrowError(ParameterError);
+
+            expect(appSchedulerModel.createScheduler).not.toHaveBeenCalled();
+        });
+
+        test('should reject malformed appQuerySelections entries', async () => {
+            const { appService, appSchedulerModel } = buildAppService();
+
+            await expect(
+                appService.createAppScheduler(
+                    appActor,
+                    appUuid,
+                    appSchedulerPayload(
+                        SchedulerFormat.CSV,
+                        { formatted: true, limit: 'table' },
+                        {
+                            appState: { view: 'orders' },
+                            appQuerySelections: [{ foo: 'bar' }],
+                        },
+                    ),
+                ),
+            ).rejects.toThrowError(ParameterError);
+
+            expect(appSchedulerModel.createScheduler).not.toHaveBeenCalled();
+        });
+
+        test('should reject appQuerySelections when the scheduler has no saved app state', async () => {
+            const { appService, appSchedulerModel } = buildAppService();
+
+            await expect(
+                appService.createAppScheduler(
+                    appActor,
+                    appUuid,
+                    appSchedulerPayload(
+                        SchedulerFormat.CSV,
+                        { formatted: true, limit: 'table' },
+                        { appQuerySelections: validSelections },
+                    ),
+                ),
+            ).rejects.toThrowError(ParameterError);
+
+            expect(appSchedulerModel.createScheduler).not.toHaveBeenCalled();
+        });
+
+        test('should accept valid appQuerySelections alongside saved app state', async () => {
+            const { appService, appSchedulerModel } = buildAppService();
+
+            await appService.createAppScheduler(
+                appActor,
+                appUuid,
+                appSchedulerPayload(
+                    SchedulerFormat.CSV,
+                    { formatted: true, limit: 'table' },
+                    {
+                        appState: { view: 'orders' },
+                        appQuerySelections: validSelections,
+                    },
+                ),
+            );
+
+            expect(appSchedulerModel.createScheduler).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    appQuerySelections: validSelections,
+                }),
+            );
+        });
+
         // The generic PATCH /schedulers path is the only way to edit an app
         // scheduler, so the format gate has to hold there too.
-        const buildAppUpdateService = () => {
+        const buildAppUpdateService = (
+            existingOverrides: Record<string, unknown> = {},
+        ) => {
             const existingAppScheduler = {
                 ...chartSchedulerInPrivateSpace,
                 savedChartUuid: null,
@@ -929,6 +1207,7 @@ describe('SchedulerService', () => {
                 appName: 'Sales App',
                 format: SchedulerFormat.IMAGE,
                 options: {},
+                ...existingOverrides,
             };
             const appUpdateSchedulerModel = {
                 getScheduler: vi.fn(async () => existingAppScheduler),
@@ -981,7 +1260,11 @@ describe('SchedulerService', () => {
                 },
             ]);
 
-        const appUpdatePayload = (format: SchedulerFormat, options: unknown) =>
+        const appUpdatePayload = (
+            format: SchedulerFormat,
+            options: unknown,
+            extra: Record<string, unknown> = {},
+        ) =>
             ({
                 name: 'scheduler',
                 cron: '0 0 * * *',
@@ -989,6 +1272,7 @@ describe('SchedulerService', () => {
                 format,
                 options,
                 targets: [],
+                ...extra,
             }) as unknown as UpdateSchedulerAndTargetsWithoutId;
 
         test('should reject a PDF format change on the generic update path', async () => {
@@ -1045,6 +1329,115 @@ describe('SchedulerService', () => {
                     schedulerUuid: 'schedulerUuid',
                     format: SchedulerFormat.IMAGE,
                 }),
+            );
+        });
+
+        const validUpdateSelections = [
+            {
+                captureKey: 'v1:abc123',
+                label: 'Revenue by month',
+                exploreName: 'orders',
+                excluded: false,
+            },
+        ];
+
+        test('should reject an app scheduler update where every selection is excluded', async () => {
+            const { appUpdateService, appUpdateSchedulerModel } =
+                buildAppUpdateService({ appState: { view: 'orders' } });
+
+            await expect(
+                appUpdateService.updateScheduler(
+                    appUpdateActor(),
+                    'schedulerUuid',
+                    appUpdatePayload(
+                        SchedulerFormat.IMAGE,
+                        {},
+                        {
+                            appQuerySelections: [
+                                { ...validUpdateSelections[0], excluded: true },
+                            ],
+                        },
+                    ),
+                ),
+            ).rejects.toThrowError(ParameterError);
+
+            expect(
+                appUpdateSchedulerModel.updateScheduler,
+            ).not.toHaveBeenCalled();
+        });
+
+        test('should reject an app scheduler update with selections but no saved app state', async () => {
+            const { appUpdateService, appUpdateSchedulerModel } =
+                buildAppUpdateService();
+
+            await expect(
+                appUpdateService.updateScheduler(
+                    appUpdateActor(),
+                    'schedulerUuid',
+                    appUpdatePayload(
+                        SchedulerFormat.IMAGE,
+                        {},
+                        {
+                            appQuerySelections: validUpdateSelections,
+                        },
+                    ),
+                ),
+            ).rejects.toThrowError(ParameterError);
+
+            expect(
+                appUpdateSchedulerModel.updateScheduler,
+            ).not.toHaveBeenCalled();
+        });
+
+        test('should accept a valid app scheduler curation update', async () => {
+            const { appUpdateService, appUpdateSchedulerModel } =
+                buildAppUpdateService();
+
+            // The update payload must re-carry appState alongside the
+            // selections: an update always writes appState from the payload
+            // (omission clears it), so "has state" is evaluated post-update.
+            await appUpdateService.updateScheduler(
+                appUpdateActor(),
+                'schedulerUuid',
+                appUpdatePayload(
+                    SchedulerFormat.IMAGE,
+                    {},
+                    {
+                        appState: { view: 'orders' },
+                        appQuerySelections: validUpdateSelections,
+                    },
+                ),
+            );
+
+            expect(
+                appUpdateSchedulerModel.updateScheduler,
+            ).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    appQuerySelections: validUpdateSelections,
+                }),
+            );
+        });
+
+        test('should clear curation to null on an explicit null update, without requiring app state', async () => {
+            const { appUpdateService, appUpdateSchedulerModel } =
+                buildAppUpdateService();
+
+            await appUpdateService.updateScheduler(
+                appUpdateActor(),
+                'schedulerUuid',
+                appUpdatePayload(
+                    SchedulerFormat.IMAGE,
+                    {},
+                    {
+                        appQuerySelections: null,
+                    },
+                ),
+            );
+
+            expect(
+                appUpdateSchedulerModel.updateScheduler,
+            ).toHaveBeenCalledWith(
+                expect.objectContaining({ appQuerySelections: null }),
             );
         });
     });

--- a/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
@@ -294,6 +294,27 @@ describe('SchedulerService', () => {
             );
         });
 
+        // A non-app send-now payload never persists anything (send-now
+        // doesn't touch SchedulerModel at all), and validateAppSchedulerDelivery
+        // is only invoked when isAppScheduler(scheduler) is true — so a stray
+        // appQuerySelections field on a chart send-now payload is not
+        // rejected, it just rides along inertly, same as appState would.
+        test('does not reject a stray appQuerySelections field on a non-app send-now payload', async () => {
+            await service.sendScheduler(userWhoCanSend, {
+                ...sendNowPayload,
+                appQuerySelections: [
+                    {
+                        captureKey: 'v1:abc123',
+                        label: 'Revenue by month',
+                        exploreName: 'orders',
+                        excluded: false,
+                    },
+                ],
+            } as unknown as CreateSchedulerAndTargets);
+
+            expect(schedulerClient.addScheduledDeliveryJob).toHaveBeenCalled();
+        });
+
         describe('app payloads', () => {
             const sendAppUuid = 'appUuid';
             const sendAppRow = {
@@ -1357,6 +1378,48 @@ describe('SchedulerService', () => {
                                 { ...validUpdateSelections[0], excluded: true },
                             ],
                         },
+                    ),
+                ),
+            ).rejects.toThrowError(ParameterError);
+
+            expect(
+                appUpdateSchedulerModel.updateScheduler,
+            ).not.toHaveBeenCalled();
+        });
+
+        test('should reject an empty appQuerySelections array on the generic update path', async () => {
+            const { appUpdateService, appUpdateSchedulerModel } =
+                buildAppUpdateService({ appState: { view: 'orders' } });
+
+            await expect(
+                appUpdateService.updateScheduler(
+                    appUpdateActor(),
+                    'schedulerUuid',
+                    appUpdatePayload(
+                        SchedulerFormat.IMAGE,
+                        {},
+                        { appQuerySelections: [] },
+                    ),
+                ),
+            ).rejects.toThrowError(ParameterError);
+
+            expect(
+                appUpdateSchedulerModel.updateScheduler,
+            ).not.toHaveBeenCalled();
+        });
+
+        test('should reject malformed appQuerySelections entries on the generic update path', async () => {
+            const { appUpdateService, appUpdateSchedulerModel } =
+                buildAppUpdateService({ appState: { view: 'orders' } });
+
+            await expect(
+                appUpdateService.updateScheduler(
+                    appUpdateActor(),
+                    'schedulerUuid',
+                    appUpdatePayload(
+                        SchedulerFormat.IMAGE,
+                        {},
+                        { appQuerySelections: [{ foo: 'bar' }] },
                     ),
                 ),
             ).rejects.toThrowError(ParameterError);

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -22,6 +22,7 @@ import {
     isSchedulerGsheetsOptions,
     isSqlChartScheduler,
     isUserWithOrg,
+    isValidAppQuerySelections,
     isValidFrequency,
     isValidSchedulerAppState,
     isValidTimezone,
@@ -50,6 +51,8 @@ import {
     UpdateSchedulerAndTargetsWithoutId,
     UserSchedulersSummary,
     type Account,
+    type AppQuerySelection,
+    type SchedulerAppState,
 } from '@lightdash/common';
 import cronstrue from 'cronstrue';
 import {
@@ -564,9 +567,12 @@ export class SchedulerService extends BaseService {
 
     // App deliveries render the app once and materialise whatever queries it ran,
     // so each query brings its own limit and GSheets/PDF have no equivalent yet.
+    // Only called once the caller already knows `scheduler` is an app scheduler.
     private static validateAppSchedulerDelivery(scheduler: {
         format: SchedulerFormat;
         options: SchedulerOptions;
+        appState?: SchedulerAppState | null;
+        appQuerySelections?: AppQuerySelection[] | null;
     }): void {
         const allowedFormats = [
             SchedulerFormat.IMAGE,
@@ -584,6 +590,29 @@ export class SchedulerService extends BaseService {
         ) {
             throw new ParameterError(
                 "Data app deliveries always use each query's own limit",
+            );
+        }
+
+        const { appQuerySelections } = scheduler;
+        if (appQuerySelections === undefined || appQuerySelections === null) {
+            return; // omitted or explicitly cleared — always allowed
+        }
+        if (!isValidAppQuerySelections(appQuerySelections)) {
+            throw new ParameterError(
+                'appQuerySelections contains malformed entries',
+            );
+        }
+        if (
+            appQuerySelections.length === 0 ||
+            appQuerySelections.every((selection) => selection.excluded)
+        ) {
+            throw new ParameterError(
+                'appQuerySelections cannot exclude every captured query',
+            );
+        }
+        if (!scheduler.appState) {
+            throw new ParameterError(
+                'appQuerySelections requires the scheduler to have saved app state',
             );
         }
     }
@@ -868,6 +897,12 @@ export class SchedulerService extends BaseService {
 
         if (isAppScheduler(existingScheduler)) {
             SchedulerService.validateAppSchedulerDelivery(updatedScheduler);
+        } else if (updatedScheduler.appQuerySelections !== undefined) {
+            // The generic PATCH endpoint is shared across every resource
+            // type; only app schedulers may curate delivered queries.
+            throw new ParameterError(
+                'appQuerySelections is only valid on data app schedulers',
+            );
         }
 
         if (updatedScheduler.format === SchedulerFormat.GSHEETS) {

--- a/packages/common/src/types/scheduler.test.ts
+++ b/packages/common/src/types/scheduler.test.ts
@@ -1,4 +1,8 @@
 import {
+    MAX_CAPTURE_LABEL_CHARS,
+    MAX_DELIVERY_QUERIES,
+} from '../ee/apps/deliveryCapture';
+import {
     getSchedulerUuid,
     getSourceSchedulerUuid,
     isValidAppQuerySelections,
@@ -120,5 +124,73 @@ describe('isValidAppQuerySelections', () => {
 
     it('rejects array entries that are themselves arrays', () => {
         expect(isValidAppQuerySelections([[]])).toBe(false);
+    });
+
+    // Consistent with parseCapturedQuery in deliveryCapture.ts, which
+    // likewise destructures only its known fields and never rejects extras.
+    it('tolerates unknown extra properties on an entry (parity with parseDeliveryCaptureManifest)', () => {
+        expect(
+            isValidAppQuerySelections([{ ...validEntry, unexpected: 'extra' }]),
+        ).toBe(true);
+    });
+
+    describe('size bounds', () => {
+        it('accepts exactly MAX_DELIVERY_QUERIES entries', () => {
+            const entries: AppQuerySelection[] = Array.from(
+                { length: MAX_DELIVERY_QUERIES },
+                (_, i) => ({ ...validEntry, captureKey: `v1:key${i}` }),
+            );
+            expect(isValidAppQuerySelections(entries)).toBe(true);
+        });
+
+        it('rejects more than MAX_DELIVERY_QUERIES entries', () => {
+            const entries: AppQuerySelection[] = Array.from(
+                { length: MAX_DELIVERY_QUERIES + 1 },
+                (_, i) => ({ ...validEntry, captureKey: `v1:key${i}` }),
+            );
+            expect(isValidAppQuerySelections(entries)).toBe(false);
+        });
+
+        it('accepts a label exactly MAX_CAPTURE_LABEL_CHARS long', () => {
+            const label = 'a'.repeat(MAX_CAPTURE_LABEL_CHARS);
+            expect(isValidAppQuerySelections([{ ...validEntry, label }])).toBe(
+                true,
+            );
+        });
+
+        it('rejects a label longer than MAX_CAPTURE_LABEL_CHARS', () => {
+            const label = 'a'.repeat(MAX_CAPTURE_LABEL_CHARS + 1);
+            expect(isValidAppQuerySelections([{ ...validEntry, label }])).toBe(
+                false,
+            );
+        });
+
+        it('accepts a captureKey exactly MAX_CAPTURE_LABEL_CHARS long', () => {
+            const captureKey = 'v1:'.padEnd(MAX_CAPTURE_LABEL_CHARS, 'a');
+            expect(
+                isValidAppQuerySelections([{ ...validEntry, captureKey }]),
+            ).toBe(true);
+        });
+
+        it('rejects a captureKey longer than MAX_CAPTURE_LABEL_CHARS', () => {
+            const captureKey = 'v1:'.padEnd(MAX_CAPTURE_LABEL_CHARS + 1, 'a');
+            expect(
+                isValidAppQuerySelections([{ ...validEntry, captureKey }]),
+            ).toBe(false);
+        });
+
+        it('accepts an exploreName exactly MAX_CAPTURE_LABEL_CHARS long', () => {
+            const exploreName = 'a'.repeat(MAX_CAPTURE_LABEL_CHARS);
+            expect(
+                isValidAppQuerySelections([{ ...validEntry, exploreName }]),
+            ).toBe(true);
+        });
+
+        it('rejects an exploreName longer than MAX_CAPTURE_LABEL_CHARS', () => {
+            const exploreName = 'a'.repeat(MAX_CAPTURE_LABEL_CHARS + 1);
+            expect(
+                isValidAppQuerySelections([{ ...validEntry, exploreName }]),
+            ).toBe(false);
+        });
     });
 });

--- a/packages/common/src/types/scheduler.test.ts
+++ b/packages/common/src/types/scheduler.test.ts
@@ -1,6 +1,8 @@
 import {
     getSchedulerUuid,
     getSourceSchedulerUuid,
+    isValidAppQuerySelections,
+    type AppQuerySelection,
     type CreateSchedulerAndTargets,
     type Scheduler,
 } from './scheduler';
@@ -44,5 +46,79 @@ describe('getSchedulerUuid', () => {
         } as unknown as CreateSchedulerAndTargets;
 
         expect(getSchedulerUuid(payload)).toBeUndefined();
+    });
+});
+
+describe('isValidAppQuerySelections', () => {
+    const validEntry: AppQuerySelection = {
+        captureKey: 'v1:abc123',
+        label: 'Revenue by month',
+        exploreName: 'orders',
+        excluded: false,
+    };
+
+    it('accepts null (no curation)', () => {
+        expect(isValidAppQuerySelections(null)).toBe(true);
+    });
+
+    it('accepts an array of valid entries, including a null exploreName', () => {
+        const entries: AppQuerySelection[] = [
+            validEntry,
+            { ...validEntry, exploreName: null, excluded: true },
+        ];
+        expect(isValidAppQuerySelections(entries)).toBe(true);
+    });
+
+    it('accepts an empty array (shape-valid; emptiness is a service-level concern)', () => {
+        expect(isValidAppQuerySelections([])).toBe(true);
+    });
+
+    it('rejects undefined', () => {
+        expect(isValidAppQuerySelections(undefined)).toBe(false);
+    });
+
+    it('rejects non-array, non-null values', () => {
+        expect(isValidAppQuerySelections('none')).toBe(false);
+        expect(isValidAppQuerySelections(42)).toBe(false);
+        expect(isValidAppQuerySelections({})).toBe(false);
+    });
+
+    it('rejects an entry missing captureKey', () => {
+        const { captureKey, ...rest } = validEntry;
+        expect(isValidAppQuerySelections([rest])).toBe(false);
+    });
+
+    it('rejects an entry with an empty captureKey', () => {
+        expect(
+            isValidAppQuerySelections([{ ...validEntry, captureKey: '' }]),
+        ).toBe(false);
+    });
+
+    it('rejects an entry with a non-string label', () => {
+        expect(isValidAppQuerySelections([{ ...validEntry, label: 42 }])).toBe(
+            false,
+        );
+    });
+
+    it('rejects an entry with a non-nullable exploreName type', () => {
+        expect(
+            isValidAppQuerySelections([{ ...validEntry, exploreName: 42 }]),
+        ).toBe(false);
+    });
+
+    it('rejects an entry with a non-boolean excluded flag', () => {
+        expect(
+            isValidAppQuerySelections([{ ...validEntry, excluded: 'true' }]),
+        ).toBe(false);
+    });
+
+    it('rejects a malformed entry mixed in with valid ones', () => {
+        expect(isValidAppQuerySelections([validEntry, { foo: 'bar' }])).toBe(
+            false,
+        );
+    });
+
+    it('rejects array entries that are themselves arrays', () => {
+        expect(isValidAppQuerySelections([[]])).toBe(false);
     });
 });

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -195,12 +195,56 @@ export const isValidSchedulerAppState = (
     !Array.isArray(value) &&
     JSON.stringify(value).length <= MAX_SCHEDULER_APP_STATE_CHARS;
 
+/**
+ * Full snapshot of what the delivery query picker showed at save time, keyed
+ * by the capture pipeline's versioned captureKey (see CAPTURE_KEY_VERSION in
+ * ee/apps/deliveryCapture). Entries are never dropped when excluded, so
+ * "expected but did not run" stays reportable against this snapshot.
+ */
+export type AppQuerySelection = {
+    captureKey: string;
+    label: string;
+    exploreName: string | null;
+    excluded: boolean;
+};
+
+const isValidAppQuerySelectionEntry = (
+    value: unknown,
+): value is AppQuerySelection => {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        return false;
+    }
+    const { captureKey, label, exploreName, excluded } = value as Record<
+        string,
+        unknown
+    >;
+    return (
+        typeof captureKey === 'string' &&
+        captureKey.length > 0 &&
+        typeof label === 'string' &&
+        (exploreName === null || typeof exploreName === 'string') &&
+        typeof excluded === 'boolean'
+    );
+};
+
+/**
+ * Fail-closed validator for the curated query snapshot on an app scheduler.
+ * `null` means "no curation" (deliver everything) and is valid on its own;
+ * any other malformed shape is rejected.
+ */
+export const isValidAppQuerySelections = (
+    value: unknown,
+): value is AppQuerySelection[] | null =>
+    value === null ||
+    (Array.isArray(value) && value.every(isValidAppQuerySelectionEntry));
+
 export type AppScheduler = SchedulerBase & {
     savedChartUuid: null;
     dashboardUuid: null;
     savedSqlUuid: null;
     appUuid: string;
     appState?: SchedulerAppState;
+    appQuerySelections: AppQuerySelection[] | null;
 };
 
 export const isAppScheduler = (
@@ -336,6 +380,7 @@ export type CreateSchedulerAndTargets = Omit<
     | 'savedChartName'
     | 'dashboardName'
     | 'savedSqlName'
+    | 'appQuerySelections'
 > & {
     slug?: string;
     targets: CreateSchedulerTarget[];
@@ -348,6 +393,9 @@ export type CreateSchedulerAndTargets = Omit<
     // for link building — must not reclassify the payload as a saved scheduler
     // (send-now filter/batch semantics key off schedulerUuid being absent).
     sourceSchedulerUuid?: string;
+    // Optional so existing app scheduler create/send-now callers keep working
+    // unchanged; omitted means "no curation" (deliver everything).
+    appQuerySelections?: AppQuerySelection[] | null;
 };
 
 export type CreateSchedulerAndTargetsWithoutIds = Omit<
@@ -373,6 +421,7 @@ export type UpdateSchedulerAndTargets = Pick<
     customViewportWidth?: number;
     selectedTabs?: string[] | null;
     appState?: SchedulerAppState | null;
+    appQuerySelections?: AppQuerySelection[] | null;
     targets: Array<
         | CreateSchedulerTarget
         | UpdateSchedulerSlackTarget

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -1,3 +1,7 @@
+import {
+    MAX_CAPTURE_LABEL_CHARS,
+    MAX_DELIVERY_QUERIES,
+} from '../ee/apps/deliveryCapture';
 import { type AiReviewNotificationEvent } from '../ee/types/aiReviewNotification';
 import assertUnreachable from '../utils/assertUnreachable';
 import { type AnyType } from './any';
@@ -208,6 +212,9 @@ export type AppQuerySelection = {
     excluded: boolean;
 };
 
+// String fields reuse the capture pipeline's label cap (deliveryCapture.ts
+// has no dedicated captureKey/exploreName constant, and a captureKey is a
+// version prefix + sha256 hex digest — comfortably under this bound).
 const isValidAppQuerySelectionEntry = (
     value: unknown,
 ): value is AppQuerySelection => {
@@ -221,8 +228,12 @@ const isValidAppQuerySelectionEntry = (
     return (
         typeof captureKey === 'string' &&
         captureKey.length > 0 &&
+        captureKey.length <= MAX_CAPTURE_LABEL_CHARS &&
         typeof label === 'string' &&
-        (exploreName === null || typeof exploreName === 'string') &&
+        label.length <= MAX_CAPTURE_LABEL_CHARS &&
+        (exploreName === null ||
+            (typeof exploreName === 'string' &&
+                exploreName.length <= MAX_CAPTURE_LABEL_CHARS)) &&
         typeof excluded === 'boolean'
     );
 };
@@ -230,13 +241,16 @@ const isValidAppQuerySelectionEntry = (
 /**
  * Fail-closed validator for the curated query snapshot on an app scheduler.
  * `null` means "no curation" (deliver everything) and is valid on its own;
- * any other malformed shape is rejected.
+ * any other malformed shape — including exceeding MAX_DELIVERY_QUERIES
+ * entries, the same cap the capture pipeline itself enforces — is rejected.
  */
 export const isValidAppQuerySelections = (
     value: unknown,
 ): value is AppQuerySelection[] | null =>
     value === null ||
-    (Array.isArray(value) && value.every(isValidAppQuerySelectionEntry));
+    (Array.isArray(value) &&
+        value.length <= MAX_DELIVERY_QUERIES &&
+        value.every(isValidAppQuerySelectionEntry));
 
 export type AppScheduler = SchedulerBase & {
     savedChartUuid: null;

--- a/packages/frontend/src/components/SchedulersView/SchedulersViewUtils.test.ts
+++ b/packages/frontend/src/components/SchedulersView/SchedulersViewUtils.test.ts
@@ -67,6 +67,7 @@ const appScheduler: Fixture<AppScheduler> = {
     dashboardUuid: null,
     savedSqlUuid: null,
     appUuid: 'app-1',
+    appQuerySelections: null,
 };
 
 describe('getSchedulerLink', () => {


### PR DESCRIPTION
## Summary

PR 1 of 3 for the app-delivery query picker: the storage and contract layer only — dark, no delivery-behavior or UI change.

- New nullable jsonb column `app_query_selections` on `scheduler` (precedent: `selected_tabs`). Shape: `Array<{ captureKey, label, exploreName, excluded }>` — a full snapshot of what the picker showed at save time (so "expected but did not run" is reportable later), `null` = no curation = deliver everything.
- `AppQuerySelection` type + fail-closed validator in common, with size bounds reusing the capture pipeline's constants (`MAX_DELIVERY_QUERIES` entries, `MAX_CAPTURE_LABEL_CHARS` per string field).
- `SchedulerModel` round-trips the column on create/update, including explicit clear-to-`null`. The insert-row whitelist keeps chart/dashboard/SQL schedulers from ever writing it; that non-persistence is now pinned by regression tests on every non-app path (silent-drop matches the existing `appState` precedent).
- `SchedulerService` validations on app-scheduler create, update, and send-now: selections rejected on non-app schedulers (update path), all-excluded rejected, selections without saved app state rejected (curation without a state snapshot would silently release every exclusion), malformed rejected via the validator.

Follow-ups in this stack: worker-side selection filtering with `APP_QUERY_MISSING` partial failures (PR 2), then the scheduler-modal picker UI fed by a preview capture render (PR 3).

## Testing

- common: validator unit tests incl. at-limit/over-limit bounds and deliberate unknown-prop tolerance (3402 passed)
- backend: model round-trip + service validation matrix + non-persistence pins across DashboardService/SavedChartService/SavedSqlService/send-now (5736 passed)
- migration up→down→up verified against local dev db; `pnpm generate-api` confirmed the new request field survives TSOA (generated files not committed)

Relates: PROD-9380