### PR TITLE
feat(ai-agents): sources section for cited memories on threads

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -67,6 +67,10 @@ import {
     MEMORY_CITATION_ALLOWED_TAGS,
     MEMORY_CITATION_COMPONENTS,
 } from './memoryCitationConfig';
+import {
+    MessageSourcesGrid,
+    MessageSourcesToggle,
+} from './MessageMemorySources';
 import { MessageModelIndicator } from './MessageModelIndicator';
 import { rehypeAiAgentContentLinks } from './rehypeContentLinks';
 import { rehypeMemoryCitationIndices } from './rehypeMemoryCitations';
@@ -88,6 +92,7 @@ import {
 } from './ToolCalls/utils/toolCallGrouping';
 import { type ToolCallSummary } from './ToolCalls/utils/types';
 import { TypingDots } from './TypingDots';
+import { useMessageMemorySources } from './useMessageMemorySources';
 
 type ToolGroup = ToolCallActivityGroup & {
     kind: 'toolGroup';
@@ -913,6 +918,10 @@ export const AssistantBubble: FC<Props> = memo(
             useDisclosure(false);
         const [feedbackText, setFeedbackText] = useState('');
 
+        const sourceSlugs = useMessageMemorySources(message.message ?? '');
+        const [sourcesExpanded, { toggle: toggleSources }] =
+            useDisclosure(false);
+
         const handleUpvote = useCallback(() => {
             updateFeedbackMutation.mutate({
                 messageUuid: message.uuid,
@@ -1200,6 +1209,13 @@ export const AssistantBubble: FC<Props> = memo(
                             </ActionIcon>
                         )}
 
+                        {sourceSlugs.length > 0 && (
+                            <MessageSourcesToggle
+                                count={sourceSlugs.length}
+                                expanded={sourcesExpanded}
+                                onToggle={toggleSources}
+                            />
+                        )}
                         <MessageModelIndicator
                             projectUuid={projectUuid}
                             agentUuid={agentUuid}
@@ -1207,6 +1223,14 @@ export const AssistantBubble: FC<Props> = memo(
                             totalTokens={message.tokenUsage?.totalTokens}
                         />
                     </Group>
+                )}
+
+                {!isLoading && sourcesExpanded && sourceSlugs.length > 0 && (
+                    <MessageSourcesGrid
+                        slugs={sourceSlugs}
+                        projectUuid={projectUuid}
+                        agentUuid={agentUuid}
+                    />
                 )}
 
                 <AgentChatDebugDrawer

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MessageMemorySources.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MessageMemorySources.module.css
@@ -1,0 +1,60 @@
+/* the neighboring subtle ActionIcons compute to ldGray.6; match them exactly */
+.toggle {
+    color: var(--mantine-color-ldGray-6);
+}
+
+.card {
+    border-color: light-dark(
+        var(--mantine-color-gray-3),
+        var(--mantine-color-ldDark-4)
+    );
+    transition:
+        border-color 120ms ease,
+        background-color 120ms ease;
+}
+
+.card:hover {
+    border-color: var(--mantine-color-indigo-4);
+    background: light-dark(
+        var(--mantine-color-indigo-0),
+        var(--mantine-color-ldDark-5)
+    );
+}
+
+.card:focus-visible {
+    outline: 2px solid var(--mantine-color-indigo-5);
+    outline-offset: 2px;
+}
+
+.cardUnavailable {
+    border-color: light-dark(
+        var(--mantine-color-gray-3),
+        var(--mantine-color-ldDark-4)
+    );
+}
+
+/* same visual language as the inline citation marker, sized for a card row */
+.indexChip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    min-width: 20px;
+    height: 20px;
+    padding: 0 4px;
+    border: 1px solid
+        light-dark(var(--mantine-color-gray-3), var(--mantine-color-ldDark-4));
+    border-radius: var(--mantine-radius-xs);
+    background: light-dark(
+        var(--mantine-color-gray-0),
+        var(--mantine-color-ldDark-6)
+    );
+    color: light-dark(
+        var(--mantine-color-gray-6),
+        var(--mantine-color-ldGray-5)
+    );
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 11px;
+    font-weight: 700;
+    line-height: 1;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MessageMemorySources.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MessageMemorySources.tsx
@@ -1,0 +1,154 @@
+import {
+    Box,
+    Button,
+    Group,
+    Paper,
+    SimpleGrid,
+    Skeleton,
+    Stack,
+    Text,
+} from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import {
+    IconChevronDown,
+    IconChevronUp,
+    IconFileDescription,
+} from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { PolymorphicPaperButton } from '../../../../../components/common/PolymorphicPaperButton';
+import { useAiAgentMemory } from '../../hooks/useAiAgentMemory';
+import { MemoryDetailsModal } from '../MemoryDetails/MemoryDetails';
+import styles from './MessageMemorySources.module.css';
+
+export const MessageSourcesToggle: FC<{
+    count: number;
+    expanded: boolean;
+    onToggle: () => void;
+}> = ({ count, expanded, onToggle }) => (
+    <Button
+        variant="subtle"
+        color="gray"
+        size="compact-xs"
+        fw={500}
+        className={styles.toggle}
+        onClick={onToggle}
+        leftSection={<MantineIcon icon={IconFileDescription} size={16} />}
+        rightSection={
+            <MantineIcon
+                icon={expanded ? IconChevronUp : IconChevronDown}
+                size={12}
+            />
+        }
+    >
+        {count} {count === 1 ? 'source' : 'sources'}
+    </Button>
+);
+
+const MemorySourceCard: FC<{
+    slug: string;
+    index: number;
+    projectUuid: string;
+    agentUuid: string;
+}> = ({ slug, index, projectUuid, agentUuid }) => {
+    const [detailsOpened, { open: openDetails, close: closeDetails }] =
+        useDisclosure(false);
+    const memoryQuery = useAiAgentMemory({ projectUuid, agentUuid, slug });
+
+    if (memoryQuery.isLoading) {
+        return (
+            <Paper withBorder radius="md" p="sm" className={styles.card}>
+                <Group gap="sm" wrap="nowrap">
+                    <Box className={styles.indexChip}>{index}</Box>
+                    <Stack gap={6} w="100%">
+                        <Skeleton height={10} width="70%" />
+                        <Skeleton height={8} width="40%" />
+                    </Stack>
+                </Group>
+            </Paper>
+        );
+    }
+
+    if (!memoryQuery.data) {
+        return (
+            <Paper
+                withBorder
+                radius="md"
+                p="sm"
+                className={styles.cardUnavailable}
+            >
+                <Group gap="sm" wrap="nowrap">
+                    <Box className={styles.indexChip}>{index}</Box>
+                    <Text size="sm" c="dimmed">
+                        Memory unavailable
+                    </Text>
+                </Group>
+            </Paper>
+        );
+    }
+
+    const memory = memoryQuery.data;
+
+    return (
+        <>
+            <PolymorphicPaperButton
+                component="button"
+                type="button"
+                withBorder
+                radius="md"
+                p="sm"
+                className={styles.card}
+                aria-label={`Show memory ${memory.title}`}
+                onClick={openDetails}
+            >
+                <Group gap="sm" wrap="nowrap" align="flex-start">
+                    <Box className={styles.indexChip}>{index}</Box>
+                    <Stack gap={2} miw={0}>
+                        <Text
+                            size="sm"
+                            fw={600}
+                            lh={1.3}
+                            lineClamp={1}
+                            ta="left"
+                        >
+                            {memory.title}
+                        </Text>
+                        <Text size="xs" c="dimmed" ta="left">
+                            Saved{' '}
+                            {new Date(memory.generatedAt).toLocaleDateString()}
+                        </Text>
+                    </Stack>
+                </Group>
+            </PolymorphicPaperButton>
+            <MemoryDetailsModal
+                opened={detailsOpened}
+                onClose={closeDetails}
+                memory={memory}
+                projectUuid={projectUuid}
+                agentUuid={agentUuid}
+            />
+        </>
+    );
+};
+
+/**
+ * Card grid for the memories a message cites inline via `<ld-mem-cite>`,
+ * numbered to match the inline markers. Toggled by `MessageSourcesToggle`.
+ */
+export const MessageSourcesGrid: FC<{
+    slugs: string[];
+    projectUuid: string;
+    agentUuid: string;
+}> = ({ slugs, projectUuid, agentUuid }) => (
+    <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="xs">
+        {slugs.map((slug, idx) => (
+            <MemorySourceCard
+                key={slug}
+                slug={slug}
+                index={idx + 1}
+                projectUuid={projectUuid}
+                agentUuid={agentUuid}
+            />
+        ))}
+    </SimpleGrid>
+);

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MessageModelIndicator.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MessageModelIndicator.tsx
@@ -32,7 +32,8 @@ export const MessageModelIndicator: FC<Props> = ({
     if (!modelDisplayName) return null;
 
     const badge = (
-        <Badge variant="transparent" color="gray" size="sm">
+        // fz matches the sources toggle so the footer reads as one metadata row
+        <Badge variant="transparent" color="gray" size="sm" fz="xs">
             {modelDisplayName}
         </Badge>
     );

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/parseMemoryCitationSlugs.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/parseMemoryCitationSlugs.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { parseMemoryCitationSlugs } from './parseMemoryCitationSlugs';
+
+describe('parseMemoryCitationSlugs', () => {
+    it('returns unique slugs in first-appearance order', () => {
+        const markdown =
+            'a<ld-mem-cite id="beta-two"></ld-mem-cite> b<ld-mem-cite id="alpha-one"/> c<ld-mem-cite id="beta-two"></ld-mem-cite>';
+        expect(parseMemoryCitationSlugs(markdown)).toEqual([
+            'beta-two',
+            'alpha-one',
+        ]);
+    });
+
+    it('ignores citations inside fenced code blocks', () => {
+        const markdown =
+            '```\n<ld-mem-cite id="in-code"></ld-mem-cite>\n```\ntext<ld-mem-cite id="in-prose"></ld-mem-cite>';
+        expect(parseMemoryCitationSlugs(markdown)).toEqual(['in-prose']);
+    });
+
+    it('ignores malformed citations', () => {
+        const markdown =
+            '<ld-mem-cite id="Bad_Slug"></ld-mem-cite><ld-mem-cite>no id</ld-mem-cite>';
+        expect(parseMemoryCitationSlugs(markdown)).toEqual([]);
+    });
+
+    it('returns empty for plain markdown', () => {
+        expect(parseMemoryCitationSlugs('no citations here')).toEqual([]);
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/parseMemoryCitationSlugs.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/parseMemoryCitationSlugs.ts
@@ -1,0 +1,23 @@
+const MEMORY_SLUG = '[a-z0-9]+(?:-[a-z0-9]+)*';
+
+const VALID_MEMORY_CITATION_REGEX = new RegExp(
+    `<ld-mem-cite\\s+id="(${MEMORY_SLUG})"\\s*(?:\\/>|>\\s*<\\/ld-mem-cite\\s*>)`,
+    'g',
+);
+const FENCED_CODE_BLOCK_REGEX = /```[\s\S]*?```|~~~[\s\S]*?~~~/g;
+
+/**
+ * Unique cited memory slugs in first-appearance order — the same order
+ * `rehypeMemoryCitationIndices` numbers the inline markers, so index N here
+ * matches marker N in the rendered message.
+ */
+export const parseMemoryCitationSlugs = (markdown: string): string[] => {
+    const prose = markdown.replace(FENCED_CODE_BLOCK_REGEX, '');
+    const slugs: string[] = [];
+    for (const match of prose.matchAll(VALID_MEMORY_CITATION_REGEX)) {
+        if (!slugs.includes(match[1])) {
+            slugs.push(match[1]);
+        }
+    }
+    return slugs;
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/useMessageMemorySources.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/useMessageMemorySources.ts
@@ -1,0 +1,10 @@
+import { useMemo } from 'react';
+import { useAiAgentMemoryEnabled } from '../../hooks/useAiOrganizationSettings';
+import { parseMemoryCitationSlugs } from './parseMemoryCitationSlugs';
+
+/** Cited memory slugs for a message, empty when the feature is off. */
+export const useMessageMemorySources = (markdown: string): string[] => {
+    const memoryEnabled = useAiAgentMemoryEnabled();
+    const slugs = useMemo(() => parseMemoryCitationSlugs(markdown), [markdown]);
+    return memoryEnabled ? slugs : [];
+};


### PR DESCRIPTION
Stacked on #26930 (memory tour).

Assistant messages that cite memories inline now surface those citations as a **sources** affordance in the message action row:

- After the copy/thumbs icons: a **"N sources"** button (document icon + chevron), followed inline by the model badge.
- Clicking expands a card grid below the row — one card per cited memory, numbered to match the inline citation markers, showing title + saved date. Clicking a card opens the memory details modal (same as clicking an inline marker).
- Collapsed by default; hidden when memory is disabled or the message has no citations.

## How

- `parseMemoryCitationSlugs` extracts unique `<ld-mem-cite>` slugs in first-appearance order (fenced-code-aware, mirroring the backend parser), so card numbering matches `rehypeMemoryCitationIndices`.
- `MessageSourcesToggle` + `MessageSourcesGrid` in `ChatElements/MessageMemorySources.tsx`; cards reuse the citation-popover visual language and share its `aiAgentMemory` query cache (fetched lazily, only when expanded).

## Testing

- Verified in the browser: toggle renders after the action icons, collapsed by default, expand/collapse flips the chevron, card numbers match inline markers, cards open the correct memory modal.
- 4 unit tests for the citation parser; typecheck + lint + `unused-exports` clean.

Closes: ZAP-815

🤖 Generated with [Claude Code](https://claude.com/claude-code)
