### PR TITLE
feat(cli): show data reference gaps in verbose validation

### DIFF
--- a/packages/cli/src/handlers/apps/validate.test.ts
+++ b/packages/cli/src/handlers/apps/validate.test.ts
@@ -10,6 +10,7 @@ import { readBundleFromDir, writeBundleToDir } from './appCodeFiles';
 import {
     buildAppsValidationReport,
     renderAppsValidationHuman,
+    renderAppsValidationJson,
     validateDataAppBuild,
     validateLocalDataApp,
     type RunDataAppBuildCommand,
@@ -512,29 +513,58 @@ describe('validateDataAppBuild', () => {
 });
 
 describe('renderAppsValidationHuman', () => {
-    it('makes partial green coverage explicit', () => {
-        const report = buildAppsValidationReport(
-            [
-                {
-                    path: '/tmp/orders-app',
-                    name: 'Orders app',
-                    projectUuid: 'project-uuid',
-                    valid: true,
-                    errors: [],
-                    warnings: [],
-                    coverage: {
-                        callSites: 14,
-                        fullyResolved: 11,
-                        partiallyResolved: 2,
-                        unresolved: 1,
-                        unanalyzed: 3,
-                    },
+    const report = buildAppsValidationReport(
+        [
+            {
+                path: '/tmp/orders-app',
+                name: 'Orders app',
+                projectUuid: 'project-uuid',
+                valid: true,
+                errors: [],
+                warnings: [],
+                coverage: {
+                    callSites: 14,
+                    fullyResolved: 11,
+                    partiallyResolved: 2,
+                    unresolved: 1,
+                    unanalyzed: 3,
                 },
-            ],
-            false,
-            true,
-        );
+                unanalyzedReferences: [
+                    {
+                        kind: 'query',
+                        unresolved: ['explore', 'dimensions'],
+                        location: {
+                            path: 'src/DynamicQuery.tsx',
+                            line: 8,
+                            column: 17,
+                        },
+                    },
+                    {
+                        kind: 'globalFilter',
+                        unresolved: ['field'],
+                        location: {
+                            path: 'src/ResultsTable.tsx',
+                            line: 42,
+                            column: 21,
+                        },
+                    },
+                    {
+                        kind: 'externalFetch',
+                        unresolved: ['alias'],
+                        location: {
+                            path: 'src/ExternalData.tsx',
+                            line: 12,
+                            column: 9,
+                        },
+                    },
+                ],
+            },
+        ],
+        false,
+        true,
+    );
 
+    it('makes partial green coverage explicit', () => {
         const output = renderAppsValidationHuman(report);
 
         expect(output).toContain(
@@ -544,5 +574,26 @@ describe('renderAppsValidationHuman', () => {
         expect(output).toContain('Validation passed');
         expect(output).toContain('Offline snapshots may be stale');
         expect(output).toContain('running Vite production builds');
+        expect(output).not.toContain('Static analysis gaps');
+    });
+
+    it('lists unresolved call sites and parts in verbose output', () => {
+        const output = renderAppsValidationHuman(report, true);
+
+        expect(output).toContain('Static analysis gaps:');
+        expect(output).toContain(
+            'src/DynamicQuery.tsx:8:17 — query (unresolved: explore, dimensions)',
+        );
+        expect(output).toContain(
+            'src/ResultsTable.tsx:42:21 — global filter (unresolved: field)',
+        );
+    });
+
+    it('keeps verbose-only reference details out of JSON output', () => {
+        const output = renderAppsValidationJson(report);
+
+        expect(JSON.parse(output)).not.toHaveProperty(
+            'apps.0.unanalyzedReferences',
+        );
     });
 });

--- a/packages/cli/src/handlers/apps/validate.ts
+++ b/packages/cli/src/handlers/apps/validate.ts
@@ -70,6 +70,12 @@ export type AppsValidationCoverage = DataAppDataReferences['stats'] & {
     unanalyzed: number;
 };
 
+export type AppsValidationUnanalyzedReference = {
+    kind: DataAppDataReferences['references'][number]['kind'];
+    unresolved: string[];
+    location: DataReferenceLocation;
+};
+
 export type AppValidationResult = {
     path: string;
     name: string | null;
@@ -78,6 +84,7 @@ export type AppValidationResult = {
     errors: AppsValidationIssue[];
     warnings: AppsValidationIssue[];
     coverage: AppsValidationCoverage;
+    unanalyzedReferences: AppsValidationUnanalyzedReference[];
 };
 
 export type AppsValidationReport = {
@@ -546,6 +553,7 @@ export const validateLocalDataApp = async (
             errors: [issue('bundle', getErrorMessage(error))],
             warnings,
             coverage: emptyCoverage(),
+            unanalyzedReferences: [],
         };
     }
 
@@ -564,6 +572,14 @@ export const validateLocalDataApp = async (
 
     const extracted = extractDataAppDataReferences(sourceFiles);
     const coverage = toCoverage(extracted.stats);
+    const unanalyzedReferences: AppsValidationUnanalyzedReference[] =
+        extracted.references
+            .filter((reference) => reference.unresolved.length > 0)
+            .map((reference) => ({
+                kind: reference.kind,
+                unresolved: [...reference.unresolved],
+                location: reference.location,
+            }));
     warnings.push(
         ...extracted.parseErrors.map((parseError) =>
             issue(
@@ -662,6 +678,7 @@ export const validateLocalDataApp = async (
         errors,
         warnings,
         coverage,
+        unanalyzedReferences,
     };
 };
 
@@ -713,8 +730,24 @@ const formatIssue = (entry: AppsValidationIssue): string => {
     return `${prefix}${entry.message}`;
 };
 
+const referenceKindLabels: Record<
+    AppsValidationUnanalyzedReference['kind'],
+    string
+> = {
+    query: 'query',
+    savedChart: 'saved chart',
+    externalFetch: 'external fetch',
+    globalFilter: 'global filter',
+};
+
+const formatUnanalyzedReference = (
+    reference: AppsValidationUnanalyzedReference,
+): string =>
+    `${reference.location.path}:${reference.location.line}:${reference.location.column} — ${referenceKindLabels[reference.kind]} (unresolved: ${reference.unresolved.join(', ')})`;
+
 export const renderAppsValidationHuman = (
     report: AppsValidationReport,
+    verbose = false,
 ): string => {
     const lines = [
         `Validating ${report.summary.apps} data app(s) using ${
@@ -738,6 +771,12 @@ export const renderAppsValidationHuman = (
             `${app.valid ? styles.success('✓') : styles.error('✗')} ${label}`,
         );
         lines.push(`  ${formatCoverage(app.coverage)}`);
+        if (verbose && app.unanalyzedReferences.length > 0) {
+            lines.push('  Static analysis gaps:');
+            for (const reference of app.unanalyzedReferences) {
+                lines.push(`    ${formatUnanalyzedReference(reference)}`);
+            }
+        }
         for (const warning of app.warnings) {
             lines.push(
                 `  ${styles.warning('warning')} ${formatIssue(warning)}`,
@@ -760,6 +799,15 @@ export const renderAppsValidationHuman = (
     );
     return `${lines.join('\n')}\n`;
 };
+
+export const renderAppsValidationJson = (
+    report: AppsValidationReport,
+): string =>
+    `${JSON.stringify(
+        report,
+        (key, value) => (key === 'unanalyzedReferences' ? undefined : value),
+        2,
+    )}\n`;
 
 export const appsValidateHandler = async (
     pathArgs: string[] | undefined,
@@ -799,8 +847,8 @@ export const appsValidateHandler = async (
     const report = buildAppsValidationReport(apps, options.live, options.build);
     process.stdout.write(
         options.format === 'json'
-            ? `${JSON.stringify(report, null, 2)}\n`
-            : renderAppsValidationHuman(report),
+            ? renderAppsValidationJson(report)
+            : renderAppsValidationHuman(report, options.verbose),
     );
 
     if (!report.valid) {


### PR DESCRIPTION
## Summary

- retain unresolved static data-reference metadata through local app validation
- list each unresolved call site, reference kind, and unresolved parts with `lightdash apps validate --verbose`
- keep default human output and JSON output unchanged

## Why

Validation previously reported only the number of data-reference call sites that could not be fully analyzed. The extractor already knew the source locations and unresolved parts, but the CLI discarded that metadata after calculating coverage. This made benign dynamic patterns difficult to diagnose.

Verbose output now exposes those details without turning unresolved values into warnings or errors.

## Validation

- `pnpm -F cli test -- src/handlers/apps/validate.test.ts` (41 files, 493 tests)
- `pnpm -F cli exec vitest run --config vitest.config.ts src/handlers/apps/validate.test.ts` (1 file, 20 tests)
- `pnpm -F cli format`
- `pnpm -F cli lint`
- `pnpm -F cli typecheck`
- `git diff --check`
- `ld apps validate --verbose` against the F1 2026 Season Overview data app