### PR TITLE
fix(ai): stop steering agents toward runSql when it is not available

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -407,7 +407,10 @@ export class McpService extends BaseService {
         this.aiRouterService = aiRouterService;
         this.aiWritebackService = aiWritebackService;
         try {
-            this.mcpServer = this.buildMcpServer({ enableGrepFields: false });
+            this.mcpServer = this.buildMcpServer({
+                enableGrepFields: false,
+                runSqlEnabled: false,
+            });
             this.setupHandlers();
         } catch (error) {
             this.logger.error('Error initializing MCP server:', error);
@@ -415,7 +418,10 @@ export class McpService extends BaseService {
         }
     }
 
-    private buildMcpServer(args: { enableGrepFields: boolean }): McpServer {
+    private buildMcpServer(args: {
+        enableGrepFields: boolean;
+        runSqlEnabled: boolean;
+    }): McpServer {
         return Sentry.wrapMcpServerWithSentry(
             new McpServer(
                 {
@@ -442,6 +448,7 @@ export class McpService extends BaseService {
                 {
                     instructions: getMcpAnalystPrompt({
                         enableGrepFields: args.enableGrepFields,
+                        runSqlEnabled: args.runSqlEnabled,
                     }),
                 },
             ),
@@ -3269,15 +3276,18 @@ export class McpService extends BaseService {
                             explores: agent.context.explores,
                             verifiedQuestions: agent.context.verifiedQuestions,
                             enableGrepFields: options.grepFieldsEnabled,
+                            runSqlEnabled: options.runSqlEnabled,
                         });
                     } catch {
                         promptText = getMcpAnalystPrompt({
                             enableGrepFields: options.grepFieldsEnabled,
+                            runSqlEnabled: options.runSqlEnabled,
                         });
                     }
                 } else {
                     promptText = getMcpAnalystPrompt({
                         enableGrepFields: options.grepFieldsEnabled,
+                        runSqlEnabled: options.runSqlEnabled,
                     });
                 }
 
@@ -3595,6 +3605,7 @@ export class McpService extends BaseService {
     }): Promise<McpServer> {
         const newServer = this.buildMcpServer({
             enableGrepFields: options?.grepFieldsEnabled ?? false,
+            runSqlEnabled: options?.runSqlEnabled ?? false,
         });
 
         // Temporarily swap the server to register handlers on the new instance.

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -1215,7 +1215,7 @@ Usage tips:
         "openWorldHint": false,
         "readOnlyHint": true,
       },
-      "description": "List all accessible projects in the organization. Projects contain explores, fields, and content. Use this to discover available projects before calling set_project to select one as the active context for subsequent operations. Each project includes a "type": prefer DEFAULT projects, which are live production environments. PREVIEW projects are ephemeral CI/PR environments that may be decommissioned — their warehouse credentials are often gone, so run_sql and run_metric_query can fail with 403 errors even when the schema is still visible. Only select a PREVIEW project if the user explicitly asks for it.",
+      "description": "List all accessible projects in the organization. Projects contain explores, fields, and content. Use this to discover available projects before calling set_project to select one as the active context for subsequent operations. Each project includes a "type": prefer DEFAULT projects, which are live production environments. PREVIEW projects are ephemeral CI/PR environments that may be decommissioned — their warehouse credentials are often gone, so queries can fail with 403 errors even when the schema is still visible. Only select a PREVIEW project if the user explicitly asks for it.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
@@ -7433,14 +7433,14 @@ Notes:
         "openWorldHint": false,
         "readOnlyHint": true,
       },
-      "description": "Poll for the result of a long-running MCP query started by run_sql or run_metric_query.
+      "description": "Poll for the result of a long-running MCP query started by a query tool such as run_metric_query.
 
-Use this tool when run_sql or run_metric_query returns a running result. Clients with structured output see this as structuredContent.result.status = "running"; text-only clients should extract the queryUuid from the content text.
+Use this tool when a query tool returns a running result. Clients with structured output see this as structuredContent.result.status = "running"; text-only clients should extract the queryUuid from the content text.
 Each call waits up to the MCP wait window before returning another running response.
 For completed run_metric_query results, If the user asked for a visual, or if a chart would make the answer easier to understand than raw rows alone, call render_chart after get_query_result returns done. render_chart currently supports completed run_metric_query results.
 
 Parameters:
-- queryUuid: The async query UUID returned by run_sql or run_metric_query.
+- queryUuid: The async query UUID returned by the query tool.
 
 Response shape (MCP CallToolResult):
 - Running: content contains polling status text and structuredContent.result contains { status: "running", queryUuid, nextPollAfterMs, heartbeatAt }. heartbeatAt is an ISO timestamp for the latest Lightdash check that confirmed the query is still running.
@@ -7458,7 +7458,7 @@ Notes:
         "additionalProperties": false,
         "properties": {
           "queryUuid": {
-            "description": "Async query UUID returned by run_sql or run_metric_query.",
+            "description": "Async query UUID returned by the query tool.",
             "format": "uuid",
             "type": "string",
           },

--- a/packages/backend/src/ee/services/ai/prompts/mcpAnalyst.ts
+++ b/packages/backend/src/ee/services/ai/prompts/mcpAnalyst.ts
@@ -1,4 +1,16 @@
-const LEGACY_MCP_ANALYST_PROMPT = `# Lightdash MCP Tools — Usage Guidelines
+// Only offered to sessions whose tools/list actually includes run_sql
+// (gated on manage:SqlRunner).
+const RUN_SQL_GUIDANCE = `### When to Use run_sql vs run_metric_query
+- **Prefer \`run_metric_query\`** for standard analysis — it leverages the semantic layer and ensures consistent metric definitions
+- **Use \`run_sql\`** only for ad-hoc queries, cross-table joins not modeled in explores, or when the user explicitly requests raw SQL
+- \`run_sql\` defaults to 500 rows (max 5000) — use the \`limit\` parameter to control result size
+- Use the SQL dialect appropriate for the connected warehouse
+
+`;
+
+const buildLegacyMcpAnalystPrompt = (
+    runSqlEnabled: boolean,
+): string => `# Lightdash MCP Tools — Usage Guidelines
 
 ## Query Building Workflow
 
@@ -15,7 +27,7 @@ const LEGACY_MCP_ANALYST_PROMPT = `# Lightdash MCP Tools — Usage Guidelines
    - Use multiple search queries in one call to find related fields efficiently
    - Look for both dimensions (for grouping) and metrics (for aggregation)
 3. **Search field values**: Use \`search_field_values\` to discover valid filter values for a dimension
-4. **Run queries**: Use \`run_metric_query\` for semantic-layer metric queries, or \`run_sql\` for custom SQL
+4. **Run queries**: Use \`run_metric_query\` for semantic-layer metric queries${runSqlEnabled ? ', or `run_sql` for custom SQL' : ''}
 5. **Poll long-running queries**: If a query returns \`status: "running"\`, call \`get_query_result\` with the \`queryUuid\` until it returns done/error/cancelled/expired
 6. **Render charts**: If the user wants a chart, call \`render_chart\` after \`run_metric_query\` or \`get_query_result\` returns done with a \`queryUuid\`
 7. **Browse content**: Use \`list_content\` to browse accessible spaces and direct content inside a space
@@ -28,13 +40,7 @@ const LEGACY_MCP_ANALYST_PROMPT = `# Lightdash MCP Tools — Usage Guidelines
 - When multiple explores match, check \`usageInCharts\` to find the most commonly used one
 - If still ambiguous, ask the user which data source they want — do NOT guess
 
-### When to Use run_sql vs run_metric_query
-- **Prefer \`run_metric_query\`** for standard analysis — it leverages the semantic layer and ensures consistent metric definitions
-- **Use \`run_sql\`** only for ad-hoc queries, cross-table joins not modeled in explores, or when the user explicitly requests raw SQL
-- \`run_sql\` defaults to 500 rows (max 5000) — use the \`limit\` parameter to control result size
-- Use the SQL dialect appropriate for the connected warehouse
-
-### Time Filtering
+${runSqlEnabled ? RUN_SQL_GUIDANCE : ''}### Time Filtering
 - If the user mentions ANY time period, you MUST add a date filter — do not rely on sort + limit
 - Use the \`inThePast\` operator for relative windows
 - Date fields from joined tables work identically in filters
@@ -48,7 +54,7 @@ const LEGACY_MCP_ANALYST_PROMPT = `# Lightdash MCP Tools — Usage Guidelines
 - Page parameters must be numbers (e.g., \`1\`) — never use \`NaN\` or \`"null"\`
 
 ### Visualization
-- \`run_metric_query\` returns metric-query data; \`run_sql\` returns SQL data; \`render_chart\` renders visuals for completed metric queries
+- \`run_metric_query\` returns metric-query data;${runSqlEnabled ? ' `run_sql` returns SQL data;' : ''} \`render_chart\` renders visuals for completed metric queries
 - Supported types: table, bar, horizontal_bar, line, scatter, pie, funnel
 - For time series: use \`line\` with \`xAxisType: 'time'\`
 - For categorical comparisons: use \`bar\` or \`horizontal_bar\`
@@ -67,7 +73,9 @@ Use table calculations for:
 - Reference using the pattern \`table_metricname\`
 `;
 
-const GREP_FIELDS_MCP_ANALYST_PROMPT = `# Lightdash MCP Tools — Usage Guidelines
+const buildGrepFieldsMcpAnalystPrompt = (
+    runSqlEnabled: boolean,
+): string => `# Lightdash MCP Tools — Usage Guidelines
 
 ## Query Building Workflow
 
@@ -82,7 +90,7 @@ const GREP_FIELDS_MCP_ANALYST_PROMPT = `# Lightdash MCP Tools — Usage Guidelin
    - Use it to confirm joined tables, required filters, filter types, case-sensitivity, and field-level hints before building the query
    - Never invent field IDs; only use exact values returned by \`grep_fields\` / \`get_metadata\`
 3. **Search field values**: Use \`search_field_values\` to discover valid filter values for a dimension
-4. **Run queries**: Use \`run_metric_query\` for semantic-layer metric queries, or \`run_sql\` for custom SQL
+4. **Run queries**: Use \`run_metric_query\` for semantic-layer metric queries${runSqlEnabled ? ', or `run_sql` for custom SQL' : ''}
 5. **Poll long-running queries**: If a query returns \`status: "running"\`, call \`get_query_result\` with the \`queryUuid\` until it returns done/error/cancelled/expired
 6. **Render charts**: If the user wants a chart, call \`render_chart\` after \`run_metric_query\` or \`get_query_result\` returns done with a \`queryUuid\`
 7. **Browse content**: Use \`list_content\` to browse accessible spaces and direct content inside a space
@@ -95,13 +103,7 @@ const GREP_FIELDS_MCP_ANALYST_PROMPT = `# Lightdash MCP Tools — Usage Guidelin
 - When multiple explores surface plausible fields, choose the one whose dimensions and metrics match the user's intended grain
 - If still ambiguous, ask the user which data source they want — do NOT guess
 
-### When to Use run_sql vs run_metric_query
-- **Prefer \`run_metric_query\`** for standard analysis — it leverages the semantic layer and ensures consistent metric definitions
-- **Use \`run_sql\`** only for ad-hoc queries, cross-table joins not modeled in explores, or when the user explicitly requests raw SQL
-- \`run_sql\` defaults to 500 rows (max 5000) — use the \`limit\` parameter to control result size
-- Use the SQL dialect appropriate for the connected warehouse
-
-### Time Filtering
+${runSqlEnabled ? RUN_SQL_GUIDANCE : ''}### Time Filtering
 - If the user mentions ANY time period, you MUST add a date filter — do not rely on sort + limit
 - Use the \`inThePast\` operator for relative windows
 - Date fields from joined tables work identically in filters
@@ -115,7 +117,7 @@ const GREP_FIELDS_MCP_ANALYST_PROMPT = `# Lightdash MCP Tools — Usage Guidelin
 - Page parameters must be numbers (e.g., \`1\`) — never use \`NaN\` or \`"null"\`
 
 ### Visualization
-- \`run_metric_query\` returns metric-query data; \`run_sql\` returns SQL data; \`render_chart\` renders visuals for completed metric queries
+- \`run_metric_query\` returns metric-query data;${runSqlEnabled ? ' `run_sql` returns SQL data;' : ''} \`render_chart\` renders visuals for completed metric queries
 - Supported types: table, bar, horizontal_bar, line, scatter, pie, funnel
 - For time series: use \`line\` with \`xAxisType: 'time'\`
 - For categorical comparisons: use \`bar\` or \`horizontal_bar\`
@@ -136,10 +138,13 @@ Use table calculations for:
 
 export const getMcpAnalystPrompt = (args?: {
     enableGrepFields?: boolean;
-}): string =>
-    args?.enableGrepFields
-        ? GREP_FIELDS_MCP_ANALYST_PROMPT
-        : LEGACY_MCP_ANALYST_PROMPT;
+    runSqlEnabled?: boolean;
+}): string => {
+    const runSqlEnabled = args?.runSqlEnabled ?? true;
+    return args?.enableGrepFields
+        ? buildGrepFieldsMcpAnalystPrompt(runSqlEnabled)
+        : buildLegacyMcpAnalystPrompt(runSqlEnabled);
+};
 
 export const MCP_ANALYST_PROMPT = getMcpAnalystPrompt();
 
@@ -149,10 +154,12 @@ export const getMcpAnalystPromptWithContext = (context: {
     explores: string[];
     verifiedQuestions: string[];
     enableGrepFields?: boolean;
+    runSqlEnabled?: boolean;
 }): string => {
     const sections: string[] = [
         getMcpAnalystPrompt({
             enableGrepFields: context.enableGrepFields,
+            runSqlEnabled: context.runSqlEnabled,
         }),
     ];
 

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -3711,8 +3711,8 @@ When to use:
 - When you need background or policy context that the data warehouse alone cannot provide.
 
 Do NOT use:
-- For data queries — use generateVisualization / runSql / findFields instead.
-- For schema or table discovery — use findExplores / listWarehouseTables instead.
+- For data queries — use generateVisualization instead.
+- For schema or table discovery — use the field discovery tools instead.
 
 Parameters:
 - (no parameters)

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -1377,7 +1377,7 @@ export const mcpListProjectsToolDefinition: ToolDefinitionWithoutMcpOutput<
     name: 'listProjects',
     title: 'List projects',
     description:
-        'List all accessible projects in the organization. Projects contain explores, fields, and content. Use this to discover available projects before calling set_project to select one as the active context for subsequent operations. Each project includes a "type": prefer DEFAULT projects, which are live production environments. PREVIEW projects are ephemeral CI/PR environments that may be decommissioned — their warehouse credentials are often gone, so run_sql and run_metric_query can fail with 403 errors even when the schema is still visible. Only select a PREVIEW project if the user explicitly asks for it.',
+        'List all accessible projects in the organization. Projects contain explores, fields, and content. Use this to discover available projects before calling set_project to select one as the active context for subsequent operations. Each project includes a "type": prefer DEFAULT projects, which are live production environments. PREVIEW projects are ephemeral CI/PR environments that may be decommissioned — their warehouse credentials are often gone, so queries can fail with 403 errors even when the schema is still visible. Only select a PREVIEW project if the user explicitly asks for it.',
     availability: ['mcp'],
     inputSchema: emptyInputSchema,
     mcp: { annotations: readOnlyAnnotations },

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolGetQueryResultArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolGetQueryResultArgs.ts
@@ -7,16 +7,16 @@ import {
 } from './toolMcpQueryResultDescription';
 import { mcpAsyncQueryUuidSchema } from './toolQueryResultSchemas';
 
-export const TOOL_GET_QUERY_RESULT_DESCRIPTION = `Poll for the result of a long-running MCP query started by run_sql or run_metric_query.
+export const TOOL_GET_QUERY_RESULT_DESCRIPTION = `Poll for the result of a long-running MCP query started by a query tool such as run_metric_query.
 
-Use this tool when run_sql or run_metric_query returns a running result. Clients with structured output see this as structuredContent.result.status = "running"; text-only clients should extract the queryUuid from the content text.
+Use this tool when a query tool returns a running result. Clients with structured output see this as structuredContent.result.status = "running"; text-only clients should extract the queryUuid from the content text.
 Each call waits up to the MCP wait window before returning another running response.
 For completed run_metric_query results, ${buildMcpVisualizationFollowUpInstruction(
     'get_query_result',
 )} render_chart currently supports completed run_metric_query results.
 
 Parameters:
-- queryUuid: The async query UUID returned by run_sql or run_metric_query.
+- queryUuid: The async query UUID returned by the query tool.
 
 ${MCP_GET_QUERY_RESULT_RESPONSE_DESCRIPTION}
 
@@ -27,7 +27,7 @@ ${MCP_QUERY_COMMON_NOTES}
 export const toolGetQueryResultArgsSchema = createToolSchema()
     .extend({
         queryUuid: mcpAsyncQueryUuidSchema.describe(
-            'Async query UUID returned by run_sql or run_metric_query.',
+            'Async query UUID returned by the query tool.',
         ),
     })
     .build();

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolListKnowledgeDocumentsArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolListKnowledgeDocumentsArgs.ts
@@ -15,8 +15,8 @@ When to use:
 - When you need background or policy context that the data warehouse alone cannot provide.
 
 Do NOT use:
-- For data queries — use generateVisualization / runSql / findFields instead.
-- For schema or table discovery — use findExplores / listWarehouseTables instead.
+- For data queries — use generateVisualization instead.
+- For schema or table discovery — use the field discovery tools instead.
 
 Parameters:
 - (no parameters)

--- a/plugins/lightdash/skills/lightdash-analytics/SKILL.md
+++ b/plugins/lightdash/skills/lightdash-analytics/SKILL.md
@@ -18,7 +18,7 @@ Never invent explore names, field IDs, metric definitions, filter values, or que
 
 ## Answering questions
 
-Prefer `run_metric_query` for questions that fit the semantic layer. Use `run_sql` only when the requested analysis cannot be represented through a governed explore.
+Prefer `run_metric_query` for questions that fit the semantic layer. Use `run_sql`, when it is available, only when the requested analysis cannot be represented through a governed explore.
 
 If a metric query is still running, poll `get_query_result` with the returned query UUID. When a visual would clarify the result, render a completed metric query with `render_chart`.
 


### PR DESCRIPTION
The `listKnowledgeDocuments` tool description told the model to reach for `runSql` / `findFields` / `findExplores` regardless of whether those tools were registered for the request, producing `AI_NoSuchToolError` events in production when agents without SQL access followed it.

The MCP surface had the same leak for `run_sql`: the server instructions served at connect time and the `lightdash-analyst` prompt steered every session toward it, including sessions where it is gated off, and a few always-registered tool descriptions named it unconditionally.

Relates: ZAP-810
Relates: #26925