### PR TITLE
feat: add v3 agent run pipeline

### DIFF
--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -39,6 +39,7 @@ import {
     ApiAiAgentThreadStreamRequest,
     ApiAiAgentThreadSummaryListResponse,
     ApiAiAgentThreadWorkstreamsResponse,
+    ApiAiAgentV3ChatRequest,
     ApiAiAgentVerifiedArtifactsResponse,
     ApiAiAgentVerifiedQuestionsResponse,
     ApiAiMcpGithubAvailabilityResponse,
@@ -106,6 +107,50 @@ import { type AiAgentService } from '../services/AiAgentService/AiAgentService';
 @Route('/api/v1/projects/{projectUuid}/aiAgents')
 @Response<ApiErrorPayload>('default', 'Error')
 export class AiAgentController extends BaseController {
+    private pipeAgentStream(
+        req: express.Request,
+        stream: Awaited<
+            ReturnType<AiAgentService['streamAgentThreadResponse']>
+        >,
+    ): void {
+        stream.pipeUIMessageStreamToResponse(req.res!);
+        let hasConsumed = false;
+        const isStreamTimeoutError = (error: unknown) =>
+            error instanceof Error &&
+            (error.name === 'BodyTimeoutError' ||
+                (error.name === 'TypeError' && error.message === 'terminated'));
+        const handleClientDisconnect = (err: Error | undefined) => {
+            if (hasConsumed) return;
+            hasConsumed = true;
+            Logger.info(
+                `Client disconnected ${
+                    err ? `with error: ${err.message}` : ''
+                }, consuming stream`,
+            );
+            if (err && !isStreamTimeoutError(err)) {
+                Sentry.captureException(err, {
+                    tags: { errorType: 'AiAgentStreamError' },
+                });
+            }
+            void stream.consumeStream({
+                onError: (error) => {
+                    Logger.error(`Error consuming stream ${String(error)}`);
+                    if (!isStreamTimeoutError(error)) {
+                        Sentry.captureException(error, {
+                            tags: { errorType: 'AiAgentStreamError' },
+                        });
+                    }
+                },
+            });
+        };
+        req.res?.on('finish', () => {
+            hasConsumed = true;
+        });
+        req.res?.on('close', handleClientDisconnect);
+        req.res?.on('error', handleClientDisconnect);
+        req.on('aborted', handleClientDisconnect);
+    }
+
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
     @Get('/')
@@ -1169,54 +1214,27 @@ export class AiAgentController extends BaseController {
                       );
                   })();
 
-        /**
-         * @ref https://github.com/lukeautry/tsoa/issues/44#issuecomment-357784246
-         * Hack to get the response object from the request
-         */
-        stream.pipeUIMessageStreamToResponse(req.res!);
+        this.pipeAgentStream(req, stream);
+    }
 
-        // If client disconnects, continue consuming the stream so side-effects complete
-        let hasConsumed = false;
-        const isStreamTimeoutError = (error: unknown) =>
-            error instanceof Error &&
-            (error.name === 'BodyTimeoutError' ||
-                (error.name === 'TypeError' && error.message === 'terminated'));
-
-        const handleClientDisconnect = (err: Error | undefined) => {
-            if (hasConsumed) return;
-            hasConsumed = true;
-            Logger.info(
-                `Client disconnected ${
-                    err ? `with error: ${err.message}` : ''
-                }, consuming stream`,
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/{agentUuid}/threads/{threadUuid}/chat')
+    @OperationId('streamAgentThreadV3Response')
+    async streamAgentThreadV3Response(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Path() agentUuid: UUID,
+        @Path() threadUuid: UUID,
+        @Body() body: ApiAiAgentV3ChatRequest,
+    ): Promise<void> {
+        assertRegisteredAccount(req.account);
+        const stream =
+            await this.getAiAgentService().streamAgentThreadV3Response(
+                toSessionUser(req.account),
+                { agentUuid, threadUuid, body },
             );
-            if (err && !isStreamTimeoutError(err)) {
-                Sentry.captureException(err, {
-                    tags: {
-                        errorType: 'AiAgentStreamError',
-                    },
-                });
-            }
-            void stream.consumeStream({
-                onError: (error) => {
-                    Logger.error(`Error consuming stream ${String(error)}`);
-                    if (!isStreamTimeoutError(error)) {
-                        Sentry.captureException(error, {
-                            tags: {
-                                errorType: 'AiAgentStreamError',
-                            },
-                        });
-                    }
-                },
-            });
-        };
-        req.res?.on('finish', () => {
-            // If the request is finished, we can stop consuming the stream
-            hasConsumed = true;
-        });
-        req.res?.on('close', handleClientDisconnect);
-        req.res?.on('error', handleClientDisconnect);
-        req.on('aborted', handleClientDisconnect);
+        this.pipeAgentStream(req, stream);
     }
 
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])

