### PR TITLE
feat(data-apps): filter app deliveries by the query selection snapshot

### DIFF
--- a/packages/backend/src/clients/EmailClient/EmailClient.test.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.test.ts
@@ -192,7 +192,7 @@ describe('EmailClient', () => {
                     context: {
                         failures: { chartName?: string; error: string }[];
                         failureCountPhrase: string;
-                        notices: { label: string; rowCount: number }[];
+                        notices: { message: string }[];
                         hasNotices: boolean;
                     };
                 }
@@ -213,7 +213,63 @@ describe('EmailClient', () => {
             // outside the failure block.
             expect(sentContext.hasNotices).toBe(true);
             expect(sentContext.notices).toEqual([
-                { type: 'limit_reached', label: 'Sessions', rowCount: 5000 },
+                {
+                    message:
+                        'Sessions reached its query limit; additional rows may exist (5000 rows delivered)',
+                },
+            ]);
+        });
+
+        test('renders identity-changed and all-queries-excluded notices as plain messages', async () => {
+            const client = new EmailClient({
+                lightdashConfig: lightdashConfigWithBasicSMTP,
+            });
+
+            await client.sendDashboardCsvNotificationEmail(
+                'recipient@example.com',
+                'subject',
+                'title',
+                'description',
+                undefined,
+                'date',
+                'frequency',
+                [
+                    {
+                        path: 'https://example.com/file.csv',
+                        filename: 'file.csv',
+                        localPath: '',
+                        truncated: false,
+                    },
+                ],
+                'https://example.com/app',
+                'https://example.com/scheduler',
+                true,
+                7,
+                false,
+                SchedulerFormat.CSV,
+                undefined,
+                [
+                    { type: 'query_identity_changed', label: 'Revenue' },
+                    { type: 'all_queries_excluded' },
+                ],
+            );
+
+            const sentContext = (
+                vi.mocked(client.transporter!.sendMail).mock
+                    .calls[0][0] as unknown as {
+                    context: { notices: { message: string }[] };
+                }
+            ).context;
+
+            expect(sentContext.notices).toEqual([
+                {
+                    message:
+                        'Revenue changed since it was selected; your query selection may not apply to it',
+                },
+                {
+                    message:
+                        'Every query captured in this delivery was excluded by your query selection, so no files were attached',
+                },
             ]);
         });
 

--- a/packages/backend/src/clients/EmailClient/EmailClient.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.ts
@@ -32,6 +32,7 @@ import Logger from '../../logging/logger';
 import {
     buildFailureCountPhrase,
     toEmailFailureFields,
+    toEmailNoticeFields,
 } from '../../utils/partialFailureUtils';
 
 const RETRYABLE_ERROR_CODES = ['ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND'];
@@ -936,7 +937,7 @@ export default class EmailClient {
                     ? buildFailureCountPhrase(failures)
                     : undefined,
                 hasFailures: failures && failures.length > 0,
-                notices,
+                notices: notices?.map(toEmailNoticeFields),
                 hasNotices: notices && notices.length > 0,
                 allChartsFailed,
             },

--- a/packages/backend/src/clients/EmailClient/templates/dashboardCsvNotification.html
+++ b/packages/backend/src/clients/EmailClient/templates/dashboardCsvNotification.html
@@ -1721,8 +1721,7 @@
                                                                                                                 >
                                                                                                                     {{#notices}}
                                                                                                                     <li style="margin-bottom: 6px; line-height: 18px">
-                                                                                                                        {{label}} reached its query limit; additional rows
-                                                                                                                        may exist ({{rowCount}} rows delivered)
+                                                                                                                        {{message}}
                                                                                                                     </li>
                                                                                                                     {{/notices}}
                                                                                                                 </ul>

--- a/packages/backend/src/clients/GoogleChat/GoogleChatClient.test.ts
+++ b/packages/backend/src/clients/GoogleChat/GoogleChatClient.test.ts
@@ -97,6 +97,31 @@ describe('postCsvsWithWebhook app failure lines', () => {
         expect(noticeText).not.toContain('<a href');
     });
 
+    it('renders identity-changed and all-queries-excluded notices', async () => {
+        const texts = await widgetTexts({
+            webhookUrl: 'https://chat.googleapis.com/v1/spaces/abc',
+            title: 'App delivery',
+            name: 'App delivery',
+            description: 'desc',
+            ctaUrl: 'https://app.lightdash.com/apps/abc',
+            csvUrls: [csvUrl],
+            footer: 'footer',
+            notices: [
+                { type: 'query_identity_changed', label: HOSTILE_LABEL },
+                { type: 'all_queries_excluded' },
+            ],
+        });
+
+        const noticeText = texts.find((text) => text.startsWith('ℹ️'));
+        expect(noticeText).toContain(
+            '- x changed since it was selected; your query selection may not apply to it',
+        );
+        expect(noticeText).toContain(
+            'Every query captured in this delivery was excluded by your query selection, so no files were attached',
+        );
+        expect(noticeText).not.toContain('<a href');
+    });
+
     it('adds no notice widget when the delivery had none', async () => {
         const texts = await widgetTexts({
             webhookUrl: 'https://chat.googleapis.com/v1/spaces/abc',

--- a/packages/backend/src/clients/GoogleChat/GoogleChatClient.ts
+++ b/packages/backend/src/clients/GoogleChat/GoogleChatClient.ts
@@ -331,14 +331,27 @@ export class GoogleChatClient {
 
         if (notices && notices.length > 0) {
             const noticeLines = notices
-                .map(
-                    (notice) =>
-                        `- ${stripMarkup(
-                            notice.label,
-                        )} reached its query limit; additional rows may exist (${
-                            notice.rowCount
-                        } rows delivered)`,
-                )
+                .map((notice) => {
+                    switch (notice.type) {
+                        case 'limit_reached':
+                            return `- ${stripMarkup(
+                                notice.label,
+                            )} reached its query limit; additional rows may exist (${
+                                notice.rowCount
+                            } rows delivered)`;
+                        case 'query_identity_changed':
+                            return `- ${stripMarkup(
+                                notice.label,
+                            )} changed since it was selected; your query selection may not apply to it`;
+                        case 'all_queries_excluded':
+                            return `- Every query captured in this delivery was excluded by your query selection, so no files were attached`;
+                        default:
+                            return assertUnreachable(
+                                notice,
+                                'Unknown delivery notice type',
+                            );
+                    }
+                })
                 .join('\n');
             widgets.push({
                 textParagraph: {

--- a/packages/backend/src/clients/MicrosoftTeams/MicrosoftTeamsClient.test.ts
+++ b/packages/backend/src/clients/MicrosoftTeams/MicrosoftTeamsClient.test.ts
@@ -194,6 +194,37 @@ describe('postCsvsWithWebhook app failure lines', () => {
         expect(noticeText).toContain('evil');
     });
 
+    it('renders identity-changed and all-queries-excluded notices as separate blocks', async () => {
+        const texts = await cardTextBlocks({
+            webhookUrl: 'https://outlook.office.com/webhook/abc',
+            title: 'App delivery',
+            name: 'App delivery',
+            description: 'desc',
+            ctaUrl: 'https://app.lightdash.com/apps/abc',
+            csvUrls: [csvUrl],
+            footer: 'footer',
+            notices: [
+                { type: 'query_identity_changed', label: 'Revenue' },
+                { type: 'all_queries_excluded' },
+            ],
+        });
+
+        expect(
+            texts.find((text) =>
+                text.includes('changed since it was selected'),
+            ),
+        ).toBe(
+            'ℹ️ Revenue changed since it was selected; your query selection may not apply to it',
+        );
+        expect(
+            texts.find((text) =>
+                text.includes('was excluded by your query selection'),
+            ),
+        ).toBe(
+            'ℹ️ Every query captured in this delivery was excluded by your query selection, so no files were attached',
+        );
+    });
+
     it('adds no notice block when the delivery had none', async () => {
         const texts = await cardTextBlocks({
             webhookUrl: 'https://outlook.office.com/webhook/abc',

--- a/packages/backend/src/clients/MicrosoftTeams/MicrosoftTeamsClient.ts
+++ b/packages/backend/src/clients/MicrosoftTeams/MicrosoftTeamsClient.ts
@@ -528,6 +528,28 @@ export class MicrosoftTeamsClient {
             ];
         };
 
+        const getNoticeText = (notice: DeliveryNotice): string => {
+            switch (notice.type) {
+                case 'limit_reached':
+                    return `${stripMarkup(
+                        notice.label,
+                    )} reached its query limit; additional rows may exist (${
+                        notice.rowCount
+                    } rows delivered)`;
+                case 'query_identity_changed':
+                    return `${stripMarkup(
+                        notice.label,
+                    )} changed since it was selected; your query selection may not apply to it`;
+                case 'all_queries_excluded':
+                    return `Every query captured in this delivery was excluded by your query selection, so no files were attached`;
+                default:
+                    return assertUnreachable(
+                        notice,
+                        'Unknown delivery notice type',
+                    );
+            }
+        };
+
         const getNoticeBlocks = (): {
             type: string;
             text: string;
@@ -535,11 +557,7 @@ export class MicrosoftTeamsClient {
         }[] =>
             (notices ?? []).map((notice) => ({
                 type: 'TextBlock',
-                text: `ℹ️ ${stripMarkup(
-                    notice.label,
-                )} reached its query limit; additional rows may exist (${
-                    notice.rowCount
-                } rows delivered)`,
+                text: `ℹ️ ${getNoticeText(notice)}`,
                 wrap: true,
             }));
 

--- a/packages/backend/src/clients/Slack/SlackMessageBlocks.test.ts
+++ b/packages/backend/src/clients/Slack/SlackMessageBlocks.test.ts
@@ -728,6 +728,33 @@ describe('SlackMessageBlocks', () => {
             expect(failureSection).toBeUndefined();
         });
 
+        it('renders an identity-changed notice and an all-queries-excluded notice', () => {
+            const notices: DeliveryNotice[] = [
+                { type: 'query_identity_changed', label: 'Revenue' },
+                { type: 'all_queries_excluded' },
+            ];
+
+            const blocks = getDashboardCsvResultsBlocks({
+                title: 'App delivery',
+                name: 'App delivery',
+                description: 'desc',
+                ctaUrl: 'https://app.lightdash.com/apps/abc',
+                csvUrls,
+                notices,
+            });
+
+            const sections = findBlocks(blocks, 'section');
+            const noticeSection = sections.find((s) =>
+                s.text?.text?.includes(':information_source:'),
+            );
+            expect(noticeSection?.text?.text).toContain(
+                'Revenue changed since it was selected; your query selection may not apply to it',
+            );
+            expect(noticeSection?.text?.text).toContain(
+                'Every query captured in this delivery was excluded by your query selection, so no files were attached',
+            );
+        });
+
         it('keeps notices out of the failure block when both failures and notices are present', () => {
             const failures: PartialFailure[] = [
                 {

--- a/packages/backend/src/clients/Slack/SlackMessageBlocks.ts
+++ b/packages/backend/src/clients/Slack/SlackMessageBlocks.ts
@@ -600,14 +600,27 @@ export const getDashboardCsvResultsBlocks = ({
             return undefined;
         }
         const noticeText = notices
-            .map(
-                (n) =>
-                    `\t• ${sanitizeText(
-                        n.label,
-                    )} reached its query limit; additional rows may exist (${
-                        n.rowCount
-                    } rows delivered)`,
-            )
+            .map((n) => {
+                switch (n.type) {
+                    case 'limit_reached':
+                        return `\t• ${sanitizeText(
+                            n.label,
+                        )} reached its query limit; additional rows may exist (${
+                            n.rowCount
+                        } rows delivered)`;
+                    case 'query_identity_changed':
+                        return `\t• ${sanitizeText(
+                            n.label,
+                        )} changed since it was selected; your query selection may not apply to it`;
+                    case 'all_queries_excluded':
+                        return `\t• Every query captured in this delivery was excluded by your query selection, so no files were attached`;
+                    default:
+                        return assertUnreachable(
+                            n,
+                            'Unknown delivery notice type',
+                        );
+                }
+            })
             .join('\n');
         return {
             type: 'section',

--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -1356,6 +1356,26 @@ describe('applyAppQuerySelections', () => {
         expect(result.identityChangedCaptureKeys.has('v1:new')).toBe(true);
     });
 
+    it('credits only one item when several share the same stale entry, not one per item', () => {
+        const staleEntry = selection({
+            captureKey: 'v1:stale',
+            label: 'Revenue by month',
+            exploreName: 'orders',
+            excluded: false,
+        });
+        const result = applyAppQuerySelections(
+            [
+                readyItem({ captureKey: 'v1:new-a' }),
+                readyItem({ captureKey: 'v1:new-b' }),
+            ],
+            [staleEntry],
+        );
+
+        expect(result.readyItems).toHaveLength(2);
+        expect(result.identityChangedCaptureKeys.size).toBe(1);
+        expect(result.missingFailures).toEqual([]);
+    });
+
     it('skips an excluded error item entirely', () => {
         const result = applyAppQuerySelections(
             [errorItem({ captureKey: 'v1:key-err' })],
@@ -1938,6 +1958,73 @@ describe('getNotificationPageData — app CSV/XLSX branch', () => {
         expect(page.notices).toEqual([
             { type: 'query_identity_changed', label: 'Revenue' },
         ]);
+        expect(page.failures ?? []).toEqual([]);
+    });
+
+    it('emits one identity-changed notice even when several delivered items share the stale entry', async () => {
+        const { task, downloadSyncQueryResults } = setup();
+
+        const page = await callGetNotificationPageData(
+            task,
+            appScheduler({
+                appQuerySelections: [
+                    selection({
+                        captureKey: 'v1:stale',
+                        label: 'Revenue',
+                        exploreName: 'orders',
+                        excluded: true,
+                    }),
+                ],
+            }),
+            manifestOf([
+                readyItem({
+                    captureKey: 'v1:new-a',
+                    label: 'Revenue',
+                    exploreName: 'orders',
+                    queryUuid: 'query-a',
+                }),
+                readyItem({
+                    captureKey: 'v1:new-b',
+                    label: 'Revenue',
+                    exploreName: 'orders',
+                    queryUuid: 'query-b',
+                    order: 1,
+                }),
+            ]),
+        );
+
+        expect(downloadSyncQueryResults).toHaveBeenCalledTimes(2);
+        expect(page.csvUrls).toHaveLength(2);
+        expect(page.notices).toEqual([
+            { type: 'query_identity_changed', label: 'Revenue' },
+        ]);
+    });
+
+    it('excludes a matching error item and reports no APP_QUERY failure for it', async () => {
+        const { task } = setup();
+
+        const page = await callGetNotificationPageData(
+            task,
+            appScheduler({
+                appQuerySelections: [
+                    selection({
+                        captureKey: 'v1:key-err',
+                        label: 'Broken query',
+                        excluded: true,
+                    }),
+                ],
+            }),
+            manifestOf([
+                readyItem({ queryUuid: 'query-a' }),
+                errorItem({
+                    captureKey: 'v1:key-err',
+                    label: 'Broken query',
+                    error: 'Query timed out',
+                }),
+            ]),
+        );
+
+        expect(page.csvUrls).toHaveLength(1);
         expect(page.failures ?? []).toEqual([]);
     });
 

--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -16,6 +16,7 @@ import {
     ThresholdOperator,
     VizAggregationOptions,
     VizIndexType,
+    type AppQuerySelection,
     type CapturedQuery,
     type CreateSchedulerAndTargets,
     type DeliveryCaptureManifest,
@@ -27,8 +28,10 @@ import {
 } from '@lightdash/common';
 import ExecutionContext from 'node-execution-context';
 import type { Mock } from 'vitest';
+import Logger from '../logging/logger';
 import type { ExecutionContextInfo } from '../logging/winston';
 import SchedulerTask, {
+    applyAppQuerySelections,
     buildItemMapFromColumns,
     buildSchedulerLogContext,
     dedupeArtifactFilename,
@@ -1235,6 +1238,173 @@ const callGetNotificationPageData = (
         appCaptureManifest,
     );
 
+const selection = (
+    overrides: Partial<AppQuerySelection> = {},
+): AppQuerySelection => ({
+    captureKey: 'v1:key-1',
+    label: 'Revenue by month',
+    exploreName: 'orders',
+    excluded: false,
+    ...overrides,
+});
+
+describe('applyAppQuerySelections', () => {
+    it('delivers everything unchanged when selections are null', () => {
+        const result = applyAppQuerySelections(
+            [readyItem(), errorItem()],
+            null,
+        );
+
+        expect(result.readyItems).toEqual([readyItem()]);
+        expect(result.errorItems).toEqual([errorItem()]);
+        expect(result.missingFailures).toEqual([]);
+        expect(result.identityChangedCaptureKeys.size).toBe(0);
+        expect(result.allQueriesExcluded).toBe(false);
+    });
+
+    it('delivers a captured ready item that is not excluded', () => {
+        const result = applyAppQuerySelections(
+            [readyItem()],
+            [selection({ excluded: false })],
+        );
+
+        expect(result.readyItems).toEqual([readyItem()]);
+        expect(result.missingFailures).toEqual([]);
+    });
+
+    it('drops a captured ready item that is excluded, without a failure', () => {
+        const result = applyAppQuerySelections(
+            [readyItem()],
+            [selection({ excluded: true })],
+        );
+
+        expect(result.readyItems).toEqual([]);
+        expect(result.missingFailures).toEqual([]);
+    });
+
+    it('delivers a captured item that is not in the snapshot at all', () => {
+        const result = applyAppQuerySelections(
+            [readyItem({ captureKey: 'v1:unrelated' })],
+            [selection({ captureKey: 'v1:key-1' })],
+        );
+
+        expect(result.readyItems).toEqual([
+            readyItem({ captureKey: 'v1:unrelated' }),
+        ]);
+        expect(result.missingFailures).toEqual([]);
+    });
+
+    it('reports a non-excluded snapshot entry with no matching captured item as missing', () => {
+        const result = applyAppQuerySelections(
+            [],
+            [selection({ excluded: false })],
+        );
+
+        expect(result.missingFailures).toEqual([
+            {
+                type: PartialFailureType.APP_QUERY_MISSING,
+                captureKey: 'v1:key-1',
+                label: 'Revenue by month',
+                identityChanged: false,
+            },
+        ]);
+    });
+
+    it('does not report an excluded snapshot entry with no matching captured item as missing', () => {
+        const result = applyAppQuerySelections(
+            [],
+            [selection({ excluded: true })],
+        );
+
+        expect(result.missingFailures).toEqual([]);
+    });
+
+    it('delivers an identity-changed item and resolves the stale entry instead of reporting it missing', () => {
+        const staleEntry = selection({
+            captureKey: 'v1:stale',
+            label: 'Revenue by month',
+            exploreName: 'orders',
+            excluded: false,
+        });
+        const result = applyAppQuerySelections(
+            [readyItem({ captureKey: 'v1:new' })],
+            [staleEntry],
+        );
+
+        expect(result.readyItems).toEqual([
+            readyItem({ captureKey: 'v1:new' }),
+        ]);
+        expect(result.identityChangedCaptureKeys.has('v1:new')).toBe(true);
+        expect(result.missingFailures).toEqual([]);
+    });
+
+    it('delivers an identity-changed item even when the stale entry was excluded', () => {
+        const staleEntry = selection({
+            captureKey: 'v1:stale',
+            label: 'Revenue by month',
+            exploreName: 'orders',
+            excluded: true,
+        });
+        const result = applyAppQuerySelections(
+            [readyItem({ captureKey: 'v1:new' })],
+            [staleEntry],
+        );
+
+        expect(result.readyItems).toEqual([
+            readyItem({ captureKey: 'v1:new' }),
+        ]);
+        expect(result.identityChangedCaptureKeys.has('v1:new')).toBe(true);
+    });
+
+    it('skips an excluded error item entirely', () => {
+        const result = applyAppQuerySelections(
+            [errorItem({ captureKey: 'v1:key-err' })],
+            [selection({ captureKey: 'v1:key-err', excluded: true })],
+        );
+
+        expect(result.errorItems).toEqual([]);
+    });
+
+    it('keeps a non-excluded error item, unaffected by selections', () => {
+        const result = applyAppQuerySelections(
+            [errorItem({ captureKey: 'v1:key-err' })],
+            [selection({ captureKey: 'v1:key-err', excluded: false })],
+        );
+
+        expect(result.errorItems).toEqual([
+            errorItem({ captureKey: 'v1:key-err' }),
+        ]);
+    });
+
+    it('flags allQueriesExcluded when every ready item is excluded and nothing is missing', () => {
+        const result = applyAppQuerySelections(
+            [readyItem()],
+            [selection({ excluded: true })],
+        );
+
+        expect(result.readyItems).toEqual([]);
+        expect(result.allQueriesExcluded).toBe(true);
+    });
+
+    it('does not flag allQueriesExcluded when a missing entry also failed to match', () => {
+        const result = applyAppQuerySelections(
+            [readyItem()],
+            [
+                selection({ excluded: true }),
+                selection({
+                    captureKey: 'v1:missing',
+                    label: 'Other query',
+                    excluded: false,
+                }),
+            ],
+        );
+
+        expect(result.readyItems).toEqual([]);
+        expect(result.allQueriesExcluded).toBe(false);
+        expect(result.missingFailures).toHaveLength(1);
+    });
+});
+
 describe('getNotificationPageData — app CSV/XLSX branch', () => {
     const setup = ({
         download,
@@ -1636,6 +1806,289 @@ describe('getNotificationPageData — app CSV/XLSX branch', () => {
         const filenames = page.csvUrls?.map((file) => file.filename) ?? [];
         expect(filenames[0]).toMatch(/^csv-Q_A-[\d-]+\.csv$/);
         expect(filenames[1]).toMatch(/^csv-Q_A-[\d-]+ \(2\)\.csv$/);
+    });
+
+    it('never downloads a query excluded by the selection snapshot', async () => {
+        const { task, downloadSyncQueryResults } = setup();
+
+        const page = await callGetNotificationPageData(
+            task,
+            appScheduler({
+                appQuerySelections: [
+                    selection({
+                        captureKey: 'v1:a',
+                        label: 'Revenue',
+                        excluded: true,
+                    }),
+                    selection({
+                        captureKey: 'v1:b',
+                        label: 'Orders',
+                        excluded: false,
+                    }),
+                ],
+            }),
+            manifestOf([
+                readyItem({
+                    captureKey: 'v1:a',
+                    label: 'Revenue',
+                    queryUuid: 'query-a',
+                }),
+                readyItem({
+                    captureKey: 'v1:b',
+                    label: 'Orders',
+                    queryUuid: 'query-b',
+                    order: 1,
+                }),
+            ]),
+        );
+
+        expect(downloadSyncQueryResults).toHaveBeenCalledTimes(1);
+        expect(downloadSyncQueryResults.mock.calls[0][0]).toMatchObject({
+            queryUuid: 'query-b',
+        });
+        expect(page.csvUrls?.map((f) => f.chartName)).toEqual(['Orders']);
+        expect(page.failures ?? []).toEqual([]);
+    });
+
+    it('delivers a captured query not mentioned in the selection snapshot at all', async () => {
+        const { task, downloadSyncQueryResults } = setup();
+
+        const page = await callGetNotificationPageData(
+            task,
+            appScheduler({
+                appQuerySelections: [
+                    selection({ captureKey: 'v1:known', excluded: true }),
+                ],
+            }),
+            manifestOf([
+                readyItem({ captureKey: 'v1:unrelated', queryUuid: 'q-1' }),
+            ]),
+        );
+
+        expect(downloadSyncQueryResults).toHaveBeenCalledTimes(1);
+        expect(page.csvUrls).toHaveLength(1);
+    });
+
+    it('reports a non-excluded snapshot entry that never ran as APP_QUERY_MISSING, without failing the ready query', async () => {
+        const { task } = setup();
+
+        const page = await callGetNotificationPageData(
+            task,
+            appScheduler({
+                appQuerySelections: [
+                    selection({
+                        captureKey: 'v1:a',
+                        label: 'Revenue',
+                        excluded: false,
+                    }),
+                    selection({
+                        captureKey: 'v1:gone',
+                        label: 'Deleted query',
+                        excluded: false,
+                    }),
+                ],
+            }),
+            manifestOf([
+                readyItem({
+                    captureKey: 'v1:a',
+                    label: 'Revenue',
+                    queryUuid: 'query-a',
+                }),
+            ]),
+        );
+
+        expect(page.csvUrls).toHaveLength(1);
+        expect(page.failures).toEqual([
+            {
+                type: PartialFailureType.APP_QUERY_MISSING,
+                captureKey: 'v1:gone',
+                label: 'Deleted query',
+                identityChanged: false,
+            },
+        ]);
+    });
+
+    it('delivers an identity-changed query and adds a notice instead of trusting the stale exclusion', async () => {
+        const { task, downloadSyncQueryResults } = setup();
+
+        const page = await callGetNotificationPageData(
+            task,
+            appScheduler({
+                appQuerySelections: [
+                    selection({
+                        captureKey: 'v1:stale',
+                        label: 'Revenue',
+                        exploreName: 'orders',
+                        excluded: true,
+                    }),
+                ],
+            }),
+            manifestOf([
+                readyItem({
+                    captureKey: 'v1:new-hash',
+                    label: 'Revenue',
+                    exploreName: 'orders',
+                    queryUuid: 'query-a',
+                }),
+            ]),
+        );
+
+        expect(downloadSyncQueryResults).toHaveBeenCalledTimes(1);
+        expect(page.csvUrls).toHaveLength(1);
+        expect(page.notices).toEqual([
+            { type: 'query_identity_changed', label: 'Revenue' },
+        ]);
+        expect(page.failures ?? []).toEqual([]);
+    });
+
+    it('sends with zero attachments, no throw, when every captured query is excluded and one snapshot entry is missing', async () => {
+        const { task, downloadSyncQueryResults } = setup();
+
+        const page = await callGetNotificationPageData(
+            task,
+            appScheduler({
+                appQuerySelections: [
+                    selection({
+                        captureKey: 'v1:a',
+                        label: 'Revenue',
+                        excluded: true,
+                    }),
+                    selection({
+                        captureKey: 'v1:gone',
+                        label: 'Deleted query',
+                        excluded: false,
+                    }),
+                ],
+            }),
+            manifestOf([
+                readyItem({
+                    captureKey: 'v1:a',
+                    label: 'Revenue',
+                    queryUuid: 'query-a',
+                }),
+            ]),
+        );
+
+        expect(downloadSyncQueryResults).not.toHaveBeenCalled();
+        expect(page.csvUrls).toEqual([]);
+        expect(page.failures).toEqual([
+            {
+                type: PartialFailureType.APP_QUERY_MISSING,
+                captureKey: 'v1:gone',
+                label: 'Deleted query',
+                identityChanged: false,
+            },
+        ]);
+    });
+
+    it('sends with zero attachments and an explanatory notice, no throw, when every captured query is excluded and nothing is missing', async () => {
+        const { task, downloadSyncQueryResults } = setup();
+
+        const page = await callGetNotificationPageData(
+            task,
+            appScheduler({
+                appQuerySelections: [
+                    selection({
+                        captureKey: 'v1:a',
+                        label: 'Revenue',
+                        excluded: true,
+                    }),
+                ],
+            }),
+            manifestOf([
+                readyItem({
+                    captureKey: 'v1:a',
+                    label: 'Revenue',
+                    queryUuid: 'query-a',
+                }),
+            ]),
+        );
+
+        expect(downloadSyncQueryResults).not.toHaveBeenCalled();
+        expect(page.csvUrls).toEqual([]);
+        expect(page.failures ?? []).toEqual([]);
+        expect(page.notices).toEqual([{ type: 'all_queries_excluded' }]);
+    });
+
+    it('does not throw "all downloads failed" when nothing was attempted because everything was excluded', async () => {
+        const { task } = setup({
+            download: async () => {
+                throw new Error('should never be called for an excluded query');
+            },
+        });
+
+        await expect(
+            callGetNotificationPageData(
+                task,
+                appScheduler({
+                    appQuerySelections: [
+                        selection({
+                            captureKey: 'v1:key-1',
+                            excluded: true,
+                        }),
+                    ],
+                }),
+                manifestOf([readyItem()]),
+            ),
+        ).resolves.toMatchObject({ csvUrls: [] });
+    });
+
+    it('falls open to delivering everything when the persisted selection snapshot is malformed', async () => {
+        const { task, downloadSyncQueryResults } = setup();
+        const warn = vi.spyOn(Logger, 'warn').mockImplementation(() => Logger);
+
+        const page = await callGetNotificationPageData(
+            task,
+            appScheduler({
+                // Not a valid AppQuerySelection[] — e.g. corrupted DB row.
+                appQuerySelections: [
+                    { captureKey: 123 },
+                ] as unknown as AppQuerySelection[],
+            }),
+            manifestOf([readyItem({ queryUuid: 'query-a' })]),
+        );
+
+        expect(downloadSyncQueryResults).toHaveBeenCalledTimes(1);
+        expect(page.csvUrls).toHaveLength(1);
+        expect(warn).toHaveBeenCalledWith(
+            expect.stringContaining('malformed appQuerySelections'),
+        );
+        warn.mockRestore();
+    });
+
+    it('applies the same filtering on a persisted scheduler as on a send-now payload', async () => {
+        // Every other test in this suite already exercises the send-now shape
+        // (appScheduler() never sets schedulerUuid); this proves a persisted
+        // scheduler — the only other shape getNotificationPageData accepts —
+        // filters identically, since both go through the same function.
+        const { task, downloadSyncQueryResults } = setup();
+        const persistedScheduler = {
+            ...appScheduler({
+                appQuerySelections: [
+                    selection({
+                        captureKey: 'v1:a',
+                        label: 'Revenue',
+                        excluded: true,
+                    }),
+                ],
+            }),
+            schedulerUuid: 'scheduler-1',
+        } as unknown as CreateSchedulerAndTargets;
+
+        const page = await callGetNotificationPageData(
+            task,
+            persistedScheduler,
+            manifestOf([
+                readyItem({
+                    captureKey: 'v1:a',
+                    label: 'Revenue',
+                    queryUuid: 'query-a',
+                }),
+            ]),
+        );
+
+        expect(downloadSyncQueryResults).not.toHaveBeenCalled();
+        expect(page.csvUrls).toEqual([]);
     });
 });
 

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -404,22 +404,14 @@ export type AppQuerySelectionFilterResult = {
     readyItems: Extract<CapturedQuery, { status: 'ready' }>[];
     errorItems: Extract<CapturedQuery, { status: 'error' }>[];
     missingFailures: AppQueryMissingPartialFailure[];
-    // captureKeys of ready items that matched a snapshot entry by
-    // label+exploreName only — reconciled against actually-delivered items
-    // by the caller, same as limit-reached notices.
+    // One captureKey per stale snapshot entry that fuzzy-matched (never one
+    // per matching item) — caller reconciles against actually-delivered items.
     identityChangedCaptureKeys: Set<string>;
     allQueriesExcluded: boolean;
 };
 
-/**
- * Applies the scheduler's saved query-selection snapshot to a capture
- * manifest's items, before any query is downloaded. `null` selections is v1
- * behavior — deliver everything, unchanged. Matching is by captureKey; a
- * captured item that matches a snapshot entry by label+exploreName but not
- * captureKey is the same logical query with a changed identity (e.g. its
- * definition changed since it was selected) — always delivered, never
- * trusting a possibly-stale exclusion against it.
- */
+// Applies the scheduler's saved query-selection snapshot before any query is
+// downloaded. `null` selections is v1 behavior: deliver everything, unchanged.
 export function applyAppQuerySelections(
     capturedItems: CapturedQuery[],
     selections: AppQuerySelection[] | null,
@@ -446,9 +438,12 @@ export function applyAppQuerySelections(
     const byCaptureKey = new Map(selections.map((s) => [s.captureKey, s]));
     const resolvedCaptureKeys = new Set<string>();
     const identityChangedCaptureKeys = new Set<string>();
-    const deliveredReadyItems: Extract<CapturedQuery, { status: 'ready' }>[] =
+    // Entries already credited with a notice — keeps N items sharing one
+    // stale entry's label+exploreName from fanning out into N notices.
+    const notifiedStaleCaptureKeys = new Set<string>();
+    const filteredReadyItems: Extract<CapturedQuery, { status: 'ready' }>[] =
         [];
-    const deliveredErrorItems: Extract<CapturedQuery, { status: 'error' }>[] =
+    const filteredErrorItems: Extract<CapturedQuery, { status: 'error' }>[] =
         [];
 
     readyItems.forEach((item) => {
@@ -456,7 +451,7 @@ export function applyAppQuerySelections(
         if (exact) {
             resolvedCaptureKeys.add(exact.captureKey);
             if (!exact.excluded) {
-                deliveredReadyItems.push(item);
+                filteredReadyItems.push(item);
             }
             return;
         }
@@ -465,9 +460,12 @@ export function applyAppQuerySelections(
         );
         if (fuzzy) {
             resolvedCaptureKeys.add(fuzzy.captureKey);
-            identityChangedCaptureKeys.add(item.captureKey);
+            if (!notifiedStaleCaptureKeys.has(fuzzy.captureKey)) {
+                notifiedStaleCaptureKeys.add(fuzzy.captureKey);
+                identityChangedCaptureKeys.add(item.captureKey);
+            }
         }
-        deliveredReadyItems.push(item);
+        filteredReadyItems.push(item);
     });
 
     errorItems.forEach((item) => {
@@ -478,7 +476,7 @@ export function applyAppQuerySelections(
                 return;
             }
         }
-        deliveredErrorItems.push(item);
+        filteredErrorItems.push(item);
     });
 
     const missingFailures: AppQueryMissingPartialFailure[] = selections
@@ -491,13 +489,13 @@ export function applyAppQuerySelections(
         }));
 
     return {
-        readyItems: deliveredReadyItems,
-        errorItems: deliveredErrorItems,
+        readyItems: filteredReadyItems,
+        errorItems: filteredErrorItems,
         missingFailures,
         identityChangedCaptureKeys,
         allQueriesExcluded:
             readyItems.length > 0 &&
-            deliveredReadyItems.length === 0 &&
+            filteredReadyItems.length === 0 &&
             missingFailures.length === 0,
     };
 }
@@ -1113,11 +1111,8 @@ export default class SchedulerTask {
                             );
                         }
 
-                        // Excluded queries are filtered out here, before any
-                        // download, never merely dropped from attachments
-                        // afterwards. A malformed snapshot fails open —
-                        // treated as null (deliver everything) — since a
-                        // corrupt curation record must not block delivery.
+                        // Excluded queries are filtered out before any download.
+                        // A malformed snapshot fails open (treated as null).
                         const rawAppQuerySelections =
                             scheduler.appQuerySelections;
                         let appQuerySelections: AppQuerySelection[] | null;
@@ -1233,9 +1228,8 @@ export default class SchedulerTask {
                             deliveredItems.push(item);
                         });
 
-                        // Zero attempts means every ready query was excluded —
-                        // a valid outcome, not a failure. Only a real all-failed
-                        // download batch throws.
+                        // Zero attempts (everything excluded) is valid, not a
+                        // failure — only a real all-failed download batch throws.
                         if (settled.length > 0 && appCsvUrls.length === 0) {
                             throw new Error(
                                 'All app delivery downloads failed',

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -63,6 +63,7 @@ import {
     isSchedulerImageOptions,
     isTableChartConfig,
     isTileInSelectedTabs,
+    isValidAppQuerySelections,
     isVizTableConfig,
     LightdashPage,
     MAX_SAFE_INTEGER,
@@ -114,6 +115,8 @@ import {
     VizColumn,
     WarehouseConnectionError,
     type Account as AccountType,
+    type AppQueryMissingPartialFailure,
+    type AppQuerySelection,
     type BatchDeliveryResult,
     type CapturedQuery,
     type DeliveryCaptureManifest,
@@ -395,6 +398,108 @@ export function dedupeArtifactFilename(
     return dotIndex === -1
         ? `${filename} (${next})`
         : `${filename.slice(0, dotIndex)} (${next})${filename.slice(dotIndex)}`;
+}
+
+export type AppQuerySelectionFilterResult = {
+    readyItems: Extract<CapturedQuery, { status: 'ready' }>[];
+    errorItems: Extract<CapturedQuery, { status: 'error' }>[];
+    missingFailures: AppQueryMissingPartialFailure[];
+    // captureKeys of ready items that matched a snapshot entry by
+    // label+exploreName only — reconciled against actually-delivered items
+    // by the caller, same as limit-reached notices.
+    identityChangedCaptureKeys: Set<string>;
+    allQueriesExcluded: boolean;
+};
+
+/**
+ * Applies the scheduler's saved query-selection snapshot to a capture
+ * manifest's items, before any query is downloaded. `null` selections is v1
+ * behavior — deliver everything, unchanged. Matching is by captureKey; a
+ * captured item that matches a snapshot entry by label+exploreName but not
+ * captureKey is the same logical query with a changed identity (e.g. its
+ * definition changed since it was selected) — always delivered, never
+ * trusting a possibly-stale exclusion against it.
+ */
+export function applyAppQuerySelections(
+    capturedItems: CapturedQuery[],
+    selections: AppQuerySelection[] | null,
+): AppQuerySelectionFilterResult {
+    const readyItems = capturedItems.filter(
+        (item): item is Extract<CapturedQuery, { status: 'ready' }> =>
+            item.status === 'ready',
+    );
+    const errorItems = capturedItems.filter(
+        (item): item is Extract<CapturedQuery, { status: 'error' }> =>
+            item.status === 'error',
+    );
+
+    if (selections === null) {
+        return {
+            readyItems,
+            errorItems,
+            missingFailures: [],
+            identityChangedCaptureKeys: new Set(),
+            allQueriesExcluded: false,
+        };
+    }
+
+    const byCaptureKey = new Map(selections.map((s) => [s.captureKey, s]));
+    const resolvedCaptureKeys = new Set<string>();
+    const identityChangedCaptureKeys = new Set<string>();
+    const deliveredReadyItems: Extract<CapturedQuery, { status: 'ready' }>[] =
+        [];
+    const deliveredErrorItems: Extract<CapturedQuery, { status: 'error' }>[] =
+        [];
+
+    readyItems.forEach((item) => {
+        const exact = byCaptureKey.get(item.captureKey);
+        if (exact) {
+            resolvedCaptureKeys.add(exact.captureKey);
+            if (!exact.excluded) {
+                deliveredReadyItems.push(item);
+            }
+            return;
+        }
+        const fuzzy = selections.find(
+            (s) => s.label === item.label && s.exploreName === item.exploreName,
+        );
+        if (fuzzy) {
+            resolvedCaptureKeys.add(fuzzy.captureKey);
+            identityChangedCaptureKeys.add(item.captureKey);
+        }
+        deliveredReadyItems.push(item);
+    });
+
+    errorItems.forEach((item) => {
+        const exact = byCaptureKey.get(item.captureKey);
+        if (exact) {
+            resolvedCaptureKeys.add(exact.captureKey);
+            if (exact.excluded) {
+                return;
+            }
+        }
+        deliveredErrorItems.push(item);
+    });
+
+    const missingFailures: AppQueryMissingPartialFailure[] = selections
+        .filter((s) => !s.excluded && !resolvedCaptureKeys.has(s.captureKey))
+        .map((s) => ({
+            type: PartialFailureType.APP_QUERY_MISSING,
+            captureKey: s.captureKey,
+            label: s.label,
+            identityChanged: false,
+        }));
+
+    return {
+        readyItems: deliveredReadyItems,
+        errorItems: deliveredErrorItems,
+        missingFailures,
+        identityChangedCaptureKeys,
+        allQueriesExcluded:
+            readyItems.length > 0 &&
+            deliveredReadyItems.length === 0 &&
+            missingFailures.length === 0,
+    };
 }
 
 export default class SchedulerTask {
@@ -994,7 +1099,7 @@ export default class SchedulerTask {
                         const capturedItems = [
                             ...appCaptureManifest.items,
                         ].sort((a, b) => a.order - b.order);
-                        const readyItems = capturedItems.filter(
+                        const capturedReadyItems = capturedItems.filter(
                             (
                                 item,
                             ): item is Extract<
@@ -1002,28 +1107,56 @@ export default class SchedulerTask {
                                 { status: 'ready' }
                             > => item.status === 'ready',
                         );
+                        if (capturedReadyItems.length === 0) {
+                            throw new Error(
+                                'App delivery render captured no successful queries',
+                            );
+                        }
 
-                        const renderFailures: PartialFailure[] = capturedItems
-                            .filter(
-                                (
-                                    item,
-                                ): item is Extract<
-                                    CapturedQuery,
-                                    { status: 'error' }
-                                > => item.status === 'error',
-                            )
-                            .map((item) => ({
+                        // Excluded queries are filtered out here, before any
+                        // download, never merely dropped from attachments
+                        // afterwards. A malformed snapshot fails open —
+                        // treated as null (deliver everything) — since a
+                        // corrupt curation record must not block delivery.
+                        const rawAppQuerySelections =
+                            scheduler.appQuerySelections;
+                        let appQuerySelections: AppQuerySelection[] | null;
+                        if (rawAppQuerySelections == null) {
+                            appQuerySelections = null;
+                        } else if (
+                            isValidAppQuerySelections(rawAppQuerySelections)
+                        ) {
+                            appQuerySelections = rawAppQuerySelections;
+                        } else {
+                            Logger.warn(
+                                `Ignoring malformed appQuerySelections on scheduler "${
+                                    scheduler.name
+                                }" (${
+                                    schedulerUuid ?? 'send-now'
+                                }); delivering all captured queries`,
+                            );
+                            appQuerySelections = null;
+                        }
+
+                        const {
+                            readyItems,
+                            errorItems: deliverableErrorItems,
+                            missingFailures,
+                            identityChangedCaptureKeys,
+                            allQueriesExcluded,
+                        } = applyAppQuerySelections(
+                            capturedItems,
+                            appQuerySelections,
+                        );
+
+                        const renderFailures: PartialFailure[] =
+                            deliverableErrorItems.map((item) => ({
                                 type: PartialFailureType.APP_QUERY,
                                 stage: 'render',
                                 captureKey: item.captureKey,
                                 label: item.label,
                                 error: item.error,
                             }));
-                        if (readyItems.length === 0) {
-                            throw new Error(
-                                'App delivery render captured no successful queries',
-                            );
-                        }
 
                         const settled = await Promise.allSettled(
                             readyItems.map((item) =>
@@ -1100,7 +1233,10 @@ export default class SchedulerTask {
                             deliveredItems.push(item);
                         });
 
-                        if (appCsvUrls.length === 0) {
+                        // Zero attempts means every ready query was excluded —
+                        // a valid outcome, not a failure. Only a real all-failed
+                        // download batch throws.
+                        if (settled.length > 0 && appCsvUrls.length === 0) {
                             throw new Error(
                                 'All app delivery downloads failed',
                             );
@@ -1108,16 +1244,36 @@ export default class SchedulerTask {
 
                         // Only for files that actually shipped — a notice about
                         // an unattached file would just confuse recipients.
-                        const appNotices: DeliveryNotice[] = deliveredItems
-                            .filter(
-                                (item) =>
-                                    item.limitReached && item.rowCount !== null,
-                            )
-                            .map((item) => ({
-                                type: 'limit_reached',
-                                label: item.label,
-                                rowCount: item.rowCount ?? 0,
-                            }));
+                        const appNotices: DeliveryNotice[] = [
+                            ...(allQueriesExcluded
+                                ? [
+                                      {
+                                          type: 'all_queries_excluded' as const,
+                                      },
+                                  ]
+                                : []),
+                            ...deliveredItems
+                                .filter((item) =>
+                                    identityChangedCaptureKeys.has(
+                                        item.captureKey,
+                                    ),
+                                )
+                                .map((item) => ({
+                                    type: 'query_identity_changed' as const,
+                                    label: item.label,
+                                })),
+                            ...deliveredItems
+                                .filter(
+                                    (item) =>
+                                        item.limitReached &&
+                                        item.rowCount !== null,
+                                )
+                                .map((item) => ({
+                                    type: 'limit_reached' as const,
+                                    label: item.label,
+                                    rowCount: item.rowCount ?? 0,
+                                })),
+                        ];
                         if (appNotices.length > 0) {
                             notices = appNotices;
                         }
@@ -1125,6 +1281,7 @@ export default class SchedulerTask {
                         const appFailures = [
                             ...renderFailures,
                             ...downloadFailures,
+                            ...missingFailures,
                             ...(appCaptureManifest.overflowCount > 0
                                 ? [
                                       {
@@ -1143,6 +1300,7 @@ export default class SchedulerTask {
 
                         if (
                             format === SchedulerFormat.XLSX &&
+                            csvUrls.length > 0 &&
                             csvOptions?.xlsxFileLayout === 'workbook'
                         ) {
                             csvUrls = await this.buildWorkbookCsvUrls({

--- a/packages/backend/src/utils/partialFailureUtils.ts
+++ b/packages/backend/src/utils/partialFailureUtils.ts
@@ -2,6 +2,7 @@ import {
     assertUnreachable,
     MAX_DELIVERY_QUERIES,
     PartialFailureType,
+    type DeliveryNotice,
     type PartialFailure,
 } from '@lightdash/common';
 
@@ -74,5 +75,29 @@ export const toEmailFailureFields = (
             };
         default:
             return assertUnreachable(failure, 'Unknown partial failure type');
+    }
+};
+
+// The email template prints `{{message}}` for each notice; unlike failures,
+// no channel-specific escaping is needed since Handlebars auto-escapes `{{}}`.
+export const toEmailNoticeFields = (
+    notice: DeliveryNotice,
+): { message: string } => {
+    switch (notice.type) {
+        case 'limit_reached':
+            return {
+                message: `${notice.label} reached its query limit; additional rows may exist (${notice.rowCount} rows delivered)`,
+            };
+        case 'query_identity_changed':
+            return {
+                message: `${notice.label} changed since it was selected; your query selection may not apply to it`,
+            };
+        case 'all_queries_excluded':
+            return {
+                message:
+                    'Every query captured in this delivery was excluded by your query selection, so no files were attached',
+            };
+        default:
+            return assertUnreachable(notice, 'Unknown delivery notice type');
     }
 };

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -728,11 +728,24 @@ export enum LightdashPage {
 }
 
 // Info-only delivery notice — never a failure, must not affect run status.
-export type DeliveryNotice = {
-    type: 'limit_reached';
-    label: string;
-    rowCount: number;
-};
+export type DeliveryNotice =
+    | {
+          type: 'limit_reached';
+          label: string;
+          rowCount: number;
+      }
+    | {
+          // A captured query matched a selection snapshot entry by label +
+          // exploreName but not captureKey — delivered anyway since a stale
+          // exclusion shouldn't silently drop it.
+          type: 'query_identity_changed';
+          label: string;
+      }
+    | {
+          // Every query the render captured was excluded by the scheduler's
+          // saved selection, so the delivery has zero attachments.
+          type: 'all_queries_excluded';
+      };
 
 export type NotificationPayloadBase = {
     schedulerUuid?: string;


### PR DESCRIPTION
## Summary

PR 2 of 3 for the app-delivery query picker: the worker now applies a scheduler's `appQuerySelections` snapshot when delivering app CSV/XLSX files. Still dark — nothing can create selections until the picker UI (next PR in the stack).

Filtering runs after capture and before downloads (excluded queries are never downloaded at all). Rules per captured manifest vs snapshot:

- Snapshot `null` — or malformed, which fail-opens with a warning — delivers everything (v1 behavior, unchanged).
- Captured and excluded: skipped. Excluded error items are also fully skipped — the user opted out of that query, so its failure shouldn't alert them.
- Captured and new since the snapshot: delivered (include-new-by-default, deliveries track the evolving app).
- In snapshot, not excluded, not captured: `APP_QUERY_MISSING` partial failure.
- Identity change (a captured query matches a stale snapshot entry by label+explore but not by `captureKey`): delivered with a `notices[]` hint, and the stale entry is marked resolved so it can't also raise a missing-failure — no double-reporting, no orange status for a healthy delivery. Deduped to one notice per stale entry.

Edge cases: an all-excluded delivery still sends (zero attachments, no "all downloads failed" throw — that guard and the XLSX workbook merge previously assumed at least one download was attempted); all-excluded with no missing entries sends with an explanatory notice. Send-now shares the identical path.

## Testing

Backend targeted suite (SchedulerTask + Slack/Teams/GChat/Email senders) 164/164; full `--changed` run 5763 passed; every rule and edge case pinned, including download-never-called-for-excluded and notices never setting `hasPartialFailures`.

Relates: PROD-9380