### PR TITLE
feat(user): server-persisted user onboarding tours (table, API, hook)

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -316,6 +316,10 @@ import {
     UserOAuthGrantsTable,
     UserOAuthGrantsTableName,
 } from '../database/entities/userOAuthGrants';
+import {
+    UserOnboardingTable,
+    UserOnboardingTableName,
+} from '../database/entities/userOnboarding';
 import { UserTable, UserTableName } from '../database/entities/users';
 import {
     ProjectUserWarehouseCredentialPreferenceTable,
@@ -534,6 +538,7 @@ declare module 'knex/types/tables' {
         [OrganizationTableName]: OrganizationTable;
         [UserTableName]: UserTable;
         [UserAvatarsTableName]: UserAvatarsTable;
+        [UserOnboardingTableName]: UserOnboardingTable;
         [EmailTableName]: EmailTable;
         [FeatureFlagsTableName]: FeatureFlagsTable;
         [FeatureFlagOverridesTableName]: FeatureFlagOverridesTable;

--- a/packages/backend/src/controllers/userController.ts
+++ b/packages/backend/src/controllers/userController.ts
@@ -1,9 +1,11 @@
 import {
+    ApiCompleteUserOnboardingTourRequest,
     ApiEmailStatusResponse,
     ApiErrorPayload,
     ApiGetAccountResponse,
     ApiGetAuthenticatedUserResponse,
     ApiGetLoginOptionsResponse,
+    ApiGetUserOnboardingResponse,
     ApiLoginEmailOtpRequest,
     ApiLoginEmailOtpResponse,
     ApiRegisterUserResponse,
@@ -197,6 +199,52 @@ export class UserController extends BaseController {
         return {
             status: 'ok',
             results: status,
+        };
+    }
+
+    /**
+     * Get the authenticated user's onboarding state, i.e. which feature tours they have completed
+     * @summary Get onboarding
+     * @param req express request
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Get('/onboarding')
+    @OperationId('GetUserOnboarding')
+    async getUserOnboarding(
+        @Request() req: express.Request,
+    ): Promise<ApiGetUserOnboardingResponse> {
+        assertRegisteredAccount(req.account);
+        const results = await this.services
+            .getUserService()
+            .getOnboarding(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results,
+        };
+    }
+
+    /**
+     * Mark a feature tour as completed for the authenticated user
+     * @summary Complete onboarding tour
+     * @param req express request
+     * @param body the tour to mark as completed
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @Post('/onboarding')
+    @OperationId('CompleteUserOnboardingTour')
+    async completeUserOnboardingTour(
+        @Request() req: express.Request,
+        @Body() body: ApiCompleteUserOnboardingTourRequest,
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        await this.services
+            .getUserService()
+            .completeOnboardingTour(req.account, body.tour);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: undefined,
         };
     }
 

--- a/packages/backend/src/database/entities/userOnboarding.ts
+++ b/packages/backend/src/database/entities/userOnboarding.ts
@@ -1,0 +1,16 @@
+import { Knex } from 'knex';
+
+export const UserOnboardingTableName = 'user_onboarding';
+
+export type DbUserOnboarding = {
+    user_uuid: string;
+    completed_tours: Record<string, boolean>;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type UserOnboardingTable = Knex.CompositeTableType<
+    DbUserOnboarding,
+    Pick<DbUserOnboarding, 'user_uuid' | 'completed_tours'>,
+    Pick<DbUserOnboarding, 'completed_tours' | 'updated_at'>
+>;

--- a/packages/backend/src/database/migrations/20260806103259_create_user_onboarding_table.ts
+++ b/packages/backend/src/database/migrations/20260806103259_create_user_onboarding_table.ts
@@ -1,0 +1,30 @@
+import { Knex } from 'knex';
+
+const USER_ONBOARDING_TABLE = 'user_onboarding';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(USER_ONBOARDING_TABLE, (table) => {
+        table
+            .uuid('user_uuid')
+            .primary()
+            .references('user_uuid')
+            .inTable('users')
+            .onDelete('CASCADE');
+        table
+            .jsonb('completed_tours')
+            .notNullable()
+            .defaultTo(knex.raw("'{}'::jsonb"));
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(USER_ONBOARDING_TABLE);
+}

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -67,6 +67,7 @@ import { UserAvatarModel } from './UserAvatarModel';
 import { UserFavoritesModel } from './UserFavoritesModel';
 import { UserModel } from './UserModel';
 import { UserOAuthGrantsModel } from './UserOAuthGrantsModel';
+import { UserOnboardingModel } from './UserOnboardingModel';
 import { UserWarehouseCredentialsModel } from './UserWarehouseCredentials/UserWarehouseCredentialsModel';
 import { ValidationModel } from './ValidationModel/ValidationModel';
 import { WarehouseAvailableTablesModel } from './WarehouseAvailableTablesModel/WarehouseAvailableTablesModel';
@@ -102,6 +103,7 @@ export type ModelManifest = {
     organizationDesignModel: OrganizationDesignModel;
     organizationMemberProfileModel: OrganizationMemberProfileModel;
     userAvatarModel: UserAvatarModel;
+    userOnboardingModel: UserOnboardingModel;
     organizationModel: OrganizationModel;
     organizationDomainVerificationModel: OrganizationDomainVerificationModel;
     organizationEmailDomainModel: OrganizationEmailDomainModel;
@@ -469,6 +471,13 @@ export class ModelRepository
         return this.getModel(
             'userAvatarModel',
             () => new UserAvatarModel({ database: this.database }),
+        );
+    }
+
+    public getUserOnboardingModel(): UserOnboardingModel {
+        return this.getModel(
+            'userOnboardingModel',
+            () => new UserOnboardingModel({ database: this.database }),
         );
     }
 

--- a/packages/backend/src/models/UserOnboardingModel.ts
+++ b/packages/backend/src/models/UserOnboardingModel.ts
@@ -1,0 +1,43 @@
+import { UserOnboardingTour } from '@lightdash/common';
+import { Knex } from 'knex';
+import { UserOnboardingTableName } from '../database/entities/userOnboarding';
+
+type UserOnboardingModelArguments = {
+    database: Knex;
+};
+
+export class UserOnboardingModel {
+    private readonly database: Knex;
+
+    constructor({ database }: UserOnboardingModelArguments) {
+        this.database = database;
+    }
+
+    async findCompletedTours(
+        userUuid: string,
+    ): Promise<Record<string, boolean>> {
+        const row = await this.database(UserOnboardingTableName)
+            .select('completed_tours')
+            .where('user_uuid', userUuid)
+            .first();
+        return row?.completed_tours ?? {};
+    }
+
+    async completeTour(
+        userUuid: string,
+        tour: UserOnboardingTour,
+    ): Promise<void> {
+        await this.database(UserOnboardingTableName)
+            .insert({
+                user_uuid: userUuid,
+                completed_tours: { [tour]: true },
+            })
+            .onConflict('user_uuid')
+            .merge({
+                completed_tours: this.database.raw(
+                    `${UserOnboardingTableName}.completed_tours || excluded.completed_tours`,
+                ),
+                updated_at: this.database.fn.now(),
+            });
+    }
+}

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1151,6 +1151,7 @@ export class ServiceRepository
                     projectModel: this.models.getProjectModel(),
                     featureFlagModel: this.models.getFeatureFlagModel(),
                     userAvatarModel: this.models.getUserAvatarModel(),
+                    userOnboardingModel: this.models.getUserOnboardingModel(),
                     rolesModel: this.models.getRolesModel(),
                 }),
         );

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -41,6 +41,7 @@ import { SessionModel } from '../models/SessionModel';
 import { UserAvatarModel } from '../models/UserAvatarModel';
 import { UserModel } from '../models/UserModel';
 import { UserOAuthGrantsModel } from '../models/UserOAuthGrantsModel';
+import { UserOnboardingModel } from '../models/UserOnboardingModel';
 import { UserWarehouseCredentialsModel } from '../models/UserWarehouseCredentials/UserWarehouseCredentialsModel';
 import { WarehouseAvailableTablesModel } from '../models/WarehouseAvailableTablesModel/WarehouseAvailableTablesModel';
 import { getOrganizationSystemRoleScopes } from '../utils/organizationRolePermissions';
@@ -250,6 +251,7 @@ const createUserService = (
                 ),
             } as unknown as FeatureFlagModel),
         userAvatarModel: {} as UserAvatarModel,
+        userOnboardingModel: {} as UserOnboardingModel,
         rolesModel: (overrides.rolesModel as RolesModel) ?? ({} as RolesModel),
     });
 
@@ -2959,6 +2961,7 @@ describe('UserService', () => {
                     })),
                 } as unknown as FeatureFlagModel,
                 userAvatarModel: {} as UserAvatarModel,
+                userOnboardingModel: {} as UserOnboardingModel,
                 rolesModel: {} as RolesModel,
             });
 
@@ -3039,6 +3042,7 @@ describe('UserService', () => {
                     })),
                 } as unknown as FeatureFlagModel,
                 userAvatarModel: {} as UserAvatarModel,
+                userOnboardingModel: {} as UserOnboardingModel,
                 rolesModel: {} as RolesModel,
             });
 

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -63,7 +63,10 @@ import {
     SpaceMemberRole,
     UpdateUserArgs,
     UpsertUserWarehouseCredentials,
+    USER_ONBOARDING_TOURS,
     UserAllowedOrganization,
+    UserOnboarding,
+    UserOnboardingTour,
     validateEmail,
     validateOrganizationEmailDomains,
     validateOrganizationNameOrThrow,
@@ -115,6 +118,7 @@ import { SessionModel } from '../models/SessionModel';
 import { UserAvatarModel } from '../models/UserAvatarModel';
 import { CreatePasswordlessUserArgs, UserModel } from '../models/UserModel';
 import { UserOAuthGrantsModel } from '../models/UserOAuthGrantsModel';
+import { UserOnboardingModel } from '../models/UserOnboardingModel';
 import { UserWarehouseCredentialsModel } from '../models/UserWarehouseCredentials/UserWarehouseCredentialsModel';
 import { WarehouseAvailableTablesModel } from '../models/WarehouseAvailableTablesModel/WarehouseAvailableTablesModel';
 import { wrapSentryTransaction } from '../utils';
@@ -161,6 +165,7 @@ type UserServiceArguments = {
     projectModel: ProjectModel;
     featureFlagModel: FeatureFlagModel;
     userAvatarModel: UserAvatarModel;
+    userOnboardingModel: UserOnboardingModel;
     rolesModel: RolesModel;
 };
 
@@ -251,6 +256,8 @@ export class UserService extends BaseService {
 
     private readonly userAvatarModel: UserAvatarModel;
 
+    private readonly userOnboardingModel: UserOnboardingModel;
+
     private readonly groupsModel: GroupsModel;
 
     private readonly sessionModel: SessionModel;
@@ -314,6 +321,7 @@ export class UserService extends BaseService {
         projectModel,
         featureFlagModel,
         userAvatarModel,
+        userOnboardingModel,
         rolesModel,
     }: UserServiceArguments) {
         super();
@@ -340,6 +348,7 @@ export class UserService extends BaseService {
         this.projectModel = projectModel;
         this.featureFlagModel = featureFlagModel;
         this.userAvatarModel = userAvatarModel;
+        this.userOnboardingModel = userOnboardingModel;
         this.rolesModel = rolesModel;
     }
 
@@ -1768,6 +1777,30 @@ export class UserService extends BaseService {
             },
         });
         return { avatarUrl: getUserAvatarUrl(user.userUuid, contentHash) };
+    }
+
+    async getOnboarding(account: RegisteredAccount): Promise<UserOnboarding> {
+        const completed = await this.userOnboardingModel.findCompletedTours(
+            account.user.userUuid,
+        );
+        return {
+            completedTours: Object.fromEntries(
+                USER_ONBOARDING_TOURS.map((tour) => [
+                    tour,
+                    completed[tour] === true,
+                ]),
+            ) as Record<UserOnboardingTour, boolean>,
+        };
+    }
+
+    async completeOnboardingTour(
+        account: RegisteredAccount,
+        tour: UserOnboardingTour,
+    ): Promise<void> {
+        await this.userOnboardingModel.completeTour(
+            account.user.userUuid,
+            tour,
+        );
     }
 
     async deleteAvatar(user: SessionUser): Promise<void> {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -320,6 +320,7 @@ export * from './types/timezone';
 export * from './types/user';
 export * from './types/userAvatars';
 export * from './types/userAttributes';
+export * from './types/userOnboarding';
 export * from './types/userWarehouseCredentials';
 export * from './types/validation';
 export * from './types/warehouse';

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -330,6 +330,7 @@ import {
     type UserAllowedOrganization,
 } from './user';
 import { type UserAvatarColorValue } from './userAvatars';
+import { type UserOnboarding } from './userOnboarding';
 import {
     type RedshiftAwsSsoCompleteResults,
     type RedshiftAwsSsoStartResults,
@@ -1183,6 +1184,7 @@ type ApiResults =
     | ApiGetComments['results']
     | ApiDeleteComment
     | ApiUserAvatarResponse['results']
+    | UserOnboarding
     | ApiSuccessEmpty
     | ApiCreateProjectResults
     | ApiDeployExploresResults

--- a/packages/common/src/types/userOnboarding.ts
+++ b/packages/common/src/types/userOnboarding.ts
@@ -1,0 +1,20 @@
+/**
+ * Registry of app-wide feature tours whose seen-flag is persisted per user.
+ * Add a key here to introduce a new tour; no schema change needed.
+ */
+export const USER_ONBOARDING_TOURS = ['memoryTour'] as const;
+
+export type UserOnboardingTour = (typeof USER_ONBOARDING_TOURS)[number];
+
+export type UserOnboarding = {
+    completedTours: Record<UserOnboardingTour, boolean>;
+};
+
+export type ApiGetUserOnboardingResponse = {
+    status: 'ok';
+    results: UserOnboarding;
+};
+
+export type ApiCompleteUserOnboardingTourRequest = {
+    tour: UserOnboardingTour;
+};

--- a/packages/frontend/src/hooks/useOnboardingTour.ts
+++ b/packages/frontend/src/hooks/useOnboardingTour.ts
@@ -1,0 +1,94 @@
+import type {
+    ApiCompleteUserOnboardingTourRequest,
+    ApiError,
+    UserOnboarding,
+    UserOnboardingTour,
+} from '@lightdash/common';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useState } from 'react';
+import { lightdashApi } from '../api';
+
+const USER_ONBOARDING_QUERY_KEY = 'user-onboarding';
+
+const getUserOnboarding = () =>
+    lightdashApi<UserOnboarding>({
+        url: '/user/onboarding',
+        method: 'GET',
+        body: undefined,
+    });
+
+const completeUserOnboardingTour = (tour: UserOnboardingTour) =>
+    lightdashApi<undefined>({
+        url: '/user/onboarding',
+        method: 'POST',
+        body: JSON.stringify({
+            tour,
+        } satisfies ApiCompleteUserOnboardingTourRequest),
+    });
+
+type UseOnboardingTourArgs = {
+    tour: UserOnboardingTour;
+    /** Gate the fetch off while the feature can't show the tour anyway. */
+    enabled?: boolean;
+};
+
+type UseOnboardingTourResult = {
+    /** Undefined while loading, then whether the user has completed this tour. */
+    isCompleted: boolean | undefined;
+    /** True once we know the tour hasn't been completed and it wasn't just closed. */
+    shouldShow: boolean;
+    /** Close the tour and persist the seen-flag server-side. */
+    closeTour: () => void;
+};
+
+/**
+ * Server-persisted analogue of `useGuidedTour`: the seen-flag lives in the
+ * `user_onboarding` table so a tour shows once per user across devices. Pair
+ * with the `<GuidedTour>` component for the spotlight rendering.
+ */
+// ts-unused-exports:disable-next-line
+export const useOnboardingTour = ({
+    tour,
+    enabled = true,
+}: UseOnboardingTourArgs): UseOnboardingTourResult => {
+    const queryClient = useQueryClient();
+    const [isDismissed, setIsDismissed] = useState(false);
+
+    const { data } = useQuery<UserOnboarding, ApiError>({
+        queryKey: [USER_ONBOARDING_QUERY_KEY],
+        queryFn: getUserOnboarding,
+        enabled,
+        staleTime: Infinity,
+    });
+
+    const { mutate } = useMutation<undefined, ApiError, UserOnboardingTour>({
+        mutationFn: completeUserOnboardingTour,
+        onSuccess: (_result, completedTour) => {
+            queryClient.setQueryData<UserOnboarding>(
+                [USER_ONBOARDING_QUERY_KEY],
+                (previous) =>
+                    previous
+                        ? {
+                              completedTours: {
+                                  ...previous.completedTours,
+                                  [completedTour]: true,
+                              },
+                          }
+                        : previous,
+            );
+        },
+    });
+
+    const isCompleted = data ? data.completedTours[tour] === true : undefined;
+
+    const closeTour = useCallback(() => {
+        setIsDismissed(true);
+        mutate(tour);
+    }, [mutate, tour]);
+
+    return {
+        isCompleted,
+        shouldShow: enabled && !isDismissed && isCompleted === false,
+        closeTour,
+    };
+};


### PR DESCRIPTION
Generic, app-wide storage for first-run feature tours: a seen-flag persisted server-side, once ever per user, across devices. First consumer is the AI agent memory tour in #26930 (stacked on top).

## How

- **Storage**: new OSS `user_onboarding` table (`user_uuid` PK/FK → users, `completed_tours jsonb default '{}'`). Any future feature tour just adds a key to the `USER_ONBOARDING_TOURS` registry in common — no schema change.
- **API**: `GET /api/v1/user/onboarding` returns completed-tour flags; `POST /api/v1/user/onboarding {tour}` marks one complete (jsonb-merge upsert, concurrency-safe). Invalid tour names are rejected at the boundary by TSOA enum validation (422).
- **Frontend**: reusable `useOnboardingTour({tour})` hook — the server-persisted analogue of the localStorage `useGuidedTour`. Unused until #26930; the `ts-unused-exports` suppression is removed there.

No user-facing behavior in this PR.

## Testing

- `curl` smoke tests: GET/POST round-trip, POST persists a `user_onboarding` row (`{"memoryTour": true}` verified via `psql`), 422 on unknown tour.
- Typecheck + lint clean on common/backend/frontend; `UserService` unit tests pass (121).

Relates: ZAP-813

🤖 Generated with [Claude Code](https://claude.com/claude-code)