--- a/packages/backend/src/ee/database/entities/aiAgentV3.ts
+++ b/packages/backend/src/ee/database/entities/aiAgentV3.ts
@@ -242,6 +242,7 @@ export type CreateAiV3Thread = {
     agentUuid: string | null;
     createdFrom: AiThreadCreatedFrom;
     lineage: AiV3ThreadLineage;
+    ownerUserUuid?: string;
 };
 
 type AiV3PartWriteBase = {

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -493,6 +493,9 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     analytics: context.lightdashAnalytics,
                     userModel: models.getUserModel(),
                     aiAgentModel: models.getAiAgentModel(),
+                    aiAgentV3Model: models.getAiAgentV3Model<AiAgentV3Model>(),
+                    aiAgentThreadRepository:
+                        models.getAiAgentThreadRepository<AiAgentThreadRepository>(),
                     aiAgentMemoryModel:
                         models.getAiAgentMemoryModel<AiAgentMemoryModel>(),
                     aiAgentDocumentModel:

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -7029,7 +7029,7 @@ export class AiAgentModel {
     async createArtifact(
         data: {
             threadUuid: string;
-            promptUuid: string;
+            promptUuid: string | null;
             artifactType: 'chart' | 'dashboard';
             title?: string;
             description?: string;
@@ -7102,7 +7102,7 @@ export class AiAgentModel {
     async createArtifactVersion(
         data: {
             artifactUuid: string;
-            promptUuid: string;
+            promptUuid: string | null;
             title?: string;
             description?: string;
             vizConfig: Record<string, unknown>;
@@ -7187,7 +7187,7 @@ export class AiAgentModel {
 
     async createOrUpdateArtifact(data: {
         threadUuid: string;
-        promptUuid: string;
+        promptUuid: string | null;
         artifactType: 'chart' | 'dashboard';
         title?: string;
         description?: string;

--- a/packages/backend/src/ee/models/AiAgentThreadRepository.ts
+++ b/packages/backend/src/ee/models/AiAgentThreadRepository.ts
@@ -1,7 +1,10 @@
 import { assertUnreachable, NotFoundError } from '@lightdash/common';
 import { type Knex } from 'knex';
 import { AiThreadTableName } from '../database/entities/ai';
-import { type AiCanonicalThread } from '../database/entities/aiAgentV3';
+import {
+    type AiAgentStorageVersion,
+    type AiCanonicalThread,
+} from '../database/entities/aiAgentV3';
 import { AiAgentV1ReadAdapter } from './AiAgentV1ReadAdapter';
 import { AiAgentV3Model } from './AiAgentV3Model';
 
@@ -45,5 +48,18 @@ export class AiAgentThreadRepository {
                     'Unsupported thread storage version',
                 );
         }
+    }
+
+    async getStorageVersion(
+        threadUuid: string,
+    ): Promise<AiAgentStorageVersion> {
+        const thread = await this.database(AiThreadTableName)
+            .select('storage_version')
+            .where('ai_thread_uuid', threadUuid)
+            .first();
+        if (thread === undefined) {
+            throw new NotFoundError('Thread not found');
+        }
+        return thread.storage_version;
     }
 }

--- a/packages/backend/src/ee/models/AiAgentV3Model.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentV3Model.integration.test.ts
@@ -7,7 +7,10 @@ import {
 import { randomUUID } from 'crypto';
 import { type Knex } from 'knex';
 import { getTestContext } from '../../vitest.setup.integration';
-import { AiThreadTableName } from '../database/entities/ai';
+import {
+    AiThreadTableName,
+    AiWebAppThreadTableName,
+} from '../database/entities/ai';
 import {
     AiMessagePartTableName,
     AiThreadMessageSequenceTableName,
@@ -108,6 +111,26 @@ describe('AiAgentV3Model', () => {
         ).rejects.toThrow('Lineage parent must use storage version 3');
     });
 
+    it('persists web thread ownership with creation', async () => {
+        const thread = await model.createThread({
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            projectUuid: SEED_PROJECT.project_uuid,
+            agentUuid: null,
+            createdFrom: 'web_app',
+            lineage: null,
+            ownerUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+        });
+        rootThreadUuids.add(thread.uuid);
+
+        await expect(
+            database(AiWebAppThreadTableName)
+                .where('ai_thread_uuid', thread.uuid)
+                .first(),
+        ).resolves.toMatchObject({
+            user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+        });
+    });
+
     it('allocates unique ordered message sequences for concurrent writers', async () => {
         const thread = await createRootThread();
 
@@ -148,6 +171,121 @@ describe('AiAgentV3Model', () => {
                 parts: [textPart(0, 'missing')],
             }),
         ).rejects.toThrow('Thread not found');
+    });
+
+    it('atomically starts one run and resumes after it freezes', async () => {
+        const thread = await createRootThread();
+        const first = await model.startRun({
+            threadUuid: thread.uuid,
+            createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            userParts: [textPart(0, 'first')],
+            modelConfig,
+        });
+
+        await expect(
+            model.startRun({
+                threadUuid: thread.uuid,
+                createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                userParts: [textPart(0, 'racing input')],
+                modelConfig,
+            }),
+        ).rejects.toThrow('This thread already has an active run');
+        await model.finishAssistantMessage({
+            messageUuid: first.assistantMessage.uuid,
+            status: 'canceled',
+            tokenUsage: null,
+            error: null,
+        });
+        const second = await model.startRun({
+            threadUuid: thread.uuid,
+            createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            userParts: [textPart(0, 'second')],
+            modelConfig,
+        });
+
+        expect(first.userMessage.threadSeq).toBe(1);
+        expect(first.assistantMessage.threadSeq).toBe(2);
+        expect(second.userMessage.threadSeq).toBe(3);
+        expect(second.assistantMessage.threadSeq).toBe(4);
+    });
+
+    it('refreshes heartbeats only while the assistant is in progress', async () => {
+        const thread = await createRootThread();
+        const assistant = await model.createAssistantMessage({
+            threadUuid: thread.uuid,
+            modelConfig,
+        });
+        const oldHeartbeat = new Date('2020-01-01T00:00:00.000Z');
+        await database(AiThreadMessageTableName)
+            .where('ai_thread_message_uuid', assistant.uuid)
+            .update({ last_heartbeat_at: oldHeartbeat });
+
+        expect(
+            await model.refreshAssistantMessageHeartbeat(assistant.uuid),
+        ).toBe(true);
+        const refreshed = await database(AiThreadMessageTableName)
+            .where('ai_thread_message_uuid', assistant.uuid)
+            .first('last_heartbeat_at');
+        expect(refreshed!.last_heartbeat_at!.getTime()).toBeGreaterThan(
+            oldHeartbeat.getTime(),
+        );
+
+        await model.finishAssistantMessage({
+            messageUuid: assistant.uuid,
+            status: 'canceled',
+            tokenUsage: null,
+            error: null,
+        });
+        expect(
+            await model.refreshAssistantMessageHeartbeat(assistant.uuid),
+        ).toBe(false);
+        const frozen = await database(AiThreadMessageTableName)
+            .where('ai_thread_message_uuid', assistant.uuid)
+            .first('last_heartbeat_at');
+        expect(frozen!.last_heartbeat_at).toEqual(refreshed!.last_heartbeat_at);
+    });
+
+    it('persists steers at their true sequence while the run is active', async () => {
+        const thread = await createRootThread();
+        const run = await model.startRun({
+            threadUuid: thread.uuid,
+            createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            userParts: [textPart(0, 'question')],
+            modelConfig,
+        });
+        const steer = await model.appendSteer({
+            threadUuid: thread.uuid,
+            assistantMessageUuid: run.assistantMessage.uuid,
+            createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            parts: [textPart(0, 'focus on revenue')],
+        });
+
+        expect(steer.threadSeq).toBe(3);
+        expect(
+            await model.getSteers({
+                threadUuid: thread.uuid,
+                assistantMessageUuid: run.assistantMessage.uuid,
+            }),
+        ).toEqual([
+            expect.objectContaining({
+                uuid: steer.uuid,
+                message: 'focus on revenue',
+            }),
+        ]);
+        await model.finishAssistantMessage({
+            messageUuid: run.assistantMessage.uuid,
+            status: 'canceled',
+            tokenUsage: null,
+            error: null,
+        });
+        await expect(
+            model.appendSteer({
+                threadUuid: thread.uuid,
+                assistantMessageUuid: run.assistantMessage.uuid,
+                createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                parts: [textPart(0, 'too late')],
+            }),
+        ).rejects.toThrow('Assistant message is frozen');
     });
 
     it('returns messages and typed parts in canonical order', async () => {

--- a/packages/backend/src/ee/models/AiAgentV3Model.ts
+++ b/packages/backend/src/ee/models/AiAgentV3Model.ts
@@ -6,7 +6,11 @@ import {
     UnexpectedServerError,
 } from '@lightdash/common';
 import { type Knex } from 'knex';
-import { AiThreadTableName, type DbAiThread } from '../database/entities/ai';
+import {
+    AiThreadTableName,
+    AiWebAppThreadTableName,
+    type DbAiThread,
+} from '../database/entities/ai';
 import {
     AI_ASSISTANT_MESSAGE_TERMINAL_STATUSES,
     AI_TOOL_PART_INTERRUPTED_STATE,
@@ -357,6 +361,13 @@ export class AiAgentV3Model {
             await trx(AiThreadMessageSequenceTableName).insert({
                 ai_thread_uuid: thread.ai_thread_uuid,
             });
+            if (data.ownerUserUuid) {
+                await trx(AiWebAppThreadTableName).insert({
+                    ai_thread_uuid: thread.ai_thread_uuid,
+                    user_uuid: data.ownerUserUuid,
+                    embed_space_uuid: null,
+                });
+            }
 
             return {
                 uuid: thread.ai_thread_uuid,
@@ -420,6 +431,58 @@ export class AiAgentV3Model {
         });
     }
 
+    async appendSteer({
+        threadUuid,
+        assistantMessageUuid,
+        createdByUserUuid,
+        parts,
+    }: {
+        threadUuid: string;
+        assistantMessageUuid: string;
+        createdByUserUuid: string;
+        parts: AiV3PartWrite[];
+    }): Promise<CreatedMessage> {
+        if (parts.length === 0) {
+            throw new ParameterError('Steer message requires content');
+        }
+        AiAgentV3Model.assertPartWrites(parts, 'user');
+        return this.database.transaction(async (trx) => {
+            const assistant = await AiAgentV3Model.getWritableAssistantMessage(
+                trx,
+                assistantMessageUuid,
+            );
+            if (assistant.ai_thread_uuid !== threadUuid) {
+                throw new NotFoundError('Assistant message not found');
+            }
+            const threadSeq = await AiAgentV3Model.allocateThreadSeq(
+                trx,
+                threadUuid,
+            );
+            const [message] = await trx(AiThreadMessageTableName)
+                .insert({
+                    ai_thread_uuid: threadUuid,
+                    thread_seq: threadSeq,
+                    role: 'user',
+                    created_by_user_uuid: createdByUserUuid,
+                })
+                .returning(['ai_thread_message_uuid', 'created_at']);
+            if (message === undefined) {
+                throw new UnexpectedServerError(
+                    'Failed to append steer message',
+                );
+            }
+            await AiAgentV3Model.insertParts(
+                trx,
+                message.ai_thread_message_uuid,
+                parts,
+            );
+            await trx(AiThreadTableName)
+                .where('ai_thread_uuid', threadUuid)
+                .update({ updated_at: message.created_at });
+            return { uuid: message.ai_thread_message_uuid, threadSeq };
+        });
+    }
+
     async createAssistantMessage({
         threadUuid,
         modelConfig,
@@ -454,6 +517,99 @@ export class AiAgentV3Model {
         });
     }
 
+    async startRun({
+        threadUuid,
+        createdByUserUuid,
+        userParts,
+        modelConfig,
+    }: {
+        threadUuid: string;
+        createdByUserUuid: string;
+        userParts: AiV3PartWrite[];
+        modelConfig: AiModelConfigEnvelope;
+    }): Promise<{
+        userMessage: CreatedMessage;
+        assistantMessage: CreatedMessage;
+    }> {
+        if (userParts.length === 0) {
+            throw new ParameterError('User message requires content');
+        }
+        AiAgentV3Model.assertPartWrites(userParts, 'user');
+        return this.database.transaction(async (trx) => {
+            await trx(AiThreadMessageSequenceTableName)
+                .where('ai_thread_uuid', threadUuid)
+                .forUpdate()
+                .first();
+            const activeAssistant = await trx(AiThreadMessageTableName)
+                .where('ai_thread_uuid', threadUuid)
+                .where('role', 'assistant')
+                .where('status', 'in_progress')
+                .first();
+            if (activeAssistant !== undefined) {
+                throw new ConflictError(
+                    'This thread already has an active run',
+                );
+            }
+
+            const userThreadSeq = await AiAgentV3Model.allocateThreadSeq(
+                trx,
+                threadUuid,
+            );
+            const [userMessage] = await trx(AiThreadMessageTableName)
+                .insert({
+                    ai_thread_uuid: threadUuid,
+                    thread_seq: userThreadSeq,
+                    role: 'user',
+                    created_by_user_uuid: createdByUserUuid,
+                })
+                .returning(['ai_thread_message_uuid', 'created_at']);
+            if (userMessage === undefined) {
+                throw new UnexpectedServerError(
+                    'Failed to append user message',
+                );
+            }
+            await AiAgentV3Model.insertParts(
+                trx,
+                userMessage.ai_thread_message_uuid,
+                userParts,
+            );
+
+            const assistantThreadSeq = await AiAgentV3Model.allocateThreadSeq(
+                trx,
+                threadUuid,
+            );
+            const [assistantMessage] = await trx(AiThreadMessageTableName)
+                .insert({
+                    ai_thread_uuid: threadUuid,
+                    thread_seq: assistantThreadSeq,
+                    role: 'assistant',
+                    status: 'in_progress',
+                    last_heartbeat_at: trx.fn.now(),
+                    model_config: modelConfig,
+                })
+                .returning('ai_thread_message_uuid');
+            if (assistantMessage === undefined) {
+                throw new UnexpectedServerError(
+                    'Failed to create assistant message',
+                );
+            }
+            await trx(AiThreadTableName)
+                .where('ai_thread_uuid', threadUuid)
+                .update({ updated_at: userMessage.created_at });
+
+            return {
+                userMessage: {
+                    uuid: userMessage.ai_thread_message_uuid,
+                    threadSeq: userThreadSeq,
+                },
+                assistantMessage: {
+                    uuid: assistantMessage.ai_thread_message_uuid,
+                    threadSeq: assistantThreadSeq,
+                },
+            };
+        });
+    }
+
     async appendParts({
         messageUuid,
         parts,
@@ -466,6 +622,81 @@ export class AiAgentV3Model {
             await AiAgentV3Model.getWritableAssistantMessage(trx, messageUuid);
             return AiAgentV3Model.insertParts(trx, messageUuid, parts);
         });
+    }
+
+    async refreshAssistantMessageHeartbeat(
+        messageUuid: string,
+    ): Promise<boolean> {
+        const updated = await this.database(AiThreadMessageTableName)
+            .where('ai_thread_message_uuid', messageUuid)
+            .where('role', 'assistant')
+            .where('status', 'in_progress')
+            .update({ last_heartbeat_at: this.database.fn.now() });
+        return updated === 1;
+    }
+
+    async isAssistantMessageInProgress(messageUuid: string): Promise<boolean> {
+        const message = await this.database(AiThreadMessageTableName)
+            .where('ai_thread_message_uuid', messageUuid)
+            .where('role', 'assistant')
+            .where('status', 'in_progress')
+            .first('ai_thread_message_uuid');
+        return message !== undefined;
+    }
+
+    async getSteers({
+        threadUuid,
+        assistantMessageUuid,
+    }: {
+        threadUuid: string;
+        assistantMessageUuid: string;
+    }): Promise<Array<{ uuid: string; message: string; createdAt: string }>> {
+        const assistant = await this.database(AiThreadMessageTableName)
+            .where('ai_thread_message_uuid', assistantMessageUuid)
+            .where('ai_thread_uuid', threadUuid)
+            .where('role', 'assistant')
+            .first('thread_seq');
+        if (!assistant) throw new NotFoundError('Assistant message not found');
+        const rows = await this.database(AiThreadMessageTableName)
+            .innerJoin(
+                AiMessagePartTableName,
+                `${AiMessagePartTableName}.ai_thread_message_uuid`,
+                `${AiThreadMessageTableName}.ai_thread_message_uuid`,
+            )
+            .where(`${AiThreadMessageTableName}.ai_thread_uuid`, threadUuid)
+            .where(`${AiThreadMessageTableName}.role`, 'user')
+            .where(
+                `${AiThreadMessageTableName}.thread_seq`,
+                '>',
+                assistant.thread_seq,
+            )
+            .where(`${AiMessagePartTableName}.type`, 'text')
+            .orderBy(`${AiThreadMessageTableName}.thread_seq`)
+            .orderBy(`${AiMessagePartTableName}.part_index`)
+            .select<
+                Array<{
+                    uuid: string;
+                    created_at: Date;
+                    payload: Record<string, unknown>;
+                }>
+            >({
+                uuid: `${AiThreadMessageTableName}.ai_thread_message_uuid`,
+                created_at: `${AiThreadMessageTableName}.created_at`,
+                payload: `${AiMessagePartTableName}.payload`,
+            });
+        const grouped = new Map<
+            string,
+            { uuid: string; message: string; createdAt: string }
+        >();
+        rows.forEach((row) => {
+            const current = grouped.get(row.uuid);
+            grouped.set(row.uuid, {
+                uuid: row.uuid,
+                message: `${current?.message ?? ''}${String(row.payload.text ?? '')}`,
+                createdAt: row.created_at.toISOString(),
+            });
+        });
+        return [...grouped.values()];
     }
 
     async updatePart({

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.shutdown.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.shutdown.test.ts
@@ -42,6 +42,15 @@ type PrivateService = {
         options: PromptResolutionOptions,
     ) => Promise<unknown>;
     generateOrStreamAgentResponse: (...args: unknown[]) => Promise<unknown>;
+    prepareAgentThreadV3Response: (...args: unknown[]) => Promise<unknown>;
+    activeV3Runs: Map<
+        string,
+        {
+            threadUuid: string;
+            abortController: AbortController;
+            persistence: { fail: ReturnType<typeof vi.fn> };
+        }
+    >;
 };
 
 const pendingState: AiPromptResponseState = {
@@ -237,5 +246,69 @@ describe('AiAgentService streamed prompt shutdown', () => {
         expect(failPendingPrompts).not.toHaveBeenCalled();
         service.endStreamPreparation();
         vi.useRealTimers();
+    });
+
+    it('rejects new v3 runs and freezes active ones during shutdown', async () => {
+        const { instance, service, failPendingPrompts } = buildService();
+        const privateService = instance as unknown as PrivateService;
+        const abortController = new AbortController();
+        const fail = vi.fn().mockResolvedValue(undefined);
+        privateService.activeV3Runs.set('message-uuid', {
+            threadUuid: 'thread-uuid',
+            abortController,
+            persistence: { fail },
+        });
+
+        await service.failInFlightStreamedPrompts();
+
+        expect(abortController.signal.aborted).toBe(true);
+        expect(fail).toHaveBeenCalledWith(
+            expect.any(Error),
+            'The server restarted while generating this response. Please try again.',
+        );
+        expect(failPendingPrompts).not.toHaveBeenCalled();
+        await expect(
+            instance.streamAgentThreadV3Response({} as never, {
+                agentUuid: 'agent-uuid',
+                threadUuid: 'thread-uuid',
+                body: { message: 'hello' },
+            }),
+        ).rejects.toThrow('The server is restarting');
+    });
+
+    it('waits for v3 admission before snapshotting active runs', async () => {
+        const { instance, service } = buildService();
+        const privateService = instance as unknown as PrivateService;
+        const preparation = createDeferred();
+        const abortController = new AbortController();
+        const fail = vi.fn().mockResolvedValue(undefined);
+        vi.spyOn(
+            privateService,
+            'prepareAgentThreadV3Response',
+        ).mockImplementation(async () => {
+            await preparation.promise;
+            privateService.activeV3Runs.set('message-uuid', {
+                threadUuid: 'thread-uuid',
+                abortController,
+                persistence: { fail },
+            });
+            return {};
+        });
+
+        const stream = instance.streamAgentThreadV3Response({} as never, {
+            agentUuid: 'agent-uuid',
+            threadUuid: 'thread-uuid',
+            body: { message: 'hello' },
+        });
+        await Promise.resolve();
+        const shutdown = service.failInFlightStreamedPrompts();
+        await Promise.resolve();
+        expect(fail).not.toHaveBeenCalled();
+
+        preparation.resolve();
+        await Promise.all([stream, shutdown]);
+
+        expect(abortController.signal.aborted).toBe(true);
+        expect(fail).toHaveBeenCalledOnce();
     });
 });

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -44,6 +44,7 @@ import {
     ApiAiAgentThreadMessageCreateResponse,
     ApiAiAgentThreadMessageVizQuery,
     ApiAiAgentThreadShareResponse,
+    ApiAiAgentV3ChatRequest,
     ApiAiMcpOAuthCredentialRequest,
     ApiAppendEvaluationRequest,
     ApiCreateAiAgent,
@@ -223,6 +224,10 @@ import { ShareService } from '../../../services/ShareService/ShareService';
 import { SpaceService } from '../../../services/SpaceService/SpaceService';
 import { wrapSentryTransaction } from '../../../utils';
 import { validatePublicHttpUrl } from '../../../utils/ssrfProtection';
+import {
+    type AiCanonicalThread,
+    type AiModelConfigEnvelope,
+} from '../../database/entities/aiAgentV3';
 import { type DbAiDeepResearchEvent } from '../../database/entities/aiDeepResearch';
 import { AiAgentDocumentModel } from '../../models/AiAgentDocumentModel';
 import { AiAgentMemoryModel } from '../../models/AiAgentMemoryModel';
@@ -238,6 +243,8 @@ import {
 } from '../../models/AiAgentModel';
 import { AiAgentReviewClassifierModel } from '../../models/AiAgentReviewClassifierModel';
 import { AiAgentReviewNotificationModel } from '../../models/AiAgentReviewNotificationModel';
+import { AiAgentThreadRepository } from '../../models/AiAgentThreadRepository';
+import { AiAgentV3Model } from '../../models/AiAgentV3Model';
 import {
     AiDeepResearchRunModel,
     type AiDeepResearchRunContextRow,
@@ -264,8 +271,13 @@ import {
     SUGGESTION_FALLBACK_CHIPS,
     type SuggestionPromptContext,
 } from '../ai/agents/suggestionGenerator';
+import { getAiAgentModelName } from '../ai/agents/telemetry';
 import { generateThreadTitle as generateTitleFromMessages } from '../ai/agents/titleGenerator';
 import { AiAgentMcpRuntimeClient } from '../ai/AiAgentMcpRuntimeClient';
+import {
+    AiAgentV3RunPersistence,
+    getAiRunErrorEnvelope,
+} from '../ai/AiAgentV3RunPersistence';
 import { Compaction } from '../ai/compaction';
 import {
     filterModelsForOrg,
@@ -276,6 +288,7 @@ import {
     presetToModelOption,
 } from '../ai/models';
 import { OrgAiCopilotConfigResolver } from '../ai/OrgAiCopilotConfigResolver';
+import { projectV3ThreadToModelMessages } from '../ai/projectV3ThreadToModelMessages';
 import {
     requestingUserRoleFromCustomRole,
     requestingUserRoleFromSystemRole,
@@ -401,6 +414,13 @@ type AgentResponseStream = {
     consumeStream: StreamTextResult<ToolSet, Output.Output>['consumeStream'];
 };
 
+type V3RunContext = {
+    persistence: AiAgentV3RunPersistence;
+    abortSignal: AbortSignal;
+    isInterrupted: () => Promise<boolean>;
+    consumeSteers: (stepNumber: number) => Promise<AiPromptSteer[]>;
+};
+
 const MAX_AI_PROMPT_CONTEXT_ITEMS = 10;
 const AI_AGENT_SHUTDOWN_ERROR_MESSAGE =
     'The server restarted while generating this response. Please try again.';
@@ -425,6 +445,8 @@ const ALLOWED_AGENT_AVATAR_MIME_TYPES = new Set([
 // wrong" even though the backend job completes and opens the PR. 15s sits
 // comfortably under the usual 30-60s idle timeouts.
 const STREAM_KEEPALIVE_INTERVAL_MS = 15_000;
+const V3_RUN_HEARTBEAT_INTERVAL_MS = 15_000;
+const V3_RUN_STOP_TIMEOUT_MS = 5_000;
 const MAX_MCP_BEARER_TOKEN_LENGTH = 8192;
 
 type GenerateAgentExecutionOptions =
@@ -467,6 +489,8 @@ type EmbedAiAgentRuntimeOptions = {
 
 type AiAgentServiceDependencies = {
     aiAgentModel: AiAgentModel;
+    aiAgentV3Model: AiAgentV3Model;
+    aiAgentThreadRepository: AiAgentThreadRepository;
     aiAgentMemoryModel: AiAgentMemoryModel;
     aiAgentDocumentModel: AiAgentDocumentModel;
     aiDeepResearchRunModel: Pick<
@@ -698,6 +722,19 @@ function validateGeneratedSuggestion(
 
 export class AiAgentService extends BaseService {
     private readonly aiAgentModel: AiAgentModel;
+
+    private readonly aiAgentV3Model: AiAgentV3Model;
+
+    private readonly aiAgentThreadRepository: AiAgentThreadRepository;
+
+    private readonly activeV3Runs = new Map<
+        string,
+        {
+            threadUuid: string;
+            abortController: AbortController;
+            persistence: AiAgentV3RunPersistence;
+        }
+    >();
 
     private readonly inFlightStreamPrompts = new Map<
         string,
@@ -1057,6 +1094,8 @@ export class AiAgentService extends BaseService {
     constructor(dependencies: AiAgentServiceDependencies) {
         super();
         this.aiAgentModel = dependencies.aiAgentModel;
+        this.aiAgentV3Model = dependencies.aiAgentV3Model;
+        this.aiAgentThreadRepository = dependencies.aiAgentThreadRepository;
         this.aiAgentMemoryModel = dependencies.aiAgentMemoryModel;
         this.aiAgentDocumentModel = dependencies.aiAgentDocumentModel;
         this.aiDeepResearchRunModel = dependencies.aiDeepResearchRunModel;
@@ -1488,6 +1527,7 @@ export class AiAgentService extends BaseService {
         const { writeActions, content } = account.authentication.data;
         const spaceUuid = writeActions?.spaceUuid;
 
+        // Non-web and embed pipelines still use their v1 executors.
         if (
             content.type !== 'aiAgent' ||
             !spaceUuid ||
@@ -2814,15 +2854,6 @@ export class AiAgentService extends BaseService {
               )
             : undefined;
 
-        const threadUuid = await this.aiAgentModel.createWebAppThread({
-            organizationUuid,
-            projectUuid: agent.projectUuid,
-            userUuid: user.userUuid,
-            createdFrom,
-            agentUuid,
-            embedSpaceUuid: runtimeOptions?.embedSpaceUuid,
-        });
-
         const aiOrganizationSettings =
             body.modelConfig || agent.modelConfig
                 ? undefined
@@ -2832,6 +2863,85 @@ export class AiAgentService extends BaseService {
             agent.modelConfig ??
             aiOrganizationSettings?.defaultAiAgentModelConfig ??
             undefined;
+
+        const { enabled: aiAgentV3Enabled } = await this.featureFlagService.get(
+            {
+                user,
+                featureFlagId: FeatureFlags.AiAgentV3,
+            },
+        );
+        if (
+            aiAgentV3Enabled &&
+            createdFrom === 'web_app' &&
+            runtimeOptions === undefined
+        ) {
+            const created = await this.aiAgentV3Model.createThread({
+                organizationUuid,
+                projectUuid: agent.projectUuid,
+                agentUuid,
+                createdFrom,
+                lineage: null,
+                ownerUserUuid: user.userUuid,
+            });
+            const firstMessage = body.prompt
+                ? await this.aiAgentV3Model.appendUserMessage({
+                      threadUuid: created.uuid,
+                      createdByUserUuid: user.userUuid,
+                      parts: [
+                          {
+                              partIndex: 0,
+                              type: 'text',
+                              payloadVersion: 1,
+                              payload: { text: body.prompt },
+                          },
+                      ],
+                  })
+                : null;
+            if (body.prompt) {
+                this.analytics.track<AiAgentPromptCreatedEvent>({
+                    event: 'ai_agent_prompt.created',
+                    userId: user.userUuid,
+                    properties: {
+                        organizationId: organizationUuid,
+                        projectId: agent.projectUuid,
+                        aiAgentId: agentUuid,
+                        threadId: created.uuid,
+                        context: 'web_app',
+                        ...AiAgentService.getPinnedContextAnalyticsProperties(
+                            context,
+                        ),
+                    },
+                });
+            }
+            const canonical = await this.aiAgentV3Model.getThread(created.uuid);
+            return {
+                uuid: created.uuid,
+                agentUuid,
+                createdAt: canonical.createdAt,
+                createdFrom,
+                title: null,
+                titleGeneratedAt: null,
+                firstMessage: {
+                    uuid: firstMessage?.uuid ?? '',
+                    message: body.prompt ?? '',
+                },
+                user: {
+                    uuid: user.userUuid,
+                    name: [user.firstName, user.lastName]
+                        .filter(Boolean)
+                        .join(' '),
+                },
+            };
+        }
+
+        const threadUuid = await this.aiAgentModel.createWebAppThread({
+            organizationUuid,
+            projectUuid: agent.projectUuid,
+            userUuid: user.userUuid,
+            createdFrom,
+            agentUuid,
+            embedSpaceUuid: runtimeOptions?.embedSpaceUuid,
+        });
 
         if (body.prompt) {
             await this.aiAgentModel.createWebAppPrompt({
@@ -5269,6 +5379,266 @@ export class AiAgentService extends BaseService {
         }
     }
 
+    private async getAccessibleV3Thread(
+        user: SessionUser,
+        agentUuid: string,
+        threadUuid: string,
+    ): Promise<{
+        agent: AiAgent;
+        thread: AiCanonicalThread;
+        ownerUuid: string;
+    }> {
+        if (!user.organizationUuid) throw new ForbiddenError();
+        const [agent, thread] = await Promise.all([
+            this.aiAgentModel.getAgent({
+                organizationUuid: user.organizationUuid,
+                agentUuid,
+            }),
+            this.aiAgentThreadRepository.getThread(threadUuid),
+        ]);
+        if (!agent) throw new NotFoundError(`Agent not found: ${agentUuid}`);
+        if (
+            thread.storageVersion !== 3 ||
+            thread.organizationUuid !== user.organizationUuid ||
+            thread.projectUuid !== agent.projectUuid ||
+            thread.agentUuid !== agentUuid
+        ) {
+            throw new NotFoundError(`Thread not found: ${threadUuid}`);
+        }
+        const ownership = await this.aiAgentModel.findThreadOwnership({
+            organizationUuid: user.organizationUuid,
+            threadUuid,
+        });
+        const ownerUuid = ownership?.ownerUserUuid;
+        if (!ownerUuid)
+            throw new NotFoundError(`Thread not found: ${threadUuid}`);
+        const hasAccess = await this.checkAgentThreadAccess(
+            user,
+            agent,
+            ownerUuid,
+        );
+        if (!hasAccess) {
+            throw new ForbiddenError(
+                'Insufficient permissions to use this agent thread',
+            );
+        }
+        return { agent, thread, ownerUuid };
+    }
+
+    async streamAgentThreadV3Response(
+        user: SessionUser,
+        options: {
+            agentUuid: string;
+            threadUuid: string;
+            body: ApiAiAgentV3ChatRequest;
+        },
+    ): Promise<AgentResponseStream> {
+        this.beginStreamPreparation();
+        try {
+            return await this.prepareAgentThreadV3Response(user, options);
+        } finally {
+            this.endStreamPreparation();
+        }
+    }
+
+    private async prepareAgentThreadV3Response(
+        user: SessionUser,
+        {
+            agentUuid,
+            threadUuid,
+            body,
+        }: {
+            agentUuid: string;
+            threadUuid: string;
+            body: ApiAiAgentV3ChatRequest;
+        },
+    ): Promise<AgentResponseStream> {
+        const message = body.message.trim();
+        if (!message) throw new ParameterError('Message is required');
+        if (!(await this.getIsCopilotEnabled(user))) {
+            throw new ForbiddenError('Copilot is not enabled');
+        }
+
+        const { agent, thread, ownerUuid } = await this.getAccessibleV3Thread(
+            user,
+            agentUuid,
+            threadUuid,
+        );
+        if (body.toolHints && body.toolHints.length > 0) {
+            this.analytics.track<AiAgentSuggestionSubmitEvent>({
+                event: 'ai_agent.suggestion_submit',
+                userId: user.userUuid,
+                properties: {
+                    organizationId: thread.organizationUuid,
+                    projectId: thread.projectUuid,
+                    agentId: agentUuid,
+                    toolHints: body.toolHints,
+                },
+            });
+        }
+        if (
+            thread.messages.some(
+                (item) =>
+                    item.role === 'assistant' &&
+                    item.metadata.status === 'in_progress',
+            )
+        ) {
+            throw new ConflictError('This thread already has an active run');
+        }
+
+        const organizationSettings =
+            body.modelConfig || agent.modelConfig
+                ? undefined
+                : await this.aiOrganizationSettingsService.getSettings(user);
+        const modelConfig =
+            body.modelConfig ??
+            agent.modelConfig ??
+            organizationSettings?.defaultAiAgentModelConfig ??
+            null;
+        const copilotConfig =
+            await this.orgAiCopilotConfigResolver.getCopilotConfig(
+                thread.organizationUuid,
+            );
+        const modelProperties = getModel(copilotConfig, {
+            enableReasoning: modelConfig?.reasoning,
+            modelName: modelConfig?.modelName,
+            provider: modelConfig?.modelProvider as AnyType,
+        });
+        const modelEnvelope: AiModelConfigEnvelope = {
+            version: 1,
+            modelName: getAiAgentModelName(modelProperties.model),
+            modelProvider:
+                modelConfig?.modelProvider ?? copilotConfig.defaultProvider,
+            reasoning: {
+                enabled: modelConfig?.reasoning ?? false,
+                effort: null,
+                budgetTokens: null,
+            },
+            limits: {
+                maxSteps: DEFAULT_AGENT_MAX_STEPS,
+                maxOutputTokens:
+                    modelProperties.callOptions.maxOutputTokens ?? null,
+            },
+            sampling: {
+                temperature: modelProperties.callOptions.temperature ?? null,
+                topP: modelProperties.callOptions.topP ?? null,
+            },
+            providerOptions: modelProperties.providerOptions ?? null,
+        };
+        const started = await this.aiAgentV3Model.startRun({
+            threadUuid,
+            createdByUserUuid: user.userUuid,
+            userParts: [
+                {
+                    partIndex: 0,
+                    type: 'text',
+                    payloadVersion: 1,
+                    payload: { text: message },
+                },
+            ],
+            modelConfig: modelEnvelope,
+        });
+        const abortController = new AbortController();
+        const persistence = new AiAgentV3RunPersistence(
+            this.aiAgentV3Model,
+            started.assistantMessage.uuid,
+            () => abortController.signal.aborted,
+            () => {
+                if (
+                    this.activeV3Runs.get(started.assistantMessage.uuid)
+                        ?.persistence === persistence
+                ) {
+                    this.activeV3Runs.delete(started.assistantMessage.uuid);
+                }
+            },
+            () => abortController.abort(),
+        );
+        this.activeV3Runs.set(started.assistantMessage.uuid, {
+            threadUuid,
+            abortController,
+            persistence,
+        });
+        try {
+            persistence.startHeartbeat(V3_RUN_HEARTBEAT_INTERVAL_MS);
+
+            const canonical = await this.aiAgentV3Model.getThread(threadUuid);
+            const prompt: AiWebAppPrompt = {
+                organizationUuid: thread.organizationUuid,
+                projectUuid: thread.projectUuid,
+                agentUuid,
+                promptUuid: started.assistantMessage.uuid,
+                threadUuid,
+                createdByUserUuid: user.userUuid,
+                userUuid: ownerUuid,
+                prompt: message,
+                createdAt: new Date(),
+                response: null,
+                errorMessage: null,
+                humanScore: null,
+                modelConfig,
+            };
+            const auditedAbility = this.createAuditedAbility(user);
+            const canManageAgent = auditedAbility.can(
+                'manage',
+                subject('AiAgent', {
+                    organizationUuid: thread.organizationUuid,
+                    projectUuid: thread.projectUuid,
+                    metadata: { agentUuid, threadUuid },
+                }),
+            );
+            const run: V3RunContext = {
+                persistence,
+                abortSignal: abortController.signal,
+                isInterrupted: async () =>
+                    abortController.signal.aborted ||
+                    !(await this.aiAgentV3Model.isAssistantMessageInProgress(
+                        started.assistantMessage.uuid,
+                    )),
+                consumeSteers: (() => {
+                    const consumed = new Set<string>();
+                    return async (stepNumber) => {
+                        const steers = await this.aiAgentV3Model.getSteers({
+                            threadUuid,
+                            assistantMessageUuid: started.assistantMessage.uuid,
+                        });
+                        return steers.flatMap((steer) => {
+                            if (consumed.has(steer.uuid)) return [];
+                            consumed.add(steer.uuid);
+                            return [
+                                {
+                                    ...steer,
+                                    promptUuid: started.assistantMessage.uuid,
+                                    consumedAt: new Date().toISOString(),
+                                    consumedStep: stepNumber,
+                                },
+                            ];
+                        });
+                    };
+                })(),
+            };
+
+            return await this.generateOrStreamAgentResponse(
+                user,
+                {
+                    messageHistory: projectV3ThreadToModelMessages(canonical),
+                    compactionSummary: null,
+                },
+                {
+                    prompt,
+                    stream: true,
+                    canManageAgent,
+                    enableSqlMode: body.enableSqlMode,
+                    autoApproveSql: body.autoApproveSql,
+                    toolHints: body.toolHints,
+                    v3Run: run,
+                },
+            );
+        } catch (error) {
+            await persistence.fail(error, getUserFacingErrorMessage(error));
+            throw error;
+        }
+    }
+
     async failInFlightStreamedPrompts(): Promise<void> {
         if (!this.shutdownPromise) {
             this.isShuttingDown = true;
@@ -5296,6 +5666,47 @@ export class AiAgentService extends BaseService {
                 Logger.warn(
                     '[AiAgent][Shutdown] Timed out waiting for terminal prompt updates',
                 );
+            }
+        }
+
+        const v3Runs = [...this.activeV3Runs.entries()];
+        if (v3Runs.length > 0) {
+            const failures = v3Runs.map(([, run]) =>
+                run.persistence.fail(
+                    new Error(AI_AGENT_SHUTDOWN_ERROR_MESSAGE),
+                    AI_AGENT_SHUTDOWN_ERROR_MESSAGE,
+                ),
+            );
+            v3Runs.forEach(([, run]) => run.abortController.abort());
+            try {
+                await this.withShutdownTimeout(Promise.all(failures));
+            } catch {
+                Logger.warn(
+                    '[AiAgent][Shutdown] Timed out draining v3 agent runs',
+                );
+                try {
+                    await this.withShutdownTimeout(
+                        Promise.allSettled(
+                            v3Runs.map(([messageUuid]) =>
+                                this.aiAgentV3Model.finishAssistantMessage({
+                                    messageUuid,
+                                    status: 'error',
+                                    tokenUsage: null,
+                                    error: getAiRunErrorEnvelope(
+                                        new Error(
+                                            AI_AGENT_SHUTDOWN_ERROR_MESSAGE,
+                                        ),
+                                        AI_AGENT_SHUTDOWN_ERROR_MESSAGE,
+                                    ),
+                                }),
+                            ),
+                        ),
+                    );
+                } catch {
+                    Logger.error(
+                        '[AiAgent][Shutdown] Failed to freeze v3 agent runs',
+                    );
+                }
             }
         }
 
@@ -5361,6 +5772,75 @@ export class AiAgentService extends BaseService {
     ): Promise<void> {
         if (!user.organizationUuid) {
             throw new ForbiddenError();
+        }
+
+        const storageVersion =
+            await this.aiAgentThreadRepository.getStorageVersion(threadUuid);
+        if (storageVersion === 3) {
+            const { thread: canonical } = await this.getAccessibleV3Thread(
+                user,
+                agentUuid,
+                threadUuid,
+            );
+            const message = canonical.messages.find(
+                (item) =>
+                    item.uuid === messageUuid && item.role === 'assistant',
+            );
+            if (!message) {
+                throw new NotFoundError(`Prompt not found: ${messageUuid}`);
+            }
+            if (message.metadata.status !== 'in_progress') {
+                throw new ConflictError('Assistant message is frozen');
+            }
+            const run = this.activeV3Runs.get(messageUuid);
+            if (run?.threadUuid === threadUuid) {
+                run.abortController.abort();
+                let timeout: ReturnType<typeof setTimeout> | undefined;
+                const terminal = await Promise.race([
+                    run.persistence.waitForTerminal().then(() => true),
+                    new Promise<false>((resolve) => {
+                        timeout = setTimeout(
+                            () => resolve(false),
+                            V3_RUN_STOP_TIMEOUT_MS,
+                        );
+                    }),
+                ]);
+                if (timeout) clearTimeout(timeout);
+                if (!terminal) {
+                    try {
+                        await this.aiAgentV3Model.finishAssistantMessage({
+                            messageUuid,
+                            status: 'canceled',
+                            tokenUsage: null,
+                            error: null,
+                        });
+                    } catch (error) {
+                        if (
+                            !(error instanceof ConflictError) ||
+                            error.message !== 'Assistant message is frozen'
+                        ) {
+                            throw error;
+                        }
+                    }
+                }
+            } else {
+                try {
+                    await this.aiAgentV3Model.finishAssistantMessage({
+                        messageUuid,
+                        status: 'canceled',
+                        tokenUsage: null,
+                        error: null,
+                    });
+                } catch (error) {
+                    if (
+                        !(error instanceof ConflictError) ||
+                        error.message !== 'Assistant message is frozen'
+                    ) {
+                        throw error;
+                    }
+                }
+            }
+            return;
         }
 
         const prompt = await this.aiAgentModel.findWebAppPrompt(messageUuid);
@@ -5429,6 +5909,54 @@ export class AiAgentService extends BaseService {
         const trimmedMessage = message.trim();
         if (trimmedMessage.length === 0) {
             throw new ParameterError('Steer message is required');
+        }
+
+        const storageVersion =
+            await this.aiAgentThreadRepository.getStorageVersion(threadUuid);
+        if (storageVersion === 3) {
+            const { thread: canonical } = await this.getAccessibleV3Thread(
+                user,
+                agentUuid,
+                threadUuid,
+            );
+            const assistant = canonical.messages.find(
+                (item) =>
+                    item.uuid === messageUuid && item.role === 'assistant',
+            );
+            if (!assistant) {
+                throw new NotFoundError(`Prompt not found: ${messageUuid}`);
+            }
+            const run = this.activeV3Runs.get(messageUuid);
+            if (
+                assistant.metadata.status !== 'in_progress' ||
+                (run !== undefined &&
+                    (run.threadUuid !== threadUuid ||
+                        run.abortController.signal.aborted))
+            ) {
+                throw new ParameterError('Cannot steer an inactive run');
+            }
+            const created = await this.aiAgentV3Model.appendSteer({
+                threadUuid,
+                assistantMessageUuid: messageUuid,
+                createdByUserUuid: user.userUuid,
+                parts: [
+                    {
+                        partIndex: 0,
+                        type: 'text',
+                        payloadVersion: 1,
+                        payload: { text: trimmedMessage },
+                    },
+                ],
+            });
+            const steer: AiPromptSteer = {
+                uuid: created.uuid,
+                promptUuid: messageUuid,
+                message: trimmedMessage,
+                createdAt: new Date().toISOString(),
+                consumedAt: null,
+                consumedStep: null,
+            };
+            return steer;
         }
 
         const prompt = await this.aiAgentModel.findWebAppPrompt(messageUuid);
@@ -8259,6 +8787,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             runtimeOptions?: EmbedAiAgentRuntimeOptions;
             suppressWritebackPreview?: boolean;
             onWarehouseQuery?: () => void | Promise<void>;
+            v3Run?: V3RunContext;
+            v3Prompt?: AiWebAppPrompt;
         },
     ) {
         const { projectUuid, organizationUuid } = prompt;
@@ -8368,6 +8898,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         };
 
         const getPrompt: GetPromptFn = async () => {
+            if (options?.v3Prompt) return options.v3Prompt;
             const webOrSlackPrompt = isSlackPrompt(prompt)
                 ? await this.aiAgentModel.findSlackPrompt(prompt.promptUuid)
                 : await this.aiAgentModel.findWebAppPrompt(prompt.promptUuid);
@@ -8977,15 +9508,19 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             storeToolResults,
             storeReasoning,
             isPromptInterrupted: (promptUuid: string) =>
-                this.aiAgentModel.hasAiPromptInterrupt(promptUuid),
+                options?.v3Run
+                    ? options.v3Run.isInterrupted()
+                    : this.aiAgentModel.hasAiPromptInterrupt(promptUuid),
             consumePromptSteers: (args: {
                 promptUuid: string;
                 stepNumber: number;
             }) =>
-                this.aiAgentModel.consumeUnconsumedPromptSteers({
-                    promptUuid: args.promptUuid,
-                    stepNumber: args.stepNumber,
-                }),
+                options?.v3Run
+                    ? options.v3Run.consumeSteers(args.stepNumber)
+                    : this.aiAgentModel.consumeUnconsumedPromptSteers({
+                          promptUuid: args.promptUuid,
+                          stepNumber: args.stepNumber,
+                      }),
             searchFieldValues: toolsRuntime.searchFieldValues,
             editDbtProject,
             editProjectContext,
@@ -9019,6 +9554,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 progressStatus?: 'in_progress' | 'complete' | 'error',
             ) => void | Promise<void>;
             runtimeOptions?: EmbedAiAgentRuntimeOptions;
+            v3Run?: V3RunContext;
         },
     ): Promise<AgentResponseStream>;
     async generateOrStreamAgentResponse(
@@ -9091,6 +9627,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             ) => void | Promise<void>;
             runtimeOptions?: EmbedAiAgentRuntimeOptions;
             execution?: GenerateAgentExecutionOptions;
+            v3Run?: V3RunContext;
         } & (
             | {
                   prompt: AiWebAppPrompt;
@@ -9133,9 +9670,10 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         const stepProgressEmitter =
             stream && !isSlackPrompt(prompt) ? new EventEmitter() : undefined;
         const aiAgentMemoryEnabled =
-            await this.aiOrganizationSettingsService.isAiAgentMemoryEnabled(
+            options.v3Run === undefined &&
+            (await this.aiOrganizationSettingsService.isAiAgentMemoryEnabled(
                 user,
-            );
+            ));
 
         const {
             listExplores,
@@ -9210,6 +9748,9 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 responseExecution.mode === 'deep_research'
                     ? responseExecution.onWarehouseQuery
                     : undefined,
+            v3Run: options.v3Run,
+            v3Prompt:
+                options.v3Run && !isSlackPrompt(prompt) ? prompt : undefined,
         });
 
         const agentSettings = await this.getAgentSettings(user, prompt);
@@ -9242,7 +9783,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 threadUuid: prompt.threadUuid,
                 preflightCanUseRawSql: responseExecution.canUseRawSql,
             }));
-        let canRunSql = enableSqlMode && canUseRawSql;
+        let canRunSql =
+            enableSqlMode && canUseRawSql && options.v3Run === undefined;
         // Fail closed when CASL would evaluate against the installer.
         if (canRunSql && !hasTrustedPromptUserIdentity) {
             this.logger.info(
@@ -9350,7 +9892,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 user,
                 featureFlagId: FeatureFlags.AiGrepFields,
             });
-        let aiWritebackEnabled = hasTrustedPromptUserIdentity;
+        let aiWritebackEnabled =
+            hasTrustedPromptUserIdentity && options.v3Run === undefined;
         if (!aiWritebackEnabled) {
             this.logger.info(
                 `Disabling editDbtProject for Slack prompt ${prompt.promptUuid} because aiRequireOAuth is off.`,
@@ -9380,6 +9923,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 featureFlagId: FeatureFlags.CodingAgent,
             },
         );
+        codingAgentEnabled &&= options.v3Run === undefined;
         if (codingAgentEnabled && !hasTrustedPromptUserIdentity) {
             this.logger.info(
                 `Disabling editRepo for Slack prompt ${prompt.promptUuid} because aiRequireOAuth is off.`,
@@ -9658,6 +10202,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             toolHints: options.toolHints ?? [],
             forceToolHints: options.forceToolHints ?? false,
             execution,
+            abortSignal: options.v3Run?.abortSignal,
         };
 
         const mcpToolSetup: AgentMcpToolSetup =
@@ -9743,10 +10288,18 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             sendFile,
             sendSlackBlocks,
             updateSlackMessage,
-            storeToolCall,
-            storeToolCallError,
-            storeToolResults,
-            storeReasoning,
+            storeToolCall: options.v3Run
+                ? async () => undefined
+                : storeToolCall,
+            storeToolCallError: options.v3Run
+                ? async () => undefined
+                : storeToolCallError,
+            storeToolResults: options.v3Run
+                ? async () => undefined
+                : storeToolResults,
+            storeReasoning: options.v3Run
+                ? async () => undefined
+                : storeReasoning,
             isPromptInterrupted,
             consumePromptSteers,
             searchFieldValues,
@@ -9766,6 +10319,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             updatePrompt: (
                 update: UpdateSlackResponse | UpdateWebAppResponse,
             ) => {
+                if (options.v3Run) return Promise.resolve();
                 const updatePromise = this.persistTrackedPromptUpdate(update);
                 if (!updatePromise) {
                     return Promise.resolve();
@@ -9880,8 +10434,17 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             ) => this.analytics.track(event),
 
             createOrUpdateArtifact: async (data) => {
-                const artifact =
-                    await this.aiAgentModel.createOrUpdateArtifact(data);
+                const artifact = await this.aiAgentModel.createOrUpdateArtifact(
+                    {
+                        ...data,
+                        promptUuid: options.v3Run ? null : data.promptUuid,
+                    },
+                );
+                if (options.v3Run) {
+                    await options.v3Run.persistence.appendArtifact(
+                        artifact.versionUuid,
+                    );
+                }
 
                 return artifact;
             },
@@ -9922,6 +10485,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     );
                 },
             },
+            streamPersistence: options.v3Run?.persistence,
         };
 
         if (!stream) {
@@ -10006,7 +10570,30 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     );
                 }
 
-                writer.merge(result.toUIMessageStream());
+                const v3Persistence = options.v3Run?.persistence;
+                const messageStream = result.toUIMessageStream(
+                    v3Persistence
+                        ? {
+                              generateMessageId: () => prompt.promptUuid,
+                              sendSources: true,
+                          }
+                        : undefined,
+                );
+                if (!v3Persistence) {
+                    writer.merge(messageStream);
+                    return;
+                }
+                writer.merge(
+                    messageStream.pipeThrough(
+                        new TransformStream({
+                            transform: async (chunk, controller) => {
+                                if (await v3Persistence.waitForUiChunk(chunk)) {
+                                    controller.enqueue(chunk);
+                                }
+                            },
+                        }),
+                    ),
+                );
             },
             onFinish: () => {
                 clearKeepalive();

--- a/packages/backend/src/ee/services/ai/AiAgentV3RunPersistence.test.ts
+++ b/packages/backend/src/ee/services/ai/AiAgentV3RunPersistence.test.ts
@@ -1,0 +1,305 @@
+import { ConflictError } from '@lightdash/common';
+import { APICallError } from 'ai';
+import { expect, it, vi } from 'vitest';
+import {
+    AiAgentV3RunPersistence,
+    getAiRunErrorEnvelope,
+} from './AiAgentV3RunPersistence';
+
+const buildModel = () => {
+    const parts: Array<{ uuid: string; payload: Record<string, unknown> }> = [];
+    return {
+        parts,
+        appendParts: vi.fn(async ({ parts: writes }) =>
+            writes.map((write: { payload: Record<string, unknown> }) => {
+                const part = {
+                    uuid: `part-${parts.length}`,
+                    payload: write.payload,
+                };
+                parts.push(part);
+                return part;
+            }),
+        ),
+        updatePart: vi.fn(async ({ partUuid, payload }) => {
+            const part = parts.find(({ uuid }) => uuid === partUuid)!;
+            part.payload = payload;
+            return { ...part, payloadVersion: 1 };
+        }),
+        finishAssistantMessage: vi.fn(async () => undefined),
+        refreshAssistantMessageHeartbeat: vi.fn(async () => true),
+    };
+};
+
+it('persists interleaved text, reasoning, and tool chunks in first-seen order', async () => {
+    const model = buildModel();
+    const persistence = new AiAgentV3RunPersistence(
+        model as never,
+        'assistant',
+        () => false,
+    );
+
+    const firstChunkAck = persistence.waitForUiChunk({
+        type: 'text-delta',
+        id: 't1',
+        delta: 'Hello ',
+    });
+    await persistence.onChunk({ type: 'text-delta', id: 't1', text: 'Hello ' });
+    await expect(firstChunkAck).resolves.toBe(true);
+    await persistence.onChunk({
+        type: 'reasoning-delta',
+        id: 'r1',
+        text: 'think',
+    });
+    await persistence.onChunk({ type: 'text-delta', id: 't1', text: 'world' });
+    await persistence.onChunk({
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'findExplores',
+        input: { query: 'orders' },
+    });
+    await persistence.onChunk({
+        type: 'tool-result',
+        toolCallId: 'call-1',
+        toolName: 'findExplores',
+        output: ['orders'],
+    });
+
+    expect(model.parts.map(({ payload }) => payload)).toEqual([
+        { text: 'Hello world' },
+        { text: 'think' },
+        {
+            state: 'output-available',
+            toolName: 'findExplores',
+            input: { query: 'orders' },
+            output: ['orders'],
+        },
+    ]);
+});
+
+it('freezes cancellation after queued partial content', async () => {
+    const model = buildModel();
+    const persistence = new AiAgentV3RunPersistence(
+        model as never,
+        'assistant',
+        () => true,
+    );
+    persistence.recordUsage({
+        inputTokens: 10,
+        outputTokens: 4,
+        totalTokens: 14,
+        reasoningTokens: 1,
+        cachedInputTokens: 3,
+        inputTokenDetails: {
+            noCacheTokens: undefined,
+            cacheReadTokens: undefined,
+            cacheWriteTokens: undefined,
+        },
+        outputTokenDetails: {
+            textTokens: undefined,
+            reasoningTokens: 1,
+        },
+    });
+
+    const partial = persistence.onChunk({
+        type: 'text-delta',
+        id: 't1',
+        text: 'partial',
+    });
+    const canceled = persistence.cancel();
+    await Promise.all([partial, canceled]);
+
+    expect(model.parts).toHaveLength(1);
+    expect(model.finishAssistantMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+            status: 'canceled',
+            error: null,
+            tokenUsage: expect.objectContaining({ totalTokens: 14 }),
+        }),
+    );
+});
+
+it('refreshes heartbeats until the run freezes', async () => {
+    vi.useFakeTimers();
+    const model = buildModel();
+    const persistence = new AiAgentV3RunPersistence(
+        model as never,
+        'assistant',
+        () => false,
+    );
+    persistence.startHeartbeat(1_000);
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(model.refreshAssistantMessageHeartbeat).toHaveBeenCalledTimes(2);
+    await persistence.cancel();
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(model.refreshAssistantMessageHeartbeat).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+});
+
+it('can persist a terminal error after a failed chunk write', async () => {
+    const model = buildModel();
+    model.appendParts.mockRejectedValueOnce(new Error('write failed'));
+    const persistence = new AiAgentV3RunPersistence(
+        model as never,
+        'assistant',
+        () => false,
+    );
+
+    await expect(
+        persistence.onChunk({
+            type: 'text-delta',
+            id: 't1',
+            text: 'partial',
+        }),
+    ).rejects.toThrow('write failed');
+    await persistence.fail(new Error('stream failed'), 'Stream failed');
+
+    expect(model.finishAssistantMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'error' }),
+    );
+});
+
+it('classifies failure from abort state when it is enqueued', async () => {
+    const model = buildModel();
+    let canceled = false;
+    const persistence = new AiAgentV3RunPersistence(
+        model as never,
+        'assistant',
+        () => canceled,
+    );
+
+    const failed = persistence.fail(
+        new Error('server restarting'),
+        'Server restarting',
+    );
+    canceled = true;
+    await failed;
+
+    expect(model.finishAssistantMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+            status: 'error',
+            error: expect.objectContaining({
+                name: 'stream_error',
+                message: 'Server restarting',
+            }),
+        }),
+    );
+});
+
+it('classifies completion from abort state when it is enqueued', async () => {
+    const model = buildModel();
+    let canceled = false;
+    const persistence = new AiAgentV3RunPersistence(
+        model as never,
+        'assistant',
+        () => canceled,
+    );
+    await persistence.onChunk({
+        type: 'text-delta',
+        id: 't1',
+        text: 'complete',
+    });
+
+    const completed = persistence.complete();
+    canceled = true;
+    await completed;
+
+    expect(model.finishAssistantMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'completed', error: null }),
+    );
+});
+
+it('stops cleanly when another server freezes the message', async () => {
+    const model = buildModel();
+    model.appendParts.mockRejectedValueOnce(
+        new ConflictError('Assistant message is frozen'),
+    );
+    const onTerminal = vi.fn();
+    const persistence = new AiAgentV3RunPersistence(
+        model as never,
+        'assistant',
+        () => false,
+        onTerminal,
+    );
+
+    const chunkAck = persistence.waitForUiChunk({
+        type: 'text-delta',
+        id: 't1',
+        delta: 'late chunk',
+    });
+    await persistence.onChunk({
+        type: 'text-delta',
+        id: 't1',
+        text: 'late chunk',
+    });
+    await expect(chunkAck).resolves.toBe(false);
+    await persistence.fail(new Error('aborted'), 'Aborted');
+
+    expect(onTerminal).toHaveBeenCalledOnce();
+    expect(model.finishAssistantMessage).not.toHaveBeenCalled();
+});
+
+it('aborts local generation when another server freezes the message', async () => {
+    const model = buildModel();
+    model.appendParts.mockRejectedValueOnce(
+        new ConflictError('Assistant message is frozen'),
+    );
+    const onFrozen = vi.fn();
+    const persistence = new AiAgentV3RunPersistence(
+        model as never,
+        'assistant',
+        () => false,
+        undefined,
+        onFrozen,
+    );
+
+    await persistence.onChunk({
+        type: 'text-delta',
+        id: 't1',
+        text: 'late chunk',
+    });
+
+    expect(onFrozen).toHaveBeenCalledOnce();
+});
+
+it('drops unmatched UI chunks instead of hanging the stream', async () => {
+    vi.useFakeTimers();
+    const persistence = new AiAgentV3RunPersistence(
+        buildModel() as never,
+        'assistant',
+        () => false,
+    );
+
+    const result = persistence.waitForUiChunk({
+        type: 'text-delta',
+        id: 't1',
+        delta: 'unmatched',
+    });
+    await vi.runAllTimersAsync();
+
+    await expect(result).resolves.toBe(false);
+    vi.useRealTimers();
+});
+
+it('uses stable error names', () => {
+    expect(
+        getAiRunErrorEnvelope(
+            new APICallError({
+                message: 'provider failed',
+                url: 'https://example.com',
+                requestBodyValues: {},
+                statusCode: 500,
+                responseHeaders: {},
+                responseBody: 'failed',
+                isRetryable: false,
+            }),
+            'Provider failed',
+        ).name,
+    ).toBe('provider_error');
+    expect(
+        getAiRunErrorEnvelope(
+            new Error('maximum context window exceeded'),
+            'Too long',
+        ).name,
+    ).toBe('context_overflow');
+});

--- a/packages/backend/src/ee/services/ai/AiAgentV3RunPersistence.ts
+++ b/packages/backend/src/ee/services/ai/AiAgentV3RunPersistence.ts
@@ -1,0 +1,538 @@
+import { ConflictError } from '@lightdash/common';
+import { APICallError, type LanguageModelUsage } from 'ai';
+import {
+    type AiRunErrorEnvelope,
+    type AiTokenUsageEnvelope,
+    type AiV3PartWrite,
+} from '../../database/entities/aiAgentV3';
+import { type AiAgentV3Model } from '../../models/AiAgentV3Model';
+
+type PersistedPart = {
+    uuid: string;
+    partIndex: number;
+    type: AiV3PartWrite['type'];
+    toolCallId?: string;
+    payload: Record<string, unknown>;
+};
+
+type StreamChunk =
+    | {
+          type: 'text-delta' | 'reasoning-delta';
+          id: string;
+          text: string;
+          providerMetadata?: Record<string, unknown>;
+      }
+    | {
+          type: 'tool-input-start';
+          id: string;
+          toolName: string;
+          providerMetadata?: Record<string, unknown>;
+          providerExecuted?: boolean;
+          dynamic?: boolean;
+          title?: string;
+      }
+    | {
+          type: 'tool-input-delta';
+          id: string;
+          delta: string;
+          providerMetadata?: Record<string, unknown>;
+      }
+    | {
+          type: 'tool-call';
+          toolCallId: string;
+          toolName: string;
+          input: unknown;
+          providerMetadata?: Record<string, unknown>;
+          providerExecuted?: boolean;
+          dynamic?: boolean;
+          invalid?: boolean;
+          error?: unknown;
+      }
+    | {
+          type: 'tool-result';
+          toolCallId: string;
+          toolName: string;
+          output: unknown;
+          providerMetadata?: Record<string, unknown>;
+          preliminary?: boolean;
+      }
+    | ({ type: 'source' } & Record<string, unknown>)
+    | { type: 'raw'; rawValue: unknown };
+
+type Model = Pick<
+    AiAgentV3Model,
+    | 'appendParts'
+    | 'updatePart'
+    | 'finishAssistantMessage'
+    | 'refreshAssistantMessageHeartbeat'
+>;
+
+const UI_CHUNK_ACK_TIMEOUT_MS = 30_000;
+
+const usageEnvelope = (
+    usage: LanguageModelUsage | undefined,
+): AiTokenUsageEnvelope | null =>
+    usage
+        ? {
+              version: 1,
+              inputTokens: usage.inputTokens ?? null,
+              outputTokens: usage.outputTokens ?? null,
+              totalTokens: usage.totalTokens ?? null,
+              reasoningTokens: usage.reasoningTokens ?? null,
+              cachedInputTokens: usage.cachedInputTokens ?? null,
+          }
+        : null;
+
+export const getAiRunErrorEnvelope = (
+    error: unknown,
+    message: string,
+): AiRunErrorEnvelope => {
+    let name = 'stream_error';
+    if (APICallError.isInstance(error)) name = 'provider_error';
+    if (error instanceof Error && error.name === 'AiAgentStepCapReachedError') {
+        name = 'step_cap_reached';
+    }
+    if (error instanceof Error && error.name === 'AiAgentEmptyResponseError') {
+        name = 'empty_response';
+    }
+    if (
+        error instanceof Error &&
+        /context.{0,20}(length|window)|maximum context/i.test(error.message)
+    ) {
+        name = 'context_overflow';
+    }
+    return { version: 1, name, message, data: null };
+};
+
+export class AiAgentV3RunPersistence {
+    private readonly parts = new Map<string, PersistedPart>();
+
+    private nextPartIndex = 0;
+
+    private queue: Promise<void> = Promise.resolve();
+
+    private terminal = false;
+
+    private heartbeat: ReturnType<typeof setInterval> | undefined;
+
+    private tokenUsage: AiTokenUsageEnvelope | null = null;
+
+    private resolveTerminal!: () => void;
+
+    private readonly terminalPromise = new Promise<void>((resolve) => {
+        this.resolveTerminal = resolve;
+    });
+
+    private readonly chunkAckResults = new Map<string, boolean[]>();
+
+    private readonly chunkAckWaiters = new Map<
+        string,
+        Array<(persisted: boolean) => void>
+    >();
+
+    constructor(
+        private readonly model: Model,
+        private readonly messageUuid: string,
+        private readonly isCanceled: () => boolean,
+        private readonly onTerminal?: () => void,
+        private readonly onFrozen?: () => void,
+    ) {}
+
+    private markTerminal(): void {
+        if (this.terminal) return;
+        this.terminal = true;
+        this.stopHeartbeat();
+        this.onTerminal?.();
+        this.resolveTerminal();
+    }
+
+    waitForTerminal(): Promise<void> {
+        return this.terminalPromise;
+    }
+
+    private static chunkAckKey(value: unknown): string | null {
+        const chunk = value as {
+            type?: unknown;
+            id?: unknown;
+            text?: unknown;
+            delta?: unknown;
+        };
+        if (
+            (chunk.type !== 'text-delta' && chunk.type !== 'reasoning-delta') ||
+            typeof chunk.id !== 'string'
+        ) {
+            return null;
+        }
+        const content =
+            typeof chunk.text === 'string' ? chunk.text : chunk.delta;
+        return typeof content === 'string'
+            ? `${chunk.type}:${chunk.id}:${content}`
+            : null;
+    }
+
+    private acknowledgeChunk(key: string, persisted: boolean): void {
+        const waiters = this.chunkAckWaiters.get(key);
+        const waiter = waiters?.shift();
+        if (waiter) {
+            if (waiters?.length === 0) this.chunkAckWaiters.delete(key);
+            waiter(persisted);
+            return;
+        }
+        const results = this.chunkAckResults.get(key) ?? [];
+        results.push(persisted);
+        this.chunkAckResults.set(key, results);
+    }
+
+    waitForUiChunk(value: unknown): Promise<boolean> {
+        const key = AiAgentV3RunPersistence.chunkAckKey(value);
+        if (!key) return Promise.resolve(true);
+        const results = this.chunkAckResults.get(key);
+        const result = results?.shift();
+        if (result !== undefined) {
+            if (results?.length === 0) this.chunkAckResults.delete(key);
+            return Promise.resolve(result);
+        }
+        return new Promise<boolean>((resolve) => {
+            const waiters = this.chunkAckWaiters.get(key) ?? [];
+            const state: { timeout?: ReturnType<typeof setTimeout> } = {};
+            const waiter = (persisted: boolean) => {
+                if (state.timeout) clearTimeout(state.timeout);
+                resolve(persisted);
+            };
+            state.timeout = setTimeout(() => {
+                const pending = this.chunkAckWaiters.get(key);
+                const index = pending?.indexOf(waiter) ?? -1;
+                if (index >= 0) pending?.splice(index, 1);
+                if (pending?.length === 0) this.chunkAckWaiters.delete(key);
+                resolve(false);
+            }, UI_CHUNK_ACK_TIMEOUT_MS);
+            waiters.push(waiter);
+            this.chunkAckWaiters.set(key, waiters);
+        });
+    }
+
+    recordUsage(usage: LanguageModelUsage): void {
+        const next = usageEnvelope(usage);
+        if (!next) return;
+        const previous = this.tokenUsage;
+        const sum = (left: number | null, right: number | null) =>
+            left === null && right === null ? null : (left ?? 0) + (right ?? 0);
+        this.tokenUsage = previous
+            ? {
+                  version: 1,
+                  inputTokens: sum(previous.inputTokens, next.inputTokens),
+                  outputTokens: sum(previous.outputTokens, next.outputTokens),
+                  totalTokens: sum(previous.totalTokens, next.totalTokens),
+                  reasoningTokens: sum(
+                      previous.reasoningTokens,
+                      next.reasoningTokens,
+                  ),
+                  cachedInputTokens: sum(
+                      previous.cachedInputTokens,
+                      next.cachedInputTokens,
+                  ),
+              }
+            : next;
+    }
+
+    startHeartbeat(intervalMs: number): void {
+        this.heartbeat = setInterval(() => {
+            void this.model
+                .refreshAssistantMessageHeartbeat(this.messageUuid)
+                .then((updated) => {
+                    if (!updated) this.stopHeartbeat();
+                })
+                .catch(() => this.stopHeartbeat());
+        }, intervalMs);
+    }
+
+    private stopHeartbeat(): void {
+        if (this.heartbeat) clearInterval(this.heartbeat);
+        this.heartbeat = undefined;
+    }
+
+    private enqueue(operation: () => Promise<void>): Promise<void> {
+        const result = this.queue.then(async () => {
+            try {
+                await operation();
+            } catch (error) {
+                if (
+                    error instanceof ConflictError &&
+                    error.message === 'Assistant message is frozen'
+                ) {
+                    this.onFrozen?.();
+                    this.markTerminal();
+                    return;
+                }
+                throw error;
+            }
+        });
+        this.queue = result.catch(() => undefined);
+        return result;
+    }
+
+    private async createPart(
+        key: string,
+        type: AiV3PartWrite['type'],
+        payload: Record<string, unknown>,
+        toolCallId?: string,
+        artifactVersionUuid?: string,
+    ): Promise<PersistedPart> {
+        const partIndex = this.nextPartIndex;
+        this.nextPartIndex += 1;
+        const write = {
+            partIndex,
+            type,
+            payloadVersion: 1,
+            payload,
+            ...(toolCallId ? { toolCallId } : {}),
+            ...(artifactVersionUuid ? { artifactVersionUuid } : {}),
+        } as AiV3PartWrite;
+        const [created] = await this.model.appendParts({
+            messageUuid: this.messageUuid,
+            parts: [write],
+        });
+        const part = {
+            uuid: created.uuid,
+            partIndex,
+            type,
+            toolCallId,
+            payload,
+        };
+        this.parts.set(key, part);
+        return part;
+    }
+
+    private async updatePart(
+        part: PersistedPart,
+        payload: Record<string, unknown>,
+    ): Promise<void> {
+        await this.model.updatePart({
+            messageUuid: this.messageUuid,
+            partUuid: part.uuid,
+            payloadVersion: 1,
+            payload,
+        });
+        const stored = [...this.parts.values()].find(
+            ({ uuid }) => uuid === part.uuid,
+        );
+        if (stored) stored.payload = payload;
+    }
+
+    async onChunk(value: unknown): Promise<void> {
+        const chunk = value as StreamChunk;
+        const ackKey = AiAgentV3RunPersistence.chunkAckKey(chunk);
+        let persisted = false;
+        try {
+            await this.enqueue(async () => {
+                if (this.terminal) return;
+                switch (chunk.type) {
+                    case 'text-delta':
+                    case 'reasoning-delta': {
+                        const type =
+                            chunk.type === 'text-delta' ? 'text' : 'reasoning';
+                        const part = this.parts.get(chunk.id);
+                        const payload = {
+                            ...(part?.payload ?? {}),
+                            text: `${String(part?.payload.text ?? '')}${chunk.text}`,
+                            ...(chunk.providerMetadata
+                                ? { providerMetadata: chunk.providerMetadata }
+                                : {}),
+                        };
+                        if (part) await this.updatePart(part, payload);
+                        else await this.createPart(chunk.id, type, payload);
+                        persisted = true;
+                        return;
+                    }
+                    case 'tool-input-start': {
+                        await this.createPart(
+                            chunk.id,
+                            'tool',
+                            {
+                                state: 'input-streaming',
+                                toolName: chunk.toolName,
+                                rawInput: '',
+                                ...(chunk.providerMetadata
+                                    ? {
+                                          providerMetadata:
+                                              chunk.providerMetadata,
+                                      }
+                                    : {}),
+                                ...(chunk.providerExecuted !== undefined
+                                    ? {
+                                          providerExecuted:
+                                              chunk.providerExecuted,
+                                      }
+                                    : {}),
+                                ...(chunk.dynamic !== undefined
+                                    ? { dynamic: chunk.dynamic }
+                                    : {}),
+                                ...(chunk.title ? { title: chunk.title } : {}),
+                            },
+                            chunk.id,
+                        );
+                        return;
+                    }
+                    case 'tool-input-delta': {
+                        const part = this.parts.get(chunk.id);
+                        if (!part) return;
+                        await this.updatePart(part, {
+                            ...part.payload,
+                            rawInput: `${String(part.payload.rawInput ?? '')}${chunk.delta}`,
+                            ...(chunk.providerMetadata
+                                ? { providerMetadata: chunk.providerMetadata }
+                                : {}),
+                        });
+                        return;
+                    }
+                    case 'tool-call': {
+                        const part = this.parts.get(chunk.toolCallId);
+                        const payload = chunk.invalid
+                            ? {
+                                  state: 'output-error',
+                                  toolName: chunk.toolName,
+                                  input: chunk.input,
+                                  error: {
+                                      name: 'invalid_tool_call',
+                                      message:
+                                          chunk.error instanceof Error
+                                              ? chunk.error.message
+                                              : String(
+                                                    chunk.error ??
+                                                        'Invalid tool call',
+                                                ),
+                                  },
+                              }
+                            : {
+                                  state: 'input-available',
+                                  toolName: chunk.toolName,
+                                  input: chunk.input,
+                              };
+                        const enriched = {
+                            ...payload,
+                            ...(chunk.providerMetadata
+                                ? { providerMetadata: chunk.providerMetadata }
+                                : {}),
+                            ...(chunk.providerExecuted !== undefined
+                                ? { providerExecuted: chunk.providerExecuted }
+                                : {}),
+                            ...(chunk.dynamic !== undefined
+                                ? { dynamic: chunk.dynamic }
+                                : {}),
+                        };
+                        if (part) await this.updatePart(part, enriched);
+                        else
+                            await this.createPart(
+                                chunk.toolCallId,
+                                'tool',
+                                enriched,
+                                chunk.toolCallId,
+                            );
+                        return;
+                    }
+                    case 'tool-result': {
+                        if (chunk.preliminary) return;
+                        const part = this.parts.get(chunk.toolCallId);
+                        const payload = {
+                            ...(part?.payload ?? { toolName: chunk.toolName }),
+                            state: 'output-available',
+                            output: chunk.output,
+                            ...(chunk.providerMetadata
+                                ? { providerMetadata: chunk.providerMetadata }
+                                : {}),
+                        };
+                        if (part) await this.updatePart(part, payload);
+                        else
+                            await this.createPart(
+                                chunk.toolCallId,
+                                'tool',
+                                payload,
+                                chunk.toolCallId,
+                            );
+                        return;
+                    }
+                    case 'source': {
+                        const { type: _type, ...source } = chunk;
+                        await this.createPart(
+                            `source:${this.nextPartIndex}`,
+                            'source',
+                            source,
+                        );
+                        return;
+                    }
+                    case 'raw':
+                        return;
+                    default:
+                        return;
+                }
+            });
+        } finally {
+            if (ackKey) this.acknowledgeChunk(ackKey, persisted);
+        }
+    }
+
+    async appendArtifact(artifactVersionUuid: string): Promise<void> {
+        return this.enqueue(async () => {
+            if (this.terminal) return;
+            await this.createPart(
+                `artifact:${artifactVersionUuid}`,
+                'artifact',
+                {},
+                undefined,
+                artifactVersionUuid,
+            );
+        });
+    }
+
+    async complete(usage?: LanguageModelUsage): Promise<void> {
+        const canceled = this.isCanceled();
+        return this.enqueue(async () => {
+            if (this.terminal) return;
+            try {
+                await this.model.finishAssistantMessage({
+                    messageUuid: this.messageUuid,
+                    status: canceled ? 'canceled' : 'completed',
+                    tokenUsage: usageEnvelope(usage) ?? this.tokenUsage,
+                    error: null,
+                });
+            } finally {
+                this.markTerminal();
+            }
+        });
+    }
+
+    async cancel(): Promise<void> {
+        return this.enqueue(async () => {
+            if (this.terminal) return;
+            try {
+                await this.model.finishAssistantMessage({
+                    messageUuid: this.messageUuid,
+                    status: 'canceled',
+                    tokenUsage: this.tokenUsage,
+                    error: null,
+                });
+            } finally {
+                this.markTerminal();
+            }
+        });
+    }
+
+    async fail(error: unknown, message: string): Promise<void> {
+        const canceled = this.isCanceled();
+        return this.enqueue(async () => {
+            if (this.terminal) return;
+            try {
+                await this.model.finishAssistantMessage({
+                    messageUuid: this.messageUuid,
+                    status: canceled ? 'canceled' : 'error',
+                    tokenUsage: this.tokenUsage,
+                    error: canceled
+                        ? null
+                        : getAiRunErrorEnvelope(error, message),
+                });
+            } finally {
+                this.markTerminal();
+            }
+        });
+    }
+}

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -163,6 +163,7 @@ export const DEEP_RESEARCH_WORKER_TOOL_NAMES = new Set([
 ]);
 
 const PERSIST_TIMEOUT_MS = 10_000;
+const V3_STREAM_CHUNK_SIZE = 128;
 
 /**
  * Decorates updatePrompt with the stream-close contract: awaiting it never
@@ -1786,6 +1787,7 @@ export const streamAgentResponse = async ({
         const result = streamText({
             ...defaultAgentOptions,
             ...args.callOptions,
+            abortSignal: args.abortSignal,
             prepareStep,
             stopWhen: [
                 stepCountIs(args.execution.maxSteps),
@@ -1796,7 +1798,8 @@ export const streamAgentResponse = async ({
             tools,
             messages,
             experimental_context: new AgentContext(availableExplores),
-            onChunk: (event) => {
+            onChunk: async (event) => {
+                await dependencies.streamPersistence?.onChunk(event.chunk);
                 // Track time to first chunk (any type) - only once
                 if (firstChunkTime === null) {
                     firstChunkTime = Date.now();
@@ -1998,6 +2001,7 @@ export const streamAgentResponse = async ({
                 }
             },
             onStepFinish: (step) => {
+                dependencies.streamPersistence?.recordUsage(step.usage);
                 if (step.reasoningText && step.reasoningText.length > 0) {
                     logger(
                         'On Step Finish',
@@ -2072,14 +2076,24 @@ export const streamAgentResponse = async ({
                             },
                         });
                     }
-                    await persistPrompt({
-                        promptUuid: args.promptUuid,
-                        errorMessage:
-                            getUserFacingErrorMessage(emptyResponseError),
-                        tokenUsage: {
-                            totalTokens: usage.totalTokens ?? 0,
-                        },
-                    });
+                    const message =
+                        getUserFacingErrorMessage(emptyResponseError);
+                    if (dependencies.streamPersistence) {
+                        await dependencies.streamPersistence.fail(
+                            emptyResponseError,
+                            message,
+                        );
+                    } else {
+                        await persistPrompt({
+                            promptUuid: args.promptUuid,
+                            errorMessage: message,
+                            tokenUsage: {
+                                totalTokens: usage.totalTokens ?? 0,
+                            },
+                        });
+                    }
+                } else if (dependencies.streamPersistence) {
+                    await dependencies.streamPersistence.complete(totalUsage);
                 } else {
                     await persistPrompt({
                         response: completeResponse,
@@ -2127,7 +2141,12 @@ export const streamAgentResponse = async ({
             },
             experimental_transform: smoothStream({
                 delayInMs: 20,
-                chunking: 'word',
+                chunking: dependencies.streamPersistence
+                    ? (buffer) =>
+                          buffer.length >= V3_STREAM_CHUNK_SIZE
+                              ? buffer.slice(0, V3_STREAM_CHUNK_SIZE)
+                              : null
+                    : 'word',
             }),
             onError: async ({ error }) => {
                 console.error(error);
@@ -2150,11 +2169,22 @@ export const streamAgentResponse = async ({
                     args.keyManagement,
                 );
 
-                await persistPrompt({
-                    promptUuid: args.promptUuid,
-                    errorMessage: userFacingMessage,
-                });
+                if (dependencies.streamPersistence) {
+                    await dependencies.streamPersistence.fail(
+                        error,
+                        userFacingMessage,
+                    );
+                } else {
+                    await persistPrompt({
+                        promptUuid: args.promptUuid,
+                        errorMessage: userFacingMessage,
+                    });
+                }
 
+                void cleanupMcpClients();
+            },
+            onAbort: async () => {
+                await dependencies.streamPersistence?.cancel();
                 void cleanupMcpClients();
             },
             experimental_telemetry: telemetry,
@@ -2182,10 +2212,14 @@ export const streamAgentResponse = async ({
             args.keyManagement,
         );
 
-        await dependencies.updatePrompt({
-            promptUuid: args.promptUuid,
-            errorMessage: userFacingMessage,
-        });
+        if (dependencies.streamPersistence) {
+            await dependencies.streamPersistence.fail(error, userFacingMessage);
+        } else {
+            await dependencies.updatePrompt({
+                promptUuid: args.promptUuid,
+                errorMessage: userFacingMessage,
+            });
+        }
 
         await cleanupMcpClients();
         throw error;

--- a/packages/backend/src/ee/services/ai/projectV3ThreadToModelMessages.test.ts
+++ b/packages/backend/src/ee/services/ai/projectV3ThreadToModelMessages.test.ts
@@ -1,0 +1,158 @@
+import { expect, it } from 'vitest';
+import { type AiCanonicalThread } from '../../database/entities/aiAgentV3';
+import { projectV3ThreadToModelMessages } from './projectV3ThreadToModelMessages';
+
+const thread = (
+    messages: AiCanonicalThread['messages'],
+): AiCanonicalThread => ({
+    uuid: 'thread',
+    storageVersion: 3,
+    organizationUuid: 'org',
+    projectUuid: 'project',
+    agentUuid: 'agent',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: null,
+    createdFrom: 'web_app',
+    title: null,
+    lineage: null,
+    messages,
+});
+
+const metadata = {
+    createdAt: '2026-01-01T00:00:00.000Z',
+    createdByUserUuid: null,
+    status: null,
+    lastHeartbeatAt: null,
+    modelConfig: null,
+    tokenUsage: null,
+    error: null,
+    hidden: false,
+    context: [],
+    legacy: null,
+};
+
+it('replays persisted text and tool activity without system messages', () => {
+    expect(
+        projectV3ThreadToModelMessages(
+            thread([
+                {
+                    uuid: 'user',
+                    role: 'user',
+                    metadata,
+                    parts: [
+                        {
+                            uuid: 'user-text',
+                            type: 'text',
+                            payloadVersion: 1,
+                            payload: { text: 'question' },
+                            toolCallId: null,
+                            artifactVersionUuid: null,
+                        },
+                    ],
+                },
+                {
+                    uuid: 'assistant',
+                    role: 'assistant',
+                    metadata: { ...metadata, status: 'completed' },
+                    parts: [
+                        {
+                            uuid: 'intro',
+                            type: 'text',
+                            payloadVersion: 1,
+                            payload: { text: 'Checking.' },
+                            toolCallId: null,
+                            artifactVersionUuid: null,
+                        },
+                        {
+                            uuid: 'tool',
+                            type: 'tool',
+                            payloadVersion: 1,
+                            payload: {
+                                state: 'output-available',
+                                toolName: 'findExplores',
+                                input: { query: 'orders' },
+                                output: ['orders'],
+                            },
+                            toolCallId: 'call-1',
+                            artifactVersionUuid: null,
+                        },
+                        {
+                            uuid: 'answer',
+                            type: 'text',
+                            payloadVersion: 1,
+                            payload: { text: 'Found it.' },
+                            toolCallId: null,
+                            artifactVersionUuid: null,
+                        },
+                    ],
+                },
+            ]),
+        ),
+    ).toEqual([
+        { role: 'user', content: 'question' },
+        {
+            role: 'assistant',
+            content: [
+                {
+                    type: 'text',
+                    text: 'Checking.',
+                    providerOptions: undefined,
+                },
+                {
+                    type: 'tool-call',
+                    toolCallId: 'call-1',
+                    toolName: 'findExplores',
+                    input: { query: 'orders' },
+                    providerOptions: undefined,
+                    providerExecuted: undefined,
+                },
+            ],
+        },
+        {
+            role: 'tool',
+            content: [
+                {
+                    type: 'tool-result',
+                    toolCallId: 'call-1',
+                    toolName: 'findExplores',
+                    output: { type: 'json', value: ['orders'] },
+                    providerOptions: undefined,
+                },
+            ],
+        },
+        {
+            role: 'assistant',
+            content: [
+                {
+                    type: 'text',
+                    text: 'Found it.',
+                    providerOptions: undefined,
+                },
+            ],
+        },
+    ]);
+});
+
+it('does not replay an in-progress assistant message', () => {
+    expect(
+        projectV3ThreadToModelMessages(
+            thread([
+                {
+                    uuid: 'assistant',
+                    role: 'assistant',
+                    metadata: { ...metadata, status: 'in_progress' },
+                    parts: [
+                        {
+                            uuid: 'partial',
+                            type: 'text',
+                            payloadVersion: 1,
+                            payload: { text: 'partial' },
+                            toolCallId: null,
+                            artifactVersionUuid: null,
+                        },
+                    ],
+                },
+            ]),
+        ),
+    ).toEqual([]);
+});

--- a/packages/backend/src/ee/services/ai/projectV3ThreadToModelMessages.ts
+++ b/packages/backend/src/ee/services/ai/projectV3ThreadToModelMessages.ts
@@ -1,0 +1,113 @@
+import {
+    type AssistantModelMessage,
+    type JSONValue,
+    type ModelMessage,
+} from 'ai';
+import { type AiCanonicalThread } from '../../database/entities/aiAgentV3';
+
+const providerOptions = (payload: Record<string, unknown>) =>
+    payload.providerMetadata as
+        | Record<string, Record<string, JSONValue>>
+        | undefined;
+
+const toolOutput = (payload: Record<string, unknown>) => {
+    if (payload.state === 'output-denied') {
+        return { type: 'execution-denied' as const, reason: 'Denied by user' };
+    }
+    const value =
+        payload.state === 'output-error'
+            ? { error: payload.error ?? { name: 'tool_error' } }
+            : payload.output;
+    return value === undefined
+        ? { type: 'text' as const, value: '' }
+        : { type: 'json' as const, value: value as JSONValue };
+};
+
+export const projectV3ThreadToModelMessages = (
+    thread: AiCanonicalThread,
+): ModelMessage[] => {
+    const messages: ModelMessage[] = [];
+
+    thread.messages.forEach((message) => {
+        if (message.role === 'compaction') {
+            return;
+        }
+
+        if (message.role === 'user') {
+            const text = message.parts
+                .filter((part) => part.type === 'text')
+                .map((part) => part.payload.text)
+                .filter((part): part is string => typeof part === 'string')
+                .join('');
+            if (text) messages.push({ role: 'user', content: text });
+            return;
+        }
+
+        if (message.metadata.status === 'in_progress') return;
+        let assistantContent: Exclude<
+            AssistantModelMessage['content'],
+            string
+        > = [];
+        const flushAssistant = () => {
+            if (assistantContent.length === 0) return;
+            messages.push({ role: 'assistant', content: assistantContent });
+            assistantContent = [];
+        };
+
+        message.parts.forEach((part) => {
+            switch (part.type) {
+                case 'text':
+                case 'reasoning': {
+                    if (typeof part.payload.text !== 'string') return;
+                    assistantContent.push({
+                        type: part.type === 'text' ? 'text' : 'reasoning',
+                        text: part.payload.text,
+                        providerOptions: providerOptions(part.payload),
+                    });
+                    return;
+                }
+                case 'tool': {
+                    const { toolName, state } = part.payload;
+                    if (
+                        !part.toolCallId ||
+                        typeof toolName !== 'string' ||
+                        typeof state !== 'string'
+                    ) {
+                        return;
+                    }
+                    assistantContent.push({
+                        type: 'tool-call',
+                        toolCallId: part.toolCallId,
+                        toolName,
+                        input: part.payload.input ?? {},
+                        providerOptions: providerOptions(part.payload),
+                        providerExecuted:
+                            typeof part.payload.providerExecuted === 'boolean'
+                                ? part.payload.providerExecuted
+                                : undefined,
+                    });
+                    if (!state.startsWith('output-')) return;
+                    flushAssistant();
+                    messages.push({
+                        role: 'tool',
+                        content: [
+                            {
+                                type: 'tool-result',
+                                toolCallId: part.toolCallId,
+                                toolName,
+                                output: toolOutput(part.payload),
+                                providerOptions: providerOptions(part.payload),
+                            },
+                        ],
+                    });
+                    return;
+                }
+                default:
+                    return;
+            }
+        });
+        flushAssistant();
+    });
+
+    return messages;
+};

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -18,7 +18,7 @@ import {
 } from '@lightdash/common';
 // eslint-disable-next-line import/extensions
 import { type OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
-import { ModelMessage } from 'ai';
+import { ModelMessage, type LanguageModelUsage } from 'ai';
 import {
     AiKeyManagement,
     type AiUsageTokens,
@@ -263,6 +263,7 @@ export type AiAgentArgs = AnyAiModel & {
     canManageAgent: boolean;
     toolHints: string[];
     execution: AiAgentExecutionConfig;
+    abortSignal?: AbortSignal;
     /**
      * When true, the first tool hint is *forced* on the opening step
      * (toolChoice), not just suggested — used by the review Build-fix run to
@@ -347,6 +348,13 @@ export type AiAgentDependencies = {
     isThreadSqlAutoApproved: IsThreadSqlAutoApprovedFn;
     loadSkill: LoadAgentSkillFn;
     perf: PerformanceMetrics;
+    streamPersistence?: {
+        onChunk: (chunk: unknown) => Promise<void>;
+        recordUsage: (usage: LanguageModelUsage) => void;
+        complete: (usage?: LanguageModelUsage) => Promise<void>;
+        fail: (error: unknown, message: string) => Promise<void>;
+        cancel: () => Promise<void>;
+    };
 };
 
 export type AiGenerateAgentResponseArgs = AiAgentArgs;

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -782,6 +782,14 @@ export type ApiAiAgentThreadStreamRequest = {
     toolHints?: string[];
 };
 
+export type ApiAiAgentV3ChatRequest = {
+    message: string;
+    modelConfig?: AiAgentModelConfig;
+    enableSqlMode?: boolean;
+    autoApproveSql?: boolean;
+    toolHints?: string[];
+};
+
 export type ApiAiAgentSqlApprovalResponse = ApiSuccess<{
     decision: 'approved' | 'rejected';
 }>;

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -141,6 +141,9 @@ export enum FeatureFlags {
     /** Enable project-scoped AI agent memory runtime. */
     AiAgentMemory = 'ai-agent-memory',
 
+    /** Persist newly created AI agent threads with the v3 conversation model. */
+    AiAgentV3 = 'ai-agent-v3',
+
     /**
      * Enable the Hexbin (H3 hexagonal binning) layer type for Map charts.
      * Gates the option in the Map Type segmented control. Existing charts


### PR DESCRIPTION
Closes: ZAP-800

### Description

- Route new web-app threads to v3 storage when the org-level ai-agent-v3 flag is enabled.
- Add the v3 chat stream pipeline with canonical replay, ordered durable parts, steers, cancellation, heartbeats, terminal envelopes, and shutdown draining.
- Keep v1 creation/runtime behavior unchanged when the flag is off.

### Verification

- Focused tests: 20 passed
- Backend and common typechecks
- Targeted backend/common lint and formatting
- Behavioral curl e2e: create, stream, steer, cancel
- Canonical DB/SSE byte equality and no legacy ai_prompt writes
- Jaeger traces under lightdash-zap797

### Stack

Base: #26924 (feature/zap-799)
