### PR TITLE
fix(content-table): drop the phantom footer strip and restyle the empty state

### DIFF
--- a/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
@@ -423,9 +423,12 @@ const MyAppsPanel: FC<MyAppsPanelProps> = ({
             highlightOnHover: true,
         },
         emptyState: {
-            emptyMessage: includePreviewApps
-                ? "You haven't created any apps yet."
-                : 'No apps in production projects. Switch to All projects to include apps from preview projects.',
+            title: includePreviewApps
+                ? "You haven't created any apps yet"
+                : 'No apps in production projects',
+            description: includePreviewApps
+                ? undefined
+                : 'Switch to All projects to include apps from preview projects.',
             entityName: 'apps',
             hasActiveFilters: selectedProjectUuids.length > 0,
             onClearFilters: resetFilters,

--- a/packages/frontend/src/components/common/ContentTable/ContentTable.module.css
+++ b/packages/frontend/src/components/common/ContentTable/ContentTable.module.css
@@ -279,13 +279,30 @@
     padding: 0;
 }
 
+/* Let the empty state absorb the leftover height instead of leaving a void
+   under it. Flex rather than height:100% so it also works when the container's
+   height comes from min-height rather than a definite height. */
+.containerEmpty {
+    display: flex;
+    flex-direction: column;
+}
+
+.containerEmpty .tableEmpty {
+    flex: 1 1 auto;
+}
+
+.tableEmpty .emptyCell,
+.tableEmpty .emptyState {
+    height: 100%;
+}
+
 .emptyState {
     align-items: center;
     color: var(--mantine-color-ldGray-6);
     display: flex;
     flex-direction: column;
     font-size: var(--mantine-font-size-sm);
-    gap: var(--mantine-spacing-sm);
+    gap: var(--mantine-spacing-md);
     justify-content: center;
     min-height: 160px;
     padding: var(--mantine-spacing-xl) var(--mantine-spacing-md);
@@ -293,12 +310,11 @@
 }
 
 .emptyStateIcon {
-    opacity: 0.42;
-    transition: opacity 180ms ease;
-}
-
-.emptyState:hover .emptyStateIcon {
-    opacity: 0.62;
+    background: var(--mantine-color-ldGray-0);
+    border-radius: var(--mantine-radius-xl);
+    box-sizing: content-box;
+    opacity: 0.9;
+    padding: var(--mantine-spacing-sm);
 }
 
 .searchInput {
@@ -374,6 +390,10 @@
             var(--mantine-color-ldDark-4),
             transparent
         );
+    }
+
+    .emptyStateIcon {
+        background: var(--mantine-color-ldDark-3);
     }
 
     .searchInput {

--- a/packages/frontend/src/components/common/ContentTable/ContentTable.tsx
+++ b/packages/frontend/src/components/common/ContentTable/ContentTable.tsx
@@ -6,8 +6,10 @@ import {
     Pagination,
     Paper,
     Skeleton,
+    Stack,
     Table,
     Text,
+    Title,
     UnstyledButton,
 } from '@mantine/core';
 import {
@@ -15,6 +17,7 @@ import {
     IconArrowUp,
     IconArrowsSort,
     IconFilter,
+    IconInbox,
     IconSearch,
 } from '@tabler/icons-react';
 import {
@@ -651,37 +654,54 @@ const DefaultEmptyState = <TData extends RowData>({
     const search = emptyState?.search?.trim();
     const isFiltered = Boolean(search) || emptyState?.hasActiveFilters === true;
     const entityName = emptyState?.entityName ?? 'records';
-    const message =
-        isFiltered && emptyState?.filteredMessage
-            ? emptyState.filteredMessage
-            : !isFiltered && emptyState?.emptyMessage
-              ? emptyState.emptyMessage
-              : search
-                ? `No ${entityName} matching "${search}"`
-                : isFiltered
-                  ? `No ${entityName} match the current filters`
-                  : 'No records to display';
+    const fallbackMessage = isFiltered
+        ? emptyState?.filteredMessage
+        : emptyState?.emptyMessage;
+    const title =
+        emptyState?.title ??
+        fallbackMessage ??
+        (search
+            ? `No ${entityName} matching "${search}"`
+            : isFiltered
+              ? `No ${entityName} match the current filters`
+              : `No ${entityName} yet`);
+    const description =
+        emptyState?.description ??
+        (search && !fallbackMessage ? 'Try a different search term.' : null);
+    const icon = search ? IconSearch : isFiltered ? IconFilter : IconInbox;
+    const canClearFilters = isFiltered && emptyState?.onClearFilters;
 
     return (
         <div className={classes.emptyState}>
             <MantineIcon
-                icon={isFiltered && search ? IconSearch : IconFilter}
-                size="xl"
+                icon={icon}
+                size="3xl"
                 color="ldGray.4"
                 className={classes.emptyStateIcon}
             />
-            <Text fz="sm" fw={500} c="ldGray.6">
-                {message}
-            </Text>
-            {isFiltered && emptyState?.onClearFilters ? (
-                <Button
-                    variant="subtle"
-                    size="xs"
-                    color="gray"
-                    onClick={emptyState.onClearFilters}
-                >
-                    Clear all filters
-                </Button>
+            <Stack align="center" gap={4} maw={360}>
+                <Title order={5} fw={600} c="foreground" ta="center">
+                    {title}
+                </Title>
+                {description ? (
+                    <Text fz="sm" c="ldGray.6" ta="center">
+                        {description}
+                    </Text>
+                ) : null}
+            </Stack>
+            {canClearFilters || emptyState?.action ? (
+                <Group gap="xs">
+                    {canClearFilters ? (
+                        <Button
+                            variant="default"
+                            size="xs"
+                            onClick={emptyState.onClearFilters}
+                        >
+                            Clear all filters
+                        </Button>
+                    ) : null}
+                    {emptyState?.action}
+                </Group>
             ) : null}
         </div>
     );
@@ -780,6 +800,7 @@ export const ContentTable = <TData extends RowData>({
     const showSkeletons =
         runtimeState.showSkeletons ||
         (runtimeState.isLoading && rows.length === 0);
+    const isEmpty = !showSkeletons && rows.length === 0;
     const hasFooter = table
         .getFooterGroups()
         .some((footerGroup) =>
@@ -815,7 +836,11 @@ export const ContentTable = <TData extends RowData>({
             <Box
                 {...containerProps}
                 ref={handleContainerRef}
-                className={cx(classes.container, containerProps.className)}
+                className={cx(
+                    classes.container,
+                    isEmpty && classes.containerEmpty,
+                    containerProps.className,
+                )}
                 style={{
                     ...columnSizeVars,
                     ...containerProps.style,
@@ -825,6 +850,7 @@ export const ContentTable = <TData extends RowData>({
                     {...tableProps}
                     className={cx(
                         classes.table,
+                        isEmpty && classes.tableEmpty,
                         tableProps.highlightOnHover === true &&
                             classes.highlightOnHover,
                         tableProps.withColumnBorders === true &&

--- a/packages/frontend/src/components/common/ContentTable/types.ts
+++ b/packages/frontend/src/components/common/ContentTable/types.ts
@@ -168,12 +168,18 @@ export type ContentTableOptions<TData extends RowData> = {
     >;
     editDisplayMode?: 'cell' | 'row' | 'table' | 'modal' | 'custom';
     emptyState?: {
+        /** Rendered below the message. Use for a primary action like "Create dashboard". */
+        action?: ReactNode;
+        /** Supporting line under the heading. */
+        description?: ReactNode;
         emptyMessage?: ReactNode;
         entityName?: string;
         filteredMessage?: ReactNode;
         hasActiveFilters?: boolean;
         onClearFilters?: () => void;
         search?: string;
+        /** Heading. Overrides emptyMessage/filteredMessage when set. */
+        title?: ReactNode;
     };
     enableBottomToolbar?: boolean;
     enableColumnActions?: boolean;

--- a/packages/frontend/src/components/common/ContentTable/useContentTable.test.tsx
+++ b/packages/frontend/src/components/common/ContentTable/useContentTable.test.tsx
@@ -54,6 +54,34 @@ describe('useContentTable', () => {
         expect(sortedRows.map((r) => r.original.name)).toEqual(['a', 'b']);
     });
 
+    test('leaves columnDef.footer undefined when the column defines no Footer', () => {
+        const columns: ContentTableColumnDef<Row>[] = [
+            { accessorKey: 'name', header: 'Name' },
+        ];
+
+        const { result } = renderHook(() =>
+            useContentTable<Row>({ columns, data }),
+        );
+
+        const [column] = result.current.getAllLeafColumns();
+
+        expect(column.columnDef.footer).toBeUndefined();
+    });
+
+    test('sets columnDef.footer when the column defines a Footer', () => {
+        const columns: ContentTableColumnDef<Row>[] = [
+            { accessorKey: 'name', header: 'Name', Footer: () => 'Total' },
+        ];
+
+        const { result } = renderHook(() =>
+            useContentTable<Row>({ columns, data }),
+        );
+
+        const [column] = result.current.getAllLeafColumns();
+
+        expect(column.columnDef.footer).toBeDefined();
+    });
+
     describe('getColumnHeaderLabel', () => {
         test('returns the original string header even though the runtime header is a render callback', () => {
             const columns: ContentTableColumnDef<Row>[] = [

--- a/packages/frontend/src/components/common/ContentTable/useContentTable.tsx
+++ b/packages/frontend/src/components/common/ContentTable/useContentTable.tsx
@@ -136,15 +136,20 @@ const toTanStackColumn = <TData extends RowData>(
 
             return compatHeader;
         },
-        footer: (footerContext) => {
-            const table = footerContext.table as ContentTableInstance<TData>;
+        ...(column.Footer
+            ? {
+                  footer: (footerContext) => {
+                      const table =
+                          footerContext.table as ContentTableInstance<TData>;
 
-            return column.Footer?.({
-                column: footerContext.column,
-                header: footerContext.header,
-                table,
-            });
-        },
+                      return column.Footer?.({
+                          column: footerContext.column,
+                          header: footerContext.header,
+                          table,
+                      });
+                  },
+              }
+            : {}),
         cell: (cellContext) => {
             const table = cellContext.table as ContentTableInstance<TData>;
             const renderedCellValue = toRenderedValue(cellContext.getValue());

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminEvalsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminEvalsTable.tsx
@@ -339,8 +339,9 @@ const AiAgentAdminEvalsTable = ({
         positionGlobalFilter: 'left',
         emptyState: {
             entityName: 'evals',
-            emptyMessage:
-                "No evals yet. Create one from an agent's Evals tab to benchmark its answers.",
+            title: 'No evals yet',
+            description:
+                "Create one from an agent's Evals tab to benchmark its answers.",
             search,
             hasActiveFilters,
             onClearFilters: resetFilters,

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
@@ -1338,8 +1338,8 @@ const AiAgentAdminReviewItemsTable = ({
         },
         emptyState: {
             entityName: 'issues',
-            emptyMessage:
-                'No issues yet. When an agent answer looks wrong, it shows up here.',
+            title: 'No issues yet',
+            description: 'When an agent answer looks wrong, it shows up here.',
             search,
             hasActiveFilters,
             onClearFilters: clearAllFilters,


### PR DESCRIPTION
## What

Two fixes to `ContentTable`, plus a restyle of its default empty state.

### 1. Every table was rendering an empty grey `<tfoot>` strip

`toTanStackColumn` attached a `footer` render function to **every** column, regardless of whether the column defined a `Footer`:

```ts
footer: (footerContext) => column.Footer?.({ ... }),   // always a function
```

`ContentTable`'s guard tests that field for truthiness:

```ts
const hasFooter = table.getFooterGroups().some((g) =>
    g.headers.some((h) => h.column.columnDef.footer),
);
```

A function that returns `undefined` is still truthy, so `hasFooter` was always `true` and every `ContentTable` in the app rendered a ~13px `ldGray-0` footer strip with no content in it. It is most visible on empty tables, where it lands mid-panel and reads as a stray grey bar, but it was present on tables with rows too.

Fixed by only attaching `footer` when the column actually defines one. `DashboardVersionComparison` is the only real footer consumer and still renders its totals row.

### 2. The empty state did not fill its container

The empty state sat pinned under the header, leaving a large void beneath it in any table whose container is tall. `InfiniteResourceTable` (All dashboards / All charts / All spaces / All apps / Space detail) pins `minHeight: 600px`, so this was the common case rather than an edge case.

Fixed with flex rather than `height: 100%`, deliberately: the container's height usually comes from `min-height`, and percentage heights do not resolve against that.

Worth flagging for a follow-up: `InfiniteResourceTable` already tried to do this itself, via `mantineTableBodyProps.sx = { flexGrow: 1, display: 'flex', justifyContent: 'center', alignItems: 'center' }`. That never took effect, because `ContentTable` only passes `includeSxStyle: true` for `mantinePaperProps` and `mantineTableContainerProps` — `sx` on the body, table and head slots is silently dropped. Left alone here; it is a separate cleanup.

### 3. Nicer empty state

Restyled to match `ResourceEmptyState`: icon in a soft circle, a heading, an optional supporting line, and an optional action.

- New `emptyState` options: `title`, `description`, `action`. The existing `emptyMessage` / `filteredMessage` still work as the heading, so no consumer breaks.
- Genuinely-empty tables now get an inbox icon instead of a filter icon — there are no filters to speak of in that state.
- Search-empty gets a magnifier and a `Try a different search term.` supporting line.
- `Clear all filters` moves from `subtle` to `default` so it reads as an action.
- Three consumers passed two-sentence `emptyMessage` strings that would now render as a heavy wrapped heading; those are split into `title` + `description`.

## Testing

- Two unit tests pinning `columnDef.footer` — undefined without a `Footer`, defined with one.
- Verified in Storybook across light and dark: empty in a tall container, empty at auto height, empty with a search term, empty with active filters, with rows, with a real footer, and loading skeletons. Those stories were scratch scaffolding and are not part of this PR.
- `typecheck`, `lint` and unit tests pass.

Not verified: the fixes were confirmed against a faithful reproduction of `InfiniteResourceTable`'s configuration rather than against the live `/dashboards` and `/spaces` pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151NydRW1px72kq9B5BYYwy
