### PR TITLE
refactor(data-apps): remove dead identityChanged field from app-query-missing failures

### DIFF
--- a/packages/backend/src/clients/GoogleChat/GoogleChatClient.test.ts
+++ b/packages/backend/src/clients/GoogleChat/GoogleChatClient.test.ts
@@ -176,16 +176,13 @@ describe('postCsvsWithWebhook app failure lines', () => {
                         type: PartialFailureType.APP_QUERY_MISSING,
                         captureKey: 'v1:def456',
                         label: HOSTILE_LABEL,
-                        identityChanged: true,
                     },
                 ],
                 csvUrls,
             );
 
             expect(text).not.toContain('<a href');
-            expect(text).toContain(
-                '- <b>x:</b> did not run in this delivery (query changed since it was selected)',
-            );
+            expect(text).toContain('- <b>x:</b> did not run in this delivery');
         },
     );
 });

--- a/packages/backend/src/clients/GoogleChat/GoogleChatClient.ts
+++ b/packages/backend/src/clients/GoogleChat/GoogleChatClient.ts
@@ -296,11 +296,7 @@ export class GoogleChatClient {
                         case PartialFailureType.APP_QUERY_MISSING:
                             return `- <b>${stripMarkup(
                                 f.label,
-                            )}:</b> did not run in this delivery${
-                                f.identityChanged
-                                    ? ' (query changed since it was selected)'
-                                    : ''
-                            }`;
+                            )}:</b> did not run in this delivery`;
                         case PartialFailureType.APP_CAPTURE_OVERFLOW:
                             return `- <b>${f.droppedCount} queries were dropped from capture (limit ${MAX_DELIVERY_QUERIES})</b>`;
                         default:

--- a/packages/backend/src/clients/MicrosoftTeams/MicrosoftTeamsClient.test.ts
+++ b/packages/backend/src/clients/MicrosoftTeams/MicrosoftTeamsClient.test.ts
@@ -270,13 +270,12 @@ describe('postCsvsWithWebhook app failure lines', () => {
                     type: PartialFailureType.APP_QUERY_MISSING,
                     captureKey: 'v1:def456',
                     label: HOSTILE_LABEL,
-                    identityChanged: true,
                 },
             ],
             csvUrls,
         );
         const text = JSON.stringify(JSON.parse(body));
         expect(text).not.toContain('[x](https://evil)');
-        expect(text).toContain('query changed since it was selected');
+        expect(text).toContain('did not run in this delivery');
     });
 });

--- a/packages/backend/src/clients/MicrosoftTeams/MicrosoftTeamsClient.ts
+++ b/packages/backend/src/clients/MicrosoftTeams/MicrosoftTeamsClient.ts
@@ -422,11 +422,7 @@ export class MicrosoftTeamsClient {
                                             type: 'TextBlock',
                                             text: `- **${stripMarkup(
                                                 f.label,
-                                            )}:** did not run in this delivery${
-                                                f.identityChanged
-                                                    ? ' (query changed since it was selected)'
-                                                    : ''
-                                            }`,
+                                            )}:** did not run in this delivery`,
                                             wrap: true,
                                             spacing: 'None',
                                         };
@@ -501,11 +497,7 @@ export class MicrosoftTeamsClient {
                                         type: 'TextBlock',
                                         text: `- **${stripMarkup(
                                             f.label,
-                                        )}:** did not run in this delivery${
-                                            f.identityChanged
-                                                ? ' (query changed since it was selected)'
-                                                : ''
-                                        }`,
+                                        )}:** did not run in this delivery`,
                                         wrap: true,
                                         spacing: 'None',
                                     };

--- a/packages/backend/src/clients/Slack/SlackMessageBlocks.test.ts
+++ b/packages/backend/src/clients/Slack/SlackMessageBlocks.test.ts
@@ -545,39 +545,12 @@ describe('SlackMessageBlocks', () => {
             expect(text).toContain('1 query failed to export');
         });
 
-        it('renders an APP_QUERY_MISSING failure, appending the identity-changed note when set', () => {
+        it('renders an APP_QUERY_MISSING failure', () => {
             const failures: PartialFailure[] = [
                 {
                     type: PartialFailureType.APP_QUERY_MISSING,
                     captureKey: 'v1:def456',
                     label: 'Signups by week',
-                    identityChanged: true,
-                },
-            ];
-
-            const blocks = getDashboardCsvResultsBlocks({
-                title: 'App delivery',
-                name: 'App delivery',
-                description: 'desc',
-                ctaUrl: 'https://app.lightdash.com/apps/abc',
-                csvUrls,
-                failures,
-            });
-
-            const sections = findBlocks(blocks, 'section');
-            const text = sections.map((s) => s.text?.text ?? '').join('\n');
-            expect(text).toContain(
-                'Signups by week: did not run in this delivery (query changed since it was selected)',
-            );
-        });
-
-        it('omits the identity-changed note for APP_QUERY_MISSING when identityChanged is false', () => {
-            const failures: PartialFailure[] = [
-                {
-                    type: PartialFailureType.APP_QUERY_MISSING,
-                    captureKey: 'v1:def456',
-                    label: 'Signups by week',
-                    identityChanged: false,
                 },
             ];
 
@@ -595,7 +568,6 @@ describe('SlackMessageBlocks', () => {
             expect(text).toContain(
                 'Signups by week: did not run in this delivery',
             );
-            expect(text).not.toContain('query changed since it was selected');
         });
 
         it('renders an APP_CAPTURE_OVERFLOW failure with the dropped count and limit', () => {
@@ -674,7 +646,6 @@ describe('SlackMessageBlocks', () => {
                     type: PartialFailureType.APP_QUERY_MISSING,
                     captureKey: 'v1:def456',
                     label: 'Signups by week',
-                    identityChanged: false,
                 },
             ];
 

--- a/packages/backend/src/clients/Slack/SlackMessageBlocks.ts
+++ b/packages/backend/src/clients/Slack/SlackMessageBlocks.ts
@@ -518,11 +518,7 @@ export const getDashboardCsvResultsBlocks = ({
                         case PartialFailureType.APP_QUERY_MISSING:
                             return `\t• ${sanitizeText(
                                 f.label,
-                            )}: did not run in this delivery${
-                                f.identityChanged
-                                    ? ' (query changed since it was selected)'
-                                    : ''
-                            }`;
+                            )}: did not run in this delivery`;
                         case PartialFailureType.APP_CAPTURE_OVERFLOW:
                             return `\t• ${f.droppedCount} queries were dropped from capture (limit ${MAX_DELIVERY_QUERIES})`;
                         default:
@@ -564,11 +560,7 @@ export const getDashboardCsvResultsBlocks = ({
                     case PartialFailureType.APP_QUERY_MISSING:
                         return `\t• ${sanitizeText(
                             f.label,
-                        )}: did not run in this delivery${
-                            f.identityChanged
-                                ? ' (query changed since it was selected)'
-                                : ''
-                        }`;
+                        )}: did not run in this delivery`;
                     case PartialFailureType.APP_CAPTURE_OVERFLOW:
                         return `\t• ${f.droppedCount} queries were dropped from capture (limit ${MAX_DELIVERY_QUERIES})`;
                     default:

--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -1305,7 +1305,6 @@ describe('applyAppQuerySelections', () => {
                 type: PartialFailureType.APP_QUERY_MISSING,
                 captureKey: 'v1:key-1',
                 label: 'Revenue by month',
-                identityChanged: false,
             },
         ]);
     });
@@ -1923,7 +1922,6 @@ describe('getNotificationPageData — app CSV/XLSX branch', () => {
                 type: PartialFailureType.APP_QUERY_MISSING,
                 captureKey: 'v1:gone',
                 label: 'Deleted query',
-                identityChanged: false,
             },
         ]);
     });
@@ -2063,7 +2061,6 @@ describe('getNotificationPageData — app CSV/XLSX branch', () => {
                 type: PartialFailureType.APP_QUERY_MISSING,
                 captureKey: 'v1:gone',
                 label: 'Deleted query',
-                identityChanged: false,
             },
         ]);
     });

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -485,7 +485,6 @@ export function applyAppQuerySelections(
             type: PartialFailureType.APP_QUERY_MISSING,
             captureKey: s.captureKey,
             label: s.label,
-            identityChanged: false,
         }));
 
     return {

--- a/packages/backend/src/utils/partialFailureUtils.ts
+++ b/packages/backend/src/utils/partialFailureUtils.ts
@@ -52,11 +52,7 @@ export const toEmailFailureFields = (
         case PartialFailureType.APP_QUERY_MISSING:
             return {
                 chartName: failure.label,
-                error: `did not run in this delivery${
-                    failure.identityChanged
-                        ? ' (query changed since it was selected)'
-                        : ''
-                }`,
+                error: 'did not run in this delivery',
             };
         case PartialFailureType.APP_CAPTURE_OVERFLOW:
             return {

--- a/packages/common/src/types/schedulerLog.ts
+++ b/packages/common/src/types/schedulerLog.ts
@@ -74,9 +74,6 @@ export type AppQueryMissingPartialFailure = {
     type: PartialFailureType.APP_QUERY_MISSING;
     captureKey: string;
     label: string;
-    /** True when a captured query matched this snapshot entry by
-     *  label+explore but not by captureKey (identity changed). */
-    identityChanged: boolean;
 };
 
 // Distinct captureKeys dropped once the app delivery hit MAX_DELIVERY_QUERIES.

--- a/packages/frontend/src/components/SchedulersView/RunDetailsModal.tsx
+++ b/packages/frontend/src/components/SchedulersView/RunDetailsModal.tsx
@@ -286,11 +286,7 @@ const PartialFailureText: FC<{
                             padding: 0,
                         }}
                     >
-                        {`did not run in this delivery${
-                            failure.identityChanged
-                                ? ' (query changed since it was selected)'
-                                : ''
-                        }`}
+                        did not run in this delivery
                     </Code>
                 </Stack>
             );


### PR DESCRIPTION
## Summary

Pure-deletion follow-up to #26935. The `identityChanged` field on `AppQueryMissingPartialFailure` shipped ahead of the selection-filtering logic, but the landed semantics divert every identity-change case to the `notices[]` path — so the field is always `false` by construction, while five consumers (Slack ×2, Teams ×2, Google Chat, email failure fields, `RunDetailsModal`) still rendered an unreachable `true` branch and its doc comment described behavior that no longer exists.

Removes the field from the type, the always-false producer assignment, and all five consumer render branches (typechecker-verified exhaustively). No behavior change on any reachable path.

## Testing

Backend targeted suite 164/164, full `--changed` run green; frontend typecheck/lint clean.

Relates: PROD-9380