### PR TITLE
fix(dev): resolve dev instance by env pin before directory basename

### DIFF
--- a/scripts/dev-ports.sh
+++ b/scripts/dev-ports.sh
@@ -39,6 +39,12 @@ SHARED_NATS_MONITOR_PORT=8222
 get_instance_id() {
     local id="${INSTANCE_ID:-}"
     if [ -z "$id" ]; then
+        # Prefer the worktree's own LD_INSTANCE_ID pin: same-basename checkouts
+        # (e.g. two clones both named "lightdash") collide on basename and would
+        # silently resolve to another worktree's slot.
+        id="$(get_env_instance_id "$(pwd)")"
+    fi
+    if [ -z "$id" ]; then
         id="$(basename "$(pwd)")"
     fi
     echo "$id"


### PR DESCRIPTION
## Summary

`scripts/dev-ports.sh` resolved the dev instance id by directory basename (unless `--instance-id` was passed). Two checkouts with the same basename — e.g. `~/dev/lightdash` and `~/dev/LD2/lightdash`, both named `lightdash` — therefore collide: flagless `claim`/`env` calls from the second checkout (including the ones inside `dev-fast-start.sh`) silently resolve to the *first* checkout's slot. From there the second worktree's fast start recycles the first instance's PM2 processes and runs migrations against its database.

This actually bit today: a worktree registered as instance `ld2` resolved to its sibling's `lightdash` slot, and its `.env.development.local` had drifted to the sibling's full port set — one `pnpm pm2:start` away from taking down the sibling's stack.

**Fix:** `get_instance_id()` now prefers the worktree's own `LD_INSTANCE_ID` pin from `./.env.development.local` (via the existing `get_env_instance_id` helper) before falling back to basename. Resolution order becomes: `--instance-id` flag → env-file pin → basename.

## Why this is low-risk

- **Normal setups are bit-identical.** On first claim the id comes from basename, and `dev-fast-start.sh`'s `reconcile_env` writes that same id back into the env file — so pin == basename for every normally-created instance, and the new branch resolves the same id the old one did. A missing/empty pin falls through to basename unchanged.
- **`--instance-id` still wins** over everything.
- **Renamed checkout:** previously basename minted a fresh slot and silently orphaned the instance's database; now the pin keeps the worktree on its original instance. A behavior change, but the friendlier one.
- **Copied env file:** was already broken incoherently (PM2 names and ports followed the copied pin while dev-ports targeted a fresh basename slot). Now all layers agree on a single identity — no longer a split-brain.
- The `gc`/stale-instance logic already treats the env-file pin as instance identity (`get_env_instance_id` exists for it), so this aligns `claim`/`env` with semantics the tooling already had. Not used in CI.

## Testing

- From the affected worktree (pin `ld2`, basename `lightdash`): flagless `claim` and `env` now resolve `ld2` / slot 1; `dev-fast-start.sh` reached `READY` against the correct instance with the sibling's stack untouched and healthy.
- From the sibling (pin == basename == `lightdash`): resolution unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
