### PR TITLE
fix(data-apps): PDF report guidance always requires a download action

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/templates.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/templates.ts
@@ -20,7 +20,7 @@ Build a slideshow-style data app:
 const PDF_REPORT_INSTRUCTIONS = `[Starter template: PDF Report]
 Build a print-optimized report:
 - Layout for A4/Letter portrait pages with comfortable internal padding.
-- Include a Download PDF button that uses the pre-installed \`html-to-image\` and \`jspdf\` packages to save the rendered report directly from the browser. Track an exporting state, disable the button while data or PDF generation is loading, and show a spinner or "Exporting..." label.
+- The report must offer a visible Download PDF button — the app is incomplete without it, on this build and after any later edit. It uses the pre-installed \`html-to-image\` and \`jspdf\` packages to save the rendered report directly from the browser. Track an exporting state, disable the button while data or PDF generation is loading, and show a spinner or "Exporting..." label.
 - Set \`@page { margin: 0; size: A4 }\` so the design fills the sheet edge-to-edge — apply your own padding inside each page (e.g. \`p-12\`) instead of relying on the browser's default page margin (which is ugly and shrinks the canvas).
 - Use a clean, document-style typography hierarchy (title, section headings, body).
 - Render charts at fixed widths so they reflow across pages cleanly.

--- a/sandboxes/data-apps/template/references/pdf-downloads.md
+++ b/sandboxes/data-apps/template/references/pdf-downloads.md
@@ -1,8 +1,8 @@
 # Client-side PDF downloads (html-to-image + jspdf)
 
-> Read this for PDF Report templates or whenever the user asks for a PDF download.
+> Read this for PDF Report templates, for any report/printable/document-shaped app, or whenever the user asks for a PDF download.
 
-For PDF Report templates, or whenever the user asks for a PDF download, use the pre-installed `html-to-image` and `jspdf` packages. Do not load PDF libraries from a CDN or ask to install packages.
+Every PDF or printable report app includes a visible Download PDF button — the app is incomplete without one, on first generation and after every edit. Use the pre-installed `html-to-image` and `jspdf` packages. Do not load PDF libraries from a CDN or ask to install packages.
 
 PDF downloads are image-based: they preserve the visible report exactly, but the exported text is not selectable/searchable. Keep `window.print()` only as a secondary Print action if useful; the Download PDF button should save a file directly.
 

--- a/sandboxes/data-apps/template/skill.md
+++ b/sandboxes/data-apps/template/skill.md
@@ -458,7 +458,9 @@ When the user asks for "Open in Google Sheets" (or any Sheets destination), read
 
 ### Client-side PDF downloads
 
-For PDF Report templates, or whenever the user asks for a PDF download, read `/app/references/pdf-downloads.md` — it has the required `html-to-image` + `jspdf` pattern and page-capture rules.
+A PDF or printable report app always includes a visible **Download PDF** button — the export action is part of the report shape, not an optional extra, and `window.print()` is only ever a secondary Print action. This applies whenever the app is report-shaped, whatever the request's wording: the PDF Report starter template, a "printable" / "document" / "report to share" ask, or an app that already renders `.pdf-page` sections. On edit turns, keep the existing Download PDF button working — an edit that removes it is a regression.
+
+Before wiring the button, read `/app/references/pdf-downloads.md` — it has the required `html-to-image` + `jspdf` pattern and page-capture rules.
 
 ### Underlying data
 


### PR DESCRIPTION
## Summary

PDF-report data apps occasionally come out with no way to save or download the PDF. Two gaps explain the "occasionally":

1. Starter-template instructions (which do mandate a Download PDF button) seed **only the initial generate** — they are not re-injected on iterate/retry, so a later edit can drop the button with nothing telling the agent that's a regression.
2. The sandbox skill's trigger for the PDF guidance was too narrow: it fired "whenever the user asks for a PDF **download**", so a freeform "printable report" / "document to share" request never tripped it and the agent could build a print-styled page with no export action.

This is the light-handed guidance fix, not a structural rework — three small wording changes that state the button as a required part of the report shape rather than an optional enhancement:

- **`sandboxes/data-apps/template/skill.md`** ("Client-side PDF downloads"): a PDF/printable report app always includes a visible Download PDF button; the requirement now triggers on the app being report-shaped (starter template, "printable"/"document" asks, existing `.pdf-page` sections) regardless of wording, and edit turns must keep the existing button — removing it is a regression. This file also ships as the `lightdash-data-app` skill in every CLI app bundle, so both generation surfaces get the fix.
- **`sandboxes/data-apps/template/references/pdf-downloads.md`**: lead line now states the button is required on first generation and after every edit, and the read-trigger covers report/printable/document-shaped apps.
- **`AppGenerateService/templates.ts`** (PDF Report starter template): the button bullet now says the app is incomplete without it, on this build and after any later edit.

## Testing

- Dry-run scenario checks with a fresh agent given only the updated skill:
  - Freeform request ("something polished we can print out and hand around" — never says PDF or download): produced a primary Download PDF button wired per `pdf-downloads.md`, with Print as secondary.
  - Edit turn on an existing report ("strip the header right down — just the title"): kept the Download PDF button by relocating it out of the header instead of deleting it, citing the regression clause.
- `templates.ts` change is a string-literal-only edit; syntax verified.

Closes: PROD-8021
Closes: #23699

🤖 Generated with [Claude Code](https://claude.com/claude-code)
